### PR TITLE
fix(desktop): unset GREP_OPTIONS in agent hook scripts

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-copilot.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-copilot.ts
@@ -11,7 +11,7 @@ import { HOOKS_DIR } from "./paths";
 export const COPILOT_HOOK_SCRIPT_NAME = "copilot-hook.sh";
 
 const COPILOT_HOOK_SIGNATURE = "# Superset copilot hook";
-const COPILOT_HOOK_VERSION = "v2";
+const COPILOT_HOOK_VERSION = "v3";
 export const COPILOT_HOOK_MARKER = `${COPILOT_HOOK_SIGNATURE} ${COPILOT_HOOK_VERSION}`;
 
 const COPILOT_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
@@ -14,7 +14,7 @@ import { HOOKS_DIR } from "./paths";
 export const CURSOR_HOOK_SCRIPT_NAME = "cursor-hook.sh";
 
 const CURSOR_HOOK_SIGNATURE = "# Superset cursor hook";
-const CURSOR_HOOK_VERSION = "v4";
+const CURSOR_HOOK_VERSION = "v5";
 export const CURSOR_HOOK_MARKER = `${CURSOR_HOOK_SIGNATURE} ${CURSOR_HOOK_VERSION}`;
 
 const CURSOR_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-gemini.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-gemini.ts
@@ -14,7 +14,7 @@ import { HOOKS_DIR } from "./paths";
 export const GEMINI_HOOK_SCRIPT_NAME = "gemini-hook.sh";
 
 const GEMINI_HOOK_SIGNATURE = "# Superset gemini hook";
