### PR TITLE
fix(shared,desktop): allow slashes in custom branch prefixes

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/branch-prefix.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/branch-prefix.ts
@@ -1,5 +1,9 @@
 import type { projects } from "@superset/local-db";
 import { settings } from "@superset/local-db";
+import {
+	branchPrefixCollides,
+	sanitizeCustomBranchPrefix,
+} from "@superset/shared/workspace-launch";
 import { localDb } from "main/lib/local-db";
 import { getBranchPrefix, sanitizeAuthorPrefix } from "./git";
 
@@ -33,15 +37,16 @@ export async function resolveBranchPrefix(
 		mode: prefixMode,
 		customPrefix,
 	});
-	// Normalize empty strings to undefined (sanitizeAuthorPrefix can return "")
+	// Normalize empty strings to undefined (sanitizing can return "")
 	const sanitizedPrefix = rawPrefix
-		? sanitizeAuthorPrefix(rawPrefix) || undefined
+		? (prefixMode === "custom"
+				? sanitizeCustomBranchPrefix(rawPrefix)
+				: sanitizeAuthorPrefix(rawPrefix)) || undefined
 		: undefined;
 
 	// Check if prefix would collide with an existing branch name
-	const existingSet = new Set(existingBranches.map((b) => b.toLowerCase()));
 	const prefixWouldCollide =
-		sanitizedPrefix && existingSet.has(sanitizedPrefix.toLowerCase());
+		sanitizedPrefix && branchPrefixCollides(sanitizedPrefix, existingBranches);
 
 	return prefixWouldCollide ? undefined : sanitizedPrefix;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/BranchPrefixControl/BranchPrefixControl.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/BranchPrefixControl/BranchPrefixControl.tsx
