### PR TITLE
perf(host-service,desktop): move hot git reads off the event loops, add ratchet enforcement

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/branches.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/branches.ts
@@ -17,6 +17,16 @@ import { getPersistedWorktreeBaseBranch } from "./utils/effective-base-branch";
 import { clearStatusCacheForWorktree } from "./utils/status-cache";
 import { runGitTask } from "./workers/git-task-runner";
 
+// Bumped by branch/base mutations so a refetch fired right after one can't
+// coalesce onto an in-flight getBranches task that read pre-mutation state.
+const branchesGeneration = new Map<string, number>();
+function bumpBranchesGeneration(worktreePath: string): void {
+	branchesGeneration.set(
+		worktreePath,
+		(branchesGeneration.get(worktreePath) ?? 0) + 1,
+	);
+}
+
 export const createBranchesRouter = () => {
 	return router({
 		getBranches: publicProcedure
@@ -43,7 +53,7 @@ export const createBranchesRouter = () => {
 							),
 						},
 						{
-							dedupeKey: `getBranches:${input.worktreePath}`,
+							dedupeKey: `getBranches:${branchesGeneration.get(input.worktreePath) ?? 0}:${input.worktreePath}`,
 							strategy: "coalesce",
 							timeoutMs: 30_000,
 						},
@@ -77,6 +87,7 @@ export const createBranchesRouter = () => {
 					.run();
 
 				clearStatusCacheForWorktree(input.worktreePath);
+				bumpBranchesGeneration(input.worktreePath);
 				return { success: true };
 			}),
 
@@ -116,6 +127,7 @@ export const createBranchesRouter = () => {
 					.run();
 
 				clearStatusCacheForWorktree(input.worktreePath);
+				bumpBranchesGeneration(input.worktreePath);
 				return { success: true };
 			}),
 	});

--- a/apps/desktop/src/lib/trpc/routers/changes/branches.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/branches.ts
@@ -1,7 +1,6 @@
 import { worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
-import type { SimpleGit } from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
@@ -9,15 +8,14 @@ import {
 	unsetBranchBaseConfig,
 } from "../workspaces/utils/base-branch-config";
 import { getCurrentBranch } from "../workspaces/utils/git";
-import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import { gitSwitchBranch } from "./security/git-commands";
 import {
 	assertRegisteredWorktree,
 	getRegisteredWorktree,
 } from "./security/path-validation";
-import { getWorktreeBaseBranch } from "./utils/effective-base-branch";
-import { getDefaultBranch } from "./utils/git-base-branch";
+import { getPersistedWorktreeBaseBranch } from "./utils/effective-base-branch";
 import { clearStatusCacheForWorktree } from "./utils/status-cache";
+import { runGitTask } from "./workers/git-task-runner";
 
 export const createBranchesRouter = () => {
 	return router({
@@ -36,43 +34,20 @@ export const createBranchesRouter = () => {
 				}> => {
 					assertRegisteredWorktree(input.worktreePath);
 
-					const git = await getSimpleGitWithShellPath(input.worktreePath);
-
-					const branchSummary = await git.branch(["-a"]);
-					const currentBranch = await getCurrentBranch(input.worktreePath);
-					const worktreeBaseBranch = await getWorktreeBaseBranch(
-						input.worktreePath,
-						currentBranch,
+					return runGitTask(
+						"getBranches",
+						{
+							worktreePath: input.worktreePath,
+							persistedWorktree: getPersistedWorktreeBaseBranch(
+								input.worktreePath,
+							),
+						},
+						{
+							dedupeKey: `getBranches:${input.worktreePath}`,
+							strategy: "coalesce",
+							timeoutMs: 30_000,
+						},
 					);
-
-					const localBranches: string[] = [];
-					const remote: string[] = [];
-
-					for (const name of Object.keys(branchSummary.branches)) {
-						if (name.startsWith("remotes/origin/")) {
-							if (name === "remotes/origin/HEAD") continue;
-							const remoteName = name.replace("remotes/origin/", "");
-							remote.push(remoteName);
-						} else {
-							localBranches.push(name);
-						}
-					}
-
-					const local = await getLocalBranchesWithDates(git, localBranches);
-					const defaultBranch = await getDefaultBranch(git, remote);
-					const checkedOutBranches = await getCheckedOutBranches(
-						git,
-						input.worktreePath,
-					);
-
-					return {
-						local,
-						remote: remote.sort(),
-						defaultBranch,
-						checkedOutBranches,
-						worktreeBaseBranch,
-						currentBranch,
-					};
 				},
 			),
 
@@ -145,60 +120,3 @@ export const createBranchesRouter = () => {
 			}),
 	});
 };
-
-async function getLocalBranchesWithDates(
-	git: SimpleGit,
-	localBranches: string[],
-): Promise<Array<{ branch: string; lastCommitDate: number }>> {
-	try {
-		const branchInfo = await git.raw([
-			"for-each-ref",
-			"--sort=-committerdate",
-			"--format=%(refname:short) %(committerdate:unix)",
-			"refs/heads/",
-		]);
-
-		const local: Array<{ branch: string; lastCommitDate: number }> = [];
-		for (const line of branchInfo.trim().split("\n")) {
-			if (!line) continue;
-			const lastSpaceIdx = line.lastIndexOf(" ");
-			const branch = line.substring(0, lastSpaceIdx);
-			const timestamp = Number.parseInt(line.substring(lastSpaceIdx + 1), 10);
-			if (localBranches.includes(branch)) {
-				local.push({
-					branch,
-					lastCommitDate: timestamp * 1000,
-				});
-			}
-		}
-		return local;
-	} catch {
-		return localBranches.map((branch) => ({ branch, lastCommitDate: 0 }));
-	}
-}
-
-async function getCheckedOutBranches(
-	git: SimpleGit,
-	currentWorktreePath: string,
-): Promise<Record<string, string>> {
-	const checkedOutBranches: Record<string, string> = {};
-
-	try {
-		const worktreeList = await git.raw(["worktree", "list", "--porcelain"]);
-		const lines = worktreeList.split("\n");
-		let currentPath: string | null = null;
-
-		for (const line of lines) {
-			if (line.startsWith("worktree ")) {
-				currentPath = line.substring(9).trim();
-			} else if (line.startsWith("branch ")) {
-				const branch = line.substring(7).trim().replace("refs/heads/", "");
-				if (currentPath && currentPath !== currentWorktreePath) {
-					checkedOutBranches[branch] = currentPath;
-				}
-			}
-		}
-	} catch {}
-
-	return checkedOutBranches;
-}

--- a/apps/desktop/src/lib/trpc/routers/changes/file-contents.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/file-contents.ts
@@ -1,12 +1,10 @@
 import type { FileContents } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
-import type { SimpleGit } from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { toRegisteredWorktreeRelativePath } from "../workspace-fs-service";
-import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
-
-const MAX_FILE_SIZE = 2 * 1024 * 1024;
+import { runGitTask } from "./workers/git-task-runner";
+import type { GitTaskPayloadMap } from "./workers/git-task-types";
 
 export const createFileContentsRouter = () => {
 	return router({
@@ -22,7 +20,6 @@ export const createFileContentsRouter = () => {
 				}),
 			)
 			.query(async ({ input }): Promise<FileContents> => {
-				const git = await getSimpleGitWithShellPath(input.worktreePath);
 				const defaultBranch = input.defaultBranch || "main";
 				const filePath = toRegisteredWorktreeRelativePath(
 					input.worktreePath,
@@ -35,18 +32,23 @@ export const createFileContentsRouter = () => {
 						)
 					: filePath;
 
-				const versions = await getGitOnlyVersions(
-					git,
-					filePath,
-					originalPath,
-					input.category,
-					defaultBranch,
-					input.commitHash,
+				const versions = await runGitTask(
+					"getFileContents",
+					buildFileContentsPayload(input, {
+						filePath,
+						originalPath,
+						defaultBranch,
+					}),
+					{
+						dedupeKey: `getFileContents:${input.worktreePath}:${input.category}:${filePath}:${originalPath}:${defaultBranch}:${input.commitHash ?? ""}`,
+						strategy: "coalesce",
+						timeoutMs: 30_000,
+					},
 				);
 
 				return {
-					original: versions.original,
-					modified: versions.modified,
+					original: versions.original ?? "",
+					modified: versions.modified ?? "",
 					language: detectLanguage(input.absolutePath),
 				};
 			}),
@@ -60,7 +62,6 @@ export const createFileContentsRouter = () => {
 				}),
 			)
 			.query(async ({ input }): Promise<{ content: string }> => {
-				const git = await getSimpleGitWithShellPath(input.worktreePath);
 				const originalPath = input.oldAbsolutePath
 					? toRegisteredWorktreeRelativePath(
 							input.worktreePath,
@@ -71,100 +72,49 @@ export const createFileContentsRouter = () => {
 							input.absolutePath,
 						);
 
-				const staged = await safeGitShow(git, `:0:${originalPath}`);
-				const content =
-					staged ?? (await safeGitShow(git, `HEAD:${originalPath}`));
-				return { content: content ?? "" };
+				const versions = await runGitTask(
+					"getFileContents",
+					{
+						worktreePath: input.worktreePath,
+						filePath: originalPath,
+						originalPath,
+						category: "original",
+					},
+					{
+						dedupeKey: `getFileContents:${input.worktreePath}:original:${originalPath}`,
+						strategy: "coalesce",
+						timeoutMs: 30_000,
+					},
+				);
+
+				return { content: versions.modified ?? versions.original ?? "" };
 			}),
 	});
 };
 
