### PR TITLE
fix(desktop): remove doubled border between workspace panes and right sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -21,7 +21,7 @@ export function SidebarHeader({
 	return (
 		<div className="flex h-10 shrink-0 items-stretch">
 			<div className="flex min-w-0 flex-1 items-center h-full overflow-hidden">
-				{tabs.map((tab) => {
+				{tabs.map((tab, index) => {
 					const isActive = activeTab === tab.id;
 					const badge =
 						typeof tab.badge === "number" && tab.badge > 0
@@ -41,6 +41,8 @@ export function SidebarHeader({
 									inverted: true,
 								}),
 								"relative flex-1 justify-center",
+								// The resizable panel already draws the sidebar's left edge.
+								index === 0 && "border-l-transparent",
 							)}
 						>
 							{tab.icon && <tab.icon className="size-3" />}


### PR DESCRIPTION
## Summary

The v2 workspace sidebar's tab header uses the inverted tab style where the active tab draws a 1px border on all sides. When the leftmost tab (Files) is active, its left border sits flush against the `ResizablePanel`'s `border-l`, rendering a 2px doubled divider across the tab-header row.

Fix: make the first tab's left border transparent — the resizable panel already draws the sidebar's left edge. Inactive tabs already had a transparent left border, so nothing else changes.

## Test Plan

- [ ] Open a v2 workspace with the right sidebar visible and the Files tab active — the divider between the panes and the sidebar is a single 1px line across the tab-header row
- [ ] Switch between Files/Changes/Review tabs — no layout shift, divider stays single

https://claude.ai/code/session_015mBAauusSAewcv7JHm5pAw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the doubled 2px divider between the main pane and the right sidebar by making the first sidebar tab’s left border transparent. Ensures a single, consistent 1px divider across the tab header with no layout shift when switching tabs.

<sup>Written for commit 7ac34b17bc00045b81b0624d6125918bce28b330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the workspace sidebar’s visual alignment by preventing a duplicated border on the first tab next to the resizable panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->