### PR TITLE
fix(api,relay,marketing,ui): clear four Sentry issue families

### DIFF
--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -2,6 +2,7 @@ import { db } from "@superset/db/client";
 import { webhookEvents } from "@superset/db/schema";
 import { eq, sql } from "drizzle-orm";
 
+import { stripNullChars } from "@/lib/strip-null-chars";
 import { webhooks } from "./webhooks";
 
 export async function POST(request: Request) {
@@ -35,7 +36,7 @@ export async function POST(request: Request) {
 			provider: "github",
 			eventId,
 			eventType: eventType ?? "unknown",
-			payload,
+			payload: stripNullChars(payload),
 			status: "pending",
 		})
 		.onConflictDoUpdate({

--- a/apps/api/src/app/api/integrations/linear/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.ts
@@ -16,6 +16,7 @@ import {
 import { mapPriorityFromLinear } from "@superset/trpc/integrations/linear";
 import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import { env } from "@/env";
+import { stripNullChars } from "@/lib/strip-null-chars";
 
 const webhookClient = new LinearWebhookClient(env.LINEAR_WEBHOOK_SECRET);
 
@@ -92,7 +93,7 @@ async function processForConnection(
 			provider: "linear",
 			eventId,
 			eventType: `${payload.type}.${payload.action}`,
-			payload,
+			payload: stripNullChars(payload),
 			status: "pending",
 		})
 		.onConflictDoUpdate({

--- a/apps/api/src/lib/strip-null-chars.ts
+++ b/apps/api/src/lib/strip-null-chars.ts
@@ -1,0 +1,23 @@
+/**
+ * Postgres jsonb rejects U+0000 anywhere in a string ("unsupported Unicode
+ * escape sequence"), and GitHub webhook payloads carry them in code diffs.
+ */
+const NULL_CHAR = String.fromCharCode(0);
+
+export function stripNullChars<T>(value: T): T {
+	if (typeof value === "string") {
+		return value.replaceAll(NULL_CHAR, "") as T;
+	}
+	if (Array.isArray(value)) {
+		return value.map(stripNullChars) as T;
+	}
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, entry]) => [
+				key.replaceAll(NULL_CHAR, ""),
+				stripNullChars(entry),
+			]),
+		) as T;
+	}
+	return value;
+}

--- a/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/components/DitheredBackground/DitheredBackground.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/components/DitheredBackground/DitheredBackground.tsx
@@ -1,12 +1,27 @@
 "use client";
 
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 
 const Dithering = lazy(() =>
 	import("@paper-design/shaders-react").then((mod) => ({
 		default: mod.Dithering,
 	})),
 );
