### PR TITLE
feat(desktop): restore onboarding funnel instrumentation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/ProviderConnectModal/ProviderConnectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/ProviderConnectModal/ProviderConnectModal.tsx
@@ -16,6 +16,7 @@ import { OpenAIOAuthDialog } from "renderer/components/Chat/ChatInterface/compon
 import { useAnthropicOAuth } from "renderer/components/Chat/ChatInterface/components/ModelPicker/hooks/useAnthropicOAuth";
 import { useOpenAIOAuth } from "renderer/components/Chat/ChatInterface/components/ModelPicker/hooks/useOpenAIOAuth";
 import { track } from "renderer/lib/analytics";
+import { trackOnboardingError } from "../../utils/onboardingAnalytics";
 
 export type Provider = "anthropic" | "openai";
 
@@ -61,7 +62,12 @@ function AnthropicConnectDialog({
 		});
 
 	const handleApiKeySubmit = async (rawKey: string) => {
-		await setApiKey.mutateAsync({ apiKey: rawKey });
+		try {
+			await setApiKey.mutateAsync({ apiKey: rawKey });
+		} catch (err) {
+			trackOnboardingError("providers", "provider_connect", "api_key_failed");
+			throw err;
+		}
 		track("onboarding_provider_connected", {
 			provider: "anthropic",
 			method: "api-key",
@@ -121,7 +127,12 @@ function OpenAIConnectDialog({
 	});
 
 	const handleApiKeySubmit = async (rawKey: string) => {
-		await setApiKey.mutateAsync({ apiKey: rawKey });
+		try {
+			await setApiKey.mutateAsync({ apiKey: rawKey });
+		} catch (err) {
+			trackOnboardingError("providers", "provider_connect", "api_key_failed");
+			throw err;
+		}
 		track("onboarding_provider_connected", {
 			provider: "openai",
 			method: "api-key",

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -6,12 +6,18 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
 import { OnboardingNavigation } from "./components/OnboardingNavigation";
+import {
+	flushOnboardingAbandoned,
+	scheduleOnboardingAbandoned,
+	trackOnboardingEntered,
+	trackOnboardingStepCompleted,
+} from "./utils/onboardingAnalytics";
 
 export const Route = createFileRoute("/_authenticated/onboarding")({
 	component: OnboardingFlowLayout,
@@ -24,12 +30,14 @@ const STEPS = [
 	{
 		path: "/onboarding",
 		match: (p: string) => p === "/onboarding",
+		slug: "providers",
 		title: "Setup Superset",
 		subtitle: "Connect your agents and tools to get started.",
 	},
 	{
 		path: "/onboarding/project",
 		match: (p: string) => p === "/onboarding/project",
+		slug: "project",
 		title: "Create or add a project",
 		subtitle: "Start from scratch, open a folder, or clone a repo.",
 	},
@@ -42,6 +50,22 @@ function OnboardingFlowLayout() {
 	const chatClient = useMemo(() => createChatServiceIpcClient(), []);
 	const location = useLocation();
 	const navigate = useNavigate();
+
+	const onboarded = Boolean(session?.user?.onboardedAt);
+	const pathname = location.pathname;
+	useEffect(() => {
+		if (isPending || onboarded) return;
+		const step = STEPS.find((s) => s.match(pathname));
+		if (step) trackOnboardingEntered(step.slug);
+	}, [isPending, onboarded, pathname]);
+
+	useEffect(() => {
+		window.addEventListener("beforeunload", flushOnboardingAbandoned);
+		return () => {
+			window.removeEventListener("beforeunload", flushOnboardingAbandoned);
+			scheduleOnboardingAbandoned();
+		};
+	}, []);
 
 	if (isPending) return null;
 	if (session?.user?.onboardedAt) {
@@ -63,7 +87,10 @@ function OnboardingFlowLayout() {
 	// Step 1 advances to the project step; the project step finishes onboarding
 	// itself the moment a project is added, so it has no footer Continue.
 	const handleContinue = isFirstStep
-		? () => navigate({ to: "/onboarding/project" })
+		? () => {
+				trackOnboardingStepCompleted("providers");
+				navigate({ to: "/onboarding/project" });
+			}
 		: null;
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -14,6 +14,7 @@ import {
 	ProviderConnectModal,
 } from "./components/ProviderConnectModal";
 import { ClaudeLogo } from "./providers/components/ClaudeLogo";
+import { trackOnboardingError } from "./utils/onboardingAnalytics";
 
 export const Route = createFileRoute("/_authenticated/onboarding/")({
 	component: OnboardingDashboardPage,
@@ -134,7 +135,12 @@ function OnboardingDashboardPage() {
 			<GhAuthDialog
 				open={ghAuthOpen}
 				onOpenChange={setGhAuthOpen}
-				onExit={() => void refetchGh()}
+				onExit={async () => {
+					const result = await refetchGh();
+					if (!(result.data?.installed && result.data.authenticated)) {
+						trackOnboardingError("providers", "gh_auth", "auth_incomplete");
+					}
+				}}
 			/>
 		</>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -27,6 +27,11 @@ import { EmptyProjectModal } from "renderer/routes/_authenticated/components/Emp
 import { TemplateGalleryModal } from "renderer/routes/_authenticated/components/TemplateGalleryModal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import {
+	markOnboardingFinished,
+	trackOnboardingError,
+	trackOnboardingStepCompleted,
+} from "../utils/onboardingAnalytics";
 
 export const Route = createFileRoute("/_authenticated/onboarding/project/")({
 	component: OnboardingProjectPage,
@@ -57,6 +62,8 @@ function OnboardingProjectPage() {
 	// Adding a project finishes onboarding: mark onboarded, then hand off to the
 	// dashboard's new-workspace modal pre-selected to the project just added.
 	const finish = async (projectId: string) => {
+		trackOnboardingStepCompleted("project");
+		markOnboardingFinished();
 		track("onboarding_finished", { outcome: "completed" });
 		try {
 			await apiTrpcClient.user.completeOnboarding.mutate();
@@ -65,6 +72,11 @@ function OnboardingProjectPage() {
 			// _authenticated guard bounces /v2-workspaces back to /onboarding.
 			await refetchSession({ query: { disableCookieCache: true } });
 		} catch (error) {
+			trackOnboardingError(
+				"project",
+				"complete_onboarding",
+				requestFailureReason(error),
+			);
 			console.error("[onboarding] completeOnboarding failed", error);
 			toast.error("Could not finish onboarding. Please try again.");
 			return;
@@ -120,6 +132,7 @@ function OnboardingProjectPage() {
 			if (isV2CloudEnabled) {
 				const activeHostUrl = await waitForHostReady();
 				if (!activeHostUrl) {
+					trackOnboardingError("project", "clone", "host_not_ready");
 					toast.error("Local host service isn't ready yet. Please try again.");
 					return;
 				}
@@ -138,6 +151,7 @@ function OnboardingProjectPage() {
 				if (projectId) await finish(projectId);
 			}
 		} catch (err) {
+			trackOnboardingError("project", "clone", cloneFailureReason(err));
 			toast.error(
 				err instanceof Error ? err.message : "Failed to clone repository",
 			);
@@ -252,6 +266,35 @@ function OnboardingProjectPage() {
 			/>
 		</div>
 	);
+}
+
+// Reason codes only — error messages can contain URLs/paths, never log them.
+function cloneFailureReason(err: unknown): string {
+	const msg = err instanceof Error ? err.message.toLowerCase() : "";
+	if (msg.includes("not found") || msg.includes("does not exist"))
+		return "repo_not_found";
+	if (
+		msg.includes("auth") ||
+		msg.includes("permission denied") ||
+		msg.includes("403")
+	)
+		return "auth_failed";
+	if (msg.includes("could not resolve host") || msg.includes("network"))
+		return "network_error";
+	if (msg.includes("already exists")) return "already_exists";
+	return "clone_failed";
+}
+
+function requestFailureReason(err: unknown): string {
+	const msg = err instanceof Error ? err.message.toLowerCase() : "";
+	if (
+		msg.includes("fetch failed") ||
+		msg.includes("load failed") ||
+		msg.includes("network")
+	)
+		return "api_unreachable";
+	if (msg.includes("unauthorized") || msg.includes("401")) return "auth_failed";
+	return "request_failed";
 }
 
 function repoNameFromUrl(url: string): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/utils/onboardingAnalytics/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/utils/onboardingAnalytics/index.ts
@@ -1,0 +1,9 @@
+export {
+	flushOnboardingAbandoned,
+	markOnboardingFinished,
+	type OnboardingStep,
+	scheduleOnboardingAbandoned,
+	trackOnboardingEntered,
+	trackOnboardingError,
+	trackOnboardingStepCompleted,
+} from "./onboardingAnalytics";

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/utils/onboardingAnalytics/onboardingAnalytics.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/utils/onboardingAnalytics/onboardingAnalytics.ts
@@ -1,0 +1,58 @@
+import { track } from "renderer/lib/analytics";
+
+export type OnboardingStep = "providers" | "project";
+
+// Module-level so remounts and route bounces within a renderer session
+// can't double-fire onboarding_started or duplicate step_started events.
+let started = false;
+let finished = false;
+let currentStep: OnboardingStep | null = null;
+let abandonTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function trackOnboardingEntered(step: OnboardingStep): void {
+	if (abandonTimer !== null) {
+		clearTimeout(abandonTimer);
+		abandonTimer = null;
+	}
+	if (!started) {
+		started = true;
+		track("onboarding_started");
+	}
+	if (currentStep !== step) {
+		currentStep = step;
+		track("onboarding_step_started", { step });
+	}
+}
+
+export function trackOnboardingStepCompleted(step: OnboardingStep): void {
+	track("onboarding_step_completed", { step });
+}
+
+/** Reason codes only — never include URLs, repo names, paths, or messages. */
+export function trackOnboardingError(
+	step: OnboardingStep,
+	action: string,
+	reason: string,
+): void {
+	track("onboarding_error", { step, action, reason });
+}
+
+export function markOnboardingFinished(): void {
+	finished = true;
+}
+
+export function flushOnboardingAbandoned(): void {
+	if (!started || finished || currentStep === null) return;
+	track("onboarding_abandoned", { step: currentStep });
+	currentStep = null;
+}
+
+// Deferred a tick so StrictMode's unmount/remount and route bounces through
+// the layout don't register as abandonment; re-entry cancels the timer.
+export function scheduleOnboardingAbandoned(): void {
+	if (abandonTimer !== null) clearTimeout(abandonTimer);
+	abandonTimer = setTimeout(() => {
+		abandonTimer = null;
+		flushOnboardingAbandoned();
+	}, 0);
+}


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

Restores renderer-side onboarding funnel instrumentation for the 2-step flow. Analytics only — no UX, navigation, gating, or experiment changes (`useNewWorkspaceScreenVariant` and all `new-workspace-screen` exposure logic untouched). All events go through the existing `track()` helper in `renderer/lib/analytics`.

## Events emitted

| Event | Properties | When |
|---|---|---|
| `onboarding_started` | — | First entry into the onboarding flow; module-level guard prevents double-fire on remount/route bounce (once per renderer session) |
| `onboarding_step_started` | `step` | Entering a step; deduped against the current step, re-fires on re-entry after abandonment |
| `onboarding_step_completed` | `step` | Step 1: Continue click. Step 2: in `finish()` immediately before `onboarding_finished` |
| `onboarding_abandoned` | `step` | Best-effort on layout unmount (deferred one tick so StrictMode double-mounts and route bounces don't count) and synchronously on `beforeunload`; suppressed once finished |
| `onboarding_error` | `step`, `action`, `reason` | Clone failure (`action: clone`), `completeOnboarding` failure (`action: complete_onboarding`), gh auth exiting unauthenticated (`action: gh_auth`), provider API-key save failure (`action: provider_connect`) |
| `onboarding_finished` | `outcome: completed` | **Unchanged** — same call site, name, and timing as before |
| `onboarding_provider_connected` | `provider`, `method` | Pre-existing, unchanged |

`reason` is always a machine-readable code mapped from the error (`repo_not_found`, `auth_failed`, `network_error`, `already_exists`, `clone_failed`, `host_not_ready`, `api_unreachable`, `request_failed`, `auth_incomplete`, `api_key_failed`) — never URLs, repo names, paths, or messages.

## Step slugs

- Step 1 (tools/providers checklist) → **`providers`** — the historical `providers` step is the closest ancestor of this surface; the old `gh-cli`/`permissions`/`adopt-worktrees` steps no longer exist as separate screens, and gh-CLI issues remain distinguishable via `onboarding_error` with `action: gh_auth`.
- Step 2 (create/add a project) → **`project`** — exact match with the historical slug.

## Verification

- `bun run lint:fix` → `bun run lint` exits 0; `apps/desktop` `bun run typecheck` clean. No colocated tests in the touched files.
- Verified end-to-end via CDP against the real dev app (renderer on this workspace's `DESKTOP_VITE_PORT=3225`, CDP 9615): `posthog.capture` was wrapped via `Page.addScriptToEvaluateOnNewDocument` so **no test events reached production PostHog**; `onboarded_at` was nulled for the dev user, the flow was walked with real UI clicks, then `onboarded_at` restored.

Captured sequence (in order, from `window.__t5Events`):

```json
[{"event":"onboarding_started","props":null},
 {"event":"onboarding_step_started","props":{"step":"providers"}},
 {"event":"onboarding_step_completed","props":{"step":"providers"}},   // Continue click
 {"event":"onboarding_step_started","props":{"step":"project"}},
 {"event":"onboarding_error","props":{"step":"project","action":"clone","reason":"repo_not_found"}},  // clone of nonexistent repo
 {"event":"onboarding_abandoned","props":{"step":"project"}},          // beforeunload path
 {"event":"onboarding_step_started","props":{"step":"providers"}},     // re-entry via Back — note: no second onboarding_started
 {"event":"onboarding_step_completed","props":{"step":"providers"}},
 {"event":"onboarding_step_started","props":{"step":"project"}},
 {"event":"onboarding_step_completed","props":{"step":"project"}},
 {"event":"onboarding_finished","props":{"outcome":"completed"}}]      // real clone; app then redirected to #/v2-workspaces
```

The abandonment leg was triggered with a dispatched `beforeunload` event (synthetic — a real reload wipes the in-page capture buffer); the layout-unmount path uses the same flush and its timer-cancel behavior is exercised by the Back/Continue route changes above, which correctly did **not** emit `onboarding_abandoned`. Everything else was end-to-end UI interaction on the live app.

Kept intentionally additive for easy rebasing against #6116/#6117.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores renderer-side onboarding funnel analytics for the 2-step flow to meet SUPER-1729. No UX, navigation, gating, or experiment changes; all events go through `track()`.

- **New Features**
  - Emits: `onboarding_started`, `onboarding_step_started`, `onboarding_step_completed`, `onboarding_abandoned`, `onboarding_error`, and keeps `onboarding_finished`/`onboarding_provider_connected` as-is. Deduped per session and step.
  - Abandon tracking: flushed on `beforeunload`; scheduled on layout unmount and canceled on re-entry to avoid false positives.
  - Error tracking: `{ step, action, reason }` with machine-readable reasons only (e.g., `repo_not_found`, `auth_failed`, `api_unreachable`, `clone_failed`, `api_key_failed`).
  - Step slugs: `providers` (tools/providers checklist) and `project` (create/add project).
  - Integrated at key points: provider API key save failures, GH auth exit unauthenticated, clone failures/host not ready, and `completeOnboarding` failures.

<sup>Written for commit 05d52123d50f544849282adfc9866c6f363445ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Added comprehensive onboarding progress tracking, including step entry, completion, abandonment, and overall completion.
  * Added error tracking for provider API-key connections, GitHub authentication, project setup, cloning, and host readiness.
  * Error reporting uses sanitized reason categories without exposing sensitive messages or paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->