### PR TITLE
fix(host-service): link pull requests on workspace creation

### DIFF
--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -194,6 +194,10 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 
 	const eventBus = new EventBus({ db, filesystem, gitWatcher });
 	eventBus.start();
+	// Post-construction wiring (the runtime is built before the EventBus):
+	// newly created workspaces get their first branch/upstream sync + PR link
+	// immediately instead of waiting for the 5-min safety net.
+	pullRequestRuntime.subscribeToWorkspaceEvents(eventBus);
 
 	const terminalAgentPersistence = new SqliteTerminalAgentBindingPersistence(
 		db,

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -24,6 +24,10 @@ interface ClientState {
 	fsSubscriptions: Map<string, FsSubscription>;
 }
 
+type WorkspaceChangedListener = (
+	message: Omit<Extract<ServerMessage, { type: "workspace:changed" }>, "type">,
+) => void;
+
 function sendMessage(socket: WsSocket, message: ServerMessage): void {
 	if (socket.readyState !== 1) return;
 	socket.send(JSON.stringify(message));
@@ -65,6 +69,8 @@ export interface EventBusOptions {
  */
 export class EventBus {
 	private readonly clients = new Map<WsSocket, ClientState>();
+	private readonly workspaceChangedListeners =
+		new Set<WorkspaceChangedListener>();
 	private readonly gitWatcher: GitWatcher;
 	private readonly filesystem: WorkspaceFilesystemManager;
 	private removeGitListener: (() => void) | null = null;
@@ -193,7 +199,29 @@ export class EventBus {
 			"type"
 		>,
 	): void {
+		// A throwing listener must not fail the emitting store write or skip
+		// the client broadcast.
+		for (const listener of this.workspaceChangedListeners) {
+			try {
+				listener(message);
+			} catch (error) {
+				console.error("[event-bus] workspace-changed listener failed", {
+					error,
+				});
+			}
+		}
 		this.broadcast({ type: "workspace:changed", ...message });
+	}
+
+	/**
+	 * In-process subscription to the same workspace lifecycle events that
+	 * `broadcastWorkspaceChanged` fans out to WebSocket clients. For host-
+	 * internal consumers (e.g. the pull-requests runtime) that need to react
+	 * without holding a socket. Returns an unsubscribe function.
+	 */
+	onWorkspaceChanged(listener: WorkspaceChangedListener): () => void {
+		this.workspaceChangedListeners.add(listener);
+		return () => this.workspaceChangedListeners.delete(listener);
 	}
 
 	/**

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -7,7 +7,9 @@ import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../../db";
 import * as schema from "../../db/schema";
 import { pullRequests, workspaces } from "../../db/schema";
+import type { WorkspaceChangedMessage } from "../../events/types";
 import { PullRequestRuntimeManager } from "./pull-requests";
+import type { WorkspaceRefsSnapshot } from "./utils/workspace-refs";
 
 // All tests run the real manager against a real, migrated, in-memory SQLite
 // DB. An earlier hand-faked DB ignored query predicates and could only hold a
@@ -143,6 +145,9 @@ function createManager(
 		execGh?: (args: string[]) => Promise<unknown>;
 		github?: () => Promise<never>;
 		git?: unknown;
+		readWorkspaceRefs?: (
+			worktreePath: string,
+		) => Promise<WorkspaceRefsSnapshot>;
 	} = {},
 ) {
 	return new PullRequestRuntimeManager({
@@ -163,6 +168,7 @@ function createManager(
 				throw new Error("octokit should not be used");
 			}) as never),
 		gitWatcher: { onChanged: () => () => {} } as never,
+		readWorkspaceRefs: overrides.readWorkspaceRefs,
 	});
 }
 
@@ -734,5 +740,112 @@ describe("default-branch guard", () => {
 		expect(getWorkspace(db, "ws-fork")?.pullRequestId).toBe(
 			getPrByNumber(db, 88)?.id,
 		);
+	});
+});
+
+type WorkspaceChangedEvent = Omit<WorkspaceChangedMessage, "type">;
+
+// Minimal in-process stand-in for EventBus.onWorkspaceChanged.
+function createFakeWorkspaceEventBus() {
+	const listeners = new Set<(event: WorkspaceChangedEvent) => void>();
+	return {
+		listeners,
+		onWorkspaceChanged(listener: (event: WorkspaceChangedEvent) => void) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		emit(event: WorkspaceChangedEvent) {
+			for (const listener of listeners) listener(event);
+		},
+	};
+}
+
+// The subscription handler fires enqueueWorkspaceSync without exposing its
+// promise, so tests observe completion through the DB row.
+async function waitFor(
+	condition: () => boolean,
+	timeoutMs = 2000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!condition() && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+describe("workspace-created event trigger", () => {
+	// The manager only consumes workspaceId (it re-reads the row from the DB),
+	// so the snapshot payload can stay null.
+	const createdEvent: WorkspaceChangedEvent = {
+		workspaceId: "ws-new",
+		eventType: "created",
+		workspace: null,
+		occurredAt: 1,
+	};
+
+	function createEventDrivenManager(db: HostDb) {
+		let refsReads = 0;
+		const manager = createManager(db, {
+			execGh: routeGh({
+				"feat/new-thing": makePrNode({
+					number: 6123,
+					headRef: "feat/new-thing",
+					headSha: "sha-new",
+				}),
+			}),
+			readWorkspaceRefs: async () => {
+				refsReads += 1;
+				return {
+					branch: "feat/new-thing",
+					headSha: "sha-new",
+					upstream: {
+						owner: REPO.owner,
+						name: REPO.name,
+						branch: "feat/new-thing",
+					},
+				};
+			},
+		});
+		return { manager, refsReads: () => refsReads };
+	}
+
+	test("links the PR on a created event without timers or gitWatcher activity", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		// Fresh-insert shape: branch set, headSha/upstream all NULL.
+		seedWorkspace(db, { id: "ws-new", branch: "feat/new-thing" });
+		const { manager } = createEventDrivenManager(db);
+		const bus = createFakeWorkspaceEventBus();
+		manager.subscribeToWorkspaceEvents(bus);
+
+		// start() is deliberately never called: no safety-net/refresh timers,
+		// and the fake gitWatcher never emits. The event alone must do it.
+		bus.emit(createdEvent);
+		await waitFor(() => Boolean(getWorkspace(db, "ws-new")?.pullRequestId));
+
+		const ws = getWorkspace(db, "ws-new");
+		expect(ws?.headSha).toBe("sha-new");
+		expect(ws?.upstreamOwner).toBe(REPO.owner);
+		expect(ws?.upstreamRepo).toBe(REPO.name);
+		expect(ws?.upstreamBranch).toBe("feat/new-thing");
+		expect(ws?.pullRequestId).toBe(getPrByNumber(db, 6123)?.id);
+
+		manager.stop();
+		expect(bus.listeners.size).toBe(0);
+	});
+
+	test("ignores updated and deleted events", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws-new", branch: "feat/new-thing" });
+		const { manager, refsReads } = createEventDrivenManager(db);
+		const bus = createFakeWorkspaceEventBus();
+		manager.subscribeToWorkspaceEvents(bus);
+
+		bus.emit({ ...createdEvent, eventType: "updated" });
+		bus.emit({ ...createdEvent, eventType: "deleted" });
+		await waitFor(() => refsReads() > 0, 100);
+
+		expect(refsReads()).toBe(0);
+		expect(getWorkspace(db, "ws-new")?.pullRequestId).toBeNull();
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -4,6 +4,7 @@ import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../../db";
 import { projects, pullRequests, workspaces } from "../../db/schema";
+import type { EventBus } from "../../events/event-bus";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
 import { type GitFactory, resolveDefaultBranchName } from "../git";
@@ -159,6 +160,7 @@ export class PullRequestRuntimeManager {
 	private safetyNetTimer: ReturnType<typeof setInterval> | null = null;
 	private projectRefreshTimer: ReturnType<typeof setInterval> | null = null;
 	private unsubscribeFromGitWatcher: (() => void) | null = null;
+	private unsubscribeFromWorkspaceEvents: (() => void) | null = null;
 	private readonly inFlightProjects = new Map<string, Promise<void>>();
 	private readonly workspaceSyncState = new Map<
 		string,
@@ -219,13 +221,34 @@ export class PullRequestRuntimeManager {
 		}, PROJECT_REFRESH_INTERVAL_MS);
 	}
 
+	// A brand-new worktree is git-idle, so `GitWatcher` never fires for it and
+	// its row (NULL upstream/head) is invisible to PR matching until the 5-min
+	// safety net. Reacting to `created` closes that gap via the same coalesced
+	// sync path. Wired post-construction because app.ts builds the EventBus
+	// after this manager. Only `created`: renames/branch edits already arrive
+	// through GitWatcher, and this manager's own row writes bypass the store
+	// emitters, so syncing can't re-trigger itself.
+	subscribeToWorkspaceEvents(
+		eventBus: Pick<EventBus, "onWorkspaceChanged">,
+	): void {
+		if (this.unsubscribeFromWorkspaceEvents) return;
+		this.unsubscribeFromWorkspaceEvents = eventBus.onWorkspaceChanged(
+			(event) => {
+				if (event.eventType !== "created") return;
+				void this.enqueueWorkspaceSync(event.workspaceId);
+			},
+		);
+	}
+
 	stop() {
 		if (this.safetyNetTimer) clearInterval(this.safetyNetTimer);
 		if (this.projectRefreshTimer) clearInterval(this.projectRefreshTimer);
 		this.unsubscribeFromGitWatcher?.();
+		this.unsubscribeFromWorkspaceEvents?.();
 		this.safetyNetTimer = null;
 		this.projectRefreshTimer = null;
 		this.unsubscribeFromGitWatcher = null;
+		this.unsubscribeFromWorkspaceEvents = null;
 	}
 
 	async getPullRequestsByWorkspaces(


### PR DESCRIPTION
Part of SUPER-1729 — https://linear.app/superset-sh/issue/SUPER-1729

## Problem

`PullRequestRuntimeManager` only reacts to `GitWatcher.onChanged` plus two independent 5-minute timers (`SAFETY_NET_INTERVAL_MS`, `PROJECT_REFRESH_INTERVAL_MS`). A freshly created worktree is git-idle, so the watcher never fires for it, and `insertLocalWorkspace` writes the row with `upstream_owner`/`upstream_repo`/`upstream_branch`/`head_sha` all NULL — which makes it invisible to `performProjectRefresh`'s `wantedRefs` matching.

**Before:** a workspace created on a branch that already has an open PR shows no PR until the timers happen to line up. Measured on a live host DB (workspace `698cfbd4-5dbb-4857-9a42-da942096dcbb`, branch `hoakiet98/super-1729-mismatch-to-new-workspace`, PR #6123 already open at creation): **~13 minutes**, not just 5. Two compounding causes:
1. The safety-net timer (writes upstream via `syncWorkspaceBranches`) and the project-refresh timer (does the PR matching) are independent 5-min intervals — if the match tick fires before the sync tick, the workspace waits another full round.
2. `syncWorkspaceBranches` walks every workspace sequentially (47 rows on that machine), each doing a git refs read, so the sweep itself takes real time.

**After:** the `workspace:changed`/`created` event triggers the existing coalesced `enqueueWorkspaceSync(workspaceId)` immediately — upstream + head sync, then `refreshProject` links the PR within seconds.

## Changes

- **`EventBus.onWorkspaceChanged(listener)`** — new in-process subscription API. `broadcastWorkspaceChanged` previously only fanned out to WebSocket clients; host-internal consumers had no way to observe workspace lifecycle. Listeners are isolated with try/catch so a throwing listener can't fail the emitting store write or skip the client broadcast.
- **`PullRequestRuntimeManager.subscribeToWorkspaceEvents(eventBus)`** — reacts to `created` events only, routing through the existing `enqueueWorkspaceSync` (already coalesced; `syncOneWorkspace` already calls `refreshProject` when the row changes, and a new row always changes: NULL → real upstream/head). Unsubscribed in `stop()`. Wired post-construction in `app.ts` because the runtime is built before the EventBus exists.
- No new polling or timers; the 5-min intervals, `REPO_PULL_REQUEST_CACHE_TTL_MS`, and `inFlightProjects` dedupe are untouched.

## No feedback loop

Only `created` is subscribed — renames/branch edits already flow through the GitWatcher path, and widening the trigger would add churn for no gain. The runtime's own row mutations use raw `this.db.update(workspaces)` (5 call sites), deliberately bypassing the store helpers that emit `workspace:changed`; those writes were left untouched, so a sync can never re-trigger itself.

## Judgement call: unchanged-row early return

`syncOneWorkspace` still only calls `refreshProject` when the row actually changed. Left as-is: a freshly created workspace always changes on its first sync (head sha NULL → real), so the created path always reaches PR matching. Removing the early return would fire `refreshProject` (GitHub calls, cache-bounded but real) on every watcher event even when nothing moved — extra traffic for no gain here. A workspace whose git state never moves still gets PR-state updates from the 5-min project-refresh timer, same as today.

## Testing

- Two new unit tests in `pull-requests.test.ts` against the real in-memory-SQLite harness: a `created` event links the PR **without** `start()` ever being called (no timers, no gitWatcher activity) and `stop()` unsubscribes; `updated`/`deleted` events trigger no sync at all.
- Mutation-tested: inverted the `eventType !== "created"` filter — the positive test went red (no PR link) and the negative test went red (updated/deleted started syncing); restored, all 14 tests green.
- `bun run lint` exits 0; `tsc --noEmit` clean; `event-bus.test.ts` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links pull requests immediately when a workspace is created, eliminating the ~13-minute delay caused by idle git state. Addresses SUPER-1729.

- **Bug Fixes**
  - Added `EventBus.onWorkspaceChanged` for in-process listeners.
  - Subscribed `PullRequestRuntimeManager` to `workspace:changed` `created` events; routes through `enqueueWorkspaceSync` to update upstream/head and run `refreshProject`.
  - Wired subscription in `app.ts`; cleanly unsubscribes in `stop()`. No new timers or polling.
  - Added tests to confirm PR linking on `created` and ignoring `updated`/`deleted`.

<sup>Written for commit a6733e9973854c1857efa7e982bf5220cbab2870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created workspaces are now detected immediately for branch and upstream synchronization.
  * Matching pull requests are linked automatically when a workspace is created.
  * Workspace updates and deletions no longer trigger unnecessary pull-request refreshes.
  * Event listener errors no longer prevent other workspace notifications from being delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Measured (CDP end-to-end, dev desktop from this branch)

Drove the real app over CDP: created a workspace via `workspaces.create` on `dependabot/npm_and_yarn/nanoid-6.0.0` (PR #6104 already open) in a project with 16 workspaces, with every `gh` invocation timestamped.

- **After (this fix):** the `created` event fired mid-mutation; `pull_request_id` was populated with PR #6104 **~14 s** after the create call (worktree add + upstream sync + GitHub round-trips). The PR chip renders in the workspace header.
- **Before (same build, subscription line disabled, host-service restarted):** creation triggered zero PR-runtime activity — no sync, no `gh` calls — and the row still had NULL `pull_request_id`/upstream/head 3 minutes later, on track for the 5–13 min timer path.
- **Cost:** the trigger produced exactly one `refreshProject` = 52 `gh` calls over ~12 s (12 per-head lookups across the project's workspaces, 1 open-PR sweep, 4 detail calls × 10 matched PRs). This is the same batch one 5-minute `PROJECT_REFRESH` tick already fires — moved earlier, not added. Creations within 60 s of any prior refresh are served from the repo-PR cache.
- **No feedback loop observed:** exactly one `workspace:changed` event consumed per creation; zero PR-runtime traffic in the 90 s after the link landed.
