### PR TITLE
fix(desktop): remove auto-detect status caption from onboarding step 1

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/page.tsx
@@ -60,13 +60,6 @@ function OnboardingDashboardPage() {
 	return (
 		<>
 			<div className="-mt-4">
-				<p className="mb-6 flex items-center gap-2 text-xs text-muted-foreground">
-					<span className="relative flex size-1.5">
-						<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-60" />
-						<span className="relative inline-flex size-1.5 rounded-full bg-emerald-500" />
-					</span>
-					Detecting automatically · statuses update as you install or sign in
-				</p>
 				<div className="divide-y divide-border">
 					<OnboardingRow
 						icon={<SiGithub className="size-4.5" />}


### PR DESCRIPTION
Removes the "Detecting automatically · statuses update as you install or sign in" caption (pulsing green dot + text) above the prerequisite rows on onboarding step 1, added in #6115. The rows' own live status labels already communicate this.

Requested by Kiet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the auto-detect status caption (pulsing green dot + text) above prerequisite rows on onboarding step 1. The row status labels already show live updates, so this reduces visual noise.

<sup>Written for commit 08939dab5e02569c8d2000d1a5d0b506f6c3fca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

