### PR TITLE
fix(host-service): restore mouse encoding on terminal reattach

### DIFF
--- a/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
@@ -59,16 +59,66 @@ describe("createModeTracker", () => {
 	});
 
 	test("focus reporting and mouse tracking are captured", () => {
-		// `?1002h` is button-tracking, NOT SGR encoding (`?1006h`). xterm.js's
-		// public IModes doesn't expose mouse encoding format, so the preamble
-		// can't restore it — clients reattaching mid-session keep the default
-		// X10 encoding. Acceptable today; revisit if a TUI relying on SGR
-		// breaks on reattach.
+		// `?1002h` is button tracking. The program never opts into SGR encoding,
+		// so a reattached client should retain the default X10 encoding.
 		const t = createModeTracker(120, 32);
 		t.feed(enc.encode("\x1b[?1004h\x1b[?1002h"));
 		const preamble = preambleString(t);
 		expect(preamble).toContain("\x1b[?1004h");
 		expect(preamble).toContain("\x1b[?1002h");
+		expect(preamble).not.toContain("?1006");
+		t.dispose();
+	});
+
+	test("alternate screen buffer is captured", () => {
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode("\x1b[?1049h"));
+		expect(preambleString(t)).toContain("\x1b[?1049h");
+		t.feed(enc.encode("\x1b[?1049l"));
+		expect(preambleString(t)).not.toContain("?1049");
+		t.dispose();
+	});
+
+	test("SGR mouse encoding is captured alongside tracking", () => {
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode("\x1b[?1002h\x1b[?1006h"));
+		const preamble = preambleString(t);
+		expect(preamble).toContain("\x1b[?1002h");
+		expect(preamble).toContain("\x1b[?1006h");
+
+		t.feed(enc.encode("\x1b[?1006l"));
+		expect(preambleString(t)).not.toContain("?1006");
+		t.dispose();
+	});
+
+	test("SGR pixel mouse encoding is captured alongside tracking", () => {
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode("\x1b[?1003h\x1b[?1016h"));
+		const preamble = preambleString(t);
+		expect(preamble).toContain("\x1b[?1003h");
+		expect(preamble).toContain("\x1b[?1016h");
+
+		t.feed(enc.encode("\x1b[?1016l"));
+		expect(preambleString(t)).not.toContain("?1016");
+		t.dispose();
+	});
+
+	test("Amp TUI modes survive unrelated output", () => {
+		const t = createModeTracker(120, 32);
+		t.feed(
+			enc.encode("\x1b[?1049h\x1b[?1002h\x1b[?1003h\x1b[?1004h\x1b[?1006h"),
+		);
+
+		const filler = "x".repeat(2048);
+		for (let i = 0; i < 100; i += 1) {
+			t.feed(enc.encode(filler));
+		}
+
+		const preamble = preambleString(t);
+		expect(preamble).toContain("\x1b[?1049h");
+		expect(preamble).toContain("\x1b[?1003h");
+		expect(preamble).toContain("\x1b[?1004h");
+		expect(preamble).toContain("\x1b[?1006h");
 		t.dispose();
 	});
 

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -43,6 +43,11 @@ type HeadlessInternals = {
 	_core?: {
 		_writeBuffer?: { writeSync(data: string | Uint8Array): void };
 		coreService?: { kittyKeyboard?: { flags: number } };
+		// Mouse encoding is not exposed by the public IModes API. Read the
+		// state service that xterm itself uses to implement Terminal.modes.
+		mouseStateService?: {
+			activeEncoding?: "DEFAULT" | "SGR" | "SGR_PIXELS";
+		};
 		optionsService?: {
 			rawOptions: { vtExtensions?: { kittyKeyboard?: boolean } };
 		};
@@ -66,11 +71,17 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 	// rather than silently throwing inside every PTY-output callback.
 	const optionsRaw = internals._core?.optionsService?.rawOptions;
 	const writeBuffer = internals._core?._writeBuffer;
-	if (!optionsRaw || typeof writeBuffer?.writeSync !== "function") {
+	const mouseState = internals._core?.mouseStateService;
+	if (
+		!optionsRaw ||
+		typeof writeBuffer?.writeSync !== "function" ||
+		mouseState?.activeEncoding !== "DEFAULT"
+	) {
 		throw new Error(
 			"@xterm/headless internals not found (optionsService.rawOptions, " +
-				"_writeBuffer.writeSync). Likely a version-pinning regression — " +
-				"check that the pinned version still exposes these.",
+				"_writeBuffer.writeSync, mouseStateService.activeEncoding). Likely a " +
+				"version-pinning regression — check that the pinned version still " +
+				"exposes these.",
 		);
 	}
 
@@ -87,6 +98,11 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 	const buildPreamble = (): Uint8Array | null => {
 		const m = term.modes;
 		const parts: string[] = [];
+
+		// Enter the buffer the running program believes is active before replaying
+		// its recent output. Alt-screen entry is normally emitted only once at TUI
+		// startup and is therefore unavailable to a fresh renderer on reattach.
+		if (term.buffer.active.type === "alternate") parts.push("\x1b[?1049h");
 
 		if (m.applicationCursorKeysMode) parts.push("\x1b[?1h");
 		if (m.applicationKeypadMode) parts.push("\x1b[?66h");
@@ -116,6 +132,16 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 				break;
 			case "none":
 				break;
+		}
+
+		// Tracking and encoding are independent xterm states. IModes exposes the
+		// former but not the latter, so restore SGR explicitly while tracking is
+		// active; otherwise a fresh xterm falls back to legacy X10 reports.
+		if (m.mouseTrackingMode !== "none") {
+			if (mouseState.activeEncoding === "SGR") parts.push("\x1b[?1006h");
+			else if (mouseState.activeEncoding === "SGR_PIXELS") {
+				parts.push("\x1b[?1016h");
+			}
 		}
 
 		const kittyFlags = internals._core?.coreService?.kittyKeyboard?.flags ?? 0;


### PR DESCRIPTION
## What & why

Fresh renderer xterms do not receive the one-shot alternate-screen and SGR mouse-encoding sequences emitted by a running TUI at startup. The reattach preamble restores mouse tracking, but without `?1006h` or `?1016h` the fresh xterm falls back to legacy X10 reports. SGR-only applications such as Amp then stop receiving usable mouse events after a renderer reload or session adoption.

Read the active encoding from xterm's pinned internal `mouseStateService`, which is the same state source xterm uses for its public mode reporting. Restore that encoding alongside mouse tracking, and restore the alternate screen before replaying buffered output. The private API dependency is validated at tracker construction so an xterm upgrade fails loudly.

Fixes #5038. Supersedes the approach in #5041 using the state service exposed directly on xterm's core.

## How I tested it

- `bun run lint`
- `bun run typecheck`
- `bun test packages/host-service/src/terminal/terminal-mode-tracker.test.ts` — 14 pass
- `bun run test` — 2,314 desktop tests pass; 34 unrelated Git/worktree tests fail in this local environment
- `cd packages/host-service && bun run test` — 688 tests pass; the local full-package run also encounters unrelated worker/native test-environment failures

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores SGR mouse encoding and alternate-screen state on terminal reattach, so TUIs (e.g., Amp) keep receiving correct mouse events after reload or session adoption. Uses `@xterm/headless` internals to mirror xterm’s own mode reporting before replaying buffered output.

- **Bug Fixes**
  - Restore SGR cell (`?1006h`) and pixel (`?1016h`) mouse encoding alongside tracking (`?1002h`/`?1003h`).
  - Enter alternate screen (`?1049h`) before replaying recent output.
  - Read `mouseStateService.activeEncoding` from xterm internals; validate at construction to fail fast if the pinned API changes.
  - Add tests for capturing alt-screen, tracking, SGR encodings, and resilience under unrelated output.

<sup>Written for commit ed4926219f774fdef642be2ec7c846ffcc00bd7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal state restoration when switching or recovering from interruptions.
  * Preserved the alternate screen buffer and mouse tracking modes more reliably.
  * Restored the correct mouse encoding for standard SGR and pixel-based mouse input.
  * Prevented unrelated terminal output from clearing supported interface modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->