### PR TITLE
feat(desktop): move resource monitor into the command palette

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
+++ b/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
@@ -3,6 +3,7 @@ import { useHotkey } from "renderer/hotkeys";
 import { CommandContextProvider } from "./core/ContextProvider";
 import { useFrameStackStore } from "./core/frames";
 import { registerAllModules } from "./modules";
+import { checkResourcesCommand } from "./modules/resources/commands";
 import { CommandPalette } from "./ui/CommandPalette/CommandPalette";
 import { DeleteWorkspaceMount } from "./ui/DeleteWorkspaceMount/DeleteWorkspaceMount";
 import { FolderImportMount } from "./ui/FolderImportMount/FolderImportMount";
@@ -30,6 +31,13 @@ export function CommandPaletteHost({ children }: { children?: ReactNode }) {
 
 function CommandPaletteTrigger() {
 	const setOpen = useFrameStackStore((s) => s.setOpen);
+	const reset = useFrameStackStore((s) => s.reset);
+	const pushFrame = useFrameStackStore((s) => s.pushFrame);
 	useHotkey("OPEN_COMMAND_PALETTE", () => setOpen(true));
+	useHotkey("CHECK_RESOURCES", () => {
+		setOpen(true);
+		reset();
+		pushFrame(checkResourcesCommand);
+	});
 	return null;
 }

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -25,6 +25,7 @@ import { SYSTEM_THEME_ID, useThemeStore } from "renderer/stores/theme/store";
 import { useWorkspaceSidebarStore } from "renderer/stores/workspace-sidebar-state";
 import type { Command, CommandProvider } from "../../core/types";
 import { ThemeFrame } from "../../ui/ThemeFrame/ThemeFrame";
+import { checkResourcesCommand } from "../resources/commands";
 
 /** Dev-only fake notices for previewing each surface via the command palette. */
 const PREVIEW_NOTICES = {
@@ -115,6 +116,18 @@ export const actionsProvider: CommandProvider = {
 				renderFrame: () => <ThemeFrame />,
 			},
 			{
+				id: "actions.toggleNotificationSounds",
+				title: context.notificationSoundsMuted
+					? "Unmute notifications"
+					: "Mute notifications",
+				section: "actions",
+				icon: context.notificationSoundsMuted ? BellIcon : BellOffIcon,
+				keywords: ["dnd", "silence", "notifications", "ringtone"],
+				run: () =>
+					toggleNotificationSoundsMuted(context.notificationSoundsMuted),
+			},
+			checkResourcesCommand,
+			{
 				id: "actions.toggleLeftSidebar",
 				title: "Toggle left sidebar",
 				section: "actions",
@@ -136,17 +149,6 @@ export const actionsProvider: CommandProvider = {
 		}
 
 		commands.push(
-			{
-				id: "actions.toggleNotificationSounds",
-				title: context.notificationSoundsMuted
-					? "Unmute notifications"
-					: "Mute notifications",
-				section: "actions",
-				icon: context.notificationSoundsMuted ? BellIcon : BellOffIcon,
-				keywords: ["dnd", "silence", "notifications", "ringtone"],
-				run: () =>
-					toggleNotificationSoundsMuted(context.notificationSoundsMuted),
-			},
 			{
 				id: "actions.showShortcuts",
 				title: "Show keyboard shortcuts",

--- a/apps/desktop/src/renderer/commandPalette/modules/index.ts
+++ b/apps/desktop/src/renderer/commandPalette/modules/index.ts
@@ -3,12 +3,14 @@ import { actionsProvider } from "./actions/commands";
 import { addProjectProvider } from "./addProject/commands";
 import { navigationProvider } from "./navigation/commands";
 import { openInProvider } from "./openIn/commands";
+import { resourcesProvider } from "./resources/commands";
 import { workspaceProvider } from "./workspace/commands";
 
 export function registerAllModules(): () => void {
 	const unregisters = [
 		registerProvider(workspaceProvider),
 		registerProvider(actionsProvider),
+		registerProvider(resourcesProvider),
 		registerProvider(openInProvider),
 		registerProvider(navigationProvider),
 		registerProvider(addProjectProvider),

--- a/apps/desktop/src/renderer/commandPalette/modules/index.ts
+++ b/apps/desktop/src/renderer/commandPalette/modules/index.ts
@@ -3,14 +3,12 @@ import { actionsProvider } from "./actions/commands";
 import { addProjectProvider } from "./addProject/commands";
 import { navigationProvider } from "./navigation/commands";
 import { openInProvider } from "./openIn/commands";
-import { resourcesProvider } from "./resources/commands";
 import { workspaceProvider } from "./workspace/commands";
 
 export function registerAllModules(): () => void {
 	const unregisters = [
 		registerProvider(workspaceProvider),
 		registerProvider(actionsProvider),
-		registerProvider(resourcesProvider),
 		registerProvider(openInProvider),
 		registerProvider(navigationProvider),
 		registerProvider(addProjectProvider),

--- a/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
@@ -1,8 +1,11 @@
 import { HiOutlineCpuChip } from "react-icons/hi2";
-import type { Command, CommandProvider } from "../../core/types";
+import type { Command } from "../../core/types";
 import { ResourcesFrame } from "../../ui/ResourcesFrame";
 
-/** Exported so the CHECK_RESOURCES hotkey can push this frame directly. */
+/**
+ * Provided by the actions module (ordering within the Actions section);
+ * also pushed directly by the CHECK_RESOURCES hotkey.
+ */
 export const checkResourcesCommand: Command = {
 	id: "resources.check",
 	title: "Check resources",
@@ -21,9 +24,4 @@ export const checkResourcesCommand: Command = {
 		"processes",
 	],
 	renderFrame: () => <ResourcesFrame />,
-};
-
-export const resourcesProvider: CommandProvider = {
-	id: "resources",
-	provide: () => [checkResourcesCommand],
 };

--- a/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
@@ -1,27 +1,29 @@
 import { HiOutlineCpuChip } from "react-icons/hi2";
-import type { CommandProvider } from "../../core/types";
+import type { Command, CommandProvider } from "../../core/types";
 import { ResourcesFrame } from "../../ui/ResourcesFrame";
+
+/** Exported so the CHECK_RESOURCES hotkey can push this frame directly. */
+export const checkResourcesCommand: Command = {
+	id: "resources.check",
+	title: "Check resources",
+	section: "actions",
+	icon: HiOutlineCpuChip,
+	hotkeyId: "CHECK_RESOURCES",
+	keywords: [
+		"resources",
+		"memory",
+		"cpu",
+		"ram",
+		"usage",
+		"performance",
+		"monitor",
+		"activity",
+		"processes",
+	],
+	renderFrame: () => <ResourcesFrame />,
+};
 
 export const resourcesProvider: CommandProvider = {
 	id: "resources",
-	provide: () => [
-		{
-			id: "resources.check",
-			title: "Check resources",
-			section: "actions",
-			icon: HiOutlineCpuChip,
-			keywords: [
-				"resources",
-				"memory",
-				"cpu",
-				"ram",
-				"usage",
-				"performance",
-				"monitor",
-				"activity",
-				"processes",
-			],
-			renderFrame: () => <ResourcesFrame />,
-		},
-	],
+	provide: () => [checkResourcesCommand],
 };

--- a/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/resources/commands.tsx
@@ -1,0 +1,27 @@
+import { HiOutlineCpuChip } from "react-icons/hi2";
+import type { CommandProvider } from "../../core/types";
+import { ResourcesFrame } from "../../ui/ResourcesFrame";
+
+export const resourcesProvider: CommandProvider = {
+	id: "resources",
+	provide: () => [
+		{
+			id: "resources.check",
+			title: "Check resources",
+			section: "actions",
+			icon: HiOutlineCpuChip,
+			keywords: [
+				"resources",
+				"memory",
+				"cpu",
+				"ram",
+				"usage",
+				"performance",
+				"monitor",
+				"activity",
+				"processes",
+			],
+			renderFrame: () => <ResourcesFrame />,
+		},
+	],
+};

--- a/apps/desktop/src/renderer/commandPalette/ui/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/CommandPalette/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useRef,
 	useState,
 } from "react";
 import { useCommandContext } from "../../core/ContextProvider";
@@ -36,6 +37,7 @@ export function CommandPalette() {
 
 	const context = useCommandContext();
 	const [query, setQuery] = useState("");
+	const inputRef = useRef<HTMLInputElement>(null);
 	const depth = frames.length;
 	const currentFrame = frames[depth - 1] ?? null;
 
@@ -66,6 +68,10 @@ export function CommandPalette() {
 	const handleBack = useCallback(() => {
 		popFrame();
 		setQuery("");
+		// Going back can unmount the focused element (the back button leaves
+		// with the last frame); return focus to the search input so keyboard
+		// navigation keeps working.
+		inputRef.current?.focus();
 	}, [popFrame]);
 
 	const handleKeyDown = useCallback(
@@ -77,6 +83,20 @@ export function CommandPalette() {
 		},
 		[query, depth, handleBack],
 	);
+
+	// cmdk's root Enter handler executes the highlighted list row no matter
+	// which element is focused, swallowing Enter aimed at buttons inside the
+	// palette (back arrow, expand chevrons). Activate the focused button
+	// ourselves; cmdk skips its own handling once the event is
+	// defaultPrevented.
+	const handleRootKeyDown = useCallback((event: React.KeyboardEvent) => {
+		if (event.key !== "Enter") return;
+		if (!(event.target instanceof HTMLElement)) return;
+		const button = event.target.closest("button");
+		if (!button) return;
+		event.preventDefault();
+		button.click();
+	}, []);
 
 	useEffect(() => {
 		if (!open) setQuery("");
@@ -111,10 +131,12 @@ export function CommandPalette() {
 					</DialogDescription>
 				</DialogHeader>
 				<Command
+					onKeyDown={handleRootKeyDown}
 					shouldFilter={!currentFrame || !currentFrame.command.renderFrame}
 					className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[cmdk-list]]:max-h-[min(500px,calc(80vh-3rem))]"
 				>
 					<CommandInput
+						ref={inputRef}
 						value={query}
 						onValueChange={setQuery}
 						placeholder={placeholder}

--- a/apps/desktop/src/renderer/commandPalette/ui/ResourcesFrame/ResourcesFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/ResourcesFrame/ResourcesFrame.tsx
@@ -1,0 +1,248 @@
+import {
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { cn } from "@superset/ui/utils";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { HiOutlineChevronDown, HiOutlineChevronRight } from "react-icons/hi2";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { ResourceMetricsSummary } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary";
+import { UsageSeverityBadge } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/UsageSeverityBadge";
+import { useResourceNavigation } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceNavigation";
+import { useResourceSnapshot } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceSnapshot";
+import type { WorkspaceMetrics } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/types";
+import {
+	formatCpu,
+	formatMemory,
+} from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/utils/formatters";
+import { getUsageSeverity } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/utils/resourceSeverity";
+import { useFrameStackStore } from "../../core/frames";
+import { useCommandPaletteQuery } from "../CommandPalette/CommandPalette";
+
+const ROW_CLASS = "gap-2 !py-2.5 text-sm";
+const METRIC_COLS =
+	"flex shrink-0 items-center tabular-nums tracking-tight justify-end";
+const CPU_COL = "w-14 text-right";
+const MEM_COL = "w-16 text-right";
+const WORKSPACE_ID_ATTR = "data-resources-workspace-id";
+
+interface ResourceRow {
+	workspace: WorkspaceMetrics;
+	sessions: WorkspaceMetrics["sessions"];
+	/** Expanded because the query matched one of its terminals. */
+	forceExpanded: boolean;
+}
+
+export function ResourcesFrame() {
+	const rawQuery = useCommandPaletteQuery();
+	const query = rawQuery.trim().toLowerCase();
+	const isV2 = useIsV2CloudEnabled();
+	const surface = isV2 ? "v2" : "v1";
+	const setOpen = useFrameStackStore((s) => s.setOpen);
+
+	const { snapshot } = useResourceSnapshot(surface);
+	const { getPaneName, navigateToWorkspace, navigateToPane } =
+		useResourceNavigation({ surface, onNavigate: () => setOpen(false) });
+
+	const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(
+		new Set(),
+	);
+
+	const queryRef = useRef(query);
+	useEffect(() => {
+		queryRef.current = query;
+	}, [query]);
+
+	// cmdk keeps focus in the search input, so ←/→ never reach the list items.
+	// While the query is empty (arrows have no caret to move), toggle the
+	// highlighted workspace instead.
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+			if (queryRef.current) return;
+			const selected = document.querySelector(
+				'[cmdk-item][data-selected="true"]',
+			);
+			const workspaceId = selected?.getAttribute(WORKSPACE_ID_ATTR);
+			if (!workspaceId) return;
+			event.preventDefault();
+			event.stopPropagation();
+			setExpandedIds((previous) => {
+				const next = new Set(previous);
+				if (event.key === "ArrowRight") {
+					next.add(workspaceId);
+				} else {
+					next.delete(workspaceId);
+				}
+				return next;
+			});
+		};
+		document.addEventListener("keydown", handleKeyDown, true);
+		return () => document.removeEventListener("keydown", handleKeyDown, true);
+	}, []);
+
+	const rows = useMemo<ResourceRow[]>(() => {
+		if (!snapshot) return [];
+		const sorted = [...snapshot.workspaces].sort((a, b) => b.memory - a.memory);
+		if (!query) {
+			return sorted.map((workspace) => ({
+				workspace,
+				sessions: workspace.sessions,
+				forceExpanded: false,
+			}));
+		}
+		return sorted.flatMap((workspace) => {
+			const workspaceMatches =
+				workspace.workspaceName.toLowerCase().includes(query) ||
+				workspace.projectName.toLowerCase().includes(query);
+			const matchingSessions = workspace.sessions.filter((session) =>
+				getPaneName(session).toLowerCase().includes(query),
+			);
+			if (!workspaceMatches && matchingSessions.length === 0) return [];
+			return [
+				{
+					workspace,
+					sessions: workspaceMatches ? workspace.sessions : matchingSessions,
+					forceExpanded: matchingSessions.length > 0,
+				},
+			];
+		});
+	}, [snapshot, query, getPaneName]);
+
+	const totals = {
+		cpu: snapshot?.totalCpu ?? 0,
+		memory: snapshot?.totalMemory ?? 0,
+	};
+
+	const toggleWorkspace = (workspaceId: string) => {
+		setExpandedIds((previous) => {
+			const next = new Set(previous);
+			if (next.has(workspaceId)) {
+				next.delete(workspaceId);
+			} else {
+				next.add(workspaceId);
+			}
+			return next;
+		});
+	};
+
+	return (
+		<>
+			{snapshot && (
+				<div className="border-b border-border/60 px-3.5 pt-3 pb-3">
+					<ResourceMetricsSummary snapshot={snapshot} />
+				</div>
+			)}
+			<CommandList>
+				<CommandEmpty>
+					{snapshot ? "No matching workspaces." : "Measuring resource usage…"}
+				</CommandEmpty>
+				{rows.length > 0 && (
+					<CommandGroup heading="Workspaces · by memory">
+						{rows.map(({ workspace, sessions, forceExpanded }) => {
+							const isExpanded =
+								forceExpanded || expandedIds.has(workspace.workspaceId);
+							const hasSessions = sessions.length > 0;
+
+							return (
+								<Fragment key={workspace.workspaceId}>
+									<CommandItem
+										value={`resources ${workspace.workspaceId}`}
+										{...{ [WORKSPACE_ID_ATTR]: workspace.workspaceId }}
+										onSelect={() => navigateToWorkspace(workspace.workspaceId)}
+										className={ROW_CLASS}
+									>
+										{hasSessions ? (
+											<button
+												type="button"
+												onClick={(event) => {
+													event.preventDefault();
+													event.stopPropagation();
+													toggleWorkspace(workspace.workspaceId);
+												}}
+												aria-label={
+													isExpanded ? "Collapse workspace" : "Expand workspace"
+												}
+												aria-expanded={isExpanded}
+												className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
+											>
+												{isExpanded ? (
+													<HiOutlineChevronDown className="!size-3.5" />
+												) : (
+													<HiOutlineChevronRight className="!size-3.5" />
+												)}
+											</button>
+										) : (
+											<span className="size-5 shrink-0" />
+										)}
+										<span className="min-w-0 flex-1 truncate">
+											{workspace.workspaceName}
+										</span>
+										<span className="max-w-32 shrink-0 truncate text-muted-foreground text-xs">
+											{workspace.projectName}
+										</span>
+										<UsageSeverityBadge
+											severity={getUsageSeverity(workspace, totals)}
+										/>
+										<span
+											className={cn(METRIC_COLS, "text-foreground/85 text-xs")}
+										>
+											<span className={CPU_COL}>
+												{formatCpu(workspace.cpu)}
+											</span>
+											<span className={MEM_COL}>
+												{formatMemory(workspace.memory)}
+											</span>
+										</span>
+									</CommandItem>
+
+									{isExpanded &&
+										sessions.map((session) => (
+											<CommandItem
+												key={session.sessionId}
+												value={`resources ${workspace.workspaceId} ${session.sessionId}`}
+												{...{ [WORKSPACE_ID_ATTR]: workspace.workspaceId }}
+												onSelect={() =>
+													navigateToPane(workspace.workspaceId, session.paneId)
+												}
+												className={cn(ROW_CLASS, "!py-2")}
+											>
+												<span className="w-5 shrink-0" />
+												<span className="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/40" />
+												<span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">
+													{getPaneName(session)}
+												</span>
+												<UsageSeverityBadge
+													severity={getUsageSeverity(session, workspace)}
+												/>
+												<span
+													className={cn(
+														METRIC_COLS,
+														"text-muted-foreground/80 text-xs",
+													)}
+												>
+													<span className={CPU_COL}>
+														{formatCpu(session.cpu)}
+													</span>
+													<span className={MEM_COL}>
+														{formatMemory(session.memory)}
+													</span>
+												</span>
+											</CommandItem>
+										))}
+								</Fragment>
+							);
+						})}
+					</CommandGroup>
+				)}
+			</CommandList>
+			<div className="flex items-center gap-4 border-t border-border/60 px-3.5 py-2 text-[11px] text-muted-foreground">
+				<span>→ expand</span>
+				<span>← collapse</span>
+				<span>↵ open workspace / jump to terminal</span>
+			</div>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/commandPalette/ui/ResourcesFrame/index.ts
+++ b/apps/desktop/src/renderer/commandPalette/ui/ResourcesFrame/index.ts
@@ -1,0 +1,1 @@
+export { ResourcesFrame } from "./ResourcesFrame";

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -731,6 +731,16 @@ export const HOTKEYS_REGISTRY = {
 		category: "Help",
 		description: "Open the global command palette",
 	},
+	CHECK_RESOURCES: {
+		key: {
+			mac: L("meta+shift+u"),
+			windows: L("ctrl+shift+alt+u"),
+			linux: L("ctrl+shift+alt+u"),
+		},
+		label: "Check Resources",
+		category: "Help",
+		description: "Open the resource usage view in the command palette",
+	},
 } as const satisfies Record<string, HotkeyRegistryDefinition>;
 
 export type HotkeyId = keyof typeof HOTKEYS_REGISTRY;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -27,7 +27,6 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { NavigationControls } from "renderer/routes/_authenticated/_dashboard/components/NavigationControls";
 import { SidebarToggle } from "renderer/routes/_authenticated/_dashboard/components/SidebarToggle";
-import { ResourceConsumption } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption";
 import { useFailedAutomations } from "renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations";
 import {
 	tasksSearchFromFilters,
@@ -332,7 +331,6 @@ export function DashboardSidebarHeader({
 				<ZoomStable enabled={isMac} className="flex items-center gap-1.5">
 					<SidebarToggle />
 					<NavigationControls />
-					<ResourceConsumption surface="v2" />
 				</ZoomStable>
 				<div className="drag h-full min-w-0 flex-1" />
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -1,4 +1,3 @@
-import type { WorkspaceState } from "@superset/panes";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -10,40 +9,20 @@ import {
 import { cn } from "@superset/ui/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useLiveQuery } from "@tanstack/react-db";
-import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import {
 	HiOutlineArrowPath,
 	HiOutlineBarsArrowDown,
 	HiOutlineCpuChip,
 } from "react-icons/hi2";
-import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
-import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import {
-	logStressEvent,
-	useRenderStressInstrumentation,
-} from "renderer/lib/performance/stress-instrumentation";
-import {
-	navigateToWorkspace as navigateToV1Workspace,
-	navigateToV2Workspace,
-} from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { getVisibleSidebarWorkspaces } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
-import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
-import { useTabsStore } from "renderer/stores/tabs/store";
+import { useRenderStressInstrumentation } from "renderer/lib/performance/stress-instrumentation";
 import { AppResourceSection } from "./components/AppResourceSection";
-import { MetricBadge } from "./components/MetricBadge";
+import { ResourceMetricsSummary } from "./components/ResourceMetricsSummary";
 import { WorkspaceResourceSection } from "./components/WorkspaceResourceSection";
-import {
-	getResourceMonitorRefetchInterval,
-	shouldQueryResourceMonitor,
-} from "./resourceConsumptionPolicy";
-import type { SessionMetrics, SortOption, UsageValues } from "./types";
-import { formatCpu, formatMemory, formatPercent } from "./utils/formatters";
-import { normalizeResourceMetricsSnapshot } from "./utils/normalizeSnapshot";
-import { getTrackedHostMemorySeverity } from "./utils/resourceSeverity";
+import { useResourceNavigation } from "./hooks/useResourceNavigation";
+import { useResourceSnapshot } from "./hooks/useResourceSnapshot";
+import type { SortOption, UsageValues } from "./types";
 
 const SORT_LABELS: Record<SortOption, string> = {
 	memory: "Memory",
@@ -60,43 +39,6 @@ function getTotalUsage(
 		cpu: cpu ?? 0,
 		memory: memory ?? 0,
 	};
-}
-
-function getTrackedMemorySharePercent(
-	totalMemory: number,
-	hostTotalMemory: number,
-): number {
-	if (hostTotalMemory <= 0) return 0;
-	return (totalMemory / hostTotalMemory) * 100;
-}
-
-function getTerminalIdFromPaneData(data: unknown): string | null {
-	if (!data || typeof data !== "object") return null;
-	const terminalId = (data as { terminalId?: unknown }).terminalId;
-	return typeof terminalId === "string" && terminalId.length > 0
-		? terminalId
-		: null;
-}
-
-function getTerminalTitleOverrides(
-	rows: Array<{ paneLayout: unknown }>,
-): Map<string, string> {
-	const overrides = new Map<string, string>();
-	for (const row of rows) {
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!Array.isArray(layout?.tabs)) continue;
-		for (const tab of layout.tabs) {
-			if (!tab.panes || typeof tab.panes !== "object") continue;
-			for (const pane of Object.values(tab.panes)) {
-				if (pane.kind !== "terminal" || !pane.titleOverride) continue;
-				const terminalId = getTerminalIdFromPaneData(pane.data);
-				if (terminalId && !overrides.has(terminalId)) {
-					overrides.set(terminalId, pane.titleOverride);
-				}
-			}
-		}
-	}
-	return overrides;
 }
 
 interface ResourceConsumptionProps {
@@ -169,170 +111,21 @@ function ResourceConsumptionContent({
 		new Set(),
 	);
 
-	const navigate = useNavigate();
-	const panes = useTabsStore((state) => state.panes);
-	const setActiveTab = useTabsStore((state) => state.setActiveTab);
-	const setFocusedPane = useTabsStore((state) => state.setFocusedPane);
-	const collections = useCollections();
-	const isV2 = surface === "v2";
-	const { data: session } = authClient.useSession();
-	const organizationId = session?.session?.activeOrganizationId ?? undefined;
-
 	useRenderStressInstrumentation("ResourceConsumptionContent", {
 		warnAt: 25,
 		getDetails: () => ({ surface }),
 	});
 
-	const { data: rawSidebarProjects = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ sp: collections.v2SidebarProjects })
-				.orderBy(({ sp }) => sp.tabOrder, "asc")
-				.select(({ sp }) => ({ projectId: sp.projectId })),
-		[collections],
-	);
-
-	const { data: rawSidebarWorkspaces = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ ws: collections.v2WorkspaceLocalState })
-				.orderBy(({ ws }) => ws.sidebarState.tabOrder, "asc")
-				.select(({ ws }) => ({
-					workspaceId: ws.workspaceId,
-					isHidden: ws.sidebarState.isHidden,
-					paneLayout: ws.paneLayout,
-				})),
-		[collections],
-	);
-
-	const sidebarProjectOrder = useMemo(
-		() => rawSidebarProjects.map((p) => p.projectId),
-		[rawSidebarProjects],
-	);
-
-	const sidebarWorkspaceOrder = useMemo(
-		() =>
-			getVisibleSidebarWorkspaces(rawSidebarWorkspaces).map(
-				(w) => w.workspaceId,
-			),
-		[rawSidebarWorkspaces],
-	);
-
-	const terminalTitleOverrides = useMemo(
-		() => getTerminalTitleOverrides(rawSidebarWorkspaces),
-		[rawSidebarWorkspaces],
-	);
-
-	// Projects are fully local — identity comes from the host fan-out.
-	const { projects: hostProjects } = useHostProjects();
-	const rawV2Projects = useMemo(
-		() =>
-			hostProjects.map((project) => ({
-				id: project.projectKey,
-				name: project.name,
-			})),
-		[hostProjects],
-	);
-
-	const { workspaces: rawV2Workspaces } = useHostWorkspaces();
-
-	const shouldQueryMetrics = shouldQueryResourceMonitor({
-		enabled: true,
-		open: true,
-	});
-
 	const {
-		data: snapshot,
+		snapshot: normalizedSnapshot,
 		refetch,
 		isFetching,
-	} = electronTrpc.resourceMetrics.getSnapshot.useQuery(
-		{
-			mode: "interactive",
-			surface,
-			organizationId,
-		},
-		{
-			enabled: shouldQueryMetrics,
-			refetchInterval: getResourceMonitorRefetchInterval(true),
-		},
-	);
+		sidebarProjectOrder,
+		sidebarWorkspaceOrder,
+	} = useResourceSnapshot(surface);
 
-	useEffect(() => {
-		if (!isFetching) return;
-		logStressEvent("resource-monitor.fetch", { surface });
-	}, [isFetching, surface]);
-
-	const normalizedSnapshot = useMemo(() => {
-		const normalized = normalizeResourceMetricsSnapshot(snapshot);
-		if (!normalized || !isV2) return normalized;
-
-		const projectById = new Map(
-			rawV2Projects.map((project) => [project.id, project]),
-		);
-		const workspaceById = new Map(
-			rawV2Workspaces.map((workspace) => [workspace.id, workspace]),
-		);
-
-		return {
-			...normalized,
-			workspaces: normalized.workspaces.map((workspace) => {
-				const v2Workspace = workspaceById.get(workspace.workspaceId);
-				const projectId = v2Workspace?.projectId ?? workspace.projectId;
-				const project = projectById.get(projectId);
-				return {
-					...workspace,
-					projectId,
-					projectName: project?.name ?? workspace.projectName,
-					workspaceName: v2Workspace?.name ?? workspace.workspaceName,
-					sessions: workspace.sessions.map((session) => ({
-						...session,
-						title:
-							terminalTitleOverrides.get(session.paneId) ??
-							session.title ??
-							null,
-					})),
-				};
-			}),
-		};
-	}, [snapshot, isV2, rawV2Projects, rawV2Workspaces, terminalTitleOverrides]);
-
-	const getPaneName = (session: SessionMetrics): string => {
-		if (isV2) {
-			return session.title ?? `Terminal ${session.sessionId.slice(0, 8)}`;
-		}
-		const pane = panes[session.paneId];
-		return pane?.name || `Pane ${session.paneId.slice(0, 6)}`;
-	};
-
-	const navigateToWorkspace = (workspaceId: string) => {
-		if (isV2) {
-			void navigateToV2Workspace(workspaceId, navigate);
-		} else {
-			void navigateToV1Workspace(workspaceId, navigate);
-		}
-		onClose();
-	};
-
-	const navigateToPane = (workspaceId: string, paneId: string) => {
-		if (isV2) {
-			void navigateToV2Workspace(workspaceId, navigate, {
-				search: {
-					terminalId: paneId,
-					focusRequestId: crypto.randomUUID(),
-				},
-			});
-			onClose();
-			return;
-		}
-
-		const pane = panes[paneId];
-		if (pane) {
-			setActiveTab(workspaceId, pane.tabId);
-			setFocusedPane(pane.tabId, paneId);
-		}
-		void navigateToV1Workspace(workspaceId, navigate);
-		onClose();
-	};
+	const { getPaneName, navigateToWorkspace, navigateToPane } =
+		useResourceNavigation({ surface, onNavigate: onClose });
 
 	const toggleWorkspace = (workspaceId: string) => {
 		setCollapsedWorkspaces((prev) => {
@@ -363,22 +156,6 @@ function ResourceConsumptionContent({
 		normalizedSnapshot?.totalMemory,
 	);
 
-	const trackedMemorySharePercent = normalizedSnapshot
-		? getTrackedMemorySharePercent(
-				normalizedSnapshot.totalMemory,
-				normalizedSnapshot.host.totalMemory,
-			)
-		: 0;
-
-	const hostShareSeverity = getTrackedHostMemorySeverity(
-		trackedMemorySharePercent,
-	);
-	const shareBarColorClass =
-		hostShareSeverity === "high"
-			? "bg-red-500/80"
-			: hostShareSeverity === "elevated"
-				? "bg-amber-500/80"
-				: "bg-foreground/40";
 	return (
 		<PopoverContent align="start" className="w-[28rem] p-0 overflow-hidden">
 			<div className="px-3.5 pt-3 pb-3 border-b border-border/60">
@@ -430,51 +207,9 @@ function ResourceConsumptionContent({
 				</div>
 
 				{normalizedSnapshot && (
-					<>
-						<div className="mt-3 grid grid-cols-3 divide-x divide-border/50">
-							<MetricBadge
-								label="CPU"
-								value={formatCpu(normalizedSnapshot.totalCpu)}
-								tooltip="Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
-							/>
-							<MetricBadge
-								label="Memory"
-								value={formatMemory(normalizedSnapshot.totalMemory)}
-								tooltip="Resident memory used by Superset and monitored terminal process trees. If this keeps climbing without dropping, a workspace process may be retaining memory. High values increase swap risk and can cause stutter."
-							/>
-							<MetricBadge
-								label="RAM Share"
-								value={formatPercent(trackedMemorySharePercent)}
-								tooltip="Percent of total system RAM used by monitored Superset resources only (not all apps). A high share means Superset is a major contributor to system memory pressure; a low share means pressure is likely elsewhere."
-							/>
-						</div>
-						<Tooltip delayDuration={150}>
-							<TooltipTrigger asChild>
-								<div
-									className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted/60"
-									role="progressbar"
-									aria-label="System RAM share"
-									aria-valuenow={Math.round(trackedMemorySharePercent)}
-									aria-valuemin={0}
-									aria-valuemax={100}
-								>
-									<div
-										className={cn(
-											"h-full rounded-full transition-[width] duration-300",
-											shareBarColorClass,
-										)}
-										style={{
-											width: `${Math.min(100, Math.max(0, trackedMemorySharePercent))}%`,
-										}}
-									/>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent side="bottom" sideOffset={6}>
-								Superset uses {formatPercent(trackedMemorySharePercent)} of
-								system RAM
-							</TooltipContent>
-						</Tooltip>
-					</>
+					<div className="mt-3">
+						<ResourceMetricsSummary snapshot={normalizedSnapshot} />
+					</div>
 				)}
 			</div>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/ResourceMetricsSummary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/ResourceMetricsSummary.tsx
@@ -24,6 +24,10 @@ export function ResourceMetricsSummary({
 		snapshot.totalMemory,
 		snapshot.host.totalMemory,
 	);
+	const clampedSharePercent = Math.min(
+		100,
+		Math.max(0, trackedMemorySharePercent),
+	);
 
 	const hostShareSeverity = getTrackedHostMemorySeverity(
 		trackedMemorySharePercent,
@@ -60,7 +64,7 @@ export function ResourceMetricsSummary({
 						className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted/60"
 						role="progressbar"
 						aria-label="System RAM share"
-						aria-valuenow={Math.round(trackedMemorySharePercent)}
+						aria-valuenow={Math.round(clampedSharePercent)}
 						aria-valuemin={0}
 						aria-valuemax={100}
 					>
@@ -69,9 +73,7 @@ export function ResourceMetricsSummary({
 								"h-full rounded-full transition-[width] duration-300",
 								shareBarColorClass,
 							)}
-							style={{
-								width: `${Math.min(100, Math.max(0, trackedMemorySharePercent))}%`,
-							}}
+							style={{ width: `${clampedSharePercent}%` }}
 						/>
 					</div>
 				</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/ResourceMetricsSummary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/ResourceMetricsSummary.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@superset/ui/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import type { ResourceMetricsSnapshot } from "../../types";
+import { formatCpu, formatMemory, formatPercent } from "../../utils/formatters";
+import { getTrackedHostMemorySeverity } from "../../utils/resourceSeverity";
+import { MetricBadge } from "../MetricBadge";
+
+function getTrackedMemorySharePercent(
+	totalMemory: number,
+	hostTotalMemory: number,
+): number {
+	if (hostTotalMemory <= 0) return 0;
+	return (totalMemory / hostTotalMemory) * 100;
+}
+
+interface ResourceMetricsSummaryProps {
+	snapshot: ResourceMetricsSnapshot;
+}
+
+export function ResourceMetricsSummary({
+	snapshot,
+}: ResourceMetricsSummaryProps) {
+	const trackedMemorySharePercent = getTrackedMemorySharePercent(
+		snapshot.totalMemory,
+		snapshot.host.totalMemory,
+	);
+
+	const hostShareSeverity = getTrackedHostMemorySeverity(
+		trackedMemorySharePercent,
+	);
+	const shareBarColorClass =
+		hostShareSeverity === "high"
+			? "bg-red-500/80"
+			: hostShareSeverity === "elevated"
+				? "bg-amber-500/80"
+				: "bg-foreground/40";
+
+	return (
+		<>
+			<div className="grid grid-cols-3 divide-x divide-border/50">
+				<MetricBadge
+					label="CPU"
+					value={formatCpu(snapshot.totalCpu)}
+					tooltip="Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
+				/>
+				<MetricBadge
+					label="Memory"
+					value={formatMemory(snapshot.totalMemory)}
+					tooltip="Resident memory used by Superset and monitored terminal process trees. If this keeps climbing without dropping, a workspace process may be retaining memory. High values increase swap risk and can cause stutter."
+				/>
+				<MetricBadge
+					label="RAM Share"
+					value={formatPercent(trackedMemorySharePercent)}
+					tooltip="Percent of total system RAM used by monitored Superset resources only (not all apps). A high share means Superset is a major contributor to system memory pressure; a low share means pressure is likely elsewhere."
+				/>
+			</div>
+			<Tooltip delayDuration={150}>
+				<TooltipTrigger asChild>
+					<div
+						className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted/60"
+						role="progressbar"
+						aria-label="System RAM share"
+						aria-valuenow={Math.round(trackedMemorySharePercent)}
+						aria-valuemin={0}
+						aria-valuemax={100}
+					>
+						<div
+							className={cn(
+								"h-full rounded-full transition-[width] duration-300",
+								shareBarColorClass,
+							)}
+							style={{
+								width: `${Math.min(100, Math.max(0, trackedMemorySharePercent))}%`,
+							}}
+						/>
+					</div>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" sideOffset={6}>
+					Superset uses {formatPercent(trackedMemorySharePercent)} of system RAM
+				</TooltipContent>
+			</Tooltip>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/ResourceMetricsSummary/index.ts
@@ -1,0 +1,1 @@
+export { ResourceMetricsSummary } from "./ResourceMetricsSummary";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceNavigation/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceNavigation/index.ts
@@ -1,0 +1,1 @@
+export { useResourceNavigation } from "./useResourceNavigation";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceNavigation/useResourceNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceNavigation/useResourceNavigation.ts
@@ -1,0 +1,79 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import {
+	navigateToWorkspace as navigateToV1Workspace,
+	navigateToV2Workspace,
+} from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import type { SessionMetrics } from "../../types";
+
+interface UseResourceNavigationOptions {
+	surface: "v1" | "v2";
+	/** Called after navigating, e.g. to close the popover or palette. */
+	onNavigate: () => void;
+}
+
+/**
+ * Navigation targets for resource rows: open a workspace, or jump straight
+ * to the pane a terminal session lives in. Also resolves display names for
+ * v1 sessions from the panes store.
+ */
+export function useResourceNavigation({
+	surface,
+	onNavigate,
+}: UseResourceNavigationOptions) {
+	const navigate = useNavigate();
+	const panes = useTabsStore((state) => state.panes);
+	const setActiveTab = useTabsStore((state) => state.setActiveTab);
+	const setFocusedPane = useTabsStore((state) => state.setFocusedPane);
+	const isV2 = surface === "v2";
+
+	const getPaneName = useCallback(
+		(session: SessionMetrics): string => {
+			if (isV2) {
+				return session.title ?? `Terminal ${session.sessionId.slice(0, 8)}`;
+			}
+			const pane = panes[session.paneId];
+			return pane?.name || `Pane ${session.paneId.slice(0, 6)}`;
+		},
+		[isV2, panes],
+	);
+
+	const navigateToWorkspace = useCallback(
+		(workspaceId: string) => {
+			if (isV2) {
+				void navigateToV2Workspace(workspaceId, navigate);
+			} else {
+				void navigateToV1Workspace(workspaceId, navigate);
+			}
+			onNavigate();
+		},
+		[isV2, navigate, onNavigate],
+	);
+
+	const navigateToPane = useCallback(
+		(workspaceId: string, paneId: string) => {
+			if (isV2) {
+				void navigateToV2Workspace(workspaceId, navigate, {
+					search: {
+						terminalId: paneId,
+						focusRequestId: crypto.randomUUID(),
+					},
+				});
+				onNavigate();
+				return;
+			}
+
+			const pane = panes[paneId];
+			if (pane) {
+				setActiveTab(workspaceId, pane.tabId);
+				setFocusedPane(pane.tabId, paneId);
+			}
+			void navigateToV1Workspace(workspaceId, navigate);
+			onNavigate();
+		},
+		[isV2, navigate, onNavigate, panes, setActiveTab, setFocusedPane],
+	);
+
+	return { getPaneName, navigateToWorkspace, navigateToPane };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceSnapshot/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceSnapshot/index.ts
@@ -1,0 +1,4 @@
+export {
+	type UseResourceSnapshotResult,
+	useResourceSnapshot,
+} from "./useResourceSnapshot";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceSnapshot/useResourceSnapshot.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/hooks/useResourceSnapshot/useResourceSnapshot.ts
@@ -1,0 +1,189 @@
+import type { WorkspaceState } from "@superset/panes";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useEffect, useMemo } from "react";
+import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { logStressEvent } from "renderer/lib/performance/stress-instrumentation";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { getVisibleSidebarWorkspaces } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import {
+	getResourceMonitorRefetchInterval,
+	shouldQueryResourceMonitor,
+} from "../../resourceConsumptionPolicy";
+import type { ResourceMetricsSnapshot } from "../../types";
+import { normalizeResourceMetricsSnapshot } from "../../utils/normalizeSnapshot";
+
+function getTerminalIdFromPaneData(data: unknown): string | null {
+	if (!data || typeof data !== "object") return null;
+	const terminalId = (data as { terminalId?: unknown }).terminalId;
+	return typeof terminalId === "string" && terminalId.length > 0
+		? terminalId
+		: null;
+}
+
+function getTerminalTitleOverrides(
+	rows: Array<{ paneLayout: unknown }>,
+): Map<string, string> {
+	const overrides = new Map<string, string>();
+	for (const row of rows) {
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!Array.isArray(layout?.tabs)) continue;
+		for (const tab of layout.tabs) {
+			if (!tab.panes || typeof tab.panes !== "object") continue;
+			for (const pane of Object.values(tab.panes)) {
+				if (pane.kind !== "terminal" || !pane.titleOverride) continue;
+				const terminalId = getTerminalIdFromPaneData(pane.data);
+				if (terminalId && !overrides.has(terminalId)) {
+					overrides.set(terminalId, pane.titleOverride);
+				}
+			}
+		}
+	}
+	return overrides;
+}
+
+export interface UseResourceSnapshotResult {
+	snapshot: ResourceMetricsSnapshot | null;
+	refetch: () => void;
+	isFetching: boolean;
+	sidebarProjectOrder: string[];
+	sidebarWorkspaceOrder: string[];
+}
+
+/**
+ * Polls the resource-metrics snapshot (2s interval) while mounted and
+ * normalizes it, enriching v2 rows with project/workspace names and terminal
+ * title overrides. Only mount this while a resource view is visible — the
+ * polling stops when the consumer unmounts.
+ */
+export function useResourceSnapshot(
+	surface: "v1" | "v2",
+): UseResourceSnapshotResult {
+	const collections = useCollections();
+	const isV2 = surface === "v2";
+	const { data: session } = authClient.useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? undefined;
+
+	const { data: rawSidebarProjects = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sp: collections.v2SidebarProjects })
+				.orderBy(({ sp }) => sp.tabOrder, "asc")
+				.select(({ sp }) => ({ projectId: sp.projectId })),
+		[collections],
+	);
+
+	const { data: rawSidebarWorkspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ ws: collections.v2WorkspaceLocalState })
+				.orderBy(({ ws }) => ws.sidebarState.tabOrder, "asc")
+				.select(({ ws }) => ({
+					workspaceId: ws.workspaceId,
+					isHidden: ws.sidebarState.isHidden,
+					paneLayout: ws.paneLayout,
+				})),
+		[collections],
+	);
+
+	const sidebarProjectOrder = useMemo(
+		() => rawSidebarProjects.map((p) => p.projectId),
+		[rawSidebarProjects],
+	);
+
+	const sidebarWorkspaceOrder = useMemo(
+		() =>
+			getVisibleSidebarWorkspaces(rawSidebarWorkspaces).map(
+				(w) => w.workspaceId,
+			),
+		[rawSidebarWorkspaces],
+	);
+
+	const terminalTitleOverrides = useMemo(
+		() => getTerminalTitleOverrides(rawSidebarWorkspaces),
+		[rawSidebarWorkspaces],
+	);
+
+	// Projects are fully local — identity comes from the host fan-out.
+	const { projects: hostProjects } = useHostProjects();
+	const rawV2Projects = useMemo(
+		() =>
+			hostProjects.map((project) => ({
+				id: project.projectKey,
+				name: project.name,
+			})),
+		[hostProjects],
+	);
+
+	const { workspaces: rawV2Workspaces } = useHostWorkspaces();
+
+	const shouldQueryMetrics = shouldQueryResourceMonitor({
+		enabled: true,
+		open: true,
+	});
+
+	const {
+		data: snapshot,
+		refetch,
+		isFetching,
+	} = electronTrpc.resourceMetrics.getSnapshot.useQuery(
+		{
+			mode: "interactive",
+			surface,
+			organizationId,
+		},
+		{
+			enabled: shouldQueryMetrics,
+			refetchInterval: getResourceMonitorRefetchInterval(true),
+		},
+	);
+
+	useEffect(() => {
+		if (!isFetching) return;
+		logStressEvent("resource-monitor.fetch", { surface });
+	}, [isFetching, surface]);
+
+	const normalizedSnapshot = useMemo(() => {
+		const normalized = normalizeResourceMetricsSnapshot(snapshot);
+		if (!normalized || !isV2) return normalized;
+
+		const projectById = new Map(
+			rawV2Projects.map((project) => [project.id, project]),
+		);
+		const workspaceById = new Map(
+			rawV2Workspaces.map((workspace) => [workspace.id, workspace]),
+		);
+
+		return {
+			...normalized,
+			workspaces: normalized.workspaces.map((workspace) => {
+				const v2Workspace = workspaceById.get(workspace.workspaceId);
+				const projectId = v2Workspace?.projectId ?? workspace.projectId;
+				const project = projectById.get(projectId);
+				return {
+					...workspace,
+					projectId,
+					projectName: project?.name ?? workspace.projectName,
+					workspaceName: v2Workspace?.name ?? workspace.workspaceName,
+					sessions: workspace.sessions.map((session) => ({
+						...session,
+						title:
+							terminalTitleOverrides.get(session.paneId) ??
+							session.title ??
+							null,
+					})),
+				};
+			}),
+		};
+	}, [snapshot, isV2, rawV2Projects, rawV2Workspaces, terminalTitleOverrides]);
+
+	return {
+		snapshot: normalizedSnapshot,
+		refetch,
+		isFetching,
+		sidebarProjectOrder,
+		sidebarWorkspaceOrder,
+	};
+}


### PR DESCRIPTION
## Summary
- Adds a **Check resources** command to the command palette (⌘⇧K → third item under Actions, or directly via a new **⌘⇧U** hotkey): a frame with the CPU / Memory / RAM-share summary pinned above a scrollable, memory-sorted workspace list whose rows expand in place to per-terminal usage.
- Removes the resource monitor (CPU-chip) button from the v2 sidebar header.
- Fixes a palette-wide keyboard bug where cmdk hijacked Enter aimed at focused buttons (back arrow, expand chevrons), silently running the highlighted row and closing the palette.

## Why / Context
This consolidates and cleans up the UI: the sidebar header was accumulating one-off icon buttons, and the resource monitor is a check-occasionally tool that fits the palette better than permanent chrome. Removing it **leaves space in the sidebar header for a persistent ports button in a later PR**.

## How It Works
- `modules/resources/commands.tsx` defines `checkResourcesCommand`; the actions provider places it third (theme → notifications → resources) since ordering within a section follows provider registration order.
- `ui/ResourcesFrame/` renders the frame. Workspace rows are cmdk items: Enter opens the workspace, Enter on a terminal row jumps to that pane focused; chevrons (or ←/→ while the query is empty) expand/collapse terminals inline; typing filters both levels and auto-expands workspaces whose terminals match.
- Shared logic extracted from the popover so both surfaces stay in sync: `useResourceSnapshot` (2s polling + normalization + v2 name/title enrichment, only while mounted), `useResourceNavigation` (open workspace / jump to pane / pane naming), `ResourceMetricsSummary` (badge strip + RAM-share bar). The v1 TopBar popover behavior is unchanged.
- New `CHECK_RESOURCES` hotkey (mac `⌘⇧U`, win/linux `Ctrl+Shift+Alt+U`) opens the palette directly on the resources frame; it's registered in the hotkey registry so it's rebindable and listed in Settings → Keyboard.
- Enter fix: a root-level `onKeyDown` on the palette's `<Command>` activates the focused button itself and `preventDefault()`s so cmdk skips its own Enter handling; `handleBack` refocuses the search input so keyboard navigation survives the back button unmounting.

## Manual QA Checklist
- [ ] ⌘K → "Check resources" appears third under Actions with the ⌘⇧U chord shown
- [ ] ⌘⇧U opens the palette directly on the resources frame from anywhere
- [ ] Metric strip matches the old popover numbers; list sorted by memory
- [ ] Chevron / →/← expands a workspace to its terminals; typing a terminal title filters and auto-expands
- [ ] Enter on a workspace opens it; Enter on a terminal jumps to that pane focused
- [ ] Shift+Tab to the back button → Enter goes back one level, palette stays open, input refocused, no hidden navigation
- [ ] v2 sidebar header no longer shows the CPU-chip button; v1 TopBar (v2 disabled) still does
- [ ] Old popover (v1 TopBar) still works after the hook extraction

## Testing
- `bun run lint`
- `bun turbo run typecheck --filter=@superset/desktop`
- `bun test src/renderer/hotkeys/` (122 pass — registry conflict checks cover the new chord)
- Not yet manually verified end-to-end in the running app; the Enter-hijack diagnosis was traced through the cmdk 1.1.1 source. QA checklist above is what to exercise.

## Follow-ups
- Persistent ports button in the freed-up sidebar header slot (separate PR)
- Suggested section in the palette root: SUPER-1685

https://claude.ai/code/session_01FSmfT59ABbjFRaQzqFqCT9

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6037">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the resource monitor into the command palette with a new “Check resources” frame and hotkey, replacing the v2 sidebar CPU button. Adds per-terminal usage and fast navigation from the palette.

- **New Features**
  - Added “Check resources” in Actions (3rd) and a `CHECK_RESOURCES` hotkey (⌘⇧U on Mac, Ctrl+Shift+Alt+U on Win/Linux) to open the resources frame.
  - Frame shows CPU/Memory/RAM-share summary and a memory-sorted workspace list; rows expand to terminals; typing filters; Enter opens workspace or jumps to terminal; ←/→ expand/collapse when the query is empty.
  - Extracted shared logic into `useResourceSnapshot`, `useResourceNavigation`, and `ResourceMetricsSummary`; v1 TopBar popover behavior is unchanged.
  - Removed the resource monitor button from the v2 sidebar header.

- **Bug Fixes**
  - Prevented `cmdk` from hijacking Enter on palette buttons; Enter now triggers the focused button and the search input is refocused after going back.
  - Clamped RAM-share progressbar `aria-valuenow` to 0–100 for accurate accessibility semantics.

<sup>Written for commit 7742fcfcf01faaf766804433e58070fcd2716201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command palette action and hotkey for checking resource usage, showing searchable CPU/RAM details with expandable workspaces and panes.
  * Added direct navigation from results to the relevant workspace and terminal pane.
* **Improvements**
  * Enhanced command palette keyboard behavior (focus retention on back navigation and better Enter handling).
  * Refreshed the dashboard resource metrics section with improved accessibility (ARIA/progress tooltip) and simplified UI via new summary/hook components.
  * Removed the resource metrics surface from the macOS pinned top row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->