### PR TITLE
fix(desktop): stabilize Codex working indicator

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -7,6 +7,7 @@ import {
 	getManagedNotifyHookCommand,
 	isSupersetManagedHookCommand,
 	MANAGED_NOTIFY_RELATIVE_PATH,
+	MANAGED_NOTIFY_RUNTIME_PATH,
 	writeFileIfChanged,
 } from "./agent-wrappers-common";
 import { getNotifyScriptPath, NOTIFY_SCRIPT_NAME } from "./notify-hook";
@@ -67,7 +68,7 @@ interface ClaudeSettingsJson {
 	[key: string]: unknown;
 }
 
-const DYNAMIC_NOTIFY_PATH_MARKER = `$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}`;
+const LEGACY_DYNAMIC_NOTIFY_PATH_MARKER = `$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}`;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -84,7 +85,8 @@ function isManagedClaudeHookCommand(
 ): boolean {
 	return (
 		command?.includes(notifyScriptPath) ||
-		command?.includes(DYNAMIC_NOTIFY_PATH_MARKER) ||
+		command?.includes(MANAGED_NOTIFY_RUNTIME_PATH) ||
+		command?.includes(LEGACY_DYNAMIC_NOTIFY_PATH_MARKER) ||
 		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
 	);
 }
@@ -310,7 +312,8 @@ function isManagedCodexHookCommand(
 ): boolean {
 	return (
 		command?.includes(notifyScriptPath) ||
-		command?.includes(DYNAMIC_NOTIFY_PATH_MARKER) ||
+		command?.includes(MANAGED_NOTIFY_RUNTIME_PATH) ||
+		command?.includes(LEGACY_DYNAMIC_NOTIFY_PATH_MARKER) ||
 		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
 	);
 }

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -67,7 +67,7 @@ interface ClaudeSettingsJson {
 	[key: string]: unknown;
 }
 
-const CLAUDE_DYNAMIC_NOTIFY_PATH_MARKER = `$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}`;
+const DYNAMIC_NOTIFY_PATH_MARKER = `$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}`;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -84,7 +84,7 @@ function isManagedClaudeHookCommand(
 ): boolean {
 	return (
 		command?.includes(notifyScriptPath) ||
-		command?.includes(CLAUDE_DYNAMIC_NOTIFY_PATH_MARKER) ||
+		command?.includes(DYNAMIC_NOTIFY_PATH_MARKER) ||
 		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
 	);
 }
@@ -310,6 +310,7 @@ function isManagedCodexHookCommand(
 ): boolean {
 	return (
 		command?.includes(notifyScriptPath) ||
+		command?.includes(DYNAMIC_NOTIFY_PATH_MARKER) ||
 		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
 	);
 }
