### PR TITLE
fix(desktop): keep projects list expanded when using the add-repo menu

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -95,6 +95,11 @@ export function DashboardSidebarWorkspacesHeader() {
 				<DropdownMenuContent
 					align="end"
 					onCloseAutoFocus={(event) => event.preventDefault()}
+					// The content portals to body but React events still bubble up the
+					// component tree — without these, selecting an item triggers the
+					// header row's collapse toggle.
+					onClick={(event) => event.stopPropagation()}
+					onKeyDown={(event) => event.stopPropagation()}
 				>
 					<DropdownMenuItem onSelect={handleImportFolder}>
 						<VscFolderOpened className="size-4" />


### PR DESCRIPTION
Selecting any item in the PROJECTS header's add-repository dropdown ("Open from folder", "Clone from URL", …) collapsed the projects list. The dropdown content portals to `document.body`, but React synthetic events still bubble up the component tree to the header row's click-to-collapse handler.

Restores the `stopPropagation` guard on the dropdown content that #5956 introduced and its revert (#5996) removed — this piece was an independent fix that got swept out with the sort feature.

https://claude.ai/code/session_01SSUQYFamkYAjs5sDQC5RLS

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6000">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Projects list expanded when selecting items in the add-repository menu. Stops React event bubbling by calling stopPropagation on the dropdown content’s click and keydown so the header’s collapse toggle doesn’t trigger.

<sup>Written for commit 10edd86511a040f73925c74ba03119c05ad77c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

