### PR TITLE
fix(desktop): stop hidden sidebar row actions from reserving title width

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -284,7 +284,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								)
 							)}
 							{!isPending && (
-								<div className="invisible flex items-center justify-end gap-1.5 group-hover:visible group-focus-within:visible">
+								<div className="hidden items-center justify-end gap-1.5 group-hover:flex group-focus-within:flex">
 									{shortcutLabel && (
 										<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
 											{shortcutLabel}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
@@ -10,7 +10,7 @@ export function DashboardSidebarWorkspaceDiffStats({
 	isActive,
 }: DashboardSidebarWorkspaceDiffStatsProps) {
 	return (
-		<div className="flex h-5 w-fit shrink-0 items-center justify-self-end font-mono text-[10px] tabular-nums group-hover:invisible group-focus-within:invisible">
+		<div className="flex h-5 w-fit shrink-0 items-center justify-self-end font-mono text-[10px] tabular-nums group-hover:hidden group-focus-within:hidden">
 			<div className="flex items-center gap-1.5 leading-none">
 				<span
 					className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}


### PR DESCRIPTION
## Summary
- Sidebar workspace titles truncated early (e.g. "Model PR metadata and lif...") even with free space to the right, because the hover-only action cluster (shortcut label + close/remove button) used `invisible`, which keeps its width in layout. The trailing grid cell stacks it with the diff stats, so every row permanently reserved the width of the wider of the two.
- Toggle `display` instead of `visibility`: actions are `hidden` until `group-hover`/`group-focus-within`, and diff stats go `hidden` (not `invisible`) while the actions are shown. Hidden elements now take no space, so titles use the full row width.

Keyboard access is preserved: the row itself is focusable, so `group-focus-within` reveals the buttons before tab order reaches them. Trade-off: a long title re-truncates while hovering a row (the actions claim their width only then) — the standard hover-revealed-actions pattern.

## Testing
- `bun turbo run typecheck --filter=@superset/desktop`
- `bunx biome check` on the touched components (clean)
- Manual: not yet verified in a running app — CSS-only change; happy to CDP-verify if wanted

## Manual QA Checklist
- [ ] Idle rows: long titles fill the row width before truncating
- [ ] Hover/focus a row: shortcut label + close button appear; diff stats hide
- [ ] Active row with diff stats: `+N −N` visible when not hovered

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix early truncation of workspace titles in the desktop sidebar by switching hover-only actions and diff stats from visibility to display toggling. Hidden elements no longer reserve width, so titles use the full row; actions appear on hover/focus and temporarily hide diff stats while visible.

<sup>Written for commit 8cb2c80b4b45e82c70bd10027cad8d1c2230ecbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

