### PR TITLE
feat(ui): safe triangle hover for chat history rail

### DIFF
--- a/packages/ui/src/components/ChatHistorySidebar/ChatHistorySidebar.stories.tsx
+++ b/packages/ui/src/components/ChatHistorySidebar/ChatHistorySidebar.stories.tsx
@@ -170,12 +170,5 @@ export const SidebarOnly: Story = {
 
 export const HiddenBelowFourMessages: Story = {
 	args: { messages: belowMinimum },
-	render: (args) => (
-		<div className="flex h-screen items-center bg-background pl-3">
-			<ChatHistorySidebar {...args} />
-			<p className="text-sm text-muted-foreground">
-				Rail renders nothing with fewer than 4 user messages.
-			</p>
-		</div>
-	),
+	render: (args) => <ChatDemo sidebarMessages={args.messages} />,
 };

--- a/packages/ui/src/components/ChatHistorySidebar/ChatHistorySidebar.tsx
+++ b/packages/ui/src/components/ChatHistorySidebar/ChatHistorySidebar.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
+import { type Point, useSafeTriangleHover } from "./hooks/useSafeTriangleHover";
 import "./chat-history-rail.css";
 
 export type ChatHistorySidebarMessage = {
@@ -52,6 +53,10 @@ export function ChatHistorySidebar({
 	const wrapperRef = useRef<HTMLElement>(null);
 	const listRef = useRef<HTMLDivElement>(null);
 	const [hovered, setHovered] = useState<HoveredRow | null>(null);
+	const safeTriangle = useSafeTriangleHover<HoveredRow>({
+		onOpen: setHovered,
+		onClose: () => setHovered(null),
+	});
 
 	const items = toRailItems(messages);
 	const activeItems = activeMessageIds
@@ -87,15 +92,23 @@ export function ChatHistorySidebar({
 
 	if (items.length < MIN_ITEMS) return null;
 
-	const handleRowEnter = (row: HTMLElement, item: RailItem) => {
+	const handleRowEnter = (
+		row: HTMLElement,
+		item: RailItem,
+		enterPoint?: Point,
+	) => {
 		const wrapper = wrapperRef.current;
 		if (!wrapper) return;
 		const rowRect = row.getBoundingClientRect();
 		const wrapperRect = wrapper.getBoundingClientRect();
-		setHovered({
-			item,
-			top: rowRect.top - wrapperRect.top + rowRect.height / 2,
-		});
+		safeTriangle.rowPointerEnter(
+			item.message.id,
+			{
+				item,
+				top: rowRect.top - wrapperRect.top + rowRect.height / 2,
+			},
+			enterPoint,
+		);
 	};
 
 	return (
@@ -103,10 +116,16 @@ export function ChatHistorySidebar({
 			ref={wrapperRef}
 			aria-label="User messages"
 			className={cn("chat-history-rail relative", className)}
-			onPointerLeave={() => setHovered(null)}
+			onPointerMove={(event) =>
+				safeTriangle.containerPointerMove({
+					x: event.clientX,
+					y: event.clientY,
+				})
+			}
+			onPointerLeave={() => safeTriangle.containerPointerLeave()}
 			onBlur={(event) => {
 				if (!event.currentTarget.contains(event.relatedTarget)) {
-					setHovered(null);
+					safeTriangle.forceClose();
 				}
 			}}
 		>
@@ -126,7 +145,16 @@ export function ChatHistorySidebar({
 						className="chat-history-rail-row group flex h-2.5 w-9 shrink-0 cursor-pointer items-center outline-none"
 						onClick={() => onMessageSelect?.(item.message)}
 						onPointerEnter={(event) =>
-							handleRowEnter(event.currentTarget, item)
+							handleRowEnter(event.currentTarget, item, {
+								x: event.clientX,
+								y: event.clientY,
+							})
+						}
+						onPointerLeave={(event) =>
+							safeTriangle.rowPointerLeave(item.message.id, {
+								x: event.clientX,
+								y: event.clientY,
+							})
 						}
 						onFocus={(event) => handleRowEnter(event.currentTarget, item)}
 					>
@@ -139,10 +167,12 @@ export function ChatHistorySidebar({
 			<AnimatePresence>
 				{hovered && (
 					<motion.div
-						className="pointer-events-none absolute left-full z-50 w-80 -translate-y-1/2 overflow-hidden rounded-xl bg-popover/95 p-2 text-sm leading-5 text-popover-foreground shadow-xl ring-[0.5px] ring-border backdrop-blur-sm"
+						ref={safeTriangle.setCardElement}
+						onPointerEnter={safeTriangle.cardPointerEnter}
+						className="absolute left-full z-50 w-80 -translate-y-1/2 overflow-hidden rounded-xl bg-popover/95 p-2 text-sm leading-5 text-popover-foreground shadow-xl ring-[0.5px] ring-border backdrop-blur-sm"
 						initial={{ opacity: 0, top: hovered.top }}
 						animate={{ opacity: 1, top: hovered.top }}
-						exit={{ opacity: 0 }}
+						exit={{ opacity: 0, pointerEvents: "none" }}
 						transition={{ duration: 0.15, ease: [0.23, 1, 0.32, 1] }}
 					>
 						<div className="truncate font-medium">

--- a/packages/ui/src/components/ChatHistorySidebar/hooks/useSafeTriangleHover/index.ts
+++ b/packages/ui/src/components/ChatHistorySidebar/hooks/useSafeTriangleHover/index.ts
@@ -1,0 +1,2 @@
+export type { Point } from "./useSafeTriangleHover";
+export { useSafeTriangleHover } from "./useSafeTriangleHover";

--- a/packages/ui/src/components/ChatHistorySidebar/hooks/useSafeTriangleHover/useSafeTriangleHover.ts
+++ b/packages/ui/src/components/ChatHistorySidebar/hooks/useSafeTriangleHover/useSafeTriangleHover.ts
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+// Cap how long we'll tolerate the pointer drifting inside the safe triangle
+// before giving up and closing anyway, in case it stalls mid-gap.
+const SAFE_TRIANGLE_MAX_TRACK_MS = 1000;
+// How long a row suppressed by another row's safe triangle waits before
+// opening anyway. Covers the case where the pointer settles on this row
+// instead of continuing on to the original card — without this, a
+// suppressed open that never gets re-requested (pointerenter only fires
+// once) would just never open.
+const SUPPRESSED_OPEN_DWELL_MS = 150;
+// Rows are only ~10px tall and the card sits flush against the rail, so the
+// cone from any leave point is extremely wide — nearly every vertical scrub
+// with a little rightward drift would land inside it and feel laggy. Only
+// arm the triangle when the pointer exits the open row actually moving
+// toward the card (Floating UI's safePolygon "requireIntent"): horizontal
+// exit speed past this threshold. Scrubs are dominantly vertical and stay
+// instant; dashes at the card arm suppression.
+const ARM_MIN_EXIT_SPEED_PX_PER_MS = 0.1;
+const POINTER_SAMPLE_MIN_INTERVAL_MS = 30;
+const POINTER_SAMPLE_MAX_AGE_MS = 120;
+
+export interface Point {
+	x: number;
+	y: number;
+}
+
+interface PointerSample {
+	point: Point;
+	time: number;
+}
+
+// The leave event's own coordinates are ~the newest sample, so measuring
+// against it gives a near-zero dt; prefer the sample at least half an
+// interval old, falling back to the one before it.
+function exitSpeedTowardCard(
+	leavePoint: Point,
+	current: PointerSample | null,
+	previous: PointerSample | null,
+): number {
+	const now = performance.now();
+	const sample =
+		current && now - current.time >= POINTER_SAMPLE_MIN_INTERVAL_MS / 2
+			? current
+			: (previous ?? current);
+	if (!sample) return 0;
+	const elapsed = now - sample.time;
+	if (elapsed <= 0 || elapsed > POINTER_SAMPLE_MAX_AGE_MS) return 0;
+	return (leavePoint.x - sample.point.x) / elapsed;
+}
+
+// Standard same-sign point-in-triangle test via cross-product signs.
+function triangleSign(p1: Point, p2: Point, p3: Point): number {
+	return (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y);
+}
+
+function isPointInTriangle(pt: Point, a: Point, b: Point, c: Point): boolean {
+	const d1 = triangleSign(pt, a, b);
+	const d2 = triangleSign(pt, b, c);
+	const d3 = triangleSign(pt, c, a);
+	const hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+	const hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+	return !(hasNegative && hasPositive);
+}
+
+// The card always renders flush against the rail's right edge, so the
+// triangle's base is the card's left edge — no collision flipping to read
+// off the element, unlike the dashboard sidebar's Radix popover. The base
+// is re-derived from the card's *current* rect on every call rather than a
+// rect captured once when tracking started — the card's bounds keep
+// changing after that (its entrance transition, and its height depends on
+// which row's content it shows).
+function isPointInsideCardCone(
+	point: Point,
+	apex: Point,
+	cardElement: HTMLElement | null,
+): boolean {
+	if (!cardElement) return false;
+	const cardRect = cardElement.getBoundingClientRect();
+	return isPointInTriangle(
+		point,
+		apex,
+		{ x: cardRect.left, y: cardRect.top },
+		{ x: cardRect.left, y: cardRect.bottom },
+	);
+}
+
+export interface UseSafeTriangleHoverOptions<Payload> {
+	onOpen: (payload: Payload) => void;
+	onClose: () => void;
+}
+
+export function useSafeTriangleHover<Payload>({
+	onOpen,
+	onClose,
+}: UseSafeTriangleHoverOptions<Payload>) {
+	const callbacksRef = useRef({ onOpen, onClose });
+	useEffect(() => {
+		callbacksRef.current = { onOpen, onClose };
+	}, [onOpen, onClose]);
+
+	const openIdRef = useRef<string | null>(null);
+	const cardElementRef = useRef<HTMLElement | null>(null);
+	const currentSampleRef = useRef<PointerSample | null>(null);
+	const previousSampleRef = useRef<PointerSample | null>(null);
+	const triangleCleanupRef = useRef<(() => void) | null>(null);
+	const activeTriangleRef = useRef<{ apex: Point; forId: string } | null>(null);
+	const suppressedOpenRef = useRef<{
+		id: string;
+		payload: Payload;
+		timer: ReturnType<typeof setTimeout>;
+	} | null>(null);
+
+	const stopSafeTriangleTracking = useCallback(() => {
+		triangleCleanupRef.current?.();
+		triangleCleanupRef.current = null;
+		activeTriangleRef.current = null;
+	}, []);
+	const cancelSuppressedOpen = useCallback(() => {
+		if (suppressedOpenRef.current) {
+			clearTimeout(suppressedOpenRef.current.timer);
+			suppressedOpenRef.current = null;
+		}
+	}, []);
+
+	const setCardElement = useCallback((element: HTMLElement | null) => {
+		cardElementRef.current = element;
+	}, []);
+
+	const containerPointerMove = useCallback((point: Point) => {
+		const now = performance.now();
+		const current = currentSampleRef.current;
+		if (current && now - current.time < POINTER_SAMPLE_MIN_INTERVAL_MS) return;
+		previousSampleRef.current = current;
+		currentSampleRef.current = { point, time: now };
+	}, []);
+
+	const performOpen = useCallback(
+		(id: string, payload: Payload) => {
+			stopSafeTriangleTracking();
+			openIdRef.current = id;
+			callbacksRef.current.onOpen(payload);
+		},
+		[stopSafeTriangleTracking],
+	);
+
+	const performClose = useCallback(() => {
+		stopSafeTriangleTracking();
+		cancelSuppressedOpen();
+		openIdRef.current = null;
+		callbacksRef.current.onClose();
+	}, [cancelSuppressedOpen, stopSafeTriangleTracking]);
+
+	// Called when a safe triangle is abandoned — the pointer strayed outside
+	// the cone, or the tracking deadline elapsed. If a sibling row grazed
+	// along the way is still waiting out its dwell timer, promote it directly
+	// instead of closing and reopening.
+	const abandonCone = useCallback(() => {
+		stopSafeTriangleTracking();
+		const pending = suppressedOpenRef.current;
+		if (pending) {
+			suppressedOpenRef.current = null;
+			clearTimeout(pending.timer);
+			performOpen(pending.id, pending.payload);
+			return;
+		}
+		performClose();
+	}, [performClose, performOpen, stopSafeTriangleTracking]);
+
+	const rowPointerEnter = useCallback(
+		(id: string, payload: Payload, enterPoint?: Point) => {
+			if (suppressedOpenRef.current && suppressedOpenRef.current.id !== id) {
+				cancelSuppressedOpen();
+			}
+
+			const activeTriangle = activeTriangleRef.current;
+			if (
+				activeTriangle &&
+				activeTriangle.forId !== id &&
+				enterPoint &&
+				isPointInsideCardCone(
+					enterPoint,
+					activeTriangle.apex,
+					cardElementRef.current,
+				)
+			) {
+				// Pointer is cutting through this row on a path aimed at the
+				// still-open card — don't switch hover yet, but don't drop the
+				// request either: if the pointer settles here instead of
+				// reaching the card, open it after a short dwell.
+				if (!suppressedOpenRef.current) {
+					const timer = setTimeout(() => {
+						suppressedOpenRef.current = null;
+						performOpen(id, payload);
+					}, SUPPRESSED_OPEN_DWELL_MS);
+					suppressedOpenRef.current = { id, payload, timer };
+				}
+				return;
+			}
+
+			cancelSuppressedOpen();
+			performOpen(id, payload);
+		},
+		[cancelSuppressedOpen, performOpen],
+	);
+
+	// Safe triangle: apex at the point the pointer left the open row, base at
+	// the card's left edge. While the pointer stays inside it, that's a path
+	// aimed at the card — hold off closing or switching rows.
+	const rowPointerLeave = useCallback(
+		(id: string, leavePoint: Point) => {
+			if (openIdRef.current !== id) return;
+			if (
+				exitSpeedTowardCard(
+					leavePoint,
+					currentSampleRef.current,
+					previousSampleRef.current,
+				) < ARM_MIN_EXIT_SPEED_PX_PER_MS
+			) {
+				return;
+			}
+			stopSafeTriangleTracking();
+			activeTriangleRef.current = { apex: leavePoint, forId: id };
+			const handlePointerMove = (event: MouseEvent) => {
+				const point = { x: event.clientX, y: event.clientY };
+				if (isPointInsideCardCone(point, leavePoint, cardElementRef.current)) {
+					return;
+				}
+				abandonCone();
+			};
+			document.addEventListener("mousemove", handlePointerMove);
+			// Backstop: if the pointer stops moving entirely (or events just
+			// don't arrive) while still "inside" the cone, don't stay open
+			// forever.
+			const deadlineTimer = setTimeout(abandonCone, SAFE_TRIANGLE_MAX_TRACK_MS);
+			triangleCleanupRef.current = () => {
+				document.removeEventListener("mousemove", handlePointerMove);
+				clearTimeout(deadlineTimer);
+			};
+		},
+		[abandonCone, stopSafeTriangleTracking],
+	);
+
+	const cardPointerEnter = useCallback(() => {
+		stopSafeTriangleTracking();
+		// Pointer reached the real target card — any row it grazed on the way
+		// was just being cut through, not settled on.
+		cancelSuppressedOpen();
+	}, [cancelSuppressedOpen, stopSafeTriangleTracking]);
+
+	const containerPointerLeave = useCallback(() => {
+		if (activeTriangleRef.current) return;
+		performClose();
+	}, [performClose]);
+
+	useEffect(
+		() => () => {
+			stopSafeTriangleTracking();
+			cancelSuppressedOpen();
+		},
+		[cancelSuppressedOpen, stopSafeTriangleTracking],
+	);
+
+	return {
+		setCardElement,
+		rowPointerEnter,
+		rowPointerLeave,
+		cardPointerEnter,
+		containerPointerMove,
+		containerPointerLeave,
+		forceClose: performClose,
+	};
+}


### PR DESCRIPTION
## Summary
- Port the safe-triangle math from the dashboard sidebar hover cards into `ChatHistorySidebar`: cutting diagonally toward the open preview card no longer flickers the card through every marker crossed on the way.
- The preview card is now hoverable (was `pointer-events-none`) — you can reach it and select its text; it drops back to non-interactive during the exit fade so the ghost doesn't intercept clicks.
- Cleaned up the `HiddenBelowFourMessages` story to render the same chat frame as the other stories instead of an ad-hoc caption layout that jumped when switching stories.

## Why / Context
The chat history rail swapped its hover card instantly on every row enter, so moving toward the card to read it flickered through sibling previews, and the card could never be reached at all. The dashboard sidebar solved the same interaction with safe-triangle tracking; this ports that logic.

## How It Works
New co-located hook `useSafeTriangleHover` (duplicated from `DashboardSidebarHoverProvider`, not shared, per our port convention):
- On leaving the open row, a triangle is armed with its apex at the leave point and base at the card's left edge (re-read from the live rect each check — the card animates in and its height varies per row). Rows entered inside the cone are suppressed instead of switching the card; settling on one for 150ms switches to it; a 1s deadline backstops a stalled pointer.
- **Geometry differs from the desktop version in one deliberate way:** rail rows are ~10px tall and the card sits flush against the rail, so the cone from any leave point is extremely wide — vertical scrubbing with slight rightward drift would constantly get suppressed and feel laggy. The triangle therefore only arms on exit intent (Floating UI `safePolygon` `requireIntent` idea): horizontal exit velocity toward the card ≥ 0.1 px/ms, sampled from nav-level pointer moves every ~30ms. Scrubbing is dominantly vertical and never arms it.
- No collision-flip handling: unlike the desktop's Radix popover, the card always renders on the rail's right.
- Kept the rail's instant open/close feel — did not port the desktop's 400ms open / 100ms close delays; the rail is a scrub affordance and suppression alone kills the flicker.

## Manual QA Checklist
Validated in Storybook (`Default`, `ManyMessages`, `SidebarOnly`, `HiddenBelowFourMessages`):
- [x] Diagonal move from a marker toward the card no longer flickers through sibling previews
- [x] Vertical scrubbing along the rail still switches previews instantly (intent gate not armed)
- [x] Pausing on a crossed marker for ~150ms switches the card to it
- [x] Pointer can reach the card; it stays open and text is selectable; leaving it closes
- [x] Keyboard focus (Tab) still opens previews; blur out of the rail closes
- [x] `HiddenBelowFourMessages` shows the normal chat frame with an empty rail column — no layout jump vs other stories

## Testing
- `bun run typecheck` (packages/ui)
- `bun run lint`
- Manual Storybook testing as above; no automated tests added

## Known Limitations
- The 0.1 px/ms intent threshold is a feel constant (`ARM_MIN_EXIT_SPEED_PX_PER_MS`); trivially tunable if trackpad testing suggests otherwise.
- Whether the app shifts layout when a chat crosses the 4-user-message threshold is up to the consumer — the stories reserve the rail column with a fixed-width wrapper, which is the pattern integrations should copy.

https://claude.ai/code/session_01PRRCuyxwMhdsWKvZr2omM4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added safe-triangle hover to `ChatHistorySidebar` to stop flicker when moving toward the preview card, and made the card hoverable/selectable. Keeps fast scrubbing while suppressing accidental switches.

- **New Features**
  - Integrated `useSafeTriangleHover`: suppresses crossed rows when heading to the card; settles after ~150ms dwell; includes a 1s backstop.
  - Preview card is interactive; it disables pointer events during the exit fade to prevent ghost clicks.
  - Arms only on exit intent (horizontal speed ≥ 0.1 px/ms), so vertical scrubbing stays instant.

- **Refactors**
  - Updated `HiddenBelowFourMessages` story to use `ChatDemo` for consistent layout with other stories.

<sup>Written for commit c5e68f5b6544971da571ef60b8f10139789eca04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history sidebar hover behavior when moving between conversation rows and preview cards.
  * Prevented the preview card from closing prematurely during pointer movement.
  * Added smoother row transitions with brief hover stabilization to reduce accidental changes.

* **Tests**
  * Updated the sidebar demonstration story to reflect the streamlined interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->