### PR TITLE
feat(desktop): add "Add agents" option to terminal preset import dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/QuickAddPresets/QuickAddPresets.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/QuickAddPresets/QuickAddPresets.tsx
@@ -3,11 +3,13 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
 import { HiMiniCommandLine } from "react-icons/hi2";
-import { LuCheck, LuChevronDown, LuPlus } from "react-icons/lu";
+import { LuCheck, LuChevronDown, LuPlus, LuSettings } from "react-icons/lu";
 import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
 
 export interface QuickAddAgentPill {
@@ -35,14 +37,12 @@ export function QuickAddPresets({
 	isPillAdded,
 	onAddPill,
 }: QuickAddPresetsProps) {
+	const navigate = useNavigate();
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button
-					size="sm"
-					variant="outline"
-					disabled={isAddDisabled || pills.length === 0}
-				>
+				<Button size="sm" variant="outline" disabled={isAddDisabled}>
 					<LuPlus className="size-4" />
 					Import agent
 					<LuChevronDown className="size-4 opacity-60" />
@@ -94,6 +94,11 @@ export function QuickAddPresets({
 						</DropdownMenuItem>
 					);
 				})}
+				{pills.length > 0 && <DropdownMenuSeparator />}
+				<DropdownMenuItem onSelect={() => navigate({ to: "/settings/agents" })}>
+					<LuSettings className="size-4 shrink-0 text-muted-foreground" />
+					<span className="flex-1">Add agents…</span>
+				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);


### PR DESCRIPTION
## Summary
- The "Import agent" dropdown in terminal preset settings now ends with an "Add agents…" item that navigates to `/settings/agents`, so users with missing agents have a direct path to configure them.
- The trigger button is no longer disabled when there are no importable agents left — the dropdown still opens and offers the settings shortcut instead of being a dead button.

## How It Works
Single change in `QuickAddPresets`, which is shared by both the v1 `PresetsSection` and v2 `V2PresetsSection`, so both terminal settings variants get the option. Follows the same separator + settings-item pattern as `AgentPicker` in automations.

## Testing
- `bun run typecheck` (desktop)
- `bun run lint`
- Manual: not run — straightforward dropdown item reusing the existing `AgentPicker` navigation pattern.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Add agents…" item to the "Import agent" dropdown in terminal preset settings (v1 and v2), linking to `/settings/agents` so users can configure missing agents. The button now opens even when no agents are available, showing the settings shortcut instead of being disabled.

<sup>Written for commit 1b9eb471bc093f6ace99428d192ebb7f84f9295a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Add agents…” option to the terminal presets menu, linking directly to agent settings.
  * Improved menu availability so the dropdown remains accessible when no presets are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->