### PR TITLE
feat(desktop): add retry buttons for failed automations

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
@@ -21,7 +21,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { HiOutlineComputerDesktop } from "react-icons/hi2";
-import { LuEllipsis, LuGitBranch, LuSparkles } from "react-icons/lu";
+import {
+	LuEllipsis,
+	LuGitBranch,
+	LuRotateCw,
+	LuSparkles,
+} from "react-icons/lu";
 import type { ProjectOption } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
 import { AgentCell } from "../AgentCell";
@@ -38,6 +43,8 @@ interface AutomationRowProps {
 	/** The automation's most recent run status; null when it has no runs. */
 	lastRunStatus: SelectAutomationRun["status"] | null;
 	isOwner: boolean;
+	/** True while a run/retry dispatch for this automation is in flight. */
+	isRetrying: boolean;
 	onRunNow: (automation: SelectAutomation) => void;
 	onDelete: (automation: SelectAutomation) => void;
 }
@@ -61,6 +68,7 @@ export function AutomationRow({
 	hostLabel,
 	lastRunStatus,
 	isOwner,
+	isRetrying,
 	onRunNow,
 	onDelete,
 }: AutomationRowProps) {
@@ -208,15 +216,47 @@ export function AutomationRow({
 										{meta.label}
 									</span>
 								);
-								return meta.failed ? (
-									<Tooltip>
-										<TooltipTrigger asChild>{cell}</TooltipTrigger>
-										<TooltipContent>
-											The last run failed. Click to see why.
-										</TooltipContent>
-									</Tooltip>
-								) : (
-									cell
+								return (
+									<span className="flex items-center gap-1">
+										{meta.failed ? (
+											<Tooltip>
+												<TooltipTrigger asChild>{cell}</TooltipTrigger>
+												<TooltipContent>
+													The last run failed. Click to see why.
+												</TooltipContent>
+											</Tooltip>
+										) : (
+											cell
+										)}
+										{meta.failed && isOwner && (
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Button
+														variant="ghost"
+														size="icon-sm"
+														disabled={isRetrying}
+														onClick={(e) => {
+															e.stopPropagation();
+															onRunNow(automation);
+														}}
+														aria-label={`Retry ${automation.name}`}
+														className={cn(
+															"size-5 text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover/row:opacity-100",
+															isRetrying && "opacity-100",
+														)}
+													>
+														<LuRotateCw
+															className={cn(
+																"size-3",
+																isRetrying && "animate-spin",
+															)}
+														/>
+													</Button>
+												</TooltipTrigger>
+												<TooltipContent>Retry now</TooltipContent>
+											</Tooltip>
+										)}
+									</span>
 								);
 							})()
 						) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -172,7 +172,7 @@ function AutomationsPage() {
 					? isStaleAgentError(message)
 						? STALE_AGENT_HELP
 						: (message ?? "Failed to retry automation")
-					: `Failed to retry ${failed.length} of ${outcomes.length} automations`,
+					: `Failed to retry ${other.length} of ${outcomes.length} automations`,
 			);
 		},
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -26,12 +26,13 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { Table, TableBody, TableHead, TableRow } from "@superset/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
-import { LuPlus, LuSearchX, LuTerminal, LuX } from "react-icons/lu";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { LuPlus, LuRotateCw, LuSearchX, LuTerminal, LuX } from "react-icons/lu";
 import { useRecentProjects } from "renderer/hooks/host-projects/useRecentProjects";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
@@ -64,6 +65,12 @@ type Scope = "mine" | "team";
 
 type AutomationSortField = "name" | "owner" | "project" | "schedule";
 
+function settledErrorMessage(result: PromiseSettledResult<unknown>) {
+	return result.status === "rejected" && result.reason instanceof Error
+		? result.reason.message
+		: null;
+}
+
 function AutomationsPage() {
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
@@ -80,6 +87,22 @@ function AutomationsPage() {
 	const [hostOfflineRun, setHostOfflineRun] = useState<{
 		hostId: string | null;
 	} | null>(null);
+	const [retryingIds, setRetryingIds] = useState<Set<string>>(new Set());
+
+	const addRetrying = useCallback((ids: string[]) => {
+		setRetryingIds((prev) => {
+			const next = new Set(prev);
+			for (const id of ids) next.add(id);
+			return next;
+		});
+	}, []);
+	const removeRetrying = useCallback((ids: string[]) => {
+		setRetryingIds((prev) => {
+			const next = new Set(prev);
+			for (const id of ids) next.delete(id);
+			return next;
+		});
+	}, []);
 
 	const runNowMutation = useMutation({
 		mutationFn: ({
@@ -89,6 +112,8 @@ function AutomationsPage() {
 			name: string;
 			targetHostId: string | null;
 		}) => apiTrpcClient.automation.runNow.mutate({ id }),
+		onMutate: ({ id }) => addRetrying([id]),
+		onSettled: (_data, _error, { id }) => removeRetrying([id]),
 		onSuccess: (_, { name }) => toast.success(`Running "${name}" now`),
 		onError: (error, { targetHostId }) => {
 			const message = error instanceof Error ? error.message : null;
@@ -101,6 +126,54 @@ function AutomationsPage() {
 				return;
 			}
 			toast.error(message ?? "Failed to trigger run");
+		},
+	});
+
+	const retryAllMutation = useMutation({
+		mutationFn: async (targets: SelectAutomation[]) => {
+			const results = await Promise.allSettled(
+				targets.map((a) =>
+					apiTrpcClient.automation.runNow.mutate({ id: a.id }),
+				),
+			);
+			return targets.map((automation, i) => ({
+				automation,
+				result: results[i],
+			}));
+		},
+		onMutate: (targets) => addRetrying(targets.map((a) => a.id)),
+		onSettled: (_data, _error, targets) =>
+			removeRetrying(targets.map((a) => a.id)),
+		onSuccess: (outcomes) => {
+			const failed = outcomes.filter((o) => o.result.status === "rejected");
+			const retried = outcomes.length - failed.length;
+			if (retried > 0) {
+				toast.success(
+					retried === 1
+						? "Retrying 1 automation"
+						: `Retrying ${retried} automations`,
+				);
+			}
+			if (failed.length === 0) return;
+			const offline = failed.find((o) =>
+				isHostOfflineError(settledErrorMessage(o.result)),
+			);
+			if (offline) {
+				setHostOfflineRun({ hostId: offline.automation.targetHostId });
+			}
+			// The host-offline dialog explains those failures; only toast the rest.
+			const other = failed.filter(
+				(o) => !isHostOfflineError(settledErrorMessage(o.result)),
+			);
+			if (other.length === 0) return;
+			const message = settledErrorMessage(other[0].result);
+			toast.error(
+				other.length === 1
+					? isStaleAgentError(message)
+						? STALE_AGENT_HELP
+						: (message ?? "Failed to retry automation")
+					: `Failed to retry ${failed.length} of ${outcomes.length} automations`,
+			);
 		},
 	});
 
@@ -140,7 +213,8 @@ function AutomationsPage() {
 			})),
 		[collections.users],
 	);
