### PR TITLE
feat(marketing): revive public roadmap page synced from internal Notion roadmap

### DIFF
--- a/.github/prompts/update-roadmap.md
+++ b/.github/prompts/update-roadmap.md
@@ -1,0 +1,48 @@
+# Monthly Public Roadmap Sync
+
+You are updating the public roadmap page at `apps/marketing/src/app/roadmap/data.ts` from the internal Notion "Product Roadmap" database. You open a PR; a human reviews and merges. You never publish directly.
+
+## Source of truth
+
+The Notion database "Product Roadmap" (data source `collection://7cbe2be9-46f2-44d6-b883-102eae5918fa`, inside the "Living 12 Month Roadmap" page). Use the Notion MCP tools (`notion-search`, `notion-fetch`, `notion-query-data-sources`). Query all rows with these columns: `Name`, `Status`, `Public`, `Public title`, `Public description`, `Public category`, `date:Date:end`.
+
+## The privacy contract (non-negotiable)
+
+1. **Only rows with `Public` checked may appear in the output.** A row without the checkbox is invisible, no matter how harmless it looks.
+2. **Only these four values cross the boundary:** `Public title`, `Public description`, `Public category`, and the lane derived from `Status`. Never copy from `Name`, `Description`, `Success measure`, `Size`, `Owner`, `Linear project`, or dates — those fields contain internal metrics, strategy notes, and ticket IDs.
+3. **Never write dates, quarters, or ETAs** for unshipped work. Shipped items get a month label only (see below).
+4. If a `Public`-checked row is missing `Public title`, `Public description`, or `Public category`, **do not improvise from internal fields.** Draft a suggestion in the PR description (clearly marked as a draft for review) and leave the item out of `data.ts` until a human fills the Notion field.
+
+## Lane mapping
+
+| Notion `Status` | `data.ts` status |
+|---|---|
+| In progress | `now` |
+| Committed | `next` |
+| Proposed | `later` |
+| Shipped | `shipped` |
+| Not now | omit |
+
+- `shipped` items: include only those shipped in the last ~3 months. `shippedDate` is a month label like `"Aug 2026"` — derive from the row's `date:Date:end` month if present, otherwise the current month.
+- `shipped` items may also carry `href` (link to the matching entry under `apps/marketing/content/changelog/`, as `/changelog/<file-slug>`) and `image` (a screenshot path from that entry, e.g. `/changelog/2026-08-02-sidebar-redesign.png`). Both come from already-public changelog content only — never from internal sources. Supplement the Notion-derived shipped lane with the month's major changelog features (title + one-line description rewritten from the entry, image, href) so the lane stays visual; keep the shipped lane to ~8 items.
+- **Tag every shipped item when you can:** prefer `href` to the changelog entry. If no entry covers the ship, find the main merged PR with `gh pr list --state merged --search "..."` and set `pr` to its public GitHub URL. If the ship spans many PRs with no clear flagship, leave it untagged rather than picking arbitrarily. Never use Linear links.
+- Keep lanes honest, not exhaustive: if `later` exceeds ~14 items, keep the most user-relevant and note the cuts in the PR description.
+
+## Output
+
+Regenerate the `ROADMAP_ITEMS` array in `apps/marketing/src/app/roadmap/data.ts`:
+
+- `id`: kebab-case slug of the public title (stable across runs — reuse existing ids where the item is unchanged).
+- `title` = `Public title`, `description` = `Public description`, `category` = `Public category`, `status` = mapped lane.
+- Order within each lane: keep the existing file's order for unchanged items; append new items at the end of their lane.
+- Do not change the types, `CATEGORIES`, `STATUS_LABELS`, or `STATUS_DESCRIPTIONS` unless a `Public category` value doesn't exist in the union — in that case flag it in the PR description instead of editing types.
+
+## Ship it
+
+1. `bun run lint:fix`, then verify `bun run lint` exits 0.
+2. Create a branch `roadmap-sync-YYYY-MM`, commit, and open a PR titled `chore(marketing): monthly public roadmap sync` using `gh`.
+3. PR description must include:
+   - A summary table of adds / moves / removals (public titles only).
+   - Any `Public`-checked rows skipped for missing public fields, with your drafted suggestions.
+   - The sentence: "Reviewer: confirm no internal metrics, dates, ticket IDs, or strategy language leaked into descriptions."
+4. If nothing changed since the last sync, do not open a PR; just report "no changes".

