### PR TITLE
feat(desktop): open ports over https via ports.json protocol field

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ports/label-cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/label-cache.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import { join } from "node:path";
 import { workspaces } from "@superset/local-db";
+import type { StaticPortLabel } from "@superset/port-scanner";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { loadStaticPorts } from "main/lib/static-ports";
@@ -8,7 +9,7 @@ import { PORTS_FILE_NAME, PROJECT_SUPERSET_DIR_NAME } from "shared/constants";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
 
 interface LabelCacheEntry {
-	labels: Map<number, string> | null;
+	labels: Map<number, StaticPortLabel> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -44,7 +45,7 @@ function safeGetPortsFileSignature(worktreePath: string): string | null {
 
 function safeLoadLabelsForWorktree(
 	worktreePath: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	try {
 		return loadLabelsForWorktree(worktreePath);
 	} catch (error) {
@@ -76,15 +77,15 @@ const labelCache = new Map<string, LabelCacheEntry>();
 
 function loadLabelsForWorktree(
 	worktreePath: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const result = loadStaticPorts(worktreePath);
 	if (!result.exists || result.error || !result.ports) {
 		return null;
 	}
 
-	const labels = new Map<number, string>();
+	const labels = new Map<number, StaticPortLabel>();
 	for (const p of result.ports) {
-		labels.set(p.port, p.label);
+		labels.set(p.port, p);
 	}
 	return labels;
 }
@@ -92,8 +93,8 @@ function loadLabelsForWorktree(
 function setLabelCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, string> | null,
-): Map<number, string> | null {
+	labels: Map<number, StaticPortLabel> | null,
+): Map<number, StaticPortLabel> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
@@ -107,7 +108,7 @@ function setLabelCache(
 
 export function getLabelsForWorkspace(
 	workspaceId: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const cached = labelCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {

--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -16,10 +16,11 @@ export const createPortsRouter = () => {
 		getAll: publicProcedure.query((): EnrichedPort[] => {
 			const detectedPorts = portManager.getAllPorts();
 			return detectedPorts.map((port) => {
-				const labels = getLabelsForWorkspace(port.workspaceId);
+				const entry = getLabelsForWorkspace(port.workspaceId)?.get(port.port);
 				return {
 					...port,
-					label: labels?.get(port.port) ?? null,
+					label: entry?.label ?? null,
+					protocol: entry?.protocol ?? null,
 					hostUrl: null,
 				};
 			});

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -72,6 +72,52 @@ describe("loadStaticPorts", () => {
 		expect(result.ports?.[0].label).toBe("Frontend");
 	});
 
+	test("loads an https protocol when provided", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend", protocol: "https" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports).toEqual([
+			{ port: 3000, label: "Frontend", protocol: "https" },
+		]);
+	});
+
+	test("accepts an explicit http protocol", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend", protocol: "http" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0].protocol).toBe("http");
+	});
+
+	test("omits protocol when not provided", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0]).not.toHaveProperty("protocol");
+	});
+
+	test("returns error when protocol is not http or https", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Frontend", protocol: "ftp" }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe('ports[0].protocol must be "http" or "https"');
+	});
+
 	test("returns error for invalid JSON syntax", () => {
 		writeFileSync(PORTS_FILE, "{ invalid json }");
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
@@ -22,6 +22,7 @@ function createResult(): HostPortsResult {
 				detectedAt: 1,
 				address: "127.0.0.1",
 				label: "Frontend",
+				protocol: null,
 			},
 		],
 	};
@@ -34,6 +35,7 @@ function createPortEvent(
 	return {
 		eventType,
 		label: "Vite",
+		protocol: null,
 		occurredAt: 2,
 		port: {
 			port: 5173,
@@ -63,6 +65,14 @@ describe("applyPortEventsToHostPortsResult", () => {
 			address: "0.0.0.0",
 			label: "Vite",
 		});
+	});
+
+	it("carries the protocol from an add event onto the port row", () => {
+		const result = applyPortEventsToHostPortsResult(createResult(), [
+			{ ...createPortEvent("add"), protocol: "https" },
+		]);
+
+		expect(result?.ports[0]).toMatchObject({ port: 5173, protocol: "https" });
 	});
 
 	it("keeps the same cache object for a remove event that does not match", () => {
@@ -280,6 +290,7 @@ describe("groupDashboardSidebarPorts", () => {
 							detectedAt: 1,
 							address: "127.0.0.1",
 							label: "Frontend",
+							protocol: null,
 						},
 						{
 							port: 3000,
@@ -290,6 +301,7 @@ describe("groupDashboardSidebarPorts", () => {
 							detectedAt: 1,
 							address: "127.0.0.1",
 							label: "Web",
+							protocol: null,
 						},
 						{
 							port: 8080,
@@ -300,6 +312,7 @@ describe("groupDashboardSidebarPorts", () => {
 							detectedAt: 1,
 							address: "127.0.0.1",
 							label: "API",
+							protocol: null,
 						},
 					],
 				},
@@ -343,6 +356,7 @@ describe("groupDashboardSidebarPorts", () => {
 							detectedAt: 1,
 							address: "127.0.0.1",
 							label: "Frontend",
+							protocol: null,
 						},
 					],
 				},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
@@ -1,6 +1,6 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { PortChangedPayload } from "@superset/workspace-client";
-import type { DetectedPort } from "shared/types";
+import type { DetectedPort, StaticPortProtocol } from "shared/types";
 import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
 
 export interface DashboardSidebarPort extends RemotePort {
@@ -11,6 +11,7 @@ export interface DashboardSidebarPort extends RemotePort {
 
 interface RemotePort extends DetectedPort {
 	label: string | null;
+	protocol: StaticPortProtocol | null;
 }
 
 export interface DashboardSidebarPortGroup {
@@ -108,7 +109,10 @@ export function applyPortEventsToHostPortsResult(
 		}
 
 		if (event.eventType === "add") {
-			ports = [...portsWithoutEventPort, { ...event.port, label: event.label }];
+			ports = [
+				...portsWithoutEventPort,
+				{ ...event.port, label: event.label, protocol: event.protocol },
+			];
 			changed = true;
 		} else {
 			ports = portsWithoutEventPort;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/usePortOpenActions/usePortOpenActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/usePortOpenActions/usePortOpenActions.ts
@@ -24,7 +24,7 @@ export function usePortOpenActions(
 	const openUrl = electronTrpc.external.openUrl.useMutation();
 	const { preferences } = useV2UserPreferences();
 	const canOpenInBrowser = port.hostType === "local-device";
-	const portUrl = `http://localhost:${port.port}`;
+	const portUrl = `${port.protocol ?? "http"}://localhost:${port.port}`;
 
 	const openExternal = () => {
 		if (!canOpenInBrowser || openUrl.isPending) return;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -27,7 +27,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 
 	const handleOpenInBrowser = () => {
 		if (openUrl.isPending) return;
-		const url = `http://localhost:${port.port}`;
+		const url = `${port.protocol ?? "http"}://localhost:${port.port}`;
 
 		if (openLinksInApp) {
 			navigateToWorkspace(port.workspaceId, navigate);

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -1,10 +1,11 @@
-export type { DetectedPort } from "@superset/port-scanner";
+export type { DetectedPort, StaticPortProtocol } from "@superset/port-scanner";
 
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, StaticPortProtocol } from "@superset/port-scanner";
 
 export interface StaticPort {
 	port: number;
 	label: string;
+	protocol?: StaticPortProtocol;
 	workspaceId: string;
 }
 
@@ -16,6 +17,9 @@ export interface StaticPortsResult {
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	// Scheme to open this port with, from `.superset/ports.json`. null → not
+	// configured; consumers fall back to http.
+	protocol: StaticPortProtocol | null;
 	// null → port belongs to the local Electron port manager.
 	// string → URL of the remote host-service that owns this port; kill routes there.
 	hostUrl: string | null;

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -30,7 +30,7 @@ Create `.superset/ports.json` in your repository:
 ```json
 {
   "ports": [
-    { "port": 3000, "label": "Frontend Dev Server" },
+    { "port": 3000, "label": "Frontend Dev Server", "protocol": "https" },
     { "port": 8080, "label": "API Server" },
     { "port": 5432, "label": "PostgreSQL" }
   ]
@@ -40,6 +40,9 @@ Create `.superset/ports.json` in your repository:
 **Fields:**
 - `port` - Port number (1-65535)
 - `label` - Display text shown in tooltip
+- `protocol` - Optional. `"http"` or `"https"`. Sets the scheme used when the
+  port is opened from the browser action. Defaults to `"http"`. Use `"https"`
+  for dev servers behind a local TLS certificate (for example `mkcert`).
 
 **Behavior:**
 - Dynamic port discovery is still authoritative
@@ -48,7 +51,8 @@ Create `.superset/ports.json` in your repository:
 - Label entries for ports that are not currently listening are ignored
 - Each workspace reads labels from its own worktree's file
 - Changes are detected automatically
-- Ports can be opened at `localhost:PORT` from the browser action
+- Ports open at `http://localhost:PORT` from the browser action, or
+  `https://localhost:PORT` when the entry sets `"protocol": "https"`
 
 **Error Handling:**
 

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -1,5 +1,5 @@
 import type { NodeWebSocket } from "@hono/node-ws";
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, StaticPortLabel } from "@superset/port-scanner";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { Hono } from "hono";
 import type { HostDb } from "../db/index.ts";
@@ -219,17 +219,20 @@ export class EventBus {
 		eventType: "add" | "remove";
 		port: DetectedPort;
 	}): void {
+		const entry =
+			eventType === "add" ? this.getStaticPortEntry(port) : undefined;
 		this.broadcast({
 			type: "port:changed",
 			workspaceId: port.workspaceId,
 			eventType,
 			port,
-			label: eventType === "add" ? this.getPortLabel(port) : null,
+			label: entry?.label ?? null,
+			protocol: entry?.protocol ?? null,
 			occurredAt: Date.now(),
 		});
 	}
 
-	private getPortLabel(port: DetectedPort): string | null {
+	private getStaticPortEntry(port: DetectedPort): StaticPortLabel | undefined {
 		const labels = getLabelsForWorkspace((workspaceId) => {
 			try {
 				return this.filesystem.resolveWorkspaceRoot(workspaceId);
@@ -237,7 +240,7 @@ export class EventBus {
 				return null;
 			}
 		}, port.workspaceId);
-		return labels?.get(port.port) ?? null;
+		return labels?.get(port.port);
 	}
 
 	private startFsWatch(

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -1,4 +1,4 @@
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, StaticPortProtocol } from "@superset/port-scanner";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { AgentLifecycleEventType } from "./map-event-type.ts";
@@ -50,6 +50,7 @@ export interface PortChangedMessage {
 	eventType: "add" | "remove";
 	port: DetectedPort;
 	label: string | null;
+	protocol: StaticPortProtocol | null;
 	occurredAt: number;
 }
 

--- a/packages/host-service/src/ports/static-ports.ts
+++ b/packages/host-service/src/ports/static-ports.ts
@@ -1,12 +1,15 @@
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { parseStaticPortsConfig } from "@superset/port-scanner";
+import {
+	parseStaticPortsConfig,
+	type StaticPortLabel,
+} from "@superset/port-scanner";
 
 const PROJECT_SUPERSET_DIR_NAME = ".superset";
 const PORTS_FILE_NAME = "ports.json";
 
 interface LabelCacheEntry {
-	labels: Map<number, string> | null;
+	labels: Map<number, StaticPortLabel> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -51,7 +54,9 @@ function readPortsFile(worktreePath: string): string | null {
 	}
 }
 
-function safeLoadLabels(worktreePath: string): Map<number, string> | null {
+function safeLoadLabels(
+	worktreePath: string,
+): Map<number, StaticPortLabel> | null {
 	try {
 		return loadLabels(worktreePath);
 	} catch (error) {
@@ -68,16 +73,16 @@ function safeLoadLabels(worktreePath: string): Map<number, string> | null {
  * Returns null if the file is missing or malformed — this endpoint is a
  * best-effort label hint, not a validator, so parse errors are silent.
  */
-function loadLabels(worktreePath: string): Map<number, string> | null {
+function loadLabels(worktreePath: string): Map<number, StaticPortLabel> | null {
 	const content = readPortsFile(worktreePath);
 	if (content === null) return null;
 
 	const parsed = parseStaticPortsConfig(content);
 	if (parsed.ports === null) return null;
 
-	const labels = new Map<number, string>();
+	const labels = new Map<number, StaticPortLabel>();
 	for (const port of parsed.ports) {
-		labels.set(port.port, port.label);
+		labels.set(port.port, port);
 	}
 	return labels;
 }
@@ -94,8 +99,8 @@ const labelCache = new Map<string, LabelCacheEntry>();
 function setLabelCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, string> | null,
-): Map<number, string> | null {
+	labels: Map<number, StaticPortLabel> | null,
+): Map<number, StaticPortLabel> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
@@ -110,7 +115,7 @@ function setLabelCache(
 export function getLabelsForWorkspace(
 	resolveWorktreePath: (workspaceId: string) => string | null,
 	workspaceId: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const cached = labelCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {

--- a/packages/host-service/src/trpc/router/ports/ports.ts
+++ b/packages/host-service/src/trpc/router/ports/ports.ts
@@ -1,4 +1,4 @@
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, StaticPortProtocol } from "@superset/port-scanner";
 import { z } from "zod";
 import { portManager } from "../../../ports/port-manager";
 import { getLabelsForWorkspace } from "../../../ports/static-ports";
@@ -6,6 +6,7 @@ import { protectedProcedure, router } from "../../index";
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	protocol: StaticPortProtocol | null;
 }
 
 export type PortEvent =
@@ -42,7 +43,12 @@ export const portsRouter = router({
 						labels = getLabelsForWorkspace(resolve, port.workspaceId);
 						labelsByWorkspace.set(port.workspaceId, labels);
 					}
-					return { ...port, label: labels?.get(port.port) ?? null };
+					const entry = labels?.get(port.port);
+					return {
+						...port,
+						label: entry?.label ?? null,
+						protocol: entry?.protocol ?? null,
+					};
 				});
 		}),
 

--- a/packages/port-scanner/src/index.ts
+++ b/packages/port-scanner/src/index.ts
@@ -11,6 +11,7 @@ export {
 export {
 	parseStaticPortsConfig,
 	type StaticPortLabel,
+	type StaticPortProtocol,
 	type StaticPortsParseResult,
 } from "./static-ports.ts";
 export type { DetectedPort } from "./types.ts";

--- a/packages/port-scanner/src/static-ports.ts
+++ b/packages/port-scanner/src/static-ports.ts
@@ -1,6 +1,9 @@
+export type StaticPortProtocol = "http" | "https";
+
 export interface StaticPortLabel {
 	port: number;
 	label: string;
+	protocol?: StaticPortProtocol;
 }
 
 export type StaticPortsParseResult =
@@ -11,7 +14,7 @@ function validatePortEntry(
 	entry: unknown,
 	index: number,
 ):
-	| { valid: true; port: number; label: string }
+	| { valid: true; port: number; label: string; protocol?: StaticPortProtocol }
 	| { valid: false; error: string } {
 	if (typeof entry !== "object" || entry === null) {
 		return { valid: false, error: `ports[${index}] must be an object` };
@@ -50,6 +53,17 @@ function validatePortEntry(
 
 	if (label.trim() === "") {
 		return { valid: false, error: `ports[${index}].label cannot be empty` };
+	}
+
+	if ("protocol" in entry) {
+		const { protocol } = entry as { protocol: unknown };
+		if (protocol !== "http" && protocol !== "https") {
+			return {
+				valid: false,
+				error: `ports[${index}].protocol must be "http" or "https"`,
+			};
+		}
+		return { valid: true, port, label: label.trim(), protocol };
 	}
 
 	return { valid: true, port, label: label.trim() };
@@ -96,7 +110,11 @@ export function parseStaticPortsConfig(
 			};
 		}
 		seenPorts.add(result.port);
-		ports.push({ port: result.port, label: result.label });
+		ports.push({
+			port: result.port,
+			label: result.label,
+			...(result.protocol ? { protocol: result.protocol } : {}),
+		});
 	}
 
 	return { ports, error: null };

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -52,6 +52,7 @@ export interface PortChangedPayload {
 	eventType: PortChangedMessage["eventType"];
 	port: PortChangedMessage["port"];
 	label: PortChangedMessage["label"];
+	protocol: PortChangedMessage["protocol"];
 	occurredAt: number;
 }
 
@@ -205,6 +206,7 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 				eventType: message.eventType,
 				port: message.port,
 				label: message.label,
+				protocol: message.protocol,
 				occurredAt: message.occurredAt,
 			});
 		} else if (message.type === "workspace:changed") {


### PR DESCRIPTION
## What

Adds an optional `protocol` field (`"http"` | `"https"`) to each entry in a
workspace's `.superset/ports.json`. When set to `"https"`, the sidebar's
port-open action opens `https://localhost:PORT` instead of `http://`.

```json
{
  "ports": [
    { "port": 3000, "label": "Frontend Dev Server", "protocol": "https" },
    { "port": 8080, "label": "API Server" }
  ]
}
```

## Why

Port open actions were hardcoded to `http://localhost:PORT`
(`usePortOpenActions.ts`, `MergedPortBadge.tsx`). Dev servers running behind a
local TLS cert (e.g. `mkcert`) 301/refuse on `http://`, so opening them from
the sidebar lands on a broken page and you have to retype the URL with
`https://`. There was no config or preference to control the scheme.

This rides the same rails the existing `label` field already uses, so it's
purely additive and backward compatible — omit `protocol` and behavior is
unchanged (defaults to `http`).

## How

`protocol` is resolved from `ports.json` alongside `label` and travels the two
existing paths that carry `label` to the renderer:

- **Query path:** `parseStaticPortsConfig` → static-port label caches (desktop
  + host-service) → `ports.getAll` enrichment → `EnrichedPort` /
  `DashboardSidebarPort`.
- **Event path:** host-service `port:changed` broadcast → `workspace-client`
  `PortChangedPayload` → `applyPortEventsToHostPortsResult`.

Both the v2 sidebar (`usePortOpenActions`) and the v1 sidebar
(`MergedPortBadge`) then build the URL as
`` `${port.protocol ?? "http"}://localhost:${port.port}` ``.

The label caches' `Map<number, string>` (port → label) becomes
`Map<number, StaticPortLabel>` so the same lookup yields both label and
protocol.

## Validation

`parseStaticPortsConfig` rejects any `protocol` that isn't exactly `"http"` or
`"https"` with `ports[N].protocol must be "http" or "https"`, consistent with
the existing per-field error messages. Malformed files are still ignored
wholesale (unchanged behavior).

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run test` — added cases:
  - `static-ports` loader: loads `https`/`http`, omits when absent, rejects an
    invalid protocol.
  - `applyPortEventsToHostPortsResult`: carries `protocol` from an add event
    onto the port row.

## Notes

- Backward compatible: entries without `protocol` serialize and behave exactly
  as before (`toEqual` on existing loader fixtures is unchanged).
- Docs updated: `apps/docs/content/docs/ports.mdx`.
- Happy to split or convert to an issue-first discussion if you'd prefer — kept
  it to one focused change per the contributing guide.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5995">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional HTTPS support for sidebar port-open actions via a new `protocol` field in `.superset/ports.json`. Defaults to HTTP, so existing configs work unchanged.

- New Features
  - Add `protocol` ("http" | "https") to `.superset/ports.json`; when set to "https", ports open at `https://localhost:PORT`.
  - Thread `protocol` through label cache, host `port:changed` events, TRPC, and renderer; exposed on `EnrichedPort` and `PortChangedPayload`.
  - Update open actions in `usePortOpenActions` and `MergedPortBadge` to use `protocol ?? "http"`.
  - Validate values in `@superset/port-scanner`; tests and docs updated.

<sup>Written for commit 11b929c679a0f02b8ee4f4addb9ab6271c9493ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-port protocol settings for `http` or `https`.
  * Port listings and live updates now retain and display protocol information.
  * Opening a port now uses its configured protocol, defaulting to HTTP.
* **Bug Fixes**
  * Improved handling of missing or invalid protocol values.
* **Documentation**
  * Updated port configuration guidance with protocol examples and HTTPS behavior.
* **Tests**
  * Added coverage for valid, missing, and invalid protocol configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->