### PR TITLE
feat(desktop): install GitHub CLI from onboarding terminal and add gh dialog end states

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/system.ts
+++ b/apps/desktop/src/lib/trpc/routers/system.ts
@@ -43,9 +43,27 @@ async function detectGhCli(): Promise<GhDetectResult> {
 	return { installed: true, authenticated, version, path: "gh" };
 }
 
+interface BrewDetectResult {
+	installed: boolean;
+	version: string | null;
+}
+
+async function detectBrew(): Promise<BrewDetectResult> {
+	try {
+		const { stdout } = await execWithShellEnv("brew", ["--version"], {
+			timeout: 5000,
+		});
+		const version = stdout.match(/Homebrew (\S+)/)?.[1] ?? null;
+		return { installed: true, version };
+	} catch {
+		return { installed: false, version: null };
+	}
+}
+
 export const createSystemRouter = () => {
 	return router({
 		detectGhCli: publicProcedure.query(detectGhCli),
+		detectBrew: publicProcedure.query(detectBrew),
 	});
 };
 

--- a/apps/desktop/src/lib/trpc/routers/system.ts
+++ b/apps/desktop/src/lib/trpc/routers/system.ts
@@ -37,7 +37,16 @@ async function detectGhCli(): Promise<GhDetectResult> {
 		);
 		authenticated = true;
 	} catch {
-		// `gh auth status` exits non-zero when not logged in.
+		// `--active` requires gh >= 2.40; retry without it for older installs.
+		// Both variants exit non-zero when not logged in.
+		try {
+			await execWithShellEnv(
+				"gh",
+				["auth", "status", "--hostname", "github.com"],
+				{ timeout: 5000 },
+			);
+			authenticated = true;
+		} catch {}
 	}
 
 	return { installed: true, authenticated, version, path: "gh" };

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -150,9 +150,7 @@ export function GhAuthDialog({
 				</DialogHeader>
 				{phase === "success" ? (
 					<div className="flex h-[296px] w-full flex-col items-center justify-center gap-2.5 rounded-lg border bg-[#151110]">
-						<div className="flex size-11 items-center justify-center rounded-full bg-emerald-500/10">
-							<LuCheck className="size-5 text-emerald-500" strokeWidth={2.5} />
-						</div>
+						<LuCheck className="size-5 text-emerald-500" strokeWidth={2} />
 						<p className="text-sm font-medium text-foreground">
 							{isInstall
 								? "GitHub CLI installed and signed in"
@@ -162,12 +160,12 @@ export function GhAuthDialog({
 				) : (
 					<>
 						{phase === "failed" ? (
-							<div className="flex min-h-11 items-center gap-2.5 rounded-md border border-destructive/30 bg-destructive/10 px-3.5 py-1.5 text-sm font-medium text-destructive">
-								<LuTriangleAlert className="size-4 shrink-0" />
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 py-1.5 text-sm text-foreground">
+								<LuTriangleAlert className="size-3.5 shrink-0 text-destructive" />
 								<span className="select-text cursor-text">
 									{isInstall
-										? "Install or sign-in canceled or failed."
-										: "Sign-in canceled or failed."}
+										? "Installation didn't complete"
+										: "Sign-in didn't complete"}
 								</span>
 								<span className="ml-auto flex shrink-0 items-center gap-2">
 									{isInstall && (
@@ -198,7 +196,7 @@ export function GhAuthDialog({
 								</span>
 							</div>
 						) : phase === "checking" ? (
-							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm font-medium text-foreground">
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm text-muted-foreground">
 								<Spinner className="size-3.5 shrink-0" />
 								Checking sign-in status…
 							</div>
@@ -229,7 +227,7 @@ export function GhAuthDialog({
 								)}
 							</div>
 						) : (
-							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm font-medium text-foreground">
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm text-muted-foreground">
 								<Spinner className="size-3.5 shrink-0" />
 								Follow the prompts below
 							</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -49,6 +49,7 @@ export function GhAuthDialog({
 	const outputBufferRef = useRef("");
 	const closeTimerRef = useRef<number | null>(null);
 	const terminalBoxRef = useRef<HTMLDivElement>(null);
+	const ptyWriteRef = useRef<((data: string) => void) | null>(null);
 	const onExitRef = useRef(onExit);
 	onExitRef.current = onExit;
 
@@ -83,7 +84,12 @@ export function GhAuthDialog({
 		const match = stripAnsi(outputBufferRef.current).match(
 			ONE_TIME_CODE_PATTERN,
 		);
-		if (match?.[1]) setOneTimeCode(match[1]);
+		if (match?.[1]) {
+			setOneTimeCode(match[1]);
+			// gh only waits for Enter so the user can copy the code first —
+			// we've captured it, so advance straight to opening the browser.
+			ptyWriteRef.current?.("\r");
+		}
 	};
 
 	const handleTerminalExit = () => {
@@ -206,7 +212,7 @@ export function GhAuthDialog({
 									{oneTimeCode}
 								</span>
 								<span className="text-xs text-muted-foreground">
-									Press Enter below, then paste this code on GitHub
+									Paste this code on GitHub — your browser is opening
 								</span>
 								{copied ? (
 									<span className="ml-auto flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-500">
@@ -236,7 +242,7 @@ export function GhAuthDialog({
 							ref={terminalBoxRef}
 							className={cn(
 								"h-[240px] w-full overflow-hidden rounded-lg border bg-[#151110] p-3 transition-opacity duration-300",
-								(oneTimeCode !== null || phase === "failed") && "opacity-60",
+								phase === "failed" && "opacity-60",
 							)}
 						>
 							{open && (
@@ -245,6 +251,9 @@ export function GhAuthDialog({
 									command={isInstall ? GH_INSTALL_COMMAND : GH_AUTH_COMMAND}
 									onExit={handleTerminalExit}
 									onOutput={handleOutput}
+									onWriterReady={(write) => {
+										ptyWriteRef.current = write;
+									}}
 								/>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -196,7 +196,7 @@ export function GhAuthDialog({
 								</span>
 							</div>
 						) : phase === "checking" ? (
-							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm text-muted-foreground">
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md bg-muted/40 px-3.5 text-sm text-muted-foreground">
 								<Spinner className="size-3.5 shrink-0" />
 								Checking sign-in status…
 							</div>
@@ -227,7 +227,7 @@ export function GhAuthDialog({
 								)}
 							</div>
 						) : (
-							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm text-muted-foreground">
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md bg-muted/40 px-3.5 text-sm text-muted-foreground">
 								<Spinner className="size-3.5 shrink-0" />
 								Follow the prompts below
 							</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -2,13 +2,13 @@ import { Button } from "@superset/ui/button";
 import {
 	Dialog,
 	DialogContent,
-	DialogDescription,
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { Spinner } from "@superset/ui/spinner";
+import { cn } from "@superset/ui/utils";
 import { useEffect, useRef, useState } from "react";
-import { LuCheck, LuCopy } from "react-icons/lu";
+import { LuCheck, LuCopy, LuTriangleAlert } from "react-icons/lu";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import stripAnsi from "strip-ansi";
 import { GhAuthTerminal } from "./GhAuthTerminal";
@@ -43,6 +43,7 @@ export function GhAuthDialog({
 	const [copied, setCopied] = useState(false);
 	const outputBufferRef = useRef("");
 	const closeTimerRef = useRef<number | null>(null);
+	const terminalBoxRef = useRef<HTMLDivElement>(null);
 	const onExitRef = useRef(onExit);
 	onExitRef.current = onExit;
 
@@ -60,6 +61,16 @@ export function GhAuthDialog({
 			}
 		};
 	}, [open]);
+
+	// Auto-copy so the happy path needs no clicks; the Copy button remains as
+	// a fallback for when the clipboard write is rejected (e.g. window unfocused).
+	useEffect(() => {
+		if (!oneTimeCode) return;
+		navigator.clipboard.writeText(oneTimeCode).then(
+			() => setCopied(true),
+			() => setCopied(false),
+		);
+	}, [oneTimeCode]);
 
 	const handleOutput = (data: string) => {
 		if (oneTimeCode) return;
@@ -96,11 +107,20 @@ export function GhAuthDialog({
 		setAttempt((prev) => prev + 1);
 	};
 
+	const focusTerminal = () => {
+		terminalBoxRef.current
+			?.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
+			?.focus();
+	};
+
 	const handleCopyCode = () => {
 		if (!oneTimeCode) return;
-		void navigator.clipboard.writeText(oneTimeCode);
-		setCopied(true);
-		window.setTimeout(() => setCopied(false), 2000);
+		navigator.clipboard.writeText(oneTimeCode).then(
+			() => setCopied(true),
+			() => {},
+		);
+		// Return focus to the terminal so Enter goes to gh, not the button.
+		focusTerminal();
 	};
 
 	const processActive = phase === "running" || phase === "checking";
@@ -109,7 +129,8 @@ export function GhAuthDialog({
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
-				className="max-w-[752px] gap-4"
+				className="gap-3 sm:max-w-[752px]"
+				aria-describedby={undefined}
 				onInteractOutside={(event) => {
 					if (processActive) event.preventDefault();
 				}}
@@ -121,82 +142,92 @@ export function GhAuthDialog({
 					<DialogTitle>
 						{isInstall ? "Install GitHub CLI" : "Sign in to GitHub CLI"}
 					</DialogTitle>
-					<DialogDescription>
-						{isInstall
-							? "Homebrew installs the GitHub CLI, then the sign-in flow starts below. "
-							: "Follow the prompts below. "}
-						Confirm authenticating Git with your GitHub credentials, then press
-						Enter to open your browser and enter the one-time code shown here.
-					</DialogDescription>
 				</DialogHeader>
-				{oneTimeCode && phase !== "success" && (
-					<div className="flex items-center justify-between rounded-md border bg-muted/50 px-3 py-2">
-						<div>
-							<p className="text-xs text-muted-foreground">One-time code</p>
-							<p className="select-text cursor-text font-mono text-lg font-semibold tracking-widest">
-								{oneTimeCode}
-							</p>
-						</div>
-						<Button
-							type="button"
-							size="sm"
-							variant="outline"
-							onClick={handleCopyCode}
-						>
-							{copied ? (
-								<>
-									<LuCheck className="size-3.5" />
-									Copied
-								</>
-							) : (
-								<>
-									<LuCopy className="size-3.5" />
-									Copy
-								</>
-							)}
-						</Button>
-					</div>
-				)}
 				{phase === "success" ? (
-					<div className="flex h-[240px] w-full items-center justify-center rounded-md border">
-						<div className="flex flex-col items-center gap-2">
-							<LuCheck className="size-6 text-emerald-500" strokeWidth={2.5} />
-							<p className="text-sm font-medium text-foreground">
-								{isInstall
-									? "GitHub CLI installed and signed in"
-									: "Signed in to GitHub"}
-							</p>
+					<div className="flex h-[296px] w-full flex-col items-center justify-center gap-2.5 rounded-lg border bg-[#151110]">
+						<div className="flex size-11 items-center justify-center rounded-full bg-emerald-500/10">
+							<LuCheck className="size-5 text-emerald-500" strokeWidth={2.5} />
 						</div>
+						<p className="text-sm font-medium text-foreground">
+							{isInstall
+								? "GitHub CLI installed and signed in"
+								: "Signed in to GitHub"}
+						</p>
 					</div>
 				) : (
-					<div className="h-[240px] w-full overflow-hidden rounded-md bg-[#151110] p-2">
-						{open && (
-							<GhAuthTerminal
-								key={attempt}
-								command={isInstall ? GH_INSTALL_COMMAND : GH_AUTH_COMMAND}
-								onExit={handleTerminalExit}
-								onOutput={handleOutput}
-							/>
+					<>
+						{phase === "failed" ? (
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border border-destructive/30 bg-destructive/10 px-3.5 py-1.5 text-sm font-medium text-destructive">
+								<LuTriangleAlert className="size-4 shrink-0" />
+								<span className="select-text cursor-text">
+									{isInstall
+										? "Install or sign-in canceled or failed."
+										: "Sign-in canceled or failed."}
+								</span>
+								<Button
+									type="button"
+									size="sm"
+									variant="outline"
+									className="ml-auto"
+									onClick={handleRetry}
+								>
+									Retry
+								</Button>
+							</div>
+						) : phase === "checking" ? (
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm font-medium text-foreground">
+								<Spinner className="size-3.5 shrink-0" />
+								Checking sign-in status…
+							</div>
+						) : oneTimeCode ? (
+							<div className="flex min-h-11 items-center gap-3 rounded-md border bg-muted/40 px-3.5 py-1.5">
+								<span className="select-text cursor-text font-mono text-lg font-semibold tracking-[0.18em] text-foreground">
+									{oneTimeCode}
+								</span>
+								<span className="text-xs text-muted-foreground">
+									Press Enter below, then paste this code on GitHub
+								</span>
+								{copied ? (
+									<span className="ml-auto flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-500">
+										<LuCheck className="size-3.5" strokeWidth={2.5} />
+										Copied
+									</span>
+								) : (
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										className="ml-auto"
+										onClick={handleCopyCode}
+									>
+										<LuCopy className="size-3.5" />
+										Copy
+									</Button>
+								)}
+							</div>
+						) : (
+							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm font-medium text-foreground">
+								<Spinner className="size-3.5 shrink-0" />
+								Follow the prompts below
+							</div>
 						)}
-					</div>
-				)}
-				{phase === "checking" && (
-					<div className="flex items-center gap-2 text-sm text-muted-foreground">
-						<Spinner className="size-3.5" />
-						Checking sign-in status…
-					</div>
-				)}
-				{phase === "failed" && (
-					<div className="flex items-center justify-between gap-2">
-						<p className="text-sm text-destructive">
-							{isInstall
-								? "Install or sign-in canceled or failed."
-								: "Sign-in canceled or failed."}
-						</p>
-						<Button type="button" size="sm" onClick={handleRetry}>
-							Retry
-						</Button>
-					</div>
+						<div
+							ref={terminalBoxRef}
+							className={cn(
+								"h-[240px] w-full overflow-hidden rounded-lg border bg-[#151110] p-3 transition-opacity duration-300",
+								(oneTimeCode !== null || phase === "failed") && "opacity-60",
+							)}
+						>
+							{open && (
+								<GhAuthTerminal
+									key={attempt}
+									command={isInstall ? GH_INSTALL_COMMAND : GH_AUTH_COMMAND}
+									onExit={handleTerminalExit}
+									onOutput={handleOutput}
+								/>
+							)}
+						</div>
+					</>
 				)}
 			</DialogContent>
 		</Dialog>

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -127,7 +127,7 @@ export function GhAuthDialog({
 	const isInstall = mode === "install";
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} modal onOpenChange={onOpenChange}>
 			<DialogContent
 				className="gap-3 sm:max-w-[752px]"
 				aria-describedby={undefined}

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -8,7 +8,12 @@ import {
 import { Spinner } from "@superset/ui/spinner";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useRef, useState } from "react";
-import { LuCheck, LuCopy, LuTriangleAlert } from "react-icons/lu";
+import {
+	LuArrowUpRight,
+	LuCheck,
+	LuCopy,
+	LuTriangleAlert,
+} from "react-icons/lu";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import stripAnsi from "strip-ansi";
 import { GhAuthTerminal } from "./GhAuthTerminal";
@@ -164,15 +169,33 @@ export function GhAuthDialog({
 										? "Install or sign-in canceled or failed."
 										: "Sign-in canceled or failed."}
 								</span>
-								<Button
-									type="button"
-									size="sm"
-									variant="outline"
-									className="ml-auto"
-									onClick={handleRetry}
-								>
-									Retry
-								</Button>
+								<span className="ml-auto flex shrink-0 items-center gap-2">
+									{isInstall && (
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											onClick={() =>
+												window.open(
+													"https://cli.github.com/",
+													"_blank",
+													"noopener,noreferrer",
+												)
+											}
+										>
+											Install manually
+											<LuArrowUpRight className="size-3" />
+										</Button>
+									)}
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										onClick={handleRetry}
+									>
+										Retry
+									</Button>
+								</span>
 							</div>
 						) : phase === "checking" ? (
 							<div className="flex min-h-11 items-center gap-2.5 rounded-md border bg-muted/40 px-3.5 text-sm font-medium text-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthDialog.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@superset/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -5,10 +6,26 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
+import { Spinner } from "@superset/ui/spinner";
+import { useEffect, useRef, useState } from "react";
+import { LuCheck, LuCopy } from "react-icons/lu";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import stripAnsi from "strip-ansi";
 import { GhAuthTerminal } from "./GhAuthTerminal";
+
+const GH_AUTH_COMMAND =
+	"gh auth login --hostname github.com --git-protocol https --web";
+const GH_INSTALL_COMMAND = `brew install gh && ${GH_AUTH_COMMAND}`;
+
+const ONE_TIME_CODE_PATTERN = /one-time code: ([A-Z0-9]{4}-[A-Z0-9]{4})/;
+
+export type GhAuthDialogMode = "auth" | "install";
+
+type Phase = "running" | "checking" | "success" | "failed";
 
 interface GhAuthDialogProps {
 	open: boolean;
+	mode: GhAuthDialogMode;
 	onOpenChange: (open: boolean) => void;
 	/** Fired when the gh process exits so the caller can re-check auth status. */
 	onExit: () => void;
@@ -16,23 +33,171 @@ interface GhAuthDialogProps {
 
 export function GhAuthDialog({
 	open,
+	mode,
 	onOpenChange,
 	onExit,
 }: GhAuthDialogProps) {
+	const [phase, setPhase] = useState<Phase>("running");
+	const [attempt, setAttempt] = useState(0);
+	const [oneTimeCode, setOneTimeCode] = useState<string | null>(null);
+	const [copied, setCopied] = useState(false);
+	const outputBufferRef = useRef("");
+	const closeTimerRef = useRef<number | null>(null);
+	const onExitRef = useRef(onExit);
+	onExitRef.current = onExit;
+
+	useEffect(() => {
+		if (!open) return;
+		setPhase("running");
+		setAttempt(0);
+		setOneTimeCode(null);
+		setCopied(false);
+		outputBufferRef.current = "";
+		return () => {
+			if (closeTimerRef.current !== null) {
+				window.clearTimeout(closeTimerRef.current);
+				closeTimerRef.current = null;
+			}
+		};
+	}, [open]);
+
+	const handleOutput = (data: string) => {
+		if (oneTimeCode) return;
+		outputBufferRef.current = (outputBufferRef.current + data).slice(-4096);
+		const match = stripAnsi(outputBufferRef.current).match(
+			ONE_TIME_CODE_PATTERN,
+		);
+		if (match?.[1]) setOneTimeCode(match[1]);
+	};
+
+	const handleTerminalExit = () => {
+		setPhase("checking");
+		onExitRef.current();
+		void electronTrpcClient.system.detectGhCli
+			.query()
+			.then((status) => {
+				if (status.installed && status.authenticated) {
+					setPhase("success");
+					closeTimerRef.current = window.setTimeout(() => {
+						onOpenChange(false);
+					}, 1500);
+				} else {
+					setPhase("failed");
+				}
+			})
+			.catch(() => setPhase("failed"));
+	};
+
+	const handleRetry = () => {
+		setPhase("running");
+		setOneTimeCode(null);
+		setCopied(false);
+		outputBufferRef.current = "";
+		setAttempt((prev) => prev + 1);
+	};
+
+	const handleCopyCode = () => {
+		if (!oneTimeCode) return;
+		void navigator.clipboard.writeText(oneTimeCode);
+		setCopied(true);
+		window.setTimeout(() => setCopied(false), 2000);
+	};
+
+	const processActive = phase === "running" || phase === "checking";
+	const isInstall = mode === "install";
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-[752px] gap-4">
+			<DialogContent
+				className="max-w-[752px] gap-4"
+				onInteractOutside={(event) => {
+					if (processActive) event.preventDefault();
+				}}
+				onFocusOutside={(event) => {
+					if (processActive) event.preventDefault();
+				}}
+			>
 				<DialogHeader>
-					<DialogTitle>Sign in to GitHub CLI</DialogTitle>
+					<DialogTitle>
+						{isInstall ? "Install GitHub CLI" : "Sign in to GitHub CLI"}
+					</DialogTitle>
 					<DialogDescription>
-						Follow the prompts below. Press Enter to open your browser,
-						authorize the device code, and this window will update once you're
-						signed in.
+						{isInstall
+							? "Homebrew installs the GitHub CLI, then the sign-in flow starts below. "
+							: "Follow the prompts below. "}
+						Confirm authenticating Git with your GitHub credentials, then press
+						Enter to open your browser and enter the one-time code shown here.
 					</DialogDescription>
 				</DialogHeader>
-				<div className="h-[240px] w-full overflow-hidden rounded-md bg-[#151110] p-2">
-					{open && <GhAuthTerminal onExit={onExit} />}
-				</div>
+				{oneTimeCode && phase !== "success" && (
+					<div className="flex items-center justify-between rounded-md border bg-muted/50 px-3 py-2">
+						<div>
+							<p className="text-xs text-muted-foreground">One-time code</p>
+							<p className="select-text cursor-text font-mono text-lg font-semibold tracking-widest">
+								{oneTimeCode}
+							</p>
+						</div>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							onClick={handleCopyCode}
+						>
+							{copied ? (
+								<>
+									<LuCheck className="size-3.5" />
+									Copied
+								</>
+							) : (
+								<>
+									<LuCopy className="size-3.5" />
+									Copy
+								</>
+							)}
+						</Button>
+					</div>
+				)}
+				{phase === "success" ? (
+					<div className="flex h-[240px] w-full items-center justify-center rounded-md border">
+						<div className="flex flex-col items-center gap-2">
+							<LuCheck className="size-6 text-emerald-500" strokeWidth={2.5} />
+							<p className="text-sm font-medium text-foreground">
+								{isInstall
+									? "GitHub CLI installed and signed in"
+									: "Signed in to GitHub"}
+							</p>
+						</div>
+					</div>
+				) : (
+					<div className="h-[240px] w-full overflow-hidden rounded-md bg-[#151110] p-2">
+						{open && (
+							<GhAuthTerminal
+								key={attempt}
+								command={isInstall ? GH_INSTALL_COMMAND : GH_AUTH_COMMAND}
+								onExit={handleTerminalExit}
+								onOutput={handleOutput}
+							/>
+						)}
+					</div>
+				)}
+				{phase === "checking" && (
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Spinner className="size-3.5" />
+						Checking sign-in status…
+					</div>
+				)}
+				{phase === "failed" && (
+					<div className="flex items-center justify-between gap-2">
+						<p className="text-sm text-destructive">
+							{isInstall
+								? "Install or sign-in canceled or failed."
+								: "Sign-in canceled or failed."}
+						</p>
+						<Button type="button" size="sm" onClick={handleRetry}>
+							Retry
+						</Button>
+					</div>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
@@ -8,21 +8,29 @@ import {
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTerminalAppearance } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance";
 
-const GH_AUTH_COMMAND =
-	"gh auth login --hostname github.com --git-protocol https --web";
-
 interface GhAuthTerminalProps {
+	command: string;
 	/** Fired when the gh process exits (success or failure). */
 	onExit: () => void;
+	/** Fired with each chunk of raw terminal output. */
+	onOutput?: (data: string) => void;
 }
 
-export function GhAuthTerminal({ onExit }: GhAuthTerminalProps) {
+export function GhAuthTerminal({
+	command,
+	onExit,
+	onOutput,
+}: GhAuthTerminalProps) {
 	const appearance = useTerminalAppearance();
 	const appearanceRef = useRef(appearance);
 	appearanceRef.current = appearance;
 	const containerRef = useRef<HTMLDivElement>(null);
 	const onExitRef = useRef(onExit);
 	onExitRef.current = onExit;
+	const onOutputRef = useRef(onOutput);
+	onOutputRef.current = onOutput;
+	const commandRef = useRef(command);
+	commandRef.current = command;
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -61,6 +69,7 @@ export function GhAuthTerminal({ onExit }: GhAuthTerminalProps) {
 			onData: (event) => {
 				if (event.type === "data") {
 					runtime.terminal.write(event.data);
+					onOutputRef.current?.(event.data);
 				} else if (event.type === "exit" && !exited) {
 					exited = true;
 					onExitRef.current();
@@ -72,7 +81,7 @@ export function GhAuthTerminal({ onExit }: GhAuthTerminalProps) {
 			paneId,
 			tabId: paneId,
 			workspaceId: paneId,
-			command: GH_AUTH_COMMAND,
+			command: commandRef.current,
 			cols: runtime.terminal.cols,
 			rows: runtime.terminal.rows,
 			skipColdRestore: true,

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
@@ -109,7 +109,10 @@ export function GhAuthTerminal({
 					void electronTrpcClient.terminal.write.mutate({ paneId, data });
 				}
 				if (exitBeforeReady) fireExit();
-			});
+			})
+			// A failed create would otherwise leave the dialog running forever
+			// with a dead terminal silently swallowing queued input.
+			.catch(() => fireExit());
 
 		return () => {
 			for (const timer of refitTimers) window.clearTimeout(timer);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
@@ -60,32 +60,56 @@ export function GhAuthTerminal({
 			window.setTimeout(refit, 350),
 		];
 
+		// Queue input until the pane exists: xterm auto-replies to terminal
+		// queries (OSC 11, DSR) at mount, and a write to a not-yet-created pane
+		// makes the terminal service synthesize an exit event for it.
+		let paneReady = false;
+		let exited = false;
+		let exitBeforeReady = false;
+		const pendingInput: string[] = [];
+		const fireExit = () => {
+			if (exited) return;
+			exited = true;
+			onExitRef.current();
+		};
+
 		const inputDisposable = runtime.terminal.onData((data) => {
+			if (!paneReady) {
+				pendingInput.push(data);
+				return;
+			}
 			void electronTrpcClient.terminal.write.mutate({ paneId, data });
 		});
 
-		let exited = false;
 		const subscription = electronTrpcClient.terminal.stream.subscribe(paneId, {
 			onData: (event) => {
 				if (event.type === "data") {
 					runtime.terminal.write(event.data);
 					onOutputRef.current?.(event.data);
-				} else if (event.type === "exit" && !exited) {
-					exited = true;
-					onExitRef.current();
+				} else if (event.type === "exit") {
+					if (paneReady) fireExit();
+					else exitBeforeReady = true;
 				}
 			},
 		});
 
-		void electronTrpcClient.terminal.createOrAttach.mutate({
-			paneId,
-			tabId: paneId,
-			workspaceId: paneId,
-			command: commandRef.current,
-			cols: runtime.terminal.cols,
-			rows: runtime.terminal.rows,
-			skipColdRestore: true,
-		});
+		void electronTrpcClient.terminal.createOrAttach
+			.mutate({
+				paneId,
+				tabId: paneId,
+				workspaceId: paneId,
+				command: commandRef.current,
+				cols: runtime.terminal.cols,
+				rows: runtime.terminal.rows,
+				skipColdRestore: true,
+			})
+			.then(() => {
+				paneReady = true;
+				for (const data of pendingInput.splice(0)) {
+					void electronTrpcClient.terminal.write.mutate({ paneId, data });
+				}
+				if (exitBeforeReady) fireExit();
+			});
 
 		return () => {
 			for (const timer of refitTimers) window.clearTimeout(timer);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/GhAuthTerminal.tsx
@@ -14,12 +14,15 @@ interface GhAuthTerminalProps {
 	onExit: () => void;
 	/** Fired with each chunk of raw terminal output. */
 	onOutput?: (data: string) => void;
+	/** Receives a writer for sending input to the pty (queued until it exists). */
+	onWriterReady?: (write: (data: string) => void) => void;
 }
 
 export function GhAuthTerminal({
 	command,
 	onExit,
 	onOutput,
+	onWriterReady,
 }: GhAuthTerminalProps) {
 	const appearance = useTerminalAppearance();
 	const appearanceRef = useRef(appearance);
@@ -29,6 +32,8 @@ export function GhAuthTerminal({
 	onExitRef.current = onExit;
 	const onOutputRef = useRef(onOutput);
 	onOutputRef.current = onOutput;
+	const onWriterReadyRef = useRef(onWriterReady);
+	onWriterReadyRef.current = onWriterReady;
 	const commandRef = useRef(command);
 	commandRef.current = command;
 
@@ -73,13 +78,15 @@ export function GhAuthTerminal({
 			onExitRef.current();
 		};
 
-		const inputDisposable = runtime.terminal.onData((data) => {
+		const writeToPty = (data: string) => {
 			if (!paneReady) {
 				pendingInput.push(data);
 				return;
 			}
 			void electronTrpcClient.terminal.write.mutate({ paneId, data });
-		});
+		};
+		const inputDisposable = runtime.terminal.onData(writeToPty);
+		onWriterReadyRef.current?.(writeToPty);
 
 		const subscription = electronTrpcClient.terminal.stream.subscribe(paneId, {
 			onData: (event) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/GhAuthDialog/index.ts
@@ -1,1 +1,1 @@
-export { GhAuthDialog } from "./GhAuthDialog";
+export { GhAuthDialog, type GhAuthDialogMode } from "./GhAuthDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -8,7 +8,7 @@ import { type ReactNode, useState } from "react";
 import { HiArrowUpRight } from "react-icons/hi2";
 import { SiGithub, SiOpenai } from "react-icons/si";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { GhAuthDialog } from "./components/GhAuthDialog";
+import { GhAuthDialog, type GhAuthDialogMode } from "./components/GhAuthDialog";
 import {
 	type Provider,
 	ProviderConnectModal,
@@ -23,7 +23,9 @@ const PREREQ_POLL_MS = 4000;
 
 function OnboardingDashboardPage() {
 	const [connectProvider, setConnectProvider] = useState<Provider | null>(null);
-	const [ghAuthOpen, setGhAuthOpen] = useState(false);
+	const [ghDialogMode, setGhDialogMode] = useState<GhAuthDialogMode | null>(
+		null,
+	);
 
 	// Poll while mounted so external changes (installing gh in a browser,
 	// signing in from a terminal) are picked up without a focus change.
@@ -34,6 +36,7 @@ function OnboardingDashboardPage() {
 		refetch: refetchGh,
 		isPending: isPendingGh,
 	} = electronTrpc.system.detectGhCli.useQuery(undefined, statusPolling);
+	const { data: brewStatus } = electronTrpc.system.detectBrew.useQuery();
 	const { data: anthropicStatus, isPending: isPendingAnthropic } =
 		chatServiceTrpc.auth.getAnthropicStatus.useQuery(undefined, statusPolling);
 	const { data: openAIStatus, isPending: isPendingOpenAI } =
@@ -53,7 +56,13 @@ function OnboardingDashboardPage() {
 			? "Not signed in"
 			: "Not installed";
 
+	const brewAvailable = brewStatus?.installed === true;
+
 	const openGitHubInstall = () => {
+		if (brewAvailable) {
+			setGhDialogMode("install");
+			return;
+		}
 		window.open("https://cli.github.com/", "_blank", "noopener,noreferrer");
 	};
 
@@ -79,10 +88,12 @@ function OnboardingDashboardPage() {
 						required
 						actionLabel={ghInstalled ? "Sign in" : "Install"}
 						actionIcon={
-							ghInstalled ? undefined : <HiArrowUpRight className="size-3.5" />
+							ghInstalled || brewAvailable ? undefined : (
+								<HiArrowUpRight className="size-3.5" />
+							)
 						}
 						onAction={
-							ghInstalled ? () => setGhAuthOpen(true) : openGitHubInstall
+							ghInstalled ? () => setGhDialogMode("auth") : openGitHubInstall
 						}
 					/>
 					<OnboardingRow
@@ -132,8 +143,11 @@ function OnboardingDashboardPage() {
 			/>
 
 			<GhAuthDialog
-				open={ghAuthOpen}
-				onOpenChange={setGhAuthOpen}
+				open={ghDialogMode !== null}
+				mode={ghDialogMode ?? "auth"}
+				onOpenChange={(open) => {
+					if (!open) setGhDialogMode(null);
+				}}
 				onExit={() => void refetchGh()}
 			/>
 		</>


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

## What

- **`system.detectBrew`**: new tRPC procedure detecting Homebrew via `execWithShellEnv("brew", ["--version"])` on the login-shell PATH (explicit `BrewDetectResult` interface).
- **Onboarding Install action**: when brew is present, the Install button now opens the terminal dialog in install mode running `brew install gh && gh auth login --hostname github.com --git-protocol https --web` (title "Install GitHub CLI"). When brew is absent, it keeps the existing external link to https://cli.github.com/.
- **GhAuthDialog end states**: on PTY exit the dialog re-runs `detectGhCli`. Installed + authenticated → brief success state, auto-close after 1.5s (row still refetches via `onExit`). Otherwise the dialog stays open with "Sign-in canceled or failed." and a Retry button that respawns a fresh terminal (new paneId via remount). The stream's exit payload does carry `exitCode`, but success is decided solely from `detectGhCli` since the auth outcome is what matters.
- **Device-code copy chip**: the output stream is buffered, ANSI-stripped (`strip-ansi`, already a desktop dep), and matched against `/one-time code: ([A-Z0-9]{4}-[A-Z0-9]{4})/`; the code renders above the terminal with a copy button. Regex verified against gh's actual output shape (`! First copy your one-time code: XXXX-XXXX` with the code bold-wrapped, across chunk boundaries).
- **Outside-click protection**: the shared Dialog defaults to `modal={false}`, so a stray outside click unmounted the terminal and killed the PTY mid-auth. While the process is running/checking, `onInteractOutside`/`onFocusOutside` are prevented.
- **Copy fix**: description now matches gh's real prompt sequence (first prompt is `? Authenticate Git with your GitHub credentials? (Y/n)`).

Deliberately unchanged: Continue is still not gated on gh state (PR #4834); page.tsx diff kept minimal since row status rendering is being reworked on another branch.

## Verification

- `bun run lint:fix` + `bun run lint` → exit 0
- `apps/desktop` `bun run typecheck` → clean
- one-time-code regex sanity-checked against simulated chunked/ANSI gh output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Homebrew detection during onboarding.
  * Added an in-app GitHub CLI installation flow when Homebrew is available.
  * Added dedicated GitHub authentication and installation modes with terminal progress, one-time code display, copy support, and status updates.
  * Added retry options and verification after installation or authentication.
* **Improvements**
  * Onboarding now provides an external GitHub CLI installation link when Homebrew is unavailable.
  * Improved compatibility with different GitHub CLI authentication environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshot evidence (CDP-verified)

**Before** (SUPER-1729 walkthrough): device code buried in a bare terminal with no copy affordance; Ctrl+C left a dead `^C` with no feedback —

<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/before/03-gh-auth-device-code.png" width="700" alt="Before: device code with no copy button" />
<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/before/04-gh-auth-aborted.png" width="500" alt="Before: dead terminal after Ctrl+C" />

**After:**

| Behavior | Screenshot |
|---|---|
| Install mode: brew → gh auth chained in one dialog, one-time code extracted into a copy chip (clipboard verified) | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/01-install-mode-dialog.png" width="600" /> <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/02-device-code-chip.png" width="600" /> |
| Failure end state: clear message + Retry | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/03-failure-state-retry.png" width="600" /> |
| Retry respawns a fresh terminal | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/04-retry-fresh-terminal.png" width="600" /> |
| Outside click no longer kills the PTY mid-auth | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/05-outside-click-still-open.png" width="600" /> |
| Success state before auto-close | <img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t2/06-success-state.png" width="600" /> |

Images live on the `evidence/super-1729` branch (never merge; deletable after the PRs land).


## Screenshots (current UI, CDP-verified in the dev app)

Guided single-strip layout: title + one morphing status strip + terminal.

**Running — follow the prompts** (install mode, full 752px width)
![running](https://gist.githubusercontent.com/Kitenite/66a780a07961eb63a265b4c402e8823d/raw/c2728ab99a7b507a7d2343f5108486d6d8f3b094/01-running-strip.png)

**Code ready — auto-copied, terminal dims** (Copy fallback shown when the clipboard write is rejected, e.g. window unfocused)
![code](https://gist.githubusercontent.com/Kitenite/66a780a07961eb63a265b4c402e8823d/raw/c2728ab99a7b507a7d2343f5108486d6d8f3b094/02-code-strip.png)

**Failure — strip turns red, Retry inline** (respawns a fresh pane)
![failure](https://gist.githubusercontent.com/Kitenite/66a780a07961eb63a265b4c402e8823d/raw/c2728ab99a7b507a7d2343f5108486d6d8f3b094/03-failure-strip.png)

**Modal overlay — background dimmed while the flow runs**
![overlay](https://gist.githubusercontent.com/Kitenite/66a780a07961eb63a265b4c402e8823d/raw/c2728ab99a7b507a7d2343f5108486d6d8f3b094/04-modal-overlay-fullwindow.png)

**Success — auto-closes after ~1.5s, row refetches to Connected**
![success](https://gist.githubusercontent.com/Kitenite/66a780a07961eb63a265b4c402e8823d/raw/c2728ab99a7b507a7d2343f5108486d6d8f3b094/06-success-panel.png)


