### PR TITLE
fix(host-service): run teardown scripts on CLI/SDK/MCP workspace deletes

### DIFF
--- a/apps/docs/content/docs/setup-teardown-scripts.mdx
+++ b/apps/docs/content/docs/setup-teardown-scripts.mdx
@@ -175,6 +175,8 @@ When teardown fails:
 2. Click "Delete Anyway" to force-delete immediately
 3. Or click "View Logs" to review the failure, then force-delete from the dialog
 
+Deleting a workspace through the CLI, SDK, or MCP also runs teardown. Since there's no one to prompt on those surfaces, a teardown failure doesn't block the delete — it's reported in the response's `warnings` instead.
+
 ## Tips
 
 - Keep setup fast: it runs on every workspace creation

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { sanitizePromptForPty } from "@superset/shared/agent-prompt-launch";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { invalidateLabelCache } from "../../../ports/static-ports";
@@ -34,6 +35,19 @@ export interface DestroyWorkspaceInput {
 	workspaceId: string;
 	deleteBranch: boolean;
 	force: boolean;
+	/**
+	 * Teardown (step 1) behavior — deliberately separate from `force`, which
+	 * only carries the destructive git semantics (skip preflight, double-force
+	 * worktree removal):
+	 *   - "blocking":    a failed script throws PRECONDITION_FAILED so an
+	 *                    interactive caller can prompt a force-retry.
+	 *   - "best-effort": always runs; a failure degrades to a warning. For
+	 *                    non-interactive callers (CLI/SDK/MCP) with nobody to
+	 *                    prompt — skipping instead would leak the resources the
+	 *                    script provisions (#6174).
+	 *   - "skip":        don't run — the interactive force-retry contract.
+	 */
+	teardownMode: "blocking" | "best-effort" | "skip";
 }
 
 /**
@@ -121,7 +135,7 @@ export const workspaceCleanupRouter = router({
 	 * Destroy a workspace in five phases:
 	 *
 	 *   0. Preflight     — dirty-worktree check (skip if force)
-	 *   1. Teardown      — run .superset/teardown.sh (skip if force)
+	 *   1. Teardown      — run .superset/teardown.sh (per teardownMode)
 	 *   2. Local cleanup — PTYs, worktree
 	 *   3. Cloud delete  ← authoritative UI state
 	 *   4. Branch delete — optional local branch cleanup
@@ -131,9 +145,8 @@ export const workspaceCleanupRouter = router({
 	 * while the path still exists, the cloud row remains so the workspace is
 	 * still visible and delete can be retried instead of orphaning disk state.
 	 *
-	 * Force semantics:
+	 * Force semantics (git only; teardown is governed by teardownMode):
 	 *   - skips preflight (step 0)
-	 *   - skips teardown  (step 1)
 	 *   - step 2b always uses `--force --force`
 	 *   - step 4 always uses `-D` regardless: the `deleteBranch`
 	 *     checkbox is the user's consent, so refusing unmerged branches
@@ -159,7 +172,14 @@ export const workspaceCleanupRouter = router({
 				force: z.boolean().default(false),
 			}),
 		)
-		.mutation(async ({ ctx, input }) => destroyWorkspace(ctx, input)),
+		.mutation(async ({ ctx, input }) =>
+			destroyWorkspace(ctx, {
+				...input,
+				// Interactive contract: force-retry is the user's explicit consent
+				// to abandon a failed teardown.
+				teardownMode: input.force ? "skip" : "blocking",
+			}),
+		),
 });
 
 export async function destroyWorkspace(
@@ -232,9 +252,8 @@ async function runDestroy(
 
 	// ─── Step 1: Teardown ──────────────────────────────────────────
 	// Script is the user's last chance to stop services / flush state
-	// before the workspace goes away. Failure here is recoverable
-	// via force-retry, which skips this step.
-	if (!input.force && local && project) {
+	// before the workspace goes away.
+	if (input.teardownMode !== "skip" && local && project) {
 		const teardown: TeardownResult = await runTeardown({
 			db: ctx.db,
 			workspaceId: input.workspaceId,
@@ -243,20 +262,23 @@ async function runDestroy(
 			projectId: local.projectId,
 		});
 		if (teardown.status === "failed") {
-			const cause: TeardownFailureCause = {
-				kind: "TEARDOWN_FAILED",
-				exitCode: teardown.exitCode,
-				signal: teardown.signal,
-				timedOut: teardown.timedOut,
-				outputTail: teardown.outputTail,
-			};
-			// Recoverable via force-retry — an expected user-script failure, not a
-			// service bug; must not be reported as a 500.
-			throw new TRPCError({
-				code: "PRECONDITION_FAILED",
-				message: "Teardown script failed",
-				cause,
-			});
+			if (input.teardownMode === "blocking") {
+				const cause: TeardownFailureCause = {
+					kind: "TEARDOWN_FAILED",
+					exitCode: teardown.exitCode,
+					signal: teardown.signal,
+					timedOut: teardown.timedOut,
+					outputTail: teardown.outputTail,
+				};
+				// Recoverable via force-retry — an expected user-script failure, not a
+				// service bug; must not be reported as a 500.
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: "Teardown script failed",
+					cause,
+				});
+			}
+			warnings.push(formatTeardownWarning(teardown));
 		}
 	}
 
@@ -391,4 +413,22 @@ async function runDestroy(
 		branchDeleted,
 		warnings,
 	};
+}
+
+function formatTeardownWarning(
+	teardown: Extract<TeardownResult, { status: "failed" }>,
+): string {
+	const detail = teardown.timedOut
+		? "timed out"
+		: teardown.exitCode !== null
+			? `exit code ${teardown.exitCode}`
+			: teardown.signal !== null
+				? `signal ${teardown.signal}`
+				: "unknown failure";
+	// Tail is raw PTY bytes; strip control sequences for the plain-text
+	// warnings channel (CLI/SDK/MCP).
+	const tail = sanitizePromptForPty(teardown.outputTail).trim();
+	return tail
+		? `Teardown script failed (${detail}): ${tail}`
+		: `Teardown script failed (${detail})`;
 }

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -160,11 +160,15 @@ export const workspaceRouter = router({
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ ctx, input }) => {
 			// Legacy external surface used by CLI/SDK/MCP. Preserve its
-			// non-interactive contract while reusing the v2 cleanup path.
+			// non-interactive contract while reusing the v2 cleanup path:
+			// force covers the git semantics (no dirty-worktree prompt), but
+			// teardown still runs — a failure lands in `warnings` since there
+			// is nobody to prompt for a force-retry (#6174).
 			return destroyWorkspace(ctx, {
 				workspaceId: input.id,
 				deleteBranch: false,
 				force: true,
+				teardownMode: "best-effort",
 			});
 		}),
 });

--- a/packages/host-service/test/helpers/fake-pty.ts
+++ b/packages/host-service/test/helpers/fake-pty.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from "node:child_process";
+import type { ServerOptions } from "@superset/pty-daemon";
+
+/**
+ * In-process PTY spawner for teardown/lifecycle tests: emits the
+ * shell-integration prompt marker, then executes each written command
+ * synchronously via `/bin/sh -c` and exits with its status. Mimics fish's
+ * `$?` rejection so shell-portability regressions stay covered.
+ */
+export function createFishLikePtySpawner(
+	writes: string[],
+): NonNullable<ServerOptions["spawnPty"]> {
+	return ({ meta }) => {
+		let dataCallback: ((data: Buffer) => void) | null = null;
+		let exitCallback:
+			| ((info: { code: number | null; signal: number | null }) => void)
+			| null = null;
+
+		queueMicrotask(() => {
+			// OSC 133;A — shell-integration prompt-start marker the terminal
+			// session waits for before sending the initial command.
+			dataCallback?.(Buffer.from("\x1b]133;A\x07"));
+		});
+
+		return {
+			pid: 42,
+			meta,
+			write(data) {
+				const command = data.toString("utf8").trim();
+				writes.push(command);
+				if (command.includes("$?")) {
+					dataCallback?.(
+						Buffer.from(
+							"fish: $? is not the exit status. In fish, please use $status.\n",
+						),
+					);
+					return;
+				}
+
+				const child = spawnSync("/bin/sh", ["-c", command], {
+					cwd: meta.cwd,
+					env: meta.env,
+				});
+				if (child.stdout.byteLength > 0) dataCallback?.(child.stdout);
+				if (child.stderr.byteLength > 0) dataCallback?.(child.stderr);
+				exitCallback?.({ code: child.status ?? 1, signal: null });
+			},
+			resize(cols, rows) {
+				meta.cols = cols;
+				meta.rows = rows;
+			},
+			kill(signal) {
+				exitCallback?.({ code: null, signal: signal === "SIGKILL" ? 9 : 1 });
+			},
+			onData(cb) {
+				dataCallback = cb;
+			},
+			onExit(cb) {
+				exitCallback = cb;
+			},
+			getMasterFd() {
+				return 0;
+			},
+		};
+	};
+}
+
+/** POSIX single-quote escape for paths embedded in fixture scripts. */
+export function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/packages/host-service/test/integration/teardown.integration.test.ts
+++ b/packages/host-service/test/integration/teardown.integration.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -9,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Server, type ServerOptions } from "@superset/pty-daemon";
+import { Server } from "@superset/pty-daemon";
 import { runTeardown } from "../../src/runtime/teardown";
 import { disposeDaemonClient } from "../../src/terminal/daemon-client-singleton";
 import {
@@ -18,6 +17,7 @@ import {
 } from "../../src/terminal/env";
 import { __resetSessionsForTesting } from "../../src/terminal/terminal";
 import { __setAccountShellForTesting } from "../../src/terminal/user-shell";
+import { createFishLikePtySpawner, shellQuote } from "../helpers/fake-pty";
 import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
 
 describe("runTeardown integration", () => {
@@ -95,65 +95,3 @@ describe("runTeardown integration", () => {
 		expect(existsSync(markerPath)).toBe(true);
 	});
 });
-
-function createFishLikePtySpawner(
-	writes: string[],
-): NonNullable<ServerOptions["spawnPty"]> {
-	return ({ meta }) => {
-		let dataCallback: ((data: Buffer) => void) | null = null;
-		let exitCallback:
-			| ((info: { code: number | null; signal: number | null }) => void)
-			| null = null;
-
-		queueMicrotask(() => {
-			// OSC 133;A — shell-integration prompt-start marker the terminal
-			// session waits for before sending the initial command.
-			dataCallback?.(Buffer.from("\x1b]133;A\x07"));
-		});
-
-		return {
-			pid: 42,
-			meta,
-			write(data) {
-				const command = data.toString("utf8").trim();
-				writes.push(command);
-				if (command.includes("$?")) {
-					dataCallback?.(
-						Buffer.from(
-							"fish: $? is not the exit status. In fish, please use $status.\n",
-						),
-					);
-					return;
-				}
-
-				const child = spawnSync("/bin/sh", ["-c", command], {
-					cwd: meta.cwd,
-					env: meta.env,
-				});
-				if (child.stdout.byteLength > 0) dataCallback?.(child.stdout);
-				if (child.stderr.byteLength > 0) dataCallback?.(child.stderr);
-				exitCallback?.({ code: child.status ?? 1, signal: null });
-			},
-			resize(cols, rows) {
-				meta.cols = cols;
-				meta.rows = rows;
-			},
-			kill(signal) {
-				exitCallback?.({ code: null, signal: signal === "SIGKILL" ? 9 : 1 });
-			},
-			onData(cb) {
-				dataCallback = cb;
-			},
-			onExit(cb) {
-				exitCallback = cb;
-			},
-			getMasterFd() {
-				return 0;
-			},
-		};
-	};
-}
-
-function shellQuote(value: string): string {
-	return `'${value.replaceAll("'", "'\\''")}'`;
-}

--- a/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Server } from "@superset/pty-daemon";
+import { disposeDaemonClient } from "../../src/terminal/daemon-client-singleton";
+import {
+	initTerminalBaseEnv,
+	resetTerminalBaseEnvForTests,
+} from "../../src/terminal/env";
+import { __resetSessionsForTesting } from "../../src/terminal/terminal";
+import { __setAccountShellForTesting } from "../../src/terminal/user-shell";
+import { cloudFlows } from "../helpers/cloud-fakes";
+import { createFishLikePtySpawner, shellQuote } from "../helpers/fake-pty";
+import {
+	createFeatureWorktreeScenario,
+	type FeatureWorktreeScenario,
+} from "../helpers/scenarios";
+
+/**
+ * Regression coverage for #6174: the external delete surface (CLI/SDK/MCP →
+ * `workspace.delete`) hardcodes `force: true` for its non-interactive git
+ * semantics, but teardown must still run — silently skipping it leaks the
+ * resources the script provisions.
+ */
+describe("workspace delete teardown integration", () => {
+	let scenario: FeatureWorktreeScenario | null = null;
+	let server: Server | null = null;
+	let tmp: string | null = null;
+
+	afterEach(async () => {
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+		resetTerminalBaseEnvForTests();
+		__setAccountShellForTesting(undefined);
+		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
+		delete process.env.SUPERSET_HOME_DIR;
+		if (server) {
+			await server.close().catch(() => {});
+			server = null;
+		}
+		if (scenario) {
+			await scenario.dispose();
+			scenario = null;
+		}
+		if (tmp) {
+			rmSync(tmp, { recursive: true, force: true });
+			tmp = null;
+		}
+	});
+
+	async function setup(teardownScript: string): Promise<{
+		scenario: FeatureWorktreeScenario;
+		markerPath: string;
+	}> {
+		tmp = mkdtempSync(join(tmpdir(), "host-service-delete-teardown-it-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		server = new Server({
+			socketPath,
+			daemonVersion: "0.0.0-delete-teardown-integration-test",
+			spawnPty: createFishLikePtySpawner([]),
+		});
+		await server.listen();
+
+		process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+		process.env.SUPERSET_HOME_DIR = tmp;
+		__setAccountShellForTesting("/bin/bash");
+		initTerminalBaseEnv({
+			HOME: process.env.HOME ?? tmp,
+			LANG: "en_US.UTF-8",
+			PATH: process.env.PATH ?? "/usr/bin:/bin",
+			SHELL: "/bin/bash",
+		});
+
+		scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		// Script lives in the main repo (gitignored scripts don't exist in
+		// worktrees); the marker lands outside the worktree since step 2b
+		// deletes the worktree directory.
+		const markerPath = join(tmp, "teardown-ran");
+		const scriptDir = join(scenario.repo.repoPath, ".superset");
+		mkdirSync(scriptDir, { recursive: true });
+		writeFileSync(
+			join(scriptDir, "teardown.sh"),
+			`#!/usr/bin/env bash\n${teardownScript.replaceAll("{{MARKER}}", shellQuote(markerPath))}\n`,
+			{ mode: 0o755 },
+		);
+		return { scenario, markerPath };
+	}
+
+	test("workspace.delete (external surface) runs teardown before removing the worktree", async () => {
+		const { scenario, markerPath } = await setup("printf ran > {{MARKER}}");
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(result.warnings).toEqual([]);
+		expect(existsSync(markerPath)).toBe(true);
+		expect(existsSync(scenario.worktreePath)).toBe(false);
+	});
+
+	test("workspace.delete surfaces a failed teardown as a warning without blocking the delete", async () => {
+		const { scenario, markerPath } = await setup(
+			"printf ran > {{MARKER}}\nexit 7",
+		);
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(existsSync(markerPath)).toBe(true);
+		expect(existsSync(scenario.worktreePath)).toBe(false);
+		expect(
+			result.warnings.some((w) =>
+				w.includes("Teardown script failed (exit code 7)"),
+			),
+		).toBe(true);
+	});
+
+	test("workspaceCleanup.destroy with force still skips teardown (interactive force-retry contract)", async () => {
+		const { scenario, markerPath } = await setup("printf ran > {{MARKER}}");
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(existsSync(markerPath)).toBe(false);
+		expect(existsSync(scenario.worktreePath)).toBe(false);
+	});
+});

