### PR TITLE
feat(desktop): swap changes-sidebar clicks to open file, cmd-click for diff

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
@@ -13,14 +13,14 @@ const map: LinkTierMap = {
 };
 
 describe("changes sidebar file policy", () => {
-	it("keeps plain click on the diff", () => {
+	it("keeps plain click on the file", () => {
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: false,
 				ctrlKey: false,
 				shiftKey: false,
 			}),
-		).toBe("diff");
+		).toBe("file");
 	});
 
 	it("maps shift-click through the settings map", () => {
@@ -33,21 +33,21 @@ describe("changes sidebar file policy", () => {
 		).toBe("diffNewTab");
 	});
 
-	it("maps cmd/ctrl-click to the file when the settings action is pane", () => {
+	it("maps cmd/ctrl-click to the diff when the settings action is pane", () => {
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: true,
 				ctrlKey: false,
 				shiftKey: false,
 			}),
-		).toBe("file");
+		).toBe("diff");
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: false,
 				ctrlKey: true,
 				shiftKey: false,
 			}),
-		).toBe("file");
+		).toBe("diff");
 	});
 
 	it("maps cmd/ctrl-shift-click to the external editor", () => {
@@ -82,7 +82,8 @@ describe("changes sidebar file policy", () => {
 
 	it("finds shortcuts for menu items from the same map", () => {
 		expect(tierForChangesSidebarFileIntent(map, "diffNewTab")).toBe("shift");
-		expect(tierForChangesSidebarFileIntent(map, "file")).toBe("meta");
+		expect(tierForChangesSidebarFileIntent(map, "diff")).toBe("meta");
+		expect(tierForChangesSidebarFileIntent(map, "file")).toBeNull();
 		expect(tierForChangesSidebarFileIntent(map, "external")).toBe("metaShift");
 	});
 });

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
@@ -22,7 +22,7 @@ function intentFor(
 	if (action === null) return null;
 	if (action === "external") return "external";
 	if (action === "newTab") return "diffNewTab";
-	return tier === "plain" ? "diff" : "file";
+	return tier === "plain" ? "file" : "diff";
 }
 
 function shortIntentLabel(intent: ChangesSidebarFileIntent): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -64,8 +64,8 @@ export function FileRowContextMenuItems({
 	const changeKey = getChangesetFileKey(file);
 
 	const policy = useChangesSidebarFilePolicy();
+	const diffTier = policy.tierForIntent("diff");
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
-	const fileTier = policy.tierForIntent("file");
 	const externalTier = policy.tierForIntent("external");
 
 	return (
@@ -75,6 +75,9 @@ export function FileRowContextMenuItems({
 			>
 				<GitCompare />
 				Open Diff
+				{diffTier && (
+					<DropdownMenuShortcut>{modifierLabel(diffTier)}</DropdownMenuShortcut>
+				)}
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onSelect={() => onSelectFile?.(file.path, true, changeKey)}
@@ -93,9 +96,6 @@ export function FileRowContextMenuItems({
 			>
 				<FileText />
 				Open File
-				{fileTier && (
-					<DropdownMenuShortcut>{modifierLabel(fileTier)}</DropdownMenuShortcut>
-				)}
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -98,8 +98,8 @@ export const FileRow = memo(function FileRow({
 	};
 
 	const policy = useChangesSidebarFilePolicy();
+	const diffTier = policy.tierForIntent("diff");
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
-	const fileTier = policy.tierForIntent("file");
 	const externalTier = policy.tierForIntent("external");
 
 	const rowButton = (
@@ -181,6 +181,11 @@ export const FileRow = memo(function FileRow({
 						>
 							<GitCompare />
 							Open Diff
+							{diffTier && (
+								<DropdownMenuShortcut>
+									{modifierLabel(diffTier)}
+								</DropdownMenuShortcut>
+							)}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onSelect={() => onSelect?.(file.path, true, changeKey)}
@@ -199,11 +204,6 @@ export const FileRow = memo(function FileRow({
 						>
 							<FileText />
 							Open File
-							{fileTier && (
-								<DropdownMenuShortcut>
-									{modifierLabel(fileTier)}
-								</DropdownMenuShortcut>
-							)}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
@@ -244,6 +244,9 @@ export const FileRow = memo(function FileRow({
 				>
 					<GitCompare />
 					Open Diff
+					{diffTier && (
+						<ContextMenuShortcut>{modifierLabel(diffTier)}</ContextMenuShortcut>
+					)}
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => onSelect?.(file.path, true, changeKey)}
@@ -262,9 +265,6 @@ export const FileRow = memo(function FileRow({
 				>
 					<FileText />
 					Open File
-					{fileTier && (
-						<ContextMenuShortcut>{modifierLabel(fileTier)}</ContextMenuShortcut>
-					)}
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}


### PR DESCRIPTION
## Summary

Swaps the click behavior on changed-file rows in the v2 changes sidebar: a plain click now opens the rendered file, and cmd/ctrl-click opens the diff view (previously the reverse).

The `sidebarFileLinks` preference stores generic actions (`pane`/`newTab`/`external`) per modifier tier; the diff-vs-file semantic for the changes sidebar is resolved in `changesSidebarFilePolicy.intentFor`, so the swap is a one-line flip there and propagates to both sidebar renderers (list + tree), tooltip hints, and menu shortcut chips — including for users with an already-persisted preference. Shift-click (diff in new tab) and cmd+shift-click (external editor) are unchanged.

Also moves the ⌘ shortcut chip in the row context/dropdown menus from "Open File" to "Open Diff", since "file" is now the plain-click action and never sits on a modifier tier.

The v1 legacy changes sidebar (`screens/main/.../FileItem.tsx`) has its own hardcoded handling and is intentionally untouched.

## Test Plan

- [x] `bun test changesSidebarFilePolicy.test.ts` — updated expectations pass (plain → file, ⌘ → diff, tier lookups)
- [x] `bun run lint` clean
- [x] `bun run typecheck` (apps/desktop) clean
- [ ] Manual: click a changed file in the sidebar → rendered file opens; ⌘-click → diff opens; menu chips show ⌘ on "Open Diff"

https://claude.ai/code/session_01DiEVMcd9RDKJz9vPGD3ojY

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped click behavior in the v2 Changes sidebar: plain click now opens the file, and Cmd/Ctrl-click opens the diff. Existing `sidebarFileLinks` preferences still apply; tooltips and menu shortcut chips are updated; shift-modifier actions are unchanged; the legacy v1 sidebar is not affected.

<sup>Written for commit ab794e57ceb99d68f4a4d19dab5f79b612edc92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Changes sidebar click behavior so regular clicks open files, while modifier-clicks open diffs.
  * Corrected shortcut hints to appear on “Open Diff” actions instead of “Open File.”
  * Updated context menu behavior and shortcut mappings for consistent file and diff actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->