### PR TITLE
docs: weekly update for PRs merged 2026-07-29 to 2026-08-05

### DIFF
--- a/apps/docs/content/docs/automations.mdx
+++ b/apps/docs/content/docs/automations.mdx
@@ -62,7 +62,7 @@ From the automation's detail page:
 
 ## Retry Failed Runs
 
-In the Automations list, hover an automation whose last run failed (`skipped (offline)` or `dispatch failed`) to reveal an inline **Retry** button that re-dispatches it. A **Retry all** button appears in the header when any of your automations have failed last runs, re-dispatching all of them at once. Both disappear automatically once nothing is failed.
+In the Automations list, hover an automation you own whose last run failed (`skipped (offline)` or `dispatch failed`) to reveal an inline **Retry** button that re-dispatches it. On the **Mine** tab, a **Retry all** button appears in the header when any of your automations have a failed last run, re-dispatching all of them at once. Both disappear when no automation has a failed latest run.
 
 ## Limits
 

--- a/apps/docs/content/docs/automations.mdx
+++ b/apps/docs/content/docs/automations.mdx
@@ -60,6 +60,10 @@ From the automation's detail page:
 - **Run now**: dispatches immediately. The run appears in **Previous runs** within seconds.
 - **Delete**: removes the automation and its run history.
 
+## Retry Failed Runs
+
+In the Automations list, hover an automation whose last run failed (`skipped (offline)` or `dispatch failed`) to reveal an inline **Retry** button that re-dispatches it. A **Retry all** button appears in the header when any of your automations have failed last runs, re-dispatching all of them at once. Both disappear automatically once nothing is failed.
+
 ## Limits
 
 - **At-least-once delivery**: Automations may dispatch more than once in rare cases (e.g. dispatcher retries). Design prompts that are safe to re-run.

--- a/apps/docs/content/docs/keyboard-shortcuts.mdx
+++ b/apps/docs/content/docs/keyboard-shortcuts.mdx
@@ -60,6 +60,8 @@ description: Customize hotkeys for common actions
 | Copy Path | ⌘⇧C |
 | Close Window | ⌘⇧Q |
 | Show Keyboard Shortcuts | ⌘/ |
+| Open Command Palette | ⌘⇧K |
+| Check Resources | ⌘⇧U |
 
 ## Customize
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -12,6 +12,7 @@
 		"recipes/pr-feedback",
 		"recipes/fan-out-refactor",
 		"recipes/nightly-audit",
+		"recipes/agent-driven-superset",
 		"orchestration",
 		"---Core Features---",
 		"workspaces",

--- a/apps/docs/content/docs/recipes/agent-driven-superset.mdx
+++ b/apps/docs/content/docs/recipes/agent-driven-superset.mdx
@@ -1,6 +1,6 @@
 ---
 title: Drive Superset from Your Agent
-description: Use the orchestrate and automate skills to fan out work and schedule it, without leaving the conversation
+description: Delegate work in parallel, then make it recurring with the automate skill — without leaving the conversation
 ---
 
 <Callout type="info" title="Use when">
@@ -9,27 +9,19 @@ description: Use the orchestrate and automate skills to fan out work and schedul
 
 ## The Idea
 
-Superset ships [skills](/skills) to your coding agents automatically, so the agent in front of you already knows how to run Superset itself. Two of them change how you work: **`superset:orchestrate`** turns that agent into a coordinator that spins up workspaces and worker agents, and **`superset:automate`** turns anything you've asked for twice into a scheduled [automation](/automations).
+Superset ships [skills](/skills) to your coding agents automatically, so the agent in front of you already knows how to run Superset itself. `superset:orchestrate` makes it a coordinator of parallel workers — that has [its own page](/orchestration). This recipe is about the move that follows: `superset:automate` turns anything you've asked for twice into a scheduled [automation](/automations), in the same conversation.
 
 ## Steps
 