-interface FileVersions {
-	original: string;
-	modified: string;
-}
-
-async function getGitOnlyVersions(
-	git: SimpleGit,
-	filePath: string,
-	originalPath: string,
-	category: "against-base" | "committed" | "staged",
-	defaultBranch: string,
-	commitHash?: string,
-): Promise<FileVersions> {
-	switch (category) {
+function buildFileContentsPayload(
+	input: {
+		worktreePath: string;
+		category: "against-base" | "committed" | "staged";
+		commitHash?: string;
+	},
+	{
+		filePath,
+		originalPath,
+		defaultBranch,
+	}: { filePath: string; originalPath: string; defaultBranch: string },
+): GitTaskPayloadMap["getFileContents"] {
+	const base = { worktreePath: input.worktreePath, filePath, originalPath };
+	switch (input.category) {
 		case "against-base":
-			return getAgainstBaseVersions(git, filePath, originalPath, defaultBranch);
-
-		case "committed":
-			if (!commitHash) {
+			return { ...base, category: "against-base", defaultBranch };
+		case "committed": {
+			if (!input.commitHash) {
 				throw new Error("commitHash required for committed category");
 			}
-			return getCommittedVersions(git, filePath, originalPath, commitHash);
-
+			return { ...base, category: "committed", commitHash: input.commitHash };
+		}
 		case "staged":
-			return getStagedVersions(git, filePath, originalPath);
+			return { ...base, category: "staged" };
 	}
-}
-
-async function safeGitShow(
-	git: SimpleGit,
-	spec: string,
-): Promise<string | null> {
-	try {
-		// Guard against memory spikes from large blobs in git history
-		try {
-			const sizeOutput = await git.raw(["cat-file", "-s", spec]);
-			const blobSize = Number.parseInt(sizeOutput.trim(), 10);
-			if (!Number.isNaN(blobSize) && blobSize > MAX_FILE_SIZE) {
-				return `[File content truncated - exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit]`;
-			}
-		} catch {}
-
-		const content = await git.show([spec]);
-		return content;
-	} catch {
-		return null;
-	}
-}
-
-async function getAgainstBaseVersions(
-	git: SimpleGit,
-	filePath: string,
-	originalPath: string,
-	defaultBranch: string,
-): Promise<FileVersions> {
-	const [original, modified] = await Promise.all([
-		safeGitShow(git, `origin/${defaultBranch}:${originalPath}`),
-		safeGitShow(git, `HEAD:${filePath}`),
-	]);
-
-	return { original: original ?? "", modified: modified ?? "" };
-}
-
-async function getCommittedVersions(
-	git: SimpleGit,
-	filePath: string,
-	originalPath: string,
-	commitHash: string,
-): Promise<FileVersions> {
-	const [original, modified] = await Promise.all([
-		safeGitShow(git, `${commitHash}^:${originalPath}`),
-		safeGitShow(git, `${commitHash}:${filePath}`),
-	]);
-
-	return { original: original ?? "", modified: modified ?? "" };
-}
-
-async function getStagedVersions(
-	git: SimpleGit,
-	filePath: string,
-	originalPath: string,
-): Promise<FileVersions> {
-	const [original, modified] = await Promise.all([
-		safeGitShow(git, `HEAD:${originalPath}`),
-		safeGitShow(git, `:0:${filePath}`),
-	]);
-
-	return { original: original ?? "", modified: modified ?? "" };
 }

--- a/apps/desktop/src/lib/trpc/routers/changes/file-contents.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/file-contents.ts
@@ -40,7 +40,16 @@ export const createFileContentsRouter = () => {
 						defaultBranch,
 					}),
 					{
-						dedupeKey: `getFileContents:${input.worktreePath}:${input.category}:${filePath}:${originalPath}:${defaultBranch}:${input.commitHash ?? ""}`,
+						// JSON-encoded: paths may contain the delimiter, and a raw
+						// join could coalesce two different files into one task.
+						dedupeKey: `getFileContents:${JSON.stringify([
+							input.worktreePath,
+							input.category,
+							filePath,
+							originalPath,
+							defaultBranch,
+							input.commitHash ?? "",
+						])}`,
 						strategy: "coalesce",
 						timeoutMs: 30_000,
 					},
@@ -81,7 +90,11 @@ export const createFileContentsRouter = () => {
 						category: "original",
 					},
 					{
-						dedupeKey: `getFileContents:${input.worktreePath}:original:${originalPath}`,
+						dedupeKey: `getFileContents:${JSON.stringify([
+							input.worktreePath,
+							"original",
+							originalPath,
+						])}`,
 						strategy: "coalesce",
 						timeoutMs: 30_000,
 					},

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/effective-base-branch.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/effective-base-branch.ts
@@ -1,11 +1,7 @@
 import { worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
-import { getBranchBaseConfig } from "../../workspaces/utils/base-branch-config";
-import {
-	type PersistedWorktreeBaseBranch,
-	selectEffectiveBaseBranch,
-} from "./select-effective-base-branch";
+import type { PersistedWorktreeBaseBranch } from "./select-effective-base-branch";
 
 export function getPersistedWorktreeBaseBranch(
 	worktreePath: string,
@@ -20,23 +16,4 @@ export function getPersistedWorktreeBaseBranch(
 			.where(eq(worktrees.path, worktreePath))
 			.get() ?? null
 	);
-}
-
-export async function getWorktreeBaseBranch(
-	worktreePath: string,
-	currentBranch: string | null,
-): Promise<string | null> {
-	const { compareBaseBranch: configuredCompareBaseBranch } = currentBranch
-		? await getBranchBaseConfig({
-				repoPath: worktreePath,
-				branch: currentBranch,
-			})
-		: { compareBaseBranch: null };
-
-	return selectEffectiveBaseBranch({
-		configuredBaseBranch: configuredCompareBaseBranch,
-		persistedWorktree: getPersistedWorktreeBaseBranch(worktreePath),
-		currentBranch,
-		defaultBranch: null,
-	});
 }

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { executeGitTask, MAX_COMMIT_LIST_COUNT } from "./git-task-handlers";
@@ -48,6 +48,15 @@ afterAll(() => {
 	rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
+function createBaseRepo(name: string): string {
+	const repoPath = join(TEST_DIR, name);
+	mkdirSync(repoPath, { recursive: true });
+	run(repoPath, "git init -q -b main");
+	run(repoPath, "git config user.email test@test.com");
+	run(repoPath, "git config user.name Test");
+	return repoPath;
+}
+
 describe("getStatus commit counting", () => {
 	test("caps the commit list at the display limit but reports the true total", async () => {
 		const commitCount = MAX_COMMIT_LIST_COUNT + 25;
@@ -76,4 +85,182 @@ describe("getStatus commit counting", () => {
 		expect(status.commits).toHaveLength(3);
 		expect(status.totalCommitCount).toBe(3);
 	}, 60_000);
+});
+
+describe("getBranches", () => {
+	test("lists branches, default branch, and worktree checkouts", async () => {
+		const repoPath = createBaseRepo("branches");
+		run(repoPath, "git commit -q --allow-empty -m base");
+		run(repoPath, "git branch feature");
+		run(repoPath, "git update-ref refs/remotes/origin/main HEAD");
+		run(
+			repoPath,
+			"git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main",
+		);
+		const wtPath = join(TEST_DIR, "branches-wt");
+		run(repoPath, `git worktree add -q ${wtPath} feature`);
+
+		const result = await executeGitTask("getBranches", {
+			worktreePath: repoPath,
+			persistedWorktree: { branch: "main", baseBranch: "develop" },
+		});
+
+		expect(result.currentBranch).toBe("main");
+		expect(result.defaultBranch).toBe("main");
+		expect(result.local.map((b) => b.branch).sort()).toEqual([
+			"feature",
+			"main",
+		]);
+		expect(result.local.every((b) => b.lastCommitDate > 0)).toBe(true);
+		expect(result.remote).toContain("main");
+		expect(result.remote.some((name) => name.includes("HEAD"))).toBe(false);
+		expect(result.checkedOutBranches).toEqual({ feature: wtPath });
+		expect(result.worktreeBaseBranch).toBe("develop");
+	}, 60_000);
+
+	test("resolves base branch from git config over persisted metadata", async () => {
+		const repoPath = createBaseRepo("branches-config");
+		run(repoPath, "git commit -q --allow-empty -m base");
+		run(repoPath, "git config branch.main.base release");
+
+		const configured = await executeGitTask("getBranches", {
+			worktreePath: repoPath,
+			persistedWorktree: { branch: "main", baseBranch: "develop" },
+		});
+		expect(configured.worktreeBaseBranch).toBe("release");
+
+		run(repoPath, "git config --unset branch.main.base");
+		const mismatched = await executeGitTask("getBranches", {
+			worktreePath: repoPath,
+			persistedWorktree: { branch: "other", baseBranch: "develop" },
+		});
+		expect(mismatched.worktreeBaseBranch).toBeNull();
+	}, 60_000);
+});
+
+describe("getAheadBehind", () => {
+	test("counts commits relative to the remote base branch", async () => {
+		const repoPath = createBranchWithCommits("ahead-behind", 2);
+		const base = run(repoPath, "git rev-parse refs/remotes/origin/main").trim();
+		const tree = run(repoPath, `git rev-parse "${base}^{tree}"`).trim();
+		const upstream = run(
+			repoPath,
+			`git commit-tree -p ${base} -m upstream ${tree}`,
+		).trim();
+		run(repoPath, `git update-ref refs/remotes/origin/main ${upstream}`);
+
+		const result = await executeGitTask("getAheadBehind", {
+			repoPath,
+			defaultBranch: "main",
+		});
+
+		expect(result).toEqual({ ahead: 2, behind: 1 });
+	}, 60_000);
+
+	test("returns zeros when the remote branch does not exist", async () => {
+		const repoPath = createBranchWithCommits("ahead-behind-missing", 1);
+
+		const result = await executeGitTask("getAheadBehind", {
+			repoPath,
+			defaultBranch: "does-not-exist",
+		});
+
+		expect(result).toEqual({ ahead: 0, behind: 0 });
+	}, 60_000);
+});
+
+describe("getFileContents", () => {
+	const TRUNCATED_MESSAGE = "[File content truncated - exceeds 2MB limit]";
+	let repoPath: string;
+	let secondCommit: string;
+
+	beforeAll(() => {
+		repoPath = createBaseRepo("file-contents");
+		writeFileSync(join(repoPath, "file.txt"), "one\n");
+		writeFileSync(join(repoPath, "file3.txt"), "gamma\n");
+		run(repoPath, "git add .");
+		run(repoPath, "git commit -q -m first");
+		run(repoPath, "git update-ref refs/remotes/origin/main HEAD");
+		writeFileSync(join(repoPath, "file.txt"), "two\n");
+		writeFileSync(join(repoPath, "big.txt"), "a".repeat(2 * 1024 * 1024 + 1));
+		run(repoPath, "git add .");
+		run(repoPath, "git commit -q -m second");
+		secondCommit = run(repoPath, "git rev-parse HEAD").trim();
+		writeFileSync(join(repoPath, "file.txt"), "three\n");
+		run(repoPath, "git add file.txt");
+		run(repoPath, "git rm -q --cached file3.txt");
+	});
+
+	test("against-base compares origin base to HEAD", async () => {
+		const result = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "file.txt",
+			originalPath: "file.txt",
+			category: "against-base",
+			defaultBranch: "main",
+		});
+		expect(result).toEqual({ original: "one\n", modified: "two\n" });
+	});
+
+	test("committed compares a commit to its parent", async () => {
+		const result = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "file.txt",
+			originalPath: "file.txt",
+			category: "committed",
+			commitHash: secondCommit,
+		});
+		expect(result).toEqual({ original: "one\n", modified: "two\n" });
+	});
+
+	test("staged compares HEAD to the index", async () => {
+		const result = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "file.txt",
+			originalPath: "file.txt",
+			category: "staged",
+		});
+		expect(result).toEqual({ original: "two\n", modified: "three\n" });
+	});
+
+	test("original prefers the index and falls back to HEAD", async () => {
+		const staged = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "file.txt",
+			originalPath: "file.txt",
+			category: "original",
+		});
+		expect(staged).toEqual({ original: null, modified: "three\n" });
+
+		const headOnly = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "file3.txt",
+			originalPath: "file3.txt",
+			category: "original",
+		});
+		expect(headOnly).toEqual({ original: "gamma\n", modified: null });
+	});
+
+	test("missing paths resolve to nulls", async () => {
+		const result = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "nope.txt",
+			originalPath: "nope.txt",
+			category: "staged",
+		});
+		expect(result).toEqual({ original: null, modified: null });
+	});
+
+	test("blobs over the size cap are replaced with a truncation notice", async () => {
+		const result = await executeGitTask("getFileContents", {
+			worktreePath: repoPath,
+			filePath: "big.txt",
+			originalPath: "big.txt",
+			category: "staged",
+		});
+		expect(result).toEqual({
+			original: TRUNCATED_MESSAGE,
+			modified: TRUNCATED_MESSAGE,
+		});
+	});
 });

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -6,16 +6,27 @@ import {
 } from "@superset/shared/media-files";
 import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
 import type { SimpleGit, StatusResult } from "simple-git";
-import { getStatusNoLock } from "../../workspaces/utils/git";
+import { getBranchBaseConfig } from "../../workspaces/utils/base-branch-config";
+import {
+	getAheadBehindCount,
+	getCurrentBranch,
+	getStatusNoLock,
+} from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";
 import { applyNumstatToFiles } from "../utils/apply-numstat";
-import { resolveEffectiveBaseBranch } from "../utils/git-base-branch";
+import {
+	getDefaultBranch,
+	resolveEffectiveBaseBranch,
+} from "../utils/git-base-branch";
 import {
 	parseGitLog,
 	parseGitStatus,
 	parseNameStatus,
 } from "../utils/parse-status";
