### PR TITLE
feat(host-service): add offLoop() worker-procedure resolver, port branchPrefix.gitInfo

### DIFF
--- a/packages/host-service/src/no-main-loop-blocking.test.ts
+++ b/packages/host-service/src/no-main-loop-blocking.test.ts
@@ -58,11 +58,10 @@ const RULES: Rule[] = [
 			"trpc/router/git/utils/git-helpers.ts": 2,
 			"trpc/router/project/project.ts": 2,
 			"trpc/router/project/utils/resolve-repo.ts": 10,
-			"trpc/router/settings/branch-prefix.ts": 2,
 			"trpc/router/workspace-creation/shared/project-helpers.ts": 3,
 		},
 		advice:
-			"simple-git is async, but a client constructed here still pays the spawn syscall + stdout drain on the event loop — cost scales linearly with call volume (measured ~830ms/min at light churn). Async isn't enough for git; route it off-loop: add a task to workers/tasks/git.ts and run it via getHostWorkerPool().",
+			"simple-git is async, but a client constructed here still pays the spawn syscall + stdout drain on the event loop — cost scales linearly with call volume (measured ~830ms/min at light churn). Async isn't enough for git; route it off-loop: add a task to workers/tasks/git.ts and expose it with an offLoop() resolver (src/trpc/off-loop.ts).",
 	},
 ];
 

