### PR TITLE
feat(desktop): add background preset launch mode

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/app-icon.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/app-icon.ts
@@ -1,0 +1,81 @@
+import { execFile } from "node:child_process";
+import { realpath } from "node:fs/promises";
+import nodePath from "node:path";
+import { promisify } from "node:util";
+import { app } from "electron";
+import { getProcessEnvWithShellPath } from "../workspaces/utils/shell-env";
+
+const execFileAsync = promisify(execFile);
+
+const iconCache = new Map<string, string | null>();
+
+function findAppBundlePath(executablePath: string): string | null {
+	let current = executablePath;
+	while (true) {
+		if (current.toLowerCase().endsWith(".app")) return current;
+		const parent = nodePath.dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+async function resolveExecutablePath(
+	executable: string,
+): Promise<string | null> {
+	try {
+		const env = await getProcessEnvWithShellPath();
+		const { stdout } = await execFileAsync("/usr/bin/which", [executable], {
+			env,
+			timeout: 5_000,
+		});
+		const resolved = stdout.trim().split("\n")[0];
+		return resolved || null;
+	} catch {
+		return null;
+	}
+}
+
+async function resolveAppIcon(executable: string): Promise<string | null> {
+	// Presets store plain commands; a path-y executable would bypass the PATH
+	// lookup semantics users expect, so only bare names are resolved.
+	if (executable.includes("/")) return null;
+
+	const resolvedPath = await resolveExecutablePath(executable);
+	if (!resolvedPath) return null;
+
+	let realPath: string;
+	try {
+		realPath = await realpath(resolvedPath);
+	} catch {
+		return null;
+	}
+
+	const bundlePath = findAppBundlePath(realPath);
+	if (!bundlePath) return null;
+
+	try {
+		// "normal" (32px) is the largest size macOS supports for getFileIcon.
+		const icon = await app.getFileIcon(bundlePath, { size: "normal" });
+		return icon.isEmpty() ? null : icon.toDataURL();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolves the macOS app-bundle icon for a CLI executable whose binary lives
+ * inside a `.app` bundle (e.g. `fork` → Fork.app, `zed` → Zed.app). Returns a
+ * data URI, or null when the executable does not belong to an app bundle.
+ */
+export async function getAppIconForExecutable(
+	executable: string,
+): Promise<string | null> {
+	if (process.platform !== "darwin") return null;
+
+	const cached = iconCache.get(executable);
+	if (cached !== undefined) return cached;
+
+	const iconDataUri = await resolveAppIcon(executable);
+	iconCache.set(executable, iconDataUri);
+	return iconDataUri;
+}

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getWorkspace } from "../workspaces/utils/db-helpers";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
+import { getAppIconForExecutable } from "./app-icon";
 import {
 	type ExternalApp,
 	getAppCommand,
@@ -257,6 +258,22 @@ export const createExternalRouter = () => {
 					}
 				}),
 			),
+
+		getCommandAppIcons: publicProcedure
+			.input(
+				z.object({
+					executables: z.array(z.string().trim().min(1)).max(50),
+				}),
+			)
+			.query(async ({ input }) => {
+				const entries = await Promise.all(
+					input.executables.map(
+						async (executable) =>
+							[executable, await getAppIconForExecutable(executable)] as const,
+					),
+				);
+				return Object.fromEntries(entries) as Record<string, string | null>;
+			}),
 
 		openFileInEditor: publicProcedure
 			.input(

--- a/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
@@ -46,6 +46,7 @@ describe("normalizeTerminalPresets", () => {
 			createPreset("new-tab"),
 			createPreset("new-tab-split-pane"),
 			createPreset("sequential"),
+			createPreset("background"),
 			createPreset("parallel"),
 			createPreset(undefined),
 		]);
@@ -54,6 +55,8 @@ describe("normalizeTerminalPresets", () => {
 			"new-tab",
 			"new-tab-split-pane",
 			"sequential",
+			// v2-only mode falls back for v1 presets
+			"new-tab",
 			"split-pane",
 			"new-tab",
 		] satisfies TerminalPreset["executionMode"][]);
@@ -100,6 +103,9 @@ describe("shouldPersistNormalizedTerminalPresets", () => {
 	it("returns true when legacy mode, project targeting, or default state exists", () => {
 		expect(
 			shouldPersistNormalizedTerminalPresets([createPreset("parallel")]),
+		).toBe(true);
+		expect(
+			shouldPersistNormalizedTerminalPresets([createPreset("background")]),
 		).toBe(true);
 		expect(
 			shouldPersistNormalizedTerminalPresets([createPreset(undefined)]),

--- a/apps/desktop/src/renderer/hooks/useCommandAppIcons/index.ts
+++ b/apps/desktop/src/renderer/hooks/useCommandAppIcons/index.ts
@@ -1,0 +1,1 @@
+export { useCommandAppIcons } from "./useCommandAppIcons";

--- a/apps/desktop/src/renderer/hooks/useCommandAppIcons/useCommandAppIcons.ts
+++ b/apps/desktop/src/renderer/hooks/useCommandAppIcons/useCommandAppIcons.ts
@@ -1,0 +1,49 @@
+import type { HostAgentConfig } from "@superset/host-service/settings";
+import { useCallback, useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	type PresetIconSource,
+	resolvePresetCommandExecutable,
+	resolveV2PresetIconKey,
+} from "renderer/lib/preset-icon-key";
+
+/**
+ * macOS app-bundle icons for presets whose commands launch GUI tools (e.g.
+ * `fork .`, `zed .`) and match no agent icon. Returns a lookup from preset to
+ * data-URI icon; presets with an agent icon, ambiguous commands or non-app
+ * executables resolve to undefined.
+ */
+export function useCommandAppIcons(
+	presets: readonly PresetIconSource[],
+	agents: HostAgentConfig[] | undefined,
+): (preset: PresetIconSource) => string | undefined {
+	const executables = useMemo(() => {
+		const unique = new Set<string>();
+		for (const preset of presets) {
+			if (resolveV2PresetIconKey(preset, agents)) continue;
+			const executable = resolvePresetCommandExecutable(preset);
+			if (executable) unique.add(executable);
+		}
+		return [...unique].sort();
+	}, [presets, agents]);
+
+	const { data: iconsByExecutable } =
+		electronTrpc.external.getCommandAppIcons.useQuery(
+			{ executables },
+			{
+				enabled: executables.length > 0,
+				staleTime: Number.POSITIVE_INFINITY,
+				refetchOnWindowFocus: false,
+			},
+		);
+
+	return useCallback(
+		(preset: PresetIconSource) => {
+			if (!iconsByExecutable) return undefined;
+			const executable = resolvePresetCommandExecutable(preset);
+			if (!executable) return undefined;
+			return iconsByExecutable[executable] ?? undefined;
+		},
+		[iconsByExecutable],
+	);
+}

--- a/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { HostAgentConfig } from "@superset/host-service/settings";
-import { resolveV2PresetIconKey } from "./preset-icon-key";
+import {
+	resolvePresetCommandExecutable,
+	resolveV2PresetIconKey,
+} from "./preset-icon-key";
 
 function createAgent(
 	overrides: Partial<HostAgentConfig> &
@@ -160,6 +163,39 @@ describe("resolveV2PresetIconKey", () => {
 					createAgent({ id: "codex-config", presetId: "codex" }),
 				],
 			),
+		).toBeUndefined();
+	});
+});
+
+describe("resolvePresetCommandExecutable", () => {
+	it("preserves the parsed executable's casing", () => {
+		expect(resolvePresetCommandExecutable({ commands: ["Fork ."] })).toBe(
+			"Fork",
+		);
+	});
+
+	it("skips path-based commands instead of stripping to a basename", () => {
+		expect(
+			resolvePresetCommandExecutable({ commands: ["./scripts/my-gui"] }),
+		).toBeUndefined();
+		expect(
+			resolvePresetCommandExecutable({
+				commands: ["/opt/homebrew/bin/fork ."],
+			}),
+		).toBeUndefined();
+	});
+
+	it("still resolves a bare command alongside skipped ones", () => {
+		expect(
+			resolvePresetCommandExecutable({
+				commands: ["./scripts/setup.sh", "fork ."],
+			}),
+		).toBe("fork");
+	});
+
+	it("returns undefined for conflicting executables", () => {
+		expect(
+			resolvePresetCommandExecutable({ commands: ["fork .", "zed ."] }),
 		).toBeUndefined();
 	});
 });

--- a/apps/desktop/src/renderer/lib/preset-icon-key.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.ts
@@ -94,3 +94,28 @@ export function resolveV2PresetIconKey(
 ): string | undefined {
 	return getLinkedIconKey(preset, agents) ?? getCommandIconKey(preset, agents);
 }
+
+/**
+ * The single executable name a preset's commands run, or undefined when the
+ * commands disagree — mirrors the ambiguity rule used for icon keys. Unlike
+ * `getExecutableName`, path-based commands are skipped (a PATH lookup of
+ * their basename could hit an unrelated binary) and casing is preserved for
+ * the case-sensitive `which` lookup.
+ */
+export function resolvePresetCommandExecutable(
+	preset: PresetIconSource,
+): string | undefined {
+	return singleValue(
+		(preset.commands ?? []).map((command) => {
+			let parsed: ReturnType<typeof parseCommandString>;
+			try {
+				parsed = parseCommandString(command.trim());
+			} catch {
+				return undefined;
+			}
+			const executable = parsed.command.trim();
+			if (!executable || /[\\/]/.test(executable)) return undefined;
+			return executable;
+		}),
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiMiniCommandLine } from "react-icons/hi2";
 import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
+import { useCommandAppIcons } from "renderer/hooks/useCommandAppIcons";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import type { HotkeyId } from "renderer/hotkeys";
 import { resolveV2PresetIcon } from "renderer/lib/preset-icon";
@@ -74,6 +75,7 @@ export function V2PresetsBar({
 	const collections = useCollections();
 	const { activeHostUrl } = useLocalHostService();
 	const { data: agents } = useV2AgentConfigs(activeHostUrl);
+	const getCommandAppIcon = useCommandAppIcons(matchedPresets, agents);
 
 	const [localVisiblePresetIds, setLocalVisiblePresetIds] = useState<string[]>(
 		() => getVisiblePresetOrder(matchedPresets),
@@ -214,7 +216,9 @@ export function V2PresetsBar({
 				</Tooltip>
 				<DropdownMenuContent align="end" className="w-56">
 					{matchedPresets.map((preset) => {
-						const icon = resolveV2PresetIcon(preset, agents, isDark);
+						const icon =
+							resolveV2PresetIcon(preset, agents, isDark) ??
+							getCommandAppIcon(preset);
 						const isVisible = isPresetVisibleInBar(preset.pinnedToBar);
 						const visibleIndex = visiblePresetIndexById.get(preset.id);
 						const hotkeyId =
@@ -281,6 +285,7 @@ export function V2PresetsBar({
 						hotkeyId={hotkeyId}
 						isDark={isDark}
 						agents={agents}
+						appIcon={getCommandAppIcon(preset)}
 						onExecutePreset={executePreset}
 						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
 						onLocalReorder={handleLocalVisibleReorder}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -23,6 +23,8 @@ interface V2PresetBarItemProps {
 	hotkeyId?: HotkeyId;
 	isDark: boolean;
 	agents: HostAgentConfig[] | undefined;
+	/** macOS app-bundle icon fallback for GUI-tool commands (data URI). */
+	appIcon?: string;
 	onExecutePreset: (preset: V2TerminalPresetRow) => void;
 	onEdit: (preset: V2TerminalPresetRow) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
@@ -35,13 +37,14 @@ export function V2PresetBarItem({
 	hotkeyId,
 	isDark,
 	agents,
+	appIcon,
 	onExecutePreset,
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
 }: V2PresetBarItemProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
-	const icon = resolveV2PresetIcon(preset, agents, isDark);
+	const icon = resolveV2PresetIcon(preset, agents, isDark) ?? appIcon;
 
 	const [{ isDragging }, drag] = useDrag(
 		() => ({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -3,17 +3,22 @@ import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback, useMemo } from "react";
+import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import { resolvePresetLaunchCommands } from "renderer/lib/agent-launch-command";
 import {
 	buildTerminalCommand,
 	normalizeTerminalCommand,
 } from "renderer/lib/terminal/launch-command";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
+import {
+	buildBackgroundTerminalCommand,
+	getPresetLaunchPlan,
+} from "renderer/stores/tabs/preset-launch";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import {
 	filterMatchingPresetsForProject,
@@ -81,6 +86,11 @@ function buildFocusedTerminalCommand({
 	return `cd ${quote([resolvedCwd])} && ${command}`;
 }
 
+// terminalId → preset display name for background launches from this renderer.
+// Module scope so it survives workspace remounts; entries are consumed by the
+// exit listener below, and lost entries just mean a missed failure toast.
+const backgroundPresetLaunches = new Map<string, string>();
+
 function selectAutoApplyPresets(
 	presets: V2TerminalPresetRow[],
 	field: "applyOnWorkspaceCreated" | "applyOnNewTab",
@@ -119,6 +129,7 @@ export function useV2PresetExecution({
 		},
 	);
 	const writeInput = workspaceTrpc.terminal.writeInput.useMutation();
+	const workspaceTrpcUtils = workspaceTrpc.useUtils();
 
 	const { data: allPresets = [] } = useLiveQuery(
 		(query) =>
@@ -142,6 +153,21 @@ export function useV2PresetExecution({
 		() => selectAutoApplyPresets(matchedPresets, "applyOnNewTab"),
 		[matchedPresets],
 	);
+
+	// Failure feedback for background preset runs. The trailing "exit"
+	// preserves the failed command's status, while kills surface as signal
+	// exits or dispose broadcasts with code 0 — so a plain non-zero exit
+	// here is a failed command.
+	useWorkspaceEvent("terminal:lifecycle", workspaceId, (payload) => {
+		if (payload.eventType !== "exit") return;
+		const presetName = backgroundPresetLaunches.get(payload.terminalId);
+		if (presetName === undefined) return;
+		backgroundPresetLaunches.delete(payload.terminalId);
+		if (payload.exitCode === 0 || payload.signal !== 0) return;
+		toast.error(`${presetName} failed`, {
+			description: `Command exited with code ${payload.exitCode}.`,
+		});
+	});
 
 	// `useV2AgentConfigs` is the cached source of truth for agent configs
 	// (`staleTime: Infinity`, invalidated on every Settings → Agents mutation),
@@ -197,6 +223,28 @@ export function useV2PresetExecution({
 			// the pane finally mounts and attaches the WS.
 			try {
 				switch (plan) {
+					case "background": {
+						const command = buildBackgroundTerminalCommand(commands);
+						if (command === null) break;
+						// No pane: the session runs behind the background-terminals
+						// button and disappears once the trailing "exit" ends the
+						// shell. The marker keeps auto-adoption from giving it a pane
+						// and shows it in the button immediately.
+						const terminalId = await launcher.create({ command, cwd });
+						markTerminalForBackground(terminalId, workspaceId);
+						backgroundPresetLaunches.set(
+							terminalId,
+							preset.name.trim() || "Preset",
+						);
+						void workspaceTrpcUtils.terminal.countBackgroundSessions.invalidate(
+							{ workspaceId },
+						);
+						void workspaceTrpcUtils.terminal.listSessions.invalidate({
+							workspaceId,
+						});
+						break;
+					}
+
 					case "active-terminal": {
 						const command = launchCommands[0];
 						if (!activeTerminal || !command) break;
@@ -306,6 +354,7 @@ export function useV2PresetExecution({
 			workspaceId,
 			workspaceQuery.data?.worktreePath,
 			writeInput,
+			workspaceTrpcUtils,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -122,9 +122,11 @@ export function useWorkspacePaneOpeners({
 	}, [store, launcher]);
 
 	const addTerminalTab = useCallback(async () => {
-		if (newTabPresets.length === 0) {
+		// Background presets create no tab, and the user still asked for one.
+		if (
+			newTabPresets.every((preset) => preset.executionMode === "background")
+		) {
 			await addBlankTerminalTab();
-			return;
 		}
 
 		// New terminal tabs are the trigger point for applyOnNewTab presets.

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -206,6 +206,7 @@ const v2ExecutionModeSchema = z.enum([
 	"new-tab",
 	"new-tab-split-pane",
 	"sequential",
+	"background",
 ]);
 
 // projectIds uses plain z.string() (not uuid) because v1 accepts arbitrary

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -1,5 +1,5 @@
 import type { HostAgentConfig } from "@superset/host-service/settings";
-import { normalizeExecutionMode } from "@superset/local-db";
+import { normalizeV2ExecutionMode } from "@superset/local-db";
 import { Badge } from "@superset/ui/badge";
 import { cn } from "@superset/ui/utils";
 import { Eye, EyeOff } from "lucide-react";
@@ -34,6 +34,8 @@ interface PresetRowProps {
 	 * `presetId` fallback. Omitted by v1 callers — no v1 row has `agentId`.
 	 */
 	agents?: HostAgentConfig[];
+	/** macOS app-bundle icon fallback for GUI-tool commands (data URI). */
+	appIcon?: string;
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
@@ -45,6 +47,7 @@ export function PresetRow({
 	rowIndex,
 	projectOptionsById,
 	agents,
+	appIcon,
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
@@ -85,11 +88,8 @@ export function PresetRow({
 	}, [preview, drop, drag]);
 
 	const isDark = useIsDarkTheme();
-	const presetIcon = resolveV2PresetIcon(
-		preset as PresetWithAgent,
-		agents,
-		isDark,
-	);
+	const presetIcon =
+		resolveV2PresetIcon(preset as PresetWithAgent, agents, isDark) ?? appIcon;
 	const commands = resolvePresetLaunchCommands(
 		preset as PresetWithAgent,
 		agents,
@@ -99,7 +99,7 @@ export function PresetRow({
 	const isWorkspaceRun = !!preset.useAsWorkspaceRun;
 	const isNewTab = !!preset.applyOnNewTab;
 	const isVisibleInBar = preset.pinnedToBar !== false;
-	const modeValue = normalizeExecutionMode(preset.executionMode);
+	const modeValue = normalizeV2ExecutionMode(preset.executionMode);
 	const modeLabel = getPresetModeLabel(modeValue, commands.length);
 	const firstCommand =
 		commands.find((cmd) => cmd.trim().length > 0)?.trim() ?? "Empty command";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getPresetModeLabel } from "./PresetRow.utils";
+import { getLaunchModeValue, getPresetModeLabel } from "./PresetRow.utils";
 
 describe("getPresetModeLabel", () => {
 	it("does not describe sequential presets as split panes", () => {
@@ -10,5 +10,23 @@ describe("getPresetModeLabel", () => {
 	it("keeps split-pane labels for split-pane presets", () => {
 		expect(getPresetModeLabel("split-pane", 1)).toBe("Split pane");
 		expect(getPresetModeLabel("split-pane", 2)).toBe("Single tab + panes");
+	});
+
+	it("labels background presets regardless of command count", () => {
+		expect(getPresetModeLabel("background", 1)).toBe("Background");
+		expect(getPresetModeLabel("background", 2)).toBe("Background");
+	});
+});
+
+describe("getLaunchModeValue", () => {
+	it("collapses single-command tab variants but keeps background", () => {
+		expect(getLaunchModeValue("sequential", false)).toBe("split-pane");
+		expect(getLaunchModeValue("new-tab-split-pane", false)).toBe("new-tab");
+		expect(getLaunchModeValue("background", false)).toBe("background");
+	});
+
+	it("passes modes through unchanged for multiple commands", () => {
+		expect(getLaunchModeValue("sequential", true)).toBe("sequential");
+		expect(getLaunchModeValue("background", true)).toBe("background");
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.ts
@@ -1,10 +1,14 @@
-import type { ExecutionMode } from "@superset/local-db/schema/zod";
+import type { V2ExecutionMode } from "@superset/local-db/schema/zod";
 
 export function getPresetModeLabel(
-	modeValue: ExecutionMode,
+	modeValue: V2ExecutionMode,
 	commandCount: number,
 ): string {
 	const hasMultipleCommands = commandCount > 1;
+
+	if (modeValue === "background") {
+		return "Background";
+	}
 
 	if (modeValue === "new-tab") {
 		return hasMultipleCommands ? "Tab per command" : "New tab";
@@ -19,4 +23,19 @@ export function getPresetModeLabel(
 	}
 
 	return hasMultipleCommands ? "Single tab + panes" : "Split pane";
+}
+
+/**
+ * Maps a stored execution mode onto the launch-mode control's value. Single
+ * command presets collapse the tab-shape variants into "split-pane" vs
+ * "new-tab"; "background" is its own control value in both layouts.
+ */
+export function getLaunchModeValue(
+	mode: V2ExecutionMode,
+	hasMultipleCommands: boolean,
+): V2ExecutionMode {
+	if (hasMultipleCommands || mode === "background") return mode;
+	return mode === "split-pane" || mode === "sequential"
+		? "split-pane"
+		: "new-tab";
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -2,6 +2,7 @@ import {
 	type ExecutionMode,
 	normalizeExecutionMode,
 	type TerminalPreset,
+	type V2ExecutionMode,
 } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
@@ -11,6 +12,7 @@ import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { usePresets } from "renderer/react-query/presets";
 import type { PresetColumnKey } from "renderer/routes/_authenticated/settings/presets/types";
+import { getLaunchModeValue } from "../PresetRow/PresetRow.utils";
 import { PresetEditorDialog } from "./components/PresetEditorDialog";
 import { PresetsTable } from "./components/PresetsTable";
 import {
@@ -380,12 +382,10 @@ export function PresetsSection({
 	const isWorkspaceRun = !!editingPreset?.useAsWorkspaceRun;
 	const isNewTab = !!editingPreset?.applyOnNewTab;
 	const hasMultipleCommands = (editingPreset?.commands.length ?? 0) > 1;
-	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
-	const modeValue: ExecutionMode = hasMultipleCommands
-		? normalizedMode
-		: normalizedMode === "split-pane" || normalizedMode === "sequential"
-			? "split-pane"
-			: "new-tab";
+	const modeValue = getLaunchModeValue(
+		normalizeExecutionMode(editingPreset?.executionMode),
+		hasMultipleCommands,
+	);
 
 	const handleEditorFieldChange = useCallback(
 		(column: PresetColumnKey, value: string) => {
@@ -453,9 +453,11 @@ export function PresetsSection({
 	}, [editingRowIndex, handleCommandsBlur]);
 
 	const handleEditorModeChange = useCallback(
-		(mode: ExecutionMode) => {
+		(mode: V2ExecutionMode) => {
 			if (editingRowIndex < 0) return;
-			handleExecutionModeChange(editingRowIndex, mode);
+			// The v1 editor never offers background, but the shared dialog is
+			// typed for it — normalize so v1 storage only sees v1 modes.
+			handleExecutionModeChange(editingRowIndex, normalizeExecutionMode(mode));
 		},
 		[editingRowIndex, handleExecutionModeChange],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -1,5 +1,5 @@
 import type { HostAgentConfig } from "@superset/host-service/settings";
-import type { ExecutionMode, TerminalPreset } from "@superset/local-db";
+import type { TerminalPreset, V2ExecutionMode } from "@superset/local-db";
 import { Alert, AlertDescription } from "@superset/ui/alert";
 import { Button } from "@superset/ui/button";
 import {
@@ -45,6 +45,7 @@ import {
 	toRelativeWorkspacePath,
 } from "shared/absolute-paths";
 import { CommandsEditor } from "../../../PresetRow/components/CommandsEditor";
+import { getLaunchModeValue } from "../../../PresetRow/PresetRow.utils";
 import type { AutoApplyField } from "../../constants";
 import type { PresetProjectOption } from "../../preset-project-options";
 import { ProjectTargetingField } from "./components/ProjectTargetingField";
@@ -79,10 +80,12 @@ interface PresetEditorDialogProps {
 	onDirectorySelect: (path: string) => void;
 	onCommandsChange: (commands: string[]) => void;
 	onCommandsBlur: () => void;
-	onModeChange: (mode: ExecutionMode) => void;
+	onModeChange: (mode: V2ExecutionMode) => void;
 	onToggleAutoApply: (field: AutoApplyField, enabled: boolean) => void;
 	onToggleWorkspaceRun: (enabled: boolean) => void;
-	modeValue: ExecutionMode;
+	modeValue: V2ExecutionMode;
+	/** Offer the background launch mode. Only v2 workspaces run it; the v1 editor omits it. */
+	supportsBackground?: boolean;
 	hasMultipleCommands: boolean;
 	isWorkspaceRun: boolean;
 	isWorkspaceCreation: boolean;
@@ -206,6 +209,7 @@ export function PresetEditorDialog({
 	onToggleAutoApply,
 	onToggleWorkspaceRun,
 	modeValue,
+	supportsBackground,
 	hasMultipleCommands,
 	isWorkspaceRun,
 	isWorkspaceCreation,
@@ -323,25 +327,19 @@ export function PresetEditorDialog({
 		}
 	};
 
-	const launchModeOptions = hasMultipleCommands
-		? [
-				{ value: "sequential", label: "All in current tab" },
-				{ value: "split-pane", label: "All in current tab (split panes)" },
-				{ value: "new-tab", label: "Each in its own new tab" },
-				{
-					value: "new-tab-split-pane",
-					label: "All in a new tab (split panes)",
-				},
-			]
-		: [
-				{ value: "split-pane", label: "Open in current tab" },
-				{ value: "new-tab", label: "Open in new tab" },
-			];
-	const launchModeValue = hasMultipleCommands
-		? modeValue
-		: modeValue === "split-pane" || modeValue === "sequential"
-			? "split-pane"
-			: "new-tab";
+	const launchModeOptions = [
+		{ value: "sequential", label: "All in current tab" },
+		{ value: "split-pane", label: "All in current tab (split panes)" },
+		{ value: "new-tab", label: "Each in its own new tab" },
+		{
+			value: "new-tab-split-pane",
+			label: "All in a new tab (split panes)",
+		},
+		...(supportsBackground
+			? [{ value: "background", label: "In the background" }]
+			: []),
+	];
+	const launchModeValue = getLaunchModeValue(modeValue, hasMultipleCommands);
 
 	const directoryAlert =
 		trimmedCwd && isAbsolutePath && directoryStatus?.exists === false ? (
@@ -522,16 +520,18 @@ export function PresetEditorDialog({
 							<DialogRow
 								label="Launch mode"
 								hint={
-									hasMultipleCommands
-										? "How grouped commands open."
-										: "How the command opens."
+									launchModeValue === "background"
+										? "Runs without opening a tab or taking focus; the terminal closes itself once the commands finish."
+										: hasMultipleCommands
+											? "How grouped commands open."
+											: "How the command opens."
 								}
 							>
 								{hasMultipleCommands ? (
 									<Select
 										value={launchModeValue}
 										onValueChange={(value) =>
-											onModeChange(value as ExecutionMode)
+											onModeChange(value as V2ExecutionMode)
 										}
 									>
 										<SelectTrigger size="sm" className="w-full">
@@ -548,10 +548,13 @@ export function PresetEditorDialog({
 								) : (
 									<Segmented
 										value={launchModeValue}
-										onChange={(value) => onModeChange(value as ExecutionMode)}
+										onChange={(value) => onModeChange(value as V2ExecutionMode)}
 										options={[
 											{ value: "split-pane", label: "Current tab" },
 											{ value: "new-tab", label: "New tab" },
+											...(supportsBackground
+												? [{ value: "background", label: "Background" }]
+												: []),
 										]}
 									/>
 								)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
@@ -2,6 +2,7 @@ import type { HostAgentConfig } from "@superset/host-service/settings";
 import type { TerminalPreset } from "@superset/local-db";
 import { cn } from "@superset/ui/utils";
 import type { RefObject } from "react";
+import { useCommandAppIcons } from "renderer/hooks/useCommandAppIcons";
 import { PresetRow } from "../../../PresetRow";
 import type { PresetProjectOption } from "../../preset-project-options";
 
@@ -32,6 +33,7 @@ export function PresetsTable({
 	onToggleVisibility,
 	bordered = true,
 }: PresetsTableProps) {
+	const getCommandAppIcon = useCommandAppIcons(presets, agents);
 	return (
 		<div
 			ref={presetsContainerRef}
@@ -52,6 +54,7 @@ export function PresetsTable({
 						rowIndex={index}
 						projectOptionsById={projectOptionsById}
 						agents={agents}
+						appIcon={getCommandAppIcon(preset)}
 						onEdit={onEdit}
 						onLocalReorder={onLocalReorder}
 						onPersistReorder={onPersistReorder}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -1,8 +1,8 @@
 import type { HostAgentConfig } from "@superset/host-service/settings";
 import {
-	type ExecutionMode,
-	normalizeExecutionMode,
+	normalizeV2ExecutionMode,
 	type TerminalPreset,
+	type V2ExecutionMode,
 } from "@superset/local-db";
 import { HOST_AGENT_PRESETS } from "@superset/shared/host-agent-presets";
 import { Button } from "@superset/ui/button";
@@ -17,6 +17,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import type { PresetColumnKey } from "renderer/routes/_authenticated/settings/presets/types";
+import { getLaunchModeValue } from "../PresetRow/PresetRow.utils";
 import { PresetEditorDialog } from "../PresetsSection/components/PresetEditorDialog";
 
 import { PresetsTable } from "../PresetsSection/components/PresetsTable";
@@ -224,7 +225,7 @@ export function V2PresetsSection({
 			projectIds?: string[] | null;
 			pinnedToBar?: boolean;
 			useAsWorkspaceRun?: boolean;
-			executionMode?: ExecutionMode;
+			executionMode?: V2ExecutionMode;
 			agentId?: string;
 		}) => {
 			const maxTabOrder = v2Presets.reduce(
@@ -402,14 +403,17 @@ export function V2PresetsSection({
 	);
 
 	const handleExecutionModeChange = useCallback(
-		(rowIndex: number, mode: ExecutionMode) => {
+		(rowIndex: number, mode: V2ExecutionMode) => {
 			setLocalPresets((currentLocal) => {
 				const preset = currentLocal[rowIndex];
 				if (!preset) return currentLocal;
 
+				// Local rows reuse the v1 TerminalPreset shape for the shared
+				// sub-components (see serverPresets); background is v2-only, so
+				// the optimistic write needs the same cast.
 				const newPresets = currentLocal.map((presetItem, index) =>
 					index === rowIndex
-						? { ...presetItem, executionMode: mode }
+						? ({ ...presetItem, executionMode: mode } as TerminalPreset)
 						: presetItem,
 				);
 
@@ -531,12 +535,10 @@ export function V2PresetsSection({
 	const isWorkspaceRun = !!editingPreset?.useAsWorkspaceRun;
 	const isNewTab = !!editingPreset?.applyOnNewTab;
 	const hasMultipleCommands = (editingPreset?.commands.length ?? 0) > 1;
-	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
-	const modeValue: ExecutionMode = hasMultipleCommands
-		? normalizedMode
-		: normalizedMode === "split-pane" || normalizedMode === "sequential"
-			? "split-pane"
-			: "new-tab";
+	const modeValue = getLaunchModeValue(
+		normalizeV2ExecutionMode(editingPreset?.executionMode),
+		hasMultipleCommands,
+	);
 
 	const handleEditorFieldChange = useCallback(
 		(column: PresetColumnKey, value: string) => {
@@ -598,7 +600,7 @@ export function V2PresetsSection({
 	}, [editingRowIndex, handleCommandsBlur]);
 
 	const handleEditorModeChange = useCallback(
-		(mode: ExecutionMode) => {
+		(mode: V2ExecutionMode) => {
 			if (editingRowIndex < 0) return;
 			handleExecutionModeChange(editingRowIndex, mode);
 		},
@@ -672,6 +674,7 @@ export function V2PresetsSection({
 				projects={projectOptions}
 				agents={agents}
 				onLinkedAgentSaved={syncLinkedPresetSnapshots}
+				supportsBackground
 				open={!!editingPreset}
 				onOpenChange={(open) => !open && handleCloseEditor()}
 				onDeletePreset={handleDeleteEditingPreset}

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeExecutionMode } from "@superset/local-db/schema/zod";
 import {
+	normalizeExecutionMode,
+	normalizeV2ExecutionMode,
+} from "@superset/local-db/schema/zod";
+import {
+	buildBackgroundTerminalCommand,
 	buildFocusedTerminalCommand,
 	getPresetLaunchPlan,
 	shouldApplyPresetPaneName,
@@ -23,6 +27,38 @@ describe("normalizeExecutionMode", () => {
 		expect(normalizeExecutionMode("sequential")).toBe("sequential");
 		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
 		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
+	});
+
+	it("maps v2-only background to new-tab", () => {
+		expect(normalizeExecutionMode("background")).toBe("new-tab");
+	});
+});
+
+describe("normalizeV2ExecutionMode", () => {
+	it("keeps background and delegates the rest to v1 normalization", () => {
+		expect(normalizeV2ExecutionMode("background")).toBe("background");
+		expect(normalizeV2ExecutionMode("parallel")).toBe("split-pane");
+		expect(normalizeV2ExecutionMode(undefined)).toBe("new-tab");
+	});
+});
+
+describe("buildBackgroundTerminalCommand", () => {
+	it("chains commands with a trailing exit so the shell always closes", () => {
+		expect(buildBackgroundTerminalCommand(["echo one", "echo two"])).toBe(
+			"echo one && echo two; exit",
+		);
+	});
+
+	it("skips blank commands", () => {
+		expect(buildBackgroundTerminalCommand(["  ", "fork ."])).toBe(
+			"fork .; exit",
+		);
+	});
+
+	it("returns null when no runnable command exists", () => {
+		expect(buildBackgroundTerminalCommand([" "])).toBeNull();
+		expect(buildBackgroundTerminalCommand([])).toBeNull();
+		expect(buildBackgroundTerminalCommand(undefined)).toBeNull();
 	});
 });
 
@@ -174,5 +210,25 @@ describe("getPresetLaunchPlan", () => {
 				hasActiveTab: true,
 			}),
 		).toBe("new-tab-single");
+	});
+
+	it("always plans background mode as background, ignoring the target", () => {
+		expect(
+			getPresetLaunchPlan({
+				mode: "background",
+				target: "active-tab",
+				commandCount: 2,
+				hasActiveTab: true,
+				hasActiveTerminal: true,
+			}),
+		).toBe("background");
+		expect(
+			getPresetLaunchPlan({
+				mode: "background",
+				target: "new-tab",
+				commandCount: 1,
+				hasActiveTab: false,
+			}),
+		).toBe("background");
 	});
 });

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
@@ -1,11 +1,12 @@
-import type { ExecutionMode } from "@superset/local-db/schema/zod";
+import type { V2ExecutionMode } from "@superset/local-db/schema/zod";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
 import { quote } from "shell-quote";
 
 export type PresetOpenTarget = "new-tab" | "active-tab";
-export type PresetMode = ExecutionMode;
+export type PresetMode = V2ExecutionMode;
 
 export type PresetLaunchPlan =
+	| "background"
 	| "active-terminal"
 	| "new-tab-single"
 	| "new-tab-multi-pane"
@@ -26,6 +27,11 @@ export function getPresetLaunchPlan({
 	hasActiveTab: boolean;
 	hasActiveTerminal?: boolean;
 }): PresetLaunchPlan {
+	// Background presets never open a pane, so the target is irrelevant.
+	if (mode === "background") {
+		return "background";
+	}
+
 	const hasMultipleCommands = commandCount > 1;
 	const shouldUseActiveTab =
 		target === "active-tab" &&
@@ -50,6 +56,18 @@ export function getPresetLaunchPlan({
 	}
 
 	return hasMultipleCommands ? "new-tab-multi-pane" : "new-tab-single";
+}
+
+export function buildBackgroundTerminalCommand(
+	commands: string[] | null | undefined,
+): string | null {
+	const runnableCommands = commands?.filter((command) => command.trim());
+	if (!runnableCommands || runnableCommands.length === 0) return null;
+	const command = buildTerminalCommand(runnableCommands);
+	// The trailing "; exit" always ends the shell once the chain finishes, so
+	// the background session cleans itself up. Bare "exit" preserves the last
+	// command's status, letting exit-event listeners report failures.
+	return `${command}; exit`;
 }
 
 export function buildFocusedTerminalCommand({

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -275,6 +275,13 @@ const localDbMock = () => ({
 		"new-tab-split-pane",
 		"sequential",
 	],
+	V2_EXECUTION_MODES: [
+		"split-pane",
+		"new-tab",
+		"new-tab-split-pane",
+		"sequential",
+		"background",
+	],
 	BRANCH_PREFIX_MODES: ["none", "github", "author", "custom"],
 	TERMINAL_LINK_BEHAVIORS: ["external-editor", "file-viewer"],
 	FILE_OPEN_MODES: ["split-pane", "new-tab"],

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -84,6 +84,11 @@ export const EXECUTION_MODES = [
 
 export type ExecutionMode = (typeof EXECUTION_MODES)[number];
 
+/** v2 workspaces additionally run presets in a pane-less background session. */
+export const V2_EXECUTION_MODES = [...EXECUTION_MODES, "background"] as const;
+
+export type V2ExecutionMode = (typeof V2_EXECUTION_MODES)[number];
+
 export function normalizeExecutionMode(mode: unknown): ExecutionMode {
 	if (
 		mode === "split-pane" ||
@@ -98,7 +103,12 @@ export function normalizeExecutionMode(mode: unknown): ExecutionMode {
 		return "split-pane";
 	}
 
+	// "background" is v2-only, so v1 surfaces fall back to new-tab too.
 	return "new-tab";
+}
+
+export function normalizeV2ExecutionMode(mode: unknown): V2ExecutionMode {
+	return mode === "background" ? "background" : normalizeExecutionMode(mode);
 }
 
 /**


### PR DESCRIPTION
## What & why

Presets that launch GUI tools (e.g. `fork .`, `zed .`) opened a foreground
terminal tab that stole focus from the CLI you were working in, needed a
manual `; exit` to close themselves and showed the generic terminal glyph
in the presets bar instead of the app's icon.

For v2 workspaces this PR adds:

- A new `background` execution mode: commands run in a pane-less
  host-service session with `; exit` appended, so nothing opens in the
  foreground, focus stays put and the terminal exits and closes itself
  when the run finishes. While running, the session sits behind the
  existing background-terminals button (adopt or kill from there) and is
  marked so session auto-adoption leaves it alone. The preset editor
  offers the mode as a "Background" segment (single command) or "In the
  background" select entry (grouped commands); the v1 editor does not
  offer it and v1 degrades legacy data to the default new-tab behaviour.
- A failure toast: `useV2PresetExecution` listens to `terminal:lifecycle`
  and toasts the preset name and exit code when a background run exits
  non-zero. Kills arrive as signal exits or dispose broadcasts with code
  0, so they stay silent.
- Real app icons for GUI-tool presets: a new `external.getCommandAppIcons`
  procedure resolves the preset's executable via login-shell `which`,
  follows symlinks to the containing `.app` bundle and returns
  `app.getFileIcon` as a cached data URI. The presets bar, its manage
  dropdown and the settings rows fall back to it, so `fork .` shows
  Fork's icon and `zed .` shows Zed's. Agent icons (Claude, Codex) keep
  precedence and non-app commands keep the terminal glyph.

## How I tested it

- `bun test` in `apps/desktop`: 2296 pass; the 3 failures
  (`shell-wrappers`, shell-env `git.test.ts`) also fail on the base
  commit in this sandbox. New unit cases cover `normalizeExecutionMode`,
  `getPresetLaunchPlan`, `buildBackgroundTerminalCommand`,
  `getPresetModeLabel` and `getLaunchModeValue`.
- `bun run typecheck --filter=@superset/desktop --filter=@superset/local-db`
  and `bun run lint` pass.
- Not verified in a running app as don't know how to test locally. May be worth a
  quick visual check that Fork/Zed presets pick up their bundle icons and
  that the background-terminals button shows the session while running
  and clears once it exits.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v2-only “background” launch mode for presets so GUI-tool commands run without opening a tab or stealing focus, and adds macOS app‑bundle icons for GUI‑tool presets like `fork .` and `zed .`. Background sessions auto‑close and show a failure toast on non‑zero exit.

- **New Features**
  - Background execution: pane‑less host session behind the background‑terminals button; appends “; exit” so it closes when done; not auto‑adopted; always uses the background plan regardless of target. The v2 editor offers “Background”/“In the background”; v1 hides it and normalizes to standard tab modes.
  - Failure feedback: listens to `terminal:lifecycle` exits; non‑zero exits from background runs toast the preset name and code; signal kills stay silent.
  - App icons for GUI tools: `external.getCommandAppIcons` resolves `.app` bundle icons via `which` + Electron `app.getFileIcon`, caching data URIs. The presets bar (items and manage menu) and settings rows fall back to these when no agent icon matches; non‑app, path‑based, or conflicting commands keep the terminal glyph.

- **Bug Fixes**
  - Opening a new terminal tab still creates a blank tab when all apply‑on‑new‑tab presets are background.

<sup>Written for commit 5a65e25f947eac15451c2f5fcb845ff59069bf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Background launch mode for terminal presets, allowing commands to run without opening a terminal pane.
  * Added status updates and error notifications for background command execution.
  * Added macOS application icons for command-based presets in preset bars and terminal settings.
  * Added clearer launch-mode settings and guidance for background execution.

* **Bug Fixes**
  * Improved handling and persistence of background presets, including mixed or invalid commands.
  * Improved command icon resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->