### PR TITLE
fix(desktop): tolerate file/directory path collisions in changes tree

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -42,6 +42,7 @@ import { FileRowContextMenuItems } from "./components/FileRowContextMenuItems";
 import { FolderContextMenuItems } from "./components/FolderContextMenuItems";
 import { ShadowRowHoverActions } from "./components/ShadowRowHoverActions";
 import { useMeasuredTreeHeight } from "./hooks/useMeasuredTreeHeight";
+import { buildCollisionSafeTreePaths } from "./utils/buildCollisionSafeTreePaths";
 import { buildTreeShape } from "./utils/buildTreeShape";
 
 const ITEM_HEIGHT = 24;
@@ -104,16 +105,29 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	onOpenFile,
 	onOpenInEditor,
 }: ChangesTreeViewProps) {
-	const paths = useMemo(() => files.map((f) => f.path), [files]);
-	const fileByPath = useMemo(() => {
+	// A changeset can contain a path that is both a file and a directory of
+	// other entries (e.g. same-named file deleted + directory added). Pierre
+	// throws on that shape, so colliding file entries get disambiguated tree
+	// paths; map back through `toRealPath` before treating one as a file path.
+	const { treePaths, toTreePath, toRealPath } = useMemo(
+		() => buildCollisionSafeTreePaths(files.map((f) => f.path)),
+		[files],
+	);
+	const fileByTreePath = useMemo(() => {
 		const map = new Map<string, ChangesetFile>();
-		for (const file of files) map.set(file.path, file);
+		for (const file of files)
+			map.set(toTreePath.get(file.path) ?? file.path, file);
 		return map;
-	}, [files]);
+	}, [files, toTreePath]);
 
-	const { dirs, dirFileCount } = useMemo(() => buildTreeShape(paths), [paths]);
+	const { dirs, dirFileCount } = useMemo(
+		() => buildTreeShape(treePaths),
+		[treePaths],
+	);
 
-	const initialGitStatusEntriesRef = useRef(buildPierreGitStatus(files));
+	const initialGitStatusEntriesRef = useRef(
+		buildPierreGitStatus(files, toTreePath),
+	);
 
 	// Callbacks routed through a ref so Pierre's stable handler closures
 	// (resolved once at `useFileTree` time) always see the latest props.
@@ -127,7 +141,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	});
 
 	const { model } = usePierreFileTree({
-		paths,
+		paths: treePaths,
 		initialExpansion: "open",
 		search: false,
 		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
@@ -146,12 +160,12 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 
 	// Keep Pierre's path set in sync as files churn (stage/unstage, new edits).
 	useEffect(() => {
-		model.resetPaths(paths);
-	}, [model, paths]);
+		model.resetPaths(treePaths);
+	}, [model, treePaths]);
 
 	useEffect(() => {
-		model.setGitStatus(buildPierreGitStatus(files));
-	}, [model, files]);
+		model.setGitStatus(buildPierreGitStatus(files, toTreePath));
+	}, [model, files, toTreePath]);
 
 	useFallthroughIcons(model);
 
@@ -162,7 +176,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	const treeHeight =
 		contentHeight != null
 			? contentHeight + HEIGHT_CUSHION
-			: (dirs.length + paths.length) * ROW_BOX + HEIGHT_CUSHION;
+			: (dirs.length + treePaths.length) * ROW_BOX + HEIGHT_CUSHION;
 
 	const setAllDirsExpanded = useCallback(
 		(expanded: boolean) => {
@@ -197,19 +211,22 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 			? toRelativeWorkspacePath(worktreePath, selectedFilePath)
 			: selectedFilePath;
 	useEffect(() => {
-		if (!selectedRelPath || !fileByPath.has(selectedRelPath)) return;
+		if (!selectedRelPath) return;
+		const selectedTreePath = toTreePath.get(selectedRelPath) ?? selectedRelPath;
+		if (!fileByTreePath.has(selectedTreePath)) return;
 		if (lastUserSelectRef.current === selectedRelPath) {
 			lastUserSelectRef.current = null;
 			return;
 		}
-		model.focusPath(selectedRelPath);
-	}, [model, selectedRelPath, fileByPath]);
+		model.focusPath(selectedTreePath);
+	}, [model, selectedRelPath, fileByTreePath, toTreePath]);
 
 	handlersRef.current.onSelect = (treePath) => {
-		lastUserSelectRef.current = treePath;
-		const file = fileByPath.get(treePath);
+		const realPath = toRealPath.get(treePath) ?? treePath;
+		lastUserSelectRef.current = realPath;
+		const file = fileByTreePath.get(treePath);
 		onSelectFile?.(
-			treePath,
+			realPath,
 			false,
 			file ? getChangesetFileKey(file) : undefined,
 		);
@@ -223,7 +240,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 			const count = dirFileCount.get(stripTrailingSlash(ctx.item.path));
 			return count ? { text: String(count) } : null;
 		}