--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -46,6 +46,7 @@ const RESOURCE_LINKS: FooterLink[] = [
 	{ href: "/community", label: "Community" },
 	{ href: "/enterprise", label: "Enterprise" },
 	{ href: "/changelog", label: "Changelog" },
+	{ href: "/roadmap", label: "Roadmap" },
 ];
 
 const LEGAL_LINKS: FooterLink[] = [

--- a/apps/marketing/src/app/components/Header/constants.ts
+++ b/apps/marketing/src/app/components/Header/constants.ts
@@ -18,6 +18,11 @@ export const PRODUCT_LINKS: NavLink[] = [
 		label: "Changelog",
 		description: "New releases and product updates.",
 	},
+	{
+		href: "/roadmap",
+		label: "Roadmap",
+		description: "What we're building now and next.",
+	},
 ];
 
 export const RESOURCE_LINKS: NavLink[] = [

--- a/apps/marketing/src/app/roadmap/components/RoadmapBoard/RoadmapBoard.tsx
+++ b/apps/marketing/src/app/roadmap/components/RoadmapBoard/RoadmapBoard.tsx
@@ -1,16 +1,28 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
+import { PRBadge } from "@/app/changelog/components/PRBadge";
 import {
 	CATEGORIES,
 	ROADMAP_ITEMS,
 	type RoadmapCategory,
 	type RoadmapItem,
 	type RoadmapStatus,
+	STATUS_DESCRIPTIONS,
 	STATUS_LABELS,
 } from "../../data";
 
 const COLUMNS: RoadmapStatus[] = ["now", "next", "later"];
+
+const STATUS_DOT: Record<RoadmapStatus, string> = {
+	now: "bg-emerald-500 animate-pulse",
+	next: "bg-amber-500",
+	later: "bg-muted-foreground/40",
+	shipped: "bg-emerald-500",
+};
+
+type ShippedItem = RoadmapItem & { status: "shipped" };
 
 function RoadmapCard({ item }: { item: RoadmapItem }) {
 	return (
@@ -28,12 +40,71 @@ function RoadmapCard({ item }: { item: RoadmapItem }) {
 	);
 }
 
-function ShippedCard({ item }: { item: RoadmapItem & { status: "shipped" } }) {
+function ShippedHighlightCard({ item }: { item: ShippedItem }) {
+	const body = (
+		<>
+			{item.image && (
+				<div className="relative aspect-video overflow-hidden border-b border-border bg-muted/20">
+					<Image
+						src={item.image}
+						alt={item.title}
+						fill
+						sizes="(min-width: 768px) 33vw, 100vw"
+						className="object-cover object-top transition-transform duration-300 group-hover:scale-[1.02]"
+					/>
+				</div>
+			)}
+			<div className="flex-1 p-4">
+				<div className="flex items-baseline justify-between gap-3">
+					<h3 className="text-sm font-medium text-foreground group-hover:text-foreground/80 transition-colors">
+						{item.title}
+					</h3>
+					<span className="text-[11px] font-mono text-muted-foreground whitespace-nowrap">
+						{item.shippedDate}
+					</span>
+				</div>
+				<p className="text-xs text-muted-foreground mt-1.5">
+					{item.description}
+				</p>
+				{item.href ? (
+					<span className="text-[11px] font-mono text-muted-foreground mt-2 block uppercase tracking-wider group-hover:text-foreground transition-colors">
+						Read the changelog →
+					</span>
+				) : (
+					item.pr && (
+						<span className="mt-2 block">
+							<PRBadge url={item.pr} />
+						</span>
+					)
+				)}
+			</div>
+		</>
+	);
+
+	if (item.href) {
+		return (
+			<a
+				href={item.href}
+				className="group flex flex-col border border-border hover:border-foreground/20 transition-colors"
+			>
+				{body}
+			</a>
+		);
+	}
 	return (
-		<div className="group flex items-start gap-3 border border-border p-4 hover:border-foreground/20 transition-colors">
+		<div className="group flex flex-col border border-border hover:border-foreground/20 transition-colors">
+			{body}
+		</div>
+	);
+}
+
+function ShippedCard({ item }: { item: ShippedItem }) {
+	const body = (
+		<>
 			<div className="flex-1 min-w-0">
-				<h3 className="text-sm font-medium text-foreground group-hover:text-foreground/80 transition-colors">
+				<h3 className="flex items-center gap-2 text-sm font-medium text-foreground group-hover:text-foreground/80 transition-colors">
 					{item.title}
+					{!item.href && item.pr && <PRBadge url={item.pr} />}
 				</h3>
 				<p className="text-xs text-muted-foreground mt-1.5 line-clamp-2">
 					{item.description}
@@ -42,6 +113,22 @@ function ShippedCard({ item }: { item: RoadmapItem & { status: "shipped" } }) {
 			<span className="text-[11px] font-mono text-muted-foreground whitespace-nowrap mt-0.5">
 				{item.shippedDate}
 			</span>
+		</>
+	);
+
+	if (item.href) {
+		return (
+			<a
+				href={item.href}
+				className="group flex items-start gap-3 border border-border p-4 hover:border-foreground/20 transition-colors"
+			>
+				{body}
+			</a>
+		);
+	}
+	return (
+		<div className="group flex items-start gap-3 border border-border p-4 hover:border-foreground/20 transition-colors">
+			{body}
 		</div>
 	);
 }
@@ -58,7 +145,11 @@ export function RoadmapBoard() {
 	const itemsFor = (status: RoadmapStatus) =>
 		filtered.filter((item) => item.status === status);
 
-	const shippedItems = filtered.filter((item) => item.status === "shipped");
+	const shippedItems = filtered.filter(
+		(item): item is ShippedItem => item.status === "shipped",
+	);
+	const shippedHighlights = shippedItems.filter((item) => item.image);
+	const shippedRest = shippedItems.filter((item) => !item.image);
 
 	return (
 		<div>
@@ -103,12 +194,19 @@ export function RoadmapBoard() {
 						>
 							{/* Column header */}
 							<div className="border-b border-border px-4 py-3">
-								<h2 className="text-xs font-mono font-medium uppercase tracking-wider text-muted-foreground">
+								<h2 className="flex items-center gap-2 text-xs font-mono font-medium uppercase tracking-wider text-muted-foreground">
+									<span
+										aria-hidden
+										className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT[status]}`}
+									/>
 									{STATUS_LABELS[status]}
-									<span className="ml-2 text-muted-foreground/50">
+									<span className="text-muted-foreground/50">
 										{items.length}
 									</span>
 								</h2>
+								<p className="text-[11px] text-muted-foreground/60 mt-1">
+									{STATUS_DESCRIPTIONS[status]}
+								</p>
 							</div>
 
 							{/* Cards */}
@@ -130,17 +228,38 @@ export function RoadmapBoard() {
 			{/* Shipped section */}
 			{shippedItems.length > 0 && (
 				<div className="mt-12">
-					<h2 className="text-xs font-mono font-medium uppercase tracking-wider text-muted-foreground mb-4">
-						{STATUS_LABELS.shipped}
-						<span className="ml-2 text-muted-foreground/50">
-							{shippedItems.length}
-						</span>
-					</h2>
-					<div className="grid grid-cols-1 md:grid-cols-2 gap-px">
-						{shippedItems.map((item) => (
-							<ShippedCard key={item.id} item={item} />
-						))}
+					<div className="flex items-baseline justify-between mb-4">
+						<h2 className="flex items-center gap-2 text-xs font-mono font-medium uppercase tracking-wider text-muted-foreground">
+							<span
+								aria-hidden
+								className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT.shipped}`}
+							/>
+							{STATUS_LABELS.shipped}
+							<span className="text-muted-foreground/50">
+								{shippedItems.length}
+							</span>
+						</h2>
+						<a
+							href="/changelog"
+							className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+						>
+							Full changelog →
+						</a>
 					</div>
+					{shippedHighlights.length > 0 && (
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px mb-px">
+							{shippedHighlights.map((item) => (
+								<ShippedHighlightCard key={item.id} item={item} />
+							))}
+						</div>
+					)}
+					{shippedRest.length > 0 && (
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-px">
+							{shippedRest.map((item) => (
+								<ShippedCard key={item.id} item={item} />
+							))}
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/apps/marketing/src/app/roadmap/data.ts
+++ b/apps/marketing/src/app/roadmap/data.ts
@@ -1,4 +1,11 @@
-export type RoadmapCategory = "Desktop" | "Web" | "Mobile" | "Integrations";
+// Generated from the internal product roadmap (Notion → .github/prompts/update-roadmap.md).
+// Only items marked Public in Notion appear here; descriptions are the public copy, not internal notes.
+export type RoadmapCategory =
+	| "Agents"
+	| "Desktop"
+	| "Platform"
+	| "Mobile"
+	| "Integrations";
 
 export type RoadmapStatus = "now" | "next" | "later" | "shipped";
 
@@ -16,13 +23,20 @@ interface ActiveRoadmapItem extends RoadmapItemBase {
 interface ShippedRoadmapItem extends RoadmapItemBase {
 	status: "shipped";
 	shippedDate: string;
+	/** Screenshot from the matching changelog entry, when one exists. */
+	image?: string;
+	/** Link to the changelog entry covering the ship. */
+	href?: string;
+	/** GitHub PR URL, for ships not (yet) covered by a changelog entry. */
+	pr?: string;
 }
 
 export type RoadmapItem = ActiveRoadmapItem | ShippedRoadmapItem;
 
 export const CATEGORIES: RoadmapCategory[] = [
+	"Agents",
 	"Desktop",
-	"Web",
+	"Platform",
 	"Mobile",
 	"Integrations",
 ];
@@ -34,197 +48,269 @@ export const STATUS_LABELS: Record<RoadmapStatus, string> = {
 	shipped: "Recently Shipped",
 };
 
+export const STATUS_DESCRIPTIONS: Record<RoadmapStatus, string> = {
+	now: "Being built right now.",
+	next: "Committed — starting soon.",
+	later: "On our radar. Order and scope may change.",
+	shipped: "Live in the app.",
+};
+
 export const ROADMAP_ITEMS: RoadmapItem[] = [
 	// ── Now ──────────────────────────────────────────
 	{
-		id: "now-1",
-		title: "Mobile companion app",
+		id: "in-app-pr-merge",
+		title: "In-app PR merge",
 		description:
-			"Monitor and manage running agents from your phone. Approve prompts on the go.",
-		category: "Mobile",
+			"Merge pull requests without leaving Superset, plus a round of chat fixes and polish.",
+		category: "Desktop",
 		status: "now",
 	},
 	{
-		id: "now-2",
-		title: "Cloud workspaces",
+		id: "mcp-manager",
+		title: "MCP manager",
 		description:
-			"Run agents in the cloud with persistent workspaces, no local machine required.",
-		category: "Web",
+			"Install, authorize, and scope MCP servers across all your workspaces from one place, with centralized OAuth.",
+		category: "Integrations",
 		status: "now",
 	},
 	{
-		id: "now-3",
-		title: "Team workspaces",
+		id: "embedded-browser",
+		title: "Embedded browser improvements",
 		description:
-			"Shared workspaces with role-based access so teams can collaborate on agent tasks.",
-		category: "Web",
+			"A better in-app browser: preview your changes and click any element to send it to the agent as context.",
+		category: "Desktop",
 		status: "now",
 	},
 	{
-		id: "now-4",
-		title: "Session restore & persistence",
+		id: "onboarding",
+		title: "Smoother onboarding",
 		description:
-			"Automatically resume agent sessions after app restart or crash recovery.",
+			"A faster path from install to your first agent run, with a guided first workspace.",
 		category: "Desktop",
 		status: "now",
 	},
 
 	// ── Next ─────────────────────────────────────────
 	{
-		id: "next-1",
-		title: "VS Code extension",
+		id: "chat-v3",
+		title: "Next-generation chat",
 		description:
-			"Launch and manage Superset agents directly from the VS Code sidebar.",
-		category: "Integrations",
+			"A rebuilt chat surface for driving agents — richer tool output, smoother steering, faster everything.",
+		category: "Agents",
 		status: "next",
 	},
 	{
-		id: "next-2",
-		title: "Agent-to-agent communication",
+		id: "native-pr-reviews",
+		title: "Native PR reviews",
 		description:
-			"Allow agents to delegate subtasks to other agents and share context.",
+			"Review pull requests inside Superset — diff pane, agent-assisted review, act on comments directly.",
 		category: "Desktop",
 		status: "next",
 	},
 	{
-		id: "next-3",
-		title: "Usage analytics dashboard",
+		id: "improved-diff-viewer",
+		title: "Improved diff viewer",
 		description:
-			"Track token usage, agent runtime, and cost breakdowns per workspace.",
-		category: "Web",
+			"A faster, clearer diff experience for reviewing what your agents changed.",
+		category: "Desktop",
 		status: "next",
 	},
 	{
-		id: "next-4",
-		title: "Webhook integrations",
+		id: "chat-background-processes",
+		title: "Background processes in chat",
 		description:
-			"Trigger agents from external events via webhooks: CI pipelines, GitHub, Slack.",
+			"Agents can watch CI checks, tail dev servers, and keep long-running processes alive while they work.",
+		category: "Agents",
+		status: "next",
+	},
+	{
+		id: "plugin-marketplace",
+		title: "Plugin marketplace",
+		description:
+			"Browse and install skills, MCP servers, and agent configs shared by the community.",
 		category: "Integrations",
+		status: "next",
+	},
+	{
+		id: "sso-saml",
+		title: "SSO (SAML / OIDC)",
+		description: "Single sign-on for organizations, self-serve configurable.",
+		category: "Platform",
 		status: "next",
 	},
 
 	// ── Later ────────────────────────────────────────
 	{
-		id: "later-1",
-		title: "Self-hosted deployment",
+		id: "project-wide-search",
+		title: "Project-wide search",
 		description:
-			"Run Superset on your own infrastructure with a single Docker Compose file.",
-		category: "Web",
-		status: "later",
-	},
-	{
-		id: "later-2",
-		title: "Agent marketplace",
-		description:
-			"Browse, install, and publish community-built agent templates and tools.",
-		category: "Web",
-		status: "later",
-	},
-	{
-		id: "later-3",
-		title: "Multi-repo orchestration",
-		description:
-			"Run coordinated agent tasks across multiple repositories simultaneously.",
+			"Search across file contents and across all your workspaces at once.",
 		category: "Desktop",
 		status: "later",
 	},
 	{
-		id: "later-4",
-		title: "JetBrains plugin",
+		id: "work-from-tickets",
+		title: "Work from tickets",
 		description:
-			"Full Superset integration for IntelliJ, WebStorm, and other JetBrains IDEs.",
+			"Start a workspace straight from a Linear ticket — the agent picks it up and reports back with a PR.",
 		category: "Integrations",
+		status: "later",
+	},
+	{
+		id: "autonomous-ticket-to-pr",
+		title: "Autonomous ticket-to-PR pipeline",
+		description:
+			"File a ticket, get back a verified, merge-ready PR — with screenshots or a screencast as proof the change works.",
+		category: "Agents",
+		status: "later",
+	},
+	{
+		id: "automations",
+		title: "Automations & event triggers",
+		description:
+			"Scheduled and event-triggered agents — cron, GitHub events, webhooks — with ready-made templates.",
+		category: "Agents",
+		status: "later",
+	},
+	{
+		id: "orchestration-chat",
+		title: "Orchestration chat",
+		description:
+			"One chat that plans a task, fans out parallel agents across worktrees, and brings the results back together.",
+		category: "Agents",
+		status: "later",
+	},
+	{
+		id: "self-verification",
+		title: "Agent self-verification",
+		description:
+			"Agents load their own preview, drive the UI, and attach screenshot proof before marking work ready for review.",
+		category: "Agents",
+		status: "later",
+	},
+	{
+		id: "session-snapshots",
+		title: "Session snapshots & revert",
+		description:
+			"Roll back an agent session to any checkpoint — conversation and file changes together.",
+		category: "Desktop",
+		status: "later",
+	},
+	{
+		id: "attention-queue",
+		title: "Attention queue",
+		description:
+			"Always know which agent needs you, with notifications that deep-link straight to the blocked agent.",
+		category: "Desktop",
+		status: "later",
+	},
+	{
+		id: "cloud-sandboxes",
+		title: "Cloud sandboxes",
+		description:
+			"Machine-unbound cloud workspaces that spin up in seconds and can be shared with teammates.",
+		category: "Platform",
+		status: "later",
+	},
+	{
+		id: "sdk-api",
+		title: "SDK & public API",
+		description:
+			"Drive workspaces, agents, and sessions programmatically from scripts, CI, or your own tools.",
+		category: "Platform",
+		status: "later",
+	},
+	{
+		id: "ios-app",
+		title: "iOS app",
+		description: "Monitor, steer, and unblock your agents from your phone.",
+		category: "Mobile",
 		status: "later",
 	},
 
 	// ── Shipped ──────────────────────────────────────
 	{
-		id: "shipped-1",
-		title: "Review tab & PR comments",
+		id: "offline-local-first",
+		title: "Offline / local-first mode",
 		description:
-			"Review tab in changes sidebar for PR review comments with inline actions.",
+			"The full core loop — import a repo, run an agent, review the diff — now works signed out and offline.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Mar 2026",
+		shippedDate: "Aug 2026",
+		pr: "https://github.com/superset-sh/superset/pull/5731",
 	},
 	{
-		id: "shipped-2",
-		title: "Configurable agent settings",
+		id: "workspace-pinning-bulk-actions",
+		title: "Workspace pinning & bulk actions",
 		description:
-			"Override presets and preview agent configuration templates directly from the UI.",
+			"Pin workspaces above your projects, then ⌘-click a batch to move, group, or delete them all at once.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Mar 2026",
+		shippedDate: "Aug 2026",
+		image: "/changelog/2026-08-02-workspace-bulk-select.png",
+		href: "/changelog/2026-08-02-workspace-pinning-bulk-actions",
 	},
 	{
-		id: "shipped-3",
-		title: "CodeMirror editor",
+		id: "sidebar-redesign",
+		title: "Cleaner, denser sidebar",
 		description:
-			"Replaced Monaco with CodeMirror: 150KB vs 5MB, significantly faster loading.",
+			"A full restyle — denser rows, port and agent chips under each workspace, one-click stop for everything.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Mar 2026",
+		shippedDate: "Aug 2026",
+		image: "/changelog/2026-08-02-sidebar-redesign.png",
+		href: "/changelog/2026-08-02-workspace-pinning-bulk-actions",
 	},
 	{
-		id: "shipped-4",
-		title: "Cross-workspace search",
+		id: "grok-kimi-agents",
+		title: "Grok & Kimi Code agents",
 		description:
-			"Search across all open workspaces simultaneously with unified results.",
+			"Grok and Kimi Code join the lineup alongside Claude Code, Codex, and friends.",
+		category: "Agents",
+		status: "shipped",
+		shippedDate: "Aug 2026",
+		image: "/changelog/2026-08-02-add-agent-picker.png",
+		href: "/changelog/2026-08-02-workspace-pinning-bulk-actions",
+	},
+	{
+		id: "stability-pass",
+		title: "Stability improvements",
+		description:
+			"A focused burn-down of crashes, hangs, and reconnect failures across the app.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Mar 2026",
+		shippedDate: "Aug 2026",
 	},
 	{
-		id: "shipped-5",
-		title: "Chat view GA",
+		id: "performance-pass",
+		title: "Lighter memory, smoother under load",
 		description:
-			"Chat view generally available with refreshed tool call visuals and rich UI cards.",
+			"Lower memory with many terminals open, smoother git in big repos, and less background CPU.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Mar 2026",
+		shippedDate: "Jul 2026",
+		image: "/changelog/2026-07-19-performance-summary.png",
+		href: "/changelog/2026-07-19-performance-memory-and-load",
 	},
 	{
-		id: "shipped-6",
-		title: "Multi-provider model picker",
+		id: "terminal-rich-input",
+		title: "Rich input for the terminal",
 		description:
-			"Copilot, Cursor Agent, and Gemini support alongside Claude and GPT models.",
-		category: "Integrations",
-		status: "shipped",
-		shippedDate: "Feb 2026",
-	},
-	{
-		id: "shipped-7",
-		title: "In-app browser",
-		description:
-			"Chrome-like browser with URL autocomplete, DevTools support, and desktop automation tools.",
+			"Press ⌘I over any terminal and compose in a real editor — multiline prompts and @file mentions.",
 		category: "Desktop",
 		status: "shipped",
-		shippedDate: "Feb 2026",
+		shippedDate: "Jul 2026",
+		image: "/changelog/2026-07-12-rich-input-hero.png",
+		href: "/changelog/2026-07-12-terminal-rich-input-mistral-vibe",
 	},
 	{
-		id: "shipped-8",
-		title: "File explorer",
+		id: "custom-terminal-agents",
+		title: "Custom terminal agents",
 		description:
-			"Hierarchical tree view with file operations, material icon theme, and drag-and-drop.",
-		category: "Desktop",
+			"Register any CLI agent alongside the built-ins, each with its own name, icon, and launch command.",
+		category: "Agents",
 		status: "shipped",
-		shippedDate: "Feb 2026",
-	},
-	{
-		id: "shipped-9",
-		title: "Linux desktop support",
-		description: "Native Linux desktop application distributed as AppImage.",
-		category: "Desktop",
-		status: "shipped",
-		shippedDate: "Feb 2026",
-	},
-	{
-		id: "shipped-10",
-		title: "Electric SQL sync",
-		description:
-			"Local-first task synchronization with Electric SQL and Linear integration via webhooks.",
-		category: "Integrations",
-		status: "shipped",
-		shippedDate: "Dec 2025",
+		shippedDate: "Jul 2026",
+		href: "/changelog/2026-07-06-custom-agents-workspace-activity-fable",
 	},
 ];

--- a/apps/marketing/src/app/roadmap/page.tsx
+++ b/apps/marketing/src/app/roadmap/page.tsx
@@ -53,7 +53,20 @@ export default function RoadmapPage() {
 					</h1>
 					<p className="text-muted-foreground mt-3 max-w-lg">
 						A look at what's in progress, what's coming next, and where{" "}
-						{COMPANY.NAME} is headed. Priorities may shift as we learn more.
+						{COMPANY.NAME} is headed. Plans further out stay intentionally
+						flexible so we can respond to what you tell us.
+					</p>
+					<p className="text-sm text-muted-foreground mt-3">
+						Want something sooner?{" "}
+						<a
+							href={COMPANY.DISCORD_URL}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-foreground underline underline-offset-4 hover:no-underline"
+						>
+							Tell us in Discord
+						</a>{" "}
+						— much of what's here started as a user request.
 					</p>
 
 					<GridCross className="bottom-0 left-0" />


### PR DESCRIPTION
## What

Revives the stale `/roadmap` page (untouched since April, with factually wrong entries like "Linux support — shipped") and gives it a governed supply line from the internal Notion Product Roadmap database.

### Page
- Fresh curated dataset: 4 In Progress / 6 Up Next / 11 Exploring / 8 Recently Shipped
- New categories: Agents / Desktop / Platform / Mobile / Integrations
- Lane explainer lines + status dots (PostHog/Zed-style); flexibility disclaimer; Discord feedback link
- Shipped lane: highlight cards with real changelog screenshots, linking to the changelog entry or flagship PR (`PRBadge`)
- Roadmap linked from header Product dropdown and footer Resources

### Sync pipeline
- Source of truth: Notion Product Roadmap DB with new `Public` / `Public title` / `Public description` / `Public category` fields — only `Public ✓` rows publish, and only those fields cross the boundary (never internal descriptions, success measures, dates, or Linear links)
- `.github/prompts/update-roadmap.md` drives the **Monthly roadmap sync** Superset automation (1st of month, 9am PT), which regenerates `data.ts` and opens a PR for human review — it never publishes directly
- Every published future item traces to a scheduled cycle in the planning docs; unscheduled backlog items were deliberately excluded

## Verification
- CDP screenshots of the rendered page at each iteration, compared against Obsidian / PostHog / Zed / Meilisearch public roadmaps
- `bun run lint` clean, marketing `tsc --noEmit` clean

Reviewer: confirm no internal metrics, dates, ticket IDs, or strategy language leaked into descriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revives the public /roadmap with a Notion‑synced, governed dataset and a clearer UI, including shipped highlights linked to our changelog. Adds a monthly sync workflow that opens a PR for review (no auto-publish) under strict privacy rules.

- **New Features**
  - Fresh roadmap data sourced from Notion via public-only fields; new categories: Agents, Desktop, Platform, Mobile, Integrations.
  - Clear lane explainers with status dots and counts; short descriptions for Now/Next/Later/Shipped.
  - Shipped section shows visual highlight cards with screenshots and links to changelog entries or a `PRBadge`, plus a “Full changelog” link.
  - Improved shipped/active card layouts, image support, and better shipped item tagging (`href` to changelog preferred, PR link fallback).
  - Monthly sync prompt at `.github/prompts/update-roadmap.md` drives a PR-based update flow; never publishes directly.
  - Privacy guardrails: only `Public`-checked items; only public title/description/category; no ETAs for unshipped; shipped get month labels; never include Linear links or internal metrics.
  - Navigation: added Roadmap to header Product dropdown and footer Resources.
  - Reviewer: confirm no internal metrics, dates, ticket IDs, or strategy language leaked into descriptions.

<sup>Written for commit d8d58ca9d56b37fb492889cfb864cc8f9d35ded3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

