### PR TITLE
fix(host-service,desktop,api): treat cancelled CI checks as non-passing in checks rollup

### DIFF
--- a/apps/api/src/app/api/github/jobs/initial-sync/route.ts
+++ b/apps/api/src/app/api/github/jobs/initial-sync/route.ts
@@ -10,6 +10,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "@/env";
 import { githubApp } from "../../octokit";
+import { computeChecksStatus } from "../../utils/computeChecksStatus";
 
 const receiver = new Receiver({
 	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
@@ -173,31 +174,7 @@ export async function POST(request: Request) {
 					}),
 				);
 
-				let checksStatus = "none";
-				if (checks.length > 0) {
-					const hasFailure = checks.some(
-						(c: {
-							name: string;
-							status: string;
-							conclusion: string | null;
-							detailsUrl?: string;
-						}) => c.conclusion === "failure" || c.conclusion === "timed_out",
-					);
-					const hasPending = checks.some(
-						(c: {
-							name: string;
-							status: string;
-							conclusion: string | null;
-							detailsUrl?: string;
-						}) => c.status !== "completed",
-					);
-
-					checksStatus = hasFailure
-						? "failure"
-						: hasPending
-							? "pending"
-							: "success";
-				}
+				const checksStatus = computeChecksStatus(checks);
 
 				await db
 					.insert(githubPullRequests)

--- a/apps/api/src/app/api/github/sync/route.ts
+++ b/apps/api/src/app/api/github/sync/route.ts
@@ -9,6 +9,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "@/env";
 import { githubApp } from "../octokit";
+import { computeChecksStatus } from "../utils/computeChecksStatus";
 
 const bodySchema = z.object({
 	organizationId: z.string().uuid(),
@@ -141,31 +142,7 @@ export async function POST(request: Request) {
 					}),
 				);
 
-				let checksStatus = "none";
-				if (checks.length > 0) {
-					const hasFailure = checks.some(
-						(c: {
-							name: string;
-							status: string;
-							conclusion: string | null;
-							detailsUrl?: string;
-						}) => c.conclusion === "failure" || c.conclusion === "timed_out",
-					);
-					const hasPending = checks.some(
-						(c: {
-							name: string;
-							status: string;
-							conclusion: string | null;
-							detailsUrl?: string;
-						}) => c.status !== "completed",
-					);
-
-					checksStatus = hasFailure
-						? "failure"
-						: hasPending
-							? "pending"
-							: "success";
-				}
+				const checksStatus = computeChecksStatus(checks);
 
 				await db
 					.insert(githubPullRequests)