+
+let webGlSupport: boolean | null = null;
+
+function supportsWebGl(): boolean {
+	if (webGlSupport !== null) return webGlSupport;
+	try {
+		const canvas = document.createElement("canvas");
+		webGlSupport = Boolean(
+			canvas.getContext("webgl2") ?? canvas.getContext("webgl"),
+		);
+	} catch {
+		webGlSupport = false;
+	}
+	return webGlSupport;
+}
 
 interface DitheredBackgroundProps {
 	colors: readonly [string, string, string, string];
@@ -17,6 +32,13 @@ export function DitheredBackground({
 	colors,
 	className = "",
 }: DitheredBackgroundProps) {
+	const [renderShader, setRenderShader] = useState(false);
+	useEffect(() => {
+		if (supportsWebGl()) setRenderShader(true);
+	}, []);
+
+	if (!renderShader) return null;
+
 	return (
 		<div
 			className={`${className} pointer-events-none opacity-30 mix-blend-screen`}

--- a/apps/relay/src/sentry.ts
+++ b/apps/relay/src/sentry.ts
@@ -11,6 +11,11 @@ export function initSentry(): void {
 		release: process.env.FLY_IMAGE_REF,
 		environment: process.env.FLY_APP_NAME ?? "relay-local",
 		tracesSampleRate: 0,
+		beforeSend(event) {
+			const exceptionType = event.exception?.values?.[0]?.type;
+			if (exceptionType === "TunnelLifecycleError") return null;
+			return event;
+		},
 		integrations: [
 			Sentry.onUncaughtExceptionIntegration({
 				exitEvenIfOtherHandlersAreRegistered: false,

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -3,6 +3,18 @@ import * as directory from "./directory";
 import { env } from "./env";
 import type { TunnelHttpResponse, TunnelRequest } from "./types";
 
+/**
+ * Expected tunnel churn (host reconnects, offline hosts, request timeouts) —
+ * routine at fleet scale. Sentry's beforeSend drops these by type so they
+ * don't bury real errors; callers still see them as failures.
+ */
+export class TunnelLifecycleError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TunnelLifecycleError";
+	}
+}
+
 type WsSocket = {
 	send: (data: string | ArrayBuffer | Uint8Array<ArrayBuffer>) => void;
 	readyState: number;
@@ -248,7 +260,7 @@ export class TunnelManager {
 
 		for (const [, pending] of tunnel.pendingRequests) {
 			clearTimeout(pending.timer);
-			pending.reject(new Error(reason));
+			pending.reject(new TunnelLifecycleError(reason));
 		}
 
 		for (const [, clientWs] of tunnel.activeChannels) {
@@ -350,7 +362,7 @@ export class TunnelManager {
 		},
 	): Promise<TunnelHttpResponse> {
 		const tunnel = this.tunnels.get(hostId);
-		if (!tunnel) throw new Error("Host not connected");
+		if (!tunnel) throw new TunnelLifecycleError("Host not connected");
 
 		if (tunnel.pendingRequests.size >= MAX_PENDING_REQUESTS_PER_TUNNEL) {
 			throw new Error("Host overloaded (pending request queue full)");
@@ -361,7 +373,7 @@ export class TunnelManager {
 		return new Promise<TunnelHttpResponse>((resolve, reject) => {
 			const timer = setTimeout(() => {
 				tunnel.pendingRequests.delete(id);
-				reject(new Error("Request timed out"));
+				reject(new TunnelLifecycleError("Request timed out"));
 			}, this.requestTimeoutMs);
 
 			tunnel.pendingRequests.set(id, { resolve, reject, timer });
@@ -383,7 +395,7 @@ export class TunnelManager {
 		clientWs: WsSocket,
 	): string {
 		const tunnel = this.tunnels.get(hostId);
-		if (!tunnel) throw new Error("Host not connected");
+		if (!tunnel) throw new TunnelLifecycleError("Host not connected");
 
 		// The host control tunnel must be open. Otherwise `send()` below silently
 		// drops the `ws:open` (it no-ops when `readyState !== 1`) and the client is

--- a/packages/ui/src/components/mesh-gradient.tsx
+++ b/packages/ui/src/components/mesh-gradient.tsx
@@ -55,8 +55,11 @@ export function MeshGradient({
 			if (gradient.conf) {
 				gradient.conf.playing = false;
 			}
+			// stripe-gradient's delayed init reads both el.parentElement and el
+			// children after we unmount, so the decoy needs a parent AND a child.
 			const dummy = document.createElement("div");
 			dummy.appendChild(document.createElement("div"));
+			document.createElement("div").appendChild(dummy);
 			gradient.el = dummy;
 			if (gradient.disconnect) {
 				gradient.disconnect();


### PR DESCRIPTION
Fixes the four highest-signal unresolved Sentry issue families whose root causes were clear from stack traces + code.

## 1. Webhook events dropped on NUL bytes — `api` (Fixes API-10)

GitHub webhook payloads carry U+0000 inside code-diff strings; Postgres jsonb rejects them (`NeonDbError: unsupported Unicode escape sequence`), so the insert into `ingest.webhook_events` failed and the event was lost (335 events / 116 orgs over 30d). New `stripNullChars` deep-cleans payloads before insert on both the GitHub and Linear webhook routes. Functionally verified against a payload shaped like the failing event.

## 2. Relay tunnel lifecycle noise — `relay` (Fixes RELAY-1, RELAY-2, RELAY-3, RELAY-4)

"Tunnel disconnected" / "Request timed out" / "Replaced by new tunnel" / "Host not connected" are routine churn but were reported as unhandled exceptions — ~66k Sentry events in 30 days, burying real errors. They're now a typed `TunnelLifecycleError` dropped in `beforeSend`; callers still receive the rejections unchanged.

## 3. Shader crash on non-WebGL browsers — `marketing` (Fixes MARKETING-35)

`@paper-design/shaders-react` throws when WebGL is unavailable (bots, old devices — 4k events / 480 users). The decorative `DitheredBackground` now feature-detects WebGL (cached probe, post-hydration) and renders nothing without it.

## 4. Gradient unmount crash — `ui`/`web` (Fixes WEB-17)

`MeshGradient`'s unmount defense swaps `stripe-gradient`'s `el` to a detached dummy — but the lib's delayed init reads `el.parentElement.classList`, and the dummy had no parent, converting the defense into the crash (694 events / 132 users on /agents). The decoy now has both a parent and a child.

## Not in this PR (triaged, deeper work)

- API-15/API-1M: crash inside better-auth 1.6.13's endpoint wrapper on `/.well-known/oauth-authorization-server` — needs an upstream check/bump.
- RELAY-5: Bun's `ws` shim rejects node-ws upgrades ("upgrade requires a Request object") — adapter-level change (`hono/bun` websocket helper).
- API-18/19/1B/1F/…: one family of transient Neon disconnects — candidate for a shared retry wrapper.
- Browser-extension noise across web/docs/marketing (MetaMask/keplr/tronlink/`onMessage`/`sseError`): to be archived in Sentry, not fixed in code.

## Verification

Typecheck clean in api, relay, marketing, ui; Biome lint exits 0; `stripNullChars` verified with a NUL-carrying payload (5/5 assertions).

https://claude.ai/code/session_01BQ71xVEeJRhAqiU4Dfc5Fs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four high-signal Sentry issue families to stop dropped webhooks, silence expected relay churn, and prevent two frontend crashes. Improves stability across `api`, `relay`, `marketing`, and `ui`.

- **Bug Fixes**
  - API-10: Strip U+0000 from GitHub/Linear webhook payloads with `stripNullChars` before writing to Postgres `jsonb` to prevent failed inserts.
  - RELAY-1/2/3/4: Classify routine tunnel churn as `TunnelLifecycleError` and drop it in Sentry `beforeSend`; callers still get rejections.
  - MARKETING-35: Gate `DitheredBackground` behind a cached WebGL feature check; render nothing when unsupported to avoid `@paper-design/shaders-react` crashes.
  - WEB-17: Update `MeshGradient` unmount decoy to have a parent and child to satisfy `stripe-gradient` delayed reads.

<sup>Written for commit 67d253386a85a6790e34f5afc7e4291dff4a917b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved webhook reliability by safely handling unexpected null characters in incoming payloads.
  - Prevented unsupported browsers or devices from displaying the marketing page’s WebGL background incorrectly.
  - Improved handling of expected connection lifecycle failures, reducing unnecessary error reporting.
  - Fixed cleanup behavior for gradient visuals to prevent potential rendering issues.

- **Reliability**
  - Preserved webhook processing behavior while making stored event data safer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->