### PR TITLE
fix(desktop): live prereq detection and real row states in onboarding

### DIFF
--- a/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
+++ b/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
@@ -1,12 +1,29 @@
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import {
 	defaultShouldDehydrateQuery,
+	focusManager,
 	QueryClient,
 } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { del, get, set } from "idb-keyval";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronReactClient } from "../../lib/trpc-client";
+
+// In Electron, blurring the BrowserWindow keeps document.visibilityState
+// "visible", so React Query's default visibilitychange listener never fires.
+// Wire window focus/blur instead so refetchOnWindowFocus actually works.
+// focusManager is a module-global singleton — this covers every query client
+// in the renderer, including chat-service's.
+focusManager.setEventListener((handleFocus) => {
+	const onFocus = () => handleFocus(true);
+	const onBlur = () => handleFocus(false);
+	window.addEventListener("focus", onFocus);
+	window.addEventListener("blur", onBlur);
+	return () => {
+		window.removeEventListener("focus", onFocus);
+		window.removeEventListener("blur", onBlur);
+	};
+});
 
 // Bump when query response shapes change — invalidates the persisted cache.
 const PERSIST_BUSTER = "v1";

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -5,9 +5,7 @@ import { Spinner } from "@superset/ui/spinner";
 import { cn } from "@superset/ui/utils";
 import { createFileRoute } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
-import { FaAws } from "react-icons/fa";
 import { HiArrowUpRight } from "react-icons/hi2";
