### PR TITLE
feat(host-service,desktop): move workspace deletion off the event loop and stop checks gating bulk delete

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/DashboardSidebarBulkDeleteDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/DashboardSidebarBulkDeleteDialog.tsx
@@ -43,7 +43,8 @@ export function DashboardSidebarBulkDeleteDialog({
 		onOpenChange,
 		onDeleted,
 	});
-	const { canConfirm, changedCount, items, unpushedCount } = inspectionSummary;
+	const { canConfirm, changedCount, items, uncheckedCount, unpushedCount } =
+		inspectionSummary;
 	const hasWarnings = changedCount > 0 || unpushedCount > 0;
 	const workspaceLabel = workspaces.length === 1 ? "workspace" : "workspaces";
 
@@ -151,9 +152,11 @@ export function DashboardSidebarBulkDeleteDialog({
 					>
 						{isDeleting
 							? `Deleting ${Math.min(completedCount + 1, workspaces.length)} of ${workspaces.length}…`
-							: hasWarnings
-								? "Delete anyway"
-								: "Delete"}
+							: uncheckedCount > 0
+								? "Delete without checking"
+								: hasWarnings
+									? "Delete anyway"
+									: "Delete"}
 					</Button>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/bulkWorkspaceDelete.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/bulkWorkspaceDelete.test.ts
@@ -12,7 +12,7 @@ const workspaces = [
 ];
 
 describe("buildBulkWorkspaceInspectionSummary", () => {
-	it("annotates risk and blocks confirmation until every target is safe", () => {
+	it("annotates risk and blocks confirmation only on hard blockers", () => {
 		const summary = buildBulkWorkspaceInspectionSummary(
 			workspaces,
 			new Map([
@@ -56,10 +56,13 @@ describe("buildBulkWorkspaceInspectionSummary", () => {
 			]),
 		);
 
+		// The main-workspace blocker gates confirmation; the failed check
+		// ("offline") does not — it flips the copy to "Delete without checking".
 		expect(summary.canConfirm).toBeFalse();
 		expect(summary.changedCount).toBe(1);
 		expect(summary.unpushedCount).toBe(1);
 		expect(summary.errorCount).toBe(1);
+		expect(summary.uncheckedCount).toBe(1);
 		expect(summary.blocked).toEqual([
 			{
 				workspaceId: "main",
@@ -74,6 +77,21 @@ describe("buildBulkWorkspaceInspectionSummary", () => {
 			hasChanges: true,
 			hasUnpushedCommits: true,
 		});
+	});
+
+	it("keeps confirmation enabled while checks are pending or failed", () => {
+		const summary = buildBulkWorkspaceInspectionSummary(
+			workspaces.slice(0, 3),
+			new Map([
+				["clean", { status: "loading" as const }],
+				["offline", { status: "error" as const }],
+			]),
+		);
+
+		expect(summary.canConfirm).toBeTrue();
+		expect(summary.loadingCount).toBe(2);
+		expect(summary.errorCount).toBe(1);
+		expect(summary.uncheckedCount).toBe(3);
 	});
 
 	it("enables confirmation when every target has a ready deletable preview", () => {
@@ -175,5 +193,59 @@ describe("executeBulkWorkspaceDeleteTargets", () => {
 			"later",
 		]);
 		expect(result.failures).toEqual([{ workspace: "raced", error: conflict }]);
+	});
+
+	it("force-retries once when shouldRetryWithForce accepts the failure", async () => {
+		const calls: Array<{ workspace: string; force: boolean }> = [];
+		const conflict = new Error("Worktree has uncommitted changes");
+
+		const result = await executeBulkWorkspaceDeleteTargets<
+			string,
+			string,
+			Error
+		>({
+			targets: ["unchecked", "clean"],
+			shouldForce: () => false,
+			shouldRetryWithForce: (workspace, error) =>
+				workspace === "unchecked" && error === conflict,
+			destroy: async (workspace, force) => {
+				calls.push({ workspace, force });
+				if (workspace === "unchecked" && !force) throw conflict;
+				return `${workspace}-deleted`;
+			},
+		});
+
+		expect(calls).toEqual([
+			{ workspace: "unchecked", force: false },
+			{ workspace: "unchecked", force: true },
+			{ workspace: "clean", force: false },
+		]);
+		expect(result.successes.map(({ workspace }) => workspace)).toEqual([
+			"unchecked",
+			"clean",
+		]);
+		expect(result.failures).toEqual([]);
+	});
+
+	it("does not retry an already-forced destroy", async () => {
+		const calls: Array<{ workspace: string; force: boolean }> = [];
+		const failure = new Error("still failing");
+
+		const result = await executeBulkWorkspaceDeleteTargets<
+			string,
+			string,
+			Error
+		>({
+			targets: ["ws"],
+			shouldForce: () => true,
+			shouldRetryWithForce: () => true,
+			destroy: async (workspace, force) => {
+				calls.push({ workspace, force });
+				throw failure;
+			},
+		});
+
+		expect(calls).toEqual([{ workspace: "ws", force: true }]);
+		expect(result.failures).toEqual([{ workspace: "ws", error: failure }]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/bulkWorkspaceDelete.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/bulkWorkspaceDelete.ts
@@ -21,11 +21,16 @@ export async function executeBulkWorkspaceDeleteTargets<
 >({
 	targets,
 	shouldForce,
+	shouldRetryWithForce,
 	destroy,
 	onSettled,
 }: {
 	targets: readonly Workspace[];
 	shouldForce: (workspace: Workspace) => boolean;
+	/** Retry a failed unforced destroy once with force. Used for conflicts on
+	 * workspaces whose preview never completed — "Delete without checking" is
+	 * the user's consent. Checked-clean races stay failures (no silent force). */
+	shouldRetryWithForce?: (workspace: Workspace, error: Failure) => boolean;
 	destroy: (workspace: Workspace, force: boolean) => Promise<Result>;
 	onSettled?: () => void;
 }): Promise<{
@@ -37,7 +42,17 @@ export async function executeBulkWorkspaceDeleteTargets<
 
 	for (const workspace of targets) {
 		try {
-			const result = await destroy(workspace, shouldForce(workspace));
+			const force = shouldForce(workspace);
+			let result: Result;
+			try {
+				result = await destroy(workspace, force);
+			} catch (error) {
+				if (!force && shouldRetryWithForce?.(workspace, error as Failure)) {
+					result = await destroy(workspace, true);
+				} else {
+					throw error;
+				}
+			}
 			successes.push({ workspace, result });
 		} catch (error) {
 			failures.push({ workspace, error: error as Failure });
@@ -119,14 +134,15 @@ export function buildBulkWorkspaceInspectionSummary(
 	return {
 		loadingCount,
 		errorCount,
+		// Pending or failed checks flip the confirm copy to "Delete without
+		// checking" instead of disabling confirmation.
+		uncheckedCount: loadingCount + errorCount,
 		blocked,
 		changedCount,
 		unpushedCount,
 		items,
-		canConfirm:
-			workspaces.length > 0 &&
-			loadingCount === 0 &&
-			errorCount === 0 &&
-			blocked.length === 0,
+		// Checks never gate deletion — only hard blockers (main workspaces,
+		// which the host refuses anyway) do.
+		canConfirm: workspaces.length > 0 && blocked.length === 0,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/useBulkWorkspaceDelete.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/useBulkWorkspaceDelete.ts
@@ -161,6 +161,14 @@ export function useBulkWorkspaceDelete({
 									inspection.preview.hasUnpushedCommits))
 						);
 					},
+					// "Delete without checking": a conflict on a workspace whose
+					// preview never completed means the unverified worktree was
+					// dirty — the user already consented, so force like the
+					// single-workspace dialog does. Checked-clean races still
+					// land in the failures pane.
+					shouldRetryWithForce: (workspace, error) =>
+						error.kind === "conflict" &&
+						inspections.get(workspace.id)?.status !== "ready",
 					destroy: (workspace, force) =>
 						destroyWorkspaceAtHost(targetFor(workspace), {
 							deleteBranch: preferences.deleteLocalBranch,

--- a/packages/host-service/src/no-main-loop-blocking.test.ts
+++ b/packages/host-service/src/no-main-loop-blocking.test.ts
@@ -63,6 +63,29 @@ const RULES: Rule[] = [
 		advice:
 			"simple-git is async, but a client constructed here still pays the spawn syscall + stdout drain on the event loop — cost scales linearly with call volume (measured ~830ms/min at light churn). Async isn't enough for git; route it off-loop: add a task to workers/tasks/git.ts and expose it with an offLoop() resolver (src/trpc/off-loop.ts).",
 	},
+	{
+		name: "on-loop git via the ctx.git() shared factory",
+		pattern: /\b(ctx|context)\.git\b/,
+		allowedCounts: {
+			// Legacy ctx.git() consumers — previously invisible to every
+			// enforcement layer (the client is constructed inside the exempt
+			// runtime/git/). Shrink by porting to worker tasks: resolve env
+			// on-loop with createGitEnvResolver, run the git work in the pool
+			// (see workspace-cleanup/git-ops.ts for the pattern).
+			"trpc/router/git/git.ts": 12,
+			"trpc/router/project/project.ts": 1,
+			"trpc/router/project/utils/ensure-main-workspace.ts": 1,
+			"trpc/router/workspace-creation/procedures/adopt.ts": 1,
+			"trpc/router/workspace-creation/procedures/list-project-worktrees.ts": 1,
+			"trpc/router/workspace-creation/procedures/search-branches.ts": 1,
+			"trpc/router/workspace-creation/utils/ai-workspace-names.ts": 1,
+			"trpc/router/workspace-creation/utils/list-branch-names.ts": 1,
+			"trpc/router/workspace/workspace.ts": 1,
+			"trpc/router/workspaces/workspaces.ts": 1,
+		},
+		advice:
+			"ctx.git() hands back an on-loop client — every call spawns and drains git on the event loop, and the ratchet's other rules can't see it. Resolve the env on-loop (createGitEnvResolver) and run the git work as a worker task instead (workers/tasks/git.ts; see workspace-cleanup/git-ops.ts).",
+	},
 ];
 
 // The worker pool and the git runtime own the primitives the rules police;

--- a/packages/host-service/src/no-main-loop-blocking.test.ts
+++ b/packages/host-service/src/no-main-loop-blocking.test.ts
@@ -84,7 +84,7 @@ const RULES: Rule[] = [
 			"trpc/router/workspaces/workspaces.ts": 1,
 		},
 		advice:
-			"ctx.git() hands back an on-loop client — every call spawns and drains git on the event loop, and the ratchet's other rules can't see it. Resolve the env on-loop (createGitEnvResolver) and run the git work as a worker task instead (workers/tasks/git.ts; see workspace-cleanup/git-ops.ts).",
+			"ctx.git() hands back an on-loop client — every call spawns and drains git on the event loop, and the ratchet's other rules can't see it. Resolve the env on-loop (createGitEnvResolver) and run the git work as a worker task instead (workers/tasks/git.ts; see workspace-cleanup/git-ops.ts). The pattern only matches direct property access — don't dodge it by destructuring/aliasing the factory off the context.",
 	},
 ];
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
@@ -16,6 +16,22 @@ import {
 	gitWorktreeRemoveTask,
 	gitWorktreeStateTask,
 } from "../../../workers/tasks/git";
+import {
+	WorkerTaskAbortedError,
+	WorkerTaskError,
+} from "../../../workers/WorkerTaskRunner";
+
+/**
+ * Pool-infrastructure failure (timeout, queue rejection, abort) — the git
+ * result is UNKNOWN, unlike a git error thrown by the task handler itself
+ * (whose original `name` — e.g. GitError — is preserved across the worker
+ * boundary). The destroy preflight fails closed on these instead of
+ * proceeding without its dirty-worktree check.
+ */
+export function isIndeterminateGitTaskFailure(err: unknown): boolean {
+	if (err instanceof WorkerTaskAbortedError) return true;
+	return err instanceof WorkerTaskError && err.name === "WorkerTaskError";
+}
 
 export const cleanupGitOps = {
 	/** Same failure surface as `ctx.git(repoPath)` — a throw here maps to the

--- a/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
@@ -1,0 +1,60 @@
+// Off-loop git operations for the workspace-delete saga. Env resolution
+// stays on the event loop (it needs the credential provider); the git
+// subprocesses — status preflight, `worktree remove` (a recursive delete
+// of the whole worktree), branch delete — run in the host worker pool.
+//
+// Exported as a mutable object: the unit tests patch these methods per
+// test and restore them (bun's mock.module leaks across test files in the
+// same process, so a module mock would poison the integration suite).
+
+import { createGitEnvResolver } from "../../../runtime/git/git";
+import type { HostServiceContext } from "../../../types";
+import { getHostWorkerPool } from "../../../workers/host-worker-pool";
+import {
+	type GitTaskEnv,
+	gitDeleteBranchTask,
+	gitWorktreeRemoveTask,
+	gitWorktreeStateTask,
+} from "../../../workers/tasks/git";
+
+export const cleanupGitOps = {
+	/** Same failure surface as `ctx.git(repoPath)` — a throw here maps to the
+	 * saga's "failed to open project repo" handling. */
+	resolveGitEnv(
+		ctx: Pick<HostServiceContext, "credentials">,
+		repoPath: string,
+	): Promise<GitTaskEnv> {
+		return createGitEnvResolver(ctx.credentials)(repoPath);
+	},
+
+	readWorktreeState(
+		input: { worktreePath: string; gitEnv: GitTaskEnv },
+		signal?: AbortSignal,
+	): Promise<{ hasChanges: boolean; hasUnpushedCommits: boolean }> {
+		return getHostWorkerPool().run(gitWorktreeStateTask, input, {
+			timeoutMs: 15_000,
+			signal,
+		});
+	},
+
+	removeWorktree(input: {
+		repoPath: string;
+		worktreePath: string;
+		gitEnv: GitTaskEnv;
+	}): Promise<{ stillRegistered: boolean }> {
+		// Generous timeout: removal recursively deletes the worktree
+		// directory, which can take a while for large trees (node_modules
+		// etc.).
+		return getHostWorkerPool().run(gitWorktreeRemoveTask, input, {
+			timeoutMs: 120_000,
+		});
+	},
+
+	deleteLocalBranch(input: {
+		repoPath: string;
+		branch: string;
+		gitEnv: GitTaskEnv;
+	}): Promise<{ deleted: boolean }> {
+		return getHostWorkerPool().run(gitDeleteBranchTask, input);
+	},
+};

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -12,7 +12,7 @@ import type {
 	TeardownFailureCause,
 } from "../../error-types";
 import { protectedProcedure, router } from "../../index";
-import { cleanupGitOps } from "./git-ops";
+import { cleanupGitOps, isIndeterminateGitTaskFailure } from "./git-ops";
 import { isMainWorkspace } from "./is-main-workspace";
 
 /**
@@ -213,6 +213,18 @@ async function runDestroy(
 			}
 		} catch (err) {
 			if (err instanceof TRPCError) throw err;
+			if (isIndeterminateGitTaskFailure(err)) {
+				// Timeout/pool failure: dirty-state is UNKNOWN. Fail closed on
+				// this destructive path rather than silently skipping the
+				// dirty-worktree block — a retry usually succeeds (the first
+				// attempt warmed the FS cache), and force skips preflight
+				// entirely as the explicit escape hatch.
+				const message = err instanceof Error ? err.message : String(err);
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Couldn't verify worktree state at ${local.worktreePath}: ${message}`,
+				});
+			}
 			// Can't read status (missing worktree dir, etc.) — not a
 			// conflict. Continue; step 3b will skip idempotently.
 		}

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -5,16 +5,14 @@ import { invalidateLabelCache } from "../../../ports/static-ports";
 import { runTeardown, type TeardownResult } from "../../../runtime/teardown";
 import { disposeSessionsByWorkspaceId } from "../../../terminal/terminal";
 import type { HostServiceContext } from "../../../types";
+import type { GitTaskEnv } from "../../../workers/tasks/git";
 import { deleteLocalWorkspace } from "../../../workspaces/local-workspace-store";
 import type {
 	DeleteInProgressCause,
 	TeardownFailureCause,
 } from "../../error-types";
 import { protectedProcedure, router } from "../../index";
-import {
-	normalizeWorktreePath,
-	parseWorktreeList,
-} from "../workspace-creation/shared/worktree-list";
+import { cleanupGitOps } from "./git-ops";
 import { isMainWorkspace } from "./is-main-workspace";
 
 /**
@@ -68,12 +66,12 @@ export const workspaceCleanupRouter = router({
 	 *   - git failures (missing worktree, broken repo) → return as canDelete
 	 *     with no warnings; the destroy saga handles those states best-effort.
 	 *
-	 * Unpushed-commit detection uses `rev-list --not --remotes` so brand-new
-	 * branches with no upstream still report unpushed commits correctly.
+	 * The git reads run in the host worker pool (gitWorktreeStateTask) so a
+	 * slow status on a large worktree can't block the event loop.
 	 */
 	inspect: protectedProcedure
 		.input(z.object({ workspaceId: z.string() }))
-		.query(async ({ ctx, input }): Promise<InspectResult> => {
+		.query(async ({ ctx, input, signal }): Promise<InspectResult> => {
 			const main = await isMainWorkspace(ctx, input.workspaceId);
 			if (main.isMain) {
 				return {
@@ -95,27 +93,19 @@ export const workspaceCleanupRouter = router({
 			}
 
 			try {
-				const git = await ctx.git(local.worktreePath);
-				const status = await git.status();
-				let hasUnpushedCommits = false;
-				try {
-					const result = await git.raw([
-						"rev-list",
-						"--count",
-						"HEAD",
-						"--not",
-						"--remotes",
-					]);
-					const count = Number.parseInt(result.trim(), 10);
-					hasUnpushedCommits = Number.isFinite(count) && count > 0;
-				} catch {
-					// Leave false — `rev-list` failure isn't a signal we can act on.
-				}
+				const gitEnv = await cleanupGitOps.resolveGitEnv(
+					ctx,
+					local.worktreePath,
+				);
+				const state = await cleanupGitOps.readWorktreeState(
+					{ worktreePath: local.worktreePath, gitEnv },
+					signal,
+				);
 				return {
 					canDelete: true,
 					reason: null,
-					hasChanges: !status.isClean(),
-					hasUnpushedCommits,
+					hasChanges: state.hasChanges,
+					hasUnpushedCommits: state.hasUnpushedCommits,
 				};
 			} catch {
 				return {
@@ -210,9 +200,12 @@ async function runDestroy(
 	// case). Missing/broken local state is handled by the cleanup phase.
 	if (!input.force && local && project) {
 		try {
-			const git = await ctx.git(local.worktreePath);
-			const status = await git.status();
-			if (!status.isClean()) {
+			const gitEnv = await cleanupGitOps.resolveGitEnv(ctx, local.worktreePath);
+			const state = await cleanupGitOps.readWorktreeState({
+				worktreePath: local.worktreePath,
+				gitEnv,
+			});
+			if (state.hasChanges) {
 				throw new TRPCError({
 					code: "CONFLICT",
 					message: "Worktree has uncommitted changes",
@@ -270,9 +263,11 @@ async function runDestroy(
 
 	// 2b. Worktree. Double-force unlocks the rare locked-worktree case and
 	//     clears stale metadata when the directory was manually removed.
+	//     Runs in the worker pool: the removal is a recursive delete of the
+	//     whole worktree directory, which would otherwise stall the loop.
 	let worktreeRemoved = false;
 	let branchDeleted = false;
-	let git: Awaited<ReturnType<typeof ctx.git>> | null = null;
+	let repoGitEnv: GitTaskEnv | null = null;
 	if (local && !project) {
 		worktreeRemoved = !existsSync(local.worktreePath);
 		if (!worktreeRemoved) {
@@ -284,7 +279,7 @@ async function runDestroy(
 	if (local && project) {
 		worktreeRemoved = !existsSync(local.worktreePath);
 		try {
-			git = await ctx.git(project.repoPath);
+			repoGitEnv = await cleanupGitOps.resolveGitEnv(ctx, project.repoPath);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			if (!worktreeRemoved) {
@@ -298,25 +293,17 @@ async function runDestroy(
 			);
 		}
 
-		if (git) {
-			// Remove against git's canonical path so a symlinked stored path
-			// (macOS `/var` → `/private/var`) still matches its registration.
-			const canonicalPath = normalizeWorktreePath(local.worktreePath);
-			// Best-effort: we trust git's registry below, not the command's
-			// exit text, which is locale- and version-dependent. `--force
-			// --force` also unregisters a worktree whose directory is already
-			// gone, so no separate prune (which would clobber other stale
-			// worktrees' metadata) is needed.
-			await git
-				.raw(["worktree", "remove", "--force", "--force", canonicalPath])
-				.catch(() => {});
-
-			// A `worktree list` failure here means the post-remove state is
-			// unknown — treat that like "still registered" and block rather
-			// than risk orphaning disk past the cloud commit point.
+		if (repoGitEnv) {
+			// A task failure here means the post-remove state is unknown —
+			// treat that like "still registered" and block rather than risk
+			// orphaning disk past the cloud commit point.
 			let stillRegistered = true;
 			try {
-				stillRegistered = await isRegisteredWorktree(git, local.worktreePath);
+				({ stillRegistered } = await cleanupGitOps.removeWorktree({
+					repoPath: project.repoPath,
+					worktreePath: local.worktreePath,
+					gitEnv: repoGitEnv,
+				}));
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				throw new TRPCError({
@@ -355,15 +342,17 @@ async function runDestroy(
 
 	// ─── Step 4: Optional branch delete ────────────────────────────
 	// After the local commit point so a failure here can't block the delete.
-	if (git && local?.branch && input.deleteBranch) {
+	// An absent ref (renamed, pruned, or never materialized) already
+	// satisfies the goal, so the task skips the delete without a scary
+	// warning; a thrown git failure lands in the warning below rather than
+	// being mistaken for "already gone".
+	if (repoGitEnv && project && local?.branch && input.deleteBranch) {
 		try {
-			// An absent ref (renamed, pruned, or never materialized) already
-			// satisfies the goal, so skip the delete without a scary warning.
-			// A thrown git failure falls through to the warning below rather
-			// than being mistaken for "already gone".
-			if (await localBranchExists(git, local.branch)) {
-				await git.raw(["branch", "-D", local.branch]);
-			}
+			await cleanupGitOps.deleteLocalBranch({
+				repoPath: project.repoPath,
+				branch: local.branch,
+				gitEnv: repoGitEnv,
+			});
 			branchDeleted = true;
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
@@ -388,30 +377,4 @@ async function runDestroy(
 		branchDeleted,
 		warnings,
 	};
-}
-
-// Authoritative "is this still a worktree git tracks" check — reads git's own
-// registry (realpath-canonicalized) instead of parsing remove's error text.
-// Calls `git.raw` directly rather than the swallowing `listGitWorktrees` so a
-// failed `worktree list` throws (state unknown) instead of looking empty.
-async function isRegisteredWorktree(
-	git: Awaited<ReturnType<HostServiceContext["git"]>>,
-	worktreePath: string,
-): Promise<boolean> {
-	const target = normalizeWorktreePath(worktreePath);
-	const raw = await git.raw(["worktree", "list", "--porcelain"]);
-	return parseWorktreeList(raw).some(
-		(w) => normalizeWorktreePath(w.path) === target,
-	);
-}
-
-// `branch --list` exits 0 whether or not the branch exists (empty output when
-// absent), so a thrown error is a real git failure — not a missing ref — and
-// propagates instead of being misread as "already deleted".
-async function localBranchExists(
-	git: Awaited<ReturnType<HostServiceContext["git"]>>,
-	branch: string,
-): Promise<boolean> {
-	const out = await git.raw(["branch", "--list", branch]);
-	return out.trim().length > 0;
 }

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -17,6 +17,10 @@ import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-fr
 import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
 import type { GitStatusSnapshotComputation } from "../../trpc/router/git/utils/git-status.ts";
 import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
+import {
+	normalizeWorktreePath,
+	parseWorktreeList,
+} from "../../trpc/router/workspace-creation/shared/worktree-list.ts";
 import { defineWorkerTask } from "../define-worker-task.ts";
 
 export interface GitTaskEnv {
@@ -85,10 +89,89 @@ export const gitIdentityTask = defineWorkerTask<
 	handler: ({ shellEnv }) => readGitIdentity(shellEnv),
 });
 
+// Delete-preview + destroy-preflight state for workspace cleanup.
+// Unpushed-commit detection uses `rev-list --not --remotes` so brand-new
+// branches with no upstream still report unpushed commits correctly.
+export const gitWorktreeStateTask = defineWorkerTask<
+	{ worktreePath: string; gitEnv: GitTaskEnv },
+	{ hasChanges: boolean; hasUnpushedCommits: boolean }
+>({
+	type: "git/worktreeState",
+	handler: async ({ worktreePath, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		const status = await git.status();
+		let hasUnpushedCommits = false;
+		try {
+			const result = await git.raw([
+				"rev-list",
+				"--count",
+				"HEAD",
+				"--not",
+				"--remotes",
+			]);
+			const count = Number.parseInt(result.trim(), 10);
+			hasUnpushedCommits = Number.isFinite(count) && count > 0;
+		} catch {
+			// Leave false — `rev-list` failure isn't a signal we can act on.
+		}
+		return { hasChanges: !status.isClean(), hasUnpushedCommits };
+	},
+});
+
+export const gitWorktreeRemoveTask = defineWorkerTask<
+	{ repoPath: string; worktreePath: string; gitEnv: GitTaskEnv },
+	{ stillRegistered: boolean }
+>({
+	type: "git/removeWorktree",
+	handler: async ({ repoPath, worktreePath, gitEnv }) => {
+		const git = createUserSimpleGit(repoPath).env(gitEnv);
+		// Remove against git's canonical path so a symlinked stored path
+		// (macOS `/var` → `/private/var`) still matches its registration.
+		const target = normalizeWorktreePath(worktreePath);
+		// Best-effort: the registry read below is authoritative, not the
+		// command's locale- and version-dependent exit text. `--force --force`
+		// also unregisters a worktree whose directory is already gone, so no
+		// separate prune (which would clobber other stale worktrees' metadata)
+		// is needed.
+		await git
+			.raw(["worktree", "remove", "--force", "--force", target])
+			.catch(() => {});
+		// A `worktree list` failure throws out of the task: the post-remove
+		// state is unknown and the caller must not treat it as removed.
+		const raw = await git.raw(["worktree", "list", "--porcelain"]);
+		return {
+			stillRegistered: parseWorktreeList(raw).some(
+				(w) => normalizeWorktreePath(w.path) === target,
+			),
+		};
+	},
+});
+
+export const gitDeleteBranchTask = defineWorkerTask<
+	{ repoPath: string; branch: string; gitEnv: GitTaskEnv },
+	{ deleted: boolean }
+>({
+	type: "git/deleteLocalBranch",
+	handler: async ({ repoPath, branch, gitEnv }) => {
+		const git = createUserSimpleGit(repoPath).env(gitEnv);
+		// `branch --list` exits 0 whether or not the branch exists (empty
+		// output when absent), so an absent ref — renamed, pruned, or never
+		// materialized — already satisfies the goal, while a thrown failure
+		// propagates instead of being misread as "already deleted".
+		const listed = await git.raw(["branch", "--list", branch]);
+		if (listed.trim().length === 0) return { deleted: false };
+		await git.raw(["branch", "-D", branch]);
+		return { deleted: true };
+	},
+});
+
 export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
 	gitCommitFilesTask,
 	gitWorkspaceRefsTask,
 	gitIdentityTask,
+	gitWorktreeStateTask,
+	gitWorktreeRemoveTask,
+	gitDeleteBranchTask,
 ];

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -15,6 +15,7 @@ import {
 	workspaceCleanupRouter,
 } from "../src/trpc/router/workspace-cleanup/workspace-cleanup";
 import type { HostServiceContext } from "../src/types";
+import { WorkerTaskError } from "../src/workers/WorkerTaskRunner";
 
 type WorkspaceRow = {
 	id: string;
@@ -609,6 +610,56 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			"Failed to delete branch feature: branch delete boom",
 		);
 		expect(cloudCallCount).toBe(1);
+	});
+
+	test("preflight pool timeout fails closed instead of skipping the dirty check", async () => {
+		const ctx = makeCtx({
+			workspace: {
+				id: "ws-1",
+				projectId: "p-1",
+				worktreePath: "/branch/wt",
+				branch: "feature",
+			},
+			project: { id: "p-1", repoPath: "/repo" },
+			// Default-named WorkerTaskError = pool infrastructure failure
+			// (timeout) — dirty-state unknown, so the destroy must not proceed.
+			worktreeState: () =>
+				Promise.reject(
+					new WorkerTaskError(
+						'Task "git/worktreeState" timed out after 15000ms',
+					),
+				),
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+		await expect(
+			caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: false,
+			}),
+		).rejects.toThrow(/Couldn't verify worktree state/);
+		expect(ctx.__mocks.cloudDelete).not.toHaveBeenCalled();
+	});
+
+	test("preflight git failure (missing worktree) still proceeds idempotently", async () => {
+		const ctx = makeCtx({
+			workspace: {
+				id: "ws-1",
+				projectId: "p-1",
+				worktreePath: "/missing/wt",
+				branch: "feature",
+			},
+			project: { id: "p-1", repoPath: "/repo" },
+			// Plain git error (handler-thrown) — cleanup handles missing state.
+			worktreeState: () => Promise.reject(new Error("fatal: not a git repo")),
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+		const result = await caller.destroy({
+			workspaceId: "ws-1",
+			deleteBranch: false,
+			force: false,
+		});
+		expect(result.success).toBe(true);
 	});
 
 	test("sqlite row-delete failure fails the destroy (local delete is the commit point)", async () => {

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
 	mkdirSync,
 	mkdtempSync,
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { cleanupGitOps } from "../src/trpc/router/workspace-cleanup/git-ops";
 import { isMainWorkspace } from "../src/trpc/router/workspace-cleanup/is-main-workspace";
 import {
 	__testDestroysInFlight,
@@ -24,23 +25,51 @@ type WorkspaceRow = {
 };
 type ProjectRow = { id: string; repoPath: string };
 
+type WorktreeState = { hasChanges: boolean; hasUnpushedCommits: boolean };
+
 interface ContextSpec {
 	workspace?: WorkspaceRow;
 	project?: ProjectRow;
 	cloudDelete?: () => Promise<unknown>;
-	gitStatus?: { isClean: () => boolean };
-	revListCount?: string | (() => Promise<string>);
-	gitFactoryThrows?: boolean;
-	worktreeRemove?: () => Promise<unknown>;
-	// Porcelain `git worktree list` output read back after the remove attempt.
-	// A path still present here means git considers the worktree live.
-	worktreeList?: string;
-	branchDelete?: () => Promise<unknown>;
-	// Whether `git branch --list` finds the branch (defaults to present).
-	branchExists?: boolean;
+	// git-ops behavior for this test; the ops are patched below so the
+	// saga's git work never spawns anything. Task-internal behaviors
+	// (rev-list swallow, `--force --force` semantics, registry verification)
+	// are covered by the real handlers in the integration suite.
+	worktreeState?: WorktreeState | (() => Promise<WorktreeState>);
+	// Simulates ctx.git()/env-resolution failure ("failed to open repo").
+	resolveGitEnvThrows?: boolean;
+	removeWorktree?: () => Promise<{ stillRegistered: boolean }>;
+	deleteBranch?: () => Promise<{ deleted: boolean }>;
 	dbDeleteThrows?: boolean | "once";
 	noApi?: boolean;
 }
+
+// Mutable per-test behavior read by the patched ops; makeCtx resets it.
+// The methods are patched in place (NOT via mock.module — bun leaks module
+// mocks across test files in the same process, which would poison the
+// integration suite's real git-ops) and restored in afterAll.
+let gitOpsSpec: ContextSpec = {};
+
+const realGitOps = { ...cleanupGitOps };
+afterAll(() => Object.assign(cleanupGitOps, realGitOps));
+
+Object.assign(cleanupGitOps, {
+	resolveGitEnv: async () => {
+		if (gitOpsSpec.resolveGitEnvThrows) throw new Error("git env boom");
+		return {};
+	},
+	readWorktreeState: async () => {
+		const state = gitOpsSpec.worktreeState;
+		if (typeof state === "function") return state();
+		return state ?? { hasChanges: false, hasUnpushedCommits: false };
+	},
+	removeWorktree: async () =>
+		gitOpsSpec.removeWorktree
+			? gitOpsSpec.removeWorktree()
+			: { stillRegistered: false },
+	deleteLocalBranch: async () =>
+		gitOpsSpec.deleteBranch ? gitOpsSpec.deleteBranch() : { deleted: true },
+} satisfies typeof realGitOps);
 
 function makeCtx(spec: ContextSpec): HostServiceContext & {
 	__mocks: {
@@ -48,6 +77,7 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 		broadcastWorkspaceChanged: ReturnType<typeof mock>;
 	};
 } {
+	gitOpsSpec = spec;
 	const workspaceRow = spec.workspace
 		? { type: "worktree", ...spec.workspace }
 		: undefined;
@@ -59,41 +89,6 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 	}));
 
 	const cloudDelete = mock(spec.cloudDelete ?? (async () => undefined));
-
-	const status = mock(async () => spec.gitStatus ?? { isClean: () => true });
-	const revList = mock(async () =>
-		typeof spec.revListCount === "function"
-			? await spec.revListCount()
-			: (spec.revListCount ?? "0\n"),
-	);
-	const worktreeRemove = mock(spec.worktreeRemove ?? (async () => undefined));
-	const worktreeList = mock(async () => spec.worktreeList ?? "");
-	const branchDelete = mock(spec.branchDelete ?? (async () => undefined));
-
-	const git = mock(async () => {
-		if (spec.gitFactoryThrows) throw new Error("git factory boom");
-		return {
-			status,
-			raw: mock(async (args: string[]) => {
-				if (args[0] === "rev-list") return await revList();
-				if (args[0] === "worktree") {
-					return args[1] === "list"
-						? await worktreeList()
-						: await worktreeRemove();
-				}
-				if (args[0] === "branch") {
-					// `branch --list <name>` is the existence probe: non-empty
-					// output means the ref exists. `branch -D` is the delete.
-					return args[1] === "--list"
-						? spec.branchExists === false
-							? ""
-							: `  ${args[2]}\n`
-						: await branchDelete();
-				}
-				throw new Error(`unexpected git raw: ${args.join(" ")}`);
-			}),
-		};
-	});
 
 	// The delete mock is shared across tables; per destroy, call #1 is the
 	// terminal-sessions sweep and call #2 is the workspace row — the one the
@@ -115,7 +110,9 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 	const ctx = {
 		isAuthenticated: true,
 		organizationId: "org-1",
-		git: git as never,
+		git: (async () => {
+			throw new Error("unexpected ctx.git call — cleanup goes through git-ops");
+		}) as never,
 		github: (async () => ({})) as never,
 		api: spec.noApi
 			? undefined
@@ -269,11 +266,10 @@ describe("workspaceCleanup.inspect", () => {
 		});
 	});
 
-	test("flags hasChanges from git status", async () => {
+	test("flags hasChanges from the worktree-state task", async () => {
 		const ctx = makeCtx({
 			...wsAndProject,
-			gitStatus: { isClean: () => false },
-			revListCount: "0\n",
+			worktreeState: { hasChanges: true, hasUnpushedCommits: false },
 		});
 		const caller = workspaceCleanupRouter.createCaller(ctx);
 		const result = await caller.inspect({ workspaceId: "ws-1" });
@@ -281,11 +277,10 @@ describe("workspaceCleanup.inspect", () => {
 		expect(result.hasUnpushedCommits).toBe(false);
 	});
 
-	test("flags hasUnpushedCommits from rev-list count > 0", async () => {
+	test("flags hasUnpushedCommits from the worktree-state task", async () => {
 		const ctx = makeCtx({
 			...wsAndProject,
-			gitStatus: { isClean: () => true },
-			revListCount: "3\n",
+			worktreeState: { hasChanges: false, hasUnpushedCommits: true },
 		});
 		const caller = workspaceCleanupRouter.createCaller(ctx);
 		const result = await caller.inspect({ workspaceId: "ws-1" });
@@ -293,22 +288,25 @@ describe("workspaceCleanup.inspect", () => {
 		expect(result.hasUnpushedCommits).toBe(true);
 	});
 
-	test("treats rev-list failure as no-unpushed-signal (doesn't block)", async () => {
+	test("swallows worktree-state task failures and returns canDelete: true", async () => {
 		const ctx = makeCtx({
 			...wsAndProject,
-			gitStatus: { isClean: () => true },
-			revListCount: () => Promise.reject(new Error("rev-list boom")),
+			worktreeState: () => Promise.reject(new Error("status boom")),
 		});
 		const caller = workspaceCleanupRouter.createCaller(ctx);
 		const result = await caller.inspect({ workspaceId: "ws-1" });
-		expect(result.hasUnpushedCommits).toBe(false);
-		expect(result.canDelete).toBe(true);
+		expect(result).toEqual({
+			canDelete: true,
+			reason: null,
+			hasChanges: false,
+			hasUnpushedCommits: false,
+		});
 	});
 
-	test("swallows git factory failures and returns canDelete: true with no warnings", async () => {
+	test("swallows git env-resolution failures and returns canDelete: true with no warnings", async () => {
 		const ctx = makeCtx({
 			...wsAndProject,
-			gitFactoryThrows: true,
+			resolveGitEnvThrows: true,
 		});
 		const caller = workspaceCleanupRouter.createCaller(ctx);
 		const result = await caller.inspect({ workspaceId: "ws-1" });
@@ -429,12 +427,9 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				cloudDelete: async () => {
 					cloudCallCount += 1;
 				},
-				worktreeRemove: async () => {
-					throw new Error("worktree remove boom");
-				},
-				// git still lists the worktree after the failed remove — the
+				// git still lists the worktree after the remove attempt — the
 				// authoritative signal that cleanup did not succeed.
-				worktreeList: `worktree ${tmp}\nHEAD 0000\nbranch refs/heads/feature\n`,
+				removeWorktree: async () => ({ stillRegistered: true }),
 			});
 			const caller = workspaceCleanupRouter.createCaller(ctx);
 
@@ -452,7 +447,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 		}
 	});
 
-	test("git open failure blocks local delete while the worktree path still exists", async () => {
+	test("worktree removal task failure blocks local delete (post-remove state unknown)", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
 		let cloudCallCount = 0;
 		try {
@@ -467,7 +462,41 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				cloudDelete: async () => {
 					cloudCallCount += 1;
 				},
-				gitFactoryThrows: true,
+				removeWorktree: async () => {
+					throw new Error("worktree list boom");
+				},
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			await expect(
+				caller.destroy({
+					workspaceId: "ws-1",
+					deleteBranch: false,
+					force: true,
+				}),
+			).rejects.toThrow(/Failed to verify worktree removal/i);
+			expect(cloudCallCount).toBe(0);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("git env-resolution failure blocks local delete while the worktree path still exists", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		let cloudCallCount = 0;
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: tmp,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: "/repo" },
+				cloudDelete: async () => {
+					cloudCallCount += 1;
+				},
+				resolveGitEnvThrows: true,
 			});
 			const caller = workspaceCleanupRouter.createCaller(ctx);
 
@@ -561,7 +590,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			cloudDelete: async () => {
 				cloudCallCount += 1;
 			},
-			branchDelete: async () => {
+			deleteBranch: async () => {
 				throw new Error("branch delete boom");
 			},
 		});

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -26,7 +26,8 @@ override-exempted. Delete an override entry when its file is fixed.
 
 The former blind spot — call sites spawning via `ctx.git()` (the shared
 factory) — is now covered by a dedicated `ctx.git` count rule in the
-host-service ratchet; no host git call site is invisible anymore.
+host-service ratchet. It matches direct property access only; destructuring
+or aliasing the factory off the context would still slip through (don't).
 
 ## Done (this branch)
 

--- a/plans/off-loop-git-reads.md
+++ b/plans/off-loop-git-reads.md
@@ -24,8 +24,9 @@ too high after a fix:
 `child_process`; tests/scripts and the ratchet-frozen legacy files are
 override-exempted. Delete an override entry when its file is fixed.
 
-Known blind spot: host-service call sites spawning via `ctx.git()` (the
-shared factory) are invisible to both layers — backlog-only below.
+The former blind spot — call sites spawning via `ctx.git()` (the shared
+factory) — is now covered by a dedicated `ctx.git` count rule in the
+host-service ratchet; no host git call site is invisible anymore.
 
 ## Done (this branch)
 
@@ -38,30 +39,43 @@ shared factory) are invisible to both layers — backlog-only below.
 - `base-ref-freshness`: common-dir rev-parse TTL-cached (was 1 spawn per
   status poll, #5776)
 - `resolve-repo.ts` / `project/handlers.ts`: recursive `rmSync` → async `rm`
+- Workspace delete (`workspace-cleanup.ts`): inspect/preflight `status()` +
+  unpushed check, `worktree remove --force --force` (recursive delete of the
+  whole worktree), branch delete → `gitWorktreeStateTask` /
+  `gitWorktreeRemoveTask` / `gitDeleteBranchTask` via
+  `workspace-cleanup/git-ops.ts`
 - Desktop: `changes.getBranches`, `workspaces.getAheadBehind`,
   `changes.get*FileContents` → changes git worker
 
 ## Backlog — host-service
 
-Priority order; port to `workers/tasks/git.ts`. Items constructing git
-clients directly have an allowlist line in `no-main-loop-blocking.test.ts`
-to delete when ported; items 1–3 and 6 spawn via `ctx.git()` (the shared
-factory) so the ratchet doesn't see them — they're backlog-only.
+Priority order; port to `workers/tasks/git.ts`. Every item has a count
+entry in `no-main-loop-blocking.test.ts` (under the direct-construction
+rule, the `ctx.git` rule, or both) — lower/delete the counts when porting.
 
 1. `trpc/router/git/git.ts` — `listCommits` (`git log`, unbounded),
    `getDiff` (2× `git show`, buffers file contents), `getBranchSyncStatus`
    (7 spawns incl. full `status()`), `renameBranch` (`ls-remote`, network)
 2. `trpc/router/workspace-creation/procedures/search-branches.ts` — network
    `fetch --prune` + 500-entry reflog walk on a typeahead query
-3. `trpc/router/workspace-cleanup/workspace-cleanup.ts` — `status()`
-   preflights + `worktree remove --force` (blocking recursive delete)
+3. `trpc/router/workspaces/workspaces.ts` — workspace CREATE is still
+   mostly on-loop: only the base-ref fetch was ported (#6093); `worktree
+   prune`, start-point resolution (`getLocalBranchHead`, rev-parses),
+   `worktree add` (spawn + full-checkout stdout drain), and
+   `branch.<name>.base` config writes all run via one `ctx.git()` client
 4. `trpc/router/project/utils/resolve-repo.ts` — `git clone` inline
    (unbounded network); worker task or spawn with streaming
 5. `trpc/router/project/project.ts` — `ctx.git()` inside `project.remove`
-   loop; hoist + worker-route `worktree remove`
+   loop; hoist + worker-route `worktree remove` (same class as the
+   workspace-delete port above; reuse `gitWorktreeRemoveTask`)
 6. `trpc/router/workspace/workspace.ts` — full `git.status()` on the legacy
    surface; also per-row `existsSync` in `workspace.list`
-7. `workspace-creation/shared/project-helpers.ts`,
+7. Small one-shot `ctx.git()` sites (one spawn each, low churn):
+   `workspace-creation/procedures/adopt.ts` + `list-project-worktrees.ts`
+   (`worktree list`), `workspace-creation/utils/list-branch-names.ts`,
+   `ai-workspace-names.ts` (`branch -m` rename),
+   `project/utils/ensure-main-workspace.ts` (current-branch probe)
+8. `workspace-creation/shared/project-helpers.ts`,
    `trpc/router/git/utils/git-helpers.ts` — cheap but on-loop; port last
    (`settings/branch-prefix.ts` done — first `offLoop()` port)
 

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -29,7 +29,8 @@
 		"VERCEL_URL",
 		"npm_lifecycle_event",
 		"RENDERER_REMOTE_DEBUG_PORT",
-		"SUPERSET_PTY_DAEMON_ADOPT_IN_DEV"
+		"SUPERSET_PTY_DAEMON_ADOPT_IN_DEV",
+		"SUPERSET_HOST_WORKER_SCRIPT_PATH"
 	],
 	"tasks": {
 		"build": {


### PR DESCRIPTION
## What & why

Workspace deletion was the last fully on-loop git surface in its class (item 3 in `plans/off-loop-git-reads.md`): the delete-dialog preview and destroy preflight ran `git status` + `rev-list` on the host-service event loop, and destroy ran `git worktree remove --force --force` there too — all via `ctx.git()`, which no enforcement layer could see.

### Host-service
- New worker tasks in `workers/tasks/git.ts`: `gitWorktreeStateTask` (status + unpushed check), `gitWorktreeRemoveTask` (remove + authoritative registry re-read), `gitDeleteBranchTask` (existence probe + `-D`). Saga semantics preserved exactly (best-effort remove with registry verification, absent-branch-is-success, list-failure blocks rather than orphans).
- New `workspace-cleanup/git-ops.ts`: resolves credential env on-loop, runs the tasks in the host worker pool (15s status / 120s remove timeouts; inspect forwards the request abort signal). Exported as a mutable object because bun `mock.module` leaks across test files in one process — the unit tests patch and restore it instead.
- The legacy `workspace.remove` surface reuses the same saga, so it's covered automatically.
- **Ratchet: new `ctx.git`/`context.git` count rule** in `no-main-loop-blocking.test.ts`, calibrated to the 10 current legacy files — the shared-factory blind spot is closed; new on-loop git call sites now fail CI.
- Plan doc updated: delete moved to Done; workspace **create** (still mostly on-loop — only its base fetch was ported in #6093) added to the backlog along with the small one-shot `ctx.git()` sites.

### Desktop (bulk delete)
- Checks no longer gate confirmation. Only hard blockers (main workspaces) disable the button; pending/failed checks flip the copy to **"Delete without checking"**.
- Confirming with unchecked workspaces: a dirty one hits the host CONFLICT preflight and is force-retried once (same consent semantics as the single-workspace dialog). Checked-clean races still land in the failures pane — #6021's deliberate no-silent-force behavior is preserved and still tested.

### Misc
- `SUPERSET_HOST_WORKER_SCRIPT_PATH` added to turbo `globalPassThroughEnv` so a dev host-service can be forced into inline pool mode for A/B measurement.

## Measured impact (A/B, pool worker vs forced-inline = pre-port behavior)
- 12 concurrent delete chains (9k dirty files each): **4.89s → 2.89s wall (41% faster)**, ~4× less event-loop busy time.
- Per-op head-of-line stalls were small even pre-port (≤10ms at 60k dirty files) — simple-git streams and parses fast. The win is throughput and aggregate loop relief, not per-op stall elimination; an in-app probe confirmed the ~100ms burst floor is renderer-side rendering, identical in both modes.

## How I tested it
- Unit + integration: host-service suite 936 pass / 0 fail (integration exercises the real task handlers against real git fixtures via the pool's inline fallback: dirty preflight, locked worktrees, stale metadata, branch delete). Bulk-delete tests updated + new coverage for the force-retry paths. All 64 DashboardSidebar tests pass. Ratchet green.
- `bun run lint` and desktop + host-service typecheck clean.
- CDP end-to-end in the dev app from this worktree (renderer port 3445, signed-in session, worker bundle confirmed in worker mode):
  - **Before/after UI**: with the host-service suspended to hold checks open — old code shows a disabled "Delete" while "Checking…"; new code shows an enabled "Delete without checking".
  - **Bulk**: cmd-clicked 4 workspaces, confirmed *while checks were still pending*, resumed the host → all 4 deleted; the dirty unchecked one exercised the conflict→force-retry path. Worktrees verified gone from disk, `git worktree list`, and host.db.
  - **Single**: dirty workspace showed "Has uncommitted changes" (the new worker task end-to-end), "Delete anyway" + branch checkbox removed worktree and branch.

## Checklist
- [x] PR title follows conventional commits
- [x] `bun run lint` and `bun run typecheck` pass
- [x] One clean commit on top of `main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves workspace deletion off the `host-service` event loop and lets desktop bulk delete proceed without completed checks, improving throughput and reducing UI stalls.

- **Refactors**
  - Ported delete saga git ops to worker tasks: `gitWorktreeStateTask`, `gitWorktreeRemoveTask`, `gitDeleteBranchTask` via `workspace-cleanup/git-ops.ts`.
  - Added a `ctx.git` count rule to the ratchet and documented direct-access-only matching; updated the off-loop plan.
  - A/B: 12 concurrent deletes are ~41% faster (4.89s → 2.89s).

- **Bug Fixes**
  - Delete preflight now fails closed when worktree state can’t be verified (pool timeout/abort), instead of proceeding without a dirty-worktree check.

<sup>Written for commit fb472a8c8a90a8060b866ef04b4a10c2f4c87ad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk workspace deletion can proceed when inspections are incomplete, with unchecked workspaces clearly identified.
  * Conflicts caused by unverified workspace state may be retried with force automatically.

* **Bug Fixes**
  * Completed clean inspections continue to block deletion when genuine conflicts are detected.
  * Workspace cleanup more reliably handles worktree removal, branch deletion, warnings, and failures.

* **Performance**
  * Git cleanup operations now run in background tasks to help keep the application responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->