### PR TITLE
feat(desktop): add safe-triangle hover intent to sidebar hover cards

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
@@ -22,6 +22,7 @@ export function DashboardSidebarHoverCardOverlay({
 		cancelClose,
 		requestClose,
 		forceClose,
+		setCardElement,
 	} = useDashboardSidebarHover();
 
 	const virtualRef = useRef<Measurable | null>(null);
@@ -53,6 +54,18 @@ export function DashboardSidebarHoverCardOverlay({
 		};
 	}, [open]);
 
+	// Register the rendered card element so the hover provider can read its
+	// live bounding box (not a cached snapshot — the popover has a CSS
+	// entrance transition, so its rect keeps changing after it mounts) when
+	// computing the safe-triangle gap between a trigger row and this card.
+	// Gated on `hasPositioned`, not just `open` — Radix doesn't insert the
+	// content node into the DOM until a frame or two after `open` flips true.
+	const contentRef = useRef<HTMLDivElement | null>(null);
+	useEffect(() => {
+		setCardElement(open && hasPositioned ? contentRef.current : null);
+		return () => setCardElement(null);
+	}, [open, hasPositioned, setCardElement]);
+
 	return (
 		<Popover
 			open={open}
@@ -64,6 +77,7 @@ export function DashboardSidebarHoverCardOverlay({
 			<PopoverAnchor virtualRef={virtualRef as RefObject<Measurable>} />
 			{payload && (
 				<PopoverContent
+					ref={contentRef}
 					side="right"
 					align="start"
 					className="w-72"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -103,14 +103,23 @@ export function DashboardSidebarWorkspaceItem({
 		[workspace],
 	);
 
-	const handleMouseEnter = useCallback(() => {
-		if (!hoverEligible || !rowRef.current) return;
-		hoverRequestOpen(id, rowRef.current, hoverPayload);
-	}, [hoverEligible, hoverRequestOpen, id, hoverPayload]);
-	const handleMouseLeave = useCallback(() => {
-		if (!hoverEligible) return;
-		hoverRequestClose(id);
-	}, [hoverEligible, hoverRequestClose, id]);
+	const handleMouseEnter = useCallback(
+		(event: React.MouseEvent) => {
+			if (!hoverEligible || !rowRef.current) return;
+			hoverRequestOpen(id, rowRef.current, hoverPayload, {
+				x: event.clientX,
+				y: event.clientY,
+			});
+		},
+		[hoverEligible, hoverRequestOpen, id, hoverPayload],
+	);
+	const handleMouseLeave = useCallback(
+		(event: React.MouseEvent) => {
+			if (!hoverEligible) return;
+			hoverRequestClose(id, { x: event.clientX, y: event.clientY });
+		},
+		[hoverEligible, hoverRequestClose, id],
+	);
 
 	const isHovered = hoverHoveredId === id;
 	useEffect(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
@@ -11,6 +11,44 @@ import type { DashboardSidebarWorkspace } from "../../types";
 
 const OPEN_DELAY_MS = 400;
 const CLOSE_DELAY_MS = 100;
+// Cap how long we'll tolerate the pointer drifting inside the safe triangle
+// before giving up and closing anyway, in case it stalls mid-gap.
+const SAFE_TRIANGLE_MAX_TRACK_MS = 1000;
+// How long a row suppressed by another row's safe triangle waits before
+// opening anyway. Covers the case where the pointer settles on this row
+// instead of continuing on to the original card — without this, a
+// suppressed open that never gets re-requested (mouseenter only fires once)
+// would just never open.
+const SUPPRESSED_OPEN_DWELL_MS = 150;
+
+interface Point {
+	x: number;
+	y: number;
+}
+
+// Standard same-sign point-in-triangle test via cross-product signs.
+function triangleSign(p1: Point, p2: Point, p3: Point): number {
+	return (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y);
+}
+
+function isPointInTriangle(pt: Point, a: Point, b: Point, c: Point): boolean {
+	const d1 = triangleSign(pt, a, b);
+	const d2 = triangleSign(pt, b, c);
+	const d3 = triangleSign(pt, c, a);
+	const hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+	const hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+	return !(hasNegative && hasPositive);
+}
+
+// The two corners of the card's near edge — the base of the safe triangle.
+// The card always renders on the sidebar's right (side="right"), so that's
+// always its left edge.
+function getNearCardCorners(cardRect: DOMRect): [Point, Point] {
+	return [
+		{ x: cardRect.left, y: cardRect.top },
+		{ x: cardRect.left, y: cardRect.bottom },
+	];
+}
 
 export interface DashboardSidebarHoverPayload {
 	workspace: DashboardSidebarWorkspace;
@@ -29,18 +67,37 @@ interface HoverContextValue {
 	payload: DashboardSidebarHoverPayload | null;
 	contextMenuOpen: boolean;
 	hoverCardSuppressed: boolean;
+	/**
+	 * `enterPoint` (the pointer position entering this trigger) lets a safe
+	 * triangle in progress for a *different* row suppress this open — rows
+	 * are stacked with no gap, so cutting diagonally toward a taller open
+	 * card routinely crosses over sibling rows on the way.
+	 */
 	requestOpen: (
 		id: string,
 		anchor: HTMLElement,
 		payload: DashboardSidebarHoverPayload,
+		enterPoint?: Point,
 	) => void;
-	requestClose: (id: string) => void;
+	/**
+	 * `leavePoint` (the pointer position where it left the trigger) enables
+	 * safe-triangle tracking: while the pointer keeps moving through the gap
+	 * on a path aimed at the open card, the close is held off instead of
+	 * firing the instant the trigger is left.
+	 */
+	requestClose: (id: string, leavePoint?: Point) => void;
 	cancelClose: () => void;
 	forceClose: () => void;
 	setContextMenuOpen: (open: boolean) => void;
 	beginHoverCardSuppression: () => void;
 	endHoverCardSuppression: () => void;
 	syncIfHovered: (id: string, payload: DashboardSidebarHoverPayload) => void;
+	/**
+	 * Registers the rendered card element so its rect can be read live, on
+	 * demand — the popover has a CSS entrance transition, so a rect snapshot
+	 * cached at mount time can go stale before its transform settles.
+	 */
+	setCardElement: (element: HTMLElement | null) => void;
 }
 
 const HoverContext = createContext<HoverContextValue | null>(null);
@@ -74,6 +131,18 @@ export function DashboardSidebarHoverProvider({
 
 	const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const cardElementRef = useRef<HTMLElement | null>(null);
+	const triangleCleanupRef = useRef<(() => void) | null>(null);
+	const activeTriangleRef = useRef<{
+		apex: Point;
+		cornerA: Point;
+		cornerB: Point;
+		forId: string;
+	} | null>(null);
+	const suppressedOpenRef = useRef<{
+		id: string;
+		timer: ReturnType<typeof setTimeout>;
+	} | null>(null);
 
 	const clearOpenTimer = useCallback(() => {
 		if (openTimerRef.current) {
@@ -87,10 +156,38 @@ export function DashboardSidebarHoverProvider({
 			closeTimerRef.current = null;
 		}
 	}, []);
+	const stopSafeTriangleTracking = useCallback(() => {
+		triangleCleanupRef.current?.();
+		triangleCleanupRef.current = null;
+		activeTriangleRef.current = null;
+	}, []);
+	const cancelSuppressedOpen = useCallback(() => {
+		if (suppressedOpenRef.current) {
+			clearTimeout(suppressedOpenRef.current.timer);
+			suppressedOpenRef.current = null;
+		}
+	}, []);
 
-	const requestOpen = useCallback<HoverContextValue["requestOpen"]>(
-		(id, anchor, payload) => {
+	const setCardElement = useCallback((element: HTMLElement | null) => {
+		cardElementRef.current = element;
+	}, []);
+
+	const scheduleClose = useCallback(() => {
+		clearCloseTimer();
+		closeTimerRef.current = setTimeout(() => {
+			setState({ hoveredId: null, anchorElement: null, payload: null });
+			closeTimerRef.current = null;
+		}, CLOSE_DELAY_MS);
+	}, [clearCloseTimer]);
+
+	const performOpen = useCallback(
+		(
+			id: string,
+			anchor: HTMLElement,
+			payload: DashboardSidebarHoverPayload,
+		) => {
 			clearCloseTimer();
+			stopSafeTriangleTracking();
 			if (stateRef.current.hoveredId !== null) {
 				clearOpenTimer();
 				setState({ hoveredId: id, anchorElement: anchor, payload });
@@ -102,35 +199,127 @@ export function DashboardSidebarHoverProvider({
 				openTimerRef.current = null;
 			}, OPEN_DELAY_MS);
 		},
-		[clearCloseTimer, clearOpenTimer],
+		[clearCloseTimer, clearOpenTimer, stopSafeTriangleTracking],
+	);
+
+	const requestOpen = useCallback<HoverContextValue["requestOpen"]>(
+		(id, anchor, payload, enterPoint) => {
+			if (suppressedOpenRef.current && suppressedOpenRef.current.id !== id) {
+				cancelSuppressedOpen();
+			}
+
+			const activeTriangle = activeTriangleRef.current;
+			if (
+				activeTriangle &&
+				activeTriangle.forId !== id &&
+				enterPoint &&
+				isPointInTriangle(
+					enterPoint,
+					activeTriangle.apex,
+					activeTriangle.cornerA,
+					activeTriangle.cornerB,
+				)
+			) {
+				// Pointer is cutting through this row on a path aimed at the
+				// still-open card — don't switch hover yet, but don't drop the
+				// request either: if the pointer settles here instead of
+				// reaching the card, open it after a short dwell.
+				if (!suppressedOpenRef.current) {
+					const timer = setTimeout(() => {
+						suppressedOpenRef.current = null;
+						performOpen(id, anchor, payload);
+					}, SUPPRESSED_OPEN_DWELL_MS);
+					suppressedOpenRef.current = { id, timer };
+				}
+				return;
+			}
+
+			cancelSuppressedOpen();
+			performOpen(id, anchor, payload);
+		},
+		[cancelSuppressedOpen, performOpen],
 	);
 
 	const requestClose = useCallback<HoverContextValue["requestClose"]>(
-		(id) => {
+		(id, leavePoint) => {
+			if (suppressedOpenRef.current?.id === id) {
+				// Left before the dwell fired — this row was just being cut
+				// through, not settled on.
+				cancelSuppressedOpen();
+			}
 			if (openTimerRef.current && stateRef.current.hoveredId === null) {
 				// Pending open for this id — cancel it.
 				clearOpenTimer();
 				return;
 			}
 			if (stateRef.current.hoveredId !== id) return;
-			clearCloseTimer();
-			closeTimerRef.current = setTimeout(() => {
-				setState({ hoveredId: null, anchorElement: null, payload: null });
-				closeTimerRef.current = null;
-			}, CLOSE_DELAY_MS);
+
+			const cardRect = cardElementRef.current?.getBoundingClientRect() ?? null;
+			if (!leavePoint || !cardRect) {
+				scheduleClose();
+				return;
+			}
+			const corners = getNearCardCorners(cardRect);
+
+			// Safe triangle: apex at the point the pointer left the trigger, base
+			// at the card's near edge. Keep the card open while the pointer stays
+			// inside it — that's a path aimed at the card, not away from it.
+			stopSafeTriangleTracking();
+			const [cornerA, cornerB] = corners;
+			activeTriangleRef.current = {
+				apex: leavePoint,
+				cornerA,
+				cornerB,
+				forId: id,
+			};
+			const handlePointerMove = (event: MouseEvent) => {
+				const point = { x: event.clientX, y: event.clientY };
+				if (isPointInTriangle(point, leavePoint, cornerA, cornerB)) {
+					return;
+				}
+				stopSafeTriangleTracking();
+				scheduleClose();
+			};
+			document.addEventListener("mousemove", handlePointerMove);
+			// Backstop: if the pointer stops moving entirely (or events just don't
+			// arrive) while still "inside" the cone, don't stay open forever.
+			const deadlineTimer = setTimeout(() => {
+				stopSafeTriangleTracking();
+				scheduleClose();
+			}, SAFE_TRIANGLE_MAX_TRACK_MS);
+			triangleCleanupRef.current = () => {
+				document.removeEventListener("mousemove", handlePointerMove);
+				clearTimeout(deadlineTimer);
+			};
 		},
-		[clearCloseTimer, clearOpenTimer],
+		[
+			cancelSuppressedOpen,
+			clearOpenTimer,
+			scheduleClose,
+			stopSafeTriangleTracking,
+		],
 	);
 
 	const cancelClose = useCallback(() => {
 		clearCloseTimer();
-	}, [clearCloseTimer]);
+		stopSafeTriangleTracking();
+		// Pointer reached the real target card — any row it grazed on the way
+		// was just being cut through, not settled on.
+		cancelSuppressedOpen();
+	}, [cancelSuppressedOpen, clearCloseTimer, stopSafeTriangleTracking]);
 
 	const forceClose = useCallback(() => {
 		clearOpenTimer();
 		clearCloseTimer();
+		stopSafeTriangleTracking();
+		cancelSuppressedOpen();
 		setState({ hoveredId: null, anchorElement: null, payload: null });
-	}, [clearCloseTimer, clearOpenTimer]);
+	}, [
+		cancelSuppressedOpen,
+		clearCloseTimer,
+		clearOpenTimer,
+		stopSafeTriangleTracking,
+	]);
 
 	const syncIfHovered = useCallback<HoverContextValue["syncIfHovered"]>(
 		(id, payload) => {
@@ -152,8 +341,15 @@ export function DashboardSidebarHoverProvider({
 		() => () => {
 			clearOpenTimer();
 			clearCloseTimer();
+			stopSafeTriangleTracking();
+			cancelSuppressedOpen();
 		},
-		[clearCloseTimer, clearOpenTimer],
+		[
+			cancelSuppressedOpen,
+			clearCloseTimer,
+			clearOpenTimer,
+			stopSafeTriangleTracking,
+		],
 	);
 
 	const value = useMemo<HoverContextValue>(
@@ -171,6 +367,7 @@ export function DashboardSidebarHoverProvider({
 			beginHoverCardSuppression,
 			endHoverCardSuppression,
 			syncIfHovered,
+			setCardElement,
 		}),
 		[
 			state.hoveredId,
@@ -185,6 +382,7 @@ export function DashboardSidebarHoverProvider({
 			beginHoverCardSuppression,
 			endHoverCardSuppression,
 			syncIfHovered,
+			setCardElement,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
@@ -41,13 +41,40 @@ function isPointInTriangle(pt: Point, a: Point, b: Point, c: Point): boolean {
 }
 
 // The two corners of the card's near edge — the base of the safe triangle.
-// The card always renders on the sidebar's right (side="right"), so that's
-// always its left edge.
-function getNearCardCorners(cardRect: DOMRect): [Point, Point] {
+// The card is configured to render on the sidebar's right (side="right"),
+// but Radix's collision avoidance (on by default; this popover doesn't
+// disable it) can flip that to the left if there's more room there — a
+// resizable sidebar dragged wide enough, or a narrow window, can trigger it.
+// Read the resolved side straight off the element rather than assuming.
+function getNearCardCorners(
+	cardElement: HTMLElement,
+	cardRect: DOMRect,
+): [Point, Point] {
+	const x =
+		cardElement.getAttribute("data-side") === "left"
+			? cardRect.right
+			: cardRect.left;
 	return [
-		{ x: cardRect.left, y: cardRect.top },
-		{ x: cardRect.left, y: cardRect.bottom },
+		{ x, y: cardRect.top },
+		{ x, y: cardRect.bottom },
 	];
+}
+
+// Re-derives the triangle's base from the card's *current* rect on every
+// call rather than a rect captured once when tracking started — the open
+// card's bounds can keep changing after that (its CSS entrance transition,
+// or content resizing as async data like diff stats loads in).
+function isPointInsideCardCone(
+	point: Point,
+	apex: Point,
+	cardElement: HTMLElement | null,
+): boolean {
+	if (!cardElement) return false;
+	const [cornerA, cornerB] = getNearCardCorners(
+		cardElement,
+		cardElement.getBoundingClientRect(),
+	);
+	return isPointInTriangle(point, apex, cornerA, cornerB);
 }
 
 export interface DashboardSidebarHoverPayload {
@@ -135,12 +162,12 @@ export function DashboardSidebarHoverProvider({
 	const triangleCleanupRef = useRef<(() => void) | null>(null);
 	const activeTriangleRef = useRef<{
 		apex: Point;
-		cornerA: Point;
-		cornerB: Point;
 		forId: string;
 	} | null>(null);
 	const suppressedOpenRef = useRef<{
 		id: string;
+		anchor: HTMLElement;
+		payload: DashboardSidebarHoverPayload;
 		timer: ReturnType<typeof setTimeout>;
 	} | null>(null);
 
@@ -202,6 +229,24 @@ export function DashboardSidebarHoverProvider({
 		[clearCloseTimer, clearOpenTimer, stopSafeTriangleTracking],
 	);
 
+	// Called when a safe triangle is abandoned — the pointer strayed outside
+	// the cone, or the tracking deadline elapsed. If a sibling row grazed
+	// along the way is still waiting out its dwell timer, promote it directly
+	// instead of closing and letting the dwell timer race a cold re-open:
+	// `performOpen` sees `hoveredId` still set here and switches instantly,
+	// with no gap and no re-applied OPEN_DELAY_MS.
+	const abandonCone = useCallback(() => {
+		stopSafeTriangleTracking();
+		const pending = suppressedOpenRef.current;
+		if (pending) {
+			suppressedOpenRef.current = null;
+			clearTimeout(pending.timer);
+			performOpen(pending.id, pending.anchor, pending.payload);
+			return;
+		}
+		scheduleClose();
+	}, [performOpen, scheduleClose, stopSafeTriangleTracking]);
+
 	const requestOpen = useCallback<HoverContextValue["requestOpen"]>(
 		(id, anchor, payload, enterPoint) => {
 			if (suppressedOpenRef.current && suppressedOpenRef.current.id !== id) {
@@ -213,11 +258,10 @@ export function DashboardSidebarHoverProvider({
 				activeTriangle &&
 				activeTriangle.forId !== id &&
 				enterPoint &&
-				isPointInTriangle(
+				isPointInsideCardCone(
 					enterPoint,
 					activeTriangle.apex,
-					activeTriangle.cornerA,
-					activeTriangle.cornerB,
+					cardElementRef.current,
 				)
 			) {
 				// Pointer is cutting through this row on a path aimed at the
@@ -229,7 +273,7 @@ export function DashboardSidebarHoverProvider({
 						suppressedOpenRef.current = null;
 						performOpen(id, anchor, payload);
 					}, SUPPRESSED_OPEN_DWELL_MS);
-					suppressedOpenRef.current = { id, timer };
+					suppressedOpenRef.current = { id, anchor, payload, timer };
 				}
 				return;
 			}
@@ -254,45 +298,36 @@ export function DashboardSidebarHoverProvider({
 			}
 			if (stateRef.current.hoveredId !== id) return;
 
-			const cardRect = cardElementRef.current?.getBoundingClientRect() ?? null;
-			if (!leavePoint || !cardRect) {
+			if (!leavePoint || !cardElementRef.current) {
 				scheduleClose();
 				return;
 			}
-			const corners = getNearCardCorners(cardRect);
 
 			// Safe triangle: apex at the point the pointer left the trigger, base
 			// at the card's near edge. Keep the card open while the pointer stays
-			// inside it — that's a path aimed at the card, not away from it.
+			// inside it — that's a path aimed at the card, not away from it. The
+			// base is re-derived from the card's live rect on each check (see
+			// isPointInsideCardCone), not captured once here.
 			stopSafeTriangleTracking();
-			const [cornerA, cornerB] = corners;
-			activeTriangleRef.current = {
-				apex: leavePoint,
-				cornerA,
-				cornerB,
-				forId: id,
-			};
+			activeTriangleRef.current = { apex: leavePoint, forId: id };
 			const handlePointerMove = (event: MouseEvent) => {
 				const point = { x: event.clientX, y: event.clientY };
-				if (isPointInTriangle(point, leavePoint, cornerA, cornerB)) {
+				if (isPointInsideCardCone(point, leavePoint, cardElementRef.current)) {
 					return;
 				}
-				stopSafeTriangleTracking();
-				scheduleClose();
+				abandonCone();
 			};
 			document.addEventListener("mousemove", handlePointerMove);
 			// Backstop: if the pointer stops moving entirely (or events just don't
 			// arrive) while still "inside" the cone, don't stay open forever.
-			const deadlineTimer = setTimeout(() => {
-				stopSafeTriangleTracking();
-				scheduleClose();
-			}, SAFE_TRIANGLE_MAX_TRACK_MS);
+			const deadlineTimer = setTimeout(abandonCone, SAFE_TRIANGLE_MAX_TRACK_MS);
 			triangleCleanupRef.current = () => {
 				document.removeEventListener("mousemove", handlePointerMove);
 				clearTimeout(deadlineTimer);
 			};
 		},
 		[
+			abandonCone,
 			cancelSuppressedOpen,
 			clearOpenTimer,
 			scheduleClose,


### PR DESCRIPTION
## Summary
- Track the pointer's trajectory when it leaves a V2 sidebar row so the workspace hover card stays open while the cursor is cutting diagonally toward it, instead of closing the instant the row is left.
- While that trajectory is active, sibling rows crossed along the way don't steal hover — but if the pointer settles on one of them instead of reaching the original card, it opens after a short dwell rather than never opening at all.
- Add a hard 1s backstop so the card can't get stuck open if the pointer stops moving mid-gap.
- Read the open card's rect live (not a cached snapshot) since the popover has a CSS entrance transition that shifts its bounds after mount.

## Test plan
- [x] `bun run typecheck` (apps/desktop) and `bun run lint:fix` clean
- [x] Verified live against the running dev app via CDP with real dispatched mouse trajectories:
  - Diagonal glide through the gap (including across sibling rows) keeps the card open
  - Landing on the card holds it open; moving away from it closes it promptly
  - A pointer that stops moving with no further events still closes via the 1s backstop
  - A sibling row settled on (not just grazed) opens via the dwell timer
  - A sibling row merely grazed through (left before the dwell) never spuriously opens

Claude-Session: https://claude.ai/code/session_01WFNW1VLsEN1xhGc5QWgM93

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds safe-triangle hover intent to the desktop sidebar so hover cards stay open while the cursor moves diagonally from a row toward the card, reducing accidental closes and flicker.

- **New Features**
  - Track pointer path after leaving a row; hold the close while inside a triangle aimed at the card.
  - Suppress sibling rows crossed en route; if the cursor settles on one, open after a short dwell — and if the cone is abandoned, promote a pending suppressed sibling immediately.
  - Add a 1s backstop so the card can’t get stuck open if the pointer stalls mid-gap.
  - Read the card’s rect live and its resolved `data-side`; recompute the triangle’s base on each check to handle the entrance transition and collision-driven side flips.

<sup>Written for commit be234ec26de077a5b239b80320dd6ad6ff8f75a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar hover cards to remain open while the pointer moves safely between a workspace item and its card.
  * Reduced accidental card switching when moving across nearby workspace rows.
  * Added brief hover delays and automatic timeouts for smoother, more predictable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->