### PR TITLE
feat(desktop): add reveal-in-Finder button to file pane header

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
@@ -2,8 +2,9 @@ import type { RendererContext } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback } from "react";
 import { LuCheck, LuCopy } from "react-icons/lu";
-import { TbExternalLink } from "react-icons/tb";
+import { TbExternalLink, TbFolderOpen } from "react-icons/tb";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { useSharedFileDocument } from "../../../../../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../../../../../types";
@@ -22,6 +23,7 @@ export function FilePaneHeaderExtras({
 	const data = context.pane.data as FilePaneData;
 	const { filePath } = data;
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+	const openInFinderMutation = electronTrpc.external.openInFinder.useMutation();
 	const { copyToClipboard, copied } = useCopyToClipboard();
 
 	const document = useSharedFileDocument({
@@ -46,6 +48,10 @@ export function FilePaneHeaderExtras({
 	const handleOpenExternal = useCallback(() => {
 		openInExternalEditor(filePath);
 	}, [filePath, openInExternalEditor]);
+
+	const handleOpenInFinder = useCallback(() => {
+		openInFinderMutation.mutate(filePath);
+	}, [filePath, openInFinderMutation]);
 
 	return (
 		<div className="flex min-w-0 items-center gap-1">
@@ -75,6 +81,19 @@ export function FilePaneHeaderExtras({
 				<TooltipContent side="bottom">
 					{copied ? "Copied" : "Copy path"}
 				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Reveal in Finder"
+						onClick={handleOpenInFinder}
+						className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						<TbFolderOpen className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Reveal in Finder</TooltipContent>
 			</Tooltip>
 			<Tooltip>
 				<TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Adds a folder-icon button to the v2 file pane header that reveals the current file in Finder via the existing `electronTrpc.external.openInFinder` mutation (`shell.showItemInFolder`).
- Sits between Copy path and Open in editor, matching the sibling buttons' styling and tooltip pattern.

## Test plan
- [ ] Open a file in the v2 workspace, click the new folder icon in the pane header, and confirm Finder opens with the file highlighted.
- [ ] Confirm tooltip reads "Reveal in Finder".

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6071">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Reveal in Finder” button to the v2 file pane header that opens the current file in Finder via `electronTrpc.external.openInFinder`.

The button sits between Copy path and Open in editor, matches existing styles, and shows the tooltip “Reveal in Finder.”

<sup>Written for commit 0879bd0be5912b86054ec3f3ebd453f3d6002d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Reveal in Finder” action to the file pane header.
  - Users can open the current file’s location directly in Finder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->