### PR TITLE
fix(marketing): support aarch64/arm64 in CLI install.sh

### DIFF
--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -38,7 +38,8 @@ detect_target() {
         Linux)
             case "$arch" in
                 x86_64) echo "linux-x64" ;;
-                *) error "Unsupported Linux architecture: $arch (only x64 is supported)" ;;
+                aarch64|arm64) echo "linux-arm64" ;;
+                *) error "Unsupported Linux architecture: $arch (only x64 and arm64 are supported)" ;;
             esac
             ;;
         *)


### PR DESCRIPTION
## Summary

`curl -fsSL https://superset.sh/cli/install.sh | sh` failed on Linux arm64 (e.g. Oracle Cloud Ampere A1, Ubuntu 24.04) with `Unsupported Linux architecture: aarch64`, even though:

- `superset-linux-arm64.tar.gz` is published on every CLI release (`release-cli.yml` builds it on `ubuntu-24.04-arm`), and it exists on the rolling `cli-latest` release (verified HTTP 200)
- `superset update` already resolves arm64 (`packages/cli/src/commands/update/command.ts:28`)

`detect_target()` in `apps/marketing/public/cli/install.sh` was the only place that didn't know about arm64. It now maps `aarch64`/`arm64` → `linux-arm64`.

Fixes #6053

## Testing

Ran `detect_target()` with a mocked `uname` across os/arch combos:

| uname -s / -m | result |
|---|---|
| Linux aarch64 | linux-arm64 |
| Linux arm64 | linux-arm64 |
| Linux x86_64 | linux-x64 |
| Linux riscv64 | error (unsupported) |
| Darwin arm64 | darwin-arm64 |
| Darwin x86_64 | error (Intel unsupported) |

Also `sh -n` syntax check passes.

https://claude.ai/code/session_01AczT2YKaxh4Pjb3pwf6rng

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6057">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI installer to support Linux arm64 (`aarch64`), mapping it to `linux-arm64` so installs work on ARM machines. Updates the error message to list supported architectures.

<sup>Written for commit 4db431c4e77b225514cb4f6b91717ab10e50685f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

