### PR TITLE
fix(host-service): project gh PR list queries and raise exec buffer

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -960,9 +960,11 @@ export class PullRequestRuntimeManager {
 						head,
 					);
 				} catch (ghError) {
+					// String(error) only — exec errors carry the child's full stdout,
+					// and inspecting megabyte payloads blocks the event loop.
 					console.warn(
 						"[host-service:pull-request-runtime] gh PR head lookup failed; falling back to Octokit",
-						{ owner: repo.owner, name: repo.name, head, error: ghError },
+						{ owner: repo.owner, name: repo.name, head, error: String(ghError) },
 					);
 					const octokit = await this.github();
 					return fetchPullRequestByHead(
@@ -996,7 +998,7 @@ export class PullRequestRuntimeManager {
 				} catch (ghError) {
 					console.warn(
 						"[host-service:pull-request-runtime] gh open-PR sweep failed; falling back to Octokit",
-						{ owner: repo.owner, name: repo.name, error: ghError },
+						{ owner: repo.owner, name: repo.name, error: String(ghError) },
 					);
 					const octokit = await this.github();
 					return fetchOpenPullRequests(octokit, {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -964,7 +964,12 @@ export class PullRequestRuntimeManager {
 					// and inspecting megabyte payloads blocks the event loop.
 					console.warn(
 						"[host-service:pull-request-runtime] gh PR head lookup failed; falling back to Octokit",
-						{ owner: repo.owner, name: repo.name, head, error: String(ghError) },
+						{
+							owner: repo.owner,
+							name: repo.name,
+							head,
+							error: String(ghError),
+						},
 					);
 					const octokit = await this.github();
 					return fetchPullRequestByHead(

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -88,6 +88,8 @@ describe("GitHub pull request REST queries", () => {
 					"direction=desc",
 					"-f",
 					"per_page=10",
+					"--jq",
+					expect.any(String),
 				],
 			},
 		]);
@@ -245,6 +247,8 @@ describe("GitHub pull request REST queries", () => {
 					"direction=desc",
 					"-f",
 					"per_page=100",
+					"--jq",
+					expect.any(String),
 				],
 			},
 		]);

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -204,6 +204,14 @@ function toStatusContextNode(
 	};
 }
 
+// Project each PR down to the fields normalizePullRequest reads. The full
+// REST objects are ~10KB each before bodies (bot-generated bodies alone can
+// reach 100KB), so a 100-PR page overflows exec buffers and wedges the event
+// loop during parse; the projection keeps null head.repo/user (deleted forks)
+// intact for the fallback chain in normalizePullRequest.
+const PULL_REQUEST_LIST_JQ =
+	"map({number, title, html_url, state, merged_at, draft, updated_at, head: {ref: .head.ref, sha: .head.sha, repo: (.head.repo | if . == null then null else {name, owner: (.owner | if . == null then null else {login} end)} end), user: (.head.user | if . == null then null else {login} end)}, base: {repo: (.base.repo | if . == null then null else {full_name} end)}})";
+
 export async function fetchPullRequestByHeadFromGh(
 	execGh: ExecGh,
 	repository: {
@@ -227,6 +235,8 @@ export async function fetchPullRequestByHeadFromGh(
 		"direction=desc",
 		"-f",
 		"per_page=10",
+		"--jq",
+		PULL_REQUEST_LIST_JQ,
 	]);
 
 	return normalizePullRequestCandidates(raw, head);
@@ -276,6 +286,8 @@ export async function fetchOpenPullRequestsFromGh(
 		"direction=desc",
 		"-f",
 		"per_page=100",
+		"--jq",
+		PULL_REQUEST_LIST_JQ,
 	]);
 
 	return asArray(raw)

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
@@ -29,6 +29,9 @@ export const execGh: ExecGh = async (args, options) => {
 		timeout: options?.timeout ?? 10_000,
 		cwd: options?.cwd,
 		env,
+		// Node's 1MB default dies on repos with ~100 open PRs carrying large
+		// bot-generated bodies (ERR_CHILD_PROCESS_STDIO_MAXBUFFER).
+		maxBuffer: 16 * 1024 * 1024,
 	});
 	const trimmed = stdout.trim();
 	if (!trimmed) return {};


### PR DESCRIPTION
## Problem

The open-PR sweep (`gh api repos/<owner>/<repo>/pulls -f state=open -f per_page=100`) returns the full REST objects — ~10KB of URLs per PR plus unbounded `body` fields. Repos with many open PRs carrying large bot-generated bodies (AI review/codegen bots) push the response past Node's default 1MB `execFile` maxBuffer, so every sweep dies with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, dumps the error (with the buffered stdout attached) into host-service.log, and re-fetches the same multi-MB payload via the Octokit fallback — on a 60s cache TTL. Found while investigating a user's recurring host-service stalls: 74 occurrences in one rotated log. **Our own repo already trips it: the raw sweep is 2.1MB.**

## Fix

1. **`--jq` projection at the `gh` boundary** for both PR list queries, keeping exactly the fields `normalizePullRequest` reads. Verified on this repo: 2,135,024 → 47,700 bytes (45x). Null `head.repo`/`head.user` (deleted forks) are preserved so the existing fallback chain is unchanged — covered by the jq expression's null guards and verified against a synthetic deleted-fork payload.
2. **`maxBuffer: 16MB`** on `execGh` so any still-large output degrades gracefully instead of killing the child.
3. **Terse fallback logging** — `String(error)` instead of the error object, which drags the child's full buffered stdout into the log (single dumps were >1MB, and inspecting them blocks the event loop).

## Verification

- 144/144 host-service tests pass (two exact-args assertions updated for the new `--jq` args).
- Typecheck + Biome clean.
- Real `gh` run against this repo confirms size reduction and parse-compatible output shape.

https://claude.ai/code/session_01BQ71xVEeJRhAqiU4Dfc5Fs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/6081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts PR list payloads at the `gh` boundary and raises the exec buffer to stop sweep crashes and log bloat in `host-service`. Stabilizes open‑PR sweeps on repos with many PRs and large bodies.

- **Bug Fixes**
  - Use `--jq` in `gh` PR list queries to return only fields read by `normalizePullRequest` (null‑safe for deleted forks).
  - Increase `execGh` `maxBuffer` to 16MB to avoid `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`.
  - Log fallback errors with `String(error)` to avoid dumping buffered stdout.

<sup>Written for commit 033e62d98366dba4ee79d9f23c45ee2de14ea744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull-request lookup reliability when using the GitHub CLI.
  - Reduced unnecessary command output while preserving required pull-request details.
  - Improved handling of deleted repositories or users in pull-request results.
  - Increased the allowed output size for GitHub CLI operations to prevent failures on larger responses.
  - Made CLI error warnings clearer and safer.
  - Improved consistency across head-specific and repository-wide pull-request searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->