### PR TITLE
feat(desktop): attach exit context to process-exit Sentry captures

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -26,6 +26,7 @@ import {
 	nextRespawnDelayMs,
 } from "./host-service-respawn";
 import {
+	ChildOutputRing,
 	findFreePort,
 	HEALTH_POLL_TIMEOUT_MS,
 	MAX_HOST_LOG_BYTES,
@@ -78,6 +79,9 @@ interface HostServiceProcess {
 	 * never kill it or delete its manifest.
 	 */
 	owned: boolean;
+	/** Set for owned children only; adopted entries have no spawn diagnostics. */
+	spawnedAt?: number;
+	output?: ChildOutputRing;
 }
 
 interface PendingStart {
@@ -674,57 +678,77 @@ export class HostServiceCoordinator extends EventEmitter {
 			}
 			throw new Error("Host service start cancelled");
 		}
-		const logFd = openRotatingLogFd(
-			path.join(manifestDir(organizationId), "host-service.log"),
-			MAX_HOST_LOG_BYTES,
-		);
-		// Dev: pipe child stdout/stderr through this process so log lines
-		// land in the developer's `bun dev` terminal. Production: hard-back
-		// stdio with the rotating log file.
 		const isDev = !app.isPackaged;
-		const stdio: childProcess.StdioOptions = isDev
-			? ["ignore", "pipe", "pipe"]
-			: logFd >= 0
-				? ["ignore", logFd, logFd]
-				: ["ignore", "ignore", "ignore"];
+		const logFd = isDev
+			? -1
+			: openRotatingLogFd(
+					path.join(manifestDir(organizationId), "host-service.log"),
+					MAX_HOST_LOG_BYTES,
+				);
+		let logFdClosed = false;
+		const closeLogFd = () => {
+			if (logFd < 0 || logFdClosed) return;
+			logFdClosed = true;
+			try {
+				fs.closeSync(logFd);
+			} catch {}
+		};
 
+		// Child stdio is always piped so this process can retain a bounded tail
+		// of recent output for crash/startup-failure captures. Production
+		// forwards the chunks to the rotating log file the child previously
+		// wrote directly; dev fans them out to the `bun dev` terminal.
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
 			child = childProcess.spawn(process.execPath, [this.scriptPath], {
 				detached: false,
-				stdio,
+				stdio: ["ignore", "pipe", "pipe"],
 				env: childEnv,
 				// Avoid a flashing CMD window on Windows.
 				windowsHide: true,
 			});
-		} finally {
-			if (logFd >= 0) {
-				try {
-					fs.closeSync(logFd);
-				} catch {
-					// Best-effort — child has its own dup of the fd.
-				}
-			}
+		} catch (error) {
+			closeLogFd();
+			throw error;
 		}
 
-		// In dev, fan child output through to parent stdout/stderr with a
-		// prefix so it's identifiable in `bun dev`.
-		if (isDev && child.stdout && child.stderr) {
-			const tag = `[hs:${organizationId.slice(0, 8)}]`;
-			pipeWithPrefix(child.stdout, process.stdout, tag);
-			pipeWithPrefix(child.stderr, process.stderr, tag);
+		const output = new ChildOutputRing();
+		if (child.stdout && child.stderr) {
+			for (const stream of [child.stdout, child.stderr]) {
+				stream.on("data", (chunk: Buffer) => {
+					output.append(chunk);
+					if (logFd >= 0 && !logFdClosed) fs.write(logFd, chunk, () => {});
+				});
+			}
+			// In dev, fan child output through to parent stdout/stderr with a
+			// prefix so it's identifiable in `bun dev`.
+			if (isDev) {
+				const tag = `[hs:${organizationId.slice(0, 8)}]`;
+				pipeWithPrefix(child.stdout, process.stdout, tag);
+				pipeWithPrefix(child.stderr, process.stderr, tag);
+			}
 		}
+		// "close" (not "exit") so buffered stdio drains into the log first.
+		child.on("close", closeLogFd);
 
 		const childPid = child.pid;
 		if (!childPid) {
+			closeLogFd();
 			this.instances.delete(organizationId);
 			throw new Error("Failed to spawn host service process");
 		}
 
 		instance.pid = childPid;
+		const spawnedAt = Date.now();
+		instance.spawnedAt = spawnedAt;
+		instance.output = output;
 		let childExited = false;
+		let childExitCode: number | null = null;
+		let childExitSignal: NodeJS.Signals | null = null;
 		child.on("exit", (code, signal) => {
 			childExited = true;
+			childExitCode = code;
+			childExitSignal = signal;
 			this.handleChildExit(organizationId, childPid, code, signal);
 		});
 		// Don't let the child block Electron's exit — stopAll() handles teardown.
@@ -743,12 +767,23 @@ export class HostServiceCoordinator extends EventEmitter {
 				this.instances.delete(organizationId);
 			}
 			if (!isStartAllowed()) removeManifest(organizationId);
-			throw new Error(
-				!isStartAllowed()
-					? "Host service start cancelled"
-					: childExited
-						? "Host service process exited during startup"
-						: `Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+			// The extra props ride into the Sentry capture of this error via
+			// extraErrorDataIntegration (see main/lib/sentry.ts).
+			throw Object.assign(
+				new Error(
+					!isStartAllowed()
+						? "Host service start cancelled"
+						: childExited
+							? "Host service process exited during startup"
+							: `Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+				),
+				{
+					exitCode: childExitCode,
+					exitSignal: childExitSignal,
+					startupPhase: "health-poll",
+					startupElapsedMs: Date.now() - spawnedAt,
+					childOutputTail: output.tail(),
+				},
 			);
 		}
 
