### PR TITLE
feat(desktop): highlight search-matched text on settings pages

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -145,6 +145,7 @@
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-highlight: var(--highlight);
 	--color-highlight-foreground: var(--highlight-foreground);
+	--color-highlight-match: var(--highlight-match);
 	--color-fill-hover: var(--fill-hover);
 	--color-fill-selected: var(--fill-selected);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
@@ -9,12 +9,12 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	getImageExtensionFromMimeType,
 	parseBase64DataUrl,
 } from "shared/file-types";
-import { HighlightText } from "../../../components/HighlightText";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
@@ -9,10 +9,12 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	getImageExtensionFromMimeType,
 	parseBase64DataUrl,
 } from "shared/file-types";
+import { HighlightText } from "../../../components/HighlightText";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -183,12 +185,18 @@ interface SettingRowProps {
 }
 
 function SettingRow({ label, hint, children }: SettingRowProps) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className="flex items-center justify-between gap-8">
 			<div className="flex-1 min-w-0">
-				<div className="text-sm font-medium">{label}</div>
+				<div className="text-sm font-medium">
+					<HighlightText text={label} query={searchQuery} />
+				</div>
 				{hint && (
-					<div className="text-xs text-muted-foreground mt-0.5">{hint}</div>
+					<div className="text-xs text-muted-foreground mt-0.5">
+						<HighlightText text={hint} query={searchQuery} />
+					</div>
 				)}
 			</div>
 			<div className="flex-shrink-0">{children}</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
@@ -26,6 +26,8 @@ import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -37,6 +39,7 @@ interface ApiKeysSettingsProps {
 }
 
 export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const collections = useCollections();
 	const [isGenerating, setIsGenerating] = useState(false);
 	const [showGenerateDialog, setShowGenerateDialog] = useState(false);
@@ -116,7 +119,9 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 		<div className="p-6 max-w-4xl w-full">
 			<div className="mb-8 flex items-start justify-between gap-4">
 				<div>
-					<h2 className="text-xl font-semibold">API keys</h2>
+					<h2 className="text-xl font-semibold">
+						<HighlightText text="API keys" query={searchQuery} />
+					</h2>
 					<p className="text-sm text-muted-foreground mt-1">
 						Manage keys for MCP server access and external integrations like
 						Claude Desktop or Claude Code.{" "}
@@ -205,7 +210,9 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 			<Dialog open={showGenerateDialog} onOpenChange={setShowGenerateDialog}>
 				<DialogContent>
 					<DialogHeader>
-						<DialogTitle>Generate API key</DialogTitle>
+						<DialogTitle>
+							<HighlightText text="Generate API key" query={searchQuery} />
+						</DialogTitle>
 						<DialogDescription>
 							Create a new API key for external integrations like Claude Desktop
 							or Claude Code.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
@@ -40,10 +40,12 @@ import {
 	resolveTerminalAppearance,
 } from "renderer/lib/terminal/appearance";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	DEFAULT_CODE_EDITOR_FONT_FAMILY,
 	DEFAULT_CODE_EDITOR_FONT_SIZE,
 } from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { useTerminalTheme } from "renderer/stores/theme";
 import { FontFamilyCombobox } from "./components/FontFamilyCombobox";
 import { FontPreview } from "./components/FontPreview";
