### PR TITLE
fix(mcp-v2): mint internal host-call token with session org only

### DIFF
--- a/packages/mcp-v2/src/auth.ts
+++ b/packages/mcp-v2/src/auth.ts
@@ -196,10 +196,13 @@ export async function resolveMcpContext(
 		);
 	}
 
+	// The minted token authorizes host calls through the relay, which trusts
+	// its organizationIds claim. Scope it to the session org only — the full
+	// membership list would let this MCP session reach hosts in other orgs.
 	const bearerToken = await mintUserJwt({
 		userId,
 		email,
-		organizationIds,
+		organizationIds: [organizationId],
 		ttlSeconds: 300,
 	});
 

--- a/packages/mcp-v2/src/in-memory.ts
+++ b/packages/mcp-v2/src/in-memory.ts
@@ -56,10 +56,12 @@ export async function createInMemoryMcpClient({
 		);
 	}
 
+	// Same scoping as resolveMcpContext: the relay trusts this claim, so the
+	// host-call token must carry only the org this client is bound to.
 	const bearerToken = await mintUserJwt({
 		userId,
 		email: user.email,
-		organizationIds,
+		organizationIds: [organizationId],
 		ttlSeconds: 300,
 	});
 


### PR DESCRIPTION
Part of the MCP v2 rework (Phase 0h) — security fix.

An MCP session (OAuth or API key) is authorized for exactly one `organizationId`, but the internal 300s JWT minted for relay/host calls carried the user's **entire** org membership list. The relay's `checkHostAccess` trusts that claim, so an MCP session scoped to org A could reach hosts in any other org the user belongs to.

- `resolveMcpContext` and `createInMemoryMcpClient` now mint the host-call token with `organizationIds: [organizationId]` (the session org).
- `McpContext.organizationIds` (full membership list) is unchanged — the in-process tRPC caller legitimately mirrors a real user session for cloud calls.
- No relay change needed: it already just reads the array. All MCP host routing uses `ctx.organizationId`, so no legitimate flow crosses orgs.

Verify: session-org host calls work; a host in another org of the same user is rejected by the relay; automations dispatch (separate `mintUserJwt` caller) untouched.

https://claude.ai/code/session_01Kub4p3Eim9pc1qaRRmGea2

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6033">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the internal 300s host-call JWT to the session’s organization to prevent cross-org host access via the relay. No relay changes; `McpContext.organizationIds` remains the full membership list for in-process cloud calls.

- **Bug Fixes**
  - Mint host-call token with `organizationIds: [organizationId]` in `resolveMcpContext` and `createInMemoryMcpClient`.
  - Blocks sessions from reaching hosts in other orgs even if the user belongs to them.

<sup>Written for commit 273936ac4984ab516d0579263f841c876e2282aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted session tokens to the specific organization associated with the active session.
  * Prevented access to hosts belonging to other organizations through cross-organization token scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->