-1. When a task splits into independent pieces, don't do the splitting yourself — hand the whole thing to the agent you're talking to:
-
-```text
-Migrate this codebase off moment.js. Split the work into independent
-slices, run one agent per slice in separate Superset workspaces, and
-report back when each finishes with the branch name and a summary.
-```
-
-2. The agent creates the workspaces, launches the workers, and tracks them — see [Agent Orchestration](/orchestration) for how the coordination works. Your job shrinks to reviewing each workspace's diff as it lands.
-3. When a delegated job turns out to be recurring — a dependency sweep, a triage pass, a weekly cleanup — promote it in the same conversation:
+1. Delegate something splittable to the agent you're talking to — "split this migration into independent slices and run a worker on each" ([Agent Orchestration](/orchestration) covers what to ask for and how the coordination works). Review each workspace's diff as it lands.
+2. When the job turns out to be recurring — a dependency sweep, a triage pass, a weekly cleanup — promote it without switching surfaces:
 
 ```text
 That worked. Make it a Superset automation that runs every Monday at 7am
 on this project, and walk me through the first run.
 ```
 
-4. The agent writes the automation prompt, schedules it, and reviews the first run with you. From then on it's a [workspace waiting for you](/recipes/nightly-audit) instead of a task on your list.
+3. The agent writes the automation prompt, schedules it, and reviews the first run with you. From then on it's a [workspace waiting for you](/recipes/nightly-audit) instead of a task on your list.
 
 ## Variations
 

--- a/apps/docs/content/docs/recipes/agent-driven-superset.mdx
+++ b/apps/docs/content/docs/recipes/agent-driven-superset.mdx
@@ -1,52 +1,38 @@
 ---
 title: Drive Superset from Your Agent
-description: Standups, automations, diagnostics, and repo setup — delegated to the agent you're already talking to
+description: Use the orchestrate and automate skills to fan out work and schedule it, without leaving the conversation
 ---
 
 <Callout type="info" title="Use when">
-	you'd rather type one sentence to the agent in front of you than click through the app: catching up on overnight work, scheduling a chore, fixing a broken setup, making a new repo workspace-ready.
+	you're mid-conversation with an agent and the next step is a Superset action — fan this work out in parallel, or make it recur on a schedule — and you'd rather say so than click through the app.
 </Callout>
 
 ## The Idea
 
-Superset ships [skills](/skills) to your coding agents automatically — Claude Code, Codex, and friends all know how to run Superset itself. That turns app chores into prompts: the agent sweeps your workspaces for a standup, writes and schedules an automation, or diagnoses why a host is offline, while you stay in the conversation you were already having.
+Superset ships [skills](/skills) to your coding agents automatically, so the agent in front of you already knows how to run Superset itself. Two of them change how you work: **`superset:orchestrate`** turns that agent into a coordinator that spins up workspaces and worker agents, and **`superset:automate`** turns anything you've asked for twice into a scheduled [automation](/automations).
 
 ## Steps
 
-1. Confirm the skills are there: ask any agent launched through Superset to "list your superset skills". You should see `superset:standup`, `superset:automate`, `superset:doctor`, and friends. (No desktop app on this machine? `npx skills add superset-sh/skills`.)
-2. Start your day in any agent session instead of clicking through workspaces:
+1. When a task splits into independent pieces, don't do the splitting yourself — hand the whole thing to the agent you're talking to:
 
 ```text
-Give me a standup of my Superset agents: what finished overnight, what
-needs my review, and what's blocked. For anything finished, tell me
-which workspace to open first and why.
+Migrate this codebase off moment.js. Split the work into independent
+slices, run one agent per slice in separate Superset workspaces, and
+report back when each finishes with the branch name and a summary.
 ```
 
-3. Act on the digest — open the workspace it points you to, review the diff, ship or re-prompt.
-4. When the same chore shows up twice in a week, promote it to a schedule in the same conversation:
+2. The agent creates the workspaces, launches the workers, and tracks them — see [Agent Orchestration](/orchestration) for how the coordination works. Your job shrinks to reviewing each workspace's diff as it lands.
+3. When a delegated job turns out to be recurring — a dependency sweep, a triage pass, a weekly cleanup — promote it in the same conversation:
 
 ```text
-That dependency sweep you just did — make it a Superset automation that
-runs weekdays at 7am on this project, and walk me through the first run.
+That worked. Make it a Superset automation that runs every Monday at 7am
+on this project, and walk me through the first run.
 ```
 
