### PR TITLE
fix(desktop): inline actionable clone errors in onboarding project step

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -42,10 +42,18 @@ const GH_AUTH_FAILURE_PATTERNS = [
 	"Repository not found",
 	"Authentication failed",
 	"could not read Username",
-	"Permission denied (publickey)",
 ];
 
-function toCloneError(message: string): CloneError {
+function toCloneError(err: unknown): CloneError {
+	const message =
+		err instanceof Error ? err.message : "Failed to clone repository";
+	if (message.includes("Permission denied (publickey)")) {
+		return {
+			message:
+				"SSH authentication failed — sign in to GitHub CLI and use the HTTPS URL instead.",
+			needsGhAuth: true,
+		};
+	}
 	if (GH_AUTH_FAILURE_PATTERNS.some((pattern) => message.includes(pattern))) {
 		return {
 			message:
@@ -154,25 +162,42 @@ function OnboardingProjectPage() {
 					return;
 				}
 				const hostService = getHostServiceClientByUrl(activeHostUrl);
-				const created = await hostService.project.create.mutate({
-					name: repoNameFromUrl(trimmed),
-					mode: { kind: "clone", parentDir: cloneTargetDir, url: trimmed },
-				});
+				let created: Awaited<
+					ReturnType<typeof hostService.project.create.mutate>
+				>;
+				try {
+					created = await hostService.project.create.mutate({
+						name: repoNameFromUrl(trimmed),
+						mode: { kind: "clone", parentDir: cloneTargetDir, url: trimmed },
+					});
+				} catch (err) {
+					setCloneError(toCloneError(err));
+					return;
+				}
 				finalizeSetup(activeHostUrl, created);
 				await finish(created.projectId);
 			} else {
-				const projectId = await createV1Project.cloneFromUrl({
-					url: trimmed,
-					parentDir: cloneTargetDir,
-				});
+				let projectId: string | null;
+				try {
+					projectId = await createV1Project.cloneFromUrl({
+						url: trimmed,
+						parentDir: cloneTargetDir,
+					});
+				} catch (err) {
+					setCloneError(toCloneError(err));
+					return;
+				}
 				if (projectId) await finish(projectId);
 			}
 		} catch (err) {
-			setCloneError(
-				toCloneError(
-					err instanceof Error ? err.message : "Failed to clone repository",
-				),
-			);
+			// Non-clone failures (setup, navigation) get the raw message, no gh advice.
+			setCloneError({
+				message:
+					err instanceof Error
+						? err.message
+						: "Something went wrong. Please try again.",
+				needsGhAuth: false,
+			});
 		} finally {
 			setBusy(false);
 		}
@@ -248,7 +273,7 @@ function OnboardingProjectPage() {
 					</Button>
 				</form>
 				{cloneError && (
-					<div className="flex flex-col items-start gap-2">
+					<div role="alert" className="flex flex-col items-start gap-2">
 						<p className="select-text cursor-text break-words text-xs text-destructive">
 							{cloneError.message}
 						</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -27,10 +27,34 @@ import { EmptyProjectModal } from "renderer/routes/_authenticated/components/Emp
 import { TemplateGalleryModal } from "renderer/routes/_authenticated/components/TemplateGalleryModal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { GhAuthDialog } from "../components/GhAuthDialog";
 
 export const Route = createFileRoute("/_authenticated/onboarding/project/")({
 	component: OnboardingProjectPage,
 });
+
+interface CloneError {
+	message: string;
+	needsGhAuth: boolean;
+}
+
+const GH_AUTH_FAILURE_PATTERNS = [
+	"Repository not found",
+	"Authentication failed",
+	"could not read Username",
+	"Permission denied (publickey)",
+];
+
+function toCloneError(message: string): CloneError {
+	if (GH_AUTH_FAILURE_PATTERNS.some((pattern) => message.includes(pattern))) {
+		return {
+			message:
+				"Couldn't access this repository — if it's private, sign in to GitHub CLI first.",
+			needsGhAuth: true,
+		};
+	}
+	return { message, needsGhAuth: false };
+}
 
 function OnboardingProjectPage() {
 	const navigate = useNavigate();
@@ -42,6 +66,8 @@ function OnboardingProjectPage() {
 	const cloneTargetDir = homeDir ? `${homeDir}/.superset/projects` : null;
 	const [url, setUrl] = useState("");
 	const [busy, setBusy] = useState(false);
+	const [cloneError, setCloneError] = useState<CloneError | null>(null);
+	const [ghAuthOpen, setGhAuthOpen] = useState(false);
 	const [emptyProjectOpen, setEmptyProjectOpen] = useState(false);
 	const [templateOpen, setTemplateOpen] = useState(false);
 
@@ -116,11 +142,15 @@ function OnboardingProjectPage() {
 		const trimmed = url.trim();
 		if (!trimmed || !cloneTargetDir) return;
 		setBusy(true);
+		setCloneError(null);
 		try {
 			if (isV2CloudEnabled) {
 				const activeHostUrl = await waitForHostReady();
 				if (!activeHostUrl) {
-					toast.error("Local host service isn't ready yet. Please try again.");
+					setCloneError({
+						message: "Local host service isn't ready yet. Please try again.",
+						needsGhAuth: false,
+					});
 					return;
 				}
 				const hostService = getHostServiceClientByUrl(activeHostUrl);
@@ -138,8 +168,10 @@ function OnboardingProjectPage() {
 				if (projectId) await finish(projectId);
 			}
 		} catch (err) {
-			toast.error(
-				err instanceof Error ? err.message : "Failed to clone repository",
+			setCloneError(
+				toCloneError(
+					err instanceof Error ? err.message : "Failed to clone repository",
+				),
 			);
 		} finally {
 			setBusy(false);
@@ -199,9 +231,12 @@ function OnboardingProjectPage() {
 				<form onSubmit={handleClone} className="flex items-center gap-2">
 					<Input
 						type="text"
-						placeholder="git@github.com:org/repo.git"
+						placeholder="https://github.com/org/repo.git"
 						value={url}
-						onChange={(e) => setUrl(e.target.value)}
+						onChange={(e) => {
+							setUrl(e.target.value);
+							if (cloneError) setCloneError(null);
+						}}
 						disabled={busy}
 						className="flex-1"
 					/>
@@ -212,6 +247,23 @@ function OnboardingProjectPage() {
 						{busy ? "Cloning…" : "Clone"}
 					</Button>
 				</form>
+				{cloneError && (
+					<div className="flex flex-col items-start gap-2">
+						<p className="select-text cursor-text break-words text-xs text-destructive">
+							{cloneError.message}
+						</p>
+						{cloneError.needsGhAuth && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setGhAuthOpen(true)}
+							>
+								Sign in to GitHub CLI
+							</Button>
+						)}
+					</div>
+				)}
 			</Card>
 
 			<Card className="flex-row items-center gap-4 p-5">
@@ -249,6 +301,11 @@ function OnboardingProjectPage() {
 					setEmptyProjectOpen(false);
 					finish(result.projectId);
 				}}
+			/>
+			<GhAuthDialog
+				open={ghAuthOpen}
+				onOpenChange={setGhAuthOpen}
+				onExit={() => setGhAuthOpen(false)}
 			/>
 		</div>
 	);


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

Onboarding step 2's "Clone a repo" card used to surface clone failures as a sonner toast of raw git stderr that fades in ~4s, with no hint that private repos 404 when GitHub CLI isn't signed in, and no retry affordance.

## Changes
- Clone failures now render as a persistent inline error under the clone input, cleared on the next submit or input edit. Error text is `select-text cursor-text` per the renderer's selectable-error rule.
- stderr matching "Repository not found", "Authentication failed", "could not read Username", or "Permission denied (publickey)" maps to "Couldn't access this repository — if it's private, sign in to GitHub CLI first." plus a **Sign in to GitHub CLI** button that opens the existing `GhAuthDialog` on this step; the entered URL stays intact for an immediate retry. Unmatched errors show their raw message inline instead of a toast.
- The "host service isn't ready" early-return also moved from toast to the same inline slot.
- Clone input placeholder changed from the SSH example to `https://github.com/org/repo.git` (SSH keys are an unchecked prerequisite).

Other cards (create, open folder, template), step 1, GhAuthDialog internals, and Continue/navigation logic are untouched.

## Verification
- `bun run lint:fix` + `bun run lint` exit 0
- `apps/desktop` `bun run typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub authentication support during project cloning.
  - Added an authentication dialog for eligible clone failures.
  - Updated the clone URL placeholder to use HTTPS.

- **Bug Fixes**
  - Improved handling and messaging for authentication-related clone errors.
  - Displayed local-host readiness and clone failures inline.
  - Cleared previous errors when the clone input changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshot evidence (CDP-verified)

**Before** (SUPER-1729 walkthrough): raw git stderr in a toast that auto-dismissed in ~4s —

<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/before/09-toast-crop.png" width="500" alt="Before: vanishing toast with raw git stderr" />

**After:**

| Behavior | Screenshot |
|---|---|
| Persistent inline error with cause + sign-in action, URL preserved | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/02-inline-error.png" width="600" /> |
| Still present 12s later (no auto-dismiss, zero toasts) | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/03-inline-error-after-12s.png" width="600" /> |
| Sign in to GitHub CLI opens the dialog right on step 2 | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/04-gh-auth-dialog.png" width="600" /> |
| URL + error intact after dialog close, ready to retry | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/05-after-dialog-close-url-intact.png" width="600" /> |
| Error clears on input edit; HTTPS placeholder | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/06-error-cleared-on-edit.png" width="600" /> <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t3/01-clone-card-placeholder.png" width="600" /> |

Images live on the `evidence/super-1729` branch (never merge; deletable after the PRs land).
