### PR TITLE
fix(host-service): seed branch from typed workspace name, rename to AI names before terminals start

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
@@ -10,8 +10,8 @@ interface ResolvedNames {
 
 /**
  * Returns whatever the user typed; null otherwise. The host-service
- * generates a friendly random for the missing side and runs the AI
- * rename for any side that wasn't user-supplied.
+ * seeds the branch from a typed name, otherwise creates with a friendly
+ * random and applies AI names as a deferred rename.
  */
 export function resolveNames(draft: DashboardNewWorkspaceDraft): ResolvedNames {
 	const branchName =

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -2,7 +2,6 @@ import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { authClient } from "renderer/lib/auth-client";
-import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showWorkspaceAutoNameWarningToast";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import type { NewWorkspacePromptContextApi } from "renderer/stores/new-workspace-prompt-context";
 import { usePromptHistoryStore } from "renderer/stores/prompt-history";
@@ -100,9 +99,9 @@ export function useSubmitWorkspace(
 
 		// PR path supplies a name (PR title) so the in-flight UI has
 		// something to show immediately. Branch path leaves both `name`
-		// and `branch` undefined when the user didn't type — the server
-		// generates a friendly random and AI-renames whichever side(s)
-		// the user didn't supply.
+		// and `branch` undefined when the user didn't type — a typed name
+		// seeds the branch slug; otherwise the server creates with a
+		// friendly random and AI-renames once names arrive.
 		const prName = isPrCheckout
 			? draft.linkedPR?.title || `PR #${draft.linkedPR?.prNumber}`
 			: undefined;
@@ -148,15 +147,6 @@ export function useSubmitWorkspace(
 
 		void completed.then((outcome) => {
 			if (!outcome.ok) return;
-
-			if (outcome.autoNameWarning) {
-				showWorkspaceAutoNameWarningToast({
-					description: outcome.autoNameWarning,
-					onOpenModelAuthSettings: () => {
-						void navigate({ to: "/settings/models" });
-					},
-				});
-			}
 
 			// The server can resolve the optimistic workspace to a different
 			// canonical id; follow it only if we're still on the optimistic route.

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -21,7 +21,7 @@ export interface SubmitArgs {
 }
 
 export type SubmitOutcome =
-	| { ok: true; workspaceId: string; autoNameWarning?: string }
+	| { ok: true; workspaceId: string }
 	| { ok: false; error: string };
 
 export interface SubmitHandle {
@@ -165,7 +165,6 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					return {
 						ok: true,
 						workspaceId: result.workspace.id,
-						autoNameWarning: result.autoNameWarning,
 					};
 				})
 				.catch<SubmitOutcome>((error: unknown) => {

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
@@ -27,7 +27,7 @@ const WORKSPACE_TITLE_MAX = 150;
 const BRANCH_NAME_MAX = 25;
 const GENERATE_TIMEOUT_MS = 5_000;
 
-function sanitizeBranchCandidate(raw: string): string {
+export function sanitizeBranchCandidate(raw: string): string {
 	return raw
 		.toLowerCase()
 		.trim()
@@ -324,33 +324,55 @@ export async function generateWorkspaceNamesFromPrompt(
 	return null;
 }
 
-interface ApplyAiRenameArgs {
+interface ApplyGeneratedNamesArgs {
 	ctx: HostServiceContext;
 	workspaceId: string;
 	repoPath: string;
 	worktreePath: string;
 	oldBranchName: string;
 	oldWorkspaceName: string;
-	prompt: string;
 	/** Replace the workspace title with an AI-picked one. Skip when the user typed a name. */
 	renameTitle: boolean;
 	/** Replace the git branch name with an AI-picked one. Skip when the user typed a branch. */
 	renameBranch: boolean;
 }
 
+interface ApplyAiRenameArgs extends ApplyGeneratedNamesArgs {
+	prompt: string;
+}
+
 /**
  * Generates an AI title+branch for a freshly-created workspace and
- * applies whichever side the caller asked for. Git rename runs first
- * (cheap to roll back); the host-local row is the source of truth and
- * commits next; the cloud mirror is pushed best-effort afterwards (a
- * failure leaves the row cloud-dirty for the reconciler).
- *
- * `renameTitle` / `renameBranch` let callers preserve user-typed
- * values: skip replacing whichever side the user supplied directly.
+ * applies whichever side the caller asked for. Callers that already
+ * have a naming call in flight should use `applyGeneratedWorkspaceNames`
+ * directly instead of paying for a second LLM call.
  */
 export async function applyAiWorkspaceRename(
 	args: ApplyAiRenameArgs,
 ): Promise<void> {
+	if (!args.renameTitle && !args.renameBranch) return;
+
+	const aiNames = await generateWorkspaceNamesFromPrompt(args.prompt);
+	if (!aiNames) return;
+
+	await applyGeneratedWorkspaceNames({ ...args, names: aiNames });
+}
+
+/**
+ * Applies already-generated names to a workspace and returns the final
+ * (name, branch) pair, or null when nothing changed. Git rename runs
+ * first (cheap to roll back); the host-local row is the source of truth
+ * and commits next; the cloud mirror is pushed best-effort afterwards
+ * (a failure leaves the row cloud-dirty for the reconciler).
+ *
+ * `renameTitle` / `renameBranch` let callers preserve user-typed
+ * values: skip replacing whichever side the user supplied directly.
+ * The worktree directory keeps its creation-time name — renaming it
+ * under running terminals/agents would break their recorded paths.
+ */
+export async function applyGeneratedWorkspaceNames(
+	args: ApplyGeneratedNamesArgs & { names: GeneratedWorkspaceNames },
+): Promise<{ name: string; branch: string } | null> {
 	const {
 		ctx,
 		workspaceId,
@@ -358,15 +380,12 @@ export async function applyAiWorkspaceRename(
 		worktreePath,
 		oldBranchName,
 		oldWorkspaceName,
-		prompt,
+		names: aiNames,
 		renameTitle,
 		renameBranch,
 	} = args;
 
-	if (!renameTitle && !renameBranch) return;
-
-	const aiNames = await generateWorkspaceNamesFromPrompt(prompt);
-	if (!aiNames) return;
+	if (!renameTitle && !renameBranch) return null;
 
 	const titleChanged =
 		renameTitle && aiNames.title !== "" && aiNames.title !== oldWorkspaceName;
@@ -374,7 +393,7 @@ export async function applyAiWorkspaceRename(
 		renameBranch &&
 		aiNames.branchName !== "" &&
 		aiNames.branchName !== oldBranchName;
-	if (!titleChanged && !branchChanged) return;
+	if (!titleChanged && !branchChanged) return null;
 
 	let deduped = oldBranchName;
 	let gitRenamed = false;
@@ -389,14 +408,17 @@ export async function applyAiWorkspaceRename(
 			await worktreeGit.raw(["branch", "-m", oldBranchName, deduped]);
 			gitRenamed = true;
 		} catch (err) {
-			console.warn("[applyAiWorkspaceRename] git branch rename failed", err);
+			console.warn(
+				"[applyGeneratedWorkspaceNames] git branch rename failed",
+				err,
+			);
 		}
 	}
 
 	const patch: { name?: string; branch?: string } = {};
 	if (titleChanged) patch.name = aiNames.title;
 	if (gitRenamed) patch.branch = deduped;
-	if (patch.name === undefined && patch.branch === undefined) return;
+	if (patch.name === undefined && patch.branch === undefined) return null;
 
 	const updated = updateLocalWorkspace(
 		{ db: ctx.db, eventBus: ctx.eventBus },
@@ -407,8 +429,10 @@ export async function applyAiWorkspaceRename(
 		// The git branch may already be renamed at this point; make the
 		// row-vs-git divergence observable instead of failing silently.
 		console.warn(
-			"[applyAiWorkspaceRename] workspace row missing after git rename",
+			"[applyGeneratedWorkspaceNames] workspace row missing after git rename",
 			{ workspaceId, patch },
 		);
+		return null;
 	}
+	return { name: updated.name, branch: updated.branch };
 }

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -39,8 +39,10 @@ import { safeResolveWorktreePath } from "../workspace-creation/shared/worktree-p
 import { generateBranchNameFromPrompt } from "../workspace-creation/utils/ai-branch-name";
 import {
 	applyAiWorkspaceRename,
+	applyGeneratedWorkspaceNames,
 	type GeneratedWorkspaceNames,
 	generateWorkspaceNamesFromPrompt,
+	sanitizeBranchCandidate,
 } from "../workspace-creation/utils/ai-workspace-names";
 import { resolveProjectBranchPrefix } from "../workspace-creation/utils/branch-prefix";
 import type { ExecGh } from "../workspace-creation/utils/exec-gh";
@@ -59,14 +61,6 @@ import {
 } from "../workspace-creation/utils/resolve-new-branch-start-point";
 import { deduplicateBranchName } from "../workspace-creation/utils/sanitize-branch";
 
-/**
- * Returned by `create` when auto-naming was wanted but the LLM call came
- * back empty: the workspace keeps a friendly-random fallback name (create
- * does not fail) and the renderer shows this as a warning toast.
- */
-const AUTO_NAME_FALLBACK_WARNING =
-	"Model naming was unavailable, so a fallback name was used.";
-
 const agentLaunchSchema = z
 	.object({
 		agent: z.string().min(1),
@@ -84,10 +78,11 @@ const agentLaunchSchema = z
 const createInputSchema = z
 	.object({
 		projectId: z.string(),
-		// Both `name` and `branch` are optional. When omitted with a
-		// non-empty agent prompt, the server generates them inline via
-		// the same LLM call (in parallel with the worktree work). When
-		// omitted with no prompt, a friendly-random fallback fills in.
+		// Both `name` and `branch` are optional. A typed `name` also seeds
+		// the branch when `branch` is omitted. When both are omitted with a
+		// non-empty agent prompt, creation proceeds with a friendly-random
+		// branch and an LLM rename is applied before terminals/agents
+		// start. With no prompt, the friendly-random fallback is final.
 		name: z.string().min(1).optional(),
 		branch: z.string().min(1).optional(),
 		pr: z.number().int().positive().optional(),
@@ -480,17 +475,20 @@ export const workspacesRouter = router({
 
 			const localProject = requireLocalProject(ctx, input.projectId);
 
-			// Kick off AI naming in parallel when the user supplied a prompt
-			// but left at least one of (name, branch) blank. The LLM call
-			// (~700ms) overlaps with `ensureMainWorkspace` + the start-point
-			// resolution, so by the time we need the resolved values for
-			// `worktree add` they're already in hand. PR path skips entirely
-			// — PR title + derived branch are already meaningful.
+			// Kick off AI naming when the user supplied a prompt but no
+			// workspace name. The worktree add and registration run with an
+			// immediately-available branch while the LLM call proceeds in
+			// parallel; the AI title (and branch, when auto-generated) is
+			// applied as a rename before terminals/agents start. A typed
+			// name suppresses naming entirely — it titles the workspace and
+			// seeds the branch. The PR and worktree-adopt paths skip too:
+			// their names are already meaningful.
 			const composerPrompt =
 				input.agents?.[0]?.prompt?.trim() || input.namingPrompt?.trim() || "";
 			const wantAi =
 				input.pr === undefined &&
-				(input.branch === undefined || input.name === undefined) &&
+				input.worktreePath === undefined &&
+				input.name === undefined &&
 				!!composerPrompt;
 			const namingAgent = input.agents?.[0]?.agent;
 			const aiNamesPromise: Promise<GeneratedWorkspaceNames | null> | null =
@@ -505,9 +503,10 @@ export const workspacesRouter = router({
 					: null;
 			aiNamesPromise?.catch(() => {});
 
-			// Stays false on the PR / worktree-adopt paths, which never attempt
-			// naming — so those can't produce a fallback warning.
-			let autoNameFellBack = false;
+			// True only when this call freshly created an auto-generated
+			// branch — the one case where the deferred AI rename may also
+			// rename the git branch.
+			let aiCanRenameBranch = false;
 
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
 
@@ -529,7 +528,7 @@ export const workspacesRouter = router({
 				);
 
 			let resolvedBranch: string;
-			let worktreePath: string;
+			let worktreePath: string | undefined;
 			let alreadyExists = false;
 			let workspaceRow: CloudWorkspace;
 
@@ -631,18 +630,19 @@ export const workspacesRouter = router({
 							);
 							mkdirSync(dirname(worktreePath), { recursive: true });
 
+							const prWorktreePath = worktreePath;
 							const rollbackWorktree = async () => {
 								try {
 									await git.raw([
 										"worktree",
 										"remove",
 										"--force",
-										worktreePath,
+										prWorktreePath,
 									]);
 								} catch (err) {
 									console.warn(
 										"[workspaces.create] failed to rollback PR worktree",
-										{ worktreePath, err },
+										{ worktreePath: prWorktreePath, err },
 									);
 								}
 							};
@@ -778,27 +778,23 @@ export const workspacesRouter = router({
 			} else {
 				const typedBranch = input.branch?.trim();
 				let plan: BranchSourcePlan;
-				let aiTitle: string | null = null;
 
 				if (typedBranch) {
 					// Typed branch: resolve start point via the existing-branch-
-					// aware planner. Title-rename can race with that lookup.
+					// aware planner.
 					resolvedBranch = typedBranch;
-					const [planResult, aiNames, existing] = await Promise.all([
+					const [planResult, existing] = await Promise.all([
 						planBranchSource(
 							git,
 							resolvedBranch,
 							input.baseBranch,
 							fetchBaseRefOffLoop,
 						),
-						aiNamesPromise ?? Promise.resolve(null),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					plan = planResult;
 					// plan.branch may carry an existing branch's canonical casing.
 					resolvedBranch = plan.branch;
-					autoNameFellBack = wantAi && aiNames === null;
-					aiTitle = aiNames?.title ?? null;
 					// Namespace newly-created branches under the configured
 					// prefix. A typed branch that resolves to an existing ref is
 					// checked out as-is and never re-prefixed.
@@ -818,13 +814,11 @@ export const workspacesRouter = router({
 						}
 					}
 				} else {
-					// Auto-gen branch: kick the LLM, the start-point resolve,
-					// and the dedupe list off in parallel — none of them depend
-					// on the others. Whichever finishes last gates the worktree
-					// add. AI's branch name wins when available; friendly random
-					// is a fallback for no-prompt or LLM failure.
-					const [aiNames, startPoint, existing] = await Promise.all([
-						aiNamesPromise ?? Promise.resolve(null),
+					// Auto-gen branch: a typed workspace name seeds the branch
+					// slug; otherwise friendly random. The AI branch name (when a
+					// prompt exists) lands as a rename after registration — the
+					// worktree add never waits for the LLM.
+					const [startPoint, existing] = await Promise.all([
 						resolveNewBranchStartPoint(
 							git,
 							input.baseBranch,
@@ -832,15 +826,16 @@ export const workspacesRouter = router({
 						),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
-					autoNameFellBack = wantAi && aiNames === null;
-					aiTitle = aiNames?.title ?? null;
 					const prefix = await resolveProjectBranchPrefix({
 						ctx,
 						project: localProject,
 						git,
 						existingBranches: existing,
 					});
-					const candidate = aiNames?.branchName || generateFriendlyBranchName();
+					const typedNameSlug = input.name
+						? sanitizeBranchCandidate(input.name)
+						: "";
+					const candidate = typedNameSlug || generateFriendlyBranchName();
 					const prefixed = prefix ? `${prefix}/${candidate}` : candidate;
 					resolvedBranch = deduplicateBranchName(prefixed, existing);
 					plan = {
@@ -878,7 +873,7 @@ export const workspacesRouter = router({
 							projectId: input.projectId,
 							branch: resolvedBranch,
 							worktreePath,
-							workspaceName: input.name ?? aiTitle ?? resolvedBranch,
+							workspaceName: input.name ?? resolvedBranch,
 							baseBranch: baseShortName,
 							idempotencyId: input.id,
 							taskId: input.taskId,
@@ -937,7 +932,7 @@ export const workspacesRouter = router({
 										projectId: input.projectId,
 										branch: resolvedBranch,
 										worktreePath,
-										workspaceName: input.name ?? aiTitle ?? resolvedBranch,
+										workspaceName: input.name ?? resolvedBranch,
 										baseBranch: baseShortName,
 										idempotencyId: input.id,
 										taskId: input.taskId,
@@ -986,13 +981,51 @@ export const workspacesRouter = router({
 								ctx,
 								id: input.id,
 								projectId: input.projectId,
-								name: input.name ?? aiTitle ?? resolvedBranch,
+								name: input.name ?? resolvedBranch,
 								branch: resolvedBranch,
 								worktreePath,
 								taskId: input.taskId,
 								rollbackWorktree,
 							});
+							aiCanRenameBranch = !typedBranch;
 						}
+					}
+				}
+			}
+
+			// Apply AI names before terminals/agents start, so setup scripts
+			// and agents only ever observe the final branch name. The naming
+			// call has been running since the top of the mutation and is
+			// bounded by its own timeouts, so this usually adds well under a
+			// second on top of the git work; the rename itself (`branch -m`
+			// plus a row update) is milliseconds. The worktree directory
+			// keeps its creation-time name.
+			if (!alreadyExists && aiNamesPromise && worktreePath !== undefined) {
+				const names = await aiNamesPromise;
+				if (names) {
+					try {
+						const applied = await applyGeneratedWorkspaceNames({
+							ctx,
+							workspaceId: workspaceRow.id,
+							repoPath: localProject.repoPath,
+							worktreePath,
+							oldBranchName: resolvedBranch,
+							oldWorkspaceName: workspaceRow.name || resolvedBranch,
+							names,
+							renameTitle: true,
+							renameBranch: aiCanRenameBranch,
+						});
+						if (applied) {
+							// Keep the original row object: it carries the create txid.
+							workspaceRow = {
+								...workspaceRow,
+								name: applied.name || applied.branch,
+								branch: applied.branch,
+							};
+							resolvedBranch = applied.branch;
+						}
+					} catch (err) {
+						console.warn("[workspaces.create] AI rename failed", err);
 					}
 				}
 			}
@@ -1093,10 +1126,6 @@ export const workspacesRouter = router({
 					? [chainedAgentResult, ...agentsResult]
 					: agentsResult,
 				alreadyExists,
-				autoNameWarning:
-					autoNameFellBack && !alreadyExists
-						? AUTO_NAME_FALLBACK_WARNING
-						: undefined,
 				txid: extractCreateTxid(workspaceRow),
 			};
 		}),


### PR DESCRIPTION
## Problem

Workspace name, branch, and worktree folder routinely diverge at creation. A report showed a workspace named `supportmaxxing` on a `sprinkle-violet` worktree folder: the typed workspace name never feeds branch generation, and the branch falls back to friendly-random words whenever the blocking LLM naming call fails or times out. That blocking call also added up to ~25s to create latency in the worst case (5s small-model + 20s agent-CLI fallback).

## Changes

- **Typed name seeds the branch.** When the user types a workspace name but no branch, the branch is now the sanitized slug of that name (`supportmaxxing` → branch/folder `supportmaxxing`). No LLM call runs — the typed name is authoritative for both title and branch.
- **Worktree creation never blocks on the LLM.** The naming call runs in parallel with the git work; worktree add and registration proceed immediately with the seed branch (typed-name slug or friendly random).
- **AI names land as a rename strictly before terminals/agents start.** After registration, create awaits the (mostly-elapsed) naming promise and applies `git branch -m` + the row update — milliseconds — before `startSetupTerminalIfPresent` and agent dispatch. Setup scripts and agents can only ever observe the final branch name, and the create response carries the renamed values (original row object kept so the create `txid` survives). Branch rename applies only to freshly-created auto-generated branches; adopted/existing and typed branches get title-only renames.
- **`autoNameWarning` removed** from the v2 create response and its renderer toast: the seed name is now a valid final state rather than a failure signal. The v1 electron flow's separate warning path is untouched.
- The adopt-by-`worktreePath` path no longer fires a naming call whose result was always discarded.

The worktree *folder* intentionally keeps its creation-time name — renaming the directory under running terminals/agents would break their recorded absolute paths, so the folder is treated as an opaque stable path.

## Testing

- `bun run typecheck` clean (host-service + desktop), `bun run lint` clean, 117 existing workspace-creation tests pass.
- Verified end-to-end against a live dev host-service (confirmed running this branch's bundle) with a hermetic scratch repo imported as a project:
  - **Prompt only**: created in 1.8s including the LLM call; folder kept the friendly seed (`defiant-tablecloth`), branch renamed to the AI slug (`relay-websocket-exponenti`), response carried final names.
  - **Typed name**: name = branch = folder = `supportmaxxing`.
  - **Typed branch + prompt**: branch kept verbatim, AI title applied.
  - **Prompt + command terminal**: the terminal's `git rev-parse --abbrev-ref HEAD` at startup returned the **post-rename** branch — the setup-script race is demonstrably gone.

https://claude.ai/code/session_01NE4bszQTqkq9txGcJ8jx9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed the branch from the typed workspace name and apply generated names via a fast rename before terminals/agents start. This removes create-time blocking and fixes cases where setup scripts saw the wrong branch.

- **Bug Fixes**
  - When no branch is typed, the branch is seeded from the typed name (sanitized slug). No naming call blocks creation.
  - Generated names are applied as a rename strictly before terminals/agents launch, so they only ever see the final branch.
  - PR checkout and worktree adoption (`worktreePath`) skip naming; friendly random is used when no name and no prompt.
  - Worktree directory is never renamed to avoid breaking absolute paths.

- **Refactors**
  - Added `applyGeneratedWorkspaceNames` and exported `sanitizeBranchCandidate` in `packages/host-service`.
  - Updated `workspaces.create` to kick naming only when `name` is omitted, run in parallel, and apply rename after registration.
  - Dropped `autoNameWarning` from the v2 response and removed its handling in `apps/desktop`.

<sup>Written for commit 02f9338236db55c7b41133d7ec8d93898e23b00a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace creation can generate AI-based names when no explicit name is provided and a prompt is available.
  - Explicit workspace names and branches are preserved.
  - Automatically generated branches receive friendly names, with duplicate branches handled automatically.

- **Bug Fixes**
  - Removed auto-name warning notifications during workspace creation.
  - Improved workspace setup sequencing for more reliable terminal and agent startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->