+import { selectEffectiveBaseBranch } from "../utils/select-effective-base-branch";
 import type {
+	GitBranchesResult,
+	GitFileVersions,
 	GitTaskPayloadMap,
 	GitTaskResultMap,
 	GitTaskType,
@@ -319,6 +330,174 @@ async function computeCommitFiles({
 	return files;
 }
 
+async function getLocalBranchesWithDates(
+	git: SimpleGit,
+	localBranches: string[],
+): Promise<Array<{ branch: string; lastCommitDate: number }>> {
+	try {
+		const branchInfo = await git.raw([
+			"for-each-ref",
+			"--sort=-committerdate",
+			"--format=%(refname:short) %(committerdate:unix)",
+			"refs/heads/",
+		]);
+
+		const local: Array<{ branch: string; lastCommitDate: number }> = [];
+		for (const line of branchInfo.trim().split("\n")) {
+			if (!line) continue;
+			const lastSpaceIdx = line.lastIndexOf(" ");
+			const branch = line.substring(0, lastSpaceIdx);
+			const timestamp = Number.parseInt(line.substring(lastSpaceIdx + 1), 10);
+			if (localBranches.includes(branch)) {
+				local.push({
+					branch,
+					lastCommitDate: timestamp * 1000,
+				});
+			}
+		}
+		return local;
+	} catch {
+		return localBranches.map((branch) => ({ branch, lastCommitDate: 0 }));
+	}
+}
+
+async function getCheckedOutBranches(
+	git: SimpleGit,
+	currentWorktreePath: string,
+): Promise<Record<string, string>> {
+	const checkedOutBranches: Record<string, string> = {};
+
+	try {
+		const worktreeList = await git.raw(["worktree", "list", "--porcelain"]);
+		const lines = worktreeList.split("\n");
+		let currentPath: string | null = null;
+
+		for (const line of lines) {
+			if (line.startsWith("worktree ")) {
+				currentPath = line.substring(9).trim();
+			} else if (line.startsWith("branch ")) {
+				const branch = line.substring(7).trim().replace("refs/heads/", "");
+				if (currentPath && currentPath !== currentWorktreePath) {
+					checkedOutBranches[branch] = currentPath;
+				}
+			}
+		}
+	} catch {}
+
+	return checkedOutBranches;
+}
+
+async function computeBranches({
+	worktreePath,
+	persistedWorktree,
+}: GitTaskPayloadMap["getBranches"]): Promise<GitBranchesResult> {
+	const git = await getSimpleGitWithShellPath(worktreePath);
+
+	const branchSummary = await git.branch(["-a"]);
+	const currentBranch = await getCurrentBranch(worktreePath);
+	const { compareBaseBranch } = currentBranch
+		? await getBranchBaseConfig({
+				repoPath: worktreePath,
+				branch: currentBranch,
+			})
+		: { compareBaseBranch: null };
+	const worktreeBaseBranch = selectEffectiveBaseBranch({
+		configuredBaseBranch: compareBaseBranch,
+		persistedWorktree,
+		currentBranch,
+		defaultBranch: null,
+	});
+
+	const localBranches: string[] = [];
+	const remote: string[] = [];
+
+	for (const name of Object.keys(branchSummary.branches)) {
+		if (name.startsWith("remotes/origin/")) {
+			if (name === "remotes/origin/HEAD") continue;
+			const remoteName = name.replace("remotes/origin/", "");
+			remote.push(remoteName);
+		} else {
+			localBranches.push(name);
+		}
+	}
+
+	const local = await getLocalBranchesWithDates(git, localBranches);
+	const defaultBranch = await getDefaultBranch(git, remote);
+	const checkedOutBranches = await getCheckedOutBranches(git, worktreePath);
+
+	return {
+		local,
+		remote: remote.sort(),
+		defaultBranch,
+		checkedOutBranches,
+		worktreeBaseBranch,
+		currentBranch,
+	};
+}
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+async function safeGitShow(
+	git: SimpleGit,
+	spec: string,
+): Promise<string | null> {
+	try {
+		// Guard against memory spikes from large blobs in git history
+		try {
+			const sizeOutput = await git.raw(["cat-file", "-s", spec]);
+			const blobSize = Number.parseInt(sizeOutput.trim(), 10);
+			if (!Number.isNaN(blobSize) && blobSize > MAX_FILE_SIZE) {
+				return `[File content truncated - exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit]`;
+			}
+		} catch {}
+
+		const content = await git.show([spec]);
+		return content;
+	} catch {
+		return null;
+	}
+}
+
+async function computeFileContents(
+	payload: GitTaskPayloadMap["getFileContents"],
+): Promise<GitFileVersions> {
+	const git = await getSimpleGitWithShellPath(payload.worktreePath);
+
+	switch (payload.category) {
+		case "against-base": {
+			const [original, modified] = await Promise.all([
+				safeGitShow(
+					git,
+					`origin/${payload.defaultBranch}:${payload.originalPath}`,
+				),
+				safeGitShow(git, `HEAD:${payload.filePath}`),
+			]);
+			return { original, modified };
+		}
+		case "committed": {
+			const [original, modified] = await Promise.all([
+				safeGitShow(git, `${payload.commitHash}^:${payload.originalPath}`),
+				safeGitShow(git, `${payload.commitHash}:${payload.filePath}`),
+			]);
+			return { original, modified };
+		}
+		case "staged": {
+			const [original, modified] = await Promise.all([
+				safeGitShow(git, `HEAD:${payload.originalPath}`),
+				safeGitShow(git, `:0:${payload.filePath}`),
+			]);
+			return { original, modified };
+		}
+		case "original": {
+			// Sequential on purpose: skip the HEAD lookup when a staged blob exists.
+			const modified = await safeGitShow(git, `:0:${payload.originalPath}`);
+			if (modified !== null) return { original: null, modified };
+			const original = await safeGitShow(git, `HEAD:${payload.originalPath}`);
+			return { original, modified: null };
+		}
+	}
+}
+
 export async function executeGitTask<TTask extends GitTaskType>(
 	taskType: TTask,
 	payload: GitTaskPayloadMap[TTask],
@@ -331,6 +510,18 @@ export async function executeGitTask<TTask extends GitTaskType>(
 		case "getCommitFiles":
 			return computeCommitFiles(
 				payload as GitTaskPayloadMap["getCommitFiles"],
+			) as Promise<GitTaskResultMap[TTask]>;
+		case "getBranches":
+			return computeBranches(
+				payload as GitTaskPayloadMap["getBranches"],
+			) as Promise<GitTaskResultMap[TTask]>;
+		case "getAheadBehind":
+			return getAheadBehindCount(
+				payload as GitTaskPayloadMap["getAheadBehind"],
+			) as Promise<GitTaskResultMap[TTask]>;
+		case "getFileContents":
+			return computeFileContents(
+				payload as GitTaskPayloadMap["getFileContents"],
 			) as Promise<GitTaskResultMap[TTask]>;
 		default: {
 			const exhaustive: never = taskType;

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -356,7 +356,10 @@ async function getLocalBranchesWithDates(
 			}
 		}
 		return local;
-	} catch {
+	} catch (error) {
+		console.warn("[git-task] branch dates unavailable, sorting degraded", {
+			error,
+		});
 		return localBranches.map((branch) => ({ branch, lastCommitDate: 0 }));
 	}
 }
@@ -382,7 +385,11 @@ async function getCheckedOutBranches(
 				}
 			}
 		}
-	} catch {}
+	} catch (error) {
+		console.warn("[git-task] worktree list failed, checked-out map empty", {
+			error,
+		});
+	}
 
 	return checkedOutBranches;
 }

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
@@ -1,6 +1,35 @@
 import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
 import type { PersistedWorktreeBaseBranch } from "../utils/select-effective-base-branch";
 
+export interface GitBranchesResult {
+	local: Array<{ branch: string; lastCommitDate: number }>;
+	remote: string[];
+	defaultBranch: string;
+	checkedOutBranches: Record<string, string>;
+	worktreeBaseBranch: string | null;
+	currentBranch: string | null;
+}
+
+interface GitFileContentsBasePayload {
+	worktreePath: string;
+	filePath: string;
+	originalPath: string;
+}
+
+export type GitFileContentsPayload =
+	| (GitFileContentsBasePayload & {
+			category: "against-base";
+			defaultBranch: string;
+	  })
+	| (GitFileContentsBasePayload & { category: "committed"; commitHash: string })
+	| (GitFileContentsBasePayload & { category: "staged" })
+	| (GitFileContentsBasePayload & { category: "original" });
+
+export interface GitFileVersions {
+	original: string | null;
+	modified: string | null;
+}
+
 export interface GitTaskPayloadMap {
 	getStatus: {
 		worktreePath: string;
@@ -11,11 +40,23 @@ export interface GitTaskPayloadMap {
 		worktreePath: string;
 		commitHash: string;
 	};
+	getBranches: {
+		worktreePath: string;
+		persistedWorktree: PersistedWorktreeBaseBranch | null;
+	};
+	getAheadBehind: {
+		repoPath: string;
+		defaultBranch: string;
+	};
+	getFileContents: GitFileContentsPayload;
 }
 
 export interface GitTaskResultMap {
 	getStatus: GitChangesStatus;
 	getCommitFiles: ChangedFile[];
+	getBranches: GitBranchesResult;
+	getAheadBehind: { ahead: number; behind: number };
+	getFileContents: GitFileVersions;
 }
 
 export type GitTaskType = keyof GitTaskPayloadMap;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -5,6 +5,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
+import { runGitTask } from "../../changes/workers/git-task-runner";
 import {
 	getProject,
 	getWorkspace,
@@ -170,10 +171,23 @@ export const createGitStatusProcedures = () => {
 					return { ahead: 0, behind: 0 };
 				}
 
-				return getAheadBehindCount({
-					repoPath: project.mainRepoPath,
-					defaultBranch: workspace.branch,
-				});
+				try {
+					return await runGitTask(
+						"getAheadBehind",
+						{
+							repoPath: project.mainRepoPath,
+							defaultBranch: workspace.branch,
+						},
+						{
+							dedupeKey: `getAheadBehind:${project.mainRepoPath}:${workspace.branch}`,
+							strategy: "coalesce",
+							timeoutMs: 30_000,
+						},
+					);
+				} catch {
+					// getAheadBehindCount swallows git errors; keep worker failures equally silent.
+					return { ahead: 0, behind: 0 };
+				}
 			}),
 
 		getGitHubStatus: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -184,8 +184,13 @@ export const createGitStatusProcedures = () => {
 							timeoutMs: 30_000,
 						},
 					);
-				} catch {
-					// getAheadBehindCount swallows git errors; keep worker failures equally silent.
+				} catch (error) {
+					// getAheadBehindCount swallows git errors, but worker-infra
+					// failures (crash/timeout) should at least leave a trace.
+					console.warn("[workspaces.getAheadBehind] worker task failed", {
+						workspaceId: input.workspaceId,
+						error,
+					});
 					return { ahead: 0, behind: 0 };
 				}
 			}),