--- a/packages/host-service/src/runtime/git/identity.test.ts
+++ b/packages/host-service/src/runtime/git/identity.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { simpleGit } from "simple-git";
+import {
+	getGitAuthorName,
+	getGitHubUsernameViaGh,
+	readGitIdentity,
+} from "./identity";
+
+let tmpDir: string;
+let repoDir: string;
+let stubBinDir: string;
+
+// Env that hides the machine's global git config so `user.name` resolution
+// is fully controlled by the temp repo's local config. Isolation goes
+// through HOME/XDG (empty temp dir) because simple-git rejects GIT_CONFIG_*
+// and GIT_EDITOR env keys as unsafe.
+function isolatedGitEnv(): Record<string, string> {
+	return {
+		HOME: path.join(tmpDir, "home"),
+		XDG_CONFIG_HOME: path.join(tmpDir, "home", ".config"),
+		PATH: process.env.PATH ?? "",
+	};
+}
+
+function writeGhStub(script: string): void {
+	const stubPath = path.join(stubBinDir, "gh");
+	fs.writeFileSync(stubPath, `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+}
+
+/** Env whose PATH resolves `gh` to the stub (plus /bin etc. for sh). */
+function stubGhEnv(): Record<string, string> {
+	return {
+		...isolatedGitEnv(),
+		PATH: `${stubBinDir}:/usr/bin:/bin`,
+	};
+}
+
+beforeAll(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-identity-test-"));
+	repoDir = path.join(tmpDir, "repo");
+	stubBinDir = path.join(tmpDir, "bin");
+	fs.mkdirSync(repoDir);
+	fs.mkdirSync(stubBinDir);
+	fs.mkdirSync(path.join(tmpDir, "home"));
+	execFileSync("git", ["init"], { cwd: repoDir });
+});
+
+afterAll(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("getGitAuthorName", () => {
+	test("returns the configured user.name", async () => {
+		execFileSync("git", ["config", "user.name", "Test Author"], {
+			cwd: repoDir,
+		});
+		const git = simpleGit(repoDir).env(isolatedGitEnv());
+		expect(await getGitAuthorName(git)).toBe("Test Author");
+	});
+
+	test("returns null when user.name is unset", async () => {
+		execFileSync("git", ["config", "--unset", "user.name"], { cwd: repoDir });
+		const git = simpleGit(repoDir).env(isolatedGitEnv());
+		expect(await getGitAuthorName(git)).toBeNull();
+	});
+});
+
+describe("getGitHubUsernameViaGh", () => {
+	test("returns the login printed by gh", async () => {
+		writeGhStub('echo "octocat"');
+		expect(await getGitHubUsernameViaGh(stubGhEnv())).toBe("octocat");
+	});
+
+	test("returns null when gh exits non-zero", async () => {
+		writeGhStub("exit 1");
+		expect(await getGitHubUsernameViaGh(stubGhEnv())).toBeNull();
+	});
+
+	test("returns null when gh prints nothing", async () => {
+		writeGhStub("exit 0");
+		expect(await getGitHubUsernameViaGh(stubGhEnv())).toBeNull();
+	});
+
+	test("returns null when gh is not installed", async () => {
+		const env = { ...isolatedGitEnv(), PATH: path.join(tmpDir, "empty") };
+		expect(await getGitHubUsernameViaGh(env)).toBeNull();
+	});
+});
+
+describe("readGitIdentity", () => {
+	test("combines gh login with the process-env git author", async () => {
+		writeGhStub('echo "hubster"');
+		// The git read intentionally uses the process env (not shellEnv), so
+		// compare against the same read done directly.
+		const { createUserSimpleGit } = await import("./simple-git");
+		const expectedAuthor = await getGitAuthorName(createUserSimpleGit());
+		expect(await readGitIdentity(stubGhEnv())).toEqual({
+			githubUsername: "hubster",
+			authorName: expectedAuthor,
+		});
+	});
+});

--- a/packages/host-service/src/runtime/git/identity.test.ts
+++ b/packages/host-service/src/runtime/git/identity.test.ts
@@ -63,7 +63,15 @@ describe("getGitAuthorName", () => {
 	});
 
 	test("returns null when user.name is unset", async () => {
-		execFileSync("git", ["config", "--unset", "user.name"], { cwd: repoDir });
+		// Tolerant unset: exits non-zero when the key was never set, so this
+		// test doesn't depend on the set-test having run first.
+		try {
+			execFileSync("git", ["config", "--unset", "user.name"], {
+				cwd: repoDir,
+			});
+		} catch {
+			// key already absent
+		}
 		const git = simpleGit(repoDir).env(isolatedGitEnv());
 		expect(await getGitAuthorName(git)).toBeNull();
 	});

--- a/packages/host-service/src/runtime/git/identity.ts
+++ b/packages/host-service/src/runtime/git/identity.ts
@@ -1,0 +1,61 @@
+// Git/GitHub identity reads. Worker-safe: no DB or event-bus imports, so
+// the git/readGitIdentity worker task can bundle this module.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { SimpleGit } from "simple-git";
+import { createUserSimpleGit } from "./simple-git";
+
+const execFileAsync = promisify(execFile);
+
+export interface ResolvedGitInfo {
+	githubUsername: string | null;
+	authorName: string | null;
+}
+
+/** Reads `user.name` from git config. Returns null when unset or unreadable. */
+export async function getGitAuthorName(git: SimpleGit): Promise<string | null> {
+	try {
+		const name = await git.getConfig("user.name");
+		return name.value?.trim() || null;
+	} catch (error) {
+		console.warn("[git-identity] failed to read git user.name:", error);
+		return null;
+	}
+}
+
+/**
+ * Resolves the authenticated GitHub username via `gh api user`, relying on
+ * the user's existing `gh auth login` session. Null on any failure
+ * (gh missing, not authenticated, network).
+ */
+export async function getGitHubUsernameViaGh(
+	shellEnv: Record<string, string>,
+): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync(
+			"gh",
+			["api", "user", "--jq", ".login"],
+			{ encoding: "utf8", timeout: 10_000, env: shellEnv },
+		);
+		return stdout.trim() || null;
+	} catch (error) {
+		console.warn("[git-identity] failed to read GitHub username:", error);
+		return null;
+	}
+}
+
+/**
+ * Git identity used to preview `author`/`github` branch prefixes in settings.
+ * `shellEnv` is only for the `gh` spawn; the git config read keeps the
+ * process env — simple-git rejects env containing GIT_EDITOR as unsafe.
+ */
+export async function readGitIdentity(
+	shellEnv: Record<string, string>,
+): Promise<ResolvedGitInfo> {
+	const [githubUsername, authorName] = await Promise.all([
+		getGitHubUsernameViaGh(shellEnv),
+		getGitAuthorName(createUserSimpleGit()),
+	]);
+	return { githubUsername, authorName };
+}

--- a/packages/host-service/src/trpc/off-loop.test.ts
+++ b/packages/host-service/src/trpc/off-loop.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import type { HostServiceContext } from "../types";
+import { defineWorkerTask } from "../workers/define-worker-task";
+import { HostWorkerPool } from "../workers/host-worker-pool";
+import { createOffLoop } from "./off-loop";
+
+const echoTask = defineWorkerTask<{ value: string }, string>({
+	type: "test/echo",
+	handler: async ({ value }) => `echoed:${value}`,
+});
+
+const fakeCtx = { isAuthenticated: true } as unknown as HostServiceContext;
+
+describe("offLoop", () => {
+	test("prepare output becomes the task input; result flows back", async () => {
+		const calls: Array<{ type: string; input: unknown }> = [];
+		const offLoop = createOffLoop(() => ({
+			run: async (def, input) => {
+				calls.push({ type: def.type, input });
+				return def.handler(input);
+			},
+		}));
+
+		const resolver = offLoop({
+			task: echoTask,
+			prepare: ({ input }: { input: { name: string } }) => ({
+				value: input.name.toUpperCase(),
+			}),
+		});
+
+		const result = await resolver({ ctx: fakeCtx, input: { name: "kiet" } });
+		expect(result).toBe("echoed:KIET");
+		expect(calls).toEqual([{ type: "test/echo", input: { value: "KIET" } }]);
+	});
+
+	test("forwards the caller's abort signal and merges options", async () => {
+		let seenOptions: unknown;
+		const offLoop = createOffLoop(() => ({
+			run: async (def, input, options) => {
+				seenOptions = options;
+				return def.handler(input);
+			},
+		}));
+
+		const controller = new AbortController();
+		const resolver = offLoop({
+			task: echoTask,
+			prepare: () => ({ value: "x" }),
+			options: () => ({ strategy: "coalesce", dedupeKey: "k" }),
+		});
+
+		await resolver({
+			ctx: fakeCtx,
+			input: undefined,
+			signal: controller.signal,
+		});
+		expect(seenOptions).toEqual({
+			strategy: "coalesce",
+			dedupeKey: "k",
+			signal: controller.signal,
+		});
+	});
+
+	test("runs the task through a real pool (inline mode)", async () => {
+		const pool = new HostWorkerPool({ scriptPathResolver: () => null });
+		const offLoop = createOffLoop(() => pool);
+		const resolver = offLoop({
+			task: echoTask,
+			prepare: () => ({ value: "pooled" }),
+		});
+		expect(await resolver({ ctx: fakeCtx, input: undefined })).toBe(
+			"echoed:pooled",
+		);
+		await pool.dispose();
+	});
+
+	test("prepare errors reject the call without reaching the pool", async () => {
+		let ran = false;
+		const offLoop = createOffLoop(() => ({
+			run: async (def, input) => {
+				ran = true;
+				return def.handler(input);
+			},
+		}));
+		const resolver = offLoop({
+			task: echoTask,
+			prepare: () => {
+				throw new Error("prepare failed");
+			},
+		});
+		await expect(resolver({ ctx: fakeCtx, input: undefined })).rejects.toThrow(
+			"prepare failed",
+		);
+		expect(ran).toBe(false);
+	});
+});

--- a/packages/host-service/src/trpc/off-loop.ts
+++ b/packages/host-service/src/trpc/off-loop.ts
@@ -1,0 +1,48 @@
+// offLoop() — resolver factory that makes a procedure body a worker task.
+// `prepare` runs on the event loop (ctx reads, credential/env resolution)
+// and returns the task input as PLAIN DATA; the task then executes in the
+// host worker pool, so its subprocess/fs work never blocks the loop. Prefer
+// this for new procedures over spawning in the resolver — the
+// no-main-loop-blocking ratchet only catches regressions after the fact.
+
+import type { HostServiceContext } from "../types";
+import type { WorkerTaskDefinition } from "../workers/define-worker-task";
+import {
+	getHostWorkerPool,
+	type HostWorkerPool,
+} from "../workers/host-worker-pool";
+import type { WorkerTaskOptions } from "../workers/WorkerTaskRunner";
+
+export interface OffLoopArgs<TInput> {
+	ctx: HostServiceContext;
+	input: TInput;
+	/** Provided by tRPC on request abort; forwarded to the task when set. */
+	signal?: AbortSignal;
+}
+
+export interface OffLoopSpec<TInput, TTaskInput, TResult> {
+	task: WorkerTaskDefinition<TTaskInput, TResult>;
+	/** On-loop stage: gather the ctx-derived data the worker needs. */
+	prepare: (args: OffLoopArgs<TInput>) => TTaskInput | Promise<TTaskInput>;
+	/** Per-call pool options (timeout, coalescing). The caller's abort signal
+	 * is forwarded automatically. */
+	options?: (
+		args: OffLoopArgs<TInput>,
+	) => Omit<WorkerTaskOptions, "signal"> | undefined;
+}
+
+export function createOffLoop(getPool: () => Pick<HostWorkerPool, "run">) {
+	return function offLoop<TInput, TTaskInput, TResult>(
+		spec: OffLoopSpec<TInput, TTaskInput, TResult>,
+	): (args: OffLoopArgs<TInput>) => Promise<TResult> {
+		return async (args) => {
+			const taskInput = await spec.prepare(args);
+			return getPool().run(spec.task, taskInput, {
+				...spec.options?.(args),
+				signal: args.signal,
+			});
+		};
+	};
+}
+
+export const offLoop = createOffLoop(getHostWorkerPool);

--- a/packages/host-service/src/trpc/router/settings/branch-prefix.ts
+++ b/packages/host-service/src/trpc/router/settings/branch-prefix.ts
@@ -4,9 +4,10 @@ import {
 } from "@superset/shared/workspace-launch";
 import { z } from "zod";
 import { hostSettings } from "../../../db/schema";
-import { createUserSimpleGit } from "../../../runtime/git/simple-git";
+import { getStrictShellEnvironment } from "../../../terminal/clean-shell-env";
+import { gitIdentityTask } from "../../../workers/tasks/git";
 import { protectedProcedure, router } from "../../index";
-import { resolveGitInfo } from "../workspace-creation/utils/branch-prefix";
+import { offLoop } from "../../off-loop";
 
 /**
  * Host-wide branch-prefix default. Projects without their own override fall
@@ -53,7 +54,14 @@ export const branchPrefixRouter = router({
 	 * Git identity for the settings preview — lets the UI show what the
 	 * `author`/`github` modes would actually resolve to.
 	 */
-	gitInfo: protectedProcedure.query(({ ctx }) => {
-		return resolveGitInfo(createUserSimpleGit(), ctx.execGh);
-	}),
+	gitInfo: protectedProcedure.query(
+		offLoop({
+			task: gitIdentityTask,
+			prepare: async () => ({
+				shellEnv: await getStrictShellEnvironment().catch(
+					() => process.env as Record<string, string>,
+				),
+			}),
+		}),
+	),
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/branch-prefix.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/branch-prefix.ts
@@ -4,20 +4,10 @@ import {
 } from "@superset/shared/workspace-launch";
 import type { SimpleGit } from "simple-git";
 import { hostSettings } from "../../../../db/schema";
+import { getGitAuthorName } from "../../../../runtime/git/identity";
 import type { HostServiceContext } from "../../../../types";
 import type { LocalProject } from "../shared/local-project";
 import type { ExecGh } from "./exec-gh";
-
-/** Reads `user.name` from git config. Returns null when unset or unreadable. */
-export async function getGitAuthorName(git: SimpleGit): Promise<string | null> {
-	try {
-		const name = await git.getConfig("user.name");
-		return name.value?.trim() || null;
-	} catch (error) {
-		console.warn("[branch-prefix] failed to read git user.name:", error);
-		return null;
-	}
-}
 
 /** Resolves the authenticated GitHub username via `gh api user`. */
 export async function getGitHubUsername(
@@ -30,23 +20,6 @@ export async function getGitHubUsername(
 		console.warn("[branch-prefix] failed to read GitHub username:", error);
 		return null;
 	}
-}
-
-export interface ResolvedGitInfo {
-	githubUsername: string | null;
-	authorName: string | null;
-}
-
-/** Git identity used to preview `author`/`github` prefixes in settings. */
-export async function resolveGitInfo(
-	git: SimpleGit,
-	execGh: ExecGh,
-): Promise<ResolvedGitInfo> {
-	const [githubUsername, authorName] = await Promise.all([
-		getGitHubUsername(execGh),
-		getGitAuthorName(git),
-	]);
-	return { githubUsername, authorName };
 }
 
 /**

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -3,6 +3,10 @@
 // host-service event loop. Credential env is resolved in-process (it needs
 // the credential provider) and crosses as plain data.
 
+import {
+	type ResolvedGitInfo,
+	readGitIdentity,
+} from "../../runtime/git/identity.ts";
 import { createUserSimpleGit } from "../../runtime/git/simple-git.ts";
 import {
 	readWorkspaceRefs,
@@ -73,9 +77,18 @@ export const gitWorkspaceRefsTask = defineWorkerTask<
 	},
 });
 
+export const gitIdentityTask = defineWorkerTask<
+	{ shellEnv: GitTaskEnv },
+	ResolvedGitInfo
+>({
+	type: "git/readGitIdentity",
+	handler: ({ shellEnv }) => readGitIdentity(shellEnv),
+});
+
 export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
 	gitCommitFilesTask,
 	gitWorkspaceRefsTask,
+	gitIdentityTask,
 ];

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -69,6 +69,12 @@ New procedures should not join this list: build them as a worker task plus
 an `offLoop()` resolver (`src/trpc/off-loop.ts`) — `prepare` runs on-loop
 and returns plain data, the task runs in the pool.
 
+Pool-level follow-up: task cancellation. Handlers are non-cancellable today
+(caller abort rejects the promise; the handler and any child process run to
+completion, bounded by their own timeouts). Proper cancellation needs an
+abort message in the worker protocol driving a per-task AbortController —
+applies to all tasks, raised on PR #6107 review.
+
 ## Backlog — desktop
 
 Same convention: entries with a `no-main-process-blocking.test.ts`

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -61,9 +61,13 @@ factory) so the ratchet doesn't see them — they're backlog-only.
    loop; hoist + worker-route `worktree remove`
 6. `trpc/router/workspace/workspace.ts` — full `git.status()` on the legacy
    surface; also per-row `existsSync` in `workspace.list`
-7. `trpc/router/settings/branch-prefix.ts`,
-   `workspace-creation/shared/project-helpers.ts`,
+7. `workspace-creation/shared/project-helpers.ts`,
    `trpc/router/git/utils/git-helpers.ts` — cheap but on-loop; port last
+   (`settings/branch-prefix.ts` done — first `offLoop()` port)
+
+New procedures should not join this list: build them as a worker task plus
+an `offLoop()` resolver (`src/trpc/off-loop.ts`) — `prepare` runs on-loop
+and returns plain data, the task runs in the pool.
 
 ## Backlog — desktop
 


### PR DESCRIPTION
**Links**
- Follow-up to #6101 / #6093; backlog: `plans/off-loop-git-reads.md`

## Summary
- Adds `offLoop()` (`src/trpc/off-loop.ts`): a resolver factory that makes a tRPC procedure's body a worker task, so new procedures are non-blocking **by construction** instead of being caught by the ratchet after the fact.
- First port: `settings.branchPrefix.gitInfo` — its `simple-git` construction and `gh api user` spawn move off the event loop, and `branch-prefix.ts` becomes the first entry deleted from the `no-main-loop-blocking` ratchet allowlist.

## Why / Context
tRPC resolvers are already async, but async is cooperative scheduling on one thread — the spawn syscall, stdout drain, and parsing still execute on the org's only event loop. The worker-pool pattern from #6093 fixes that, but each port took ad-hoc boilerplate (resolve env, get pool, run task). `offLoop()` packages the pattern so the off-loop path is the path of least resistance. Resolver closures can't cross threads, so this is deliberately per-procedure opt-in: `prepare` runs on-loop and returns plain data, everything else runs in the pool.

## How It Works
- `offLoop({ task, prepare, options? })` returns a resolver: `prepare({ctx, input, signal})` gathers ctx-derived data on-loop (cheap: DB reads, credential/env resolution), the task runs via `getHostWorkerPool()` (worker thread, inline fallback preserved), and the caller's abort signal is forwarded to the pool.
- `createOffLoop(getPool)` is the DI seam; the exported `offLoop` binds the singleton pool.
- Identity reads move to worker-safe `runtime/git/identity.ts` (no DB imports, keeping the worker bundle lean). The `gh` spawn gets the TTL-cached strict shell env as data; the git config read intentionally keeps the process env because simple-git rejects env containing `GIT_EDITOR`/`GIT_CONFIG_*` as unsafe (found the hard way in tests — applying the shell env to git would have thrown in production).
- The ratchet's git-rule advice now points at `offLoop()`, and the plan doc tells new procedures to use it.

## Manual QA Checklist
- [x] Settings → branch prefix preview still resolves author/github names (desktop against a dev host) — see verification comment

## Testing
- `bun run typecheck`, `bun run lint` — clean
- New tests: `runtime/git/identity.test.ts` (real temp repo with HOME-isolated git config; stubbed `gh` on PATH covering success/exit-1/empty/missing) and `trpc/off-loop.test.ts` (prepare→task data flow, signal forwarding + option merge, real `HostWorkerPool` inline mode, prepare-error short-circuit)
- Mutation-checked: dropping signal forwarding, returning `""` instead of null for empty gh output, and ignoring the prepare result each failed exactly their corresponding tests
- Full host-service `bun test` suite passes; `no-main-loop-blocking` ratchet passes with the branch-prefix entry deleted (the stale-count check forces the deletion)

## Design Decisions
- **Why a resolver factory instead of a custom procedure builder**: keeps full access to tRPC's input/meta/middleware chaining; the helper only standardizes the resolver body. A builder would duplicate tRPC's generics for no added safety.
- **Why per-procedure opt-in**: closures don't serialize; a transparent middleware that moves arbitrary resolvers off-loop is impossible. `prepare` is the explicit on-loop/off-loop boundary.

## Follow-ups
- Port backlog items in `plans/off-loop-git-reads.md` through `offLoop()` (listCommits/getDiff next per priority order)
- Desktop equivalent wrapping `runGitTask` (different typed-union worker architecture)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `offLoop()` to run tRPC procedure bodies in the worker pool to avoid event-loop blocking. Ports `settings.branchPrefix.gitInfo` to use it, moving `simple-git` and `gh` identity reads off-loop.

- **New Features**
  - `offLoop()` resolver factory: `prepare` runs on-loop; the task runs in the worker pool; forwards abort signals and supports task options.
  - `gitIdentityTask`: reads Git/GitHub identity via `runtime/git/identity.ts` (worker-safe). `simple-git` uses the process env; `gh` runs with the strict shell env.
  - `settings.branchPrefix.gitInfo` now uses `offLoop()` + `gitIdentityTask`, so `simple-git` construction and `gh api user` no longer block the loop.

- **Refactors**
  - Removed `settings/branch-prefix.ts` from the `no-main-loop-blocking` allowlist; ratchet advice now points to `offLoop()`.
  - Updated `plans/off-loop-git-reads.md` to track worker-task cancellation as a follow-up.

<sup>Written for commit 48d6fbfe2ad570c6233cd44c749fdcc0e9266a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git identity detection for configured author names and authenticated GitHub usernames.
  * Git information retrieval now runs in the background to keep requests responsive.
  * Added safe fallback behavior when GitHub CLI or shell environment details are unavailable.

* **Bug Fixes**
  * Improved handling of failed, missing, or incomplete Git identity lookups.

* **Tests**
  * Added comprehensive coverage for Git identity detection, background processing, abort handling, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
