### PR TITLE
fix(host-service): stage long agent launch commands as a script to dodge MAX_CANON truncation

### DIFF
--- a/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
@@ -127,6 +127,69 @@ describe("initialCommand delivery", () => {
 		await disposeSessionAndWait(terminalId, db);
 	});
 
+	test("staging failure falls back to typing the full command", async () => {
+		const terminalId = `e2e-fallback-${randomUUID().slice(0, 8)}`;
+		const outFile = path.join(TEST_HOME, `fallback-${terminalId}`);
+		// Over the 512-byte staging threshold but under MAX_CANON, so the
+		// typed-directly fallback still delivers it intact.
+		const payload = `fb-${"y".repeat(540)}-fb`;
+		const command = `printf '%s' '${payload}' > "${outFile}"`;
+		assert.ok(Buffer.byteLength(command, "utf8") > 512);
+		assert.ok(Buffer.byteLength(command, "utf8") < 1000);
+
+		// Point tmpdir at a nonexistent directory so writeFileSync throws.
+		const origTmpdir = process.env.TMPDIR;
+		process.env.TMPDIR = path.join(TEST_HOME, "no-such-dir", "nested");
+		try {
+			const session = await createTerminalSessionInternal({
+				terminalId,
+				workspaceId,
+				db,
+				listed: true,
+				initialCommand: command,
+			});
+			assert.ok(!("error" in session), JSON.stringify(session));
+			if ("error" in session) return;
+
+			await waitFor(
+				() =>
+					fs.existsSync(outFile) &&
+					fs.readFileSync(outFile, "utf8") === payload,
+				10_000,
+			);
+		} finally {
+			process.env.TMPDIR = origTmpdir;
+			await disposeSessionAndWait(terminalId, db);
+		}
+	});
+
+	test("pre-Enter teardown unlinks the staged script", async () => {
+		const terminalId = `e2e-cleanup-${randomUUID().slice(0, 8)}`;
+		const command = `echo ${"z".repeat(600)}`;
+
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: command,
+		});
+		assert.ok(!("error" in session), JSON.stringify(session));
+		if ("error" in session) return;
+
+		const staged = () =>
+			fs
+				.readdirSync(os.tmpdir())
+				.filter((f) => f.startsWith(`superset-launch-${terminalId}`));
+
+		// The script exists in the write→delayed-Enter window…
+		await waitFor(() => staged().length === 1, 5_000);
+
+		// …and disposing the session before the Enter fires removes it.
+		await disposeSessionAndWait(terminalId, db);
+		await waitFor(() => staged().length === 0, 5_000);
+	});
+
 	test("short commands are still typed verbatim into the PTY", async () => {
 		const terminalId = `e2e-shortcmd-${randomUUID().slice(0, 8)}`;
 		const id = randomUUID().slice(0, 6);

--- a/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
@@ -1,0 +1,167 @@
+// End-to-end tests for initialCommand delivery: long commands must survive
+// the canonical-mode PTY input path. The kernel line discipline caps a
+// canonical-mode input line at MAX_CANON (1024 bytes on macOS) and silently
+// drops the rest — typing a >1KB agent launch command lost its closing quote
+// and wedged the shell at `quote>` (#5092). Long commands are now staged as a
+// self-deleting temp script and delivered via a short source line.
+//
+// Same harness as terminal.send-snapshot.node-test.ts: real pty-daemon Server
+// (in-process), real SQLite host DB, real /bin/sh.
+//
+//   node --experimental-strip-types --test <file>
+// (or Electron-as-Node / tsx loader — see terminal.send-snapshot.node-test.ts)
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { Server } from "@superset/pty-daemon";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+	snapshotSession,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-initcmd-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-initcmd-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-initcmd-e2e",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-initcmd-e2e";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting("/bin/sh");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: process.env.HOME ?? TEST_HOME,
+		SHELL: "/bin/sh",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({
+			id: workspaceId,
+			projectId,
+			worktreePath,
+			branch: "main",
+		})
+		.run();
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe("initialCommand delivery", () => {
+	test("a >2KB initialCommand executes fully (no MAX_CANON truncation)", async () => {
+		const terminalId = `e2e-longcmd-${randomUUID().slice(0, 8)}`;
+		const outFile = path.join(TEST_HOME, `long-${terminalId}`);
+		// Well past the 1024-byte canonical-mode line cap. The head/tail
+		// sentinels prove neither end of the payload was clipped.
+		const payload = `head-${"x".repeat(2400)}-tail`;
+		const command = `printf '%s' '${payload}' > "${outFile}"`;
+		assert.ok(Buffer.byteLength(command, "utf8") > 2048);
+
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: command,
+		});
+		assert.ok(!("error" in session), JSON.stringify(session));
+		if ("error" in session) return;
+
+		// The command round-trips byte-for-byte, so nothing was truncated and
+		// the shell is not stuck at a continuation prompt.
+		await waitFor(
+			() =>
+				fs.existsSync(outFile) && fs.readFileSync(outFile, "utf8") === payload,
+			10_000,
+		);
+
+		// The staged launch script removed itself when it ran.
+		const leftovers = fs
+			.readdirSync(os.tmpdir())
+			.filter((f) => f.startsWith(`superset-launch-${terminalId}`));
+		assert.deepEqual(leftovers, []);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
+	test("short commands are still typed verbatim into the PTY", async () => {
+		const terminalId = `e2e-shortcmd-${randomUUID().slice(0, 8)}`;
+		const id = randomUUID().slice(0, 6);
+		const outFile = path.join(TEST_HOME, `short-${terminalId}`);
+
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: `echo run-${id} > "${outFile}"`,
+		});
+		assert.ok(!("error" in session));
+		if ("error" in session) return;
+
+		await waitFor(() => fs.existsSync(outFile), 10_000);
+
+		// The PTY echoed the typed command itself — not a staged source line.
+		const snap = await snapshotSession({ terminalId, workspaceId, db });
+		assert.ok(!("error" in snap), JSON.stringify(snap));
+		if ("error" in snap) return;
+		assert.ok(
+			snap.text.includes(`echo run-${id}`),
+			`expected typed command echo, got: ${JSON.stringify(snap.text)}`,
+		);
+		assert.ok(!snap.text.includes("superset-launch-"));
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+});
+
+async function waitFor(predicate: () => boolean, ms: number): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > ms) throw new Error("waitFor timed out");
+		await new Promise((r) => setTimeout(r, 25));
+	}
+}