@@ -1,6 +1,6 @@
 import {
 	type BranchPrefixMode,
-	sanitizeSegment,
+	sanitizeCustomBranchPrefix,
 } from "@superset/shared/workspace-launch";
 import { Input } from "@superset/ui/input";
 import {
@@ -70,7 +70,7 @@ export function BranchPrefixControl({
 	};
 
 	const handleCustomPrefixBlur = () => {
-		const sanitized = sanitizeSegment(customPrefixInput);
+		const sanitized = sanitizeCustomBranchPrefix(customPrefixInput);
 		setCustomPrefixInput(sanitized);
 		// Empty sanitized prefix: don't persist `mode=custom, customPrefix=null`
 		// — that lies about user intent. Leave the dropdown alone so they can

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
@@ -1,7 +1,7 @@
 import type { BranchPrefixMode } from "@superset/local-db";
 import {
 	resolveBranchPrefix,
-	sanitizeSegment,
+	sanitizeCustomBranchPrefix,
 } from "@superset/shared/workspace-launch";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
@@ -99,7 +99,7 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 	};
 
 	const handleCustomPrefixBlur = () => {
-		const sanitized = sanitizeSegment(customPrefixInput);
+		const sanitized = sanitizeCustomBranchPrefix(customPrefixInput);
 		setCustomPrefixInput(sanitized);
 		setBranchPrefix.mutate({
 			mode: "custom",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -1,7 +1,7 @@
 import type { BranchPrefixMode } from "@superset/local-db";
 import {
 	resolveBranchPrefix,
-	sanitizeSegment,
+	sanitizeCustomBranchPrefix,
 } from "@superset/shared/workspace-launch";
 import {
 	AlertDialog,
@@ -187,7 +187,7 @@ export function ProjectSettings({
 	};
 
 	const handleCustomPrefixBlur = () => {
-		const sanitized = sanitizeSegment(customPrefixInput);
+		const sanitized = sanitizeCustomBranchPrefix(customPrefixInput);
 		setCustomPrefixInput(sanitized);
 		updateProject.mutate({
 			id: projectId,

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/branch-prefix.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/branch-prefix.ts
@@ -1,5 +1,6 @@
 import {
 	type BranchPrefixMode,
+	branchPrefixCollides,
 	resolveBranchPrefix,
 } from "@superset/shared/workspace-launch";
 import type { SimpleGit } from "simple-git";
@@ -70,6 +71,5 @@ export async function resolveProjectBranchPrefix({
 	});
 	if (!prefix) return undefined;
 
-	const existingSet = new Set(existingBranches.map((b) => b.toLowerCase()));
-	return existingSet.has(prefix.toLowerCase()) ? undefined : prefix;
+	return branchPrefixCollides(prefix, existingBranches) ? undefined : prefix;
 }

--- a/packages/shared/src/workspace-launch/branch.test.ts
+++ b/packages/shared/src/workspace-launch/branch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+	branchPrefixCollides,
+	DEFAULT_BRANCH_SEGMENT_MAX_LENGTH,
 	deduplicateBranchName,
+	resolveBranchPrefix,
 	sanitizeAuthorPrefix,
 	sanitizeBranchName,
 	sanitizeBranchNameWithMaxLength,
@@ -183,6 +186,122 @@ describe("sanitizeBranchNameWithMaxLength", () => {
 				preserveFirstSegmentCase: true,
 			}),
 		).toBe("Fix_Bug");
+	});
+});
+
+describe("resolveBranchPrefix", () => {
+	test("keeps slashes in a custom prefix", () => {
+		expect(
+			resolveBranchPrefix({ mode: "custom", customPrefix: "user/my-name" }),
+		).toBe("user/my-name");
+	});
+
+	test("preserves case so the saved prefix survives branch creation", () => {
+		expect(
+			resolveBranchPrefix({ mode: "custom", customPrefix: "User/My-Team" }),
+		).toBe("User/My-Team");
+	});
+
+	test("sanitizes each segment of a custom prefix", () => {
+		expect(
+			resolveBranchPrefix({ mode: "custom", customPrefix: "my team/a b!" }),
+		).toBe("my-team/a-b");
+	});
+
+	test("returns null for a custom prefix that sanitizes away", () => {
+		expect(resolveBranchPrefix({ mode: "custom", customPrefix: "///" })).toBe(
+			null,
+		);
+	});
+
+	test("returns null when custom mode has no prefix", () => {
+		expect(resolveBranchPrefix({ mode: "custom", customPrefix: null })).toBe(
+			null,
+		);
+	});
+
+	test("caps a custom prefix at half the branch-name budget", () => {
+		expect(
+			resolveBranchPrefix({
+				mode: "custom",
+				customPrefix: `user/${"x".repeat(60)}`,
+			}),
+		).toHaveLength(50);
+	});
+
+	// Capping per segment instead of in total would let this through at ~400
+	// characters. Nothing trims `${prefix}/${slug}` before `git worktree add`,
+	// so the ceiling has to hold here no matter how many segments are typed.
+	test("bounds a custom prefix however many segments it has", () => {
+		const many = Array.from({ length: 8 }, () => "x".repeat(60)).join("/");
+		const resolved = resolveBranchPrefix({
+			mode: "custom",
+			customPrefix: many,
+		});
+		expect(resolved?.length).toBeLessThanOrEqual(50);
+	});
+
+	test("keeps author and github prefixes to a single segment", () => {
+		expect(
+			resolveBranchPrefix({ mode: "author", authorPrefix: "Ada/Lovelace" }),
+		).toBe("AdaLovelace");
+		expect(
+			resolveBranchPrefix({ mode: "github", githubUsername: "Ada-L" }),
+		).toBe("Ada-L");
+	});
+
+	test("falls back to the author prefix when github has no username", () => {
+		expect(resolveBranchPrefix({ mode: "github", authorPrefix: "Ada" })).toBe(
+			"Ada",
+		);
+	});
+
+	test("returns null for none and unset modes", () => {
+		expect(resolveBranchPrefix({ mode: "none" })).toBe(null);
+		expect(resolveBranchPrefix({ mode: null })).toBe(null);
+	});
+
+	// The settings inputs persist this sanitizer's output directly. Resolving
+	// that value again has to be a no-op, or the prefix shown in settings and
+	// the one the branch is created with drift apart.
+	test("resolving an already-saved custom prefix changes nothing", () => {
+		const saved = sanitizeBranchNameWithMaxLength(
+			"User/My Team",
+			DEFAULT_BRANCH_SEGMENT_MAX_LENGTH,
+			{ preserveCase: true },
+		);
+		expect(saved).toBe("User/My-Team");
+		expect(resolveBranchPrefix({ mode: "custom", customPrefix: saved })).toBe(
+			saved,
+		);
+	});
+});
+
+describe("branchPrefixCollides", () => {
+	test("detects an exact match", () => {
+		expect(branchPrefixCollides("user", ["main", "user"])).toBe(true);
+	});
+
+	test("detects an ancestor that is already a branch", () => {
+		expect(branchPrefixCollides("user/team", ["main", "user"])).toBe(true);
+	});
+
+	test("detects an ancestor several levels up", () => {
+		expect(branchPrefixCollides("a/b/c", ["a"])).toBe(true);
+	});
+
+	test("allows a prefix whose ancestors are free", () => {
+		expect(branchPrefixCollides("user/team", ["main", "user-team"])).toBe(
+			false,
+		);
+	});
+
+	test("does not treat a descendant branch as a collision", () => {
+		expect(branchPrefixCollides("user", ["user/team/task"])).toBe(false);
+	});
+
+	test("compares case-insensitively", () => {
+		expect(branchPrefixCollides("User/Team", ["user"])).toBe(true);
 	});
 });
 

--- a/packages/shared/src/workspace-launch/branch.ts
+++ b/packages/shared/src/workspace-launch/branch.ts
@@ -183,6 +183,27 @@ export function sanitizeUserBranchName(
 	return cleaned;
 }
 
+/**
+ * How much of a branch name a custom prefix may occupy — half the budget, so
+ * the slug that follows still has room. The bound belongs here: nothing
+ * downstream trims `${prefix}/${slug}` before it reaches `git worktree add`.
+ */
+const CUSTOM_BRANCH_PREFIX_MAX_LENGTH = DEFAULT_BRANCH_NAME_MAX_LENGTH / 2;
+
+/**
+ * Normalizes a custom prefix typed in settings. The settings inputs persist
+ * this value as-is, and `resolveBranchPrefix` runs it again when the branch is
+ * created, so both sides have to sanitize identically — otherwise the prefix
+ * shown in settings is not the one you get on the branch.
+ */
+export function sanitizeCustomBranchPrefix(prefix: string): string {
+	return sanitizeBranchNameWithMaxLength(
+		prefix,
+		CUSTOM_BRANCH_PREFIX_MAX_LENGTH,
+		{ preserveCase: true },
+	);
+}
+
 export function resolveBranchPrefix({
 	mode,
 	customPrefix,
@@ -199,8 +220,9 @@ export function resolveBranchPrefix({
 		case "none":
 			return null;
 		case "custom":
-			prefix = customPrefix || null;
-			break;
+			return customPrefix
+				? sanitizeCustomBranchPrefix(customPrefix) || null
+				: null;
 		case "author":
 			prefix = authorPrefix || null;
 			break;
@@ -215,4 +237,20 @@ export function resolveBranchPrefix({
 				preserveCase: true,
 			})
 		: null;
+}
+
+/**
+ * True when the prefix, or any path above it, is already a branch. Git stores
+ * refs as files, so `user` and `user/team/task` can't both exist — a nested
+ * prefix has to be clear at every level, not just at its full path.
+ */
+export function branchPrefixCollides(
+	prefix: string,
+	existingBranches: string[],
+): boolean {
+	const existing = new Set(existingBranches.map((b) => b.toLowerCase()));
+	const segments = prefix.toLowerCase().split("/");
+	return segments.some((_, index) =>
+		existing.has(segments.slice(0, index + 1).join("/")),
+	);
 }


### PR DESCRIPTION
<!--
PR titles become the squash-merge commit subject, so use conventional commit format:
  feat(desktop): add copy-logs button to failed CI checks
  fix(web): guard against missing PR in workspace header
-->
## What & why

fixes #5367

The custom branch prefix ran through `sanitizeSegment`, which strips `/`, so
`user/my-name` was saved as `usermy-name`.

It now uses `sanitizeBranchName`, which cleans each segment and keeps the
slashes. The 50 character cap is unchanged, and author/GitHub prefixes stay
single segments.

Both the settings inputs and the resolvers needed it. The inputs are what you
watch eat the slash; the resolvers would strip it again when the branch is
created.

Prefixes saved before this fix stay mangled — retyping fixes them.

## How I tested it

Settings → Git & worktrees → Branch prefix → Custom prefix, typed `user/my-name`:

- before: input becomes `usermy-name`, preview `usermy-name/branch-name`
- after: input keeps `user/my-name`, preview `user/my-name/branch-name`

Created a workspace and got `user/my-name/<slug>`. 

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint`
- [x] `bun run typecheck` fails in `@superset/ui`
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow slashes in custom branch prefixes and keep them across settings, previews, and branch creation. Sanitization now preserves case, caps the total prefix length to half of the branch-name budget, and blocks prefixes that collide (case-insensitively) with existing branch paths (fixes #5367).

- **Bug Fixes**
  - Consistent custom-prefix sanitization in inputs and resolvers so saved values match the preview and created branch; returns null when the prefix sanitizes away.
  - Detect exact and ancestor collisions (case-insensitive) against existing branches in desktop and `host-service`.

- **Migration**
  - Previously saved custom prefixes that lost slashes stay mangled; retype the prefix to fix.

<sup>Written for commit aebba843c46399e32ea718aa6374249bb3205bc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom branch-prefix sanitization across workspace, project, and Git settings.
  * Custom prefixes now preserve letter casing while enforcing valid branch-name formatting and length limits.
  * Improved detection of branch-prefix conflicts, including existing branches and nested paths.
  * Empty or fully sanitized prefixes are handled safely without disrupting branch creation.
  * Added consistent handling for custom, author-derived, GitHub-derived, unset, and disabled prefix modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->