### PR TITLE
fix(desktop): classify quit-time terminal-host disposal as typed non-500

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -36,6 +36,26 @@ const SAFE_ID = z
 	);
 
 /**
+ * App quit disposes the terminal-host client while requests are still in
+ * flight, so any terminal procedure can be rejected by that teardown —
+ * translated once here rather than per procedure.
+ */
+const terminalProcedure = publicProcedure.use(async ({ next }) => {
+	const result = await next();
+	if (
+		!result.ok &&
+		result.error.cause instanceof TerminalHostClientDisposedError
+	) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: "Terminal host client disposed",
+			cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" },
+		});
+	}
+	return result;
+});
+
+/**
  * Terminal router using daemon-backed terminal runtime
  * Sessions are keyed by paneId and linked to workspaces for cwd resolution
  *
@@ -60,7 +80,7 @@ export const createTerminalRouter = () => {
 	}
 
 	return router({
-		createOrAttach: publicProcedure
+		createOrAttach: terminalProcedure
 			.input(
 				z.object({
 					paneId: SAFE_ID,
@@ -187,11 +207,7 @@ export const createTerminalRouter = () => {
 						});
 					}
 					if (error instanceof TerminalHostClientDisposedError) {
-						throw new TRPCError({
-							code: "PRECONDITION_FAILED",
-							message: "Terminal host client disposed",
-							cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" },
-						});
+						throw error;
 					}
 					if (DEBUG_TERMINAL) {
 						console.warn("[Terminal Router] createOrAttach failed:", {
@@ -206,7 +222,7 @@ export const createTerminalRouter = () => {
 				}
 			}),
 
-		cancelCreateOrAttach: publicProcedure
+		cancelCreateOrAttach: terminalProcedure
 			.input(
 				z.object({
 					paneId: SAFE_ID,
@@ -218,7 +234,7 @@ export const createTerminalRouter = () => {
 				return { success: true };
 			}),
 
-		write: publicProcedure
+		write: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -259,13 +275,13 @@ export const createTerminalRouter = () => {
 				}
 			}),
 
-		ackColdRestore: publicProcedure
+		ackColdRestore: terminalProcedure
 			.input(z.object({ paneId: z.string() }))
 			.mutation(({ input }) => {
 				terminal.ackColdRestore(input.paneId);
 			}),
 
-		resize: publicProcedure
+		resize: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -278,7 +294,7 @@ export const createTerminalRouter = () => {
 				terminal.resize(input);
 			}),
 
-		signal: publicProcedure
+		signal: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -289,7 +305,7 @@ export const createTerminalRouter = () => {
 				terminal.signal(input);
 			}),
 
-		kill: publicProcedure
+		kill: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -299,7 +315,7 @@ export const createTerminalRouter = () => {
 				await terminal.kill(input);
 			}),
 
-		detach: publicProcedure
+		detach: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -309,7 +325,7 @@ export const createTerminalRouter = () => {
 				terminal.detach(input);
 			}),
 
-		clearScrollback: publicProcedure
+		clearScrollback: terminalProcedure
 			.input(
 				z.object({
 					paneId: z.string(),
@@ -319,12 +335,12 @@ export const createTerminalRouter = () => {
 				await terminal.clearScrollback(input);
 			}),
 
-		listDaemonSessions: publicProcedure.query(async () => {
+		listDaemonSessions: terminalProcedure.query(async () => {
 			const { sessions } = await terminal.management.listSessions();
 			return { sessions };
 		}),
 
-		killAllDaemonSessions: publicProcedure.mutation(async () => {
+		killAllDaemonSessions: terminalProcedure.mutation(async () => {
 			const client = getTerminalHostClient();
 			const before = await terminal.management.listSessions();
 			const beforeIds = before.sessions.map((s) => s.sessionId);
@@ -388,7 +404,7 @@ export const createTerminalRouter = () => {
 			return { killedCount, remainingCount };
 		}),
 
-		killDaemonSessionsForWorkspace: publicProcedure
+		killDaemonSessionsForWorkspace: terminalProcedure
 			.input(z.object({ workspaceId: z.string() }))
 			.mutation(async ({ input }) => {
 				const { sessions } = await terminal.management.listSessions();
@@ -419,23 +435,23 @@ export const createTerminalRouter = () => {
 				return { killedCount: toKill.length };
 			}),
 
-		clearTerminalHistory: publicProcedure.mutation(async () => {
+		clearTerminalHistory: terminalProcedure.mutation(async () => {
 			await terminal.management.resetHistoryPersistence();
 			return { success: true };
 		}),
 
 		/** Restart daemon to recover from stuck state. Kills all sessions. */
