### PR TITLE
fix(host-service): send initialCommand Enter as a separate delayed write

### DIFF
--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -211,6 +211,16 @@ type TerminalSocket = {
 const SHELL_READY_TIMEOUT_MS = 15_000;
 
 /**
+ * Gap between writing the initialCommand text and the Enter (`\r`) that runs
+ * it. The shell-ready marker fires from precmd, before the line editor reads
+ * input — plugin init in that window can flush the PTY input queue, eating a
+ * newline bundled with the command while the text itself survives in the edit
+ * buffer (typed-but-never-run). A separated, delayed Enter lands after that
+ * init storm.
+ */
+const INITIAL_COMMAND_ENTER_DELAY_MS = 500;
+
+/**
  * Shell readiness lifecycle:
  * - `pending`     — shell initialising; scanner active
  * - `ready`       — OSC 133;A detected; scanner off
@@ -847,9 +857,7 @@ function queueInitialCommand(
 ): void {
 	if (session.initialCommandQueued || session.exited) return;
 	session.initialCommandQueued = true;
-	const cmd = initialCommand.endsWith("\n")
-		? initialCommand
-		: `${initialCommand}\n`;
+	const commandText = initialCommand.replace(/[\r\n]+$/, "");
 	// Marker-backed shells can run interactive startup hooks that read or flush
 	// PTY input before the first prompt (direnv/devenv is one example). Wait for
 	// that prompt so the command cannot be consumed as startup input. Launches
@@ -857,9 +865,20 @@ function queueInitialCommand(
 	// marker resolves it via SHELL_READY_TIMEOUT_MS — the command must
 	// eventually run; only session teardown may cancel it.
 	void session.shellReadyPromise.then(() => {
-		if (!session.exited && session.shellReadyState !== "cancelled") {
-			session.pty.write(cmd);
-		}
+		if (session.exited || session.shellReadyState === "cancelled") return;
+		// The OSC 133;A marker fires from precmd, which runs BEFORE the line
+		// editor starts reading input. Plugin init in that gap (vi-mode,
+		// syntax-highlighting) can flush the PTY input queue mid-read, eating a
+		// trailing newline sent in the same write: the command text survives in
+		// the editor's buffer but never executes. Send Enter as its own delayed
+		// write — and as `\r`, what a real Enter key sends, bound to accept-line
+		// in every keymap — so it lands after the init storm. One Enter total,
+		// so a double-run is impossible.
+		session.pty.write(commandText);
+		setTimeout(() => {
+			if (session.exited || session.shellReadyState === "cancelled") return;
+			session.pty.write("\r");
+		}, INITIAL_COMMAND_ENTER_DELAY_MS);
 	});
 }
 

--- a/packages/host-service/test/integration/setup-scripts.integration.test.ts
+++ b/packages/host-service/test/integration/setup-scripts.integration.test.ts
@@ -123,10 +123,14 @@ describe("setup scripts integration", () => {
 		expect(created.terminals).toHaveLength(1);
 		expect(created.terminals[0]?.label).toBe("Workspace Setup");
 
+		// The command text and its Enter arrive as separate writes (the Enter is
+		// delayed so shell startup can't eat it) — assert both, in order.
 		await waitFor(
-			() => writes.includes("echo setup-a && echo setup-b\n"),
+			() =>
+				writes.includes("echo setup-a && echo setup-b") &&
+				writes.indexOf("\r") > writes.indexOf("echo setup-a && echo setup-b"),
 			5000,
-			() => `expected setup command write, got ${JSON.stringify(writes)}`,
+			() => `expected setup command write + Enter, got ${JSON.stringify(writes)}`,
 		);
 
 		const workspaceRow = scenario.host.db

--- a/packages/host-service/test/integration/setup-scripts.integration.test.ts
+++ b/packages/host-service/test/integration/setup-scripts.integration.test.ts
@@ -130,7 +130,8 @@ describe("setup scripts integration", () => {
 				writes.includes("echo setup-a && echo setup-b") &&
 				writes.indexOf("\r") > writes.indexOf("echo setup-a && echo setup-b"),
 			5000,
-			() => `expected setup command write + Enter, got ${JSON.stringify(writes)}`,
+			() =>
+				`expected setup command write + Enter, got ${JSON.stringify(writes)}`,
 		);
 
 		const workspaceRow = scenario.host.db


### PR DESCRIPTION
## What

Agent and preset launches could end up **typed at the prompt but never executed**: the workspace was created, the agent terminal opened, and the full launch command (`'claude' '--dangerously-skip-permissions' '<prompt>'`) sat in the shell's edit buffer with the cursor blinking after it. Reported as "the new workspace page creates a workspace but doesn't start the agent" — but it's page-agnostic and hits every `initialCommand` consumer (modal creates, automations, setup terminals).

## Root cause

The OSC 133;A shell-ready marker is emitted from a `precmd` hook, which runs **before the prompt is drawn and before the line editor starts reading input**. Writing `command\n` in that gap lets shell plugin init (oh-my-zsh vi-mode, syntax-highlighting — worst under first-create load) flush the PTY input queue mid-read: the command text survives into the editor's buffer, the trailing newline is lost.

Confirmed live via CDP against the dev app: on the first workspace create after boot the command was stuck unexecuted; sending **one synthetic Enter keypress** launched Claude immediately, which then completed the prompt's task — proving only the newline was missing. This is the residual hole in the #4963 → #5774 (first-prompt gate) → #5927 (15s bound) series.

## Fix

In `queueInitialCommand`:
- strip trailing newlines from the command text and write it alone;
- 500ms later, send Enter as its **own** write — and as `\r` (what a real Enter key sends, bound to accept-line in every keymap) instead of `\n` (relies on the ^J binding).

Exactly one Enter is ever sent, so double-execution is impossible. If startup eats the text itself, the stray `\r` is a no-op at an empty prompt — every failure mode is strictly no-worse than before. Same technique VS Code shell integration uses; v1 avoided the class entirely by launching via `shell -lc`, which is why v1 never hit this.

## Verification

- `bun run test:e2e` (host-service): 20/20 pass, including the direnv input-consumption simulation and the promptness bound (command executed in 517ms with the new delay).
- End-to-end via CDP on the dev desktop app: pre-fix, first create after boot reproduced the stuck command (screenshot evidence, before/after Enter). Post-fix, restarted the app and ran the full `/new-workspace` flow twice with real input events — both creates launched Claude, which replied within ~2s. Setup terminals unaffected.
- Biome + `tsc` clean.

https://claude.ai/code/session_01CwWxQTQW2zLeN9hhRkQNxT

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an intermittent issue where the initial launch command was typed but not executed. We now send the command text and Enter separately with a short delay for reliable execution.

- **Bug Fixes**
  - In `packages/host-service/src/terminal/terminal.ts`, strip trailing CR/LF from `initialCommand` and write only the text.
  - Send Enter as a separate `\r` 500 ms after shell-ready to avoid plugin init eating it.
  - Update `packages/host-service/test/integration/setup-scripts.integration.test.ts` to assert split write and delayed `\r`; tidy assertion formatting.
  - Applies to all `initialCommand` flows (new workspace, modal creates, automations, setup terminals).

<sup>Written for commit 56af20635358bb3954fc2fef1bf1ec82378f3246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of terminal “initial command” execution by sending the command text and the Enter keystroke as two separate, ordered writes.
  * Normalized the command text to remove any trailing CR/LF characters before sending, and added a brief delay for better alignment with shell readiness.
* **Tests**
  * Updated the integration test to assert the command is written without `\n`, and that the Enter (`\r`) write occurs afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->