### PR TITLE
feat(desktop,host-service): add native streaming PR diff viewer built on @pierre/diffs 1.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -79,7 +79,7 @@
 		"@mastra/core": "1.33.1",
 		"@paper-design/shaders-react": "0.0.77",
 		"@parcel/watcher": "2.5.6",
-		"@pierre/diffs": "1.2.12",
+		"@pierre/diffs": "1.3.1",
 		"@pierre/trees": "1.0.0-beta.5",
 		"@radix-ui/react-dialog": "1.1.15",
 		"@radix-ui/react-label": "2.1.8",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/PullRequestDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/PullRequestDiff.tsx
@@ -1,0 +1,161 @@
+import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
+import { Button } from "@superset/ui/button";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useSettings } from "renderer/stores/settings";
+import { PullRequestDiffSidebar } from "./components/PullRequestDiffSidebar";
+import { usePullRequestDiffTheme } from "./hooks/usePullRequestDiffTheme";
+import {
+	type PullRequestCollapseMode,
+	usePullRequestPatch,
+} from "./hooks/usePullRequestPatch";
+import { createPullRequestFileLoader } from "./utils/createPullRequestFileLoader";
+
+interface PullRequestDiffProps {
+	hostUrl: string | null;
+	projectId: string;
+	prNumber: number;
+}
+
+export function PullRequestDiff({
+	hostUrl,
+	projectId,
+	prNumber,
+}: PullRequestDiffProps) {
+	const viewerRef = useRef<CodeViewHandle<undefined>>(null);
+	const settingsDiffStyle = useSettings((s) => s.diffStyle);
+	const [diffStyle, setDiffStyle] = useState<"split" | "unified">(
+		settingsDiffStyle,
+	);
+	const [collapseMode, setCollapseMode] =
+		useState<PullRequestCollapseMode>("expanded");
+
+	const {
+		applyCollapseMode,
+		errorMessage,
+		initialItems,
+		loadState,
+		retry,
+		stats,
+		treeSource,
+	} = usePullRequestPatch({ hostUrl, projectId, prNumber, viewerRef });
+
+	const { options, style } = usePullRequestDiffTheme({ diffStyle });
+	const loadDiffFiles = useMemo(
+		() =>
+			hostUrl
+				? createPullRequestFileLoader({ hostUrl, projectId, prNumber })
+				: undefined,
+		[hostUrl, projectId, prNumber],
+	);
+	const codeViewOptions = useMemo(
+		() => ({ ...options, loadDiffFiles }),
+		[options, loadDiffFiles],
+	);
+
+	const handleSelectTreeItem = useCallback((itemId: string) => {
+		const viewer = viewerRef.current;
+		if (viewer == null) {
+			return;
+		}
+		const item = viewer.getItem(itemId);
+		if (item != null && item.collapsed === true) {
+			item.collapsed = false;
+			item.version = typeof item.version === "number" ? item.version + 1 : 1;
+			viewer.updateItem(item);
+		}
+		viewer.scrollTo({
+			type: "item",
+			id: itemId,
+			align: "start",
+			behavior: "smooth",
+		});
+	}, []);
+
+	const handleToggleCollapseMode = useCallback(() => {
+		setCollapseMode((current) => {
+			const next = current === "expanded" ? "collapsed" : "expanded";
+			applyCollapseMode(next);
+			return next;
+		});
+	}, [applyCollapseMode]);
+
+	if (loadState === "error") {
+		return (
+			<div className="flex h-full w-full flex-col items-center justify-center gap-3">
+				<p className="max-w-lg cursor-text select-text text-sm text-destructive">
+					{errorMessage ?? "Failed to load diff"}
+				</p>
+				<Button variant="outline" size="sm" onClick={retry}>
+					Retry
+				</Button>
+			</div>
+		);
+	}
+
+	if (
+		loadState === "fetching" ||
+		(loadState === "streaming" && initialItems.length === 0)
+	) {
+		return (
+			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+				Loading diff…
+			</div>
+		);
+	}
+
+	if (loadState === "ready" && initialItems.length === 0) {
+		return (
+			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+				No changes
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full w-full min-h-0">
+			<PullRequestDiffSidebar
+				source={treeSource}
+				stats={stats}
+				onSelectItem={handleSelectTreeItem}
+			/>
+			<div className="flex h-full min-w-0 flex-1 flex-col">
+				<div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2 text-xs text-muted-foreground">
+					{loadState === "streaming" ? <span>Streaming…</span> : null}
+					<div className="ml-auto flex items-center gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-6 px-2 text-xs"
+							onClick={handleToggleCollapseMode}
+						>
+							{collapseMode === "expanded" ? "Collapse all" : "Expand all"}
+						</Button>
+						<Button
+							variant={diffStyle === "unified" ? "secondary" : "ghost"}
+							size="sm"
+							className="h-6 px-2 text-xs"
+							onClick={() => setDiffStyle("unified")}
+						>
+							Unified
+						</Button>
+						<Button
+							variant={diffStyle === "split" ? "secondary" : "ghost"}
+							size="sm"
+							className="h-6 px-2 text-xs"
+							onClick={() => setDiffStyle("split")}
+						>
+							Split
+						</Button>
+					</div>
+				</div>
+				<CodeView
+					ref={viewerRef}
+					className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
+					style={style}
+					initialItems={initialItems}
+					options={codeViewOptions}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/components/PullRequestDiffSidebar/PullRequestDiffSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/components/PullRequestDiffSidebar/PullRequestDiffSidebar.tsx
@@ -1,0 +1,94 @@
+import {
+	FileTree as PierreFileTree,
+	useFileTree as usePierreFileTree,
+} from "@pierre/trees/react";
+import { memo, useEffect, useRef } from "react";
+import { useFallthroughIcons } from "renderer/lib/fileIcons";
+import {
+	createPierreTreeStyle,
+	PIERRE_TREE_UNSAFE_CSS,
+} from "renderer/lib/pierreTree";
+import type {
+	PullRequestDiffStats,
+	PullRequestTreeSource,
+} from "../../utils/patchAccumulator";
+
+const TREE_ROW_HEIGHT = 24;
+const TREE_LEVEL_INDENT = 12;
+const TREE_STYLE = createPierreTreeStyle({
+	rowHeight: TREE_ROW_HEIGHT,
+	levelIndent: TREE_LEVEL_INDENT,
+});
+
+interface PullRequestDiffSidebarProps {
+	source: PullRequestTreeSource | null;
+	stats: PullRequestDiffStats | null;
+	onSelectItem: (itemId: string) => void;
+}
+
+export const PullRequestDiffSidebar = memo(function PullRequestDiffSidebar({
+	source,
+	stats,
+	onSelectItem,
+}: PullRequestDiffSidebarProps) {
+	const sourceRef = useRef(source);
+	sourceRef.current = source;
+	// The tree model is constructed once and never re-reads its options, so
+	// selection routes through a ref to reach the latest closure.
+	const onSelectItemRef = useRef(onSelectItem);
+	onSelectItemRef.current = onSelectItem;
+
+	const { model } = usePierreFileTree({
+		paths: [],
+		initialExpansion: "open",
+		search: false,
+		flattenEmptyDirectories: true,
+		stickyFolders: true,
+		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
+		icons: { set: "complete", colored: true },
+		itemHeight: TREE_ROW_HEIGHT,
+		onSelectionChange: (paths) => {
+			const last = paths[paths.length - 1];
+			if (!last || last.endsWith("/")) return;
+			const itemId = sourceRef.current?.pathToItemId.get(last);
+			if (itemId != null) {
+				onSelectItemRef.current(itemId);
+			}
+		},
+	});
+
+	useFallthroughIcons(model);
+
+	const appliedVersionRef = useRef(0);
+	useEffect(() => {
+		if (source == null || source.version === appliedVersionRef.current) {
+			return;
+		}
+		appliedVersionRef.current = source.version;
+		model.resetPaths(source.paths);
+		model.setGitStatus(source.gitStatus);
+	}, [model, source]);
+
+	return (
+		<div className="flex h-full w-64 shrink-0 flex-col border-r border-border">
+			<PierreFileTree
+				model={model}
+				className="min-h-0 flex-1 overflow-auto overscroll-contain py-1"
+				style={TREE_STYLE}
+			/>
+			{stats ? (
+				<div className="flex shrink-0 items-center gap-2 border-t border-border px-3 py-2 text-xs text-muted-foreground tabular-nums">
+					<span>
+						{stats.fileCount} {stats.fileCount === 1 ? "file" : "files"}
+					</span>
+					<span className="text-green-600 dark:text-green-400">
+						+{stats.additions}
+					</span>
+					<span className="text-red-600 dark:text-red-400">
+						−{stats.deletions}
+					</span>
+				</div>
+			) : null}
+		</div>
+	);
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/components/PullRequestDiffSidebar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/components/PullRequestDiffSidebar/index.ts
@@ -1,0 +1,1 @@
+export { PullRequestDiffSidebar } from "./PullRequestDiffSidebar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestDiffTheme/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestDiffTheme/index.ts
@@ -1,0 +1,1 @@
+export { usePullRequestDiffTheme } from "./usePullRequestDiffTheme";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestDiffTheme/usePullRequestDiffTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestDiffTheme/usePullRequestDiffTheme.ts
@@ -1,0 +1,106 @@
+import type { CodeViewOptions } from "@pierre/diffs";
+import { useQuery } from "@tanstack/react-query";
+import { type CSSProperties, useMemo } from "react";
+import {
+	resolveEditorLineHeight,
+	resolveFontVariantLigatures,
+} from "renderer/lib/editor-typography";
+import { FONT_SETTINGS_QUERY_KEY } from "renderer/lib/font-settings";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { DEFAULT_CODE_EDITOR_FONT_SIZE } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants";
+import {
+	DIFF_POOL_RENDER_OPTIONS,
+	getDiffsTheme,
+	getDiffViewerStyle,
+} from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
+import { useResolvedTheme, useTerminalTheme } from "renderer/stores/theme";
+
+interface UsePullRequestDiffThemeOptions {
+	diffStyle: "split" | "unified";
+}
+
+export function usePullRequestDiffTheme({
+	diffStyle,
+}: UsePullRequestDiffThemeOptions) {
+	const activeTheme = useResolvedTheme();
+	const terminalTheme = useTerminalTheme();
+	const { data: fontSettings } = useQuery({
+		queryKey: FONT_SETTINGS_QUERY_KEY,
+		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
+		staleTime: 30_000,
+	});
+
+	const parsedEditorFontSize =
+		typeof fontSettings?.editorFontSize === "number"
+			? fontSettings.editorFontSize
+			: typeof fontSettings?.editorFontSize === "string"
+				? Number.parseFloat(fontSettings.editorFontSize)
+				: Number.NaN;
+	const editorFontSize = Number.isFinite(parsedEditorFontSize)
+		? parsedEditorFontSize
+		: DEFAULT_CODE_EDITOR_FONT_SIZE;
+	const surfaceBg = terminalTheme?.background ?? "var(--background)";
+
+	const style = useMemo(
+		() =>
+			({
+				...getDiffViewerStyle(activeTheme, {
+					fontFamily: fontSettings?.editorFontFamily ?? undefined,
+					fontSize: editorFontSize,
+				}),
+				"--diffs-line-height": `${resolveEditorLineHeight(
+					editorFontSize,
+					fontSettings?.editorLineHeight ?? undefined,
+				)}px`,
+				fontWeight: fontSettings?.editorFontWeight ?? undefined,
+				letterSpacing:
+					fontSettings?.editorLetterSpacing == null
+						? undefined
+						: `${fontSettings.editorLetterSpacing}px`,
+				fontVariantLigatures: resolveFontVariantLigatures(
+					fontSettings?.editorLigatures ?? undefined,
+				),
+				backgroundColor: surfaceBg,
+			}) as CSSProperties,
+		[
+			activeTheme,
+			fontSettings?.editorFontFamily,
+			fontSettings?.editorFontWeight,
+			fontSettings?.editorLetterSpacing,
+			fontSettings?.editorLigatures,
+			fontSettings?.editorLineHeight,
+			editorFontSize,
+			surfaceBg,
+		],
+	);
+
+	const options = useMemo<CodeViewOptions<undefined>>(
+		() => ({
+			diffStyle,
+			overflow: "wrap",
+			stickyHeaders: true,
+			theme: getDiffsTheme(activeTheme),
+			themeType: activeTheme.type,
+			layout: {
+				paddingTop: 0,
+				paddingBottom: 8,
+				gap: 8,
+			},
+			...DIFF_POOL_RENDER_OPTIONS,
+			tokenizeMaxLength: 200_000,
+			unsafeCSS: `
+				* { user-select: text; -webkit-user-select: text; }
+				/* Pierre sets --diffs-light-bg/--diffs-dark-bg inline on
+				 * <pre data-diff> from the Shiki theme; inline beats :host
+				 * so we override at the pre. */
+				[data-diff] {
+					--diffs-light-bg: ${surfaceBg} !important;
+					--diffs-dark-bg: ${surfaceBg} !important;
+				}
+			`,
+		}),
+		[activeTheme, diffStyle, surfaceBg],
+	);
+
+	return { options, style };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestPatch/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestPatch/index.ts
@@ -1,0 +1,5 @@
+export {
+	type PullRequestCollapseMode,
+	type PullRequestPatchLoadState,
+	usePullRequestPatch,
+} from "./usePullRequestPatch";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestPatch/usePullRequestPatch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/hooks/usePullRequestPatch/usePullRequestPatch.ts
@@ -1,0 +1,347 @@
+import { type CodeViewItem, parsePatchFiles, processFile } from "@pierre/diffs";
+import type { CodeViewHandle } from "@pierre/diffs/react";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { getHostServiceHeaders } from "renderer/lib/host-service-auth";
+import {
+	appendFileDiff,
+	createPatchAccumulator,
+	type PullRequestDiffStats,
+	type PullRequestTreeSource,
+	snapshotTreeSource,
+	takePendingItems,
+} from "../../utils/patchAccumulator";
+import { streamGitPatchFiles } from "../../utils/streamGitPatchFiles";
+
+// Batching cadence ported from Pierre's diffshub (usePatchLoader): parse on
+// an 8ms work budget so the main thread never stalls, publish the first
+// viewport-sized batch fast, then append in coarser batches while the rest
+// of the patch streams in.
+const STREAM_PUBLISH_INTERVAL_MS = 100;
+const STREAM_INITIAL_PUBLISH_INTERVAL_MS = 500;
+const STREAM_WORK_BUDGET_MS = 8;
+const BATCH_FILE_COUNT = 25;
+const BATCH_FILE_COUNT_MAX = 96;
+const ESTIMATED_FILE_ROW_HEIGHT = 24;
+
+export type PullRequestPatchLoadState =
+	| "fetching"
+	| "streaming"
+	| "ready"
+	| "error";
+
+export type PullRequestCollapseMode = "expanded" | "collapsed";
+
+interface UsePullRequestPatchOptions {
+	hostUrl: string | null;
+	projectId: string;
+	prNumber: number;
+	viewerRef: RefObject<CodeViewHandle<undefined> | null>;
+}
+
+interface UsePullRequestPatchResult {
+	applyCollapseMode: (mode: PullRequestCollapseMode) => void;
+	errorMessage: string | null;
+	initialItems: CodeViewItem[];
+	loadState: PullRequestPatchLoadState;
+	retry: () => void;
+	stats: PullRequestDiffStats | null;
+	treeSource: PullRequestTreeSource | null;
+}
+
+function getInitialBatchSize(): number {
+	const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+	if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) {
+		return BATCH_FILE_COUNT;
+	}
+	return Math.min(
+		BATCH_FILE_COUNT_MAX,
+		Math.max(
+			BATCH_FILE_COUNT,
+			Math.ceil(viewportHeight / ESTIMATED_FILE_ROW_HEIGHT),
+		),
+	);
+}
+
+function yieldToBrowser(): Promise<void> {
+	return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+export function usePullRequestPatch({
+	hostUrl,
+	projectId,
+	prNumber,
+	viewerRef,
+}: UsePullRequestPatchOptions): UsePullRequestPatchResult {
+	const [initialItems, setInitialItems] = useState<CodeViewItem[]>([]);
+	const [stats, setStats] = useState<PullRequestDiffStats | null>(null);
+	const [treeSource, setTreeSource] = useState<PullRequestTreeSource | null>(
+		null,
+	);
+	const [loadState, setLoadState] =
+		useState<PullRequestPatchLoadState>("fetching");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [loadAttempt, setLoadAttempt] = useState(0);
+	const requestIdRef = useRef(0);
+	const collapseModeRef = useRef<PullRequestCollapseMode>("expanded");
+	// The viewer handle does not expose item enumeration, so collapse-all
+	// walks our own index of every item handed to the viewer.
+	const loadedItemIdsRef = useRef<Set<string>>(new Set());
+
+	const applyCollapseMode = useCallback(
+		(mode: PullRequestCollapseMode) => {
+			collapseModeRef.current = mode;
+			const targetCollapsed = mode === "collapsed";
+			const viewer = viewerRef.current;
+			if (viewer == null) {
+				setInitialItems((prev) =>
+					prev.map((item) =>
+						item.type === "diff" &&
+						(item.collapsed === true) !== targetCollapsed
+							? { ...item, collapsed: targetCollapsed }
+							: item,
+					),
+				);
+				return;
+			}
+			for (const itemId of loadedItemIdsRef.current) {
+				const item = viewer.getItem(itemId);
+				if (item == null || item.type !== "diff") {
+					continue;
+				}
+				if ((item.collapsed === true) === targetCollapsed) {
+					continue;
+				}
+				item.collapsed = targetCollapsed;
+				item.version = typeof item.version === "number" ? item.version + 1 : 1;
+				viewer.updateItem(item);
+			}
+		},
+		[viewerRef],
+	);
+
+	useEffect(() => {
+		if (!hostUrl) {
+			return;
+		}
+
+		const controller = new AbortController();
+		const requestId = ++requestIdRef.current;
+		const isCurrentRequest = () =>
+			requestIdRef.current === requestId && !controller.signal.aborted;
+
+		setInitialItems([]);
+		setStats(null);
+		setTreeSource(null);
+		setErrorMessage(null);
+		setLoadState("fetching");
+		loadedItemIdsRef.current = new Set();
+
+		// Pre-mutates fresh items so they arrive in the viewer matching the
+		// current collapse mode, and records their ids for later bulk updates.
+		const prepareItemsForViewer = (items: readonly CodeViewItem[]) => {
+			const targetCollapsed = collapseModeRef.current === "collapsed";
+			for (const item of items) {
+				loadedItemIdsRef.current.add(item.id);
+				if (item.type === "diff") {
+					item.collapsed = targetCollapsed;
+				}
+			}
+		};
+
+		const cacheKeyPrefix = `pr-${projectId}-${prNumber}-${loadAttempt}`;
+
+		async function loadPatch() {
+			try {
+				const accumulator = createPatchAccumulator();
+				let pendingPublishFileCount = 0;
+				let hasPublishedInitialItems = false;
+				let lastPublishTime = performance.now();
+				let lastWorkYieldTime = lastPublishTime;
+				const initialPublishFileBatchSize = getInitialBatchSize();
+
+				const publishPendingData = async () => {
+					if (pendingPublishFileCount === 0 || !isCurrentRequest()) {
+						return;
+					}
+
+					pendingPublishFileCount = 0;
+					lastPublishTime = performance.now();
+					const pendingItems = takePendingItems(accumulator);
+					prepareItemsForViewer(pendingItems);
+					setStats({ ...accumulator.stats });
+					setTreeSource(snapshotTreeSource(accumulator));
+					if (!hasPublishedInitialItems) {
+						hasPublishedInitialItems = true;
+						setInitialItems(pendingItems);
+					} else {
+						const viewer = viewerRef.current;
+						if (viewer != null) {
+							viewer.addItems(pendingItems);
+						} else {
+							setInitialItems((prev) => [...prev, ...pendingItems]);
+						}
+					}
+					await yieldToBrowser();
+					lastWorkYieldTime = performance.now();
+				};
+
+				const publishPendingDataIfNeeded = async () => {
+					if (pendingPublishFileCount === 0) {
+						return;
+					}
+
+					const elapsed = performance.now() - lastPublishTime;
+					const publishFileBatchSize = hasPublishedInitialItems
+						? BATCH_FILE_COUNT
+						: initialPublishFileBatchSize;
+					const publishInterval = hasPublishedInitialItems
+						? STREAM_PUBLISH_INTERVAL_MS
+						: STREAM_INITIAL_PUBLISH_INTERVAL_MS;
+					if (
+						pendingPublishFileCount < publishFileBatchSize &&
+						elapsed < publishInterval
+					) {
+						return;
+					}
+
+					await publishPendingData();
+				};
+
+				const shouldDeferInitialPublishForBatchTarget = () => {
+					if (hasPublishedInitialItems) {
+						return false;
+					}
+
+					const elapsed = performance.now() - lastPublishTime;
+					return (
+						pendingPublishFileCount < initialPublishFileBatchSize &&
+						elapsed < STREAM_INITIAL_PUBLISH_INTERVAL_MS
+					);
+				};
+
+				const appendStreamedFile = async (fileText: string) => {
+					const fileDiff = processFile(fileText, {
+						cacheKey: `${cacheKeyPrefix}-0-${accumulator.fileIndex}`,
+						isGitDiff: true,
+					});
+					if (fileDiff == null) {
+						return;
+					}
+
+					appendFileDiff(accumulator, fileDiff);
+					pendingPublishFileCount++;
+					const elapsedWork = performance.now() - lastWorkYieldTime;
+					if (elapsedWork >= STREAM_WORK_BUDGET_MS) {
+						if (shouldDeferInitialPublishForBatchTarget()) {
+							await yieldToBrowser();
+							lastWorkYieldTime = performance.now();
+						} else {
+							await publishPendingData();
+						}
+					} else {
+						await publishPendingDataIfNeeded();
+					}
+				};
+
+				const commitFullPatch = async (patchContent: string) => {
+					if (!isCurrentRequest()) {
+						return;
+					}
+					await yieldToBrowser();
+					if (!isCurrentRequest()) {
+						return;
+					}
+					const parsedPatches = parsePatchFiles(patchContent, cacheKeyPrefix);
+					for (const parsedPatch of parsedPatches) {
+						for (const fileDiff of parsedPatch.files) {
+							appendFileDiff(accumulator, fileDiff);
+						}
+					}
+					prepareItemsForViewer(takePendingItems(accumulator));
+					setStats({ ...accumulator.stats });
+					setTreeSource(snapshotTreeSource(accumulator));
+					setInitialItems(accumulator.items);
+					setLoadState("ready");
+				};
+
+				const response = await fetch(
+					`${hostUrl}/pull-requests/diff?${new URLSearchParams({
+						projectId,
+						prNumber: String(prNumber),
+					})}`,
+					{
+						signal: controller.signal,
+						headers: getHostServiceHeaders(hostUrl ?? ""),
+						cache: "no-store",
+					},
+				);
+				if (!response.ok) {
+					const detail = (await response.text()).trim();
+					throw new Error(
+						detail.length > 0 ? detail : `Request failed (${response.status})`,
+					);
+				}
+				if (response.body == null) {
+					await commitFullPatch(await response.text());
+					return;
+				}
+
+				if (!isCurrentRequest()) {
+					return;
+				}
+				setLoadState("streaming");
+				await yieldToBrowser();
+				if (!isCurrentRequest()) {
+					return;
+				}
+
+				const fallbackPatchContent = await streamGitPatchFiles(
+					response.body,
+					appendStreamedFile,
+				);
+				if (!isCurrentRequest()) {
+					return;
+				}
+
+				await publishPendingData();
+				if (fallbackPatchContent != null) {
+					await commitFullPatch(fallbackPatchContent);
+					return;
+				}
+
+				setStats({ ...accumulator.stats });
+				setLoadState("ready");
+			} catch (error) {
+				if (!isCurrentRequest()) {
+					return;
+				}
+				setErrorMessage(
+					error instanceof Error ? error.message : "Failed to load diff",
+				);
+				setLoadState("error");
+			}
+		}
+
+		void loadPatch();
+
+		return () => {
+			controller.abort();
+		};
+	}, [hostUrl, projectId, prNumber, loadAttempt, viewerRef]);
+
+	return {
+		applyCollapseMode,
+		errorMessage,
+		initialItems,
+		loadState,
+		retry: () => setLoadAttempt((attempt) => attempt + 1),
+		stats,
+		treeSource,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/index.ts
@@ -1,0 +1,1 @@
+export { PullRequestDiff } from "./PullRequestDiff";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/createPullRequestFileLoader/createPullRequestFileLoader.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/createPullRequestFileLoader/createPullRequestFileLoader.ts
@@ -1,0 +1,96 @@
+import type {
+	FileDiffContentsLoader,
+	FileDiffLoadedFiles,
+	FileDiffMetadata,
+} from "@pierre/diffs";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+interface CreatePullRequestFileLoaderOptions {
+	hostUrl: string;
+	projectId: string;
+	prNumber: number;
+}
+
+// Diffs calls this when the user expands unchanged context: the patch only
+// carries hunks, so full old/new contents are fetched on demand and cached
+// per file for the lifetime of the viewer.
+export function createPullRequestFileLoader({
+	hostUrl,
+	projectId,
+	prNumber,
+}: CreatePullRequestFileLoaderOptions): FileDiffContentsLoader {
+	const loadedFilesCache = new Map<string, Promise<FileDiffLoadedFiles>>();
+
+	return (fileDiff) => {
+		switch (fileDiff.type) {
+			case "new":
+			case "deleted":
+				return Promise.reject(
+					new Error(`Cannot hydrate ${fileDiff.type} diffs.`),
+				);
+			case "change":
+			case "rename-changed":
+			case "rename-pure": {
+				const cacheKey = getFileDiffCacheKey(fileDiff);
+				const cached = loadedFilesCache.get(cacheKey);
+				if (cached != null) {
+					return cached;
+				}
+
+				const promise = loadFiles(
+					hostUrl,
+					projectId,
+					prNumber,
+					fileDiff.type,
+					fileDiff.name,
+					fileDiff.prevName,
+				).catch((error: unknown) => {
+					loadedFilesCache.delete(cacheKey);
+					throw error;
+				});
+				loadedFilesCache.set(cacheKey, promise);
+				return promise;
+			}
+		}
+	};
+}
+
+function getFileDiffCacheKey(fileDiff: FileDiffMetadata): string {
+	return [
+		fileDiff.cacheKey ?? "",
+		fileDiff.prevObjectId ?? "",
+		fileDiff.newObjectId ?? "",
+		fileDiff.type,
+		fileDiff.prevName ?? "",
+		fileDiff.name,
+	].join("\0");
+}
+
+async function loadFiles(
+	hostUrl: string,
+	projectId: string,
+	prNumber: number,
+	type: "change" | "rename-changed" | "rename-pure",
+	name: string,
+	prevName: string | undefined,
+): Promise<FileDiffLoadedFiles> {
+	const client = getHostServiceClientByUrl(hostUrl);
+	const result = await client.pullRequests.getDiffFiles.query({
+		projectId,
+		prNumber,
+		type,
+		name,
+		prevName,
+	});
+
+	if (type === "rename-pure") {
+		if (result.newFile == null) {
+			throw new Error(`No file contents returned for ${name}.`);
+		}
+		return { oldFile: null, newFile: result.newFile };
+	}
+	if (result.oldFile == null || result.newFile == null) {
+		throw new Error(`Incomplete file contents returned for ${name}.`);
+	}
+	return { oldFile: result.oldFile, newFile: result.newFile };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/createPullRequestFileLoader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/createPullRequestFileLoader/index.ts
@@ -1,0 +1,1 @@
+export { createPullRequestFileLoader } from "./createPullRequestFileLoader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/patchAccumulator/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/patchAccumulator/index.ts
@@ -1,0 +1,9 @@
+export {
+	appendFileDiff,
+	createPatchAccumulator,
+	type PatchAccumulator,
+	type PullRequestDiffStats,
+	type PullRequestTreeSource,
+	snapshotTreeSource,
+	takePendingItems,
+} from "./patchAccumulator";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/patchAccumulator/patchAccumulator.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/patchAccumulator/patchAccumulator.ts
@@ -1,0 +1,117 @@
+import type {
+	ChangeTypes,
+	CodeViewItem,
+	FileDiffMetadata,
+} from "@pierre/diffs";
+import type { GitStatus, GitStatusEntry } from "@pierre/trees";
+
+export interface PullRequestDiffStats {
+	fileCount: number;
+	additions: number;
+	deletions: number;
+}
+
+export interface PullRequestTreeSource {
+	paths: readonly string[];
+	gitStatus: readonly GitStatusEntry[];
+	pathToItemId: ReadonlyMap<string, string>;
+	version: number;
+}
+
+export interface PatchAccumulator {
+	fileIndex: number;
+	items: CodeViewItem[];
+	pendingItems: CodeViewItem[];
+	stats: PullRequestDiffStats;
+	usedItemIds: Set<string>;
+	paths: string[];
+	gitStatus: GitStatusEntry[];
+	pathToItemId: Map<string, string>;
+	treeVersion: number;
+}
+
+export function createPatchAccumulator(): PatchAccumulator {
+	return {
+		fileIndex: 0,
+		items: [],
+		pendingItems: [],
+		stats: { fileCount: 0, additions: 0, deletions: 0 },
+		usedItemIds: new Set(),
+		paths: [],
+		gitStatus: [],
+		pathToItemId: new Map(),
+		treeVersion: 0,
+	};
+}
+
+export function appendFileDiff(
+	accumulator: PatchAccumulator,
+	fileDiff: FileDiffMetadata,
+): void {
+	accumulator.fileIndex++;
+	const item: CodeViewItem = {
+		id: claimItemId(accumulator, fileDiff.name),
+		type: "diff",
+		fileDiff,
+	};
+	accumulator.items.push(item);
+	accumulator.pendingItems.push(item);
+	accumulator.stats.fileCount++;
+	for (const hunk of fileDiff.hunks) {
+		accumulator.stats.additions += hunk.additionLines;
+		accumulator.stats.deletions += hunk.deletionLines;
+	}
+	if (!accumulator.pathToItemId.has(fileDiff.name)) {
+		accumulator.paths.push(fileDiff.name);
+		accumulator.gitStatus.push({
+			path: fileDiff.name,
+			status: mapChangeTypeToGitStatus(fileDiff.type),
+		});
+		accumulator.pathToItemId.set(fileDiff.name, item.id);
+	}
+}
+
+export function takePendingItems(
+	accumulator: PatchAccumulator,
+): CodeViewItem[] {
+	const pending = accumulator.pendingItems;
+	accumulator.pendingItems = [];
+	return pending;
+}
+
+export function snapshotTreeSource(
+	accumulator: PatchAccumulator,
+): PullRequestTreeSource {
+	accumulator.treeVersion++;
+	return {
+		paths: accumulator.paths.slice(),
+		gitStatus: accumulator.gitStatus.slice(),
+		pathToItemId: accumulator.pathToItemId,
+		version: accumulator.treeVersion,
+	};
+}
+
+// Both rename variants fold into 'renamed' so the tree shows a consistent
+// rename badge regardless of whether content also changed.
+function mapChangeTypeToGitStatus(type: ChangeTypes): GitStatus {
+	switch (type) {
+		case "new":
+			return "added";
+		case "deleted":
+			return "deleted";
+		case "rename-pure":
+		case "rename-changed":
+			return "renamed";
+		case "change":
+			return "modified";
+	}
+}
+
+function claimItemId(accumulator: PatchAccumulator, name: string): string {
+	let id = name;
+	for (let suffix = 2; accumulator.usedItemIds.has(id); suffix++) {
+		id = `${name}#${suffix}`;
+	}
+	accumulator.usedItemIds.add(id);
+	return id;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/streamGitPatchFiles/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/streamGitPatchFiles/index.ts
@@ -1,0 +1,1 @@
+export { streamGitPatchFiles } from "./streamGitPatchFiles";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/streamGitPatchFiles/streamGitPatchFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/components/PullRequestDiff/utils/streamGitPatchFiles/streamGitPatchFiles.ts
@@ -1,0 +1,236 @@
+// Ported from Pierre's diffshub (apps/diffshub/lib/streamGitPatchFiles.ts,
+// Apache-2.0). Splits a streaming git patch on `diff --git` boundaries so
+// each complete file can be parsed and rendered before the download ends.
+
+const COMMIT_HASH_METADATA_PATTERN = /^From\s+([a-f0-9]+)\s/im;
+const GIT_FILE_BOUNDARY = "diff --git ";
+const GIT_FILE_BOUNDARY_WITH_NEWLINE = `\n${GIT_FILE_BOUNDARY}`;
+const GIT_FILE_BOUNDARY_SCAN_OVERLAP =
+	GIT_FILE_BOUNDARY_WITH_NEWLINE.length - 1;
+const NON_WHITESPACE_PATTERN = /\S/;
+
+export async function streamGitPatchFiles(
+	body: ReadableStream<Uint8Array>,
+	onFileText: (fileText: string) => Promise<void>,
+): Promise<string | undefined> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	const parser = createGitPatchFileStreamParser();
+
+	try {
+		for (;;) {
+			const result = await reader.read();
+			if (result.done) {
+				break;
+			}
+			if (result.value.byteLength > 0) {
+				parser.push(decoder.decode(result.value, { stream: true }));
+				await consumeAvailableStreamedFiles(parser, onFileText);
+			}
+		}
+
+		const finalText = decoder.decode();
+		if (finalText.length > 0) {
+			parser.push(finalText);
+			await consumeAvailableStreamedFiles(parser, onFileText);
+		}
+		const result = parser.finish();
+		if (result.fileText != null) {
+			await onFileText(result.fileText);
+		}
+		await consumeAvailableStreamedFiles(parser, onFileText);
+		return result.fallbackPatchContent;
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+interface GitPatchFileStreamFinishResult {
+	fallbackPatchContent?: string;
+	fileText?: string;
+}
+
+interface GitPatchFileStreamParser {
+	finish(): GitPatchFileStreamFinishResult;
+	push(chunk: string): void;
+	takeAvailableFile(): string | undefined;
+}
+
+async function consumeAvailableStreamedFiles(
+	parser: GitPatchFileStreamParser,
+	onFileText: (fileText: string) => Promise<void>,
+): Promise<void> {
+	for (;;) {
+		const fileText = parser.takeAvailableFile();
+		if (fileText == null) {
+			return;
+		}
+		await onFileText(fileText);
+	}
+}
+
+// Buffers the current file until the following `diff --git` header arrives so
+// each parsed file is complete before it is appended to the viewer.
+function createGitPatchFileStreamParser(): GitPatchFileStreamParser {
+	let buffer = "";
+	let currentFileBoundaryIndex: number | undefined;
+	let nextBoundarySearchIndex = 0;
+	let sawFileBoundary = false;
+
+	function takeAvailableFile(): string | undefined {
+		if (currentFileBoundaryIndex == null) {
+			currentFileBoundaryIndex = findNextGitFileBoundary(
+				buffer,
+				nextBoundarySearchIndex,
+			);
+			if (currentFileBoundaryIndex == null) {
+				nextBoundarySearchIndex = getNextBoundarySearchIndex(buffer, 0);
+				return undefined;
+			}
+
+			sawFileBoundary = true;
+			nextBoundarySearchIndex = currentFileBoundaryIndex + 1;
+		}
+
+		for (;;) {
+			const fileBoundaryIndex = currentFileBoundaryIndex;
+			if (fileBoundaryIndex == null) {
+				return undefined;
+			}
+
+			const nextBoundaryIndex = findNextGitFileBoundary(
+				buffer,
+				nextBoundarySearchIndex,
+			);
+			if (nextBoundaryIndex == null) {
+				nextBoundarySearchIndex = getNextBoundarySearchIndex(
+					buffer,
+					fileBoundaryIndex + 1,
+				);
+				return undefined;
+			}
+
+			const splitIndex = getStreamedFileSplitIndex(
+				buffer,
+				fileBoundaryIndex,
+				nextBoundaryIndex,
+			);
+			const fileText = buffer.slice(0, splitIndex);
+
+			buffer = buffer.slice(splitIndex);
+			currentFileBoundaryIndex = findNextGitFileBoundary(buffer, 0);
+			nextBoundarySearchIndex =
+				currentFileBoundaryIndex == null ? 0 : currentFileBoundaryIndex + 1;
+			if (NON_WHITESPACE_PATTERN.test(fileText)) {
+				return fileText;
+			}
+		}
+	}
+
+	return {
+		push(chunk: string) {
+			if (chunk.length === 0) {
+				return;
+			}
+			buffer += chunk;
+		},
+		takeAvailableFile,
+		finish() {
+			const fileText = takeAvailableFile();
+			if (fileText != null) {
+				return { fileText };
+			}
+
+			if (!NON_WHITESPACE_PATTERN.test(buffer)) {
+				buffer = "";
+				return {};
+			}
+			if (!sawFileBoundary) {
+				const fullPatchText = buffer;
+				buffer = "";
+				return { fallbackPatchContent: fullPatchText };
+			}
+
+			const finalFileText = buffer;
+			buffer = "";
+			return { fileText: finalFileText };
+		},
+	};
+}
+
+function getNextBoundarySearchIndex(
+	text: string,
+	minimumIndex: number,
+): number {
+	return Math.max(minimumIndex, text.length - GIT_FILE_BOUNDARY_SCAN_OVERLAP);
+}
+
+function findNextGitFileBoundary(
+	text: string,
+	fromIndex: number,
+): number | undefined {
+	const startIndex = Math.max(fromIndex, 0);
+	if (startIndex === 0 && text.startsWith(GIT_FILE_BOUNDARY)) {
+		return 0;
+	}
+
+	const boundaryIndex = text.indexOf(
+		GIT_FILE_BOUNDARY_WITH_NEWLINE,
+		startIndex,
+	);
+	return boundaryIndex === -1 ? undefined : boundaryIndex + 1;
+}
+
+function getStreamedFileSplitIndex(
+	text: string,
+	firstBoundaryIndex: number,
+	nextBoundaryIndex: number,
+): number {
+	return (
+		findLastCommitMetadataBoundary(
+			text,
+			firstBoundaryIndex + 1,
+			nextBoundaryIndex,
+		) ?? nextBoundaryIndex
+	);
+}
+
+function findLastCommitMetadataBoundary(
+	text: string,
+	startIndex: number,
+	endIndex: number,
+): number | undefined {
+	const minimumBoundaryIndex = Math.max(startIndex, 0);
+	const maximumBoundaryIndex = Math.min(endIndex, text.length);
+	if (minimumBoundaryIndex >= maximumBoundaryIndex) {
+		return undefined;
+	}
+
+	let newlineIndex = text.lastIndexOf("\nFrom ", maximumBoundaryIndex - 1);
+	for (;;) {
+		if (newlineIndex === -1) {
+			return undefined;
+		}
+
+		const boundaryIndex = newlineIndex + 1;
+		if (boundaryIndex < minimumBoundaryIndex) {
+			return undefined;
+		}
+		if (boundaryIndex >= maximumBoundaryIndex) {
+			newlineIndex = text.lastIndexOf("\nFrom ", newlineIndex - 1);
+			continue;
+		}
+
+		const lineEndIndex = text.indexOf("\n", boundaryIndex + 1);
+		const line = text.slice(
+			boundaryIndex,
+			lineEndIndex === -1 || lineEndIndex > maximumBoundaryIndex
+				? maximumBoundaryIndex
+				: lineEndIndex,
+		);
+		if (COMMIT_HASH_METADATA_PATTERN.test(line)) {
+			return boundaryIndex;
+		}
+		newlineIndex = text.lastIndexOf("\nFrom ", newlineIndex - 1);
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/pr/$prNumber/page.tsx
@@ -2,7 +2,7 @@ import { Button } from "@superset/ui/button";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { HiArrowLeft } from "react-icons/hi2";
 import { LuExternalLink, LuPlus } from "react-icons/lu";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
@@ -19,6 +19,7 @@ import {
 } from "renderer/stores/new-workspace-draft";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import { Route as TasksLayoutRoute } from "../../layout";
+import { PullRequestDiff } from "./components/PullRequestDiff";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/tasks/pr/$prNumber/",
@@ -36,6 +37,15 @@ function PullRequestDetailPage() {
 	const updateDraft = useNewWorkspaceDraftStore((s) => s.updateDraft);
 	const resetDraft = useNewWorkspaceDraftStore((s) => s.resetDraft);
 	const openModal = useOpenNewWorkspaceModal();
+	const [activeTab, setActiveTab] = useState<"overview" | "changes">(
+		"overview",
+	);
+	const [hasOpenedChanges, setHasOpenedChanges] = useState(false);
+
+	const openChangesTab = () => {
+		setActiveTab("changes");
+		setHasOpenedChanges(true);
+	};
 
 	const backSearch = useMemo(() => {
 		const s: Record<string, string> = {};
@@ -129,40 +139,75 @@ function PullRequestDetailPage() {
 				onAddToWorkspace={handleAddToWorkspace}
 			/>
 
-			<ScrollArea className="flex-1 min-h-0">
-				<div className="px-6 py-6 max-w-4xl">
-					<div className="flex items-start gap-3 mb-4">
-						<PRIcon state={state} className="size-5 shrink-0 mt-1" />
-						<h1 className="text-2xl font-semibold leading-tight">
-							{data.title}
-						</h1>
-					</div>
+			<div className="flex items-center gap-1 border-b border-border px-6 py-1.5 shrink-0">
+				<Button
+					variant={activeTab === "overview" ? "secondary" : "ghost"}
+					size="sm"
+					className="h-7 px-3 text-xs"
+					onClick={() => setActiveTab("overview")}
+				>
+					Overview
+				</Button>
+				<Button
+					variant={activeTab === "changes" ? "secondary" : "ghost"}
+					size="sm"
+					className="h-7 px-3 text-xs"
+					onClick={openChangesTab}
+				>
+					Files changed
+				</Button>
+			</div>
 
-					<div className="flex items-center gap-3 text-xs text-muted-foreground mb-6">
-						<span className="capitalize">{stateLabel}</span>
-						{data.author && (
-							<>
-								<span>·</span>
-								<span>by {data.author}</span>
-							</>
-						)}
-						{branchSummary && (
-							<>
-								<span>·</span>
-								<span className="font-mono">{branchSummary}</span>
-							</>
+			{activeTab === "overview" ? (
+				<ScrollArea className="flex-1 min-h-0">
+					<div className="px-6 py-6 max-w-4xl">
+						<div className="flex items-start gap-3 mb-4">
+							<PRIcon state={state} className="size-5 shrink-0 mt-1" />
+							<h1 className="text-2xl font-semibold leading-tight">
+								{data.title}
+							</h1>
+						</div>
+
+						<div className="flex items-center gap-3 text-xs text-muted-foreground mb-6">
+							<span className="capitalize">{stateLabel}</span>
+							{data.author && (
+								<>
+									<span>·</span>
+									<span>by {data.author}</span>
+								</>
+							)}
+							{branchSummary && (
+								<>
+									<span>·</span>
+									<span className="font-mono">{branchSummary}</span>
+								</>
+							)}
+						</div>
+
+						{data.body.trim() ? (
+							<MarkdownRenderer content={data.body} />
+						) : (
+							<p className="text-sm text-muted-foreground italic">
+								No description provided.
+							</p>
 						)}
 					</div>
+				</ScrollArea>
+			) : null}
 
-					{data.body.trim() ? (
-						<MarkdownRenderer content={data.body} />
-					) : (
-						<p className="text-sm text-muted-foreground italic">
-							No description provided.
-						</p>
-					)}
+			{hasOpenedChanges ? (
+				<div
+					className={
+						activeTab === "changes" ? "flex-1 min-h-0 flex flex-col" : "hidden"
+					}
+				>
+					<PullRequestDiff
+						hostUrl={hostUrl}
+						projectId={projectId}
+						prNumber={data.number}
+					/>
 				</div>
-			</ScrollArea>
+			) : null}
 		</div>
 	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -157,7 +157,7 @@
         "@mastra/core": "1.33.1",
         "@paper-design/shaders-react": "0.0.77",
         "@parcel/watcher": "2.5.6",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.1",
         "@pierre/trees": "1.0.0-beta.5",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-label": "2.1.8",
@@ -2288,11 +2288,11 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.1", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-jSAm+Rybo7milxGg7ps7KjM3QZl2exhE9uYjQ4RSCdPNa9GS0mD4vBP99MoFhV95bLDKL1KSMdy0596BMLUacw=="],
 
-    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 
-    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+    "@pierre/theming": ["@pierre/theming@1.0.0", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.5", "", { "dependencies": { "@pierre/theming": "0.0.2", "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-IzxkB9qv6GLbeEXObhlAD205LfYHiLeRwJdnaIdX0f5keTZF4X9EfiuEQ3QiyxOxouVVmUX3rX7m6a8zNMo/wA=="],
 
@@ -6982,6 +6982,8 @@
 
     "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
+    "@pierre/trees/@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+
     "@pierre/trees/preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
 
     "@poppinss/colors/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -8097,6 +8099,8 @@
     "@neondatabase/serverless/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "@pierre/trees/@pierre/theming/@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
 
     "@puppeteer/browsers/tar-fs/tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,7 +10,10 @@ minimumReleaseAge = 259200
 # next 16.2.11 (published 2026-07-21) is a security release fixing the SSRF,
 # cache-confusion, and middleware-bypass advisories flagged by Dependabot;
 # versions are pinned exact. Safe to remove this exclusion after 2026-07-24.
+# @pierre/diffs 1.3.1 (published 2026-08-01) is the pinned-exact base for the
+# rewritten PR diff viewer. Safe to remove this exclusion after 2026-08-04.
 minimumReleaseAgeExcludes = [
+	"@pierre/diffs",
 	"next",
 	"@next/env",
 	"@next/swc-darwin-arm64",

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -24,7 +24,10 @@ import type { GitCredentialProvider } from "./runtime/git";
 import { createGitEnvResolver, createGitFactory } from "./runtime/git";
 import { runMainWorkspaceSweep } from "./runtime/main-workspace-sweep";
 import { runProjectBackfill } from "./runtime/project-backfill";
-import { PullRequestRuntimeManager } from "./runtime/pull-requests";
+import {
+	PullRequestRuntimeManager,
+	registerPullRequestDiffRoute,
+} from "./runtime/pull-requests";
 import { runWorkspaceBackfill } from "./runtime/workspace-backfill";
 import { registerWorkspaceTerminalRoute } from "./terminal/terminal";
 import {
@@ -259,6 +262,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	app.use("/acp-sessions/*", wsAuth);
 
 	registerEventBusRoute({ app, eventBus, upgradeWebSocket });
+	registerPullRequestDiffRoute({ app, db, hostAuth: providers.hostAuth });
 	registerWorkspaceTerminalRoute({
 		app,
 		db,

--- a/packages/host-service/src/runtime/pull-requests/diff-route.ts
+++ b/packages/host-service/src/runtime/pull-requests/diff-route.ts
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import type { Hono } from "hono";
+import { stream } from "hono/streaming";
+import type { HostDb } from "../../db";
+import type { HostAuthProvider } from "../../providers/host-auth";
+import { getStrictShellEnvironment } from "../../terminal/clean-shell-env";
+import { resolveGithubRepo } from "../../trpc/router/workspace-creation/shared/project-helpers";
+
+const PR_DIFF_TIMEOUT_MS = 120_000;
+const STDERR_CAPTURE_LIMIT = 4096;
+
+interface RegisterPullRequestDiffRouteOptions {
+	app: Hono;
+	db: HostDb;
+	hostAuth: HostAuthProvider;
+}
+
+/**
+ * Streams `gh pr diff` stdout straight to the client so the renderer can
+ * parse and paint files as the patch downloads instead of waiting for the
+ * full response.
+ */
+export function registerPullRequestDiffRoute({
+	app,
+	db,
+	hostAuth,
+}: RegisterPullRequestDiffRouteOptions) {
+	app.get("/pull-requests/diff", async (c) => {
+		if (!(await hostAuth.validate(c.req.raw))) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		const projectId = c.req.query("projectId");
+		const prNumber = Number.parseInt(c.req.query("prNumber") ?? "", 10);
+		if (!projectId || !Number.isInteger(prNumber) || prNumber <= 0) {
+			return c.json({ error: "projectId and prNumber are required" }, 400);
+		}
+
+		let repoSlug: string;
+		try {
+			const repo = await resolveGithubRepo({ db }, projectId);
+			repoSlug = `${repo.owner}/${repo.name}`;
+		} catch (err) {
+			return c.json(
+				{ error: err instanceof Error ? err.message : String(err) },
+				400,
+			);
+		}
+
+		const env = await getStrictShellEnvironment().catch(
+			() => process.env as Record<string, string>,
+		);
+		const child = spawn(
+			"gh",
+			["pr", "diff", String(prNumber), "--repo", repoSlug],
+			{ env, timeout: PR_DIFF_TIMEOUT_MS, killSignal: "SIGTERM" },
+		);
+
+		let stderr = "";
+		child.stderr.setEncoding("utf8");
+		child.stderr.on("data", (chunk: string) => {
+			if (stderr.length < STDERR_CAPTURE_LIMIT) stderr += chunk;
+		});
+		const exited = new Promise<number | null>((resolve) => {
+			child.on("close", resolve);
+			child.on("error", () => resolve(null));
+		});
+
+		// Hold the response until the first stdout chunk (or exit) so early
+		// gh failures still produce a real error status instead of a
+		// truncated 200 stream.
+		const stdout = child.stdout[Symbol.asyncIterator]();
+		let first: IteratorResult<Buffer>;
+		try {
+			first = await stdout.next();
+		} catch {
+			first = { done: true, value: undefined };
+		}
+		if (first.done) {
+			const code = await exited;
+			if (code !== 0) {
+				return c.json(
+					{ error: stderr.trim() || `gh pr diff exited with code ${code}` },
+					502,
+				);
+			}
+			return c.body("", 200, { "Content-Type": "text/plain; charset=utf-8" });
+		}
+
+		c.header("Content-Type", "text/plain; charset=utf-8");
+		c.header("Cache-Control", "no-store");
+		return stream(c, async (s) => {
+			s.onAbort(() => {
+				child.kill("SIGTERM");
+			});
+			await s.write(first.value);
+			for (
+				let next = await stdout.next();
+				!next.done;
+				next = await stdout.next()
+			) {
+				await s.write(next.value);
+			}
+		});
+	});
+}

--- a/packages/host-service/src/runtime/pull-requests/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/index.ts
@@ -1,3 +1,4 @@
+export { registerPullRequestDiffRoute } from "./diff-route";
 export {
 	type CheckoutPullRequestMetadata,
 	PullRequestRuntimeManager,

--- a/packages/host-service/src/trpc/router/pull-requests/procedures/get-diff-files.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/procedures/get-diff-files.ts
@@ -1,0 +1,150 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure } from "../../../index";
+import { resolveGithubRepo } from "../../workspace-creation/shared/project-helpers";
+import { execGh } from "../../workspace-creation/utils/exec-gh";
+
+const getDiffFilesInputSchema = z.object({
+	projectId: z.string(),
+	prNumber: z.number().int().positive(),
+	type: z.enum(["change", "rename-changed", "rename-pure"]),
+	name: z.string(),
+	prevName: z.string().optional(),
+});
+
+interface PullRequestDiffFile {
+	name: string;
+	contents: string;
+	cacheKey: string;
+}
+
+interface PullRequestDiffRefs {
+	oldRepo: string;
+	oldRef: string;
+	newRepo: string;
+	newRef: string;
+}
+
+const ghPullRefsSchema = z.object({
+	baseSha: z.string(),
+	headSha: z.string(),
+	baseRepo: z.string().nullable(),
+	headRepo: z.string().nullable(),
+});
+
+const REFS_CACHE_TTL_MS = 5 * 60_000;
+const FILE_TIMEOUT_MS = 30_000;
+const FILE_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
+
+const refsCache = new Map<
+	string,
+	{ promise: Promise<PullRequestDiffRefs>; expiresAt: number }
+>();
+
+// The PR's visible diff is head vs merge-base (GitHub's three-dot compare),
+// so hydrating the old side must read the merge-base commit, not the live
+// base branch tip.
+async function resolvePullRequestDiffRefs(
+	repoSlug: string,
+	prNumber: number,
+): Promise<PullRequestDiffRefs> {
+	const cacheKey = `${repoSlug.toLowerCase()}#${prNumber}`;
+	const cached = refsCache.get(cacheKey);
+	if (cached && cached.expiresAt > Date.now()) {
+		return cached.promise;
+	}
+
+	const promise = (async (): Promise<PullRequestDiffRefs> => {
+		const rawRefs = await execGh([
+			"api",
+			`repos/${repoSlug}/pulls/${prNumber}`,
+			"--jq",
+			"{baseSha: .base.sha, headSha: .head.sha, baseRepo: .base.repo.full_name, headRepo: .head.repo.full_name}",
+		]);
+		const refs = ghPullRefsSchema.parse(rawRefs);
+		const baseRepo = refs.baseRepo ?? repoSlug;
+		const headRepo = refs.headRepo ?? repoSlug;
+		const compareRange =
+			baseRepo.toLowerCase() === headRepo.toLowerCase()
+				? `${refs.baseSha}...${refs.headSha}`
+				: `${baseRepo.split("/")[0]}:${refs.baseSha}...${headRepo.split("/")[0]}:${refs.headSha}`;
+		const mergeBaseSha = await execGh([
+			"api",
+			`repos/${baseRepo}/compare/${compareRange}`,
+			"--jq",
+			".merge_base_commit.sha",
+		]);
+		if (typeof mergeBaseSha !== "string" || mergeBaseSha.length === 0) {
+			throw new Error(`No merge base for ${repoSlug}#${prNumber}`);
+		}
+		return {
+			oldRepo: baseRepo,
+			oldRef: mergeBaseSha,
+			newRepo: headRepo,
+			newRef: refs.headSha,
+		};
+	})();
+	promise.catch(() => {
+		if (refsCache.get(cacheKey)?.promise === promise) {
+			refsCache.delete(cacheKey);
+		}
+	});
+	refsCache.set(cacheKey, {
+		promise,
+		expiresAt: Date.now() + REFS_CACHE_TTL_MS,
+	});
+	return promise;
+}
+
+async function fetchFileAtRef(
+	repoSlug: string,
+	ref: string,
+	path: string,
+): Promise<PullRequestDiffFile> {
+	const encodedPath = path
+		.replace(/^\/+/, "")
+		.split("/")
+		.map(encodeURIComponent)
+		.join("/");
+	const contents = await execGh(
+		[
+			"api",
+			`repos/${repoSlug}/contents/${encodedPath}?ref=${ref}`,
+			"-H",
+			"Accept: application/vnd.github.raw",
+		],
+		{ timeout: FILE_TIMEOUT_MS, maxBuffer: FILE_MAX_BUFFER_BYTES, raw: true },
+	);
+	if (typeof contents !== "string") {
+		throw new Error(`Unexpected contents for ${path}@${ref}`);
+	}
+	return { name: path, contents, cacheKey: `${repoSlug}@${ref}:${path}` };
+}
+
+export const getDiffFiles = protectedProcedure
+	.input(getDiffFilesInputSchema)
+	.query(async ({ ctx, input }) => {
+		const repo = await resolveGithubRepo(ctx, input.projectId);
+		const repoSlug = `${repo.owner}/${repo.name}`;
+		try {
+			const refs = await resolvePullRequestDiffRefs(repoSlug, input.prNumber);
+			if (input.type === "rename-pure") {
+				const newFile = await fetchFileAtRef(
+					refs.newRepo,
+					refs.newRef,
+					input.name,
+				);
+				return { oldFile: null, newFile };
+			}
+			const [oldFile, newFile] = await Promise.all([
+				fetchFileAtRef(refs.oldRepo, refs.oldRef, input.prevName ?? input.name),
+				fetchFileAtRef(refs.newRepo, refs.newRef, input.name),
+			]);
+			return { oldFile, newFile };
+		} catch (err) {
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: `Failed to load PR #${input.prNumber} file ${input.name}: ${err instanceof Error ? err.message : String(err)}`,
+			});
+		}
+	});

--- a/packages/host-service/src/trpc/router/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/pull-requests.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../../index";
 import { getContent } from "./procedures/get-content";
+import { getDiffFiles } from "./procedures/get-diff-files";
 
 export const pullRequestsRouter = router({
 	getByWorkspaces: protectedProcedure
@@ -29,4 +30,5 @@ export const pullRequestsRouter = router({
 			return { ok: true };
 		}),
 	getContent,
+	getDiffFiles,
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/project-helpers.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/project-helpers.ts
@@ -37,7 +37,7 @@ export interface ResolvedGithubRepo {
  * Remote preference: configured `remoteName` → `origin` → first GitHub remote.
  */
 export async function resolveGithubRepo(
-	ctx: HostServiceContext,
+	ctx: Pick<HostServiceContext, "db">,
 	projectId: string,
 ): Promise<ResolvedGithubRepo> {
 	const local = ctx.db.query.projects

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
@@ -7,6 +7,9 @@ const execFileAsync = promisify(execFile);
 export interface ExecGhOptions {
 	cwd?: string;
 	timeout?: number;
+	maxBuffer?: number;
+	/** Return stdout verbatim instead of trimming and attempting JSON.parse. */
+	raw?: boolean;
 }
 
 /**
@@ -27,9 +30,11 @@ export const execGh: ExecGh = async (args, options) => {
 	const { stdout } = await execFileAsync("gh", args, {
 		encoding: "utf8",
 		timeout: options?.timeout ?? 10_000,
+		maxBuffer: options?.maxBuffer,
 		cwd: options?.cwd,
 		env,
 	});
+	if (options?.raw) return stdout;
 	const trimmed = stdout.trim();
 	if (!trimmed) return {};
 	try {


### PR DESCRIPTION
## Summary

First step of the diff-viewer rewrite: a diffshub-style native **Files changed** tab on the PR detail page (`tasks/pr/$prNumber`), built from scratch on `@pierre/diffs` 1.3.1 with Pierre's diffshub app pipeline ported nearly verbatim. This is the foundation the workspace DiffPane will be ported onto next; no existing diff code paths were modified.

### How it works

- **Streaming end to end** — host-service gains `GET /pull-requests/diff`, which pipes `gh pr diff` stdout straight into the HTTP response. The renderer splits the stream on `diff --git` boundaries (port of diffshub's incremental parser), parses each file on an 8ms work budget, publishes a viewport-sized first batch, then appends via `viewer.addItems()` — files paint while the patch is still downloading.
- **Virtualized rendering** — one `CodeView` for the whole changeset; only rows near the viewport are mounted, highlighting runs in the existing app-wide shiki worker pool.
- **On-demand context expansion** — new `pullRequests.getDiffFiles` procedure resolves the PR's merge-base/head refs (cross-repo aware, 5-min cache) and fetches full file contents via `gh api`, wired into 1.3's `loadDiffFiles` partial-diff hydration.
- **Sidebar** — `@pierre/trees` file tree with git-status coloring, sticky folders, click-to-scroll (auto-expands collapsed files), plus diff stats and Collapse all / Expand all and Unified/Split toggles.

Also upgrades `@pierre/diffs` 1.2.12 → 1.3.1 (the Edit release); the existing workspace DiffPane compiles unchanged. The bunfig release-age exclusion is removable after 2026-08-04.

### Verification (CDP, real dev stack, real PRs)

- 5-file PR: stats match GitHub exactly; context expansion hydrates and realigns hunks.
- 95-file / +2873-line PR: first files paint **~770ms** after clicking the tab, stream completes ~1s, 3 `<pre>` surfaces mounted at any time.
- Tree click, collapse-all, and split/unified verified with before/after screenshots.

### Follow-ups

- Port the workspace DiffPane onto this foundation (kills the fetch-all-contents + rediff-on-every-render plumbing), then delete the legacy v1 LightDiffViewer path.
- Candidate diffshub ports: line-anchored review comments, status-filtered tree, line-selection deep links, wrap/line-number toggles.

https://claude.ai/code/session_01BpQqCmbQmBViy7rf6Gtuig

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native, streaming “Files changed” tab to the PR detail page using `@pierre/diffs` 1.3.1 for fast, virtualized diff viewing. First files render while the patch is still downloading for a snappier experience.

- **New Features**
  - Streaming pipeline: host-service `GET /pull-requests/diff` pipes `gh pr diff` stdout directly to the client.
  - Incremental parsing: split on `diff --git`, publish a viewport-sized first batch, then append as data streams.
  - Virtualized `CodeView` with worker-pool syntax highlighting.
  - On-demand context: `pullRequests.getDiffFiles` resolves merge-base/head refs and fetches contents via `gh api` (5‑min cache).
  - Sidebar: `@pierre/trees` file tree with git-status colors, click-to-scroll, Collapse/Expand all, Unified/Split toggles, and stats.
  - Performance: ~770ms to first paint on a 95‑file PR; stream completes ~1s.

- **Dependencies**
  - Upgrade `@pierre/diffs` from 1.2.12 to 1.3.1.
  - Add bunfig minimumReleaseAge exclusion for `@pierre/diffs` (removable after 2026‑08‑04).

<sup>Written for commit 61ca242869f1e8ccfebcc7fb50d4de63a8480c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Files changed** tab to pull request pages.
  * Added a diff viewer with split or unified layouts, file navigation, search, statistics, and collapse/expand controls.
  * Added support for streamed diff loading and expanding file context.
  * Added loading, empty, retryable error, and rename handling states.

* **Bug Fixes**
  * Improved handling of large, streamed, empty, and incomplete diffs.
  * Added validation and safeguards for diff file retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->