--- a/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
@@ -89,14 +89,20 @@ describe("workspace delete teardown integration", () => {
 		mkdirSync(scriptDir, { recursive: true });
 		writeFileSync(
 			join(scriptDir, "teardown.sh"),
-			`#!/usr/bin/env bash\n${teardownScript.replaceAll("{{MARKER}}", shellQuote(markerPath))}\n`,
+			`#!/usr/bin/env bash\n${teardownScript
+				.replaceAll("{{WORKTREE}}", shellQuote(scenario.worktreePath))
+				.replaceAll("{{MARKER}}", shellQuote(markerPath))}\n`,
 			{ mode: 0o755 },
 		);
 		return { scenario, markerPath };
 	}
 
 	test("workspace.delete (external surface) runs teardown before removing the worktree", async () => {
-		const { scenario, markerPath } = await setup("printf ran > {{MARKER}}");
+		// `test -d` pins the ordering: the marker only appears if the worktree
+		// still exists when teardown runs.
+		const { scenario, markerPath } = await setup(
+			"test -d {{WORKTREE}} && printf ran > {{MARKER}}",
+		);
 
 		const result = await scenario.host.trpc.workspace.delete.mutate({
 			id: scenario.featureWorkspaceId,
@@ -111,7 +117,7 @@ describe("workspace delete teardown integration", () => {
 
 	test("workspace.delete surfaces a failed teardown as a warning without blocking the delete", async () => {
 		const { scenario, markerPath } = await setup(
-			"printf ran > {{MARKER}}\nexit 7",
+			'echo "external resources not cleaned" >&2\nprintf ran > {{MARKER}}\nexit 7',
 		);
 
 		const result = await scenario.host.trpc.workspace.delete.mutate({
@@ -122,11 +128,12 @@ describe("workspace delete teardown integration", () => {
 		expect(result.worktreeRemoved).toBe(true);
 		expect(existsSync(markerPath)).toBe(true);
 		expect(existsSync(scenario.worktreePath)).toBe(false);
-		expect(
-			result.warnings.some((w) =>
-				w.includes("Teardown script failed (exit code 7)"),
-			),
-		).toBe(true);
+		const teardownWarning = result.warnings.find((w) =>
+			w.includes("Teardown script failed (exit code 7)"),
+		);
+		expect(teardownWarning).toBeDefined();
+		// The warning must carry the script's output tail, not just the exit code.
+		expect(teardownWarning).toContain("external resources not cleaned");
 	});
 
 	test("workspaceCleanup.destroy with force still skips teardown (interactive force-retry contract)", async () => {

--- a/packages/mcp/src/tools/workspaces/delete.ts
+++ b/packages/mcp/src/tools/workspaces/delete.ts
@@ -8,7 +8,7 @@ export function register(server: McpServer): void {
 		name: "workspaces_delete",
 		annotations: { destructiveHint: true },
 		description:
-			"Delete a workspace by UUID on its host. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces. Use hosts_list / workspaces_list to find the hostId.",
+			"Delete a workspace by UUID on its host. The host service runs the project's teardown script (.superset/config.json teardown commands or .superset/teardown.sh, if configured), then removes the git worktree from disk before returning. A teardown failure does not block the delete; it is reported in `warnings`. Cannot delete 'main'-type workspaces. Use hosts_list / workspaces_list to find the hostId.",
 		inputSchema: {
 			hostId: z
 				.string()


### PR DESCRIPTION
## Summary

Fixes #6174.

`.superset` teardown scripts only ran on the interactive (desktop/mobile) delete path. The legacy external surface `workspace.delete` — the one CLI, SDK, and MCP `workspaces_delete` all funnel through — hardcoded `force: true`, and `force` doubled as "skip teardown". Every programmatic delete silently skipped the user's teardown script, leaked externally provisioned resources (databases, vhosts, tunnels), and returned a clean `{"success":true,...,"warnings":[]}`.

## Fix

Split the two meanings that were riding on one flag:

- `force` now carries only the destructive **git** semantics: skip the dirty-worktree preflight, `--force --force` worktree removal.
- A new `teardownMode` on `DestroyWorkspaceInput` governs step 1:
  - `"blocking"` — failure throws the typed `PRECONDITION_FAILED` so the interactive caller can prompt force-retry (unchanged v2 renderer contract; `workspaceCleanup.destroy` maps `force → skip`, else `blocking`).
  - `"best-effort"` — the external surface: teardown always runs; a failure doesn't block the delete (there's nobody to prompt) and lands in `warnings` with exit info and the ANSI-stripped output tail. The CLI already prints `warnings`, so failures surface there too.
  - `"skip"` — the interactive force-retry escape hatch.

Also updated the MCP tool description and the setup/teardown docs to state the non-interactive contract.

## Tests

New `workspace-delete-teardown.integration.test.ts` (real git fixture + fake pty-daemon, extracted the spawner from `teardown.integration.test.ts` into a shared helper):

1. `workspace.delete` runs teardown before removing the worktree (fails on the old behavior — verified by mutating the fix back).
2. A failing teardown (`exit 7`) doesn't block the delete and lands in `warnings` (also fails on the old behavior).
3. `workspaceCleanup.destroy` with `force: true` still skips teardown (guards the renderer's force-retry contract).

Existing delete-path suites (`workspace-cleanup`, `workspace-create-delete`, `bug-hunt-*`) pass unchanged; `bun run typecheck` and `bun run lint` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure teardown scripts run on non-interactive workspace deletes (CLI/SDK/MCP) to prevent leaked resources. Split git “force” from teardown behavior and surface teardown failures as warnings.

- **Bug Fixes**
  - `workspace.delete` now runs teardown before removing the worktree; failures don’t block and appear in `warnings` with an ANSI-stripped output tail.
  - Separated git `force` from teardown via `teardownMode` on `DestroyWorkspaceInput` (`blocking` | `best-effort` | `skip`).
  - Interactive v2 flow unchanged: normal delete blocks on failure; force-retry skips teardown.
  - Updated docs and MCP `workspaces_delete` description for the non-interactive contract; added integration tests that pin ordering and warning tail content.

<sup>Written for commit 3db5fb4449d55554f4f4a75f8670c048190ee83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace deletion now runs configured teardown scripts across CLI, SDK, and MCP workflows.
  * Non-interactive deletions continue when teardown fails and return sanitized warnings.
  * Forced interactive cleanup explicitly skips teardown scripts.

* **Documentation**
  * Updated setup and workspace deletion guidance to explain teardown behavior and failure handling.

* **Tests**
  * Added integration coverage for successful teardown, warning-based failures, and forced cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->