-5. When something's off — a host shows offline, terminals won't attach, auth looks stale — don't debug it yourself:
-
-```text
-Superset says this host is offline but the machine is right here. Diagnose
-and fix it.
-```
-
-6. If the agent finds a real bug in Superset along the way, have it file the report: "report this to the Superset team" sends it privately from your account so the team can reply.
-
-## Steering the Skills
-
-- You rarely need skill names: agents pick the right one from a plain request ("what did my agents do last night?" → `superset:standup`)
-- To be explicit, invoke directly: `/superset:standup` in Claude Code, `/superset/standup` in the in-app chat
-- Skills update with the app — no reinstalling, and files you authored at the same paths are never touched
+4. The agent writes the automation prompt, schedules it, and reviews the first run with you. From then on it's a [workspace waiting for you](/recipes/nightly-audit) instead of a task on your list.
 
 ## Variations
 
-- **New repo, first workspace**: "make this repo Superset-ready" has the agent author `.superset/config.json` with setup and run scripts, then verify with a real workspace
-- **Agent as coordinator**: "run these three refactors in parallel in separate workspaces" hands the whole [Fan Out](/recipes/fan-out-refactor) pattern to one orchestrating agent — see [Agent Orchestration](/orchestration)
-- **Level up**: "audit how I use Superset and show me what I'm missing" gets you a personalized tour of the features you haven't adopted yet
+- **Catch up instead of fan out**: "what did my agents do overnight?" gets you a standup digest of finished, blocked, and needs-review work
+- **When Superset itself misbehaves**: "diagnose why this host shows offline" has the agent fix it instead of you reading logs
+- The full list of shipped skills — and how they're delivered and updated — is on the [Skills](/skills) page

--- a/apps/docs/content/docs/recipes/agent-driven-superset.mdx
+++ b/apps/docs/content/docs/recipes/agent-driven-superset.mdx
@@ -1,0 +1,52 @@
+---
+title: Drive Superset from Your Agent
+description: Standups, automations, diagnostics, and repo setup — delegated to the agent you're already talking to
+---
+
+<Callout type="info" title="Use when">
+	you'd rather type one sentence to the agent in front of you than click through the app: catching up on overnight work, scheduling a chore, fixing a broken setup, making a new repo workspace-ready.
+</Callout>
+
+## The Idea
+
+Superset ships [skills](/skills) to your coding agents automatically — Claude Code, Codex, and friends all know how to run Superset itself. That turns app chores into prompts: the agent sweeps your workspaces for a standup, writes and schedules an automation, or diagnoses why a host is offline, while you stay in the conversation you were already having.
+
+## Steps
+
+1. Confirm the skills are there: ask any agent launched through Superset to "list your superset skills". You should see `superset:standup`, `superset:automate`, `superset:doctor`, and friends. (No desktop app on this machine? `npx skills add superset-sh/skills`.)
+2. Start your day in any agent session instead of clicking through workspaces:
+
+```text
+Give me a standup of my Superset agents: what finished overnight, what
+needs my review, and what's blocked. For anything finished, tell me
+which workspace to open first and why.
+```
+
+3. Act on the digest — open the workspace it points you to, review the diff, ship or re-prompt.
+4. When the same chore shows up twice in a week, promote it to a schedule in the same conversation:
+
+```text
+That dependency sweep you just did — make it a Superset automation that
+runs weekdays at 7am on this project, and walk me through the first run.
+```
+
+5. When something's off — a host shows offline, terminals won't attach, auth looks stale — don't debug it yourself:
+
+```text
+Superset says this host is offline but the machine is right here. Diagnose
+and fix it.
+```
+
+6. If the agent finds a real bug in Superset along the way, have it file the report: "report this to the Superset team" sends it privately from your account so the team can reply.
+
+## Steering the Skills
+
+- You rarely need skill names: agents pick the right one from a plain request ("what did my agents do last night?" → `superset:standup`)
+- To be explicit, invoke directly: `/superset:standup` in Claude Code, `/superset/standup` in the in-app chat
+- Skills update with the app — no reinstalling, and files you authored at the same paths are never touched
+
+## Variations
+
+- **New repo, first workspace**: "make this repo Superset-ready" has the agent author `.superset/config.json` with setup and run scripts, then verify with a real workspace
+- **Agent as coordinator**: "run these three refactors in parallel in separate workspaces" hands the whole [Fan Out](/recipes/fan-out-refactor) pattern to one orchestrating agent — see [Agent Orchestration](/orchestration)
+- **Level up**: "audit how I use Superset and show me what I'm missing" gets you a personalized tour of the features you haven't adopted yet

