### PR TITLE
perf(desktop): stop gating org switch on Electric preload

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.ts
+++ b/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.ts
@@ -53,7 +53,7 @@ export function useHostProjects(): UseHostProjectsResult {
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 
-	const { hosts } = useKnownHosts();
+	const { hosts, settled: knownHostsSettled } = useKnownHosts();
 
 	const targets = useMemo(
 		() =>
@@ -205,8 +205,10 @@ export function useHostProjects(): UseHostProjectsResult {
 	);
 
 	// Never vacuously ready: zero targets means host discovery hasn't run
-	// yet (cold start), not "no projects exist".
+	// yet (cold start), not "no projects exist". Known-hosts settlement gates
+	// too — see useHostWorkspaces: before it settles the fan-out is local-only.
 	const isReady =
+		knownHostsSettled &&
 		targets.length > 0 &&
 		queries.every(
 			(query, index) =>

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -74,7 +74,11 @@ export function useHostWorkspacesSource(
 	const { activeHostUrl, machineId } = useLocalHostService();
 	const relayUrl = useRelayUrl();
 
-	const { hosts, organizationId: knownHostsOrgId } = useKnownHosts();
+	const {
+		hosts,
+		organizationId: knownHostsOrgId,
+		settled: knownHostsSettled,
+	} = useKnownHosts();
 
 	const { data: cloudRows = [] } = useLiveQuery(
 		(q) => q.from({ workspaces: collections.v2Workspaces }),
@@ -229,7 +233,14 @@ export function useHostWorkspacesSource(
 	// rows without reaching ready), so gating on cloudReady would hang the
 	// empty state forever for a genuinely-empty local host while offline.
 	// A scoped host that hasn't resolved to a target yet is still loading.
+	// Known-hosts settlement IS a gate, though: targets derive from it, and
+	// before it settles the fan-out covers only the local host — every query
+	// answering then means "the hosts we know of answered", not "every host
+	// answered". Reporting ready off that would flash not-found for remote
+	// workspaces right after an org switch (offline stays fine: a prior
+	// session's snapshot settles it without Electric).
 	const isReady =
+		knownHostsSettled &&
 		(scopedHostId === undefined || targets.length > 0) &&
 		queries.every(
 			(query, index) =>

--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
@@ -29,6 +29,13 @@ export type { KnownHostRow } from "./useKnownHosts.utils";
 export function useKnownHosts(): {
 	hosts: KnownHostRow[];
 	organizationId: string | null;
+	/**
+	 * True once the host list is trustworthy: Electric reached ready, or this
+	 * org's IndexedDB snapshot loaded. Until then the list may be missing
+	 * remote hosts entirely — gate "host/workspace doesn't exist" conclusions
+	 * on this, never row rendering.
+	 */
+	settled: boolean;
 } {
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
@@ -88,5 +95,9 @@ export function useKnownHosts(): {
 		);
 	}, [liveRows, liveReady, snapshot, organizationId]);
 
-	return { hosts, organizationId };
+	const settled =
+		liveReady ||
+		(snapshot !== null && snapshot.organizationId === organizationId);
+
+	return { hosts, organizationId, settled };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -21,7 +21,7 @@ export function useNavigateAwayFromWorkspace() {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
 	const collections = useCollections();
-	const { workspaces } = useHostWorkspaces();
+	const { workspaces, isReady } = useHostWorkspaces();
 	const workspaceIds = useMemo(
 		() => new Set(workspaces.map((workspace) => workspace.id)),
 		[workspaces],
@@ -43,7 +43,10 @@ export function useNavigateAwayFromWorkspace() {
 				activeWorkspaceId,
 				removedWorkspaceId: workspaceId,
 				orderedWorkspaceIds: getFlattenedV2WorkspaceIds(collections),
-				isWorkspaceValid: (id) => workspaceIds.has(id),
+				// Before the host fan-out settles, an unlisted sibling means
+				// "unknown", not "gone" — prefer navigating to it over home; the
+				// workspace route's own not-found handling covers a true miss.
+				isWorkspaceValid: (id) => !isReady || workspaceIds.has(id),
 				isWorkspaceDeleting: (id) =>
 					additionalDeletingWorkspaceIds?.has(id) === true || isDeleting(id),
 			});
@@ -59,7 +62,7 @@ export function useNavigateAwayFromWorkspace() {
 				reportRemovalNavigationError,
 			);
 		},
-		[collections, workspaceIds, isDeleting, matchRoute, navigate],
+		[collections, workspaceIds, isDeleting, matchRoute, navigate, isReady],
 	);
 
 	return { navigateAwayFromWorkspace };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -163,7 +163,8 @@ export function TasksView({
 	);
 
 	// Projects are fully local — identity comes from the host fan-out.
-	const { projects: hostProjects } = useHostProjects();
+	const { projects: hostProjects, isReady: hostProjectsReady } =
+		useHostProjects();
 	const v2Projects = useMemo(
 		() =>
 			hostProjects.map((project) => ({
@@ -174,7 +175,9 @@ export function TasksView({
 	);
 
 	useEffect(() => {
-		if (!v2Projects) return;
+		// A partial fan-out must not rewrite the user's filter: the selected
+		// project may live on a host that hasn't answered yet.
+		if (!hostProjectsReady) return;
 		if (projectFilter && v2Projects.some((p) => p.id === projectFilter)) return;
 		const firstProject = v2Projects[0];
 		if (!firstProject) return;
@@ -183,7 +186,7 @@ export function TasksView({
 			search: buildSearch({ project: firstProject.id }),
 			replace: true,
 		});
-	}, [projectFilter, v2Projects, navigate, buildSearch]);
+	}, [hostProjectsReady, projectFilter, v2Projects, navigate, buildSearch]);
 
 	const isLinearConnected =
 		integrations?.some((i) => i.provider === "linear") ?? false;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -107,7 +107,7 @@ export function useCommandWatcher() {
 		],
 	);
 
-	const { data: pendingCommands } = useLiveQuery(
+	const { data: pendingCommands, isReady: pendingCommandsReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ commands: collections.agentCommands })
@@ -245,8 +245,13 @@ export function useCommandWatcher() {
 	);
 
 	useEffect(() => {
+		// Strict readiness before executing: SQLite-cached rows can carry a
+		// stale "pending" status for commands the server already resolved.
+		// Acting on them re-runs tools (worktree create, terminal writes) and
+		// overwrites the server's final status.
 		if (
 			!shouldWatch ||
+			!pendingCommandsReady ||
 			!deviceInfo?.deviceId ||
 			!pendingCommands ||
 			!organizationId
@@ -303,6 +308,7 @@ export function useCommandWatcher() {
 		}
 	}, [
 		shouldWatch,
+		pendingCommandsReady,
 		deviceInfo?.deviceId,
 		organizationId,
 		pendingCommands,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -911,14 +911,18 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	};
 }
 
-// Unbounded org-content tables whose initial sync scales with org size. They
-// start syncing during preload but never gate its promise — the org switch
-// commits once the core set is warm and these render cache-first as rows land.
-const deferredPreloadCollections: ReadonlySet<string> = new Set([
-	"tasks",
-	"chatSessions",
-	"githubPullRequests",
-	"automationRuns",
+// The only collections the org switch must wait for: the sidebar workspace
+// list fans out from these (rows, host reachability, access filtering) and
+// joins them for names and repo labels. Everything else starts syncing during
+// preload but renders cache-first as rows land — settings and content panes
+// all tolerate a not-yet-ready collection. localStorage-backed collections
+// hydrate synchronously at construction, so gating never applies to them.
+const gatingPreloadCollections: ReadonlySet<string> = new Set([
+	"v2Workspaces",
+	"v2Hosts",
+	"v2UsersHosts",
+	"users",
+	"githubRepositories",
 ]);
 
 /**
@@ -934,12 +938,12 @@ export async function preloadCollections(
 	for (const [name, collection] of Object.entries(collections)) {
 		if (name === "organizations") continue;
 		const preload = (collection as Collection<object>).preload();
-		if (deferredPreloadCollections.has(name)) {
+		if (gatingPreloadCollections.has(name)) {
+			gatingPreloads.push(preload);
+		} else {
 			preload.catch((error) => {
 				console.error(`[collections] Deferred preload failed: ${name}`, error);
 			});
-		} else {
-			gatingPreloads.push(preload);
 		}
 	}
 	await Promise.allSettled(gatingPreloads);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -911,42 +911,27 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	};
 }
 
-// The only collections the org switch must wait for: the sidebar workspace
-// list fans out from these (rows, host reachability, access filtering) and
-// joins them for names and repo labels. Everything else starts syncing during
-// preload but renders cache-first as rows land — settings and content panes
-// all tolerate a not-yet-ready collection. localStorage-backed collections
-// hydrate synchronously at construction, so gating never applies to them.
-const gatingPreloadCollections: ReadonlySet<string> = new Set([
-	"v2Workspaces",
-	"v2Hosts",
-	"v2UsersHosts",
-	"users",
-	"githubRepositories",
-]);
-
 /**
- * Preload collections for an organization by starting Electric sync.
- * Collections are lazy — they don't fetch data until subscribed or preloaded.
- * Call this eagerly so data is ready when the user switches orgs.
+ * Start Electric sync for every collection of an organization. Collections
+ * are lazy — they don't fetch until subscribed or preloaded.
+ *
+ * Resolves once sync is STARTED, not once it completes. `preload()` on a
+ * persisted collection only settles after Electric's initial network sync,
+ * but SQLite-persisted rows hydrate into the collection immediately — the UI
+ * renders cache-first either way, and a never-synced org streams in exactly
+ * like first boot does. Waiting here only delays the switch and lets any
+ * single wedged shape hang it indefinitely.
  */
 export async function preloadCollections(
 	organizationId: string,
 ): Promise<void> {
 	const collections = getCollections(organizationId);
-	const gatingPreloads: Promise<void>[] = [];
 	for (const [name, collection] of Object.entries(collections)) {
 		if (name === "organizations") continue;
-		const preload = (collection as Collection<object>).preload();
-		if (gatingPreloadCollections.has(name)) {
-			gatingPreloads.push(preload);
-		} else {
-			preload.catch((error) => {
-				console.error(`[collections] Deferred preload failed: ${name}`, error);
-			});
-		}
+		(collection as Collection<object>).preload().catch((error) => {
+			console.error(`[collections] Preload failed: ${name}`, error);
+		});
 	}
-	await Promise.allSettled(gatingPreloads);
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -911,6 +911,16 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	};
 }
 
+// Unbounded org-content tables whose initial sync scales with org size. They
+// start syncing during preload but never gate its promise — the org switch
+// commits once the core set is warm and these render cache-first as rows land.
+const deferredPreloadCollections: ReadonlySet<string> = new Set([
+	"tasks",
+	"chatSessions",
+	"githubPullRequests",
+	"automationRuns",
+]);
+
 /**
  * Preload collections for an organization by starting Electric sync.
  * Collections are lazy — they don't fetch data until subscribed or preloaded.
@@ -920,13 +930,19 @@ export async function preloadCollections(
 	organizationId: string,
 ): Promise<void> {
 	const collections = getCollections(organizationId);
-	const collectionsToPreload = Object.entries(collections)
-		.filter(([name]) => name !== "organizations")
-		.map(([, collection]) => collection as Collection<object>);
-
-	await Promise.allSettled(
-		collectionsToPreload.map((c) => (c as Collection<object>).preload()),
-	);
+	const gatingPreloads: Promise<void>[] = [];
+	for (const [name, collection] of Object.entries(collections)) {
+		if (name === "organizations") continue;
+		const preload = (collection as Collection<object>).preload();
+		if (deferredPreloadCollections.has(name)) {
+			preload.catch((error) => {
+				console.error(`[collections] Deferred preload failed: ${name}`, error);
+			});
+		} else {
+			gatingPreloads.push(preload);
+		}
+	}
+	await Promise.allSettled(gatingPreloads);
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -5,6 +5,7 @@ import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { HiArrowRight } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
+import { resolveCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -38,8 +39,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 	);
 	const isOwner = currentMember?.role === "owner";
 
-	// Get subscription from Electric (preloaded, instant)
-	const { data: subscriptionsData } = useLiveQuery(
+	const { data: subscriptionsData, isReady: subscriptionsReady } = useLiveQuery(
 		(q) => q.from({ subscriptions: collections.subscriptions }),
 		[collections],
 	);
@@ -47,18 +47,29 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 		(s) => s.status === "active",
 	);
 
-	// Derive plan from subscription data (not session, which can be stale)
-	const plan: PlanTier = (subscriptionData?.plan as PlanTier) ?? "free";
+	// Subscription rows win over the session (which can lag a checkout), but a
+	// cold collection must not read as "free" — fall back to the session plan
+	// until rows or readiness arrive.
+	const plan: PlanTier = resolveCurrentPlan({
+		subscriptionPlan: subscriptionData?.plan,
+		sessionPlan: session?.session?.plan,
+		subscriptionsLoaded:
+			subscriptionsReady || (subscriptionsData?.length ?? 0) > 0,
+	});
 
-	// Get member count from Electric
-	const { data: membersData } = useLiveQuery(
+	const { data: membersData, isReady: membersReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ members: collections.members })
 				.select(({ members }) => ({ id: members.id })),
 		[collections],
 	);
-	const memberCount = membersData ? membersData.length : undefined;
+	// Seats are billed from this — never derive it from a cold collection.
+	// undefined (not 0) keeps the upgrade action disabled until synced.
+	const memberCount =
+		membersReady && membersData && membersData.length > 0
+			? membersData.length
+			: undefined;
 
 	const showOverview = isItemVisible(
 		SETTING_ITEM_ID.BILLING_OVERVIEW,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -9,6 +9,7 @@ import { differenceInDays, format } from "date-fns";
 import { Fragment, useState } from "react";
 import { HiArrowLeft, HiArrowUpRight, HiCheck } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
+import { resolveCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -218,8 +219,7 @@ function PlansPage() {
 
 	const activeOrgId = session?.session?.activeOrganizationId;
 
-	// Get subscription from Electric (preloaded, instant)
-	const { data: subscriptionsData } = useLiveQuery(
+	const { data: subscriptionsData, isReady: subscriptionsReady } = useLiveQuery(
 		(q) => q.from({ subscriptions: collections.subscriptions }),
 		[collections],
 	);
@@ -227,7 +227,15 @@ function PlansPage() {
 		(s) => s.status === "active",
 	);
 
-	const currentPlan: PlanTier = (subscriptionData?.plan as PlanTier) ?? "free";
+	// A cold collection must not read as "free": that renders a live Upgrade
+	// action for an org that may already be paying. Session plan fills in
+	// until rows or readiness arrive.
+	const currentPlan: PlanTier = resolveCurrentPlan({
+		subscriptionPlan: subscriptionData?.plan,
+		sessionPlan: session?.session?.plan,
+		subscriptionsLoaded:
+			subscriptionsReady || (subscriptionsData?.length ?? 0) > 0,
+	});
 	const cancelAt = subscriptionData?.cancelAt;
 
 	const isCurrentlyYearly =
@@ -238,14 +246,18 @@ function PlansPage() {
 			new Date(subscriptionData.periodStart),
 		) > 60;
 
-	const { data: membersData } = useLiveQuery(
+	const { data: membersData, isReady: membersReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ members: collections.members })
 				.select(({ members }) => ({ id: members.id })),
 		[collections],
 	);
-	const memberCount = membersData?.length ?? 1;
+	// Seats are billed from this — never derive it from a cold collection.
+	const memberCount =
+		membersReady && membersData && membersData.length > 0
+			? membersData.length
+			: undefined;
 
 	const currentPlanLabelByTier: Record<PlanTier, string> = {
 		free: "Free",
@@ -308,6 +320,8 @@ function PlansPage() {
 			}
 			return;
 		}
+
+		if (memberCount === undefined) return;
 
 		setIsUpgrading(true);
 		try {


### PR DESCRIPTION
## What

`preloadCollections` awaited initial Electric sync for every collection in the destination org, so an org switch (#6132) waited on the slowest of ~22 shapes — up to minutes on large orgs, indefinitely if any shape wedged in Electric's internal retries.

It now starts every shape's sync and resolves immediately. The switch commits after the `setActive` + `refetchSession` round trips; collection data renders cache-first as it hydrates.

## Why waiting was buying nothing

`preload()` on a persisted collection only settles after Electric's **initial network sync** — the wrapped `markReady` in `@tanstack/db-sqlite-persistence-core` defers to the source (Electric) sync's markReady. But SQLite-persisted rows hydrate into the collection immediately, before ready. So:

- **Revisited org** (common case): the full UI is already on screen from cache; the gate was waiting for Electric to catch up on data the user could already see.
- **Never-visited org**: there is no cache, so nothing the gate waits for changes what's shown first — skeletons stream in exactly like first boot already does (first boot never had a preload gate).

## Cold-window audit and hardening

Since boot was always ungated, the app already tolerates cold collections everywhere reachable at startup. Three parallel audits (navigation/redirects, write/seed/reconcile effects, plan gating and identity lookups) swept every consumer for spots that assumed warm data. No data-loss paths exist — every reconcile/delete is localStorage-driven, user-confirmed, or readiness-gated — but three holes needed guards, fixed here:

1. **Host fan-out readiness** (the one true regression from this change): `useKnownHosts` derives query targets from the Electric `v2Hosts` collection; cold, that meant local-host-only, and `useHostWorkspaces.isReady` flipped true without remote hosts — flashing a false "Workspace not found" for remote workspaces right after a switch. `useKnownHosts` now exposes `settled` (Electric ready **or** this org's IndexedDB snapshot loaded — offline-first preserved) and both fan-outs fold it into `isReady`. Also fixes two adjacent pre-existing holes: delete-navigation bouncing home instead of to a sibling, and the tasks view rewriting the project filter during a partial fan-out.
2. **Billing** (pre-existing at boot, window widened here): both billing surfaces derived plan straight from cold `subscriptions` (Pro org rendered as Free with a live Upgrade action) and seats from cold `members` (`BillingOverview`'s `=== undefined` guard was dead code — `useLiveQuery` returns `[]`, not `undefined`; `plans/page`'s `?? 1` let `[]` through as 0). An upgrade could post `seats: 0` to Stripe. Plan now resolves through `resolveCurrentPlan`'s session fallback; seats stay `undefined` and the action disabled until `members` is strictly ready.
3. **Agent command watcher** (pre-existing rule-9 violation): executed commands off SQLite-cached rows whose `pending` status the server may have already resolved — re-running tools (worktree create, terminal writes) and overwriting final statuses. Execution now waits for strict readiness of the `agentCommands` live query.

Verified safe without changes: `useCurrentPlan`/`usePaywall` (session-plan fallback, no paywall flash), all sidebar seeding/derivation (localStorage-keyed, never concludes "missing" from Electric), all reconcile/delete paths, migration triggers (ledger/localStorage-driven), onboarding and stale-route redirects (collection-free), member-role surfaces (degrade by hiding admin UI only), automations/tasks not-found pages (readiness-gated or server-backstopped).

## What's kept

- All `preload()` calls still happen (switch + boot), so shapes without a mounted subscriber warm in the background. Failures logged per collection; terminal Electric errors still surface via `handleElectricSyncError`.
- Signature stays `Promise<void>`, so #6133's `displayedOrganizationId` advance needs no changes — it now advances right after `setActive` commits.

## Tradeoff

This deliberately drops the "never show a half-synced org" gate: a first-ever visit to an org cuts over to skeletons instead of holding the previous view — same experience as first boot, in exchange for removing the multi-minute blank of #6132 and the wedged-shape hang. #6133's doc wording ("advances once the destination is warm") wants a tweak after this merges.

https://claude.ai/code/session_012bQaGgxjAMKTU47fDAFKwb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading speed when switching between organizations by allowing collection data to preload asynchronously.
  * The interface can become usable sooner while remaining collections continue loading in the background.
  * Collection loading failures are handled independently, helping prevent one failure from blocking other data.

* **Bug Fixes**
  * Prevented incomplete host, project, and workspace data from appearing during startup or organization changes.
  * Improved navigation and task filtering while data is still loading.
  * Prevented billing pages from showing incorrect plans or using unavailable member counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #6132
