### PR TITLE
feat(cli): add Intel Mac (darwin-x64) builds to CLI distribution

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -52,7 +52,7 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          for target in darwin-arm64 linux-x64 linux-arm64; do
+          for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
             url="https://github.com/superset-sh/superset/releases/download/${TAG}/superset-${target}.tar.gz"
             echo "Fetching SHA for $url"
             tmp=$(mktemp)
@@ -77,6 +77,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           DARWIN_ARM64_SHA: ${{ steps.shas.outputs.darwin_arm64_sha }}
+          DARWIN_X64_SHA: ${{ steps.shas.outputs.darwin_x64_sha }}
           LINUX_X64_SHA: ${{ steps.shas.outputs.linux_x64_sha }}
           LINUX_ARM64_SHA: ${{ steps.shas.outputs.linux_arm64_sha }}
         run: |
@@ -93,6 +94,10 @@ jobs:
               on_arm do
                 url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-arm64.tar.gz"
                 sha256 "{darwin_arm64}"
+              end
+              on_intel do
+                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-x64.tar.gz"
+                sha256 "{darwin_x64}"
               end
             end
 
@@ -121,6 +126,7 @@ jobs:
           print(template.format(
               version=os.environ["VERSION"],
               darwin_arm64=os.environ["DARWIN_ARM64_SHA"],
+              darwin_x64=os.environ["DARWIN_X64_SHA"],
               linux_x64=os.environ["LINUX_X64_SHA"],
               linux_arm64=os.environ["LINUX_ARM64_SHA"],
           ), end="")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,6 @@ jobs:
     name: Build CLI
     uses: ./.github/workflows/build-cli.yml
     with:
-      targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
+      targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"macos-15-intel","target":"darwin-x64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
       upload: false
     secrets: inherit

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-cli.yml
     with:
-      targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
+      targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"macos-15-intel","target":"darwin-x64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
     secrets: inherit
 
   release:

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -31,7 +31,7 @@ detect_target() {
         Darwin)
             case "$arch" in
                 arm64) echo "darwin-arm64" ;;
-                x86_64) error "Intel Macs are not supported. Apple Silicon (arm64) only." ;;
+                x86_64) echo "darwin-x64" ;;
                 *) error "Unsupported macOS architecture: $arch" ;;
             esac
             ;;

--- a/packages/cli/scripts/smoke-test.sh
+++ b/packages/cli/scripts/smoke-test.sh
@@ -6,7 +6,7 @@
 #
 # Usage: smoke-test.sh <dist-dir> <target>
 #   <dist-dir>  extracted distribution root (contains bin/, lib/, share/)
-#   <target>    darwin-arm64 | linux-x64 | linux-arm64
+#   <target>    darwin-arm64 | darwin-x64 | linux-x64 | linux-arm64
 #
 # The decisive check is "boot the host service": a missing or unshippable
 # module (@mastra/core, @xterm/headless, anything reached via createRequire)


### PR DESCRIPTION
## Summary

`install.sh` currently hard-rejects Intel Macs ("Intel Macs are not supported. Apple Silicon (arm64) only."), but almost all of the darwin-x64 support already exists:

- `packages/cli/scripts/build-dist.ts` lists `darwin-x64` as a valid target with its native-package mapping (`@libsql/darwin-x64`, `@parcel/watcher-darwin-x64`, `@duckdb/node-bindings-darwin-x64`, universal tokenizers) already filled in
- `superset update` already resolves Intel Macs to `darwin-x64`
- Upstream artifacts exist: Node 22.13.0 darwin-x64 runtime and better-sqlite3 v12.6.2 `node-v127-darwin-x64` prebuild both return HTTP 200; node-pty ships darwin prebuilds in its npm package
- `build-cli.yml` and `smoke-test.sh` are target-generic for `darwin-*`

This PR wires it the rest of the way:

- **release-cli.yml / ci.yml**: add `{"os": "macos-15-intel", "target": "darwin-x64"}` to the build matrix (same native-runner pattern as `linux-arm64` on `ubuntu-24.04-arm`)
- **install.sh**: `Darwin x86_64` → `darwin-x64` instead of erroring
- **bump-homebrew.yml**: fetch the darwin-x64 sha and render an `on_intel` block under `on_macos`
- **smoke-test.sh**: usage comment lists the new target

## Testing

- `detect_target()` exercised with mocked `uname`: Darwin x86_64 → `darwin-x64`, arm64 and error branches unchanged
- Homebrew formula template rendered locally with dummy SHAs — valid formula with both `on_macos` blocks
- All three workflow files parse as YAML; `sh -n` passes on install.sh
- CI build dry run on this branch via `release-cli.yml` `workflow_dispatch` (results in comments)

Note: existing Intel Mac users who previously saw the error need no migration — the installer and `superset update` both resolve `darwin-x64` from the same release assets once the next CLI release publishes the tarball.

https://claude.ai/code/session_01AczT2YKaxh4Pjb3pwf6rng

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6059">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Intel Mac (`darwin-x64`) builds to the CLI and installer so Intel users can install and update without errors. Updates CI, release, and Homebrew to ship and verify the new target.

- **New Features**
  - CI and release: add `{"os":"macos-15-intel","target":"darwin-x64"}` to build matrices.
  - Installer: map `Darwin x86_64` to `darwin-x64` (removes the hard-reject).
  - Homebrew: fetch `darwin-x64` SHA and render an `on_intel` block under `on_macos`.
  - Smoke test: usage now includes `darwin-x64`.

- **Migration**
  - No action needed. Intel Mac installs will resolve `darwin-x64` after the next CLI release.

<sup>Written for commit 9a30c432f038d6fd3e858cd398616723ecdda5e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for macOS Intel devices.
  * Added macOS Intel artifacts to automated builds and releases.
  * Added Homebrew installation support for Intel Macs.

* **Documentation**
  * Updated supported platform documentation to include macOS Intel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->