--- a/apps/docs/content/docs/setup-teardown-scripts.mdx
+++ b/apps/docs/content/docs/setup-teardown-scripts.mdx
@@ -25,6 +25,8 @@ Create `.superset/config.json` in your project:
 
 Setup and teardown commands run sequentially in the workspace directory.
 
+By default, an agent launched at workspace creation starts immediately, in parallel with setup. Enable **Settings → Experimental → Wait for workspace setup before starting agents** to chain the agent after the setup commands in the same terminal: the agent only starts once setup succeeds, and no separate setup pane is left behind.
+
 ## Run Script
 
 The `run` field defines commands that start your dev server or other long-running processes. Unlike setup/teardown, run commands are:

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -9,7 +9,7 @@ The **Tasks** and **Pull requests** views bring your issue tracker and open pull
 
 ## Where Tasks Come From
 
-Tasks sync from your connected tracker (see [Linear Integration](/use-with-linear)) alongside Superset-native tasks, and GitHub Issues are available as a source inside the Tasks view. The view lists issues from the whole connected Linear workspace; filter by status, priority, or assignee to narrow it to yours.
+Tasks sync from your connected tracker (see [Linear Integration](/use-with-linear)) alongside Superset-native tasks, and GitHub Issues are available as a source inside the Tasks view. The Linear source lists issues from the whole connected workspace; filter by status, priority, or assignee to narrow it to yours.
 
 ## What You Can Do
 

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -1,15 +1,15 @@
 ---
-title: Tasks & PRs
+title: Tasks & Pull Requests
 description: Track work items and pull requests without leaving the app
 ---
 
-The **Tasks & PRs** view brings your issue tracker and open pull requests into Superset, so delegating a task to an agent doesn't start with a copy-paste from Linear.
+The **Tasks** and **Pull requests** views bring your issue tracker and open pull requests into Superset, so delegating a task to an agent doesn't start with a copy-paste from Linear. Each is its own destination in the dashboard sidebar, with independent filters that are restored when you come back.
 
 ![Creating a task from the desktop](/images/create-task.png)
 
 ## Where Tasks Come From
 
-Tasks sync from your connected tracker (see [Linear Integration](/use-with-linear)) alongside Superset-native tasks. The view lists issues from the whole connected Linear workspace; filter by status, priority, or assignee to narrow it to yours.
+Tasks sync from your connected tracker (see [Linear Integration](/use-with-linear)) alongside Superset-native tasks, and GitHub Issues are available as a source inside the Tasks view. The view lists issues from the whole connected Linear workspace; filter by status, priority, or assignee to narrow it to yours.
 
 ## What You Can Do
 
@@ -25,6 +25,6 @@ The point of having tasks in Superset is delegation. Launch an agent from a task
 - The **Task Prompt Template** (per agent, under **Settings → Agents**) controls how the task is turned into a prompt
 - The **Auto-run command** toggle controls whether the agent starts immediately or stages the command for review
 
-## PRs
+## Pull Requests
 
