### PR TITLE
feat(desktop): gate new-workspace-screen experiment via created_at flag targeting

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -12,11 +12,21 @@ export function PostHogUserIdentifier() {
 
 	useEffect(() => {
 		if (!user) return;
+		const createdAt = user.createdAt
+			? new Date(user.createdAt).toISOString()
+			: undefined;
 		posthog.identify(user.id, {
 			email: user.email,
 			name: user.name,
 			desktop_version: window.App.appVersion,
+			...(createdAt ? { created_at: createdAt } : {}),
 		});
+		if (createdAt) {
+			// Included in flag evaluation requests so release conditions can
+			// target account age immediately, without waiting for ingestion.
+			// `false` skips the built-in reload; reloadFeatureFlags below covers it.
+			posthog.setPersonPropertiesForFlags({ created_at: createdAt }, false);
+		}
 		posthog.reloadFeatureFlags();
 		setUserId({ userId: user.id });
 	}, [user, setUserId]);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspaceScreenVariant/useNewWorkspaceScreenVariant.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspaceScreenVariant/useNewWorkspaceScreenVariant.ts
@@ -1,26 +1,19 @@
-import {
-	FEATURE_FLAGS,
-	NEW_WORKSPACE_SCREEN_EXPERIMENT_START,
-} from "@superset/shared/constants";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
 import { useLayoutEffect, useState } from "react";
-import { authClient } from "renderer/lib/auth-client";
-
-function isEligible(createdAt: Date | string | null | undefined): boolean {
-	if (createdAt == null) return false;
-	const created =
-		createdAt instanceof Date
-			? createdAt.getTime()
-			: new Date(createdAt).getTime();
-	if (Number.isNaN(created)) return false;
-	return created >= new Date(NEW_WORKSPACE_SCREEN_EXPERIMENT_START).getTime();
-}
 
 /**
  * Assigns the new-workspace-screen experiment arm. Calls `getFeatureFlag`
  * imperatively (not `useFeatureFlagVariantKey`) so the `$feature_flag_called`
- * exposure event fires only when an eligible user actually reaches the
- * new-workspace surface — never on app load or for pre-cutoff accounts.
+ * exposure event fires only when a user actually reaches the new-workspace
+ * surface — never on app load.
+ *
+ * Eligibility (new accounts only) lives on the flag itself: a release
+ * condition on the `created_at` person property, which the renderer sends
+ * with flag requests at identify time (PostHogUserIdentifier). Ineligible
+ * accounts — and old builds that never send `created_at` — get `false` back,
+ * which renders control; a non-variant response is not counted as experiment
+ * exposure.
  *
  * The override flag short-circuits everything: it forces the screen without
  * ever evaluating the experiment flag, so overridden users (team, dev
@@ -34,8 +27,6 @@ export function useNewWorkspaceScreenVariant(
 	isOpen: boolean,
 ): "control" | "test" | null {
 	const posthog = usePostHog();
-	const { data: session } = authClient.useSession();
-	const eligible = isEligible(session?.user?.createdAt);
 	const overrideEnabled = useFeatureFlagEnabled(
 		FEATURE_FLAGS.NEW_WORKSPACE_SCREEN_OVERRIDE,
 	);
@@ -45,10 +36,6 @@ export function useNewWorkspaceScreenVariant(
 		if (!isOpen) return;
 		if (overrideEnabled) {
 			setVariant("test");
-			return;
-		}
-		if (!eligible) {
-			setVariant("control");
 			return;
 		}
 		// Evaluate only after flags have loaded: getFeatureFlag before the first
@@ -71,7 +58,7 @@ export function useNewWorkspaceScreenVariant(
 			unsubscribe?.();
 			window.clearTimeout(fallback);
 		};
-	}, [isOpen, eligible, overrideEnabled, posthog]);
+	}, [isOpen, overrideEnabled, posthog]);
 
 	return variant;
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -95,11 +95,6 @@ export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-08T06:59:00.000Z";
 // Bump this if the release slips.
 export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-09T17:00:00.000Z";
 
-// Eligibility cutoff for the new-workspace-screen experiment: only accounts
-// created on/after this date enter the experiment, so exposure stays scoped to
-// new users. Bump only before launch; changing it mid-experiment skews arms.
-export const NEW_WORKSPACE_SCREEN_EXPERIMENT_START = "2026-07-22T00:00:00.000Z";
-
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",
@@ -138,10 +133,11 @@ export const FEATURE_FLAGS = {
 	HIRING_BANNER: "hiring-banner",
 	/**
 	 * Experiment flag (control/test): renders the new-workspace surface as a
-	 * full-screen view with sample prompts instead of the dense modal. Only
-	 * evaluated for accounts created on/after
-	 * NEW_WORKSPACE_SCREEN_EXPERIMENT_START and only when the surface opens,
-	 * so `$feature_flag_called` exposure matches the experiment population.
+	 * full-screen view with sample prompts instead of the dense modal.
+	 * Eligibility (new accounts only) is a release condition on the flag —
+	 * `created_at` person property, sent with flag requests at identify time —
+	 * and the flag is only evaluated when the surface opens, so
+	 * `$feature_flag_called` exposure matches the experiment population.
 	 */
 	NEW_WORKSPACE_SCREEN: "new-workspace-screen",
 	/**


### PR DESCRIPTION
## What

Moves the new-workspace-screen experiment's "new accounts only" eligibility gate from a build constant into PostHog flag targeting:

- **`PostHogUserIdentifier` (desktop)** now sends `created_at` (ISO, from the better-auth session) with `posthog.identify` and via `setPersonPropertiesForFlags`, so it is included in flag evaluation requests and release conditions can match it **immediately** — no waiting for ingestion, which matters because the population this experiment targets evaluates the flag seconds after signup.
- **`useNewWorkspaceScreenVariant`** drops the client-side `createdAt >= NEW_WORKSPACE_SCREEN_EXPERIMENT_START` check; the flag decides eligibility server-side. Non-variant responses (`false`/`undefined`) render control, and are not counted as experiment exposure.
- **`NEW_WORKSPACE_SCREEN_EXPERIMENT_START`** is deleted from `@superset/shared/constants`.

## Why

Launch-blocker for the experiment: the constant was frozen at `2026-07-22` in shipped builds (1.18.0–1.18.3), so activating the flag today would enroll two weeks of pre-launch signups — active users whose first-open experience already happened — right when Bayesian results are jumpiest, and bumping the constant can't fix builds already in the wild.

With flag-side targeting, old builds exclude themselves: they never send `created_at`, no stored person has it, so the release condition fails and they keep the existing modal with zero enrollment. The cutoff date now lives in flag config instead of a release, and any future "new users only" experiment gets this for free.

## Launch sequence (after merge)

1. Ship in the next desktop release.
2. Add the release condition on flag `new-workspace-screen`: `created_at` is-date-after `<release ship date>`, keep 50/50 control/test.
3. Launch experiment 387127. Don't touch the condition mid-flight.

## Verification

- `bun run lint` clean; `@superset/desktop` + `@superset/shared` typecheck pass. (`@superset/marketing` typecheck fails identically on clean `origin/main` — pre-existing `@types/hast` 3.0.4/3.0.5 duplication, unrelated.)

https://claude.ai/code/session_01JBQXrhBontVKDzqU7GrQY6


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the new workspace screen experiment via PostHog flag targeting on the `created_at` person property, replacing the build-time cutoff. This keeps pre-launch users out and lets old builds self-exclude safely.

- **Refactors**
  - Send `created_at` (ISO) with `posthog.identify` and `setPersonPropertiesForFlags` so flags can target account age immediately.
  - `useNewWorkspaceScreenVariant`: remove client-side cutoff; the flag decides eligibility; non-variant returns render control; exposure only when the surface opens.
  - Delete `NEW_WORKSPACE_SCREEN_EXPERIMENT_START` from `@superset/shared/constants`.

- **Migration**
  - Ship in the next desktop release.
  - In PostHog, add a release condition on `new-workspace-screen`: `created_at` is-date-after <ship date>; keep 50/50.
  - Launch the experiment; do not change the condition mid-flight.

<sup>Written for commit b365f3748e8a23012ce5118392d17beeab2ea312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved eligibility checks for the new workspace setup experience using account creation timing.
  * Updated feature-flag evaluation to provide a reliable control experience when eligibility or variants are unavailable.
  * Added account creation timestamps to product analytics and feature-flag context when available.
  * Improved loading and fallback behavior while feature flags are being evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->