### PR TITLE
feat(chat): client + react entries — session client, reconnecting stream, useChatSession

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -720,11 +720,23 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.2",
         "@superset/typescript": "workspace:*",
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.0",
         "@types/bun": "1.3.14",
         "@types/node": "24.12.0",
+        "@types/react": "19.2.14",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
         "typescript": "6.0.3",
       },
+      "peerDependencies": {
+        "react": "19.2.3",
+      },
+      "optionalPeers": [
+        "react",
+      ],
     },
     "packages/chat-legacy": {
       "name": "@superset/chat-legacy",
@@ -1868,6 +1880,8 @@
     "@gorhom/portal": ["@gorhom/portal@1.0.14", "", { "dependencies": { "nanoid": "^3.3.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.2", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.2" } }, "sha512-DKoY/tiFGcY0FmNwtdrHNfOeU3YjrO2EOGSmRk3OlAjKLfZXRtnjiCPAfmhsOMIQEkp2KenTUDxpgZbzpd7OVQ=="],
 
     "@headless-tree/core": ["@headless-tree/core@1.6.3", "", {}, "sha512-en0EOaZfiCRF2B8DEnhGhSaUf3hVr9Bauye8G8aswPbHOKSyhJiN4bsczz1GvqF4Xb7Ga3LP0vLA6Zih7YLoyw=="],
 
@@ -3037,6 +3051,8 @@
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.10.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11" } }, "sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ=="],
 
+    "@testing-library/react": ["@testing-library/react@16.3.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw=="],
+
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tiptap/core": ["@tiptap/core@3.21.0", "", { "peerDependencies": { "@tiptap/pm": "^3.21.0" } }, "sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ=="],
@@ -3373,6 +3389,8 @@
 
     "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/which": ["@types/which@2.0.2", "", {}, "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -3599,7 +3617,7 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-find-index": ["array-find-index@1.0.2", "", {}, "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw=="],
 
@@ -3742,6 +3760,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
@@ -4153,7 +4173,7 @@
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
@@ -4243,7 +4263,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -4612,6 +4632,8 @@
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -5539,7 +5561,7 @@
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
-    "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -6461,7 +6483,7 @@
 
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -6723,6 +6745,8 @@
 
     "@expo/cli/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
+    "@expo/cli/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+
     "@expo/cli/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -6755,6 +6779,8 @@
 
     "@expo/metro-config/postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
+    "@expo/metro-runtime/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+
     "@expo/package-manager/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
 
     "@expo/package-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -6768,6 +6794,8 @@
     "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@gorhom/portal/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -6963,19 +6991,15 @@
 
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
-
-    "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@types/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "@types/three/fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "@upstash/qstash/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
-
-    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "@wdio/config/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -7051,6 +7075,8 @@
 
     "cheerio/undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
+    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "chrome-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "chromium-edge-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -7121,6 +7147,8 @@
 
     "dmg-license/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "edgedriver/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
@@ -7150,6 +7178,8 @@
     "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "expo/babel-preset-expo": ["babel-preset-expo@56.0.18", "", { "dependencies": { "@babel/generator": "^7.20.5", "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-class-static-block": "^7.27.1", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-logical-assignment-operators": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.28.6", "@babel/plugin-transform-react-jsx-development": "^7.27.1", "@babel/plugin-transform-react-pure-annotations": "^7.27.1", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-plugin-codegen": "0.85.3", "babel-plugin-react-compiler": "^1.0.0", "babel-plugin-react-native-web": "~0.21.0", "babel-plugin-syntax-hermes-parser": "^0.33.3", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4" }, "peerDependencies": { "@babel/runtime": "^7.20.0", "expo": "*", "expo-widgets": "^56.0.24", "react-refresh": ">=0.14.0 <1.0.0" }, "optionalPeers": ["@babel/runtime", "expo", "expo-widgets"] }, "sha512-QHEa3AasSFjnA08ciQkKKdVKWPRc2ye6UvxwCweYr3rKATBwTUVOuA0mzRD2PFVdB16R9yqgHROpiqL+K4A0Ww=="],
+
+    "expo/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "expo/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -7241,6 +7271,8 @@
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
@@ -7252,6 +7284,8 @@
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-validate/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
@@ -7272,6 +7306,8 @@
     "line-column-path/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "locate-app/type-fest": ["type-fest@4.26.0", "", {}, "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "mastracode/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.104", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.41" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-D1d/whdUWF8KrXr9TzK6/S1wD9WmmxJ5DRWgGJX6Ip8iZW0up/yRtWuZwTkuX86bOPQTd2c370lIVteEBUGxPg=="],
 
@@ -7377,7 +7413,11 @@
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
@@ -7416,6 +7456,8 @@
     "react-native/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "react-native/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "react-native/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -7530,6 +7572,8 @@
     "webdriver/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 
     "webdriverio/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "webdriverio/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "webdriverio/serialize-error": ["serialize-error@12.0.0", "", { "dependencies": { "type-fest": "^4.31.0" } }, "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw=="],
 
@@ -7687,6 +7731,8 @@
 
     "@expo/cli/ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
+    "@expo/cli/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "@expo/cli/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "@expo/cli/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
@@ -7739,6 +7785,8 @@
 
     "@expo/metro-config/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
+    "@expo/metro-runtime/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "@expo/package-manager/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@expo/package-manager/ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
@@ -7750,6 +7798,8 @@
     "@expo/package-manager/ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
     "@expo/xcpretty/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -7949,12 +7999,6 @@
 
     "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "@testing-library/dom/pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
     "@wdio/config/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "@wdio/config/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
@@ -7990,8 +8034,6 @@
     "ava/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
 
     "builder-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "cheerio/htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -8106,6 +8148,8 @@
     "expo-router/@radix-ui/react-tabs/@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ=="],
 
     "expo-router/@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
+    "expo/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "fastembed/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
@@ -8363,6 +8407,8 @@
 
     "jest-validate/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "jest-validate/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -8436,6 +8482,8 @@
     "prosemirror-markdown/@types/markdown-it/@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "react-email/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "react-native/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
 

--- a/packages/chat-runtime/README.md
+++ b/packages/chat-runtime/README.md
@@ -19,7 +19,7 @@ The runtime speaks only the vocabulary in `plans/chat-protocol-v1.md`; it never 
 | `stream/` | `subscriptions/` — `SubscriptionHub`: replay-then-live subscribe, per-subscriber delta channels, reset frames, delta coalescing |
 | `commands/` | The client-facing verbs, each parsed with the `@superset/chat` command schemas and deduped by `commandId` |
 | `router/` | `router/` — `createChatRouter(runtime, { resolveCwd })`, the tRPC surface over `commands/` (the package owns its own `initTRPC`; procedures close over the runtime, and the host resolves `cwd` — clients never send it) — and `wsSink/`, the structural WebSocket→`Sink` adapter host-service's stream route mounts |
-| `testing/` | The cross-cutting test helpers no single module owns — `fixtures/` (protocol item factories), `testUtils/` (sinks, schedules, waits) and `testRuntime/` (the bun-sqlite runtime). Internal only: relative imports, no package export. Helpers that do have an owner stay beside it, like `harness/fake/` |
+| `testing/` | The cross-cutting test helpers no single module owns — `fixtures/` (protocol item factories), `testUtils/` (sinks, schedules, waits) and `testRuntime/` (the bun-sqlite runtime). Test-only: exported as `@superset/chat-runtime/testing` so sibling chat packages' headless tests can drive a real runtime, never imported by shipping code. Helpers that do have an owner stay beside it, like `harness/fake/` |
 
 ## Wiring a harness
 

--- a/packages/chat-runtime/package.json
+++ b/packages/chat-runtime/package.json
@@ -8,6 +8,10 @@
 			"types": "./src/index.ts",
 			"default": "./src/index.ts"
 		},
+		"./testing": {
+			"types": "./src/testing/index.ts",
+			"default": "./src/testing/index.ts"
+		},
 		"./package.json": "./package.json"
 	},
 	"scripts": {

--- a/packages/chat-runtime/src/router/index.ts
+++ b/packages/chat-runtime/src/router/index.ts
@@ -1,4 +1,9 @@
-export type { ChatRouter, ChatRouterOptions } from "./router";
+export type {
+	ChatRouter,
+	ChatRouterInputs,
+	ChatRouterOptions,
+	ChatRouterOutputs,
+} from "./router";
 export { createChatCallerFactory, createChatRouter } from "./router";
 export type { WsSinkSocket } from "./wsSink";
 export { createWsSink } from "./wsSink";

--- a/packages/chat-runtime/src/router/router/index.ts
+++ b/packages/chat-runtime/src/router/router/index.ts
@@ -1,2 +1,7 @@
-export type { ChatRouter, ChatRouterOptions } from "./router";
+export type {
+	ChatRouter,
+	ChatRouterInputs,
+	ChatRouterOptions,
+	ChatRouterOutputs,
+} from "./router";
 export { createChatCallerFactory, createChatRouter } from "./router";

--- a/packages/chat-runtime/src/router/router/router.ts
+++ b/packages/chat-runtime/src/router/router/router.ts
@@ -8,6 +8,7 @@ import {
 	respondToApprovalInputSchema,
 	setModeInputSchema,
 } from "@superset/chat/protocol";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { initTRPC, TRPCError } from "@trpc/server";
 import type { ChatRuntime } from "../../index";
 
@@ -98,3 +99,6 @@ export function createChatRouter(
 }
 
 export type ChatRouter = ReturnType<typeof createChatRouter>;
+
+export type ChatRouterInputs = inferRouterInputs<ChatRouter>;
+export type ChatRouterOutputs = inferRouterOutputs<ChatRouter>;

--- a/packages/chat-runtime/src/testing/index.ts
+++ b/packages/chat-runtime/src/testing/index.ts
@@ -1,0 +1,3 @@
+export * from "./fixtures";
+export * from "./testRuntime";
+export * from "./testUtils";

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -11,6 +11,14 @@
 		"./core": {
 			"types": "./src/core/index.ts",
 			"default": "./src/core/index.ts"
+		},
+		"./client": {
+			"types": "./src/client/index.ts",
+			"default": "./src/client/index.ts"
+		},
+		"./react": {
+			"types": "./src/react/index.ts",
+			"default": "./src/react/index.ts"
 		}
 	},
 	"scripts": {
@@ -22,9 +30,23 @@
 		"zod": "4.4.3"
 	},
 	"devDependencies": {
+		"@happy-dom/global-registrator": "20.0.2",
 		"@superset/typescript": "workspace:*",
+		"@testing-library/dom": "10.4.1",
+		"@testing-library/react": "16.3.0",
 		"@types/bun": "1.3.14",
 		"@types/node": "24.12.0",
+		"@types/react": "19.2.14",
+		"react": "19.2.3",
+		"react-dom": "19.2.3",
 		"typescript": "6.0.3"
+	},
+	"peerDependencies": {
+		"react": "19.2.3"
+	},
+	"peerDependenciesMeta": {
+		"react": {
+			"optional": true
+		}
 	}
 }

