### PR TITLE
fix(deps): drop stray root hono dependency breaking sherif

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "@superset/repo",
-      "dependencies": {
-        "hono": "4.12.27",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
         "@types/bun": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,5 @@
 		"sharp",
 		"utf-8-validate",
 		"workerd"
-	],
-	"dependencies": {
-		"hono": "4.12.27"
-	}
+	]
 }


### PR DESCRIPTION
## Summary
- #5857 (the hono 4.12.27 / node-server bump) accidentally added a `dependencies: { hono }` block to the private root `package.json` — a stray `bun add` at the root. Sherif's `root-package-dependencies` rule fails on it, so `bunx sherif` (and anything running it in CI) has been red since.
- The root entry did nothing: the workspace-wide pin already lives in root `overrides.hono: 4.12.27`, and all three consumers (`apps/relay`, `packages/host-service`, `packages/chat`) declare the same exact version. This removes the block and the corresponding `bun.lock` entry (`bun install` on the pinned bun 1.3.14).

## Test plan
- [x] `bunx sherif` → "No issues found" across 34 packages
- [x] `bun run lint` exits 0
- [x] `bun install` clean ("1 package removed", lockfile synced)

https://claude.ai/code/session_016ksykKEcEB1WYYBGwDFeuX

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stray root `hono` dependency from the private root `package.json` that broke `sherif`’s root-package-dependencies rule. Synced `bun.lock`; the workspace already pins `hono` via `overrides` and consumers declare it, so no behavior change.

<sup>Written for commit 106389da23d311f4b28d99ebbccb4701722b5030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused root-level package dependency.
  * No user-facing functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->