### PR TITLE
refactor(relay): API-served relay endpoint, and deploy relay2 with production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -476,6 +476,37 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy
 
+  deploy-relay2:
+    name: Deploy Relay2 to Cloudflare
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Bun
+        id: setup-bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Deploy Worker
+        working-directory: apps/relay2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy
+
   deploy-docs:
     name: Deploy Docs to Vercel
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two things relay2 needs that missed the #6165 merge.

## 1. The API decides which relay you're on

Tonight's rollout attempt exposed that relay config delivery — not the relay — is the fragile part. Three separate failures, all from evaluating the PostHog flag on the client:

- **Spawn race.** The desktop resolved the relay URL when spawning host-service, and `getRelayUrl()` silently returns the default when PostHog hasn't identified the user *yet*. A cold start usually loses that race, so the host locks onto the old relay and never re-checks — restarting the app just replays it. One machine sat on the wrong relay through three restarts with no error anywhere.
- **Split-brain.** Clients read the flag live; hosts read it at spawn. Flipping the flag pointed every client at the new relay while every host was still on the old one, which surfaced as a wall of 503s and `Host is not online`.
- **No observability.** Nothing records which relay a host actually chose, so the only way to tell was reading relay-side logs and inferring.

`host.relayEndpoint` (jwtProcedure) resolves the flag **server-side, once**, and the host-service, renderer, and CLI all read that same answer. The host-service asks for itself after authenticating instead of trusting what spawned it, so there's no identification to race. `env.RELAY_URL` remains the fallback for an unreachable API.

## 2. relay2 deploys with production

A `deploy-relay2` job in `deploy-production.yml`, a copy of `deploy-electric-proxy` using the same runner, cache, and Cloudflare secrets. Until this lands, relay2 deploys are manual `wrangler deploy`.

https://claude.ai/code/session_01A2JifsfA63nWthegPwNt8G