### PR TITLE
fix(desktop): confirm before closing active ports

### DIFF
--- a/apps/desktop/src/renderer/hooks/ports/usePortKillActions/confirmClosePorts.test.ts
+++ b/apps/desktop/src/renderer/hooks/ports/usePortKillActions/confirmClosePorts.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AlertOptions } from "@superset/ui/atoms/Alert";
+
+let suppressed = false;
+const suppress = mock(() => {
+	suppressed = true;
+});
+
+mock.module("renderer/stores/terminal-close-confirm/store", () => ({
+	useTerminalCloseConfirmStore: {
+		getState: () => ({ suppressed, suppress }),
+	},
+}));
+
+const { confirmClosePorts } = await import("./confirmClosePorts");
+
+describe("confirmClosePorts", () => {
+	beforeEach(() => {
+		suppressed = false;
+		suppress.mockClear();
+	});
+
+	it("confirms a single port with running-process copy", async () => {
+		let options: AlertOptions | undefined;
+		const showAlert = mock((nextOptions: AlertOptions) => {
+			options = nextOptions;
+			return true;
+		});
+
+		const confirmation = confirmClosePorts(1, showAlert);
+
+		expect(options?.title).toBe("This port is still in use");
+		expect(options?.description).toBe(
+			"Closing this port will end the process using it.",
+		);
+		expect(options?.actions[0]?.label).toBe("Close port");
+
+		await options?.actions[0]?.onClick?.({ checkboxChecked: false });
+		expect(await confirmation).toBe(true);
+	});
+
+	it("uses plural copy and resolves false when canceled", async () => {
+		let options: AlertOptions | undefined;
+		const showAlert = (nextOptions: AlertOptions) => {
+			options = nextOptions;
+			return true;
+		};
+
+		const confirmation = confirmClosePorts(2, showAlert);
+
+		expect(options?.title).toBe("These ports are still in use");
+		expect(options?.description).toBe(
+			"Closing these ports will end the processes using them.",
+		);
+		expect(options?.actions[0]?.label).toBe("Close ports");
+
+		await options?.actions[1]?.onClick?.({ checkboxChecked: false });
+		expect(await confirmation).toBe(false);
+	});
+
+	it("resolves false when the dialog is dismissed", async () => {
+		let options: AlertOptions | undefined;
+		const confirmation = confirmClosePorts(1, (nextOptions) => {
+			options = nextOptions;
+			return true;
+		});
+
+		options?.onDismiss?.();
+
+		expect(await confirmation).toBe(false);
+	});
+
+	it("persists the shared running-process suppression preference", async () => {
+		let options: AlertOptions | undefined;
+		const showAlert = mock((nextOptions: AlertOptions) => {
+			options = nextOptions;
+			return true;
+		});
+		const confirmation = confirmClosePorts(1, showAlert);
+
+		await options?.actions[0]?.onClick?.({
+			checkboxChecked: true,
+		});
+		expect(await confirmation).toBe(true);
+		expect(suppressed).toBe(true);
+		expect(suppress).toHaveBeenCalledTimes(1);
+
+		expect(await confirmClosePorts(1, showAlert)).toBe(true);
+		expect(showAlert).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails open when the alert layer is unavailable", async () => {
+		expect(await confirmClosePorts(1, () => false)).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/ports/usePortKillActions/confirmClosePorts.ts
+++ b/apps/desktop/src/renderer/hooks/ports/usePortKillActions/confirmClosePorts.ts
@@ -1,0 +1,50 @@
+import { type AlertOptions, alert } from "@superset/ui/atoms/Alert";
+import { useTerminalCloseConfirmStore } from "renderer/stores/terminal-close-confirm/store";
+
+type ShowAlert = (options: AlertOptions) => boolean;
+
+/**
+ * Confirm before terminating the process or processes that own detected ports.
+ * This shares the running-process suppression preference with terminal close
+ * confirmations so "Don't ask again" behaves consistently.
+ */
+export function confirmClosePorts(
+	portCount: number,
+	showAlert: ShowAlert = alert,
+): Promise<boolean> {
+	if (portCount === 0 || useTerminalCloseConfirmStore.getState().suppressed) {
+		return Promise.resolve(true);
+	}
+
+	const isSinglePort = portCount === 1;
+
+	return new Promise<boolean>((resolve) => {
+		const shown = showAlert({
+			title: isSinglePort
+				? "This port is still in use"
+				: "These ports are still in use",
+			description: isSinglePort
+				? "Closing this port will end the process using it."
+				: "Closing these ports will end the processes using them.",
+			checkbox: { label: "Don't ask again" },
+			onDismiss: () => resolve(false),
+			actions: [
+				{
+					label: isSinglePort ? "Close port" : "Close ports",
+					variant: "destructive",
+					onClick: ({ checkboxChecked }) => {
+						if (checkboxChecked) {
+							useTerminalCloseConfirmStore.getState().suppress();
+						}
+						resolve(true);
+					},
+				},
+				{ label: "Cancel", variant: "ghost", onClick: () => resolve(false) },
+			],
+		});
+
+		// Match terminal-close behavior: never leave the action hanging if the
+		// global alert layer is unavailable.
+		if (!shown) resolve(true);
+	});
+}

--- a/apps/desktop/src/renderer/hooks/ports/usePortKillActions/usePortKillActions.ts
+++ b/apps/desktop/src/renderer/hooks/ports/usePortKillActions/usePortKillActions.ts
@@ -1,6 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { type QueryKey, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import { confirmClosePorts } from "./confirmClosePorts";
 import {
 	killPortTarget,
 	type LocalPortKill,
@@ -36,7 +37,9 @@ export function usePortKillActions<TPort extends PortKillTarget>({
 	}, [queryClient, refreshQueryKey]);
 
 	const killPort = useCallback(
-		async (port: TPort): Promise<PortKillResult> => {
+		async (port: TPort): Promise<PortKillResult | undefined> => {
+			if (!(await confirmClosePorts(1))) return;
+
 			setPendingCount((count) => count + 1);
 			try {
 				const result = await killPortTarget(port, localKill);
@@ -57,6 +60,7 @@ export function usePortKillActions<TPort extends PortKillTarget>({
 	const killPorts = useCallback(
 		async (ports: TPort[]): Promise<PortKillResult[]> => {
 			if (ports.length === 0) return [];
+			if (!(await confirmClosePorts(ports.length))) return [];
 
 			setPendingCount((count) => count + 1);
 			try {


### PR DESCRIPTION
## Summary

- add the existing destructive alert pattern before closing active ports
- guard both individual port close actions and “Close all ports” through the shared port-kill hook
- share the running-process “Don’t ask again” preference with terminal-close confirmations
- cover singular, plural, cancel, dismiss, suppression, and unavailable-alert behavior

## Why

The ports hover card called the kill path immediately. “Close all ports” could therefore terminate running processes with no confirmation, even though terminal and agent close flows already protect the same destructive outcome.

The root cause was that `usePortKillActions` delegated directly to `killPortTarget` without a destructive-action guard. Centralizing the guard in that hook covers both sidebar implementations and prevents individual port buttons from bypassing it.

## Impact

Users now see a destructive confirmation before closing one or many active ports. Cancel and dismiss preserve the processes; confirming keeps the existing kill and refresh behavior. The optional suppression setting stays consistent with other running-process warnings.

## Verification

- `bun run lint:fix`
- `bun run lint`
- `bun test apps/desktop/src/renderer/hooks/ports/usePortKillActions/confirmClosePorts.test.ts apps/desktop/src/renderer/hooks/ports/usePortKillActions/killPortTarget.test.ts`
- `bun run --cwd apps/desktop typecheck`
- exact-worktree Electron/CDP journey on renderer `http://localhost:3105`, workspace route `/v2-workspace/06367ee2-0f02-4525-a2b8-f4a23923c0ea`
  - baseline: clicking “Close all ports” terminated listeners on 58278 and 58279 without a confirmation
  - fixed cancel path: both listeners remained active
  - fixed confirm path: both listeners stopped and the active-port chip disappeared
  - individual port action displayed the singular warning and preserved both listeners on cancel

Screenshots are attached in the visual verification comment below.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a confirmation before closing active ports in the desktop app. Protects both single-port and “Close all ports” actions, matching terminal close behavior and preventing accidental process kills.

- **Bug Fixes**
  - Added a destructive confirm step in the shared port-kill hook.
  - Reused the terminal “Don’t ask again” setting for port closes.
  - Supported singular/plural copy, cancel, dismiss, and unavailable-alert fallback.
  - Added unit tests for confirm, cancel, dismiss, suppression, and fallback paths.

<sup>Written for commit ec2814c7a485d1b6aee1a1b7b1abb5b72a806d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before closing processes associated with ports.
  * Supports single- and multi-port messaging, cancellation, and a “Don’t ask again” option.
  * Closing actions are skipped when confirmation is canceled, while existing failure notifications remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->