### PR TITLE
fix(desktop): surface Grok permission request notifications

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-grok.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-grok.ts
@@ -28,6 +28,7 @@ const GROK_MANAGED_HOOK_EVENTS = [
 	"PostToolUseFailure",
 	"Stop",
 	"StopFailure",
+	"Notification",
 ] as const;
 
 const GROK_MANAGED_HOOK_COMMAND = getManagedNotifyHookCommand("grok");
@@ -57,7 +58,14 @@ export function getGrokHooksJsonContent(): string {
 	const hooks = Object.fromEntries(
 		GROK_MANAGED_HOOK_EVENTS.map((event) => [
 			event,
-			[{ hooks: [{ type: "command", command: GROK_MANAGED_HOOK_COMMAND }] }],
+			[
+				{
+					...(event === "Notification"
+						? { matcher: "^permission_prompt$" }
+						: {}),
+					hooks: [{ type: "command", command: GROK_MANAGED_HOOK_COMMAND }],
+				},
+			],
 		]),
 	);
 	return `${JSON.stringify({ hooks }, null, 2)}\n`;

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-grok.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-grok.ts
@@ -31,6 +31,15 @@ const GROK_MANAGED_HOOK_EVENTS = [
 	"Notification",
 ] as const;
 
+// Grok Notification subtypes where the agent is blocked waiting on the user:
+// tool and plan approvals both arrive as permission_prompt; ask_user_question
+// arrives as elicitation_dialog. notify-hook.template.sh filters on the same
+// list — a test asserts the two stay in sync.
+export const GROK_BLOCKING_NOTIFICATION_TYPES = [
+	"permission_prompt",
+	"elicitation_dialog",
+] as const;
+
 const GROK_MANAGED_HOOK_COMMAND = getManagedNotifyHookCommand("grok");
 
 // Vendor hook configs Superset also manages. Grok replays them in compat mode
@@ -61,7 +70,9 @@ export function getGrokHooksJsonContent(): string {
 			[
 				{
 					...(event === "Notification"
-						? { matcher: "^permission_prompt$" }
+						? {
+								matcher: `^(${GROK_BLOCKING_NOTIFICATION_TYPES.join("|")})$`,
+							}
 						: {}),
 					hooks: [{ type: "command", command: GROK_MANAGED_HOOK_COMMAND }],
 				},

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -32,7 +32,7 @@ mock.module("shared/env.shared", () => ({
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v4",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v5",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},
@@ -1805,15 +1805,18 @@ describe("grok hooks json", () => {
 			"PostToolUseFailure",
 			"Stop",
 			"StopFailure",
+			"Notification",
 		]);
 		expect(events).not.toContain("PreToolUse");
 		for (const definitions of Object.values(parsed.hooks)) {
 			const [definition] = definitions as Array<{
+				matcher?: string;
 				hooks: Array<{ type: string; command: string }>;
 			}>;
 			expect(definition.hooks[0].type).toBe("command");
 			expect(definition.hooks[0].command).toContain("SUPERSET_AGENT_ID=grok");
 		}
+		expect(parsed.hooks.Notification[0].matcher).toBe("^permission_prompt$");
 	});
 });
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -1778,6 +1778,7 @@ describe("kimi config.toml", () => {
 });
 
 import {
+	GROK_BLOCKING_NOTIFICATION_TYPES,
 	GROK_COMPAT_MARKER_END,
 	GROK_COMPAT_MARKER_START,
 	getGrokConfigTomlContent,
@@ -1816,7 +1817,19 @@ describe("grok hooks json", () => {
 			expect(definition.hooks[0].type).toBe("command");
 			expect(definition.hooks[0].command).toContain("SUPERSET_AGENT_ID=grok");
 		}
-		expect(parsed.hooks.Notification[0].matcher).toBe("^permission_prompt$");
+		expect(parsed.hooks.Notification[0].matcher).toBe(
+			`^(${GROK_BLOCKING_NOTIFICATION_TYPES.join("|")})$`,
+		);
+	});
+
+	it("keeps the notify template's subtype filter in sync with the matcher", () => {
+		const template = readFileSync(
+			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
+			"utf-8",
+		);
+		expect(template).toContain(
+			`${GROK_BLOCKING_NOTIFICATION_TYPES.join("|")}) EVENT_TYPE="PermissionRequest"`,
+		);
 	});
 });
 

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -84,6 +84,18 @@ describe("getNotifyScriptContent", () => {
 		);
 	});
 
