### PR TITLE
fix(desktop): bump Electron to 40.9.3 to resolve Dependabot alerts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -266,7 +266,7 @@
 		"@vitejs/plugin-react": "5.2.0",
 		"code-inspector-plugin": "1.4.5",
 		"cross-env": "10.1.0",
-		"electron": "40.8.5",
+		"electron": "40.9.3",
 		"electron-builder": "26.8.1",
 		"electron-vite": "4.0.1",
 		"material-icon-theme": "5.32.0",

--- a/bun.lock
+++ b/bun.lock
@@ -344,7 +344,7 @@
         "@vitejs/plugin-react": "5.2.0",
         "code-inspector-plugin": "1.4.5",
         "cross-env": "10.1.0",
-        "electron": "40.8.5",
+        "electron": "40.9.3",
         "electron-builder": "26.8.1",
         "electron-vite": "4.0.1",
         "material-icon-theme": "5.32.0",
@@ -4175,7 +4175,7 @@
 
     "electric-proxy": ["electric-proxy@workspace:apps/electric-proxy"],
 
-    "electron": ["electron@40.8.5", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A=="],
+    "electron": ["electron@40.9.3", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-rDcJOT6BBE689Ada+4jD3rVr05pMv9MZOgT0x/rIMVDF9c4ttx4RTb6lVARTyxZC7uqpirttCtcli1eg1DX5qg=="],
 
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 


### PR DESCRIPTION
## Summary
- Bumps `electron` from `40.8.5` to `40.9.3` in `apps/desktop/package.json`
- Resolves all 9 open Dependabot alerts on this repo (#263–#271), including 2 high-severity issues:
  - #270 (high): custom protocol with `supportFetchAPI` but not `corsEnabled` allows cross-origin reads
  - #267 (high): context isolation bypass via `Function.prototype.bind` hijack
  - #263, #265, #268, #269, #271 (medium)
  - #264, #266 (low)
- `bun install` re-ran `@electron/rebuild` for native deps (`better-sqlite3`, `node-pty`, `@parcel/watcher`, etc.) against 40.9.3 — all rebuilt cleanly.

## Test plan
- [x] `bun install` — native modules rebuilt successfully against Electron 40.9.3
- [x] `bun run lint:fix` — clean, no issues
- [x] `bun run typecheck` (apps/desktop) — clean
- [ ] Manual smoke test of the desktop app on a dev build (not run in this session)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `electron` from 40.8.5 to 40.9.3 in `apps/desktop` to patch security vulnerabilities. Resolves 9 Dependabot alerts (#263–#271), including high-severity custom-protocol CORS bypass and context isolation bypass.

<sup>Written for commit 895e7d5f8e231024de2613fdd1fd9913c38a3149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

