### PR TITLE
fix(api): stop proxy clobbering CORS headers on .well-known routes

### DIFF
--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -42,12 +42,34 @@ function getCorsHeaders(origin: string | null, deploymentOrigin: string) {
 			"Producer-Expected-Seq",
 			"Producer-Received-Seq",
 			"ETag",
+			// Lets browser MCP clients read the RFC 9728 challenge off a 401
+			"WWW-Authenticate",
 		].join(", "),
 		"Access-Control-Allow-Credentials": "true",
 	};
 }
 
+const wellKnownCorsHeaders = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers":
+		"Content-Type, Authorization, MCP-Protocol-Version",
+};
+
 export default function proxy(req: NextRequest) {
+	// .well-known discovery routes set their own public CORS headers;
+	// overwriting them with the app-origin allowlist breaks browser-based
+	// MCP/OAuth discovery.
+	if (req.nextUrl.pathname.startsWith("/.well-known/")) {
+		if (req.method === "OPTIONS") {
+			return new NextResponse(null, {
+				status: 204,
+				headers: wellKnownCorsHeaders,
+			});
+		}
+		return NextResponse.next();
+	}
+
 	const origin = req.headers.get("origin");
 	const corsHeaders = getCorsHeaders(origin, req.nextUrl.origin);
 


### PR DESCRIPTION
Part of the MCP v2 rework (Phase 0c).

**What's actually broken today (verified against prod):** simple GETs to `.well-known/*` work fine — route-set `Access-Control-Allow-Origin: *` survives the proxy because Next.js lets route-handler headers win over middleware headers on conflict. But **OPTIONS preflights fail for non-app origins**: the proxy answers OPTIONS itself (before the route runs) using the app-origin allowlist, returning an empty `access-control-allow-origin` — so any browser-based client whose request triggers a preflight (e.g. MCP Inspector in a browser tab sending `MCP-Protocol-Version`) is blocked. Discovery responses also carry incoherent merged headers (`allow-credentials: true` alongside `*`, `DELETE` in allowed methods on static JSON).

Changes:
- `.well-known/*` paths bypass the app-CORS proxy: OPTIONS gets a public 204 preflight; other methods pass through untouched so the routes fully own their headers.
- `WWW-Authenticate` added to `Access-Control-Expose-Headers` so browser MCP clients on allowed origins can read the RFC 9728 resource-metadata challenge off a 401.

Impact is narrow (native/server-side MCP clients never noticed), but this removes the preflight trap and the header soup before the auth rework builds on these discovery routes.

Verify (prod repro of the bug):
`curl -s -D- -o /dev/null -X OPTIONS -H "Origin: https://x.example" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: mcp-protocol-version" https://api.superset.sh/.well-known/oauth-protected-resource` → today returns empty `access-control-allow-origin`; on this branch's preview it returns `*`.

https://claude.ai/code/session_01Kub4p3Eim9pc1qaRRmGea2