### PR TITLE
fix(marketing): stop click from closing hover-opened nav dropdowns

### DIFF
--- a/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
+++ b/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
@@ -11,6 +11,7 @@ import {
 } from "@superset/ui/navigation-menu";
 import { cn } from "@superset/ui/utils";
 import Link from "next/link";
+import { useState } from "react";
 import {
 	type NavLink,
 	PRODUCT_LINKS,
@@ -24,11 +25,26 @@ const triggerClass = cn(
 );
 
 export function DesktopNav() {
+	// Radix's NavigationMenu is uncontrolled by default, so a hover-opened
+	// trigger and a click on that same trigger both race to set its shared
+	// internal `value` — a click toggles, so clicking a menu that hover just
+	// opened immediately closes it again. Controlling `value` ourselves lets
+	// us make click idempotent (open-only) instead of toggling, so it can
+	// never fight with the hover-intent timers.
+	const [openMenu, setOpenMenu] = useState("");
+
+	const ignoreCloseClick = (menu: string) => (event: React.MouseEvent) => {
+		if (openMenu === menu) event.preventDefault();
+	};
+
 	return (
-		<NavigationMenu>
+		<NavigationMenu value={openMenu} onValueChange={setOpenMenu}>
 			<NavigationMenuList>
-				<NavigationMenuItem>
-					<NavigationMenuTrigger className={triggerClass}>
+				<NavigationMenuItem value="product">
+					<NavigationMenuTrigger
+						className={triggerClass}
+						onClick={ignoreCloseClick("product")}
+					>
 						Product
 					</NavigationMenuTrigger>
 					<NavigationMenuContent>
@@ -40,8 +56,11 @@ export function DesktopNav() {
 					</NavigationMenuContent>
 				</NavigationMenuItem>
 
-				<NavigationMenuItem>
-					<NavigationMenuTrigger className={triggerClass}>
+				<NavigationMenuItem value="resources">
+					<NavigationMenuTrigger
+						className={triggerClass}
+						onClick={ignoreCloseClick("resources")}
+					>
 						Resources
 					</NavigationMenuTrigger>
 					<NavigationMenuContent>


### PR DESCRIPTION
## Summary
- Fix a race in the marketing top nav where clicking "Resources" (or "Product") right after it opened via hover would immediately close it again, producing a flicker/flash.

## Why / Context
`DesktopNav.tsx` used an uncontrolled Radix `NavigationMenu`. Hovering a trigger schedules an async ~200ms open via Radix's internal timers, while a click on the same trigger calls Radix's `onItemSelect`, which **toggles** the shared `value` synchronously. Since "Resources"/"Product" have no destination link — they're pure dropdown triggers — a click there doesn't select anything; it just toggles the panel. In the common case where a user's mouse arrives on the trigger (opening it via hover) and then clicks, the click closed the panel that hover had just opened, producing the reported "buggy"/racy feel and the flashing (rapid mount/unmount of the dropdown content replaying its animation).

## How It Works
Made `NavigationMenu` controlled (`value`/`onValueChange`) and gave each dropdown trigger a custom `onClick` that calls `event.preventDefault()` only when that menu is already open — this suppresses Radix's internal toggle-to-close in that one case, without touching any other behavior (opening via click when closed, closing via mouse-leave, switching between triggers, keyboard/Escape).

## Manual QA Checklist
Verified via CDP against the local dev server, reproducing the exact hover → click sequence:
- [x] Before fix: hover opens "Resources" (`data-state: open`), then a click at the same position closes it (`data-state: closed`) — bug reproduced
- [x] After fix: same hover → click sequence stays `open` throughout
- [x] No regression: moving the mouse away from an open dropdown still closes it
- [x] No regression: hovering "Product" while "Resources" is open still switches correctly (Resources closes, Product opens)

## Testing
- `bun run typecheck` (`@superset/marketing`)
- `bun run lint:fix` (clean, no changes needed)
- Manual: CDP-driven browser verification described above (see Manual QA Checklist)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hover→click race in the marketing desktop nav where clicking "Product" or "Resources" right after hover-open would close it and flicker. Dropdowns now stay open on click without changing other interactions.

- **Bug Fixes**
  - Made `NavigationMenu` in `DesktopNav.tsx` controlled via `value`/`onValueChange` (from `@superset/ui/navigation-menu`).
  - Added trigger `onClick` that calls `event.preventDefault()` only when its menu is already open to stop the toggle-to-close.

<sup>Written for commit 5e5cd7a9a0a650489c7bb7fe192291e11641144f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop navigation menu behavior when interacting with product and resources menus.
  * Prevented menus from unexpectedly closing when clicking an already-open item.
  * Better coordinated menu behavior across hover and click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->