### PR TITLE
fix(desktop): launch Zed via bundle IDs so any release channel opens

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -166,6 +166,42 @@ describe("getAppCommand", () => {
 		});
 	});
 
+	describe("Zed (multi-channel)", () => {
+		// `open -a Zed` fails for a user whose only install is Zed Preview (its
+		// app is "Zed Preview", not "Zed"). Resolving by bundle ID across release
+		// channels launches whichever channel is installed.
+		test("returns bundle ID candidates across release channels", () => {
+			const result = getAppCommand("zed", "/path/to/file");
+			expect(result).toEqual([
+				{ command: "open", args: ["-b", "dev.zed.Zed", "/path/to/file"] },
+				{
+					command: "open",
+					args: ["-b", "dev.zed.Zed-Preview", "/path/to/file"],
+				},
+				{
+					command: "open",
+					args: ["-b", "dev.zed.Zed-Nightly", "/path/to/file"],
+				},
+				{ command: "open", args: ["-b", "dev.zed.Zed-Dev", "/path/to/file"] },
+			]);
+		});
+
+		// Zed opens a directory as a project via a plain open-document event, so
+		// (unlike JetBrains, #5090) it must NOT get the `-n ... --args` treatment.
+		test("opens a folder directly, without -n/--args", () => {
+			const result = getAppCommand("zed", "/Users/me/worktree");
+			for (const cmd of result ?? []) {
+				expect(cmd.args).not.toContain("-n");
+				expect(cmd.args).not.toContain("--args");
+			}
+		});
+
+		test("still resolves via the `zed` CLI on Linux", () => {
+			const result = getAppCommand("zed", "/path/to/file", "linux");
+			expect(result).toEqual([{ command: "zed", args: ["/path/to/file"] }]);
+		});
+	});
+
 	// Regression test for #5090: "Open in IntelliJ opens the base project
 	// instead of the worktree".
 	//

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -10,7 +10,7 @@ const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
 	cursor: "Cursor",
 	antigravity: "Antigravity",
 	devin: "Devin",
-	zed: "Zed",
+	zed: null, // Multi-channel, uses bundle IDs (stable/preview/nightly/dev)
 	xcode: "Xcode",
 	iterm: "iTerm",
 	warp: "Warp",
@@ -33,13 +33,25 @@ const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
 };
 
 /**
- * Bundle ID candidates for JetBrains IDEs with multiple editions.
- * `open -b <bundleId>` works regardless of the .app display name,
- * so "IntelliJ IDEA Ultimate.app" and "IntelliJ IDEA CE.app" both resolve correctly.
+ * Bundle ID candidates for apps with multiple installable variants — JetBrains
+ * editions and Zed release channels. `open -b <bundleId>` works regardless of
+ * the .app display name, so "IntelliJ IDEA Ultimate.app"/"IntelliJ IDEA CE.app"
+ * and "Zed.app"/"Zed Preview.app" all resolve correctly. Candidates are tried in
+ * order and the first installed one wins, so a user who has only a non-stable
+ * variant still launches — `open -a Zed` fails outright for someone whose only
+ * install is Zed Preview (its app is named "Zed Preview", not "Zed").
  */
 const BUNDLE_ID_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
 	intellij: ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"],
 	pycharm: ["com.jetbrains.pycharm", "com.jetbrains.pycharm.ce"],
+	// Zed release channels, most-common first. A user typically installs one
+	// channel; trying stable → preview → nightly → dev launches whichever exists.
+	zed: [
+		"dev.zed.Zed",
+		"dev.zed.Zed-Preview",
+		"dev.zed.Zed-Nightly",
+		"dev.zed.Zed-Dev",
+	],
 };
 
 /** Map of app IDs to their Linux CLI commands */


### PR DESCRIPTION
## What
Resolve "Open in Zed" by bundle ID across release channels (stable/preview/nightly/dev) instead of by the `Zed` app display name.

## Why
The IDE menu shows every editor regardless of what is installed, but clicking **Zed** ran `open -a Zed <path>`, which fails outright for anyone whose only install is **Zed Preview** (its app is named "Zed Preview", bundle id `dev.zed.Zed-Preview`) — so the item looked present but never launched. Resolving via `open -b <bundleId>` across channels launches whichever one is installed. The router already tries candidates in order and falls through on failure, mirroring the existing IntelliJ/PyCharm multi-variant handling in the same file. Zed stays out of `JETBRAINS_APPS`, so it keeps `-b <id> <path>` (no `-n --args`), which correctly opens a worktree folder as a project.

No schema/UI/icon changes; `default_app`/`default_editor` are plain text columns (no migration). Linux is unaffected (still resolves via the `zed` CLI).

## Test
Added a `Zed (multi-channel)` block in `helpers.test.ts` (channel candidates, no `-n`/`--args`, Linux CLI path). Verified at the shell that `open -b dev.zed.Zed` (absent) exits non-zero → falls through, and `open -b dev.zed.Zed-Preview <folder>` opens Zed Preview.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Open in Zed” on macOS by launching via bundle IDs across release channels (stable, preview, nightly, dev) so the installed Zed opens reliably. Linux still uses the `zed` CLI; no schema or UI changes.

- Bug Fixes
  - Resolve Zed with `open -b` using bundle IDs: `dev.zed.Zed`, `dev.zed.Zed-Preview`, `dev.zed.Zed-Nightly`, `dev.zed.Zed-Dev`.
  - Do not pass `-n` or `--args` to Zed; folders open directly as projects.
  - Added tests for channel candidates and Linux CLI handling.

<sup>Written for commit d0360b74a47c9edf55a7d9004470ad0e5fa943f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS support for opening projects with Zed across release channels.
  * Ensured project and directory paths open correctly without unintended launch arguments.
  * Preserved Linux support using the standard Zed command-line invocation.

* **Tests**
  * Added coverage for Zed’s macOS channel detection and cross-platform project opening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->