### PR TITLE
fix(desktop): toggle sidebar activity pill details

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/DashboardSidebarAgentsChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/DashboardSidebarAgentsChip.tsx
@@ -24,16 +24,16 @@ interface DashboardSidebarAgentsChipProps {
 /**
  * Running-agents chip on the workspace row: one avatar (the agent whose
  * status most needs attention, newest session on ties) plus the total count.
- * Hovering the row swaps the count for an × — clicking then stops every
- * agent; hovering the chip opens a card listing each agent with its own
- * open/stop actions.
+ * Hovering or clicking the chip opens a card listing each agent with its own
+ * open/stop actions; clicking the chip again closes the card.
  */
 export function DashboardSidebarAgentsChip({
 	workspaceId,
 	agents,
 }: DashboardSidebarAgentsChipProps) {
 	const { isPending, killAgents } = useDashboardSidebarAgentKill(workspaceId);
-	const { hold, release } = useDashboardSidebarChipHoverSuppression();
+	const { isOpen, onOpenChange, onPointerEnter, onPointerLeave, toggleOpen } =
+		useDashboardSidebarChipHoverSuppression();
 
 	const primaryAgent = agents.reduce((best, agent) => {
 		if (STATUS_PRIORITY[agent.status] !== STATUS_PRIORITY[best.status]) {
@@ -60,19 +60,23 @@ export function DashboardSidebarAgentsChip({
 
 	return (
 		<HoverCard
+			open={isOpen}
 			openDelay={150}
 			closeDelay={120}
-			onOpenChange={(open) => (open ? hold() : release())}
+			onOpenChange={onOpenChange}
 		>
 			<HoverCardTrigger asChild>
 				<Badge asChild variant="secondary">
 					<button
 						type="button"
-						onPointerEnter={hold}
-						onPointerLeave={release}
+						onPointerEnter={onPointerEnter}
+						onPointerLeave={onPointerLeave}
+						onPointerDown={(event) => {
+							event.stopPropagation();
+						}}
 						onClick={(event) => {
 							event.stopPropagation();
-							void handleStopAll();
+							toggleOpen();
 						}}
 						onKeyDown={(event) => {
 							if (event.key === "Enter" || event.key === " ") {
@@ -81,7 +85,8 @@ export function DashboardSidebarAgentsChip({
 						}}
 						disabled={isPending}
 						aria-busy={isPending}
-						aria-label={`${agents.length} running agents — stop all`}
+						aria-expanded={isOpen}
+						aria-label={`${agents.length} running agents — ${isOpen ? "hide" : "show"} details`}
 						className={cn(
 							"group/chip h-[18px] overflow-visible bg-muted/60 px-1.5 py-0 text-[9px] font-medium tabular-nums text-muted-foreground",
 							"[&>svg]:size-2.5 hover:bg-muted hover:text-foreground disabled:opacity-70",
@@ -94,17 +99,7 @@ export function DashboardSidebarAgentsChip({
 								strokeWidth={STROKE_WIDTH}
 							/>
 						) : (
-							// The count and the × share one grid cell and cross-fade while
-							// the chip itself is hovered, so it never changes width.
-							<span className="grid shrink-0 items-center justify-items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								<span className="transition-opacity group-focus-within/chip:opacity-0 group-hover/chip:opacity-0 motion-reduce:transition-none">
-									{agents.length}
-								</span>
-								<LuX
-									className="size-2.5 opacity-0 transition-opacity group-focus-within/chip:opacity-100 group-hover/chip:opacity-100 motion-reduce:transition-none"
-									strokeWidth={STROKE_WIDTH}
-								/>
-							</span>
+							<span className="shrink-0">{agents.length}</span>
 						)}
 					</button>
 				</Badge>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarPortsChip/DashboardSidebarPortsChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarPortsChip/DashboardSidebarPortsChip.tsx
@@ -19,15 +19,16 @@ interface DashboardSidebarPortsChipProps {
 }
 
 /**
- * Port-count chip on the workspace row. Hovering the row swaps the count for
- * an × — clicking then kills every port at once; hovering the chip opens a
- * card listing each port with its own open/close actions.
+ * Port-count chip on the workspace row. Hovering or clicking the chip opens a
+ * card listing each port with its own open/close actions; clicking the chip
+ * again closes the card.
  */
 export function DashboardSidebarPortsChip({
 	ports,
 }: DashboardSidebarPortsChipProps) {
 	const { isPending, killPorts } = useDashboardSidebarPortKill();
-	const { hold, release } = useDashboardSidebarChipHoverSuppression();
+	const { isOpen, onOpenChange, onPointerEnter, onPointerLeave, toggleOpen } =
+		useDashboardSidebarChipHoverSuppression();
 
 	const handleCloseAll = async () => {
 		if (isPending) return;
@@ -42,19 +43,23 @@ export function DashboardSidebarPortsChip({
 
 	return (
 		<HoverCard
+			open={isOpen}
 			openDelay={150}
 			closeDelay={120}
-			onOpenChange={(open) => (open ? hold() : release())}
+			onOpenChange={onOpenChange}
 		>
 			<HoverCardTrigger asChild>
 				<Badge asChild variant="secondary">
 					<button
 						type="button"
-						onPointerEnter={hold}
-						onPointerLeave={release}
+						onPointerEnter={onPointerEnter}
+						onPointerLeave={onPointerLeave}
+						onPointerDown={(event) => {
+							event.stopPropagation();
+						}}
 						onClick={(event) => {
 							event.stopPropagation();
-							void handleCloseAll();
+							toggleOpen();
 						}}
 						onKeyDown={(event) => {
 							if (event.key === "Enter" || event.key === " ") {
@@ -63,7 +68,8 @@ export function DashboardSidebarPortsChip({
 						}}
 						disabled={isPending}
 						aria-busy={isPending}
-						aria-label={`${ports.length} active ${ports.length === 1 ? "port" : "ports"} — close all`}
+						aria-expanded={isOpen}
+						aria-label={`${ports.length} active ${ports.length === 1 ? "port" : "ports"} — ${isOpen ? "hide" : "show"} details`}
 						className={cn(
 							"group/chip h-[18px] bg-muted/60 px-1.5 py-0 text-[9px] font-medium tabular-nums text-muted-foreground",
 							"[&>svg]:size-2.5 hover:bg-muted hover:text-foreground disabled:opacity-70",
@@ -79,17 +85,7 @@ export function DashboardSidebarPortsChip({
 								strokeWidth={STROKE_WIDTH}
 							/>
 						) : (
-							// The count and the × share one grid cell and cross-fade while
-							// the chip itself is hovered, so it never changes width.
-							<span className="grid shrink-0 items-center justify-items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								<span className="transition-opacity group-focus-within/chip:opacity-0 group-hover/chip:opacity-0 motion-reduce:transition-none">
-									{ports.length}
-								</span>
-								<LuX
-									className="size-2.5 opacity-0 transition-opacity group-focus-within/chip:opacity-100 group-hover/chip:opacity-100 motion-reduce:transition-none"
-									strokeWidth={STROKE_WIDTH}
-								/>
-							</span>
+							<span className="shrink-0">{ports.length}</span>
 						)}
 					</button>
 				</Badge>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarChipHoverSuppression/useDashboardSidebarChipHoverSuppression.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarChipHoverSuppression/useDashboardSidebarChipHoverSuppression.ts
@@ -1,20 +1,27 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDashboardSidebarHover } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider";
 
 interface UseDashboardSidebarChipHoverSuppressionResult {
-	hold: () => void;
-	release: () => void;
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+	onPointerEnter: () => void;
+	onPointerLeave: () => void;
+	toggleOpen: () => void;
 }
 
 /**
- * Ref-counted hold on the sidebar's workspace hover card while a chip (or its
- * own hover card) has the pointer. Holds still owned on unmount are released
- * automatically — a chip can disappear mid-hover after a bulk close.
+ * Controls a chip's hover card and keeps a ref-counted hold on the sidebar's
+ * workspace hover card while the chip (or its card) is active. Holds still
+ * owned on unmount are released automatically — a chip can disappear
+ * mid-hover after a bulk close.
  */
 export function useDashboardSidebarChipHoverSuppression(): UseDashboardSidebarChipHoverSuppressionResult {
 	const { beginHoverCardSuppression, endHoverCardSuppression } =
 		useDashboardSidebarHover();
 	const holdsRef = useRef(0);
+	const isOpenRef = useRef(false);
+	const dismissedByClickRef = useRef(false);
+	const [isOpen, setIsOpen] = useState(false);
 
 	const hold = useCallback(() => {
 		holdsRef.current += 1;
@@ -27,6 +34,41 @@ export function useDashboardSidebarChipHoverSuppression(): UseDashboardSidebarCh
 		endHoverCardSuppression();
 	}, [endHoverCardSuppression]);
 
+	const onOpenChange = useCallback(
+		(open: boolean) => {
+			// A pending hover-open timer can fire after the user clicks to close.
+			// Keep the card dismissed until the pointer leaves or it is clicked again.
+			if (open && dismissedByClickRef.current) return;
+			if (isOpenRef.current === open) return;
+
+			isOpenRef.current = open;
+			setIsOpen(open);
+			if (open) {
+				hold();
+			} else {
+				release();
+			}
+		},
+		[hold, release],
+	);
+
+	const onPointerEnter = useCallback(() => {
+		// Do not clear a click dismissal here. Removing the hover-card content can
+		// produce another enter while the pointer is still over the trigger.
+		hold();
+	}, [hold]);
+
+	const onPointerLeave = useCallback(() => {
+		dismissedByClickRef.current = false;
+		release();
+	}, [release]);
+
+	const toggleOpen = useCallback(() => {
+		const nextOpen = !isOpenRef.current;
+		dismissedByClickRef.current = !nextOpen;
+		onOpenChange(nextOpen);
+	}, [onOpenChange]);
+
 	useEffect(
 		() => () => {
 			while (holdsRef.current > 0) {
@@ -37,5 +79,11 @@ export function useDashboardSidebarChipHoverSuppression(): UseDashboardSidebarCh
 		[endHoverCardSuppression],
 	);
 
-	return { hold, release };
+	return {
+		isOpen,
+		onOpenChange,
+		onPointerEnter,
+		onPointerLeave,
+		toggleOpen,
+	};
 }


### PR DESCRIPTION
## Summary
- keep port and agent counts visible instead of swapping them for destructive × actions
- toggle each details hover card when its pill is clicked
- retain explicit bulk stop/close actions inside the details card

## Testing
- `bun run lint`
- `bun run --filter @superset/desktop typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidebar activity pills (Agents, Ports) toggle their details on click while keeping counts visible. Removes the hover “×” and stabilizes hover behavior for fewer accidental bulk actions.

- **Bug Fixes**
  - Clicking a pill now opens/closes its details card; hover still opens, and post-click the card stays closed until pointer leaves or clicked again.
  - Pills always show counts; bulk stop/close actions live inside the details card.
  - Controlled open state via `useDashboardSidebarChipHoverSuppression` to suppress the parent hover card, avoid delayed re-open after click, and clean up on unmount; improved accessibility with `aria-expanded` and clearer labels.

<sup>Written for commit bc52a6ee2354b475bfcafe6d07fa58f9bae835b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking the Agents or Ports chip now opens its details instead of immediately stopping agents or closing ports.
  * Stop-all actions remain available within the expanded details cards.
  * Improved hover and pointer behavior to prevent unintended reopening or dismissal.

* **Accessibility**
  * Added expanded-state and show/hide labels for Agents and Ports details.
  * Counts remain visible directly on each chip for clearer status at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->