### PR TITLE
fix(desktop): remove empty top strip on automations, tasks, and workspaces views

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
@@ -51,6 +51,9 @@ export function AutomationDetailHeader({
 				</BreadcrumbList>
 			</Breadcrumb>
 
+			{/* Window-drag leaf standing in for the hidden TopBar. */}
+			<div className="drag h-full min-w-0 flex-1" />
+
 			<div className="flex items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -295,6 +295,9 @@ function AutomationsPage() {
 					</Tabs>
 				</div>
 
+				{/* Window-drag leaf standing in for the hidden TopBar. */}
+				<div className="drag h-full min-w-0 flex-1" />
+
 				<div className="flex items-center gap-2">
 					<Button
 						asChild

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -70,6 +70,10 @@ function DashboardLayout() {
 	const onV1WorkspaceRoute = currentWorkspaceMatch !== false;
 	const onV2WorkspaceRoute = v2WorkspaceMatch !== false;
 	const onNewWorkspaceRoute = matchRoute({ to: "/new-workspace" }) !== false;
+	const onDashboardViewRoute =
+		matchRoute({ to: "/automations", fuzzy: true }) !== false ||
+		matchRoute({ to: "/tasks", fuzzy: true }) !== false ||
+		matchRoute({ to: "/v2-workspaces", fuzzy: true }) !== false;
 	const versionMismatch =
 		(isV2CloudEnabled && onV1WorkspaceRoute) ||
 		(!isV2CloudEnabled && onV2WorkspaceRoute);
@@ -202,14 +206,16 @@ function DashboardLayout() {
 	// their header; collapsed rails host it via their headroom spacer plus the
 	// tab bar's leading inset. Only a fully closed sidebar keeps the TopBar,
 	// whose inset then keeps content clear of the macOS traffic lights. The
-	// new-workspace page brings its own drag strip, so it hides the TopBar
-	// whenever the expanded sidebar sits outside the column.
+	// new-workspace page brings its own drag strip, and the dashboard views
+	// (automations/tasks/workspaces) carry drag fillers in their own headers,
+	// so they hide the TopBar whenever the expanded sidebar sits outside the
+	// column — otherwise it renders as an empty strip above their headers.
 	const hideTopBar =
 		(onV2WorkspaceRoute &&
 			!versionMismatch &&
 			isV2CloudEnabled &&
 			isWorkspaceSidebarOpen) ||
-		(onNewWorkspaceRoute && sidebarOutsideColumn);
+		((onNewWorkspaceRoute || onDashboardViewRoute) && sidebarOutsideColumn);
 
 	return (
 		<div className="flex h-full w-full overflow-hidden">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskDetailHeader/TaskDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/TaskDetailHeader/TaskDetailHeader.tsx
@@ -27,6 +27,8 @@ export function TaskDetailHeader({
 				<HiArrowLeft className="w-4 h-4" />
 			</Button>
 			<span className="text-sm text-muted-foreground">{task.slug}</span>
+			{/* Window-drag leaf standing in for the hidden TopBar. */}
+			<div className="drag -my-4 min-w-0 flex-1 self-stretch" />
 			<div className="ml-auto flex items-center gap-1">
 				{task.externalUrl && (
 					<a

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -190,6 +190,9 @@ export function TasksTopBar({
 					)}
 				</div>
 
+				{/* Window-drag leaf standing in for the hidden TopBar. */}
+				<div className="drag h-full min-w-0 flex-1" />
+
 				{/* Right side: create + view toggle + search */}
 				<div className="flex items-center gap-2">
 					{showTaskOnlyControls && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
@@ -200,6 +200,8 @@ function Header({
 			<span className="text-sm text-muted-foreground font-mono tabular-nums">
 				#{issueNumber}
 			</span>
+			{/* Window-drag leaf standing in for the hidden TopBar. */}
+			<div className="drag -my-4 min-w-0 flex-1 self-stretch" />
 			<div className="ml-auto flex items-center gap-1">
 				{url && (
 					<a

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/page.tsx
@@ -197,6 +197,8 @@ function Header({
 			<span className="text-sm text-muted-foreground font-mono tabular-nums">
 				#{prNumber}
 			</span>
+			{/* Window-drag leaf standing in for the hidden TopBar. */}
+			<div className="drag -my-4 min-w-0 flex-1 self-stretch" />
 			<div className="ml-auto flex items-center gap-1">
 				{url && (
 					<a

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -109,6 +109,9 @@ export function V2WorkspacesHeader({
 			<div className="flex w-full flex-wrap items-center justify-between gap-3 px-6 py-4">
 				<h1 className="text-sm font-semibold tracking-tight">Workspaces</h1>
 
+				{/* Window-drag leaf standing in for the hidden TopBar. */}
+				<div className="drag -my-4 min-w-0 flex-1 self-stretch" />
+
 				<div className="flex flex-wrap items-center gap-2">
 					<InputGroup className="w-72">
 						<InputGroupAddon align="inline-start">


### PR DESCRIPTION
## Summary
- On the v2 dashboard with the expanded sidebar, the TopBar rendered as a completely empty 48px strip above the Automations, Tasks, and Workspaces views. It's now hidden there, so each view's header sits flush with the window top.

## Why / Context
When the expanded v2 sidebar sits outside the TopBar column, the sidebar header already hosts the traffic-light pad, sidebar toggle, and nav controls — leaving the TopBar with nothing to show on these routes. The workspace detail and new-workspace routes already hid it; these three views were the remaining places showing the dead strip.

## How It Works
- `_dashboard/layout.tsx` extends `hideTopBar` to `/automations`, `/tasks`, and `/v2-workspaces` (fuzzy, so detail pages match too), gated on `sidebarOutsideColumn`. With the sidebar collapsed or closed the TopBar still renders, since it then carries the toggle, nav controls, and traffic-light inset.
- Each affected header (Automations list + detail, Tasks top bar + task/issue/PR detail, Workspaces) gains an empty `drag` filler leaf so the window stays draggable across the top, following the drag-on-empty-leaves rule.

## Manual QA Checklist
Verified end-to-end over CDP against the dev app (signed-in session, expanded v2 sidebar), navigating by real clicks on the sidebar buttons:
- [x] Automations: header renders at window top, no 48px bar in the DOM
- [x] Tasks: TasksTopBar renders at window top
- [x] Workspaces: header h1 at top, no bar
- [x] Baseline (pre-fix boot state) showed the empty TopBar strip above these views
- [ ] Collapsed/closed sidebar still shows the TopBar with toggle + nav (code-path only, not exercised live)
- [ ] Window dragging from the header filler areas (drag regions can't be exercised via CDP)

## Testing
- `bun run lint`
- `bun run typecheck` (desktop)

https://claude.ai/code/session_015PEPRDMRZobovARaZiBHgd

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6023">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an empty 48px top strip on Automations, Tasks, and Workspaces in the v2 desktop dashboard. The TopBar is now hidden on these routes when the expanded sidebar hosts the window controls, so headers sit flush with the top.

- **Bug Fixes**
  - Hide TopBar on `/automations`, `/tasks`, and `/v2-workspaces` (fuzzy) when `sidebarOutsideColumn` is true.
  - Keep TopBar when the sidebar is collapsed or closed to show the toggle, nav, and traffic-light inset.
  - Add drag filler elements to each view header to keep the window draggable.

<sup>Written for commit 4787b8f9b92ac368965b2dfe47d6f9ba10d0585c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved window dragging across automation, task, issue, pull request, and workspace views.
  * Updated dashboard layouts to provide consistent draggable header areas when the top bar is hidden.
  * Preserved existing header actions, search, filters, navigation, and workspace controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->