### PR TITLE
fix(desktop): stop pane layout corruption when dragging a single-pane tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -1,11 +1,16 @@
 import { cn } from "@superset/ui/utils";
-import { useContext, useRef } from "react";
+import { useContext, useMemo, useRef } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
-import { MosaicWindow, MosaicWindowContext } from "react-mosaic-component";
+import {
+	MosaicContext,
+	MosaicWindow,
+	MosaicWindowContext,
+} from "react-mosaic-component";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { SplitOrientation } from "../../hooks";
 import { useSplitOrientation } from "../../hooks";
+import { guardMosaicActions } from "./mosaic-update-guards";
 
 export interface PaneHandlers {
 	onFocus: () => void;
@@ -64,6 +69,14 @@ export function BasePaneWindow({
 	const isResizing = useDragPaneStore((s) => s.isResizing);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
+	const mosaicContext = useContext(MosaicContext);
+	const guardedMosaicContext = useMemo(
+		() => ({
+			...mosaicContext,
+			mosaicActions: guardMosaicActions(mosaicContext.mosaicActions),
+		}),
+		[mosaicContext],
+	);
 
 	const handleFocus = () => {
 		setFocusedPane(tabId, paneId);
@@ -93,32 +106,36 @@ export function BasePaneWindow({
 	const isRoot = path.length === 0;
 
 	return (
-		<MosaicWindow<string>
-			path={path}
-			title=""
-			renderToolbar={() =>
-				isRoot ? (
-					<RootDraggable>{renderToolbar(handlers)}</RootDraggable>
-				) : (
-					renderToolbar(handlers)
-				)
-			}
-			className={cn(
-				isActive && "mosaic-window-focused",
-				workspaceRunState && `workspace-run-pane-${workspaceRunState}`,
-			)}
-			onDragStart={() => setDragging(paneId, tabId)}
-			onDragEnd={() => clearDragging()}
-		>
-			{/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: Focus handler for pane */}
-			<div
-				ref={containerRef}
-				className={contentClassName}
-				style={isDragging || isResizing ? { pointerEvents: "none" } : undefined}
-				onClick={handleFocus}
+		<MosaicContext.Provider value={guardedMosaicContext}>
+			<MosaicWindow<string>
+				path={path}
+				title=""
+				renderToolbar={() =>
+					isRoot ? (
+						<RootDraggable>{renderToolbar(handlers)}</RootDraggable>
+					) : (
+						renderToolbar(handlers)
+					)
+				}
+				className={cn(
+					isActive && "mosaic-window-focused",
+					workspaceRunState && `workspace-run-pane-${workspaceRunState}`,
+				)}
+				onDragStart={() => setDragging(paneId, tabId)}
+				onDragEnd={() => clearDragging()}
 			>
-				{children}
-			</div>
-		</MosaicWindow>
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: Focus handler for pane */}
+				<div
+					ref={containerRef}
+					className={contentClassName}
+					style={
+						isDragging || isResizing ? { pointerEvents: "none" } : undefined
+					}
+					onClick={handleFocus}
+				>
+					{children}
+				</div>
+			</MosaicWindow>
+		</MosaicContext.Provider>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/mosaic-update-guards.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/mosaic-update-guards.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { MosaicNode, MosaicRootActions } from "react-mosaic-component";
+import { createHideUpdate, updateTree } from "react-mosaic-component";
+import { guardMosaicActions } from "./mosaic-update-guards";
+
+const LEAF_ROOT: MosaicNode<string> = "pane-1784897806279-1ke7qdxay";
+const SPLIT_ROOT: MosaicNode<string> = {
+	direction: "row",
+	first: "pane-a",
+	second: "pane-b",
+	splitPercentage: 50,
+};
+
+function createActions(root: MosaicNode<string> | null) {
+	const actions = {
+		expand: mock(),
+		remove: mock(),
+		hide: mock(),
+		replaceWith: mock(),
+		updateTree: mock(),
+		getRoot: () => root,
+	} satisfies MosaicRootActions<string>;
+	return { actions, guarded: guardMosaicActions(actions) };
+}
+
+describe("guardMosaicActions", () => {
+	it("skips hide when the root is a single leaf", () => {
+		expect(() => updateTree(LEAF_ROOT, [createHideUpdate([])])).toThrow();
+
+		const { actions, guarded } = createActions(LEAF_ROOT);
+		guarded.hide([]);
+
+		expect(actions.hide).not.toHaveBeenCalled();
+	});
+
+	it("forwards hide when the path resolves to a branch", () => {
+		const { actions, guarded } = createActions(SPLIT_ROOT);
+		guarded.hide(["first"]);
+
+		expect(actions.hide).toHaveBeenCalledWith(["first"]);
+	});
+
+	it("skips a splitPercentage update addressed to a leaf", () => {
+		const leafRoot = createActions(LEAF_ROOT);
+		leafRoot.guarded.updateTree([
+			{ path: [], spec: { splitPercentage: { $set: undefined } } },
+		]);
+
+		const splitRoot = createActions(SPLIT_ROOT);
+		splitRoot.guarded.updateTree([
+			{ path: ["first"], spec: { splitPercentage: { $set: undefined } } },
+		]);
+
+		expect(leafRoot.actions.updateTree).not.toHaveBeenCalled();
+		expect(splitRoot.actions.updateTree).not.toHaveBeenCalled();
+	});
+
+	it("forwards a splitPercentage update addressed to a branch", () => {
+		const updates = [
+			{ path: [], spec: { splitPercentage: { $set: undefined } } },
+		];
+		const { actions, guarded } = createActions(SPLIT_ROOT);
+		guarded.updateTree(updates);
+
+		expect(actions.updateTree).toHaveBeenCalledWith(updates, undefined);
+	});
+
+	it("forwards $set updates regardless of the node at the path", () => {
+		const updates = [{ path: [], spec: { $set: SPLIT_ROOT } }];
+		const { actions, guarded } = createActions(LEAF_ROOT);
+		guarded.updateTree(updates);
+
+		expect(actions.updateTree).toHaveBeenCalledWith(updates, undefined);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/mosaic-update-guards.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/mosaic-update-guards.ts
@@ -1,0 +1,42 @@
+import type {
+	MosaicNode,
+	MosaicRootActions,
+	MosaicUpdate,
+} from "react-mosaic-component";
+import {
+	createHideUpdate,
+	getNodeAtPath,
+	isParent,
+} from "react-mosaic-component";
+
+export function canApplyMosaicUpdate<T extends string | number>(
+	root: MosaicNode<T> | null,
+	update: MosaicUpdate<T>,
+): boolean {
+	if ("$set" in update.spec) return true;
+
+	const node = getNodeAtPath(root, update.path);
+	return node !== null && isParent(node);
+}
+
+export function guardMosaicActions<T extends string | number>(
+	actions: MosaicRootActions<T>,
+): MosaicRootActions<T> {
+	return {
+		...actions,
+		hide: (path) => {
+			if (canApplyMosaicUpdate(actions.getRoot(), createHideUpdate<T>(path))) {
+				actions.hide(path);
+			}
+		},
+		updateTree: (updates, suppressOnRelease) => {
+			const root = actions.getRoot();
+			const applicable = updates.filter((update) =>
+				canApplyMosaicUpdate(root, update),
+			);
+			if (applicable.length > 0) {
+				actions.updateTree(applicable, suppressOnRelease);
+			}
+		},
+	};
+}


### PR DESCRIPTION
## Problem

`TypeError: Cannot create property 'splitPercentage' on string 'pane-…'` thrown from immutability-helper in the renderer (Sentry DESKTOP-HA, recurring since May as DESKTOP-A8/2D, ~160 events).

## Root cause

react-mosaic only connects a `MosaicWindow`'s drag source when `path.length > 0` (`draggableAndNotRoot` in `MosaicWindow.tsx`), because its drag lifecycle mutates the **parent branch** of the dragged node:

- drag start: `mosaicActions.hide(path)` → `createHideUpdate(path)` → `{path: dropRight(path), spec: {splitPercentage: {$set: 100}}}`
- drag end without a drop: `updateTree([{path: dropRight(path), spec: {splitPercentage: {$set: undefined}}}])`

`RootDraggable` in `BasePaneWindow` deliberately re-enables the drag source for root panes (`path === []`) so a single pane can be dragged to another tab. For a tab with one pane the layout root is a bare string leaf, so both updates target path `[]` and immutability-helper tries to assign a property on a string → TypeError. The same shape mismatch occurs for any path that resolves to a leaf after the tree changed shape mid-drag.

## Fix

`guardMosaicActions` wraps the mosaic root actions the window sees: an update whose spec is not a `$set` is skipped when its path does not resolve to a branch node in the *current* tree. `$set` updates (splits, drops, removals) pass through untouched, so cross-tab drag of a single pane keeps working; the meaningless hide/restore at a leaf root becomes a no-op instead of a crash.

## Verification

- New unit tests in `mosaic-update-guards.test.ts`, including a reproduction asserting that react-mosaic's own hide update throws on a leaf root.
- `bun test` over `TabView/` and `stores/tabs/`: 116 pass, 0 fail.
- `bun run typecheck` clean for the touched files (pre-existing `@superset/chat-legacy` module-resolution errors elsewhere are unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops pane layout corruption and TypeError when dragging a single-pane tab. Guards `react-mosaic-component` updates so leaf-root changes become no-ops while cross-tab dragging still works.

- **Bug Fixes**
  - Wrapped `MosaicContext` with `guardMosaicActions` to skip non-$set updates when the path resolves to a leaf or goes stale.
  - Let `$set` updates through (splits, drops, removals) to keep drag-and-drop behavior intact.
  - Added unit tests in `mosaic-update-guards.test.ts`; relevant test suites pass.

<sup>Written for commit e15be02d0c49bff09017c279fd0a28781978678d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

