### PR TITLE
feat(desktop): add flag-gated New chat opener for chat-v3 pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
@@ -10,6 +10,7 @@ import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 interface AddTabMenuProps {
 	onAddTerminal: () => void;
 	onAddChat: () => void;
+	onAddChatV3?: (() => void) | undefined;
 	onAddBrowser: () => void;
 	showPresetsBar: boolean;
 	onToggleShowPresetsBar: (enabled: boolean) => void;
@@ -18,6 +19,7 @@ interface AddTabMenuProps {
 export function AddTabMenu({
 	onAddTerminal,
 	onAddChat,
+	onAddChatV3,
 	onAddBrowser,
 	showPresetsBar,
 	onToggleShowPresetsBar,
@@ -34,6 +36,12 @@ export function AddTabMenu({
 				<span>Chat</span>
 				<HotkeyMenuShortcut hotkeyId="NEW_CHAT" />
 			</DropdownMenuItem>
+			{onAddChatV3 && (
+				<DropdownMenuItem className="gap-2" onClick={onAddChatV3}>
+					<TbMessageCirclePlus className="size-4" />
+					<span>Chat v3</span>
+				</DropdownMenuItem>
+			)}
 			<DropdownMenuItem className="gap-2" onClick={onAddBrowser}>
 				<TbWorld className="size-4" />
 				<span>Browser</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceEmptyState/WorkspaceEmptyState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceEmptyState/WorkspaceEmptyState.tsx
@@ -11,6 +11,7 @@ import { useTheme } from "renderer/stores/theme";
 interface WorkspaceEmptyStateProps {
 	onOpenBrowser: () => void;
 	onOpenChat: () => void;
+	onOpenChatV3?: (() => void) | undefined;
 	onOpenQuickOpen: () => void;
 	onOpenTerminal: () => void;
 }
@@ -26,6 +27,7 @@ interface WorkspaceEmptyStateAction {
 export function WorkspaceEmptyState({
 	onOpenBrowser,
 	onOpenChat,
+	onOpenChatV3,
 	onOpenQuickOpen,
 	onOpenTerminal,
 }: WorkspaceEmptyStateProps) {
@@ -51,6 +53,17 @@ export function WorkspaceEmptyState({
 				icon: TbMessageCirclePlus,
 				onClick: onOpenChat,
 			},
+			...(onOpenChatV3
+				? [
+						{
+							id: "chat-v3",
+							label: "Open Chat v3",
+							display: [],
+							icon: TbMessageCirclePlus,
+							onClick: onOpenChatV3,
+						},
+					]
+				: []),
 			{
 				id: "browser",
 				label: "Open Browser",
@@ -72,6 +85,7 @@ export function WorkspaceEmptyState({
 			newGroupDisplay,
 			onOpenBrowser,
 			onOpenChat,
+			onOpenChatV3,
 			onOpenQuickOpen,
 			onOpenTerminal,
 			quickOpenDisplay,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -5,6 +5,7 @@ import type { StoreApi } from "zustand/vanilla";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
+	ChatV3PaneData,
 	CommentPaneData,
 	DiffFocusSide,
 	DiffPaneData,
@@ -36,6 +37,7 @@ export function useWorkspacePaneOpeners({
 	) => void;
 	addTerminalTab: () => Promise<void>;
 	addChatTab: () => void;
+	addChatV3Tab: () => void;
 	addBrowserTab: () => void;
 	openCommentPane: (comment: CommentPaneData) => void;
 } {
@@ -145,6 +147,17 @@ export function useWorkspacePaneOpeners({
 		});
 	}, [store]);
 
+	const addChatV3Tab = useCallback(() => {
+		store.getState().addTab({
+			panes: [
+				{
+					kind: "chat-v3",
+					data: { sessionId: null } as ChatV3PaneData,
+				},
+			],
+		});
+	}, [store]);
+
 	const addBrowserTab = useCallback(() => {
 		store.getState().addTab({
 			panes: [
@@ -189,6 +202,7 @@ export function useWorkspacePaneOpeners({
 		openDiffPane,
 		addTerminalTab,
 		addChatTab,
+		addChatV3Tab,
 		addBrowserTab,
 		openCommentPane,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,6 +1,8 @@
 import { Workspace } from "@superset/panes";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { createFileRoute } from "@tanstack/react-router";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 import { useQuickOpenStore } from "renderer/commandPalette/ui/QuickOpen/quickOpenStore";
@@ -200,6 +202,7 @@ function V2WorkspaceContent() {
 		openDiffPane,
 		addTerminalTab,
 		addChatTab,
+		addChatV3Tab,
 		addBrowserTab,
 		openCommentPane,
 	} = useWorkspacePaneOpeners({
@@ -208,6 +211,7 @@ function V2WorkspaceContent() {
 		newTabPresets,
 		executePreset,
 	});
+	const isChatV3Enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3) ?? false;
 
 	const quickOpenOpen = useQuickOpenStore(
 		(s) => s.open && s.target?.workspaceId === workspaceId,
@@ -331,6 +335,7 @@ function V2WorkspaceContent() {
 								<AddTabMenu
 									onAddTerminal={addTerminalTab}
 									onAddChat={addChatTab}
+									onAddChatV3={isChatV3Enabled ? addChatV3Tab : undefined}
 									onAddBrowser={addBrowserTab}
 									showPresetsBar={showPresetsBar}
 									onToggleShowPresetsBar={setShowPresetsBar}
@@ -378,6 +383,7 @@ function V2WorkspaceContent() {
 								<WorkspaceEmptyState
 									onOpenBrowser={addBrowserTab}
 									onOpenChat={addChatTab}
+									onOpenChatV3={isChatV3Enabled ? addChatV3Tab : undefined}
 									onOpenQuickOpen={handleQuickOpen}
 									onOpenTerminal={addTerminalTab}
 								/>


### PR DESCRIPTION
Adds "Chat v3" to the tab-bar + menu and "Open Chat v3" to the workspace empty state, mirroring the existing Chat affordances exactly, gated on FEATURE_FLAGS.CHAT_V3. Makes the flagged pane openable by click instead of CDP addTab.

https://claude.ai/code/session_01XRFCEPsfmJHu2SenDKYJ2h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flag-gated Chat v3 opener so users can open a `chat-v3` pane from the Add Tab menu and the workspace empty state when FEATURE_FLAGS.CHAT_V3 is on. Mirrors the existing Chat opener and avoids relying on CDP addTab.

- **New Features**
  - Added addChatV3Tab to open a `chat-v3` pane (sessionId: null).
  - AddTabMenu shows “Chat v3” when an onAddChatV3 handler is provided.
  - WorkspaceEmptyState shows “Open Chat v3” when an onOpenChatV3 handler is provided.
  - Gated via PostHog `useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3)` in the workspace page (disabled by default).

<sup>Written for commit 90f46f2ddbf3f5a8e6217f9bbf94a68aa0355453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chat v3 as an available workspace tab.
  * Users can open Chat v3 from the workspace’s add-tab menu.
  * Empty workspaces now offer an “Open Chat v3” action.
  * Chat v3 options appear only when the feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->