### PR TITLE
docs(cli): document terminals list/read/send/close and address review nits

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -884,8 +884,9 @@ superset terminals create --workspace ws_…
 		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
 		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
 	]}
-	output="Array<TerminalSession>"
-	quiet="terminal IDs"
+	output={`{
+  sessions: Array<TerminalSession>;
+}`}
 >
 List the live terminal sessions in a workspace. Presence in the list means the
 PTY exists, not that an agent inside it is working or idle.
@@ -900,6 +901,9 @@ PTY exists, not that an agent inside it is working or idle.
 		{ flag: "--max-lines <n>", description: "Limit how many trailing lines to return." },
 	]}
 	output={`{
+  terminalId: string;
+  cols: number;
+  rows: number;
   text: string;
 }`}
 >
@@ -916,6 +920,7 @@ superset terminals read --workspace ws_… --terminal term_… --max-lines 240
 		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
 		{ flag: "--terminal <id>", required: true, description: "Terminal session ID." },
 		{ flag: "--text <string>", required: true, description: "Text to deliver to the terminal." },
+		{ flag: "--no-submit", description: "Stage the text without pressing Enter." },
 		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
 	]}
 >

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -878,6 +878,62 @@ superset terminals create --workspace ws_…
 ```
 </Command>
 
+<Command
+	name="superset terminals list"
+	options={[
+		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
+		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
+	]}
+	output="Array<TerminalSession>"
+	quiet="terminal IDs"
+>
+List the live terminal sessions in a workspace. Presence in the list means the
+PTY exists, not that an agent inside it is working or idle.
+</Command>
+
+<Command
+	name="superset terminals read"
+	options={[
+		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
+		{ flag: "--terminal <id>", required: true, description: "Terminal session ID." },
+		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
+		{ flag: "--max-lines <n>", description: "Limit how many trailing lines to return." },
+	]}
+	output={`{
+  text: string;
+}`}
+>
+Read a terminal's current screen back as text without mutating the session.
+
+```bash
+superset terminals read --workspace ws_… --terminal term_… --max-lines 240
+```
+</Command>
+
+<Command
+	name="superset terminals send"
+	options={[
+		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
+		{ flag: "--terminal <id>", required: true, description: "Terminal session ID." },
+		{ flag: "--text <string>", required: true, description: "Text to deliver to the terminal." },
+		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
+	]}
+>
+Send a follow-up message to a terminal already running in a workspace, e.g. to
+give an agent new instructions mid-session.
+</Command>
+
+<Command
+	name="superset terminals close"
+	options={[
+		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
+		{ flag: "--terminal <id>", required: true, description: "Terminal session ID." },
+		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
+	]}
+>
+Close (dispose) a terminal running in a workspace. This ends the session.
+</Command>
+
 ---
 
 ### tasks (alias: `t`)

--- a/apps/docs/content/docs/recipes/pr-feedback.mdx
+++ b/apps/docs/content/docs/recipes/pr-feedback.mdx
@@ -19,8 +19,8 @@ Addressing review feedback is high-interruption, low-creativity work. Create a w
 2. Prompt an agent to work through the feedback. The `gh` CLI is already authenticated in every workspace:
 
 ```text
-Read all review feedback on this PR: `gh pr view --comments` for discussion,
-plus `gh api repos/{owner}/{repo}/pulls/{number}/comments` for inline code comments.
+Read all review feedback on this PR, including inline code comments
+(`gh pr view --comments` misses those; use the pulls comments API for them).
 Address each comment: make the change, or reply explaining why not.
 Commit with one commit per comment, referencing it. Do not force-push.
 Summarize what you changed and what you pushed back on in your final message.

--- a/apps/docs/content/docs/recipes/pr-feedback.mdx
+++ b/apps/docs/content/docs/recipes/pr-feedback.mdx
@@ -19,8 +19,10 @@ Addressing review feedback is high-interruption, low-creativity work. Create a w
 2. Prompt an agent to work through the feedback. The `gh` CLI is already authenticated in every workspace:
 
 ```text
-Read all review feedback on this PR, including inline code comments
-(`gh pr view --comments` misses those; use the pulls comments API for them).
+Read all review feedback on this PR. `gh pr view --comments` misses inline
+code comments, so also run
+`gh api repos/{owner}/{repo}/pulls/{pr}/comments --paginate`
+with this repo's owner/name and this PR's number.
 Address each comment: make the change, or reply explaining why not.
 Commit with one commit per comment, referencing it. Do not force-push.
 Summarize what you changed and what you pushed back on in your final message.

--- a/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
@@ -60,7 +60,7 @@ export default function NavigationBar() {
 					<MobileSearchIcon />
 					<SidebarTrigger />
 					<ul className="navbar:flex items-center gap-2 hidden shrink-0">
-						<NavLink href={`${COMPANY.MARKETING_URL}/changelog`} external>
+						<NavLink href={COMPANY.CHANGELOG_URL} external>
 							Changelog
 						</NavLink>
 						<NavLink href={COMPANY.MARKETING_URL} external>

--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -1,5 +1,4 @@
 import { Card, Cards } from "fumadocs-ui/components/card";
-import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import {
@@ -42,8 +41,6 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
 		...defaultMdxComponents,
 		Card,
 		Cards,
-		Step,
-		Steps,
 		BookOpen,
 		Bot,
 		CalendarClock,


### PR DESCRIPTION
Follow-up to #6175, addressing the remaining review comments:

- **CLI reference**: the `terminals` section documented only `create`; adds `list`, `read`, `send`, and `close` with flags and output shapes
- NavigationBar uses the shared `COMPANY.CHANGELOG_URL` constant instead of re-deriving the URL
- Removes unused `Step`/`Steps` MDX component registration
- PR-feedback recipe prompt no longer contains unresolved `{owner}/{repo}` placeholders

Verified: typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the CLI reference to cover `terminals` subcommands—`list`, `read`, `send`, `close`—with corrected output shapes and flags, including `--no-submit` for `send`. Also tidied docs: clarified the PR-feedback recipe to fetch inline code comments (no unresolved placeholders), switched NavigationBar to `COMPANY.CHANGELOG_URL`, and removed unused `Step`/`Steps` MDX components.

<sup>Written for commit f8d5f4740a7959275c57491e986062fa37ea385a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list, read, send text to, and close live terminal sessions.
  * Terminal output can optionally be limited to a specified number of trailing lines.
  * Added an option to send terminal text without submitting it.

* **Documentation**
  * Updated pull request feedback guidance to include inline review comments.
  * Improved Changelog navigation with a dedicated destination.
  * Removed obsolete step components from documentation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->