### PR TITLE
fix(auth): accept /mcp alias as OAuth audience

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -246,6 +246,7 @@ export const auth = betterAuth({
 				`${env.NEXT_PUBLIC_API_URL}/`,
 				`${env.NEXT_PUBLIC_API_URL}/api/agent/mcp`,
 				`${env.NEXT_PUBLIC_API_URL}/api/v2/agent/mcp`,
+				`${env.NEXT_PUBLIC_API_URL}/mcp`,
 			],
 			silenceWarnings: {
 				oauthAuthServerConfig: true,

--- a/packages/mcp-v2/src/auth.ts
+++ b/packages/mcp-v2/src/auth.ts
@@ -133,7 +133,12 @@ async function resolveOAuth(
 			jwksUrl: `${apiUrl}/api/auth/jwks`,
 			verifyOptions: {
 				issuer: apiUrl,
-				audience: [apiUrl, `${apiUrl}/`, `${apiUrl}/api/v2/agent/mcp`],
+				audience: [
+					apiUrl,
+					`${apiUrl}/`,
+					`${apiUrl}/api/v2/agent/mcp`,
+					`${apiUrl}/mcp`,
+				],
 			},
 		})) as Record<string, unknown>;
 	} catch {


### PR DESCRIPTION
First step toward making `api.superset.sh/mcp` the canonical MCP URL (de-versioning the v2 path).

`/mcp` re-exports the v2 MCP handler and marketing `llms.txt` already advertises it as an alias — but it was missing from `validAudiences` (token issuance) and from the mcp-v2 verifier's audience list. An OAuth client that used the alias as its RFC 8707 resource got working discovery, a successful consent flow, and then every token rejected.

- `packages/auth`: add `${API_URL}/mcp` to `validAudiences`
- `packages/mcp-v2`: add it to the verification audience list

The remaining canonical-URL flip (docs, .well-known, server card, openapi advertising `/mcp` first; `/api/v2/agent/mcp` kept forever as legacy alias) rides with the A3 transport-hygiene PR. Both URLs become declared OAuth resources in the B2 protected-resources migration, which removes these duplicated lists entirely.

Note: may need a trivial conflict resolution with #6077, which removes the adjacent v1 audience line.

Verify: OAuth flow with resource `https://api.superset.sh/mcp` issues tokens that pass tool calls on both URLs.

https://claude.ai/code/session_01Kub4p3Eim9pc1qaRRmGea2

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `/mcp` as a valid OAuth audience so clients using the alias get tokens that verify with the v2 MCP handler. Adds `${API_URL}/mcp` to both issuance and verification audience lists.

- **Bug Fixes**
  - `packages/auth`: add `${API_URL}/mcp` to `validAudiences`.
  - `packages/mcp-v2`: add `${API_URL}/mcp` to JWT verification audiences.

<sup>Written for commit d30fb0ba1a3aa138d3c6e3a9ba3670ad09c3e223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication compatibility for MCP requests by accepting the MCP API endpoint as a valid token audience.
  * Prevented valid access tokens from being rejected when issued for the MCP endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->