### PR TITLE
fix(host-service): classify missing-worktree git errors as NOT_FOUND instead of 500

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
+++ b/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { workspaces } from "../../../../db/schema";
@@ -14,6 +15,16 @@ export function resolveWorktreePath(
 		throw new TRPCError({
 			code: "NOT_FOUND",
 			message: "Workspace not found",
+		});
+	}
+	// A worktree deleted outside the app is a routine lifecycle state, not a
+	// bug — classify it here so simple-git's construct error can't escape any
+	// git.* procedure as a reportable 500.
+	if (!existsSync(workspace.worktreePath)) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Worktree no longer exists on disk",
+			cause: { kind: "WORKTREE_MISSING", worktreePath: workspace.worktreePath },
 		});
 	}
 	return workspace.worktreePath;

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -9,6 +9,7 @@ import {
 	updateLocalWorkspace,
 } from "../../../workspaces/local-workspace-store";
 import { protectedProcedure, router } from "../../index";
+import { resolveWorktreePath } from "../git/utils/resolve-worktree";
 import { destroyWorkspace } from "../workspace-cleanup";
 
 export const workspaceRouter = router({
@@ -130,18 +131,8 @@ export const workspaceRouter = router({
 	gitStatus: protectedProcedure
 		.input(z.object({ id: z.string() }))
 		.query(async ({ ctx, input }) => {
-			const localWorkspace = ctx.db.query.workspaces
-				.findFirst({ where: eq(workspaces.id, input.id) })
-				.sync();
-
-			if (!localWorkspace) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Workspace not found",
-				});
-			}
-
-			const git = await ctx.git(localWorkspace.worktreePath);
+			const worktreePath = resolveWorktreePath(ctx, input.id);
+			const git = await ctx.git(worktreePath);
 			const status = await git.status();
 
 			return {


### PR DESCRIPTION
## Problem

[HOST-SERVICE-W](https://superset-sh.sentry.io/issues/HOST-SERVICE-W) (escalating, 16 events/minute on canary `1.18.3-canary.20260805123527`): when a workspace's worktree directory no longer exists — deleted externally or a cleanup raced the poll loop — every polled git tRPC endpoint (`git.getStatus`, `git.listCommits`, `git.listBranches`, `git.getBranchSyncStatus`, ...) constructs simple-git on the missing path, throws `GitConstructError: Cannot use simple-git on a directory that does not exist`, and escapes as `INTERNAL_SERVER_ERROR` into Sentry — once per batched procedure per poll.

This is an expected lifecycle state, not a bug, so per the error-handling contract (#6164) it must be classified at the throw site — the dumb 500=report Sentry middleware stays filter-free.

## Fix

- `resolveWorktreePath` — the shared boundary every `git.*` procedure resolves the workspace path through — now checks the directory exists and throws a typed `NOT_FOUND` with cause `{ kind: "WORKTREE_MISSING", worktreePath }`, mirroring the desktop v1 changes-router convention. Non-500 → not captured by the Sentry middleware; the renderer already degrades on error results (`workspace.get` already exposes `worktreeExists`).
- `workspace.gitStatus` (legacy CLI/SDK surface) had the same hole via a direct `ctx.git(worktreePath)`; it now routes through the same helper.

## Related

[DESKTOP-H0](https://superset-sh.sentry.io/issues/DESKTOP-H0) is the same error via the desktop project, but through the desktop v1 changes/workspaces routers. That path is already classified on main (`pathExistsCached` guard → `NOT_FOUND` `WORKTREE_MISSING`, plus `GitEnvironmentError` → `PRECONDITION_FAILED`); its remaining events all come from released builds ≤ 1.18.3 whose bundles predate those guards (verified against event stacks), so it drains as users update — no further code change needed.

Refs HOST-SERVICE-W

https://claude.ai/code/session_01JAJWZrVSdXGbsfiGvwCyKW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classified missing workspace worktrees as NOT_FOUND to prevent `simple-git` construct errors from surfacing as 500s during git polling. This stops Sentry noise (Refs HOST-SERVICE-W) and keeps the UI degrading gracefully.

- **Bug Fixes**
  - Added an existence check in `resolveWorktreePath` to throw `NOT_FOUND` with `{ kind: "WORKTREE_MISSING", worktreePath }`, preventing `simple-git` construct errors from escaping as 500s across all `git.*` procedures.
  - Routed `workspace.gitStatus` through `resolveWorktreePath` to apply the same guard.

<sup>Written for commit 97431855edc2cc3e1c49dc09cf10229c5d073cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a workspace worktree is missing.
  * Git status requests now return a clear “not found” error instead of failing unexpectedly.
  * Added structured error details to help identify missing worktree paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