@@ -353,7 +354,7 @@ export function getCodexGlobalHooksJsonPath(): string {
 
 /**
  * Reads existing ~/.codex/hooks.json, merges our hook definitions
- * (identified by notify script path), and preserves any user-defined hooks.
+ * (identified by the managed notify script), and preserves user-defined hooks.
  *
  * Codex hooks.json uses the same nested structure as Claude/Droid:
  *   { hooks: { EventName: [{ matcher?, hooks: [{ type, command }] }] } }
@@ -394,11 +395,9 @@ export function getCodexGlobalHooksJsonContent(
 		existing.hooks[eventName] = filtered;
 	}
 
-	// Inline SUPERSET_AGENT_ID like getClaudeManagedHookCommand so the v2
-	// payload carries identity even when codex is launched outside the wrapper.
-	// Quote the path: codex executes via /bin/sh -lc, so a space in $HOME
-	// (e.g. "/Users/Some User/...") would otherwise word-split.
-	const codexCommand = `SUPERSET_AGENT_ID=codex "${notifyScriptPath}"`;
+	// Resolve the active Superset home when the hook runs. A global absolute path
+	// becomes stale whenever another dev worktree rewrites hooks.json or is removed.
+	const codexCommand = getManagedNotifyHookCommand("codex");
 
 	const managedEvents: Array<{
 		eventName: "SessionStart" | "UserPromptSubmit" | "Stop";

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
@@ -10,15 +10,19 @@ export { SUPERSET_MANAGED_BINARIES };
 /** Path (under SUPERSET_HOME_DIR) of the runtime notify hook script. */
 export const MANAGED_NOTIFY_RELATIVE_PATH = `hooks/${NOTIFY_SCRIPT_NAME}`;
 
+/** Runtime notify path with the canonical production home as a shell fallback. */
+export const MANAGED_NOTIFY_RUNTIME_PATH = `\${SUPERSET_HOME_DIR:-$HOME/.superset}/${MANAGED_NOTIFY_RELATIVE_PATH}`;
+
 /**
  * Shell command written into an agent's global hook config. The notify path is
  * resolved at runtime from SUPERSET_HOME_DIR so one shared config works for both
- * dev and prod installs, and `SUPERSET_AGENT_ID` is inlined so the v2 hook
- * payload carries wrapper-level identity even when the agent is launched outside
- * the Superset wrapper (system PATH resolves the real binary directly).
+ * dev and prod installs. Direct launches outside a Superset terminal fall back
+ * to the canonical ~/.superset home. `SUPERSET_AGENT_ID` is inlined so the v2
+ * hook payload carries wrapper-level identity even when the system PATH resolves
+ * the real binary directly.
  */
 export function getManagedNotifyHookCommand(agentId: string): string {
-	return `[ -n "$SUPERSET_HOME_DIR" ] && [ -x "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" ] && SUPERSET_AGENT_ID=${agentId} "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" || true`;
+	return `[ -x "${MANAGED_NOTIFY_RUNTIME_PATH}" ] && SUPERSET_AGENT_ID=${agentId} "${MANAGED_NOTIFY_RUNTIME_PATH}" || true`;
 }
 
 // Dev setup (.superset/lib/setup/steps.sh) points SUPERSET_HOME_DIR at

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -87,12 +87,39 @@ const {
 	getPiExtensionPath,
 	PI_EXTENSION_MARKER,
 } = await import("./agent-wrappers");
-const { getManagedNotifyHookCommand, reconcileManagedEntries } = await import(
-	"./agent-wrappers-common"
-);
+const {
+	getManagedNotifyHookCommand,
+	MANAGED_NOTIFY_RUNTIME_PATH,
+	reconcileManagedEntries,
+} = await import("./agent-wrappers-common");
 
 const managedClaudeHookCommand = getClaudeManagedHookCommand();
 const managedCodexHookCommand = getManagedNotifyHookCommand("codex");
+
+describe("getManagedNotifyHookCommand", () => {
+	it("uses the canonical Superset home for direct launches without an environment override", () => {
+		const fallbackHome = path.join(TEST_ROOT, "fallback home");
+		const fallbackHookPath = path.join(
+			fallbackHome,
+			".superset",
+			"hooks",
+			"notify.sh",
+		);
+		mkdirSync(path.dirname(fallbackHookPath), { recursive: true });
+		writeFileSync(
+			fallbackHookPath,
+			'#!/bin/sh\nprintf "%s" "$SUPERSET_AGENT_ID"\n',
+		);
+		chmodSync(fallbackHookPath, 0o755);
+
+		const output = execFileSync("/bin/sh", ["-c", managedCodexHookCommand], {
+			encoding: "utf-8",
+			env: { HOME: fallbackHome },
+		});
+
+		expect(output).toBe("codex");
+	});
+});
 
 describe("reconcileManagedEntries", () => {
 	it("preserves user-managed entries while replacing stale managed entries", () => {
@@ -1226,9 +1253,7 @@ describe("agent-wrappers codex hooks.json", () => {
 				}>
 			>;
 		};
-		expect(managedCodexHookCommand).toContain(
-			"$SUPERSET_HOME_DIR/hooks/notify.sh",
-		);
+		expect(managedCodexHookCommand).toContain(MANAGED_NOTIFY_RUNTIME_PATH);
 		expect(managedCodexHookCommand).toContain("SUPERSET_AGENT_ID=codex");
 		expect(content).not.toContain(notifyPath);
 
@@ -1384,6 +1409,8 @@ describe("agent-wrappers codex hooks.json", () => {
 		const codexHooksPath = path.join(mockedHomeDir, ".codex", "hooks.json");
 		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
 		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+		const legacyDynamicCommand =
+			'[ -n "$SUPERSET_HOME_DIR" ] && [ -x "$SUPERSET_HOME_DIR/hooks/notify.sh" ] && SUPERSET_AGENT_ID=codex "$SUPERSET_HOME_DIR/hooks/notify.sh" || true';
 
 		mkdirSync(path.dirname(codexHooksPath), { recursive: true });
 		writeFileSync(
@@ -1393,7 +1420,10 @@ describe("agent-wrappers codex hooks.json", () => {
 					hooks: {
 						SessionStart: [
 							{
-								hooks: [{ type: "command", command: staleHookPath }],
+								hooks: [
+									{ type: "command", command: staleHookPath },
+									{ type: "command", command: legacyDynamicCommand },
+								],
 							},
 						],
 						Stop: [
@@ -1446,6 +1476,11 @@ describe("agent-wrappers codex hooks.json", () => {
 			expect(
 				hooks.some((def) =>
 					def.hooks.some((hook) => hook.command.includes(staleHookPath)),
+				),
+			).toBe(false);
+			expect(
+				hooks.some((def) =>
+					def.hooks.some((hook) => hook.command === legacyDynamicCommand),
 				),
 			).toBe(false);
 		}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -87,9 +87,12 @@ const {
 	getPiExtensionPath,
 	PI_EXTENSION_MARKER,
 } = await import("./agent-wrappers");
-const { reconcileManagedEntries } = await import("./agent-wrappers-common");
+const { getManagedNotifyHookCommand, reconcileManagedEntries } = await import(
+	"./agent-wrappers-common"
+);
 
 const managedClaudeHookCommand = getClaudeManagedHookCommand();
+const managedCodexHookCommand = getManagedNotifyHookCommand("codex");
 
 describe("reconcileManagedEntries", () => {
 	it("preserves user-managed entries while replacing stale managed entries", () => {
@@ -1223,8 +1226,12 @@ describe("agent-wrappers codex hooks.json", () => {
 				}>
 			>;
 		};
+		expect(managedCodexHookCommand).toContain(
+			"$SUPERSET_HOME_DIR/hooks/notify.sh",
+		);
+		expect(managedCodexHookCommand).toContain("SUPERSET_AGENT_ID=codex");
+		expect(content).not.toContain(notifyPath);
 
-		const expectedCommand = `SUPERSET_AGENT_ID=codex "${notifyPath}"`;
 		for (const eventName of [
 			"SessionStart",
 			"UserPromptSubmit",
@@ -1234,7 +1241,7 @@ describe("agent-wrappers codex hooks.json", () => {
 			expect(Array.isArray(hooks)).toBe(true);
 			expect(
 				hooks.some((def) =>
-					def.hooks.some((hook) => hook.command === expectedCommand),
+					def.hooks.some((hook) => hook.command === managedCodexHookCommand),
 				),
 			).toBe(true);
 		}
@@ -1339,7 +1346,6 @@ describe("agent-wrappers codex hooks.json", () => {
 			),
 		).toBe(true);
 
-		const expectedManagedCommand = `SUPERSET_AGENT_ID=codex "${notifyPath}"`;
 		// Adds managed hooks for SessionStart, UserPromptSubmit, Stop
 		for (const eventName of ["SessionStart", "UserPromptSubmit", "Stop"]) {
 			expect(
@@ -1347,7 +1353,7 @@ describe("agent-wrappers codex hooks.json", () => {
 					(def: { hooks: Array<{ command: string }> }) =>
 						def.hooks.some(
 							(hook: { command: string }) =>
-								hook.command === expectedManagedCommand,
+								hook.command === managedCodexHookCommand,
 						),
 				),
 			).toBe(true);
@@ -1359,7 +1365,7 @@ describe("agent-wrappers codex hooks.json", () => {
 				(def: { hooks: Array<{ command: string }> }) =>
 					def.hooks.some(
 						(hook: { command: string }) =>
-							hook.command === expectedManagedCommand,
+							hook.command === managedCodexHookCommand,
 					),
 			),
 		).toBe(false);
@@ -1368,13 +1374,13 @@ describe("agent-wrappers codex hooks.json", () => {
 				(def: { hooks: Array<{ command: string }> }) =>
 					def.hooks.some(
 						(hook: { command: string }) =>
-							hook.command === expectedManagedCommand,
+							hook.command === managedCodexHookCommand,
 					),
 			),
 		).toBe(false);
 	});
 
-	it("replaces stale Codex hook commands from old superset paths", () => {
+	it("replaces stale Codex hook commands with a worktree-independent command", () => {
 		const codexHooksPath = path.join(mockedHomeDir, ".codex", "hooks.json");
 		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
 		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
@@ -1409,9 +1415,11 @@ describe("agent-wrappers codex hooks.json", () => {
 		expect(content).not.toBeNull();
 		if (content === null) throw new Error("Expected content");
 
-		// Second run should be idempotent
+		// A different worktree should keep the same global command and config.
 		writeFileSync(codexHooksPath, content);
-		const content2 = getCodexGlobalHooksJsonContent(currentHookPath);
+		const content2 = getCodexGlobalHooksJsonContent(
+			"/tmp/.superset-another/hooks/notify.sh",
+		);
 
 		const parsed = JSON.parse(content) as {
 			hooks: Record<
@@ -1423,7 +1431,6 @@ describe("agent-wrappers codex hooks.json", () => {
 			>;
 		};
 
-		const expectedManagedCommand = `SUPERSET_AGENT_ID=codex "${currentHookPath}"`;
 		for (const eventName of [
 			"SessionStart",
 			"UserPromptSubmit",
@@ -1433,7 +1440,7 @@ describe("agent-wrappers codex hooks.json", () => {
 			expect(Array.isArray(hooks)).toBe(true);
 			expect(
 				hooks.some((def) =>
-					def.hooks.some((hook) => hook.command === expectedManagedCommand),
+					def.hooks.some((hook) => hook.command === managedCodexHookCommand),
 				),
 			).toBe(true);
 			expect(
@@ -1499,7 +1506,6 @@ describe("agent-wrappers codex hooks.json", () => {
 			>;
 		};
 
-		const expectedManagedCommand = `SUPERSET_AGENT_ID=codex "${currentHookPath}"`;
 		expect(parsed.hooks.UserPromptSubmit).toBeDefined();
 		expect(
 			parsed.hooks.UserPromptSubmit?.some((def) =>
@@ -1515,7 +1521,7 @@ describe("agent-wrappers codex hooks.json", () => {
 		).toBe(false);
 		expect(
 			parsed.hooks.UserPromptSubmit?.some((def) =>
-				def.hooks.some((hook) => hook.command === expectedManagedCommand),
+				def.hooks.some((hook) => hook.command === managedCodexHookCommand),
 			),
 		).toBe(true);
 	});
@@ -1563,7 +1569,6 @@ describe("agent-wrappers codex hooks.json", () => {
 			>;
 		};
 
-		const expectedManagedCommand = `SUPERSET_AGENT_ID=codex "${currentHookPath}"`;
 		for (const eventName of [
 			"SessionStart",
 			"UserPromptSubmit",
@@ -1573,7 +1578,7 @@ describe("agent-wrappers codex hooks.json", () => {
 			expect(Array.isArray(hooks)).toBe(true);
 			expect(
 				hooks.some((def) =>
-					def.hooks.some((hook) => hook.command === expectedManagedCommand),
+					def.hooks.some((hook) => hook.command === managedCodexHookCommand),
 				),
 			).toBe(true);
 			expect(


### PR DESCRIPTION
## Summary

- resolve Codex native lifecycle hooks through the active `SUPERSET_HOME_DIR` at runtime instead of persisting one worktree's absolute `notify.sh` path
- recognize the shared runtime command as Superset-managed so hook reconciliation stays idempotent
- preserve user-defined Codex hooks while replacing stale Superset paths

## Root cause

Claude already stores a guarded runtime command in its global hook config, but Codex stored the absolute notify path from whichever Superset instance initialized most recently. Starting a different dev worktree rewrote that global path and Codex's exact hook-definition trust entry; removing that worktree left native `SessionStart`, `UserPromptSubmit`, and `Stop` hooks pointing at a missing script. Codex itself continued working, but Superset never received the lifecycle event that drives the sidebar indicator.

The wrapper log watcher could mask this for the default preset, which is why the failure is most visible when Codex is launched directly or the watcher cannot observe the current session format.

This is intentionally the narrow hook-path correction. It overlaps the Codex command portion of #6072, while leaving that PR's broader per-agent toggle and hook-scoping work untouched.

## Verification

- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — 52 passed
- `bun run lint` — passed, zero warnings
- `bun run --cwd apps/desktop typecheck` — passed
- `bun run --cwd apps/desktop compile:app` — passed
- exact-worktree Electron CDP journey — passed on renderer `http://localhost:3205`, CDP `9341`, route `/v2-workspace/f1582787-5b36-4eba-a906-c13bf7000263`
  - opened **Open Terminal** through real pointer input
  - launched `/Users/roshvan/.local/bin/codex` directly with native hooks enabled
  - submitted a real prompt through terminal input
  - confirmed the sidebar spinner appears while Codex is working and clears after `Stop`
- `bun run typecheck` — unrelated current-main failure in `apps/docs`: cannot resolve `@superset/ui/overflow-fade-container`; desktop-scoped typecheck passes

## Visual verification

**Before — stale absolute hook:** Codex is working, but `SessionStart` and `UserPromptSubmit` fail with code 127 and the sidebar remains idle.

![Codex working while stale native hooks fail and the sidebar remains idle](https://github.com/user-attachments/assets/7637bcd4-7efe-4e0f-ba2e-c6fcaed36baa)

**After — active Codex turn:** native hooks run successfully and the amber spinner is visible beside Delta newest.

![Codex working with the amber Superset sidebar spinner visible](https://github.com/user-attachments/assets/2ab1ce9e-de8b-4b82-a568-1ef209ee089d)

**After completion:** the response completes and the sidebar returns to its idle dot after the `Stop` lifecycle.

![Codex response complete and the Superset sidebar indicator returned to idle](https://github.com/user-attachments/assets/35f6b630-dd9b-4542-9470-1d2454d13ea3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex and Claude managed hook detection across different worktree locations.
  * Updated managed hooks to use a consistent environment-based notification path, preventing stale or location-specific configurations.
  * Preserved user-defined hooks while safely replacing outdated managed entries.
  * Prevented managed hooks from being added to unsupported event types.
  * Improved hook reliability when the notification script is unavailable or not executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->