### PR TITLE
feat(desktop): catch missing GitHub CLI at PR creation instead of failing mid-agent

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -7,6 +7,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { useSettings } from "renderer/stores/settings";
 import type { CommentPaneData, DiffFocusSide } from "../../types";
 import { FilesTab } from "./components/FilesTab";
+import { GhCliGateDialog } from "./components/GhCliGateDialog";
 import { PRActionHeader } from "./components/PRActionHeader";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { useChangesTab } from "./hooks/useChangesTab";
@@ -125,7 +126,7 @@ export function WorkspaceSidebar({
 	});
 
 	const { flowState, onRetry } = usePRFlowState(workspaceId);
-	const dispatch = usePRFlowDispatch({
+	const { dispatch, ghGate, recheckGhGate, dismissGhGate } = usePRFlowDispatch({
 		onOpenChat: onOpenChat ?? (() => {}),
 	});
 
@@ -169,6 +170,13 @@ export function WorkspaceSidebar({
 			<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
 				{activeTabDef?.content}
 			</div>
+			{ghGate && (
+				<GhCliGateDialog
+					reason={ghGate}
+					onRecheck={recheckGhGate}
+					onDismiss={dismissGhGate}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/GhCliGateDialog/GhCliGateDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/GhCliGateDialog/GhCliGateDialog.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { useState } from "react";
+import { GhAuthDialog } from "renderer/routes/_authenticated/onboarding/components/GhAuthDialog";
+import type { GhCliGateReason } from "../../hooks/usePRFlowDispatch";
+
+const GH_CLI_INSTALL_URL = "https://cli.github.com/";
+
+interface GhCliGateDialogProps {
+	reason: GhCliGateReason;
+	/** Re-runs gh detection; the caller resumes the PR flow once it passes. */
+	onRecheck: () => void;
+	onDismiss: () => void;
+}
+
+/**
+ * Pre-flight gate shown when "Create PR" is clicked but the GitHub CLI is
+ * missing or signed out. Swaps to the embedded gh sign-in dialog (rather than
+ * stacking on top of it) so only one dialog is on screen at a time.
+ */
+export function GhCliGateDialog({
+	reason,
+	onRecheck,
+	onDismiss,
+}: GhCliGateDialogProps) {
+	const [signInOpen, setSignInOpen] = useState(false);
+
+	if (signInOpen) {
+		return (
+			<GhAuthDialog
+				open
+				onOpenChange={(open) => {
+					if (open) return;
+					setSignInOpen(false);
+					onRecheck();
+				}}
+				onExit={() => {
+					setSignInOpen(false);
+					onRecheck();
+				}}
+			/>
+		);
+	}
+
+	const notInstalled = reason === "not-installed";
+
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) onDismiss();
+			}}
+		>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle className="select-text cursor-text">
+						{notInstalled
+							? "GitHub CLI isn't installed"
+							: "GitHub CLI isn't signed in"}
+					</DialogTitle>
+					<DialogDescription className="select-text cursor-text">
+						{notInstalled
+							? "Creating a pull request uses the GitHub CLI (gh), which wasn't found on this machine. Install it, then check again to continue."
+							: "Creating a pull request uses the GitHub CLI (gh), which isn't signed in to GitHub. Sign in to continue — your PR will pick up where it left off."}
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter>
+					{notInstalled ? (
+						<>
+							<Button
+								variant="outline"
+								onClick={() =>
+									window.open(
+										GH_CLI_INSTALL_URL,
+										"_blank",
+										"noopener,noreferrer",
+									)
+								}
+							>
+								Get GitHub CLI
+							</Button>
+							<Button onClick={onRecheck}>Check again</Button>
+						</>
+					) : (
+						<Button onClick={() => setSignInOpen(true)}>
+							Sign in to GitHub
+						</Button>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/GhCliGateDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/GhCliGateDialog/index.ts
@@ -1,0 +1,1 @@
+export { GhCliGateDialog } from "./GhCliGateDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/index.ts
@@ -1,6 +1,11 @@
 export type {
+	GhCliGateReason,
 	OpenChatFn,
 	PRFlowDispatch,
 	PRFlowDispatchArgs,
 } from "./usePRFlowDispatch";
-export { planDispatch, usePRFlowDispatch } from "./usePRFlowDispatch";
+export {
+	getGhCliGateReason,
+	planDispatch,
+	usePRFlowDispatch,
+} from "./usePRFlowDispatch";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/usePRFlowDispatch.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/usePRFlowDispatch.test.ts
@@ -3,7 +3,7 @@ import type {
 	BranchSyncStatus,
 	PRFlowState,
 } from "../../components/PRActionHeader/utils/getPRFlowState";
-import { planDispatch } from "./usePRFlowDispatch";
+import { getGhCliGateReason, planDispatch } from "./usePRFlowDispatch";
 
 const sync: BranchSyncStatus = {
 	hasRepo: true,
@@ -58,6 +58,26 @@ describe("planDispatch", () => {
 				{ kind: "unavailable", reason: "default-branch" },
 				{ draft: false },
 			),
+		).toBeNull();
+	});
+});
+
+describe("getGhCliGateReason", () => {
+	test("missing gh → not-installed", () => {
+		expect(getGhCliGateReason({ installed: false, authenticated: false })).toBe(
+			"not-installed",
+		);
+	});
+
+	test("installed but signed out → not-authenticated", () => {
+		expect(getGhCliGateReason({ installed: true, authenticated: false })).toBe(
+			"not-authenticated",
+		);
+	});
+
+	test("installed and signed in → no gate", () => {
+		expect(
+			getGhCliGateReason({ installed: true, authenticated: true }),
 		).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/usePRFlowDispatch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/usePRFlowDispatch.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { ChatPaneData } from "../../../../types";
 import { buildPRContext } from "../../components/PRActionHeader/utils/buildPRContext";
 import type { PRFlowState } from "../../components/PRActionHeader/utils/getPRFlowState";
@@ -19,14 +19,28 @@ export interface PRFlowDispatchArgs {
 
 export type PRFlowDispatch = (args: PRFlowDispatchArgs) => void;
 
+export type GhCliGateReason = "not-installed" | "not-authenticated";
+
 interface UsePRFlowDispatchOptions {
 	onOpenChat: OpenChatFn;
 }
 
+interface UsePRFlowDispatchResult {
+	dispatch: PRFlowDispatch;
+	/** Non-null when the last dispatch was blocked on the GitHub CLI. */
+	ghGate: GhCliGateReason | null;
+	/** Re-detects gh; resumes the blocked dispatch once it's ready. */
+	recheckGhGate: () => void;
+	dismissGhGate: () => void;
+}
+
 export function usePRFlowDispatch({
 	onOpenChat,
-}: UsePRFlowDispatchOptions): PRFlowDispatch {
-	return useCallback(
+}: UsePRFlowDispatchOptions): UsePRFlowDispatchResult {
+	const [ghGate, setGhGate] = useState<GhCliGateReason | null>(null);
+	const pendingRef = useRef<PRFlowDispatchArgs | null>(null);
+
+	const proceed = useCallback(
 		({ state, draft }: PRFlowDispatchArgs) => {
 			const plan = planDispatch(state, { draft: draft === true });
 			if (!plan) return;
@@ -38,6 +52,63 @@ export function usePRFlowDispatch({
 		},
 		[onOpenChat],
 	);
+
+	const dispatch = useCallback<PRFlowDispatch>(
+		(args) => {
+			void (async () => {
+				const gate = await detectGhCliGate();
+				if (gate) {
+					pendingRef.current = args;
+					setGhGate(gate);
+					return;
+				}
+				proceed(args);
+			})();
+		},
+		[proceed],
+	);
+
+	const recheckGhGate = useCallback(() => {
+		void (async () => {
+			const gate = await detectGhCliGate();
+			if (gate) {
+				setGhGate(gate);
+				return;
+			}
+			setGhGate(null);
+			const pending = pendingRef.current;
+			pendingRef.current = null;
+			if (pending) proceed(pending);
+		})();
+	}, [proceed]);
+
+	const dismissGhGate = useCallback(() => {
+		pendingRef.current = null;
+		setGhGate(null);
+	}, []);
+
+	return { dispatch, ghGate, recheckGhGate, dismissGhGate };
+}
+
+async function detectGhCliGate(): Promise<GhCliGateReason | null> {
+	try {
+		// Dynamic import keeps this module loadable outside Electron (tests).
+		const { electronTrpcClient } = await import("renderer/lib/trpc-client");
+		const gh = await electronTrpcClient.system.detectGhCli.query();
+		return getGhCliGateReason(gh);
+	} catch {
+		// Detection failing must not block the PR flow itself.
+		return null;
+	}
+}
+
+export function getGhCliGateReason(gh: {
+	installed: boolean;
+	authenticated: boolean;
+}): GhCliGateReason | null {
+	if (!gh.installed) return "not-installed";
+	if (!gh.authenticated) return "not-authenticated";
+	return null;
 }
 
 interface DispatchPlan {


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

Onboarding deliberately doesn't block on the GitHub CLI (#4834), which is only safe if the point of use degrades gracefully. Today the v2 PR flow dispatches a prompt telling the agent to run `gh pr create` without ever checking that gh exists or is signed in — so the user's failure mode is the agent hitting a raw "command not found" mid-session.

## What changed

- `usePRFlowDispatch` now checks `system.detectGhCli` before dispatching the PR-creation prompt. If gh is missing or signed out, the dispatch is parked (not dropped) and a gate surfaces instead. If detection itself errors, we fail open — a broken detector must not block the PR flow.
- New `GhCliGateDialog` explains the specific problem and offers the fix inline:
  - **"GitHub CLI isn't signed in"** → a "Sign in to GitHub" button that opens the existing embedded-terminal `GhAuthDialog` (reused as-is from onboarding, no internal changes).
  - **"GitHub CLI isn't installed"** → "Get GitHub CLI" (opens https://cli.github.com/) plus "Check again". PR #6117's brew-based install has not landed on main yet, so the link is the install affordance for now; once #6117 merges this dialog can adopt the same install mode.
- After the user resolves the problem (auth dialog exits, or "Check again" passes), the parked dispatch resumes automatically — the PR flow continues without re-clicking Create PR. "Check again" also re-classifies: install gh while the not-installed dialog is up and it flips to the sign-in state.
- Dialog title/description carry `select-text cursor-text` per the renderer's error-text rule.

## Surface choice

I went with a pre-flight dialog dispatched from the flow hook rather than inline state in `PRActionHeader`. The header is a quiet icon-only bar (the whole action surface is a 16px icon), so there's no room to render an actionable error inline, and the gate is a point-in-time interruption of a click, not a persistent status — a dialog matches that shape and keeps the diff small. The gate state lives in `usePRFlowDispatch` because that's the single choke point every PR-creation dispatch goes through, so future entry points inherit the gate for free.

`GhAuthDialog` stays in its onboarding location and is imported cross-route (precedent: `GhAuthTerminal` already imports from a v2-workspace path). I deliberately did not move it to a shared folder because #6117 is actively changing that component and a mechanical move would conflict with it; happy to do the move as a follow-up once #6117 lands.

Note: `CREATE_PR_BUTTON_ENABLED` remains `false` — the create flow is still dormant in v2. The gate ships with it and was verified with the flag temporarily flipped (see below).

## Screenshot evidence (CDP-verified)

Verified end-to-end in the real dev app over CDP (port 9614, this worktree's renderer on vite port 3085), driving the actual Create PR button with real mouse input. gh states were simulated via a temporary uncommitted shim in `detectGhCli` reading `/tmp/t4-sim.json`, and the dormant `CREATE_PR_BUTTON_ENABLED` flag was temporarily flipped to reach the button; both shims were reverted (git status clean) before push. The embedded terminal was never driven past its first prompt — no real auth was performed.

**(a) gh not installed → click Create PR:**

![not installed](https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t4/a-not-installed.png)

**(b) gh installed but signed out — reached by clicking "Check again" in (a) after flipping the sim, proving re-detection re-classifies the gate:**

![not signed in](https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t4/b-not-signed-in.png)

**(c) "Sign in to GitHub" opens the embedded gh sign-in terminal (reused GhAuthDialog, live `gh auth login` prompt visible; auth not completed):**

![sign-in dialog](https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t4/c-sign-in-dialog.png)

**Resume path (measured, not screenshot-able since the chat wiring is no-op today):** with the sim flipped to authenticated and the auth dialog closed (simulating a completed sign-in), the parked dispatch fired without re-clicking Create PR — a temporary marker on the `onOpenChat` callback recorded `{ prompt: "/pr/create-pr", files: [{ filename: "pr-context.md", mediaType: "text/markdown" }] }`. The `onOpenChat` prop isn't passed by page.tsx yet (chat-driven create is "plan phase 7" scaffolding), so the happy-path dispatch has no visible UI today; the marker shim was also reverted.

**(d) happy path unchanged — sim removed (machine's real gh is installed + authenticated), click Create PR: no dialog, dispatch fires immediately (same marker measurement):**

![happy path](https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/t4/d-happy-path.png)

## Checks

- `bun run lint:fix` + `bun run lint` → exit 0
- `apps/desktop` `bun run typecheck` → clean
- `bun test` on `usePRFlowDispatch` + `PRActionHeader` utils dirs → 39 pass, 0 fail (new `getGhCliGateReason` cases included; `buildPRContext` output unchanged so its tests are untouched)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects GitHub CLI presence and sign-in before starting PR creation, gating the action with a clear dialog and resuming automatically once fixed. Addresses Linear SUPER-1729 by preventing mid-session failures when `gh` is missing or signed out.

- **New Features**
  - `usePRFlowDispatch` now checks `system.detectGhCli`; if `gh` is missing or signed out, it parks the dispatch and shows a gate. Detection failures fail open.
  - Added `GhCliGateDialog` with actions to install (`Get GitHub CLI`), recheck, or sign in via the embedded `GhAuthDialog`.
  - After resolution, the parked PR creation continues without another click; recheck updates the gate state when `gh` becomes available.
  - `WorkspaceSidebar` renders the gate; `usePRFlowDispatch` exposes `ghGate`, `recheckGhGate`, `dismissGhGate`. Introduced `getGhCliGateReason` with tests.

<sup>Written for commit 3db67b22a476ec44caf1319c4034adafa2574e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub CLI readiness check before pull request actions.
  * Added guidance for installing or signing in to GitHub CLI when required.
  * Added options to retry the check or dismiss the prompt.

* **Bug Fixes**
  * GitHub CLI detection failures no longer prevent pull request actions from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->