--- a/apps/api/src/app/api/github/utils/computeChecksStatus/computeChecksStatus.test.ts
+++ b/apps/api/src/app/api/github/utils/computeChecksStatus/computeChecksStatus.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { computeChecksStatus, type SyncedCheck } from "./computeChecksStatus";
+
+function check(
+	conclusion: string | null,
+	status = conclusion === null ? "in_progress" : "completed",
+): SyncedCheck {
+	return { name: `check-${conclusion ?? status}`, status, conclusion };
+}
+
+describe("computeChecksStatus", () => {
+	test("returns none for an empty list", () => {
+		expect(computeChecksStatus([])).toBe("none");
+	});
+
+	test("a cancelled check rolls up as failure, not success", () => {
+		expect(computeChecksStatus([check("cancelled")])).toBe("failure");
+		expect(computeChecksStatus([check("success"), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
+	test("terminal non-passing conclusions roll up as failure", () => {
+		expect(computeChecksStatus([check("failure")])).toBe("failure");
+		expect(computeChecksStatus([check("timed_out")])).toBe("failure");
+		expect(computeChecksStatus([check("action_required")])).toBe("failure");
+		expect(computeChecksStatus([check("startup_failure")])).toBe("failure");
+	});
+
+	test("failure takes precedence over pending", () => {
+		expect(computeChecksStatus([check(null), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
+	test("pending wins when nothing failed", () => {
+		expect(computeChecksStatus([check("success"), check(null)])).toBe(
+			"pending",
+		);
+	});
+
+	test("skipped and neutral checks fold into success", () => {
+		expect(
+			computeChecksStatus([
+				check("success"),
+				check("skipped"),
+				check("neutral"),
+			]),
+		).toBe("success");
+	});
+});

--- a/apps/api/src/app/api/github/utils/computeChecksStatus/computeChecksStatus.ts
+++ b/apps/api/src/app/api/github/utils/computeChecksStatus/computeChecksStatus.ts
@@ -1,0 +1,30 @@
+export interface SyncedCheck {
+	name: string;
+	status: string;
+	conclusion: string | null;
+	detailsUrl?: string;
+}
+
+export type ChecksStatus = "none" | "pending" | "success" | "failure";
+
+const FAILING_CONCLUSIONS = new Set([
+	"failure",
+	"timed_out",
+	"cancelled",
+	"action_required",
+	"startup_failure",
+]);
+
+export function computeChecksStatus(checks: SyncedCheck[]): ChecksStatus {
+	if (checks.length === 0) return "none";
+	if (
+		checks.some(
+			(check) =>
+				check.conclusion !== null && FAILING_CONCLUSIONS.has(check.conclusion),
+		)
+	) {
+		return "failure";
+	}
+	if (checks.some((check) => check.status !== "completed")) return "pending";
+	return "success";
+}

--- a/apps/api/src/app/api/github/utils/computeChecksStatus/index.ts
+++ b/apps/api/src/app/api/github/utils/computeChecksStatus/index.ts
@@ -1,0 +1,5 @@
+export {
+	type ChecksStatus,
+	computeChecksStatus,
+	type SyncedCheck,
+} from "./computeChecksStatus";

--- a/apps/api/src/app/api/github/webhook/webhooks.ts
+++ b/apps/api/src/app/api/github/webhook/webhooks.ts
@@ -10,6 +10,11 @@ import { and, eq } from "drizzle-orm";
 
 import { env } from "@/env";
 
+import {
+	computeChecksStatus,
+	type SyncedCheck,
+} from "../utils/computeChecksStatus";
+
 export const webhooks = new Webhooks({ secret: env.GH_WEBHOOK_SECRET });
 
 webhooks.on(
@@ -356,13 +361,7 @@ webhooks.on(
 
 			if (!currentPr) continue;
 
-			const currentChecks =
-				(currentPr.checks as Array<{
-					name: string;
-					status: string;
-					conclusion: string | null;
-					detailsUrl?: string;
-				}>) ?? [];
+			const currentChecks = (currentPr.checks as SyncedCheck[]) ?? [];
 
 			const newCheck = {
 				name: checkRun.name,
@@ -381,21 +380,7 @@ webhooks.on(
 				currentChecks.push(newCheck);
 			}
 
-			const hasFailure = currentChecks.some(
-				(c) =>
-					c.conclusion === "failure" ||
-					c.conclusion === "timed_out" ||
-					c.conclusion === "action_required",
-			);
-			const hasPending = currentChecks.some((c) => c.status !== "completed");
-
-			const checksStatus = hasFailure
-				? "failure"
-				: hasPending
-					? "pending"
-					: currentChecks.length > 0
-						? "success"
-						: "none";
+			const checksStatus = computeChecksStatus(currentChecks);
 
 			console.log(
 				`[github/webhook] Check ${checkRun.status}/${checkRun.conclusion}:`,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
@@ -8,6 +8,7 @@ import {
 import { resolveRemoteBranchNameForGitHubStatus } from "./github";
 import {
 	branchMatchesPR,
+	computeChecksStatus,
 	getPRHeadBranchCandidates,
 	prMatchesLocalBranch,
 	shouldAcceptPRMatch,
@@ -42,6 +43,48 @@ describe("branchMatchesPR", () => {
 
 	test("rejects partial suffix match that is not a path segment", () => {
 		expect(branchMatchesPR("my-thing", "thing")).toBe(false);
+	});
+});
+
+describe("computeChecksStatus", () => {
+	test("returns none for a missing or empty rollup", () => {
+		expect(computeChecksStatus(null)).toBe("none");
+		expect(computeChecksStatus([])).toBe("none");
+	});
+
+	test("a single cancelled check rolls up as failure, not success", () => {
+		expect(computeChecksStatus([{ conclusion: "CANCELLED" }])).toBe("failure");
+	});
+
+	test("a cancelled check among successes rolls up as failure", () => {
+		expect(
+			computeChecksStatus([
+				{ conclusion: "SUCCESS" },
+				{ conclusion: "CANCELLED" },
+			]),
+		).toBe("failure");
+	});
+
+	test("failure conclusions roll up as failure", () => {
+		expect(computeChecksStatus([{ conclusion: "FAILURE" }])).toBe("failure");
+		expect(computeChecksStatus([{ state: "ERROR" }])).toBe("failure");
+		expect(computeChecksStatus([{ conclusion: "TIMED_OUT" }])).toBe("failure");
+	});
+
+	test("pending wins when nothing failed", () => {
+		expect(
+			computeChecksStatus([{ conclusion: "SUCCESS" }, { state: "PENDING" }]),
+		).toBe("pending");
+	});
+
+	test("skipped and neutral checks stay non-blocking and fold into success", () => {
+		expect(
+			computeChecksStatus([
+				{ conclusion: "SUCCESS" },
+				{ conclusion: "SKIPPED" },
+				{ conclusion: "NEUTRAL" },
+			]),
+		).toBe("success");
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
@@ -17,6 +17,7 @@ import {
 	getPullRequestRepoArgs,
 	shouldRefreshCachedRepoContext,
 } from "./repo-context";
+import { GHCheckContextSchema } from "./types";
 
 describe("branchMatchesPR", () => {
 	test("matches same-repo branch exactly", () => {
@@ -69,11 +70,32 @@ describe("computeChecksStatus", () => {
 		expect(computeChecksStatus([{ conclusion: "FAILURE" }])).toBe("failure");
 		expect(computeChecksStatus([{ state: "ERROR" }])).toBe("failure");
 		expect(computeChecksStatus([{ conclusion: "TIMED_OUT" }])).toBe("failure");
+		expect(computeChecksStatus([{ conclusion: "ACTION_REQUIRED" }])).toBe(
+			"failure",
+		);
+		expect(computeChecksStatus([{ conclusion: "STARTUP_FAILURE" }])).toBe(
+			"failure",
+		);
+	});
+
+	test("cancelled takes precedence over pending", () => {
+		expect(
+			computeChecksStatus([{ state: "PENDING" }, { conclusion: "CANCELLED" }]),
+		).toBe("failure");
 	});
 
 	test("pending wins when nothing failed", () => {
 		expect(
 			computeChecksStatus([{ conclusion: "SUCCESS" }, { state: "PENDING" }]),
+		).toBe("pending");
+	});
+
+	test("unknown and expected statuses roll up as pending, never success", () => {
+		expect(
+			computeChecksStatus([{ conclusion: "SUCCESS" }, { state: "EXPECTED" }]),
+		).toBe("pending");
+		expect(
+			computeChecksStatus([{ conclusion: "SUCCESS" }, { conclusion: "STALE" }]),
 		).toBe("pending");
 	});
 
@@ -85,6 +107,25 @@ describe("computeChecksStatus", () => {
 				{ conclusion: "NEUTRAL" },
 			]),
 		).toBe("success");
+	});
+});
+
+describe("GHCheckContextSchema", () => {
+	test("accepts every gh conclusion and state so PRs are never dropped", () => {
+		for (const conclusion of [
+			"STARTUP_FAILURE",
+			"STALE",
+			"CANCELLED",
+			"ACTION_REQUIRED",
+		]) {
+			expect(
+				GHCheckContextSchema.safeParse({ name: "ci", conclusion }).success,
+			).toBe(true);
+		}
+		expect(
+			GHCheckContextSchema.safeParse({ context: "ci", state: "EXPECTED" })
+				.success,
+		).toBe(true);
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -447,7 +447,7 @@ function parseChecks(rollup: GHPRResponse["statusCheckRollup"]): CheckItem[] {
 	});
 }
 
-function computeChecksStatus(
+export function computeChecksStatus(
 	rollup: GHPRResponse["statusCheckRollup"],
 ): NonNullable<GitHubStatus["pr"]>["checksStatus"] {
 	if (!rollup || rollup.length === 0) {
@@ -460,7 +460,12 @@ function computeChecksStatus(
 	for (const ctx of rollup) {
 		const status = ctx.state || ctx.conclusion;
 
-		if (status === "FAILURE" || status === "ERROR" || status === "TIMED_OUT") {
+		if (
+			status === "FAILURE" ||
+			status === "ERROR" ||
+			status === "TIMED_OUT" ||
+			status === "CANCELLED"
+		) {
 			hasFailure = true;
 		} else if (
 			status === "PENDING" ||

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -432,7 +432,9 @@ function parseChecks(rollup: GHPRResponse["statusCheckRollup"]): CheckItem[] {
 		} else if (
 			rawStatus === "FAILURE" ||
 			rawStatus === "ERROR" ||
-			rawStatus === "TIMED_OUT"
+			rawStatus === "TIMED_OUT" ||
+			rawStatus === "ACTION_REQUIRED" ||
+			rawStatus === "STARTUP_FAILURE"
 		) {
 			status = "failure";
 		} else if (rawStatus === "SKIPPED" || rawStatus === "NEUTRAL") {
@@ -450,34 +452,17 @@ function parseChecks(rollup: GHPRResponse["statusCheckRollup"]): CheckItem[] {
 export function computeChecksStatus(
 	rollup: GHPRResponse["statusCheckRollup"],
 ): NonNullable<GitHubStatus["pr"]>["checksStatus"] {
-	if (!rollup || rollup.length === 0) {
+	const checks = parseChecks(rollup);
+	if (checks.length === 0) {
 		return "none";
 	}
-
-	let hasFailure = false;
-	let hasPending = false;
-
-	for (const ctx of rollup) {
-		const status = ctx.state || ctx.conclusion;
-
-		if (
-			status === "FAILURE" ||
-			status === "ERROR" ||
-			status === "TIMED_OUT" ||
-			status === "CANCELLED"
-		) {
-			hasFailure = true;
-		} else if (
-			status === "PENDING" ||
-			status === "" ||
-			status === null ||
-			status === undefined
-		) {
-			hasPending = true;
-		}
+	if (
+		checks.some(
+			(check) => check.status === "failure" || check.status === "cancelled",
+		)
+	) {
+		return "failure";
 	}
-
-	if (hasFailure) return "failure";
-	if (hasPending) return "pending";
+	if (checks.some((check) => check.status === "pending")) return "pending";
 	return "success";
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 export const GHCheckContextSchema = z.object({
 	name: z.string().optional(),
 	context: z.string().optional(), // StatusContext uses 'context' instead of 'name'
-	state: z.enum(["SUCCESS", "FAILURE", "PENDING", "ERROR"]).optional(),
+	state: z
+		.enum(["SUCCESS", "FAILURE", "PENDING", "ERROR", "EXPECTED"])
+		.optional(),
 	status: z.string().optional(), // CheckRun status: COMPLETED, IN_PROGRESS, etc.
 	conclusion: z
 		.enum([
@@ -14,6 +16,8 @@ export const GHCheckContextSchema = z.object({
 			"SKIPPED",
 			"TIMED_OUT",
 			"ACTION_REQUIRED",
+			"STARTUP_FAILURE",
+			"STALE",
 			"NEUTRAL",
 			"", // Can be empty string when in progress
 		])

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/computeChecksStatus/computeChecksStatus.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/computeChecksStatus/computeChecksStatus.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { PullRequest } from "../getPRFlowState";
+import { coerceCheckStatus, computeChecksRollup } from "./computeChecksStatus";
+
+type CheckRun = PullRequest["checks"][number];
+
+function check(
+	status: string,
+	conclusion: CheckRun["conclusion"] = null,
+): CheckRun {
+	return {
+		name: `check-${status}-${conclusion ?? "none"}`,
+		status: status as CheckRun["status"],
+		conclusion,
+		detailsUrl: null,
+		startedAt: null,
+		completedAt: null,
+	};
+}
+
+describe("coerceCheckStatus", () => {
+	test("passes through already-effective statuses", () => {
+		expect(coerceCheckStatus("cancelled", null)).toBe("cancelled");
+		expect(coerceCheckStatus("failure", null)).toBe("failure");
+	});
+
+	test("resolves raw status/conclusion pairs", () => {
+		expect(coerceCheckStatus("in_progress", null)).toBe("pending");
+		expect(coerceCheckStatus("completed", null)).toBe("pending");
+		expect(coerceCheckStatus("completed", "cancelled")).toBe("cancelled");
+		expect(coerceCheckStatus("completed", "action_required")).toBe("failure");
+	});
+});
+
+describe("computeChecksRollup", () => {
+	test("returns none when no relevant checks exist", () => {
+		expect(computeChecksRollup([]).overall).toBe("none");
+		expect(computeChecksRollup([check("skipped")]).overall).toBe("none");
+	});
+
+	test("a cancelled check rolls up as failure, not success", () => {
+		const rollup = computeChecksRollup([check("success"), check("cancelled")]);
+		expect(rollup.overall).toBe("failure");
+		expect(rollup.failureCount).toBe(1);
+		expect(rollup.relevantCount).toBe(2);
+	});
+
+	test("a raw completed/cancelled check rolls up as failure", () => {
+		expect(computeChecksRollup([check("completed", "cancelled")]).overall).toBe(
+			"failure",
+		);
+	});
+
+	test("cancelled takes precedence over pending", () => {
+		expect(
+			computeChecksRollup([check("in_progress"), check("cancelled")]).overall,
+		).toBe("failure");
+	});
+
+	test("pending wins when nothing failed", () => {
+		expect(
+			computeChecksRollup([check("success"), check("in_progress")]).overall,
+		).toBe("pending");
+	});
+
+	test("skipped checks stay excluded from the rollup", () => {
+		const rollup = computeChecksRollup([check("success"), check("skipped")]);
+		expect(rollup.overall).toBe("success");
+		expect(rollup.relevantCount).toBe(1);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/computeChecksStatus/computeChecksStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/computeChecksStatus/computeChecksStatus.ts
@@ -55,9 +55,9 @@ export function computeChecksRollup(checks: CheckRun[]): ChecksRollup {
 	let pendingCount = 0;
 	for (const c of checks) {
 		const s = coerceCheckStatus(c.status, c.conclusion);
-		if (s === "skipped" || s === "cancelled") continue;
+		if (s === "skipped") continue;
 		if (s === "success") successCount++;
-		else if (s === "failure") failureCount++;
+		else if (s === "failure" || s === "cancelled") failureCount++;
 		else pendingCount++;
 	}
 	const relevantCount = successCount + failureCount + pendingCount;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ChecksSection/ChecksSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ChecksSection/ChecksSection.tsx
@@ -54,10 +54,7 @@ export function ChecksSection({
 	const [open, setOpen] = useState(true);
 
 	const relevantChecks = useMemo(
-		() =>
-			checks.filter(
-				(check) => check.status !== "skipped" && check.status !== "cancelled",
-			),
+		() => checks.filter((check) => check.status !== "skipped"),
 		[checks],
 	);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksList/ChecksList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksList/ChecksList.tsx
@@ -11,10 +11,8 @@ interface ChecksListProps {
 export function ChecksList({ checks }: ChecksListProps) {
 	const [expanded, setExpanded] = useState(false);
 
-	// Filter out skipped/cancelled for display count, but show all when expanded
-	const relevantChecks = checks.filter(
-		(c) => c.status !== "skipped" && c.status !== "cancelled",
-	);
+	// Skipped checks are noise; everything else (including cancelled) counts
+	const relevantChecks = checks.filter((c) => c.status !== "skipped");
 
 	if (relevantChecks.length === 0) return null;
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksSummary/ChecksSummary.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksSummary/ChecksSummary.tsx
@@ -11,9 +11,7 @@ export function ChecksSummary({ checks, status }: ChecksSummaryProps) {
 	if (status === "none") return null;
 
 	const passing = checks.filter((c) => c.status === "success").length;
-	const total = checks.filter(
-		(c) => c.status !== "skipped" && c.status !== "cancelled",
-	).length;
+	const total = checks.filter((c) => c.status !== "skipped").length;
 
 	const config = {
 		success: {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -182,7 +182,7 @@ export function ReviewPanel({
 	const requestedReviewers = pr.requestedReviewers ?? [];
 
 	const relevantChecks = pr.checks.filter(
-		(check) => check.status !== "skipped" && check.status !== "cancelled",
+		(check) => check.status !== "skipped",
 	);
 	const passingChecks = relevantChecks.filter(
 		(check) => check.status === "success",

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
@@ -1,13 +1,31 @@
 import { describe, expect, test } from "bun:test";
+import type { GitHubCheckContextNode } from "../github-query";
 import {
 	coercePullRequestState,
 	computeChecksStatus,
 	mapPullRequestState,
 	type PullRequestCheck,
+	parseCheckContexts,
 } from "./pull-request-mappers";
 
 function check(status: PullRequestCheck["status"]): PullRequestCheck {
 	return { name: `check-${status}`, status, url: null };
+}
+
+function checkRunNode(
+	conclusion: string | null,
+	status = "COMPLETED",
+): GitHubCheckContextNode {
+	return {
+		__typename: "CheckRun",
+		name: `run-${conclusion ?? status}`,
+		conclusion,
+		detailsUrl: null,
+		status,
+		startedAt: null,
+		completedAt: null,
+		checkSuite: null,
+	};
 }
 
 describe("mapPullRequestState", () => {
@@ -57,11 +75,37 @@ describe("computeChecksStatus", () => {
 		);
 	});
 
+	test("cancelled takes precedence over pending", () => {
+		expect(computeChecksStatus([check("pending"), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
 	test("skipped checks stay non-blocking and fold into success", () => {
 		expect(computeChecksStatus([check("success"), check("skipped")])).toBe(
 			"success",
 		);
 		expect(computeChecksStatus([check("skipped")])).toBe("success");
+	});
+});
+
+describe("parseCheckContexts", () => {
+	test("maps terminal check-run conclusions to their effective status", () => {
+		const statuses = parseCheckContexts([
+			checkRunNode("CANCELLED"),
+			checkRunNode("ACTION_REQUIRED"),
+			checkRunNode("STARTUP_FAILURE"),
+			checkRunNode("SKIPPED"),
+		]).map((check) => check.status);
+
+		expect(statuses).toEqual(["cancelled", "failure", "failure", "skipped"]);
+	});
+
+	test("keeps a completed run without a conclusion pending", () => {
+		expect(parseCheckContexts([checkRunNode(null)])[0]?.status).toBe("pending");
+		expect(
+			parseCheckContexts([checkRunNode(null, "IN_PROGRESS")])[0]?.status,
+		).toBe("pending");
 	});
 });
 

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
 	coercePullRequestState,
+	computeChecksStatus,
 	mapPullRequestState,
+	type PullRequestCheck,
 } from "./pull-request-mappers";
+
+function check(status: PullRequestCheck["status"]): PullRequestCheck {
+	return { name: `check-${status}`, status, url: null };
+}
 
 describe("mapPullRequestState", () => {
 	test("maps merged and closed states regardless of other flags", () => {
@@ -21,6 +27,41 @@ describe("mapPullRequestState", () => {
 	test("an open PR not in the queue stays open", () => {
 		expect(mapPullRequestState("OPEN", false, false)).toBe("open");
 		expect(mapPullRequestState("OPEN", false)).toBe("open");
+	});
+});
+
+describe("computeChecksStatus", () => {
+	test("returns none for an empty list", () => {
+		expect(computeChecksStatus([])).toBe("none");
+	});
+
+	test("a single cancelled check rolls up as failure, not success", () => {
+		expect(computeChecksStatus([check("cancelled")])).toBe("failure");
+	});
+
+	test("a cancelled check among successes rolls up as failure", () => {
+		expect(computeChecksStatus([check("success"), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
+	test("failure takes precedence over pending", () => {
+		expect(computeChecksStatus([check("pending"), check("failure")])).toBe(
+			"failure",
+		);
+	});
+
+	test("pending wins when nothing failed", () => {
+		expect(computeChecksStatus([check("success"), check("pending")])).toBe(
+			"pending",
+		);
+	});
+
+	test("skipped checks stay non-blocking and fold into success", () => {
+		expect(computeChecksStatus([check("success"), check("skipped")])).toBe(
+			"success",
+		);
+		expect(computeChecksStatus([check("skipped")])).toBe("success");
 	});
 });
 

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -163,6 +163,7 @@ function mapCheckRunStatus(
 		case "FAILURE":
 		case "TIMED_OUT":
 		case "ACTION_REQUIRED":
+		case "STARTUP_FAILURE":
 			return "failure";
 		case "CANCELLED":
 			return "cancelled";

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -90,7 +90,13 @@ export function parseCheckContexts(
 
 export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 	if (checks.length === 0) return "none";
-	if (checks.some((check) => check.status === "failure")) return "failure";
+	if (
+		checks.some(
+			(check) => check.status === "failure" || check.status === "cancelled",
+		)
+	) {
+		return "failure";
+	}
 	if (checks.some((check) => check.status === "pending")) return "pending";
 	return "success";
 }


### PR DESCRIPTION
> **Fixes #5667** — [bug] A cancelled CI check shows the PR checks indicator as green ("success")

## Why this PR still matters

Two other open PRs (#5668, #5669) fix one copy of this bug; this PR fixes all three copies, plus the bugs sitting next to them. The bug: a **cancelled** CI check rolls up green, so you can merge believing CI passed. Cancelled runs are routine — superseded commits, concurrency-group cancels, manual cancels — yet every checks rollup showed that terminal, non-passing result as "success". The same fall-through existed in **three independent surfaces**: host-service (the persisted `pull_requests.checks_status` behind `getPullRequestsByWorkspaces`), the v1 desktop resolver, and the cloud API (which persists `github_pull_requests.checks_status` behind the v2 dashboard — where the rollup was copy-pasted three times and already drifting: the webhook caught `action_required`; `sync`/`initial-sync` didn't).

Auditing the rollups surfaced two adjacent bugs, both fixed here: conclusions that rolled up green or stayed pending forever (`ACTION_REQUIRED`, `STARTUP_FAILURE`), and a v1 zod enum that **rejected real `gh` conclusion values** (`STARTUP_FAILURE`, `STALE`, state `EXPECTED`) — silently dropping the whole PR from resolution.

## Prior art

Two earlier attempts at #5667 are open and unmerged. Both touch only the host-service rollup:

- **#5668** (open, @abhay-codes07) and **#5669** (open draft, github-actions triage bot, branch `triage/issue-5667-29273694628`) make the same one-function change: add `cancelled` to the failing set in host-service `computeChecksStatus` (`pull-request-mappers.ts`), plus unit tests for that function. Verified against both diffs — each touches exactly those two host-service files and nothing else.

What this PR does beyond them (each delta checked against their actual diffs):

- **Fixes all three rollup copies**: host-service, the v1 desktop resolver, and the cloud API (three duplicated inline rollups become one shared util). The persisted status, the v1 indicator, and the v2 dashboard can no longer disagree. With #5668/#5669 alone, the v1 and API rollups keep showing cancelled as green.
- **Aligns the v2 renderer**: `computeChecksRollup` skipped cancelled entirely (`continue`), so the review tab / PR header could stay green even after a host-service-only fix. Neither prior PR touches the renderer.
- **Fixes the adjacent fall-throughs**: host-service `mapCheckRunStatus` left `STARTUP_FAILURE` as `pending` forever, and the v1 resolver / API `sync`/`initial-sync` treated `ACTION_REQUIRED` as green. Both prior PRs leave these as-is.
- **Fixes the v1 zod PR-dropping bug**: `GHCheckContextSchema` rejected real `gh` values (`STARTUP_FAILURE`, `STALE`, state `EXPECTED`) and silently dropped the whole PR from resolution. Untouched by both prior PRs.
- **More evidence**: 70 tests across 4 co-located suites (vs. single host-service suites of ~5–7 tests each), plus typecheck on all three affected packages.

## Before → after

| Check result | Before | After |
|---|---|---|
| `cancelled` | rolled up **green** (host-service, v1 desktop, all 3 API rollups); excluded from the v2 UI rollup and counts | `failure`, visible and counted, everywhere |
| `action_required` | **green** in v1 resolver and API `sync`/`initial-sync` (only the webhook caught it) | `failure` everywhere |
| `startup_failure` | `pending` **forever** (host-service); PR **silently dropped** from v1 resolution (zod rejected it) | `failure` everywhere |
| `stale` / state `EXPECTED` | PR **silently dropped** from v1 resolution (zod rejected them) | `pending` (never green) |
| `skipped` / `neutral` | non-blocking | non-blocking (unchanged) |

Precedence is now the same on every surface: **failure (incl. cancelled) > pending > success**; empty list = `none`.

## What changed, by surface

**host-service** — `packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts`
- `computeChecksStatus` treats `cancelled` as failing; `mapCheckRunStatus` maps `STARTUP_FAILURE` → `failure` (previously `pending` forever).

**desktop v1 resolver** — `apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts`, `types.ts`
- `computeChecksStatus` now derives from `parseChecks`, so the rollup can never disagree with the per-check list. `cancelled` counts as failure; `ACTION_REQUIRED`/`STARTUP_FAILURE` parse as failure; `STALE`/`EXPECTED` stay pending.
- `GHCheckContextSchema` enums now cover the full `gh` conclusion/state sets, so PRs with those values are no longer dropped from resolution.

**desktop v2 renderer** — `.../PRActionHeader/utils/computeChecksStatus/computeChecksStatus.ts`, plus `ChecksSection.tsx`, `ReviewPanel.tsx`, `ChecksSummary.tsx`, `ChecksList.tsx`
- `computeChecksRollup` skipped cancelled (`continue`), so the review tab / PR header could stay green while the persisted status said failure. Cancelled now adds to `failureCount`. The relevant-check filters keep cancelled visible and counted (only `skipped` stays hidden).

**cloud API** — new shared util `apps/api/src/app/api/github/utils/computeChecksStatus/`, adopted by `webhook/webhooks.ts`, `sync/route.ts`, `jobs/initial-sync/route.ts`
- Replaces three duplicated inline rollups with one implementation. Its failing set is `failure | timed_out | cancelled | action_required | startup_failure`.

## Test evidence

`bun test` on the four co-located suites — **70 pass, 0 fail**:

- host-service `pull-request-mappers.test.ts` — cancelled rolls up as failure, cancelled beats pending, skipped folds into success; `parseCheckContexts` maps `CANCELLED`/`ACTION_REQUIRED`/`STARTUP_FAILURE`/`SKIPPED` and keeps conclusion-less runs pending.
- desktop `github.test.ts` — same rollup cases against raw `gh` shapes; `EXPECTED`/`STALE` roll up as pending (never success); `GHCheckContextSchema` accepts every `gh` conclusion/state so PRs are never dropped.
- desktop v2 `computeChecksStatus.test.ts` (new) — `coerceCheckStatus` + `computeChecksRollup`, incl. cancelled-as-failure, cancelled-beats-pending, and skipped exclusion.
- api `computeChecksStatus.test.ts` (new) — shared cloud rollup util, incl. precedence cases.

`bun run lint` exits 0; `turbo typecheck` passes for `@superset/api`, `@superset/desktop`, `@superset/host-service`.

## Why merge now

The checks indicator is the signal you read before clicking merge. Until this lands, every cancelled run on a PR's head commit shows as passed — on every surface. The change is low-risk: it only corrects indicator/summary status (nothing gates merges on `checksStatus`), it makes the three surfaces agree instead of drift, and 70 tests pin the behavior. After it lands, you can merge trusting the badge.

## Scope notes

- The rollup only sees checks on the current head commit, so superseded-commit cancels don't turn new pushes red. A lingering cancelled check on the head genuinely means CI did not pass — GitHub's own branch protection treats it the same way.
- v1 maps `ACTION_REQUIRED`/`STARTUP_FAILURE` to `failure` at parse time to match host-service; `STALE`/`EXPECTED` stay `pending`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub pull request check status accuracy across synchronization, webhooks, and workspace views.
  * Cancelled and startup-failure checks are now correctly treated as failures.
  * Pending, successful, skipped, and neutral checks are classified more consistently.
  * Cancelled checks now appear in check summaries and lists instead of being omitted.
  * Expanded support for additional GitHub check states, reducing incorrect pull request status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->