### PR TITLE
fix(desktop): make needs-input attention indicator yellow instead of red

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
@@ -14,7 +14,7 @@ import { DashboardSidebarAgentAvatar } from "../DashboardSidebarAgentAvatar";
 const STATUS_TEXT_CLASS: Record<RunningAgentStatus, string> = {
 	idle: "text-muted-foreground",
 	working: "text-amber-500",
-	permission: "text-red-500",
+	permission: "text-yellow-500",
 	failed: "text-red-500",
 	review: "text-green-500",
 };

--- a/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
@@ -7,8 +7,8 @@ export type { ActivePaneStatus } from "shared/tabs-types";
 /** Lookup object for status indicator styling - avoids if/else chains */
 const STATUS_CONFIG = {
 	permission: {
-		pingColor: "bg-red-400",
-		dotColor: "bg-red-500",
+		pingColor: "bg-yellow-400",
+		dotColor: "bg-yellow-500",
 		pulse: true,
 		tooltip: "Needs input",
 	},
@@ -42,7 +42,8 @@ interface StatusIndicatorProps {
 
 /**
  * Visual indicator for pane/workspace status.
- * - Red pulsing: needs user input (permission)
+ * - Yellow pulsing: needs user input (permission)
+ * - Red pulsing: agent failed
  * - Amber pulsing: agent working
  * - Green static: ready for review
  */

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -20,7 +20,7 @@ export type PaneType =
  * Pane status for agent lifecycle indicators
  * - idle: No indicator shown (default)
  * - working: Agent actively processing (amber)
- * - permission: Agent blocked, needs user action (red)
+ * - permission: Agent blocked, needs user action (yellow)
  * - review: Agent completed, ready for review (green)
  * - failed: Agent turn/process ended in failure, needs attention (red)
  */


### PR DESCRIPTION
## Summary
- The `permission` pane status (agent asking a question / waiting on user input) pulsed red, visually identical to `failed`. It now pulses yellow so "needs your input" reads as attention, not as an error. Red stays reserved for failures.

## How It Works
- `StatusIndicator` is the single shared dot component for all attention indicators (v1 and v2 sidebar workspace icons, tab panes, chat pane titles, agent avatars), so swapping its `permission` entry to `bg-yellow-400/500` covers every surface at once.
- The agent hover-card rows have their own status→text-color map; its `permission` entry moved to `text-yellow-500` to match.
- Doc comments in `tabs-types.ts` and the `StatusIndicator` JSDoc updated to reflect the new mapping.

## Manual QA Checklist
- [ ] Agent hitting a permission prompt / asking a question shows a pulsing yellow dot on the sidebar workspace icon (expanded and collapsed)
- [ ] Agent failure still shows a pulsing red dot
- [ ] Agents-chip hover card shows yellow status text for a waiting agent, red for a failed one
- [ ] Working (amber spinner) and needs-input (yellow dot) remain distinguishable at a glance

## Testing
- `bun run lint` — clean
- `bun turbo run typecheck --filter=@superset/desktop` — clean
- Not manually verified in the running app (color-only change to existing Tailwind class maps)

## Known Limitations
- Yellow (needs input) and amber (working) are neighboring hues; they remain distinguishable since working renders as the ASCII spinner rather than a dot at the workspace level, but we can push the yellow brighter if it feels too close.
- The sunset v1 `WorkspacesListView` unread dot keeps its red ping (v1 UI is being removed; left untouched deliberately).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6017">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the “needs input” (permission) attention indicator from red to yellow across the desktop UI to avoid confusion with failures. Red stays reserved for failed; amber remains working and green remains review.

<sup>Written for commit c1b37dac62ad7d273e4838074f338a7aad5f1d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated permission-related status indicators from red to yellow.
  - Sidebar labels and status indicators now consistently use yellow to signal that user action is required.
- **Documentation**
  - Updated status descriptions to reflect the new yellow appearance and meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->