### PR TITLE
fix(desktop): make sidebar drag overlays transparent over black

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -251,7 +251,11 @@ export function DashboardSidebar({
 										{createPortal(
 											<DragOverlay dropAnimation={null}>
 												{activeProject && (
-													<div className="bg-background shadow-lg border-b border-border">
+													// Transparent on purpose: the sidebar surface comes from
+													// window vibrancy, so any opaque bg renders as a solid
+													// slab. Sortable siblings make room, so the row floats
+													// over empty sidebar, not over other rows.
+													<div>
 														<DashboardSidebarProjectSection
 															project={activeProject}
 															isSidebarCollapsed={isCollapsed}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -17,9 +17,12 @@ interface SidebarDragOverlayProps {
 export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
 	if (!activeItem) return null;
 
+	// Transparent on purpose (both branches): the sidebar surface comes from
+	// window vibrancy, so an opaque bg renders as a solid slab under the
+	// dragged row.
 	if (activeItem.type === "workspace") {
 		return (
-			<div className="bg-background shadow-lg">
+			<div>
 				<DashboardSidebarWorkspaceItem workspace={activeItem.workspace} />
 			</div>
 		);
@@ -31,7 +34,6 @@ export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
 
 	return (
 		<div
-			className="bg-background shadow-lg"
 			style={{
 				borderLeft: hasColor
 					? `2px solid ${section.color}`


### PR DESCRIPTION
The sidebar's visible surface comes from window vibrancy — its DOM chain is fully transparent — so the drag overlays' opaque `bg-background` (`#151110`) rendered as a solid slab under the dragged row that clearly mismatched the sidebar. Present since the original DnD PR (#3222); surfaced while testing #5996.

Fix: drop the background/shadow from the project, workspace, and section drag overlays. During a drag, dnd-kit's sortable siblings make room, so the floating row hovers over empty sidebar surface and needs no backdrop. Verified live over CDP with before/after screenshots — the dragged row now blends with the sidebar.

Independent of #5996 (applies with or without the revert).

https://claude.ai/code/session_01SSUQYFamkYAjs5sDQC5RLS

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make desktop dashboard sidebar drag overlays transparent so they blend with window vibrancy instead of showing a dark slab during drag. Remove opaque backgrounds and shadows from project, workspace, and section overlays, and drop the project overlay’s bottom border; sortable siblings already make room so no backdrop is needed.

<sup>Written for commit 742872f1d1e2a73910b8c451790afe3b33a092ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop overlays in the dashboard sidebar by removing opaque backgrounds and shadows.
  * Overlays now render transparently and float cleanly above the sidebar, avoiding visual obstruction of other rows and empty areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->