-		const file = fileByPath.get(ctx.item.path);
+		const file = fileByTreePath.get(ctx.item.path);
 		if (!file) return null;
 		const text = formatDiffStats(file.additions, file.deletions);
 		return text ? { text } : null;
@@ -234,19 +251,25 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		{
 			getFileIntent: filePolicy.getIntent,
 			onSelectDiff: (rel, openInNewTab) => {
-				lastUserSelectRef.current = rel;
-				const file = fileByPath.get(rel);
+				const realPath = toRealPath.get(rel) ?? rel;
+				lastUserSelectRef.current = realPath;
+				const file = fileByTreePath.get(rel);
 				onSelectFile?.(
-					rel,
+					realPath,
 					openInNewTab,
 					file ? getChangesetFileKey(file) : undefined,
 				);
 			},
 			onOpenFile: (rel, openInNewTab) => {
 				if (!worktreePath) return;
-				onOpenFile?.(toAbsoluteWorkspacePath(worktreePath, rel), openInNewTab);
+				const realPath = toRealPath.get(rel) ?? rel;
+				onOpenFile?.(
+					toAbsoluteWorkspacePath(worktreePath, realPath),
+					openInNewTab,
+				);
 			},
-			openInExternalEditor: (rel) => onOpenInEditor?.(rel),
+			openInExternalEditor: (rel) =>
+				onOpenInEditor?.(toRealPath.get(rel) ?? rel),
 		},
 	);
 
@@ -291,7 +314,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 					/>
 				);
 			}
-			const file = fileByPath.get(item.path);
+			const file = fileByTreePath.get(item.path);
 			return file ? fileMenuItems(file) : null;
 		})();
 		if (!menuItems) return null;
@@ -308,7 +331,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 
 	const renderHoverInlineActions = (treePath: string) => {
 		if (sectionKind !== "unstaged") return null;
-		const file = fileByPath.get(treePath);
+		const file = fileByTreePath.get(treePath);
 		if (!file) return null;
 		return (
 			<Tooltip>
@@ -331,7 +354,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	};
 
 	const renderHoverMenuContent = (treePath: string) => {
-		const file = fileByPath.get(treePath);
+		const file = fileByTreePath.get(treePath);
 		return file ? fileMenuItems(file) : null;
 	};
 
@@ -385,9 +408,12 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	);
 });
 
