### PR TITLE
feat(desktop): add per-project workspace sorting

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
@@ -5,4 +5,5 @@ export {
 	useV2SourcesNotificationStatus,
 	useV2WorkspaceIsUnread,
 	useV2WorkspaceNotificationStatus,
+	useV2WorkspaceNotificationStatuses,
 } from "./useV2NotificationStatus";

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -1,5 +1,5 @@
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import {
 	getV2NotificationSourceKey,
 	getV2NotificationSourcesForPane,
@@ -24,23 +24,34 @@ import {
 const TERMINAL_PREFIX = "terminal:";
 const TERMINAL_AGENT_BINDINGS_QUERY_KEY = ["terminal-agent-bindings"] as const;
 
-function useTerminalAgentBindingsCacheVersion(
+function useTerminalAgentBindingsCacheSnapshot(
 	queryClient: QueryClient,
-): number {
-	const [cacheVersion, setCacheVersion] = useState(0);
+): string {
+	const subscribe = useCallback(
+		(onStoreChange: () => void) =>
+			queryClient.getQueryCache().subscribe((event) => {
+				if (
+					(event.type === "updated" || event.type === "removed") &&
+					event.query.queryKey[0] === TERMINAL_AGENT_BINDINGS_QUERY_KEY[0]
+				) {
+					onStoreChange();
+				}
+			}),
+		[queryClient],
+	);
+	const getSnapshot = useCallback(
+		() =>
+			queryClient
+				.getQueryCache()
+				.findAll({ queryKey: TERMINAL_AGENT_BINDINGS_QUERY_KEY })
+				.filter((query) => query.state.data !== undefined)
+				.map((query) => `${query.queryHash}:${query.state.dataUpdateCount}`)
+				.sort()
+				.join("|"),
+		[queryClient],
+	);
 
-	useEffect(() => {
-		return queryClient.getQueryCache().subscribe((event) => {
-			if (
-				(event.type === "updated" || event.type === "removed") &&
-				event.query.queryKey[0] === TERMINAL_AGENT_BINDINGS_QUERY_KEY[0]
-			) {
-				setCacheVersion((version) => version + 1);
-			}
-		});
-	}, [queryClient]);
-
-	return cacheVersion;
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 function terminalIdsFromSources(
@@ -108,9 +119,9 @@ export function useV2WorkspaceNotificationStatuses(
 	const terminalSeenAt = useV2NotificationStore(
 		(state) => state.terminalSeenAt,
 	);
-	const cacheVersion = useTerminalAgentBindingsCacheVersion(queryClient);
+	const cacheSnapshot = useTerminalAgentBindingsCacheSnapshot(queryClient);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheSnapshot re-reads the query cache
 	return useMemo(() => {
 		const requestedIds = new Set(workspaceIds);
 		const statusesByWorkspaceId = new Map<
@@ -146,7 +157,7 @@ export function useV2WorkspaceNotificationStatuses(
 				getHighestPriorityStatus(statuses),
 			]),
 		);
-	}, [cacheVersion, manualUnread, queryClient, terminalSeenAt, workspaceIds]);
+	}, [cacheSnapshot, manualUnread, queryClient, terminalSeenAt, workspaceIds]);
 }
 
 export function useV2WorkspaceIsUnread(workspaceId: string): boolean {
@@ -192,9 +203,9 @@ export function useV2AttentionWorkspaceCount(): number {
 	const terminalSeenAt = useV2NotificationStore(
 		(state) => state.terminalSeenAt,
 	);
-	const cacheVersion = useTerminalAgentBindingsCacheVersion(queryClient);
+	const cacheSnapshot = useTerminalAgentBindingsCacheSnapshot(queryClient);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheSnapshot re-reads the query cache
 	return useMemo(() => {
 		const workspaceIds = new Set(Object.keys(manualUnread));
 		const entries = queryClient.getQueriesData<TerminalAgentBinding[]>({
@@ -217,5 +228,5 @@ export function useV2AttentionWorkspaceCount(): number {
 			}
 		}
 		return workspaceIds.size;
-	}, [cacheVersion, manualUnread, terminalSeenAt, queryClient]);
+	}, [cacheSnapshot, manualUnread, terminalSeenAt, queryClient]);
 }

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	getV2NotificationSourceKey,
@@ -22,6 +22,26 @@ import {
 } from "../useTerminalAgentStatuses";
 
 const TERMINAL_PREFIX = "terminal:";
+const TERMINAL_AGENT_BINDINGS_QUERY_KEY = ["terminal-agent-bindings"] as const;
+
+function useTerminalAgentBindingsCacheVersion(
+	queryClient: QueryClient,
+): number {
+	const [cacheVersion, setCacheVersion] = useState(0);
+
+	useEffect(() => {
+		return queryClient.getQueryCache().subscribe((event) => {
+			if (
+				(event.type === "updated" || event.type === "removed") &&
+				event.query.queryKey[0] === TERMINAL_AGENT_BINDINGS_QUERY_KEY[0]
+			) {
+				setCacheVersion((version) => version + 1);
+			}
+		});
+	}, [queryClient]);
+
+	return cacheVersion;
+}
 
 function terminalIdsFromSources(
 	sources: Iterable<V2NotificationSourceInput>,
@@ -88,18 +108,7 @@ export function useV2WorkspaceNotificationStatuses(
 	const terminalSeenAt = useV2NotificationStore(
 		(state) => state.terminalSeenAt,
 	);
-	const [cacheVersion, setCacheVersion] = useState(0);
-
-	useEffect(() => {
-		return queryClient.getQueryCache().subscribe((event) => {
-			if (
-				event.type === "updated" &&
-				event.query.queryKey[0] === "terminal-agent-bindings"
-			) {
-				setCacheVersion((version) => version + 1);
-			}
-		});
-	}, [queryClient]);
+	const cacheVersion = useTerminalAgentBindingsCacheVersion(queryClient);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
 	return useMemo(() => {
@@ -116,7 +125,7 @@ export function useV2WorkspaceNotificationStatuses(
 		}
 
 		const entries = queryClient.getQueriesData<TerminalAgentBinding[]>({
-			queryKey: ["terminal-agent-bindings"],
+			queryKey: TERMINAL_AGENT_BINDINGS_QUERY_KEY,
 		});
 		for (const [, bindings] of entries) {
 			for (const binding of bindings ?? []) {
@@ -183,21 +192,13 @@ export function useV2AttentionWorkspaceCount(): number {
 	const terminalSeenAt = useV2NotificationStore(
 		(state) => state.terminalSeenAt,
 	);
-	const [cacheVersion, setCacheVersion] = useState(0);
-
-	useEffect(() => {
-		return queryClient.getQueryCache().subscribe((event) => {
-			if (event.query.queryKey[0] === "terminal-agent-bindings") {
-				setCacheVersion((version) => version + 1);
-			}
-		});
-	}, [queryClient]);
+	const cacheVersion = useTerminalAgentBindingsCacheVersion(queryClient);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
 	return useMemo(() => {
 		const workspaceIds = new Set(Object.keys(manualUnread));
 		const entries = queryClient.getQueriesData<TerminalAgentBinding[]>({
-			queryKey: ["terminal-agent-bindings"],
+			queryKey: TERMINAL_AGENT_BINDINGS_QUERY_KEY,
 		});
 		for (const [, bindings] of entries) {
 			for (const binding of bindings ?? []) {

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -10,6 +10,7 @@ import {
 import {
 	type ActivePaneStatus,
 	getHighestPriorityStatus,
+	type PaneStatus,
 } from "shared/tabs-types";
 import {
 	type TerminalAgentBinding,
@@ -72,6 +73,71 @@ export function useV2WorkspaceNotificationStatus(
 		manualUnread ? "review" : undefined,
 		...statuses.values(),
 	]);
+}
+
+/**
+ * Highest-priority status for each requested workspace. This aggregates the
+ * terminal binding queries already mounted by sidebar rows, so sorting by
+ * agent status does not create a second request per workspace.
+ */
+export function useV2WorkspaceNotificationStatuses(
+	workspaceIds: readonly string[],
+): ReadonlyMap<string, ActivePaneStatus | null> {
+	const queryClient = useQueryClient();
+	const manualUnread = useV2NotificationStore((state) => state.manualUnread);
+	const terminalSeenAt = useV2NotificationStore(
+		(state) => state.terminalSeenAt,
+	);
+	const [cacheVersion, setCacheVersion] = useState(0);
+
+	useEffect(() => {
+		return queryClient.getQueryCache().subscribe((event) => {
+			if (
+				event.type === "updated" &&
+				event.query.queryKey[0] === "terminal-agent-bindings"
+			) {
+				setCacheVersion((version) => version + 1);
+			}
+		});
+	}, [queryClient]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
+	return useMemo(() => {
+		const requestedIds = new Set(workspaceIds);
+		const statusesByWorkspaceId = new Map<
+			string,
+			Array<PaneStatus | undefined>
+		>();
+
+		for (const workspaceId of workspaceIds) {
+			statusesByWorkspaceId.set(workspaceId, [
+				manualUnread[workspaceId] ? "review" : undefined,
+			]);
+		}
+
+		const entries = queryClient.getQueriesData<TerminalAgentBinding[]>({
+			queryKey: ["terminal-agent-bindings"],
+		});
+		for (const [, bindings] of entries) {
+			for (const binding of bindings ?? []) {
+				if (!requestedIds.has(binding.workspaceId)) continue;
+				statusesByWorkspaceId.get(binding.workspaceId)?.push(
+					deriveTerminalAgentStatus({
+						lastEventType: binding.lastEventType,
+						lastEventAt: binding.lastEventAt,
+						lastSeenAt: terminalSeenAt[binding.terminalId],
+					}),
+				);
+			}
+		}
+
+		return new Map(
+			[...statusesByWorkspaceId].map(([workspaceId, statuses]) => [
+				workspaceId,
+				getHighestPriorityStatus(statuses),
+			]),
+		);
+	}, [cacheVersion, manualUnread, queryClient, terminalSeenAt, workspaceIds]);
 }
 
 export function useV2WorkspaceIsUnread(workspaceId: string): boolean {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -27,6 +27,7 @@ import { createPortal } from "react-dom";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
 import { HiringBanner } from "renderer/components/HiringBanner";
 import { UpdatesPill } from "renderer/components/UpdatesPill";
+import { useV2WorkspaceNotificationStatuses } from "renderer/hooks/host-service/useV2NotificationStatus";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
@@ -49,6 +50,7 @@ import { DashboardSidebarPortsProvider } from "./providers/DashboardSidebarPorts
 import type { DashboardSidebarProject } from "./types";
 import { filterDashboardSidebarProjects } from "./utils/filterDashboardSidebarProjects";
 import { sortDashboardSidebarProjects } from "./utils/sortDashboardSidebarProjects";
+import { sortProjectChildren } from "./utils/sortProjectChildren";
 
 interface DashboardSidebarProps {
 	isCollapsed?: boolean;
@@ -162,19 +164,48 @@ export function DashboardSidebar({
 		setProjectOrder(groups.map((p) => p.id));
 	}, [groups]);
 
+	const workspaceIds = useMemo(
+		() =>
+			groups.flatMap((project) =>
+				project.children.flatMap((child) =>
+					child.type === "workspace"
+						? [child.workspace.id]
+						: child.section.workspaces.map((workspace) => workspace.id),
+				),
+			),
+		[groups],
+	);
+	const workspaceStatuses = useV2WorkspaceNotificationStatuses(workspaceIds);
+	const workspaceSortedGroups = useMemo(
+		() =>
+			groups.map((project) => {
+				const children = sortProjectChildren(
+					project.children,
+					project.workspaceSortOrder,
+					workspaceStatuses,
+				);
+				return children === project.children
+					? project
+					: { ...project, children };
+			}),
+		[groups, workspaceStatuses],
+	);
+
 	const orderedGroups = useMemo(() => {
-		const byId = new Map(groups.map((g) => [g.id, g]));
+		const byId = new Map(
+			workspaceSortedGroups.map((group) => [group.id, group]),
+		);
 		return projectOrder
 			.map((id) => byId.get(id))
 			.filter((g): g is DashboardSidebarProject => g != null);
-	}, [groups, projectOrder]);
+	}, [workspaceSortedGroups, projectOrder]);
 
 	const sortedGroups = useMemo(
 		() =>
 			sortMode === "manual"
 				? orderedGroups
-				: sortDashboardSidebarProjects(groups, sortMode),
-		[sortMode, orderedGroups, groups],
+				: sortDashboardSidebarProjects(workspaceSortedGroups, sortMode),
+		[sortMode, orderedGroups, workspaceSortedGroups],
 	);
 
 	const displayedGroups = useMemo(
@@ -274,7 +305,9 @@ export function DashboardSidebar({
 										}}
 										onDragStart={({ active }) => {
 											if (isDragDisabled) return;
-											const project = groups.find((p) => p.id === active.id);
+											const project = displayedGroups.find(
+												(candidate) => candidate.id === active.id,
+											);
 											setActiveProject(project ?? null);
 										}}
 										onDragEnd={handleDragEnd}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -52,6 +52,7 @@ export function DashboardSidebarProjectSection({
 		renameSection,
 		renameValue,
 		setRenameValue,
+		setWorkspaceSortOrder,
 		startRename,
 		submitRename,
 		toggleSectionCollapsed,
@@ -81,6 +82,7 @@ export function DashboardSidebarProjectSection({
 						workspaceShortcutLabels={workspaceShortcutLabels}
 						onWorkspaceHover={onWorkspaceHover}
 						onToggleCollapse={() => onToggleCollapse(project.id)}
+						disableReordering={project.workspaceSortOrder !== "manual"}
 					/>
 				</div>
 			</DashboardSidebarProjectContextMenu>
@@ -108,6 +110,8 @@ export function DashboardSidebarProjectSection({
 					onStartRename={startRename}
 					onToggleCollapse={() => onToggleCollapse(project.id)}
 					onNewWorkspace={handleNewWorkspace}
+					workspaceSortOrder={project.workspaceSortOrder}
+					onWorkspaceSortOrderChange={setWorkspaceSortOrder}
 					{...(dragHandleAttributes ?? {})}
 					{...(dragHandleListeners ?? {})}
 				/>
@@ -132,6 +136,7 @@ export function DashboardSidebarProjectSection({
 							onDeleteSection={deleteSection}
 							onRenameSection={renameSection}
 							onToggleSectionCollapse={toggleSectionCollapsed}
+							disableReordering={project.workspaceSortOrder !== "manual"}
 						/>
 					</motion.div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/DashboardSidebarCollapsedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/DashboardSidebarCollapsedProjectContent.tsx
@@ -24,6 +24,7 @@ interface DashboardSidebarCollapsedProjectContentProps
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: () => void;
+	disableReordering?: boolean;
 }
 
 export const DashboardSidebarCollapsedProjectContent = forwardRef<
@@ -41,6 +42,7 @@ export const DashboardSidebarCollapsedProjectContent = forwardRef<
 			workspaceShortcutLabels,
 			onWorkspaceHover,
 			onToggleCollapse,
+			disableReordering = false,
 			className,
 			...props
 		},
@@ -131,8 +133,9 @@ export const DashboardSidebarCollapsedProjectContent = forwardRef<
 														parsed.realId,
 													)}
 													disabled={
-														workspace.type === "main" &&
-														workspace.hostType === "local-device"
+														disableReordering ||
+														(workspace.type === "main" &&
+															workspace.hostType === "local-device")
 													}
 												/>
 											);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -22,6 +22,7 @@ interface DashboardSidebarExpandedProjectContentProps {
 	onDeleteSection: (sectionId: string) => void;
 	onRenameSection: (sectionId: string, name: string) => void;
 	onToggleSectionCollapse: (sectionId: string) => void;
+	disableReordering?: boolean;
 }
 
 export function DashboardSidebarExpandedProjectContent({
@@ -34,6 +35,7 @@ export function DashboardSidebarExpandedProjectContent({
 	onDeleteSection,
 	onRenameSection,
 	onToggleSectionCollapse,
+	disableReordering = false,
 }: DashboardSidebarExpandedProjectContentProps) {
 	const {
 		sensors,
@@ -88,6 +90,7 @@ export function DashboardSidebarExpandedProjectContent({
 												onDelete={onDeleteSection}
 												onRename={onRenameSection}
 												onToggleCollapse={onToggleSectionCollapse}
+												disabled={disableReordering}
 											/>
 										);
 									}
@@ -125,8 +128,9 @@ export function DashboardSidebarExpandedProjectContent({
 															parsed.realId,
 														)}
 														disabled={
-															workspace.type === "main" &&
-															workspace.hostType === "local-device"
+															disableReordering ||
+															(workspace.type === "main" &&
+																workspace.hostType === "local-device")
 														}
 													/>
 												</motion.div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -3,7 +3,9 @@ import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
+import { DashboardSidebarWorkspaceSortMenu } from "./components/DashboardSidebarWorkspaceSortMenu";
 
 interface DashboardSidebarProjectRowProps
 	extends ComponentPropsWithoutRef<"div"> {
@@ -18,6 +20,8 @@ interface DashboardSidebarProjectRowProps
 	onStartRename: () => void;
 	onToggleCollapse: () => void;
 	onNewWorkspace: () => void;
+	workspaceSortOrder: DashboardSidebarWorkspaceSort;
+	onWorkspaceSortOrderChange: (value: DashboardSidebarWorkspaceSort) => void;
 }
 
 export const DashboardSidebarProjectRow = forwardRef<
@@ -37,6 +41,8 @@ export const DashboardSidebarProjectRow = forwardRef<
 			onStartRename,
 			onToggleCollapse,
 			onNewWorkspace,
+			workspaceSortOrder,
+			onWorkspaceSortOrderChange,
 			className,
 			...props
 		},
@@ -95,7 +101,12 @@ export const DashboardSidebarProjectRow = forwardRef<
 				</div>
 
 				{!isRenaming && (
-					<div className="ml-1 flex size-6 shrink-0 items-center justify-center">
+					<div className="ml-1 flex shrink-0 items-center justify-center">
+						<DashboardSidebarWorkspaceSortMenu
+							projectName={projectName}
+							value={workspaceSortOrder}
+							onValueChange={onWorkspaceSortOrderChange}
+						/>
 						<Tooltip delayDuration={500}>
 							<TooltipTrigger asChild>
 								<button
@@ -107,7 +118,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 									onKeyDown={(event) => event.stopPropagation()}
 									onContextMenu={(event) => event.stopPropagation()}
 									aria-label="New workspace"
-									className="hidden size-full items-center justify-center rounded transition-colors hover:bg-fill-hover group-hover:flex group-has-[:focus]:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="flex size-6 items-center justify-center rounded opacity-0 transition-[background-color,opacity] hover:bg-fill-hover group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<HiMiniPlus className="size-4 text-muted-foreground" />
 								</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/components/DashboardSidebarWorkspaceSortMenu/DashboardSidebarWorkspaceSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/components/DashboardSidebarWorkspaceSortMenu/DashboardSidebarWorkspaceSortMenu.tsx
@@ -1,0 +1,124 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { HiOutlineBarsArrowDown } from "react-icons/hi2";
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+
+interface DashboardSidebarWorkspaceSortMenuProps {
+	projectName: string;
+	value: DashboardSidebarWorkspaceSort;
+	onValueChange: (value: DashboardSidebarWorkspaceSort) => void;
+}
+
+const SORT_OPTIONS: Array<{
+	value: DashboardSidebarWorkspaceSort;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "manual",
+		label: "Manual order",
+		description: "Drag to arrange",
+	},
+	{
+		value: "status",
+		label: "Agent status",
+		description: "Action and working first",
+	},
+	{
+		value: "created-desc",
+		label: "Newest first",
+		description: "Recently created first",
+	},
+	{
+		value: "created-asc",
+		label: "Oldest first",
+		description: "Earliest created first",
+	},
+	{
+		value: "name",
+		label: "Name",
+		description: "A to Z",
+	},
+];
+
+const SORT_LABELS = Object.fromEntries(
+	SORT_OPTIONS.map((option) => [option.value, option.label]),
+) as Record<DashboardSidebarWorkspaceSort, string>;
+
+export function DashboardSidebarWorkspaceSortMenu({
+	projectName,
+	value,
+	onValueChange,
+}: DashboardSidebarWorkspaceSortMenuProps) {
+	const isManual = value === "manual";
+	const label = SORT_LABELS[value];
+
+	return (
+		<DropdownMenu>
+			<Tooltip delayDuration={400}>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							aria-label={`Sort ${projectName} workspaces. Current order: ${label}`}
+							onClick={(event) => event.stopPropagation()}
+							onKeyDown={(event) => event.stopPropagation()}
+							onContextMenu={(event) => event.stopPropagation()}
+							className={cn(
+								"flex size-6 items-center justify-center rounded text-muted-foreground transition-[background-color,color,opacity]",
+								"hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+								"data-[state=open]:bg-muted data-[state=open]:text-foreground data-[state=open]:opacity-100",
+								isManual
+									? "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+									: "bg-muted/70 text-foreground",
+							)}
+						>
+							<HiOutlineBarsArrowDown className="size-4" />
+						</button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" sideOffset={4}>
+					Sort workspaces · {label}
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenuContent
+				align="end"
+				className="w-56"
+				onClick={(event) => event.stopPropagation()}
+				onKeyDown={(event) => event.stopPropagation()}
+				onCloseAutoFocus={(event) => event.preventDefault()}
+			>
+				<DropdownMenuLabel>Sort workspaces</DropdownMenuLabel>
+				<DropdownMenuRadioGroup
+					value={value}
+					onValueChange={(nextValue) =>
+						onValueChange(nextValue as DashboardSidebarWorkspaceSort)
+					}
+				>
+					{SORT_OPTIONS.map((option) => (
+						<DropdownMenuRadioItem
+							key={option.value}
+							value={option.value}
+							className="items-start py-2"
+						>
+							<span className="flex min-w-0 flex-col">
+								<span>{option.label}</span>
+								<span className="text-xs font-normal text-muted-foreground">
+									{option.description}
+								</span>
+							</span>
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/components/DashboardSidebarWorkspaceSortMenu/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/components/DashboardSidebarWorkspaceSortMenu/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarWorkspaceSortMenu } from "./DashboardSidebarWorkspaceSortMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -41,6 +41,7 @@ export function useDashboardSidebarProjectSectionActions({
 		deleteSection,
 		removeProjectFromSidebar,
 		renameSection,
+		setProjectWorkspaceSortOrder,
 		toggleProjectCollapsed,
 		toggleSectionCollapsed,
 	} = useDashboardSidebarState();
@@ -114,6 +115,12 @@ export function useDashboardSidebarProjectSectionActions({
 		}
 	};
 
+	const setWorkspaceSortOrder = (
+		workspaceSortOrder: DashboardSidebarProject["workspaceSortOrder"],
+	) => {
+		setProjectWorkspaceSortOrder(project.id, workspaceSortOrder);
+	};
+
 	return {
 		cancelRename,
 		confirmRemoveFromSidebar,
@@ -126,6 +133,7 @@ export function useDashboardSidebarProjectSectionActions({
 		renameSection,
 		renameValue,
 		setRenameValue,
+		setWorkspaceSortOrder,
 		startRename,
 		submitRename,
 		toggleSectionCollapsed,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -18,6 +18,7 @@ interface DashboardSidebarSectionHeaderProps
 	onCancelRename: () => void;
 	onToggleCollapse: () => void;
 	actions?: ReactNode;
+	isReorderable?: boolean;
 }
 
 export const DashboardSidebarSectionHeader = forwardRef<
@@ -34,6 +35,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 			onCancelRename,
 			onToggleCollapse,
 			actions,
+			isReorderable = true,
 			className,
 			...props
 		},
@@ -63,7 +65,12 @@ export const DashboardSidebarSectionHeader = forwardRef<
 				)}
 				{...props}
 			>
-				<div className="mr-2 grid h-5 w-5 shrink-0 cursor-grab items-center justify-center active:cursor-grabbing [&>*]:col-start-1 [&>*]:row-start-1">
+				<div
+					className={cn(
+						"mr-2 grid h-5 w-5 shrink-0 items-center justify-center [&>*]:col-start-1 [&>*]:row-start-1",
+						isReorderable && "cursor-grab active:cursor-grabbing",
+					)}
+				>
 					<HiChevronRight
 						className={cn(
 							"size-3 text-muted-foreground transition-transform duration-150",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -17,6 +17,7 @@ interface SortableSectionHeaderProps {
 	onDelete: (sectionId: string) => void;
 	onRename: (sectionId: string, name: string) => void;
 	onToggleCollapse: (sectionId: string) => void;
+	disabled?: boolean;
 }
 
 export function SortableSectionHeader({
@@ -25,6 +26,7 @@ export function SortableSectionHeader({
 	onDelete,
 	onRename,
 	onToggleCollapse,
+	disabled = false,
 }: SortableSectionHeaderProps) {
 	const { setSectionColor } = useDashboardSidebarState();
 	const { clearPendingSectionRename, pendingRenameSectionId } =
@@ -39,7 +41,7 @@ export function SortableSectionHeader({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: sortableId });
+	} = useSortable({ id: sortableId, disabled });
 
 	const hasColor =
 		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
@@ -94,6 +96,7 @@ export function SortableSectionHeader({
 						setIsRenaming(false);
 					}}
 					onToggleCollapse={() => onToggleCollapse(section.id)}
+					isReorderable={!disabled}
 					actions={
 						<DashboardSidebarSectionActionsDropdown
 							color={section.color}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -23,6 +23,7 @@ function makeProject(
 		createdAt: DATE,
 		updatedAt: DATE,
 		isCollapsed: false,
+		workspaceSortOrder: "manual",
 		...overrides,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -1,3 +1,4 @@
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
 import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import type {
@@ -20,6 +21,7 @@ export interface SidebarProjectInput {
 	createdAt: Date;
 	updatedAt: Date;
 	isCollapsed: boolean;
+	workspaceSortOrder: DashboardSidebarWorkspaceSort;
 }
 
 export interface SidebarSectionInput {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -186,6 +186,7 @@ export function useDashboardSidebarData() {
 				.select(({ sidebarProjects }) => ({
 					projectId: sidebarProjects.projectId,
 					isCollapsed: sidebarProjects.isCollapsed,
+					workspaceSortOrder: sidebarProjects.workspaceSortOrder,
 				})),
 		[collections],
 	);
@@ -213,6 +214,7 @@ export function useDashboardSidebarData() {
 					createdAt: new Date(project.createdAt),
 					updatedAt: new Date(project.updatedAt),
 					isCollapsed: row.isCollapsed,
+					workspaceSortOrder: row.workspaceSortOrder,
 				},
 			];
 		});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -1,3 +1,4 @@
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
 
 export type DashboardSidebarWorkspaceHostType =
@@ -87,5 +88,6 @@ export interface DashboardSidebarProject {
 	createdAt: Date;
 	updatedAt: Date;
 	isCollapsed: boolean;
+	workspaceSortOrder: DashboardSidebarWorkspaceSort;
 	children: DashboardSidebarProjectChild[];
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/index.ts
@@ -1,0 +1,1 @@
+export { sortProjectChildren } from "./sortProjectChildren";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/sortProjectChildren.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/sortProjectChildren.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import type {
+	DashboardSidebarProjectChild,
+	DashboardSidebarWorkspace,
+} from "../../types";
+import { sortProjectChildren } from "./sortProjectChildren";
+
+function makeWorkspace(
+	id: string,
+	createdAt: string,
+	overrides: Partial<DashboardSidebarWorkspace> = {},
+): DashboardSidebarWorkspace {
+	return {
+		id,
+		projectId: "project-1",
+		hostId: "host-1",
+		hostType: "local-device",
+		type: "worktree",
+		hostIsOnline: null,
+		accentColor: null,
+		name: id,
+		branch: id,
+		pullRequest: null,
+		repoUrl: null,
+		branchExistsOnRemote: false,
+		previewUrl: null,
+		needsRebase: null,
+		behindCount: null,
+		createdAt: new Date(createdAt),
+		updatedAt: new Date(createdAt),
+		taskId: null,
+		isPinned: false,
+		pendingTransaction: null,
+		...overrides,
+	};
+}
+
+function getWorkspaceIds(children: DashboardSidebarProjectChild[]): string[] {
+	return children.flatMap((child) =>
+		child.type === "workspace"
+			? [child.workspace.id]
+			: child.section.workspaces.map((workspace) => workspace.id),
+	);
+}
+
+const statuses = new Map<string, ActivePaneStatus | null>();
+
+describe("sortProjectChildren", () => {
+	it("preserves the exact persisted order in manual mode", () => {
+		const children: DashboardSidebarProjectChild[] = [
+			{
+				type: "workspace",
+				workspace: makeWorkspace("second", "2026-02-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("first", "2026-01-01"),
+			},
+		];
+
+		expect(sortProjectChildren(children, "manual", statuses)).toBe(children);
+	});
+
+	it("sorts top-level and grouped workspaces without moving group headers", () => {
+		const children: DashboardSidebarProjectChild[] = [
+			{
+				type: "workspace",
+				workspace: makeWorkspace("older-top", "2026-01-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("newer-top", "2026-04-01"),
+			},
+			{
+				type: "section",
+				section: {
+					id: "section-1",
+					projectId: "project-1",
+					name: "Grouped",
+					createdAt: new Date("2026-01-01"),
+					isCollapsed: false,
+					tabOrder: 3,
+					color: null,
+					workspaces: [
+						makeWorkspace("older-grouped", "2026-02-01"),
+						makeWorkspace("newer-grouped", "2026-03-01"),
+					],
+				},
+			},
+		];
+
+		const sorted = sortProjectChildren(children, "created-desc", statuses);
+
+		expect(getWorkspaceIds(sorted)).toEqual([
+			"newer-top",
+			"older-top",
+			"newer-grouped",
+			"older-grouped",
+		]);
+		expect(sorted[2]?.type).toBe("section");
+	});
+
+	it("orders urgent and working agents ahead of idle workspaces", () => {
+		const children: DashboardSidebarProjectChild[] = [
+			{
+				type: "workspace",
+				workspace: makeWorkspace("idle", "2026-04-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("working", "2026-01-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("permission", "2026-02-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("review", "2026-03-01"),
+			},
+		];
+		const agentStatuses = new Map<string, ActivePaneStatus | null>([
+			["working", "working"],
+			["permission", "permission"],
+			["review", "review"],
+		]);
+
+		expect(
+			getWorkspaceIds(sortProjectChildren(children, "status", agentStatuses)),
+		).toEqual(["permission", "working", "review", "idle"]);
+	});
+
+	it("keeps the local main workspace pinned for every automatic sort", () => {
+		const children: DashboardSidebarProjectChild[] = [
+			{
+				type: "workspace",
+				workspace: makeWorkspace("new-worktree", "2026-04-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("local-main", "2026-01-01", {
+					type: "main",
+				}),
+			},
+		];
+
+		for (const sortOrder of [
+			"status",
+			"created-desc",
+			"created-asc",
+			"name",
+		] as const) {
+			expect(
+				getWorkspaceIds(sortProjectChildren(children, sortOrder, statuses))[0],
+			).toBe("local-main");
+		}
+	});
+
+	it("supports oldest-first and natural name ordering", () => {
+		const children: DashboardSidebarProjectChild[] = [
+			{
+				type: "workspace",
+				workspace: makeWorkspace("Agent 10", "2026-03-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("Agent 2", "2026-02-01"),
+			},
+			{
+				type: "workspace",
+				workspace: makeWorkspace("Agent 1", "2026-01-01"),
+			},
+		];
+
+		expect(
+			getWorkspaceIds(sortProjectChildren(children, "created-asc", statuses)),
+		).toEqual(["Agent 1", "Agent 2", "Agent 10"]);
+		expect(
+			getWorkspaceIds(sortProjectChildren(children, "name", statuses)),
+		).toEqual(["Agent 1", "Agent 2", "Agent 10"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/sortProjectChildren.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortProjectChildren/sortProjectChildren.ts
@@ -1,0 +1,93 @@
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import { type ActivePaneStatus, STATUS_PRIORITY } from "shared/tabs-types";
+import type {
+	DashboardSidebarProjectChild,
+	DashboardSidebarWorkspace,
+} from "../../types";
+
+type WorkspaceStatuses = ReadonlyMap<string, ActivePaneStatus | null>;
+
+function isPinnedMainWorkspace(workspace: DashboardSidebarWorkspace): boolean {
+	return workspace.type === "main" && workspace.hostType === "local-device";
+}
+
+function compareWorkspaceNames(
+	left: DashboardSidebarWorkspace,
+	right: DashboardSidebarWorkspace,
+): number {
+	return (
+		left.name.localeCompare(right.name, undefined, {
+			numeric: true,
+			sensitivity: "base",
+		}) || left.id.localeCompare(right.id)
+	);
+}
+
+function compareWorkspaces(
+	left: DashboardSidebarWorkspace,
+	right: DashboardSidebarWorkspace,
+	sortOrder: Exclude<DashboardSidebarWorkspaceSort, "manual">,
+	statuses: WorkspaceStatuses,
+): number {
+	const leftIsPinned = isPinnedMainWorkspace(left);
+	const rightIsPinned = isPinnedMainWorkspace(right);
+	if (leftIsPinned !== rightIsPinned) return leftIsPinned ? -1 : 1;
+
+	if (sortOrder === "status") {
+		const statusDelta =
+			STATUS_PRIORITY[statuses.get(right.id) ?? "idle"] -
+			STATUS_PRIORITY[statuses.get(left.id) ?? "idle"];
+		if (statusDelta !== 0) return statusDelta;
+
+		const createdDelta = right.createdAt.getTime() - left.createdAt.getTime();
+		if (createdDelta !== 0) return createdDelta;
+	}
+
+	if (sortOrder === "created-desc") {
+		const createdDelta = right.createdAt.getTime() - left.createdAt.getTime();
+		if (createdDelta !== 0) return createdDelta;
+	}
+
+	if (sortOrder === "created-asc") {
+		const createdDelta = left.createdAt.getTime() - right.createdAt.getTime();
+		if (createdDelta !== 0) return createdDelta;
+	}
+
+	return compareWorkspaceNames(left, right);
+}
+
+/**
+ * Applies a project-level viewing order without mutating its persisted manual
+ * order or moving workspaces across group boundaries.
+ */
+export function sortProjectChildren(
+	children: DashboardSidebarProjectChild[],
+	sortOrder: DashboardSidebarWorkspaceSort,
+	statuses: WorkspaceStatuses,
+): DashboardSidebarProjectChild[] {
+	if (sortOrder === "manual") return children;
+
+	const compare = (
+		left: DashboardSidebarWorkspace,
+		right: DashboardSidebarWorkspace,
+	) => compareWorkspaces(left, right, sortOrder, statuses);
+	const topLevelWorkspaces = children
+		.flatMap((child) => (child.type === "workspace" ? [child.workspace] : []))
+		.sort(compare);
+	let topLevelIndex = 0;
+
+	return children.map((child) => {
+		if (child.type === "workspace") {
+			const workspace = topLevelWorkspaces[topLevelIndex++];
+			return { type: "workspace", workspace };
+		}
+
+		return {
+			type: "section",
+			section: {
+				...child.section,
+				workspaces: [...child.section.workspaces].sort(compare),
+			},
+		};
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
@@ -54,6 +54,7 @@ export function makeProject(
 		createdAt: new Date("2026-01-01"),
 		updatedAt: new Date("2026-01-01"),
 		isCollapsed: false,
+		workspaceSortOrder: "manual",
 		children: [],
 		...overrides,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -13,6 +13,7 @@ import {
 	getPrependTabOrder,
 	isSidebarWorkspaceVisible,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import type { DashboardSidebarWorkspaceSort } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
@@ -224,6 +225,16 @@ export function useDashboardSidebarState() {
 				collections.v2SidebarProjects.update(projectId, (draft) => {
 					draft.tabOrder = index + 1;
 				});
+			});
+		},
+		[collections],
+	);
+
+	const setProjectWorkspaceSortOrder = useCallback(
+		(projectId: string, workspaceSortOrder: DashboardSidebarWorkspaceSort) => {
+			if (!collections.v2SidebarProjects.get(projectId)) return;
+			collections.v2SidebarProjects.update(projectId, (draft) => {
+				draft.workspaceSortOrder = workspaceSortOrder;
 			});
 		},
 		[collections],
@@ -525,6 +536,7 @@ export function useDashboardSidebarState() {
 		reorderWorkspaces,
 		renameSection,
 		setSectionColor,
+		setProjectWorkspaceSortOrder,
 		setWorkspacePinned,
 		toggleProjectCollapsed,
 		toggleSectionCollapsed,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -2,12 +2,34 @@ import { describe, expect, it } from "bun:test";
 import type { WorkspaceState } from "@superset/panes";
 import {
 	DEFAULT_V2_USER_PREFERENCES,
+	dashboardSidebarProjectSchema,
 	healV2UserPreferences,
 	healWorkspaceLocalState,
 	sanitizePaneLayout,
 } from "./schema";
 
 type PaneLayout = WorkspaceState<unknown>;
+
+describe("dashboardSidebarProjectSchema", () => {
+	it("defaults existing project rows to manual workspace order", () => {
+		const row = dashboardSidebarProjectSchema.parse({
+			projectId: "11111111-1111-4111-8111-111111111111",
+			createdAt: "2026-01-01T00:00:00.000Z",
+		});
+
+		expect(row.workspaceSortOrder).toBe("manual");
+	});
+
+	it("preserves an automatic workspace order", () => {
+		const row = dashboardSidebarProjectSchema.parse({
+			projectId: "11111111-1111-4111-8111-111111111111",
+			createdAt: "2026-01-01T00:00:00.000Z",
+			workspaceSortOrder: "status",
+		});
+
+		expect(row.workspaceSortOrder).toBe("status");
+	});
+});
 
 describe("healV2UserPreferences", () => {
 	it("returns full defaults for empty/non-object input", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -7,12 +7,21 @@ const persistedDateSchema = z
 	.union([z.string(), z.date()])
 	.transform((value) => (typeof value === "string" ? new Date(value) : value));
 
+export const dashboardSidebarWorkspaceSortSchema = z.enum([
+	"manual",
+	"status",
+	"created-desc",
+	"created-asc",
+	"name",
+]);
+
 export const dashboardSidebarProjectSchema = z.object({
 	projectId: z.string().uuid(),
 	createdAt: persistedDateSchema,
 	isCollapsed: z.boolean().default(false),
 	tabOrder: z.number().int().default(0),
 	defaultOpenInApp: z.string().nullable().default(null),
+	workspaceSortOrder: dashboardSidebarWorkspaceSortSchema.default("manual"),
 });
 
 const paneWorkspaceStateSchema = z.custom<WorkspaceState<unknown>>();
@@ -233,6 +242,9 @@ export const v2TerminalPresetSchema = z.object({
 
 export type DashboardSidebarProjectRow = z.infer<
 	typeof dashboardSidebarProjectSchema
+>;
+export type DashboardSidebarWorkspaceSort = z.infer<
+	typeof dashboardSidebarWorkspaceSortSchema
 >;
 export type WorkspaceLocalStateRow = z.infer<typeof workspaceLocalStateSchema>;
 export type WorkspaceRunState = z.infer<typeof workspaceRunStateSchema>;


### PR DESCRIPTION
## What changed

- add a per-project workspace sort menu with Manual, Agent status, Newest first, Oldest first, and Name modes
- keep local main pinned and preserve section boundaries while sorting workspaces inside each group
- persist each project's selected view order locally without rewriting its manual drag order
- disable workspace and section dragging while an automatic order is active, then restore the exact manual order when switched back
- aggregate existing agent status cache data so actionable and working workspaces can move to the top without extra requests per workspace

## Why

Projects can accumulate many concurrent agent workspaces. A small project-level control makes it easy to find the oldest or newest work, scan alphabetically, or bring work needing attention forward while preserving the user's hand-arranged order.

## Verification

- rebased onto current `main` and resolved the new project sorting/filtering and workspace pinning integrations
- `bun install --frozen-lockfile`
- `bun run lint:fix`
- `bun run lint` (0 warnings)
- `bun run typecheck` in `apps/desktop`
- 62 focused desktop tests across workspace/project sorting, filtering, persistence, data building, navigation, deletion, and ports
- `git diff --check`
- exact-worktree Electron E2E at renderer `http://localhost:3125` with CDP on `9342`
  - created a disposable project plus four workspaces through visible UI input
  - verified Manual, Agent status, Newest first, and Oldest first ordering
  - marked a workspace unread through its visible context menu and confirmed status ordering
  - verified the project-level controls landed on `main` coexist with the per-project workspace control
  - reloaded the renderer after the rebase and confirmed both the selected sort and resulting order persisted
  - restarted the full Electron process and confirmed the selected sort and resulting order persisted
  - captured visual and numeric DOM-order evidence
- addressed both concrete CodeRabbit cache-subscription findings; the final incremental review produced no actionable comments

## Screenshots

### Sort menu

![Per-project workspace sort menu](https://github.com/user-attachments/assets/56755839-65da-4c9d-b2f2-8e4751cc9a02)

### Agent status

Actionable workspace moves ahead of newer idle work while local main remains pinned.

![Agent-status workspace order](https://github.com/user-attachments/assets/728c5373-4d95-4386-be2e-2270c77c50cb)

### Oldest first

![Oldest-first workspace order](https://github.com/user-attachments/assets/46e474ad-6eb6-4834-8213-78242ddd8985)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace sorting options in the dashboard sidebar (manual, status, created date, and name).
  * Sorting is now notification/activity-aware when using the status mode.
  * Added per-project workspace sort controls, including disabling drag-and-drop when automatic sorting is selected.

* **Bug Fixes**
  * Fixed dragged project selection when filters are active.
  * Automatic sorting now preserves pinned workspaces and keeps grouped layouts stable (while maintaining manual order when selected).

* **Tests**
  * Expanded coverage for sort modes, pinned placement, default settings, and workspace sort schema behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->