### PR TITLE
fix(desktop): attach child stderr tail and exit context to host-service crash reports

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -618,6 +618,8 @@ describe("HostServiceCoordinator respawn after a crash", () => {
 			port: 55555,
 			secret: "secret",
 			status: "running",
+			spawnedAt: Date.now(),
+			outputTail: "",
 			owned: true,
 		});
 	}

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -71,6 +71,9 @@ interface HostServiceProcess {
 	port: number;
 	secret: string;
 	status: HostServiceStatus;
+	spawnedAt: number;
+	/** Rolling tail of the child's stdout/stderr, attached to crash reports. */
+	outputTail: string;
 	/**
 	 * True when this instance spawned the child and owns its lifecycle (may
 	 * SIGTERM it and remove its manifest). False when the entry was *adopted*
@@ -104,6 +107,19 @@ const START_OR_ADOPT_DEADLINE_MS = SPAWN_LOCK_STALE_MS + HEALTH_POLL_TIMEOUT_MS;
 
 /** Poll interval while waiting for a peer instance's spawn to go healthy. */
 const ADOPT_WAIT_INTERVAL_MS = 250;
+
+/**
+ * A Node abort dumps ~5KB of native + JS backtrace on the way down, so a
+ * smaller window would evict the assertion line and every app log before it.
+ */
+const MAX_OUTPUT_TAIL_BYTES = 16_384;
+
+/**
+ * `exit` fires before the child's piped stdio has drained, so the crash report
+ * waits this long for the last output — a native abort message is written on
+ * the way down and would otherwise be missed.
+ */
+const CRASH_REPORT_FLUSH_MS = 500;
 
 // High, uncommon user-space range: above usual web/dev server ports and below
 // macOS's default ephemeral range, while still falling back if occupied.
@@ -632,6 +648,8 @@ export class HostServiceCoordinator extends EventEmitter {
 			port,
 			secret: manifest.authToken,
 			status: "running",
+			spawnedAt: manifest.startedAt,
+			outputTail: "",
 			owned: false,
 		});
 		this.rememberPort(organizationId, port);
@@ -662,6 +680,8 @@ export class HostServiceCoordinator extends EventEmitter {
 			port,
 			secret,
 			status: "starting",
+			spawnedAt: Date.now(),
+			outputTail: "",
 			owned: true,
 		};
 		this.instances.set(organizationId, instance);
@@ -678,34 +698,41 @@ export class HostServiceCoordinator extends EventEmitter {
 			path.join(manifestDir(organizationId), "host-service.log"),
 			MAX_HOST_LOG_BYTES,
 		);
-		// Dev: pipe child stdout/stderr through this process so log lines
-		// land in the developer's `bun dev` terminal. Production: hard-back
-		// stdio with the rotating log file.
+		// Output is piped rather than handing the log fd straight to the child so
+		// the coordinator can keep a tail of it for crash reports; it is written
+		// through to the same rotating log file (and, in dev, to this process's
+		// stdout/stderr) so logging is unchanged.
 		const isDev = !app.isPackaged;
-		const stdio: childProcess.StdioOptions = isDev
-			? ["ignore", "pipe", "pipe"]
-			: logFd >= 0
-				? ["ignore", logFd, logFd]
-				: ["ignore", "ignore", "ignore"];
+		const logStream =
+			logFd >= 0 ? fs.createWriteStream("", { fd: logFd }) : null;
+		// An unhandled stream error would take down the main process; losing log
+		// lines must not.
+		logStream?.on("error", () => {});
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
 			child = childProcess.spawn(process.execPath, [this.scriptPath], {
 				detached: false,
-				stdio,
+				stdio: ["ignore", "pipe", "pipe"],
 				env: childEnv,
 				// Avoid a flashing CMD window on Windows.
 				windowsHide: true,
 			});
-		} finally {
-			if (logFd >= 0) {
-				try {
-					fs.closeSync(logFd);
-				} catch {
-					// Best-effort — child has its own dup of the fd.
-				}
-			}
+		} catch (error) {
+			logStream?.end();
+			throw error;
 		}
+
+		for (const source of [child.stdout, child.stderr]) {
+			source?.on("error", () => {});
+			source?.on("data", (chunk: Buffer) => {
+				instance.outputTail = (
+					instance.outputTail + chunk.toString("utf8")
+				).slice(-MAX_OUTPUT_TAIL_BYTES);
+				logStream?.write(chunk);
+			});
+		}
+		child.once("close", () => logStream?.end());
 
 		// In dev, fan child output through to parent stdout/stderr with a
 		// prefix so it's identifiable in `bun dev`.
