### PR TITLE
fix(desktop,host-service): generate workspace titles in the user's prompt language

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts
@@ -117,7 +117,7 @@ describe("generateWorkspaceNameFromPrompt", () => {
 			agentId: "workspace-namer",
 			agentName: "Workspace Namer",
 			instructions:
-				"You generate concise workspace titles. 20 characters or less. Return ONLY the title, nothing else.",
+				"You generate concise workspace titles. 20 characters or less. Write the title in the same language as the user's message. Return ONLY the title, nothing else.",
 			tracingContext: { surface: "workspace-auto-name" },
 		});
 	});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.ts
@@ -43,7 +43,7 @@ export async function generateWorkspaceNameFromPrompt(prompt: string): Promise<{
 				agentId: "workspace-namer",
 				agentName: "Workspace Namer",
 				instructions:
-					"You generate concise workspace titles. 20 characters or less. Return ONLY the title, nothing else.",
+					"You generate concise workspace titles. 20 characters or less. Write the title in the same language as the user's message. Return ONLY the title, nothing else.",
 				tracingContext: { surface: "workspace-auto-name" },
 			});
 			if (generated !== null && generated !== undefined) {

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
@@ -77,8 +77,8 @@ const INSTRUCTIONS = [
 	"You name new code workspaces from the user's initial prompt.",
 	"The prompt describes work to do in an existing repository. Name that work; do not answer the prompt, ask questions, or request more context. Always infer useful names, even when the prompt is vague.",
 	"Return a structured object with two fields:",
-	`- title: a short human-readable label (<= ${WORKSPACE_TITLE_MAX} chars). Full words only; never cut mid-word. No trailing punctuation.`,
-	`- branchName: a kebab-case git branch name (<= ${BRANCH_NAME_MAX} chars, 2-4 words). Only a-z 0-9 and dashes. No prefixes.`,
+	`- title: a short human-readable label (<= ${WORKSPACE_TITLE_MAX} chars). Full words only; never cut mid-word. No trailing punctuation. Written in the same language as the user's prompt.`,
+	`- branchName: a kebab-case git branch name (<= ${BRANCH_NAME_MAX} chars, 2-4 words). Only a-z 0-9 and dashes. No prefixes. Always in English, regardless of the prompt language.`,
 	"Both fields must describe the same underlying task; the branch is just a compact slug of the title.",
 ].join("\n");
 


### PR DESCRIPTION
## What & why

Workspace auto-naming always produces English titles, even when the workspace creation prompt is written in another language (e.g. Chinese or Japanese). The naming instructions never mention language, so the small model defaults to English.

This adds a language directive to both naming paths:

- **desktop** `ai-name.ts` (workspace-namer): ask for the title in the same language as the user's message.
- **host-service** `ai-workspace-names.ts` (combined title/branch generation): title follows the prompt language; `branchName` is explicitly pinned to English, since it is sanitized to `[a-z0-9-]` anyway and a non-Latin branch candidate would be stripped to nothing.

English prompts keep producing English titles, so this is behavior-neutral for existing users.

## How I tested it

- `bun test` on `ai-name.test.ts` and `ai-workspace-names.test.ts` (7 pass; the exact-match instruction assertion in `ai-name.test.ts` is updated accordingly)
- `bunx biome check` on the three touched files — clean
- `bun run typecheck` in `apps/desktop` and `packages/host-service` — clean

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workspace auto-naming now outputs titles in the same language as the user's prompt across desktop and host-service. Branch names stay English to keep valid kebab-case slugs.

- **Bug Fixes**
  - Desktop and host-service naming instructions now request the title in the user's prompt language; tests updated accordingly.
  - `branchName` is explicitly kept in English to ensure safe a-z/0-9/dash slugs.

<sup>Written for commit 40fc673974e13a99f96f0e565bae5d2be23fdad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace titles generated from prompts now match the language used in the original message.
  - Generated branch names are consistently written in English, regardless of the prompt language.
  - Workspace and branch naming continues to prioritize concise, title-only results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->