### PR TITLE
feat(chat-runtime): tRPC router over commands + WebSocket sink adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -764,6 +764,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@superset/chat": "workspace:*",
+        "@trpc/server": "11.16.0",
         "better-sqlite3": "12.6.2",
         "drizzle-orm": "0.45.2",
         "zod": "4.4.3",

--- a/packages/chat-runtime/README.md
+++ b/packages/chat-runtime/README.md
@@ -18,7 +18,7 @@ The runtime speaks only the vocabulary in `plans/chat-protocol-v1.md`; it never 
 | `sessions/` | `liveSession/` (one running session: event pump, FIFO prompt queue, cancel) and `registry/`, which builds one per harness |
 | `stream/` | `subscriptions/` — `SubscriptionHub`: replay-then-live subscribe, per-subscriber delta channels, reset frames, delta coalescing |
 | `commands/` | The client-facing verbs, each parsed with the `@superset/chat` command schemas and deduped by `commandId` |
-| `router/` | `router/` — `createChatRouter(runtime)`, the tRPC surface over `commands/` (the package owns its own `initTRPC`; procedures close over the runtime) — and `wsSink/`, the structural WebSocket→`Sink` adapter host-service's stream route mounts |
+| `router/` | `router/` — `createChatRouter(runtime, { resolveCwd })`, the tRPC surface over `commands/` (the package owns its own `initTRPC`; procedures close over the runtime, and the host resolves `cwd` — clients never send it) — and `wsSink/`, the structural WebSocket→`Sink` adapter host-service's stream route mounts |
 | `testing/` | The cross-cutting test helpers no single module owns — `fixtures/` (protocol item factories), `testUtils/` (sinks, schedules, waits) and `testRuntime/` (the bun-sqlite runtime). Internal only: relative imports, no package export. Helpers that do have an owner stay beside it, like `harness/fake/` |
 
 ## Wiring a harness

--- a/packages/chat-runtime/README.md
+++ b/packages/chat-runtime/README.md
@@ -18,6 +18,7 @@ The runtime speaks only the vocabulary in `plans/chat-protocol-v1.md`; it never 
 | `sessions/` | `liveSession/` (one running session: event pump, FIFO prompt queue, cancel) and `registry/`, which builds one per harness |
 | `stream/` | `subscriptions/` — `SubscriptionHub`: replay-then-live subscribe, per-subscriber delta channels, reset frames, delta coalescing |
 | `commands/` | The client-facing verbs, each parsed with the `@superset/chat` command schemas and deduped by `commandId` |
+| `router/` | `router/` — `createChatRouter(runtime)`, the tRPC surface over `commands/` (the package owns its own `initTRPC`; procedures close over the runtime) — and `wsSink/`, the structural WebSocket→`Sink` adapter host-service's stream route mounts |
 | `testing/` | The cross-cutting test helpers no single module owns — `fixtures/` (protocol item factories), `testUtils/` (sinks, schedules, waits) and `testRuntime/` (the bun-sqlite runtime). Internal only: relative imports, no package export. Helpers that do have an owner stay beside it, like `harness/fake/` |
 
 ## Wiring a harness

--- a/packages/chat-runtime/package.json
+++ b/packages/chat-runtime/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@superset/chat": "workspace:*",
+		"@trpc/server": "11.16.0",
 		"better-sqlite3": "12.6.2",
 		"drizzle-orm": "0.45.2",
 		"zod": "4.4.3"

--- a/packages/chat-runtime/src/index.ts
+++ b/packages/chat-runtime/src/index.ts
@@ -15,6 +15,7 @@ export * from "./harness";
 export * from "./journal";
 export * from "./projection";
 export * from "./replay";
+export * from "./router";
 export * from "./sessions";
 export * from "./stream";
 

--- a/packages/chat-runtime/src/router/index.ts
+++ b/packages/chat-runtime/src/router/index.ts
@@ -1,4 +1,4 @@
-export type { ChatRouter } from "./router";
+export type { ChatRouter, ChatRouterOptions } from "./router";
 export { createChatCallerFactory, createChatRouter } from "./router";
 export type { WsSinkSocket } from "./wsSink";
 export { createWsSink } from "./wsSink";

--- a/packages/chat-runtime/src/router/index.ts
+++ b/packages/chat-runtime/src/router/index.ts
@@ -1,0 +1,4 @@
+export type { ChatRouter } from "./router";
+export { createChatCallerFactory, createChatRouter } from "./router";
+export type { WsSinkSocket } from "./wsSink";
+export { createWsSink } from "./wsSink";