--- a/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
@@ -158,14 +158,21 @@ describe("initialCommand delivery", () => {
 				10_000,
 			);
 		} finally {
-			process.env.TMPDIR = origTmpdir;
+			if (origTmpdir === undefined) {
+				delete process.env.TMPDIR;
+			} else {
+				process.env.TMPDIR = origTmpdir;
+			}
 			await disposeSessionAndWait(terminalId, db);
 		}
 	});
 
 	test("pre-Enter teardown unlinks the staged script", async () => {
 		const terminalId = `e2e-cleanup-${randomUUID().slice(0, 8)}`;
-		const command = `echo ${"z".repeat(600)}`;
+		const sentinel = path.join(TEST_HOME, `cleanup-ran-${terminalId}`);
+		// Padded past the staging threshold; the sentinel write distinguishes
+		// "guard unlinked the script" from "script ran and self-deleted".
+		const command = `echo ran > "${sentinel}" # ${"z".repeat(600)}`;
 
 		const session = await createTerminalSessionInternal({
 			terminalId,
@@ -188,6 +195,11 @@ describe("initialCommand delivery", () => {
 		// …and disposing the session before the Enter fires removes it.
 		await disposeSessionAndWait(terminalId, db);
 		await waitFor(() => staged().length === 0, 5_000);
+
+		// Past the Enter delay, the command must never have executed — the
+		// script vanished via the teardown unlink, not via self-delete-and-run.
+		await new Promise((r) => setTimeout(r, 700));
+		assert.equal(fs.existsSync(sentinel), false);
 	});
 
 	test("short commands are still typed verbatim into the PTY", async () => {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,5 +1,8 @@
-import { existsSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { existsSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, isAbsolute, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import type { NodeWebSocket } from "@hono/node-ws";
 import { hasRunningForegroundProcess } from "@superset/pty-daemon/process-tree";
@@ -224,6 +227,18 @@ const SHELL_READY_TIMEOUT_MS = 15_000;
 const INITIAL_COMMAND_ENTER_DELAY_MS = 500;
 
 /**
+ * Byte ceiling for typing an initialCommand directly into the PTY. The
+ * shell-ready marker fires from precmd, before the line editor switches the
+ * TTY to raw mode; input written in that gap queues under the kernel's
+ * canonical-mode line discipline, which silently drops every byte past
+ * MAX_CANON (1024 on macOS). Long agent launches lost their closing quote
+ * and wedged the shell at `quote>` (#5092). Commands over this limit are
+ * staged as a temp script and only a short source line is typed; 512 leaves
+ * margin for platforms with tighter line-discipline limits.
+ */
+const MAX_TYPED_INITIAL_COMMAND_BYTES = 512;
+
+/**
  * Shell readiness lifecycle:
  * - `pending`     — shell initialising; scanner active
  * - `ready`       — OSC 133;A detected; scanner off
@@ -281,6 +296,12 @@ interface TerminalSession {
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
 	scanState: ShellReadyScanState;
 	initialCommandQueued: boolean;
+	/**
+	 * Basename of the launch shell. Picks the source keyword when a long
+	 * initialCommand is staged as a script (fish 4 removed `.`; sh/ksh
+	 * have no `source`).
+	 */
+	launchShellName: string;
 
 	/**
 	 * Side-channel UTF-8 decoder. portManager.checkOutputForHint takes a
@@ -854,6 +875,44 @@ function cancelShellReady(session: TerminalSession): void {
 	}
 }
 
+/**
+ * Stage an oversized initialCommand as a temp script and return the short
+ * source line to type instead, keeping the typed input under MAX_CANON.
+ * Sourcing (not `sh <path>`) preserves the interactive shell context, so the
+ * command behaves exactly as if typed. The script deletes itself on its first
+ * line — the shell keeps reading from the already-open fd — so cleanup never
+ * waits on a long-running agent process. Returns null when the write fails;
+ * the caller falls back to typing the full text.
+ */
+function stageInitialCommandScript(
+	session: TerminalSession,
+	commandText: string,
+): { typedLine: string; scriptPath: string } | null {
+	const safeId = session.terminalId.replace(/[^\w-]/g, "_").slice(0, 60);
+	const scriptPath = join(
+		tmpdir(),
+		`superset-launch-${safeId}-${randomBytes(4).toString("hex")}.sh`,
+	);
+	// tmpdir paths never contain quotes, so this quoting is identical in
+	// POSIX shells and fish.
+	const quotedPath = `'${scriptPath.replaceAll("'", "'\\''")}'`;
+	const sourceKeyword = session.launchShellName === "fish" ? "source" : ".";
+	try {
+		writeFileSync(
+			scriptPath,
+			`command rm -f -- ${quotedPath}\n${commandText}\n`,
+			{ mode: 0o600, flag: "wx" },
+		);
+	} catch (error) {
+		console.warn("[terminal] failed to stage long initial command; typing it", {
+			terminalId: session.terminalId,
+			error,
+		});
+		return null;
+	}
+	return { typedLine: `${sourceKeyword} ${quotedPath}`, scriptPath };
+}
+
 function queueInitialCommand(
 	session: TerminalSession,
 	initialCommand: string,
@@ -869,6 +928,21 @@ function queueInitialCommand(
 	// eventually run; only session teardown may cancel it.
 	void session.shellReadyPromise.then(() => {
 		if (session.exited || session.shellReadyState === "cancelled") return;
+		// Even after the marker, the TTY is still in canonical mode (the marker
+		// fires from precmd, before the line editor takes over), so whatever we
+		// type here rides the kernel's MAX_CANON line limit. Long commands go
+		// to disk; only a short source line is typed.
+		let typedText = commandText;
+		let scriptPath: string | null = null;
+		if (
+			Buffer.byteLength(commandText, "utf8") > MAX_TYPED_INITIAL_COMMAND_BYTES
+		) {
+			const staged = stageInitialCommandScript(session, commandText);
+			if (staged) {
+				typedText = staged.typedLine;
+				scriptPath = staged.scriptPath;
+			}
+		}
 		// The OSC 133;A marker fires from precmd, which runs BEFORE the line
 		// editor starts reading input. Plugin init in that gap (vi-mode,
 		// syntax-highlighting) can flush the PTY input queue mid-read, eating a
@@ -877,9 +951,14 @@ function queueInitialCommand(
 		// write — and as `\r`, what a real Enter key sends, bound to accept-line
 		// in every keymap — so it lands after the init storm. One Enter total,
 		// so a double-run is impossible.
-		session.pty.write(commandText);
+		session.pty.write(typedText);
 		setTimeout(() => {
-			if (session.exited || session.shellReadyState === "cancelled") return;
+			if (session.exited || session.shellReadyState === "cancelled") {
+				// Enter never sent — the staged script won't run, so it can't
+				// self-delete.
+				if (scriptPath) void rm(scriptPath, { force: true }).catch(() => {});
+				return;
+			}
 			session.pty.write("\r");
 		}, INITIAL_COMMAND_ENTER_DELAY_MS);
 	});
@@ -1424,6 +1503,7 @@ export async function createTerminalSessionInternal({
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
 		initialCommandQueued: isAdopted,
+		launchShellName: basename(shell),
 		portHintDecoder: new StringDecoder("utf8"),
 		modeTracker: createModeTracker(cols, rows),
 	};

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -898,8 +898,10 @@ void (async () => {
 				// raced another instance's sweep — skip
 			}
 		}
-	} catch {
-		// best-effort
+	} catch (error) {
+		// Non-fatal, but this sweep is the only cleanup for crash-stranded
+		// prompt-bearing scripts — surface the miss instead of hiding it.
+		console.warn("[terminal] stale launch-script sweep failed", { error });
 	}
 })();
 
@@ -954,8 +956,15 @@ function queueInitialCommand(
 	// without a verified marker resolve this promise immediately, and a missing
 	// marker resolves it via SHELL_READY_TIMEOUT_MS — the command must
 	// eventually run; only session teardown may cancel it.
+	// Dispose paths that never see onExit (daemon callbacks are unsubscribed
+	// first) leave `exited` false and a non-pending readyState untouched —
+	// only the registry reliably says the session is gone.
+	const isDefunct = () =>
+		session.exited ||
+		session.shellReadyState === "cancelled" ||
+		sessions.get(session.terminalId) !== session;
 	void session.shellReadyPromise.then(() => {
-		if (session.exited || session.shellReadyState === "cancelled") return;
+		if (isDefunct()) return;
 		// Even after the marker, the TTY is still in canonical mode (the marker
 		// fires from precmd, before the line editor takes over), so whatever we
 		// type here rides the kernel's MAX_CANON line limit. Long commands go
@@ -981,7 +990,7 @@ function queueInitialCommand(
 		// so a double-run is impossible.
 		session.pty.write(typedText);
 		setTimeout(() => {
-			if (session.exited || session.shellReadyState === "cancelled") {
+			if (isDefunct()) {
 				// Enter never sent — the staged script won't run, so it can't
 				// self-delete.
 				if (scriptPath) void rm(scriptPath, { force: true }).catch(() => {});

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, writeFileSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, isAbsolute, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
@@ -874,6 +874,34 @@ function cancelShellReady(session: TerminalSession): void {
 		session.shellReadyResolve = null;
 	}
 }
+
+/**
+ * A staged launch script normally lives well under a second (self-deletes on
+ * execution; unlinked on pre-Enter teardown), but a host-service crash inside
+ * that window skips both paths and leaves the prompt-bearing file behind.
+ * Sweep stale ones at boot — age-gated so a concurrently-running instance's
+ * just-staged script is never touched.
+ */
+const LAUNCH_SCRIPT_STALE_MS = 60 * 60 * 1000;
+void (async () => {
+	try {
+		const dir = tmpdir();
+		for (const name of await readdir(dir)) {
+			if (!name.startsWith("superset-launch-")) continue;
+			const scriptPath = join(dir, name);
+			try {
+				const { mtimeMs } = await stat(scriptPath);
+				if (Date.now() - mtimeMs > LAUNCH_SCRIPT_STALE_MS) {
+					await rm(scriptPath, { force: true });
+				}
+			} catch {
+				// raced another instance's sweep — skip
+			}
+		}
+	} catch {
+		// best-effort
+	}
+})();
 
 /**
  * Stage an oversized initialCommand as a temp script and return the short


### PR DESCRIPTION
**Links**
- Fixes #5092

## Summary
- Launching a terminal agent with a long `--prompt` (>~1KB) silently truncated the typed launch command and wedged the workspace shell at zsh's `quote>` continuation prompt — the agent never started even though the dispatch reported ok.
- `queueInitialCommand` now stages commands over 512 bytes as a self-deleting `0600` temp script and types only a short `. <path>` source line; short commands keep the existing type-directly path.

## Why / Context
`queueInitialCommand` delivers the agent launch command by typing it into the shell's PTY after the OSC 133;A shell-ready marker. That marker fires from `precmd`, **before** the line editor switches the TTY to raw mode, so the typed bytes queue under the kernel's canonical-mode line discipline — which caps an input line at MAX_CANON (1024 bytes on macOS) and silently discards the rest. A shell-quoted `'claude' '--dangerously-skip-permissions' '<long prompt>'` line loses its closing quote; when the delayed Enter lands, zsh sits at `quote>` forever.

Reproduced live via `superset workspaces create --agent claude --prompt "$(python3 -c 'print("x"*2500)')"` against v1.18.x: the typed line survived at **exactly 1024 bytes** (981 of 2500 prompt chars), shell wedged at `quote>`, no claude process.

## How It Works
- New `MAX_TYPED_INITIAL_COMMAND_BYTES = 512` threshold (conservative — other platforms/line disciplines can be tighter than 1024).
- Over-threshold commands are written to `$TMPDIR/superset-launch-<terminalId>-<rand>.sh` (mode `0600`, `wx` flag so it never clobbers) and the typed line becomes `. '<path>'` — sourcing preserves the interactive shell context so the agent process behaves exactly as if typed. Fish gets `source` (fish 4 removed `.`); every other launch shell (zsh/bash/sh/ksh) uses POSIX `.`.
- The script's first line is `command rm -f -- <path>`: the shell keeps reading from the already-open fd, so cleanup happens immediately and never waits on a long-running agent. If the session is torn down before the delayed Enter fires, the un-run script is unlinked (async `rm`, best-effort).
- If staging fails (e.g. tmpdir not writable), it falls back to typing the full text — today's behavior.
- Shell-ready wait and delayed-Enter semantics are unchanged. All `initialCommand` producers (agents, terminal-agents, setup-terminal, command-terminal, teardown) funnel through `createTerminalSessionInternal` → `queueInitialCommand`, so this one site covers them all.

## Manual QA Checklist
- [x] **Before (prod v1.18.x, unfixed):** `superset workspaces create --agent claude --prompt <2500 chars>` → terminal read shows the typed line cut at exactly 1024 bytes, shell at `quote>`, no claude process
- [x] **After (this branch, dev desktop stack):** identical `workspaces.create` call with `agents:[{agent:"claude", prompt:"x".repeat(2500)}]` → claude TUI launches with the full 2500-char prompt and responds to it; `terminal_agent_bindings` reaches `Stop`
- [x] Staged script self-deletes (no `superset-launch-*` leftovers in tmpdir after launch)
- [x] Short commands still typed verbatim (screen echo shows the command itself, not a source line)

## Testing
- New `terminal.initial-command.node-test.ts` (same real-PTY harness as `terminal.send-snapshot.node-test.ts`): queues a >2KB initialCommand into a real `/bin/sh` session and asserts the command round-trips byte-for-byte, the staged script self-deletes, and short commands are typed verbatim. **Verified it catches the regression**: fails (wedged shell, timeout) against unfixed `terminal.ts`, passes with the fix.
- `bun test` (host-service): 950 pass
- `node --test terminal.adoption.node-test.ts`: 20/20
- `bun run lint` / `bun run typecheck`: clean

## Known Limitations
- The `terminals send` / `writeInput` follow-up path is intentionally unchanged: by the time follow-ups arrive the foreground program has the TTY in raw mode, so MAX_CANON doesn't apply. Sending >1KB single-line input to a program sitting in canonical mode (bare `read`, `cat`) still truncates — same as any real terminal.
- `terminal.send-snapshot.node-test.ts`'s three tRPC-caller subtests fail under `--experimental-strip-types` on baseline too (extensionless-import loader limitation documented in that file's header) — unrelated, use the tsx loader for those.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long agent launch commands from being truncated by the TTY line discipline by staging them as a temp script and typing a short source line instead. Also fixes a cleanup leak on dispose-before-Enter and adds a boot-time sweep for stale scripts.

- **Bug Fixes**
  - Stage `initialCommand` >512 bytes to a `0600` temp script in `$TMPDIR`, then type `. '<path>'` (or `source` for fish); the script self-deletes on its first line to preserve interactive context without leaks.
  - On dispose-before-Enter or session eviction, unlink the staged script and skip sending Enter; fall back to typing the full text if staging fails; warn if the boot sweep fails; sweep `superset-launch-*` files older than 1h on start.
  - Applies to all initial command paths via `createTerminalSessionInternal` → `queueInitialCommand`.

- **Testing**
  - Real-PTY node tests cover: a >2KB command executes fully; the staged script self-deletes; short commands are typed verbatim; staging failure falls back (with proper TMPDIR restore); pre-Enter teardown unlinks the staged file with a sentinel proving it never ran.

<sup>Written for commit dc350d76ab5ce4df7e592d44dcb6545b29490c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal startup support for long initial commands.
  * Commands exceeding terminal input limits now launch reliably without truncation.
  * Added shell-aware handling for launching staged commands.
  * Temporary launch files are automatically cleaned up after execution or cancellation.
* **Bug Fixes**
  * Added a fallback to preserve command delivery when temporary staging is unavailable.
  * Improved cleanup of leftover temporary launch files during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->