### PR TITLE
fix(desktop): redirect stale v1 workspace routes to new workspace

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import {
 	createFileRoute,
+	Navigate,
 	Outlet,
 	useMatchRoute,
 	useNavigate,
@@ -226,7 +227,19 @@ function DashboardLayout() {
 				<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
 					{!sidebarOutsideColumn && sidebarPanel}
 					<div className="relative flex flex-1 min-h-0 min-w-0">
-						{versionMismatch ? <CrossVersionMismatchState /> : <Outlet />}
+						{versionMismatch ? (
+							// A v2 user on a stale v1 workspace route has nothing to go
+							// back to, so send them somewhere actionable instead of a
+							// dead-end "pick a workspace" screen. v1 users keep the
+							// static state — /new-workspace is a v2-only surface.
+							isV2CloudEnabled ? (
+								<Navigate to="/new-workspace" replace />
+							) : (
+								<CrossVersionMismatchState />
+							)
+						) : (
+							<Outlet />
+						)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

## Problem

A v2 user who lands on a **v1 workspace route** — restored session from before the v1→v2 migration, a stale link, a bookmarked URL — hits `versionMismatch` in the dashboard layout and gets `CrossVersionMismatchState`:

> **Pick a workspace** — Select a workspace from the sidebar to get started.

It's a dead end. There is no action on the screen, and the instruction ("pick from the sidebar") is the one thing the user evidently didn't want to do. Reported from a real session with a fully populated sidebar:

<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/mismatch/01-before-pick-a-workspace.png" width="800" alt="Before: Pick a workspace dead end" />

## Change

When `versionMismatch` is true **and v2 is enabled**, redirect to `/new-workspace` (the create surface) instead of rendering the dead-end state. v1 users keep the existing static state — `/new-workspace` renders the v2 create screen and isn't a valid destination for them.

```diff
-{versionMismatch ? <CrossVersionMismatchState /> : <Outlet />}
+{versionMismatch ? (
+    isV2CloudEnabled ? <Navigate to="/new-workspace" replace /> : <CrossVersionMismatchState />
+) : (
+    <Outlet />
+)}
```

`replace` so the dead route doesn't linger in history.

## Relationship to the new-workspace-screen experiment

**None — this path is not part of it.** The `new-workspace-screen` experiment only swaps the `/v2-workspaces` empty state when a user has **zero** workspaces (`isEmptyDashboard`). This is the opposite case: workspaces exist, the route is just from the wrong version. No variant is evaluated here and no exposure event fires, so the running 50/50 experiment is unaffected.

## Verification (CDP, real dev app)

Renderer on this worktree's vite port, CDP 9621, page target matched before driving.

- **Redirect works end-to-end:** the dev app booted with its persisted last-active route pointing at a v1 workspace (`#/workspace/24e05c49-…`) and auto-redirected to `#/new-workspace`, landing on the real create screen — sample prompts, agent picker, prompt input. `"Pick a workspace"` absent from the DOM.

<img src="https://raw.githubusercontent.com/superset-sh/superset/evidence/super-1729/mismatch/02-after-redirect-new-workspace.png" width="800" alt="After: redirected to the new workspace screen" />

- **No redirect loop:** hash stable at `#/new-workspace` across a 3s re-check; `history.length === 1` (replace, not push).
- **Scoped correctly:** clicking a v2 workspace navigates to `#/v2-workspace/<id>` and renders normally — no redirect.
- `bun run lint:fix` + `bun run lint` → exit 0; `apps/desktop` `tsc --noEmit` → clean.

Honest note on the before-shot: it's the reported real-session screenshot, not one I re-staged. After my first boot exercised the redirect, the app's persisted last-active route became a v2 workspace, and synthetic hash navigation doesn't remount TanStack routes — so I couldn't re-enter the mismatch state locally to photograph the old behavior. The "after" evidence above is a genuine end-to-end run of exactly the reported scenario.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect v2 users who land on stale v1 workspace routes to `/new-workspace` so they don’t hit the dead-end “Pick a workspace” screen. Uses history replace; v1 users keep the existing static state.

- **Bug Fixes**
  - When `versionMismatch` and v2 are enabled, navigate to `/new-workspace` with `replace`.
  - Preserve v1 behavior (still shows `CrossVersionMismatchState`).
  - Not part of the `new-workspace-screen` experiment; unrelated to empty-state logic.
  - Related to SUPER-1729.

<sup>Written for commit 3cc5038483d6043c3d05da2868f25827b4d15405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * v2 users experiencing a version mismatch are now automatically redirected to the new workspace setup.
  * v1 users continue to see the existing version mismatch guidance.
  * Normal navigation remains unchanged when versions match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->