### PR TITLE
chore(desktop): upload host-service bundle sourcemaps to its own Sentry project

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -43,6 +43,22 @@ const sentryPlugin = process.env.SENTRY_AUTH_TOKEN
 		})
 	: null;
 
+// host-service runs as a child process reporting to its own Sentry project,
+// and sourcemap lookup is per-project — its bundles must also be uploaded
+// there or host-service stacks stay unsymbolicated. Debug IDs are derived
+// from file content, so the double injection with sentryPlugin is identical.
+const hostServiceSentryPlugin = process.env.SENTRY_AUTH_TOKEN
+	? sentryVitePlugin({
+			org: "superset-sh",
+			project: "host-service",
+			authToken: process.env.SENTRY_AUTH_TOKEN,
+			release: { name: version },
+			sourcemaps: {
+				assets: ["**/host-service.js*", "**/host-worker.js*"],
+			},
+		})
+	: null;
+
 export default defineConfig({
 	main: {
 		plugins: [tsconfigPaths, copyResourcesPlugin()],
@@ -129,7 +145,7 @@ export default defineConfig({
 					dir: resolve(devPath, "main"),
 				},
 				external: ["electron", ...mainExternalizedDependencies],
-				plugins: [sentryPlugin].filter(Boolean),
+				plugins: [sentryPlugin, hostServiceSentryPlugin].filter(Boolean),
 			},
 		},
 		resolve: {


### PR DESCRIPTION
## Why

Host-service just gained real Sentry reporting (#6164), but its stacks arrive unsymbolicated: the existing sentryVitePlugin uploads all main-process sourcemaps to the desktop project, while host-service events land in the host-service project — and Sentry's debug-ID sourcemap lookup is per-project.

## What

A second, asset-scoped sentryVitePlugin instance in the electron-vite main build uploads just host-service.js*/host-worker.js* to the host-service project (same content-derived debug IDs, so the double injection is a no-op; same version release name, matching HOST_SERVICE_SENTRY_RELEASE = app.getVersion()).

No runtime changes; build-time upload only. Takes effect on the next desktop release build (the workflow already passes SENTRY_AUTH_TOKEN).

## Verification

- Biome clean on the changed file (config-only change; CI runs the full suite).
- Post-release: open any host-service issue in Sentry and confirm frames resolve to packages/host-service/src/... instead of minified host-service.js offsets.

https://claude.ai/code/session_012u6VZtfQgoTh8qS4NqCb7e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads host-service sourcemaps to the `host-service` Sentry project so its error stacks symbolicate correctly. Build-only change applied in the Electron main build; no runtime changes.

- **Bug Fixes**
  - Added a second `sentryVitePlugin` scoped to `**/host-service.js*` and `**/host-worker.js*`, targeting the `host-service` Sentry project.
  - Uses the app version for the release name and content-derived debug IDs, so double injection is safe.
  - Enabled only when `SENTRY_AUTH_TOKEN` is set; takes effect on the next desktop release build.

<sup>Written for commit ee773190fbcfa355d9d40d1a8ef5ca8f8f726b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error diagnostics for desktop host services, enabling more accurate issue investigation.
  * No changes to visible desktop functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->