### PR TITLE
fix(desktop): garbage-collect persisted terminal scrollback in localStorage

### DIFF
--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "./lib/boot-errors";
 import { persistentHistory } from "./lib/persistent-hash-history";
 import { posthog } from "./lib/posthog";
+import { pruneExpiredTerminalState } from "./lib/terminal/terminal-buffer-gc";
 import { electronQueryClient } from "./providers/ElectronTRPCProvider";
 import { NotFound } from "./routes/not-found";
 import { routeTree } from "./routeTree.gen";
@@ -23,6 +24,10 @@ import "./styles/bundled-fonts.css";
 
 const rootElement = document.querySelector("app");
 initBootErrorHandling(rootElement);
+
+// Before any terminal mounts: unbounded persisted scrollback wedged the
+// renderer once it grew to hundreds of orphaned buffers (23.7 MB observed).
+pruneExpiredTerminalState();
 
 const router = createRouter({
 	routeTree,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+	pruneExpiredTerminalState,
+	removeTerminalStatePersistedAt,
+	TERMINAL_BUFFER_KEY_PREFIX,
+	TERMINAL_DIMS_KEY_PREFIX,
+	TERMINAL_PERSISTED_AT_KEY,
+	touchTerminalStatePersistedAt,
+} from "./terminal-buffer-gc";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+function createFakeStorage(): {
+	values: Map<string, string>;
+	storage: Storage;
+} {
+	const values = new Map<string, string>();
+	const storage = {
+		get length() {
+			return values.size;
+		},
+		clear: () => values.clear(),
+		getItem: (key: string) => values.get(key) ?? null,
+		key: (index: number) => Array.from(values.keys())[index] ?? null,
+		removeItem: (key: string) => values.delete(key),
+		setItem: (key: string, value: string) => values.set(key, value),
+	} as Storage;
+	return { values, storage };
+}
+
+function seedTerminal(
+	values: Map<string, string>,
+	terminalId: string,
+	buffer = "scrollback",
+) {
+	values.set(`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`, buffer);
+	values.set(
+		`${TERMINAL_DIMS_KEY_PREFIX}${terminalId}`,
+		JSON.stringify({ cols: 120, rows: 32 }),
+	);
+}
+
+function readIndex(values: Map<string, string>): Record<string, number> {
+	const raw = values.get(TERMINAL_PERSISTED_AT_KEY);
+	return raw ? JSON.parse(raw) : {};
+}
+
+describe("pruneExpiredTerminalState", () => {
+	test("removes entries with no persisted-at stamp", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "legacy");
+		values.set("unrelated-key", "kept");
+
+		pruneExpiredTerminalState(storage, NOW);
+
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}legacy`)).toBe(false);
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}legacy`)).toBe(false);
+		expect(values.get("unrelated-key")).toBe("kept");
+	});
+
+	test("keeps fresh entries and removes ones older than the TTL", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "fresh");
+		seedTerminal(values, "stale");
+		touchTerminalStatePersistedAt("fresh", storage, NOW - 1 * DAY_MS);
+		touchTerminalStatePersistedAt("stale", storage, NOW - 15 * DAY_MS);
+
+		pruneExpiredTerminalState(storage, NOW);
+
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}fresh`)).toBe(true);
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}fresh`)).toBe(true);
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}stale`)).toBe(false);
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}stale`)).toBe(false);
+		expect(Object.keys(readIndex(values))).toEqual(["fresh"]);
+	});
+
+	test("evicts oldest entries once buffers exceed the size budget", () => {
+		const { values, storage } = createFakeStorage();
+		const big = "x".repeat(900_000);
+		for (const [id, ageDays] of [
+			["newest", 1],
+			["middle", 2],
+			["oldest", 3],
+		] as const) {
+			seedTerminal(values, id, big);
+			touchTerminalStatePersistedAt(id, storage, NOW - ageDays * DAY_MS);
+		}
+
+		pruneExpiredTerminalState(storage, NOW);
+
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}newest`)).toBe(true);
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}middle`)).toBe(true);
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}oldest`)).toBe(false);
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}oldest`)).toBe(false);
+	});
+
+	test("drops index rows whose storage keys are gone", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "live");
+		touchTerminalStatePersistedAt("live", storage, NOW);
+		touchTerminalStatePersistedAt("ghost", storage, NOW);
+		values.delete(`${TERMINAL_BUFFER_KEY_PREFIX}ghost`);
+
+		pruneExpiredTerminalState(storage, NOW);
+
+		expect(Object.keys(readIndex(values))).toEqual(["live"]);
+	});
+
+	test("prunes a dims key whose buffer never persisted", () => {
+		const { values, storage } = createFakeStorage();
+		values.set(
+			`${TERMINAL_DIMS_KEY_PREFIX}dims-only`,
+			JSON.stringify({ cols: 80, rows: 24 }),
+		);
+
+		pruneExpiredTerminalState(storage, NOW);
+
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}dims-only`)).toBe(false);
+	});
+});
+
+describe("persisted-at index maintenance", () => {
+	test("touch stamps and remove deletes a terminal's entry", () => {
+		const { values, storage } = createFakeStorage();
+
+		touchTerminalStatePersistedAt("t1", storage, NOW);
+		expect(readIndex(values)).toEqual({ t1: NOW });
+
+		removeTerminalStatePersistedAt("t1", storage);
+		expect(readIndex(values)).toEqual({});
+	});
+
+	test("touch survives a corrupt index blob", () => {
+		const { values, storage } = createFakeStorage();
+		values.set(TERMINAL_PERSISTED_AT_KEY, "not-json");
+
+		touchTerminalStatePersistedAt("t1", storage, NOW);
+
+		expect(readIndex(values)).toEqual({ t1: NOW });
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
@@ -1,0 +1,125 @@
+export const TERMINAL_BUFFER_KEY_PREFIX = "terminal-buffer:";
+export const TERMINAL_DIMS_KEY_PREFIX = "terminal-dims:";
+/** Single JSON map of terminalId -> epoch ms of the last persist/restore. */
+export const TERMINAL_PERSISTED_AT_KEY = "terminal-buffer-persisted-at";
+
+/**
+ * Persisted buffers are only deleted on an explicit terminal kill; terminals
+ * that disappear any other way (workspace deleted, host reset, crash) would
+ * leak their snapshot forever — measured at 945 entries / 23.7 MB after two
+ * months, enough to wedge the renderer on the synchronous localStorage load.
+ * Boot-time GC drops entries not touched within the TTL and enforces a total
+ * size budget so the store stays bounded regardless of how terminals die.
+ */
+const MAX_PERSISTED_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const MAX_TOTAL_BUFFER_CHARS = 2_000_000;
+
+type PersistedAtIndex = Record<string, number>;
+
+function readIndex(storage: Storage): PersistedAtIndex {
+	try {
+		const raw = storage.getItem(TERMINAL_PERSISTED_AT_KEY);
+		if (!raw) return {};
+		const parsed: unknown = JSON.parse(raw);
+		if (typeof parsed !== "object" || parsed === null) return {};
+		const index: PersistedAtIndex = {};
+		for (const [id, persistedAt] of Object.entries(parsed)) {
+			if (typeof persistedAt === "number") index[id] = persistedAt;
+		}
+		return index;
+	} catch {
+		return {};
+	}
+}
+
+function writeIndex(storage: Storage, index: PersistedAtIndex): void {
+	try {
+		storage.setItem(TERMINAL_PERSISTED_AT_KEY, JSON.stringify(index));
+	} catch {}
+}
+
+export function touchTerminalStatePersistedAt(
+	terminalId: string,
+	storage: Storage = localStorage,
+	now: number = Date.now(),
+): void {
+	const index = readIndex(storage);
+	index[terminalId] = now;
+	writeIndex(storage, index);
+}
+
+export function removeTerminalStatePersistedAt(
+	terminalId: string,
+	storage: Storage = localStorage,
+): void {
+	const index = readIndex(storage);
+	if (!(terminalId in index)) return;
+	delete index[terminalId];
+	writeIndex(storage, index);
+}
+
+function removeTerminalState(storage: Storage, terminalId: string): void {
+	try {
+		storage.removeItem(`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`);
+		storage.removeItem(`${TERMINAL_DIMS_KEY_PREFIX}${terminalId}`);
+	} catch {}
+}
+
+/**
+ * Run once at renderer boot, before any terminal mounts. Entries with no
+ * stamp predate the bounded store and are treated as expired — a one-time
+ * scrollback-restore loss on first launch after the upgrade, in exchange for
+ * clearing the accumulated bloat immediately instead of after a full TTL.
+ */
+export function pruneExpiredTerminalState(
+	storage: Storage = localStorage,
+	now: number = Date.now(),
+): void {
+	try {
+		const index = readIndex(storage);
+
+		const ids = new Set<string>();
+		for (let i = 0; i < storage.length; i++) {
+			const key = storage.key(i);
+			if (!key) continue;
+			if (key.startsWith(TERMINAL_BUFFER_KEY_PREFIX)) {
+				ids.add(key.slice(TERMINAL_BUFFER_KEY_PREFIX.length));
+			} else if (key.startsWith(TERMINAL_DIMS_KEY_PREFIX)) {
+				ids.add(key.slice(TERMINAL_DIMS_KEY_PREFIX.length));
+			}
+		}
+
+		const survivors: Array<{ id: string; persistedAt: number }> = [];
+		for (const id of ids) {
+			const persistedAt = index[id];
+			if (
+				persistedAt === undefined ||
+				now - persistedAt > MAX_PERSISTED_AGE_MS
+			) {
+				removeTerminalState(storage, id);
+				delete index[id];
+			} else {
+				survivors.push({ id, persistedAt });
+			}
+		}
+
+		// Newest-first size budget: buffers past the cap go, whatever their age.
+		survivors.sort((a, b) => b.persistedAt - a.persistedAt);
+		let totalChars = 0;
+		for (const { id } of survivors) {
+			const buffer = storage.getItem(`${TERMINAL_BUFFER_KEY_PREFIX}${id}`);
+			totalChars += buffer?.length ?? 0;
+			if (totalChars > MAX_TOTAL_BUFFER_CHARS) {
+				removeTerminalState(storage, id);
+				delete index[id];
+			}
+		}
+
+		// Index rows whose buffer and dims are both gone are dead weight.
+		for (const id of Object.keys(index)) {
+			if (!ids.has(id)) delete index[id];
+		}
+
+		writeIndex(storage, index);
+	} catch {}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
@@ -330,6 +330,59 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 		}
 	});
 
+	test("release disposes with clear and never persists an ended session", () => {
+		const terminalId = "release-session-ended";
+		const serialize = mock(() => "dead session scrollback");
+		const entry = {
+			terminalId,
+			instanceId: terminalId,
+			runtime: {
+				terminalId,
+				serializeAddon: { serialize },
+				lastCols: 120,
+				lastRows: 32,
+			},
+			transport: { sessionEnded: true },
+			linkManager: null,
+			pendingLinkHandlers: null,
+			disposeBufferChangeListener: null,
+			lastUsedAt: 1,
+		};
+		const registryInternals = terminalRuntimeRegistry as unknown as {
+			entries: Map<string, typeof entry>;
+			entryKeysByTerminalId: Map<string, Set<string>>;
+			disposeEntry: (
+				disposedEntry: typeof entry,
+				options: { persistedState?: "clear" | "preserve" },
+			) => void;
+		};
+		const entryKey = `${terminalId}\u0000${terminalId}`;
+		const disposeCalls: { persistedState?: "clear" | "preserve" }[] = [];
+		registryInternals.entries.set(entryKey, entry);
+		registryInternals.entryKeysByTerminalId.set(
+			terminalId,
+			new Set([entryKey]),
+		);
+		registryInternals.disposeEntry = (_entry, options) => {
+			disposeCalls.push(options);
+		};
+
+		try {
+			terminalRuntimeRegistry.release(terminalId);
+
+			expect(serialize).not.toHaveBeenCalled();
+			expect(fakeStorage.values.has(`terminal-buffer:${terminalId}`)).toBe(
+				false,
+			);
+			expect(disposeCalls).toEqual([{ persistedState: "clear" }]);
+		} finally {
+			delete (terminalRuntimeRegistry as unknown as { disposeEntry?: unknown })
+				.disposeEntry;
+			registryInternals.entries.delete(entryKey);
+			registryInternals.entryKeysByTerminalId.delete(terminalId);
+		}
+	});
+
 	test("dispose clears persisted state even when eviction already removed the entry", () => {
 		const terminalId = "evicted-terminal";
 		fakeStorage.values.set(`terminal-buffer:${terminalId}`, "scrollback");

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -89,7 +89,11 @@ class TerminalRuntimeRegistryImpl {
 			terminalId,
 			instanceId,
 			runtime: null,
-			transport: createTransport(),
+			// A destroyed PTY (exit / session-gone) has nothing left to restore —
+			// drop the persisted scrollback the moment the server says so.
+			transport: createTransport({
+				onSessionEnded: () => clearPersistedRuntimeState(terminalId),
+			}),
 			linkManager: null,
 			pendingLinkHandlers: null,
 			disposeBufferChangeListener: null,
@@ -293,6 +297,11 @@ class TerminalRuntimeRegistryImpl {
 
 		entry.lastUsedAt = ++this.useSeq;
 		detachFromContainer(entry.runtime);
+		// detachFromContainer persists unconditionally; a dead session's snapshot
+		// must not outlive the PTY.
+		if (entry.transport.sessionEnded) {
+			clearPersistedRuntimeState(terminalId);
+		}
 		this.scheduleParkedEviction();
 	}
 
@@ -339,6 +348,10 @@ class TerminalRuntimeRegistryImpl {
 			(entry) => entry.runtime?.terminal.buffer.active.type === "alternate",
 		);
 		for (const entry of victims) {
+			if (entry.transport.sessionEnded) {
+				this.disposeEntry(entry, { persistedState: "clear" });
+				continue;
+			}
 			if (!entry.runtime || !tryPersistRuntimeState(entry.runtime)) {
 				this.warnPersistFailureOnce(entry.terminalId);
 				continue;
@@ -409,6 +422,10 @@ class TerminalRuntimeRegistryImpl {
 				)
 			: this.getEntries(terminalId);
 		for (const entry of entries) {
+			if (entry.transport.sessionEnded) {
+				this.disposeEntry(entry, { persistedState: "clear" });
+				continue;
+			}
 			if (entry.runtime && !tryPersistRuntimeState(entry.runtime)) {
 				this.warnPersistFailureOnce(entry.terminalId);
 				continue;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -18,14 +18,20 @@ import {
 	wrapWrite,
 } from "./parser-idle-gate";
 import { loadAddons } from "./terminal-addons";
+import {
+	removeTerminalStatePersistedAt,
+	TERMINAL_BUFFER_KEY_PREFIX,
+	TERMINAL_DIMS_KEY_PREFIX,
+	touchTerminalStatePersistedAt,
+} from "./terminal-buffer-gc";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
 import { installInputModeReclaimer } from "./terminalInputModeReclaimer";
 
 const SERIALIZE_SCROLLBACK = 1000;
-const STORAGE_KEY_PREFIX = "terminal-buffer:";
-const DIMS_KEY_PREFIX = "terminal-dims:";
+const STORAGE_KEY_PREFIX = TERMINAL_BUFFER_KEY_PREFIX;
+const DIMS_KEY_PREFIX = TERMINAL_DIMS_KEY_PREFIX;
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 const RESIZE_DEBOUNCE_MS = 75;
@@ -96,6 +102,7 @@ function persistBuffer(
 	try {
 		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
 		localStorage.setItem(`${STORAGE_KEY_PREFIX}${terminalId}`, data);
+		touchTerminalStatePersistedAt(terminalId);
 		return true;
 	} catch {
 		return false;
@@ -105,7 +112,11 @@ function persistBuffer(
 function restoreBuffer(terminalId: string, terminal: XTerm) {
 	try {
 		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${terminalId}`);