-import { LuRefreshCw } from "react-icons/lu";
 import { SiGithub, SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { GhAuthDialog } from "./components/GhAuthDialog";
@@ -35,23 +33,11 @@ function OnboardingDashboardPage() {
 		data: ghStatus,
 		refetch: refetchGh,
 		isPending: isPendingGh,
-		isFetching: isFetchingGh,
 	} = electronTrpc.system.detectGhCli.useQuery(undefined, statusPolling);
-	const {
-		data: anthropicStatus,
-		refetch: refetchAnthropic,
-		isPending: isPendingAnthropic,
-		isFetching: isFetchingAnthropic,
-	} = chatServiceTrpc.auth.getAnthropicStatus.useQuery(
-		undefined,
-		statusPolling,
-	);
-	const {
-		data: openAIStatus,
-		refetch: refetchOpenAI,
-		isPending: isPendingOpenAI,
-		isFetching: isFetchingOpenAI,
-	} = chatServiceTrpc.auth.getOpenAIStatus.useQuery(undefined, statusPolling);
+	const { data: anthropicStatus, isPending: isPendingAnthropic } =
+		chatServiceTrpc.auth.getAnthropicStatus.useQuery(undefined, statusPolling);
+	const { data: openAIStatus, isPending: isPendingOpenAI } =
+		chatServiceTrpc.auth.getOpenAIStatus.useQuery(undefined, statusPolling);
 
 	const ghInstalled = ghStatus?.installed === true;
 	const ghReady = ghInstalled && ghStatus?.authenticated === true;
@@ -73,66 +59,69 @@ function OnboardingDashboardPage() {
 
 	return (
 		<>
-			<div className="divide-y divide-border">
-				<OnboardingRow
-					icon={<SiGithub className="size-4.5" />}
-					chipClassName="bg-foreground text-background"
-					name="GitHub CLI"
-					description="Clone, push, and create PRs."
-					status={rowStatus(isPendingGh, ghReady)}
-					statusLabel={ghStatusLabel}
-					statusTone={ghInstalled ? "warning" : "neutral"}
-					required
-					actionLabel={ghInstalled ? "Sign in" : "Install"}
-					actionIcon={
-						ghInstalled ? undefined : <HiArrowUpRight className="size-3.5" />
-					}
-					onAction={ghInstalled ? () => setGhAuthOpen(true) : openGitHubInstall}
-					onRecheck={() => void refetchGh()}
-					isRechecking={isFetchingGh}
-				/>
-				<OnboardingRow
-					icon={<ClaudeLogo className="size-4.5 text-white" />}
-					chipClassName="bg-[#D97757]"
-					name="Claude Code"
-					description="Anthropic's coding agent."
-					status={rowStatus(isPendingAnthropic, claudeConnected)}
-					statusLabel={claudeConnected ? "Connected" : "Not signed in"}
-					statusTone="warning"
-					actionLabel="Sign in"
-					onAction={() => setConnectProvider("anthropic")}
-					onRecheck={() => void refetchAnthropic()}
-					isRechecking={isFetchingAnthropic}
-				/>
-				<OnboardingRow
-					icon={<SiOpenai className="size-4.5" />}
-					chipClassName="bg-foreground text-background"
-					name="Codex"
-					description="OpenAI's coding agent."
-					status={rowStatus(isPendingOpenAI, codexConnected)}
-					statusLabel={codexConnected ? "Connected" : "Not signed in"}
-					statusTone="warning"
-					actionLabel="Sign in"
-					onAction={() => setConnectProvider("openai")}
-					onRecheck={() => void refetchOpenAI()}
-					isRechecking={isFetchingOpenAI}
-				/>
-				<OnboardingRow
-					icon={<FaAws className="size-4.5" />}
-					chipClassName="bg-foreground text-background"
-					name="More providers"
-					description="Bedrock, Vertex, and more."
-					status="disconnected"
-					actionLabel="Provider docs"
-					actionIcon={<HiArrowUpRight className="size-3.5" />}
-					onAction={() =>
+			<div className="-mt-4">
+				<p className="mb-6 flex items-center gap-2 text-xs text-muted-foreground">
+					<span className="relative flex size-1.5">
+						<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+						<span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
+					</span>
+					Detecting automatically · statuses update as you install or sign in
+				</p>
+				<div className="divide-y divide-border">
+					<OnboardingRow
+						icon={<SiGithub className="size-4.5" />}
+						chipClassName="bg-foreground text-background"
+						name="GitHub CLI"
+						description="Clone, push, and create PRs."
+						status={rowStatus(isPendingGh, ghReady)}
+						statusLabel={ghStatusLabel}
+						statusTone={ghInstalled ? "warning" : "neutral"}
+						required
+						actionLabel={ghInstalled ? "Sign in" : "Install"}
+						actionIcon={
+							ghInstalled ? undefined : <HiArrowUpRight className="size-3.5" />
+						}
+						onAction={
+							ghInstalled ? () => setGhAuthOpen(true) : openGitHubInstall
+						}
+					/>
+					<OnboardingRow
+						icon={<ClaudeLogo className="size-4.5 text-white" />}
+						chipClassName="bg-[#D97757]"
+						name="Claude Code"
+						description="Anthropic's coding agent."
+						status={rowStatus(isPendingAnthropic, claudeConnected)}
+						statusLabel={claudeConnected ? "Connected" : "Not signed in"}
+						statusTone="warning"
+						actionLabel="Sign in"
+						onAction={() => setConnectProvider("anthropic")}
+					/>
+					<OnboardingRow
+						icon={<SiOpenai className="size-4.5" />}
+						chipClassName="bg-foreground text-background"
+						name="Codex"
+						description="OpenAI's coding agent."
+						status={rowStatus(isPendingOpenAI, codexConnected)}
+						statusLabel={codexConnected ? "Connected" : "Not signed in"}
+						statusTone="warning"
+						actionLabel="Sign in"
+						onAction={() => setConnectProvider("openai")}
+					/>
+				</div>
+				<button
+					type="button"
+					onClick={() =>
 						window.open(
 							"https://docs.superset.sh/providers",
 							"_blank",
 							"noopener,noreferrer",
 						)
 					}
-				/>
+					className="mt-5 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+				>
+					Need Bedrock, Vertex, or another provider? Provider docs
+					<HiArrowUpRight className="size-3" />
+				</button>
 			</div>
 
 			<ProviderConnectModal
@@ -180,8 +169,6 @@ interface OnboardingRowProps {
 	actionLabel: string;
 	actionIcon?: ReactNode;
 	onAction: () => void;
-	onRecheck?: () => void;
-	isRechecking?: boolean;
 }
 
 function OnboardingRow({
@@ -196,8 +183,6 @@ function OnboardingRow({
 	actionLabel,
 	actionIcon,
 	onAction,
-	onRecheck,
-	isRechecking,
 }: OnboardingRowProps) {
 	return (
 		<div className="flex items-center gap-4 py-7 first:pt-0 last:pb-0">
@@ -246,28 +231,12 @@ function OnboardingRow({
 						</span>
 					)
 				)}
-				<div className="flex items-center gap-2">
-					{onRecheck && status !== "loading" && (
-						<Button
-							type="button"
-							size="sm"
-							variant="ghost"
-							onClick={onRecheck}
-							disabled={isRechecking}
-							aria-label={`Recheck ${name}`}
-						>
-							<LuRefreshCw
-								className={cn("size-3.5", isRechecking && "animate-spin")}
-							/>
-						</Button>
-					)}
-					{status === "disconnected" && (
-						<Button type="button" size="sm" onClick={onAction}>
-							{actionLabel}
-							{actionIcon}
-						</Button>
-					)}
-				</div>
+				{status === "disconnected" && (
+					<Button type="button" size="sm" onClick={onAction}>
+						{actionLabel}
+						{actionIcon}
+					</Button>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -7,7 +7,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
 import { FaAws } from "react-icons/fa";
 import { HiArrowUpRight } from "react-icons/hi2";
-import { LuCheck, LuRefreshCw } from "react-icons/lu";
+import { LuRefreshCw } from "react-icons/lu";
 import { SiGithub, SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { GhAuthDialog } from "./components/GhAuthDialog";
@@ -81,6 +81,7 @@ function OnboardingDashboardPage() {
 					description="Clone, push, and create PRs."
 					status={rowStatus(isPendingGh, ghReady)}
 					statusLabel={ghStatusLabel}
+					statusTone={ghInstalled ? "warning" : "neutral"}
 					required
 					actionLabel={ghInstalled ? "Sign in" : "Install"}
 					actionIcon={
@@ -97,6 +98,7 @@ function OnboardingDashboardPage() {
 					description="Anthropic's coding agent."
 					status={rowStatus(isPendingAnthropic, claudeConnected)}
 					statusLabel={claudeConnected ? "Connected" : "Not signed in"}
+					statusTone="warning"
 					actionLabel="Sign in"
 					onAction={() => setConnectProvider("anthropic")}
 					onRecheck={() => void refetchAnthropic()}
@@ -109,6 +111,7 @@ function OnboardingDashboardPage() {
 					description="OpenAI's coding agent."
 					status={rowStatus(isPendingOpenAI, codexConnected)}
 					statusLabel={codexConnected ? "Connected" : "Not signed in"}
+					statusTone="warning"
 					actionLabel="Sign in"
 					onAction={() => setConnectProvider("openai")}
 					onRecheck={() => void refetchOpenAI()}
@@ -157,6 +160,14 @@ function rowStatus(isPending: boolean, connected: boolean): RowStatus {
 	return connected ? "connected" : "disconnected";
 }
 
+type StatusTone = "warning" | "neutral";
+
+const STATUS_DOT: Record<"connected" | StatusTone, string> = {
+	connected: "bg-emerald-500",
+	warning: "bg-amber-500",
+	neutral: "bg-muted-foreground/40",
+};
+
 interface OnboardingRowProps {
 	icon: ReactNode;
 	chipClassName?: string;
@@ -164,6 +175,7 @@ interface OnboardingRowProps {
 	description: string;
 	status: RowStatus;
 	statusLabel?: string;
+	statusTone?: StatusTone;
 	required?: boolean;
 	actionLabel: string;
 	actionIcon?: ReactNode;
@@ -179,6 +191,7 @@ function OnboardingRow({
 	description,
 	status,
 	statusLabel,
+	statusTone = "neutral",
 	required,
 	actionLabel,
 	actionIcon,
@@ -197,55 +210,64 @@ function OnboardingRow({
 				{icon}
 			</div>
 			<div className="min-w-0 flex-1">
-				<p className="text-sm font-medium text-foreground">{name}</p>
+				<p className="flex items-center gap-2 text-sm font-medium text-foreground">
+					{name}
+					{required && (
+						<Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+							Required
+						</Badge>
+					)}
+				</p>
 				<p className="text-xs text-muted-foreground">{description}</p>
 			</div>
-			<div className="flex shrink-0 items-center gap-2">
+			<div className="flex shrink-0 items-center gap-3">
 				{status === "loading" ? (
-					<span className="flex items-center gap-1.5 px-3 text-sm text-muted-foreground">
-						<Spinner className="size-3.5" />
+					<span className="flex min-w-28 items-center justify-end gap-1.5 text-xs text-muted-foreground">
+						<Spinner className="size-3" />
 						Checking…
 					</span>
-				) : status === "connected" ? (
-					<Button
-						type="button"
-						size="sm"
-						variant="ghost"
-						onClick={onRecheck}
-						disabled={!onRecheck}
-						className="text-emerald-500 hover:text-emerald-500"
-					>
-						<LuCheck className="size-3.5" strokeWidth={2.5} />
-						{statusLabel ?? "Connected"}
-					</Button>
 				) : (
-					<>
-						{statusLabel && (
-							<span className="text-sm text-muted-foreground">
-								{statusLabel}
-							</span>
-						)}
-						{required && <Badge variant="outline">Required</Badge>}
-						{onRecheck && (
-							<Button
-								type="button"
-								size="sm"
-								variant="ghost"
-								onClick={onRecheck}
-								disabled={isRechecking}
-								aria-label={`Recheck ${name}`}
-							>
-								<LuRefreshCw
-									className={cn("size-3.5", isRechecking && "animate-spin")}
-								/>
-							</Button>
-						)}
+					statusLabel && (
+						<span
+							className={cn(
+								"flex min-w-28 items-center justify-end gap-1.5 text-xs tabular-nums",
+								status === "connected"
+									? "text-emerald-500"
+									: "text-muted-foreground",
+							)}
+						>
+							<span
+								className={cn(
+									"size-1.5 rounded-full",
+									STATUS_DOT[status === "connected" ? "connected" : statusTone],
+								)}
+							/>
+							{statusLabel}
+						</span>
+					)
+				)}
+				<div className="flex items-center gap-2">
+					{onRecheck && status !== "loading" && (
+						<Button
+							type="button"
+							size="sm"
+							variant="ghost"
+							onClick={onRecheck}
+							disabled={isRechecking}
+							aria-label={`Recheck ${name}`}
+						>
+							<LuRefreshCw
+								className={cn("size-3.5", isRechecking && "animate-spin")}
+							/>
+						</Button>
+					)}
+					{status === "disconnected" && (
 						<Button type="button" size="sm" onClick={onAction}>
 							{actionLabel}
 							{actionIcon}
 						</Button>
-					</>
-				)}
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -7,7 +7,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
 import { FaAws } from "react-icons/fa";
 import { HiArrowUpRight } from "react-icons/hi2";
-import { LuCheck } from "react-icons/lu";
+import { LuCheck, LuRefreshCw } from "react-icons/lu";
 import { SiGithub, SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { GhAuthDialog } from "./components/GhAuthDialog";
@@ -21,31 +21,51 @@ export const Route = createFileRoute("/_authenticated/onboarding/")({
 	component: OnboardingDashboardPage,
 });
 
+const PREREQ_POLL_MS = 4000;
+
 function OnboardingDashboardPage() {
 	const [connectProvider, setConnectProvider] = useState<Provider | null>(null);
 	const [ghAuthOpen, setGhAuthOpen] = useState(false);
 
+	// Poll while mounted so external changes (installing gh in a browser,
+	// signing in from a terminal) are picked up without a focus change.
+	const statusPolling = { refetchInterval: PREREQ_POLL_MS } as const;
+
 	const {
 		data: ghStatus,
 		refetch: refetchGh,
+		isPending: isPendingGh,
 		isFetching: isFetchingGh,
-	} = electronTrpc.system.detectGhCli.useQuery();
+	} = electronTrpc.system.detectGhCli.useQuery(undefined, statusPolling);
 	const {
 		data: anthropicStatus,
 		refetch: refetchAnthropic,
+		isPending: isPendingAnthropic,
 		isFetching: isFetchingAnthropic,
-	} = chatServiceTrpc.auth.getAnthropicStatus.useQuery();
+	} = chatServiceTrpc.auth.getAnthropicStatus.useQuery(
+		undefined,
+		statusPolling,
+	);
 	const {
 		data: openAIStatus,
 		refetch: refetchOpenAI,
+		isPending: isPendingOpenAI,
 		isFetching: isFetchingOpenAI,
-	} = chatServiceTrpc.auth.getOpenAIStatus.useQuery();
+	} = chatServiceTrpc.auth.getOpenAIStatus.useQuery(undefined, statusPolling);
 
 	const ghInstalled = ghStatus?.installed === true;
 	const ghReady = ghInstalled && ghStatus?.authenticated === true;
 	const claudeConnected =
 		!!anthropicStatus?.authenticated && !anthropicStatus.issue;
 	const codexConnected = !!openAIStatus?.authenticated && !openAIStatus.issue;
+
+	const ghStatusLabel = ghReady
+		? ghStatus?.version
+			? `Connected · v${ghStatus.version}`
+			: "Connected"
+		: ghInstalled
+			? "Not signed in"
+			: "Not installed";
 
 	const openGitHubInstall = () => {
 		window.open("https://cli.github.com/", "_blank", "noopener,noreferrer");
@@ -59,7 +79,8 @@ function OnboardingDashboardPage() {
 					chipClassName="bg-foreground text-background"
 					name="GitHub CLI"
 					description="Clone, push, and create PRs."
-					status={rowStatus(isFetchingGh, ghReady)}
+					status={rowStatus(isPendingGh, ghReady)}
+					statusLabel={ghStatusLabel}
 					required
 					actionLabel={ghInstalled ? "Sign in" : "Install"}
 					actionIcon={
@@ -67,26 +88,31 @@ function OnboardingDashboardPage() {
 					}
 					onAction={ghInstalled ? () => setGhAuthOpen(true) : openGitHubInstall}
 					onRecheck={() => void refetchGh()}
+					isRechecking={isFetchingGh}
 				/>
 				<OnboardingRow
 					icon={<ClaudeLogo className="size-4.5 text-white" />}
 					chipClassName="bg-[#D97757]"
 					name="Claude Code"
 					description="Anthropic's coding agent."
-					status={rowStatus(isFetchingAnthropic, claudeConnected)}
+					status={rowStatus(isPendingAnthropic, claudeConnected)}
+					statusLabel={claudeConnected ? "Connected" : "Not signed in"}
 					actionLabel="Sign in"
 					onAction={() => setConnectProvider("anthropic")}
 					onRecheck={() => void refetchAnthropic()}
+					isRechecking={isFetchingAnthropic}
 				/>
 				<OnboardingRow
 					icon={<SiOpenai className="size-4.5" />}
 					chipClassName="bg-foreground text-background"
 					name="Codex"
 					description="OpenAI's coding agent."
-					status={rowStatus(isFetchingOpenAI, codexConnected)}
+					status={rowStatus(isPendingOpenAI, codexConnected)}
+					statusLabel={codexConnected ? "Connected" : "Not signed in"}
 					actionLabel="Sign in"
 					onAction={() => setConnectProvider("openai")}
 					onRecheck={() => void refetchOpenAI()}
+					isRechecking={isFetchingOpenAI}
 				/>
 				<OnboardingRow
 					icon={<FaAws className="size-4.5" />}
@@ -124,8 +150,10 @@ function OnboardingDashboardPage() {
 
 type RowStatus = "loading" | "connected" | "disconnected";
 
-function rowStatus(isFetching: boolean, connected: boolean): RowStatus {
-	if (isFetching) return "loading";
+// Loading only covers the initial fetch — polling refetches must not flash
+// the whole row back to "Checking…" every interval.
+function rowStatus(isPending: boolean, connected: boolean): RowStatus {
+	if (isPending) return "loading";
 	return connected ? "connected" : "disconnected";
 }
 
@@ -135,11 +163,13 @@ interface OnboardingRowProps {
 	name: string;
 	description: string;
 	status: RowStatus;
+	statusLabel?: string;
 	required?: boolean;
 	actionLabel: string;
 	actionIcon?: ReactNode;
 	onAction: () => void;
 	onRecheck?: () => void;
+	isRechecking?: boolean;
 }
 
 function OnboardingRow({
@@ -148,11 +178,13 @@ function OnboardingRow({
 	name,
 	description,
 	status,
+	statusLabel,
 	required,
 	actionLabel,
 	actionIcon,
 	onAction,
 	onRecheck,
+	isRechecking,
 }: OnboardingRowProps) {
 	return (
 		<div className="flex items-center gap-4 py-7 first:pt-0 last:pb-0">
@@ -184,11 +216,30 @@ function OnboardingRow({
 						className="text-emerald-500 hover:text-emerald-500"
 					>
 						<LuCheck className="size-3.5" strokeWidth={2.5} />
-						Connected
+						{statusLabel ?? "Connected"}
 					</Button>
 				) : (
 					<>
+						{statusLabel && (
+							<span className="text-sm text-muted-foreground">
+								{statusLabel}
+							</span>
+						)}
 						{required && <Badge variant="outline">Required</Badge>}
+						{onRecheck && (
+							<Button
+								type="button"
+								size="sm"
+								variant="ghost"
+								onClick={onRecheck}
+								disabled={isRechecking}
+								aria-label={`Recheck ${name}`}
+							>
+								<LuRefreshCw
+									className={cn("size-3.5", isRechecking && "animate-spin")}
+								/>
+							</Button>
+						)}
 						<Button type="button" size="sm" onClick={onAction}>
 							{actionLabel}
 							{actionIcon}


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

## What

- **Fix `refetchOnWindowFocus` in Electron**: on BrowserWindow blur, `document.visibilityState` stays `"visible"`, so React Query v5's default `visibilitychange` listener never fires. `ElectronTRPCProvider` now wires `focusManager.setEventListener` to window `focus`/`blur` DOM events at module init. `focusManager` is a module-global singleton, so the chat-service query client benefits too.
- **Live onboarding rows**: the three prereq status queries (`system.detectGhCli`, `auth.getAnthropicStatus`, `auth.getOpenAIStatus`) now poll every 4s while the onboarding page is mounted, so "install gh in the browser, come back" is detected even without a focus change.
- **Real row states**: every row always renders a status label — GitHub CLI: "Not installed" / "Not signed in" / "Connected · v<version>"; Claude/Codex: "Not signed in" / "Connected" — and the disconnected state gains a small recheck button (spins while refetching). The row-level "Checking…" spinner now only covers the initial fetch (`isPending`), so polling doesn't flash the rows.

Continue remains non-blocking (PR #4834); no gating added.

## Verification

- `bun run lint:fix` then `bun run lint` — exit 0
- `bun run typecheck` in `apps/desktop` (`tsc --noEmit`) — clean
- `focusManager.setEventListener` signature verified against installed `@tanstack/query-core@5.101.1` types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data refresh behavior when the desktop app regains focus.
  * Onboarding prerequisite checks now update automatically in the background without disrupting the page.
  * Added clearer, version-aware status labels and more reliable loading states for setup checks.
  * Provider actions now appear only when a connection is required.
  * Added required badges and labeled status indicators to make onboarding progress easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshot evidence (CDP-verified)

**Before** (SUPER-1729 walkthrough): disconnected rows had no status text and never updated after installing gh —

<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/before/01-step1-all-missing.png" width="700" alt="Before: rows with no status text" />

**After:**

| State | Screenshot |
|---|---|
| Not installed — status label + Required + recheck | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/01-not-installed.png" width="600" /> |
| App blurred, state changed externally (row correctly stale, polling paused) | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/04-blurred-stale.png" width="600" /> |
| Refocus → immediate refetch flips the row | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/05-focus-refetch.png" width="600" /> |
| Poll tick catches a state change with no interaction (before/after) | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/06-polling-before.png" width="600" /> <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/07-polling-after-connected.png" width="600" /> |
| Recheck button spinning, then confirming against real gh | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/08-recheck-spinning.png" width="600" /> <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t1/09-recheck-real-connected.png" width="600" /> |

Images live on the `evidence/super-1729` branch (never merge; deletable after the PRs land).