-const GEMINI_HOOK_VERSION = "v3";
+const GEMINI_HOOK_VERSION = "v4";
 export const GEMINI_HOOK_MARKER = `${GEMINI_HOOK_SIGNATURE} ${GEMINI_HOOK_VERSION}`;
 
 const GEMINI_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -32,7 +32,7 @@ mock.module("shared/env.shared", () => ({
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v5",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v6",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},
@@ -746,9 +746,9 @@ exit 0
 	});
 
 	it("bumps hook script markers when hook semantics change", () => {
-		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v2");
-		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v4");
-		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v3");
+		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v3");
+		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v5");
+		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v4");
 	});
 
 	it("replaces stale Mastra hook commands from old superset paths", () => {

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -13,7 +13,10 @@ function readNotifyHookTemplate(): string {
 	return readFileSync(notifyHookTemplatePath, "utf-8");
 }
 
-function runNotifyHook(input: Record<string, unknown>) {
+function runNotifyHook(
+	input: Record<string, unknown>,
+	extraEnv: Record<string, string> = {},
+) {
 	const script = readNotifyHookTemplate()
 		.replaceAll("{{MARKER}}", NOTIFY_SCRIPT_MARKER)
 		.replaceAll("{{DEFAULT_PORT}}", "48763");
@@ -23,6 +26,7 @@ function runNotifyHook(input: Record<string, unknown>) {
 			...process.env,
 			SUPERSET_AGENT_ID: "grok",
 			SUPERSET_DEBUG_HOOKS: "1",
+			...extraEnv,
 		},
 		stdin: Buffer.from(JSON.stringify(input)),
 		stdout: "pipe",
@@ -32,7 +36,7 @@ function runNotifyHook(input: Record<string, unknown>) {
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v5");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v6");
 	});
 
 	it("emits the v2 host-service payload with full agent identity", () => {
@@ -105,6 +109,20 @@ describe("getNotifyScriptContent", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.stderr.toString()).toBe("");
 	});
+
+	// BSD grep honors GREP_OPTIONS and, with --color=always, wraps piped
+	// matches in ANSI codes; without the unset guard every extraction comes
+	// back empty and the hook silently drops the event.
+	it("delivers events when the user's shell exports GREP_OPTIONS", () => {
+		const result = runNotifyHook(
+			{ session_id: "sess-123", hook_event_name: "Stop" },
+			{ GREP_OPTIONS: "--color=always", GREP_COLOR: "1;35;40" },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toContain("[notify-hook] event=Stop");
+		expect(result.stderr.toString()).toContain("hookSessionId=sess-123");
+	});
 });
 
 describe("per-agent hook scripts dispatch to v2", () => {
@@ -121,6 +139,7 @@ describe("per-agent hook scripts dispatch to v2", () => {
 				path.join(import.meta.dir, "templates", template),
 				"utf-8",
 			);
+			expect(script).toContain("unset GREP_OPTIONS");
 			expect(script).toContain(buildExpectedV2Payload(agentIdVar));
 			expect(script).toContain('curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL"');
 			expect(script).toContain(

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -4,7 +4,7 @@ import { env } from "shared/env.shared";
 import { HOOKS_DIR } from "./paths";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v5";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v6";
 
 const NOTIFY_SCRIPT_TEMPLATE_PATH = path.join(
 	__dirname,

--- a/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
@@ -3,6 +3,10 @@
 # GitHub Copilot CLI lifecycle hook. JSON in via stdin; MUST print valid
 # JSON to stdout before exit so copilot doesn't block on the hook.
 
+# GREP_OPTIONS from the user's shell (e.g. --color=always) makes grep wrap
+# piped matches in ANSI codes, emptying the session-id extraction below.
+unset GREP_OPTIONS
+
 INPUT=$(cat)
 HOOK_SESSION_ID=$(printf '%s' "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 

--- a/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
@@ -2,6 +2,10 @@
 {{MARKER}}
 # cursor-agent lifecycle hook. Event name comes via argv from hooks.json.
 
+# GREP_OPTIONS from the user's shell (e.g. --color=always) makes grep wrap
+# piped matches in ANSI codes, emptying the session-id extraction below.
+unset GREP_OPTIONS
+
 INPUT=$(cat)
 HOOK_SESSION_ID=$(printf '%s' "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 

--- a/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
@@ -3,6 +3,11 @@
 # Gemini CLI lifecycle hook. JSON in via stdin; MUST print valid JSON to
 # stdout before exit so gemini doesn't block on the hook.
 
+# GREP_OPTIONS from the user's shell (e.g. --color=always) makes grep wrap
+# piped matches in ANSI codes, emptying every extraction below — events
+# would be silently dropped.
+unset GREP_OPTIONS
+
 INPUT=$(cat)
 
 EVENT_TYPE=$(printf '%s' "$INPUT" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -4,6 +4,11 @@
 # host-service endpoint, with a v1 Electron hook fallback while both
 # terminal stacks are supported.
 
+# GREP_OPTIONS from the user's shell (e.g. --color=always) makes grep wrap
+# piped matches in ANSI codes, emptying every extraction below — events
+# would be silently dropped.
+unset GREP_OPTIONS
+
 # Codex passes JSON as argv; Claude/Mastra/Droid/Kimi/Grok pipe via stdin.
 if [ -n "$1" ]; then
   INPUT="$1"


### PR DESCRIPTION
## What & why

If a user's shell exports `GREP_OPTIONS='--color=always'` (a common dotfile setting), **all agent notifications silently stop working**: no sidebar status dots, no completion sounds — while everything else looks healthy.

Root cause: the hook scripts parse agent lifecycle JSON with two-stage `grep` pipelines, e.g.

```sh
EVENT_TYPE=$(echo "$INPUT" | grep -oE '"hook_event_name"...' | grep -oE '"[^"]*"$' | tr -d '"')
```

BSD grep (macOS `/usr/bin/grep`) honors `GREP_OPTIONS`, and with `--color=always` it wraps matches in ANSI codes even when piping:

```
^[[1;35;40m^[[K"hook_event_name":"Stop"^[[m^[[K
```

The second-stage `grep '"[^"]*"$'` no longer matches (the line ends in escape codes, not `"`), so `EVENT_TYPE` comes back empty and `notify.sh` exits on its parse-failure guard. Every event from every agent is dropped before it reaches the host-service — the hook exits 0, so nothing ever surfaces in logs. The terminal env (with the inherited `GREP_OPTIONS`) is captured at PTY creation and persists across app restarts, so the breakage looks like a permanent app bug on that machine.

Fix: `unset GREP_OPTIONS` at the top of the four templates that parse with grep. Affected templates:

- `notify-hook.template.sh` (claude/codex/mastra/droid/kimi/grok) — all events dropped
- `gemini-hook.template.sh` — all events dropped
- `copilot-hook.template.sh` / `cursor-hook.template.sh` — event type arrives via argv, so only the session-id extraction was lost (guarded anyway)
- `codex-wrapper-exec.template.sh` only uses `pgrep`, which ignores `GREP_OPTIONS` — untouched

Hook markers are bumped (notify v5→v6, gemini v3→v4, copilot v2→v3, cursor v4→v5) per the "bump when hook semantics change" convention.

Debugged on a machine where this was reproducible: hooks fired, `curl` to the v2 endpoint worked, but `terminal_agent_bindings` stayed empty until `GREP_OPTIONS` was unset — after which events flowed and dots/sounds returned immediately.

## How I tested it

- `bun test src/main/lib/agent-setup/notify-hook.test.ts src/main/lib/agent-setup/agent-wrappers.test.ts` — 62 pass, including a new regression test that runs the notify hook with `GREP_OPTIONS='--color=always'` and asserts the Stop event and session id still parse (fails on `main` on macOS)
- `tsc --noEmit` (desktop) and Biome check on changed files pass
- Manually verified the failure and the fix end-to-end on macOS 26 / BSD grep against a live host-service

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops agent notifications from silently failing when the user’s shell sets GREP_OPTIONS (e.g., --color=always). Unsets GREP_OPTIONS in hook scripts and bumps hook markers so installed hooks are regenerated.

- **Bug Fixes**
  - Unset GREP_OPTIONS in `notify-hook`, `gemini-hook`, `copilot-hook`, and `cursor-hook` templates to keep grep parsing stable on BSD grep.
  - Bumped hook markers: notify v6, gemini v4, copilot v3, cursor v5 (triggers auto-rewrite).
  - Added a regression test that runs the notify hook with GREP_OPTIONS='--color=always' and verifies event/session parsing.
  - Codex wrapper unchanged; for copilot/cursor only session-id extraction was affected (event type comes via argv).

<sup>Written for commit 95eaf166fbc0447862c2dd3fcef94dd951d62797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent hook reliability when shell environments define grep formatting options.
  - Prevented session and event data from being incorrectly parsed under affected environments.
  - Updated hook versions so existing installations can receive the latest hook behavior.

- **Tests**
  - Added coverage confirming events remain delivered correctly with inherited grep options.
  - Updated expected hook version markers for Copilot, Cursor, Gemini, and notification hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->