### PR TITLE
docs(contributing): strongly prefer screenshots and add CDP capture guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,11 @@ PR titles become the squash-merge commit subject, so use conventional commit for
 
 ## How I tested it
 
-<!-- What you ran or clicked to verify this works. For UI changes, add a screenshot or recording below. -->
+<!--
+What you ran or clicked to verify this works. Screenshots are strongly preferred
+for anything user-visible — before/after for bug fixes. See "Capturing screenshots
+via CDP" in CONTRIBUTING.md for how to capture them from the dev app.
+-->
 
 ## Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,18 @@ See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide.
 
 - **A conventional-commit title.** We squash-merge with the title as the commit subject, so it needs to look like `feat(desktop): add copy-logs button` or `fix(web): guard against missing PR`.
 - **One change per PR.** Small PRs get reviewed in hours. If you found an unrelated bug along the way, open a second PR.
-- **Proof it works.** Say what you ran or clicked. UI changes need a screenshot or recording.
+- **Proof it works — screenshots strongly preferred.** Say what you ran or clicked, and show it. Any user-visible change needs a screenshot or recording in the PR description; for bug fixes, before/after screenshots are ideal. A PR with screenshots gets reviewed much faster than one we have to check out and run ourselves. See [capturing screenshots via CDP](#capturing-screenshots-via-cdp) below.
 - **A linked issue for non-trivial changes** so reviewers have the context.
+
+### Capturing screenshots via CDP
+
+The dev desktop app exposes the Chrome DevTools Protocol, so you (or your coding agent) can drive the real app and capture screenshots without manual cropping:
+
+1. Launch the dev app with a debugging port: `RENDERER_REMOTE_DEBUG_PORT=9222 bun dev` (pick an unused port — multiple workspaces often run at once).
+2. Confirm you're attached to *this* workspace's app: fetch `http://127.0.0.1:<port>/json/list` and check the page target's URL matches your workspace's `DESKTOP_VITE_PORT` from `.env`. Never assume a responding CDP endpoint is yours.
+3. Navigate the real UI to the state you changed (real clicks and input, not injected DOM state), then capture with `Page.captureScreenshot`.
+
+For the full workflow — attaching over WebSocket, matching the right renderer, and repairing auth — see [`apps/desktop/AGENTS.md`](./apps/desktop/AGENTS.md) ("Verifying renderer changes via CDP") and the "CDP UI Verification" section of [`AGENTS.md`](./AGENTS.md) for what counts as end-to-end evidence. `apps/desktop/scripts/cdp-smoke-integrations.ts` is a working example script.
 
 ## Style
 


### PR DESCRIPTION
## What & why

Contribution guidance now strongly prefers screenshots as proof for anything user-visible, and tells contributors (and their coding agents) how to capture them from the dev desktop app via CDP.

- **CONTRIBUTING.md**: the "Proof it works" bullet now requires a screenshot/recording for user-visible changes (before/after for bug fixes), and a new "Capturing screenshots via CDP" section covers launching with `RENDERER_REMOTE_DEBUG_PORT`, verifying the CDP target belongs to your workspace, and capturing real UI interactions — linking to the detailed runbooks in `apps/desktop/AGENTS.md` and root `AGENTS.md` instead of duplicating them.
- **pull_request_template.md**: the "How I tested it" hint now states the screenshot preference and points at the new CONTRIBUTING.md section.

## Test Plan

- [x] Docs-only change; verified the `#capturing-screenshots-via-cdp` anchor and relative links resolve.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens contribution guidelines by preferring screenshots/recordings for any user-visible change and adds clear CDP screenshot capture guidance for the dev desktop app. Updates the PR template to ask for before/after screenshots and link to the new section.

- CONTRIBUTING.md: new “Capturing screenshots via CDP” section (launch with `RENDERER_REMOTE_DEBUG_PORT`, verify the correct target, capture with `Page.captureScreenshot`) and a stronger “Proof it works” requirement.
- pull_request_template.md: “How I tested it” now prefers screenshots and links to the new CDP section.

<sup>Written for commit 586e88131ac7417e67f362fb90d53a9c9616194a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