-function buildPierreGitStatus(files: ChangesetFile[]): PierreGitStatusEntry[] {
+function buildPierreGitStatus(
+	files: ChangesetFile[],
+	toTreePath: Map<string, string>,
+): PierreGitStatusEntry[] {
 	return files.map((file) => ({
-		path: file.path,
+		path: toTreePath.get(file.path) ?? file.path,
 		status: FILE_STATUS_TO_PIERRE[file.status],
 	}));
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/buildCollisionSafeTreePaths.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/buildCollisionSafeTreePaths.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { buildCollisionSafeTreePaths } from "./buildCollisionSafeTreePaths";
+
+const ZWSP = "\u200b";
+
+/** The invariant Pierre needs: no tree path is also a directory prefix of another. */
+function expectNoCollisions(treePaths: string[]) {
+	const dirPrefixes = new Set<string>();
+	for (const path of treePaths) {
+		let slash = path.indexOf("/");
+		while (slash !== -1) {
+			dirPrefixes.add(path.slice(0, slash));
+			slash = path.indexOf("/", slash + 1);
+		}
+	}
+	for (const path of treePaths) {
+		expect(dirPrefixes.has(path)).toBe(false);
+	}
+}
+
+describe("buildCollisionSafeTreePaths", () => {
+	it("passes collision-free paths through untouched", () => {
+		const paths = ["a/b.ts", "a/c.ts", "d.ts"];
+		const result = buildCollisionSafeTreePaths(paths);
+		expect(result.treePaths).toEqual(paths);
+		expect(result.toTreePath.size).toBe(0);
+		expect(result.toRealPath.size).toBe(0);
+	});
+
+	it("disambiguates a file that is also a directory (file listed first)", () => {
+		const result = buildCollisionSafeTreePaths([
+			"skills",
+			"skills/pdf/SKILL.md",
+		]);
+		expect(result.treePaths).toEqual([`skills${ZWSP}`, "skills/pdf/SKILL.md"]);
+		expect(result.toTreePath.get("skills")).toBe(`skills${ZWSP}`);
+		expect(result.toRealPath.get(`skills${ZWSP}`)).toBe("skills");
+		expectNoCollisions(result.treePaths);
+	});
+
+	it("disambiguates a file that is also a directory (directory listed first)", () => {
+		const result = buildCollisionSafeTreePaths([
+			"skills/pdf/SKILL.md",
+			"skills",
+		]);
+		expect(result.treePaths).toEqual(["skills/pdf/SKILL.md", `skills${ZWSP}`]);
+		expect(result.toTreePath.get("skills")).toBe(`skills${ZWSP}`);
+		expect(result.toRealPath.get(`skills${ZWSP}`)).toBe("skills");
+		expectNoCollisions(result.treePaths);
+	});
+
+	it("handles nested collisions at multiple depths", () => {
+		const result = buildCollisionSafeTreePaths(["a", "a/b", "a/b/c.ts"]);
+		expect(result.treePaths).toEqual([`a${ZWSP}`, `a/b${ZWSP}`, "a/b/c.ts"]);
+		expect(result.toRealPath.get(`a${ZWSP}`)).toBe("a");
+		expect(result.toRealPath.get(`a/b${ZWSP}`)).toBe("a/b");
+		expectNoCollisions(result.treePaths);
+	});
+
+	it("keeps every input path represented exactly once", () => {
+		const paths = ["skills", "skills/pdf/SKILL.md", "skills/web/SKILL.md"];
+		const { treePaths, toRealPath } = buildCollisionSafeTreePaths(paths);
+		expect(treePaths).toHaveLength(paths.length);
+		const realPaths = treePaths.map((p) => toRealPath.get(p) ?? p);
+		expect(realPaths).toEqual(paths);
+	});
+
+	it("stays unique when a marker-suffixed path already exists", () => {
+		const result = buildCollisionSafeTreePaths([
+			"skills",
+			`skills${ZWSP}`,
+			"skills/pdf/SKILL.md",
+		]);
+		expect(new Set(result.treePaths).size).toBe(3);
+		expect(result.toTreePath.get("skills")).toBe(`skills${ZWSP}${ZWSP}`);
+		expectNoCollisions(result.treePaths);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/buildCollisionSafeTreePaths.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/buildCollisionSafeTreePaths.ts
@@ -1,0 +1,48 @@
+// A changeset can legitimately contain a path that is both a file entry and a
+// parent directory of other entries (e.g. a file deleted and a same-named
+// directory added in the same change set). `@pierre/trees` keys children by
+// exact segment name and throws on that shape, so colliding file entries get
+// a zero-width-space suffix: visually identical, but a distinct tree path.
+const COLLISION_MARKER = "\u200b";
+
+export interface CollisionSafeTreePaths {
+	/** Paths safe to hand to `@pierre/trees`; same order as the input. */
+	treePaths: string[];
+	/** Real changeset path → tree path. Only remapped entries are present. */
+	toTreePath: Map<string, string>;
+	/** Tree path → real changeset path. Only remapped entries are present. */
+	toRealPath: Map<string, string>;
+}
+
+/**
+ * Disambiguate file paths that collide with directories implied by other
+ * paths in the list. Tree paths returned here are display/tree identifiers
+ * only — map them back through `toRealPath` before treating them as
+ * changeset paths.
+ */
+export function buildCollisionSafeTreePaths(
+	paths: string[],
+): CollisionSafeTreePaths {
+	const dirPrefixes = new Set<string>();
+	for (const path of paths) {
+		let slash = path.indexOf("/");
+		while (slash !== -1) {
+			dirPrefixes.add(path.slice(0, slash));
+			slash = path.indexOf("/", slash + 1);
+		}
+	}
+	const toTreePath = new Map<string, string>();
+	const toRealPath = new Map<string, string>();
+	const taken = new Set(paths);
+	const treePaths = paths.map((path) => {
+		if (!dirPrefixes.has(path)) return path;
+		let treePath = path + COLLISION_MARKER;
+		while (taken.has(treePath) || dirPrefixes.has(treePath))
+			treePath += COLLISION_MARKER;
+		taken.add(treePath);
+		toTreePath.set(path, treePath);
+		toRealPath.set(treePath, path);
+		return treePath;
+	});
+	return { treePaths, toTreePath, toRealPath };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/utils/buildCollisionSafeTreePaths/index.ts
@@ -1,0 +1,4 @@
+export {
+	buildCollisionSafeTreePaths,
+	type CollisionSafeTreePaths,
+} from "./buildCollisionSafeTreePaths";


### PR DESCRIPTION
## Problem

Rendering a changes section in the workspace sidebar's Changes tab crashes when the section's changed-path list contains a path that is simultaneously a file entry and a parent directory of other entries (e.g. a file deleted and a same-named directory added in the same change set, or a symlink/submodule swap). `@pierre/trees` keys children by exact segment name and throws `Path collides with an existing file while creating directory`, and the section re-renders into the same crash repeatedly — the Changes tab is effectively broken for as long as the changeset exists. 3 events on release 1.15.1.

## Root cause

`ChangesTreeView` handed the raw `files.map((f) => f.path)` list straight to Pierre at both the initial `usePierreFileTree({ paths })` call and the `model.resetPaths(paths)` sync. A git changeset can legitimately contain the file+directory shape, so the renderer must tolerate it.

## Fix

New co-located helper `buildCollisionSafeTreePaths` disambiguates any file path that is also a directory prefix of another path by appending a zero-width-space suffix to its tree path — visually identical, but a distinct segment for Pierre — and returns bidirectional `toTreePath`/`toRealPath` maps. Verified against the real Pierre builder that the raw list throws in both orderings (file-first and directory-first) and the disambiguated list builds cleanly in both.

`ChangesTreeView` now feeds the collision-safe list to `usePierreFileTree`, `model.resetPaths`, `buildTreeShape`, and `setGitStatus`, keys its file lookup by tree path, and maps tree paths back to real changeset paths before they leave the component (diff selection, open file, external editor, selection echo). Every changed file stays visible and actionable; no entry is dropped.

## Verification

`bunx biome check <changed files>`:
```
Checked 4 files in 6ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`: passes (tsc --noEmit, exit 0).

`bun test .../buildCollisionSafeTreePaths.test.ts`:
```
 6 pass
 0 fail
 26 expect() calls
Ran 6 tests across 1 file. [65.00ms]
```

Mutation check: reverting the helper to pass-through makes 4 of the 6 tests fail, so the tests catch the regression.

Direct check against `@pierre/trees` `PathStoreBuilder`:
```
file-first raw -> throws: Path collides with an existing file while creating directory "skills"
file-first safe -> ok
dir-first raw -> throws: Path collides with an existing file while creating directory "skills"
dir-first safe -> ok
```

Refs DESKTOP-HJ

https://claude.ai/code/session_258293a5-982b-4459-b3f5-11d12493402b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Changes tab when a path is both a file and a directory prefix (e.g., a deleted file and a same-named added directory). We disambiguate file entries for `@pierre/trees` with a zero‑width‑space suffix and map back to real paths for all user actions.

- **Bug Fixes**
  - Added `buildCollisionSafeTreePaths` to produce safe tree paths with bidirectional maps.
  - Used safe paths in `usePierreFileTree`, `model.resetPaths`, `buildTreeShape`, and git status; mapped back for selection, diff, open, and external editor.
  - Prevents crashes; all changed files remain visible and actionable.
  - Tests cover file-first/dir-first and nested collisions, including pre-existing ZWSP cases. Aligns with DESKTOP-HJ.

<sup>Written for commit 82dd14786d5d65fa66f633ce17cd5f4feb0926f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