@@ -717,6 +744,7 @@ export class HostServiceCoordinator extends EventEmitter {
 
 		const childPid = child.pid;
 		if (!childPid) {
+			logStream?.end();
 			this.instances.delete(organizationId);
 			throw new Error("Failed to spawn host service process");
 		}
@@ -880,21 +908,33 @@ export class HostServiceCoordinator extends EventEmitter {
 		// so the supervisor is the only place these are observable. Imported
 		// lazily: a static @sentry/electron import needs electron APIs the
 		// coordinator tests' stub does not provide.
-		void import("@sentry/electron/main")
-			.then((Sentry) =>
-				Sentry.captureMessage(`host-service crashed (${cause})`, {
-					level: "error",
-					tags: {
-						exit_code: String(code ?? "none"),
-						exit_signal: signal ?? "none",
-					},
-					extra: {
-						organizationId,
-						respawnAttempts: this.respawns.get(organizationId)?.attempts ?? 0,
-					},
-				}),
-			)
-			.catch(() => {});
+		const respawnAttempts = this.respawns.get(organizationId)?.attempts ?? 0;
+		const flushTimer = setTimeout(() => {
+			void import("@sentry/electron/main")
+				.then((Sentry) =>
+					Sentry.captureMessage(`host-service crashed (${cause})`, {
+						level: "error",
+						tags: {
+							exit_code: String(code ?? "none"),
+							exit_signal: signal ?? "none",
+						},
+						extra: {
+							organizationId,
+							respawnAttempts,
+							pid: childPid,
+							version: app.getVersion(),
+							uptimeMs: Date.now() - current.spawnedAt,
+							// The child's own auth secret can reach its logs (request
+							// headers); never ship it to Sentry.
+							outputTail: current.outputTail
+								.split(current.secret)
+								.join("[redacted]"),
+						},
+					}),
+				)
+				.catch(() => {});
+		}, CRASH_REPORT_FLUSH_MS);
+		flushTimer.unref?.();
 		this.scheduleRespawn(organizationId, cause);
 	}
 

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import * as Sentry from "@sentry/electron/main";
 import { workspaces, worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import type { BrowserWindow } from "electron";
@@ -338,6 +339,16 @@ export async function MainWindow() {
 	window.webContents.on("render-process-gone", (_event, details) => {
 		console.error("[main-window] Renderer process gone:", details);
 		log.error("[main-window] Renderer process gone", details);
+		// The Sentry SDK's own capture for this event runs off the app-level
+		// listener it registered at init, so it fires before this one and cannot
+		// be tagged retroactively — report the details separately.
+		Sentry.captureMessage(`renderer process gone (${details.reason})`, {
+			level: "error",
+			tags: {
+				renderer_gone_reason: details.reason,
+				renderer_gone_exit_code: String(details.exitCode),
+			},
+		});
 	});
 
 	window.webContents.on("preload-error", (_event, preloadPath, error) => {


### PR DESCRIPTION
## Why

Sentry **DESKTOP-H1** — `host-service crashed (signal SIGABRT)` — is undiagnosable. The capture in `host-service-coordinator.ts` sent only the message plus the org id, and SIGABRT is almost certainly a native-module abort, so the child can't self-report. In packaged builds the coordinator handed the rotating log fd straight to the child (`stdio: ["ignore", logFd, logFd]`), so it never saw a byte of the output either.

**DESKTOP-H9** — `'renderer' process exited with 'launch-failed'` — has the same problem: our handler logs the full `details`, but the Sentry event carries none of it.

## What changed

**host-service crash reports**

- Child stdout/stderr are piped through the coordinator and written through to the same rotating `host-service.log` (dev keeps its prefixed pass-through to `bun dev`). Logging behaviour is unchanged; the coordinator can now see the output.
- A 16KB rolling tail is kept per child and attached to the crash capture as `outputTail`, alongside `pid`, `uptimeMs` (since spawn), `respawnAttempts`, and `version`. Existing `exit_code` / `exit_signal` tags are unchanged.
- The capture waits 500ms after `exit`: piped stdio drains *after* the process is gone, so capturing synchronously would miss exactly the abort message we're after.
- The child's own auth secret is redacted from the tail before it leaves the process. Env is never attached.
- `error` listeners on the log stream and the child's stdio, so a failed write can't take down the main process.

**renderer crashes**

`render-process-gone` now captures `reason` and `exitCode` as tags. Note this is a *separate* event rather than an enrichment of the SDK's own: `@sentry/electron` captures from an `app`-level listener registered at `Sentry.init`, which fires before this `webContents` listener, so that event can't be tagged retroactively.

## Verification

- `bunx biome check` clean on the changed files; `bun run typecheck` shows no new errors (pre-existing failures are unbuilt `@superset/chat-legacy` module resolution on main).
- `bun test src/main/lib/` — 509 pass, 0 fail.
- Ran a standalone harness reproducing the exact spawn/capture pattern against a child that writes app logs and then `process.abort()`s (real SIGABRT). With the original 4KB window the ~5KB Node abort backtrace **evicted the assertion line itself** — that's why the tail is 16KB. At 16KB the captured tail contains the app log line, the `Assertion ... failed` line, and the full backtrace, with the secret rendered as `[redacted]` and the log file byte-identical to the child's output.

## Trade-off

Production child output now flows through the main process instead of directly to a file, so a wedged main process could apply backpressure to a very chatty child once the 64KB pipe fills. Dev has always run this way, and the handlers drain unconditionally.

## What the next SIGABRT will carry

`outputTail` (last 16KB of the child's own logs and its abort backtrace, secret-redacted), `uptimeMs`, `respawnAttempts`, `pid`, `version`, plus the existing exit code/signal tags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve crash diagnostics by attaching the child process output tail and exit context to host-service crash reports. Also tag renderer process exits with reason and exit code for clearer Sentry events.

- **Bug Fixes**
  - Pipe child stdout/stderr through the coordinator and write through to the rotating log; dev passthrough stays.
  - Keep a 16KB rolling output tail and attach to Sentry as outputTail with pid, uptimeMs, respawnAttempts, and app version; wait 500ms post-exit to capture drained output.
  - Redact the child’s auth secret from the tail; never include env.
  - Add error handlers on log and stdio streams so failed writes don’t crash the main process.
  - Capture renderer `render-process-gone` via a separate `@sentry/electron` event and tag with reason and exitCode.

<sup>Written for commit 585bb2ce97f32500a56b07dbd5857b8e5192e038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host-service crash reporting with recent process output and detailed exit information.
  * Ensured service logs are captured and closed reliably, including after startup failures.
  * Added clearer reporting for renderer process terminations, including termination reasons and exit codes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->