### PR TITLE
feat(shared): add Opus 5 to the Superset chat model picker

### DIFF
--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -41,6 +41,7 @@ export interface SupersetChatModel extends AgentModelOption {
  * model edits here so the two never drift.
  */
 export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
+	{ id: "anthropic/claude-opus-5", label: "Opus 5", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7", provider: "Anthropic" },
 	{ id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },


### PR DESCRIPTION
## Summary
- Adds `anthropic/claude-opus-5` ("Opus 5") to `SUPERSET_CHAT_MODELS` in `packages/shared/src/agent-models.ts`, ahead of Opus 4.8/4.7, so it appears as a selectable model in Superset's chat picker.

## Test plan
- [x] `bun test packages/shared/src/agent-models.test.ts` passes (30/30)

https://claude.ai/code/session_017z3HU2pHREPMyfPatBrCfi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `anthropic/claude-opus-5` (Opus 5) to the Superset chat model picker by updating `SUPERSET_CHAT_MODELS` in `packages/shared/src/agent-models.ts`. Ordered above Opus 4.8/4.7 so it shows first among Opus models.

<sup>Written for commit b69a0289e4304c7e976867220af8451094998b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Claude Opus 5 to the available chat model options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->