### PR TITLE
fix(desktop): repair tray updater require, guard clipboard writes, classify updater/keychain/job noise

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -87,17 +87,31 @@ export const createGitOperationsRouter = () => {
 					action: "push",
 				});
 
-				if (input.setUpstream && !hasUpstream) {
-					await pushWithResolvedUpstream({
-						git,
-						worktreePath: input.worktreePath,
-						localBranch,
-					});
-				} else {
-					await pushCurrentBranch({
-						git,
-						worktreePath: input.worktreePath,
-						localBranch,
+				try {
+					if (input.setUpstream && !hasUpstream) {
+						await pushWithResolvedUpstream({
+							git,
+							worktreePath: input.worktreePath,
+							localBranch,
+						});
+					} else {
+						await pushCurrentBranch({
+							git,
+							worktreePath: input.worktreePath,
+							localBranch,
+						});
+					}
+				} catch (error) {
+					if (error instanceof TRPCError) {
+						throw error;
+					}
+					// git refuses a push for reasons that live in the user's repo,
+					// remote or hooks — a rejected ref, missing credentials, a
+					// pre-push hook exiting non-zero. Surface git's own text.
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: error instanceof Error ? error.message : String(error),
+						cause: error,
 					});
 				}
 

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "node:events";
+import * as Sentry from "@sentry/electron/main";
 import { app, dialog } from "electron";
 import log from "electron-log/main";
-import { autoUpdater } from "electron-updater";
+import { autoUpdater, type UpdateCheckResult } from "electron-updater";
 import { env } from "main/env.main";
 import { setSkipQuitConfirmation } from "main/index";
 import { appState } from "main/lib/app-state";
@@ -80,6 +81,40 @@ const SILENT_ERROR_PATTERNS = [
 function isNetworkError(error: Error | string): boolean {
 	const message = typeof error === "string" ? error : error.message;
 	return SILENT_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+const ENVIRONMENT_ERRNO_CODES = [
+	"ENOENT",
+	"EACCES",
+	"EPERM",
+	"EBUSY",
+	"ENOSPC",
+];
+const UPDATER_PATH_MARKERS = ["-updater", "shipit"];
+
+// Update failures owned by the user's machine, not by us: a corrupt or
+// half-removed updater cache, an app bundle that can't be written, and stalled
+// requests. Squirrel and electron-updater surface these as plain messages
+// without errno properties, so match on the text.
+function isEnvironmentUpdateError(message: string): boolean {
+	const lowerMessage = message.toLowerCase();
+	if (
+		lowerMessage.includes("read-only volume") ||
+		lowerMessage.includes("the request timed out")
+	) {
+		return true;
+	}
+	return (
+		ENVIRONMENT_ERRNO_CODES.some((code) => message.includes(`${code}:`)) &&
+		UPDATER_PATH_MARKERS.some((marker) => lowerMessage.includes(marker))
+	);
+}
+
+// electron-updater starts the auto-download inside checkForUpdates and hands
+// back its promise unattached; every rejection has already gone through the
+// `error` event, so the copy only needs to stop being unhandled.
+function releaseDownloadPromise(result: UpdateCheckResult | null): void {
+	result?.downloadPromise?.catch(() => {});
 }
 
 let currentStatus: AutoUpdateStatus = AUTO_UPDATE_STATUS.IDLE;
@@ -170,15 +205,18 @@ export function checkForUpdates(): void {
 	}
 	isDismissed = false;
 	emitStatus(AUTO_UPDATE_STATUS.CHECKING);
-	autoUpdater.checkForUpdates().catch((error) => {
-		if (isNetworkError(error)) {
-			log.info("[auto-updater] Network unavailable, will retry later");
-			emitStatus(AUTO_UPDATE_STATUS.IDLE);
-			return;
-		}
-		log.error("[auto-updater] Failed to check for updates:", error);
-		emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
-	});
+	autoUpdater
+		.checkForUpdates()
+		.then(releaseDownloadPromise)
+		.catch((error) => {
+			if (isNetworkError(error)) {
+				log.info("[auto-updater] Network unavailable, will retry later");
+				emitStatus(AUTO_UPDATE_STATUS.IDLE);
+				return;
+			}
+			log.error("[auto-updater] Failed to check for updates:", error);
+			emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
+		});
 }
 
 export function checkForUpdatesInteractive(): void {
@@ -205,6 +243,7 @@ export function checkForUpdatesInteractive(): void {
 	autoUpdater
 		.checkForUpdates()
 		.then((result) => {
+			releaseDownloadPromise(result);
 			if (
 				!result?.updateInfo ||
 				gte(app.getVersion(), result.updateInfo.version)
@@ -337,6 +376,9 @@ export function setupAutoUpdater(): void {
 		);
 		void clearCachedUpdate(`error: ${error?.message ?? "unknown"}`);
 		emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
+		if (!isEnvironmentUpdateError(error?.message ?? String(error))) {
+			Sentry.captureException(error);
+		}
 	});
 
 	autoUpdater.on("checking-for-update", () => {

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -10,6 +10,7 @@ import {
 import { loadToken } from "lib/trpc/routers/auth/utils/auth-functions";
 import { env } from "main/env.main";
 import { focusMainWindow, quitApp } from "main/index";
+import { checkForUpdatesInteractive } from "main/lib/auto-updater";
 import {
 	getHostServiceCoordinator,
 	type HostServiceStatusEvent,
@@ -226,8 +227,6 @@ async function updateTrayMenu(): Promise<void> {
 		{
 			label: "Check for Updates",
 			click: () => {
-				// Imported lazily to avoid circular dependency
-				const { checkForUpdatesInteractive } = require("../auto-updater");
 				checkForUpdatesInteractive();
 			},
 		},

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-provider.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-provider.ts
@@ -1,0 +1,27 @@
+import type { IClipboardProvider } from "@xterm/addon-clipboard";
+
+/**
+ * Clipboard provider for xterm's ClipboardAddon (OSC 52 copy/paste).
+ *
+ * OSC 52 arrives from the PTY whenever the program decides to copy, which is
+ * routinely while the window is in the background. Chromium rejects clipboard
+ * writes from an unfocused document, and the addon's default provider leaves
+ * that rejection unhandled.
+ */
+export class FocusAwareClipboardProvider implements IClipboardProvider {
+	readText(): Promise<string> {
+		return navigator.clipboard.readText();
+	}
+
+	async writeText(_selection: string, text: string): Promise<void> {
+		if (!document.hasFocus()) return;
+		try {
+			await navigator.clipboard.writeText(text);
+		} catch (error) {
+			if (error instanceof DOMException && error.name === "NotAllowedError") {
+				return;
+			}
+			throw error;
+		}
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -7,6 +7,7 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { Utf8Base64 } from "./clipboard-base64";
+import { FocusAwareClipboardProvider } from "./clipboard-provider";
 
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
@@ -32,7 +33,9 @@ export function loadAddons(
 	let ligaturesAddon: LigaturesAddon | null = null;
 
 	// Utf8Base64 replaces the addon's UTF-8-unsafe default codec (#4839).
-	terminal.loadAddon(new ClipboardAddon(new Utf8Base64()));
+	terminal.loadAddon(
+		new ClipboardAddon(new Utf8Base64(), new FocusAwareClipboardProvider()),
+	);
 
 	const unicode11 = new Unicode11Addon();
 	terminal.loadAddon(unicode11);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -14,6 +14,7 @@ import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { Utf8Base64 } from "renderer/lib/terminal/clipboard-base64";
+import { FocusAwareClipboardProvider } from "renderer/lib/terminal/clipboard-provider";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import {
 	createParserIdleGate,
@@ -114,7 +115,10 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const searchAddon = new SearchAddon();
 
 	// Utf8Base64 replaces the addon's UTF-8-unsafe default codec (#4839).
-	const clipboardAddon = new ClipboardAddon(new Utf8Base64());
+	const clipboardAddon = new ClipboardAddon(
+		new Utf8Base64(),
+		new FocusAwareClipboardProvider(),
+	);
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
 


### PR DESCRIPTION
Four Sentry desktop signals, each fixed at its call site. No `beforeSend` filters and no middleware allowlists were added — per the contract from #6164, anything still reaching Sentry is a real bug.

### 1. Tray "Check for Updates" threw MODULE_NOT_FOUND (real bug)

`apps/desktop/src/main/lib/tray/index.ts` lazily `require`d `"../auto-updater"` with a comment about breaking a circular dependency. That relative path does not exist in the flat `dist/main` bundle, so every click on the menu item threw `Error: Cannot find module '../auto-updater'` from `menu.click`. Replaced with a static import on `main/lib/auto-updater`, the same alias `lib/trpc/routers/auto-update/index.ts` already uses. The cycle it worried about (`auto-updater` ↔ `main/index`) already exists and is safe here because `checkForUpdatesInteractive` is only called from a click handler, never at module evaluation.

### 2. Unhandled clipboard rejection from OSC 52 (real bug)

Both terminal stacks constructed `new ClipboardAddon(new Utf8Base64())`, leaving the addon's default `BrowserClipboardProvider` in place. That provider returns `navigator.clipboard.writeText(...)` and the addon never attaches a rejection handler. OSC 52 arrives from the PTY regardless of window focus, and Chromium refuses clipboard writes from an unfocused document, so background copies surfaced as `NotAllowedError: Document is not focused`.

New `FocusAwareClipboardProvider` (`renderer/lib/terminal/clipboard-provider.ts`) skips the write when `document.hasFocus()` is false and swallows `NotAllowedError`, rethrowing anything else. Wired into `renderer/lib/terminal/terminal-addons.ts` (v2) and the v1 `Terminal/helpers.ts`.

### 3. electron-updater noise (expected environment)

Root cause: `autoUpdater.checkForUpdates()` starts the auto-download internally and hands back `result.downloadPromise` unattached. Nothing ever consumed it, so every Squirrel failure landed as an unhandled rejection in the main process — which is why these arrived with `mechanism: auto.node.onunhandledrejection` and no stack trace, and why the existing `autoUpdater.on("error")` handler never suppressed them. That accounts for `Cannot update while running on a read-only volume` (1083 events), the `ENOENT rename '…-updater/pending/….zip'` and `ENOENT lstat '…ShipIt…'` families, and `The request timed out.`

Both check paths now consume `downloadPromise`. The `error` event stays the single classification point: it still logs, still clears the corrupt cache, and still emits the same `ERROR` status to the renderer, but now reports to Sentry only when the message is not a known user-environment shape (read-only volume, request timeout, or an errno on an updater cache path). Updater failures we do not recognize still reach Sentry — this is not a blanket swallow.

### 4. Pre-push hook output filed as a Sentry issue (expected environment)

`changes.push` let simple-git's `GitError` escape as `INTERNAL_SERVER_ERROR`, so a user's failing pre-push hook uploaded its entire build log as the Sentry error message (`recordJobRun(jobs.ts)` in the culprit line is the user's own project, not ours). The push is now translated to `PRECONDITION_FAILED` with git's own text preserved, so the `Push failed: …` toast is unchanged. Already-classified `TRPCError`s thrown inside the push helpers pass through untouched.

## Not fixed

- **`OSStatus -60006`** (`DESKTOP-H5`, authorization cancelled, message localized to Japanese): skipped. The event is an unhandled rejection in the main process with no stack trace, and no `safeStorage`/`keytar`/Authorization Services call site exists under `src/main`. Identifying it would be speculation.
- **`changes.sync`** reaches the same `pushCurrentBranch` helper and can still 500 on a failing pre-push hook. Left out to keep this diff scoped to the reported signal; worth a follow-up.

## Verification

`bunx biome check` clean on all six files. `apps/desktop` typecheck shows 67 errors, identical to the count on the base commit with the changes stashed — all from unbuilt `@superset/chat-legacy` / `@superset/email` workspace packages, none in the changed files.

Claude-Session: https://claude.ai/code/session_012u6VZtfQgoTh8qS4NqCb7e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four desktop issues that caused noisy Sentry reports and a broken “Check for Updates” menu item. Improves updater error handling, guards background clipboard writes, and surfaces clearer git push errors.

- **Bug Fixes**
  - Tray updater: replaced lazy require with static import `main/lib/auto-updater` to stop MODULE_NOT_FOUND in the packaged app.
  - Clipboard: added `FocusAwareClipboardProvider` for `@xterm/addon-clipboard` with `Utf8Base64`; skips writes when unfocused and swallows `NotAllowedError`.
  - Updater: for `electron-updater`, consume `checkForUpdates()` `downloadPromise` to prevent unhandled rejections; keep a single `error` handler and report to Sentry only for non-environment errors (not read-only volume, timeouts, or errno on `-updater`/ShipIt paths).
  - Git push: convert non-`TRPCError` push failures (e.g., pre-push hooks) to `PRECONDITION_FAILED` with git’s message; existing `TRPCError`s pass through.

<sup>Written for commit fcc99275fbd404172ab2ec8e8c17c12b9ca4c3aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Git push operations, providing clearer failure feedback.
  * Prevented update-related errors from causing unhandled failures, while reporting unexpected issues for investigation.
  * Improved terminal clipboard behavior when the app is unfocused or clipboard access is restricted.
* **Improvements**
  * Update checks now handle downloads more reliably in both interactive and background scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->