### PR TITLE
fix(desktop): namespace host-service Sentry env vars to stop DSN leaking to spawned tools

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -797,11 +797,14 @@ export class HostServiceCoordinator extends EventEmitter {
 			// canary and dev builds, never on stable. The host gates its router
 			// and WS stream route on this env var.
 			...(isInternalBuild() ? { SUPERSET_ACP_SESSIONS: "1" } : {}),
+			// Namespaced so terminals/agents spawned by the host service don't
+			// inherit a generic SENTRY_DSN — third-party tools with a Sentry SDK
+			// auto-pick it up and report into our project.
 			...(app.isPackaged && mainEnv.SENTRY_DSN_HOST_SERVICE
 				? {
-						SENTRY_DSN: mainEnv.SENTRY_DSN_HOST_SERVICE,
-						SENTRY_RELEASE: app.getVersion(),
-						SENTRY_ENVIRONMENT: "production",
+						HOST_SERVICE_SENTRY_DSN: mainEnv.SENTRY_DSN_HOST_SERVICE,
+						HOST_SERVICE_SENTRY_RELEASE: app.getVersion(),
+						HOST_SERVICE_SENTRY_ENVIRONMENT: "production",
 					}
 				: {}),
 			// Read by the child's parent watchdog so it can self-exit if

--- a/packages/host-service/src/sentry.ts
+++ b/packages/host-service/src/sentry.ts
@@ -4,10 +4,12 @@ let initialized = false;
 
 export function initSentry(options: { organizationId?: string }): void {
 	if (initialized) return;
-	const dsn = process.env.SENTRY_DSN;
+	const dsn = process.env.HOST_SERVICE_SENTRY_DSN;
 	if (!dsn) return;
 	Sentry.init({
 		dsn,
+		release: process.env.HOST_SERVICE_SENTRY_RELEASE,
+		environment: process.env.HOST_SERVICE_SENTRY_ENVIRONMENT,
 		tracesSampleRate: 0,
 		// safety.ts keeps the process alive through uncaught exceptions; Sentry
 		// must capture them without re-introducing the exit.


### PR DESCRIPTION
## Problem

The desktop main process passes `SENTRY_DSN`, `SENTRY_RELEASE`, and `SENTRY_ENVIRONMENT` into the host-service child environment. Terminals and agent sessions spawned by the host service inherit that environment, and Sentry SDKs default to reading `SENTRY_DSN` from env — so any third-party tool a user runs that bundles a Sentry SDK silently reports **its** telemetry into **our** host-service project.

First sighting: HOST-SERVICE-1 — an unrelated MCP server (`xcodebuildmcp@2.6.2`) on a user's machine reporting info-level shutdown summaries under our DSN. With the error quota freshly reset, this is a new unbounded noise source.

## Fix

- Rename the vars the coordinator injects to `HOST_SERVICE_SENTRY_DSN` / `HOST_SERVICE_SENTRY_RELEASE` / `HOST_SERVICE_SENTRY_ENVIRONMENT` so spawned processes never see the generic names.
- `packages/host-service/src/sentry.ts` reads the namespaced DSN and now passes `release`/`environment` explicitly to `Sentry.init` (they previously worked only via SDK env auto-pickup, which is the exact mechanism that leaked).

No other spawner passes a DSN to the host service (checked cli/host-client).

Fixes HOST-SERVICE-1

https://claude.ai/code/session_01H97pSkZUbm8EPyToTpoxi2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaced the host-service Sentry env vars to stop `SENTRY_DSN` leaking to spawned terminals/agents. Prevents third‑party tools with Sentry SDKs from reporting into our host-service project (fixes HOST-SERVICE-1).

- **Bug Fixes**
  - Desktop now injects `HOST_SERVICE_SENTRY_DSN`, `HOST_SERVICE_SENTRY_RELEASE`, `HOST_SERVICE_SENTRY_ENVIRONMENT` instead of `SENTRY_*`.
  - Host service reads the namespaced vars and sets `release` and `environment` explicitly in `Sentry.init`.

<sup>Written for commit d7f8d844ba524abc3a25996a947add5786bd068a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

