### PR TITLE
fix(desktop): improve worktree-import feedback for old hosts and partial failures

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -149,7 +149,17 @@ export function useDashboardSidebarProjectSectionActions({
 			).workspaceCreation.listProjectWorktrees.query({
 				projectId: project.id,
 			});
-			// `=== false` also skips hosts too old to report tracked-ness.
+			// Hosts that predate the annotations return entries without the
+			// fields; say so instead of a misleading "already tracked".
+			if (
+				worktrees.length > 0 &&
+				typeof worktrees[0]?.hasWorkspace !== "boolean"
+			) {
+				toast.error(
+					"Project's host runs an older Superset version that cannot report untracked worktrees — update it to import",
+				);
+				return;
+			}
 			const untracked = worktrees.filter(
 				(worktree) =>
 					worktree.hasWorkspace === false && worktree.isMainWorktree === false,
@@ -204,8 +214,11 @@ export function useDashboardSidebarProjectSectionActions({
 			);
 			const imported = outcomes.length - errors.length;
 			if (errors.length > 0) {
+				const uniqueErrors = [...new Set(errors)];
+				const suffix =
+					uniqueErrors.length > 1 ? ` (+${uniqueErrors.length - 1} more)` : "";
 				toast.error(
-					`Imported ${imported} of ${untracked.length} worktrees: ${errors[0]}`,
+					`Imported ${imported} of ${untracked.length} worktrees — ${errors.length} failed: ${uniqueErrors[0]}${suffix}`,
 				);
 			} else {
 				toast.success(


### PR DESCRIPTION
Follow-ups from the #6097 review comments (cubic P2 + CodeRabbit minor):

- **Old-host detection**: if the serving host predates the `hasWorkspace`/`isMainWorktree` annotations on `listProjectWorktrees`, the entries carry no tracked-ness fields and the strict filter matched nothing, so users saw a misleading "All of this project's worktrees are already tracked". Now that case gets a dedicated error toast telling them to update the host. Only affects remote hosts running older host-service builds — the local host is pinned to the bundled version.
- **Partial-failure toast**: previously only the first error was shown. Now it reports the failed count and deduplicated errors: `Imported 1 of 3 worktrees — 2 failed: <first unique error> (+1 more)`.

No behavior change for the normal import path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves worktree import feedback in the desktop dashboard. When a host is too old to report untracked worktrees, we show a clear update toast; for partial imports, we report how many failed and deduplicate the errors.

<sup>Written for commit e98db6a0e4f84291b9d1db344f13815eff1f761c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree import compatibility checks for older hosts missing workspace information.
  * Prevented duplicate import error notifications and now summarizes additional distinct errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->