### PR TITLE
docs(remote-workspaces): clarify ports are not forwarded locally

### DIFF
--- a/apps/docs/content/docs/agent-integration.mdx
+++ b/apps/docs/content/docs/agent-integration.mdx
@@ -81,7 +81,7 @@ Get notified when agents finish. Configure sounds in Settings.
 
 ## Agent Skills
 
-Teach any agent to drive Superset itself with the official [skills](https://github.com/superset-sh/skills) — one for the `superset` CLI, one for the [MCP server](/mcp-server):
+Teach any agent to drive Superset itself with the official [skills](https://github.com/superset-sh/skills), one for the `superset` CLI and one for the [MCP server](/mcp-server):
 
 ```bash
 npx skills add superset-sh/skills

--- a/apps/docs/content/docs/browser.mdx
+++ b/apps/docs/content/docs/browser.mdx
@@ -36,3 +36,5 @@ Open the DevTools pane alongside any browser tab to inspect and debug the page r
 ## Ports Integration
 
 When Superset detects a port in use (e.g. `localhost:3000`), clicking its external link icon opens it in an in-app browser tab instead of the system browser.
+
+This works for workspaces on the machine you're using. For [remote workspaces](/remote-workspaces), detected ports are listening on the remote host and are not forwarded to your local machine, so `localhost` URLs won't reach them without your own tunnel. See [Port Management](/ports#remote-workspaces).

--- a/apps/docs/content/docs/browser.mdx
+++ b/apps/docs/content/docs/browser.mdx
@@ -37,4 +37,4 @@ Open the DevTools pane alongside any browser tab to inspect and debug the page r
 
 When Superset detects a port in use (e.g. `localhost:3000`), clicking its external link icon opens it in an in-app browser tab instead of the system browser.
 
-For [remote workspaces](/remote-workspaces), ports listen on the remote host and aren't forwarded locally — see [forward a port yourself](/ports#forward-a-port-yourself).
+For [remote workspaces](/remote-workspaces), ports listen on the remote host and aren't forwarded locally; see [forward a port yourself](/ports#forward-a-port-yourself).

--- a/apps/docs/content/docs/browser.mdx
+++ b/apps/docs/content/docs/browser.mdx
@@ -37,4 +37,4 @@ Open the DevTools pane alongside any browser tab to inspect and debug the page r
 
 When Superset detects a port in use (e.g. `localhost:3000`), clicking its external link icon opens it in an in-app browser tab instead of the system browser.
 
-This works for workspaces on the machine you're using. For [remote workspaces](/remote-workspaces), detected ports are listening on the remote host and are not forwarded to your local machine, so `localhost` URLs won't reach them without your own tunnel. See [Port Management](/ports#remote-workspaces).
+For [remote workspaces](/remote-workspaces), ports listen on the remote host and aren't forwarded locally — see [forward a port yourself](/ports#forward-a-port-yourself).

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -394,7 +394,7 @@ superset org members list -s satya
 
 ### projects
 
-A project is a repository checked out on a host. Projects are host-owned —
+A project is a repository checked out on a host. Projects are host-owned:
 each host serves the projects set up on that machine; there is no org-wide
 listing. Workspaces branch off a host's checkout.
 
@@ -591,7 +591,7 @@ than silently falling through to the cloud.
 	quiet="workspace IDs"
 >
 List workspaces on a host. Defaults to this machine; pass `--host <id>` for
-another host. Workspaces are host-owned — there is no org-wide listing (the
+another host. Workspaces are host-owned; there is no org-wide listing (the
 desktop app is the cross-host view). `projectName` falls back to the raw
 project id when the host doesn't know the project's name.
 </Command>
@@ -1059,7 +1059,7 @@ Use [`automations logs`](#superset-automations-logs-id) for run history.
 >
 Create an automation. Provide `--prompt` or `--prompt-file`; if both are
 present, the inline `--prompt` value is used. At least one of `--project`
-or `--workspace` must be provided, and it must exist on the target host —
+or `--workspace` must be provided, and it must exist on the target host;
 the CLI verifies this before creating the automation.
 
 ```bash

--- a/apps/docs/content/docs/cli/getting-started.mdx
+++ b/apps/docs/content/docs/cli/getting-started.mdx
@@ -171,7 +171,7 @@ superset workspaces list --host h_…  # another host
 Every host-scoped command targets exactly one host. Reads
 (`workspaces list`, `projects list`) default to this machine; mutating
 host commands (`projects create`, `projects setup`, `workspaces create`)
-require an explicit `--host` or `--local` — there's no default. There is
+require an explicit `--host` or `--local`; there's no default. There is
 no org-wide listing; the desktop app is the cross-host view.
 
 ## Where state lives

--- a/apps/docs/content/docs/cli/host-server.mdx
+++ b/apps/docs/content/docs/cli/host-server.mdx
@@ -109,7 +109,7 @@ record, and ensures the main workspace.
 If a previous machine of yours already created the project, adopt it
 instead of running `create` again: `create` would register a second,
 unrelated project for the same repo. Projects are host-owned, so pick the
-ID from a machine that has it — `projects list --host <id>` — then:
+ID from a machine that has it (`projects list --host <id>`), then:
 
 ```bash
 # Clone the project's repo onto this machine

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -48,7 +48,7 @@ Create `.superset/ports.json` in your repository:
 - Label entries for ports that are not currently listening are ignored
 - Each workspace reads labels from its own worktree's file
 - Changes are detected automatically
-- Ports can be opened at `localhost:PORT` from the browser action
+- Ports can be opened at `localhost:PORT` from the browser action when the workspace runs on the machine you're using (see [Remote workspaces](#remote-workspaces))
 
 **Error Handling:**
 
@@ -59,6 +59,12 @@ If `ports.json` is malformed:
 **Tips:**
 - Commit `.superset/ports.json` to share port labels with your team
 - **Pro tip:** If you want deterministic per-workspace port ranges, implement it in setup/teardown scripts by reserving a range in a shared file (for example `~/.superset/port-allocations.json`) during setup and releasing it during teardown. See this repo's examples: [`.superset/setup.sh`](https://github.com/superset-sh/superset/blob/main/.superset/setup.sh) and [`.superset/teardown.sh`](https://github.com/superset-sh/superset/blob/main/.superset/teardown.sh).
+
+## Remote Workspaces
+
+For [remote workspaces](/remote-workspaces), the ports sidebar lists ports listening **on the remote host**, not on your local machine. Superset does not forward remote ports to your local machine yet, so `localhost:PORT` URLs only resolve on the host itself — opening one from your local browser won't reach the remote server.
+
+To reach a remote port today, set up your own tunnel to the host, for example [Tailscale](https://tailscale.com) or SSH local forwarding (`ssh -L 3000:localhost:3000 user@host`). Built-in port forwarding is on the roadmap.
 
 ## Discovery and Updates
 

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -64,7 +64,25 @@ If `ports.json` is malformed:
 
 For [remote workspaces](/remote-workspaces), the ports sidebar lists ports listening **on the remote host**, not on your local machine. Superset does not forward remote ports to your local machine yet, so `localhost:PORT` URLs only resolve on the host itself — opening one from your local browser won't reach the remote server.
 
-To reach a remote port today, set up your own tunnel to the host, for example [Tailscale](https://tailscale.com) or SSH local forwarding (`ssh -L 3000:localhost:3000 user@host`). Built-in port forwarding is on the roadmap.
+To reach a remote port today, set up your own tunnel to the host. Built-in port forwarding is on the roadmap.
+
+### Forward a port yourself
+
+**SSH local forwarding** — if you can SSH into the host, forward the port to your local machine:
+
+```bash
+ssh -N -L 3000:localhost:3000 user@remote-host
+```
+
+Then open `http://localhost:3000` in your local browser. This works even when the dev server only listens on loopback. `-N` keeps the tunnel open without starting a shell; the forward lasts as long as the SSH session. Repeat `-L` for additional ports.
+
+**Tailscale** — install [Tailscale](https://tailscale.com) on both machines. On the host, expose the port to your tailnet:
+
+```bash
+tailscale serve 3000
+```
+
+Then open the URL it prints (e.g. `https://remote-host.your-tailnet.ts.net`) from any device on your tailnet. `tailscale serve` proxies to `localhost` on the host, so it also works for loopback-only dev servers. If the server listens on all interfaces (`0.0.0.0`), you can skip `serve` and hit the host's tailnet name or IP directly, e.g. `http://remote-host:3000`.
 
 ## Discovery and Updates
 

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -48,7 +48,7 @@ Create `.superset/ports.json` in your repository:
 - Label entries for ports that are not currently listening are ignored
 - Each workspace reads labels from its own worktree's file
 - Changes are detected automatically
-- Ports can be opened at `localhost:PORT` from the browser action when the workspace runs on the machine you're using (see [Remote workspaces](#remote-workspaces))
+- Ports can be opened at `localhost:PORT` from the browser action ([local workspaces only](#remote-workspaces))
 
 **Error Handling:**
 
@@ -62,27 +62,23 @@ If `ports.json` is malformed:
 
 ## Remote Workspaces
 
-For [remote workspaces](/remote-workspaces), the ports sidebar lists ports listening **on the remote host**, not on your local machine. Superset does not forward remote ports to your local machine yet, so `localhost:PORT` URLs only resolve on the host itself — opening one from your local browser won't reach the remote server.
-
-To reach a remote port today, set up your own tunnel to the host. Built-in port forwarding is on the roadmap.
+For [remote workspaces](/remote-workspaces), the sidebar lists ports listening **on the remote host**. Superset doesn't forward them to your machine yet (it's on the roadmap), so `localhost:PORT` only works on the host itself.
 
 ### Forward a port yourself
 
-**SSH local forwarding** — if you can SSH into the host, forward the port to your local machine:
+**SSH** — forward the port, then open `http://localhost:3000` locally:
 
 ```bash
 ssh -N -L 3000:localhost:3000 user@remote-host
 ```
 
-Then open `http://localhost:3000` in your local browser. This works even when the dev server only listens on loopback. `-N` keeps the tunnel open without starting a shell; the forward lasts as long as the SSH session. Repeat `-L` for additional ports.
-
-**Tailscale** — install [Tailscale](https://tailscale.com) on both machines. On the host, expose the port to your tailnet:
+**[Tailscale](https://tailscale.com)** — on the host, expose the port to your tailnet and open the URL it prints:
 
 ```bash
 tailscale serve 3000
 ```
 
-Then open the URL it prints (e.g. `https://remote-host.your-tailnet.ts.net`) from any device on your tailnet. `tailscale serve` proxies to `localhost` on the host, so it also works for loopback-only dev servers. If the server listens on all interfaces (`0.0.0.0`), you can skip `serve` and hit the host's tailnet name or IP directly, e.g. `http://remote-host:3000`.
+Both work for servers that only listen on loopback. If the server binds `0.0.0.0`, you can skip the tunnel and hit the host's Tailscale name directly (`http://remote-host:3000`).
 
 ## Discovery and Updates
 

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -66,13 +66,13 @@ For [remote workspaces](/remote-workspaces), the sidebar lists ports listening *
 
 ### Forward a port yourself
 
-**SSH** — forward the port, then open `http://localhost:3000` locally:
+**SSH**: forward the port, then open `http://localhost:3000` locally:
 
 ```bash
 ssh -N -L 3000:localhost:3000 user@remote-host
 ```
 
-**[Tailscale](https://tailscale.com)** — on the host, expose the port to your tailnet and open the URL it prints:
+**[Tailscale](https://tailscale.com)**: on the host, expose the port to your tailnet and open the URL it prints:
 
 ```bash
 tailscale serve 3000

--- a/apps/docs/content/docs/remote-workspaces.mdx
+++ b/apps/docs/content/docs/remote-workspaces.mdx
@@ -84,7 +84,7 @@ Pick a remote host to see the workspaces hosted there. Open one and you get the 
 
 ### Ports on a remote host
 
-The ports sidebar shows ports listening **on the remote host** — they aren't forwarded to your machine yet, so `localhost:PORT` only works on the host itself. Forwarding is on the roadmap; until then, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
+The ports sidebar shows ports listening **on the remote host**. They aren't forwarded to your machine yet, so `localhost:PORT` only works on the host itself. Forwarding is on the roadmap; until then, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
 
 ## Turning access off
 

--- a/apps/docs/content/docs/remote-workspaces.mdx
+++ b/apps/docs/content/docs/remote-workspaces.mdx
@@ -80,7 +80,11 @@ On any other device signed into the same organization, open the desktop app's **
 
 ![Device filter in the workspaces list](/images/remote-workspaces-device-filter.png)
 
-Pick a remote host to see the workspaces hosted there. Open one and you get the full Superset experience (terminals, ports, agent runs, the diff viewer) proxied through the relay to the host machine.
+Pick a remote host to see the workspaces hosted there. Open one and you get the full Superset experience (terminals, agent runs, the diff viewer) proxied through the relay to the host machine.
+
+### Ports on a remote host
+
+The ports sidebar for a remote workspace shows ports listening **on the remote host**. Superset does not forward those ports to the machine you're browsing from yet, so `localhost:PORT` URLs only work on the host itself — your local browser can't reach them directly. To access a remote dev server today, set up your own tunnel to the host (for example [Tailscale](https://tailscale.com) or SSH local forwarding: `ssh -L 3000:localhost:3000 user@host`). Built-in port forwarding is on the roadmap. See [Port Management](/ports#remote-workspaces).
 
 ## Turning access off
 

--- a/apps/docs/content/docs/remote-workspaces.mdx
+++ b/apps/docs/content/docs/remote-workspaces.mdx
@@ -84,7 +84,7 @@ Pick a remote host to see the workspaces hosted there. Open one and you get the 
 
 ### Ports on a remote host
 
-The ports sidebar for a remote workspace shows ports listening **on the remote host**. Superset does not forward those ports to the machine you're browsing from yet, so `localhost:PORT` URLs only work on the host itself — your local browser can't reach them directly. Built-in port forwarding is on the roadmap. To access a remote dev server today, set up your own tunnel to the host with SSH or Tailscale — see [Forward a port yourself](/ports#forward-a-port-yourself).
+The ports sidebar shows ports listening **on the remote host** — they aren't forwarded to your machine yet, so `localhost:PORT` only works on the host itself. Forwarding is on the roadmap; until then, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
 
 ## Turning access off
 

--- a/apps/docs/content/docs/remote-workspaces.mdx
+++ b/apps/docs/content/docs/remote-workspaces.mdx
@@ -84,7 +84,7 @@ Pick a remote host to see the workspaces hosted there. Open one and you get the 
 
 ### Ports on a remote host
 
-The ports sidebar for a remote workspace shows ports listening **on the remote host**. Superset does not forward those ports to the machine you're browsing from yet, so `localhost:PORT` URLs only work on the host itself — your local browser can't reach them directly. To access a remote dev server today, set up your own tunnel to the host (for example [Tailscale](https://tailscale.com) or SSH local forwarding: `ssh -L 3000:localhost:3000 user@host`). Built-in port forwarding is on the roadmap. See [Port Management](/ports#remote-workspaces).
+The ports sidebar for a remote workspace shows ports listening **on the remote host**. Superset does not forward those ports to the machine you're browsing from yet, so `localhost:PORT` URLs only work on the host itself — your local browser can't reach them directly. Built-in port forwarding is on the roadmap. To access a remote dev server today, set up your own tunnel to the host with SSH or Tailscale — see [Forward a port yourself](/ports#forward-a-port-yourself).
 
 ## Turning access off
 

--- a/apps/docs/content/docs/sdk/advanced.mdx
+++ b/apps/docs/content/docs/sdk/advanced.mdx
@@ -39,7 +39,7 @@ app.post('/webhooks/sentry', async (c) => {
 
   // 2. Spin up a worktree on a developer's machine and dispatch an agent
   //    inside it. The SDK creates the worktree, then runs the agent with
-  //    your prompt — you don't manage the dispatch loop.
+  //    your prompt; you don't manage the dispatch loop.
   const result = await client.workspaces.create({
     hostId: TARGET_HOST_ID,
     projectId: PROJECT_ID,
@@ -113,7 +113,7 @@ const dispatched = await Promise.all(
           prompt: [
             `Pick up task ${task.slug}: "${task.title}".`,
             ``,
-            task.description ?? '(no description — read recent changes for context)',
+            task.description ?? '(no description; read recent changes for context)',
             ``,
             `Investigate, make the fix, run the relevant tests, push the branch, and`,
             `update task ${task.id} with a one-paragraph summary of what changed and why.`,

--- a/apps/docs/content/docs/sdk/getting-started.mdx
+++ b/apps/docs/content/docs/sdk/getting-started.mdx
@@ -86,9 +86,9 @@ const urgent = await client.tasks.list({
   creatorMe: true,
 });
 
-// Inspect what else you have — projects and workspaces are host-owned
+// Inspect what else you have: projects and workspaces are host-owned
 const [host] = await client.hosts.list();
-if (!host) throw new Error('No hosts registered — run `superset start` on a machine');
+if (!host) throw new Error('No hosts registered; run `superset start` on a machine');
 const projects = await client.projects.list({ hostId: host.id });
 const automations = await client.automations.list();
 
@@ -135,11 +135,11 @@ try {
   await client.tasks.create({ title: '' });
 } catch (err) {
   if (err instanceof RateLimitError) {
-    // 429 — already retried up to maxRetries; back off further if you keep hitting it
+    // 429: already retried up to maxRetries; back off further if you keep hitting it
   } else if (err instanceof NotFoundError) {
     // 404
   } else if (err instanceof APIError) {
-    // anything else — err.status, err.headers, err.error (the parsed body)
+    // anything else: err.status, err.headers, err.error (the parsed body)
     console.error(`Superset returned ${err.status}:`, err.error);
   }
 }

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -117,7 +117,7 @@ Returns `Array<TaskStatus>`. Each entry is `{ id, name, color, type, position }`
 
 ### `workspaces.list({ hostId, projectId?, search? })`
 
-List workspaces on a host. Workspaces are host-owned — there is no org-wide
+List workspaces on a host. Workspaces are host-owned. There is no org-wide
 listing; enumerate hosts with [`hosts.list()`](#hostslist) and query each one
 you care about.
 
@@ -126,12 +126,12 @@ const workspaces = await client.workspaces.list({ hostId: '<machineId>' });
 ```
 
 Returns `Array<Workspace>`. Rows include the host-served `projectName`
-(`string | null` — null when the workspace's project row is missing on that
+(`string | null`; null when the workspace's project row is missing on that
 host, so don't assume it's always present).
 
 ### `workspaces.create({ hostId, projectId, name, branch?, pr?, baseBranch?, taskId?, agents?, command? })`
 
-Create a worktree on a specific host. Provide exactly one of `branch` or `pr` (a pull request number — the host checks out the verified PR head and derives the branch). `baseBranch` picks the fork point when `branch` doesn't exist yet, and `taskId` links the new workspace to a task. Optionally spawn one or more agents inside it as soon as the worktree is ready, and/or run a one-off shell `command` in the worktree. Goes through the relay tunnel: the host must be online.
+Create a worktree on a specific host. Provide exactly one of `branch` or `pr` (a pull request number; the host checks out the verified PR head and derives the branch). `baseBranch` picks the fork point when `branch` doesn't exist yet, and `taskId` links the new workspace to a task. Optionally spawn one or more agents inside it as soon as the worktree is ready, and/or run a one-off shell `command` in the worktree. Goes through the relay tunnel: the host must be online.
 
 Each entry in `agents` takes a preset id (e.g. `"claude"`) or a `HostAgentConfig` instance UUID: the host service resolves it against its configured rows and copies their stored `command`, `args`, and `env`. Set `effort` to override the agent's reasoning effort for that launch, or omit it to use the agent's own default. Use [`agents.list({ hostId })`](#agentslist-hostid-) to enumerate what's installed. `command` is independent of `agents`. Pass either or both.
 
@@ -141,7 +141,7 @@ const result = await client.workspaces.create({
   projectId: '<uuid>',       // see projects.list()
   name: 'wire-up-auth',
   branch: 'feat/auth',
-  agents: [                  // optional — spawn agents on creation
+  agents: [                  // optional: spawn agents on creation
     { agent: 'claude', effort: 'high', prompt: 'Implement the auth flow described in SUPER-100.' },
     { agent: 'claude', prompt: 'Write integration tests for the new auth flow.' },
   ],
@@ -185,7 +185,7 @@ await client.workspaces.delete('<workspaceId>', { hostId: '<machineId>' });
 
 ### `projects.list({ hostId })`
 
-List projects set up on a host. Projects are host-owned — there is no
+List projects set up on a host. Projects are host-owned; there is no
 org-wide project registry.
 
 ```ts
@@ -322,7 +322,7 @@ await client.automations.update({ id, rrule: 'FREQ=WEEKLY;BYDAY=MO' });
 ### `automations.run(id)`
 
 Dispatch immediately, off-schedule. Goes through the relay to the automation's
-target host. Returns identifiers for the dispatched run, not the full run row —
+target host. Returns identifiers for the dispatched run, not the full run row;
 use [`automations.logs(id)`](#automationslogsid-params) for status.
 
 ```ts

--- a/apps/marketing/content/changelog/2026-04-27-hosts-settings-terminal-sessions.mdx
+++ b/apps/marketing/content/changelog/2026-04-27-hosts-settings-terminal-sessions.mdx
@@ -10,7 +10,7 @@ image: /changelog/v2-public-beta.png
 
 ## Remote workspaces
 
-Every workspace in 2.0 is a cloud workspace. Point your local app at any Superset device on the same network — a beefier box across the room, a cloud VM, a teammate's host — and run workspaces on it as if they were local. Terminal, file editor, and chat all behave the same way <PRBadge url="https://github.com/superset-sh/superset/pull/3566" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3606" />, and ports running on the remote surface in your sidebar so your local browser can hit them <PRBadge url="https://github.com/superset-sh/superset/pull/3676" />.
+Every workspace in 2.0 is a cloud workspace. Point your local app at any Superset device on the same network — a beefier box across the room, a cloud VM, a teammate's host — and run workspaces on it as if they were local. Terminal, file editor, and chat all behave the same way <PRBadge url="https://github.com/superset-sh/superset/pull/3566" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3606" />, and ports listening on the remote host show up in your sidebar <PRBadge url="https://github.com/superset-sh/superset/pull/3676" />.
 
 ![Sidebar with a Cloud workspace group and a remote workspace hover card](/changelog/v2-remote-workspaces.png)
 

--- a/apps/marketing/content/changelog/2026-07-06-custom-agents-workspace-activity-fable.mdx
+++ b/apps/marketing/content/changelog/2026-07-06-custom-agents-workspace-activity-fable.mdx
@@ -17,9 +17,9 @@ You can now add your own custom terminal agents alongside the built-ins, each wi
 
 The v2 sidebar now surfaces what each workspace is actually doing in a single compact activity strip.
 
-<Video src="/changelog/2026-07-06-activity-strip.mp4" title="Running agents and forwarded ports shown inline on the workspace item" />
+<Video src="/changelog/2026-07-06-activity-strip.mp4" title="Running agents and open ports shown inline on the workspace item" />
 
-- Running agents and forwarded ports live inline on the workspace item <PRBadge url="https://github.com/superset-sh/superset/pull/5414" />
+- Running agents and open ports live inline on the workspace item <PRBadge url="https://github.com/superset-sh/superset/pull/5414" />
 - Running and PR state persist across restarts, with a Clear Status action <PRBadge url="https://github.com/superset-sh/superset/pull/5349" />
 - Live-work sections are emphasized so in-progress workspaces stand out <PRBadge url="https://github.com/superset-sh/superset/pull/5416" />
 - Agent chips stay hidden unless multiple agents are running <PRBadge url="https://github.com/superset-sh/superset/pull/5445" />
@@ -65,7 +65,7 @@ The macOS dock icon now shows a badge for workspaces with unread activity or tha
 - Batched folder-level Discard All to avoid git index.lock races <PRBadge url="https://github.com/superset-sh/superset/pull/5442" />
 - Fixed terminal resize bricking the parser mid inline-image decode <PRBadge url="https://github.com/superset-sh/superset/pull/5352" />
 - Kept workspace PR and diff state from drifting out of sync with GitHub <PRBadge url="https://github.com/superset-sh/superset/pull/5455" />
-- Recovered v2 forwarded ports promptly after a host-service restart <PRBadge url="https://github.com/superset-sh/superset/pull/5430" />
+- Recovered v2 open ports promptly after a host-service restart <PRBadge url="https://github.com/superset-sh/superset/pull/5430" />
 - Detect ports for terminals without an attached renderer <PRBadge url="https://github.com/superset-sh/superset/pull/5325" />
 - Kept device and workspace host in sync for automations <PRBadge url="https://github.com/superset-sh/superset/pull/5394" />
 - Fixed billing to read invoices from the org's canonical Stripe customer <PRBadge url="https://github.com/superset-sh/superset/pull/5406" />

--- a/apps/marketing/content/changelog/2026-07-06-tweet.md
+++ b/apps/marketing/content/changelog/2026-07-06-tweet.md
@@ -17,7 +17,7 @@ We're betting the future is many specialized agents, not one — so we added Pol
 
 2. Workspace activity strip 👀
 
-When you're running a fleet of agents you need to see the whole board at a glance. The v2 sidebar now shows what each workspace is actually doing — running agents and forwarded ports inline on every row, persisted across restarts, with in-progress work pushed to the top.
+When you're running a fleet of agents you need to see the whole board at a glance. The v2 sidebar now shows what each workspace is actually doing — running agents and open ports inline on every row, persisted across restarts, with in-progress work pushed to the top.
 
 3. Fable 5 + reasoning effort 🧠
 


### PR DESCRIPTION
## Summary

Product docs incorrectly implied that ports from remote workspaces are forwarded to the user's local machine. They are not (yet) — the ports sidebar shows ports listening **on the remote host**, and `localhost:PORT` URLs only resolve on the host itself. This PR fixes the docs to describe the real behavior.

Ground truth: Kiet's support reply to a Pro user (Aug 2) — ports list = remote host ports; no local forwarding yet; proper forwarding is planned; workaround today is the user's own tunnel (Tailscale or `ssh -L`).

## Changes

- **apps/docs/content/docs/ports.mdx** — new *Remote Workspaces* section stating ports are host-local, not forwarded; tunnel workaround; forwarding on the roadmap. Scoped the `localhost:PORT` browser-action bullet to local workspaces.
- **apps/docs/content/docs/remote-workspaces.mdx** — removed "ports" from the list of things proxied through the relay; added *Ports on a remote host* subsection with the same clarification.
- **apps/docs/content/docs/browser.mdx** — noted the ports→in-app-browser integration only reaches local workspaces; linked to the new docs section.
- **Marketing changelogs** — removed the claim that "your local browser can hit" remote ports (2026-04-27) and renamed "forwarded ports" to "open ports" (2026-07-06 entry + tweet copy).

Docs/content only — no product code touched.

## Verification

- `grep` sweep: no remaining doc text claims remote ports are forwarded or reachable via local localhost.
- `bun run lint` exits 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that remote workspace ports are not forwarded to your machine; they are host‑local. Adds a quick how‑to for tunneling (`ssh -L`, Tailscale `serve`) and standardizes punctuation across docs; built‑in forwarding is on the roadmap.

- **Bug Fixes**
  - Ports docs: Added Remote Workspaces section; scoped `localhost:PORT` to local workspaces; added “Forward a port yourself” (SSH, Tailscale); updated `browser.mdx` and `remote-workspaces.mdx` to link and reflect this.
  - Copy cleanup: Replaced em dashes with plain punctuation across docs/CLI/SDK pages; updated marketing changelogs/tweet to say “open ports” and removed the local‑browser claim.

<sup>Written for commit 93ae1fa064f1e8c2763656a5ed7ca9f41ce27201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how ports work in local and remote workspaces.
  * Documented SSH and Tailscale tunneling options for accessing remote ports.
  * Explained direct access for remote servers bound to `0.0.0.0`.
  * Updated port terminology across workspace activity and changelog content.
  * Improved punctuation, formatting, and readability throughout CLI, SDK, and agent integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->