-		if (data) terminal.write(data);
+		if (data) {
+			terminal.write(data);
+			// Restored-but-never-detached terminals must stay fresh for boot GC.
+			touchTerminalStatePersistedAt(terminalId);
+		}
 	} catch {}
 }
 
@@ -172,6 +183,7 @@ function clearPersistedDimensions(terminalId: string) {
 export function clearPersistedRuntimeState(terminalId: string): void {
 	clearPersistedBuffer(terminalId);
 	clearPersistedDimensions(terminalId);
+	removeTerminalStatePersistedAt(terminalId);
 }
 
 function hostIsVisible(container: HTMLDivElement | null): boolean {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -479,6 +479,74 @@ describe("terminal-ws-transport", () => {
 		expect(transport.connectionState).toBe("disconnected");
 	});
 
+	test("PTY exit marks the session ended and fires the callback once", () => {
+		const onSessionEnded = mock(() => {});
+		const transport = createTransport({ onSessionEnded });
+		const terminal = createMockTerminal();
+		connect(transport, terminal, "ws://host/terminal/t1");
+		const socket = FakeRelaySocket.instances.at(-1);
+		if (!socket) throw new Error("expected relay socket instance");
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(transport.sessionEnded).toBe(false);
+
+		socket.message(JSON.stringify({ type: "exit", exitCode: 0, signal: 0 }));
+		expect(transport.sessionEnded).toBe(true);
+		expect(onSessionEnded).toHaveBeenCalledTimes(1);
+	});
+
+	test("a session-gone attach error marks the session ended", () => {
+		const onSessionEnded = mock(() => {});
+		const transport = createTransport({ onSessionEnded });
+		connect(transport, createMockTerminal(), "ws://host/terminal/t1");
+		const socket = FakeRelaySocket.instances.at(-1);
+		if (!socket) throw new Error("expected relay socket instance");
+		socket.open();
+
+		socket.message(
+			JSON.stringify({
+				type: "error",
+				message: 'Terminal session "t1" has exited.',
+				code: "session-gone",
+			}),
+		);
+
+		expect(transport.sessionEnded).toBe(true);
+		expect(onSessionEnded).toHaveBeenCalledTimes(1);
+	});
+
+	test("a plain server error does not mark the session ended", () => {
+		const onSessionEnded = mock(() => {});
+		const transport = createTransport({ onSessionEnded });
+		connect(transport, createMockTerminal(), "ws://host/terminal/t1");
+		const socket = FakeRelaySocket.instances.at(-1);
+		if (!socket) throw new Error("expected relay socket instance");
+		socket.open();
+
+		socket.message(
+			JSON.stringify({
+				type: "error",
+				message: "Internal terminal attach error",
+			}),
+		);
+
+		expect(transport.sessionEnded).toBe(false);
+		expect(onSessionEnded).not.toHaveBeenCalled();
+	});
+
+	test("a successful re-attach resets the session-ended flag", () => {
+		const { transport, socket } = connectAttached();
+
+		socket.message(JSON.stringify({ type: "exit", exitCode: 0, signal: 0 }));
+		expect(transport.sessionEnded).toBe(true);
+
+		// The session was re-created under the same id and the retry attached.
+		reconnect(transport);
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(transport.sessionEnded).toBe(false);
+	});
+
 	test("ignores late events from a socket detached during teardown", () => {
 		const { transport, socket } = connectAttached();
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -30,7 +30,9 @@ export interface TerminalLogEntry {
 // JSON.
 type TerminalServerMessage =
 	| { type: "attached"; terminalId: string }
-	| { type: "error"; message: string }
+	// `code: "session-gone"` = the server says the session is permanently
+	// destroyed (not found / disposed / exited), not a transient attach failure.
+	| { type: "error"; message: string; code?: string }
 	| { type: "exit"; exitCode: number; signal: number }
 	| { type: "title"; title: string | null };
 
@@ -55,7 +57,19 @@ export interface TerminalTransport {
 	 * status indicator.
 	 */
 	lastDiagnosis: TerminalFailureClassification | null;
+	/**
+	 * True once the server has said the PTY is gone for good (live `exit`
+	 * message or a `session-gone` attach error). Distinct from `_terminated`,
+	 * which also covers access denials and unknown errors where the PTY may
+	 * still be alive. Persistence paths must clear — never write — the
+	 * persisted scrollback of a session-ended terminal. Reset on `attached`
+	 * (the session was re-created under the same id).
+	 */
+	sessionEnded: boolean;
 
+	/** Internal: invoked once each time the session-ended signal arrives, so
+	 * the owner can drop persisted scrollback immediately. */
+	_onSessionEnded: (() => void) | null;
 	/** Internal: the shared reconnecting relay socket (partysocket). Created
 	 * once on first connect; it re-signs the URL and runs the relay preflight
 	 * before every (re)dial and retries indefinitely. */
@@ -172,6 +186,12 @@ function maybeSurfaceDiagnosis(
 	});
 }
 
+function markSessionEnded(transport: TerminalTransport) {
+	if (transport.sessionEnded) return;
+	transport.sessionEnded = true;
+	transport._onSessionEnded?.();
+}
+
 function setConnectionState(
 	transport: TerminalTransport,
 	state: ConnectionState,
@@ -242,7 +262,9 @@ export function clearLogs(transport: TerminalTransport) {
 	}
 }
 
-export function createTransport(): TerminalTransport {
+export function createTransport(
+	options: { onSessionEnded?: () => void } = {},
+): TerminalTransport {
 	return {
 		connectionState: "disconnected",
 		currentUrl: null,
@@ -252,6 +274,8 @@ export function createTransport(): TerminalTransport {
 		logs: [],
 		logListeners: new Set(),
 		lastDiagnosis: null,
+		sessionEnded: false,
+		_onSessionEnded: options.onSessionEnded ?? null,
 		_socket: null,
 		_terminal: null,
 		_onDataDisposable: null,
@@ -545,6 +569,9 @@ function attachSocketListeners(
 		if (message.type === "attached") {
 			transport.lastDiagnosis = null;
 			transport._diagnosisLogged = false;
+			// A successful attach means the session exists again (re-created or
+			// respawned under the same id) — its scrollback is worth keeping.
+			transport.sessionEnded = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
 			return;
@@ -558,6 +585,9 @@ function attachSocketListeners(
 			pushLog(transport, "error", message.message);
 			// Server closes after this; reconnecting would just hit the same error.
 			transport._terminated = true;
+			if (message.code === "session-gone") {
+				markSessionEnded(transport);
+			}
 			socket.close();
 			return;
 		}
@@ -565,6 +595,7 @@ function attachSocketListeners(
 		if (message.type === "exit") {
 			transport._writeCoalescer?.flushSync();
 			transport._terminated = true;
+			markSessionEnded(transport);
 			transport.lastDiagnosis = {
 				category: "unknown",
 				message: `The terminal session ended (exit code ${message.exitCode}).`,
@@ -708,6 +739,8 @@ export function disposeTransport(transport: TerminalTransport) {
 	transport._terminal = null;
 	transport._diagnosisLogged = false;
 	transport._terminated = false;
+	transport.sessionEnded = false;
+	transport._onSessionEnded = null;
 	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
 	transport.stateListeners.clear();

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -158,7 +158,10 @@ type TerminalClientMessage =
 // from live data.
 type TerminalServerMessage =
 	| { type: "attached"; terminalId: string }
-	| { type: "error"; message: string }
+	// `code: "session-gone"` marks the session as permanently destroyed (not
+	// found / disposed / exited) so the renderer can drop persisted scrollback;
+	// plain errors leave it unset and the renderer keeps its snapshot.
+	| { type: "error"; message: string; code?: "session-gone" }
 	| { type: "exit"; exitCode: number; signal: number }
 	| { type: "title"; title: string | null };
 
@@ -1635,7 +1638,7 @@ export function registerWorkspaceTerminalRoute({
 				return true;
 			};
 			const resolveSessionForAttach = async (): Promise<
-				TerminalSession | { error: string }
+				TerminalSession | { error: string; code?: "session-gone" }
 			> => {
 				const existing = sessions.get(terminalId);
 				if (existing) {
@@ -1656,13 +1659,20 @@ export function registerWorkspaceTerminalRoute({
 				if (!record) {
 					return {
 						error: `Terminal session "${terminalId}" not found; create it before connecting.`,
+						code: "session-gone",
 					};
 				}
 				if (record.status === "disposed") {
-					return { error: `Terminal session "${terminalId}" is disposed.` };
+					return {
+						error: `Terminal session "${terminalId}" is disposed.`,
+						code: "session-gone",
+					};
 				}
 				if (record.status === "exited") {
-					return { error: `Terminal session "${terminalId}" has exited.` };
+					return {
+						error: `Terminal session "${terminalId}" has exited.`,
+						code: "session-gone",
+					};
 				}
 				if (!record.originWorkspaceId) {
 					return {
@@ -1718,7 +1728,11 @@ export function registerWorkspaceTerminalRoute({
 					void (async () => {
 						const session = await resolveSessionForAttach();
 						if ("error" in session) {
-							sendMessage(ws, { type: "error", message: session.error });
+							sendMessage(ws, {
+								type: "error",
+								message: session.error,
+								code: session.code,
+							});
 							ws.close(1011, session.error);
 							return;
 						}


### PR DESCRIPTION
## Problem

Terminal scrollback is persisted to renderer localStorage (`terminal-buffer:<id>` + `terminal-dims:<id>`) so panes can restore across remounts and relaunches. Those entries were only deleted on an **explicit terminal kill** (`terminalRuntimeRegistry.dispose()`). Terminals that disappear any other way — PTY exit, workspace deleted, host reset, crash, org switch — leaked their snapshot forever.

Measured on a real install after ~2 months: **945 orphaned buffers / 23.7 MB**, enough that Chromium's synchronous localStorage load wedged the renderer (652% CPU, 6.31 GB RSS, unresponsive AX queries).

## Fix (two layers)

**1. Destroyed PTY ⇒ scrollback deleted, immediately.**
- host-service tags attach errors for permanently-destroyed sessions (not found / disposed / exited) with `code: "session-gone"` on the existing error message (additive, version-skew safe).
- The renderer transport tracks that signal plus live `exit` messages as `sessionEnded`, distinct from `_terminated` (which also covers access denials where the PTY may still be alive). The signal clears the persisted snapshot on the spot, and every persistence path — detach, release, parked eviction — clears instead of re-persisting a dead session's buffer. A successful re-attach resets the flag (session re-created under the same id).

**2. Boot-time GC bounds the store no matter how a terminal dies.**
- Every persist/restore stamps the terminal in a single `terminal-buffer-persisted-at` index.
- At renderer boot, before any terminal mounts, `pruneExpiredTerminalState()` removes: unstamped entries (all pre-existing bloat, cleaned on first launch after this ships — a one-time scrollback-restore loss), entries older than a **14-day TTL** (covers deaths the renderer never observes, e.g. workspace deleted while the app is closed), and oldest entries beyond a **2M-char (~4 MB) total budget**.

Pruning deliberately does not cross-reference pane layouts: `v2WorkspaceLocalState` is org-scoped and cache-first, so reading it for GC could delete valid buffers for evicted orgs / not-ready collections.

## Relationship to #5965

Complementary, not overlapping fixes: #5965 guards the TanStack-DB localStorage **collections** write path against the QuotaExceededError rollback→retry loop once the store is already full, and reclaims orphaned snapshots only reactively on that quota path. This PR stops the terminal-snapshot store from growing unbounded in the first place and ties snapshot lifetime to PTY lifetime. Both touch `terminal-runtime(-registry).ts`, so whichever lands second needs a small rebase.

## Testing

- `terminal-buffer-gc.test.ts`: legacy pruning, TTL, size-budget eviction order, index hygiene, dims-only orphans, corrupt-index recovery. Core tests verified to fail when their behavior is mutated out.
- `terminal-ws-transport.test.ts`: exit ⇒ `sessionEnded` + callback fired once; `session-gone` attach error ⇒ same; plain error ⇒ untouched; re-attach resets.
- `terminal-runtime-registry.test.ts`: release of an ended session disposes with `clear` and never serializes.
- Full terminal lib suite: 304 pass. `bun run typecheck --filter=desktop --filter=@superset/host-service` and `bun run lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic garbage collection for persisted terminal scrollback and dimensions at desktop startup, including TTL-based pruning and a size cap.
  * Introduced persisted-state tracking so terminal history retention is updated as terminals are persisted, restored, or cleared.
* **Bug Fixes**
  * Improved session-ended handling to reliably clear persisted terminal state and avoid retaining snapshots after terminal termination.
  * Enhanced persistence cleanup to remove stale entries and keep the persisted-at index consistent.
  * Improved robustness when persisted GC index data is missing or corrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->