### PR TITLE
fix(host-service): verify the default branch exists before using it

### DIFF
--- a/packages/host-service/src/runtime/git/refs.ts
+++ b/packages/host-service/src/runtime/git/refs.ts
@@ -39,7 +39,10 @@ export function asRemoteRef(
 	return `refs/remotes/${remote}/${name}`;
 }
 
-async function refExists(git: SimpleGit, fullRef: string): Promise<boolean> {
+export async function refExists(
+	git: SimpleGit,
+	fullRef: string,
+): Promise<boolean> {
 	try {
 		// Don't use `--quiet` — simple-git's `raw` mis-resolves on empty
 		// stderr and reports the missing ref as a success with empty stdout.
@@ -200,23 +203,77 @@ export async function resolveRef(
 	return options.headFallback ? { kind: "head" } : null;
 }
 
+// Reached only when `origin/HEAD` cannot answer. The remote is the
+// authoritative source, and `git remote set-head origin --auto` is what asks
+// it; the branch picker runs that whenever it has the network.
+const DEFAULT_BRANCH_CANDIDATES = ["main", "master", "develop", "trunk"];
+
 /**
- * Resolve the repo's default branch name (typically `main`) from
- * `origin/HEAD`. Falls back to `"main"` if symbolic-ref isn't set.
+ * The branch `origin/HEAD` names, or null when unset or stale.
+ *
+ * Git writes `origin/HEAD` at clone time and never refreshes it on fetch, so
+ * it outlives an upstream rename and even the branch being deleted. Trust it
+ * only while the branch it names still resolves.
+ *
+ * That check is local, so it can only catch a stale symref once the branch it
+ * names is gone from `refs/remotes/`. A plain `git fetch` leaves the old
+ * remote-tracking ref in place, so the symref still looks valid until a
+ * `--prune`. `git remote set-head origin --auto` is what actually settles it,
+ * and the branch picker runs both.
+ */
+export async function readOriginHeadBranch(
+	git: SimpleGit,
+): Promise<string | null> {
+	let target: string;
+	try {
+		target = (
+			await git.raw(["symbolic-ref", asRemoteRef("origin", "HEAD")])
+		).trim();
+	} catch {
+		return null;
+	}
+	// Read the full refname, not `--short`: git will happily point this symref
+	// at a local branch, and the short form of `refs/heads/foo` is bare `foo`,
+	// indistinguishable from a real remote-tracking branch. See GIT_REFS.md.
+	const prefix = asRemoteRef("origin", "");
+	if (!target.startsWith(prefix)) return null;
+	const branch = target.slice(prefix.length);
+	if (!branch) return null;
+	return (await refExists(git, asRemoteRef("origin", branch))) ? branch : null;
+}
+
+/**
+ * Resolve the repo's default branch name (typically `main`). Falls back to the
+ * first conventional name that exists — remote-tracking, then local — and then
+ * to any branch at all, rather than naming one the repo may not have.
+ *
+ * Throws if the repo can't be enumerated: a repo we can't read is not a repo
+ * with no branches, and inventing a name here puts new worktrees on a base
+ * that doesn't exist.
  */
 export async function resolveDefaultBranchName(
 	git: SimpleGit,
 ): Promise<string> {
-	try {
-		const ref = await git.raw([
-			"symbolic-ref",
-			"refs/remotes/origin/HEAD",
-			"--short",
-		]);
-		return ref.trim().replace(/^origin\//, "");
-	} catch {
-		return "main";
+	const fromOriginHead = await readOriginHeadBranch(git);
+	if (fromOriginHead) return fromOriginHead;
+
+	const branches = await listBranchShortNames(git, "origin");
+	for (const names of [branches.remoteTracking, branches.local]) {
+		const candidate = DEFAULT_BRANCH_CANDIDATES.find((name) =>
+			names.includes(name),
+		);
+		if (candidate) return candidate;
 	}
+
+	// Nothing conventional. The branch HEAD is on beats an alphabetical pick,
+	// and both beat a made-up `main`; only an empty repo, which has no branch
+	// to name, falls through to that.
+	const head = await git
+		.raw(["symbolic-ref", "--short", "HEAD"])
+		.then((out) => out.trim())
+		.catch(() => "");
+	if (head && branches.local.includes(head)) return head;
+	return branches.remoteTracking[0] ?? branches.local[0] ?? "main";
 }
 
 /**

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -123,16 +123,25 @@ function getPrByNumber(db: HostDb, prNumber: number) {
 		.get();
 }
 
-// Answers only the origin/HEAD symref (default branch); every other git call
-// throws, asserting the refresh path never depends on live git.
+// Answers the origin/HEAD symref and the existence check that validates it;
+// every other git call throws, asserting the refresh path never depends on
+// live git.
 function defaultBranchGit(defaultBranch: string) {
+	const remoteRef = `refs/remotes/origin/${defaultBranch}`;
+	const remoteRev = `${remoteRef}^{commit}`;
 	return (async () => ({
 		raw: async (args: string[]) => {
 			if (
 				args[0] === "symbolic-ref" &&
 				args.includes("refs/remotes/origin/HEAD")
 			) {
-				return `origin/${defaultBranch}\n`;
+				// Full refname, as the reader asks for it without `--short`.
+				return `${remoteRef}\n`;
+			}
+			// The symref is only trusted while the branch it names resolves.
+			if (args[0] === "rev-parse" && args[1] === "--verify") {
+				if (args[2] === remoteRev) return `${"0".repeat(40)}\n`;
+				throw new Error("fatal: Needed a single revision");
 			}
 			throw new Error(`unexpected git raw: ${args.join(" ")}`);
 		},

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -4,7 +4,10 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { pullRequests, workspaces } from "../../../db/schema";
-import { createGitEnvResolver } from "../../../runtime/git";
+import {
+	createGitEnvResolver,
+	resolveDefaultBranchName,
+} from "../../../runtime/git";
 import { createUserSimpleGit } from "../../../runtime/git/simple-git";
 import type { HostServiceContext } from "../../../types";
 import { getHostWorkerPool } from "../../../workers/host-worker-pool";
@@ -29,10 +32,7 @@ import type {
 } from "./types";
 import { scheduleBaseRefFetch } from "./utils/base-ref-freshness";
 import { gitConfigWrite } from "./utils/config-write";
-import {
-	getDefaultBranchName,
-	resolveBaseComparison,
-} from "./utils/git-helpers";
+import { resolveBaseComparison } from "./utils/git-helpers";
 import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
 import {
 	type GraphQLThreadsResult,
@@ -548,7 +548,9 @@ export const gitRouter = router({
 			).trim();
 			const isDetached = !currentBranch || currentBranch === "HEAD";
 
-			const defaultBranch = await getDefaultBranchName(git);
+			const defaultBranch = await resolveDefaultBranchName(git).catch(
+				() => null,
+			);
 			const isDefaultBranch =
 				!isDetached && !!defaultBranch && currentBranch === defaultBranch;
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
@@ -4,12 +4,12 @@ import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
-import { resolveUpstream } from "../../../../runtime/git/refs";
 import {
-	getChangedFilesForDiff,
-	getDefaultBranchName,
-	resolveBaseComparison,
-} from "./git-helpers";
+	readOriginHeadBranch,
+	resolveDefaultBranchName,
+	resolveUpstream,
+} from "../../../../runtime/git/refs";
+import { getChangedFilesForDiff, resolveBaseComparison } from "./git-helpers";
 
 /**
  * Integration tests that exercise the git-correctness fixes against real
@@ -117,8 +117,8 @@ describe("resolveBaseComparison (integration)", () => {
 		git = await initRepo(repo);
 		await commitFile(git, repo, "README.md", "hello", "initial");
 		// Simulate a remote so origin/HEAD can be set. We don't need an
-		// actual remote to fetch from — `symbolic-ref` on the remote HEAD
-		// is all getDefaultBranchName reads.
+		// actual remote to fetch from — the remote-tracking refs are all
+		// the default-branch lookup reads.
 		await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
 		await git.raw([
 			"symbolic-ref",
@@ -173,6 +173,21 @@ describe("resolveBaseComparison (integration)", () => {
 		});
 	});
 
+	// A stale symref used to collapse this to null, and the commits view then
+	// diffed HEAD..HEAD and showed nothing. Detection still finds `main`.
+	test("still resolves a base when origin/HEAD names a pruned branch", async () => {
+		await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			"refs/remotes/origin/master",
+		]);
+		expect(await resolveBaseComparison(git)).toEqual({
+			branchName: "main",
+			baseRef: "origin/main",
+			fetchTarget: { remote: "origin", branch: "main" },
+		});
+	});
+
 	test("returns null when no default branch can be resolved", async () => {
 		const emptyRepo = mkTmp();
 		try {
@@ -185,9 +200,9 @@ describe("resolveBaseComparison (integration)", () => {
 	});
 });
 
-// ── getDefaultBranchName ───────────────────────────────────────────
+// ── readOriginHeadBranch ───────────────────────────────────────────
 
-describe("getDefaultBranchName (integration)", () => {
+describe("readOriginHeadBranch (integration)", () => {
 	let repo: string;
 	let git: SimpleGit;
 
@@ -201,29 +216,61 @@ describe("getDefaultBranchName (integration)", () => {
 		rmSync(repo, { recursive: true, force: true });
 	});
 
+	async function pointOriginHeadAt(branch: string) {
+		await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			`refs/remotes/origin/${branch}`,
+		]);
+	}
+
 	test("returns null when origin/HEAD not set", async () => {
-		expect(await getDefaultBranchName(git)).toBeNull();
+		expect(await readOriginHeadBranch(git)).toBeNull();
 	});
 
-	test("returns 'main' when origin/HEAD points at origin/main", async () => {
+	test("returns the branch origin/HEAD points at", async () => {
+		await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
+		await pointOriginHeadAt("main");
+		expect(await readOriginHeadBranch(git)).toBe("main");
+	});
+
+	// git writes origin/HEAD at clone time and never refreshes it, so the
+	// symref outlives the branch it names. Reading it without checking hands
+	// back a branch nothing can be forked from.
+	test("returns null when origin/HEAD points at a branch that is gone", async () => {
+		await git.raw(["update-ref", "refs/remotes/origin/master", "HEAD"]);
+		await pointOriginHeadAt("master");
+		await git.raw(["update-ref", "-d", "refs/remotes/origin/master"]);
+		expect(await readOriginHeadBranch(git)).toBeNull();
+	});
+
+	// The check is local, so it only fires once the branch is actually gone.
+	// A plain `git fetch` keeps the old remote-tracking ref, so after an
+	// upstream rename the symref still looks valid until a `--prune`.
+	// `git remote set-head origin --auto` is what settles it.
+	test("still returns the old branch when it survives unpruned", async () => {
+		await git.raw(["update-ref", "refs/remotes/origin/master", "HEAD"]);
+		await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
+		await pointOriginHeadAt("master");
+		expect(await readOriginHeadBranch(git)).toBe("master");
+	});
+
+	// git accepts a symref aimed anywhere, and the short form of
+	// `refs/heads/feature` is bare `feature`, which looks exactly like a
+	// remote-tracking branch name. Detection must not read it as one.
+	test("returns null when origin/HEAD points outside refs/remotes/origin", async () => {
+		await git.raw(["branch", "feature"]);
+		await git.raw(["update-ref", "refs/remotes/origin/feature", "HEAD"]);
 		await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
 		await git.raw([
 			"symbolic-ref",
 			"refs/remotes/origin/HEAD",
-			"refs/remotes/origin/main",
+			"refs/heads/feature",
 		]);
-		expect(await getDefaultBranchName(git)).toBe("main");
-	});
 
-	test("returns 'master' when origin/HEAD points at origin/master", async () => {
-		await git.raw(["branch", "master"]);
-		await git.raw(["update-ref", "refs/remotes/origin/master", "HEAD"]);
-		await git.raw([
-			"symbolic-ref",
-			"refs/remotes/origin/HEAD",
-			"refs/remotes/origin/master",
-		]);
-		expect(await getDefaultBranchName(git)).toBe("master");
+		expect(await readOriginHeadBranch(git)).toBeNull();
+		// Falling through to the candidate scan finds the real default.
+		expect(await resolveDefaultBranchName(git)).toBe("main");
 	});
 });
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -6,7 +6,12 @@ import {
 	isBinaryMediaFile,
 } from "@superset/shared/media-files";
 import type { SimpleGit } from "simple-git";
-import { resolveUpstream } from "../../../../runtime/git/refs";
+import {
+	asRemoteRef,
+	refExists,
+	resolveDefaultBranchName,
+	resolveUpstream,
+} from "../../../../runtime/git/refs";
 import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
 import type { Branch, ChangedFile, FileStatus } from "../types";
 
@@ -133,26 +138,17 @@ export function parseNameStatus(
 	return results;
 }
 
-export async function getDefaultBranchName(
-	git: SimpleGit,
-): Promise<string | null> {
-	try {
-		const ref = await git.raw([
-			"symbolic-ref",
-			"refs/remotes/origin/HEAD",
-			"--short",
-		]);
-		return ref.trim().replace(/^origin\//, "");
-	} catch {
-		return null;
-	}
-}
-
 /**
  * Resolve the base comparison for "this branch vs its upstream default"
  * views. Honors the local default branch's configured upstream
  * (e.g. `upstream/main`) before falling back to `origin/<name>`. Returns
  * null when no default branch can be determined.
+ *
+ * A stale `origin/HEAD` must not collapse this to null: the caller then diffs
+ * `HEAD..HEAD` and shows no commits at all. `resolveDefaultBranchName` only
+ * returns branches that exist, so it is safe here, but it may name one that
+ * has no `origin/` counterpart. When nothing was explicitly asked for, the
+ * fallback is offered only if that remote-tracking ref resolves.
  */
 export async function resolveBaseComparison(
 	git: SimpleGit,
@@ -164,7 +160,8 @@ export async function resolveBaseComparison(
 	// tracks another local branch and there is nothing to fetch.
 	fetchTarget: { remote: string; branch: string } | null;
 } | null> {
-	const branchName = explicitBranch ?? (await getDefaultBranchName(git));
+	const branchName =
+		explicitBranch ?? (await resolveDefaultBranchName(git).catch(() => null));
 	if (!branchName) return null;
 	const upstream = await resolveUpstream(git, branchName);
 	// Git encodes a branch tracking another local branch as
@@ -181,6 +178,15 @@ export async function resolveBaseComparison(
 						branch: upstream.remoteBranch,
 					},
 				};
+	}
+	// An explicit pick is honored as-is; it may name a branch that exists
+	// upstream but has not been fetched yet, and `fetchTarget` is what fetches
+	// it. A detected default gets no such benefit of the doubt.
+	if (
+		!explicitBranch &&
+		!(await refExists(git, asRemoteRef("origin", branchName)))
+	) {
+		return null;
 	}
 	return {
 		branchName,

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
@@ -44,6 +44,10 @@ export const searchBranches = protectedProcedure
 			markRefetchRemote(input.projectId);
 			try {
 				await git.fetch(["--prune", "--quiet", "--no-tags"]);
+				// `fetch` never updates `origin/HEAD`, so ask the remote what its
+				// default branch is while we have the network. Without this the
+				// stale ref is worked around on every read, never corrected.
+				await git.raw(["remote", "set-head", "origin", "--auto"]);
 			} catch {
 				// offline — proceed with cached refs
 			}

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
@@ -19,10 +19,19 @@ function createMockGit(existingFullRefs: Set<string>, defaultBranch?: string) {
 				args[0] === "symbolic-ref" &&
 				args[1] === "refs/remotes/origin/HEAD"
 			) {
-				if (defaultBranch) return `origin/${defaultBranch}`;
+				// Full refname, as the reader asks for it without `--short`.
+				if (defaultBranch) return `refs/remotes/origin/${defaultBranch}`;
 				throw new Error(
 					"fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
 				);
+			}
+			// Fallback path once origin/HEAD can't answer: enumerate branches,
+			// then ask which one HEAD is on.
+			if (args[0] === "for-each-ref") {
+				return `${[...existingFullRefs].join("\n")}\n`;
+			}
+			if (args[0] === "symbolic-ref" && args[2] === "HEAD") {
+				throw new Error("fatal: ref HEAD is not a symbolic ref");
 			}
 			throw new Error(`Unexpected raw args: ${args.join(" ")}`);
 		}),


### PR DESCRIPTION
## What & why

Refs #5400. Superset showed `master` as the default branch on repos whose
default is `main`, and created new worktrees from it.

The default branch came from `origin/HEAD`. Git writes that ref when you clone
and never updates it, so it survives an upstream rename, or even the branch
being deleted. When the ref was missing, the code fell back to a hardcoded
`main`, which a repo whose only branch is `master` does not have. Either way
the name did not exist, so the worktree was created from HEAD instead.

Three changes:

- **`search-branches.ts`** runs `git remote set-head origin --auto` next to the
  fetch the picker already does, so the ref gets corrected from the remote
  rather than worked around on every read. The remote is the only authoritative
  source; detection cannot ask it directly because it runs per keystroke.
- **`refs.ts`** checks the branch still exists before trusting the ref. When
  the ref cannot answer, the fallback prefers a common name that exists, then
  the branch HEAD is on, then any branch at all. Only an empty repo reaches
  `main`. A repo that cannot be read now raises instead of guessing.
- **`git-helpers.ts`** held a second copy of the same lookup without the check,
  so diff views compared against a branch that was gone. It uses the shared
  reader now, and the `git.ts` sync-status call site follows.

The issue also asks for a per project override for ambiguous repos. That needs
a schema column and a settings screen, so I left it for a follow up.

## How I tested it

Real repos built in each broken state, before and after the picker's refresh:

```
                                    symref before  ->  after        detected
cloned before an upstream rename     origin/master     origin/main  main    ok
origin/HEAD points at a deleted br.  origin/master     origin/main  main    ok
local repo, only branch is master    (not set)         (not set)    master  ok
```

Offline, with no refresh, detection is still right on all three. Also checked
the fallback on repos with no usable `origin/HEAD`: a repo whose only branch is
`production` returns `production`, and an unreadable repo raises rather than
answering `main`.

Two new cases in `git-helpers.integration.test.ts`: a ref naming a deleted
branch returns null, and a ref whose branch survives unpruned still returns the
old name, which pins the limit of a local-only check.

In the dev desktop app on a repo cloned before an upstream rename, the branch
picker showed `master` before and `main` after, and the new worktree was
created from `main`.

`bun test` in `packages/host-service`: 948 pass, 0 fail.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved default-branch detection across Git repositories, including common branch names and fallback scenarios.
  - Handles missing, stale, or outdated remote default-branch references more reliably.
  - Refreshing remote branches now updates default-branch information automatically when possible.
  - Branch comparison and workspace setup continue gracefully when default-branch information cannot be resolved.
- **Bug Fixes**
  - Prevented invalid Git references from producing incorrect default branches or unnecessary errors.
  - Improved handling of repositories with deleted, unpruned, or unavailable remote branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->