-		restartDaemon: publicProcedure.mutation(async () => {
+		restartDaemon: terminalProcedure.mutation(async () => {
 			return restartDaemonShared();
 		}),
 
-		getSession: publicProcedure
+		getSession: terminalProcedure
 			.input(z.string())
 			.query(async ({ input: paneId }) => {
 				return terminal.getSession(paneId);
 			}),
 
-		getWorkspaceCwd: publicProcedure
+		getWorkspaceCwd: terminalProcedure
 			.input(z.string())
 			.query(({ input: workspaceId }) => {
 				const workspace = localDb
@@ -459,7 +475,7 @@ export const createTerminalRouter = () => {
 				return worktree?.path ?? null;
 			}),
 
-		stream: publicProcedure
+		stream: terminalProcedure
 			.input(z.string())
 			.subscription(({ input: paneId }) => {
 				return observable<

--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -11,7 +11,10 @@ import {
 	TERMINAL_SESSION_KILLED_MESSAGE,
 	TerminalKilledError,
 } from "main/lib/terminal/errors";
-import { getTerminalHostClient } from "main/lib/terminal-host/client";
+import {
+	getTerminalHostClient,
+	TerminalHostClientDisposedError,
+} from "main/lib/terminal-host/client";
 import { getWorkspaceRuntimeRegistry } from "main/lib/workspace-runtime";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
@@ -181,6 +184,13 @@ export const createTerminalRouter = () => {
 						throw new TRPCError({
 							code: "BAD_REQUEST",
 							message: TERMINAL_ATTACH_CANCELED_MESSAGE,
+						});
+					}
+					if (error instanceof TerminalHostClientDisposedError) {
+						throw new TRPCError({
+							code: "PRECONDITION_FAILED",
+							message: "Terminal host client disposed",
+							cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" },
 						});
 					}
 					if (DEBUG_TERMINAL) {

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -147,6 +147,18 @@ interface PendingRequest {
 // TerminalHostClient
 // =============================================================================
 
+/**
+ * Rejection for requests in flight when the client is intentionally torn down
+ * (dispose/disconnect, e.g. during app quit) — distinct from an unexpected
+ * socket drop, which still rejects with a generic "Connection lost" error.
+ */
+export class TerminalHostClientDisposedError extends Error {
+	constructor() {
+		super("Terminal host client disposed");
+		this.name = "TerminalHostClientDisposedError";
+	}
+}
+
 export interface TerminalHostClientEvents {
 	data: (sessionId: string, data: string) => void;
 	exit: (sessionId: string, exitCode: number, signal?: number) => void;
@@ -769,8 +781,10 @@ export class TerminalHostClient extends EventEmitter {
 	 */
 	private resetConnectionState({
 		emitDisconnected,
+		pendingRequestError,
 	}: {
 		emitDisconnected: boolean;
+		pendingRequestError?: Error;
 	}): void {
 		// Destroy sockets (best-effort; close handlers may also fire)
 		try {
@@ -802,7 +816,7 @@ export class TerminalHostClient extends EventEmitter {
 		// Reject all pending requests
 		for (const [id, pending] of this.pendingRequests.entries()) {
 			clearTimeout(pending.timeoutId);
-			pending.reject(new Error("Connection lost"));
+			pending.reject(pendingRequestError ?? new Error("Connection lost"));
 			this.pendingRequests.delete(id);
 		}
 
@@ -1646,7 +1660,10 @@ export class TerminalHostClient extends EventEmitter {
 	disconnect(): void {
 		// Explicit disconnect should not emit a disconnected event (caller controls UX)
 		this.disconnectArmed = true;
-		this.resetConnectionState({ emitDisconnected: false });
+		this.resetConnectionState({
+			emitDisconnected: false,
+			pendingRequestError: new TerminalHostClientDisposedError(),
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Refs [DESKTOP-HD](https://superset-sh.sentry.io/issues/DESKTOP-HD): a normal app quit racing an in-flight terminal request was being reported as a 500.

During quit, `runQuitCleanup` → `disposeTerminalHostClient` → `dispose` → `disconnect` → `resetConnectionState` rejected every pending terminal-host request with a generic `Error("Connection lost")`. An in-flight `terminal.createOrAttach` mutation then surfaced that as `INTERNAL_SERVER_ERROR`, which the Sentry tRPC middleware captures.

## Changes

Per the error-handling contract (#6164 — typed causes at throw sites, never a Sentry filter):

- `TerminalHostClient.disconnect()` (the intentional teardown path: `dispose`/`shutdown`) now rejects pending requests with a typed `TerminalHostClientDisposedError` instead of the generic error.
- The `terminal.createOrAttach` catch translates that error to `PRECONDITION_FAILED` with `cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" }`, so it never reaches the Sentry middleware as a 500.
- Genuine unexpected connection loss (`handleDisconnect` on socket drop, connect-failure resets) keeps the generic `Error("Connection lost")` rejection and still reports.

## Verification

- `bunx biome check` clean on both changed files
- `cd apps/desktop && bun run typecheck` passes

https://claude.ai/code/session_017sk3KSZ5NLrpTedKWRX2k8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent normal app quit from being reported as a 500 when a terminal request is in flight. Quit-time terminal-host teardown now uses a typed error and maps to a non-500 tRPC code.

- **Bug Fixes**
  - Added `TerminalHostClientDisposedError`; used on explicit `disconnect`/`dispose` to reject pending requests.
  - In `terminal.createOrAttach`, translate this to `PRECONDITION_FAILED` with `cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" }`; unexpected socket drops keep the generic "Connection lost" and still report.

<sup>Written for commit 8ed37ff44b378176b577744bbda56e14cb4969ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal connection error handling during intentional shutdowns.
  * Standardized error responses when terminal sessions are disposed.
  * Preserved clear “connection lost” messaging for unexpected disconnects.
  * Improved handling of pending terminal requests during connection resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->