### PR TITLE
fix(desktop): keep v2 preset commands fresh after agent edits

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -8,9 +8,10 @@ export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
  * Caller passes the host URL explicitly so this hook works for any host the
  * user is targeting (local, remote-via-relay, or whatever the new-workspace
  * modal has resolved). Cache is keyed on URL so distinct hosts don't share
- * entries. Configs only change via Settings → Agents mutations that invalidate
- * this key — `staleTime: Infinity` keeps the startup prefetch warm across
- * navigation instead of every consumer refetching on mount.
+ * entries. Settings → Agents mutations invalidate this key for instant
+ * same-session updates; the bounded staleTime exists for writes that bypass
+ * the renderer (CLI, host-service restarts, other clients on the same host),
+ * which previously stayed invisible until an app restart.
  */
 export function useV2AgentConfigs(hostUrl: string | null) {
 	return useQuery({
@@ -22,6 +23,6 @@ export function useV2AgentConfigs(hostUrl: string | null) {
 				hostUrl,
 			).settings.agentConfigs.list.query();
 		},
-		staleTime: Number.POSITIVE_INFINITY,
+		staleTime: 30_000,
 	});
 }

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -9,9 +9,11 @@ export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
  * user is targeting (local, remote-via-relay, or whatever the new-workspace
  * modal has resolved). Cache is keyed on URL so distinct hosts don't share
  * entries. Settings → Agents mutations invalidate this key for instant
