### PR TITLE
docs: remove nonexistent "All devices" filter option

### DIFF
--- a/apps/docs/content/docs/remote-workspaces.mdx
+++ b/apps/docs/content/docs/remote-workspaces.mdx
@@ -76,8 +76,7 @@ Open **Settings → Hosts** in the desktop app, pick the host, and use **Add mem
 On any other device signed into the same organization, open the desktop app's **Workspaces** list. Use the **Device** filter in the top right to pick a remote host:
 
 - **This device**: workspaces on the machine you're using now
-- **All devices**: everything you can reach
-- **Other devices**: each remote host that has opted in, with an online indicator
+- **Other devices**: each remote host that has opted in, listed by name with an online indicator
 
 ![Device filter in the workspaces list](/images/remote-workspaces-device-filter.png)
 


### PR DESCRIPTION
## Summary

`remote-workspaces.mdx` documents an **All devices** option in the Workspaces Device filter. That option does not exist — `git grep "All devices" apps/desktop/src` returns nothing.

The picker actually renders a **This device** item plus an **Other devices** group listing each opted-in remote host by name with an online indicator (`V2WorkspacesHeader.tsx:201-225`). Users following the docs would look for a control that was never built.

## Test plan
- [x] Verified against `origin/main`: zero occurrences of `All devices` in `apps/desktop/src`; only `DEVICE_FILTER_THIS_DEVICE` plus per-host ids exist
- [x] `bun run lint` exits 0

Found while triaging #6047, the last output of the now-removed `update-docs.yml` workflow. The rest of that PR's salvageable content (`terminals list/send/read/close` in the CLI and SDK references, plus five short feature notes) is not included here and still needs a separate pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated device filter documentation to list remote hosts under **Other devices**.
  * Removed the separate **All devices** option from the documented filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->