--- a/packages/chat/src/client/index.ts
+++ b/packages/chat/src/client/index.ts
@@ -1,0 +1,2 @@
+export * from "./sessionClient";
+export * from "./subscribeToSession";

--- a/packages/chat/src/client/sessionClient/index.ts
+++ b/packages/chat/src/client/sessionClient/index.ts
@@ -1,0 +1,9 @@
+export type {
+	ChatTransport,
+	GetItemsPage,
+	PromptOptions,
+	SessionClient,
+	SessionClientOptions,
+	SessionSubscribeOptions,
+} from "./sessionClient";
+export { createSessionClient } from "./sessionClient";

--- a/packages/chat/src/client/sessionClient/sessionClient.test.ts
+++ b/packages/chat/src/client/sessionClient/sessionClient.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import type { ChatRuntime, FakeHarnessScript } from "@superset/chat-runtime";
+import {
+	createChatCallerFactory,
+	createChatRouter,
+} from "@superset/chat-runtime";
+import {
+	agentMessage,
+	createTestRuntime,
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+	turn,
+	waitFor,
+} from "@superset/chat-runtime/testing";
+import type { Envelope } from "../../protocol/envelope";
+import { isDurableEnvelope } from "../../protocol/envelope";
+import { createMemoryStreamServer } from "../../testing/memoryStream";
+import type { ChatTransport } from "./sessionClient";
+import { createSessionClient } from "./sessionClient";
+
+function turnScript(
+	turnId: string,
+	itemId: string,
+): FakeHarnessScript["turns"][number] {
+	return [
+		{ kind: "turn", turn: turn(turnId) },
+		{ kind: "item", item: agentMessage(itemId, "done"), turnId },
+		{
+			kind: "turn",
+			turn: turn(turnId, { status: "completed", completedAtMs: 2 }),
+		},
+		{ kind: "session", session: { status: "idle" } },
+	];
+}
+
+const SCRIPT: FakeHarnessScript = {
+	turns: [turnScript("t1", "a1"), turnScript("t2", "a2")],
+};
+
+function startStack(): {
+	runtime: ChatRuntime;
+	transport: ChatTransport;
+	server: ReturnType<typeof createMemoryStreamServer>;
+} {
+	const { harnesses } = fakeHarnessRegistry(SCRIPT);
+	const runtime = createTestRuntime({ harnesses });
+	const router = createChatRouter(runtime, {
+		resolveCwd: () => "/tmp/workspace",
+	});
+	const transport: ChatTransport = createChatCallerFactory(router)({});
+	const server = createMemoryStreamServer(runtime);
+	return { runtime, transport, server };
+}
+
+async function idle(runtime: ChatRuntime, sessionId: string): Promise<void> {
+	await waitFor(() => runtime.sessions.get(sessionId)?.status === "idle");
+}
+
+describe("createSessionClient", () => {
+	test("prompt, getSession and getItems pagination round trip", async () => {
+		const { runtime, transport, server } = startStack();
+		const created = await transport.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+		});
+		const client = createSessionClient({
+			sessionId: created.sessionId,
+			transport,
+			streamBaseUrl: "ws://test/chat-v3",
+			createSocket: server.createSocket,
+		});
+
+		await client.prompt({
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		await idle(runtime, created.sessionId);
+
+		const session = await client.getSession();
+		expect(session.session).toMatchObject({ sessionId: created.sessionId });
+		expect(session.cursor).toEqual({
+			epoch: created.epoch,
+			seq: runtime.journal.cursor(created.sessionId).seq,
+		});
+
+		const newest = await client.getItems({ limit: 2 });
+		expect(newest.ok).toBe(true);
+		if (!newest.ok) return;
+		expect(newest.envelopes).toHaveLength(2);
+		expect(newest.nextBefore).not.toBeNull();
+
+		const older = await client.getItems({
+			before: newest.nextBefore ?? undefined,
+			limit: 2,
+		});
+		if (!older.ok) return;
+		expect(older.envelopes.at(-1)?.cursor.seq).toBe(
+			(newest.nextBefore?.seq ?? 0) - 1,
+		);
+		await runtime.dispose();
+	});
+
+	test("a retried prompt with the same commandId dedupes through the transport", async () => {
+		const { runtime, transport, server } = startStack();
+		const created = await transport.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+		});
+		const client = createSessionClient({
+			sessionId: created.sessionId,
+			transport,
+			streamBaseUrl: "ws://test/chat-v3",
+			createSocket: server.createSocket,
+		});
+
+		const commandId = randomUUID();
+		const first = await client.prompt({
+			commandId,
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		const retried = await client.prompt({
+			commandId,
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		expect(retried).toEqual(first);
+		await idle(runtime, created.sessionId);
+
+		const page = await client.getItems({});
+		if (!page.ok) return;
+		const userMessages = page.envelopes.filter(
+			(envelope) =>
+				envelope.event.type === "item" &&
+				envelope.event.item.kind === "user_message",
+		);
+		expect(
+			new Set(
+				userMessages.map((envelope) =>
+					envelope.event.type === "item" ? envelope.event.item.id : "",
+				),
+			).size,
+		).toBe(1);
+		await runtime.dispose();
+	});
+
+	test("subscribe streams live envelopes and close tears the stream down", async () => {
+		const { runtime, transport, server } = startStack();
+		const created = await transport.createSession({
+			commandId: randomUUID(),
+			workspaceId: "workspace-1",
+			harness: FAKE_HARNESS,
+		});
+		const client = createSessionClient({
+			sessionId: created.sessionId,
+			transport,
+			streamBaseUrl: "ws://test/chat-v3",
+			createSocket: server.createSocket,
+		});
+
+		const received: Envelope[] = [];
+		client.subscribe({
+			deltas: [],
+			onEnvelope: (envelope) => received.push(envelope),
+		});
+
+		await client.prompt({
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		await idle(runtime, created.sessionId);
+		await waitFor(() => received.length >= 4);
+
+		const kinds = received
+			.filter(isDurableEnvelope)
+			.filter((envelope) => envelope.event.type === "item")
+			.map((envelope) =>
+				envelope.event.type === "item" ? envelope.event.item.kind : "",
+			);
+		expect(kinds).toContain("user_message");
+		expect(kinds).toContain("agent_message");
+
+		expect(server.openConnections()).toHaveLength(1);
+		client.close();
+		expect(server.openConnections()).toHaveLength(0);
+		await runtime.dispose();
+	});
+});

--- a/packages/chat/src/client/sessionClient/sessionClient.ts
+++ b/packages/chat/src/client/sessionClient/sessionClient.ts
@@ -1,0 +1,150 @@
+import type {
+	ChatRouterInputs,
+	ChatRouterOutputs,
+} from "@superset/chat-runtime";
+import type { Cursor } from "../../protocol/cursor";
+import type { DeltaChannel, Envelope } from "../../protocol/envelope";
+import type { Decision, UserContent } from "../../protocol/items";
+import type {
+	SessionStream,
+	StreamSocketFactory,
+	StreamStatus,
+	Wait,
+} from "../subscribeToSession";
+import { buildStreamUrl, subscribeToSession } from "../subscribeToSession";
+
+export type ChatTransport = {
+	[Procedure in keyof ChatRouterInputs & keyof ChatRouterOutputs]: (
+		input: ChatRouterInputs[Procedure],
+	) => Promise<ChatRouterOutputs[Procedure]>;
+};
+
+export type GetItemsPage = {
+	before?: Cursor;
+	limit?: number;
+};
+
+export type PromptOptions = {
+	content: UserContent[];
+	clientId: string;
+	commandId?: string;
+};
+
+export type SessionSubscribeOptions = {
+	deltas?: readonly DeltaChannel[];
+	since?: Cursor | null;
+	onEnvelope(envelope: Envelope): void;
+	onReset?(reason: string): void;
+	onStatusChange?(status: StreamStatus): void;
+};
+
+export type SessionClientOptions = {
+	sessionId: string;
+	transport: ChatTransport;
+	streamBaseUrl: string;
+	createSocket: StreamSocketFactory;
+	mintId?(): string;
+	wait?: Wait;
+	backoffInitialMs?: number;
+	backoffMaxMs?: number;
+};
+
+export type SessionClient = {
+	sessionId: string;
+	getSession(): Promise<ChatRouterOutputs["getSession"]>;
+	getItems(page?: GetItemsPage): Promise<ChatRouterOutputs["getItems"]>;
+	prompt(options: PromptOptions): Promise<ChatRouterOutputs["prompt"]>;
+	cancelTurn(turnId: string): Promise<void>;
+	respondToApproval(approvalId: string, decision: Decision): Promise<void>;
+	setMode(modeId: string): Promise<void>;
+	subscribe(options: SessionSubscribeOptions): SessionStream;
+	close(): void;
+};
+
+export function createSessionClient(
+	options: SessionClientOptions,
+): SessionClient {
+	const mintId = options.mintId ?? (() => crypto.randomUUID());
+	const sessionId = options.sessionId;
+	const streams = new Set<SessionStream>();
+
+	return {
+		sessionId,
+
+		getSession: () => options.transport.getSession({ sessionId }),
+
+		getItems: (page = {}) =>
+			options.transport.getItems({
+				sessionId,
+				before: page.before,
+				limit: page.limit,
+			}),
+
+		prompt: (promptOptions) =>
+			options.transport.prompt({
+				commandId: promptOptions.commandId ?? mintId(),
+				sessionId,
+				clientId: promptOptions.clientId,
+				content: promptOptions.content,
+			}),
+
+		cancelTurn: async (turnId) => {
+			await options.transport.cancelTurn({
+				commandId: mintId(),
+				sessionId,
+				turnId,
+			});
+		},
+
+		respondToApproval: async (approvalId, decision) => {
+			await options.transport.respondToApproval({
+				commandId: mintId(),
+				sessionId,
+				approvalId,
+				decision,
+			});
+		},
+
+		setMode: async (modeId) => {
+			await options.transport.setMode({
+				commandId: mintId(),
+				sessionId,
+				modeId,
+			});
+		},
+
+		subscribe(subscribeOptions) {
+			const deltas = subscribeOptions.deltas ?? [];
+			const stream = subscribeToSession({
+				createSocket: options.createSocket,
+				url: (since) =>
+					buildStreamUrl({
+						baseUrl: options.streamBaseUrl,
+						sessionId,
+						deltas,
+						since,
+					}),
+				since: subscribeOptions.since,
+				onEnvelope: subscribeOptions.onEnvelope,
+				onReset: subscribeOptions.onReset,
+				onStatusChange: subscribeOptions.onStatusChange,
+				wait: options.wait,
+				backoffInitialMs: options.backoffInitialMs,
+				backoffMaxMs: options.backoffMaxMs,
+			});
+			streams.add(stream);
+			return {
+				cursor: () => stream.cursor(),
+				close: () => {
+					streams.delete(stream);
+					stream.close();
+				},
+			};
+		},
+
+		close() {
+			for (const stream of [...streams]) stream.close();
+			streams.clear();
+		},
+	};
+}

--- a/packages/chat/src/client/subscribeToSession/index.ts
+++ b/packages/chat/src/client/subscribeToSession/index.ts
@@ -1,0 +1,15 @@
+export type {
+	SessionStream,
+	StreamSocket,
+	StreamSocketFactory,
+	StreamStatus,
+	StreamUrlParams,
+	SubscribeToSessionOptions,
+	Wait,
+} from "./subscribeToSession";
+export {
+	buildStreamUrl,
+	DEFAULT_BACKOFF_INITIAL_MS,
+	DEFAULT_BACKOFF_MAX_MS,
+	subscribeToSession,
+} from "./subscribeToSession";

--- a/packages/chat/src/client/subscribeToSession/subscribeToSession.test.ts
+++ b/packages/chat/src/client/subscribeToSession/subscribeToSession.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import type { ChatRuntime, FakeHarnessScript } from "@superset/chat-runtime";
+import {
+	agentMessage,
+	createRecordingSink,
+	createTestRuntime,
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+	turn,
+	waitFor,
+} from "@superset/chat-runtime/testing";
+import { emptySnapshot, reduceMany } from "../../core";
+import type { Envelope } from "../../protocol/envelope";
+import { createManualWait } from "../../testing/manualWait";
+import { createMemoryStreamServer } from "../../testing/memoryStream";
+import type { StreamSocket, StreamStatus } from "./subscribeToSession";
+import { buildStreamUrl, subscribeToSession } from "./subscribeToSession";
+
+const STREAMING_TURN: FakeHarnessScript = {
+	turns: [
+		[
+			{ kind: "turn", turn: turn("t1") },
+			{ kind: "delta", delta: { type: "text", itemId: "a1", append: "a" } },
+			{ kind: "delta", delta: { type: "text", itemId: "a1", append: "b" } },
+			{ kind: "item", item: agentMessage("a1", "ab"), turnId: "t1" },
+			{
+				kind: "turn",
+				turn: turn("t1", { status: "completed", completedAtMs: 2 }),
+			},
+			{ kind: "session", session: { status: "idle" } },
+		],
+	],
+};
+
+function startStack(script: FakeHarnessScript): {
+	runtime: ChatRuntime;
+	server: ReturnType<typeof createMemoryStreamServer>;
+	sessionId: string;
+} {
+	const { harnesses } = fakeHarnessRegistry(script);
+	const runtime = createTestRuntime({ harnesses });
+	const server = createMemoryStreamServer(runtime);
+	const created = runtime.commands.createSession({
+		commandId: randomUUID(),
+		workspaceId: "workspace-1",
+		harness: FAKE_HARNESS,
+		cwd: "/tmp/workspace",
+	});
+	return { runtime, server, sessionId: created.sessionId };
+}
+
+function prompt(runtime: ChatRuntime, sessionId: string): void {
+	runtime.commands.prompt({
+		commandId: randomUUID(),
+		sessionId,
+		clientId: "client-1",
+		content: [{ type: "text", text: "go" }],
+	});
+}
+
+describe("buildStreamUrl", () => {
+	test("formats the stream path with encoded since and delta channels", () => {
+		expect(
+			buildStreamUrl({
+				baseUrl: "ws://host/chat-v3/",
+				sessionId: "session one",
+				deltas: ["text", "terminal"],
+				since: { epoch: "e1", seq: 5 },
+			}),
+		).toBe(
+			"ws://host/chat-v3/sessions/session%20one/stream?since=e1%3A5&deltas=text,terminal",
+		);
+		expect(
+			buildStreamUrl({
+				baseUrl: "ws://host/chat-v3",
+				sessionId: "s",
+				deltas: [],
+				since: null,
+			}),
+		).toBe("ws://host/chat-v3/sessions/s/stream");
+	});
+});
+
+describe("subscribeToSession", () => {
+	test("a dropped consumer resumes from its cursor and converges with one that never dropped", async () => {
+		const { runtime, server, sessionId } = startStack(STREAMING_TURN);
+		const always = createRecordingSink();
+		runtime.subscribe(sessionId, { deltas: [] }, always.sink);
+
+		const manual = createManualWait();
+		const received: Envelope[] = [];
+		const stream = subscribeToSession({
+			createSocket: server.createSocket,
+			url: (since) =>
+				buildStreamUrl({
+					baseUrl: "ws://test/chat-v3",
+					sessionId,
+					deltas: [],
+					since,
+				}),
+			onEnvelope: (envelope) => received.push(envelope),
+			wait: manual.wait,
+		});
+
+		prompt(runtime, sessionId);
+		await waitFor(() => received.length >= 3);
+		server.openConnections()[0]?.drop();
+		const droppedAt = received.length;
+
+		await waitFor(() => runtime.sessions.get(sessionId)?.status === "idle");
+		expect(received).toHaveLength(droppedAt);
+		expect(manual.pendingCount()).toBe(1);
+
+		manual.flush();
+		await waitFor(() => received.length === always.envelopes.length);
+
+		expect(received).toEqual(always.envelopes);
+		expect(reduceMany(emptySnapshot(), received)).toEqual(
+			reduceMany(emptySnapshot(), always.envelopes),
+		);
+		stream.close();
+		await runtime.dispose();
+	});
+
+	test("a reset frame clears the resume cursor and signals refetch", async () => {
+		const { runtime, server, sessionId } = startStack(STREAMING_TURN);
+		const resets: string[] = [];
+		const received: Envelope[] = [];
+		const stream = subscribeToSession({
+			createSocket: server.createSocket,
+			url: (since) =>
+				buildStreamUrl({
+					baseUrl: "ws://test/chat-v3",
+					sessionId,
+					deltas: [],
+					since,
+				}),
+			since: { epoch: "stale-epoch", seq: 2 },
+			onEnvelope: (envelope) => received.push(envelope),
+			onReset: (reason) => resets.push(reason),
+		});
+
+		await waitFor(() => received.length >= 1);
+		expect(resets).toEqual(["epoch_changed"]);
+		expect(received[0]).toMatchObject({ reset: { reason: "epoch_changed" } });
+		expect(stream.cursor()).toBeNull();
+
+		prompt(runtime, sessionId);
+		await waitFor(() => runtime.sessions.get(sessionId)?.status === "idle");
+		await waitFor(() => received.length > 1);
+		expect(stream.cursor()).not.toBeNull();
+		stream.close();
+		await runtime.dispose();
+	});
+
+	test("reconnect delays grow exponentially, cap, and reset after a successful open", async () => {
+		const manual = createManualWait();
+		const failing = (url: string): StreamSocket => {
+			void url;
+			const socket: StreamSocket = {
+				onopen: null,
+				onmessage: null,
+				onclose: null,
+				onerror: null,
+				close() {},
+			};
+			queueMicrotask(() => socket.onclose?.());
+			return socket;
+		};
+		const received: Envelope[] = [];
+		const stream = subscribeToSession({
+			createSocket: failing,
+			url: () => "ws://test/chat-v3/sessions/s/stream",
+			onEnvelope: (envelope) => received.push(envelope),
+			wait: manual.wait,
+			backoffInitialMs: 100,
+			backoffMaxMs: 1000,
+		});
+
+		for (let round = 0; round < 5; round += 1) {
+			await waitFor(() => manual.pendingCount() === 1);
+			manual.flush();
+		}
+		await waitFor(() => manual.delays.length >= 5);
+		expect(manual.delays.slice(0, 5)).toEqual([100, 200, 400, 800, 1000]);
+		stream.close();
+
+		const { runtime, server, sessionId } = startStack(STREAMING_TURN);
+		const reopening = createManualWait();
+		const statuses: StreamStatus[] = [];
+		const reopened = subscribeToSession({
+			createSocket: server.createSocket,
+			url: (since) =>
+				buildStreamUrl({
+					baseUrl: "ws://test/chat-v3",
+					sessionId,
+					deltas: [],
+					since,
+				}),
+			onEnvelope: () => {},
+			onStatusChange: (status) => statuses.push(status),
+			wait: reopening.wait,
+			backoffInitialMs: 100,
+			backoffMaxMs: 1000,
+		});
+
+		await waitFor(() => statuses.includes("open"));
+		server.openConnections()[0]?.drop();
+		await waitFor(() => reopening.delays.length === 1);
+		reopening.flush();
+		await waitFor(
+			() => statuses.filter((status) => status === "open").length >= 2,
+		);
+		server.openConnections()[0]?.drop();
+		await waitFor(() => reopening.delays.length === 2);
+		expect(reopening.delays).toEqual([100, 100]);
+		reopened.close();
+		await runtime.dispose();
+	});
+});

--- a/packages/chat/src/client/subscribeToSession/subscribeToSession.ts
+++ b/packages/chat/src/client/subscribeToSession/subscribeToSession.ts
@@ -1,0 +1,161 @@
+import type { Cursor } from "../../protocol/cursor";
+import { serializeCursor } from "../../protocol/cursor";
+import type { DeltaChannel, Envelope } from "../../protocol/envelope";
+import {
+	envelopeSchema,
+	isDurableEnvelope,
+	isResetEnvelope,
+} from "../../protocol/envelope";
+
+export type StreamSocket = {
+	onopen: ((...args: never[]) => unknown) | null;
+	onmessage: ((...args: never[]) => unknown) | null;
+	onclose: ((...args: never[]) => unknown) | null;
+	onerror: ((...args: never[]) => unknown) | null;
+	close(): void;
+};
+
+export type StreamSocketFactory = (url: string) => StreamSocket;
+
+export type Wait = (callback: () => void, delayMs: number) => () => void;
+
+export type StreamStatus = "connecting" | "open" | "closed";
+
+export type SubscribeToSessionOptions = {
+	createSocket: StreamSocketFactory;
+	url(since: Cursor | null): string;
+	since?: Cursor | null;
+	onEnvelope(envelope: Envelope): void;
+	onReset?(reason: string): void;
+	onStatusChange?(status: StreamStatus): void;
+	backoffInitialMs?: number;
+	backoffMaxMs?: number;
+	wait?: Wait;
+};
+
+export type SessionStream = {
+	close(): void;
+	cursor(): Cursor | null;
+};
+
+export const DEFAULT_BACKOFF_INITIAL_MS = 250;
+export const DEFAULT_BACKOFF_MAX_MS = 10_000;
+
+const defaultWait: Wait = (callback, delayMs) => {
+	const timer = setTimeout(callback, delayMs);
+	return () => clearTimeout(timer);
+};
+
+export type StreamUrlParams = {
+	baseUrl: string;
+	sessionId: string;
+	deltas: readonly DeltaChannel[];
+	since: Cursor | null;
+};
+
+export function buildStreamUrl(params: StreamUrlParams): string {
+	const base = params.baseUrl.endsWith("/")
+		? params.baseUrl.slice(0, -1)
+		: params.baseUrl;
+	const query: string[] = [];
+	if (params.since) {
+		query.push(`since=${encodeURIComponent(serializeCursor(params.since))}`);
+	}
+	if (params.deltas.length > 0) {
+		query.push(`deltas=${params.deltas.join(",")}`);
+	}
+	const suffix = query.length > 0 ? `?${query.join("&")}` : "";
+	return `${base}/sessions/${encodeURIComponent(params.sessionId)}/stream${suffix}`;
+}
+
+export function subscribeToSession(
+	options: SubscribeToSessionOptions,
+): SessionStream {
+	const wait = options.wait ?? defaultWait;
+	const initialMs = options.backoffInitialMs ?? DEFAULT_BACKOFF_INITIAL_MS;
+	const maxMs = options.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+
+	let since: Cursor | null = options.since ?? null;
+	let attempts = 0;
+	let closed = false;
+	let socket: StreamSocket | null = null;
+	let cancelReconnect: (() => void) | null = null;
+
+	const setStatus = (status: StreamStatus) => {
+		options.onStatusChange?.(status);
+	};
+
+	const handleFrame = (data: unknown) => {
+		if (typeof data !== "string") return;
+		let raw: unknown;
+		try {
+			raw = JSON.parse(data);
+		} catch {
+			return;
+		}
+		const parsed = envelopeSchema.safeParse(raw);
+		if (!parsed.success) return;
+		const envelope = parsed.data;
+		if (isDurableEnvelope(envelope)) since = envelope.cursor;
+		if (isResetEnvelope(envelope)) {
+			since = null;
+			options.onReset?.(envelope.reset.reason);
+		}
+		options.onEnvelope(envelope);
+	};
+
+	const scheduleReconnect = () => {
+		if (closed) return;
+		attempts += 1;
+		const delayMs = Math.min(initialMs * 2 ** (attempts - 1), maxMs);
+		cancelReconnect = wait(() => {
+			cancelReconnect = null;
+			connect();
+		}, delayMs);
+	};
+
+	function connect(): void {
+		if (closed) return;
+		setStatus("connecting");
+		let next: StreamSocket;
+		try {
+			next = options.createSocket(options.url(since));
+		} catch {
+			scheduleReconnect();
+			return;
+		}
+		socket = next;
+		next.onopen = () => {
+			if (socket !== next) return;
+			attempts = 0;
+			setStatus("open");
+		};
+		next.onmessage = (event: { data: unknown }) => {
+			if (socket !== next) return;
+			handleFrame(event.data);
+		};
+		next.onclose = () => {
+			if (socket !== next) return;
+			socket = null;
+			setStatus("closed");
+			scheduleReconnect();
+		};
+		next.onerror = () => {};
+	}
+
+	connect();
+
+	return {
+		close() {
+			if (closed) return;
+			closed = true;
+			cancelReconnect?.();
+			cancelReconnect = null;
+			const current = socket;
+			socket = null;
+			current?.close();
+			setStatus("closed");
+		},
+		cursor: () => since,
+	};
+}

--- a/packages/chat/src/react/index.ts
+++ b/packages/chat/src/react/index.ts
@@ -1,0 +1,3 @@
+export * from "./useApprovals";
+export * from "./useChatSession";
+export * from "./useTimeline";

--- a/packages/chat/src/react/useApprovals/index.ts
+++ b/packages/chat/src/react/useApprovals/index.ts
@@ -1,0 +1,1 @@
+export { useApprovals } from "./useApprovals";

--- a/packages/chat/src/react/useApprovals/useApprovals.test.tsx
+++ b/packages/chat/src/react/useApprovals/useApprovals.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { approvalRequest, turn } from "@superset/chat-runtime/testing";
+import type { SessionSnapshot } from "../../core";
+import { emptySnapshot, reduceMany } from "../../core";
+import type { DurableEvent } from "../../protocol/envelope";
+import type { ApprovalRequest } from "../../protocol/items";
+import { registerDom } from "../../testing/registerDom";
+import { useApprovals } from "./useApprovals";
+
+registerDom();
+const { render } = await import("@testing-library/react");
+
+function buildSnapshot(): SessionSnapshot {
+	const envelope = (seq: number, event: DurableEvent) => ({
+		v: 1 as const,
+		sessionId: "session-1",
+		cursor: { epoch: "e1", seq },
+		ts: seq,
+		event,
+	});
+	return reduceMany(emptySnapshot(), [
+		envelope(1, { type: "turn", turn: turn("t1") }),
+		envelope(2, {
+			type: "item",
+			item: approvalRequest("ap1"),
+			turnId: "t1",
+		}),
+		envelope(3, {
+			type: "item",
+			item: approvalRequest("ap2", { status: "approved" }),
+			turnId: "t1",
+		}),
+	]);
+}
+
+let results: ApprovalRequest[][] = [];
+
+function Probe(props: { snapshot: SessionSnapshot }) {
+	results.push(useApprovals(props.snapshot));
+	return null;
+}
+
+describe("useApprovals", () => {
+	test("returns only pending approvals and memoizes on snapshot identity", () => {
+		results = [];
+		const snapshot = buildSnapshot();
+		const view = render(<Probe snapshot={snapshot} />);
+		const first = results.at(-1);
+		expect(first?.map((approval) => approval.id)).toEqual(["ap1"]);
+
+		view.rerender(<Probe snapshot={snapshot} />);
+		expect(results.at(-1)).toBe(first);
+		view.unmount();
+	});
+});

--- a/packages/chat/src/react/useApprovals/useApprovals.ts
+++ b/packages/chat/src/react/useApprovals/useApprovals.ts
@@ -1,0 +1,8 @@
+import { useMemo } from "react";
+import type { SessionSnapshot } from "../../core";
+import { derivePendingApprovals } from "../../core";
+import type { ApprovalRequest } from "../../protocol/items";
+
+export function useApprovals(snapshot: SessionSnapshot): ApprovalRequest[] {
+	return useMemo(() => derivePendingApprovals(snapshot), [snapshot]);
+}

--- a/packages/chat/src/react/useChatSession/index.ts
+++ b/packages/chat/src/react/useChatSession/index.ts
@@ -1,0 +1,7 @@
+export type {
+	ChatSession,
+	ChatSessionStatus,
+	FrameScheduler,
+	UseChatSessionOptions,
+} from "./useChatSession";
+export { DEFAULT_DELTAS, useChatSession } from "./useChatSession";

--- a/packages/chat/src/react/useChatSession/useChatSession.test.tsx
+++ b/packages/chat/src/react/useChatSession/useChatSession.test.tsx
@@ -1,0 +1,298 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import type { ChatRuntime, FakeHarnessScript } from "@superset/chat-runtime";
+import {
+	createChatCallerFactory,
+	createChatRouter,
+} from "@superset/chat-runtime";
+import {
+	agentMessage,
+	createManualSchedule,
+	createRecordingSink,
+	createTestRuntime,
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+	turn,
+	waitFor,
+} from "@superset/chat-runtime/testing";
+import type { ChatTransport, SessionClient } from "../../client";
+import { createSessionClient } from "../../client";
+import { emptySnapshot, reduceMany } from "../../core";
+import { createManualWait } from "../../testing/manualWait";
+import { createMemoryStreamServer } from "../../testing/memoryStream";
+import { registerDom } from "../../testing/registerDom";
+import type { ChatSession, FrameScheduler } from "./useChatSession";
+import { useChatSession } from "./useChatSession";
+
+registerDom();
+const {
+	act,
+	render,
+	waitFor: domWaitFor,
+} = await import("@testing-library/react");
+
+function turnScript(
+	turnId: string,
+	itemId: string,
+): FakeHarnessScript["turns"][number] {
+	return [
+		{ kind: "turn", turn: turn(turnId) },
+		{ kind: "item", item: agentMessage(itemId, "done"), turnId },
+		{
+			kind: "turn",
+			turn: turn(turnId, { status: "completed", completedAtMs: 2 }),
+		},
+		{ kind: "session", session: { status: "idle" } },
+	];
+}
+
+const SCRIPT: FakeHarnessScript = {
+	turns: [turnScript("t1", "a1"), turnScript("t2", "a2")],
+};
+
+type Stack = {
+	runtime: ChatRuntime;
+	transport: ChatTransport;
+	server: ReturnType<typeof createMemoryStreamServer>;
+	sessionId: string;
+	makeClient(overrides?: {
+		wait?: ReturnType<typeof createManualWait>["wait"];
+		transport?: ChatTransport;
+	}): SessionClient;
+};
+
+async function startStack(): Promise<Stack> {
+	const { harnesses } = fakeHarnessRegistry(SCRIPT);
+	const runtime = createTestRuntime({ harnesses });
+	const router = createChatRouter(runtime, {
+		resolveCwd: () => "/tmp/workspace",
+	});
+	const transport: ChatTransport = createChatCallerFactory(router)({});
+	const server = createMemoryStreamServer(runtime);
+	const created = await transport.createSession({
+		commandId: randomUUID(),
+		workspaceId: "workspace-1",
+		harness: FAKE_HARNESS,
+	});
+	return {
+		runtime,
+		transport,
+		server,
+		sessionId: created.sessionId,
+		makeClient: (overrides = {}) =>
+			createSessionClient({
+				sessionId: created.sessionId,
+				transport: overrides.transport ?? transport,
+				streamBaseUrl: "ws://test/chat-v3",
+				createSocket: server.createSocket,
+				wait: overrides.wait,
+			}),
+	};
+}
+
+let latest: ChatSession | null = null;
+let renders = 0;
+
+function Probe(props: {
+	client: SessionClient;
+	scheduler?: FrameScheduler;
+	pageSize?: number;
+}) {
+	renders += 1;
+	latest = useChatSession({
+		client: props.client,
+		deltas: [],
+		scheduler: props.scheduler,
+		pageSize: props.pageSize,
+	});
+	return null;
+}
+
+function session(): ChatSession {
+	if (!latest) throw new Error("hook not rendered");
+	return latest;
+}
+
+describe("useChatSession", () => {
+	test("seeds, streams a turn, and clears the outbox on clientId echo", async () => {
+		const stack = await startStack();
+		const always = createRecordingSink();
+		stack.runtime.subscribe(stack.sessionId, { deltas: [] }, always.sink);
+
+		const client = stack.makeClient();
+		const view = render(<Probe client={client} />);
+		await domWaitFor(() => expect(session().status).toBe("ready"));
+
+		act(() => {
+			session().sendPrompt([{ type: "text", text: "hello" }]);
+		});
+		expect(session().outbox).toHaveLength(1);
+
+		await domWaitFor(() => expect(session().outbox).toHaveLength(0));
+		await domWaitFor(() =>
+			expect(session().snapshot.session?.status).toBe("idle"),
+		);
+
+		const itemKinds = [...session().snapshot.items.values()].map(
+			(stored) => stored.item.kind,
+		);
+		expect(itemKinds).toContain("user_message");
+		expect(itemKinds).toContain("agent_message");
+
+		expect(session().snapshot).toEqual(
+			reduceMany(emptySnapshot(), always.envelopes),
+		);
+		view.unmount();
+		client.close();
+		await stack.runtime.dispose();
+	});
+
+	test("reconnects after a drop and converges with a subscriber that never dropped", async () => {
+		const stack = await startStack();
+		const always = createRecordingSink();
+		stack.runtime.subscribe(stack.sessionId, { deltas: [] }, always.sink);
+
+		const manual = createManualWait();
+		const client = stack.makeClient({ wait: manual.wait });
+		const view = render(<Probe client={client} />);
+		await domWaitFor(() => expect(session().status).toBe("ready"));
+		await domWaitFor(() => expect(session().connection).toBe("open"));
+
+		act(() => {
+			session().sendPrompt([{ type: "text", text: "hello" }]);
+		});
+		await domWaitFor(() =>
+			expect(session().snapshot.turns.size).toBeGreaterThanOrEqual(1),
+		);
+		act(() => {
+			stack.server.openConnections()[0]?.drop();
+		});
+		expect(session().connection).toBe("closed");
+
+		await waitFor(
+			() => stack.runtime.sessions.get(stack.sessionId)?.status === "idle",
+		);
+		act(() => {
+			manual.flush();
+		});
+		await domWaitFor(() => expect(session().connection).toBe("open"));
+		await domWaitFor(() =>
+			expect(session().snapshot).toEqual(
+				reduceMany(emptySnapshot(), always.envelopes),
+			),
+		);
+		view.unmount();
+		client.close();
+		await stack.runtime.dispose();
+	});
+
+	test("coalesces buffered envelopes into one commit per scheduled frame", async () => {
+		const stack = await startStack();
+		const scheduler = createManualSchedule();
+		const client = stack.makeClient();
+		const view = render(
+			<Probe client={client} scheduler={scheduler.schedule} />,
+		);
+		await domWaitFor(() => expect(session().status).toBe("ready"));
+
+		act(() => {
+			session().sendPrompt([{ type: "text", text: "hello" }]);
+		});
+		await domWaitFor(() => expect(session().outbox).toHaveLength(1));
+		await waitFor(
+			() => stack.runtime.sessions.get(stack.sessionId)?.status === "idle",
+		);
+		await waitFor(() => scheduler.pendingCount() === 1);
+		expect(session().snapshot.items.size).toBe(0);
+
+		const before = renders;
+		act(() => {
+			scheduler.flush();
+		});
+		expect(renders - before).toBe(1);
+		expect(session().snapshot.items.size).toBe(2);
+		expect(session().snapshot.session?.status).toBe("idle");
+		expect(session().outbox).toHaveLength(0);
+		view.unmount();
+		client.close();
+		await stack.runtime.dispose();
+	});
+
+	test("loadOlder pages history backwards until exhausted", async () => {
+		const stack = await startStack();
+		const seedClient = stack.makeClient();
+		await seedClient.prompt({
+			clientId: "client-1",
+			content: [{ type: "text", text: "hello" }],
+		});
+		await waitFor(
+			() => stack.runtime.sessions.get(stack.sessionId)?.status === "idle",
+		);
+
+		const client = stack.makeClient();
+		const view = render(<Probe client={client} pageSize={2} />);
+		await domWaitFor(() => expect(session().status).toBe("ready"));
+		expect(session().hasOlder).toBe(true);
+		const seededCount = session().snapshot.items.size;
+
+		while (session().hasOlder) {
+			await act(async () => {
+				await session().loadOlder();
+			});
+		}
+		expect(session().snapshot.items.size).toBeGreaterThanOrEqual(seededCount);
+		const full = await client.getItems({});
+		if (!full.ok) throw new Error("expected page");
+		expect(session().snapshot).toEqual(
+			reduceMany(emptySnapshot(), full.envelopes),
+		);
+		view.unmount();
+		client.close();
+		await stack.runtime.dispose();
+	});
+
+	test("auto-resyncs through getItems when the stream resets", async () => {
+		const stack = await startStack();
+		let getItemsCalls = 0;
+		const countingTransport: ChatTransport = {
+			createSession: (input) => stack.transport.createSession(input),
+			prompt: (input) => stack.transport.prompt(input),
+			cancelTurn: (input) => stack.transport.cancelTurn(input),
+			respondToApproval: (input) => stack.transport.respondToApproval(input),
+			setMode: (input) => stack.transport.setMode(input),
+			getSession: (input) => stack.transport.getSession(input),
+			listSessions: (input) => stack.transport.listSessions(input),
+			getItems: (input) => {
+				getItemsCalls += 1;
+				return stack.transport.getItems(input);
+			},
+		};
+		const client = stack.makeClient({ transport: countingTransport });
+		const view = render(<Probe client={client} />);
+		await domWaitFor(() => expect(session().status).toBe("ready"));
+
+		act(() => {
+			session().sendPrompt([{ type: "text", text: "hello" }]);
+		});
+		await domWaitFor(() =>
+			expect(session().snapshot.session?.status).toBe("idle"),
+		);
+		const itemsBefore = session().snapshot.items.size;
+		const callsBefore = getItemsCalls;
+
+		act(() => {
+			stack.runtime.subscriptions.publish({
+				v: 1,
+				sessionId: stack.sessionId,
+				ts: Date.now(),
+				reset: { reason: "journal_missing" },
+			});
+		});
+		await domWaitFor(() => expect(getItemsCalls).toBeGreaterThan(callsBefore));
+		await domWaitFor(() => expect(session().snapshot.pendingReset).toBeNull());
+		expect(session().snapshot.items.size).toBe(itemsBefore);
+		view.unmount();
+		client.close();
+		await stack.runtime.dispose();
+	});
+});

--- a/packages/chat/src/react/useChatSession/useChatSession.ts
+++ b/packages/chat/src/react/useChatSession/useChatSession.ts
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SessionClient, SessionStream, StreamStatus } from "../../client";
+import type { OutboxEntry, SessionSnapshot } from "../../core";
+import { emptySnapshot, Outbox, reduceMany } from "../../core";
+import type { Cursor } from "../../protocol/cursor";
+import type { DeltaChannel, Envelope } from "../../protocol/envelope";
+import { isDurableEnvelope } from "../../protocol/envelope";
+import type { Decision, UserContent, UserMessage } from "../../protocol/items";
+
+export type FrameScheduler = (flush: () => void) => () => void;
+
+const defaultScheduler: FrameScheduler = (flush) => {
+	const scope = globalThis as {
+		requestAnimationFrame?: (callback: () => void) => number;
+		cancelAnimationFrame?: (handle: number) => void;
+	};
+	if (typeof scope.requestAnimationFrame === "function") {
+		const frame = scope.requestAnimationFrame(() => flush());
+		return () => scope.cancelAnimationFrame?.(frame);
+	}
+	const timer = setTimeout(flush, 16);
+	return () => clearTimeout(timer);
+};
+
+export const DEFAULT_DELTAS: readonly DeltaChannel[] = [
+	"text",
+	"tool_input",
+	"terminal",
+];
+
+export type UseChatSessionOptions = {
+	client: SessionClient;
+	deltas?: readonly DeltaChannel[];
+	pageSize?: number;
+	scheduler?: FrameScheduler;
+};
+
+export type ChatSessionStatus = "loading" | "ready";
+
+export type ChatSession = {
+	snapshot: SessionSnapshot;
+	status: ChatSessionStatus;
+	connection: StreamStatus;
+	outbox: OutboxEntry[];
+	hasOlder: boolean;
+	sendPrompt(content: UserContent[]): void;
+	retryPrompt(clientId: string): void;
+	discardPrompt(clientId: string): void;
+	loadOlder(): Promise<void>;
+	cancelTurn(turnId: string): Promise<void>;
+	respondToApproval(approvalId: string, decision: Decision): Promise<void>;
+	setMode(modeId: string): Promise<void>;
+};
+
+function confirmEchoes(outbox: Outbox, batch: readonly Envelope[]): void {
+	for (const envelope of batch) {
+		if (!isDurableEnvelope(envelope)) continue;
+		if (envelope.event.type !== "item") continue;
+		const item = envelope.event.item;
+		if (item.kind !== "user_message") continue;
+		const clientId = (item as UserMessage).clientId;
+		if (clientId) outbox.confirm(clientId);
+	}
+}
+
+export function useChatSession(options: UseChatSessionOptions): ChatSession {
+	const client = options.client;
+	const pageSize = options.pageSize;
+	const deltasKey = (options.deltas ?? DEFAULT_DELTAS).join(",");
+
+	const [snapshot, setSnapshot] = useState<SessionSnapshot>(emptySnapshot);
+	const [status, setStatus] = useState<ChatSessionStatus>("loading");
+	const [connection, setConnection] = useState<StreamStatus>("connecting");
+	const [outboxEntries, setOutboxEntries] = useState<OutboxEntry[]>([]);
+	const [hasOlder, setHasOlder] = useState(false);
+
+	const schedulerRef = useRef(options.scheduler ?? defaultScheduler);
+	schedulerRef.current = options.scheduler ?? defaultScheduler;
+
+	const pendingRef = useRef<Envelope[]>([]);
+	const cancelFlushRef = useRef<(() => void) | null>(null);
+	const nextBeforeRef = useRef<Cursor | null>(null);
+	const resyncingRef = useRef(false);
+	const clientRef = useRef(client);
+	clientRef.current = client;
+
+	const outbox = useMemo(
+		() =>
+			new Outbox({
+				send: async (entry) => {
+					await client.prompt({
+						commandId: entry.commandId,
+						clientId: entry.clientId,
+						content: entry.content,
+					});
+				},
+			}),
+		[client],
+	);
+
+	useEffect(() => {
+		setOutboxEntries(outbox.snapshot());
+		return outbox.subscribe(() => setOutboxEntries(outbox.snapshot()));
+	}, [outbox]);
+
+	const commit = useCallback(() => {
+		cancelFlushRef.current = null;
+		const batch = pendingRef.current;
+		pendingRef.current = [];
+		if (batch.length === 0) return;
+		confirmEchoes(outbox, batch);
+		setSnapshot((prev) => reduceMany(prev, batch));
+	}, [outbox]);
+
+	const enqueue = useCallback(
+		(envelope: Envelope) => {
+			pendingRef.current.push(envelope);
+			if (!cancelFlushRef.current) {
+				cancelFlushRef.current = schedulerRef.current(commit);
+			}
+		},
+		[commit],
+	);
+
+	const resync = useCallback(async () => {
+		if (resyncingRef.current) return;
+		resyncingRef.current = true;
+		try {
+			const page = await client.getItems({ limit: pageSize });
+			if (clientRef.current !== client) return;
+			if (!page.ok) return;
+			nextBeforeRef.current = page.nextBefore;
+			setHasOlder(page.nextBefore !== null);
+			setSnapshot((prev) =>
+				reduceMany(
+					{ ...prev, cursor: null, pendingReset: null },
+					page.envelopes,
+				),
+			);
+		} finally {
+			resyncingRef.current = false;
+		}
+	}, [client, pageSize]);
+
+	useEffect(() => {
+		if (snapshot.pendingReset) void resync();
+	}, [snapshot.pendingReset, resync]);
+
+	useEffect(() => {
+		let cancelled = false;
+		let stream: SessionStream | null = null;
+		const deltas = deltasKey ? (deltasKey.split(",") as DeltaChannel[]) : [];
+
+		setStatus("loading");
+		setConnection("connecting");
+		setSnapshot(emptySnapshot());
+		setHasOlder(false);
+		nextBeforeRef.current = null;
+		pendingRef.current = [];
+
+		const seed = async () => {
+			const session = await client.getSession();
+			const page = await client.getItems({ limit: pageSize });
+			if (cancelled) return;
+			let seeded = emptySnapshot();
+			if (page.ok) {
+				seeded = reduceMany(seeded, page.envelopes);
+				nextBeforeRef.current = page.nextBefore;
+				setHasOlder(page.nextBefore !== null);
+			}
+			setSnapshot(seeded);
+			setStatus("ready");
+			stream = client.subscribe({
+				deltas,
+				since: seeded.cursor ?? session.cursor,
+				onEnvelope: enqueue,
+				onReset: () => {
+					void resync();
+				},
+				onStatusChange: setConnection,
+			});
+		};
+		void seed();
+
+		return () => {
+			cancelled = true;
+			cancelFlushRef.current?.();
+			cancelFlushRef.current = null;
+			pendingRef.current = [];
+			stream?.close();
+		};
+	}, [client, deltasKey, pageSize, enqueue, resync]);
+
+	const sendPrompt = useCallback(
+		(content: UserContent[]) => {
+			outbox.enqueue(content);
+			void outbox.flush();
+		},
+		[outbox],
+	);
+
+	const retryPrompt = useCallback(
+		(clientId: string) => {
+			outbox.retry(clientId);
+			void outbox.flush();
+		},
+		[outbox],
+	);
+
+	const discardPrompt = useCallback(
+		(clientId: string) => {
+			outbox.discard(clientId);
+		},
+		[outbox],
+	);
+
+	const loadOlder = useCallback(async () => {
+		const before = nextBeforeRef.current;
+		if (!before) return;
+		nextBeforeRef.current = null;
+		const page = await client.getItems({ before, limit: pageSize });
+		if (clientRef.current !== client) return;
+		if (!page.ok) {
+			nextBeforeRef.current = before;
+			return;
+		}
+		nextBeforeRef.current = page.nextBefore;
+		setHasOlder(page.nextBefore !== null);
+		setSnapshot((prev) => {
+			const older = reduceMany(emptySnapshot(), page.envelopes);
+			return {
+				...prev,
+				turns: new Map([...older.turns, ...prev.turns]),
+				items: new Map([...older.items, ...prev.items]),
+			};
+		});
+	}, [client, pageSize]);
+
+	const cancelTurn = useCallback(
+		(turnId: string) => client.cancelTurn(turnId),
+		[client],
+	);
+	const respondToApproval = useCallback(
+		(approvalId: string, decision: Decision) =>
+			client.respondToApproval(approvalId, decision),
+		[client],
+	);
+	const setMode = useCallback(
+		(modeId: string) => client.setMode(modeId),
+		[client],
+	);
+
+	return {
+		snapshot,
+		status,
+		connection,
+		outbox: outboxEntries,
+		hasOlder,
+		sendPrompt,
+		retryPrompt,
+		discardPrompt,
+		loadOlder,
+		cancelTurn,
+		respondToApproval,
+		setMode,
+	};
+}

--- a/packages/chat/src/react/useTimeline/index.ts
+++ b/packages/chat/src/react/useTimeline/index.ts
@@ -1,0 +1,1 @@
+export { useTimeline } from "./useTimeline";

--- a/packages/chat/src/react/useTimeline/useTimeline.test.tsx
+++ b/packages/chat/src/react/useTimeline/useTimeline.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+	agentMessage,
+	turn,
+	userMessage,
+} from "@superset/chat-runtime/testing";
+import type { SessionSnapshot, TurnGroup } from "../../core";
+import { emptySnapshot, reduceMany } from "../../core";
+import type { DurableEvent } from "../../protocol/envelope";
+import { registerDom } from "../../testing/registerDom";
+import { useTimeline } from "./useTimeline";
+
+registerDom();
+const { render } = await import("@testing-library/react");
+
+function envelope(seq: number, event: DurableEvent) {
+	return {
+		v: 1 as const,
+		sessionId: "session-1",
+		cursor: { epoch: "e1", seq },
+		ts: seq,
+		event,
+	};
+}
+
+function buildSnapshot(): SessionSnapshot {
+	return reduceMany(emptySnapshot(), [
+		envelope(1, { type: "turn", turn: turn("t1") }),
+		envelope(2, {
+			type: "item",
+			item: userMessage("u1", "hello", { startedAtMs: 0 }),
+			turnId: "t1",
+		}),
+		envelope(3, {
+			type: "item",
+			item: agentMessage("a1", "done"),
+			turnId: "t1",
+		}),
+		envelope(4, {
+			type: "turn",
+			turn: turn("t1", { status: "completed", completedAtMs: 2 }),
+		}),
+	]);
+}
+
+let results: TurnGroup[][] = [];
+
+function Probe(props: { snapshot: SessionSnapshot }) {
+	results.push(useTimeline(props.snapshot));
+	return null;
+}
+
+describe("useTimeline", () => {
+	test("derives turn groups and memoizes on snapshot identity", () => {
+		results = [];
+		const snapshot = buildSnapshot();
+		const view = render(<Probe snapshot={snapshot} />);
+		const first = results.at(-1);
+		expect(first).toHaveLength(1);
+		expect(first?.[0]?.turnId).toBe("t1");
+		expect(first?.[0]?.turn?.status).toBe("completed");
+		expect(
+			first?.[0]?.entries.map((entry) =>
+				entry.kind === "item" ? entry.item.id : entry.items.map((i) => i.id),
+			),
+		).toEqual(["u1", "a1"]);
+
+		view.rerender(<Probe snapshot={snapshot} />);
+		expect(results.at(-1)).toBe(first);
+
+		const changed = reduceMany(snapshot, [
+			envelope(5, {
+				type: "item",
+				item: agentMessage("a2", "more"),
+				turnId: "t1",
+			}),
+		]);
+		view.rerender(<Probe snapshot={changed} />);
+		expect(results.at(-1)).not.toBe(first);
+		expect(results.at(-1)?.[0]?.entries).toHaveLength(3);
+		view.unmount();
+	});
+});

--- a/packages/chat/src/react/useTimeline/useTimeline.ts
+++ b/packages/chat/src/react/useTimeline/useTimeline.ts
@@ -1,0 +1,7 @@
+import { useMemo } from "react";
+import type { SessionSnapshot, TurnGroup } from "../../core";
+import { deriveTimeline } from "../../core";
+
+export function useTimeline(snapshot: SessionSnapshot): TurnGroup[] {
+	return useMemo(() => deriveTimeline(snapshot), [snapshot]);
+}

--- a/packages/chat/src/testing/manualWait/index.ts
+++ b/packages/chat/src/testing/manualWait/index.ts
@@ -1,0 +1,2 @@
+export type { ManualWait } from "./manualWait";
+export { createManualWait } from "./manualWait";

--- a/packages/chat/src/testing/manualWait/manualWait.ts
+++ b/packages/chat/src/testing/manualWait/manualWait.ts
@@ -1,0 +1,32 @@
+import type { Wait } from "../../client";
+
+export type ManualWait = {
+	wait: Wait;
+	delays: number[];
+	flush(): void;
+	pendingCount(): number;
+};
+
+export function createManualWait(): ManualWait {
+	type Entry = { callback: () => void };
+	let pending: Entry[] = [];
+	const delays: number[] = [];
+	const wait: Wait = (callback, delayMs) => {
+		delays.push(delayMs);
+		const entry: Entry = { callback };
+		pending.push(entry);
+		return () => {
+			pending = pending.filter((candidate) => candidate !== entry);
+		};
+	};
+	return {
+		wait,
+		delays,
+		flush: () => {
+			const batch = pending;
+			pending = [];
+			for (const entry of batch) entry.callback();
+		},
+		pendingCount: () => pending.length,
+	};
+}

--- a/packages/chat/src/testing/memoryStream/index.ts
+++ b/packages/chat/src/testing/memoryStream/index.ts
@@ -1,0 +1,5 @@
+export type {
+	MemoryConnection,
+	MemoryStreamServer,
+} from "./memoryStream";
+export { createMemoryStreamServer } from "./memoryStream";

--- a/packages/chat/src/testing/memoryStream/memoryStream.ts
+++ b/packages/chat/src/testing/memoryStream/memoryStream.ts
@@ -1,0 +1,107 @@
+import type { ChatRuntime, WsSinkSocket } from "@superset/chat-runtime";
+import { createWsSink } from "@superset/chat-runtime";
+import type { StreamSocket } from "../../client";
+import type { Cursor } from "../../protocol/cursor";
+import { parseCursor } from "../../protocol/cursor";
+import type { DeltaChannel } from "../../protocol/envelope";
+import { deltaChannelSchema } from "../../protocol/envelope";
+
+type MemorySocket = {
+	onopen: (() => void) | null;
+	onmessage: ((event: { data: string }) => void) | null;
+	onclose: (() => void) | null;
+	onerror: (() => void) | null;
+	close(): void;
+};
+
+export type MemoryConnection = {
+	url: string;
+	isOpen(): boolean;
+	drop(): void;
+};
+
+export type MemoryStreamServer = {
+	createSocket(url: string): StreamSocket;
+	connections: MemoryConnection[];
+	openConnections(): MemoryConnection[];
+};
+
+function parseSince(value: string | null): Cursor | undefined {
+	if (!value) return undefined;
+	return parseCursor(value);
+}
+
+function parseDeltas(value: string | null): DeltaChannel[] {
+	return (value ?? "")
+		.split(",")
+		.filter(Boolean)
+		.map((channel) => deltaChannelSchema.parse(channel));
+}
+
+export function createMemoryStreamServer(
+	runtime: ChatRuntime,
+): MemoryStreamServer {
+	const connections: MemoryConnection[] = [];
+
+	const createSocket = (url: string): StreamSocket => {
+		const parsed = new URL(url);
+		const match = /\/sessions\/([^/]+)\/stream$/.exec(parsed.pathname);
+		const sessionId = decodeURIComponent(match?.[1] ?? "");
+		const since = parseSince(parsed.searchParams.get("since"));
+		const deltas = parseDeltas(parsed.searchParams.get("deltas"));
+
+		let closed = false;
+		let subscription: { unsubscribe(): void } | null = null;
+
+		const socket: MemorySocket = {
+			onopen: null,
+			onmessage: null,
+			onclose: null,
+			onerror: null,
+			close() {
+				teardown();
+			},
+		};
+
+		const teardown = () => {
+			if (closed) return;
+			closed = true;
+			subscription?.unsubscribe();
+			subscription = null;
+			socket.onclose?.();
+		};
+
+		const serverSocket: WsSinkSocket = {
+			send: (data) => {
+				if (!closed) socket.onmessage?.({ data });
+			},
+			close: () => teardown(),
+			onclose: null,
+		};
+
+		connections.push({
+			url,
+			isOpen: () => !closed,
+			drop: () => teardown(),
+		});
+
+		queueMicrotask(() => {
+			if (closed) return;
+			socket.onopen?.();
+			subscription = runtime.subscribe(
+				sessionId,
+				{ since, deltas },
+				createWsSink(serverSocket),
+			);
+		});
+
+		return socket;
+	};
+
+	return {
+		createSocket,
+		connections,
+		openConnections: () =>
+			connections.filter((connection) => connection.isOpen()),
+	};
+}

--- a/packages/chat/src/testing/registerDom/index.ts
+++ b/packages/chat/src/testing/registerDom/index.ts
@@ -1,0 +1,1 @@
+export { registerDom } from "./registerDom";

--- a/packages/chat/src/testing/registerDom/registerDom.ts
+++ b/packages/chat/src/testing/registerDom/registerDom.ts
@@ -1,0 +1,8 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+export function registerDom(): void {
+	if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+	(
+		globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+	).IS_REACT_ACT_ENVIRONMENT = true;
+}

--- a/packages/chat/tsconfig.json
+++ b/packages/chat/tsconfig.json
@@ -1,9 +1,13 @@
 {
 	"extends": "@superset/typescript/base.json",
 	"compilerOptions": {
-		"rootDir": "./src",
-		"lib": ["ES2022"]
+		"lib": ["ES2022"],
+		"jsx": "react-jsx",
+		"paths": {
+			"@superset/chat-runtime": ["../chat-runtime/src/index.ts"],
+			"@superset/chat-runtime/testing": ["../chat-runtime/src/testing/index.ts"]
+		}
 	},
-	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+	"include": ["src/**/*.ts", "src/**/*.tsx"],
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Chunk B of plans/chat-v3-pane-mount.md. ./client: reconnecting WS consumer (envelope-parsed frames, cursor resume, reset-keeps-connection, injectable backoff) + sessionClient over a structural ChatTransport typed via type-only ChatRouterInputs/Outputs — no runtime dep on chat-runtime (tsconfig-paths type bridge; avoids the turbo package cycle) and no @trpc/server in the client package. ./react: useChatSession (seed→reduce→live tail, outbox clientId-echo clearing, one commit per frame with RN-safe scheduler fallback, loadOlder with older-merges-under semantics, auto-resync on reset) + useTimeline/useApprovals. 32 tests incl. hook-level reconnect parity against a real runtime over an in-memory socket pair.

https://claude.ai/code/session_01XRFCEPsfmJHu2SenDKYJ2h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reconnecting session stream, a typed session client, and React hooks for chat sessions. This delivers reliable live updates with resume, pagination, and a simple API for apps.

- New Features
  - `@superset/chat` client
    - `subscribeToSession`: reconnecting stream with since-cursor resume, reset handling, and configurable exponential backoff.
    - `createSessionClient`: typed transport over `ChatRouterInputs/Outputs` (no runtime dep), prompt dedupe by `commandId`, item pagination, approvals/mode/turn controls, and multiple managed streams.
  - `@superset/chat` React
    - `useChatSession`: seeds via `getSession` + `getItems`, batches live frames into one commit per animation frame (RN-safe timeout fallback), clears outbox on clientId echo, loads older pages, and auto-resyncs on stream reset.
    - `useTimeline` and `useApprovals`: memoized derived views of the session snapshot.
  - Testing utilities
    - In-memory stream server with drop/reconnect controls, manual wait scheduler, and DOM registrator for hook tests. 32 tests cover reconnect, pagination, and hook parity.

- Refactors
  - `@superset/chat-runtime`: adds `./testing` export for cross-package tests and exposes `ChatRouterInputs/Outputs` for client typing.
  - `@superset/chat`: adds `./client` and `./react` entry points; uses a tsconfig type-only bridge to avoid a package cycle; no `@trpc/server` in the client.

<sup>Written for commit f98ceecf449344c9fba3a65448b9439047295bdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a typed chat session client for creating sessions, sending prompts, pagination, approvals, mode changes, and lifecycle management.
  - Added reliable live session subscriptions with reconnect support and stream recovery.
  - Added React hooks for managing chat sessions, pending approvals, and conversation timelines.
  - Added public package entry points for client and React integrations.
  - Added reusable testing utilities and public runtime testing exports.

- **Tests**
  - Added comprehensive coverage for streaming, reconnection, pagination, approvals, timelines, and session workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->