### PR TITLE
revert(desktop): restore plain-click-opens-diff on changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
@@ -13,14 +13,14 @@ const map: LinkTierMap = {
 };
 
 describe("changes sidebar file policy", () => {
-	it("keeps plain click on the file", () => {
+	it("keeps plain click on the diff", () => {
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: false,
 				ctrlKey: false,
 				shiftKey: false,
 			}),
-		).toBe("file");
+		).toBe("diff");
 	});
 
 	it("maps shift-click through the settings map", () => {
@@ -33,21 +33,21 @@ describe("changes sidebar file policy", () => {
 		).toBe("diffNewTab");
 	});
 
-	it("maps cmd/ctrl-click to the diff when the settings action is pane", () => {
+	it("maps cmd/ctrl-click to the file when the settings action is pane", () => {
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: true,
 				ctrlKey: false,
 				shiftKey: false,
 			}),
-		).toBe("diff");
+		).toBe("file");
 		expect(
 			resolveChangesSidebarFileIntent(map, {
 				metaKey: false,
 				ctrlKey: true,
 				shiftKey: false,
 			}),
-		).toBe("diff");
+		).toBe("file");
 	});
 
 	it("maps cmd/ctrl-shift-click to the external editor", () => {
@@ -82,8 +82,7 @@ describe("changes sidebar file policy", () => {
 
 	it("finds shortcuts for menu items from the same map", () => {
 		expect(tierForChangesSidebarFileIntent(map, "diffNewTab")).toBe("shift");
-		expect(tierForChangesSidebarFileIntent(map, "diff")).toBe("meta");
-		expect(tierForChangesSidebarFileIntent(map, "file")).toBeNull();
+		expect(tierForChangesSidebarFileIntent(map, "file")).toBe("meta");
 		expect(tierForChangesSidebarFileIntent(map, "external")).toBe("metaShift");
 	});
 });

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
@@ -22,7 +22,7 @@ function intentFor(
 	if (action === null) return null;
 	if (action === "external") return "external";
 	if (action === "newTab") return "diffNewTab";
-	return tier === "plain" ? "file" : "diff";
+	return tier === "plain" ? "diff" : "file";
 }
 
 function shortIntentLabel(intent: ChangesSidebarFileIntent): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -64,8 +64,8 @@ export function FileRowContextMenuItems({
 	const changeKey = getChangesetFileKey(file);
 
 	const policy = useChangesSidebarFilePolicy();
-	const diffTier = policy.tierForIntent("diff");
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
+	const fileTier = policy.tierForIntent("file");
 	const externalTier = policy.tierForIntent("external");
 
 	return (
@@ -75,9 +75,6 @@ export function FileRowContextMenuItems({
 			>
 				<GitCompare />
 				Open Diff
-				{diffTier && (
-					<DropdownMenuShortcut>{modifierLabel(diffTier)}</DropdownMenuShortcut>
-				)}
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onSelect={() => onSelectFile?.(file.path, true, changeKey)}
@@ -96,6 +93,9 @@ export function FileRowContextMenuItems({
 			>
 				<FileText />
 				Open File
+				{fileTier && (
+					<DropdownMenuShortcut>{modifierLabel(fileTier)}</DropdownMenuShortcut>
+				)}
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -98,8 +98,8 @@ export const FileRow = memo(function FileRow({
 	};
 
 	const policy = useChangesSidebarFilePolicy();
-	const diffTier = policy.tierForIntent("diff");
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
+	const fileTier = policy.tierForIntent("file");
 	const externalTier = policy.tierForIntent("external");
 
 	const rowButton = (
@@ -181,11 +181,6 @@ export const FileRow = memo(function FileRow({
 						>
 							<GitCompare />
 							Open Diff
-							{diffTier && (
-								<DropdownMenuShortcut>
-									{modifierLabel(diffTier)}
-								</DropdownMenuShortcut>
-							)}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onSelect={() => onSelect?.(file.path, true, changeKey)}
@@ -204,6 +199,11 @@ export const FileRow = memo(function FileRow({
 						>
 							<FileText />
 							Open File
+							{fileTier && (
+								<DropdownMenuShortcut>
+									{modifierLabel(fileTier)}
+								</DropdownMenuShortcut>
+							)}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
@@ -244,9 +244,6 @@ export const FileRow = memo(function FileRow({
 				>
 					<GitCompare />
 					Open Diff
-					{diffTier && (
-						<ContextMenuShortcut>{modifierLabel(diffTier)}</ContextMenuShortcut>
-					)}
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => onSelect?.(file.path, true, changeKey)}
@@ -265,6 +262,9 @@ export const FileRow = memo(function FileRow({
 				>
 					<FileText />
 					Open File
+					{fileTier && (
+						<ContextMenuShortcut>{modifierLabel(fileTier)}</ContextMenuShortcut>
+					)}
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}


### PR DESCRIPTION
## Summary
- Reverts #5979 (954050c54): plain click on a row in the Changes sidebar opens the diff again, and cmd/ctrl-click opens the file (restoring the pre-#5979 default).
- Updates the context-menu shortcut hints (⌘) to match: shown next to "Open File" instead of "Open Diff".

## Test plan
- [x] `bun test apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts` passes
- [ ] Manually verify in the desktop app: plain click on a changed file opens its diff; ⌘/Ctrl-click opens the file

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6062">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the previous Changes sidebar behavior: plain click opens the diff; Cmd/Ctrl-click opens the file. Shows the modifier next to 'Open File' in menus and updates tests.

<sup>Written for commit 7a0bcfdd940e4e1d56ab73d3579f971400ef232e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Changes sidebar keyboard shortcuts so plain clicks open diffs, while modified clicks open files.
  * Added shortcut indicators for the “Open File” actions in menus and context menus.
  * Removed the modifier shortcut indicator from the “Open Diff” action.
* **Bug Fixes**
  * Corrected shortcut tier mapping for file and diff actions in the Changes sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->