@@ -138,6 +140,7 @@ export function FontSettingSection({
 		showEditor ? "editor" : "terminal",
 	);
 	const config = VARIANT_CONFIG[variant];
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 	const queryClient = useQueryClient();
 	const terminalTheme = useTerminalTheme();
@@ -312,7 +315,9 @@ export function FontSettingSection({
 							) : (
 								<SquareTerminal className="size-4 text-muted-foreground" />
 							)}
-							<h4 className="text-sm font-medium">{config.title}</h4>
+							<h4 className="text-sm font-medium">
+								<HighlightText text={config.title} query={searchQuery} />
+							</h4>
 						</div>
 						<p className="mt-1 text-xs text-muted-foreground">
 							{config.description}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/MarkdownStyleSection/MarkdownStyleSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/MarkdownStyleSection/MarkdownStyleSection.tsx
@@ -5,19 +5,24 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@superset/ui/select";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	type MarkdownStyle,
 	useMarkdownStyle,
 	useSetMarkdownStyle,
 } from "renderer/stores";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 export function MarkdownStyleSection() {
 	const markdownStyle = useMarkdownStyle();
 	const setMarkdownStyle = useSetMarkdownStyle();
+	const searchQuery = useSettingsSearchQuery();
 
 	return (
 		<div>
-			<h3 className="text-sm font-medium mb-1">Markdown style</h3>
+			<h3 className="text-sm font-medium mb-1">
+				<HighlightText text="Markdown style" query={searchQuery} />
+			</h3>
 			<p className="text-xs text-muted-foreground mb-3">
 				Rendering style for markdown files. Tufte uses elegant serif typography
 				inspired by Edward Tufte's books.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
@@ -353,7 +353,10 @@ export function ThemeSection() {
 						<HighlightText text="Custom themes" query={searchQuery} />
 					</div>
 					<div className="text-xs text-muted-foreground">
-						Import a theme file or grab a starter to edit.
+						<HighlightText
+							text="Import a theme file or grab a starter to edit."
+							query={searchQuery}
+						/>
 					</div>
 				</div>
 				<div className="flex items-center gap-2 shrink-0">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
@@ -18,6 +18,7 @@ import {
 	HiOutlineArrowUpTray,
 } from "react-icons/hi2";
 import { ThemeSwatch } from "renderer/components/ThemeSwatch";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	SYSTEM_THEME_ID,
 	useSetSystemThemePreference,
@@ -27,6 +28,7 @@ import {
 	useThemeId,
 	useThemeStore,
 } from "renderer/stores";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	builtInThemes,
 	darkTheme as defaultDarkTheme,
@@ -70,11 +72,20 @@ function ThemeRow({
 	includeSystem,
 }: ThemeRowProps) {
 	const isSystem = includeSystem !== undefined && value === SYSTEM_THEME_ID;
+	const searchQuery = useSettingsSearchQuery();
 	return (
 		<div className="flex items-center justify-between gap-6 p-4">
 			<div className="min-w-0 flex-1">
-				<div className="text-sm font-medium">{label}</div>
-				<div className="text-xs text-muted-foreground">{hint}</div>
+				<div className="text-sm font-medium">
+					<HighlightText text={label} query={searchQuery} />
+				</div>
+				<div className="text-xs text-muted-foreground">
+					{typeof hint === "string" ? (
+						<HighlightText text={hint} query={searchQuery} />
+					) : (
+						hint
+					)}
+				</div>
 			</div>
 			<Select value={value} onValueChange={onValueChange}>
 				<SelectTrigger size="sm" className="w-auto min-w-44 px-2">
@@ -130,6 +141,7 @@ function ThemeRow({
 }
 
 export function ThemeSection() {
+	const searchQuery = useSettingsSearchQuery();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const [isImporting, setIsImporting] = useState(false);
 	const activeThemeId = useThemeId();
@@ -337,7 +349,9 @@ export function ThemeSection() {
 			)}
 			<div className="flex items-center justify-between gap-6 p-4">
 				<div className="min-w-0 flex-1">
-					<div className="text-sm font-medium">Custom themes</div>
+					<div className="text-sm font-medium">
+						<HighlightText text="Custom themes" query={searchQuery} />
+					</div>
 					<div className="text-xs text-muted-foreground">
 						Import a theme file or grab a starter to edit.
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -9,6 +9,8 @@ import {
 } from "@superset/ui/select";
 import { Switch } from "@superset/ui/switch";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -20,6 +22,7 @@ interface BehaviorSettingsProps {
 }
 
 export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const showConfirmQuit = isItemVisible(
 		SETTING_ITEM_ID.BEHAVIOR_CONFIRM_QUIT,
 		visibleItems,
@@ -139,7 +142,10 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">
 							<Label htmlFor="confirm-on-quit" className="text-sm font-medium">
-								Confirm before quitting
+								<HighlightText
+									text="Confirm before quitting"
+									query={searchQuery}
+								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Show a confirmation dialog when quitting the app
@@ -157,7 +163,9 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 				{showFileOpenMode && (
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">
-							<Label className="text-sm font-medium">File open mode</Label>
+							<Label className="text-sm font-medium">
+								<HighlightText text="File open mode" query={searchQuery} />
+							</Label>
 							<p className="text-xs text-muted-foreground">
 								Choose how files open when no preview pane exists
 							</p>
@@ -184,7 +192,7 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">
 							<Label htmlFor="resource-monitor" className="text-sm font-medium">
-								Resource monitor
+								<HighlightText text="Resource monitor" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Show CPU and memory usage in the top bar
@@ -210,7 +218,10 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								htmlFor="open-links-in-app"
 								className="text-sm font-medium"
 							>
-								Open links in the in-app browser
+								<HighlightText
+									text="Open links in the in-app browser"
+									query={searchQuery}
+								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Open links from chat and terminal in the in-app browser instead

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -8,6 +8,8 @@ import { env } from "renderer/env.renderer";
 import { resolveCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -26,6 +28,7 @@ interface BillingOverviewProps {
 export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
+	const searchQuery = useSettingsSearchQuery();
 	const [isUpgrading, setIsUpgrading] = useState(false);
 	const [isCanceling, setIsCanceling] = useState(false);
 	const [isRestoring, setIsRestoring] = useState(false);
@@ -159,7 +162,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 				</div>
 				<Button variant="ghost" size="sm" asChild>
 					<Link to="/settings/billing/plans">
-						All plans
+						<HighlightText text="All plans" query={searchQuery} />
 						<HiArrowRight className="h-3 w-3" />
 					</Link>
 				</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.test.tsx
@@ -22,7 +22,7 @@ describe("HighlightText", () => {
 			<HighlightText text="Branch prefix" query="branch" />,
 		);
 		expect(markup).toBe(
-			'<mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> prefix',
+			'<span><mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> prefix</span>',
 		);
 	});
 
@@ -40,7 +40,7 @@ describe("HighlightText", () => {
 			<HighlightText text="Branch prefix" query="branch prefix" />,
 		);
 		expect(markup).toBe(
-			'<mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> <mark class="rounded-sm bg-highlight-match text-inherit">prefix</mark>',
+			'<span><mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> <mark class="rounded-sm bg-highlight-match text-inherit">prefix</mark></span>',
 		);
 	});
 
@@ -56,7 +56,24 @@ describe("HighlightText", () => {
 			<HighlightText text="Wait 5s (approx.)" query="5s (approx.)" />,
 		);
 		expect(markup).toBe(
-			'Wait <mark class="rounded-sm bg-highlight-match text-inherit">5s</mark> <mark class="rounded-sm bg-highlight-match text-inherit">(approx.)</mark>',
+			'<span>Wait <mark class="rounded-sm bg-highlight-match text-inherit">5s</mark> <mark class="rounded-sm bg-highlight-match text-inherit">(approx.)</mark></span>',
+		);
+	});
+
+	it("wraps matched output in a single element so flex/grid gap spacing never applies between segments", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="branch" />,
+		);
+		expect(markup.startsWith("<span>")).toBe(true);
+		expect(markup.endsWith("</span>")).toBe(true);
+	});
+
+	it("prefers the longer term when one term is a prefix of another, instead of splitting the word", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="bran branch" />,
+		);
+		expect(markup).toBe(
+			'<span><mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> prefix</span>',
 		);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { HighlightText } from "./HighlightText";
+
+describe("HighlightText", () => {
+	it("returns plain text unchanged when the query is empty", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="" />,
+		);
+		expect(markup).toBe("Branch prefix");
+	});
+
+	it("returns plain text unchanged when whitespace-only", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="   " />,
+		);
+		expect(markup).toBe("Branch prefix");
+	});
+
+	it("wraps a single matching term in a mark", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="branch" />,
+		);
+		expect(markup).toBe(
+			'<mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> prefix',
+		);
+	});
+
+	it("is case-insensitive", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="PREFIX" />,
+		);
+		expect(markup).toContain(
+			'<mark class="rounded-sm bg-highlight-match text-inherit">prefix</mark>',
+		);
+	});
+
+	it("highlights each of multiple terms independently", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="branch prefix" />,
+		);
+		expect(markup).toBe(
+			'<mark class="rounded-sm bg-highlight-match text-inherit">Branch</mark> <mark class="rounded-sm bg-highlight-match text-inherit">prefix</mark>',
+		);
+	});
+
+	it("leaves text unchanged when no term matches", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Branch prefix" query="worktree" />,
+		);
+		expect(markup).toBe("Branch prefix");
+	});
+
+	it("does not treat regex metacharacters in the query as regex syntax", () => {
+		const markup = renderToStaticMarkup(
+			<HighlightText text="Wait 5s (approx.)" query="5s (approx.)" />,
+		);
+		expect(markup).toBe(
+			'Wait <mark class="rounded-sm bg-highlight-match text-inherit">5s</mark> <mark class="rounded-sm bg-highlight-match text-inherit">(approx.)</mark>',
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.tsx
@@ -1,0 +1,38 @@
+import { Fragment, type ReactNode } from "react";
+import { splitSearchTerms } from "../../utils/settings-search";
+
+interface HighlightTextProps {
+	text: string;
+	query: string;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function HighlightText({ text, query }: HighlightTextProps): ReactNode {
+	const terms = splitSearchTerms(query);
+	if (terms.length === 0) return text;
+
+	const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+	const parts = text.split(pattern);
+	if (parts.length === 1) return text;
+
+	return (
+		<Fragment>
+			{parts.map((part, i) =>
+				// split() with a single capturing group alternates unmatched text
+				// (even indices) and matched terms (odd indices).
+				i % 2 === 1 ? (
+					// biome-ignore lint/suspicious/noArrayIndexKey: parts come from a stable split of static text
+					<mark key={i} className="rounded-sm bg-highlight-match text-inherit">
+						{part}
+					</mark>
+				) : part ? (
+					// biome-ignore lint/suspicious/noArrayIndexKey: parts come from a stable split of static text
+					<Fragment key={i}>{part}</Fragment>
+				) : null,
+			)}
+		</Fragment>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/HighlightText.tsx
@@ -14,12 +14,23 @@ export function HighlightText({ text, query }: HighlightTextProps): ReactNode {
 	const terms = splitSearchTerms(query);
 	if (terms.length === 0) return text;
 
-	const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+	// Longest term first: when one term is a prefix of another (e.g. "bran"
+	// and "branch"), matching the longer one first avoids the shorter term
+	// "stealing" the match and leaving the rest of the word unhighlighted.
+	const sortedTerms = [...terms].sort((a, b) => b.length - a.length);
+	const pattern = new RegExp(
+		`(${sortedTerms.map(escapeRegExp).join("|")})`,
+		"gi",
+	);
 	const parts = text.split(pattern);
 	if (parts.length === 1) return text;
 
 	return (
-		<Fragment>
+		// A single wrapper element so this always counts as one flex/grid item
+		// in the caller's layout, regardless of how many parts it contains —
+		// a bare Fragment here would let a `gap-*` container space the
+		// highlighted and unhighlighted segments apart from each other.
+		<span>
 			{parts.map((part, i) =>
 				// split() with a single capturing group alternates unmatched text
 				// (even indices) and matched terms (odd indices).
@@ -33,6 +44,6 @@ export function HighlightText({ text, query }: HighlightTextProps): ReactNode {
 					<Fragment key={i}>{part}</Fragment>
 				) : null,
 			)}
-		</Fragment>
+		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/HighlightText/index.ts
@@ -1,0 +1,1 @@
+export { HighlightText } from "./HighlightText";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsRow/SettingsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsRow/SettingsRow.tsx
@@ -1,5 +1,7 @@
 import { Label } from "@superset/ui/label";
 import type { ReactNode } from "react";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { HighlightText } from "../HighlightText";
 
 interface SettingsRowProps {
 	label: string;
@@ -14,13 +16,23 @@ export function SettingsRow({
 	htmlFor,
 	children,
 }: SettingsRowProps) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className="flex items-center justify-between gap-8 py-2.5">
 			<div className="min-w-0 flex-1">
 				<Label htmlFor={htmlFor} className="text-sm font-medium">
-					{label}
+					<HighlightText text={label} query={searchQuery} />
 				</Label>
-				{hint && <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p>}
+				{hint && (
+					<p className="mt-0.5 text-xs text-muted-foreground">
+						{typeof hint === "string" ? (
+							<HighlightText text={hint} query={searchQuery} />
+						) : (
+							hint
+						)}
+					</p>
+				)}
 			</div>
 			<div className="shrink-0">{children}</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -6,10 +6,12 @@ import {
 	useIsV2OnlyUser,
 } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	useInlineWorkspacePortsEnabled,
 	useInlineWorkspacePortsStore,
 } from "renderer/stores/inline-workspace-ports";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { useOpenV1ImportModal } from "renderer/stores/v1-import-modal";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 import {
@@ -30,6 +32,7 @@ interface ExperimentalSettingsProps {
 export function ExperimentalSettings({
 	visibleItems,
 }: ExperimentalSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const showSupersetV2 = isItemVisible(
 		SETTING_ITEM_ID.EXPERIMENTAL_SUPERSET_V2,
 		visibleItems,
@@ -77,7 +80,7 @@ export function ExperimentalSettings({
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label htmlFor="superset-v2" className="text-sm font-medium">
-								Try Superset v2
+								<HighlightText text="Try Superset v2" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Use the new workspace experience.
@@ -99,7 +102,9 @@ export function ExperimentalSettings({
 				{showV1Migration && !isV2OnlyUser && (
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
-							<Label className="text-sm font-medium">Import from v1</Label>
+							<Label className="text-sm font-medium">
+								<HighlightText text="Import from v1" query={searchQuery} />
+							</Label>
 							<p className="text-xs text-muted-foreground">
 								Bring v1 projects, workspaces, and terminal presets over to v2.
 								Each item is imported individually and can be retried.
@@ -129,7 +134,10 @@ export function ExperimentalSettings({
 								htmlFor="inline-workspace-ports"
 								className="text-sm font-medium"
 							>
-								Inline workspace ports
+								<HighlightText
+									text="Inline workspace ports"
+									query={searchQuery}
+								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Show detected ports under each workspace in the sidebar instead
@@ -147,7 +155,7 @@ export function ExperimentalSettings({
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label htmlFor="workspace-agents" className="text-sm font-medium">
-								Workspace agents
+								<HighlightText text="Workspace agents" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Show running agents under each workspace in the sidebar, with

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -83,7 +83,10 @@ export function ExperimentalSettings({
 								<HighlightText text="Try Superset v2" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Use the new workspace experience.
+								<HighlightText
+									text="Use the new workspace experience."
+									query={searchQuery}
+								/>
 							</p>
 						</div>
 						<Switch
@@ -106,12 +109,17 @@ export function ExperimentalSettings({
 								<HighlightText text="Import from v1" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Bring v1 projects, workspaces, and terminal presets over to v2.
-								Each item is imported individually and can be retried.
+								<HighlightText
+									text="Bring v1 projects, workspaces, and terminal presets over to v2. Each item is imported individually and can be retried."
+									query={searchQuery}
+								/>
 							</p>
 							{!isV2CloudEnabled && (
 								<p className="text-xs text-muted-foreground">
-									Available when v2 is enabled.
+									<HighlightText
+										text="Available when v2 is enabled."
+										query={searchQuery}
+									/>
 								</p>
 							)}
 						</div>
@@ -140,8 +148,10 @@ export function ExperimentalSettings({
 								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Show detected ports under each workspace in the sidebar instead
-								of a single panel at the bottom.
+								<HighlightText
+									text="Show detected ports under each workspace in the sidebar instead of a single panel at the bottom."
+									query={searchQuery}
+								/>
 							</p>
 						</div>
 						<Switch
@@ -158,8 +168,10 @@ export function ExperimentalSettings({
 								<HighlightText text="Workspace agents" query={searchQuery} />
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Show running agents under each workspace in the sidebar, with
-								their live status.
+								<HighlightText
+									text="Show running agents under each workspace in the sidebar, with their live status."
+									query={searchQuery}
+								/>
 							</p>
 						</div>
 						<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/components/WaitForSetupBeforeAgentSetting/WaitForSetupBeforeAgentSetting.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/components/WaitForSetupBeforeAgentSetting/WaitForSetupBeforeAgentSetting.tsx
@@ -49,8 +49,10 @@ export function WaitForSetupBeforeAgentSetting() {
 					/>
 				</Label>
 				<p className="text-xs text-muted-foreground">
-					Run the agent in the Workspace Setup terminal once setup finishes
-					instead of starting a second terminal alongside it
+					<HighlightText
+						text="Run the agent in the Workspace Setup terminal once setup finishes instead of starting a second terminal alongside it"
+						query={searchQuery}
+					/>
 				</p>
 			</div>
 			<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/components/WaitForSetupBeforeAgentSetting/WaitForSetupBeforeAgentSetting.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/components/WaitForSetupBeforeAgentSetting/WaitForSetupBeforeAgentSetting.tsx
@@ -1,6 +1,8 @@
 import { Label } from "@superset/ui/label";
 import { Switch } from "@superset/ui/switch";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 /**
  * Experimental toggle for the wait-for-setup agent gate. Self-contained
@@ -9,6 +11,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
  * host `workspaces.create` chaining (v2).
  */
 export function WaitForSetupBeforeAgentSetting() {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 	const { data: waitForSetupBeforeAgent, isLoading } =
 		electronTrpc.settings.getWaitForSetupBeforeAgent.useQuery();
@@ -40,7 +43,10 @@ export function WaitForSetupBeforeAgentSetting() {
 					htmlFor="wait-for-setup-before-agent"
 					className="text-sm font-medium"
 				>
-					Wait for workspace setup before starting agents
+					<HighlightText
+						text="Wait for workspace setup before starting agents"
+						query={searchQuery}
+					/>
 				</Label>
 				<p className="text-xs text-muted-foreground">
 					Run the agent in the Workspace Setup terminal once setup finishes

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
@@ -15,6 +15,8 @@ import {
 import { Switch } from "@superset/ui/switch";
 import { useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { BRANCH_PREFIX_MODE_LABELS } from "../../../utils/branch-prefix";
 import {
 	isItemVisible,
@@ -28,6 +30,7 @@ interface GitSettingsProps {
 }
 
 export function GitSettings({ visibleItems }: GitSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const showDeleteLocalBranch = isItemVisible(
 		SETTING_ITEM_ID.GIT_DELETE_LOCAL_BRANCH,
 		visibleItems,
@@ -137,7 +140,10 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 								htmlFor="delete-local-branch"
 								className="text-sm font-medium"
 							>
-								Delete local branch on workspace removal
+								<HighlightText
+									text="Delete local branch on workspace removal"
+									query={searchQuery}
+								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Also delete the local git branch when deleting a worktree
@@ -156,7 +162,9 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 				{showBranchPrefix && (
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">
-							<Label className="text-sm font-medium">Branch prefix</Label>
+							<Label className="text-sm font-medium">
+								<HighlightText text="Branch prefix" query={searchQuery} />
+							</Label>
 							<p className="text-xs text-muted-foreground">
 								Group new branches under a folder.{" "}
 								<code className="bg-muted px-1.5 py-0.5 rounded text-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
@@ -146,8 +146,10 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 								/>
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Also delete the local git branch when deleting a worktree
-								workspace
+								<HighlightText
+									text="Also delete the local git branch when deleting a worktree workspace"
+									query={searchQuery}
+								/>
 							</p>
 						</div>
 						<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/components/UserWorktreeLocationSection/UserWorktreeLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/components/UserWorktreeLocationSection/UserWorktreeLocationSection.tsx
@@ -60,7 +60,10 @@ function V1Body() {
 				<HighlightText text="Worktree location" query={searchQuery} />
 			</Label>
 			<p className="text-xs text-muted-foreground">
-				Base directory for new worktrees
+				<HighlightText
+					text="Base directory for new worktrees"
+					query={searchQuery}
+				/>
 			</p>
 			<WorktreeLocationPicker
 				currentPath={worktreeBaseDir}
@@ -136,13 +139,18 @@ function V2Body() {
 						<HighlightText text="Worktree location" query={searchQuery} />
 					</Label>
 					<p className="text-xs text-muted-foreground">
-						{hasMultipleHosts
-							? `Base directory for new worktrees on ${
-									selectedHost?.isLocal
-										? "this device"
-										: (selectedHost?.name ?? "this device")
-								}`
-							: "Base directory for new worktrees"}
+						{hasMultipleHosts ? (
+							`Base directory for new worktrees on ${
+								selectedHost?.isLocal
+									? "this device"
+									: (selectedHost?.name ?? "this device")
+							}`
+						) : (
+							<HighlightText
+								text="Base directory for new worktrees"
+								query={searchQuery}
+							/>
+						)}
 					</p>
 				</div>
 				{hasMultipleHosts && effectiveHostId ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/components/UserWorktreeLocationSection/UserWorktreeLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/components/UserWorktreeLocationSection/UserWorktreeLocationSection.tsx
@@ -5,6 +5,7 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	HostSelect,
 	type HostSelectOption,
@@ -18,6 +19,7 @@ import {
 	useDefaultWorktreePath,
 	WorktreeLocationPicker,
 } from "renderer/routes/_authenticated/settings/components/WorktreeLocationPicker";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 export function UserWorktreeLocationSection() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
@@ -25,6 +27,7 @@ export function UserWorktreeLocationSection() {
 }
 
 function V1Body() {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 	const defaultWorktreePath = useDefaultWorktreePath();
 
@@ -53,7 +56,9 @@ function V1Body() {
 
 	return (
 		<div className="space-y-0.5">
-			<Label className="text-sm font-medium">Worktree location</Label>
+			<Label className="text-sm font-medium">
+				<HighlightText text="Worktree location" query={searchQuery} />
+			</Label>
 			<p className="text-xs text-muted-foreground">
 				Base directory for new worktrees
 			</p>
@@ -70,6 +75,7 @@ function V1Body() {
 }
 
 function V2Body() {
+	const searchQuery = useSettingsSearchQuery();
 	const { machineId } = useLocalHostService();
 	const { currentDeviceName, localHostId, otherHosts } =
 		useWorkspaceHostOptions();
@@ -126,7 +132,9 @@ function V2Body() {
 		<div className="space-y-2">
 			<div className="flex items-start justify-between gap-3">
 				<div className="space-y-0.5">
-					<Label className="text-sm font-medium">Worktree location</Label>
+					<Label className="text-sm font-medium">
+						<HighlightText text="Worktree location" query={searchQuery} />
+					</Label>
 					<p className="text-xs text-muted-foreground">
 						{hasMultipleHosts
 							? `Base directory for new worktrees on ${

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -10,6 +10,8 @@ import {
 } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import type { CandidateRow } from "./components/AddMemberDropdown";
 import { AddMemberDropdown } from "./components/AddMemberDropdown";
 import { DeleteHostSection } from "./components/DeleteHostSection";
@@ -34,6 +36,7 @@ interface HostSettingsProps {
 
 export function HostSettings({ hostId }: HostSettingsProps) {
 	const collections = useCollections();
+	const searchQuery = useSettingsSearchQuery();
 	const { data: session } = authClient.useSession();
 	const currentUserId = session?.user?.id ?? null;
 	const actions = useOptimisticCollectionActions();
@@ -181,7 +184,9 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 				<section className="space-y-3">
 					<div className="flex items-end justify-between gap-4">
 						<div>
-							<h3 className="text-sm font-medium">Members</h3>
+							<h3 className="text-sm font-medium">
+								<HighlightText text="Members" query={searchQuery} />
+							</h3>
 							{!isOwner && (
 								<p className="text-sm text-muted-foreground mt-0.5">
 									Only owners can change membership.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/DeleteHostSection/DeleteHostSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/DeleteHostSection/DeleteHostSection.tsx
@@ -16,6 +16,8 @@ import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 interface DeleteHostSectionProps {
 	hostId: string;
@@ -29,6 +31,7 @@ export function DeleteHostSection({
 	isLocalHost,
 }: DeleteHostSectionProps) {
 	const navigate = useNavigate();
+	const searchQuery = useSettingsSearchQuery();
 	const actions = useOptimisticCollectionActions();
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
@@ -74,7 +77,9 @@ export function DeleteHostSection({
 	return (
 		<div className="flex items-center justify-between gap-8 py-2.5">
 			<div className="min-w-0 flex-1">
-				<p className="text-sm font-medium">Delete host</p>
+				<p className="text-sm font-medium">
+					<HighlightText text="Delete host" query={searchQuery} />
+				</p>
 				<p
 					id={deleteHostDescriptionId}
 					className="mt-0.5 text-xs text-muted-foreground"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/WorktreeLocationSection/WorktreeLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/WorktreeLocationSection/WorktreeLocationSection.tsx
@@ -1,3 +1,5 @@
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	useSetV2WorktreeBaseDir,
 	useV2WorktreeLocationSettings,
@@ -19,6 +21,7 @@ export function WorktreeLocationSection({
 	isOnline,
 	canEdit,
 }: WorktreeLocationSectionProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const settingsQuery = useV2WorktreeLocationSettings(hostUrl, {
 		enabled: isOnline,
 	});
@@ -34,7 +37,9 @@ export function WorktreeLocationSection({
 	return (
 		<section className="space-y-3">
 			<div>
-				<h3 className="text-sm font-medium">Worktrees</h3>
+				<h3 className="text-sm font-medium">
+					<HighlightText text="Worktrees" query={searchQuery} />
+				</h3>
 				<p className="mt-0.5 text-sm text-muted-foreground">
 					Default location for new worktree workspaces on this host.
 				</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -9,6 +9,8 @@ import { env } from "renderer/env.renderer";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -34,6 +36,7 @@ export function IntegrationsSettings({
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 	const collections = useCollections();
+	const searchQuery = useSettingsSearchQuery();
 
 	const { data: integrations } = useLiveQuery(
 		(q) =>
@@ -124,7 +127,7 @@ export function IntegrationsSettings({
 			<div className="space-y-1">
 				{showLinear && (
 					<IntegrationRow
-						name="Linear"
+						name={<HighlightText text="Linear" query={searchQuery} />}
 						description="Sync issues bidirectionally with Linear."
 						icon={<SiLinear className="size-5" />}
 						isConnected={isLinearConnected}
@@ -135,7 +138,7 @@ export function IntegrationsSettings({
 
 				{showGithub && (
 					<IntegrationRow
-						name="GitHub"
+						name={<HighlightText text="GitHub" query={searchQuery} />}
 						description="Connect repos and sync pull requests."
 						icon={<FaGithub className="size-5" />}
 						isConnected={isGithubConnected}
@@ -147,7 +150,7 @@ export function IntegrationsSettings({
 
 				{showSlack && (
 					<IntegrationRow
-						name="Slack"
+						name={<HighlightText text="Slack" query={searchQuery} />}
 						description="Manage tasks from Slack conversations."
 						icon={<FaSlack className="size-5" />}
 						isConnected={isSlackConnected}
@@ -165,7 +168,7 @@ export function IntegrationsSettings({
 }
 
 interface IntegrationRowProps {
-	name: string;
+	name: React.ReactNode;
 	description: string;
 	icon: React.ReactNode;
 	isConnected: boolean;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
@@ -27,6 +27,8 @@ import {
 	useKeyboardPreferencesStore,
 	useRecordHotkeys,
 } from "renderer/hotkeys";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 const CATEGORY_ORDER: HotkeyCategory[] = [
 	"Navigation",
@@ -128,6 +130,7 @@ function getHotkeysByCategory(): Record<
 const hotkeysByCategory = getHotkeysByCategory();
 
 function KeyboardShortcutsPage() {
+	const settingsSearchQuery = useSettingsSearchQuery();
 	const [searchQuery, setSearchQuery] = useState("");
 	const [recordingId, setRecordingId] = useState<HotkeyId | null>(null);
 	const [pendingConflict, setPendingConflict] = useState<{
@@ -202,7 +205,12 @@ function KeyboardShortcutsPage() {
 			{/* Header */}
 			<div className="mb-6 flex items-start justify-between gap-4">
 				<div>
-					<h2 className="text-xl font-semibold">Keyboard shortcuts</h2>
+					<h2 className="text-xl font-semibold">
+						<HighlightText
+							text="Keyboard shortcuts"
+							query={settingsSearchQuery}
+						/>
+					</h2>
 					<p className="text-sm text-muted-foreground mt-1">
 						Customize keyboard shortcuts for your workflow. Press{" "}
 						<KbdGroup>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinkTierMapper/LinkTierMapper.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinkTierMapper/LinkTierMapper.tsx
@@ -15,6 +15,8 @@ import {
 	modifierLabel,
 	type Surface,
 } from "renderer/lib/clickPolicy";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 type SlotValue = LinkAction | "none";
 
@@ -46,6 +48,7 @@ export function LinkTierMapper({
 	idPrefix,
 	surface,
 }: LinkTierMapperProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const pick = useCallback(
 		(tier: LinkTier, nextSlot: SlotValue) => {
 			const nextAction = fromSlot(nextSlot);
@@ -57,8 +60,12 @@ export function LinkTierMapper({
 
 	return (
 		<div>
-			<h3 className="text-sm font-medium mb-1">{title}</h3>
-			<p className="text-xs text-muted-foreground mb-3">{description}</p>
+			<h3 className="text-sm font-medium mb-1">
+				<HighlightText text={title} query={searchQuery} />
+			</h3>
+			<p className="text-xs text-muted-foreground mb-3">
+				<HighlightText text={description} query={searchQuery} />
+			</p>
 			<div className="space-y-2">
 				{TIERS.map((tier) => {
 					const id = `${idPrefix}-${tier}`;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
@@ -14,6 +14,8 @@ import {
 	type LinkAction,
 	type LinkTierMap,
 } from "renderer/lib/clickPolicy";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -28,6 +30,7 @@ interface LinksSettingsProps {
 }
 
 export function LinksSettings({ visibleItems }: LinksSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const {
 		preferences,
 		setFileLinks,
@@ -100,7 +103,9 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 
 				{showPort && (
 					<div>
-						<h3 className="text-sm font-medium mb-1">Ports</h3>
+						<h3 className="text-sm font-medium mb-1">
+							<HighlightText text="Ports" query={searchQuery} />
+						</h3>
 						<p className="text-xs text-muted-foreground mb-3">
 							Where detected-port badges in the sidebar open when clicked.
 						</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/MembersSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/MembersSettings.tsx
@@ -18,6 +18,8 @@ import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -32,6 +34,7 @@ interface MembersSettingsProps {
 }
 
 export function MembersSettings({ visibleItems }: MembersSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const activeOrganizationId = session?.session?.activeOrganizationId;
@@ -118,7 +121,9 @@ export function MembersSettings({ visibleItems }: MembersSettingsProps) {
 					)}
 
 					<div className="max-w-5xl space-y-4">
-						<h3 className="text-lg font-semibold">Team Members</h3>
+						<h3 className="text-lg font-semibold">
+							<HighlightText text="Team Members" query={searchQuery} />
+						</h3>
 
 						{showMembersList &&
 							(!isReady && members.length === 0 ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/PendingInvitations/PendingInvitations.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/PendingInvitations/PendingInvitations.tsx
@@ -12,6 +12,8 @@ import {
 import { and, eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -33,6 +35,7 @@ export function PendingInvitations({
 	organizationId,
 	organizationName,
 }: PendingInvitationsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const collections = useCollections();
 
 	const shouldShowSection = isItemVisible(
@@ -85,7 +88,9 @@ export function PendingInvitations({
 		return (
 			<div className="space-y-4">
 				<div className="flex items-center justify-between">
-					<h3 className="text-lg font-semibold">Pending Invitations</h3>
+					<h3 className="text-lg font-semibold">
+						<HighlightText text="Pending Invitations" query={searchQuery} />
+					</h3>
 					{showInvite && (
 						<InviteMemberButton
 							currentUserRole={currentUserRole}
@@ -113,7 +118,9 @@ export function PendingInvitations({
 	return (
 		<div className="space-y-4">
 			<div className="flex items-center justify-between">
-				<h3 className="text-lg font-semibold">Pending Invitations</h3>
+				<h3 className="text-lg font-semibold">
+					<HighlightText text="Pending Invitations" query={searchQuery} />
+				</h3>
 				{showInvite && (
 					<InviteMemberButton
 						currentUserRole={currentUserRole}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/components/ConfigRow/ConfigRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/components/ConfigRow/ConfigRow.tsx
@@ -2,6 +2,8 @@ import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
 import { cn } from "@superset/ui/utils";
 import type { ReactNode } from "react";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 interface ConfigRowProps {
 	title: string;
@@ -34,13 +36,17 @@ export function ConfigRow({
 	disableClear,
 	className,
 }: ConfigRowProps) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className={cn("space-y-1.5", className)}>
 			<Label htmlFor={htmlFor} className="text-sm font-medium">
-				{title}
+				<HighlightText text={title} query={searchQuery} />
 			</Label>
 			{description ? (
-				<p className="text-xs text-muted-foreground -mt-1">{description}</p>
+				<p className="text-xs text-muted-foreground -mt-1">
+					<HighlightText text={description} query={searchQuery} />
+				</p>
 			) : null}
 			<div className="flex items-center gap-2">
 				<div className="min-w-0 flex-1">{field}</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/components/SettingsSection/SettingsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/components/SettingsSection/SettingsSection.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 interface SettingsSectionProps {
 	title: string;
@@ -15,17 +17,19 @@ export function SettingsSection({
 	action,
 	children,
 }: SettingsSectionProps) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<section className="space-y-3">
 			<div className="flex items-start justify-between gap-4">
 				<div className="min-w-0">
 					<h3 className="flex items-center gap-2 text-sm font-medium">
 						{icon}
-						{title}
+						<HighlightText text={title} query={searchQuery} />
 					</h3>
 					{description ? (
 						<p className="text-xs text-muted-foreground mt-0.5">
-							{description}
+							<HighlightText text={description} query={searchQuery} />
 						</p>
 					) : null}
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
@@ -30,10 +30,12 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	getImageExtensionFromMimeType,
 	parseBase64DataUrl,
 } from "shared/file-types";
+import { HighlightText } from "../../../components/HighlightText";
 import { MemberActions } from "../../../members/components/MembersSettings/components/MemberActions";
 import { PendingInvitations } from "../../../members/components/PendingInvitations";
 import type { TeamMember } from "../../../members/types";
@@ -57,13 +59,19 @@ interface SettingsRowProps {
 }
 
 function SettingsRow({ label, hint, htmlFor, children }: SettingsRowProps) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className="flex items-center justify-between gap-8 py-2.5">
 			<div className="flex-1 min-w-0">
 				<Label htmlFor={htmlFor} className="text-sm font-medium">
-					{label}
+					<HighlightText text={label} query={searchQuery} />
 				</Label>
-				{hint && <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>}
+				{hint && (
+					<p className="text-xs text-muted-foreground mt-0.5">
+						<HighlightText text={hint} query={searchQuery} />
+					</p>
+				)}
 			</div>
 			<div className="shrink-0">{children}</div>
 		</div>
@@ -76,6 +84,7 @@ export function OrganizationSettings({
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 	const collections = useCollections();
+	const searchQuery = useSettingsSearchQuery();
 
 	const [isSlugDialogOpen, setIsSlugDialogOpen] = useState(false);
 	const [logoPreview, setLogoPreview] = useState<string | null>(null);
@@ -396,7 +405,9 @@ export function OrganizationSettings({
 							{showMembersList && (
 								<div>
 									<div className="mb-3">
-										<h3 className="text-sm font-medium">Members</h3>
+										<h3 className="text-sm font-medium">
+											<HighlightText text="Members" query={searchQuery} />
+										</h3>
 										<p className="text-xs text-muted-foreground mt-0.5">
 											Everyone with access to this organization.
 										</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
@@ -30,12 +30,12 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	getImageExtensionFromMimeType,
 	parseBase64DataUrl,
 } from "shared/file-types";
-import { HighlightText } from "../../../components/HighlightText";
 import { MemberActions } from "../../../members/components/MembersSettings/components/MemberActions";
 import { PendingInvitations } from "../../../members/components/PendingInvitations";
 import type { TeamMember } from "../../../members/types";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
@@ -4,6 +4,8 @@ import { Label } from "@superset/ui/label";
 import { Skeleton } from "@superset/ui/skeleton";
 import { LuExternalLink } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { HighlightText } from "../../../components/HighlightText";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -35,11 +37,17 @@ function PermissionRow({
 	granted: boolean | undefined;
 	onRequest: () => void;
 }) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className="flex items-center justify-between gap-6">
 			<div className="min-w-0 flex-1 space-y-0.5">
-				<Label className="text-sm font-medium">{label}</Label>
-				<p className="text-xs text-muted-foreground">{description}</p>
+				<Label className="text-sm font-medium">
+					<HighlightText text={label} query={searchQuery} />
+				</Label>
+				<p className="text-xs text-muted-foreground">
+					<HighlightText text={description} query={searchQuery} />
+				</p>
 			</div>
 			<div className="flex items-center gap-3 shrink-0">
 				<StatusBadge granted={granted} />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/components/PermissionsSettings/PermissionsSettings.tsx
@@ -4,8 +4,8 @@ import { Label } from "@superset/ui/label";
 import { Skeleton } from "@superset/ui/skeleton";
 import { LuExternalLink } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { HighlightText } from "../../../components/HighlightText";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -36,9 +36,9 @@ import {
 	useImportAllWorktrees,
 	useOpenExternalWorktree,
 } from "renderer/react-query/workspaces";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { ClickablePath } from "../../../../components/ClickablePath";
-import { HighlightText } from "../../../../components/HighlightText";
 import {
 	useDefaultWorktreePath,
 	WorktreeLocationPicker,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -36,7 +36,9 @@ import {
 	useImportAllWorktrees,
 	useOpenExternalWorktree,
 } from "renderer/react-query/workspaces";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { ClickablePath } from "../../../../components/ClickablePath";
+import { HighlightText } from "../../../../components/HighlightText";
 import {
 	useDefaultWorktreePath,
 	WorktreeLocationPicker,
@@ -63,15 +65,19 @@ export function SettingsSection({
 	description?: string;
 	children: ReactNode;
 }) {
+	const searchQuery = useSettingsSearchQuery();
+
 	return (
 		<div className="space-y-3">
 			<div>
 				<h3 className="text-sm font-medium text-foreground flex items-center gap-2">
 					{icon}
-					{title}
+					<HighlightText text={title} query={searchQuery} />
 				</h3>
 				{description && (
-					<p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+					<p className="text-sm text-muted-foreground mt-0.5">
+						<HighlightText text={description} query={searchQuery} />
+					</p>
 				)}
 			</div>
 			{children}
@@ -88,6 +94,7 @@ export function ProjectSettings({
 	projectId,
 	visibleItems,
 }: ProjectSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 	const { data: project } = electronTrpc.projects.get.useQuery({
 		id: projectId,
@@ -417,7 +424,10 @@ export function ProjectSettings({
 							<div className="flex items-center justify-between">
 								<div className="space-y-0.5">
 									<Label className="text-sm font-medium">
-										Import Worktrees
+										<HighlightText
+											text="Import Worktrees"
+											query={searchQuery}
+										/>
 									</Label>
 									<p className="text-xs text-muted-foreground">
 										{importableExternalWorktrees.length} external worktree

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
@@ -9,6 +9,8 @@ import {
 } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { invalidateProjectScriptQueries } from "renderer/lib/project-scripts";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { EXTERNAL_LINKS } from "shared/constants";
 
 interface ScriptsEditorProps {
@@ -166,6 +168,7 @@ function ScriptTextarea({
 type SaveStatus = "idle" | "saving" | "saved";
 
 export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 
 	const { data: configData, isLoading } =
@@ -348,7 +351,9 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 		<div className={cn("space-y-3", className)}>
 			<div className="flex items-center justify-between gap-2">
 				<div className="flex items-center gap-2">
-					<h3 className="text-base font-semibold text-foreground">Scripts</h3>
+					<h3 className="text-base font-semibold text-foreground">
+						<HighlightText text="Scripts" query={searchQuery} />
+					</h3>
 					{saveStatus === "saving" && (
 						<span className="text-xs text-muted-foreground flex items-center gap-1">
 							<span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettingsHeader/ProjectSettingsHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettingsHeader/ProjectSettingsHeader.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 interface ProjectSettingsHeaderProps {
 	title: string;
@@ -9,9 +11,12 @@ export function ProjectSettingsHeader({
 	title,
 	children,
 }: ProjectSettingsHeaderProps) {
+	const searchQuery = useSettingsSearchQuery();
 	return (
 		<div className="mb-8">
-			<h2 className="text-xl font-semibold">{title}</h2>
+			<h2 className="text-xl font-semibold">
+				<HighlightText text={title} query={searchQuery} />
+			</h2>
 			{children && <div className="mt-1">{children}</div>}
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -6,12 +6,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { HiArrowPath, HiCheck, HiPlay, HiPlus, HiStop } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import {
 	AVAILABLE_RINGTONES,
 	type Ringtone,
 	useSelectedRingtoneId,
 	useSetRingtone,
 } from "renderer/stores";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { CUSTOM_RINGTONE_ID } from "shared/ringtones";
 import {
 	isItemVisible,
@@ -107,6 +109,7 @@ interface RingtonesSettingsProps {
 }
 
 export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const showNotification = isItemVisible(
 		SETTING_ITEM_ID.RINGTONES_NOTIFICATION,
 		visibleItems,
@@ -286,7 +289,12 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 					<div>
 						<div className="mb-3 flex items-start justify-between gap-2">
 							<div>
-								<h3 className="text-sm font-medium mb-1">Notification sound</h3>
+								<h3 className="text-sm font-medium mb-1">
+									<HighlightText
+										text="Notification sound"
+										query={searchQuery}
+									/>
+								</h3>
 								<p className="text-xs text-muted-foreground">
 									Pick a sound or add your own. Custom audio supports .mp3,
 									.wav, and .ogg.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { ExposeViaRelayConfirmDialog } from "renderer/routes/_authenticated/components/ExposeViaRelayConfirmDialog";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -16,6 +18,7 @@ interface SecuritySettingsProps {
 }
 
 export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const showRelayToggle = isItemVisible(
 		SETTING_ITEM_ID.SECURITY_EXPOSE_HOST_SERVICE_VIA_RELAY,
 		visibleItems,
@@ -90,7 +93,10 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 							htmlFor="expose-host-service-via-relay"
 							className="text-sm font-medium"
 						>
-							Allow remote workspaces to access this device via relay
+							<HighlightText
+								text="Allow remote workspaces to access this device via relay"
+								query={searchQuery}
+							/>
 						</Label>
 						<p className="text-xs text-muted-foreground">
 							When off, your local tools and files cannot be reached from any

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/teams/components/TeamsSettings/TeamsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/teams/components/TeamsSettings/TeamsSettings.tsx
@@ -11,9 +11,12 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { CreateTeamButton } from "./components/CreateTeamButton";
 
 export function TeamsSettings() {
+	const searchQuery = useSettingsSearchQuery();
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const navigate = useNavigate();
@@ -44,7 +47,9 @@ export function TeamsSettings() {
 			<div className="p-8">
 				<div className="max-w-5xl flex items-end justify-between gap-4">
 					<div>
-						<h2 className="text-2xl font-semibold">Teams</h2>
+						<h2 className="text-2xl font-semibold">
+							<HighlightText text="Teams" query={searchQuery} />
+						</h2>
 						<p className="text-sm text-muted-foreground mt-1">
 							Organize your work into teams. Tasks and integrations can sync
 							per-team.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/BackgroundTerminalsSetting.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/BackgroundTerminalsSetting.tsx
@@ -3,6 +3,8 @@ import { Label } from "@superset/ui/label";
 import { useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	DEFAULT_TERMINAL_PARKED_RUNTIME_CAP,
 	MAX_TERMINAL_PARKED_RUNTIME_CAP,
@@ -10,6 +12,7 @@ import {
 } from "shared/constants";
 
 export function BackgroundTerminalsSetting() {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 
 	const { data: cap, isLoading } =
@@ -64,7 +67,10 @@ export function BackgroundTerminalsSetting() {
 					htmlFor="terminal-background-limit"
 					className="text-sm font-medium"
 				>
-					Background terminal memory
+					<HighlightText
+						text="Background terminal memory"
+						query={searchQuery}
+					/>
 				</Label>
 				<p className="text-xs text-muted-foreground max-w-md leading-relaxed">
 					How many hidden terminals stay fully loaded (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/LinkBehaviorSetting.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/LinkBehaviorSetting.tsx
@@ -8,8 +8,11 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 export function LinkBehaviorSetting() {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 
 	const { data: terminalLinkBehavior, isLoading } =
@@ -40,7 +43,7 @@ export function LinkBehaviorSetting() {
 		<div className="flex items-center justify-between">
 			<div className="space-y-0.5">
 				<Label htmlFor="terminal-link-behavior" className="text-sm font-medium">
-					Terminal file links
+					<HighlightText text="Terminal file links" query={searchQuery} />
 				</Label>
 				<p className="text-xs text-muted-foreground">
 					Choose how to open file paths when Cmd+clicking in the terminal

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -10,7 +10,9 @@ import { HiOutlinePlus } from "react-icons/hi2";
 import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { usePresets } from "renderer/react-query/presets";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import type { PresetColumnKey } from "renderer/routes/_authenticated/settings/presets/types";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { PresetEditorDialog } from "./components/PresetEditorDialog";
 import { PresetsTable } from "./components/PresetsTable";
 import {
@@ -37,6 +39,7 @@ export function PresetsSection({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: PresetsSectionProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const isDark = useIsDarkTheme();
 	const { data: groupedProjects = [] } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
@@ -480,7 +483,9 @@ export function PresetsSection({
 		<div className="space-y-4">
 			<div className="flex items-center justify-between">
 				<div className="space-y-0.5">
-					<Label className="text-sm font-medium">Terminal Presets</Label>
+					<Label className="text-sm font-medium">
+						<HighlightText text="Terminal Presets" query={searchQuery} />
+					</Label>
 					<p className="text-xs text-muted-foreground">
 						Presets let you quickly launch terminals with pre-configured
 						commands.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
@@ -11,8 +11,11 @@ import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
 import { useMemo, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 export function SessionsSection() {
+	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 
 	const { data: daemonSessions } =
@@ -132,7 +135,9 @@ export function SessionsSection() {
 			<div className="rounded-md border border-border/60 p-4 space-y-3">
 				<div className="space-y-0.5">
 					<div className="flex items-center justify-between">
-						<Label className="text-sm font-medium">Terminal daemon</Label>
+						<Label className="text-sm font-medium">
+							<HighlightText text="Terminal daemon" query={searchQuery} />
+						</Label>
 						<Button
 							variant="ghost"
 							size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -16,7 +16,9 @@ import { getAgentCommandText } from "renderer/lib/agent-launch-command";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import type { PresetColumnKey } from "renderer/routes/_authenticated/settings/presets/types";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { PresetEditorDialog } from "../PresetsSection/components/PresetEditorDialog";
 
 import { PresetsTable } from "../PresetsSection/components/PresetsTable";
@@ -54,6 +56,7 @@ export function V2PresetsSection({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: V2PresetsSectionProps) {
+	const searchQuery = useSettingsSearchQuery();
 	const isDark = useIsDarkTheme();
 	const collections = useCollections();
 
@@ -626,7 +629,9 @@ export function V2PresetsSection({
 			<div className="rounded-lg border border-border overflow-hidden divide-y divide-border">
 				<div className="flex items-start justify-between gap-3 p-4">
 					<div className="min-w-0">
-						<h3 className="text-sm font-medium">Terminal presets</h3>
+						<h3 className="text-sm font-medium">
+							<HighlightText text="Terminal presets" query={searchQuery} />
+						</h3>
 						<p className="text-xs text-muted-foreground mt-0.5">
 							Pre-configured terminal launches. Click a preset to edit, drag to
 							reorder.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
@@ -70,6 +70,7 @@ export function V2SessionsSection() {
 }
 
 function V2SessionsSectionInner() {
+	const searchQuery = useSettingsSearchQuery();
 	const [confirmRestartOpen, setConfirmRestartOpen] = useState(false);
 	const [showSessionList, setShowSessionList] = useState(false);
 	// Phase 2: when handoff fails, the failure dialog asks whether to
@@ -181,7 +182,7 @@ function V2SessionsSectionInner() {
 				<div className="flex items-start justify-between gap-4">
 					<div>
 						<h3 className="text-sm font-medium flex items-baseline gap-2">
-							Terminal daemon
+							<HighlightText text="Terminal daemon" query={searchQuery} />
 							{versionLabel ? (
 								<span className="text-xs font-mono font-normal text-muted-foreground/80">
 									{versionLabel}
@@ -189,7 +190,10 @@ function V2SessionsSectionInner() {
 							) : null}
 						</h3>
 						<p className="text-sm text-muted-foreground mt-0.5">
-							Owns every PTY session and survives app restarts.
+							<HighlightText
+								text="Owns every PTY session and survives app restarts."
+								query={searchQuery}
+							/>
 						</p>
 					</div>
 					<div className="flex flex-wrap gap-2 shrink-0">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
@@ -36,15 +36,20 @@ import {
 	getHostServiceWsToken,
 } from "renderer/lib/host-service-auth";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 
 const REFETCH_WHILE_OPEN_MS = 5_000;
 
 export function V2SessionsSection() {
+	const searchQuery = useSettingsSearchQuery();
 	const { activeHostUrl } = useLocalHostService();
 	if (!activeHostUrl) {
 		return (
 			<div className="space-y-1">
-				<h3 className="text-sm font-medium">Terminal daemon</h3>
+				<h3 className="text-sm font-medium">
+					<HighlightText text="Terminal daemon" query={searchQuery} />
+				</h3>
 				<p className="text-sm text-muted-foreground">
 					Host service is starting…
 				</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -1491,8 +1491,12 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 	},
 ];
 
+export function splitSearchTerms(query: string): string[] {
+	return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
 export function searchSettings(query: string): SettingsItem[] {
-	const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	const terms = splitSearchTerms(query);
 	if (terms.length === 0) return SETTINGS_ITEMS;
 
 	return SETTINGS_ITEMS.filter((item) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
@@ -8,6 +8,8 @@ import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	HostSelect,
 	type HostSelectOption,
@@ -32,6 +34,7 @@ export function V2ProjectSettings({
 	hostId,
 }: V2ProjectSettingsProps) {
 	const navigate = useNavigate();
+	const searchQuery = useSettingsSearchQuery();
 	const { machineId } = useLocalHostService();
 	const { currentDeviceName, localHostId, otherHosts } =
 		useWorkspaceHostOptions();
@@ -225,7 +228,9 @@ export function V2ProjectSettings({
 					{targetHostUrl && (
 						<div className="pt-4">
 							<div className="mb-3">
-								<h3 className="text-sm font-medium">Scripts</h3>
+								<h3 className="text-sm font-medium">
+									<HighlightText text="Scripts" query={searchQuery} />
+								</h3>
 								<p className="mt-0.5 text-xs text-muted-foreground">
 									Runs in a terminal for setup, teardown, and the workspace Run
 									button.


### PR DESCRIPTION
## Summary
- Add a `HighlightText` component that wraps matched search-term substrings in `<mark>`, reusing the app's existing `--highlight-match` CSS token (already used by in-app markdown/chat/diff search) so the color is consistent and theme-aware for free.
- Wire it into the settings search flow: the three shared row/section primitives (`SettingsRow`, `ConfigRow`, `SettingsSection`) plus every individual settings page's label/description text across Account, Organization, Appearance, Behavior, Security, Git, Experimental, Terminal, Links, Members, Hosts, Integrations, API Keys, Project, Billing, Ringtones, Keyboard, and Teams.
- Consolidate a few settings pages that had reimplemented their own local row component instead of importing the shared one (`AccountSettings`, `OrganizationSettings`, `ThemeSection`, `PermissionsSettings`, `ProjectSettings`), so they pick up highlighting without duplicating the wrap logic per call site.

## Why / Context
Settings search already filters the sidebar down to matching sections and shows a match-count badge, but once you land on a page there was no indication of *where* the term actually matched — you had to scan the whole page yourself. This adds the highlight so the matched substring is visible directly on the row.

## How It Works
- `splitSearchTerms(query)` is extracted out of the existing `searchSettings` filter logic in `settings-search.ts` and reused by `HighlightText`, so filtering and highlighting can never drift out of sync (same term-splitting, same case-insensitive matching).
- `HighlightText` is a pure `{ text, query }` component — no store coupling — that case-insensitively matches each search term against the text, escapes regex metacharacters, and wraps matches in `<mark className="rounded-sm bg-highlight-match text-inherit">`. Empty query or no match returns the original text unchanged (no wrapper element).
- `--color-highlight-match` is promoted from an existing `--highlight-match` CSS variable into a real Tailwind utility (`bg-highlight-match`) in `globals.css`, mirroring how `--highlight`/`--highlight-foreground` were already promoted. No new color introduced.
- Coverage is scoped to text that corresponds to an entry in the static `SETTINGS_ITEMS` search registry — dynamic/user-supplied text (preset names, member names/emails, org names, script contents, etc.) is intentionally never wrapped, since none of that is part of what the search box can actually match against.

## Manual QA Checklist

Verified end-to-end against the running dev app via CDP (real keyboard shortcut to open Settings, real dispatched keystrokes into the search box, real sidebar clicks — not synthetic DOM/state assignment):

- [x] Cmd+, opens Settings; typing "worktree" highlights the matching substring in both the row label ("**Worktree** location") and hint text ("new **worktree**s on this device") on the Git & Worktrees page
- [x] Clicking a different matching section in the sidebar preserves highlighting on the new page
- [x] Clearing the search input removes all `<mark>` elements with no leftover DOM wrapper (0 count, plain text restored)
- [x] Dark theme: highlight background resolves to `rgba(224, 120, 80, 0.2)` — matches `globals.css` exactly
- [x] Light theme (switched via the real theme picker): highlight background resolves to `rgba(255, 211, 61, 0.35)` — matches `globals.css` exactly, confirmed the token flips correctly since this app gates dark as the `:root` default and light as the override, not the usual `dark:` Tailwind variant
- [x] Partial-word matching renders correctly (e.g. "theme" highlights inside "themes" without highlighting the trailing "s")

## Testing
- `bun run lint:fix` / `bun run lint` — 0 issues
- `bun run typecheck` (filtered to `@superset/desktop`) — passes
- `bun test` (`apps/desktop`) — 2508 pass, 0 fail
- New unit tests: `HighlightText.test.tsx` covers empty query, single/multiple terms, case-insensitivity, regex-metacharacter queries, and no-match passthrough

## Design Decisions
- **Why not migrate every duplicated local row component to the shared `SettingsRow`**: a few pages (e.g. `AccountSettings`) had local row variants with slightly different className details (padding, `Label` vs `div`) than the shared component. Rather than risk a visual regression I couldn't individually verify across every page, I added highlighting in-place inside each local wrapper instead of swapping components — same outcome, lower risk. Only wrapper components with no material layout differences were consolidated onto the shared `SettingsRow`/`SettingsSection`.
- **Why reuse `--highlight-match` instead of a new token**: this exact codebase already has a "search match" color for the in-app markdown/chat/diff search UI (via the CSS Custom Highlight API). Reusing it keeps "search match" visually consistent everywhere instead of introducing a second, slightly different highlight color.

## Known Limitations
- Page-level `<h2>` headers only highlight when the header text closely matches a real `SETTINGS_ITEMS` registry title (e.g. "API keys", "Teams"). Headers with no corresponding registry item (e.g. "Account", "Integrations", "Permissions") are left unwrapped, since there's nothing in the registry for that literal page-title text to match against.
- Coverage is scoped to plain string label/title/hint/description props feeding through row components — content rendered as complex `ReactNode` (e.g. the Appearance "Theme" row's hint, which contains marketplace/docs links) is intentionally left unwrapped rather than risk mangling embedded interactive elements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlight search matches across settings so users can see exactly where their query applies. Adds a reusable `HighlightText` component and wires it into labels, hints, headings, dialog titles, and integration names with the existing theme-aware match color.

- **New Features**
  - Added `HighlightText` to wrap matched terms in <mark> using `bg-highlight-match`; integrated across shared rows/sections and individual pages (labels, hints, page/dialog titles, integration names).
  - Matching reuses `splitSearchTerms` for consistent, case-insensitive, regex-safe behavior and prefers longer terms first; scoped to registry-backed static text only.

- **Bug Fixes**
  - Prevented layout gaps by wrapping output in a single `<span>` and fixed missing highlighting in the normal V2 "Terminal daemon" path.
  - Wrapped previously missed hints/descriptions (Git, Experimental, Wait-For-Setup, Worktree Location, Theme “Custom themes”); added tests for empty queries, multi-term cases, regex metacharacters, longer-term precedence, and the single-wrapper behavior.

<sup>Written for commit 4d29ad7af309c704aab1dc3b99febe58b4300470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings search results now highlight matching terms across settings pages, labels, headings, descriptions, hints, and integration names.
  * Highlighting supports multiple terms, case-insensitive matching, overlapping terms, and special characters.
  * Added consistent visual styling for matched text throughout settings.

* **Tests**
  * Added coverage for empty queries, whitespace, multiple matches, case handling, unmatched text, overlapping terms, and special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->