@@ -891,6 +926,9 @@ export class HostServiceCoordinator extends EventEmitter {
 					extra: {
 						organizationId,
 						respawnAttempts: this.respawns.get(organizationId)?.attempts ?? 0,
+						uptimeMs:
+							current.spawnedAt != null ? Date.now() - current.spawnedAt : null,
+						childOutputTail: current.output?.tail() ?? null,
 					},
 				}),
 			)

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -5,6 +5,58 @@ import path from "node:path";
 /** Rotate per-org host-service.log once it exceeds this size. */
 export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 
+/** Lines of recent child output retained for crash/startup-failure captures. */
+export const CHILD_OUTPUT_TAIL_LINES = 50;
+const CHILD_OUTPUT_MAX_LINE_CHARS = 300;
+
+const USER_PATH_PATTERNS = [
+	/[A-Za-z]:\\Users\\[^\\/\s"']+/g,
+	/\/(?:Users|home)\/[^\\/\s"']+/g,
+];
+
+export function scrubUserPaths(text: string): string {
+	let scrubbed = text;
+	for (const pattern of USER_PATH_PATTERNS) {
+		scrubbed = scrubbed.replace(pattern, "~");
+	}
+	return scrubbed;
+}
+
+/**
+ * Bounded ring of a child process's most recent output lines. User paths are
+ * scrubbed on entry so captures built from the tail never carry usernames.
+ */
+export class ChildOutputRing {
+	private lines: string[] = [];
+	private pending = "";
+
+	append(chunk: Buffer): void {
+		const text = this.pending + chunk.toString("utf8");
+		const parts = text.split("\n");
+		this.pending = parts.pop() ?? "";
+		for (const line of parts) {
+			this.push(line.replace(/\r$/, ""));
+		}
+		if (this.pending.length > CHILD_OUTPUT_MAX_LINE_CHARS) {
+			this.push(this.pending);
+			this.pending = "";
+		}
+	}
+
+	tail(): string[] {
+		if (!this.pending) return [...this.lines];
+		return [
+			...this.lines,
+			scrubUserPaths(this.pending.slice(0, CHILD_OUTPUT_MAX_LINE_CHARS)),
+		].slice(-CHILD_OUTPUT_TAIL_LINES);
+	}
+
+	private push(line: string): void {
+		this.lines.push(scrubUserPaths(line.slice(0, CHILD_OUTPUT_MAX_LINE_CHARS)));
+		if (this.lines.length > CHILD_OUTPUT_TAIL_LINES) this.lines.shift();
+	}
+}
+
 // Before the server becomes reachable, startup must still clear DB migrate and
 // the daemon bootstrap (the shell-env snapshot now runs in the background, off
 // the critical path). At boot every known org starts at once, and multiple app

--- a/apps/desktop/src/main/lib/sentry.ts
+++ b/apps/desktop/src/main/lib/sentry.ts
@@ -1,9 +1,11 @@
 import * as Sentry from "@sentry/electron/main";
 import { IPCMode } from "@sentry/electron/main";
-import { session } from "electron";
+import { app, session } from "electron";
 import { env } from "../env.main";
 
 let sentryInitialized = false;
+
+let lastProcessExit: Record<string, unknown> | null = null;
 
 export function initSentry(): void {
 	if (sentryInitialized) return;
@@ -13,21 +15,66 @@ export function initSentry(): void {
 	}
 
 	try {
+		// Registered before Sentry.init so these listeners run ahead of the
+		// SDK's own process-gone listeners: by the time childProcessIntegration
+		// captures its message-only event, the processor below already has the
+		// details to attach.
+		app.on("render-process-gone", (_event, _contents, details) => {
+			lastProcessExit = {
+				process: "renderer",
+				reason: details.reason,
+				exit_code: details.exitCode,
+				occurred_at: new Date().toISOString(),
+			};
+		});
+		app.on("child-process-gone", (_event, details) => {
+			lastProcessExit = {
+				process: details.type,
+				reason: details.reason,
+				exit_code: details.exitCode,
+				name: details.name,
+				service_name: details.serviceName,
+				occurred_at: new Date().toISOString(),
+			};
+		});
+
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
 			tracesSampleRate: 0,
 			sendDefaultPii: false,
 			ipcMode: IPCMode.Classic,
+			// Lifts non-standard props off thrown errors (e.g. the host-service
+			// coordinator's exit diagnostics) into event extras.
+			integrations: [Sentry.extraErrorDataIntegration()],
 			getSessions: () => [
 				session.defaultSession,
 				session.fromPartition("persist:superset"),
 			],
 		});
 
+		Sentry.addEventProcessor((event) => {
+			if (lastProcessExit && event.message?.includes(" process exited with ")) {
+				event.contexts = {
+					...event.contexts,
+					"process-exit": lastProcessExit,
+					...gpuFeatureStatusContext(),
+				};
+			}
+			return event;
+		});
+
 		sentryInitialized = true;
 		console.log("[sentry] Initialized in main process");
 	} catch (error) {
 		console.error("[sentry] Failed to initialize in main:", error);
+	}
+}
+
+function gpuFeatureStatusContext(): Record<string, Record<string, unknown>> {
+	try {
+		return { "gpu-feature-status": { ...app.getGPUFeatureStatus() } };
+	} catch {
+		return {};
 	}
 }


