### PR TITLE
fix(desktop): prevent sidebar localStorage state loss and token-swap remounts

### DIFF
--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -75,9 +75,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	electronTrpc.auth.onTokenChanged.useSubscription(undefined, {
 		onData: async (data) => {
 			if (data?.token && data?.expiresAt) {
-				setAuthToken(null);
-				await authClient.signOut({ fetchOptions: { throw: false } });
+				// Swap atomically: a null-token + awaited sign-out gap let a
+				// concurrent get-session read "no session" and unmount the whole
+				// authenticated tree. The stale JWT re-mints on the next 401.
 				setAuthToken(data.token);
+				setJwt(null);
 				try {
 					await refetchSession();
 				} catch (err) {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -112,19 +112,31 @@ const createIndexedCollection = ((
 	createCollection({ ...config, ...indexDefaults })) as typeof createCollection;
 
 /**
- * Applied to every localStorage-backed collection so an exhausted store drops
- * the write instead of throwing, which is what stops the rollback/retry loop
- * that freezes the renderer.
+ * Applied to every localStorage-backed collection:
+ * - `startSync: true` + `gcTime: 0`: hydrate at construction, never GC. The
+ *   sidebar mutation helpers read `.state` non-reactively, and a write into a
+ *   not-yet-hydrated (or GC'd) collection rewrites the whole storage key from
+ *   empty memory — erasing every persisted row for the org.
+ * - `withReadHeal`: per-row tolerant reads — one malformed entry escaping to
+ *   the library's hydration catch-all would blank the entire store.
+ * - `withQuotaGuard`: an exhausted store drops the write instead of throwing,
+ *   which is what stops the rollback/retry loop that freezes the renderer.
  */
-const guardQuota = <T>(options: T): T =>
-	withQuotaGuard(options, {
-		// Oldest-first by the terminal GC's persisted-at index (24h pressure TTL)
-		// — survives relaunches, unlike registry membership.
-		reclaim: () => reclaimTerminalStateForQuota(),
-		// Not passed by reference: the guard's second argument is the error, which
-		// would land in the notice's optional `mode` slot.
-		onPersistFailed: (storageKey) => notifyQuotaExhausted(storageKey),
-	});
+const hardenLocalCollection = <T>(
+	options: T,
+	heal?: (raw: unknown) => unknown,
+): T =>
+	withQuotaGuard(
+		withReadHeal({ ...options, startSync: true, gcTime: 0 } as T, heal),
+		{
+			// Oldest-first by the terminal GC's persisted-at index (24h pressure TTL)
+			// — survives relaunches, unlike registry membership.
+			reclaim: () => reclaimTerminalStateForQuota(),
+			// Not passed by reference: the guard's second argument is the error, which
+			// would land in the notice's optional `mode` slot.
+			onPersistFailed: (storageKey) => notifyQuotaExhausted(storageKey),
+		},
+	);
 
 type ElectricSyncConfig = ReturnType<typeof electricCollectionOptions>;
 const createPersistedElectricCollection = ((config: ElectricSyncConfig) => {
@@ -764,7 +776,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2SidebarProjects = createIndexedCollection(
 		localStorageCollectionOptions(
-			guardQuota({
+			hardenLocalCollection({
 				id: `v2_sidebar_projects-${organizationId}`,
 				storageKey: `v2-sidebar-projects-${organizationId}`,
 				schema: dashboardSidebarProjectSchema,
@@ -782,18 +794,16 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2WorkspaceLocalState = createIndexedCollection(
 		localStorageCollectionOptions(
-			guardQuota(
-				withReadHeal(
-					{
-						id: `v2_workspace_local_state-${organizationId}`,
-						storageKey: `v2-workspace-local-state-${organizationId}`,
-						schema: workspaceLocalStateSchema,
-						// Explicit type so `withReadHeal`'s passthrough generic keeps the
-						// linkage between schema and getKey for downstream inference.
-						getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
-					},
-					healWorkspaceLocalState,
-				),
+			hardenLocalCollection(
+				{
+					id: `v2_workspace_local_state-${organizationId}`,
+					storageKey: `v2-workspace-local-state-${organizationId}`,
+					schema: workspaceLocalStateSchema,
+					// Explicit type so `withReadHeal`'s passthrough generic keeps the
+					// linkage between schema and getKey for downstream inference.
+					getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
+				},
+				healWorkspaceLocalState,
 			),
 		),
 	);
@@ -812,7 +822,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2SidebarSections = createIndexedCollection(
 		localStorageCollectionOptions(
-			guardQuota({
+			hardenLocalCollection({
 				id: `v2_sidebar_sections-${organizationId}`,
 				storageKey: `v2-sidebar-sections-${organizationId}`,
 				schema: dashboardSidebarSectionSchema,
@@ -831,7 +841,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2TerminalPresets = createIndexedCollection(
 		localStorageCollectionOptions(
-			guardQuota({
+			hardenLocalCollection({
 				id: `v2_terminal_presets-${organizationId}`,
 				storageKey: `v2-terminal-presets-${organizationId}`,
 				schema: v2TerminalPresetSchema,
@@ -842,27 +852,25 @@ function createOrgCollections(organizationId: string): OrgCollections {
 
 	const v2UserPreferences = createCollection(
 		localStorageCollectionOptions(
-			guardQuota(
-				withReadHeal(
-					{
-						id: `v2_user_preferences-${organizationId}`,
-						storageKey: `v2-user-preferences-${organizationId}`,
-						schema: v2UserPreferencesSchema,
-						// Cast widens the inferred literal "preferences" key to string so
-						// the collection slots into the shared OrgCollections.{...<TKey=string>}
-						// shape alongside the other v2 collections. Explicit `item` type so
-						// `withReadHeal`'s passthrough generic keeps schema/getKey linkage.
-						getKey: (item: V2UserPreferencesRow) => item.id as string,
-					},
-					healV2UserPreferences,
-				),
+			hardenLocalCollection(
+				{
+					id: `v2_user_preferences-${organizationId}`,
+					storageKey: `v2-user-preferences-${organizationId}`,
+					schema: v2UserPreferencesSchema,
+					// Cast widens the inferred literal "preferences" key to string so
+					// the collection slots into the shared OrgCollections.{...<TKey=string>}
+					// shape alongside the other v2 collections. Explicit `item` type so
+					// `withReadHeal`'s passthrough generic keeps schema/getKey linkage.
+					getKey: (item: V2UserPreferencesRow) => item.id as string,
+				},
+				healV2UserPreferences,
 			),
 		),
 	);
 
 	const failedWorkspaceCreates = createIndexedCollection(
 		localStorageCollectionOptions(
-			guardQuota({
+			hardenLocalCollection({
 				id: `failed_workspace_creates-${organizationId}`,
 				storageKey: `failed-workspace-creates-${organizationId}`,
 				schema: failedWorkspaceCreateSchema,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/localCollectionLifecycle.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/localCollectionLifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import { z } from "zod";
+
+/**
+ * Pins the @tanstack/db lifecycle semantics `hardenLocalCollection` relies on
+ * (collections.ts): a localStorage collection only hydrates when sync starts,
+ * and a mutation on a never-synced (`idle`) collection re-serializes the whole
+ * storage key from empty memory — erasing every persisted row. `startSync:
+ * true` makes that state unrepresentable. If a library upgrade changes either
+ * behavior, these tests flag that the hardening needs a fresh look.
+ */
+
+const rowSchema = z.object({ id: z.string(), label: z.string() });
+type Row = z.infer<typeof rowSchema>;
+
+function makeMapStorage() {
+	const map = new Map<string, string>();
+	return {
+		store: map,
+		api: {
+			getItem: (key: string) => map.get(key) ?? null,
+			setItem: (key: string, value: string) => {
+				map.set(key, value);
+			},
+			removeItem: (key: string) => {
+				map.delete(key);
+			},
+		},
+	};
+}
+
+const noopEvents = {
+	addEventListener: () => {},
+	removeEventListener: () => {},
+};
+
+function seedRow(
+	storage: { setItem(k: string, v: string): void },
+	key: string,
+) {
+	storage.setItem(
+		key,
+		JSON.stringify({
+			"s:existing": {
+				versionKey: "v0",
+				data: { id: "existing", label: "old" },
+			},
+		}),
+	);
+}
+
+function makeCollection(
+	storage: ReturnType<typeof makeMapStorage>["api"],
+	key: string,
+	options: { startSync?: boolean } = {},
+) {
+	return createCollection(
+		localStorageCollectionOptions({
+			id: key,
+			storageKey: key,
+			schema: rowSchema,
+			getKey: (item: Row) => item.id,
+			storage,
+			storageEventApi: noopEvents,
+			gcTime: 0,
+			...options,
+		}),
+	);
+}
+
+describe("localStorage collection lifecycle", () => {
+	it("startSync: true — insert on a fresh collection preserves existing rows", () => {
+		const { store, api: storage } = makeMapStorage();
+		seedRow(storage, "test-live");
+
+		const collection = makeCollection(storage, "test-live", {
+			startSync: true,
+		});
+		collection.insert({ id: "new", label: "new" });
+
+		expect(collection.get("existing")?.label).toBe("old");
+		const persisted = store.get("test-live") ?? "";
+		expect(persisted).toContain('"id":"existing"');
+		expect(persisted).toContain('"id":"new"');
+	});
+
+	it("without startSync — the same insert wipes the store (the hazard being defended against)", () => {
+		const { store, api: storage } = makeMapStorage();
+		seedRow(storage, "test-idle");
+
+		const collection = makeCollection(storage, "test-idle");
+		collection.insert({ id: "new", label: "new" });
+
+		// Library behavior pin, not desired behavior: the idle collection never
+		// hydrated, so the whole-store rewrite drops the pre-existing row. If
+		// this starts passing rows through, startSync may no longer be needed.
+		expect(store.get("test-idle") ?? "").not.toContain('"id":"existing"');
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
@@ -56,17 +56,54 @@ describe("withReadHeal parser", () => {
 		expect(parsed["s:bar"]?.data).toEqual({ b: 2, healed: true });
 	});
 
-	it("passes non-envelope values through unchanged", () => {
-		const heal = () => {
-			throw new Error("should not be called for non-envelope values");
+	it("drops non-envelope entries so they never reach the library's hydration", () => {
+		// A non-envelope value passed through would make the library throw
+		// InvalidStorageDataFormatError inside its whole-store try/catch,
+		// hydrating EVERY row as lost.
+		const opts = withReadHeal(
+			{} as {
+				parser?: { parse: (s: string) => unknown };
+			},
+		);
+		const raw = JSON.stringify({
+			"s:foo": "string-not-an-envelope",
+			"s:bar": { versionKey: "v1", data: { b: 2 } },
+		});
+		const parsed = opts.parser?.parse(raw) as Record<string, unknown>;
+		expect(parsed["s:foo"]).toBeUndefined();
+		expect(parsed["s:bar"]).toEqual({ versionKey: "v1", data: { b: 2 } });
+	});
+
+	it("drops only the entry whose heal throws, keeping the rest", () => {
+		const heal = (raw: unknown) => {
+			const data = raw as { poison?: boolean };
+			if (data.poison) throw new Error("unhealable");
+			return data;
 		};
 		const opts = withReadHeal(
 			{} as { parser?: { parse: (s: string) => unknown } },
 			heal,
 		);
-		const raw = JSON.stringify({ "s:foo": "string-not-an-envelope" });
+		const raw = JSON.stringify({
+			"s:bad": { versionKey: "v1", data: { poison: true } },
+			"s:good": { versionKey: "v2", data: { a: 1 } },
+		});
 		const parsed = opts.parser?.parse(raw) as Record<string, unknown>;
-		expect(parsed["s:foo"]).toBe("string-not-an-envelope");
+		expect(parsed["s:bad"]).toBeUndefined();
+		expect(parsed["s:good"]).toEqual({ versionKey: "v2", data: { a: 1 } });
+	});
+
+	it("defaults to an identity heal when none is provided", () => {
+		const opts = withReadHeal(
+			{} as {
+				parser?: { parse: (s: string) => unknown };
+			},
+		);
+		const raw = JSON.stringify({
+			"s:foo": { versionKey: "v1", data: { a: 1 } },
+		});
+		const parsed = opts.parser?.parse(raw) as Record<string, unknown>;
+		expect(parsed["s:foo"]).toEqual({ versionKey: "v1", data: { a: 1 } });
 	});
 });
 
@@ -154,6 +191,50 @@ describe("withReadHeal end-to-end via real localStorageCollectionOptions", () =>
 		// buildHint. If this ever starts returning a defined value the wrapper
 		// may no longer be needed.
 		expect(row?.sidebarFileLinks).toBeUndefined();
+	});
+
+	it("hydrates surviving rows when the store holds one corrupt entry", async () => {
+		const { api: storage } = makeMapStorage();
+		const workspaceId = "11111111-1111-1111-1111-111111111111";
+		const projectId = "22222222-2222-2222-2222-222222222222";
+		storage.setItem(
+			"test-corrupt",
+			JSON.stringify({
+				// Not a {versionKey, data} envelope: without the per-row drop the
+				// library throws mid-hydration and treats the WHOLE store as empty,
+				// and the next mutation persists that emptiness.
+				"s:corrupt": 42,
+				[`s:${workspaceId}`]: {
+					versionKey: "v0",
+					data: {
+						workspaceId,
+						createdAt: "2026-01-01T00:00:00.000Z",
+						paneLayout: { version: 1, tabs: [], activeTabId: null },
+						sidebarState: { projectId },
+					},
+				},
+			}),
+		);
+
+		const collection = createCollection(
+			localStorageCollectionOptions(
+				withReadHeal(
+					{
+						id: "test-corrupt",
+						storageKey: "test-corrupt",
+						schema: workspaceLocalStateSchema,
+						getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
+						storage,
+						storageEventApi: noopEvents,
+					},
+					healWorkspaceLocalState,
+				),
+			),
+		);
+		await collection.preload();
+
+		expect(collection.get(workspaceId)?.sidebarState.projectId).toBe(projectId);
+		expect(collection.size).toBe(1);
 	});
 
 	it("heals a workspaceLocalState row missing optional + nested fields", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
@@ -13,10 +13,16 @@ import type { Parser } from "@tanstack/react-db";
  *
  * The library expects parsed entries to have `{ versionKey, data }` — we
  * preserve that envelope and only reshape `data`.
+ *
+ * Parsing is per-row tolerant, which is why every localStorage collection
+ * applies this wrapper even without a custom `heal`: the library hydrates the
+ * whole store inside one try/catch, so a single malformed entry (or a heal
+ * throw) escaping to it discards every row — and the next mutation persists
+ * that emptiness. Bad entries are dropped here instead, so the rest survive.
  */
 export function withReadHeal<T>(
 	options: T,
-	heal: (raw: unknown) => unknown,
+	heal: (raw: unknown) => unknown = (raw) => raw,
 ): T {
 	const baseParser: Parser = (options as { parser?: Parser }).parser ?? JSON;
 	const healingParser: Parser = {
@@ -33,15 +39,24 @@ export function withReadHeal<T>(
 			const result: Record<string, unknown> = {};
 			for (const [key, value] of Object.entries(parsed)) {
 				if (
-					value &&
-					typeof value === "object" &&
-					"versionKey" in value &&
-					"data" in value
+					!value ||
+					typeof value !== "object" ||
+					!("versionKey" in value) ||
+					!("data" in value)
 				) {
-					const entry = value as { versionKey: unknown; data: unknown };
+					console.warn(
+						`[withReadHeal] Dropping malformed stored entry "${key}"`,
+					);
+					continue;
+				}
+				const entry = value as { versionKey: unknown; data: unknown };
+				try {
 					result[key] = { ...entry, data: heal(entry.data) };
-				} else {
-					result[key] = value;
+				} catch (error) {
+					console.warn(
+						`[withReadHeal] Dropping unhealable stored entry "${key}"`,
+						error,
+					);
 				}
 			}
 			return result;


### PR DESCRIPTION
## Summary
- Hardens all six localStorage-backed sidebar collections so a write can never erase previously persisted rows, and one corrupt row can never blank the whole store on load.
- Removes the manufactured signed-out window during bearer-token rotation that unmounted the entire authenticated tree (sidebar included) mid-session.

## Why / Context
Investigation into the dashboard sidebar "randomly losing state" found two independent failure classes in `@tanstack/db` 0.6.14's localStorage collections (verified against the shipped library source):

1. **Insert-on-idle wipes the store.** Collections hydrate lazily; `.state`/`.get()` on a never-synced collection silently return empty, and `insert()` doesn't auto-start sync for `idle` collections. Every mutation re-serializes the *entire* store from memory, so an insert before hydration rewrote `v2-workspace-local-state-<orgId>` (etc.) from near-empty memory — permanently erasing all placement rows, pins, sections, and pane layouts for the org. The default 5-minute GC reintroduces the same hazard after subscribers unmount.
2. **One corrupt entry blanks hydration.** The library loads the whole store inside a single try/catch that returns an empty map: one malformed entry (or a heal-function throw) discards every row, and the next mutation persists the emptiness.

Separately, `AuthProvider.onTokenChanged` did `setAuthToken(null)` → awaited `signOut()` → `setAuthToken(new)`. Any `get-session` fired in that gap (window focus, network reconnect) read "no session", which redirected to `/sign-in` and unmounted the whole dashboard — dropping all ephemeral UI state until the follow-up refetch remounted it.

## How It Works
- `hardenLocalCollection` (collections.ts) folds the existing quota guard and read heal together with `startSync: true` + `gcTime: 0`, applied uniformly to all six localStorage collections. Collections hydrate synchronously at construction and are never GC'd, making the `idle`/`cleaned-up` states unrepresentable — the non-reactive `.state` reads in the sidebar mutation helpers become unconditionally correct with no per-call-site readiness gates.
- `withReadHeal` now parses per-row: non-envelope entries and heal throws drop that row (with a console warning) instead of escaping to the library's whole-store catch-all. `heal` defaults to identity so every collection gets the tolerance, not just the two with custom heals.
- `onTokenChanged` swaps the token atomically and refetches the session; the stale-identity JWT is cleared and re-mints via the existing 401-refresh path.

## Manual QA / CDP Verification
Driven end-to-end over CDP against this worktree's dev app (renderer on port 7965, signed-in session + active org verified first):
- [x] **Corrupt-entry survival (fix present)**: injected a non-envelope entry into `v2-workspace-local-state-<org>` (21 entries on disk), froze the dying page's writes, hard-reloaded ignoring cache. The renderer logged `[withReadHeal] Dropping malformed stored entry "s:__corrupt__"` at hydration, the sidebar rendered all 3 projects and every workspace row, and the on-disk store diffed byte-identical to the pre-test backup (20/20 rows: pane layouts, tabOrder, hidden flags, viewedFiles all intact). Screenshot captured.
- [x] **Failure mode confirmed in the real renderer**: probing the app's actual Vite-optimized `@tanstack/db` build in-page (`createCollection` + `localStorageCollectionOptions` over a store with one corrupt + one valid entry) hydrates **zero** rows — the whole-store blanking is real in the shipped runtime, not just under bun test.
- [x] Self-heal observed live: the next collection write after a corrupted boot rewrote the store minus the dropped entry, valid rows untouched (21 → 20).
- App-level pre-fix A/B (git-checkout of the old parser into the running dev server) was inconclusive due to dev-mode HMR/transform-cache ambiguity — the pre-fix failure evidence is the in-renderer library probe above plus the pinned unit tests below.
- Not exercised manually: the insert-on-idle wipe (requires precise pre-hydration timing; pinned by `localCollectionLifecycle.test.ts` against the real library) and the token-rotation swap (requires a live OAuth deep-link; covered by code-path analysis in the description).

## Testing
- `bun test src/renderer/routes/_authenticated/providers/CollectionsProvider/` — 48 pass, including:
  - new `localCollectionLifecycle.test.ts`: insert on a fresh `startSync: true` collection preserves existing storage rows; companion test pins the library's wipe behavior without it (if that ever changes, the hardening can be revisited)
  - new `withReadHeal` cases: corrupt entry dropped per-row while sibling rows hydrate; heal throw drops only its own row
- `bun run lint` (exit 0)
- `bun run typecheck` (desktop)

## Design Decisions
- **Config over guards**: rather than adding readiness gates at every `.insert()` call site (there are several ungated ones, e.g. the ensure-on-visit effect in `v2-workspace/layout.tsx`), the collection lifecycle is fixed so the dangerous states cannot occur. Net complexity goes down — one wrapper instead of three at each call site.
- **`gcTime: 0`**: these stores are a few KB of localStorage; keeping them live forever is cheaper than the correctness risk of re-hydration windows.

## Known Limitations / Follow-ups
- Dropping the `signOut()` round trip means a previous user's server-side session isn't revoked on deep-link account switch; identity is governed by the bearer token, so this is cosmetic.
- Not addressed here (flagged during the same investigation): the server persists `activeOrganizationId = null` when a membership read transiently returns empty (`packages/auth/src/lib/resolve-session-organization-state.ts`) — deserves its own PR; and the library's cross-tab storage-event sync is inert for these collections (the storage wrapper breaks its `storageArea` identity check) plus leaks its storage listener across GC cycles — upstream issues, latent while the app has a single window.

## Risks / Rollout
- Risk: `startSync: true` moves hydration into `createOrgCollections` (render path). Synchronous localStorage reads of small stores; no measurable startup cost expected.
- Rollback: revert the commit — no schema or data-format changes; persisted stores are readable by both old and new code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sidebar state loss and mid-session unmounts by hardening all localStorage-backed sidebar collections and making auth token swaps atomic. Persisted rows are now safe, and token rotations no longer trigger sign-out flashes.

- **Bug Fixes**
  - Sidebar persistence: All six `localStorage` collections now hydrate on construct and never GC (`startSync: true`, `gcTime: 0`). Per-row tolerant parsing via `withReadHeal` drops bad entries instead of blanking stores; applied via a `hardenLocalCollection` wrapper that also keeps the quota guard. This prevents insert-on-idle wipes and corrupt-entry blanking in `@tanstack/react-db`.
  - Token rotation: `AuthProvider` now swaps tokens atomically and clears the stale JWT before refetch, removing the brief signed-out window that redirected to `/sign-in` and unmounted the sidebar.

<sup>Written for commit 24af1b16de3cbe401f6e9022f6ac7f48d861fb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session refresh behavior when authentication tokens change, avoiding unnecessary sign-outs.
  - Hardened local data storage to better handle quota limits, synchronization, and cleanup.
  - Corrupted or unrepairable stored entries are now discarded without preventing valid data from loading.
  - Preserved existing local data when initializing synchronized collections.

- **Tests**
  - Added coverage for local storage lifecycle behavior and recovery from invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
