### PR TITLE
fix(desktop): rename add-repo button copy to Add/Open project

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -265,7 +265,7 @@ export function DashboardSidebarHeader({
 								<DropdownMenuTrigger asChild>
 									<button
 										type="button"
-										aria-label="Add repository"
+										aria-label="Add project"
 										className="group/addrepo flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover"
 									>
 										<VscNewFolder className="size-3.5 group-hover/addrepo:hidden" />
@@ -273,7 +273,7 @@ export function DashboardSidebarHeader({
 									</button>
 								</DropdownMenuTrigger>
 							</TooltipTrigger>
-							<TooltipContent side="right">Add repository</TooltipContent>
+							<TooltipContent side="right">Add project</TooltipContent>
 						</Tooltip>
 						<DropdownMenuContent
 							align="start"
@@ -281,7 +281,7 @@ export function DashboardSidebarHeader({
 						>
 							<DropdownMenuItem onSelect={handleImportFolder}>
 								<VscFolderOpened className="size-4" />
-								Open from folder
+								Open project
 							</DropdownMenuItem>
 							<DropdownMenuItem onSelect={() => openNewProject()}>
 								<VscGithubAlt className="size-4" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -80,7 +80,7 @@ export function DashboardSidebarWorkspacesHeader() {
 						<DropdownMenuTrigger asChild>
 							<button
 								type="button"
-								aria-label="Add repository"
+								aria-label="Add project"
 								onClick={(event) => event.stopPropagation()}
 								onKeyDown={(event) => event.stopPropagation()}
 								className="group/addrepo flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
@@ -90,7 +90,7 @@ export function DashboardSidebarWorkspacesHeader() {
 							</button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
-					<TooltipContent side="bottom">Add repository</TooltipContent>
+					<TooltipContent side="bottom">Add project</TooltipContent>
 				</Tooltip>
 				<DropdownMenuContent
 					align="end"
@@ -103,7 +103,7 @@ export function DashboardSidebarWorkspacesHeader() {
 				>
 					<DropdownMenuItem onSelect={handleImportFolder}>
 						<VscFolderOpened className="size-4" />
-						Open from folder
+						Open project
 					</DropdownMenuItem>
 					<DropdownMenuItem onSelect={() => openNewProject()}>
 						<VscGithubAlt className="size-4" />


### PR DESCRIPTION
## Summary
- Sidebar "add repository" button (collapsed + expanded states) now shows tooltip "Add project" instead of "Add repository", with matching `aria-label`.
- First item in the dropdown menu renamed from "Open from folder" to "Open project".

## Test plan
- [ ] Hover the add-project button in the dashboard sidebar (collapsed and expanded) and confirm the tooltip reads "Add project".
- [ ] Open the dropdown and confirm the first item reads "Open project" and still imports a folder on click.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6061">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the sidebar “add repository” copy to use “project” terminology. The add button tooltip and aria-label now say “Add project,” and the first dropdown item is “Open project” in both the main and Workspaces sidebars.

<sup>Written for commit d8ebbd25f856b924e37880aabd2c8232ae1572de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sidebar accessibility labels and tooltips to consistently say “Add project.”
  * Renamed the dropdown option “Open from folder” to “Open project” for clearer project-related wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->