### PR TITLE
feat(desktop): re-land sidebar filter/sort with activity-based ordering

### DIFF
--- a/apps/desktop/docs/SIDEBAR_ACTIVITY_SORT.md
+++ b/apps/desktop/docs/SIDEBAR_ACTIVITY_SORT.md
@@ -1,0 +1,175 @@
+# Sidebar "Last updated" sort: activity signal design
+
+Status: shipped with the re-land of the sidebar filter/sort feature
+(`reland-sidebar-sort-filter`, reapplying #5956 after revert #5996).
+Covers what signal drives the "Last updated" sort, why, the current
+polling implementation, and the alternatives considered — including the
+ones that are "more correct" and what it would take to move to them.
+
+## The problem
+
+The dashboard sidebar offers three sort modes for projects and their
+workspaces: manual, date created, and last updated. The first shipped
+version of "Last updated" sorted on `v2_workspaces.updatedAt` and had
+two defects, one crash and one semantic:
+
+1. **Crash**: rows reaching the sidebar through the Electric cloud
+   fallback carry ISO **strings** in `updatedAt`/`createdAt` at runtime
+   (the Electric client's default parser handles int/bool/float but not
+   `timestamptz`, and we pass no custom `parser`), while the Drizzle
+   `SelectV2Workspace` type claims `Date`. `workspace.updatedAt.getTime()`
+   threw and took the whole sidebar down for anyone with remote
+   workspaces. Host-served rows are unaffected (superjson revives real
+   `Date`s over tRPC).
+2. **Semantics**: the host only writes `v2_workspaces.updatedAt` on
+   metadata patches — rename, PR linkage, branch changes. Sending an
+   agent a message never touches it, so the one thing "Last updated"
+   obviously should respond to didn't reorder anything. This is what got
+   the feature reverted.
+
+## What "activity" means now
+
+The host-service already tracks exactly the signal we want. Every agent
+hook event POSTs to `notifications.hook`, which normalizes the event
+(`UserPromptSubmit`/`PostToolUse` → `Start`, `Stop`/turn-complete →
+`Stop`, `PreToolUse`/`Notification` → `PermissionRequest`, session
+start/end → `Attached`/`Detached`, agent-agnostic across
+Claude/Codex/OpenCode/Grok) and records it on the terminal's agent
+binding as `lastEventAt` (epoch ms, persisted in the host's SQLite via
+`terminal-agents/persistence.ts`, so it survives host restarts). The
+same feed drives the sidebar working/idle status dots.
+
+A workspace's effective activity timestamp is:
+
+```
+max(updatedAt, newest lastEventAt across the workspace's agent bindings)
+```
+
+so metadata updates still count, and both directions of a conversation
+count (prompt submit bumps immediately; tool use and turn completion
+keep bumping). Things that intentionally do **not** count: plain
+(non-agent) terminal typing, and merely viewing a workspace.
+
+Sorting applies the effective timestamp at every level, stably
+(name → id tie-breaks), with NaN-safe coercion for the string-date rows:
+
+- workspaces within a project and within sections
+  (`sortDashboardSidebarProjectChildren`),
+- sections rank among loose workspaces by their newest member,
+- the local main workspace stays pinned first,
+- projects rank by their most-active workspace
+  (`getProjectActivityTimestamp`).
+
+## Current implementation: per-host polling
+
+`useDashboardSidebarData` reuses the pull-request query targets (one
+entry per reachable host, local or relay-routed) and runs one
+react-query per host against `terminalAgents.list`:
+
+- `enabled` only while the sort mode is `"updated"` — manual/created
+  users generate zero extra traffic;
+- `refetchInterval: 10_000`;
+- results collapse into `Map<workspaceId, newest lastEventAt>`,
+  JSON-fingerprinted for stable identity, then threaded onto each
+  `DashboardSidebarWorkspace` as `lastAgentActivityAt` by the builders.
+
+Properties:
+
+- **Latency**: 0–10s from agent event to reorder. Measured live: a
+  synthetic `UserPromptSubmit` moved an idle workspace to the top of its
+  project in ~4s.
+- **Cost**: one cheap host round-trip per host per 10s, only while the
+  mode is active and the window focused (react-query pauses intervals in
+  background, refetches on focus).
+- **Failure mode**: an unreachable host contributes nothing; its
+  workspaces fall back to `updatedAt`. Nothing crashes, order degrades
+  gracefully.
+
+Why polling first: it's stateless, self-healing by construction, and
+identical in shape to the adjacent PR-status queries, so it was the
+lowest-risk way to re-land a previously-reverted feature. The latency is
+its only real cost.
+
+## Alternative 1 (recommended next): event-bus push + slow-poll self-heal
+
+The renderer already holds a WebSocket to each host's event bus (it
+powers the status dots), `notifications.hook` broadcasts
+`agent:lifecycle` on that bus *before* it writes the store, and the bus
+client supports wildcard subscriptions — `bus.on("agent:lifecycle", "*",
+cb)` receives events for every workspace on the host over the existing
+connection.
+
+Design:
+
+- one `"*"` listener per reachable host; on event, patch the activity
+  map in place via `queryClient.setQueryData` (the payload carries
+  `workspaceId` + `occurredAt` — no refetch round trip needed);
+- keep the poll as reconciliation at a long interval (~60s) plus the
+  default refetch-on-focus, to catch events missed while a WS was down
+  (host restart, laptop sleep). Pure push with no reconciliation drifts
+  silently — `useTerminalAgentBindings` documents exactly this failure
+  mode and uses the same event+staleTime hybrid one level down.
+
+Result: effectively instant reordering with *less* steady-state traffic
+than the 10s poll. Contained change inside `useDashboardSidebarData`.
+The only reason it isn't in the initial re-land is sequencing: land the
+proven-simple version first.
+
+## Alternative 2 (most correct long-term): persist activity to the cloud
+
+Both approaches above only rank hosts you can currently reach. The
+fully correct model is server-side: the host (already the writer of
+workspace rows) debounce-bumps a `lastActivityAt` column on
+`v2_workspaces` (or a small activity table) on agent events, and
+Electric pushes it to every device reactively — this is arguably what
+`updatedAt` should have meant all along.
+
+Gains: cross-device correctness (see that your desktop at home is busy,
+from your laptop), offline-host ranking from last-known cloud state, no
+renderer fan-out at all.
+
+Costs / open questions, which is why it's deferred:
+
+- write volume: agent events are chatty; needs debouncing (e.g. ≥30s
+  per workspace) and an answer for hosts that are offline mid-burst;
+- schema + API surface: a migration, host write path, and backfill;
+- it must *not* be conflated with `updatedAt`, or every activity bump
+  looks like a metadata edit to other consumers;
+- the Electric string-date issue applies to any new timestamp column:
+  either fix the missing `parser` in our shape options first, or the new
+  column arrives as strings too and every consumer needs coercion.
+
+If/when this lands, the renderer side collapses: the sort reads
+`max(updatedAt, lastActivityAt)` straight off the row and both the poll
+and the push wiring get deleted.
+
+## Alternatives rejected
+
+- **`chat_sessions.lastActiveAt`** (cloud table, Electric-synced, has
+  `v2WorkspaceId`): only chat panes write it. Terminal agent panes — the
+  dominant way people talk to Claude in v2 — never touch it.
+- **Local interaction tracking** (bump a localStorage timestamp when the
+  user opens/messages a workspace): per-device only, misses the
+  "agent finished while I was elsewhere" bump entirely, and adds a
+  second source of truth next to the host's binding store.
+- **Faster polling**: trivially shrinks latency but scales traffic
+  inversely and still isn't instant; strictly dominated by push.
+
+## Known limitations of the shipped version
+
+- 0–10s reorder latency (see Alternative 1).
+- Unreachable hosts fall back to `updatedAt` ranking.
+- Pinned rows keep pin order — the Pinned section ignores sort modes by
+  design.
+- A messaged workspace ranks by newest event, it does not pin to #1: an
+  agent actively working elsewhere (its `PostToolUse` events keep
+  bumping) can legitimately out-rank it moments later.
+- The `SelectV2Workspace` string-vs-`Date` type lie is still only
+  patched at the sidebar entry points (`mergeHostWorkspaces`
+  normalization + NaN-safe `toTime` in the sort). The root fix — an
+  Electric `parser` for timestamp columns in the shared shape options —
+  is intentionally out of scope here because it changes runtime types
+  for every consumer of every Electric collection and needs its own
+  audited PR. Note that persisted IndexedDB snapshots written before
+  that fix will still contain strings, so defensive coercion in sort
+  paths stays necessary regardless.

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import type { SelectV2Workspace } from "@superset/db/schema";
+import {
+	type HostWorkspaceRow,
+	type HostWorkspacesQueryTarget,
+	mergeHostWorkspaces,
+} from "./useHostWorkspaces.utils";
+
+function makeTarget(machineId: string): HostWorkspacesQueryTarget {
+	return {
+		machineId,
+		organizationId: "org-1",
+		hostUrl: `http://host/${machineId}`,
+		isLocal: false,
+	};
+}
+
+function makeHostRow(overrides: Partial<HostWorkspaceRow>): HostWorkspaceRow {
+	return {
+		id: "w-host",
+		organizationId: "org-1",
+		projectId: "p-1",
+		hostId: "host-a",
+		name: "host workspace",
+		branch: "main",
+		type: "worktree",
+		createdByUserId: null,
+		taskId: null,
+		createdAt: new Date("2026-07-01"),
+		updatedAt: new Date("2026-07-02"),
+		worktreePath: "/tmp/w",
+		worktreeExists: true,
+		...overrides,
+	};
+}
+
+// Electric rows carry ISO strings at runtime (the shape parser doesn't
+// handle timestamptz), despite the SelectV2Workspace type saying Date.
+function makeCloudRow(
+	overrides: Partial<Record<keyof SelectV2Workspace, unknown>>,
+): SelectV2Workspace {
+	return {
+		id: "w-cloud",
+		organizationId: "org-1",
+		projectId: "p-1",
+		hostId: "host-b",
+		name: "cloud workspace",
+		branch: "main",
+		type: "worktree",
+		createdByUserId: null,
+		taskId: null,
+		createdAt: "2026-06-01T00:00:00.000Z",
+		updatedAt: "2026-06-02T00:00:00.000Z",
+		...overrides,
+	} as SelectV2Workspace;
+}
+
+describe("mergeHostWorkspaces", () => {
+	it("converts cloud-fallback rows' string timestamps into real Dates", () => {
+		const merged = mergeHostWorkspaces({
+			hostResults: [],
+			cloudRows: [makeCloudRow({})],
+		});
+
+		expect(merged).toHaveLength(1);
+		const row = merged[0];
+		expect(row?.source).toBe("cloud");
+		expect(row?.createdAt).toBeInstanceOf(Date);
+		expect(row?.updatedAt).toBeInstanceOf(Date);
+		expect(row?.createdAt.getTime()).toBe(
+			new Date("2026-06-01T00:00:00.000Z").getTime(),
+		);
+		expect(row?.updatedAt.getTime()).toBe(
+			new Date("2026-06-02T00:00:00.000Z").getTime(),
+		);
+	});
+
+	it("keeps host-served rows authoritative over cloud rows for the same host", () => {
+		const target = makeTarget("host-a");
+		const merged = mergeHostWorkspaces({
+			hostResults: [
+				{
+					target,
+					rows: [makeHostRow({ id: "w-1", hostId: "host-a" })],
+					reachable: true,
+				},
+			],
+			cloudRows: [
+				makeCloudRow({ id: "w-stale", hostId: "host-a" }),
+				makeCloudRow({ id: "w-other", hostId: "host-b" }),
+			],
+		});
+
+		expect(merged.map((row) => row.id).sort()).toEqual(["w-1", "w-other"]);
+		const other = merged.find((row) => row.id === "w-other");
+		expect(other?.updatedAt).toBeInstanceOf(Date);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -226,6 +226,10 @@ export function mergeHostWorkspaces({
 		seenIds.add(row.id);
 		items.push({
 			...row,
+			// Electric rows carry ISO strings at runtime (the shape parser
+			// doesn't handle timestamptz), despite the SelectV2Workspace type.
+			createdAt: new Date(row.createdAt),
+			updatedAt: new Date(row.updatedAt),
 			hostReachable: false,
 			source: "cloud",
 		});

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_V2_USER_PREFERENCES,
 	type LinkAction,
 	type LinkTierMap,
+	type SidebarProjectSortMode,
 	V2_USER_PREFERENCES_ID,
 	type V2UserPreferencesRow,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
@@ -24,6 +25,7 @@ export interface V2UserPreferencesApi {
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean | ((prev: boolean) => boolean)) => void;
 	toggleShowPresetsBar: () => void;
+	setSidebarProjectSortMode: (next: SidebarProjectSortMode) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -200,6 +202,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setShowPresetsBar((prev) => !prev);
 	}, [setShowPresetsBar]);
 
+	const setSidebarProjectSortMode = useCallback(
+		(next: SidebarProjectSortMode) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					sidebarProjectSortMode: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.sidebarProjectSortMode = next;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -212,5 +233,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setDeleteLocalBranch,
 		setShowPresetsBar,
 		toggleShowPresetsBar,
+		setSidebarProjectSortMode,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
@@ -23,8 +23,8 @@ function describeRunError(error: string): string {
 const STATUS_DOT: Record<SelectAutomationRun["status"], string> = {
 	dispatched: "bg-emerald-500",
 	dispatching: "bg-amber-500",
-	skipped_offline: "bg-red-500",
-	dispatch_failed: "bg-red-500",
+	skipped_offline: "bg-destructive",
+	dispatch_failed: "bg-destructive",
 };
 
 interface PreviousRunsListProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
@@ -48,8 +48,8 @@ const LAST_RUN_META: Record<
 > = {
 	dispatched: { dot: "bg-emerald-500", label: "ran" },
 	dispatching: { dot: "bg-amber-500", label: "running" },
-	skipped_offline: { dot: "bg-red-500", label: "failed", failed: true },
-	dispatch_failed: { dot: "bg-red-500", label: "failed", failed: true },
+	skipped_offline: { dot: "bg-destructive", label: "failed", failed: true },
+	dispatch_failed: { dot: "bg-destructive", label: "failed", failed: true },
 };
 
 export function AutomationRow({
@@ -196,7 +196,7 @@ export function AutomationRow({
 									<span
 										className={cn(
 											"flex items-center gap-1.5",
-											meta.failed && "text-red-600 dark:text-red-400",
+											meta.failed && "text-destructive",
 										)}
 									>
 										<span

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -27,6 +27,7 @@ import { createPortal } from "react-dom";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
 import { HiringBanner } from "renderer/components/HiringBanner";
 import { UpdatesPill } from "renderer/components/UpdatesPill";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -46,6 +47,8 @@ import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcu
 import { DashboardSidebarHoverProvider } from "./providers/DashboardSidebarHoverProvider";
 import { DashboardSidebarPortsProvider } from "./providers/DashboardSidebarPortsProvider";
 import type { DashboardSidebarProject } from "./types";
+import { filterDashboardSidebarProjects } from "./utils/filterDashboardSidebarProjects";
+import { sortDashboardSidebarProjects } from "./utils/sortDashboardSidebarProjects";
 
 interface DashboardSidebarProps {
 	isCollapsed?: boolean;
@@ -55,6 +58,11 @@ interface SortableProjectWrapperProps {
 	project: DashboardSidebarProject;
 	isCollapsed: boolean;
 	isDraggingProject: boolean;
+	isDragDisabled: boolean;
+	// Inner (workspace/section) drag is gated separately: a non-manual sort
+	// only reorders projects, but an active filter prunes children, and a
+	// drop committed from a pruned list would corrupt hidden siblings' order.
+	isInnerDragDisabled: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -64,6 +72,8 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 	project,
 	isCollapsed,
 	isDraggingProject,
+	isDragDisabled,
+	isInnerDragDisabled,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
@@ -75,7 +85,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: project.id });
+	} = useSortable({ id: project.id, disabled: isDragDisabled });
 
 	return (
 		<div
@@ -90,6 +100,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 				project={project}
 				isSidebarCollapsed={isCollapsed}
 				isDraggingProject={isDraggingProject}
+				isDragDisabled={isInnerDragDisabled}
 				workspaceShortcutLabels={workspaceShortcutLabels}
 				onWorkspaceHover={onWorkspaceHover}
 				onToggleCollapse={onToggleCollapse}
@@ -121,6 +132,14 @@ export function DashboardSidebar({
 	const workspacesListCollapsed = useSidebarWorkspacesCollapseStore(
 		(s) => s.isCollapsed,
 	);
+	const { preferences, setSidebarProjectSortMode } = useV2UserPreferences();
+	const sortMode = preferences.sidebarProjectSortMode;
+	const [projectFilterQuery, setProjectFilterQuery] = useState("");
+	// The icon-only sidebar hides the header (and its filter input); a filter
+	// left active there would invisibly hide projects.
+	useEffect(() => {
+		if (isCollapsed) setProjectFilterQuery("");
+	}, [isCollapsed]);
 
 	const sensors = useSensors(
 		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
@@ -150,7 +169,25 @@ export function DashboardSidebar({
 			.filter((g): g is DashboardSidebarProject => g != null);
 	}, [groups, projectOrder]);
 
-	const workspaceShortcutLabels = useDashboardSidebarShortcuts(orderedGroups);
+	const sortedGroups = useMemo(
+		() =>
+			sortMode === "manual"
+				? orderedGroups
+				: sortDashboardSidebarProjects(groups, sortMode),
+		[sortMode, orderedGroups, groups],
+	);
+
+	const displayedGroups = useMemo(
+		() => filterDashboardSidebarProjects(sortedGroups, projectFilterQuery),
+		[sortedGroups, projectFilterQuery],
+	);
+
+	const isFilterActive = projectFilterQuery.trim() !== "";
+	const isDragDisabled = sortMode !== "manual" || isFilterActive;
+
+	// Sorted but unfiltered, so shortcut labels stay stable while typing a
+	// filter query.
+	const workspaceShortcutLabels = useDashboardSidebarShortcuts(sortedGroups);
 
 	const activeV2Project = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;
@@ -182,6 +219,10 @@ export function DashboardSidebar({
 
 	const handleDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
+			if (isDragDisabled) {
+				setActiveProject(null);
+				return;
+			}
 			if (over && active.id !== over.id) {
 				const oldIndex = projectOrder.indexOf(String(active.id));
 				const newIndex = projectOrder.indexOf(String(over.id));
@@ -193,7 +234,7 @@ export function DashboardSidebar({
 			}
 			setActiveProject(null);
 		},
-		[projectOrder, reorderProjects],
+		[isDragDisabled, projectOrder, reorderProjects],
 	);
 
 	return (
@@ -204,7 +245,14 @@ export function DashboardSidebar({
 						<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
 							<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
-							{!isCollapsed && <DashboardSidebarWorkspacesHeader />}
+							{!isCollapsed && (
+								<DashboardSidebarWorkspacesHeader
+									sortMode={sortMode}
+									onSortModeChange={setSidebarProjectSortMode}
+									filterQuery={projectFilterQuery}
+									onFilterQueryChange={setProjectFilterQuery}
+								/>
+							)}
 
 							<OverflowFadeContainer
 								fadeEdges={["top", "bottom"]}
@@ -225,6 +273,7 @@ export function DashboardSidebar({
 											droppable: { strategy: MeasuringStrategy.Always },
 										}}
 										onDragStart={({ active }) => {
+											if (isDragDisabled) return;
 											const project = groups.find((p) => p.id === active.id);
 											setActiveProject(project ?? null);
 										}}
@@ -232,21 +281,29 @@ export function DashboardSidebar({
 										onDragCancel={() => setActiveProject(null)}
 									>
 										<SortableContext
-											items={projectOrder}
+											items={displayedGroups.map((project) => project.id)}
 											strategy={verticalListSortingStrategy}
 										>
-											{orderedGroups.map((project) => (
+											{displayedGroups.map((project) => (
 												<SortableProjectWrapper
 													key={project.id}
 													project={project}
 													isCollapsed={isCollapsed}
 													isDraggingProject={activeProject != null}
+													isDragDisabled={isDragDisabled}
+													isInnerDragDisabled={isFilterActive}
 													workspaceShortcutLabels={workspaceShortcutLabels}
 													onWorkspaceHover={refreshWorkspacePullRequest}
 													onToggleCollapse={toggleProjectCollapsed}
 												/>
 											))}
 										</SortableContext>
+
+										{isFilterActive && displayedGroups.length === 0 && (
+											<div className="select-text cursor-text px-4 py-2 text-xs text-muted-foreground">
+												No projects match "{projectFilterQuery.trim()}"
+											</div>
+										)}
 
 										{createPortal(
 											<DragOverlay dropAnimation={null}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -16,6 +16,7 @@ interface DashboardSidebarProjectSectionProps {
 	project: DashboardSidebarProject;
 	isSidebarCollapsed?: boolean;
 	isDraggingProject?: boolean;
+	isDragDisabled?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -27,6 +28,7 @@ export function DashboardSidebarProjectSection({
 	project,
 	isSidebarCollapsed = false,
 	isDraggingProject = false,
+	isDragDisabled = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
@@ -124,6 +126,7 @@ export function DashboardSidebarProjectSection({
 							projectId={project.id}
 							isCollapsed={project.isCollapsed}
 							projectChildren={project.children}
+							isDragDisabled={isDragDisabled}
 							workspaceShortcutLabels={workspaceShortcutLabels}
 							onWorkspaceHover={onWorkspaceHover}
 							onDeleteSection={deleteSection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -16,6 +16,7 @@ interface DashboardSidebarExpandedProjectContentProps {
 	projectId: string;
 	isCollapsed: boolean;
 	projectChildren: DashboardSidebarProjectChild[];
+	isDragDisabled?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onDeleteSection: (sectionId: string) => void;
@@ -27,6 +28,7 @@ export function DashboardSidebarExpandedProjectContent({
 	projectId,
 	isCollapsed,
 	projectChildren,
+	isDragDisabled = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onDeleteSection,
@@ -48,7 +50,7 @@ export function DashboardSidebarExpandedProjectContent({
 		workspacesById,
 		sectionsById,
 		handlers,
-	} = useSidebarDnd({ projectId, projectChildren });
+	} = useSidebarDnd({ projectId, projectChildren, disabled: isDragDisabled });
 
 	return (
 		<AnimatePresence initial={false}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -8,6 +8,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { HiChevronRight } from "react-icons/hi2";
 import {
 	VscFolderOpened,
@@ -16,16 +17,38 @@ import {
 	VscNewFolder,
 } from "react-icons/vsc";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import {
 	useOpenEmptyProjectModal,
 	useOpenNewProjectModal,
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
 import { useSidebarWorkspacesCollapseStore } from "renderer/stores/sidebar-workspaces-collapse";
+import { DashboardSidebarProjectsFilterInput } from "./components/DashboardSidebarProjectsFilterInput";
+import { DashboardSidebarProjectsSortMenu } from "./components/DashboardSidebarProjectsSortMenu";
 
-export function DashboardSidebarWorkspacesHeader() {
+interface DashboardSidebarWorkspacesHeaderProps {
+	sortMode: SidebarProjectSortMode;
+	onSortModeChange: (mode: SidebarProjectSortMode) => void;
+	filterQuery: string;
+	onFilterQueryChange: (query: string) => void;
+}
+
+export function DashboardSidebarWorkspacesHeader({
+	sortMode,
+	onSortModeChange,
+	filterQuery,
+	onFilterQueryChange,
+}: DashboardSidebarWorkspacesHeaderProps) {
 	const isCollapsed = useSidebarWorkspacesCollapseStore((s) => s.isCollapsed);
 	const toggleCollapsed = useSidebarWorkspacesCollapseStore((s) => s.toggle);
+	const [isFilterExpanded, setIsFilterExpanded] = useState(false);
+
+	const handleFilterExpandedChange = (expanded: boolean) => {
+		setIsFilterExpanded(expanded);
+		// Filtering a hidden list is useless — reveal it when the search opens.
+		if (expanded && isCollapsed) toggleCollapsed();
+	};
 	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
@@ -66,14 +89,28 @@ export function DashboardSidebarWorkspacesHeader() {
 			}}
 			className="group flex min-h-8 w-full shrink-0 items-center gap-1.5 py-1.5 pl-4 pr-2 text-[10px] font-semibold uppercase tracking-[0.075em] text-muted-foreground transition-colors"
 		>
-			<span className="min-w-0 truncate text-left">Projects</span>
-			<HiChevronRight
-				className={cn(
-					"size-3 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
-					!isCollapsed && "rotate-90",
-				)}
+			{!isFilterExpanded && (
+				<>
+					<span className="min-w-0 truncate text-left">Projects</span>
+					<HiChevronRight
+						className={cn(
+							"size-3 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
+							!isCollapsed && "rotate-90",
+						)}
+					/>
+					<div className="min-w-0 flex-1" />
+				</>
+			)}
+			<DashboardSidebarProjectsFilterInput
+				query={filterQuery}
+				onQueryChange={onFilterQueryChange}
+				isExpanded={isFilterExpanded}
+				onExpandedChange={handleFilterExpandedChange}
 			/>
-			<div className="min-w-0 flex-1" />
+			<DashboardSidebarProjectsSortMenu
+				sortMode={sortMode}
+				onSortModeChange={onSortModeChange}
+			/>
 			<DropdownMenu>
 				<Tooltip delayDuration={700}>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
@@ -1,0 +1,95 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useEffect, useRef } from "react";
+import { HiMagnifyingGlass, HiXMark } from "react-icons/hi2";
+
+interface DashboardSidebarProjectsFilterInputProps {
+	query: string;
+	onQueryChange: (query: string) => void;
+	isExpanded: boolean;
+	onExpandedChange: (expanded: boolean) => void;
+}
+
+export function DashboardSidebarProjectsFilterInput({
+	query,
+	onQueryChange,
+	isExpanded,
+	onExpandedChange,
+}: DashboardSidebarProjectsFilterInputProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (isExpanded) inputRef.current?.focus();
+	}, [isExpanded]);
+
+	if (!isExpanded) {
+		return (
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Filter projects"
+						onClick={(event) => {
+							event.stopPropagation();
+							onExpandedChange(true);
+						}}
+						onKeyDown={(event) => event.stopPropagation()}
+						className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
+					>
+						<HiMagnifyingGlass className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Filter projects</TooltipContent>
+			</Tooltip>
+		);
+	}
+
+	const collapse = () => {
+		onQueryChange("");
+		onExpandedChange(false);
+	};
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: stops the header row's collapse toggle from firing on input interaction
+		<div
+			className="flex min-w-0 flex-1 items-center gap-1 rounded-md bg-fill-hover px-1.5"
+			onClick={(event) => event.stopPropagation()}
+			onKeyDown={(event) => {
+				event.stopPropagation();
+				if (event.key === "Escape") collapse();
+			}}
+		>
+			<HiMagnifyingGlass className="size-3 shrink-0 text-muted-foreground" />
+			<input
+				ref={inputRef}
+				value={query}
+				onChange={(event) => onQueryChange(event.target.value)}
+				onBlur={() => {
+					if (query.trim() === "") collapse();
+				}}
+				placeholder="Filter projects…"
+				aria-label="Filter projects"
+				className="h-6 w-full min-w-0 bg-transparent text-xs font-normal normal-case tracking-normal text-foreground placeholder:text-muted-foreground focus:outline-none"
+			/>
+			{query !== "" && (
+				<button
+					type="button"
+					aria-label="Clear filter"
+					// preventDefault on mousedown so the input never blurs; the
+					// clearing lives in onClick so keyboard activation works too
+					onMouseDown={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+					}}
+					onClick={(event) => {
+						event.stopPropagation();
+						onQueryChange("");
+						inputRef.current?.focus();
+					}}
+					className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+				>
+					<HiXMark className="size-3" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarProjectsFilterInput } from "./DashboardSidebarProjectsFilterInput";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -1,0 +1,79 @@
+import {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { VscListFilter } from "react-icons/vsc";
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+
+const SORT_MODE_LABELS: Record<SidebarProjectSortMode, string> = {
+	manual: "Manual order",
+	created: "Date created",
+	updated: "Last updated",
+};
+
+const SORT_MODES: SidebarProjectSortMode[] = ["manual", "updated", "created"];
+
+interface DashboardSidebarProjectsSortMenuProps {
+	sortMode: SidebarProjectSortMode;
+	onSortModeChange: (mode: SidebarProjectSortMode) => void;
+}
+
+export function DashboardSidebarProjectsSortMenu({
+	sortMode,
+	onSortModeChange,
+}: DashboardSidebarProjectsSortMenuProps) {
+	return (
+		<DropdownMenu>
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							aria-label="Sort projects"
+							onClick={(event) => event.stopPropagation()}
+							onKeyDown={(event) => event.stopPropagation()}
+							className={cn(
+								"flex size-6 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-fill-hover hover:text-foreground",
+								sortMode === "manual"
+									? "text-muted-foreground"
+									: "text-foreground",
+							)}
+						>
+							<VscListFilter className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					Sort projects ({SORT_MODE_LABELS[sortMode]})
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenuContent
+				align="end"
+				onCloseAutoFocus={(event) => event.preventDefault()}
+				// The content portals to body but React events still bubble up the
+				// component tree — without these, selecting an item triggers the
+				// header row's collapse toggle.
+				onClick={(event) => event.stopPropagation()}
+				onKeyDown={(event) => event.stopPropagation()}
+			>
+				<DropdownMenuLabel className="text-xs font-normal text-muted-foreground/70">
+					Sort by
+				</DropdownMenuLabel>
+				{SORT_MODES.map((mode) => (
+					<DropdownMenuCheckboxItem
+						key={mode}
+						checked={sortMode === mode}
+						onCheckedChange={() => onSortModeChange(mode)}
+					>
+						{SORT_MODE_LABELS[mode]}
+					</DropdownMenuCheckboxItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarProjectsSortMenu } from "./DashboardSidebarProjectsSortMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -75,6 +75,7 @@ function build(params: {
 		visibleSidebarWorkspaces: params.visibleSidebarWorkspaces ?? [],
 		machineId: MACHINE_ID,
 		pullRequestsByWorkspaceId: new Map(),
+		agentActivityByWorkspaceId: new Map(),
 	});
 }
 
@@ -206,6 +207,7 @@ describe("buildDashboardSidebarPinnedWorkspaces", () => {
 			],
 			machineId: MACHINE_ID,
 			pullRequestsByWorkspaceId: new Map(),
+			agentActivityByWorkspaceId: new Map(),
 		});
 
 		expect(rows.map((row) => row.id)).toEqual(["pinned-1"]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -73,6 +73,7 @@ function decorateSidebarWorkspace(
 	project: Pick<SidebarProjectInput, "githubOwner" | "githubRepoName">,
 	machineId: string,
 	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>,
+	agentActivityByWorkspaceId: Map<string, number>,
 ): DashboardSidebarWorkspace {
 	const hostType: DashboardSidebarWorkspace["hostType"] =
 		workspace.hostId === machineId ? "local-device" : "remote-device";
@@ -99,6 +100,7 @@ function decorateSidebarWorkspace(
 		behindCount: null,
 		createdAt: workspace.createdAt,
 		updatedAt: workspace.updatedAt,
+		lastAgentActivityAt: agentActivityByWorkspaceId.get(workspace.id) ?? null,
 		taskId: workspace.taskId,
 		isPinned: workspace.pinnedAt != null,
 		pendingTransaction: workspace.pendingTransaction,
@@ -116,11 +118,13 @@ export function buildDashboardSidebarPinnedWorkspaces({
 	sidebarProjects,
 	machineId,
 	pullRequestsByWorkspaceId,
+	agentActivityByWorkspaceId,
 }: {
 	pinnedSidebarWorkspaces: SidebarWorkspaceInput[];
 	sidebarProjects: SidebarProjectInput[];
 	machineId: string;
 	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>;
+	agentActivityByWorkspaceId: Map<string, number>;
 }): DashboardSidebarPinnedWorkspace[] {
 	const projectsById = new Map(
 		sidebarProjects.map((project) => [project.id, project]),
@@ -135,6 +139,7 @@ export function buildDashboardSidebarPinnedWorkspaces({
 					project,
 					machineId,
 					pullRequestsByWorkspaceId,
+					agentActivityByWorkspaceId,
 				),
 				projectName: project.name,
 				projectIconUrl: project.iconUrl,
@@ -149,6 +154,7 @@ export interface BuildDashboardSidebarProjectsParams {
 	visibleSidebarWorkspaces: SidebarWorkspaceInput[];
 	machineId: string;
 	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>;
+	agentActivityByWorkspaceId: Map<string, number>;
 }
 
 export function buildDashboardSidebarProjects({
@@ -157,6 +163,7 @@ export function buildDashboardSidebarProjects({
 	visibleSidebarWorkspaces,
 	machineId,
 	pullRequestsByWorkspaceId,
+	agentActivityByWorkspaceId,
 }: BuildDashboardSidebarProjectsParams): DashboardSidebarProject[] {
 	const projectsById = new Map<
 		string,
@@ -211,6 +218,7 @@ export function buildDashboardSidebarProjects({
 			project,
 			machineId,
 			pullRequestsByWorkspaceId,
+			agentActivityByWorkspaceId,
 		);
 
 		if (workspace.sectionId) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -3,6 +3,7 @@ import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -444,6 +445,44 @@ export function useDashboardSidebarData() {
 	const pullRequestsByWorkspaceId =
 		useStablePullRequestsByWorkspaceId(pullRequestRows);
 
+	// Terminal-agent activity per workspace, for "Last updated" sorting.
+	// `v2_workspaces.updatedAt` only moves on metadata writes (rename, PR
+	// links), so sending an agent a message wouldn't reorder anything — the
+	// hosts' agent bindings track the real activity. Polled only while the
+	// sort mode needs it.
+	const sortMode = useV2UserPreferences().preferences.sidebarProjectSortMode;
+	const agentActivityQueries = useQueries({
+		queries: pullRequestQueryTargets.map((target) => ({
+			queryKey: ["dashboard-sidebar-agent-activity", target.hostUrl] as const,
+			enabled: sortMode === "updated",
+			refetchInterval: 10_000,
+			queryFn: async () => {
+				const client = getHostServiceClientByUrl(target.hostUrl);
+				return client.terminalAgents.list.query();
+			},
+		})),
+	});
+	const agentActivityEntries = useJsonStable(
+		useMemo(() => {
+			const latestByWorkspaceId = new Map<string, number>();
+			for (const query of agentActivityQueries) {
+				for (const binding of query.data ?? []) {
+					const previous = latestByWorkspaceId.get(binding.workspaceId) ?? 0;
+					if (binding.lastEventAt > previous) {
+						latestByWorkspaceId.set(binding.workspaceId, binding.lastEventAt);
+					}
+				}
+			}
+			return [...latestByWorkspaceId.entries()].sort(([left], [right]) =>
+				left.localeCompare(right),
+			);
+		}, [agentActivityQueries]),
+	);
+	const agentActivityByWorkspaceId = useMemo(
+		() => new Map(agentActivityEntries),
+		[agentActivityEntries],
+	);
+
 	// Pinned rows render only in the top-level Pinned section, so they are
 	// partitioned out before the per-project tree is built. PR polling targets
 	// derive from the pre-partition list above, so pinned rows keep PR status.
@@ -460,8 +499,10 @@ export function useDashboardSidebarData() {
 				visibleSidebarWorkspaces: unpinnedRows,
 				machineId,
 				pullRequestsByWorkspaceId,
+				agentActivityByWorkspaceId,
 			}),
 		[
+			agentActivityByWorkspaceId,
 			machineId,
 			pullRequestsByWorkspaceId,
 			sidebarProjects,
@@ -478,8 +519,15 @@ export function useDashboardSidebarData() {
 				sidebarProjects,
 				machineId,
 				pullRequestsByWorkspaceId,
+				agentActivityByWorkspaceId,
 			}),
-		[machineId, pinnedRows, pullRequestsByWorkspaceId, sidebarProjects],
+		[
+			agentActivityByWorkspaceId,
+			machineId,
+			pinnedRows,
+			pullRequestsByWorkspaceId,
+			sidebarProjects,
+		],
 	);
 	const pinnedWorkspaces = useJsonStable(computedPinnedWorkspaces);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -98,16 +98,21 @@ function parseFlatItems(items: UniqueIdentifier[]): ParsedFlatItems {
 interface UseSidebarDndOptions {
 	projectId: string;
 	projectChildren: DashboardSidebarProjectChild[];
+	// While the sidebar filter is active, projectChildren is a pruned subset —
+	// committing a drop from it would rewrite tabOrder against incomplete data
+	// and corrupt the order of the hidden siblings.
+	disabled?: boolean;
 }
 
 export function useSidebarDnd({
 	projectId,
 	projectChildren,
+	disabled = false,
 }: UseSidebarDndOptions) {
 	const { reorderProjectChildren, moveWorkspaceToSectionAtIndex } =
 		useDashboardSidebarState();
 
-	const sensors = useSensors(
+	const enabledSensors = useSensors(
 		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
 		useSensor(TouchSensor, {
 			activationConstraint: { delay: 200, tolerance: 5 },
@@ -290,10 +295,11 @@ export function useSidebarDnd({
 
 	const onDragStart = useCallback(
 		({ active }: DragStartEvent) => {
+			if (disabled) return;
 			setActiveId(active.id);
 			clonedRef.current = [...flatItems];
 		},
-		[flatItems],
+		[disabled, flatItems],
 	);
 
 	const onDragOver = useCallback(({ over }: DragOverEvent) => {
@@ -372,7 +378,8 @@ export function useSidebarDnd({
 	}, []);
 
 	return {
-		sensors,
+		// No sensors means dnd-kit can never activate a drag.
+		sensors: disabled ? [] : enabledSensors,
 		measuring,
 		collisionDetection: closestCenter,
 		flatItems,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -42,6 +42,13 @@ export interface DashboardSidebarWorkspace {
 	behindCount: number | null;
 	createdAt: Date;
 	updatedAt: Date;
+	/**
+	 * Epoch ms of the newest terminal-agent event on this workspace (from the
+	 * host's agent bindings), or null when no agent has run / the host is
+	 * unreachable. `updatedAt` only tracks metadata writes, so "Last updated"
+	 * sorting uses the max of both.
+	 */
+	lastAgentActivityAt: number | null;
 	taskId: string | null;
 	isPinned: boolean;
 	pendingTransaction: WorkspaceTransactionSnapshot | null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import {
+	makeProject,
+	makeSection,
+	makeWorkspace,
+} from "../testProjectFixtures";
+import { filterDashboardSidebarProjects } from "./filterDashboardSidebarProjects";
+
+const projects = [
+	makeProject({
+		id: "p-superset",
+		name: "Superset",
+		isCollapsed: true,
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({ id: "w1", name: "fix-login" }),
+			},
+			{
+				type: "section",
+				section: makeSection({
+					id: "s1",
+					name: "Backend",
+					isCollapsed: true,
+					workspaces: [
+						makeWorkspace({ id: "w2", name: "api-cleanup" }),
+						makeWorkspace({ id: "w3", name: "db-migration" }),
+					],
+				}),
+			},
+		],
+	}),
+	makeProject({
+		id: "p-marketing",
+		name: "Marketing Site",
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({ id: "w4", name: "hero-redesign" }),
+			},
+		],
+	}),
+];
+
+describe("filterDashboardSidebarProjects", () => {
+	it("returns the same array reference for an empty or whitespace query", () => {
+		expect(filterDashboardSidebarProjects(projects, "")).toBe(projects);
+		expect(filterDashboardSidebarProjects(projects, "   ")).toBe(projects);
+	});
+
+	it("keeps a name-matched project whole but expanded", () => {
+		const result = filterDashboardSidebarProjects(projects, "SUPER");
+		expect(result).toHaveLength(1);
+		expect(result[0]?.id).toBe("p-superset");
+		expect(result[0]?.isCollapsed).toBe(false);
+		expect(result[0]?.children).toHaveLength(2);
+	});
+
+	it("prunes to matching workspaces and expands their project and section", () => {
+		const result = filterDashboardSidebarProjects(projects, "api");
+		expect(result).toHaveLength(1);
+		const project = result[0];
+		expect(project?.isCollapsed).toBe(false);
+		expect(project?.children).toHaveLength(1);
+		const child = project?.children[0];
+		if (child?.type !== "section") throw new Error("expected section");
+		expect(child.section.isCollapsed).toBe(false);
+		expect(child.section.workspaces.map((w) => w.id)).toEqual(["w2"]);
+	});
+
+	it("keeps a whole section when the section name matches", () => {
+		const result = filterDashboardSidebarProjects(projects, "backend");
+		const child = result[0]?.children[0];
+		if (child?.type !== "section") throw new Error("expected section");
+		expect(child.section.workspaces).toHaveLength(2);
+	});
+
+	it("drops projects with no match anywhere", () => {
+		expect(filterDashboardSidebarProjects(projects, "hero")).toHaveLength(1);
+		expect(filterDashboardSidebarProjects(projects, "zzz")).toHaveLength(0);
+	});
+
+	it("keeps object references when nothing changes (memo stability)", () => {
+		// p-marketing is already expanded and all its workspaces match, so the
+		// original object must pass through untouched.
+		const byName = filterDashboardSidebarProjects(projects, "marketing");
+		expect(byName[0]).toBe(projects[1]);
+
+		const byWorkspace = filterDashboardSidebarProjects(projects, "hero");
+		expect(byWorkspace[0]).toBe(projects[1]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
@@ -1,0 +1,80 @@
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarProjectChild,
+} from "../../types";
+
+function matches(text: string, normalizedQuery: string): boolean {
+	return text.toLowerCase().includes(normalizedQuery);
+}
+
+// Reuse the input objects whenever nothing about them changes — the sidebar's
+// memoized rows rely on referential stability, and the filter reruns on every
+// keystroke.
+function expandProject(
+	project: DashboardSidebarProject,
+): DashboardSidebarProject {
+	return project.isCollapsed ? { ...project, isCollapsed: false } : project;
+}
+
+function expandSection(
+	child: Extract<DashboardSidebarProjectChild, { type: "section" }>,
+): DashboardSidebarProjectChild {
+	return child.section.isCollapsed
+		? { type: "section", section: { ...child.section, isCollapsed: false } }
+		: child;
+}
+
+function filterChildren(
+	children: DashboardSidebarProjectChild[],
+	normalizedQuery: string,
+): DashboardSidebarProjectChild[] {
+	return children.flatMap((child): DashboardSidebarProjectChild[] => {
+		if (child.type === "workspace") {
+			return matches(child.workspace.name, normalizedQuery) ? [child] : [];
+		}
+		if (matches(child.section.name, normalizedQuery)) {
+			return [expandSection(child)];
+		}
+		const workspaces = child.section.workspaces.filter((workspace) =>
+			matches(workspace.name, normalizedQuery),
+		);
+		if (workspaces.length === 0) return [];
+		if (workspaces.length === child.section.workspaces.length) {
+			return [expandSection(child)];
+		}
+		return [
+			{
+				type: "section",
+				section: { ...child.section, isCollapsed: false, workspaces },
+			},
+		];
+	});
+}
+
+/**
+ * Case-insensitive substring filter over projects. A project survives when its
+ * name matches (kept whole) or when any of its workspaces/sections match
+ * (pruned to the matches). Surviving projects and matched sections come back
+ * expanded so the matches are actually visible; the persisted collapse state
+ * is never written.
+ */
+export function filterDashboardSidebarProjects(
+	projects: DashboardSidebarProject[],
+	query: string,
+): DashboardSidebarProject[] {
+	const normalizedQuery = query.trim().toLowerCase();
+	if (normalizedQuery === "") return projects;
+
+	return projects.flatMap((project): DashboardSidebarProject[] => {
+		if (matches(project.name, normalizedQuery)) {
+			return [expandProject(project)];
+		}
+		const children = filterChildren(project.children, normalizedQuery);
+		if (children.length === 0) return [];
+		const childrenUnchanged =
+			children.length === project.children.length &&
+			children.every((child, index) => child === project.children[index]);
+		if (childrenUnchanged) return [expandProject(project)];
+		return [{ ...project, isCollapsed: false, children }];
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/index.ts
@@ -1,0 +1,1 @@
+export { filterDashboardSidebarProjects } from "./filterDashboardSidebarProjects";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
@@ -1,0 +1,4 @@
+export {
+	getProjectActivityTimestamp,
+	sortDashboardSidebarProjects,
+} from "./sortDashboardSidebarProjects";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import {
+	makeProject,
+	makeSection,
+	makeWorkspace,
+} from "../testProjectFixtures";
+import {
+	getProjectActivityTimestamp,
+	sortDashboardSidebarProjects,
+} from "./sortDashboardSidebarProjects";
+
+describe("getProjectActivityTimestamp", () => {
+	it("uses the most recently updated workspace, including inside sections", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			updatedAt: new Date("2026-06-01"),
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w1",
+						name: "one",
+						updatedAt: new Date("2026-02-01"),
+					}),
+				},
+				{
+					type: "section",
+					section: makeSection({
+						id: "s1",
+						name: "Section",
+						workspaces: [
+							makeWorkspace({
+								id: "w2",
+								name: "two",
+								updatedAt: new Date("2026-03-01"),
+							}),
+						],
+					}),
+				},
+			],
+		});
+		expect(getProjectActivityTimestamp(project)).toBe(
+			new Date("2026-03-01").getTime(),
+		);
+	});
+
+	it("falls back to the project's own updatedAt when there are no workspaces", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			updatedAt: new Date("2026-05-01"),
+		});
+		expect(getProjectActivityTimestamp(project)).toBe(
+			new Date("2026-05-01").getTime(),
+		);
+	});
+});
+
+describe("sortDashboardSidebarProjects", () => {
+	const older = makeProject({
+		id: "p-older",
+		name: "Older",
+		createdAt: new Date("2026-01-01"),
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({
+					id: "w1",
+					name: "busy",
+					updatedAt: new Date("2026-07-01"),
+				}),
+			},
+		],
+	});
+	const newer = makeProject({
+		id: "p-newer",
+		name: "Newer",
+		createdAt: new Date("2026-04-01"),
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({
+					id: "w2",
+					name: "idle",
+					updatedAt: new Date("2026-05-01"),
+				}),
+			},
+		],
+	});
+
+	it("returns the input untouched in manual mode", () => {
+		const projects = [older, newer];
+		expect(sortDashboardSidebarProjects(projects, "manual")).toBe(projects);
+	});
+
+	it("sorts newest created first in created mode", () => {
+		expect(
+			sortDashboardSidebarProjects([older, newer], "created").map((p) => p.id),
+		).toEqual(["p-newer", "p-older"]);
+	});
+
+	it("sorts by workspace activity in updated mode", () => {
+		expect(
+			sortDashboardSidebarProjects([newer, older], "updated").map((p) => p.id),
+		).toEqual(["p-older", "p-newer"]);
+	});
+
+	it("breaks timestamp ties by name", () => {
+		const a = makeProject({ id: "p-a", name: "Apple" });
+		const b = makeProject({ id: "p-b", name: "Banana" });
+		expect(
+			sortDashboardSidebarProjects([b, a], "created").map((p) => p.id),
+		).toEqual(["p-a", "p-b"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { DashboardSidebarProjectChild } from "../../types";
 import {
 	makeProject,
 	makeSection,
@@ -6,6 +7,7 @@ import {
 } from "../testProjectFixtures";
 import {
 	getProjectActivityTimestamp,
+	sortDashboardSidebarProjectChildren,
 	sortDashboardSidebarProjects,
 } from "./sortDashboardSidebarProjects";
 
@@ -152,6 +154,37 @@ describe("sortDashboardSidebarProjects", () => {
 		).toEqual(["p-string", "p-date"]);
 	});
 
+	it("sorts workspaces inside each project by updatedAt in updated mode", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-old",
+						name: "old",
+						updatedAt: new Date("2026-02-01"),
+					}),
+				},
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-new",
+						name: "new",
+						updatedAt: new Date("2026-06-01"),
+					}),
+				},
+			],
+		});
+		const [sorted] = sortDashboardSidebarProjects([project], "updated");
+		expect(
+			sorted?.children.map((c) =>
+				c.type === "workspace" ? c.workspace.id : c.section.id,
+			),
+		).toEqual(["w-new", "w-old"]);
+	});
+
 	it("falls back to name order instead of throwing on garbage timestamps", () => {
 		const garbage = makeProject({
 			id: "p-garbage",
@@ -168,5 +201,114 @@ describe("sortDashboardSidebarProjects", () => {
 				(p) => p.id,
 			),
 		).toEqual(["p-garbage", "p-garbage-2"]);
+	});
+});
+
+describe("sortDashboardSidebarProjectChildren", () => {
+	const mainChild: DashboardSidebarProjectChild = {
+		type: "workspace",
+		workspace: makeWorkspace({
+			id: "w-main",
+			name: "local",
+			type: "main",
+			updatedAt: new Date("2026-01-01"),
+		}),
+	};
+	const oldWorktree: DashboardSidebarProjectChild = {
+		type: "workspace",
+		workspace: makeWorkspace({
+			id: "w-old",
+			name: "old",
+			updatedAt: new Date("2026-02-01"),
+			createdAt: new Date("2026-06-01"),
+		}),
+	};
+	const newWorktree: DashboardSidebarProjectChild = {
+		type: "workspace",
+		workspace: makeWorkspace({
+			id: "w-new",
+			name: "new",
+			updatedAt: new Date("2026-06-01"),
+			createdAt: new Date("2026-02-01"),
+		}),
+	};
+	const section: DashboardSidebarProjectChild = {
+		type: "section",
+		section: makeSection({
+			id: "s1",
+			name: "Section",
+			createdAt: new Date("2026-01-15"),
+			workspaces: [
+				makeWorkspace({
+					id: "w-s-old",
+					name: "section-old",
+					updatedAt: new Date("2026-03-01"),
+				}),
+				makeWorkspace({
+					id: "w-s-new",
+					name: "section-new",
+					updatedAt: new Date("2026-04-01"),
+				}),
+			],
+		}),
+	};
+
+	const childIds = (children: DashboardSidebarProjectChild[]) =>
+		children.map((c) =>
+			c.type === "workspace" ? c.workspace.id : c.section.id,
+		);
+
+	it("returns children untouched in manual mode", () => {
+		const children = [oldWorktree, newWorktree];
+		expect(sortDashboardSidebarProjectChildren(children, "manual")).toBe(
+			children,
+		);
+	});
+
+	it("keeps the local main pinned first despite older activity", () => {
+		const sorted = sortDashboardSidebarProjectChildren(
+			[oldWorktree, newWorktree, mainChild],
+			"updated",
+		);
+		expect(childIds(sorted)).toEqual(["w-main", "w-new", "w-old"]);
+	});
+
+	it("sorts workspaces inside sections and ranks sections by activity", () => {
+		// Section activity (2026-04-01) beats w-old (02-01), loses to w-new (06-01).
+		const sorted = sortDashboardSidebarProjectChildren(
+			[section, oldWorktree, newWorktree],
+			"updated",
+		);
+		expect(childIds(sorted)).toEqual(["w-new", "s1", "w-old"]);
+		const sortedSection = sorted.find((c) => c.type === "section");
+		expect(
+			sortedSection?.type === "section"
+				? sortedSection.section.workspaces.map((w) => w.id)
+				: [],
+		).toEqual(["w-s-new", "w-s-old"]);
+	});
+
+	it("uses createdAt for workspaces and the section's own createdAt in created mode", () => {
+		// By createdAt: w-old (06-01) > w-new (02-01) > section (01-15).
+		const sorted = sortDashboardSidebarProjectChildren(
+			[section, oldWorktree, newWorktree],
+			"created",
+		);
+		expect(childIds(sorted)).toEqual(["w-old", "w-new", "s1"]);
+	});
+
+	it("does not mutate the input children or sections", () => {
+		const children = [section, oldWorktree, newWorktree];
+		const sectionWorkspaceIds =
+			section.type === "section"
+				? section.section.workspaces.map((w) => w.id)
+				: [];
+		sortDashboardSidebarProjectChildren(children, "updated");
+		expect(childIds(children)).toEqual(["s1", "w-old", "w-new"]);
+		expect(
+			section.type === "section"
+				? section.section.workspaces.map((w) => w.id)
+				: [],
+		).toEqual(sectionWorkspaceIds);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -312,3 +312,145 @@ describe("sortDashboardSidebarProjectChildren", () => {
 		).toEqual(sectionWorkspaceIds);
 	});
 });
+
+// updatedAt only moves on metadata writes; agent activity (host terminal-agent
+// bindings) is what "Last updated" is actually about, so the newer of the two
+// must win at every level.
+describe("agent activity in updated mode", () => {
+	it("ranks a workspace with newer agent activity above a newer updatedAt", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-metadata",
+						name: "renamed-recently",
+						updatedAt: new Date("2026-06-01"),
+					}),
+				},
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-agent",
+						name: "prompted-just-now",
+						updatedAt: new Date("2026-02-01"),
+						lastAgentActivityAt: new Date("2026-07-01").getTime(),
+					}),
+				},
+			],
+		});
+		const [sorted] = sortDashboardSidebarProjects([project], "updated");
+		expect(
+			sorted?.children.map((c) =>
+				c.type === "workspace" ? c.workspace.id : c.section.id,
+			),
+		).toEqual(["w-agent", "w-metadata"]);
+	});
+
+	it("bubbles agent activity up to project ordering", () => {
+		const staleMetadata = makeProject({
+			id: "p-agent",
+			name: "AgentBusy",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w1",
+						name: "one",
+						updatedAt: new Date("2026-01-01"),
+						lastAgentActivityAt: new Date("2026-07-01").getTime(),
+					}),
+				},
+			],
+		});
+		const freshMetadata = makeProject({
+			id: "p-idle",
+			name: "Idle",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w2",
+						name: "two",
+						updatedAt: new Date("2026-05-01"),
+					}),
+				},
+			],
+		});
+		expect(
+			sortDashboardSidebarProjects(
+				[freshMetadata, staleMetadata],
+				"updated",
+			).map((p) => p.id),
+		).toEqual(["p-agent", "p-idle"]);
+	});
+
+	it("bubbles agent activity inside a section up to the section's rank", () => {
+		const section: DashboardSidebarProjectChild = {
+			type: "section",
+			section: makeSection({
+				id: "s1",
+				name: "Section",
+				workspaces: [
+					makeWorkspace({
+						id: "w-s",
+						name: "sectioned",
+						updatedAt: new Date("2026-01-01"),
+						lastAgentActivityAt: new Date("2026-07-01").getTime(),
+					}),
+				],
+			}),
+		};
+		const loose: DashboardSidebarProjectChild = {
+			type: "workspace",
+			workspace: makeWorkspace({
+				id: "w-loose",
+				name: "loose",
+				updatedAt: new Date("2026-05-01"),
+			}),
+		};
+		const sorted = sortDashboardSidebarProjectChildren(
+			[loose, section],
+			"updated",
+		);
+		expect(
+			sorted.map((c) =>
+				c.type === "workspace" ? c.workspace.id : c.section.id,
+			),
+		).toEqual(["s1", "w-loose"]);
+	});
+
+	it("ignores agent activity in created mode", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-created-late",
+						name: "late",
+						createdAt: new Date("2026-06-01"),
+					}),
+				},
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-created-early",
+						name: "early",
+						createdAt: new Date("2026-02-01"),
+						lastAgentActivityAt: new Date("2026-07-01").getTime(),
+					}),
+				},
+			],
+		});
+		const [sorted] = sortDashboardSidebarProjects([project], "created");
+		expect(
+			sorted?.children.map((c) =>
+				c.type === "workspace" ? c.workspace.id : c.section.id,
+			),
+		).toEqual(["w-created-late", "w-created-early"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -113,4 +113,60 @@ describe("sortDashboardSidebarProjects", () => {
 			sortDashboardSidebarProjects([b, a], "created").map((p) => p.id),
 		).toEqual(["p-a", "p-b"]);
 	});
+
+	// Electric collection rows carry ISO strings at runtime despite the Date
+	// type; sorting must coerce them, never throw mid-render.
+	it("sorts workspaces whose timestamps are ISO strings at runtime", () => {
+		const stringDated = makeProject({
+			id: "p-string",
+			name: "StringDates",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-string",
+						name: "cloud-fallback",
+						updatedAt: "2026-07-01T00:00:00.000Z" as unknown as Date,
+					}),
+				},
+			],
+		});
+		const dateDated = makeProject({
+			id: "p-date",
+			name: "DateDates",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-date",
+						name: "host-served",
+						updatedAt: new Date("2026-05-01"),
+					}),
+				},
+			],
+		});
+		expect(
+			sortDashboardSidebarProjects([dateDated, stringDated], "updated").map(
+				(p) => p.id,
+			),
+		).toEqual(["p-string", "p-date"]);
+	});
+
+	it("falls back to name order instead of throwing on garbage timestamps", () => {
+		const garbage = makeProject({
+			id: "p-garbage",
+			name: "Apple",
+			createdAt: "not-a-date" as unknown as Date,
+		});
+		const alsoGarbage = makeProject({
+			id: "p-garbage-2",
+			name: "Banana",
+			createdAt: "also-not-a-date" as unknown as Date,
+		});
+		expect(
+			sortDashboardSidebarProjects([alsoGarbage, garbage], "created").map(
+				(p) => p.id,
+			),
+		).toEqual(["p-garbage", "p-garbage-2"]);
+	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -1,0 +1,44 @@
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { DashboardSidebarProject } from "../../types";
+import { getProjectChildrenWorkspaces } from "../projectChildren";
+
+// The host only bumps a project's own updatedAt on metadata patches (e.g.
+// rename), so "recent activity" comes from the workspaces inside it.
+export function getProjectActivityTimestamp(
+	project: DashboardSidebarProject,
+): number {
+	const workspaces = getProjectChildrenWorkspaces(project.children);
+	if (workspaces.length === 0) {
+		return project.updatedAt?.getTime() ?? project.createdAt.getTime();
+	}
+	return Math.max(
+		...workspaces.map((workspace) => workspace.updatedAt.getTime()),
+	);
+}
+
+function compareStable(
+	left: DashboardSidebarProject,
+	right: DashboardSidebarProject,
+	byTimestamp: (project: DashboardSidebarProject) => number,
+): number {
+	const diff = byTimestamp(right) - byTimestamp(left);
+	if (diff !== 0) return diff;
+	const byName = left.name.localeCompare(right.name);
+	if (byName !== 0) return byName;
+	return left.id.localeCompare(right.id);
+}
+
+export function sortDashboardSidebarProjects(
+	projects: DashboardSidebarProject[],
+	mode: SidebarProjectSortMode,
+): DashboardSidebarProject[] {
+	if (mode === "manual") return projects;
+	if (mode === "created") {
+		return [...projects].sort((left, right) =>
+			compareStable(left, right, (project) => project.createdAt.getTime()),
+		);
+	}
+	return [...projects].sort((left, right) =>
+		compareStable(left, right, getProjectActivityTimestamp),
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -1,5 +1,9 @@
 import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
-import type { DashboardSidebarProject } from "../../types";
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarProjectChild,
+	DashboardSidebarWorkspace,
+} from "../../types";
 import { getProjectChildrenWorkspaces } from "../projectChildren";
 
 // Timestamps are typed as Date but can arrive as ISO strings at runtime
@@ -27,16 +31,98 @@ export function getProjectActivityTimestamp(
 	);
 }
 
-function compareStable(
-	left: DashboardSidebarProject,
-	right: DashboardSidebarProject,
-	byTimestamp: (project: DashboardSidebarProject) => number,
+function makeStableComparator<Item>(
+	byTimestamp: (item: Item) => number,
+	byName: (item: Item) => string,
+	byId: (item: Item) => string,
+): (left: Item, right: Item) => number {
+	return (left, right) => {
+		const diff = byTimestamp(right) - byTimestamp(left);
+		if (!Number.isNaN(diff) && diff !== 0) return diff;
+		const names = byName(left).localeCompare(byName(right));
+		if (names !== 0) return names;
+		return byId(left).localeCompare(byId(right));
+	};
+}
+
+function getWorkspaceTimestamp(
+	workspace: DashboardSidebarWorkspace,
+	mode: SidebarProjectSortMode,
 ): number {
-	const diff = byTimestamp(right) - byTimestamp(left);
-	if (!Number.isNaN(diff) && diff !== 0) return diff;
-	const byName = left.name.localeCompare(right.name);
-	if (byName !== 0) return byName;
-	return left.id.localeCompare(right.id);
+	return mode === "created"
+		? toTime(workspace.createdAt)
+		: toTime(workspace.updatedAt);
+}
+
+// Mirrors the project-level rules one level down: "created" uses the
+// section's own createdAt, "updated" uses its most recently updated
+// workspace (falling back to createdAt when empty).
+function getChildTimestamp(
+	child: DashboardSidebarProjectChild,
+	mode: SidebarProjectSortMode,
+): number {
+	if (child.type === "workspace") {
+		return getWorkspaceTimestamp(child.workspace, mode);
+	}
+	const { section } = child;
+	if (mode === "created") return toTime(section.createdAt);
+	const activity = section.workspaces
+		.map((workspace) => toTime(workspace.updatedAt))
+		.filter((time) => !Number.isNaN(time));
+	return activity.length > 0
+		? Math.max(...activity)
+		: toTime(section.createdAt);
+}
+
+function isLocalMainChild(child: DashboardSidebarProjectChild): boolean {
+	return (
+		child.type === "workspace" &&
+		child.workspace.type === "main" &&
+		child.workspace.hostType === "local-device"
+	);
+}
+
+/**
+ * Orders a project's children for a non-manual sort mode: workspaces inside
+ * each section sort by the mode, sections reorder among the loose workspaces
+ * by their own timestamp, and the local main workspace stays pinned first.
+ */
+export function sortDashboardSidebarProjectChildren(
+	children: DashboardSidebarProjectChild[],
+	mode: SidebarProjectSortMode,
+): DashboardSidebarProjectChild[] {
+	if (mode === "manual") return children;
+
+	const compareWorkspaces = makeStableComparator<DashboardSidebarWorkspace>(
+		(workspace) => getWorkspaceTimestamp(workspace, mode),
+		(workspace) => workspace.name,
+		(workspace) => workspace.id,
+	);
+	const compareChildren = makeStableComparator<DashboardSidebarProjectChild>(
+		(child) => getChildTimestamp(child, mode),
+		(child) =>
+			child.type === "workspace" ? child.workspace.name : child.section.name,
+		(child) =>
+			child.type === "workspace" ? child.workspace.id : child.section.id,
+	);
+
+	const sortedInside = children.map((child) =>
+		child.type === "section"
+			? {
+					...child,
+					section: {
+						...child.section,
+						workspaces: [...child.section.workspaces].sort(compareWorkspaces),
+					},
+				}
+			: child,
+	);
+
+	const mains = sortedInside.filter(isLocalMainChild).sort(compareChildren);
+	const rest = sortedInside
+		.filter((child) => !isLocalMainChild(child))
+		.sort(compareChildren);
+	return [...mains, ...rest];
 }
 
 export function sortDashboardSidebarProjects(
@@ -44,12 +130,19 @@ export function sortDashboardSidebarProjects(
 	mode: SidebarProjectSortMode,
 ): DashboardSidebarProject[] {
 	if (mode === "manual") return projects;
-	if (mode === "created") {
-		return [...projects].sort((left, right) =>
-			compareStable(left, right, (project) => toTime(project.createdAt)),
-		);
-	}
-	return [...projects].sort((left, right) =>
-		compareStable(left, right, getProjectActivityTimestamp),
+
+	const compareProjects = makeStableComparator<DashboardSidebarProject>(
+		mode === "created"
+			? (project) => toTime(project.createdAt)
+			: getProjectActivityTimestamp,
+		(project) => project.name,
+		(project) => project.id,
 	);
+
+	return projects
+		.map((project) => ({
+			...project,
+			children: sortDashboardSidebarProjectChildren(project.children, mode),
+		}))
+		.sort(compareProjects);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -16,6 +16,19 @@ function toTime(value: Date | string | number | null | undefined): number {
 	return new Date(value).getTime();
 }
 
+// A workspace's updatedAt only moves on metadata writes (rename, PR links),
+// so real recency also considers the newest terminal-agent event the host
+// recorded for it — whichever is later wins.
+function getWorkspaceActivityTime(
+	workspace: DashboardSidebarWorkspace,
+): number {
+	const updatedAt = toTime(workspace.updatedAt);
+	const agentAt = workspace.lastAgentActivityAt ?? Number.NaN;
+	if (Number.isNaN(updatedAt)) return agentAt;
+	if (Number.isNaN(agentAt)) return updatedAt;
+	return Math.max(updatedAt, agentAt);
+}
+
 // The host only bumps a project's own updatedAt on metadata patches (e.g.
 // rename), so "recent activity" comes from the workspaces inside it.
 export function getProjectActivityTimestamp(
@@ -26,9 +39,7 @@ export function getProjectActivityTimestamp(
 		const updatedAt = toTime(project.updatedAt);
 		return Number.isNaN(updatedAt) ? toTime(project.createdAt) : updatedAt;
 	}
-	return Math.max(
-		...workspaces.map((workspace) => toTime(workspace.updatedAt)),
-	);
+	return Math.max(...workspaces.map(getWorkspaceActivityTime));
 }
 
 function makeStableComparator<Item>(
@@ -51,7 +62,7 @@ function getWorkspaceTimestamp(
 ): number {
 	return mode === "created"
 		? toTime(workspace.createdAt)
-		: toTime(workspace.updatedAt);
+		: getWorkspaceActivityTime(workspace);
 }
 
 // Mirrors the project-level rules one level down: "created" uses the
@@ -67,7 +78,7 @@ function getChildTimestamp(
 	const { section } = child;
 	if (mode === "created") return toTime(section.createdAt);
 	const activity = section.workspaces
-		.map((workspace) => toTime(workspace.updatedAt))
+		.map(getWorkspaceActivityTime)
 		.filter((time) => !Number.isNaN(time));
 	return activity.length > 0
 		? Math.max(...activity)

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -2,6 +2,16 @@ import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/prov
 import type { DashboardSidebarProject } from "../../types";
 import { getProjectChildrenWorkspaces } from "../projectChildren";
 
+// Timestamps are typed as Date but can arrive as ISO strings at runtime
+// (Electric collection rows, persisted caches). Sorting is cosmetic, so
+// coerce instead of trusting the type — a bad value must never throw
+// mid-render and take the sidebar down with it.
+function toTime(value: Date | string | number | null | undefined): number {
+	if (value == null) return Number.NaN;
+	if (value instanceof Date) return value.getTime();
+	return new Date(value).getTime();
+}
+
 // The host only bumps a project's own updatedAt on metadata patches (e.g.
 // rename), so "recent activity" comes from the workspaces inside it.
 export function getProjectActivityTimestamp(
@@ -9,10 +19,11 @@ export function getProjectActivityTimestamp(
 ): number {
 	const workspaces = getProjectChildrenWorkspaces(project.children);
 	if (workspaces.length === 0) {
-		return project.updatedAt?.getTime() ?? project.createdAt.getTime();
+		const updatedAt = toTime(project.updatedAt);
+		return Number.isNaN(updatedAt) ? toTime(project.createdAt) : updatedAt;
 	}
 	return Math.max(
-		...workspaces.map((workspace) => workspace.updatedAt.getTime()),
+		...workspaces.map((workspace) => toTime(workspace.updatedAt)),
 	);
 }
 
@@ -22,7 +33,7 @@ function compareStable(
 	byTimestamp: (project: DashboardSidebarProject) => number,
 ): number {
 	const diff = byTimestamp(right) - byTimestamp(left);
-	if (diff !== 0) return diff;
+	if (!Number.isNaN(diff) && diff !== 0) return diff;
 	const byName = left.name.localeCompare(right.name);
 	if (byName !== 0) return byName;
 	return left.id.localeCompare(right.id);
@@ -35,7 +46,7 @@ export function sortDashboardSidebarProjects(
 	if (mode === "manual") return projects;
 	if (mode === "created") {
 		return [...projects].sort((left, right) =>
-			compareStable(left, right, (project) => project.createdAt.getTime()),
+			compareStable(left, right, (project) => toTime(project.createdAt)),
 		);
 	}
 	return [...projects].sort((left, right) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
@@ -23,6 +23,7 @@ export function makeWorkspace(
 		behindCount: null,
 		createdAt: new Date("2026-01-01"),
 		updatedAt: new Date("2026-01-01"),
+		lastAgentActivityAt: null,
 		taskId: null,
 		isPinned: false,
 		pendingTransaction: null,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
@@ -1,0 +1,60 @@
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../types";
+
+export function makeWorkspace(
+	overrides: Partial<DashboardSidebarWorkspace> & { id: string; name: string },
+): DashboardSidebarWorkspace {
+	return {
+		projectId: "project-1",
+		hostId: "host-1",
+		hostType: "local-device",
+		type: "worktree",
+		hostIsOnline: true,
+		accentColor: null,
+		branch: overrides.name,
+		pullRequest: null,
+		repoUrl: null,
+		branchExistsOnRemote: false,
+		previewUrl: null,
+		needsRebase: null,
+		behindCount: null,
+		createdAt: new Date("2026-01-01"),
+		updatedAt: new Date("2026-01-01"),
+		taskId: null,
+		isPinned: false,
+		pendingTransaction: null,
+		...overrides,
+	};
+}
+
+export function makeSection(
+	overrides: Partial<DashboardSidebarSection> & { id: string; name: string },
+): DashboardSidebarSection {
+	return {
+		projectId: "project-1",
+		createdAt: new Date("2026-01-01"),
+		isCollapsed: false,
+		tabOrder: 0,
+		color: null,
+		workspaces: [],
+		...overrides,
+	};
+}
+
+export function makeProject(
+	overrides: Partial<DashboardSidebarProject> & { id: string; name: string },
+): DashboardSidebarProject {
+	return {
+		githubOwner: null,
+		githubRepoName: null,
+		iconUrl: null,
+		createdAt: new Date("2026-01-01"),
+		updatedAt: new Date("2026-01-01"),
+		isCollapsed: false,
+		children: [],
+		...overrides,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -326,6 +326,12 @@ function isCompleteLinkTierMap(
 	);
 }
 
+const sidebarProjectSortModeSchema = z.enum(["manual", "created", "updated"]);
+
+export type SidebarProjectSortMode = z.infer<
+	typeof sidebarProjectSortModeSchema
+>;
+
 export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
@@ -338,6 +344,7 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	sidebarProjectSortMode: sidebarProjectSortModeSchema.default("manual"),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -356,6 +363,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	sidebarProjectSortMode: "manual",
 };
 
 /**


### PR DESCRIPTION
## Summary

Re-lands the dashboard sidebar filter + sort feature (#5956, reverted in #5996) with the fixes that motivated the revert:

1. **Reapply #5956** — pure revert-of-revert; the filter input, sort menu, and preference plumbing come back unchanged. Applies cleanly over #5997/#5999/#6000 (the #6000 stopPropagation guard survives).
2. **Crash fix** — Electric cloud-fallback rows carry ISO-string timestamps at runtime (the shape parser doesn't handle `timestamptz`, despite the `SelectV2Workspace` type). They're normalized to real `Date`s where they enter `mergeHostWorkspaces`, and the sort coerces defensively (`toTime`, NaN-safe tie-breaks) so bad data can never crash the sidebar again. Fixes the `workspace.updatedAt.getTime is not a function` crash.
3. **Workspace-level sorting** — non-manual modes now sort workspaces inside each project *and* inside sections, rank sections among loose workspaces by their newest member, and keep the local main workspace pinned first.
4. **"Last updated" means real activity** — the revert reason: `v2_workspaces.updatedAt` only moves on metadata writes, so messaging an agent never reordered anything. The sidebar now polls each reachable host's `terminalAgents.list` (10s interval, only while the sort mode is "Last updated") and ranks everything by `max(updatedAt, newest agent hook event)`. Sending a Claude message reorders within ~10s.
5. **Design doc** — `apps/desktop/docs/SIDEBAR_ACTIVITY_SORT.md` records the signal semantics, the polling trade-off, and the follow-up paths (event-bus push for instant reordering; cloud-persisted activity as the long-term model; Electric timestamp-parser root fix as its own PR).

## Verification

- Full desktop suite: 2305 pass / 0 fail (new tests for string-date coercion, agent-activity ranking at workspace/section/project levels, merge normalization).
- Live via CDP against the dev app: sort menu + filter exercised end-to-end; rendered order matches the ranking computed from real host binding data and provably diverges from `updatedAt`-only ordering; a synthetic `UserPromptSubmit` on a 3-day-idle workspace moved it to the top of its project in ~4s.
- Typecheck and lint clean.

## Notes

- Overlaps with #6001: the reapply restores the automations `bg-destructive` color changes that #6001 also contains. Merge either first; the other becomes a trivial rebase/close.
- Pinned rows intentionally keep pin order; unreachable hosts fall back to `updatedAt` ranking.

https://claude.ai/code/session_01SSUQYFamkYAjs5sDQC5RLS

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-lands the dashboard sidebar filter and sort, and makes “Last updated” use real agent activity so recent conversations reorder projects and workspaces. Also fixes a crash from cloud string timestamps.

- New Features
  - Added project filter input and sort menu in the sidebar header; choice is saved in `sidebarProjectSortMode`.
  - “Last updated” now ranks by max(`updatedAt`, latest agent event), polling each reachable host’s `terminalAgents.list` every 10s only while this mode is active. Applies at workspace, section, and project levels; the local main workspace stays first.
  - Non-manual modes sort workspaces within projects and within sections; sections rank among loose workspaces by their newest member.
  - Drag-and-drop is disabled when sort ≠ manual or a filter is active to avoid corrupting hidden items; filter expands matched projects/sections and shows a simple “no match” state.

- Bug Fixes
  - Prevented sidebar crash by coercing Electric cloud-fallback `createdAt`/`updatedAt` strings to `Date` in `mergeHostWorkspaces`; sorting uses NaN-safe coercion with name/id tie-breakers.
  - Standardized automation failure colors to `bg-destructive`.

<sup>Written for commit be67fa804f87166caee96e936552a7d9d3c61b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sidebar project sorting by manual order, creation date, or recent activity.
  - Added project and workspace filtering with matching results automatically expanded.
  - Added persistent sorting preferences and improved controls in the sidebar header.
  - Recent agent activity now contributes to “Last updated” ordering.

- **Bug Fixes**
  - Improved handling of cloud workspace timestamps.
  - Prevented drag-and-drop reordering while filtering or using non-manual sorting.
  - Standardized failed automation status styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->