- * same-session updates; the bounded staleTime exists for writes that bypass
- * the renderer (CLI, host-service restarts, other clients on the same host),
- * which previously stayed invisible until an app restart.
+ * same-session updates; the bounded staleTime and unconditional focus refetch
+ * exist for writes that bypass the renderer (CLI, host-service restarts, other
+ * clients on the same host), which previously stayed invisible until an app
+ * restart. Acting on an external edit means refocusing the app, so focus is
+ * the earliest moment the fresh value can matter.
  */
 export function useV2AgentConfigs(hostUrl: string | null) {
 	return useQuery({
@@ -24,5 +26,6 @@ export function useV2AgentConfigs(hostUrl: string | null) {
 			).settings.agentConfigs.list.query();
 		},
 		staleTime: 30_000,
+		refetchOnWindowFocus: "always",
 	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -98,6 +98,28 @@ export function V2AgentsSettings({
 		);
 	};
 
+	// Linked terminal presets keep a `commands` snapshot as the launch fallback
+	// for when the agent config isn't loaded; refresh it so an edited agent
+	// command can't resurface stale via that fallback.
+	const syncLinkedPresetSnapshots = (updated: HostAgentConfig) => {
+		const commandText = getAgentCommandText(updated);
+		if (commandText.trim().length === 0) return;
+		for (const preset of collections.v2TerminalPresets.values()) {
+			if (
+				preset.agentId !== updated.id &&
+				preset.agentId !== updated.presetId
+			) {
+				continue;
+			}
+			if (preset.commands.length === 1 && preset.commands[0] === commandText) {
+				continue;
+			}
+			collections.v2TerminalPresets.update(preset.id, (draft) => {
+				draft.commands = [commandText];
+			});
+		}
+	};
+
 	const setupAgentMutation = electronTrpc.settings.setupAgent.useMutation();
 	const collections = useCollections();
 
@@ -323,6 +345,7 @@ export function V2AgentsSettings({
 						}
 						onChanged={(updated) => {
 							updateCachedConfig(updated);
+							syncLinkedPresetSnapshots(updated);
 							invalidate();
 						}}
 						onDeleted={() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -64,6 +64,12 @@ interface PresetEditorDialogProps {
 	 * row has agentId, so the linked branch stays dormant.
 	 */
 	agents?: HostAgentConfig[];
+	/**
+	 * Called after a linked-agent command save succeeds so the owner can keep
+	 * the preset rows' `commands` snapshot (the launch fallback when the agent
+	 * config isn't loaded) in sync with the edited command.
+	 */
+	onLinkedAgentSaved?: (updated: HostAgentConfig) => void;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onDeletePreset: () => void;
@@ -186,6 +192,7 @@ export function PresetEditorDialog({
 	preset,
 	projects,
 	agents,
+	onLinkedAgentSaved,
 	open,
 	onOpenChange,
 	onDeletePreset,
@@ -256,6 +263,7 @@ export function PresetEditorDialog({
 				),
 			);
 			void queryClient.invalidateQueries(queryFamily);
+			onLinkedAgentSaved?.(updated);
 		},
 		onError: (err) =>
 			toast.error(err instanceof Error ? err.message : "Failed to save"),

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -1,3 +1,4 @@
+import type { HostAgentConfig } from "@superset/host-service/settings";
 import {
 	type ExecutionMode,
 	normalizeExecutionMode,
@@ -288,6 +289,27 @@ export function V2PresetsSection({
 			collections.v2TerminalPresets.delete(id);
 		},
 		[collections.v2TerminalPresets],
+	);
+
+	// The stored `commands` array is the launch fallback used whenever the
+	// agent config isn't loaded, so it must track the edited agent command —
+	// otherwise launches can silently run the command from preset-creation time.
+	const syncLinkedPresetSnapshots = useCallback(
+		(updated: HostAgentConfig) => {
+			const commandText = getAgentCommandText(updated);
+			if (commandText.trim().length === 0) return;
+			for (const preset of serverPresetsRef.current) {
+				const row = preset as V2TerminalPresetRow;
+				if (row.agentId !== updated.id && row.agentId !== updated.presetId) {
+					continue;
+				}
+				if (row.commands.length === 1 && row.commands[0] === commandText) {
+					continue;
+				}
+				updateV2Preset(row.id, { commands: [commandText] });
+			}
+		},
+		[updateV2Preset],
 	);
 
 	const reorderV2Presets = useCallback(
@@ -649,6 +671,7 @@ export function V2PresetsSection({
 				preset={editingPreset}
 				projects={projectOptions}
 				agents={agents}
+				onLinkedAgentSaved={syncLinkedPresetSnapshots}
 				open={!!editingPreset}
 				onOpenChange={(open) => !open && handleCloseEditor()}
 				onDeletePreset={handleDeleteEditingPreset}


### PR DESCRIPTION
## Problem

Report: someone edited v2 presets and the change only took effect after quitting and restarting the desktop app.

The edit UI itself works — verified every surface end-to-end over CDP (bar right-click → dialog, settings row click, cold deep-link reload, field/toggle persistence, linked-agent command save, edit → launch, delete). The staleness lives in how **agent-linked** presets (the default Claude/Codex/Copilot presets all are) resolve their launch command:

1. `useV2AgentConfigs` cached with `staleTime: Infinity` and refreshed only by explicit same-session invalidation. Any agent-config write that bypasses the renderer's mutation surfaces — CLI, host-service restart/heal, another client on the same host, or a future missed invalidation call site — left the preset bar, editor, and launcher resolving the old command until app restart.
2. The preset row's `commands` snapshot is the launch fallback whenever the agents query hasn't resolved (right after startup, transient host hiccup). It was written once at preset creation and never refreshed, so it replayed the creation-time command regardless of later agent edits.

## Fix

- `useV2AgentConfigs`: bound `staleTime` to 30s. Same-session mutations still invalidate for instant updates; out-of-band writes now heal within seconds instead of requiring a restart.
- Sync the linked presets' `commands` snapshot whenever an agent command is saved, from both edit surfaces:
  - `PresetEditorDialog` gains an optional `onLinkedAgentSaved` callback; `V2PresetsSection` uses it to update matching preset rows.
  - Settings → Agents (`V2AgentsSettings`) does the same in its `onChanged` handler.

## Verification

- Live-verified in the dev app over CDP: editing the Claude linked command now updates the preset row's stored snapshot in lockstep (before the fix, the snapshot demonstrably kept the old command); reverting the edit syncs back.
- Full edit → persist → propagate → launch pipeline re-verified: an edited preset immediately runs its new command in a fresh terminal.
- `bun run typecheck` and `bun run lint` clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale launch commands for v2 agent-linked terminal presets. Presets now pick up agent command edits within seconds or as soon as you refocus the app, so launches use the latest command without restarting.

- **Bug Fixes**
  - Bounded `useV2AgentConfigs` cache to a 30s `staleTime` and added refetch on window focus; renderer mutations still invalidate instantly, and out-of-band edits (CLI/other clients/host restarts) refresh on refocus.
  - Keep linked presets’ `commands` snapshot in sync on agent command save from both edit surfaces (Preset Editor Dialog via `onLinkedAgentSaved`, and Settings → Agents via `onChanged`) to avoid launching the creation-time command when the agent config hasn’t loaded.

<sup>Written for commit 55b35e007a497c0985cbc19bb68fc91413f705cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linked terminal presets now automatically stay synchronized when associated agent configurations or commands are updated.
  * Agent configuration data refreshes after changes, with cached results becoming stale after 30 seconds.
  * Preset command snapshots are updated only when necessary, preventing unintended overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->