### PR TITLE
feat(desktop): add sign-out option to onboarding flow

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingNavigation/OnboardingNavigation.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingNavigation/OnboardingNavigation.tsx
@@ -1,7 +1,8 @@
 import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
-import { HiArrowLeft } from "react-icons/hi2";
+import { HiArrowLeft, HiOutlineArrowRightOnRectangle } from "react-icons/hi2";
 import { LuCircleHelp } from "react-icons/lu";
+import { useSignOut } from "renderer/hooks/useSignOut";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { PaginationDots } from "../PaginationDots";
 
@@ -23,6 +24,7 @@ export function OnboardingNavigation({
 	continueLabel,
 }: OnboardingNavigationProps) {
 	const openUrl = electronTrpc.external.openUrl.useMutation();
+	const signOut = useSignOut();
 
 	return (
 		<div className="mx-auto flex w-full max-w-[1200px] items-center px-12 pt-4 pb-8">
@@ -45,6 +47,10 @@ export function OnboardingNavigation({
 				<PaginationDots current={currentStep} total={totalSteps} />
 			</div>
 			<div className="flex flex-1 items-center justify-end gap-2">
+				<Button size="sm" variant="ghost" onClick={() => signOut()}>
+					<HiOutlineArrowRightOnRectangle />
+					Sign out
+				</Button>
 				<Button
 					size="sm"
 					variant="ghost"

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingNavigation/OnboardingNavigation.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingNavigation/OnboardingNavigation.tsx
@@ -47,7 +47,13 @@ export function OnboardingNavigation({
 				<PaginationDots current={currentStep} total={totalSteps} />
 			</div>
 			<div className="flex flex-1 items-center justify-end gap-2">
-				<Button size="sm" variant="ghost" onClick={() => signOut()}>
+				<Button
+					size="sm"
+					variant="ghost"
+					onClick={async () => {
+						await signOut();
+					}}
+				>
 					<HiOutlineArrowRightOnRectangle />
 					Sign out
 				</Button>


### PR DESCRIPTION
## Summary
- Add a "Sign out" button to the onboarding footer (next to "Get support"), so a user who lands on onboarding signed into the wrong account has a way out.

## Why / Context
The onboarding wizard ("Setup Superset" → connect agent tools → create/add a project) previously had no exit affordance — only "Get support" and "Continue". A user stuck there (e.g. signed into the wrong account) had no way to sign out short of force-quitting the app.

## How It Works
Reuses the existing `useSignOut()` hook (same one used in Account Settings and the org dropdown menu) in `OnboardingNavigation`. The `_authenticated` route guard already redirects reactively to `/sign-in` once the session clears, so no extra navigation logic was needed.

## Manual QA Checklist
Verified end-to-end via CDP against a running dev build (not just a synthetic handler call):
- [x] "Sign out" renders in the onboarding footer alongside "Get support"
- [x] A real synthetic click (`Input.dispatchMouseEvent`) on the button triggers the actual sign-out flow (posthog reset, electron tRPC mutation, better-auth signOut)
- [x] App redirects to `/sign-in` after sign-out completes
- [x] Confirmed via screenshots before/after the click

To reach the onboarding screen for a normally-onboarded dev account, the `onboardedAt` field was spoofed client-side at the network layer (CDP `Fetch` domain intercepting `/api/auth/get-session`) — no database writes were involved, and the actual sign-out click and its consequences were completely real.

## Testing
- `bun run lint:fix` (clean)
- `cd apps/desktop && bun run typecheck` (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Sign out" button to the onboarding footer (next to "Get support") so users can switch accounts from the wizard without quitting the app. Uses the existing `useSignOut()` hook and now awaits it to handle errors correctly; the `_authenticated` guard redirects to `/sign-in` after the session clears.

<sup>Written for commit 16a3cff2243fbf06ae079c31f132e684bf8b764e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Sign out” option to the onboarding navigation.
  * Positioned sign-out access alongside support and continuation controls.
  * Users can now securely exit their session directly from the onboarding flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->