### PR TITLE
fix(desktop): guard localStorage collections against quota-exceeded rollback loops

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+	clearAllTerminalState,
 	pruneExpiredTerminalState,
+	reclaimTerminalStateForQuota,
 	removeTerminalStatePersistedAt,
 	TERMINAL_BUFFER_KEY_PREFIX,
 	TERMINAL_DIMS_KEY_PREFIX,
@@ -117,6 +119,57 @@ describe("pruneExpiredTerminalState", () => {
 		pruneExpiredTerminalState(storage, NOW);
 
 		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}dims-only`)).toBe(false);
+	});
+});
+
+describe("reclaimTerminalStateForQuota", () => {
+	test("frees unstamped and older-than-24h entries, keeps fresh ones", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "fresh");
+		seedTerminal(values, "day-old");
+		seedTerminal(values, "legacy");
+		touchTerminalStatePersistedAt("fresh", storage, NOW - 60_000);
+		touchTerminalStatePersistedAt("day-old", storage, NOW - 2 * DAY_MS);
+
+		const removed = reclaimTerminalStateForQuota(storage, NOW);
+
+		expect(removed).toBe(4); // day-old + legacy, buffer and dims each
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}fresh`)).toBe(true);
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}day-old`)).toBe(false);
+		expect(values.has(`${TERMINAL_DIMS_KEY_PREFIX}legacy`)).toBe(false);
+		expect(Object.keys(readIndex(values))).toEqual(["fresh"]);
+	});
+
+	test("returns 0 when every snapshot is fresh", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "fresh");
+		touchTerminalStatePersistedAt("fresh", storage, NOW);
+
+		expect(reclaimTerminalStateForQuota(storage, NOW)).toBe(0);
+		expect(values.has(`${TERMINAL_BUFFER_KEY_PREFIX}fresh`)).toBe(true);
+	});
+});
+
+describe("clearAllTerminalState", () => {
+	test("removes every snapshot and the index, fresh ones included", () => {
+		const { values, storage } = createFakeStorage();
+		seedTerminal(values, "fresh");
+		seedTerminal(values, "legacy");
+		touchTerminalStatePersistedAt("fresh", storage, NOW);
+		values.set("unrelated-key", "kept");
+
+		const removed = clearAllTerminalState(storage);
+
+		expect(removed).toBe(4);
+		expect(values.has(TERMINAL_PERSISTED_AT_KEY)).toBe(false);
+		expect(values.get("unrelated-key")).toBe("kept");
+		expect(
+			Array.from(values.keys()).filter(
+				(k) =>
+					k.startsWith(TERMINAL_BUFFER_KEY_PREFIX) ||
+					k.startsWith(TERMINAL_DIMS_KEY_PREFIX),
+			),
+		).toEqual([]);
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
@@ -13,6 +13,8 @@ export const TERMINAL_PERSISTED_AT_KEY = "terminal-buffer-persisted-at";
  */
 const MAX_PERSISTED_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_TOTAL_BUFFER_CHARS = 2_000_000;
+/** Aggressive TTL for when a quota-exhausted write needs space right now. */
+const QUOTA_PRESSURE_AGE_MS = 24 * 60 * 60 * 1000;
 
 type PersistedAtIndex = Record<string, number>;
 
@@ -58,11 +60,86 @@ export function removeTerminalStatePersistedAt(
 	writeIndex(storage, index);
 }
 
-function removeTerminalState(storage: Storage, terminalId: string): void {
+/** Removes a terminal's buffer + dims keys, reporting how many existed. */
+function removeTerminalState(storage: Storage, terminalId: string): number {
+	let removed = 0;
 	try {
-		storage.removeItem(`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`);
-		storage.removeItem(`${TERMINAL_DIMS_KEY_PREFIX}${terminalId}`);
+		for (const key of [
+			`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`,
+			`${TERMINAL_DIMS_KEY_PREFIX}${terminalId}`,
+		]) {
+			if (storage.getItem(key) !== null) {
+				storage.removeItem(key);
+				removed++;
+			}
+		}
 	} catch {}
+	return removed;
+}
+
+function collectTerminalIds(storage: Storage): Set<string> {
+	const ids = new Set<string>();
+	for (let i = 0; i < storage.length; i++) {
+		const key = storage.key(i);
+		if (!key) continue;
+		if (key.startsWith(TERMINAL_BUFFER_KEY_PREFIX)) {
+			ids.add(key.slice(TERMINAL_BUFFER_KEY_PREFIX.length));
+		} else if (key.startsWith(TERMINAL_DIMS_KEY_PREFIX)) {
+			ids.add(key.slice(TERMINAL_DIMS_KEY_PREFIX.length));
+		}
+	}
+	return ids;
+}
+
+/**
+ * Quota-pressure reclaim for `withQuotaGuard`: a collection write just failed
+ * on a full store, so shrink the snapshot budget to a 24h TTL and free
+ * everything older (unstamped included). Returns removed key count; 0 tells
+ * the guard a retry is pointless.
+ */
+export function reclaimTerminalStateForQuota(
+	storage: Storage = localStorage,
+	now: number = Date.now(),
+): number {
+	try {
+		const index = readIndex(storage);
+		let removed = 0;
+		for (const id of collectTerminalIds(storage)) {
+			const persistedAt = index[id];
+			if (
+				persistedAt !== undefined &&
+				now - persistedAt <= QUOTA_PRESSURE_AGE_MS
+			) {
+				continue;
+			}
+			removed += removeTerminalState(storage, id);
+			delete index[id];
+		}
+		if (removed > 0) writeIndex(storage, index);
+		return removed;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Drop every persisted terminal snapshot, fresh ones included. Costs parked
+ * terminals their restore, so only call from an explicit user action (the
+ * quota toast's "Free up space"). Returns removed key count.
+ */
+export function clearAllTerminalState(storage: Storage = localStorage): number {
+	try {
+		let removed = 0;
+		for (const id of collectTerminalIds(storage)) {
+			removed += removeTerminalState(storage, id);
+		}
+		if (storage.getItem(TERMINAL_PERSISTED_AT_KEY) !== null) {
+			storage.removeItem(TERMINAL_PERSISTED_AT_KEY);
+		}
+		return removed;
+	} catch {
+		return 0;
+	}
 }
 
 /**
@@ -77,17 +154,7 @@ export function pruneExpiredTerminalState(
 ): void {
 	try {
 		const index = readIndex(storage);
-
-		const ids = new Set<string>();
-		for (let i = 0; i < storage.length; i++) {
-			const key = storage.key(i);
-			if (!key) continue;
-			if (key.startsWith(TERMINAL_BUFFER_KEY_PREFIX)) {
-				ids.add(key.slice(TERMINAL_BUFFER_KEY_PREFIX.length));
-			} else if (key.startsWith(TERMINAL_DIMS_KEY_PREFIX)) {
-				ids.add(key.slice(TERMINAL_DIMS_KEY_PREFIX.length));
-			}
-		}
+		const ids = collectTerminalIds(storage);
 
 		const survivors: Array<{ id: string; persistedAt: number }> = [];
 		for (const id of ids) {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -50,6 +50,7 @@ import { env } from "renderer/env.renderer";
 import { track } from "renderer/lib/analytics";
 import { getAuthToken, getJwt } from "renderer/lib/auth-client";
 import { refreshJwtAfterUnauthorized } from "renderer/lib/jwt-refresh";
+import { reclaimTerminalStateForQuota } from "renderer/lib/terminal/terminal-buffer-gc";
 import superjson from "superjson";
 import { z } from "zod";
 import {
@@ -70,6 +71,8 @@ import {
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
 import { evictInactiveOrgs } from "./evictInactiveOrgs";
+import { notifyQuotaExhausted } from "./notifyQuotaExhausted";
+import { withQuotaGuard } from "./withQuotaGuard";
 import { withReadHeal } from "./withReadHeal";
 
 const columnMapper = snakeCamelMapper();
@@ -107,6 +110,21 @@ const createIndexedCollection = ((
 	config: Parameters<typeof createCollection>[0],
 ) =>
 	createCollection({ ...config, ...indexDefaults })) as typeof createCollection;
+
+/**
+ * Applied to every localStorage-backed collection so an exhausted store drops
+ * the write instead of throwing, which is what stops the rollback/retry loop
+ * that freezes the renderer.
+ */
+const guardQuota = <T>(options: T): T =>
+	withQuotaGuard(options, {
+		// Oldest-first by the terminal GC's persisted-at index (24h pressure TTL)
+		// — survives relaunches, unlike registry membership.
+		reclaim: () => reclaimTerminalStateForQuota(),
+		// Not passed by reference: the guard's second argument is the error, which
+		// would land in the notice's optional `mode` slot.
+		onPersistFailed: (storageKey) => notifyQuotaExhausted(storageKey),
+	});
 
 type ElectricSyncConfig = ReturnType<typeof electricCollectionOptions>;
 const createPersistedElectricCollection = ((config: ElectricSyncConfig) => {
@@ -745,12 +763,17 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	);
 
 	const v2SidebarProjects = createIndexedCollection(
-		localStorageCollectionOptions({
-			id: `v2_sidebar_projects-${organizationId}`,
-			storageKey: `v2-sidebar-projects-${organizationId}`,
-			schema: dashboardSidebarProjectSchema,
-			getKey: (item) => item.projectId,
-		}),
+		localStorageCollectionOptions(
+			guardQuota({
+				id: `v2_sidebar_projects-${organizationId}`,
+				storageKey: `v2-sidebar-projects-${organizationId}`,
+				schema: dashboardSidebarProjectSchema,
+				// Explicit type for the same reason `withReadHeal` needs one: a
+				// passthrough generic drops the contextual typing that would
+				// otherwise narrow the key to string.
+				getKey: (item: DashboardSidebarProjectRow) => item.projectId,
+			}),
+		),
 	);
 	v2SidebarProjects.createIndex(
 		(sidebarProject) => sidebarProject.tabOrder,
@@ -759,16 +782,18 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2WorkspaceLocalState = createIndexedCollection(
 		localStorageCollectionOptions(
-			withReadHeal(
-				{
-					id: `v2_workspace_local_state-${organizationId}`,
-					storageKey: `v2-workspace-local-state-${organizationId}`,
-					schema: workspaceLocalStateSchema,
-					// Explicit type so `withReadHeal`'s passthrough generic keeps the
-					// linkage between schema and getKey for downstream inference.
-					getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
-				},
-				healWorkspaceLocalState,
+			guardQuota(
+				withReadHeal(
+					{
+						id: `v2_workspace_local_state-${organizationId}`,
+						storageKey: `v2-workspace-local-state-${organizationId}`,
+						schema: workspaceLocalStateSchema,
+						// Explicit type so `withReadHeal`'s passthrough generic keeps the
+						// linkage between schema and getKey for downstream inference.
+						getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
+					},
+					healWorkspaceLocalState,
+				),
 			),
 		),
 	);
@@ -786,12 +811,14 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	);
 
 	const v2SidebarSections = createIndexedCollection(
-		localStorageCollectionOptions({
-			id: `v2_sidebar_sections-${organizationId}`,
-			storageKey: `v2-sidebar-sections-${organizationId}`,
-			schema: dashboardSidebarSectionSchema,
-			getKey: (item) => item.sectionId,
-		}),
+		localStorageCollectionOptions(
+			guardQuota({
+				id: `v2_sidebar_sections-${organizationId}`,
+				storageKey: `v2-sidebar-sections-${organizationId}`,
+				schema: dashboardSidebarSectionSchema,
+				getKey: (item: DashboardSidebarSectionRow) => item.sectionId,
+			}),
+		),
 	);
 	v2SidebarSections.createIndex(
 		(section) => section.projectId,
@@ -803,39 +830,45 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	);
 
 	const v2TerminalPresets = createIndexedCollection(
-		localStorageCollectionOptions({
-			id: `v2_terminal_presets-${organizationId}`,
-			storageKey: `v2-terminal-presets-${organizationId}`,
-			schema: v2TerminalPresetSchema,
-			getKey: (item) => item.id,
-		}),
+		localStorageCollectionOptions(
+			guardQuota({
+				id: `v2_terminal_presets-${organizationId}`,
+				storageKey: `v2-terminal-presets-${organizationId}`,
+				schema: v2TerminalPresetSchema,
+				getKey: (item: V2TerminalPresetRow) => item.id,
+			}),
+		),
 	);
 
 	const v2UserPreferences = createCollection(
 		localStorageCollectionOptions(
-			withReadHeal(
-				{
-					id: `v2_user_preferences-${organizationId}`,
-					storageKey: `v2-user-preferences-${organizationId}`,
-					schema: v2UserPreferencesSchema,
-					// Cast widens the inferred literal "preferences" key to string so
-					// the collection slots into the shared OrgCollections.{...<TKey=string>}
-					// shape alongside the other v2 collections. Explicit `item` type so
-					// `withReadHeal`'s passthrough generic keeps schema/getKey linkage.
-					getKey: (item: V2UserPreferencesRow) => item.id as string,
-				},
-				healV2UserPreferences,
+			guardQuota(
+				withReadHeal(
+					{
+						id: `v2_user_preferences-${organizationId}`,
+						storageKey: `v2-user-preferences-${organizationId}`,
+						schema: v2UserPreferencesSchema,
+						// Cast widens the inferred literal "preferences" key to string so
+						// the collection slots into the shared OrgCollections.{...<TKey=string>}
+						// shape alongside the other v2 collections. Explicit `item` type so
+						// `withReadHeal`'s passthrough generic keeps schema/getKey linkage.
+						getKey: (item: V2UserPreferencesRow) => item.id as string,
+					},
+					healV2UserPreferences,
+				),
 			),
 		),
 	);
 
 	const failedWorkspaceCreates = createIndexedCollection(
-		localStorageCollectionOptions({
-			id: `failed_workspace_creates-${organizationId}`,
-			storageKey: `failed-workspace-creates-${organizationId}`,
-			schema: failedWorkspaceCreateSchema,
-			getKey: (item) => item.id,
-		}),
+		localStorageCollectionOptions(
+			guardQuota({
+				id: `failed_workspace_creates-${organizationId}`,
+				storageKey: `failed-workspace-creates-${organizationId}`,
+				schema: failedWorkspaceCreateSchema,
+				getKey: (item: FailedWorkspaceCreateRow) => item.id,
+			}),
+		),
 	);
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/notifyQuotaExhausted.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/notifyQuotaExhausted.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, mock } from "bun:test";
+
+interface ToastCall {
+	level: "warning" | "success";
+	title: string;
+	options?: {
+		id?: string;
+		description?: string;
+		action?: { label: string; onClick: () => void };
+	};
+}
+
+const toastCalls: ToastCall[] = [];
+
+// Only sonner is mocked. `terminal-buffer-gc` is deliberately left alone:
+// `mock.module` replaces a module for the whole test process, so stubbing it
+// here would silently hand its own test file a stub to assert against.
+mock.module("@superset/ui/sonner", () => ({
+	toast: {
+		warning: (title: string, options?: ToastCall["options"]) => {
+			toastCalls.push({ level: "warning", title, options });
+		},
+		success: (title: string, options?: ToastCall["options"]) => {
+			toastCalls.push({ level: "success", title, options });
+		},
+	},
+}));
+
+const { describeClearedSnapshots, notifyQuotaExhausted } = await import(
+	"./notifyQuotaExhausted"
+);
+
+/** Silences the deduped warning so assertions read only the toast behaviour. */
+function withSilencedWarnings(run: () => void): string[] {
+	const warnings: string[] = [];
+	const realWarn = console.warn;
+	console.warn = (message: string) => warnings.push(message);
+	try {
+		run();
+	} finally {
+		console.warn = realWarn;
+	}
+	return warnings;
+}
+
+function reset(): void {
+	toastCalls.length = 0;
+}
+
+describe("notifyQuotaExhausted", () => {
+	it("warns once per storage key, however often the write fails", () => {
+		reset();
+
+		const warnings = withSilencedWarnings(() => {
+			notifyQuotaExhausted("warn-dedupe-a", "silent");
+			notifyQuotaExhausted("warn-dedupe-a", "silent");
+			notifyQuotaExhausted("warn-dedupe-a", "silent");
+			notifyQuotaExhausted("warn-dedupe-b", "silent");
+		});
+
+		// The loop this replaced fired ~40x a second, so an un-deduped log would
+		// just relocate the problem.
+		expect(warnings).toHaveLength(2);
+		expect(warnings[0]).toContain("warn-dedupe-a");
+		expect(warnings[1]).toContain("warn-dedupe-b");
+	});
+
+	it("raises no toast in silent mode", () => {
+		reset();
+
+		withSilencedWarnings(() => notifyQuotaExhausted("silent-key", "silent"));
+
+		expect(toastCalls).toHaveLength(0);
+	});
+
+	it("explains the consequence in notify mode, without an action", () => {
+		reset();
+
+		withSilencedWarnings(() => notifyQuotaExhausted("notify-key", "notify"));
+
+		expect(toastCalls).toHaveLength(1);
+		expect(toastCalls[0]?.level).toBe("warning");
+		expect(toastCalls[0]?.title).toBe("Storage is full");
+		expect(toastCalls[0]?.options?.description).toContain("revert");
+		expect(toastCalls[0]?.options?.action).toBeUndefined();
+	});
+
+	it("reuses one toast id so a later failure can re-raise a dismissed toast", () => {
+		reset();
+
+		withSilencedWarnings(() => {
+			notifyQuotaExhausted("toast-id-a", "notify");
+			notifyQuotaExhausted("toast-id-b", "notify");
+		});
+
+		expect(toastCalls[0]?.options?.id).toBeTruthy();
+		expect(toastCalls[1]?.options?.id).toBe(
+			toastCalls[0]?.options?.id as string,
+		);
+	});
+
+	it("offers the reclaim action only in offer-reclaim mode", () => {
+		reset();
+
+		withSilencedWarnings(() =>
+			notifyQuotaExhausted("offer-key", "offer-reclaim"),
+		);
+
+		expect(toastCalls[0]?.options?.action?.label).toBe("Free up space");
+	});
+});
+
+describe("describeClearedSnapshots", () => {
+	it("says so plainly when there was nothing to clear", () => {
+		expect(describeClearedSnapshots(0)).toBe(
+			"No saved terminal scrollback left to clear",
+		);
+	});
+
+	// The count is storage entries, not terminals: each terminal persists a
+	// buffer and a dimensions key, so calling 2 entries "2 terminals" would
+	// report double the real number.
+	it("counts storage entries rather than terminals", () => {
+		expect(describeClearedSnapshots(2)).toContain("2 saved terminal entries");
+		expect(describeClearedSnapshots(2)).not.toContain("terminals");
+	});
+
+	it("singularises a single entry", () => {
+		expect(describeClearedSnapshots(1)).toContain("1 saved terminal entry");
+		expect(describeClearedSnapshots(1)).not.toContain("entries");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/notifyQuotaExhausted.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/notifyQuotaExhausted.ts
@@ -1,0 +1,81 @@
+import { toast } from "@superset/ui/sonner";
+import { clearAllTerminalState } from "renderer/lib/terminal/terminal-buffer-gc";
+
+/**
+ * What the user sees when localStorage is full and reclaiming orphaned
+ * terminal snapshots did not free enough for the write to land.
+ *
+ * The write is dropped either way — there is genuinely no room, and dropping it
+ * instead of throwing is what stops the freeze (see `withQuotaGuard`). This
+ * only decides how loudly to say so, which is a product call rather than a
+ * correctness one, so the modes are kept side by side and selected by
+ * `QUOTA_NOTICE_MODE`:
+ *
+ * - `silent`: console only, matching how `terminal-runtime-registry` already
+ *   handles the same error. Quietest, but the user later finds their layout
+ *   reverted with no explanation.
+ * - `notify`: also raises a toast. Explains the reverted layout, but offers
+ *   nothing to act on.
+ * - `offer-reclaim`: adds an action that clears parked terminals' scrollback.
+ *   The only option that can actually free space, and the only one that costs
+ *   the user something visible.
+ */
+export type QuotaNoticeMode = "silent" | "notify" | "offer-reclaim";
+
+export const QUOTA_NOTICE_MODE: QuotaNoticeMode = "offer-reclaim";
+
+const TOAST_ID = "localstorage-quota-exhausted";
+
+const warnedStorageKeys = new Set<string>();
+
+/**
+ * Warns once per storage key. The loop this replaces fired ~40x a second, so an
+ * un-deduped log would just relocate the problem; the toast dedupes separately
+ * via a stable `id`, which lets a dismissed toast reappear on a later failure.
+ */
+function warnOnce(storageKey: string): void {
+	if (warnedStorageKeys.has(storageKey)) return;
+	warnedStorageKeys.add(storageKey);
+	console.warn(
+		`[collections] localStorage is full; "${storageKey}" will not persist. Changes stay in memory but revert on next launch.`,
+	);
+}
+
+/**
+ * Exported so the wording is testable without mocking the storage module. The
+ * count is storage entries, not terminals — each terminal persists a buffer and
+ * a dimensions key — so it is described as such rather than implying a terminal
+ * count twice the real one.
+ */
+export function describeClearedSnapshots(cleared: number): string {
+	if (cleared === 0) return "No saved terminal scrollback left to clear";
+	return `Cleared ${cleared} saved terminal ${cleared === 1 ? "entry" : "entries"}`;
+}
+
+function reclaimFromToast(): void {
+	toast.success(describeClearedSnapshots(clearAllTerminalState()), {
+		id: TOAST_ID,
+	});
+}
+
+/**
+ * `mode` defaults to the configured `QUOTA_NOTICE_MODE`; it is a parameter so
+ * every branch stays reachable from tests regardless of which one ships.
+ */
+export function notifyQuotaExhausted(
+	storageKey: string,
+	mode: QuotaNoticeMode = QUOTA_NOTICE_MODE,
+): void {
+	warnOnce(storageKey);
+	if (mode === "silent") return;
+
+	toast.warning("Storage is full", {
+		id: TOAST_ID,
+		description:
+			"Layout and sidebar changes are kept for this session but revert when Superset restarts.",
+		action:
+			mode === "offer-reclaim"
+				? { label: "Free up space", onClick: reclaimFromToast }
+				: undefined,
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import { z } from "zod";
+import { withQuotaGuard } from "./withQuotaGuard";
+
+function quotaError(): Error {
+	const error = new Error("exceeded the quota");
+	error.name = "QuotaExceededError";
+	return error;
+}
+
+/**
+ * Map-backed store that refuses writes once the retained bytes exceed `limit`,
+ * the way Chromium refuses once the origin's budget is gone.
+ */
+function makeQuotaLimitedStorage(limit: number) {
+	const map = new Map<string, string>();
+	const usedBytes = () => {
+		let total = 0;
+		for (const [key, value] of map) total += key.length + value.length;
+		return total;
+	};
+	return {
+		store: map,
+		usedBytes,
+		api: {
+			getItem: (key: string) => map.get(key) ?? null,
+			setItem: (key: string, value: string) => {
+				const replaced = map.get(key)?.length ?? 0;
+				if (usedBytes() - replaced + key.length + value.length > limit) {
+					throw quotaError();
+				}
+				map.set(key, value);
+			},
+			removeItem: (key: string) => {
+				map.delete(key);
+			},
+		},
+	};
+}
+
+const noopEvents = {
+	addEventListener: () => {},
+	removeEventListener: () => {},
+};
+
+const rowSchema = z.object({ id: z.string(), payload: z.string() });
+type Row = z.infer<typeof rowSchema>;
+
+/** Let a mutation's transaction settle, since rollback happens off the call. */
+const settleTransactions = () =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("withQuotaGuard", () => {
+	it("writes straight through when there is room (identity)", () => {
+		const storage = makeQuotaLimitedStorage(1000);
+		let reclaimCalls = 0;
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: storage.api,
+				reclaim: () => {
+					reclaimCalls += 1;
+					return 0;
+				},
+				onPersistFailed: () => {},
+			},
+		) as { storage: typeof storage.api };
+
+		guarded.storage.setItem("k", "v");
+
+		expect(storage.store.get("k")).toBe("v");
+		expect(reclaimCalls).toBe(0);
+	});
+
+	it("reclaims and retries, landing the write", () => {
+		const storage = makeQuotaLimitedStorage(40);
+		storage.store.set("terminal-buffer:gone", "x".repeat(20));
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: storage.api,
+				reclaim: () => {
+					storage.store.delete("terminal-buffer:gone");
+					return 1;
+				},
+				onPersistFailed: () => {
+					throw new Error("should not be reached");
+				},
+			},
+		) as { storage: typeof storage.api };
+
+		guarded.storage.setItem("collection", "y".repeat(20));
+
+		expect(storage.store.get("collection")).toBe("y".repeat(20));
+		expect(storage.store.has("terminal-buffer:gone")).toBe(false);
+	});
+
+	it("fails soft when reclaim frees nothing", () => {
+		const storage = makeQuotaLimitedStorage(10);
+		const failures: string[] = [];
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: storage.api,
+				reclaim: () => 0,
+				onPersistFailed: (key) => failures.push(key),
+			},
+		) as { storage: typeof storage.api };
+
+		expect(() =>
+			guarded.storage.setItem("collection", "z".repeat(100)),
+		).not.toThrow();
+		expect(failures).toEqual(["collection"]);
+	});
+
+	it("skips the retry when reclaim reports nothing freed", () => {
+		const storage = makeQuotaLimitedStorage(10);
+		let setItemCalls = 0;
+		const counting = {
+			...storage.api,
+			setItem: (key: string, value: string) => {
+				setItemCalls += 1;
+				storage.api.setItem(key, value);
+			},
+		};
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: counting,
+				reclaim: () => 0,
+				onPersistFailed: () => {},
+			},
+		) as { storage: typeof counting };
+
+		guarded.storage.setItem("collection", "z".repeat(100));
+
+		expect(setItemCalls).toBe(1);
+	});
+
+	it("fails soft when even the post-reclaim retry cannot fit", () => {
+		const storage = makeQuotaLimitedStorage(30);
+		storage.store.set("terminal-buffer:gone", "x".repeat(10));
+		const failures: string[] = [];
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: storage.api,
+				reclaim: () => {
+					storage.store.delete("terminal-buffer:gone");
+					return 1;
+				},
+				onPersistFailed: (key) => failures.push(key),
+			},
+		) as { storage: typeof storage.api };
+
+		expect(() =>
+			guarded.storage.setItem("collection", "z".repeat(500)),
+		).not.toThrow();
+		expect(failures).toEqual(["collection"]);
+	});
+
+	it("rethrows failures that are not quota exhaustion", () => {
+		const guarded = withQuotaGuard(
+			{},
+			{
+				storage: {
+					getItem: () => null,
+					removeItem: () => {},
+					setItem: () => {
+						throw new DOMException("blocked", "SecurityError");
+					},
+				},
+				reclaim: () => {
+					throw new Error("reclaim must not run for non-quota errors");
+				},
+				onPersistFailed: () => {},
+			},
+		) as { storage: { setItem: (k: string, v: string) => void } };
+
+		expect(() => guarded.storage.setItem("k", "v")).toThrow("blocked");
+	});
+
+	it("keeps an inserted row in memory when the write cannot land", async () => {
+		// The regression that matters: TanStack DB rolls a transaction back when
+		// persistence throws, the live query re-emits, and the effect that queued
+		// the insert re-runs — a synchronous retry loop. A row that survives a
+		// failed write proves the rollback no longer happens.
+		//
+		// The rollback is asynchronous: unguarded, the row is still present
+		// synchronously after `insert` and only disappears once the transaction
+		// settles. Asserting before that flush passes against broken code too, so
+		// this test is only meaningful with the await below.
+		const storage = makeQuotaLimitedStorage(60);
+		const collection = createCollection(
+			localStorageCollectionOptions(
+				withQuotaGuard(
+					{
+						id: "quota-guard-rows",
+						storageKey: "quota-guard-rows",
+						schema: rowSchema,
+						getKey: (item: Row) => item.id,
+						storageEventApi: noopEvents,
+					},
+					{
+						storage: storage.api,
+						reclaim: () => 0,
+						onPersistFailed: () => {},
+					},
+				),
+			),
+		);
+		await collection.preload();
+
+		collection.insert({ id: "row-1", payload: "p".repeat(200) });
+		await settleTransactions();
+
+		expect(collection.get("row-1")).toBeDefined();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.ts
@@ -1,0 +1,94 @@
+/**
+ * `@tanstack/db`'s `localStorageCollectionOptions` re-serializes the whole
+ * collection on every mutation and rethrows `QuotaExceededError`. The library
+ * treats that throw as a failed transaction and rolls the optimistic write
+ * back, which makes the live query re-emit, which makes the effect that queued
+ * the write queue it again — a synchronous retry loop that pegs the renderer
+ * and survives restarts, because the full store is on disk.
+ *
+ * This wrapper installs a `storage` whose `setItem` absorbs that failure:
+ * reclaim space, retry once, and if it still cannot land, return normally. Not
+ * throwing is the fix — no throw means no rollback, so the loop cannot form at
+ * any of the ~15 sites that write to these collections. The cost is that memory
+ * and disk disagree until the next launch, which is strictly better than an
+ * app that has to be recovered by deleting a folder in Finder.
+ *
+ * Reclaim is injected rather than implemented here so this stays ignorant of
+ * what is worth deleting; see `selectOrphanedTerminalSnapshots`.
+ */
+
+/** The slice of `Storage` the library actually calls. */
+export interface QuotaGuardStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+	removeItem(key: string): void;
+}
+
+export interface QuotaGuardHandlers {
+	/** Frees space and reports how many keys it removed; 0 skips the retry. */
+	reclaim: () => number;
+	/** Called when a write is abandoned, once the retry has also failed. */
+	onPersistFailed: (storageKey: string, error: unknown) => void;
+	/** Defaults to `window.localStorage`; overridden in tests. */
+	storage?: QuotaGuardStorage;
+}
+
+/**
+ * Chromium reports exhaustion as `QuotaExceededError`; older WebKit and Firefox
+ * builds use a numeric code or their own name. Anything else is a genuine
+ * defect and is rethrown, so this never masks unrelated storage failures.
+ */
+function isQuotaExceeded(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const legacyCode = (error as DOMException).code;
+	return (
+		error.name === "QuotaExceededError" ||
+		error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+		legacyCode === 22 ||
+		legacyCode === 1014
+	);
+}
+
+function guardStorage(
+	base: QuotaGuardStorage,
+	{ reclaim, onPersistFailed }: QuotaGuardHandlers,
+): QuotaGuardStorage {
+	return {
+		getItem: (key) => base.getItem(key),
+		removeItem: (key) => {
+			base.removeItem(key);
+		},
+		setItem: (key, value) => {
+			try {
+				base.setItem(key, value);
+				return;
+			} catch (error) {
+				if (!isQuotaExceeded(error)) throw error;
+				if (reclaim() === 0) {
+					onPersistFailed(key, error);
+					return;
+				}
+			}
+			try {
+				base.setItem(key, value);
+			} catch (retryError) {
+				if (!isQuotaExceeded(retryError)) throw retryError;
+				onPersistFailed(key, retryError);
+			}
+		},
+	};
+}
+
+/**
+ * Wrap `localStorageCollectionOptions` input so quota exhaustion degrades to a
+ * dropped write instead of a rollback loop. Composes with `withReadHeal`, and
+ * respects a `storage` already present on the options so tests keep control of
+ * the backing store.
+ */
+export function withQuotaGuard<T>(options: T, handlers: QuotaGuardHandlers): T {
+	const base =
+		handlers.storage ??
+		(options as { storage?: QuotaGuardStorage }).storage ??
+		window.localStorage;
+	return { ...options, storage: guardStorage(base, handlers) } as T;
+}


### PR DESCRIPTION
Reworked from #5965 by @snehendu098 — thank you for the excellent diagnosis and the `withQuotaGuard` design, both kept here. Refs #5496 (fixes the freeze mechanism; the growth contributors are tracked separately in SUPER-1686). Opened as a new PR because the original fork doesn't allow maintainer edits and the branch needed reworking on top of #6036.

## Problem (from #5965)

When localStorage is full, `@tanstack/db`'s `localStorageCollectionOptions` re-serializes the whole collection on every mutation and rethrows `QuotaExceededError`. The library rolls the optimistic write back → the live query re-emits → the effect that queued the write retries — a synchronous ~40x/s loop that pegs the renderer at >110% CPU and survives restarts because the full store is on disk.

## Fix

`withQuotaGuard` (unchanged from #5965) wraps every localStorage-backed collection's `storage`: on quota error it reclaims space, retries once, then **returns without throwing**. No throw → no rollback → the loop cannot form at any of the write sites. Non-quota errors still rethrow.

## Changes from #5965

- **Reclaim victim selection**: driven by the terminal GC's durable `terminal-buffer-persisted-at` index from #6036 (24h pressure TTL, unstamped included) instead of registry membership + an in-memory `preservedSnapshotTerminalIds` set. The in-memory set reset on relaunch, so a quota event shortly after boot could delete restorable snapshots of terminals in not-yet-opened workspaces. This also deletes `selectOrphanedTerminalSnapshots`, `terminalSnapshotStorage`, and the two registry additions outright (−4 files, −36 registry lines).
- **Key prefixes stay canonical in `terminal-buffer-gc.ts`** — the `shared/constants.ts` copies are dropped.
- **`QUOTA_NOTICE_MODE` ships as `offer-reclaim`** instead of `silent`: genuine exhaustion surfaces a toast with a working "Free up space" action (clears all persisted scrollback via `clearAllTerminalState`) rather than a console-only warning the user never sees.

## Testing

- `withQuotaGuard` tests kept verbatim from #5965 (quota absorb, retry-once, non-quota rethrow, reclaim-0 skip).
- `notifyQuotaExhausted` tests kept (warn dedupe, mode branches, toast id reuse).
- New `terminal-buffer-gc` tests for `reclaimTerminalStateForQuota` (24h TTL, fresh kept, key counts, index hygiene — mutation-checked) and `clearAllTerminalState`.
- 350 tests pass across the touched dirs; `bun run typecheck --filter=desktop` and `bun run lint` clean.
- CDP verification against the merged result to follow on this PR.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents renderer-freezing retry loops when `localStorage` is full by guarding all `@tanstack/react-db` collections: on quota errors we reclaim space, retry once, then drop the write instead of throwing. Refs SUPER-1686 (fixes the freeze mechanism; growth contributors tracked separately).

- **Bug Fixes**
  - Added `withQuotaGuard` to all `localStorage`-backed collections; non-quota errors still throw, quota errors reclaim once and return without throwing.
  - Eliminates the rollback/retry loop and keeps changes in memory for the session instead of pegging CPU.

- **New Features**
  - Quota reclaim is driven by the terminal GC’s durable `terminal-buffer-persisted-at` index with a 24h pressure TTL via `reclaimTerminalStateForQuota` (plus `clearAllTerminalState`).
  - User notice now uses `offer-reclaim`: deduped warning and a toast with “Free up space” to clear saved terminal scrollback.

<sup>Written for commit b2a9e1721ba6d05a2137a246617a8be6aade5b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery when local storage reaches its limit, helping preserve app responsiveness.
  * Added user notifications when storage is full, including an option to free space by clearing saved terminal history.
  * Added cleanup of older saved terminal snapshots to reclaim storage space.

* **Bug Fixes**
  * Prevented storage-limit errors from interrupting local state updates.
  * Preserved in-memory changes when persistence temporarily fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->