### PR TITLE
fix(host-service): guard websocket upgrade sockets against peer resets

### DIFF
--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -122,9 +122,12 @@ async function main(): Promise<void> {
 	// that takes down the whole process. Keep a listener attached for the
 	// socket's lifetime so resets are logged instead.
 	server.on("upgrade", (request: IncomingMessage, socket: Duplex) => {
+		// Path only: the upgrade URL's query string carries HOST_SERVICE_SECRET
+		// as `token` for relayed connections.
+		const requestPath = request.url?.split("?")[0] ?? "<unknown>";
 		socket.on("error", (error: NodeJS.ErrnoException) => {
 			console.warn(
-				`[host-service] upgrade socket error (${error.code ?? error.message}) on ${request.url ?? "<unknown>"} from ${request.socket.remoteAddress ?? "<unknown>"}`,
+				`[host-service] upgrade socket error (${error.code ?? error.message}) on ${requestPath} from ${request.socket.remoteAddress ?? "<unknown>"}`,
 			);
 		});
 	});

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
 import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { getSupervisor, startDaemonBootstrap } from "./daemon";
@@ -113,6 +115,18 @@ async function main(): Promise<void> {
 				hostServiceSecret: env.HOST_SERVICE_SECRET,
 			});
 		}
+	});
+	// Node detaches its own socket error handling before emitting 'upgrade',
+	// and @hono/node-ws awaits app.request() before ws adopts the socket — a
+	// peer reset in that window is an uncaught ECONNRESET at TCP.onStreamRead
+	// that takes down the whole process. Keep a listener attached for the
+	// socket's lifetime so resets are logged instead.
+	server.on("upgrade", (request: IncomingMessage, socket: Duplex) => {
+		socket.on("error", (error: NodeJS.ErrnoException) => {
+			console.warn(
+				`[host-service] upgrade socket error (${error.code ?? error.message}) on ${request.url ?? "<unknown>"} from ${request.socket.remoteAddress ?? "<unknown>"}`,
+			);
+		});
 	});
 	injectWebSocket(server);
 }


### PR DESCRIPTION
## Problem

[HOST-SERVICE-5](https://superset-sh.sentry.io/issues/HOST-SERVICE-5): fatal `Error: read ECONNRESET` with a single frame at `TCP.onStreamRead` — a raw TCP socket emitting `'error'` with no listener attached.

Root cause: Node's http server detaches its own socket error handling before emitting `'upgrade'`, and `@hono/node-ws`'s `injectWebSocket` upgrade handler then `await`s `app.request()` before `ws.handleUpgrade` adopts the socket (which is when `ws` attaches its own error handler). A peer resetting the connection during that async window — or after the non-ws rejection path's `socket.end()` — emits an unhandled `'error'` on the bare socket, which surfaces as an uncaught exception in the host-service process.

## Fix

Attach an `'error'` listener to the socket on every `'upgrade'` event, registered before `injectWebSocket`. It logs the error code, request path, and remote address. The listener stays attached for the socket's lifetime, so it also covers any later gaps; once `ws` adopts the socket its own handler destroys it as before.

Deliberately no `Sentry.captureException` here — peer resets are routine network noise, and the point is to stop them from being reported as fatals. Also deliberately not a `process.on('uncaughtException')` swallow — `safety.ts` already provides that as a last resort; this handles the error at the socket where the context lives.

## Audit of other socket sites (no changes needed)

- **http server request sockets**: Node attaches its own per-connection error handler and routes errors to `'clientError'`, which has safe default handling (destroy + 400). No crash path.
- **DaemonClient (unix socket)**: `'error'` handler attached on connect; connect-phase errors reject the open promise. Also would show as `Pipe.onStreamRead`, not `TCP`.
- **TunnelClient (relay + local channel WebSockets)**: all sockets have `onerror`/`onclose` handlers; undici WebSocket errors never throw uncaught.
- **pty-daemon server**: per-connection `'error'` handler present; daemon has no Sentry init, so it can't be the source of this issue anyway.
- **Server-side `ws` connections**: `@hono/node-ws` attaches `ws.on('error')` in `upgradeWebSocket`, and `ws` handles underlying socket errors by destroying the socket without emitting.

Refs HOST-SERVICE-5.

https://claude.ai/code/session_01KLJknVKnpN3ExAL8aCpQKG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent host-service crashes caused by unhandled ECONNRESET during WebSocket upgrades. Attach a per-upgrade socket error listener so peer resets are logged (path only), not fatal.

- **Bug Fixes**
  - Add server 'upgrade' handler that registers `socket.on('error')` before `injectWebSocket` in `@hono/node-ws`, covering the async window before `ws` adopts the socket.
  - Log error code, remote address, and request path only (query string stripped to avoid leaking the `token`/`HOST_SERVICE_SECRET`); no Sentry capture to avoid noise. Refs HOST-SERVICE-5.

<sup>Written for commit 9bd47593be9a67a6c0cda863bbe14d42ec5321df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection error handling.
  * Prevented socket errors during connection upgrades from unexpectedly terminating the service.
  * Added clearer diagnostic logging for connection resets and other WebSocket errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
