### PR TITLE
fix(relay): filter client-abandoned WS upgrade errors from Sentry

### DIFF
--- a/apps/relay/src/sentry.ts
+++ b/apps/relay/src/sentry.ts
@@ -12,8 +12,12 @@ export function initSentry(): void {
 		environment: process.env.FLY_APP_NAME ?? "relay-local",
 		tracesSampleRate: 0,
 		beforeSend(event) {
-			const exceptionType = event.exception?.values?.[0]?.type;
-			if (exceptionType === "TunnelLifecycleError") return null;
+			const exception = event.exception?.values?.[0];
+			if (exception?.type === "TunnelLifecycleError") return null;
+			// Client hung up during the async auth that runs before the WS
+			// handshake: Bun's node:ws shim then calls server.upgrade() with the
+			// already-released Request and throws. The client is gone either way.
+			if (exception?.value === "upgrade requires a Request object") return null;
 			return event;
 		},
 		integrations: [


### PR DESCRIPTION
## Summary

RELAY-5 (`TypeError: upgrade requires a Request object`, 515 occurrences since June) is a client-gone race, not a relay fault:

1. A WS upgrade request hits the relay; the auth middleware awaits JWT verification + `checkHostAccess` (network round-trips) before `@hono/node-ws` completes the handshake.
2. The client disconnects during that window.
3. Bun's `node:ws` shim (`completeUpgrade`) then calls `server.upgrade(socket[kBunInternals], …)`, but the underlying Bun `Request` was released with the connection — `server.upgrade(undefined)` throws, surfacing as an unhandled rejection.

The client is gone either way, so this drops the event in `beforeSend` alongside the `TunnelLifecycleError` churn filter added in #6080. The process already survives these via the suppressed `unhandledRejection` handler; this just stops the Sentry noise.

Fixes RELAY-5

## Test plan

- `bun run lint` clean, relay `typecheck` clean
- After merge (relay auto-deploys on main): confirm RELAY-5 stops receiving events

https://claude.ai/code/session_012u6VZtfQgoTh8qS4NqCb7e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters client-abandoned WebSocket upgrade errors from Sentry in the relay to reduce noise. Fixes RELAY-5.

- **Bug Fixes**
  - Ignore `node:ws` "upgrade requires a Request object" exceptions in Sentry `beforeSend`, which happen when clients disconnect during async JWT/host access checks before the `@hono/node-ws` handshake completes.

<sup>Written for commit e13d13f36a4701927fe5342f44c380c260e8d7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reports by filtering out known upgrade-related errors.
  * Continued suppressing expected tunnel lifecycle errors from error monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->