### PR TITLE
perf(desktop): only query diff stats for the active sidebar workspace item

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -9,7 +9,11 @@ export interface DiffStats {
 	deletions: number;
 }
 
-export function useDiffStats(workspaceId: string): DiffStats | null {
+export function useDiffStats(
+	workspaceId: string,
+	options?: { enabled?: boolean },
+): DiffStats | null {
+	const enabled = options?.enabled ?? true;
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
 	const queryKey = useMemo(
@@ -19,7 +23,7 @@ export function useDiffStats(workspaceId: string): DiffStats | null {
 
 	const { data: status } = useQuery({
 		queryKey,
-		enabled: Boolean(workspaceId) && Boolean(hostUrl),
+		enabled: enabled && Boolean(workspaceId) && Boolean(hostUrl),
 		queryFn: () => {
 			if (!hostUrl) return null;
 			return getHostServiceClientByUrl(hostUrl).git.getStatus.query({
@@ -35,6 +39,9 @@ export function useDiffStats(workspaceId: string): DiffStats | null {
 		void queryClient.invalidateQueries({ queryKey });
 	}, [queryClient, queryKey]);
 
+	// Stays subscribed while disabled: invalidation marks the cached stats
+	// stale so they refetch when the query is re-enabled (staleTime is
+	// Infinity, so a gated subscription would freeze counts).
 	useWorkspaceEvent(
 		"git:changed",
 		workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -45,7 +45,6 @@ export function DashboardSidebarWorkspaceItem({
 		pullRequest,
 	} = workspace;
 	const isMainWorkspace = workspace.type === "main";
-	const diffStats = useDiffStats(id);
 	const workspaceStatus = useV2WorkspaceNotificationStatus(id);
 	const {
 		cancelRename,
@@ -77,6 +76,10 @@ export function DashboardSidebarWorkspaceItem({
 		isMainWorkspace,
 		isPinned: workspace.isPinned,
 	});
+
+	// Only the active workspace row shows line counts, so skip the per-item
+	// git status query everywhere else.
+	const diffStats = useDiffStats(id, { enabled: isActive });
 
 	const { v2Workspaces: v2WorkspaceActions } = useOptimisticCollectionActions();
 	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(


### PR DESCRIPTION
## Summary

Every `DashboardSidebarWorkspaceItem` called `useDiffStats(id)`, firing a background `git.getStatus` request per sidebar workspace — even though the expanded row only renders the +/− line-count badge for the **active** item. On a sidebar with N workspaces, N−1 of those git status reads were pure waste.

- `useDiffStats` now takes an optional `{ enabled }` option (defaults to `true`; hover-card overlay and other callers unaffected) gating the `git.getStatus` query.
- The `git:changed` subscription intentionally stays on while disabled: it's a cheap listener on the shared per-host event bus, and its invalidation marks the cached stats stale so counts refetch when the item becomes active again (with `staleTime: Infinity`, gating it would freeze counts at their last-active values).
- `DashboardSidebarWorkspaceItem` passes `{ enabled: isActive }`.

The v1 `WorkspaceSidebar` already gates its fetch on hover, so no changes there.

## Test plan

- `bun run lint` clean, `tsc --noEmit` passes in `apps/desktop`
- Active workspace row still shows +/− diff stats and updates on git changes
- Switching to a workspace whose files changed while it was inactive refetches (invalidation marks the disabled query stale)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch diff stats only for the active sidebar workspace to eliminate redundant `git.getStatus` calls and reduce background work. `useDiffStats` now accepts `{ enabled }`, used by `DashboardSidebarWorkspaceItem`, while the `git:changed` subscription remains to invalidate stale data so counts refresh when the item becomes active again.

<sup>Written for commit aefca5f0c6f38ff694fcb2394be790d54a72de1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

