### PR TITLE
feat(desktop,host-service): show full commit message on hover in v2 changes tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -125,6 +125,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 					filter={filter}
 					onFilterChange={onFilterChange}
 					commits={commits.data?.commits ?? []}
+					workspaceId={workspaceId}
 					uncommittedCount={
 						status.data.staged.length + status.data.unstaged.length
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesToolbar/ChangesToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesToolbar/ChangesToolbar.tsx
@@ -14,6 +14,7 @@ interface ChangesToolbarProps {
 	filter: ChangesFilter;
 	onFilterChange: (filter: ChangesFilter) => void;
 	commits: Commit[];
+	workspaceId: string;
 	uncommittedCount: number;
 	totalFiles: number;
 	totalAdditions: number;
@@ -39,6 +40,7 @@ export function ChangesToolbar({
 	filter,
 	onFilterChange,
 	commits,
+	workspaceId,
 	uncommittedCount,
 	totalFiles,
 	totalAdditions,
@@ -59,6 +61,7 @@ export function ChangesToolbar({
 					filter={filter}
 					onFilterChange={onFilterChange}
 					commits={commits}
+					workspaceId={workspaceId}
 					uncommittedCount={uncommittedCount}
 				/>
 				<span className="whitespace-nowrap">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/CommitFilterDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/CommitFilterDropdown.tsx
@@ -32,6 +32,7 @@ interface CommitFilterDropdownProps {
 	filter: ChangesFilter;
 	onFilterChange: (filter: ChangesFilter) => void;
 	commits: Commit[];
+	workspaceId: string;
 	uncommittedCount?: number;
 }
 
@@ -39,6 +40,7 @@ export function CommitFilterDropdown({
 	filter,
 	onFilterChange,
 	commits,
+	workspaceId,
 	uncommittedCount,
 }: CommitFilterDropdownProps) {
 	const [rangeModalOpen, setRangeModalOpen] = useState(false);
@@ -106,6 +108,7 @@ export function CommitFilterDropdown({
 								>
 									<CommitRow
 										commit={commit}
+										workspaceId={workspaceId}
 										isSelected={
 											filter.kind === "commit" && filter.hash === commit.hash
 										}
@@ -121,6 +124,7 @@ export function CommitFilterDropdown({
 				open={rangeModalOpen}
 				onOpenChange={setRangeModalOpen}
 				commits={commits}
+				workspaceId={workspaceId}
 				onSelect={(fromHash, toHash) =>
 					onFilterChange({ kind: "range", fromHash, toHash })
 				}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
@@ -1,6 +1,9 @@
 import type { AppRouter } from "@superset/host-service";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { workspaceTrpc } from "@superset/workspace-client";
 import type { inferRouterOutputs } from "@trpc/server";
 import { Check } from "lucide-react";
+import { useState } from "react";
 
 type Commit =
 	inferRouterOutputs<AppRouter>["git"]["listCommits"]["commits"][number];
@@ -18,26 +21,74 @@ function timeAgo(date: string): string {
 
 interface CommitRowProps {
 	commit: Commit;
+	workspaceId: string;
 	isSelected?: boolean;
 	wrap?: boolean;
 }
 
 export function CommitRow({
 	commit,
+	workspaceId,
 	isSelected,
 	wrap = false,
 }: CommitRowProps) {
+	const [open, setOpen] = useState(false);
+
+	// listCommits only carries `%s`, so the body is fetched per commit and only
+	// once the card is actually opened. Commit messages are immutable, so a
+	// hover that reopens the same card never refetches.
+	const message = workspaceTrpc.git.getCommitMessage.useQuery(
+		{ workspaceId, commitHash: commit.hash },
+		{ enabled: open, staleTime: Number.POSITIVE_INFINITY },
+	);
+	const subject = message.data?.subject ?? commit.message;
+	const body = message.data?.body ?? "";
+
 	return (
-		<div className="flex min-w-0 flex-1 items-start justify-between gap-2">
-			<div className="min-w-0 flex-1 overflow-hidden">
-				<div className={wrap ? "text-sm wrap-break-word" : "truncate text-sm"}>
-					{commit.message}
+		<Tooltip open={open} onOpenChange={setOpen} delayDuration={400}>
+			<TooltipTrigger asChild>
+				<div className="flex min-w-0 flex-1 items-start justify-between gap-2">
+					<div className="min-w-0 flex-1 overflow-hidden">
+						<div
+							className={wrap ? "text-sm wrap-break-word" : "truncate text-sm"}
+						>
+							{commit.message}
+						</div>
+						<div className="truncate text-xs text-muted-foreground">
+							{commit.shortHash} · {commit.author} · {timeAgo(commit.date)}
+						</div>
+					</div>
+					{isSelected && <Check className="mt-0.5 size-3.5 shrink-0" />}
 				</div>
-				<div className="truncate text-xs text-muted-foreground">
+			</TooltipTrigger>
+			{/* The arrow points back at the hovered row, which matters in a list
+			    this dense. Only the message scrolls: bodies are unbounded, and a
+			    long one would otherwise grow the card past the window — the
+			    arrow and the hash line have to stay put and visible.
+			    The card is wide enough for a conventionally wrapped body (~72
+			    columns) so the message is not re-wrapped into a ragged column
+			    on top of the author's own line breaks. */}
+			<TooltipContent
+				side="left"
+				align="start"
+				showArrow
+				collisionPadding={8}
+				className="w-[26rem] max-w-[calc(100vw-6rem)] p-0 text-wrap"
+			>
+				<div className="max-h-64 overflow-y-auto px-2.5 py-2">
+					<div className="font-medium text-foreground wrap-break-word">
+						{subject}
+					</div>
+					{body && (
+						<div className="mt-1.5 cursor-text select-text whitespace-pre-wrap font-normal leading-relaxed wrap-break-word">
+							{body}
+						</div>
+					)}
+				</div>
+				<div className="border-border border-t px-2.5 py-1.5 font-normal text-[11px] text-muted-foreground/70">
 					{commit.shortHash} · {commit.author} · {timeAgo(commit.date)}
 				</div>
-			</div>
-			{isSelected && <Check className="mt-0.5 size-3.5 shrink-0" />}
-		</div>
+			</TooltipContent>
+		</Tooltip>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
@@ -20,6 +20,7 @@ interface RangeModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	commits: Commit[];
+	workspaceId: string;
 	onSelect: (fromHash: string, toHash: string) => void;
 }
 
@@ -27,6 +28,7 @@ export function RangeModal({
 	open,
 	onOpenChange,
 	commits,
+	workspaceId,
 	onSelect,
 }: RangeModalProps) {
 	const [fromIdx, setFromIdx] = useState<number | null>(null);
@@ -95,7 +97,7 @@ export function RangeModal({
 											: "hover:bg-accent/50"
 									}`}
 								>
-									<CommitRow commit={commit} wrap />
+									<CommitRow commit={commit} workspaceId={workspaceId} wrap />
 								</button>
 							);
 						})}

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -10,10 +10,12 @@ import type { HostServiceContext } from "../../../types";
 import { getHostWorkerPool } from "../../../workers/host-worker-pool";
 import {
 	gitCommitFilesTask,
+	gitCommitMessageTask,
 	gitFetchBaseRefTask,
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
+import { offLoop } from "../../off-loop";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
 	ChangedFile,
@@ -28,6 +30,7 @@ import type {
 	PullRequestState,
 } from "./types";
 import { scheduleBaseRefFetch } from "./utils/base-ref-freshness";
+import { isValidCommitHash } from "./utils/commit-message";
 import { gitConfigWrite } from "./utils/config-write";
 import {
 	getDefaultBranchName,
@@ -266,6 +269,37 @@ export const gitRouter = router({
 
 			return { files };
 		}),
+
+	/**
+	 * Subject + body for one commit. listCommits only carries `%s`, so this is
+	 * the only way to read a commit's body without leaving the app.
+	 */
+	getCommitMessage: queryProcedure
+		.meta({ timeoutMs: 15_000 })
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				commitHash: z.string().refine(isValidCommitHash, "Not a commit hash"),
+			}),
+		)
+		.query(
+			offLoop({
+				task: gitCommitMessageTask,
+				prepare: async ({ ctx, input }) => {
+					const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+					return {
+						worktreePath,
+						commitHash: input.commitHash,
+						gitEnv: await resolveGitTaskEnv(ctx, worktreePath),
+					};
+				},
+				options: ({ input }) => ({
+					timeoutMs: 15_000,
+					strategy: "coalesce",
+					dedupeKey: `${input.workspaceId}:commit-message:${input.commitHash}`,
+				}),
+			}),
+		),
 
 	getBaseBranch: queryProcedure
 		.input(z.object({ workspaceId: z.string() }))

--- a/packages/host-service/src/trpc/router/git/utils/commit-message.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/commit-message.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { isValidCommitHash, splitCommitMessage } from "./commit-message";
+
+describe("splitCommitMessage", () => {
+	test("subject-only message has an empty body", () => {
+		expect(splitCommitMessage("fix(ui): tighten chip spacing\n")).toEqual({
+			subject: "fix(ui): tighten chip spacing",
+			body: "",
+		});
+	});
+
+	test("splits subject from body at the first blank line", () => {
+		const raw =
+			"feat(landing): peraga cara kerja\n\nContoh Adem diganti marjan.\n";
+
+		expect(splitCommitMessage(raw)).toEqual({
+			subject: "feat(landing): peraga cara kerja",
+			body: "Contoh Adem diganti marjan.",
+		});
+	});
+
+	test("preserves blank lines and indentation inside the body", () => {
+		const raw = ["subject", "", "para one", "", "  - indented bullet", ""].join(
+			"\n",
+		);
+
+		expect(splitCommitMessage(raw).body).toBe(
+			"para one\n\n  - indented bullet",
+		);
+	});
+
+	test("keeps trailers, which is where Co-Authored-By lives", () => {
+		const raw =
+			"subject\n\nwhy this change\n\nCo-Authored-By: Someone <someone@example.com>\n";
+
+		expect(splitCommitMessage(raw).body).toContain(
+			"Co-Authored-By: Someone <someone@example.com>",
+		);
+	});
+
+	test("folds a wrapped subject onto one line, matching %s", () => {
+		const raw = "a subject that git\nwrapped across lines\n\nbody\n";
+
+		expect(splitCommitMessage(raw).subject).toBe(
+			"a subject that git wrapped across lines",
+		);
+	});
+
+	test("only the first blank line splits — later ones stay in the body", () => {
+		const raw = "subject\n\nfirst\n\nsecond\n";
+
+		expect(splitCommitMessage(raw)).toEqual({
+			subject: "subject",
+			body: "first\n\nsecond",
+		});
+	});
+
+	test("handles CRLF line endings", () => {
+		expect(splitCommitMessage("subject\r\n\r\nbody line\r\n")).toEqual({
+			subject: "subject",
+			body: "body line",
+		});
+	});
+
+	test("empty input yields empty subject and body", () => {
+		expect(splitCommitMessage("")).toEqual({ subject: "", body: "" });
+	});
+});
+
+describe("isValidCommitHash", () => {
+	test("accepts short, full, and uppercase hex object names", () => {
+		expect(isValidCommitHash("48aa309")).toBe(true);
+		expect(isValidCommitHash("b7bc64f4e2c1a09d3f5e8a7b6c4d2e1f0a9b8c7d")).toBe(
+			true,
+		);
+		expect(isValidCommitHash("48AA309")).toBe(true);
+	});
+
+	test("rejects flags and revision expressions", () => {
+		expect(isValidCommitHash("--output=/tmp/pwned")).toBe(false);
+		expect(isValidCommitHash("HEAD~1")).toBe(false);
+		expect(isValidCommitHash("HEAD; rm -rf /")).toBe(false);
+		expect(isValidCommitHash("feat/sveltekit-studio-db")).toBe(false);
+	});
+
+	test("rejects input that is too short or not hex", () => {
+		expect(isValidCommitHash("48aa3")).toBe(false);
+		expect(isValidCommitHash("")).toBe(false);
+		expect(isValidCommitHash("zzzzzzz")).toBe(false);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/commit-message.ts
+++ b/packages/host-service/src/trpc/router/git/utils/commit-message.ts
@@ -1,0 +1,42 @@
+/** Full commit message, split the way git itself presents it. */
+export interface CommitMessage {
+	/** First paragraph, folded to one line — matches `git log --format=%s`. */
+	subject: string;
+	/** Everything after the first blank line, verbatim. Empty when absent. */
+	body: string;
+}
+
+/**
+ * `git log --format=%s` collapses a multi-line first paragraph into a single
+ * line, so folding here keeps a popover header identical to the list row that
+ * opened it. Everything after the first blank line is the body and is left
+ * untouched — blank lines and indentation are meaningful in trailers and
+ * bullet lists.
+ */
+export function splitCommitMessage(raw: string): CommitMessage {
+	const normalized = raw.replace(/\r\n/g, "\n").replace(/^\n+/, "");
+	const separator = normalized.indexOf("\n\n");
+
+	if (separator === -1) {
+		return { subject: foldSubject(normalized), body: "" };
+	}
+
+	return {
+		subject: foldSubject(normalized.slice(0, separator)),
+		body: normalized.slice(separator + 2).replace(/\s+$/, ""),
+	};
+}
+
+function foldSubject(paragraph: string): string {
+	return paragraph.replace(/\s*\n\s*/g, " ").trim();
+}
+
+/**
+ * Restricts a ref to a hex object name before it reaches `git log`. Without
+ * this a caller could pass a flag (`--output=…`) or a revision expression
+ * (`HEAD~1`, a branch name) and read something other than the commit the UI
+ * is showing.
+ */
+export function isValidCommitHash(hash: string): boolean {
+	return /^[0-9a-fA-F]{7,64}$/.test(hash);
+}

--- a/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
+++ b/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
@@ -3,8 +3,13 @@ import { eq } from "drizzle-orm";
 import { workspaces } from "../../../../db/schema";
 import type { protectedProcedure } from "../../../index";
 
+/** Only `db` is read, so this also accepts the plain context an offLoop()
+ * `prepare` stage receives (where request-only fields are optional). */
 export function resolveWorktreePath(
-	ctx: Parameters<Parameters<typeof protectedProcedure.query>[0]>[0]["ctx"],
+	ctx: Pick<
+		Parameters<Parameters<typeof protectedProcedure.query>[0]>[0]["ctx"],
+		"db"
+	>,
 	workspaceId: string,
 ): string {
 	const workspace = ctx.db.query.workspaces

--- a/packages/host-service/src/workers/tasks/git.test.ts
+++ b/packages/host-service/src/workers/tasks/git.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit, { type SimpleGit } from "simple-git";
+import { type GitTaskEnv, gitCommitMessageTask } from "./git.ts";
+
+const SUBJECT = "feat(landing): peraga cara kerja pakai contoh marjan";
+const BODY = [
+	"Contoh Adem diganti marjan. Semua isinya diambil apa adanya.",
+	"",
+	"  - urutan baris disusun ulang",
+	"",
+	"Co-Authored-By: Someone <someone@example.com>",
+].join("\n");
+
+/** Mirrors what createGitEnvResolver hands the task in production: a plain
+ * string map, not a live process env. */
+const gitEnv: GitTaskEnv = {
+	...(Object.fromEntries(
+		Object.entries(process.env).filter(
+			(entry): entry is [string, string] => typeof entry[1] === "string",
+		),
+	) as GitTaskEnv),
+	GIT_OPTIONAL_LOCKS: "0",
+};
+
+async function initRepo(path: string): Promise<SimpleGit> {
+	const git = simpleGit(path);
+	await git.init();
+	await git.raw(["config", "user.email", "test@example.com"]);
+	await git.raw(["config", "user.name", "test"]);
+	await git.raw(["config", "commit.gpgsign", "false"]);
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+	await writeFile(join(path, "README.md"), "test\n");
+	await git.raw(["add", "README.md"]);
+	await git.raw(["commit", "-m", `${SUBJECT}\n\n${BODY}`]);
+	return git;
+}
+
+describe("git/getCommitMessage", () => {
+	let worktreePath: string;
+	let git: SimpleGit;
+	let hash: string;
+
+	beforeEach(async () => {
+		worktreePath = mkdtempSync(join(tmpdir(), "superset-commit-message-"));
+		git = await initRepo(worktreePath);
+		hash = (await git.revparse(["HEAD"])).trim();
+	});
+
+	afterEach(() => {
+		rmSync(worktreePath, { recursive: true, force: true });
+	});
+
+	// The gap this task exists to close: listCommits builds its rows from %s,
+	// so the body never reaches the renderer no matter how the UI renders it.
+	test("the commit list format (%s) carries only the subject", async () => {
+		const raw = await git.raw(["log", "-1", "--format=%s"]);
+
+		expect(raw.trim()).toBe(SUBJECT);
+		expect(raw).not.toContain("Co-Authored-By");
+	});
+
+	test("recovers subject and body from a full hash", async () => {
+		const message = await gitCommitMessageTask.handler({
+			worktreePath,
+			commitHash: hash,
+			gitEnv,
+		});
+
+		expect(message.subject).toBe(SUBJECT);
+		expect(message.body).toBe(BODY);
+	});
+
+	test("accepts an abbreviated hash", async () => {
+		const shortHash = (await git.revparse(["--short", "HEAD"])).trim();
+
+		const message = await gitCommitMessageTask.handler({
+			worktreePath,
+			commitHash: shortHash,
+			gitEnv,
+		});
+
+		expect(message.subject).toBe(SUBJECT);
+		expect(message.body).toContain("Co-Authored-By");
+	});
+
+	test("rejects refs that are not hex object names", async () => {
+		for (const commitHash of ["HEAD", "HEAD~1", "main", "--output=/tmp/x"]) {
+			await expect(
+				gitCommitMessageTask.handler({ worktreePath, commitHash, gitEnv }),
+			).rejects.toThrow("Not a commit hash");
+		}
+	});
+});

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -14,6 +14,11 @@ import {
 } from "../../runtime/pull-requests/utils/workspace-refs.ts";
 import type { ChangedFile } from "../../trpc/router/git/types.ts";
 import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-freshness.ts";
+import {
+	type CommitMessage,
+	isValidCommitHash,
+	splitCommitMessage,
+} from "../../trpc/router/git/utils/commit-message.ts";
 import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
 import type { GitStatusSnapshotComputation } from "../../trpc/router/git/utils/git-status.ts";
 import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
@@ -67,6 +72,26 @@ export const gitCommitFilesTask = defineWorkerTask<
 		const git = createUserSimpleGit(worktreePath).env(gitEnv);
 		const from = fromHash ? fromHash : `${commitHash}^`;
 		return getChangedFilesForDiff(git, [from, commitHash]);
+	},
+});
+
+// Read on demand rather than widening the commit list: listCommits is polled
+// and can carry every commit ahead of the base branch, so shipping each body
+// with every refresh would cost far more than a field the UI reads one commit
+// at a time. The hash is re-validated here, not just at the call site, so the
+// task can't be handed a flag or revision expression by a future caller.
+export const gitCommitMessageTask = defineWorkerTask<
+	{ worktreePath: string; commitHash: string; gitEnv: GitTaskEnv },
+	CommitMessage
+>({
+	type: "git/getCommitMessage",
+	handler: async ({ worktreePath, commitHash, gitEnv }) => {
+		if (!isValidCommitHash(commitHash)) {
+			throw new Error(`Not a commit hash: ${commitHash}`);
+		}
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		const raw = await git.raw(["log", "-1", "--format=%B", commitHash, "--"]);
+		return splitCommitMessage(raw);
 	},
 });
 
@@ -169,6 +194,7 @@ export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
 	gitCommitFilesTask,
+	gitCommitMessageTask,
 	gitWorkspaceRefsTask,
 	gitIdentityTask,
 	gitWorktreeStateTask,


### PR DESCRIPTION
Closes #6043.

Hovering a commit in the v2 Changes tab now shows its full message — subject plus body — without leaving the app.

![Hover card showing a commit's full message in the v2 Changes tab](https://raw.githubusercontent.com/RobithYusuf/superset/pr6043-screenshot/docs/pr6043-hover-card.png)

## Why hovering couldn't already do this

`git.listCommits` builds its rows with `git log <base>..HEAD --format=%H\t%h\t%s\t%an\t%ae\t%aI`. `%s` is the subject only, so `Commit.message` can never hold more than the first line. The truncated row is the visible half of the problem; the other half is that a tooltip over it would only repeat that same subject, because nothing else is in the payload. Trailers like `Co-Authored-By:` were invisible for the same reason.

The first test in `workers/tasks/git.test.ts` pins that down against a real temp repo, so the gap can't quietly reopen.

## What changed

**Backend.** A `git/getCommitMessage` worker task runs `git log -1 --format=%B <hash> --`, and `splitCommitMessage()` splits the result into `{ subject, body }`. It folds a wrapped subject onto one line the way git's own `%s` does, so the card header matches the row that opened it. `isValidCommitHash()` restricts the ref to a hex object name so it can't reach `git log` as a flag or a revision expression — enforced inside the task, not just at the call site.

The `getCommitMessage` query goes through `offLoop()`, so no `ctx.git()` and no `createUserSimpleGit` on the event loop. The `no-main-loop-blocking` counts for `trpc/router/git/git.ts` are unchanged at 12 and 2.

I fetch the body on demand rather than widening `listCommits`: that query is polled and can carry every commit ahead of the base branch, so sending every body on each refresh would cost far more than a field the UI reads one commit at a time. `%b` also contains newlines, which would break the tab-separated line parsing `listCommits` depends on.

**Renderer.** `CommitRow` wraps its existing markup in a `Tooltip`. The query is enabled only while the card is open and uses an infinite `staleTime` — commit messages don't change, so reopening the same card never refetches. Only the message area scrolls; the arrow and the hash line stay put, since bodies are unbounded and a long one would otherwise grow the card past the window. `workspaceId` is threaded down from `ChangesTabContent` so the row can query.

Both the filter dropdown and the range modal render `CommitRow`, so this covers both.

## Scope

Kept narrow on purpose, following the note on #6044:

- v2 only — the v1 `ChangesView` is untouched.
- A tooltip rather than a popover. The row sits inside a Radix `DropdownMenuItem`, where a popover means nested portals and focus-trap conflicts; a tooltip takes no focus and needed no structural change to the menu.
- No new setting. "See all commits" is already covered by the base-branch selector, and `listCommits` has no cap. Full history or a commit graph is a different ask and belongs to the #5594 tracker.

One drive-by: `resolveWorktreePath` is narrowed to `Pick<ctx, "db">`. It only ever reads `db`, and the old signature demanded a request-scoped context that an `offLoop()` `prepare` stage doesn't have. Every existing caller still satisfies it.

## Credit

The investigation and the `splitCommitMessage` / `isValidCommitHash` shape come from #6044, which was closed for targeting the v1 surface and for predating the `no-main-process-blocking` ratchet added in #6093. This is the same feature rebuilt on v2 with the git read going through the worker pool, as suggested there.

## Tests

`utils/commit-message.test.ts` — 11 tests: subject-only, blank lines and indentation preserved in the body, trailers kept, wrapped-subject folding, CRLF, empty input; hash validation accepts short/full/uppercase hex and rejects `--output=…`, `HEAD~1`, branch names, and too-short input.

`workers/tasks/git.test.ts` — 4 tests over a real temp repo: the `%s` reproduction, subject + body from a full hash, the same from an abbreviated hash, and rejection of non-hex refs.

```
bun test src/workers/tasks/git.test.ts \
         src/trpc/router/git/utils/commit-message.test.ts \
         src/no-main-loop-blocking.test.ts   → 19 pass, 0 fail
bun run lint        → exit 0
bun run typecheck   → 34/34
```

Mutation-checked; each deliberate break failed exactly the tests that should catch it — `%B`→`%s` (2 fail), hash guard removed (1 fail), subject folding disabled (2 fail).

The screenshot above is this branch driven over CDP against a local stack, hovering a commit in this repo's own history. I opened the dropdown and hovered rows with dispatched pointer events and read the rendered card back to confirm it matches the hovered row, so the card content is verified, not just its presence.

`bun run test` in full shows 35 pre-existing failures in `@superset/host-service` on my machine (`ENOENT reading node_modules/better-sqlite3`). The count is identical on a clean `main`, so it's unrelated; this branch takes that package from 711 to 726 passing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the full commit message (subject + body) on hover in the v2 Changes tab. Adds a lightweight backend query and a tooltip UI so you can read details, including trailers, without leaving the app.

- New Features
  - Backend (`@superset/host-service`): `git/getCommitMessage` worker task via `offLoop` runs `git log -1 --format=%B`, splits to `{ subject, body }`, and validates refs with `isValidCommitHash`.
  - UI (`@superset/ui/tooltip`, `@superset/workspace-client`): Tooltip in `CommitRow` fetches on hover only, caches forever, and scrolls the message area while keeping header/meta fixed.
  - Scope: v2 only; applies to the commit filter dropdown and the range modal.
  - Performance: `listCommits` stays slim; query is coalesced/deduped; no main-loop blocking.
  - Minor: `resolveWorktreePath` narrowed to `Pick<ctx, "db">`.

<sup>Written for commit a911b8bf073b87f88f0f0bb8126887afd481fd22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit entries now provide expandable tooltips with full commit messages, subjects, bodies, and metadata.
  * Commit messages can be retrieved for both full and abbreviated commit hashes.
  * Commit history range views now retain workspace context consistently.

* **Bug Fixes**
  * Improved validation prevents invalid commit references and option-like values from being processed.

* **Tests**
  * Added coverage for commit-message formatting, line endings, trailers, hash validation, and Git message retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->