### PR TITLE
feat(desktop): place newly added projects at the top of the sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -121,7 +121,9 @@ function ensureSidebarProjectRecord(
 	collections.v2SidebarProjects.insert({
 		projectId,
 		createdAt: new Date(),
-		tabOrder: getNextTabOrder([
+		// Prepend, matching new workspaces: the project you just added is
+		// the one you're about to work in.
+		tabOrder: getPrependTabOrder([
 			...collections.v2SidebarProjects.state.values(),
 		]),
 		isCollapsed: false,


### PR DESCRIPTION
New workspaces prepend to the top of their project's lane (`getPrependTabOrder`), but newly added projects appended to the bottom of the sidebar's project list (`getNextTabOrder`). One-line swap to the existing prepend helper so a just-added project lands at the top — it's the one you're about to work in, and it matches workspace placement semantics.

Applies to every path that first places a project in the sidebar (add repository, folder import, project setup finalize).

Note: best paired with #5999 — without it, the live query's stale incremental ordering can render a newly prepended project at the bottom until reload, which is exactly the confusion that surfaced this.

https://claude.ai/code/session_01SSUQYFamkYAjs5sDQC5RLS

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6002">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Newly added projects now appear at the top of the sidebar, matching how new workspaces prepend.
We now use `getPrependTabOrder` when inserting a project so the one you just added shows first across add repository, folder import, and project setup finalize.

<sup>Written for commit 6f4651467a310b2913820cd9505ac4ab97bc1f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created projects now appear first in the dashboard sidebar, making them easier to access immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->