### PR TITLE
chore(mcp-v2): report real package version in telemetry

### DIFF
--- a/apps/api/src/app/api/v2/agent/[transport]/route.ts
+++ b/apps/api/src/app/api/v2/agent/[transport]/route.ts
@@ -2,6 +2,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import {
 	createMcpServer,
 	isMcpUnauthorized,
+	MCP_SERVER_VERSION,
 	type McpContext,
 	resolveMcpContext,
 } from "@superset/mcp-v2";
@@ -53,7 +54,7 @@ async function handle(req: Request): Promise<Response> {
 					success: event.success,
 					error_message: event.errorMessage,
 					mcp_server: "superset-v2",
-					mcp_server_version: "0.1.0",
+					mcp_server_version: MCP_SERVER_VERSION,
 				},
 				groups: { organization: event.organizationId },
 			});

--- a/packages/mcp-v2/src/index.ts
+++ b/packages/mcp-v2/src/index.ts
@@ -7,4 +7,4 @@ export {
 export { createMcpCaller } from "./caller";
 export type { McpToolCallEmitter, McpToolCallEvent } from "./define-tool";
 export type { McpServerOptions } from "./server";
-export { createMcpServer } from "./server";
+export { createMcpServer, MCP_SERVER_VERSION } from "./server";

--- a/packages/mcp-v2/src/server.ts
+++ b/packages/mcp-v2/src/server.ts
@@ -3,6 +3,8 @@ import packageJson from "../package.json" with { type: "json" };
 import type { McpToolCallEmitter } from "./define-tool";
 import { registerTools } from "./tools/register";
 
+export const MCP_SERVER_VERSION = packageJson.version;
+
 export interface McpServerOptions {
 	onToolCall?: McpToolCallEmitter;
 }


### PR DESCRIPTION
Part of the MCP v2 rework (Phase 0f, re-scoped).

`mcp_tool_called` now reports the real `@superset/mcp-v2` package version (exported as `MCP_SERVER_VERSION`) instead of a hardcoded `"0.1.0"`. Version segmentation becomes load-bearing during the Phase 3 toolset rework (comparing error rates and client behavior across the breaking change).

The v1 endpoint hit counter originally in this PR was dropped — v1 usage is assumed zero and all of v1 is being sunset, so no instrumentation is needed.

https://claude.ai/code/session_01Kub4p3Eim9pc1qaRRmGea2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP usage analytics now report the current server version automatically, improving the accuracy of event data.
* **Refactor**
  * Centralized server version information so it stays consistent across the MCP server and telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->