+	it("normalizes Grok ask_user_question notifications to PermissionRequest", () => {
+		const result = runNotifyHook({
+			hookEventName: "notification",
+			notificationType: "elicitation_dialog",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toContain(
+			"[notify-hook] event=PermissionRequest",
+		);
+	});
+
 	it("ignores unrelated Grok notification subtypes", () => {
 		const result = runNotifyHook({
 			hookEventName: "notification",

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -3,16 +3,40 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { NOTIFY_SCRIPT_MARKER } from "./notify-hook";
 
+const notifyHookTemplatePath = path.join(
+	import.meta.dir,
+	"templates",
+	"notify-hook.template.sh",
+);
+
+function readNotifyHookTemplate(): string {
+	return readFileSync(notifyHookTemplatePath, "utf-8");
+}
+
+function runNotifyHook(input: Record<string, unknown>) {
+	const script = readNotifyHookTemplate()
+		.replaceAll("{{MARKER}}", NOTIFY_SCRIPT_MARKER)
+		.replaceAll("{{DEFAULT_PORT}}", "48763");
+	return Bun.spawnSync({
+		cmd: ["bash", "-c", script],
+		env: {
+			...process.env,
+			SUPERSET_AGENT_ID: "grok",
+			SUPERSET_DEBUG_HOOKS: "1",
+		},
+		stdin: Buffer.from(JSON.stringify(input)),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v4");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v5");
 	});
 
 	it("emits the v2 host-service payload with full agent identity", () => {
-		const script = readFileSync(
-			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
-			"utf-8",
-		);
+		const script = readNotifyHookTemplate();
 
 		expect(script).toContain('HOOK_SESSION_ID=$(echo "$INPUT"');
 		expect(script).toContain(
@@ -26,10 +50,7 @@ describe("getNotifyScriptContent", () => {
 	});
 
 	it("gives the v2 host-service hook enough time to deliver", () => {
-		const script = readFileSync(
-			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
-			"utf-8",
-		);
+		const script = readNotifyHookTemplate();
 
 		expect(script).toContain(
 			'curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \\\n    --connect-timeout 2 --max-time 5',
@@ -37,10 +58,7 @@ describe("getNotifyScriptContent", () => {
 	});
 
 	it("falls back to the v1 Electron hook when v2 is unavailable", () => {
-		const script = readFileSync(
-			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
-			"utf-8",
-		);
+		const script = readNotifyHookTemplate();
 
 		expect(script).toContain(
 			'if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then',
@@ -52,6 +70,28 @@ describe("getNotifyScriptContent", () => {
 		expect(script).toContain("terminalId=$SUPERSET_TERMINAL_ID");
 		expect(script).toContain("SUPERSET_TAB_ID");
 		expect(script).toContain("SUPERSET_PANE_ID");
+	});
+
+	it("normalizes Grok permission notifications to PermissionRequest", () => {
+		const result = runNotifyHook({
+			hookEventName: "notification",
+			notificationType: "permission_prompt",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toContain(
+			"[notify-hook] event=PermissionRequest",
+		);
+	});
+
+	it("ignores unrelated Grok notification subtypes", () => {
+		const result = runNotifyHook({
+			hookEventName: "notification",
+			notificationType: "idle_prompt",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toBe("");
 	});
 });
 

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -4,7 +4,7 @@ import { env } from "shared/env.shared";
 import { HOOKS_DIR } from "./paths";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v4";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v5";
 
 const NOTIFY_SCRIPT_TEMPLATE_PATH = path.join(
 	__dirname,

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -40,12 +40,17 @@ if [ -z "$EVENT_TYPE" ]; then
 fi
 
 # Grok serializes its configured Notification event as lowercase
-# "notification". Only an actual permission prompt means the agent is blocked
-# waiting for the user; ignore unrelated notification subtypes.
+# "notification". Only subtypes where the agent is blocked waiting on the
+# user count: permission_prompt (tool/plan approval) and elicitation_dialog
+# (ask_user_question — the common case, since Superset launches grok with
+# --always-approve so tool approvals rarely prompt). Keep the case pattern
+# in sync with GROK_BLOCKING_NOTIFICATION_TYPES in agent-wrappers-grok.ts.
 if [ "$EVENT_TYPE" = "notification" ]; then
   NOTIFICATION_TYPE=$(echo "$INPUT" | grep -oE '"notificationType"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
-  [ "$NOTIFICATION_TYPE" != "permission_prompt" ] && exit 0
-  EVENT_TYPE="PermissionRequest"
+  case "$NOTIFICATION_TYPE" in
+    permission_prompt|elicitation_dialog) EVENT_TYPE="PermissionRequest" ;;
+    *) exit 0 ;;
+  esac
 fi
 
 # UserPromptSubmit normalizes here; other aliases are mapped server-side

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -39,6 +39,15 @@ if [ -z "$EVENT_TYPE" ]; then
   esac
 fi
 
+# Grok serializes its configured Notification event as lowercase
+# "notification". Only an actual permission prompt means the agent is blocked
+# waiting for the user; ignore unrelated notification subtypes.
+if [ "$EVENT_TYPE" = "notification" ]; then
+  NOTIFICATION_TYPE=$(echo "$INPUT" | grep -oE '"notificationType"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+  [ "$NOTIFICATION_TYPE" != "permission_prompt" ] && exit 0
+  EVENT_TYPE="PermissionRequest"
+fi
+
 # UserPromptSubmit normalizes here; other aliases are mapped server-side
 # by mapEventType so the wire stays a single source of truth.
 [ "$EVENT_TYPE" = "UserPromptSubmit" ] && EVENT_TYPE="Start"


### PR DESCRIPTION
<!--
PR titles become the squash-merge commit subject, so use conventional commit format:
  feat(desktop): add copy-logs button to failed CI checks
  fix(web): guard against missing PR in workspace header
-->

## What & why

<!-- What changed and the problem it solves. Link the issue if there is one (e.g. "fixes #123"). -->

Grok was recently added as a first class agent, but it does not send notifications on permission requests the same way Claude Code does through Superset. This PR adds that feature by mapping Grok's Notification + Permission_prompt to Superset's PermissionRequest.



## How I tested it

<!-- What you ran or clicked to verify this works. For UI changes, add a screenshot or recording below. -->

1. Built and launched the packaged Superset Canary app.
2. Opened Claude and Grok terminals with approval prompts enabled.
3. Asked each agent to run a command outside the project directory:
   `touch "$HOME/grok-permission-probe.txt"`
4. Switched away from Superset while the permission request was pending.
5. Before the fix, Claude displayed the needs-input indicator and macOS notification, while Grok displayed neither.
6. After the fix, Grok displayed the same needs-input indicator and notification as Claude.

Also ran:

`bun test apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`

Result: 59 tests passed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6025">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Grok permission request notifications in the desktop app so users see the needs-input badge and macOS alert, matching Claude.

- **Bug Fixes**
  - Added Grok `Notification` hook with `matcher: "^(permission_prompt|elicitation_dialog)$"` to route blocking prompts to the notify hook.
  - Normalized these subtypes to `PermissionRequest` and ignored non-blocking ones like `idle_prompt`.
  - Centralized the blocking list in `GROK_BLOCKING_NOTIFICATION_TYPES`, synced the template filter via a test, and bumped the notify hook marker to v5.

<sup>Written for commit 855e3b462786ca230d47bb9aaafbd5b1fb97af1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Grok notification handling for blocking notification subtypes.
  - Blocking Grok notifications are now normalized and delivered as permission requests.

- **Bug Fixes**
  - Notifications outside the blocking subtype set (e.g., idle prompts) are ignored to avoid unnecessary alerts.
  - Updated generated notification hook scripts to the latest v5 marker and adjusted delivery behavior accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->