### PR TITLE
fix(desktop): confirm before stopping agents

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/confirmStopAgents.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/confirmStopAgents.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AlertOptions } from "@superset/ui/atoms/Alert";
+
+let suppressed = false;
+const suppress = mock(() => {
+	suppressed = true;
+});
+
+mock.module("renderer/stores/terminal-close-confirm/store", () => ({
+	useTerminalCloseConfirmStore: {
+		getState: () => ({ suppressed, suppress }),
+	},
+}));
+
+const { confirmStopAgents } = await import("./confirmStopAgents");
+
+describe("confirmStopAgents", () => {
+	beforeEach(() => {
+		suppressed = false;
+		suppress.mockClear();
+	});
+
+	it("confirms stopping one agent with clear terminal-session copy", async () => {
+		let options: AlertOptions | undefined;
+		const showAlert = mock((nextOptions: AlertOptions) => {
+			options = nextOptions;
+			return true;
+		});
+
+		const confirmation = confirmStopAgents(1, showAlert);
+
+		expect(options?.title).toBe("This agent is still running");
+		expect(options?.description).toBe(
+			"Stopping this agent will end its terminal session and interrupt any work in progress.",
+		);
+		expect(options?.actions[0]?.label).toBe("Stop agent");
+
+		await options?.actions[0]?.onClick?.({ checkboxChecked: false });
+		expect(await confirmation).toBe(true);
+	});
+
+	it("uses plural copy and resolves false when canceled", async () => {
+		let options: AlertOptions | undefined;
+		const confirmation = confirmStopAgents(2, (nextOptions) => {
+			options = nextOptions;
+			return true;
+		});
+
+		expect(options?.title).toBe("These agents are still running");
+		expect(options?.description).toBe(
+			"Stopping these agents will end their terminal sessions and interrupt any work in progress.",
+		);
+		expect(options?.actions[0]?.label).toBe("Stop agents");
+
+		await options?.actions[1]?.onClick?.({ checkboxChecked: false });
+		expect(await confirmation).toBe(false);
+	});
+
+	it("resolves false when the dialog is dismissed", async () => {
+		let options: AlertOptions | undefined;
+		const confirmation = confirmStopAgents(1, (nextOptions) => {
+			options = nextOptions;
+			return true;
+		});
+
+		options?.onDismiss?.();
+
+		expect(await confirmation).toBe(false);
+	});
+
+	it("persists the shared running-process suppression preference", async () => {
+		let options: AlertOptions | undefined;
+		const showAlert = mock((nextOptions: AlertOptions) => {
+			options = nextOptions;
+			return true;
+		});
+		const confirmation = confirmStopAgents(1, showAlert);
+
+		await options?.actions[0]?.onClick?.({ checkboxChecked: true });
+		expect(await confirmation).toBe(true);
+		expect(suppressed).toBe(true);
+		expect(suppress).toHaveBeenCalledTimes(1);
+
+		expect(await confirmStopAgents(1, showAlert)).toBe(true);
+		expect(showAlert).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows an empty selection without opening the dialog", async () => {
+		const showAlert = mock((_options: AlertOptions) => true);
+
+		expect(await confirmStopAgents(0, showAlert)).toBe(true);
+		expect(showAlert).not.toHaveBeenCalled();
+	});
+
+	it("fails open when the alert layer is unavailable", async () => {
+		expect(await confirmStopAgents(1, () => false)).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/confirmStopAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/confirmStopAgents.ts
@@ -1,0 +1,50 @@
+import { type AlertOptions, alert } from "@superset/ui/atoms/Alert";
+import { useTerminalCloseConfirmStore } from "renderer/stores/terminal-close-confirm/store";
+
+type ShowAlert = (options: AlertOptions) => boolean;
+
+/**
+ * Confirm before disposing the terminal sessions that own running agents.
+ * This shares the running-process suppression preference with terminal and port
+ * confirmations so "Don't ask again" behaves consistently.
+ */
+export function confirmStopAgents(
+	agentCount: number,
+	showAlert: ShowAlert = alert,
+): Promise<boolean> {
+	if (agentCount === 0 || useTerminalCloseConfirmStore.getState().suppressed) {
+		return Promise.resolve(true);
+	}
+
+	const isSingleAgent = agentCount === 1;
+
+	return new Promise<boolean>((resolve) => {
+		const shown = showAlert({
+			title: isSingleAgent
+				? "This agent is still running"
+				: "These agents are still running",
+			description: isSingleAgent
+				? "Stopping this agent will end its terminal session and interrupt any work in progress."
+				: "Stopping these agents will end their terminal sessions and interrupt any work in progress.",
+			checkbox: { label: "Don't ask again" },
+			onDismiss: () => resolve(false),
+			actions: [
+				{
+					label: isSingleAgent ? "Stop agent" : "Stop agents",
+					variant: "destructive",
+					onClick: ({ checkboxChecked }) => {
+						if (checkboxChecked) {
+							useTerminalCloseConfirmStore.getState().suppress();
+						}
+						resolve(true);
+					},
+				},
+				{ label: "Cancel", variant: "ghost", onClick: () => resolve(false) },
+			],
+		});
+
+		// Match the terminal and port close behavior: never leave the action
+		// hanging if the global alert layer is unavailable.
+		if (!shown) resolve(true);
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/useDashboardSidebarAgentKill.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarAgentKill/useDashboardSidebarAgentKill.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { getTerminalAgentBindingsQueryKey } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { confirmStopAgents } from "./confirmStopAgents";
 
 interface UseDashboardSidebarAgentKillResult {
 	isPending: boolean;
@@ -27,6 +28,7 @@ export function useDashboardSidebarAgentKill(
 
 	const killAgent = useCallback(
 		async (terminalId: string): Promise<void> => {
+			if (!(await confirmStopAgents(1))) return;
 			if (!hostUrl) {
 				toast.error("Failed to kill agent", {
 					description: "No host is available for this workspace",
@@ -55,6 +57,7 @@ export function useDashboardSidebarAgentKill(
 	const killAgents = useCallback(
 		async (terminalIds: string[]): Promise<number> => {
 			if (terminalIds.length === 0) return 0;
+			if (!(await confirmStopAgents(terminalIds.length))) return 0;
 			if (!hostUrl) {
 				toast.error("Failed to stop agents", {
 					description: "No host is available for this workspace",


### PR DESCRIPTION
## What changed

- add a destructive confirmation before stopping one or multiple sidebar agents
- explain that stopping an agent ends its terminal session and interrupts in-progress work
- share the existing terminal/port "Don't ask again" preference for consistent process-termination behavior
- cover singular, plural, cancel, dismiss, suppression, empty-selection, and unavailable-alert behavior

## Why

Port and terminal termination already warn before ending a running process, but the adjacent agent controls disposed their terminal sessions immediately. That inconsistency made both the row-level stop button and **Stop all agents** easy to trigger without a recovery opportunity.

The guard now lives in the shared sidebar agent-kill hook, so every current individual and bulk entry point follows the same confirmation path.

## Validation

- `bun test <confirmStopAgents.test.ts> <confirmClosePorts.test.ts>` — 11 passed
- `bun run lint` — clean, zero warnings
- `bun run typecheck` — 34/34 tasks successful
- `bun run --cwd apps/desktop compile:app` — production desktop bundle successful
- `git diff --check`

Exact-worktree Electron/CDP verification used renderer `http://localhost:3185`, dedicated CDP `9327`, and an authenticated local development session. Real pointer input exercised the workspace row, agents chip, per-agent stop control, Cancel, **Stop all agents**, and the destructive confirmation.

Regression evidence under the same route and host observations:

- before the guard, **Stop all agents** immediately changed bindings from 2 to 0 with no confirmation
- after the guard, Cancel preserved bindings at 2 to 2
- confirming the bulk dialog changed bindings and active terminal sessions from 2 to 0, removed the agents chip, and showed **Stopped 2 agents**

## Visual verification

Before/after and singular/plural confirmation screenshots are attached in a PR comment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a destructive confirmation before stopping one or multiple sidebar agents to prevent accidental termination. Aligns agent stop behavior with terminal and port confirmations and respects the global “Don’t ask again” preference.

- **Bug Fixes**
  - Introduced `confirmStopAgents` and integrated it into single and bulk stop flows.
  - Uses `@superset/ui/atoms/Alert` with a destructive action and a “Don’t ask again” checkbox; suppression is shared with terminal/port closes.
  - Covers cancel, dialog dismiss, empty selection, and fails open if the alert layer is unavailable.
  - Updated `useDashboardSidebarAgentKill` to gate agent termination on confirmation.

<sup>Written for commit 4b9fad33afb27e57312fd0604a6c46a09ae025e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

