### PR TITLE
fix(desktop): allow drag-to-select text in browser pane URL input

### DIFF
--- a/apps/desktop/src/renderer/lib/dnd.ts
+++ b/apps/desktop/src/renderer/lib/dnd.ts
@@ -1,5 +1,29 @@
 import { createDragDropManager } from "dnd-core";
+import type { MouseEvent } from "react";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 // Single, shared DragDropManager for the entire renderer
 export const dragDropManager = createDragDropManager(HTML5Backend);
+
+/**
+ * Chromium resolves a mouse drag to the nearest `draggable` ancestor, so a
+ * drag-to-select gesture inside a text input nested in a drag handle (e.g. a
+ * pane header) moves the pane instead of selecting text. Attach to the input's
+ * onMouseDown to suspend the ancestor's draggable for the gesture; it is
+ * restored on mouseup.
+ */
+export function suspendAncestorDragForTextSelection(
+	event: MouseEvent<HTMLElement>,
+) {
+	const dragSource =
+		event.currentTarget.closest<HTMLElement>('[draggable="true"]');
+	if (!dragSource) return;
+	dragSource.draggable = false;
+	window.addEventListener(
+		"mouseup",
+		() => {
+			dragSource.draggable = true;
+		},
+		{ once: true },
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -5,6 +5,7 @@ import {
 	TbLoader2,
 	TbRefresh,
 } from "react-icons/tb";
+import { suspendAncestorDragForTextSelection } from "renderer/lib/dnd";
 import { UrlSuggestions } from "./components/UrlSuggestions";
 import { useUrlAutocomplete } from "./hooks/useUrlAutocomplete";
 
@@ -154,6 +155,7 @@ export function BrowserToolbar({
 							className="h-[22px] w-full rounded-sm border border-ring bg-transparent px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
 							spellCheck={false}
 							autoComplete="off"
+							onMouseDown={suspendAncestorDragForTextSelection}
 						/>
 					</form>
 				) : (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -5,6 +5,7 @@ import {
 	TbLoader2,
 	TbRefresh,
 } from "react-icons/tb";
+import { suspendAncestorDragForTextSelection } from "renderer/lib/dnd";
 import { UrlSuggestions } from "./components/UrlSuggestions";
 import { useUrlAutocomplete } from "./hooks/useUrlAutocomplete";
 
@@ -159,6 +160,7 @@ export function BrowserToolbar({
 							className="h-[22px] w-full rounded-sm border border-ring bg-transparent px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
 							spellCheck={false}
 							autoComplete="off"
+							onMouseDown={suspendAncestorDragForTextSelection}
 						/>
 					</form>
 				) : (


### PR DESCRIPTION
## Summary
Dragging to select text in the browser pane's URL input moved the whole pane instead of highlighting text. The pane header (URL bar included) is an HTML5 drag source for pane rearranging, and Chromium resolves a mouse drag to the nearest `draggable` ancestor — so the selection gesture was captured as a pane drag.

Fix: a shared `suspendAncestorDragForTextSelection` helper in `renderer/lib/dnd.ts` that, on mousedown inside the input, flips the ancestor drag handle's `draggable` off for the duration of the gesture and restores it on mouseup. Applied to the URL input in both the v1 and v2 browser toolbars. Dragging the pane from anywhere else on the header is unchanged.

## Test Plan
- [x] In the browser pane, click the URL bar then drag across the text — text highlights, pane stays put (verified in the dev app)
- [x] Pane can still be dragged by its header outside the input
- [x] `bun run lint` and desktop `typecheck` pass

https://claude.ai/code/session_01NmhVFPiyghGd2CwoSgepWx

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6046">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drag-to-select in the browser pane URL input by temporarily disabling the header’s drag handle during text selection. Text now highlights as expected; dragging the pane from the rest of the header is unchanged.

- **Bug Fixes**
  - Added `suspendAncestorDragForTextSelection` in `renderer/lib/dnd.ts` to disable the nearest `draggable` ancestor on mousedown and restore it on mouseup.
  - Wired the helper to the URL input `onMouseDown` in both v1 and v2 browser toolbars.

<sup>Written for commit bb0ab764fed97e99bea9678f16acffbfc166cb4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL field interactions by preventing unintended drag behavior while selecting or editing text.
  * Text selection in browser toolbar URL inputs now works more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->