### PR TITLE
fix(desktop): keep sidebar Projects chevron visible while the section is collapsed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -69,8 +69,12 @@ export function DashboardSidebarWorkspacesHeader() {
 			<span className="min-w-0 truncate text-left">Projects</span>
 			<HiChevronRight
 				className={cn(
-					"size-3 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
-					!isCollapsed && "rotate-90",
+					"size-3 shrink-0 text-muted-foreground transition-[opacity,transform] duration-150",
+					// Stays visible while collapsed — it's the only cue that the
+					// project rows are hidden rather than missing (GH #6009).
+					isCollapsed
+						? "opacity-100"
+						: "rotate-90 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
 				)}
 			/>
 			<div className="min-w-0 flex-1" />


### PR DESCRIPTION
Fixes #6009.

## What happened

The entire "PROJECTS" header strip is a collapse toggle (`role="button"` with `onClick={toggleCollapsed}`), and the state persists to localStorage (`sidebar-workspaces-collapse`). One stray click on the strip collapses the section — but the chevron that indicates the collapsed state was `opacity-0` unless hovered, so the section just looked **empty**: header and + button render, zero project rows, survives Cmd+R and restarts. The collapsed icon rail bypasses the gate (`isCollapsed || !workspacesListCollapsed` in `DashboardSidebar.tsx`), which is why icons still showed there — exactly the confusing split the reporter described.

The macOS App Management prompt in the report is coincidental; nothing ties this store to permissions. The likely sequence is a click into the sidebar afterwards landing on the header strip (same accidental-toggle class as #6000).

## The fix

Keep the chevron visible (right-pointing) whenever the section is collapsed, so the state reads as "collapsed, click to expand" instead of "my projects are gone". Expanded behavior is unchanged: chevron stays hover/focus-only.

## Evidence (CDP-driven dev app, real header clicks)

Reproduced end-to-end before the fix: one synthetic click on the header persisted `{"isCollapsed":true}` and emptied the section; rail icons unaffected; state survived `location.reload()`; clicking the header again restored all rows.

| Before (collapsed = looks broken) | After (collapsed) | After (expanded, unchanged) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/superset-sh/superset/evidence/fix-6009-projects-collapsed-chevron/before-fix-collapsed.png) | ![after collapsed](https://raw.githubusercontent.com/superset-sh/superset/evidence/fix-6009-projects-collapsed-chevron/after-fix-collapsed.png) | ![after expanded](https://raw.githubusercontent.com/superset-sh/superset/evidence/fix-6009-projects-collapsed-chevron/after-fix-expanded.png) |

Screenshots captured via `Page.captureScreenshot` on this branch's dev app (unhovered — the after-collapsed chevron is visible with no mouse over it). `bun run lint` and `apps/desktop` typecheck pass.

Note: #6010 attempted the same idea but was closed unmerged; the reporter never got a build with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Projects chevron visible when the section is collapsed in the desktop sidebar, so it’s clear the list is hidden and can be expanded. Fixes #6009 where an accidental header click collapsed Projects and it looked empty across reloads; expanded behavior is unchanged.

<sup>Written for commit 03e655cc1068c0247242f87572caa9dadfe2149f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