-	const { lastRunStatusById, markMyFailuresSeen } = useFailedAutomations();
+	const { lastRunStatusById, failedIds, markMyFailuresSeen } =
+		useFailedAutomations();
 
 	// Opening the page clears the sidebar failure badge; failures that sync in
 	// while it stays open are marked seen too, until a newer run fails.
@@ -195,6 +269,17 @@ function AutomationsPage() {
 		[automations, currentUserId],
 	);
 	const teamCount = automations.length - mineCount;
+
+	// Only owned automations can be retried; runNow is owner-gated server-side.
+	const failedMine = useMemo(
+		() =>
+			currentUserId
+				? automations.filter(
+						(a) => a.ownerUserId === currentUserId && failedIds.has(a.id),
+					)
+				: [],
+		[automations, currentUserId, failedIds],
+	);
 
 	const visible = useMemo(() => {
 		if (!currentUserId) return automations;
@@ -299,6 +384,34 @@ function AutomationsPage() {
 				<div className="drag h-full min-w-0 flex-1" />
 
 				<div className="flex items-center gap-2">
+					{scope === "mine" && failedMine.length > 0 && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									className="h-8 gap-1.5 px-3"
+									disabled={retryAllMutation.isPending}
+									onClick={() => retryAllMutation.mutate(failedMine)}
+								>
+									<LuRotateCw
+										className={cn(
+											"size-4",
+											retryAllMutation.isPending && "animate-spin",
+										)}
+									/>
+									<span>Retry all</span>
+									<span className="tabular-nums text-xs text-muted-foreground">
+										{failedMine.length}
+									</span>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								Retry every automation whose last run failed
+							</TooltipContent>
+						</Tooltip>
+					)}
 					<Button
 						asChild
 						variant="ghost"
@@ -487,6 +600,7 @@ function AutomationsPage() {
 												lastRunStatusById.get(automation.id) ?? null
 											}
 											isOwner={automation.ownerUserId === currentUserId}
+											isRetrying={retryingIds.has(automation.id)}
 											onRunNow={(a) =>
 												runNowMutation.mutate({
 													id: a.id,


### PR DESCRIPTION
## Summary

Adds user-facing retry for automations in the Automations tab. A retry is a fresh dispatch through the existing `automation.runNow` mutation — no backend changes.

- **Per-row Retry**: failed rows (`skipped_offline` / `dispatch_failed`) get an inline retry icon next to the red "failed" label in the Last run column. Hover-revealed (matching the row-actions pattern), owner-only, spins while the dispatch is in flight.
- **Retry all**: header button (Mine tab only) with a failed count; re-dispatches every owned automation whose last run failed via `Promise.allSettled`, then reports one summary — success toast, host-offline dialog if any target host is offline, and a single error toast for other failures (stale-agent help for a single failure, "failed X of N" otherwise).
- Hidden automatically when nothing is failed: statuses stream back via Electric, so the failed set and button unmount without cache invalidation.
- Shared in-flight id set drives per-row spinners for both individual and bulk retries; existing host-offline / stale-agent error handling carries over unchanged.

## Test Plan

- [x] `bun run typecheck` (desktop) and `bun run lint` pass
- [x] CDP-verified against the dev app with real synced data: "Retry all 10" renders in the header with failed rows present; hovering a failed row reveals the inline Retry button with tooltip
- [ ] Click-through of an actual retry dispatch (creates real runs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry actions for failed automations in the Automations tab, including per-row retry and a “Retry all” option for your automations. Uses the existing `automation.runNow` mutation; no backend changes.

- **New Features**
  - Per-row retry: inline icon next to failed status (`skipped_offline` / `dispatch_failed`), hover-revealed, owner-only, with a spinner while dispatching.
  - Retry all (Mine tab): button with failed count; retries all owned failed automations via `Promise.allSettled` and shows one summary (success toast, host-offline dialog if any offline targets, single error toast for other failures with stale-agent help for a single failure or “failed X of N”).
  - Live updates: the failed set and “Retry all” unmount automatically as statuses stream back; no cache invalidation needed.
  - Shared in-flight state: a unified id set drives per-row spinners for both individual and bulk retries; existing host-offline/stale-agent handling remains unchanged.

- **Bug Fixes**
  - Bulk retry error toast counts only non-offline failures (offline ones are handled by the dialog).

<sup>Written for commit 5b8100db31105f2dc5ce1692028d59225d4d15d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

