### PR TITLE
chore(marketing): remove SSO/SAML from roadmap

### DIFF
--- a/apps/marketing/src/app/roadmap/data.ts
+++ b/apps/marketing/src/app/roadmap/data.ts
@@ -131,14 +131,6 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		category: "Integrations",
 		status: "next",
 	},
-	{
-		id: "sso-saml",
-		title: "SSO (SAML / OIDC)",
-		description: "Single sign-on for organizations, self-serve configurable.",
-		category: "Platform",
-		status: "next",
-	},
-
 	// ── Later ────────────────────────────────────────
 	{
 		id: "project-wide-search",


### PR DESCRIPTION
## Summary
- Remove the "SSO (SAML / OIDC)" item from the public marketing roadmap (`apps/marketing/src/app/roadmap/data.ts`)

## Testing
List what you ran (CI will run the rest):
- Content-only change; reviewed diff for correctness

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "SSO (SAML / OIDC)" item from the public marketing roadmap to keep the roadmap accurate and avoid confusion. Change is limited to `apps/marketing/src/app/roadmap/data.ts`; no functionality or build behavior is affected.

<sup>Written for commit bb101a34c0c09e5b3495a5e0bdb6a01186f5beab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

