### PR TITLE
feat(desktop): hook up Open in Finder for v2 sidebar projects

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useDashboardSidebarSectionRename } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSectionRenameContext";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -75,8 +76,25 @@ export function useDashboardSidebarProjectSectionActions({
 			});
 	};
 
-	const handleOpenInFinder = () => {
-		toast.info("Open in Finder is coming soon");
+	const handleOpenInFinder = async () => {
+		const hostProject = hostProjects.find(
+			(item) => item.projectKey === project.id,
+		);
+		const localRepoPath =
+			machineId && hostProject?.hostIds.includes(machineId)
+				? hostProject.repoPath
+				: undefined;
+		if (!localRepoPath) {
+			toast.error("Project folder is not on this machine");
+			return;
+		}
+		try {
+			await electronTrpcClient.external.openInFinder.mutate(localRepoPath);
+		} catch (error) {
+			toast.error(
+				`Failed to open in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
 	};
 
 	const handleOpenSettings = () => {


### PR DESCRIPTION
## Summary
- Replace the "Open in Finder is coming soon" stub in the v2 dashboard sidebar's project context menu with a working implementation, matching what workspaces already do.

## How It Works
The project-section actions hook already queries `useHostProjects()` (for the rename flow), and those rows carry each project's `repoPath`, with the local host's replica winning that field in the merge. The handler looks up the project's row and only proceeds when the local machine is among the hosts serving it — guaranteeing `repoPath` is a path on this machine — then calls the existing `external.openInFinder` electron tRPC procedure (`shell.showItemInFolder`), same as the v2 workspace context menu. Remote-only projects get a "Project folder is not on this machine" error toast.

Like workspaces and the v1 project header, this reveals the project folder highlighted inside its parent directory rather than opening the folder itself.

## Testing
- `bun run typecheck`
- `bun run lint`
- Manual: not exercised in the running app — the wiring mirrors the adjacent workspace-item handler verbatim. Worth a quick click-through: right-click a local project → Open in Finder reveals the repo folder; a remote-only project shows the error toast.

https://claude.ai/code/session_013TPMhwhzMEe5RLShvs7Y5w

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Open in Finder in the v2 dashboard sidebar project menu, matching workspace behavior. Opens the local project folder and shows a clear error for remote-only projects.

- **New Features**
  - Uses `useHostProjects()` to resolve a local `repoPath` and only proceeds if the current machine serves the project, then calls `electronTrpcClient.external.openInFinder`.
  - Shows toast errors when the project folder isn’t on this machine or if the open action fails.

<sup>Written for commit a8b0c06df9aa391bfe07288be89310df7dea1784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to open locally hosted project repositories directly in Finder.

* **Bug Fixes**
  * Replaced the “coming soon” notification with actionable error messages when a project path is unavailable or the operation fails.
  * Prevented Finder access for projects that aren’t hosted locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->