--- a/packages/chat-runtime/src/router/router/index.ts
+++ b/packages/chat-runtime/src/router/router/index.ts
@@ -1,0 +1,2 @@
+export type { ChatRouter } from "./router";
+export { createChatCallerFactory, createChatRouter } from "./router";

--- a/packages/chat-runtime/src/router/router/index.ts
+++ b/packages/chat-runtime/src/router/router/index.ts
@@ -1,2 +1,2 @@
-export type { ChatRouter } from "./router";
+export type { ChatRouter, ChatRouterOptions } from "./router";
 export { createChatCallerFactory, createChatRouter } from "./router";

--- a/packages/chat-runtime/src/router/router/router.test.ts
+++ b/packages/chat-runtime/src/router/router/router.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { FakeHarnessScript } from "../../harness/fake";
 import type { ChatRuntime } from "../../index";
 import { agentMessage, turn } from "../../testing/fixtures";
@@ -29,8 +32,21 @@ const SCRIPT: FakeHarnessScript = {
 function newCaller() {
 	const { harnesses, adapters } = fakeHarnessRegistry(SCRIPT);
 	const runtime = createTestRuntime({ harnesses });
-	const caller = createChatCallerFactory(createChatRouter(runtime))({});
-	return { runtime, caller, adapterCount: () => adapters.length };
+	const cwd = mkdtempSync(join(tmpdir(), "chat-router-cwd-"));
+	const resolvedWorkspaceIds: string[] = [];
+	const router = createChatRouter(runtime, {
+		resolveCwd: (workspaceId) => {
+			resolvedWorkspaceIds.push(workspaceId);
+			return cwd;
+		},
+	});
+	const caller = createChatCallerFactory(router)({});
+	return {
+		runtime,
+		caller,
+		resolvedWorkspaceIds,
+		adapterCount: () => adapters.length,
+	};
 }
 
 function createSessionInput(workspaceId = "workspace-1") {
@@ -38,7 +54,6 @@ function createSessionInput(workspaceId = "workspace-1") {
 		commandId: randomUUID(),
 		workspaceId,
 		harness: FAKE_HARNESS,
-		cwd: "/tmp/workspace",
 	};
 }
 
@@ -58,9 +73,10 @@ async function promptIdle(
 
 describe("createChatRouter", () => {
 	test("create, prompt and getItems round trip through the router", async () => {
-		const { runtime, caller } = newCaller();
+		const { runtime, caller, resolvedWorkspaceIds } = newCaller();
 		const created = await caller.createSession(createSessionInput());
 		expect(created.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(resolvedWorkspaceIds).toEqual(["workspace-1"]);
 
 		await promptIdle(caller, runtime, created.sessionId);
 
@@ -91,9 +107,8 @@ describe("createChatRouter", () => {
 		await expect(
 			caller.createSession({
 				commandId: randomUUID(),
-				workspaceId: "workspace-1",
+				workspaceId: "",
 				harness: FAKE_HARNESS,
-				cwd: "",
 			}),
 		).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
@@ -118,6 +133,39 @@ describe("createChatRouter", () => {
 		await expect(
 			caller.getItems({ sessionId: created.sessionId, limit: 0 }),
 		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+		await runtime.dispose();
+	});
+
+	test("command errors surface as typed tRPC errors", async () => {
+		const { runtime, caller } = newCaller();
+
+		await expect(
+			caller.createSession({
+				commandId: randomUUID(),
+				workspaceId: "workspace-1",
+				harness: "nope",
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		await expect(
+			caller.prompt({
+				commandId: randomUUID(),
+				sessionId: "missing",
+				clientId: "client-1",
+				content: [{ type: "text", text: "hi" }],
+			}),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+		const created = await caller.createSession(createSessionInput());
+		await runtime.live.dispose(created.sessionId);
+		await expect(
+			caller.prompt({
+				commandId: randomUUID(),
+				sessionId: created.sessionId,
+				clientId: "client-1",
+				content: [{ type: "text", text: "hi" }],
+			}),
+		).rejects.toMatchObject({ code: "CONFLICT" });
 		await runtime.dispose();
 	});
 

--- a/packages/chat-runtime/src/router/router/router.test.ts
+++ b/packages/chat-runtime/src/router/router/router.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import type { FakeHarnessScript } from "../../harness/fake";
+import type { ChatRuntime } from "../../index";
+import { agentMessage, turn } from "../../testing/fixtures";
+import { createTestRuntime } from "../../testing/testRuntime";
+import {
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+	journalEnvelopes,
+	waitFor,
+} from "../../testing/testUtils";
+import { createChatCallerFactory, createChatRouter } from "./router";
+
+const SCRIPT: FakeHarnessScript = {
+	turns: [
+		[
+			{ kind: "turn", turn: turn("t1") },
+			{ kind: "item", item: agentMessage("a1", "done"), turnId: "t1" },
+			{
+				kind: "turn",
+				turn: turn("t1", { status: "completed", completedAtMs: 2 }),
+			},
+			{ kind: "session", session: { status: "idle" } },
+		],
+	],
+};
+
+function newCaller() {
+	const { harnesses, adapters } = fakeHarnessRegistry(SCRIPT);
+	const runtime = createTestRuntime({ harnesses });
+	const caller = createChatCallerFactory(createChatRouter(runtime))({});
+	return { runtime, caller, adapterCount: () => adapters.length };
+}
+
+function createSessionInput(workspaceId = "workspace-1") {
+	return {
+		commandId: randomUUID(),
+		workspaceId,
+		harness: FAKE_HARNESS,
+		cwd: "/tmp/workspace",
+	};
+}
+
+async function promptIdle(
+	caller: ReturnType<typeof newCaller>["caller"],
+	runtime: ChatRuntime,
+	sessionId: string,
+): Promise<void> {
+	await caller.prompt({
+		commandId: randomUUID(),
+		sessionId,
+		clientId: "client-1",
+		content: [{ type: "text", text: "hello" }],
+	});
+	await waitFor(() => runtime.sessions.get(sessionId)?.status === "idle");
+}
+
+describe("createChatRouter", () => {
+	test("create, prompt and getItems round trip through the router", async () => {
+		const { runtime, caller } = newCaller();
+		const created = await caller.createSession(createSessionInput());
+		expect(created.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+		await promptIdle(caller, runtime, created.sessionId);
+
+		const page = await caller.getItems({ sessionId: created.sessionId });
+		expect(page.ok).toBe(true);
+		if (!page.ok) return;
+		const itemKinds = page.envelopes
+			.filter((envelope) => envelope.event.type === "item")
+			.map((envelope) =>
+				envelope.event.type === "item" ? envelope.event.item.kind : "",
+			);
+		expect(itemKinds).toContain("user_message");
+		expect(itemKinds).toContain("agent_message");
+
+		const session = await caller.getSession({ sessionId: created.sessionId });
+		expect(session.session).toMatchObject({ sessionId: created.sessionId });
+		expect(session.cursor).toEqual({
+			epoch: created.epoch,
+			seq: runtime.journal.cursor(created.sessionId).seq,
+		});
+		await runtime.dispose();
+	});
+
+	test("invalid input is rejected by the zod schemas", async () => {
+		const { runtime, caller } = newCaller();
+		const created = await caller.createSession(createSessionInput());
+
+		await expect(
+			caller.createSession({
+				commandId: randomUUID(),
+				workspaceId: "workspace-1",
+				harness: FAKE_HARNESS,
+				cwd: "",
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		await expect(
+			caller.prompt({
+				commandId: "not-a-uuid",
+				sessionId: created.sessionId,
+				clientId: "client-1",
+				content: [{ type: "text", text: "hi" }],
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		await expect(
+			caller.prompt({
+				commandId: randomUUID(),
+				sessionId: created.sessionId,
+				clientId: "client-1",
+				content: [],
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		await expect(
+			caller.getItems({ sessionId: created.sessionId, limit: 0 }),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+		await runtime.dispose();
+	});
+
+	test("a retried commandId dedupes through the router", async () => {
+		const { runtime, caller, adapterCount } = newCaller();
+		const input = createSessionInput();
+		const first = await caller.createSession(input);
+		const second = await caller.createSession(input);
+
+		expect(second).toEqual(first);
+		expect(adapterCount()).toBe(1);
+		expect(await caller.listSessions({})).toHaveLength(1);
+
+		const promptInput = {
+			commandId: randomUUID(),
+			sessionId: first.sessionId,
+			clientId: "client-1",
+			content: [{ type: "text" as const, text: "hello" }],
+		};
+		const promptResult = await caller.prompt(promptInput);
+		const retried = await caller.prompt(promptInput);
+		expect(retried).toEqual(promptResult);
+
+		await waitFor(
+			() => runtime.sessions.get(first.sessionId)?.status === "idle",
+		);
+		const userMessages = journalEnvelopes(runtime, first.sessionId).filter(
+			(envelope) =>
+				envelope.event.type === "item" &&
+				envelope.event.item.kind === "user_message",
+		);
+		expect(
+			new Set(
+				userMessages.map((envelope) =>
+					envelope.event.type === "item" ? envelope.event.item.id : "",
+				),
+			).size,
+		).toBe(1);
+		await runtime.dispose();
+	});
+
+	test("listSessions filters by workspace and honours the limit", async () => {
+		const { runtime, caller } = newCaller();
+		await caller.createSession(createSessionInput("workspace-1"));
+		await caller.createSession(createSessionInput("workspace-2"));
+
+		expect(await caller.listSessions({})).toHaveLength(2);
+		expect(
+			await caller.listSessions({ workspaceId: "workspace-2" }),
+		).toHaveLength(1);
+		expect(await caller.listSessions({ limit: 1 })).toHaveLength(1);
+		await runtime.dispose();
+	});
+});

--- a/packages/chat-runtime/src/router/router/router.ts
+++ b/packages/chat-runtime/src/router/router/router.ts
@@ -1,5 +1,6 @@
 import {
 	cancelTurnInputSchema,
+	createSessionInputSchema,
 	getItemsInputSchema,
 	getSessionInputSchema,
 	listSessionsInputSchema,
@@ -7,35 +8,80 @@ import {
 	respondToApprovalInputSchema,
 	setModeInputSchema,
 } from "@superset/chat/protocol";
-import { initTRPC } from "@trpc/server";
-import { createSessionCommandSchema } from "../../commands";
+import { initTRPC, TRPCError } from "@trpc/server";
 import type { ChatRuntime } from "../../index";
 
 const t = initTRPC.create();
 
 export const createChatCallerFactory = t.createCallerFactory;
 
-export function createChatRouter(runtime: ChatRuntime) {
+export type ChatRouterOptions = {
+	resolveCwd(workspaceId: string): string | Promise<string>;
+};
+
+const UNKNOWN_HARNESS = /^unknown harness /;
+const NOT_RUNNING = /^chat session (.+) is not running$/;
+
+function mapCommandError(runtime: ChatRuntime, error: unknown): unknown {
+	if (error instanceof TRPCError) return error;
+	if (!(error instanceof Error)) return error;
+	if (UNKNOWN_HARNESS.test(error.message)) {
+		return new TRPCError({
+			code: "BAD_REQUEST",
+			message: error.message,
+			cause: error,
+		});
+	}
+	const sessionId = NOT_RUNNING.exec(error.message)?.[1];
+	if (sessionId) {
+		return new TRPCError({
+			code: runtime.sessions.get(sessionId) ? "CONFLICT" : "NOT_FOUND",
+			message: error.message,
+			cause: error,
+		});
+	}
+	return error;
+}
+
+export function createChatRouter(
+	runtime: ChatRuntime,
+	options: ChatRouterOptions,
+) {
+	function guarded<T>(execute: () => T): T {
+		try {
+			return execute();
+		} catch (error) {
+			throw mapCommandError(runtime, error);
+		}
+	}
+
 	return t.router({
 		createSession: t.procedure
-			.input(createSessionCommandSchema)
-			.mutation(({ input }) => runtime.commands.createSession(input)),
+			.input(createSessionInputSchema)
+			.mutation(async ({ input }) => {
+				const cwd = await options.resolveCwd(input.workspaceId);
+				return guarded(() => runtime.commands.createSession({ ...input, cwd }));
+			}),
 
 		prompt: t.procedure
 			.input(promptInputSchema)
-			.mutation(({ input }) => runtime.commands.prompt(input)),
+			.mutation(({ input }) => guarded(() => runtime.commands.prompt(input))),
 
 		cancelTurn: t.procedure
 			.input(cancelTurnInputSchema)
-			.mutation(({ input }) => runtime.commands.cancelTurn(input)),
+			.mutation(({ input }) =>
+				guarded(() => runtime.commands.cancelTurn(input)),
+			),
 
 		respondToApproval: t.procedure
 			.input(respondToApprovalInputSchema)
-			.mutation(({ input }) => runtime.commands.respondToApproval(input)),
+			.mutation(({ input }) =>
+				guarded(() => runtime.commands.respondToApproval(input)),
+			),
 
 		setMode: t.procedure
 			.input(setModeInputSchema)
-			.mutation(({ input }) => runtime.commands.setMode(input)),
+			.mutation(({ input }) => guarded(() => runtime.commands.setMode(input))),
 
 		getSession: t.procedure
 			.input(getSessionInputSchema)

--- a/packages/chat-runtime/src/router/router/router.ts
+++ b/packages/chat-runtime/src/router/router/router.ts
@@ -1,0 +1,54 @@
+import {
+	cancelTurnInputSchema,
+	getItemsInputSchema,
+	getSessionInputSchema,
+	listSessionsInputSchema,
+	promptInputSchema,
+	respondToApprovalInputSchema,
+	setModeInputSchema,
+} from "@superset/chat/protocol";
+import { initTRPC } from "@trpc/server";
+import { createSessionCommandSchema } from "../../commands";
+import type { ChatRuntime } from "../../index";
+
+const t = initTRPC.create();
+
+export const createChatCallerFactory = t.createCallerFactory;
+
+export function createChatRouter(runtime: ChatRuntime) {
+	return t.router({
+		createSession: t.procedure
+			.input(createSessionCommandSchema)
+			.mutation(({ input }) => runtime.commands.createSession(input)),
+
+		prompt: t.procedure
+			.input(promptInputSchema)
+			.mutation(({ input }) => runtime.commands.prompt(input)),
+
+		cancelTurn: t.procedure
+			.input(cancelTurnInputSchema)
+			.mutation(({ input }) => runtime.commands.cancelTurn(input)),
+
+		respondToApproval: t.procedure
+			.input(respondToApprovalInputSchema)
+			.mutation(({ input }) => runtime.commands.respondToApproval(input)),
+
+		setMode: t.procedure
+			.input(setModeInputSchema)
+			.mutation(({ input }) => runtime.commands.setMode(input)),
+
+		getSession: t.procedure
+			.input(getSessionInputSchema)
+			.query(({ input }) => runtime.commands.getSession(input)),
+
+		listSessions: t.procedure
+			.input(listSessionsInputSchema)
+			.query(({ input }) => runtime.commands.listSessions(input)),
+
+		getItems: t.procedure
+			.input(getItemsInputSchema)
+			.query(({ input }) => runtime.commands.getItems(input)),
+	});
+}
+
+export type ChatRouter = ReturnType<typeof createChatRouter>;

--- a/packages/chat-runtime/src/router/wsSink/index.ts
+++ b/packages/chat-runtime/src/router/wsSink/index.ts
@@ -1,0 +1,2 @@
+export type { WsSinkSocket } from "./wsSink";
+export { createWsSink } from "./wsSink";

--- a/packages/chat-runtime/src/router/wsSink/wsSink.test.ts
+++ b/packages/chat-runtime/src/router/wsSink/wsSink.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { envelopeSchema } from "@superset/chat/protocol";
+import type { FakeHarnessScript } from "../../harness/fake";
+import { agentMessage, turn } from "../../testing/fixtures";
+import { createTestRuntime } from "../../testing/testRuntime";
+import {
+	createRecordingSink,
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+	waitFor,
+} from "../../testing/testUtils";
+import type { WsSinkSocket } from "./wsSink";
+import { createWsSink } from "./wsSink";
+
+const SCRIPT: FakeHarnessScript = {
+	turns: [
+		[
+			{ kind: "turn", turn: turn("t1") },
+			{ kind: "item", item: agentMessage("a1", "done"), turnId: "t1" },
+			{
+				kind: "turn",
+				turn: turn("t1", { status: "completed", completedAtMs: 2 }),
+			},
+			{ kind: "session", session: { status: "idle" } },
+		],
+	],
+};
+
+function createFakeSocket() {
+	const frames: string[] = [];
+	let closeCalls = 0;
+	const socket: WsSinkSocket = {
+		send: (data) => {
+			frames.push(data);
+		},
+		close: () => {
+			closeCalls += 1;
+			socket.onclose?.();
+		},
+		onclose: null,
+	};
+	return { socket, frames, closeCalls: () => closeCalls };
+}
+
+describe("createWsSink", () => {
+	test("serialized envelopes parse back and match a direct subscription", async () => {
+		const { harnesses } = fakeHarnessRegistry(SCRIPT);
+		const runtime = createTestRuntime({ harnesses });
+		const created = runtime.commands.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+			cwd: "/tmp/workspace",
+		});
+
+		const direct = createRecordingSink();
+		const { socket, frames } = createFakeSocket();
+		runtime.subscribe(created.sessionId, { deltas: [] }, direct.sink);
+		runtime.subscribe(created.sessionId, { deltas: [] }, createWsSink(socket));
+
+		runtime.commands.prompt({
+			commandId: randomUUID(),
+			sessionId: created.sessionId,
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		await waitFor(
+			() => runtime.sessions.get(created.sessionId)?.status === "idle",
+		);
+
+		const parsed = frames.map((frame) =>
+			envelopeSchema.parse(JSON.parse(frame)),
+		);
+		expect(parsed.length).toBeGreaterThan(0);
+		expect(parsed).toEqual(direct.envelopes);
+		await runtime.dispose();
+	});
+
+	test("close closes the socket once and a closed socket drops sends", async () => {
+		const { harnesses } = fakeHarnessRegistry(SCRIPT);
+		const runtime = createTestRuntime({ harnesses });
+		const created = runtime.commands.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+			cwd: "/tmp/workspace",
+		});
+
+		let callerHandlerRuns = 0;
+		const { socket, frames, closeCalls } = createFakeSocket();
+		socket.onclose = () => {
+			callerHandlerRuns += 1;
+		};
+		const sink = createWsSink(socket);
+		runtime.subscribe(created.sessionId, { deltas: [] }, sink);
+		const sentBeforeClose = frames.length;
+
+		sink.close();
+		sink.close();
+		expect(closeCalls()).toBe(1);
+		expect(callerHandlerRuns).toBe(1);
+
+		sink.send({
+			v: 1,
+			sessionId: created.sessionId,
+			ts: Date.now(),
+			reset: { reason: "invalid_cursor" },
+		});
+		expect(frames).toHaveLength(sentBeforeClose);
+		await runtime.dispose();
+	});
+
+	test("a socket closed by the peer stops the sink from sending", async () => {
+		const { harnesses } = fakeHarnessRegistry(SCRIPT);
+		const runtime = createTestRuntime({ harnesses });
+		const created = runtime.commands.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+			cwd: "/tmp/workspace",
+		});
+
+		const { socket, frames } = createFakeSocket();
+		const sink = createWsSink(socket);
+		runtime.subscribe(created.sessionId, { deltas: [] }, sink);
+		const sentBeforeClose = frames.length;
+
+		socket.onclose?.();
+		sink.send({
+			v: 1,
+			sessionId: created.sessionId,
+			ts: Date.now(),
+			reset: { reason: "invalid_cursor" },
+		});
+		expect(frames).toHaveLength(sentBeforeClose);
+		await runtime.dispose();
+	});
+});

--- a/packages/chat-runtime/src/router/wsSink/wsSink.test.ts
+++ b/packages/chat-runtime/src/router/wsSink/wsSink.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { envelopeSchema } from "@superset/chat/protocol";
 import type { FakeHarnessScript } from "../../harness/fake";
+import type { ChatRuntime } from "../../index";
 import { agentMessage, turn } from "../../testing/fixtures";
 import { createTestRuntime } from "../../testing/testRuntime";
 import {
@@ -10,7 +11,6 @@ import {
 	fakeHarnessRegistry,
 	waitFor,
 } from "../../testing/testUtils";
-import type { WsSinkSocket } from "./wsSink";
 import { createWsSink } from "./wsSink";
 
 const SCRIPT: FakeHarnessScript = {
@@ -27,11 +27,18 @@ const SCRIPT: FakeHarnessScript = {
 	],
 };
 
-function createFakeSocket() {
+type FakeSocket = {
+	send: (data: string) => void;
+	close: () => void;
+	onclose: ((event?: unknown) => unknown) | null;
+};
+
+function createFakeSocket(options: { failSends?: boolean } = {}) {
 	const frames: string[] = [];
 	let closeCalls = 0;
-	const socket: WsSinkSocket = {
+	const socket: FakeSocket = {
 		send: (data) => {
+			if (options.failSends) throw new Error("socket gone");
 			frames.push(data);
 		},
 		close: () => {
@@ -43,31 +50,34 @@ function createFakeSocket() {
 	return { socket, frames, closeCalls: () => closeCalls };
 }
 
+function newRuntime(): { runtime: ChatRuntime; sessionId: string } {
+	const { harnesses } = fakeHarnessRegistry(SCRIPT);
+	const runtime = createTestRuntime({ harnesses });
+	const created = runtime.commands.createSession({
+		commandId: randomUUID(),
+		workspaceId: "workspace-1",
+		harness: FAKE_HARNESS,
+		cwd: "/tmp/workspace",
+	});
+	return { runtime, sessionId: created.sessionId };
+}
+
 describe("createWsSink", () => {
 	test("serialized envelopes parse back and match a direct subscription", async () => {
-		const { harnesses } = fakeHarnessRegistry(SCRIPT);
-		const runtime = createTestRuntime({ harnesses });
-		const created = runtime.commands.createSession({
-			commandId: randomUUID(),
-			workspaceId: "workspace-1",
-			harness: FAKE_HARNESS,
-			cwd: "/tmp/workspace",
-		});
+		const { runtime, sessionId } = newRuntime();
 
 		const direct = createRecordingSink();
 		const { socket, frames } = createFakeSocket();
-		runtime.subscribe(created.sessionId, { deltas: [] }, direct.sink);
-		runtime.subscribe(created.sessionId, { deltas: [] }, createWsSink(socket));
+		runtime.subscribe(sessionId, { deltas: [] }, direct.sink);
+		runtime.subscribe(sessionId, { deltas: [] }, createWsSink(socket));
 
 		runtime.commands.prompt({
 			commandId: randomUUID(),
-			sessionId: created.sessionId,
+			sessionId,
 			clientId: "client-1",
 			content: [{ type: "text", text: "hello" }],
 		});
-		await waitFor(
-			() => runtime.sessions.get(created.sessionId)?.status === "idle",
-		);
+		await waitFor(() => runtime.sessions.get(sessionId)?.status === "idle");
 
 		const parsed = frames.map((frame) =>
 			envelopeSchema.parse(JSON.parse(frame)),
@@ -77,33 +87,28 @@ describe("createWsSink", () => {
 		await runtime.dispose();
 	});
 
-	test("close closes the socket once and a closed socket drops sends", async () => {
-		const { harnesses } = fakeHarnessRegistry(SCRIPT);
-		const runtime = createTestRuntime({ harnesses });
-		const created = runtime.commands.createSession({
-			commandId: randomUUID(),
-			workspaceId: "workspace-1",
-			harness: FAKE_HARNESS,
-			cwd: "/tmp/workspace",
-		});
+	test("close closes the socket once, detaches, and drops later sends", async () => {
+		const { runtime, sessionId } = newRuntime();
 
-		let callerHandlerRuns = 0;
-		const { socket, frames, closeCalls } = createFakeSocket();
-		socket.onclose = () => {
-			callerHandlerRuns += 1;
+		const events: unknown[] = [];
+		const previous = (event?: unknown) => {
+			events.push(event);
 		};
+		const { socket, frames, closeCalls } = createFakeSocket();
+		socket.onclose = previous;
 		const sink = createWsSink(socket);
-		runtime.subscribe(created.sessionId, { deltas: [] }, sink);
+		runtime.subscribe(sessionId, { deltas: [] }, sink);
 		const sentBeforeClose = frames.length;
 
 		sink.close();
 		sink.close();
 		expect(closeCalls()).toBe(1);
-		expect(callerHandlerRuns).toBe(1);
+		expect(events).toHaveLength(1);
+		expect(socket.onclose).toBe(previous);
 
 		sink.send({
 			v: 1,
-			sessionId: created.sessionId,
+			sessionId,
 			ts: Date.now(),
 			reset: { reason: "invalid_cursor" },
 		});
@@ -111,29 +116,58 @@ describe("createWsSink", () => {
 		await runtime.dispose();
 	});
 
-	test("a socket closed by the peer stops the sink from sending", async () => {
-		const { harnesses } = fakeHarnessRegistry(SCRIPT);
-		const runtime = createTestRuntime({ harnesses });
-		const created = runtime.commands.createSession({
-			commandId: randomUUID(),
-			workspaceId: "workspace-1",
-			harness: FAKE_HARNESS,
-			cwd: "/tmp/workspace",
-		});
+	test("a peer close passes the event through and stops the sink", async () => {
+		const { runtime, sessionId } = newRuntime();
 
+		const events: unknown[] = [];
+		const previous = (event?: unknown) => {
+			events.push(event);
+		};
 		const { socket, frames } = createFakeSocket();
+		socket.onclose = previous;
 		const sink = createWsSink(socket);
-		runtime.subscribe(created.sessionId, { deltas: [] }, sink);
+		runtime.subscribe(sessionId, { deltas: [] }, sink);
 		const sentBeforeClose = frames.length;
 
-		socket.onclose?.();
+		const closeEvent = { code: 1000 };
+		socket.onclose?.(closeEvent);
+		expect(events).toEqual([closeEvent]);
+		expect(socket.onclose).toBe(previous);
+
 		sink.send({
 			v: 1,
-			sessionId: created.sessionId,
+			sessionId,
 			ts: Date.now(),
 			reset: { reason: "invalid_cursor" },
 		});
 		expect(frames).toHaveLength(sentBeforeClose);
+		await runtime.dispose();
+	});
+
+	test("a throwing send closes the sink and socket", async () => {
+		const { runtime, sessionId } = newRuntime();
+
+		const { socket, frames, closeCalls } = createFakeSocket({
+			failSends: true,
+		});
+		const sink = createWsSink(socket);
+
+		sink.send({
+			v: 1,
+			sessionId,
+			ts: Date.now(),
+			reset: { reason: "invalid_cursor" },
+		});
+		expect(frames).toHaveLength(0);
+		expect(closeCalls()).toBe(1);
+
+		sink.send({
+			v: 1,
+			sessionId,
+			ts: Date.now(),
+			reset: { reason: "invalid_cursor" },
+		});
+		expect(closeCalls()).toBe(1);
 		await runtime.dispose();
 	});
 });

--- a/packages/chat-runtime/src/router/wsSink/wsSink.ts
+++ b/packages/chat-runtime/src/router/wsSink/wsSink.ts
@@ -1,0 +1,27 @@
+import type { Sink } from "../../stream";
+
+export type WsSinkSocket = {
+	send(data: string): void;
+	close(): void;
+	onclose: (() => void) | null;
+};
+
+export function createWsSink(socket: WsSinkSocket): Sink {
+	let open = true;
+	const previous = socket.onclose;
+	socket.onclose = () => {
+		open = false;
+		previous?.();
+	};
+	return {
+		send(envelope) {
+			if (!open) return;
+			socket.send(JSON.stringify(envelope));
+		},
+		close() {
+			if (!open) return;
+			open = false;
+			socket.close();
+		},
+	};
+}

--- a/packages/chat-runtime/src/router/wsSink/wsSink.ts
+++ b/packages/chat-runtime/src/router/wsSink/wsSink.ts
@@ -3,25 +3,38 @@ import type { Sink } from "../../stream";
 export type WsSinkSocket = {
 	send(data: string): void;
 	close(): void;
-	onclose: (() => void) | null;
+	onclose: ((...args: never[]) => unknown) | null;
 };
 
 export function createWsSink(socket: WsSinkSocket): Sink {
 	let open = true;
 	const previous = socket.onclose;
-	socket.onclose = () => {
+
+	function handleClose(...args: never[]): unknown {
 		open = false;
-		previous?.();
+		if (socket.onclose === handleClose) socket.onclose = previous;
+		return previous?.(...args);
+	}
+	socket.onclose = handleClose;
+
+	const close = (): void => {
+		if (!open) return;
+		open = false;
+		if (socket.onclose === handleClose) socket.onclose = previous;
+		try {
+			socket.close();
+		} catch {}
 	};
+
 	return {
 		send(envelope) {
 			if (!open) return;
-			socket.send(JSON.stringify(envelope));
+			try {
+				socket.send(JSON.stringify(envelope));
+			} catch {
+				close();
+			}
 		},
-		close() {
-			if (!open) return;
-			open = false;
-			socket.close();
-		},
+		close,
 	};
 }


### PR DESCRIPTION
Stacked on #6167. The package now owns its transport surface: createChatRouter(runtime) (own initTRPC, procedures close over the runtime, inputs are exactly the protocol schemas, ChatRouter type exported for end-to-end inference) + createWsSink turning any structural WebSocket into a runtime Sink. Host-service's future mount = createChatRouter(runtime) at a path + wsSink per socket. 7 new tests (57 total green).

https://claude.ai/code/session_01XRFCEPsfmJHu2SenDKYJ2h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tRPC router over chat commands and a WebSocket sink adapter for streaming envelopes. The router resolves cwd on the host and returns typed tRPC errors for common failures.

- **New Features**
  - Router: `createChatRouter(runtime, { resolveCwd })` exposes 8 protocol commands as tRPC procedures with `zod` inputs from `@superset/chat/protocol`; exports `ChatRouter`, `ChatRouterOptions`, and `createChatCallerFactory`.
  - Host-resolved cwd: `createSession` calls `resolveCwd(workspaceId)`; clients never send `cwd`.
  - Typed errors: unknown harness → `BAD_REQUEST`; not-running sessions → `NOT_FOUND`/`CONFLICT`; invalid inputs rejected by `zod`.
  - `createWsSink(socket)` adapts any structural WebSocket to the runtime `Sink`, JSON-serializes envelopes, chains/restores `onclose`, closes on send error, and is idempotent on peer/host close; exports `WsSinkSocket`.

- **Dependencies**
  - Added `@trpc/server@11.16.0` to `packages/chat-runtime`.

<sup>Written for commit a3cb2b64fdbcd875cd8292eee5ce9396e5845587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

