### PR TITLE
fix(desktop): stop v1 renderer xterm from double-answering terminal queries

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Verifies the renderer-side suppressors keep terminal queries from
+ * generating replies. In v1 the terminal-host daemon's headless emulator is
+ * the canonical answerer; a renderer reply round-trips back to PTY stdin
+ * ~20-40ms late and lands in whatever program is reading stdin — go-survey
+ * CLIs abort with "unexpected escape sequence from terminal: ['\x1b' ']']"
+ * (#3499).
+ *
+ * Uses `@xterm/headless` (same parser as `@xterm/xterm`; window polyfill
+ * comes from the `apps/desktop/bunfig.toml` test preload). Headless answers
+ * DA/DSR itself, so those are asserted via `onData`. OSC 10/11/12 and
+ * `CSI ?996n` replies are produced by browser-side theme handlers that do
+ * not exist in headless, so those are asserted via the handler chain: a
+ * probe handler registered BEFORE the suppressors stands in for xterm's
+ * earlier-registered built-in handler (most recently registered runs first;
+ * `false` falls through). Suppressed = probe never reached.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { suppressQueryResponses } from "./suppressQueryResponses";
+
+const { Terminal } = await import("@xterm/headless");
+
+const ESC = "\x1b";
+const CSI = `${ESC}[`;
+const OSC = `${ESC}]`;
+const BEL = "\x07";
+
+type Headless = InstanceType<typeof Terminal>;
+
+function makeTerminal(): { terminal: Headless; captured: string[] } {
+	const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+	const captured: string[] = [];
+	terminal.onData((data) => captured.push(data));
+	return { terminal, captured };
+}
+
+function install(terminal: Headless): () => void {
+	// suppressQueryResponses takes `@xterm/xterm` Terminal but only touches
+	// `.parser`, which is shape-compatible with `@xterm/headless`.
+	return suppressQueryResponses(terminal as unknown as XTerm);
+}
+
+async function write(terminal: Headless, data: string): Promise<void> {
+	await new Promise<void>((resolve) => terminal.write(data, () => resolve()));
+}
+
+describe("suppressQueryResponses", () => {
+	describe("queries headless answers itself (asserted via onData)", () => {
+		let terminal: Headless;
+		let captured: string[];
+		let cleanup: () => void;
+
+		beforeEach(() => {
+			({ terminal, captured } = makeTerminal());
+			cleanup = install(terminal);
+		});
+
+		afterEach(() => {
+			cleanup();
+			terminal.dispose();
+		});
+
+		test.each([
+			["DA1 `CSI c`", `${CSI}c`],
+			["DA1 `CSI 0c`", `${CSI}0c`],
+			["DA2 `CSI > c`", `${CSI}>c`],
+			["DSR status `CSI 5n`", `${CSI}5n`],
+			["DSR cursor `CSI 6n`", `${CSI}6n`],
+			["DECXCPR `CSI ? 6 n`", `${CSI}?6n`],
+		])("%s emits no reply", async (_name, sequence) => {
+			await write(terminal, sequence);
+			expect(captured).toEqual([]);
+		});
+
+		test("disposing restores xterm's default DA1 auto-reply", async () => {
+			cleanup();
+			// Re-arm cleanup with a no-op so afterEach stays valid.
+			cleanup = () => {};
+			await write(terminal, `${CSI}c`);
+			expect(captured.join("")).toMatch(new RegExp(`^${ESC}\\[\\?\\d`));
+		});
+	});
+
+	describe("handler-chain contract (probe = xterm's built-in handler)", () => {
+		let terminal: Headless;
+		let cleanup: () => void;
+
+		afterEach(() => {
+			cleanup();
+			terminal.dispose();
+		});
+
+		function setupOscProbe(code: number): { calls: string[] } {
+			({ terminal } = makeTerminal());
+			const calls: string[] = [];
+			terminal.parser.registerOscHandler(code, (data) => {
+				calls.push(data);
+				return false;
+			});
+			cleanup = install(terminal);
+			return { calls };
+		}
+
+		test.each([
+			[10],
+			[11],
+			[12],
+		])("OSC %i `?` query never reaches the built-in handler", async (code) => {
+			const { calls } = setupOscProbe(code);
+			await write(terminal, `${OSC}${code};?${BEL}`);
+			expect(calls).toEqual([]);
+		});
+
+		test("OSC 11 `?` query with ST terminator is also suppressed", async () => {
+			const { calls } = setupOscProbe(11);
+			await write(terminal, `${OSC}11;?${ESC}\\`);
+			expect(calls).toEqual([]);
+		});
+
+		test("OSC 11 mixed stacked payload `?;rgb:...` is suppressed", async () => {
+			const { calls } = setupOscProbe(11);
+			await write(terminal, `${OSC}11;?;rgb:00/00/00${BEL}`);
+			expect(calls).toEqual([]);
+		});
+
+		test("OSC 11 set command falls through to the built-in handler", async () => {
+			const { calls } = setupOscProbe(11);
+			await write(terminal, `${OSC}11;rgb:00/00/00${BEL}`);
+			expect(calls).toEqual(["rgb:00/00/00"]);
+		});
+
+		function setupCsiProbe(id: { prefix?: string; final: string }): {
+			calls: (number | number[])[][];
+		} {
+			({ terminal } = makeTerminal());
+			const calls: (number | number[])[][] = [];
+			terminal.parser.registerCsiHandler(id, (params) => {
+				calls.push([...params]);
+				return false;
+			});
+			cleanup = install(terminal);
+			return { calls };
+		}
+
+		test("`CSI ?996n` (color-scheme query) falls through — renderer must keep answering it", async () => {
+			const { calls } = setupCsiProbe({ prefix: "?", final: "n" });
+			await write(terminal, `${CSI}?996n`);
+			expect(calls).toEqual([[996]]);
+		});
+
+		test("`CSI ?6n` (DECXCPR) does not fall through", async () => {
+			const { calls } = setupCsiProbe({ prefix: "?", final: "n" });
+			await write(terminal, `${CSI}?6n`);
+			expect(calls).toEqual([]);
+		});
+
+		test("`CSI 0n` (DSR param outside 5/6) falls through", async () => {
+			const { calls } = setupCsiProbe({ final: "n" });
+			await write(terminal, `${CSI}0n`);
+			expect(calls).toEqual([[0]]);
+		});
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.ts
@@ -1,21 +1,42 @@
 import type { Terminal } from "@xterm/xterm";
 
 /**
- * Registers parser hooks to suppress terminal query responses from being displayed.
+ * Keeps the renderer xterm silent on terminal query traffic.
  *
- * These handlers intercept specific response-only sequences that should not appear
- * as visible text. We only suppress sequences where the response has a DIFFERENT
- * format than the query, ensuring we don't break terminal functionality.
+ * v1 architecture: the terminal-host daemon's HeadlessEmulator owns the
+ * canonical reply to DA1/DA2/DSR terminal queries — it answers instantly,
+ * straight into PTY stdin (see the `emulator.onData` hook in `session.ts`).
+ * The renderer xterm sees the same PTY output and would auto-reply too; that
+ * duplicate travels renderer → tRPC → `Session.write()` → PTY stdin
+ * ~20-40ms later. `Session.write()` only drops escape input while the shell
+ * is initializing, so after the first prompt the duplicate lands in whatever
+ * program is reading stdin — go-survey CLIs (gh, vercel, spacectl) abort
+ * with "unexpected escape sequence from terminal: ['\x1b' ']']" and stray
+ * text like `^[[2;1R` leaks onto the prompt (#3499).
  *
- * SAFE to suppress (response-only, query uses different format):
- * - CSI R: CPR response (query is CSI 6n)
- * - CSI I/O: Focus reports (no query, just mode enable)
- * - CSI $y: Mode report (query is CSI $p)
+ * Query-side suppression (handler matches the QUERY and returns `true`,
+ * bypassing xterm's default action so no reply is ever generated):
  *
- * NOT suppressed (would break queries/commands):
- * - CSI c: DA query AND response both end in 'c'
- * - CSI t: Window query AND response both end in 't'
- * - OSC colors: Set command AND response have same format
+ * - DA1 (`CSI c`), DA2 (`CSI > c`), DSR (`CSI 5n`/`CSI 6n`, param-gated),
+ *   DECXCPR (`CSI ? 6 n`, param-gated): the daemon emulator answers these.
+ * - OSC 10/11/12 payloads where any `;`-slot is `?` (color queries):
+ *   deliberately left UNANSWERED — an intentional capability reduction.
+ *   Programs treat a missing reply as a capability gap (and the
+ *   `TERM_THEME`/`COLORFGBG` env hints cover theme detection), whereas a
+ *   renderer reply is exactly the late-stdin leak above. Set commands
+ *   (color-spec slots, no `?`) fall through so themes still propagate.
+ *   Mixed stacked payloads (`?;rgb:...`) are treated as queries: dropping
+ *   their set-slots is preferred over leaking a reply.
+ * - `CSI ? 996 n` (color-scheme query) is intentionally NOT suppressed:
+ *   only the renderer can answer it (`CSI ?997;Pn n`), so suppression would
+ *   delete the capability rather than dedupe it.
+ *
+ * Response-side handlers (predate this change, kept as-is): CPR (`CSI R`),
+ * focus reports (`CSI I`/`CSI O`), ANSI mode report (`CSI $y`) are consumed
+ * so replayed/echoed responses never render. Known pre-existing caveats,
+ * out of scope here: the `I` matcher also swallows CHT (cursor forward
+ * tabulation), and the no-prefix `$y` matcher does not match DEC-mode
+ * reports (`CSI ? … $y`).
  *
  * @param terminal - The xterm.js Terminal instance
  * @returns Cleanup function to dispose all registered handlers
@@ -24,22 +45,55 @@ export function suppressQueryResponses(terminal: Terminal): () => void {
 	const disposables: { dispose: () => void }[] = [];
 	const parser = terminal.parser;
 
-	// CSI sequences ending in 'R' - Cursor Position Report (SAFE)
-	// Query: ESC[6n (ends in 'n'), Response: ESC[24;1R (ends in 'R')
-	// Different final bytes, so suppressing 'R' only catches responses
+	// --- Query-side: never auto-reply; the daemon emulator answers. ---
+
+	// DA1 — Primary Device Attributes. Query: `CSI c` / `CSI 0c`.
+	disposables.push(parser.registerCsiHandler({ final: "c" }, () => true));
+
+	// DA2 — Secondary Device Attributes. Query: `CSI > c`.
+	disposables.push(
+		parser.registerCsiHandler({ prefix: ">", final: "c" }, () => true),
+	);
+
+	// DSR — Device Status Report. Gate on params 5 (status) / 6 (CPR); other
+	// DSR params fall through untouched.
+	disposables.push(
+		parser.registerCsiHandler({ final: "n" }, (params) => {
+			const code = params[0];
+			return code === 5 || code === 6;
+		}),
+	);
+
+	// DECXCPR — `CSI ? 6 n`. Gate on param 6 so `CSI ?996n` (color-scheme
+	// query, renderer-answered) keeps working.
+	disposables.push(
+		parser.registerCsiHandler(
+			{ prefix: "?", final: "n" },
+			(params) => params[0] === 6,
+		),
+	);
+
+	// OSC 10/11/12 — fg/bg/cursor color. Suppress query payloads (any slot
+	// `?`); set commands fall through to the default handler.
+	for (const code of [10, 11, 12]) {
+		disposables.push(
+			parser.registerOscHandler(code, (data) =>
+				data.split(";").some((slot) => slot === "?"),
+			),
+		);
+	}
+
+	// --- Response-side (pre-existing): consume response-shaped sequences so
+	// they never render as text. See header for known caveats.
+
+	// CPR — Cursor Position Report response: `CSI Pr;Pc R`.
 	disposables.push(parser.registerCsiHandler({ final: "R" }, () => true));
 
-	// CSI sequences ending in 'I' - Focus In report (SAFE)
-	// No query - this is sent when terminal gains focus (mode 1004)
+	// Focus reports (mode 1004): `CSI I` in, `CSI O` out.
 	disposables.push(parser.registerCsiHandler({ final: "I" }, () => true));
-
-	// CSI sequences ending in 'O' - Focus Out report (SAFE)
-	// No query - this is sent when terminal loses focus (mode 1004)
 	disposables.push(parser.registerCsiHandler({ final: "O" }, () => true));
 
-	// CSI sequences ending in 'y' with '$' intermediate - Mode Reports (SAFE)
-	// Query: ESC[?Ps$p (ends in 'p'), Response: ESC[?Ps;Pm$y (ends in 'y')
-	// Different final bytes, so suppressing '$y' only catches responses
+	// ANSI mode report: `CSI Ps;Pm $y`.
 	disposables.push(
 		parser.registerCsiHandler({ intermediates: "$", final: "y" }, () => true),
 	);


### PR DESCRIPTION
Fixes #3499 (please reopen, the repro below is deterministic). Related: #3894.

## Problem

Interactive CLIs break in v1 terminals. Example, `gh auth switch`:

```
could not prompt: unexpected escape sequence from terminal: ['\x1b' ']']
```

When a program queries the terminal, two things answer. The daemon's headless emulator replies instantly. The renderer xterm replies again about 40ms later, and that late duplicate lands in the program's stdin while it is reading user input. The escape filter in `Session.write()` only runs during shell startup, so after the first prompt every duplicate gets through. Trace from a local repro:

```
t+0ms   emulator answers  \x1b[2;1R
t+38ms  renderer sends    \x1b]11;rgb:1515/1111/1010\x1b\  plus a duplicate \x1b[2;1R
```

## Fix

The renderer xterm stops auto replying to queries the daemon already answers: DA1, DA2, DSR 5 and 6. It also stops replying to OSC 10/11/12 color queries. Nothing answers those now, which is intentional: programs treat a missing reply as unsupported, and the `TERM_THEME` and `COLORFGBG` env hints cover theme detection. Color set commands still pass through so themes keep working. `CSI ?996n` is untouched because only the renderer can answer it.

v2 is untouched. There the renderer is the only answerer, so suppressing it would hang shells that wait for DA1 (fish waits up to 10 seconds). That is also why this PR takes only the v1 part of what #3894 attempted, with narrower matchers.

## Testing

A new 16 case test suite covers each suppressed query and everything that must keep working. Verified end to end locally: `gh auth switch` failed every time before the fix and works after it, with exactly one reply per query in the trace. Lint, typecheck and the desktop suite pass on current main. Screenshots in the first comment.
