### PR TITLE
fix(host-service): reject dot-only directory names when creating empty/template projects

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -11,6 +11,7 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	realpathSync,
 	rmSync,
 	writeFileSync,
@@ -321,50 +322,76 @@ async function expectBadRequestDirName(promise: Promise<unknown>) {
 	expect((err as TRPCError).message).toMatch(/Invalid directory name/);
 }
 
+let dotGuardParentDir: string;
+let dotGuardSentinel: string;
+
+/**
+ * parentDir with a sentinel file NEXT TO it: a ".."-escape resolves to
+ * workRoot, so a git init landing there — or the failure-cleanup rmSync
+ * wiping it — is visible from outside parentDir.
+ */
+function setupDotGuardDirs(): void {
+	dotGuardParentDir = join(workRoot, "projects");
+	mkdirSync(dotGuardParentDir);
+	dotGuardSentinel = join(workRoot, "outside.txt");
+	writeFileSync(dotGuardSentinel, "preserved");
+}
+
+function expectNoEscapeSideEffects(): void {
+	// Nothing created inside parentDir, nothing init'ed or deleted above it.
+	expect(readdirSync(dotGuardParentDir)).toEqual([]);
+	expect(existsSync(join(workRoot, ".git"))).toBe(false);
+	expect(existsSync(dotGuardSentinel)).toBe(true);
+}
+
 describe("initEmptyRepo", () => {
+	beforeEach(setupDotGuardDirs);
+
 	test("throws when the directory name is '.'", async () => {
 		// "." would join() back to parentDir itself; like
 		// deriveCloneDirectoryName, dot-only segments are reserved.
-		const parentDir = join(workRoot, "projects");
-		mkdirSync(parentDir);
-
-		await expectBadRequestDirName(initEmptyRepo(parentDir, "."));
-		// Nothing was initialized in (or above) the parent directory.
-		expect(existsSync(join(parentDir, ".git"))).toBe(false);
-		expect(existsSync(join(workRoot, ".git"))).toBe(false);
+		await expectBadRequestDirName(initEmptyRepo(dotGuardParentDir, "."));
+		expectNoEscapeSideEffects();
 	});
 
 	test("throws when the directory name is '..'", async () => {
 		// ".." would join() to parentDir's parent — escaping the projects dir.
-		const parentDir = join(workRoot, "projects");
-		mkdirSync(parentDir);
+		await expectBadRequestDirName(initEmptyRepo(dotGuardParentDir, ".."));
+		expectNoEscapeSideEffects();
+	});
 
-		await expectBadRequestDirName(initEmptyRepo(parentDir, ".."));
-		expect(existsSync(join(workRoot, ".git"))).toBe(false);
+	test("throws when the directory name trims to dots (' .. ')", async () => {
+		// Windows path normalization strips trailing dots/spaces, so a padded
+		// " .. " can collapse back to "..". The guard rejects the trimmed form.
+		await expectBadRequestDirName(initEmptyRepo(dotGuardParentDir, " .. "));
+		expectNoEscapeSideEffects();
 	});
 });
 
 describe("cloneTemplateInto", () => {
 	const templateUrl = "https://github.com/acme/template.git";
 
-	test("throws when the directory name is '.'", async () => {
-		const parentDir = join(workRoot, "projects");
-		mkdirSync(parentDir);
+	beforeEach(setupDotGuardDirs);
 
+	test("throws when the directory name is '.'", async () => {
 		await expectBadRequestDirName(
-			cloneTemplateInto(templateUrl, parentDir, "."),
+			cloneTemplateInto(templateUrl, dotGuardParentDir, "."),
 		);
-		expect(existsSync(join(parentDir, ".git"))).toBe(false);
+		expectNoEscapeSideEffects();
 	});
 
 	test("throws when the directory name is '..'", async () => {
-		const parentDir = join(workRoot, "projects");
-		mkdirSync(parentDir);
-
 		await expectBadRequestDirName(
-			cloneTemplateInto(templateUrl, parentDir, ".."),
+			cloneTemplateInto(templateUrl, dotGuardParentDir, ".."),
 		);
-		expect(existsSync(join(workRoot, ".git"))).toBe(false);
+		expectNoEscapeSideEffects();
+	});
+
+	test("throws when the directory name trims to dots (' . ')", async () => {
+		await expectBadRequestDirName(
+			cloneTemplateInto(templateUrl, dotGuardParentDir, " . "),
+		);
+		expectNoEscapeSideEffects();
 	});
 });
 

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -17,9 +17,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { TRPCError } from "@trpc/server";
 import simpleGit, { type SimpleGit } from "simple-git";
 import {
 	cloneRepoInto,
+	cloneTemplateInto,
+	initEmptyRepo,
 	initLocalRepoInPlace,
 	resolveLocalRepo,
 } from "./resolve-repo";
@@ -303,6 +306,65 @@ describe("initLocalRepoInPlace", () => {
 		await expect(initLocalRepoInPlace(file)).rejects.toThrow(
 			/Path is not a directory/,
 		);
+	});
+});
+
+// ── initEmptyRepo / cloneTemplateInto ─────────────────────────────
+
+async function expectBadRequestDirName(promise: Promise<unknown>) {
+	const err = await promise.then(
+		() => null,
+		(e: unknown) => e,
+	);
+	expect(err).toBeInstanceOf(TRPCError);
+	expect((err as TRPCError).code).toBe("BAD_REQUEST");
+	expect((err as TRPCError).message).toMatch(/Invalid directory name/);
+}
+
+describe("initEmptyRepo", () => {
+	test("throws when the directory name is '.'", async () => {
+		// "." would join() back to parentDir itself; like
+		// deriveCloneDirectoryName, dot-only segments are reserved.
+		const parentDir = join(workRoot, "projects");
+		mkdirSync(parentDir);
+
+		await expectBadRequestDirName(initEmptyRepo(parentDir, "."));
+		// Nothing was initialized in (or above) the parent directory.
+		expect(existsSync(join(parentDir, ".git"))).toBe(false);
+		expect(existsSync(join(workRoot, ".git"))).toBe(false);
+	});
+
+	test("throws when the directory name is '..'", async () => {
+		// ".." would join() to parentDir's parent — escaping the projects dir.
+		const parentDir = join(workRoot, "projects");
+		mkdirSync(parentDir);
+
+		await expectBadRequestDirName(initEmptyRepo(parentDir, ".."));
+		expect(existsSync(join(workRoot, ".git"))).toBe(false);
+	});
+});
+
+describe("cloneTemplateInto", () => {
+	const templateUrl = "https://github.com/acme/template.git";
+
+	test("throws when the directory name is '.'", async () => {
+		const parentDir = join(workRoot, "projects");
+		mkdirSync(parentDir);
+
+		await expectBadRequestDirName(
+			cloneTemplateInto(templateUrl, parentDir, "."),
+		);
+		expect(existsSync(join(parentDir, ".git"))).toBe(false);
+	});
+
+	test("throws when the directory name is '..'", async () => {
+		const parentDir = join(workRoot, "projects");
+		mkdirSync(parentDir);
+
+		await expectBadRequestDirName(
+			cloneTemplateInto(templateUrl, parentDir, ".."),
+		);
+		expect(existsSync(join(workRoot, ".git"))).toBe(false);
 	});
 });
 

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -268,7 +268,7 @@ export async function initEmptyRepo(
 	parentDir: string,
 	dirName: string,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName)) {
+	if (!dirName.trim() || /[/\\]/.test(dirName) || /^\.+$/.test(dirName)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: `Invalid directory name: "${dirName}"`,
@@ -311,7 +311,7 @@ export async function cloneTemplateInto(
 	dirName: string,
 	credentials?: GitCredentialProvider,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName)) {
+	if (!dirName.trim() || /[/\\]/.test(dirName) || /^\.+$/.test(dirName)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: `Invalid directory name: "${dirName}"`,

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -256,6 +256,23 @@ export async function resolveMatchingSlug(
 }
 
 /**
+ * Rejects directory names that would escape (or alias) `<parentDir>/<dirName>`:
+ * empty/whitespace-only names, embedded path separators, and dot-only names
+ * (`join(parentDir, "..")` resolves outside the parent). The dot check runs on
+ * the trimmed name so padded variants like `" .. "` — which Windows path
+ * normalization collapses back to `".."` — are rejected too.
+ */
+function validateDirectoryName(dirName: string): void {
+	const trimmed = dirName.trim();
+	if (!trimmed || /[/\\]/.test(dirName) || /^\.+$/.test(trimmed)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Invalid directory name: "${dirName}"`,
+		});
+	}
+}
+
+/**
  * Empty git repo at `<parentDir>/<dirName>`: atomic mkdir (fails on EEXIST,
  * so we never blow away someone else's directory), `git init`, initial
  * empty commit. Cleans up the dir on any post-mkdir failure.
@@ -268,12 +285,7 @@ export async function initEmptyRepo(
 	parentDir: string,
 	dirName: string,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName) || /^\.+$/.test(dirName)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Invalid directory name: "${dirName}"`,
-		});
-	}
+	validateDirectoryName(dirName);
 
 	const resolvedParentDir = resolvePath(parentDir);
 	ensureParentDirectory(resolvedParentDir);
@@ -311,12 +323,7 @@ export async function cloneTemplateInto(
 	dirName: string,
 	credentials?: GitCredentialProvider,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName) || /^\.+$/.test(dirName)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Invalid directory name: "${dirName}"`,
-		});
-	}
+	validateDirectoryName(dirName);
 
 	const resolvedParentDir = resolvePath(parentDir);
 	ensureParentDirectory(resolvedParentDir);


### PR DESCRIPTION
> **Fixes #5664** — Creating an empty/template project named "." or ".." escapes the projects directory

## Prior art

Two earlier attempts at #5664 exist. Both opened 2026-07-13, both still open and unmerged, no human review:

- **#5665** (@abhay-codes07, `fix/empty-project-dirname-guard`) — shared `assertUsableDirName` in both `initEmptyRepo` and `cloneTemplateInto`. Rejects the **trimmed** name when it equals `.` or `..`. 6 guard-only tests that assert the thrown error.
- **#5666** (github-actions triage bot, branch `triage/issue-5664-29261598250`) — shared `assertValidDirName` in both functions. But its dot check compares the **raw** string (`dirName === "."` / `dirName === ".."`) while its emptiness check trims — the same raw-vs-trimmed drift this bug class comes from. So a padded `" .. "` still passes its guard. 5 tests including one positive case, with `.git`-absence checks.

Both prior PRs fix the core reported repro (a literal `.` or `..`). Verified against their actual diffs, this PR closes what they leave open:

- **Trimmed, dot-only regex (`/^\.+$/`)** — rejects padded variants like `" .. "` (passes #5666's raw-string check; Windows path normalization strips trailing dots/spaces and collapses it back to `..`) and longer dot-only names like `"..."` (passes both prior guards; contained on POSIX but hit by the same trailing-dot stripping on Windows).
- **Escape-proof tests, not just thrown-error tests** — each rejection case asserts nothing was created inside the parent dir, no `.git` was init'ed above it, and a sentinel file *outside* the parent (where a `..` escape or its cleanup `rmSync` would land) survives. Neither prior PR plants a sentinel; #5665 asserts only the throw.
- **Evidence-gated verification actually run** — with the source fix reverted, all 6 new tests fail; on the branch, 36/36 pass; `tsc --noEmit` and Biome clean.

## Why this PR still matters

Two open PRs (#5665, #5666) already fix the literal `.`/`..` case. What only this PR closes: the padded `" .. "` hole in the bot's guard, the `"..."` name that escapes both guards, and escape-proof tests instead of throw-only ones.

The underlying bug: `initEmptyRepo` and `cloneTemplateInto` write to `join(parentDir, dirName)`. The directory-name guard is the only thing keeping that write inside `<parentDir>/<dirName>`. It rejected empty names and path separators, but not dot-only names. So a bad name could land writes outside the projects folder: `..` resolves to the parent's parent, and `.` aliases the projects directory itself. Today luck catches the escape, not design — `claimEmptyTargetDir`'s atomic `mkdir` hits the existing directory, and the user gets a baffling `Directory already exists` error for a project that was never created (#5664).

This is the incomplete half of an existing boundary. The sibling clone-from-URL path (`deriveCloneDirectoryName`) already rejects `.`/`..` as reserved segments, with tests. The empty/template paths carried their own weaker copy of the guard. That duplication is how this bug happened, and it stays a regression magnet until the guard is shared: both creation paths sit next to a failure-cleanup `rmSync(targetPath, { recursive: true, force: true })`. Any future change that lets a dot name reach `targetPath` turns a confusing error into recursive deletion **above** the projects directory.

## What changed

One production file, `packages/host-service/src/trpc/router/project/utils/resolve-repo.ts`:

- **Shared `validateDirectoryName` helper** replaces the two duplicated inline guards in `initEmptyRepo` and `cloneTemplateInto`. Same `BAD_REQUEST` / `Invalid directory name` error, one source of truth, no future drift.
- **New rejection: dot-only names** (`/^\.+$/`), checked on the **trimmed** name, matching the existing emptiness check. That also closes the padded variants: `" .. "` passes a raw-string regex, but Windows path normalization strips trailing dots/spaces and collapses it back to `..`.
- That is the only behavior change. Every currently-valid name is accepted exactly as before.

No bypass around the guard: the handler-side slug (`dirNameForEmpty` in `project/handlers.ts`) keeps dots and runs *before* the guard, so inputs like `" . "` and `"-.-"` reach it as the literal `"."` that would have been joined.

## Tests (evidence-gated)

6 new tests in `resolve-repo.test.ts`, mirroring the existing `deriveCloneDirectoryName` dot-segment tests: `initEmptyRepo` and `cloneTemplateInto` each throw `BAD_REQUEST` for `.`, `..`, and a whitespace-padded dot name. Each test also checks for escape side effects: nothing created inside the parent dir, no `.git` init'ed above it, and a sentinel file *outside* the parent (where a `..` escape or its cleanup `rmSync` would land) survives untouched. The sentinel keeps guarding even if the surrounding creation/cleanup code changes later.

- `bun test resolve-repo.test.ts`: **36 pass / 0 fail** on this branch.
- With the source fix reverted (tests kept): **all 6 new tests fail** — they catch the bug, not just the implementation.
- `tsc --noEmit` clean in `packages/host-service`; Biome clean on both changed files.

## Why merge now

An incomplete path boundary next to a `recursive: true` cleanup gets worse silently. The fix is a small, mechanical diff: one shared validator, one added rejection case, zero change for valid names. It brings all three project-creation paths under one rule, with regression tests that pin the boundary down.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5986">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository creation and cloning validation for directory names.
  * Prevented unsafe names, including path separators, empty values, and dot-only names, from escaping the intended destination.
  * Added consistent error handling for invalid directory names across repository initialization and template cloning.
  * Added safeguards to ensure protected files and directories remain unaffected by invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->