### PR TITLE
chore(desktop): surface model settings for ai/autocomplete search, explain autoname auth

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/models/components/ModelsSettings/ModelsSettings.tsx
@@ -235,7 +235,10 @@ export function ModelsSettings({ visibleItems }: ModelsSettingsProps) {
 				<div className="mb-8">
 					<h2 className="text-xl font-semibold">Models</h2>
 					<p className="mt-1 text-sm text-muted-foreground">
-						Manage provider accounts, API keys, and overrides.
+						Manage provider accounts, API keys, and overrides. Connecting
+						Anthropic or OpenAI below is also what powers automatic workspace
+						naming — without one connected, new workspaces fall back to a name
+						derived from your prompt.
 					</p>
 				</div>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -934,13 +934,16 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"auth",
 			"workspace naming",
 			"auto name",
+			"ai",
+			"autocomplete",
+			"auto complete",
 		],
 	},
 	{
 		id: SETTING_ITEM_ID.MODELS_OPENAI,
 		section: "models",
 		title: "OpenAI Model Auth",
-		description: "Connect OpenAI for supported model tasks",
+		description: "Connect OpenAI for workspace naming and other model tasks",
 		keywords: [
 			"models",
 			"openai",
@@ -950,6 +953,9 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"auth",
 			"workspace naming",
 			"auto name",
+			"ai",
+			"autocomplete",
+			"auto complete",
 		],
 	},
 	{


### PR DESCRIPTION
## Summary
- Add "ai", "autocomplete", and "auto complete" as search keywords on the Anthropic and OpenAI model-auth settings entries, so typing those terms in settings search now surfaces both providers (previously "ai" only matched OpenAI via its title, and "autocomplete" matched nothing).
- Align the OpenAI entry's description with its existing keywords by mentioning workspace naming.
- Add a line to the Models settings page explaining that connecting Anthropic or OpenAI is what powers automatic workspace naming, and that without one connected, new workspaces fall back to a prompt-derived name.

## Test plan
- [x] `bun test` on `settings-search.test.ts` — 9 pass
- [x] Verified `searchSettings("ai")`, `searchSettings("autocomplete")`, `searchSettings("auto complete")` all return both Anthropic and OpenAI model-auth entries
- [x] `bun run lint` — clean
- [x] `bun run typecheck` (apps/desktop) — clean

https://claude.ai/code/session_019fzCi32yQi1WSeVPceUWop

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve settings search and clarify how automatic workspace naming works. Typing “ai” or “autocomplete” now surfaces both Anthropic and OpenAI model auth, and the Models page explains the naming requirement and fallback.

- **New Features**
  - Settings search: added keywords “ai”, “autocomplete”, and “auto complete” to Anthropic and OpenAI model-auth entries.
  - Copy: OpenAI entry now mentions workspace naming; Models settings page explains that connecting Anthropic or OpenAI enables auto-naming, otherwise names fall back to the prompt.

<sup>Written for commit 32a8392f0679f8cc78b5ad9d7b32740ef10a72a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