--- a/apps/desktop/src/no-main-process-blocking.test.ts
+++ b/apps/desktop/src/no-main-process-blocking.test.ts
@@ -1,0 +1,136 @@
+// Ratchet: keeps blocking work off the Electron main process. Every
+// electronTrpc call is served by this one event loop — an in-process git
+// spawn or sync fs walk stalls all of them. Git reads belong in the changes
+// git worker (src/lib/trpc/routers/changes/workers/).
+//
+// Two failure modes, both intentional:
+//  - a NON-allowlisted file matches → new blocking call site; add a worker
+//    task type instead of extending the list.
+//  - an allowlisted file stops matching → it was fixed; DELETE its entry so
+//    the ratchet only ever tightens.
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC_DIR = path.resolve(import.meta.dirname);
+const SELF = path.resolve(
+	import.meta.dirname,
+	"no-main-process-blocking.test.ts",
+);
+
+// Main-process code only: lib/trpc routers and main/. The renderer has its
+// own thread and the worker dir owns the git primitives.
+const SCANNED_DIRS = ["lib", "main"];
+
+interface Rule {
+	name: string;
+	pattern: RegExp;
+	allowedFiles: string[];
+	advice: string;
+}
+
+const RULES: Rule[] = [
+	{
+		name: "sync subprocess (execSync/spawnSync/execFileSync)",
+		pattern: /\b(execSync|spawnSync|execFileSync)\s*\(/,
+		allowedFiles: [
+			// Dead code (no callers) — delete rather than call on main.
+			"main/lib/agent-setup/utils.ts",
+			// Cold daemon-recovery path only (connect failure / respawn).
+			"main/lib/terminal-host/client.ts",
+		],
+		advice:
+			"Sync subprocesses hard-block the main process for their full runtime. Use async spawn/execFile.",
+	},
+	{
+		name: "sync recursive fs (rmSync/cpSync)",
+		pattern: /\b(rmSync|cpSync)\s*\(/,
+		allowedFiles: [
+			// Workspace-setup copy, cold path.
+			"lib/trpc/routers/workspaces/utils/setup.ts",
+		],
+		advice:
+			"Recursive sync fs walks block the main process for the whole tree. Use `await rm/cp` from node:fs/promises.",
+	},
+	{
+		name: "in-process git client construction",
+		pattern: /\b(simpleGit|getSimpleGitWithShellPath)\s*\(/,
+		allowedFiles: [
+			// The factory module itself — permanent entry.
+			"lib/trpc/routers/workspaces/utils/git-client.ts",
+			// Legacy on-main git spawners — shrink this list by porting reads
+			// to worker task types (changes/workers/git-task-types.ts).
+			"lib/trpc/routers/changes/git-operations.ts",
+			"lib/trpc/routers/changes/security/git-commands.ts",
+			"lib/trpc/routers/changes/staging.ts",
+			"lib/trpc/routers/projects/projects.ts",
+			"lib/trpc/routers/workspaces/utils/base-branch-config.ts",
+			"lib/trpc/routers/workspaces/utils/git.ts",
+		],
+		advice:
+			"Constructing a git client here runs the subprocess spawn + stdout drain on the Electron main process. Add a task type to changes/workers/ and route through runGitTask.",
+	},
+];
+
+const EXEMPT_DIR_SUFFIXES = ["lib/trpc/routers/changes/workers"];
+const EXEMPT_FILE_PATTERNS = [/\.test\.tsx?$/, /(^|\/)test-helpers\.ts$/];
+
+function* walk(dir: string): Generator<string> {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules" || entry.name === "dist") continue;
+			yield* walk(full);
+			continue;
+		}
+		if (!entry.isFile()) continue;
+		if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) continue;
+		if (full === SELF) continue;
+		yield full;
+	}
+}
+
+function relevantFiles(): string[] {
+	const files: string[] = [];
+	for (const scanned of SCANNED_DIRS) {
+		const root = path.join(SRC_DIR, scanned);
+		if (!fs.existsSync(root)) continue;
+		for (const file of walk(root)) {
+			const rel = path.relative(SRC_DIR, file);
+			const dir = path.dirname(rel);
+			if (EXEMPT_DIR_SUFFIXES.some((suffix) => dir.endsWith(suffix))) continue;
+			if (EXEMPT_FILE_PATTERNS.some((pattern) => pattern.test(rel))) continue;
+			files.push(rel);
+		}
+	}
+	return files;
+}
+
+describe("no new main-process blocking call sites", () => {
+	const files = relevantFiles();
+
+	for (const rule of RULES) {
+		test(rule.name, () => {
+			const matched = new Set<string>();
+			const offenders: string[] = [];
+
+			for (const rel of files) {
+				const contents = fs.readFileSync(path.join(SRC_DIR, rel), "utf-8");
+				if (!rule.pattern.test(contents)) continue;
+				matched.add(rel);
+				if (!rule.allowedFiles.includes(rel)) offenders.push(rel);
+			}
+
+			expect(offenders, `New blocking call site(s). ${rule.advice}`).toEqual(
+				[],
+			);
+
+			const stale = rule.allowedFiles.filter((rel) => !matched.has(rel));
+			expect(
+				stale,
+				"Allowlisted file(s) no longer match — remove them from allowedFiles so the ratchet tightens.",
+			).toEqual([]);
+		});
+	}
+});

--- a/apps/desktop/src/no-main-process-blocking.test.ts
+++ b/apps/desktop/src/no-main-process-blocking.test.ts
@@ -73,7 +73,9 @@ const RULES: Rule[] = [
 	},
 ];
 
