### PR TITLE
fix(desktop): clear seeded setup-script prompt when New Workspace modal is dismissed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
@@ -40,10 +40,10 @@ export function V2SetupScriptCard({
 	// Configure → open the new-workspace modal seeded with a prompt that walks
 	// the agent through writing setup/teardown scripts for this project, rather
 	// than sending the user to the settings page to hand-write config.json.
+	// seedPrompt marks the draft as seeded so dismissing the modal without
+	// creating discards the prefill instead of persisting it like a user draft.
 	const handleConfigure = () => {
-		const draftStore = useNewWorkspaceDraftStore.getState();
-		draftStore.resetDraft();
-		draftStore.updateDraft({ prompt: setupScriptPrompt });
+		useNewWorkspaceDraftStore.getState().seedPrompt(setupScriptPrompt);
 		openNewWorkspaceModal(projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
@@ -1,7 +1,9 @@
 import { PromptInputProvider } from "@superset/ui/ai-elements/prompt-input";
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { NewWorkspaceScreen } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen";
 import { DashboardNewWorkspaceDraftProvider } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext";
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/new-workspace/",
@@ -21,6 +23,16 @@ export const Route = createFileRoute(
  */
 function NewWorkspacePage() {
 	const { projectId } = Route.useSearch();
+
+	// The screen has no dismiss interaction — leaving the route is the
+	// dismissal. Discard an unedited seeded prompt (e.g. the setup-script
+	// Configure hand-off) on unmount so it doesn't resurface on the next open.
+	// Successful create resets the draft first, making this a no-op there.
+	useEffect(
+		() => () => useNewWorkspaceDraftStore.getState().discardSeededPrompt(),
+		[],
+	);
+
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={() => {}}>
 			<PromptInputProvider>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -10,7 +10,8 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -48,6 +49,15 @@ export function DashboardNewWorkspaceModal() {
 	const variant = useNewWorkspaceScreenVariant(isOpen);
 	const isScreen = variant === "test";
 
+	// Dismissing (Esc / click outside) without creating discards a seeded
+	// prompt (e.g. the setup-script Configure card) so the next plain open
+	// starts clean. User-typed drafts are untouched — discardSeededPrompt is
+	// a no-op once the prompt has been edited.
+	const handleDismiss = useCallback(() => {
+		useNewWorkspaceDraftStore.getState().discardSeededPrompt();
+		closeModal();
+	}, [closeModal]);
+
 	// Test arm: the create surface is a page, not a modal. Store opens (the
 	// "+" button, hotkey, onboarding hand-off) redirect to the route instead.
 	useEffect(() => {
@@ -71,7 +81,7 @@ export function DashboardNewWorkspaceModal() {
 				<Dialog
 					modal
 					open={isOpen}
-					onOpenChange={(open) => !open && closeModal()}
+					onOpenChange={(open) => !open && handleDismiss()}
 				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -10,7 +10,7 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
 import {
 	useCloseNewWorkspaceModal,
@@ -49,14 +49,22 @@ export function DashboardNewWorkspaceModal() {
 	const variant = useNewWorkspaceScreenVariant(isOpen);
 	const isScreen = variant === "test";
 
-	// Dismissing (Esc / click outside) without creating discards a seeded
-	// prompt (e.g. the setup-script Configure card) so the next plain open
-	// starts clean. User-typed drafts are untouched — discardSeededPrompt is
-	// a no-op once the prompt has been edited.
-	const handleDismiss = useCallback(() => {
-		useNewWorkspaceDraftStore.getState().discardSeededPrompt();
-		closeModal();
-	}, [closeModal]);
+	// Any modal close without a successful create (Esc, click outside, and
+	// programmatic closes like "Configure agents" or "Go to setup") discards a
+	// seeded prompt (e.g. the setup-script Configure card) so the next plain
+	// open starts clean. User-typed or edited drafts are untouched — discard is
+	// a no-op unless the prompt is an unedited seed, and a successful create
+	// resets the draft before closing. The test-arm redirect close is excluded
+	// so the seed survives the hand-off to /new-workspace, which discards it
+	// on unmount instead.
+	const wasOpenRef = useRef(isOpen);
+	useEffect(() => {
+		const wasOpen = wasOpenRef.current;
+		wasOpenRef.current = isOpen;
+		if (wasOpen && !isOpen && !isScreen) {
+			useNewWorkspaceDraftStore.getState().discardSeededPrompt();
+		}
+	}, [isOpen, isScreen]);
 
 	// Test arm: the create surface is a page, not a modal. Store opens (the
 	// "+" button, hotkey, onboarding hand-off) redirect to the route instead.
@@ -81,7 +89,7 @@ export function DashboardNewWorkspaceModal() {
 				<Dialog
 					modal
 					open={isOpen}
-					onOpenChange={(open) => !open && handleDismiss()}
+					onOpenChange={(open) => !open && closeModal()}
 				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+
+const store = useNewWorkspaceDraftStore;
+
+describe("new workspace draft store", () => {
+	afterEach(() => {
+		store.getState().resetDraft();
+	});
+
+	it("discards a seeded prompt that was never edited", () => {
+		store.getState().seedPrompt("configure setup scripts...");
+		expect(store.getState().prompt).toBe("configure setup scripts...");
+		expect(store.getState().promptSeeded).toBe(true);
+
+		store.getState().discardSeededPrompt();
+
+		expect(store.getState().prompt).toBe("");
+		expect(store.getState().promptSeeded).toBe(false);
+	});
+
+	it("keeps a seeded prompt the user edited", () => {
+		store.getState().seedPrompt("configure setup scripts...");
+		store
+			.getState()
+			.updateDraft({ prompt: "configure setup scripts... plus my notes" });
+
+		store.getState().discardSeededPrompt();
+
+		expect(store.getState().prompt).toBe(
+			"configure setup scripts... plus my notes",
+		);
+	});
+
+	it("keeps a user-typed prompt (never seeded)", () => {
+		store.getState().updateDraft({ prompt: "my own draft" });
+
+		store.getState().discardSeededPrompt();
+
+		expect(store.getState().prompt).toBe("my own draft");
+	});
+
+	it("stays seeded through non-prompt draft updates", () => {
+		store.getState().seedPrompt("configure setup scripts...");
+		store.getState().updateDraft({ selectedProjectId: "project-1" });
+		// Editor hydration re-emitting identical content is not an edit.
+		store.getState().updateDraft({ prompt: "configure setup scripts..." });
+
+		expect(store.getState().promptSeeded).toBe(true);
+
+		store.getState().discardSeededPrompt();
+
+		expect(store.getState().prompt).toBe("");
+		// User-selected fields survive; only the seeded prompt is discarded.
+		expect(store.getState().selectedProjectId).toBe("project-1");
+	});
+
+	it("resets the seeded flag and bumps resetKey on seed", () => {
+		const before = store.getState().resetKey;
+		store.getState().updateDraft({ workspaceName: "stale", prompt: "old" });
+
+		store.getState().seedPrompt("seeded");
+
+		expect(store.getState().resetKey).toBe(before + 1);
+		expect(store.getState().workspaceName).toBe("");
+		expect(store.getState().prompt).toBe("seeded");
+	});
+
+	it("clears the seeded flag on resetDraft", () => {
+		store.getState().seedPrompt("seeded");
+		store.getState().resetDraft();
+
+		expect(store.getState().promptSeeded).toBe(false);
+		expect(store.getState().prompt).toBe("");
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -45,11 +45,21 @@ export interface NewWorkspaceDraft {
 
 interface NewWorkspaceDraftState extends NewWorkspaceDraft {
 	resetKey: number;
+	/**
+	 * True while `prompt` holds prefilled content (e.g. the setup-script
+	 * Configure card) that the user hasn't edited yet. Lets dismissal discard
+	 * the seed without touching user-typed drafts.
+	 */
+	promptSeeded: boolean;
 	updateDraft: (patch: Partial<NewWorkspaceDraft>) => void;
 	addAttachment: (attachment: DraftAttachment) => void;
 	updateAttachment: (localId: string, patch: Partial<DraftAttachment>) => void;
 	removeAttachment: (localId: string) => void;
 	resetDraft: () => void;
+	/** Resets the draft and prefills `prompt` with seeded (non-user) content. */
+	seedPrompt: (prompt: string) => void;
+	/** Clears `prompt` if it still holds an unedited seed; no-op otherwise. */
+	discardSeededPrompt: () => void;
 }
 
 function buildInitialDraft(): NewWorkspaceDraft {
@@ -74,7 +84,17 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 	(set) => ({
 		...buildInitialDraft(),
 		resetKey: 0,
-		updateDraft: (patch) => set((state) => ({ ...state, ...patch })),
+		promptSeeded: false,
+		updateDraft: (patch) =>
+			set((state) => ({
+				...state,
+				...patch,
+				// Any actual prompt edit turns the seed into user content.
+				promptSeeded:
+					patch.prompt !== undefined && patch.prompt !== state.prompt
+						? false
+						: state.promptSeeded,
+			})),
 		addAttachment: (attachment) =>
 			set((state) => ({
 				...state,
@@ -98,11 +118,25 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 			set((state) => ({
 				...buildInitialDraft(),
 				resetKey: state.resetKey + 1,
+				promptSeeded: false,
 				updateDraft: state.updateDraft,
 				addAttachment: state.addAttachment,
 				updateAttachment: state.updateAttachment,
 				removeAttachment: state.removeAttachment,
 				resetDraft: state.resetDraft,
+				seedPrompt: state.seedPrompt,
+				discardSeededPrompt: state.discardSeededPrompt,
 			})),
+		seedPrompt: (prompt) =>
+			set((state) => ({
+				...buildInitialDraft(),
+				resetKey: state.resetKey + 1,
+				prompt,
+				promptSeeded: true,
+			})),
+		discardSeededPrompt: () =>
+			set((state) =>
+				state.promptSeeded ? { prompt: "", promptSeeded: false } : {},
+			),
 	}),
 );


### PR DESCRIPTION
> **Fixes #5372** — [bug] New Workspace modal keeps the setup-script prompt after dismissing Configure

You click **Configure** on the Setup-scripts card, close the modal, and a prompt you never typed keeps coming back every time you open New Workspace. The composer sits behind the **+** button, the hotkey, and the onboarding hand-off — the core create-workspace entry point. User-reported with a repro video in #5372.

## What users see

1. Click **Configure** on the "Setup scripts" sidebar card. The New Workspace modal opens pre-filled with a setup-script prompt.
2. Dismiss the modal (Esc / click outside) without creating.
3. Click **+ / New Workspace**. The composer still shows the setup-script prompt instead of an empty draft, and it comes back on every open until you create a workspace.

Repro video (from the issue): https://github.com/user-attachments/assets/04ef4e13-1385-4ff9-9588-0b4c4e4a8596

## Root cause

The Configure card writes its prompt into the shared `useNewWorkspaceDraftStore`. That store persists across modal open/close on purpose — user-typed drafts should survive dismissal — and only resets on a successful create. It can't tell seeded content from user content, so the seed survives dismissal too.

## Fix: distinguish seeded from user-typed content

A `promptSeeded` flag marks "the prompt holds prefilled content the user hasn't touched". Dismissal discards only a still-unedited seed:

- `new-workspace-draft.ts` — `seedPrompt(prompt)` resets the draft, prefills the prompt, and sets the flag (replacing the card's `resetDraft()` + `updateDraft({ prompt })` pair). `discardSeededPrompt()` clears the prompt only while the flag is set; no-op otherwise.
- `updateDraft` clears the flag only on an actual prompt change (`patch.prompt !== state.prompt`). Editor hydration that re-emits identical content doesn't count as an edit. (Traced the tiptap path too: `onUpdate` fires only on doc-changed transactions, and the external content sync uses `emitUpdate: false`, so no normalized echo can silently claim the seed.)

### All close paths are covered

A naive `onOpenChange`-only fix would have left the bug alive in two arms:

| Close path | How it's handled |
|---|---|
| Esc / click outside | `DashboardNewWorkspaceModal` watches the open→closed transition and calls `discardSeededPrompt()` — one watcher covers every close, however triggered |
| Programmatic closes ("Configure agents" via `onBeforeConfigureAgents={closeModal}`, "Go to setup" via `handleGoToSetup`) | These call `closeModal()` directly and **bypass Radix's `onOpenChange`** — the same transition watcher catches them |
| Successful create | `closeAndResetDraft()` runs first, so the discard is a no-op |
| Screen-variant redirect (`/new-workspace` experiment arm) | Excluded from the modal watcher so the seed **survives the hand-off** to the route; the screen has no dismiss interaction — leaving the route is the dismissal — so the page discards an unedited seed on unmount instead |

### User-typed draft persistence (an intentional feature) is untouched

- A prompt the user typed is never marked seeded, so discard is a no-op.
- Editing the seed by one character flips the flag off. The edited draft then persists across dismissal like any user draft.
- The discard clears only the prompt. Selected project, host, workspace name, linked issues, and attachments survive.
- Task-page flows that prefill `linkedIssues` via `resetDraft()` + `updateDraft(...)` never set the flag and are unaffected.
- The store is plain in-memory zustand (no persist middleware), so no stale `promptSeeded` survives a restart.

## Verification

- `new-workspace-draft.test.ts` (new, co-located): **6/6 pass** under `bun test` — seed discarded on dismiss; edited seed kept; user-typed prompt kept; identical-content re-emission not an edit; `seedPrompt` resets stale draft state and bumps `resetKey`; `resetDraft` clears the flag.
- `apps/desktop` `tsc --noEmit`: clean (exit 0) at the PR head.
- Biome check on all changed files: 0 diagnostics.
- Traced end-to-end: Configure → `seedPrompt` → modal renders `draft.prompt` (`key={resetKey}`) → any non-create close → discard → next open is empty. Test arm: seed survives the redirect to `/new-workspace` and is discarded on route unmount.

## Prior art

Two earlier attempts at #5372 exist. Neither merged, and both were written on 2026-06-27 — before the `/new-workspace` screen experiment landed (#5907, 2026-07-24, `useNewWorkspaceScreenVariant`) and added a close path neither accounts for. Claims below are verified against each PR's diff.

**#5374 — triage bot (`triage/issue-5372-28297613248`), closed unmerged 2026-07-11.** Same core idea (a `seededFromConfigure` flag + `dismissDraft()`), but:

- Wired only to Radix `onOpenChange`. The programmatic closes ("Configure agents" via `onBeforeConfigureAgents={closeModal}`, "Go to setup" via `handleGoToSetup`) call `closeModal()` directly and never pass through `onOpenChange`, so the seed survives those closes — the bug stays reachable.
- Its `updateDraft` is unchanged, so **editing the seeded prompt never clears the flag**, and `dismissDraft()` runs a full `resetDraft()`. Dismissing after editing the seed destroys the user's edits, and any seeded dismiss also wipes user-filled non-prompt fields (project, workspace name). This PR clears only the still-unedited prompt and keeps everything else.
- 2 store tests; no screen-variant handling.

**#5373 — @preetecool, still open.** The closest prior art and a genuinely good attempt: the same seeded-flag design (`promptSeededFromSetupCard`), the same same-value-write guard in `updateDraft`, and a discard inside the modal store's `closeModal()` — which *does* cover the programmatic close paths. Honest deltas:

- **It breaks Configure in the experiment's test arm on today's main.** The screen-variant redirect calls `closeModal()` + `navigate("/new-workspace")` during the hand-off, so a discard inside `closeModal()` wipes the seed **before** the route renders it — Configure would open an empty screen for test-arm users. This PR excludes the redirect close from the modal watcher and discards on route unmount instead, so the seed survives the hand-off and still can't leak into the next open. (#5373 predates the experiment, so this isn't a flaw in its original context — it's what landing it today would do.)
- It couples the modal store to the draft store (`new-workspace-modal.ts` imports `new-workspace-draft`). This PR keeps the stores independent and puts the discard at the two UI surfaces that own dismissal semantics.
- By its own description it was verified at unit level only ("Not yet clicked through the running Electron app"). This PR's flows were traced end-to-end against current main (post-#5907) and passed an adversarial review pass.

No other branches, PRs, or issue comments reference #5372 (checked `gh pr list --search`, the issue timeline, and `git ls-remote 'refs/heads/triage/issue-5372*'`).

## Why this PR still matters

#5373, an open PR by a human contributor, uses the same design idea — but it predates the `/new-workspace` screen experiment and would wipe the seed during the test-arm hand-off; this PR is the one that works on today's main. The bug sits on the first-run path: the Setup-scripts card exists to nudge new users, and every dismissal plants a wall of text they must notice and delete before typing their own prompt. The diff is contained (one store + flag, two discard call sites, one call-site swap, tests) and changes nothing for user-typed drafts.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup guidance now pre-fills the new workspace prompt when configuring a workspace.
  * Seeded prompts are automatically cleared when dismissed or left unused.

* **Bug Fixes**
  * User-edited prompts are preserved when closing and reopening the new workspace flow.
  * Draft cleanup no longer removes unrelated workspace selections or fields.

* **Tests**
  * Added coverage for seeded prompt behavior, edits, resets, and draft preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->