### PR TITLE
style(desktop): soften automation failed red to destructive token

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
@@ -23,8 +23,8 @@ function describeRunError(error: string): string {
 const STATUS_DOT: Record<SelectAutomationRun["status"], string> = {
 	dispatched: "bg-emerald-500",
 	dispatching: "bg-amber-500",
-	skipped_offline: "bg-red-500",
-	dispatch_failed: "bg-red-500",
+	skipped_offline: "bg-destructive",
+	dispatch_failed: "bg-destructive",
 };
 
 interface PreviousRunsListProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
@@ -48,8 +48,8 @@ const LAST_RUN_META: Record<
 > = {
 	dispatched: { dot: "bg-emerald-500", label: "ran" },
 	dispatching: { dot: "bg-amber-500", label: "running" },
-	skipped_offline: { dot: "bg-red-500", label: "failed", failed: true },
-	dispatch_failed: { dot: "bg-red-500", label: "failed", failed: true },
+	skipped_offline: { dot: "bg-destructive", label: "failed", failed: true },
+	dispatch_failed: { dot: "bg-destructive", label: "failed", failed: true },
 };
 
 export function AutomationRow({
@@ -196,7 +196,7 @@ export function AutomationRow({
 									<span
 										className={cn(
 											"flex items-center gap-1.5",
-											meta.failed && "text-red-600 dark:text-red-400",
+											meta.failed && "text-destructive",
 										)}
 									>
 										<span


### PR DESCRIPTION
Automation failed-state dots and labels used `bg-red-500` / `text-red-600 dark:text-red-400`, which reads harsh against the dark ember theme. This switches them to the semantic `destructive` token (muted brick red in dark mode).

Restores the styling that #5956 introduced and its revert (#5996) removed — the last independent fragment of that PR worth keeping (alongside #6000). The actual sort/filter feature stays out pending the activity-signal rework.

https://claude.ai/code/session_01SSUQYFamkYAjs5sDQC5RLS

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches automation failure indicators to the semantic `destructive` color to soften the red and align with design tokens, improving readability in the dark ember theme. Updates `skipped_offline` and `dispatch_failed` dots and labels in PreviousRunsList and AutomationRow (`bg-red-500` and `text-red-600 dark:text-red-400` → `bg-destructive` / `text-destructive`).

<sup>Written for commit 744152d7c72fe02c9bc3faaddae424f000ee3249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated automation run status indicators to use the standard destructive color styling for skipped offline and dispatch-failed states.
  * Improved failure status text styling for clearer visual consistency across automation lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->