-const EXEMPT_DIR_SUFFIXES = ["lib/trpc/routers/changes/workers"];
+// Prefix, not dirname-suffix: nested subdirectories of the worker dir are
+// worker code too.
+const EXEMPT_DIR_PREFIXES = ["lib/trpc/routers/changes/workers/"];
 const EXEMPT_FILE_PATTERNS = [/\.test\.tsx?$/, /(^|\/)test-helpers\.ts$/];
 
 function* walk(dir: string): Generator<string> {
@@ -97,9 +99,10 @@ function relevantFiles(): string[] {
 		const root = path.join(SRC_DIR, scanned);
 		if (!fs.existsSync(root)) continue;
 		for (const file of walk(root)) {
-			const rel = path.relative(SRC_DIR, file);
-			const dir = path.dirname(rel);
-			if (EXEMPT_DIR_SUFFIXES.some((suffix) => dir.endsWith(suffix))) continue;
+			// Forward slashes so allowlists match on Windows too.
+			const rel = path.relative(SRC_DIR, file).split(path.sep).join("/");
+			if (EXEMPT_DIR_PREFIXES.some((prefix) => rel.startsWith(prefix)))
+				continue;
 			if (EXEMPT_FILE_PATTERNS.some((pattern) => pattern.test(rel))) continue;
 			files.push(rel);
 		}

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -21,7 +21,7 @@ import {
 import { ChatRuntimeManager } from "./runtime/chat";
 import { WorkspaceFilesystemManager } from "./runtime/filesystem";
 import type { GitCredentialProvider } from "./runtime/git";
-import { createGitFactory } from "./runtime/git";
+import { createGitEnvResolver, createGitFactory } from "./runtime/git";
 import { runMainWorkspaceSweep } from "./runtime/main-workspace-sweep";
 import { runProjectBackfill } from "./runtime/project-backfill";
 import { PullRequestRuntimeManager } from "./runtime/pull-requests";
@@ -37,6 +37,8 @@ import {
 	type ExecGh,
 } from "./trpc/router/workspace-creation/utils/exec-gh";
 import type { ApiClient } from "./types";
+import { getHostWorkerPool } from "./workers/host-worker-pool";
+import { gitWorkspaceRefsTask } from "./workers/tasks/git";
 
 export interface CreateAppOptions {
 	config: {
@@ -104,12 +106,28 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	// pull-requests runtime (event-driven branch sync) subscribe to it.
 	const gitWatcher = new GitWatcher(db, filesystem);
 	gitWatcher.start();
+	// Per-workspace branch/HEAD/upstream reads run in the worker pool: the
+	// PR-sync loop fires them for every workspace on each watcher event and
+	// 5-min sweep, which would otherwise spawn+drain git on the event loop.
+	const resolveGitEnv = createGitEnvResolver(providers.credentials);
 	const pullRequestRuntime = new PullRequestRuntimeManager({
 		db,
 		execGh,
 		git,
 		github,
 		gitWatcher,
+		readWorkspaceRefs: async (worktreePath) => {
+			const gitEnv = await resolveGitEnv(worktreePath);
+			return getHostWorkerPool().run(
+				gitWorkspaceRefsTask,
+				{ worktreePath, gitEnv },
+				{
+					timeoutMs: 15_000,
+					strategy: "coalesce",
+					dedupeKey: `${worktreePath}:workspace-refs`,
+				},
+			);
+		},
 	});
 	pullRequestRuntime.start();
 	const chatRuntime =

--- a/packages/host-service/src/no-main-loop-blocking.test.ts
+++ b/packages/host-service/src/no-main-loop-blocking.test.ts
@@ -1,0 +1,128 @@
+// Ratchet: keeps blocking work off the host-service event loop. One slow
+// in-process git spawn (or a sync fs walk) head-of-line blocks every tRPC
+// response this process serves. Git subprocess work belongs in the worker
+// pool (src/workers/) — see workers/tasks/git.ts for the pattern.
+//
+// Two failure modes, both intentional:
+//  - a NON-allowlisted file matches → new blocking call site; route it
+//    through the worker pool (or async fs) instead of extending the list.
+//  - an allowlisted file stops matching → it was fixed; DELETE its entry so
+//    the ratchet only ever tightens.
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC_DIR = path.resolve(import.meta.dirname);
+const SELF = path.resolve(import.meta.dirname, "no-main-loop-blocking.test.ts");
+
+interface Rule {
+	name: string;
+	pattern: RegExp;
+	/** Line-level escape: lines matching this are not violations. */
+	allowLine?: RegExp;
+	/** Repo-relative (from src/) files allowed to match — the ratchet. */
+	allowedFiles: string[];
+	advice: string;
+}
+
+const RULES: Rule[] = [
+	{
+		name: "sync subprocess (execSync/spawnSync/execFileSync)",
+		pattern: /\b(execSync|spawnSync|execFileSync)\s*\(/,
+		allowedFiles: [
+			// Reads a shell-configured credential command at provider init.
+			"providers/model-providers/LocalModelProvider/utils/resolveAnthropicCredential.ts",
+		],
+		advice:
+			"Sync subprocesses hard-block the event loop for their full runtime. Use async exec/spawn, or a worker task for git.",
+	},
+	{
+		name: "sync recursive fs (rmSync/cpSync)",
+		pattern: /\b(rmSync|cpSync)\s*\(/,
+		allowedFiles: [
+			// Bounded: single attachment files, not repo trees.
+			"trpc/router/attachments/storage.ts",
+		],
+		advice:
+			"Recursive sync fs walks block the loop for the whole tree. Use `await rm/cp` from node:fs/promises.",
+	},
+	{
+		name: "in-process git client construction",
+		pattern: /\b(createUserSimpleGit|simpleGit)\s*\(/,
+		allowedFiles: [
+			// Legacy on-loop git spawners — shrink this list by porting call
+			// sites to worker tasks (workers/tasks/git.ts).
+			"trpc/router/git/git.ts",
+			"trpc/router/git/utils/git-helpers.ts",
+			"trpc/router/project/project.ts",
+			"trpc/router/project/utils/resolve-repo.ts",
+			"trpc/router/settings/branch-prefix.ts",
+			"trpc/router/workspace-creation/shared/project-helpers.ts",
+		],
+		advice:
+			"Constructing a git client here runs the subprocess spawn + stdout drain on the event loop. Add a task to workers/tasks/git.ts and run it via getHostWorkerPool().",
+	},
+];
+
+// The worker pool and the git runtime own the primitives the rules police;
+// tests (bun + node-test) may do whatever they need.
+const EXEMPT_DIR_PREFIXES = ["workers/", "runtime/git/"];
+const EXEMPT_FILE_PATTERNS = [/\.test\.ts$/, /\.node-test\.ts$/];
+
+function* walk(dir: string): Generator<string> {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules" || entry.name === "dist") continue;
+			yield* walk(full);
+			continue;
+		}
+		if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
+		if (full === SELF) continue;
+		yield full;
+	}
+}
+
+function relevantFiles(): string[] {
+	const files: string[] = [];
+	for (const file of walk(SRC_DIR)) {
+		const rel = path.relative(SRC_DIR, file);
+		if (EXEMPT_DIR_PREFIXES.some((prefix) => rel.startsWith(prefix))) continue;
+		if (EXEMPT_FILE_PATTERNS.some((pattern) => pattern.test(rel))) continue;
+		files.push(rel);
+	}
+	return files;
+}
+
+describe("no new main-loop blocking call sites", () => {
+	const files = relevantFiles();
+
+	for (const rule of RULES) {
+		test(rule.name, () => {
+			const matched = new Set<string>();
+			const offenders: string[] = [];
+
+			for (const rel of files) {
+				const contents = fs.readFileSync(path.join(SRC_DIR, rel), "utf-8");
+				const lines = contents.split("\n");
+				const hit = lines.some(
+					(line) => rule.pattern.test(line) && !rule.allowLine?.test(line),
+				);
+				if (!hit) continue;
+				matched.add(rel);
+				if (!rule.allowedFiles.includes(rel)) offenders.push(rel);
+			}
+
+			expect(offenders, `New blocking call site(s). ${rule.advice}`).toEqual(
+				[],
+			);
+
+			const stale = rule.allowedFiles.filter((rel) => !matched.has(rel));
+			expect(
+				stale,
+				"Allowlisted file(s) no longer match — remove them from allowedFiles so the ratchet tightens.",
+			).toEqual([]);
+		});
+	}
+});

--- a/packages/host-service/src/no-main-loop-blocking.test.ts
+++ b/packages/host-service/src/no-main-loop-blocking.test.ts
@@ -87,7 +87,8 @@ function* walk(dir: string): Generator<string> {
 function relevantFiles(): string[] {
 	const files: string[] = [];
 	for (const file of walk(SRC_DIR)) {
-		const rel = path.relative(SRC_DIR, file);
+		// Forward slashes so allowlists match on Windows too.
+		const rel = path.relative(SRC_DIR, file).split(path.sep).join("/");
 		if (EXEMPT_DIR_PREFIXES.some((prefix) => rel.startsWith(prefix))) continue;
 		if (EXEMPT_FILE_PATTERNS.some((pattern) => pattern.test(rel))) continue;
 		files.push(rel);

--- a/packages/host-service/src/runtime/git/git.test.ts
+++ b/packages/host-service/src/runtime/git/git.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { createGitEnvResolver } from "./git";
+import type { GitCredentialProvider } from "./types";
+
+// Real temp repos (not mocks): the cache under test exists to avoid a real
+// `git remote get-url` subprocess, so the assertion must be on how many
+// times the provider sees the resolved URL, driven by actual git state.
+async function initRepoWithOrigin(url: string): Promise<string> {
+	const dir = mkdtempSync(join(tmpdir(), "git-env-resolver-"));
+	const git = simpleGit(dir);
+	await git.init();
+	await git.addRemote("origin", url);
+	return dir;
+}
+
+function createRecordingProvider(): GitCredentialProvider & {
+	urlsSeen: (string | null)[];
+} {
+	const urlsSeen: (string | null)[] = [];
+	return {
+		urlsSeen,
+		getCredentials: async (remoteUrl: string | null) => {
+			if (remoteUrl !== null) urlsSeen.push(remoteUrl);
+			return { env: {} };
+		},
+		getToken: async () => null,
+	};
+}
+
+describe("createGitEnvResolver", () => {
+	test("resolves the origin remote URL into provider credentials", async () => {
+		const repo = await initRepoWithOrigin("https://github.com/acme/one.git");
+		const provider = createRecordingProvider();
+
+		await createGitEnvResolver(provider)(repo);
+
+		expect(provider.urlsSeen).toEqual(["https://github.com/acme/one.git"]);
+	});
+
+	test("caches the remote URL per repoPath across resolver instances", async () => {
+		const repo = await initRepoWithOrigin("https://github.com/acme/two.git");
+		const provider = createRecordingProvider();
+
+		// Fresh resolver per call mirrors resolveGitTaskEnv, which constructs
+		// one per request — the cache must live at module level to help.
+		await createGitEnvResolver(provider)(repo);
+		await createGitEnvResolver(provider)(repo);
+		await createGitEnvResolver(provider)(repo);
+
+		expect(provider.urlsSeen).toEqual([
+			"https://github.com/acme/two.git",
+			"https://github.com/acme/two.git",
+			"https://github.com/acme/two.git",
+		]);
+		// The subprocess-level dedupe is observable via timing-independent
+		// state: mutate the remote and confirm the stale URL is still served
+		// from cache within the TTL.
+		const git = simpleGit(repo);
+		await git.remote([
+			"set-url",
+			"origin",
+			"https://github.com/acme/moved.git",
+		]);
+		await createGitEnvResolver(provider)(repo);
+		expect(provider.urlsSeen[3]).toBe("https://github.com/acme/two.git");
+	});
+
+	test("does not leak one repo's URL to another repoPath", async () => {
+		const repoA = await initRepoWithOrigin("https://github.com/acme/a.git");
+		const repoB = await initRepoWithOrigin("https://github.com/acme/b.git");
+		const provider = createRecordingProvider();
+
+		await createGitEnvResolver(provider)(repoA);
+		await createGitEnvResolver(provider)(repoB);
+
+		expect(provider.urlsSeen).toEqual([
+			"https://github.com/acme/a.git",
+			"https://github.com/acme/b.git",
+		]);
+	});
+
+	test("sets GIT_OPTIONAL_LOCKS and merges provider env", async () => {
+		const repo = await initRepoWithOrigin("https://github.com/acme/env.git");
+		const provider: GitCredentialProvider = {
+			getCredentials: async (remoteUrl: string | null) => {
+				const env: Record<string, string> = remoteUrl
+					? { GIT_ASKPASS: "/tmp/askpass" }
+					: { BASE: "1" };
+				return { env };
+			},
+			getToken: async () => null,
+		};
+
+		const env = await createGitEnvResolver(provider)(repo);
+
+		expect(env).toEqual({
+			BASE: "1",
+			GIT_ASKPASS: "/tmp/askpass",
+			GIT_OPTIONAL_LOCKS: "0",
+		});
+	});
+});

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -12,18 +12,31 @@ const remoteUrlCache = new Map<
 	string,
 	{ url: string | null; resolvedAt: number }
 >();
+// Cold-miss coalescing: a boot burst of status polls would otherwise spawn
+// one `git remote get-url` per concurrent caller before the first caches.
+const remoteUrlInFlight = new Map<string, Promise<string | null>>();
 
-async function getRemoteUrlCached(
+function getRemoteUrlCached(
 	repoPath: string,
 	env: Record<string, string>,
 ): Promise<string | null> {
 	const cached = remoteUrlCache.get(repoPath);
 	if (cached && Date.now() - cached.resolvedAt < REMOTE_URL_TTL_MS) {
-		return cached.url;
+		return Promise.resolve(cached.url);
 	}
-	const url = await getRemoteUrl(createUserSimpleGit(repoPath).env(env));
-	remoteUrlCache.set(repoPath, { url, resolvedAt: Date.now() });
-	return url;
+	const inFlight = remoteUrlInFlight.get(repoPath);
+	if (inFlight) return inFlight;
+
+	const resolving = getRemoteUrl(createUserSimpleGit(repoPath).env(env))
+		.then((url) => {
+			remoteUrlCache.set(repoPath, { url, resolvedAt: Date.now() });
+			return url;
+		})
+		.finally(() => {
+			remoteUrlInFlight.delete(repoPath);
+		});
+	remoteUrlInFlight.set(repoPath, resolving);
+	return resolving;
 }
 
 /**

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -2,6 +2,30 @@ import { createUserSimpleGit } from "./simple-git";
 import type { GitCredentialProvider, GitFactory } from "./types";
 import { getRemoteUrl } from "./utils";
 
+// Remote-URL lookup per repo, TTL-cached: without it every env resolution
+// (each ctx.git() call, each worker-task env — ~30 call sites, some in
+// loops) spawns `git remote get-url origin` on the event loop. Credentials
+// themselves are NOT cached here; the provider stays authoritative for
+// refresh/expiry. A changed origin URL is picked up within the TTL.
+const REMOTE_URL_TTL_MS = 5 * 60_000;
+const remoteUrlCache = new Map<
+	string,
+	{ url: string | null; resolvedAt: number }
+>();
+
+async function getRemoteUrlCached(
+	repoPath: string,
+	env: Record<string, string>,
+): Promise<string | null> {
+	const cached = remoteUrlCache.get(repoPath);
+	if (cached && Date.now() - cached.resolvedAt < REMOTE_URL_TTL_MS) {
+		return cached.url;
+	}
+	const url = await getRemoteUrl(createUserSimpleGit(repoPath).env(env));
+	remoteUrlCache.set(repoPath, { url, resolvedAt: Date.now() });
+	return url;
+}
+
 /**
  * Resolve the env a git invocation for `repoPath` needs (credentials for the
  * repo's remote + lock hygiene). Split out from the factory so worker tasks
@@ -10,8 +34,10 @@ import { getRemoteUrl } from "./utils";
 export function createGitEnvResolver(provider: GitCredentialProvider) {
 	return async (repoPath: string): Promise<Record<string, string>> => {
 		const initialCredentials = await provider.getCredentials(null);
-		const git = createUserSimpleGit(repoPath).env(initialCredentials.env);
-		const remoteUrl = await getRemoteUrl(git);
+		const remoteUrl = await getRemoteUrlCached(
+			repoPath,
+			initialCredentials.env,
+		);
 		const credentials = await provider.getCredentials(remoteUrl);
 
 		return {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -38,6 +38,10 @@ import {
 	parseChecksJson,
 	type ReviewDecision,
 } from "./utils/pull-request-mappers";
+import {
+	readWorkspaceRefs,
+	type WorkspaceRefsSnapshot,
+} from "./utils/workspace-refs";
 
 // Long-cadence sweep that catches anything `GitWatcher` might miss
 // (overflow, fs.watch errors, transient watcher failures). Steady-state
@@ -53,130 +57,6 @@ const PROJECT_REFRESH_INTERVAL_MS = 5 * 60_000;
 // PROJECT_REFRESH). Otherwise the cache is always stale at poll time and
 // each tick fires fresh GitHub calls for the same upstream branch.
 const REPO_PULL_REQUEST_CACHE_TTL_MS = 60_000;
-const UNBORN_HEAD_ERROR_PATTERNS = [
-	"ambiguous argument 'head'",
-	"unknown revision or path not in the working tree",
-	"bad revision 'head'",
-	"not a valid object name head",
-	"needed a single revision",
-];
-
-async function getCurrentBranchName(git: Awaited<ReturnType<GitFactory>>) {
-	try {
-		const branch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
-		const trimmed = branch.trim();
-		return trimmed || null;
-	} catch {
-		try {
-			const branch = await git.revparse(["--abbrev-ref", "HEAD"]);
-			const trimmed = branch.trim();
-			return trimmed && trimmed !== "HEAD" ? trimmed : null;
-		} catch {
-			return null;
-		}
-	}
-}
-
-async function getHeadSha(git: Awaited<ReturnType<GitFactory>>) {
-	try {
-		const branch = await git.revparse(["HEAD"]);
-		const trimmed = branch.trim();
-		return trimmed || null;
-	} catch (error) {
-		const message =
-			error instanceof Error
-				? error.message.toLowerCase()
-				: String(error).toLowerCase();
-		if (
-			UNBORN_HEAD_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
-		) {
-			return null;
-		}
-
-		throw error;
-	}
-}
-
-// `pushRemote` / `branch.remote` accept a remote name or a URL.
-async function resolveRemoteValueToUrl(
-	git: Awaited<ReturnType<GitFactory>>,
-	value: string,
-): Promise<string | null> {
-	if (/^(https?:|git@|ssh:)/.test(value)) return value;
-	try {
-		const url = await git.remote(["get-url", value]);
-		return typeof url === "string" ? url.trim() || null : null;
-	} catch {
-		return null;
-	}
-}
-
-async function resolveWorkspaceUpstream(
-	git: Awaited<ReturnType<GitFactory>>,
-	localBranch: string,
-): Promise<{ owner: string; name: string; branch: string } | null> {
-	// `@{push}` resolves remote+branch respecting all config precedence in one call.
-	const pushRef = await tryRaw(git, [
-		"rev-parse",
-		"--abbrev-ref",
-		`${localBranch}@{push}`,
-	]);
-	if (pushRef) {
-		const slash = pushRef.indexOf("/");
-		if (slash > 0) {
-			const url = await resolveRemoteValueToUrl(git, pushRef.slice(0, slash));
-			const parsed = url ? parseGitHubRemote(url) : null;
-			if (parsed) {
-				return {
-					owner: parsed.owner,
-					name: parsed.name,
-					branch: pushRef.slice(slash + 1),
-				};
-			}
-		}
-	}
-
-	// Fallback when `@{push}` isn't configured — mirrors gh's config chain.
-	// Require `branch.<n>.merge`; without it, `remote.pushDefault` alone would
-	// re-open the same-name collision hole on untracked branches.
-	const mergeRef = await tryConfig(git, `branch.${localBranch}.merge`);
-	const trackedBranch = mergeRef?.replace(/^refs\/heads\//, "");
-	if (!trackedBranch) return null;
-
-	const remoteValue =
-		(await tryConfig(git, `branch.${localBranch}.pushRemote`)) ??
-		(await tryConfig(git, "remote.pushDefault")) ??
-		(await tryConfig(git, `branch.${localBranch}.remote`));
-	if (!remoteValue) return null;
-
-	const url = await resolveRemoteValueToUrl(git, remoteValue);
-	const parsed = url ? parseGitHubRemote(url) : null;
-	if (!parsed) return null;
-
-	// `gh pr checkout` renames the local branch on collision (`main` →
-	// `quueli-main`) but the PR's headRefName stays `main`, so we key on the
-	// tracked remote branch, not the local name.
-	return { owner: parsed.owner, name: parsed.name, branch: trackedBranch };
-}
-
-async function tryRaw(
-	git: Awaited<ReturnType<GitFactory>>,
-	args: string[],
-): Promise<string | null> {
-	try {
-		return (await git.raw(args)).trim() || null;
-	} catch {
-		return null;
-	}
-}
-
-async function tryConfig(
-	git: Awaited<ReturnType<GitFactory>>,
-	key: string,
-): Promise<string | null> {
-	return tryRaw(git, ["config", "--get", key]);
-}
-
 // Dedup + link-assignment key. Branch stays case-sensitive: `feature` and
 // `Feature` are distinct branches with distinct PRs, so collapsing them here
 // would mislink. Case drift is tolerated only in the fallback in
@@ -215,6 +95,10 @@ export interface PullRequestRuntimeManagerOptions {
 	git: GitFactory;
 	github: () => Promise<Octokit>;
 	gitWatcher: GitWatcher;
+	/** Override to run the per-workspace branch/HEAD/upstream read off the
+	 * event loop (app wiring passes a worker-pool-backed reader). Defaults
+	 * to reading in-process via `git`. */
+	readWorkspaceRefs?: (worktreePath: string) => Promise<WorkspaceRefsSnapshot>;
 }
 
 interface NormalizedRepoIdentity {
@@ -288,6 +172,9 @@ export class PullRequestRuntimeManager {
 		string,
 		{ promise: Promise<GitHubPullRequestNode[]>; fetchedAt: number }
 	>();
+	private readonly readWorkspaceRefs: (
+		worktreePath: string,
+	) => Promise<WorkspaceRefsSnapshot>;
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
 		this.db = options.db;
@@ -295,6 +182,9 @@ export class PullRequestRuntimeManager {
 		this.git = options.git;
 		this.github = options.github;
 		this.gitWatcher = options.gitWatcher;
+		this.readWorkspaceRefs =
+			options.readWorkspaceRefs ??
+			(async (worktreePath) => readWorkspaceRefs(await this.git(worktreePath)));
 	}
 
 	start() {
@@ -528,12 +418,11 @@ export class PullRequestRuntimeManager {
 		workspace: typeof workspaces.$inferSelect,
 	): Promise<string | null> {
 		try {
-			const git = await this.git(workspace.worktreePath);
-			const branch = await getCurrentBranchName(git);
+			const { branch, headSha, upstream } = await this.readWorkspaceRefs(
+				workspace.worktreePath,
+			);
 			if (!branch) return null;
 
-			const headSha = await getHeadSha(git);
-			const upstream = await resolveWorkspaceUpstream(git, branch);
 			const upstreamOwner = upstream?.owner ?? null;
 			const upstreamRepo = upstream?.name ?? null;
 			const upstreamBranch = upstream?.branch ?? null;

--- a/packages/host-service/src/runtime/pull-requests/utils/workspace-refs.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/workspace-refs.ts
@@ -1,0 +1,152 @@
+// Reads the workspace's branch/HEAD/upstream trio for PR sync. Lives in its
+// own module (not pull-requests.ts) so the worker task can import it without
+// pulling the runtime's DB/Octokit graph into the worker bundle.
+
+import { parseGitHubRemote } from "@superset/shared/github-remote";
+import type { SimpleGit } from "simple-git";
+
+const UNBORN_HEAD_ERROR_PATTERNS = [
+	"ambiguous argument 'head'",
+	"unknown revision or path not in the working tree",
+	"bad revision 'head'",
+	"not a valid object name head",
+	"needed a single revision",
+];
+
+export interface WorkspaceUpstream {
+	owner: string;
+	name: string;
+	branch: string;
+}
+
+export interface WorkspaceRefsSnapshot {
+	branch: string | null;
+	headSha: string | null;
+	upstream: WorkspaceUpstream | null;
+}
+
+async function getCurrentBranchName(git: SimpleGit): Promise<string | null> {
+	try {
+		const branch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
+		const trimmed = branch.trim();
+		return trimmed || null;
+	} catch {
+		try {
+			const branch = await git.revparse(["--abbrev-ref", "HEAD"]);
+			const trimmed = branch.trim();
+			return trimmed && trimmed !== "HEAD" ? trimmed : null;
+		} catch {
+			return null;
+		}
+	}
+}
+
+async function getHeadSha(git: SimpleGit): Promise<string | null> {
+	try {
+		const branch = await git.revparse(["HEAD"]);
+		const trimmed = branch.trim();
+		return trimmed || null;
+	} catch (error) {
+		const message =
+			error instanceof Error
+				? error.message.toLowerCase()
+				: String(error).toLowerCase();
+		if (
+			UNBORN_HEAD_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
+		) {
+			return null;
+		}
+
+		throw error;
+	}
+}
+
+// `pushRemote` / `branch.remote` accept a remote name or a URL.
+async function resolveRemoteValueToUrl(
+	git: SimpleGit,
+	value: string,
+): Promise<string | null> {
+	if (/^(https?:|git@|ssh:)/.test(value)) return value;
+	try {
+		const url = await git.remote(["get-url", value]);
+		return typeof url === "string" ? url.trim() || null : null;
+	} catch {
+		return null;
+	}
+}
+
+async function resolveWorkspaceUpstream(
+	git: SimpleGit,
+	localBranch: string,
+): Promise<WorkspaceUpstream | null> {
+	// `@{push}` resolves remote+branch respecting all config precedence in one call.
+	const pushRef = await tryRaw(git, [
+		"rev-parse",
+		"--abbrev-ref",
+		`${localBranch}@{push}`,
+	]);
+	if (pushRef) {
+		const slash = pushRef.indexOf("/");
+		if (slash > 0) {
+			const url = await resolveRemoteValueToUrl(git, pushRef.slice(0, slash));
+			const parsed = url ? parseGitHubRemote(url) : null;
+			if (parsed) {
+				return {
+					owner: parsed.owner,
+					name: parsed.name,
+					branch: pushRef.slice(slash + 1),
+				};
+			}
+		}
+	}
+
+	// Fallback when `@{push}` isn't configured — mirrors gh's config chain.
+	// Require `branch.<n>.merge`; without it, `remote.pushDefault` alone would
+	// re-open the same-name collision hole on untracked branches.
+	const mergeRef = await tryConfig(git, `branch.${localBranch}.merge`);
+	const trackedBranch = mergeRef?.replace(/^refs\/heads\//, "");
+	if (!trackedBranch) return null;
+
+	const remoteValue =
+		(await tryConfig(git, `branch.${localBranch}.pushRemote`)) ??
+		(await tryConfig(git, "remote.pushDefault")) ??
+		(await tryConfig(git, `branch.${localBranch}.remote`));
+	if (!remoteValue) return null;
+
+	const url = await resolveRemoteValueToUrl(git, remoteValue);
+	const parsed = url ? parseGitHubRemote(url) : null;
+	if (!parsed) return null;
+
+	// `gh pr checkout` renames the local branch on collision (`main` →
+	// `quueli-main`) but the PR's headRefName stays `main`, so we key on the
+	// tracked remote branch, not the local name.
+	return { owner: parsed.owner, name: parsed.name, branch: trackedBranch };
+}
+
+async function tryRaw(git: SimpleGit, args: string[]): Promise<string | null> {
+	try {
+		return (await git.raw(args)).trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+async function tryConfig(git: SimpleGit, key: string): Promise<string | null> {
+	return tryRaw(git, ["config", "--get", key]);
+}
+
+/**
+ * One call = the whole per-workspace read the PR-sync loop needs. Unborn
+ * HEAD yields `{branch: null, ...}`; unexpected `rev-parse HEAD` failures
+ * propagate (the sync loop logs and skips the workspace).
+ */
+export async function readWorkspaceRefs(
+	git: SimpleGit,
+): Promise<WorkspaceRefsSnapshot> {
+	const branch = await getCurrentBranchName(git);
+	if (!branch) return { branch: null, headSha: null, upstream: null };
+
+	const headSha = await getHeadSha(git);
+	const upstream = await resolveWorkspaceUpstream(git, branch);
+	return { branch, headSha, upstream };
+}

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
@@ -43,17 +43,19 @@ describe("scheduleBaseRefFetch", () => {
 		expect(fetchCalls).toHaveLength(1);
 	});
 
-	test("resolves the common dir fresh each call (no path cache)", async () => {
+	test("resolves the common dir once within the TTL (path cache)", async () => {
 		const { git, revParseCalls } = createGit();
 		const target = { remote: "origin", branch: "fresh-branch" };
 		await scheduleBaseRefFetch(git, "/repo/wt-fresh", target);
 		await scheduleBaseRefFetch(git, "/repo/wt-fresh", target);
-		// One rev-parse per call — a cached path→dir mapping would skip the
-		// second and risk keying a reused path off a stale repo's common dir.
+		// One rev-parse across both calls — resolving per call spawns git on
+		// the event loop before the fetch-TTL check, on every status poll. A
+		// stale mapping only mis-keys the dedupe (extra/suppressed fetch,
+		// TTL-bounded); the fetch itself always runs in worktreePath.
 		const commonDirCalls = revParseCalls.filter(
 			(args) => args[1] === "--git-common-dir",
 		);
-		expect(commonDirCalls).toHaveLength(2);
+		expect(commonDirCalls).toHaveLength(1);
 	});
 
 	test("coalesces concurrent calls into a single in-flight fetch", async () => {
@@ -79,9 +81,11 @@ describe("scheduleBaseRefFetch", () => {
 			fetches++;
 		};
 
+		// Paths must be unique to this test: the commonDir cache is keyed by
+		// worktree path, so reusing another test's path would resolve stale.
 		await Promise.all([
-			scheduleBaseRefFetch(a.git, "/repo/wt-a", target, fetchBaseRef),
-			scheduleBaseRefFetch(b.git, "/repo/wt-b", target, fetchBaseRef),
+			scheduleBaseRefFetch(a.git, "/repo/wt-shared-a", target, fetchBaseRef),
+			scheduleBaseRefFetch(b.git, "/repo/wt-shared-b", target, fetchBaseRef),
 		]);
 
 		expect(fetches).toBe(1);

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
@@ -17,16 +17,28 @@ export interface BaseRefFetchTarget {
 const lastFetchStartedAt = new Map<string, number>();
 const inFlightFetches = new Map<string, Promise<void>>();
 
-// Resolved fresh, not path-cached: a worktree path can be reused by a
-// different repo, and a stale mapping would key the dedup off the wrong repo
-// and suppress a needed fetch.
+// TTL-cached per worktree path: resolving spawns a git subprocess on the
+// event loop BEFORE the fetch-TTL check, i.e. every status poll pays it even
+// when the fetch is suppressed. A worktree path re-pointed at a different
+// repo within the TTL only mis-keys the dedupe entry (one extra or one
+// suppressed fetch, bounded by the TTL) — the fetch itself always runs in
+// `worktreePath`, so it can never hit the wrong repo.
+const COMMON_DIR_TTL_MS = 5 * 60_000;
+const commonDirCache = new Map<string, { dir: string; resolvedAt: number }>();
+
 async function resolveCommonDir(
 	git: SimpleGit,
 	worktreePath: string,
 ): Promise<string> {
+	const cached = commonDirCache.get(worktreePath);
+	if (cached && Date.now() - cached.resolvedAt < COMMON_DIR_TTL_MS) {
+		return cached.dir;
+	}
 	// `--git-common-dir` may print a path relative to the worktree root.
 	const raw = (await git.raw(["rev-parse", "--git-common-dir"])).trim();
-	return resolve(worktreePath, raw);
+	const dir = resolve(worktreePath, raw);
+	commonDirCache.set(worktreePath, { dir, resolvedAt: Date.now() });
+	return dir;
 }
 
 /**

--- a/packages/host-service/src/trpc/router/project/handlers.ts
+++ b/packages/host-service/src/trpc/router/project/handlers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { rmSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { projects } from "../../../db/schema";
@@ -86,7 +86,7 @@ async function persistFromResolved(
 		}
 		if (args.cleanupRepoPathOnFailure) {
 			try {
-				rmSync(args.resolved.repoPath, { recursive: true, force: true });
+				await rm(args.resolved.repoPath, { recursive: true, force: true });
 			} catch (cleanupErr) {
 				console.warn("[project.create] repo dir cleanup failed", {
 					repoPath: args.resolved.repoPath,

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -79,11 +79,24 @@ function ensureParentDirectory(path: string): void {
 	}
 }
 
+/** Rollback delete inside catch blocks: must never throw, or it would
+ * replace the original error the caller is about to re-throw. */
+async function rollbackTargetDir(targetPath: string): Promise<void> {
+	try {
+		await rm(targetPath, { recursive: true, force: true });
+	} catch (cleanupErr) {
+		console.warn("[project] rollback cleanup failed", {
+			targetPath,
+			cleanupErr,
+		});
+	}
+}
+
 /**
  * Atomic claim: `mkdir` without `recursive` throws EEXIST when the path is
  * present, which avoids the TOCTOU window between an `existsSync` check
  * and the work that follows. If anything fails after this, the caller
- * created the dir and can rmSync it without risk of nuking someone else's.
+ * created the dir and can delete it without risk of nuking someone else's.
  */
 function claimEmptyTargetDir(targetPath: string): void {
 	try {
@@ -298,7 +311,7 @@ export async function initEmptyRepo(
 		}
 		return { repoPath: targetPath, remoteName: null, parsed: null };
 	} catch (err) {
-		await rm(targetPath, { recursive: true, force: true });
+		await rollbackTargetDir(targetPath);
 		throw err;
 	}
 }
@@ -346,7 +359,7 @@ export async function cloneTemplateInto(
 		}
 		return { repoPath: targetPath, remoteName: null, parsed: null };
 	} catch (err) {
-		await rm(targetPath, { recursive: true, force: true });
+		await rollbackTargetDir(targetPath);
 		throw err;
 	}
 }
@@ -396,7 +409,7 @@ export async function cloneRepoInto(
 		const git = createUserSimpleGit();
 		await (env ? git.env(env) : git).clone(repoCloneUrl, targetPath);
 	} catch (err) {
-		await rm(targetPath, { recursive: true, force: true });
+		await rollbackTargetDir(targetPath);
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: `Failed to clone repository: ${
@@ -411,7 +424,7 @@ export async function cloneRepoInto(
 		}
 		return await resolveLocalRepo(targetPath);
 	} catch (err) {
-		await rm(targetPath, { recursive: true, force: true });
+		await rollbackTargetDir(targetPath);
 		throw err;
 	}
 }

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -1,4 +1,8 @@
-import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+// Recursive deletes go through async `rm`: a failed clone/init rolls back an
+// entire repo directory, and rmSync would hold the event loop for the whole
+// walk.
+import { rm } from "node:fs/promises";
 import { join, resolve as resolvePath } from "node:path";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { TRPCError } from "@trpc/server";
@@ -294,7 +298,7 @@ export async function initEmptyRepo(
 		}
 		return { repoPath: targetPath, remoteName: null, parsed: null };
 	} catch (err) {
-		rmSync(targetPath, { recursive: true, force: true });
+		await rm(targetPath, { recursive: true, force: true });
 		throw err;
 	}
 }
@@ -330,7 +334,7 @@ export async function cloneTemplateInto(
 		await (env ? cloneGit.env(env) : cloneGit).clone(templateUrl, targetPath, [
 			"--depth=1",
 		]);
-		rmSync(join(targetPath, ".git"), { recursive: true, force: true });
+		await rm(join(targetPath, ".git"), { recursive: true, force: true });
 
 		await gitInitMainBranch(targetPath);
 		const git = createUserSimpleGit(targetPath);
@@ -342,7 +346,7 @@ export async function cloneTemplateInto(
 		}
 		return { repoPath: targetPath, remoteName: null, parsed: null };
 	} catch (err) {
-		rmSync(targetPath, { recursive: true, force: true });
+		await rm(targetPath, { recursive: true, force: true });
 		throw err;
 	}
 }
@@ -392,7 +396,7 @@ export async function cloneRepoInto(
 		const git = createUserSimpleGit();
 		await (env ? git.env(env) : git).clone(repoCloneUrl, targetPath);
 	} catch (err) {
-		rmSync(targetPath, { recursive: true, force: true });
+		await rm(targetPath, { recursive: true, force: true });
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: `Failed to clone repository: ${
@@ -407,7 +411,7 @@ export async function cloneRepoInto(
 		}
 		return await resolveLocalRepo(targetPath);
 	} catch (err) {
-		rmSync(targetPath, { recursive: true, force: true });
+		await rm(targetPath, { recursive: true, force: true });
 		throw err;
 	}
 }

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
@@ -117,6 +117,45 @@ describe("resolveNewBranchStartPoint", () => {
 		expect(git.fetch).not.toHaveBeenCalled();
 	});
 
+	test("uses the injected fetcher instead of git.fetch when provided", async () => {
+		const git = createMockGit({
+			existingRefs: new Set(["refs/heads/main", "refs/remotes/origin/main"]),
+			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
+		});
+		const fetchRemoteRef = mock(async (_target: unknown) => undefined);
+
+		const result = await resolveNewBranchStartPoint(
+			git,
+			"main",
+			fetchRemoteRef,
+		);
+
+		expect(result.kind).toBe("remote-tracking");
+		expect(fetchRemoteRef).toHaveBeenCalledWith({
+			remote: "origin",
+			branch: "main",
+		});
+		expect(git.fetch).not.toHaveBeenCalled();
+	});
+
+	test("swallows injected fetcher errors and still returns the start point", async () => {
+		const git = createMockGit({
+			existingRefs: new Set(["refs/heads/main", "refs/remotes/origin/main"]),
+			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
+		});
+		const fetchRemoteRef = mock(async (_target: unknown) => {
+			throw new Error("worker pool unavailable");
+		});
+
+		const result = await resolveNewBranchStartPoint(
+			git,
+			"main",
+			fetchRemoteRef,
+		);
+
+		expect(result.kind).toBe("remote-tracking");
+	});
+
 	test("swallows fetch errors and still returns the resolved start point", async () => {
 		const git = createMockGit({
 			existingRefs: new Set(["refs/heads/main", "refs/remotes/origin/main"]),

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.ts
@@ -3,8 +3,11 @@ import {
 	type ResolvedRef,
 	resolveUpstream,
 } from "../../../../runtime/git/refs";
+import type { BaseRefFetchTarget } from "../../git/utils/base-ref-freshness";
 import type { GitClient } from "../shared/types";
 import { resolveStartPoint } from "./resolve-start-point";
+
+export type BaseRefFetcher = (target: BaseRefFetchTarget) => Promise<unknown>;
 
 /**
  * Resolve the start point a *new* branch should fork from. No
@@ -24,6 +27,10 @@ import { resolveStartPoint } from "./resolve-start-point";
 export async function resolveNewBranchStartPoint(
 	git: GitClient,
 	baseBranch: string | undefined,
+	// Callers on the host-service event loop pass a worker-pool-backed
+	// fetcher so the network fetch doesn't spawn/drain in-process.
+	fetchRemoteRef: BaseRefFetcher = (target) =>
+		git.fetch([target.remote, target.branch, "--quiet", "--no-tags"]),
 ): Promise<ResolvedRef> {
 	let startPoint = await resolveStartPoint(git, baseBranch);
 
@@ -51,12 +58,10 @@ export async function resolveNewBranchStartPoint(
 
 	if (startPoint.kind === "remote-tracking") {
 		try {
-			await git.fetch([
-				startPoint.remote,
-				startPoint.shortName,
-				"--quiet",
-				"--no-tags",
-			]);
+			await fetchRemoteRef({
+				remote: startPoint.remote,
+				branch: startPoint.shortName,
+			});
 		} catch (err) {
 			console.warn(
 				`[workspaces.create] fetch ${startPoint.remoteShortName} failed:`,

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -5,8 +5,11 @@ import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
+import { createGitEnvResolver } from "../../../runtime/git";
 import { type ResolvedRef, resolveRef } from "../../../runtime/git/refs";
 import type { HostServiceContext } from "../../../types";
+import { getHostWorkerPool } from "../../../workers/host-worker-pool";
+import { gitFetchBaseRefTask } from "../../../workers/tasks/git";
 import {
 	getLocalWorkspace,
 	insertLocalWorkspace,
@@ -50,7 +53,10 @@ import {
 	PrBranchConflictError,
 } from "../workspace-creation/utils/pr-branch-materialize";
 import { derivePrLocalBranchName } from "../workspace-creation/utils/pr-branch-name";
-import { resolveNewBranchStartPoint } from "../workspace-creation/utils/resolve-new-branch-start-point";
+import {
+	type BaseRefFetcher,
+	resolveNewBranchStartPoint,
+} from "../workspace-creation/utils/resolve-new-branch-start-point";
 import { deduplicateBranchName } from "../workspace-creation/utils/sanitize-branch";
 
 /**
@@ -250,10 +256,32 @@ interface BranchSourcePlan {
 	usedExistingBranch: boolean;
 }
 
+/** Base-ref fetch for workspace creation, executed in the worker pool so the
+ * network fetch's spawn + stdout drain stay off the host-service event loop.
+ * Concurrent creates on the same base coalesce into one fetch. */
+function createWorkerBaseRefFetcher(
+	ctx: Pick<HostServiceContext, "credentials">,
+	repoPath: string,
+): BaseRefFetcher {
+	return async (target) => {
+		const gitEnv = await createGitEnvResolver(ctx.credentials)(repoPath);
+		return getHostWorkerPool().run(
+			gitFetchBaseRefTask,
+			{ worktreePath: repoPath, target, gitEnv },
+			{
+				timeoutMs: 30_000,
+				strategy: "coalesce",
+				dedupeKey: `${repoPath}:base-ref:${target.remote}/${target.branch}`,
+			},
+		);
+	};
+}
+
 async function planBranchSource(
 	git: GitClient,
 	branch: string,
 	baseBranch: string | undefined,
+	fetchRemoteRef?: BaseRefFetcher,
 ): Promise<BranchSourcePlan> {
 	const resolved = await resolveRef(git, branch);
 
@@ -278,7 +306,11 @@ async function planBranchSource(
 		});
 	}
 
-	const startPoint = await resolveNewBranchStartPoint(git, baseBranch);
+	const startPoint = await resolveNewBranchStartPoint(
+		git,
+		baseBranch,
+		fetchRemoteRef,
+	);
 	return { branch, startPoint, usedExistingBranch: false };
 }
 
@@ -477,6 +509,10 @@ export const workspacesRouter = router({
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
 
 			const git = await ctx.git(localProject.repoPath);
+			const fetchBaseRefOffLoop = createWorkerBaseRefFetcher(
+				ctx,
+				localProject.repoPath,
+			);
 			const worktreeBaseDir =
 				localProject.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
 
@@ -746,7 +782,12 @@ export const workspacesRouter = router({
 					// aware planner. Title-rename can race with that lookup.
 					resolvedBranch = typedBranch;
 					const [planResult, aiNames, existing] = await Promise.all([
-						planBranchSource(git, resolvedBranch, input.baseBranch),
+						planBranchSource(
+							git,
+							resolvedBranch,
+							input.baseBranch,
+							fetchBaseRefOffLoop,
+						),
 						aiNamesPromise ?? Promise.resolve(null),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
@@ -781,7 +822,11 @@ export const workspacesRouter = router({
 					// is a fallback for no-prompt or LLM failure.
 					const [aiNames, startPoint, existing] = await Promise.all([
 						aiNamesPromise ?? Promise.resolve(null),
-						resolveNewBranchStartPoint(git, input.baseBranch),
+						resolveNewBranchStartPoint(
+							git,
+							input.baseBranch,
+							fetchBaseRefOffLoop,
+						),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					autoNameFellBack = wantAi && aiNames === null;

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -4,6 +4,10 @@
 // the credential provider) and crosses as plain data.
 
 import { createUserSimpleGit } from "../../runtime/git/simple-git.ts";
+import {
+	readWorkspaceRefs,
+	type WorkspaceRefsSnapshot,
+} from "../../runtime/pull-requests/utils/workspace-refs.ts";
 import type { ChangedFile } from "../../trpc/router/git/types.ts";
 import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-freshness.ts";
 import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
@@ -58,8 +62,20 @@ export const gitCommitFilesTask = defineWorkerTask<
 	},
 });
 
+export const gitWorkspaceRefsTask = defineWorkerTask<
+	{ worktreePath: string; gitEnv: GitTaskEnv },
+	WorkspaceRefsSnapshot
+>({
+	type: "git/readWorkspaceRefs",
+	handler: async ({ worktreePath, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		return readWorkspaceRefs(git);
+	},
+});
+
 export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
 	gitCommitFilesTask,
+	gitWorkspaceRefsTask,
 ];

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -24,10 +24,12 @@ entries):
 - Desktop: `changes.getBranches`, `workspaces.getAheadBehind`,
   `changes.get*FileContents` → changes git worker
 
-## Backlog — host-service (allowlist of `no-main-loop-blocking.test.ts`)
+## Backlog — host-service
 
-Priority order; each entry = port to `workers/tasks/git.ts` then delete its
-allowlist line.
+Priority order; port to `workers/tasks/git.ts`. Items constructing git
+clients directly have an allowlist line in `no-main-loop-blocking.test.ts`
+to delete when ported; items 1–3 and 6 spawn via `ctx.git()` (the shared
+factory) so the ratchet doesn't see them — they're backlog-only.
 
 1. `trpc/router/git/git.ts` — `listCommits` (`git log`, unbounded),
    `getDiff` (2× `git show`, buffers file contents), `getBranchSyncStatus`
@@ -46,7 +48,10 @@ allowlist line.
    `workspace-creation/shared/project-helpers.ts`,
    `trpc/router/git/utils/git-helpers.ts` — cheap but on-loop; port last
 
-## Backlog — desktop (allowlist of `no-main-process-blocking.test.ts`)
+## Backlog — desktop
+
+Same convention: entries with a `no-main-process-blocking.test.ts`
+allowlist line lose it when ported; the rest are backlog-only.
 
 1. `workspaces.getGitHubStatus` path (`workspaces/utils/github/*`) — `gh` +
    `ls-remote` polled 10–30s per workspace (biggest remaining win)

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -1,0 +1,61 @@
+# Off-loop git reads
+
+Both single-threaded event loops (host-service per org, Electron main) serve
+all tRPC traffic; any in-process git spawn or sync fs walk head-of-line
+blocks every response. Worker pools exist on both sides — coverage, not
+infrastructure, is the gap.
+
+Enforced by ratchet tests (fail on new call sites, fail on stale allowlist
+entries):
+- `packages/host-service/src/no-main-loop-blocking.test.ts`
+- `apps/desktop/src/no-main-process-blocking.test.ts`
+
+## Done (this branch)
+
+- Workspace-create base fetch → `gitFetchBaseRefTask` (was inline `git fetch`
+  per create, #5913 regression)
+- PR-sync per-workspace refs read → `gitWorkspaceRefsTask` (was 5–8 spawns ×
+  N workspaces per watcher event / 5-min sweep)
+- `ctx.git()` env resolution: remote-URL lookup TTL-cached (was 1 spawn per
+  call, ~30 sites)
+- `base-ref-freshness`: common-dir rev-parse TTL-cached (was 1 spawn per
+  status poll, #5776)
+- `resolve-repo.ts` / `project/handlers.ts`: recursive `rmSync` → async `rm`
+- Desktop: `changes.getBranches`, `workspaces.getAheadBehind`,
+  `changes.get*FileContents` → changes git worker
+
+## Backlog — host-service (allowlist of `no-main-loop-blocking.test.ts`)
+
+Priority order; each entry = port to `workers/tasks/git.ts` then delete its
+allowlist line.
+
+1. `trpc/router/git/git.ts` — `listCommits` (`git log`, unbounded),
+   `getDiff` (2× `git show`, buffers file contents), `getBranchSyncStatus`
+   (7 spawns incl. full `status()`), `renameBranch` (`ls-remote`, network)
+2. `trpc/router/workspace-creation/procedures/search-branches.ts` — network
+   `fetch --prune` + 500-entry reflog walk on a typeahead query
+3. `trpc/router/workspace-cleanup/workspace-cleanup.ts` — `status()`
+   preflights + `worktree remove --force` (blocking recursive delete)
+4. `trpc/router/project/utils/resolve-repo.ts` — `git clone` inline
+   (unbounded network); worker task or spawn with streaming
+5. `trpc/router/project/project.ts` — `ctx.git()` inside `project.remove`
+   loop; hoist + worker-route `worktree remove`
+6. `trpc/router/workspace/workspace.ts` — full `git.status()` on the legacy
+   surface; also per-row `existsSync` in `workspace.list`
+7. `trpc/router/settings/branch-prefix.ts`,
+   `workspace-creation/shared/project-helpers.ts`,
+   `trpc/router/git/utils/git-helpers.ts` — cheap but on-loop; port last
+
+## Backlog — desktop (allowlist of `no-main-process-blocking.test.ts`)
+
+1. `workspaces.getGitHubStatus` path (`workspaces/utils/github/*`) — `gh` +
+   `ls-remote` polled 10–30s per workspace (biggest remaining win)
+2. `changes/staging.ts` — the two `git.status()` reads inside discard-all
+   (worker already computes the same status)
+3. `projects.ts` — `getBranchesLocal` / `getBranches` (network fetch) /
+   `searchBranches`; `cloneRepo` inline clone
+4. `changes/git-operations.ts` + `security/git-commands.ts` — mutations;
+   need write-serialization guarantees before moving
+5. `workspaces/utils/git.ts` — grab-bag; port per-function as consumers move
+6. `main/lib/agent-setup/utils.ts` — dead `execFileSync` code; delete
+7. `git-status.ts:335` — `existsSync` per worktree row → `pathExistsCached`


### PR DESCRIPTION
## Problem

Both single-threaded event loops — host-service (per org) and Electron main — serve all tRPC traffic, and recent changes kept adding in-process git reads to them. One slow spawn (or an inline network fetch) head-of-line blocks every response on that loop, which is why the app feels unresponsive under load. Worker pools exist on both sides; coverage was the gap — only 3 host-service tasks and 2 desktop tasks were worker-routed, everything else ran on the loop.

Profiling the live app confirmed the mechanism: ~830ms of raw `spawn` self-time per minute on host-service at light watcher churn, scaling linearly with git-call volume.

## Changes

**Host-service**
- **#5913 regression**: workspace-create's inline `git fetch` (any upstream base) now runs via the existing `gitFetchBaseRefTask` in the worker pool, coalesced per repo+ref. The await stays — forking from a fresh tip was the point — but the spawn/drain leaves the loop.
- **New `git/readWorkspaceRefs` worker task**: the PR-sync loop's 5–8 spawns × N workspaces (every git-watcher event + 5-min sweep) collapse into one off-loop task per workspace. Helpers moved verbatim to `runtime/pull-requests/utils/workspace-refs.ts` so the worker bundle doesn't pull in the runtime's DB/Octokit graph.
- **`ctx.git()` env resolution**: the `git remote get-url origin` spawn is TTL-cached per repo (~30 call sites paid it per call, one inside `project.remove`'s loop). Credentials stay uncached — the provider remains authoritative.
- **base-ref freshness (#5776)**: the `rev-parse --git-common-dir` spawn that ran *before* the fetch-TTL check on every status poll is now TTL-cached per worktree path. A stale entry can only mis-key the dedupe (one extra/suppressed fetch, TTL-bounded) — the fetch itself always runs in the worktree path.
- **Recursive `rmSync` rollbacks** in `resolve-repo.ts` / `project/handlers.ts` → async `rm` (deleting an entire failed clone held the loop for the whole walk).

**Desktop**
- `changes.getBranches` (~6 serialized spawns, polled every 10s per inactive pane + per hovered sidebar row), `workspaces.getAheadBehind` (rev-list per sidebar row), and both file-contents procedures (`cat-file -s` + `git show` pairs) now run in the changes git worker. Response shapes are byte-identical; the localDb reads stay on main and cross as payload data, mirroring the existing `getStatus` pattern.

**Enforcement — how we keep it this way**
Two ratchet tests fail CI on regressions:
- `packages/host-service/src/no-main-loop-blocking.test.ts`
- `apps/desktop/src/no-main-process-blocking.test.ts`

Each bans sync subprocesses, recursive sync fs, and in-process git-client construction outside the worker dirs. Current legacy offenders are allowlisted; any **new** matching file fails with advice pointing at the worker-task pattern, and an allowlisted file that gets fixed **also** fails until its entry is deleted — the lists only shrink. Remaining migration backlog with priorities: `plans/off-loop-git-reads.md`.

## Verification

- Unit/integration: host-service 920 pass (1 pre-existing pty-daemon flake, passes in isolation); desktop worker-handler tests 12/12 over real temp repos, mutation-checked (5 deliberate impl mutations each failed exactly their corresponding test); both ratchet tests verified to fail in both directions. Typecheck + `bun run lint` clean.
- CDP end-to-end on the dev app built from this branch: `getBranches` / `getAheadBehind` / `getGitFileContents` driven through the real renderer→IPC→worker path against a registered worktree, cross-checked against direct git (branch name, 1488 local refs, 2642-byte base blob — all exact matches). Real-click navigation into a v2 workspace populated the Changes panel via live host-service `git.getStatus` through the worker pool, reporting exactly this branch's own diff (23 files +1308 −389). Worker bundles confirmed loaded, zero inline-fallback warnings.

Follow-up idea (not in this PR): add event-loop-delay p99 to the `resource_snapshot` telemetry so future loop-blocking regressions surface in PostHog instead of user reports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves hot git reads and network fetches off the host-service and Electron main event loops into worker pools, and adds ratchet tests to prevent new blocking call sites. This reduces UI stalls and keeps tRPC responsive under load.

- **Refactors**
  - Host-service: workspace-create base fetch now runs via `gitFetchBaseRefTask` (coalesced per repo+ref); PR sync reads branch/HEAD/upstream via `git/readWorkspaceRefs`; `ctx.git()` env resolution TTL-caches and coalesces `git remote get-url origin`; base-ref freshness TTL-caches `--git-common-dir`; recursive `rmSync` rollbacks replaced with guarded async `rm`.
  - Desktop: moved `changes.getBranches`, `workspaces.getAheadBehind`, and `changes.getFileContents` to the changes git worker via `runGitTask`; hardened dedupe keys (JSON-encoded paths for file-contents; per-worktree generation bump after base/branch mutations); worker failures now log and degrade to safe defaults. Response shapes unchanged.

- **Enforcement**
  - Added CI ratchet tests (`packages/host-service/src/no-main-loop-blocking.test.ts`, `apps/desktop/src/no-main-process-blocking.test.ts`) to block sync subprocesses, recursive sync fs, and on-loop git-client construction outside worker dirs; allowlists only shrink. Backlog tracked in `plans/off-loop-git-reads.md`.

<sup>Written for commit 6c8516b877ba17ee82591f11c0e0225f5b9cc82d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness by moving Git operations off the main application loop.
  * Reduced repeated repository lookups through short-term caching.

* **Bug Fixes**
  * Improved branch, worktree, ahead/behind, pull-request, and file comparison handling.
  * Added safer handling for missing remotes, unborn branches, missing files, and large file contents.
  * Improved repository cleanup reliability during failed operations.

* **Reliability**
  * Added timeouts and request coalescing to prevent hangs and duplicate work.
  * Improved workspace creation and synchronization when resolving branches and remote references.

* **Tests**
  * Expanded coverage for Git operations, caching, cleanup, and non-blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->