### PR TITLE
feat(desktop,host-service): add right-click import of untracked worktrees

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -10,6 +10,7 @@ import { DashboardSidebarCollapsedProjectContent } from "./components/DashboardS
 import { DashboardSidebarExpandedProjectContent } from "./components/DashboardSidebarExpandedProjectContent";
 import { DashboardSidebarProjectContextMenu } from "./components/DashboardSidebarProjectContextMenu";
 import { DashboardSidebarProjectRow } from "./components/DashboardSidebarProjectRow";
+import { ImportWorktreesDialog } from "./components/ImportWorktreesDialog";
 import { useDashboardSidebarProjectSectionActions } from "./hooks/useDashboardSidebarProjectSectionActions";
 
 interface DashboardSidebarProjectSectionProps {
@@ -40,15 +41,20 @@ export function DashboardSidebarProjectSection({
 
 	const {
 		cancelRename,
+		confirmImportWorktrees,
 		confirmRemoveFromSidebar,
 		deleteSection,
+		handleImportWorktrees,
 		handleNewSection,
 		handleNewWorkspace,
 		handleOpenInFinder,
 		handleOpenSettings,
+		importableWorktrees,
+		isImportingWorktrees,
 		isRenaming,
 		renameSection,
 		renameValue,
+		setImportableWorktrees,
 		setRenameValue,
 		startRename,
 		submitRename,
@@ -59,10 +65,24 @@ export function DashboardSidebarProjectSection({
 
 	const totalWorkspaceCount = flattenedCollapsedWorkspaces.length;
 
+	// Rendered only while open so the checkbox state resets per invocation.
+	const importWorktreesDialog = importableWorktrees && (
+		<ImportWorktreesDialog
+			open
+			worktrees={importableWorktrees}
+			isImporting={isImportingWorktrees}
+			onOpenChange={(open) => {
+				if (!open) setImportableWorktrees(null);
+			}}
+			onConfirm={confirmImportWorktrees}
+		/>
+	);
+
 	if (isSidebarCollapsed) {
 		return (
 			<DashboardSidebarProjectContextMenu
 				onCreateSection={handleNewSection}
+				onImportWorktrees={handleImportWorktrees}
 				onOpenInFinder={handleOpenInFinder}
 				onOpenSettings={handleOpenSettings}
 				onRemoveFromSidebar={confirmRemoveFromSidebar}
@@ -80,6 +100,7 @@ export function DashboardSidebarProjectSection({
 						onWorkspaceHover={onWorkspaceHover}
 						onToggleCollapse={() => onToggleCollapse(project.id)}
 					/>
+					{importWorktreesDialog}
 				</div>
 			</DashboardSidebarProjectContextMenu>
 		);
@@ -89,6 +110,7 @@ export function DashboardSidebarProjectSection({
 		<div className="mt-1 first:mt-0">
 			<DashboardSidebarProjectContextMenu
 				onCreateSection={handleNewSection}
+				onImportWorktrees={handleImportWorktrees}
 				onOpenInFinder={handleOpenInFinder}
 				onOpenSettings={handleOpenSettings}
 				onRemoveFromSidebar={confirmRemoveFromSidebar}
@@ -133,6 +155,7 @@ export function DashboardSidebarProjectSection({
 					</motion.div>
 				)}
 			</AnimatePresence>
+			{importWorktreesDialog}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectContextMenu/DashboardSidebarProjectContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectContextMenu/DashboardSidebarProjectContextMenu.tsx
@@ -6,6 +6,7 @@ import {
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import {
+	LuFolderInput,
 	LuFolderOpen,
 	LuFolderPlus,
 	LuPencil,
@@ -15,6 +16,7 @@ import {
 
 interface DashboardSidebarProjectContextMenuProps {
 	onCreateSection: () => void;
+	onImportWorktrees: () => void;
 	onOpenInFinder: () => void;
 	onOpenSettings: () => void;
 	onRemoveFromSidebar: () => void;
@@ -24,6 +26,7 @@ interface DashboardSidebarProjectContextMenuProps {
 
 export function DashboardSidebarProjectContextMenu({
 	onCreateSection,
+	onImportWorktrees,
 	onOpenInFinder,
 	onOpenSettings,
 	onRemoveFromSidebar,
@@ -50,6 +53,10 @@ export function DashboardSidebarProjectContextMenu({
 				<ContextMenuItem onSelect={onCreateSection}>
 					<LuFolderPlus className="size-4 mr-2" />
 					New group
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={onImportWorktrees}>
+					<LuFolderInput className="size-4 mr-2" />
+					Import untracked worktrees
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/ImportWorktreesDialog/ImportWorktreesDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/ImportWorktreesDialog/ImportWorktreesDialog.tsx
@@ -1,0 +1,116 @@
+import { Button } from "@superset/ui/button";
+import { Checkbox } from "@superset/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Label } from "@superset/ui/label";
+import { useState } from "react";
+import { LuGitBranch } from "react-icons/lu";
+
+export interface ImportableWorktree {
+	branch: string;
+	path: string;
+}
+
+interface ImportWorktreesDialogProps {
+	open: boolean;
+	worktrees: ImportableWorktree[];
+	isImporting: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: (options: { runSetup: boolean }) => void;
+}
+
+export function ImportWorktreesDialog({
+	open,
+	worktrees,
+	isImporting,
+	onOpenChange,
+	onConfirm,
+}: ImportWorktreesDialogProps) {
+	const [runSetup, setRunSetup] = useState(false);
+	const count = worktrees.length;
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={isImporting ? undefined : onOpenChange}
+			modal
+		>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Import untracked worktrees</DialogTitle>
+					<DialogDescription>
+						{count === 1
+							? "1 worktree in this repository has no workspace. It will be imported as a workspace."
+							: `${count} worktrees in this repository have no workspace. They will be imported as workspaces.`}
+					</DialogDescription>
+				</DialogHeader>
+				<ul className="-mx-2.5 max-h-64 overflow-x-hidden overflow-y-auto overscroll-contain">
+					{worktrees.map((worktree) => (
+						<li
+							key={worktree.path}
+							className="grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3 rounded-md px-2.5 py-2"
+						>
+							<LuGitBranch
+								className="size-4 shrink-0 text-muted-foreground"
+								strokeWidth={2}
+							/>
+							<div className="flex min-w-0 flex-col">
+								<span
+									className="truncate text-[13px] font-medium leading-4 text-foreground"
+									title={worktree.branch}
+								>
+									{worktree.branch}
+								</span>
+								<span
+									className="mt-0.5 truncate font-mono text-[11px] leading-4 text-muted-foreground"
+									title={worktree.path}
+								>
+									{worktree.path}
+								</span>
+							</div>
+						</li>
+					))}
+				</ul>
+				<div className="flex items-center gap-2">
+					<Checkbox
+						id="import-worktrees-run-setup"
+						checked={runSetup}
+						onCheckedChange={(checked) => setRunSetup(checked === true)}
+						disabled={isImporting}
+					/>
+					<Label
+						htmlFor="import-worktrees-run-setup"
+						className="cursor-pointer text-[13px] font-normal text-muted-foreground"
+					>
+						Run setup script in each imported workspace
+					</Label>
+				</div>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={isImporting}
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => onConfirm({ runSetup })}
+						disabled={isImporting}
+					>
+						{isImporting
+							? "Importing…"
+							: count === 1
+								? "Import 1 worktree"
+								: `Import ${count} worktrees`}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/ImportWorktreesDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/ImportWorktreesDialog/index.ts
@@ -1,0 +1,2 @@
+export type { ImportableWorktree } from "./ImportWorktreesDialog";
+export { ImportWorktreesDialog } from "./ImportWorktreesDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -1,7 +1,7 @@
 import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -10,7 +10,9 @@ import { useDashboardSidebarSectionRename } from "renderer/routes/_authenticated
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import type { DashboardSidebarProject } from "../../../../types";
+import type { ImportableWorktree } from "../../components/ImportWorktreesDialog";
 
 interface UseDashboardSidebarProjectSectionActionsOptions {
 	project: DashboardSidebarProject;
@@ -36,6 +38,13 @@ export function useDashboardSidebarProjectSectionActions({
 	// undefined (not null) when no host serves it — null would resolve to
 	// the local host and rename the wrong replica.
 	const servingHostUrl = useHostUrl(servingHostId ?? undefined);
+	const { submit } = useWorkspaceCreates();
+	const importingWorktreesRef = useRef(false);
+	// Non-null while the import confirmation dialog is open.
+	const [importableWorktrees, setImportableWorktrees] = useState<
+		ImportableWorktree[] | null
+	>(null);
+	const [isImportingWorktrees, setIsImportingWorktrees] = useState(false);
 	const { requestSectionRename } = useDashboardSidebarSectionRename();
 	const {
 		createSection,
@@ -124,6 +133,94 @@ export function useDashboardSidebarProjectSectionActions({
 		openModal(project.id);
 	};
 
+	// Menu action: list the worktrees git knows about that have no workspace
+	// row yet and open the confirmation dialog.
+	const handleImportWorktrees = async () => {
+		if (importingWorktreesRef.current) return;
+		if (!servingHostUrl) {
+			toast.error(
+				"Project's host is unreachable — cannot import worktrees right now",
+			);
+			return;
+		}
+		try {
+			const { worktrees } = await getHostServiceClientByUrl(
+				servingHostUrl,
+			).workspaceCreation.listProjectWorktrees.query({
+				projectId: project.id,
+			});
+			// `=== false` also skips hosts too old to report tracked-ness.
+			const untracked = worktrees.filter(
+				(worktree) =>
+					worktree.hasWorkspace === false && worktree.isMainWorktree === false,
+			);
+			if (untracked.length === 0) {
+				toast.info("All of this project's worktrees are already tracked");
+				return;
+			}
+			setImportableWorktrees(untracked);
+		} catch (error) {
+			toast.error(
+				`Failed to list worktrees: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	// Dialog confirm: adopt each worktree via the `worktreePath` branch of
+	// `workspaces.create` (no `git worktree add`; setup only when opted in).
+	const confirmImportWorktrees = async ({
+		runSetup,
+	}: {
+		runSetup: boolean;
+	}) => {
+		const untracked = importableWorktrees;
+		if (importingWorktreesRef.current || !untracked) return;
+		if (!servingHostId) {
+			toast.error(
+				"Project's host is unreachable — cannot import worktrees right now",
+			);
+			return;
+		}
+		importingWorktreesRef.current = true;
+		setIsImportingWorktrees(true);
+		try {
+			const outcomes = await Promise.all(
+				untracked.map(
+					(worktree) =>
+						submit({
+							hostId: servingHostId,
+							snapshot: {
+								id: crypto.randomUUID(),
+								projectId: project.id,
+								branch: worktree.branch,
+								worktreePath: worktree.path,
+								runSetup,
+							},
+						}).completed,
+				),
+			);
+			const errors = outcomes.flatMap((outcome) =>
+				outcome.ok ? [] : [outcome.error],
+			);
+			const imported = outcomes.length - errors.length;
+			if (errors.length > 0) {
+				toast.error(
+					`Imported ${imported} of ${untracked.length} worktrees: ${errors[0]}`,
+				);
+			} else {
+				toast.success(
+					imported === 1
+						? "Imported 1 worktree as a workspace"
+						: `Imported ${imported} worktrees as workspaces`,
+				);
+			}
+			setImportableWorktrees(null);
+		} finally {
+			importingWorktreesRef.current = false;
+			setIsImportingWorktrees(false);
+		}
+	};
+
 	const handleNewSection = () => {
 		const sectionId = createSection(project.id);
 		requestSectionRename(sectionId);
@@ -134,15 +231,20 @@ export function useDashboardSidebarProjectSectionActions({
 
 	return {
 		cancelRename,
+		confirmImportWorktrees,
 		confirmRemoveFromSidebar,
 		deleteSection,
+		handleImportWorktrees,
 		handleNewSection,
 		handleNewWorkspace,
 		handleOpenInFinder,
 		handleOpenSettings,
+		importableWorktrees,
+		isImportingWorktrees,
 		isRenaming,
 		renameSection,
 		renameValue,
+		setImportableWorktrees,
 		setRenameValue,
 		startRename,
 		submitRename,

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/list-project-worktrees.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/list-project-worktrees.ts
@@ -1,14 +1,20 @@
+import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { workspaces } from "../../../../db/schema";
 import { protectedProcedure } from "../../../index";
 import { requireLocalProject } from "../shared/local-project";
-import { listGitWorktrees } from "../shared/worktree-list";
+import {
+	listGitWorktrees,
+	normalizeWorktreePath,
+} from "../shared/worktree-list";
 
 /**
  * Returns the live `git worktree list` for a project — only entries that
  * are valid adoption targets (have a real branch checked out, not bare,
- * not prunable). Used by the v1→v2 importer to filter out v1 workspaces
- * whose worktree no longer exists on disk before showing them as
- * importable rows.
+ * not prunable) — annotated with whether a workspace row already tracks
+ * them. Used by the v1→v2 importer to filter out v1 workspaces whose
+ * worktree no longer exists on disk, and by the sidebar's "Import
+ * Worktrees" action to find untracked worktrees.
  */
 export const listProjectWorktrees = protectedProcedure
 	.input(z.object({ projectId: z.string() }))
@@ -16,12 +22,45 @@ export const listProjectWorktrees = protectedProcedure
 		const localProject = requireLocalProject(ctx, input.projectId);
 		const git = await ctx.git(localProject.repoPath);
 		const records = await listGitWorktrees(git);
-		const worktrees: { branch: string; path: string }[] = [];
+
+		// Tracking key is (projectId, branch) — same as searchBranches — but
+		// also match by normalized path so a tracked worktree whose branch was
+		// renamed out from under its row isn't offered for re-import.
+		const workspaceRows = ctx.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.projectId, input.projectId))
+			.all();
+		const workspaceBranches = new Set(
+			workspaceRows.map((row) => row.branch).filter(Boolean),
+		);
+		const workspacePaths = new Set(
+			workspaceRows
+				.map((row) => row.worktreePath)
+				.filter(Boolean)
+				.map(normalizeWorktreePath),
+		);
+		const mainRepoPath = normalizeWorktreePath(localProject.repoPath);
+
+		const worktrees: {
+			branch: string;
+			path: string;
+			hasWorkspace: boolean;
+			isMainWorktree: boolean;
+		}[] = [];
 		for (const record of records) {
 			if (record.bare) continue;
 			if (record.prunable) continue;
 			if (!record.branch) continue;
-			worktrees.push({ branch: record.branch, path: record.path });
+			const normalizedPath = normalizeWorktreePath(record.path);
+			worktrees.push({
+				branch: record.branch,
+				path: record.path,
+				hasWorkspace:
+					workspaceBranches.has(record.branch) ||
+					workspacePaths.has(normalizedPath),
+				isMainWorktree: normalizedPath === mainRepoPath,
+			});
 		}
 		return { worktrees };
 	});

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -106,6 +106,9 @@ const createInputSchema = z
 		// inferring the path from `branch`. When present, `branch` is
 		// caller context only; the server reads the current branch from git.
 		worktreePath: z.string().min(1).optional(),
+		// When false, skip the setup terminal. Used by worktree import,
+		// where the worktree is usually already set up.
+		runSetup: z.boolean().optional(),
 	})
 	.refine((value) => !(value.branch && value.pr), {
 		message: "`branch` and `pr` cannot both be set",
@@ -1030,7 +1033,7 @@ export const workspacesRouter = router({
 			}
 
 			let chainedAgentResult: AgentLaunchResult | null = null;
-			if (!alreadyExists) {
+			if (!alreadyExists && input.runSetup !== false) {
 				const { terminal, warning, chained } =
 					await startSetupTerminalIfPresent({
 						ctx,


### PR DESCRIPTION
## What

Adds an **Import untracked worktrees** action to the project right-click menu in the v2 sidebar. It lists every git worktree of the project's repo that has no workspace row and imports them as workspaces via the existing `workspaces.create` adopt path (no `git worktree add`).

Clicking the menu item opens a confirmation dialog showing the count and the list (branch + path) of worktrees that will be imported, plus a **Run setup script** checkbox that defaults to off — imported worktrees are usually already set up.


## How

- **host-service** `workspaceCreation.listProjectWorktrees`: entries now carry `hasWorkspace` (workspace row matches by branch — the canonical tracking key — or by realpath-normalized path, catching rows whose branch was renamed) and `isMainWorktree` (never offer the main repo checkout). Additive, so the v1→v2 importer callers are unaffected.
- **host-service** `workspaces.create`: new optional `runSetup` input; `false` skips the setup terminal. All existing callers omit it, so behavior is unchanged for them. Old hosts strip the unknown key and keep today's behavior.
- **desktop**: new `ImportWorktreesDialog` (borderless rows matching the V1 ImportRow pattern, truncation with `title` tooltips, `max-h-64` scroll with `overscroll-contain`); the menu action fetches the untracked list and opens it; confirm submits each via `useWorkspaceCreates().submit` with `runSetup`, so optimistic sidebar rows, pane layout, and failure cleanup are handled by the existing pipeline. Re-running when everything is tracked toasts instead of opening the dialog; adoption is idempotent server-side.

## Verification

CDP-driven end-to-end against the dev app from this branch (instance ownership + session verified):
- Right-click → menu item → dialog with correct count/list; long branch names truncate; 8-row list scrolls.
- Confirm with checkbox **off**: workspaces created for exactly the untracked worktrees (main repo excluded), and a sentinel-writing `.superset/setup.sh` did **not** run.
- Confirm with checkbox **on**: sentinel files written in each imported workspace — setup ran.
- Re-run: "All of this project's worktrees are already tracked" toast, no new rows.
- `bun run lint`, monorepo typecheck, and host-service workspace-creation/workspaces suites (incl. the main-loop-blocking ratchet) all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a right-click “Import untracked worktrees” action in the v2 desktop sidebar to adopt existing git worktrees as workspaces, with an optional setup step. This avoids creating new worktrees and makes adoption quick and safe.

- **New Features**
  - `desktop`: Project context menu gains “Import untracked worktrees,” opening a dialog that lists each untracked worktree (branch + path) and a “Run setup script” checkbox (off by default). If none are untracked, a toast is shown; otherwise, each is created via the existing create flow with optimistic UI; main checkout is excluded.
  - `host-service`: `workspaceCreation.listProjectWorktrees` now includes `hasWorkspace` (matched by branch or normalized path) and `isMainWorktree` to support filtering.
  - `host-service`: `workspaces.create` accepts optional `runSetup`; when `false`, the setup terminal is skipped. Existing callers are unchanged; older hosts ignore unknown input.

<sup>Written for commit ac905b7c8d7289406e5d7c4f841f91ddc9d6fba6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing untracked worktrees directly from the project sidebar.
  * Review available branches and paths before importing them as workspaces.
  * Optionally run setup scripts during import.
  * Import actions are available in both expanded and collapsed project menus.
* **Bug Fixes**
  * Improved worktree detection to distinguish existing workspaces from the main repository and avoid duplicate imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->