### PR TITLE
fix(desktop): focus new-workspace prompt at end of existing text on remount

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -468,7 +468,7 @@ export function PromptGroup({
 					content={prompt}
 					onChange={(markdown) => updateDraft({ prompt: markdown })}
 					onPasteFiles={(files) => attachments.add(files)}
-					autoFocus="start"
+					autoFocus={prompt ? "end" : "start"}
 					placeholder="What do you want to do?"
 					className="flex flex-col min-h-[100px] max-h-[200px] px-3 pt-3"
 					editorClassName="overflow-y-auto text-sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -562,7 +562,7 @@ export function NewWorkspaceScreen({
 						onChange={(markdown) => updateDraft({ prompt: markdown })}
 						onPasteFiles={(files) => attachments.add(files)}
 						onEnterSubmit={handleSubmit}
-						autoFocus={promptSeed > 0 ? "end" : "start"}
+						autoFocus={draft.prompt ? "end" : "start"}
 						placeholder="What do you want to do?"
 						className="flex flex-col min-h-[80px] max-h-[200px] px-3 pt-3"
 						editorClassName="overflow-y-auto text-sm"


### PR DESCRIPTION
## Summary
Switching back to the new-workspace composer remounts the Tiptap `MarkdownEditor` with the persisted draft, but the caret always landed at the start of the text. Both v2 composers now focus at the end when draft text exists, and at the start otherwise.

- `DashboardNewWorkspaceForm/PromptGroup`: was hardcoded `autoFocus="start"` → `autoFocus={prompt ? "end" : "start"}`
- `NewWorkspaceScreen`: `promptSeed > 0` only covered the sample-prompt remount; `autoFocus={draft.prompt ? "end" : "start"}` subsumes it (draft is non-empty at that remount too)

`autoFocus` is only read at editor creation (remount via `key`), so the changing prop has no effect mid-typing.

## Test Plan
- [ ] Type a prompt in the new-workspace modal, close/switch away, reopen — caret is at end of text
- [ ] Open composer with empty draft — caret at start, placeholder shown
- [ ] Pick a sample prompt in NewWorkspaceScreen — editor remounts with caret at end
- [x] `bun run lint` and desktop `typecheck` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the new workspace prompt so the cursor lands at the end of existing draft text on remount, letting users keep typing without repositioning. If the draft is empty, the cursor starts at the beginning and the placeholder shows.

- **Bug Fixes**
  - Dashboard modal prompt: `autoFocus` is now `prompt ? "end" : "start"`.
  - New workspace screen: `autoFocus` now uses `draft.prompt ? "end" : "start"` instead of `promptSeed`, covering sample prompts and persisted drafts.

<sup>Written for commit 2e4b33649b98b0fe3e88e13f26d02150d38c5068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor placement in the Markdown prompt editor.
  * Existing prompts now place the cursor at the end of the text when opened.
  * Empty prompt fields place the cursor at the beginning for immediate typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->