### PR DESCRIPTION
Three process-exit Sentry issues are currently message-only and undiagnosable as captured (Refs DESKTOP-HC, DESKTOP-H1, DESKTOP-H9 — enrichment only, the issues stay open as their own trackers). This enriches the capture sites; no changes to spawning/restart logic beyond holding the diagnostics.

## Host-service coordinator (DESKTOP-HC spawn failure, DESKTOP-H1 crash)

- Child stdio is now always piped so the coordinator retains a bounded ring of the child's last 50 stdout/stderr lines (`ChildOutputRing`, 300 chars/line, absolute `/Users|/home|C:\Users` paths scrubbed to `~` on entry). In production the parent forwards the chunks to the same rotating `host-service.log` the child previously wrote directly (fd closed on child `close` so buffered stdio drains); dev keeps the `[hs:*]` fan-out to the `bun dev` terminal.
- The startup-failure throw (`Host service process exited during startup` / health-poll timeout) now carries `exitCode`, `exitSignal`, `startupPhase`, `startupElapsedMs`, and `childOutputTail` as props on the Error. `extraErrorDataIntegration` (newly registered in main's `Sentry.init`) lifts them into event extras, so they land on the existing issue wherever the error is captured (currently the tRPC middleware) without changing its fingerprint.
- The crash `captureMessage` (`host-service crashed (signal ...)`) gains `uptimeMs` and `childOutputTail` extras alongside the existing exit code/signal tags.

## Renderer/child process exits (DESKTOP-H9)

These events come from `@sentry/electron`'s child-process integration, which captures a message-only event and only attaches the details to a breadcrumb *after* the capture. Main's Sentry init now registers its own `render-process-gone` / `child-process-gone` listeners **before** `Sentry.init` (so they run ahead of the SDK's) to stash the latest exit details, and an event processor attaches them — reason, exit code, process type/name, timestamp, plus `app.getGPUFeatureStatus()` — as contexts on the SDK's `'<process>' process exited with '<reason>'` events. Same message, same issue, now with data.

## Verification

- `cd apps/desktop && bun run typecheck` — clean
- `bunx biome check` on the three changed files — clean
- `bun test src/main/lib/host-service-coordinator.test.ts` — 35 pass

https://claude.ai/code/session_012de22Cn9VdPkPthGHAqPDQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rich context to Sentry process-exit events so message-only issues are diagnosable. Covers host-service startup/crash (DESKTOP-HC, DESKTOP-H1) and renderer/child exits (DESKTOP-H9) without changing fingerprints.

- **New Features**
  - Host-service: always pipe child stdout/stderr and retain a small tail of recent lines (paths scrubbed); forward to rotating log in prod and to the dev console in dev.
  - Startup failures now include `exitCode`, `exitSignal`, `startupPhase`, `startupElapsedMs`, and `childOutputTail`; surfaced via `Sentry.extraErrorDataIntegration()`.
  - Crash capture adds `uptimeMs` and `childOutputTail` to extras.
  - Main Sentry: pre-`Sentry.init` listeners for `render-process-gone` and `child-process-gone` stash exit details; an event processor adds reason, exit code, process type/name, timestamp, and `app.getGPUFeatureStatus()` as contexts on `@sentry/electron` process-exit messages.

<sup>Written for commit 88a8c40cce74106cc9fde5af0918b5197124c615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

