### PR TITLE
fix(terminal): forward DISPLAY/XAUTHORITY/WAYLAND_DISPLAY to the PTY so clipboard image paste works on Linux

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -298,6 +298,19 @@ describe("env", () => {
 				expect(result.BASH_ENV).toBe("/Users/test/.superset-dev/bash/rcfile");
 			});
 
+			it("should include X11/Wayland display vars (clipboard image paste, #5003)", () => {
+				const env = {
+					DISPLAY: ":0",
+					XAUTHORITY: "/tmp/xauth_abc123",
+					WAYLAND_DISPLAY: "wayland-0",
+					PATH: "/usr/bin",
+				};
+				const result = buildSafeEnv(env);
+				expect(result.DISPLAY).toBe(":0");
+				expect(result.XAUTHORITY).toBe("/tmp/xauth_abc123");
+				expect(result.WAYLAND_DISPLAY).toBe("wayland-0");
+			});
+
 			it("should include proxy vars (both cases)", () => {
 				const env = {
 					HTTP_PROXY: "http://proxy:8080",

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -213,6 +213,10 @@ const ALLOWED_ENV_VARS = new Set([
 
 	// Terminal/display
 	"DISPLAY",
+	// X11 auth cookie and Wayland socket. Needed alongside DISPLAY so
+	// clipboard tools (xclip/xsel/wl-paste) can reach the display server. (#5003)
+	"XAUTHORITY",
+	"WAYLAND_DISPLAY",
 	"COLORTERM",
 	"TERM_PROGRAM",
 	"TERM_PROGRAM_VERSION",

--- a/packages/host-service/src/terminal/clean-shell-env.test.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.test.ts
@@ -12,6 +12,9 @@ describe("buildMinimalEnv", () => {
 		"HOME",
 		"PATH",
 		"SHELL",
+		"DISPLAY",
+		"XAUTHORITY",
+		"WAYLAND_DISPLAY",
 	];
 	const original: Record<string, string | undefined> = {};
 
@@ -43,6 +46,20 @@ describe("buildMinimalEnv", () => {
 		process.env.SSH_AGENT_PID = "12345";
 		const env = buildMinimalEnv();
 		expect(env.SSH_AGENT_PID).toBe("12345");
+	});
+
+	test("propagates DISPLAY and XAUTHORITY so X11 clipboard reads work (#5003)", () => {
+		process.env.DISPLAY = ":0";
+		process.env.XAUTHORITY = "/tmp/xauth_abc123";
+		const env = buildMinimalEnv();
+		expect(env.DISPLAY).toBe(":0");
+		expect(env.XAUTHORITY).toBe("/tmp/xauth_abc123");
+	});
+
+	test("propagates WAYLAND_DISPLAY so Wayland clipboard reads work (#5003)", () => {
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+		const env = buildMinimalEnv();
+		expect(env.WAYLAND_DISPLAY).toBe("wayland-0");
 	});
 });
 

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -46,6 +46,15 @@ const SHELL_BOOTSTRAP_KEYS = [
 	"REQUESTS_CA_BUNDLE",
 	// System-level timezone override.
 	"TZ",
+	// Linux display server connection. Set by the display manager or session
+	// script, not by rc files. The bootstrap shell only sees what we pass here,
+	// so omitting these strips them from the snapshot that becomes the PTY env.
+	// Terminal agents shell out to xclip/xsel/wl-paste to read images from the
+	// clipboard; without a reachable display server those reads fail and image
+	// paste reports "no image in the clipboard". (#5003)
+	"DISPLAY",
+	"XAUTHORITY",
+	"WAYLAND_DISPLAY",
 ];
 
 const COMMON_MACOS_PATHS = [


### PR DESCRIPTION
## Symptom

On Linux, pasting an image into a terminal agent (Claude Code, Codex) with Ctrl+V
fails with "no image found on clipboard", while the same paste works in a native
terminal.

## Root cause

Terminal agents shell out to `xclip`/`xsel`/`wl-paste` to read images from the
clipboard. Claude Code's probe is:

    xclip -selection clipboard -t TARGETS -o | grep -E "image/(png|jpeg|...)"
      || wl-paste -l | grep -E "image/(png|jpeg|...)"

Those tools need `DISPLAY` + `XAUTHORITY` (X11) or `WAYLAND_DISPLAY` (Wayland).
Neither reaches the PTY, for two independent reasons:

1. **`SHELL_BOOTSTRAP_KEYS` in `packages/host-service/src/terminal/clean-shell-env.ts`.**
   The v2 PTY env comes from a shell snapshot (`resolveTerminalBaseEnv` ->
   `getStrictShellEnvironment` -> `spawnCleanShellEnv`), and that bootstrap shell
   is spawned with `buildMinimalEnv()`. Anything not in `SHELL_BOOTSTRAP_KEYS` is
   absent from the snapshot that becomes the terminal env. The list has no display
   vars, so they are dropped even when host-service itself has them.

2. **`ALLOWED_ENV_VARS` in `apps/desktop/src/main/lib/terminal/env.ts`.**
   The v1 allowlist includes `DISPLAY` but not `XAUTHORITY` or `WAYLAND_DISPLAY`,
   so the X11 auth cookie can never reach the PTY on setups with a non-default
   cookie path, and Wayland sessions get no display socket at all.

## This is not startx-specific

#5003 attributes the empty `DISPLAY` to `startx` without a display manager, and
the scope note on #5004 treats it as niche. It is not. Reproduced on a stock
SDDM + `startplasma-x11` session (openSUSE Tumbleweed, KDE Plasma, X11):

    # Superset's own processes have both vars:
    $ tr '\0' '\n' < /proc/$PTY_DAEMON_PID/environ | grep -E '^(DISPLAY|XAUTHORITY)='
    DISPLAY=:0

    # The shell it spawns has neither:
    $ tr '\0' '\n' < /proc/$PTY_SHELL_PID/environ | grep -cE '^(DISPLAY|XAUTHORITY)='
    0

Note the daemon *does* have `DISPLAY`, so the allowlist alone cannot explain the
loss. The bootstrap-shell snapshot in (1) is what drops it, which makes this
portable across Linux sessions rather than specific to one launcher.

Confirming the vars are what the probe needs, with an image on the clipboard:

    $ DISPLAY=:0 XAUTHORITY=/tmp/xauth_xxxxxx xclip -selection clipboard -t TARGETS -o | grep image/png
    image/png
    $ env -u DISPLAY  ... same command ...   -> exit 1
    $ env -u XAUTHORITY DISPLAY=:0 ... same command ...   -> exit 1

Both vars are required; `DISPLAY` alone is not enough on setups whose cookie is
not at `~/.Xauthority` (SDDM writes `/tmp/xauth_*`).

## The fix

- Add `DISPLAY`, `XAUTHORITY`, `WAYLAND_DISPLAY` to `SHELL_BOOTSTRAP_KEYS`.
- Add `XAUTHORITY`, `WAYLAND_DISPLAY` to `ALLOWED_ENV_VARS`.

Both are user-session connection details, not secrets, and sit alongside the
`SSH_AUTH_SOCK` precedent (#4238) of forwarding session vars the shell cannot
re-derive.

## Tests

Regression tests in both files. Verified they fail on the unpatched source:

    (fail) buildMinimalEnv > propagates DISPLAY and XAUTHORITY so X11 clipboard reads work (#5003)
    (fail) buildMinimalEnv > propagates WAYLAND_DISPLAY so Wayland clipboard reads work (#5003)
    (fail) env > buildSafeEnv > ... > should include X11/Wayland display vars (clipboard image paste, #5003)
    89 pass, 3 fail

With the fix: `92 pass, 0 fail` across the two files. `biome check` clean.

Closes #5003. Supersedes #5004 (closed unmerged), which fixed only the allowlist
half and left the snapshot path, the one that actually drops `DISPLAY`, untouched.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward Linux display env vars to PTY so clipboard image paste works in terminal agents. Fixes “no image found on clipboard” in Claude Code and Codex on X11 and Wayland.

- **Bug Fixes**
  - Added DISPLAY, XAUTHORITY, and WAYLAND_DISPLAY to `SHELL_BOOTSTRAP_KEYS` in `packages/host-service` so the bootstrap shell snapshot preserves them.
  - Allowed `XAUTHORITY` and `WAYLAND_DISPLAY` in `ALLOWED_ENV_VARS` in `apps/desktop` (DISPLAY was already allowed).
  - Added regression tests for X11 and Wayland clipboard image detection. Closes #5003.

<sup>Written for commit aaccb43a655b45fae96949c273177493e3866696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux desktop terminal support by preserving X11 and Wayland display settings.
  * Terminal sessions can now access graphical applications using `DISPLAY`, `XAUTHORITY`, and `WAYLAND_DISPLAY` when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->