### PR TITLE
docs(mcp): fix stale tool lists and counts in docs, marketing, and SDK reference

### DIFF
--- a/apps/docs/content/docs/mcp-server.mdx
+++ b/apps/docs/content/docs/mcp-server.mdx
@@ -17,6 +17,8 @@ Superset provides an [MCP (Model Context Protocol)](https://modelcontextprotocol
 |----------|------------|
 | **Tasks** | list, get (by id or slug), create, update, delete, list statuses |
 | **Workspaces** | list (per host), create on a host, update, delete |
+| **Agents** | list agents on a host, launch an agent session in a workspace |
+| **Terminals** | create in a workspace, list, send input, read screen, close |
 | **Automations** | list, get metadata, get/set prompt body, create, update metadata, pause, resume, run on demand, list runs, delete |
 | **Projects** | list projects on a host |
 | **Hosts** | list hosts (registered machines) you have access to |
@@ -318,6 +320,10 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `terminals_create` | Create a terminal session in a workspace, optionally running a command |
+| `terminals_list` | List terminal sessions in a workspace |
+| `terminals_send` | Write text into a running terminal (presses Enter by default) |
+| `terminals_read` | Read the terminal screen as plain text (current screen plus recent scrollback) |
+| `terminals_close` | Close a terminal session and kill its process |
 
 ### Automations
 

--- a/apps/marketing/src/lib/llms.ts
+++ b/apps/marketing/src/lib/llms.ts
@@ -53,7 +53,7 @@ export function buildDeveloperResourcesSection(): string[] {
 		"",
 		`- [API docs](${docsUrl}/mcp-server): Superset MCP server documentation`,
 		`- [OpenAPI spec](${API_URL}/openapi.json): OpenAPI 3.1 description of the Superset API surface`,
-		`- [MCP server](${MCP_SERVER_URL}): Model Context Protocol server (Streamable HTTP transport) — 27 tools for tasks, workspaces, agents, automations, terminals, hosts, and projects. Alias: ${API_URL}/mcp`,
+		`- [MCP server](${MCP_SERVER_URL}): Model Context Protocol server (Streamable HTTP transport) — tools for tasks, workspaces, agents, automations, terminals, hosts, and projects; full catalog in the server card. Alias: ${API_URL}/mcp`,
 		`- [Docs MCP server](${docsUrl}/mcp): search and read the Superset documentation over MCP (Streamable HTTP, no auth)`,
 		`- [MCP server card](${baseUrl}/.well-known/mcp/server-card.json): machine-readable MCP server description`,
 		`- [A2A agent card](${baseUrl}/.well-known/agent-card.json): Agent-to-Agent capability card`,

--- a/packages/sdk/api.md
+++ b/packages/sdk/api.md
@@ -96,10 +96,23 @@ Types:
 
 - <code><a href="./src/resources/terminals.ts">TerminalCreateParams</a></code>
 - <code><a href="./src/resources/terminals.ts">TerminalCreateResult</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalListParams</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalListResult</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalSummary</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalSendParams</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalSendResult</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalReadParams</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalReadResult</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalCloseParams</a></code>
+- <code><a href="./src/resources/terminals.ts">TerminalCloseResult</a></code>
 
 Methods:
 
 - <code title="host post /api/trpc/terminal.createSession">client.terminals.<a href="./src/resources/terminals.ts">create</a>({ hostId, workspaceId, command?, cwd? }) -> TerminalCreateResult</code>
+- <code title="host post /api/trpc/terminal.listSessions">client.terminals.<a href="./src/resources/terminals.ts">list</a>({ hostId, workspaceId }) -> TerminalListResult</code>
+- <code title="host post /api/trpc/terminal.send">client.terminals.<a href="./src/resources/terminals.ts">send</a>({ hostId, workspaceId, terminalId, text, submit? }) -> TerminalSendResult</code>
+- <code title="host post /api/trpc/terminal.snapshot">client.terminals.<a href="./src/resources/terminals.ts">read</a>({ hostId, workspaceId, terminalId, maxLines? }) -> TerminalReadResult</code>
+- <code title="host post /api/trpc/terminal.killSession">client.terminals.<a href="./src/resources/terminals.ts">close</a>({ hostId, workspaceId, terminalId }) -> TerminalCloseResult</code>
 
 # Automations
 


### PR DESCRIPTION
Part of the MCP v2 rework (Phase 0a).

- `apps/docs` mcp-server.mdx: capabilities table gains the missing **Agents** and **Terminals** rows; terminals tool table now lists all 5 tools (was only `terminals_create`).
- `apps/marketing` llms.ts: drops the hardcoded "27 tools" (actual count is 31, and it will change again during the toolset rework) — points at the self-updating server card instead.
- `packages/sdk` api.md: documents all five `client.terminals.*` methods and their types (only `create` was listed; the resource has shipped list/send/read/close for a while).

Docs-only, no behavior change.

https://claude.ai/code/session_01Kub4p3Eim9pc1qaRRmGea2

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6029">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale MCP tool lists across docs, marketing, and SDK. Adds Agents/Terminals to capabilities, lists all terminal tools, documents `client.terminals.{create,list,send,read,close}`, and replaces the hardcoded tool count with the self-updating server card.

Docs-only; no behavior changes.

<sup>Written for commit 3950b1ae94273414eca8fe3f193d4b0adadfe711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for agent capabilities, including listing agents and launching agent sessions in workspaces.
  * Expanded terminal tool coverage to include listing sessions, sending input, reading screens, and closing sessions.
  * Documented additional terminal session operations and their associated SDK methods.
  * Updated MCP server resources to reference the full tool catalog instead of a fixed tool count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->