-Pull requests appear alongside tasks, and PR-based workspaces show review status and CI checks in the sidebar. See [Workspaces](/workspaces#pr-status) and the [Diff Viewer](/diff-viewer) for the review loop.
+The **Pull requests** view lists PRs from your projects' repositories, with its own repository, open/closed, and search filters. Open a PR from the list to see its detail view, and PR-based workspaces show review status and CI checks in the sidebar. See [Workspaces](/workspaces#pr-status) and the [Diff Viewer](/diff-viewer) for the review loop.

--- a/apps/docs/content/docs/workspaces.mdx
+++ b/apps/docs/content/docs/workspaces.mdx
@@ -17,7 +17,9 @@ Press **⌘N** or click "New Workspace". Create from:
 - **Existing branch** - Continue work on a branch
 - **Pull request** - Review or continue a PR
 
-In the prompt-first workspace flow, **Link pull request** lets you search by title or PR number, or paste the full PR URL to match it directly.
+In the prompt-first workspace flow, **Link pull request** lets you search by title or PR number, or paste the full PR URL to match it directly. The prompt box also keeps a searchable history of your previous prompts — click the history icon to reuse one.
+
+If you type a workspace name yourself, it's used directly as the branch name. Otherwise Superset generates a name from your prompt.
 
 Each workspace gets:
 - Own git branch
@@ -28,6 +30,8 @@ Each workspace gets:
 ## Import Worktrees
 
 If you have existing git worktrees on disk, use the **Import** tab in the New Workspace modal to bring them into Superset. Click **Import all** to bulk-import all discovered worktrees at once.
+
+You can also right-click a project in the sidebar and choose **Import untracked worktrees**. A confirmation dialog lists the branches and paths that will be imported; the **Run setup script** checkbox is off by default, since existing worktrees are usually already set up.
 
 ## Ahead/Behind Status
 
@@ -41,6 +45,15 @@ For **local (branch-based) workspaces**, the sidebar shows how far the active br
 PR-based workspaces show pull request state in the sidebar.
 
 Hover a workspace to see review status, CI checks, and GitHub links. If the branch has a deployment preview, you'll also see an **Open Preview** button.
+
+## Bulk Actions
+
+Select multiple workspaces within a project to act on them at once:
+
+- **⌘-click** toggles a workspace in and out of the selection; **Shift-click** selects a range
+- While workspaces are selected, the Projects header becomes a toolbar with **Move**, **Ungroup**, **Delete**, and **Clear**
+- **Move** puts the selection into a new or existing group; **Ungroup** removes grouped members from their group
+- Bulk delete previews every workspace and flags dirty or unpushed changes before you confirm
 
 ## Use Cases
 

--- a/apps/docs/content/docs/workspaces.mdx
+++ b/apps/docs/content/docs/workspaces.mdx
@@ -19,7 +19,7 @@ Press **⌘N** or click "New Workspace". Create from:
 
 In the prompt-first workspace flow, **Link pull request** lets you search by title or PR number, or paste the full PR URL to match it directly. The prompt box also keeps a searchable history of your previous prompts — click the history icon to reuse one.
 
-If you type a workspace name yourself, it's used directly as the branch name. Otherwise Superset generates a name from your prompt.
+If you type a workspace name yourself, the branch name is derived from it (slugified to kebab-case). Otherwise Superset generates a name from your prompt.
 
 Each workspace gets:
 - Own git branch


### PR DESCRIPTION
## Summary
- Weekly docs update covering user-facing changes from PRs merged in the last 7 days, per the Weekly Docs Update SOP. Five pages updated plus one new recipe; every UI contract (hotkeys, setting labels, menu items) verified against source, not PR descriptions.

## What changed, by driving PR
- **`recipes/agent-driven-superset.mdx`** (new) — "Drive Superset from Your Agent": fan out work with `superset:orchestrate` and schedule recurring chores with `superset:automate`, from the agent you're already talking to; links the [Skills](/skills) page for the full list. Registered in `meta.json` under Recipes (#6181)
- **`tasks.mdx`** — Tasks and Pull requests are now separate sidebar destinations with independently persisted filters; the dedicated PR view has repository/state/search filters; GitHub Issues noted as a Tasks source (#5975)
- **`workspaces.mdx`** — prompt history popover in the new-workspace flow (#6083); typed workspace name is used directly as the branch name (#6129); right-click **Import untracked worktrees** with Run-setup-script checkbox (#6097); new **Bulk Actions** section for multi-select Move/Ungroup/Delete (#6021)
- **`automations.mdx`** — new **Retry Failed Runs** section: inline per-row Retry and header Retry-all for failed last runs (#6139)
- **`keyboard-shortcuts.mdx`** — added Open Command Palette ⌘⇧K and Check Resources ⌘⇧U, verified against `apps/desktop/src/renderer/hotkeys/registry.ts` (#6037)
- **`setup-teardown-scripts.mdx`** — documented the experimental **Wait for workspace setup before starting agents** setting (#5925)

Deliberately skipped: self-documenting PRs (#6181's own skills/orchestration page updates, #6176), docs/marketing PRs, onboarding and platform changes already covered by #6175/#6180, transient v1→v2 migration UX, bug fixes restoring expected behavior, and internal/perf/polish work.

## Testing
- `bun run --cwd apps/docs typecheck` (compiles all MDX) — clean after each commit
- `bun run lint:fix` then `bun run lint` — exit 0
- Checked for stale cross-references to the old "Tasks & PRs" naming across `apps/docs` — none remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented retry and retry-all actions for failed automation runs.
  * Added keyboard shortcuts for opening the command palette and checking resources.
  * Clarified setup behavior, task and pull-request workflows, and workspace management features.
  * Documented prompt history search, automatic branch naming, worktree imports, and bulk workspace actions.
  * Added a recipe for using Superset-enabled coding agents and linked it in the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
