### PR TITLE
fix(desktop): drop the hover remove button on the local main sidebar row

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -113,6 +113,10 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 
 		const creationStatusText = isPending ? "Creating…" : null;
 		const isMainWorkspace = workspace.type === "main";
+		// No hover action button on the local main workspace: a stray click on the
+		// minus would remove the project's anchor row. Removal stays available via
+		// the context menu.
+		const isLocalMainWorkspace = isMainWorkspace && hostType === "local-device";
 		const workspaceKindTitle = isMainWorkspace
 			? "Main workspace"
 			: "Worktree workspace";
@@ -317,7 +321,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 											{shortcutLabel}
 										</span>
 									)}
-									{isMainWorkspace ? (
+									{isLocalMainWorkspace ? null : isMainWorkspace ? (
 										<Tooltip delayDuration={300}>
 											<TooltipTrigger asChild>
 												<button


### PR DESCRIPTION
## Summary
- The local main workspace row in the v2 sidebar no longer shows the hover minus ("Remove from sidebar") button — a stray click on it removed the project's anchor row and reset the workspace's pane layout.
- Deliberate removal is untouched: the row context menu's "Remove from Sidebar", the command palette command, and the Workspaces-page unpin all still work. Remote mains keep the minus button; worktree rows keep their close (X) button.

## Manual QA
Verified over CDP against the real dev app (before/after): with the change stashed, the local main row rendered the minus button and a click removed the row; with the change applied, the local main row renders no hover action button while the worktree row's close button and the context-menu removal path still work end-to-end.

## Testing
- `bun run typecheck` (desktop, exit 0)
- `bun run lint` (exit 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace sidebar actions to show only the options applicable to each workspace type.
  * Local main workspaces no longer display remove or close actions.
  * Other main workspaces retain the remove option, while non-main workspaces retain the close option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->