### PR TITLE
feat(shared): add harness selector to the polygraph terminal agent

### DIFF
--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -28,6 +28,9 @@ describe("AGENT_MODEL_SUPPORT", () => {
 			} else if (entry.modelEnv) {
 				// env-based presets (Vibe) carry the model via an env var, no flag
 				expect(entry.modelFlag).toBeNull();
+			} else if (entry.presetId === "polygraph") {
+				// polygraph's dropdown picks the harness it launches, not a model
+				expect(entry.modelFlag).toBe("--agent");
 			} else {
 				expect(entry.modelFlag).toBe("--model");
 			}
@@ -107,6 +110,21 @@ describe("buildAgentModelArgs", () => {
 		for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
 			expect(buildAgentModelArgs("codex", model)).toEqual(["--model", model]);
 		}
+	});
+
+	it("builds polygraph harness args for every supported harness", () => {
+		for (const harness of ["claude", "codex", "opencode"]) {
+			expect(buildAgentModelArgs("polygraph", harness)).toEqual([
+				"--agent",
+				harness,
+			]);
+		}
+	});
+
+	it("omits the polygraph harness flag when unset or unknown", () => {
+		expect(buildAgentModelArgs("polygraph", undefined)).toEqual([]);
+		expect(buildAgentModelArgs("polygraph", "")).toEqual([]);
+		expect(buildAgentModelArgs("polygraph", "gemini")).toEqual([]);
 	});
 });
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -139,6 +139,20 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		],
 	},
 	{
+		// Polygraph's picker selects the harness it launches, not a model: the
+		// selection rides `polygraph session start --agent <id>`. The launch
+		// plumbing is flag-agnostic, so it reuses this catalog. Unset
+		// ("Default") omits the flag and polygraph falls back to its own
+		// `--agent auto` resolution.
+		presetId: "polygraph",
+		modelFlag: "--agent",
+		models: [
+			{ id: "claude", label: "Claude" },
+			{ id: "codex", label: "Codex" },
+			{ id: "opencode", label: "OpenCode" },
+		],
+	},
+	{
 		presetId: "superset",
 		modelFlag: null,
 		models: SUPERSET_CHAT_MODELS.map(({ id, label }) => ({ id, label })),


### PR DESCRIPTION
Adds an agent selector to the built-in polygraph terminal agent so users can pick which harness polygraph launches: Claude, Codex, or OpenCode.

Follows the pattern established for the effort selector (#5375): one new entry in the `AGENT_MODEL_SUPPORT` catalog (`presetId: "polygraph"`, flag `--agent`) plus tests — the generic `AgentModelSelect` dropdown, localStorage persistence, and submit wiring all activate automatically, no bespoke plumbing.

Details:

- When nothing is selected (Default), the flag is omitted entirely so the polygraph CLI applies its own default (`--agent auto`).
- Selected values map to `polygraph session start --agent <claude|codex|opencode> -- '<prompt>'`, with flag and value as separate argv tokens before the `--` prompt separator, same as the other flag+value entries.
- Labels (Claude / Codex / OpenCode) match how these harnesses are named in `BUILTIN_TERMINAL_AGENTS`.
- Stale/unknown stored selections degrade to the Default behavior (flag omitted).
- The entry is inert on mobile surfaces (`ModelPickerScreen`, `NewChatWidget`) until polygraph is offered as an agent there.

Testing: `bun test` in `packages/shared` (718 pass, including 2 new cases for `buildAgentModelArgs` with the polygraph preset), `bun run typecheck`, and `biome check` on touched files.

Context: discussed with @Kitenite in Slack — polygraph-specific controls for the polygraph agent type, starting with harness selection.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6068">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a harness selector to the polygraph terminal agent so users can choose Claude, Codex, or OpenCode. This uses the existing model picker logic and emits the correct `--agent` args for polygraph.

- **New Features**
  - Added polygraph entry to `AGENT_MODEL_SUPPORT` (`presetId: "polygraph"`, flag `--agent`) with harness options Claude, Codex, OpenCode.
  - Selection emits `--agent <id>` before the `--` prompt; unset/unknown omits the flag so polygraph falls back to `--agent auto`.
  - Added tests for `buildAgentModelArgs` covering supported and unknown harness values.

<sup>Written for commit edf6f9ea7c6bbe2b4e556aa815e06bd1cae66043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the Polygraph agent with Claude, Codex, and OpenCode harnesses.
  * Added validation to ensure a supported harness is selected when using Polygraph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->