### PR TITLE
fix(host-service): reap worker child processes on task timeout/abort instead of leaking zombies

### DIFF
--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -58,6 +58,7 @@
 		"test": "bun test --pass-with-no-tests",
 		"test:integration": "bun test --pass-with-no-tests test/integration",
 		"test:integration:daemon": "node --experimental-strip-types --test src/terminal/DaemonClient/DaemonClient.node-test.ts src/daemon/DaemonSupervisor.node-test.ts",
+		"test:integration:workers": "node --experimental-strip-types --test src/workers/worker-termination.node-test.ts",
 		"test:e2e": "bun run scripts/test-e2e.ts",
 		"bench": "bun test test/integration/pull-requests-scaling.bench.ts",
 		"profile:git-status": "bun run scripts/git-status-large-repo-profile.ts",

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
 import type {
 	SerializedWorkerError,
+	WorkerShutdownRequestMessage,
 	WorkerTaskRequestMessage,
 	WorkerTaskResponseMessage,
 } from "./worker-task-protocol.ts";
@@ -52,6 +53,9 @@ interface WorkerTaskRunnerOptions {
 	idleTimeoutMs?: number;
 	/** Extra execArgv for spawned workers (tests pass strip-types flags). */
 	execArgv?: string[];
+	/** How long a worker gets to honor a cooperative shutdown (kill + reap
+	 * its child processes) before it is hard-terminated. */
+	shutdownGraceMs?: number;
 }
 
 interface WorkerSlot {
@@ -60,6 +64,7 @@ interface WorkerSlot {
 	activeTaskId: string | null;
 	terminating: boolean;
 	idleTimer?: NodeJS.Timeout;
+	graceTimer?: NodeJS.Timeout;
 }
 
 interface QueuedTask {
@@ -80,6 +85,8 @@ interface QueuedTask {
 
 export const DEFAULT_TIMEOUT_MS = 60_000;
 
+export const DEFAULT_SHUTDOWN_GRACE_MS = 5_000;
+
 export class WorkerTaskRunner {
 	private readonly workerScriptPath: string;
 	private readonly concurrency: number;
@@ -87,6 +94,7 @@ export class WorkerTaskRunner {
 	private readonly debug: boolean;
 	private readonly idleTimeoutMs?: number;
 	private readonly execArgv?: string[];
+	private readonly shutdownGraceMs: number;
 	private readonly workerSlots = new Map<number, WorkerSlot>();
 	private readonly queue: string[] = [];
 	private readonly tasks = new Map<string, QueuedTask>();
@@ -102,6 +110,7 @@ export class WorkerTaskRunner {
 		this.debug = options.debug ?? false;
 		this.idleTimeoutMs = options.idleTimeoutMs;
 		this.execArgv = options.execArgv;
+		this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
 	}
 
 	/** Live (non-terminating) worker count — exposed for idle-reap tests. */
@@ -210,17 +219,24 @@ export class WorkerTaskRunner {
 		}
 		this.queue.length = 0;
 
+		const exits: Promise<void>[] = [];
 		for (const slot of this.workerSlots.values()) {
-			slot.terminating = true;
-			this.clearIdleTimer(slot);
 			if (slot.activeTaskId) {
 				this.rejectTask(
 					slot.activeTaskId,
 					new WorkerTaskAbortedError("Worker runner disposed"),
 				);
 			}
-			await slot.worker.terminate();
+			exits.push(
+				new Promise<void>((resolve) => {
+					slot.worker.once("exit", () => resolve());
+				}),
+			);
+			// Slots already terminating keep their in-flight shutdown; their
+			// grace timer still guarantees the exit awaited below.
+			this.shutdownSlot(slot);
 		}
+		await Promise.all(exits);
 
 		this.workerSlots.clear();
 	}
@@ -333,9 +349,9 @@ export class WorkerTaskRunner {
 				slot.idleTimer = undefined;
 				if (slot.activeTaskId || slot.terminating || this.disposed) return;
 				this.log(`reaping idle worker ${slot.id}`);
-				slot.terminating = true;
-				this.workerSlots.delete(slot.id);
-				void slot.worker.terminate();
+				// The slot stays mapped (as terminating) until the worker exits;
+				// handleWorkerFailure removes it then.
+				this.shutdownSlot(slot);
 			}, this.idleTimeoutMs);
 			slot.idleTimer.unref?.();
 		}
@@ -345,6 +361,40 @@ export class WorkerTaskRunner {
 		if (slot.idleTimer) {
 			clearTimeout(slot.idleTimer);
 			slot.idleTimer = undefined;
+		}
+	}
+
+	/** Retire a worker without stranding its children: ask it to SIGKILL +
+	 * reap in-flight child processes and exit on its own; hard-terminate only
+	 * if it doesn't within the grace period. terminate() destroys the thread's
+	 * libuv process handles, so any child it hadn't reaped would stay
+	 * <defunct> under host-service until the process dies (#6152). */
+	private shutdownSlot(slot: WorkerSlot): void {
+		if (slot.terminating) return;
+		slot.terminating = true;
+		this.clearIdleTimer(slot);
+
+		slot.worker.once("exit", () => this.clearGraceTimer(slot));
+		slot.graceTimer = setTimeout(() => {
+			slot.graceTimer = undefined;
+			this.log(`worker ${slot.id} ignored shutdown request; terminating`);
+			void slot.worker.terminate();
+		}, this.shutdownGraceMs);
+		slot.graceTimer.unref?.();
+
+		const request: WorkerShutdownRequestMessage = { kind: "shutdown" };
+		try {
+			slot.worker.postMessage(request);
+		} catch {
+			this.clearGraceTimer(slot);
+			void slot.worker.terminate();
+		}
+	}
+
+	private clearGraceTimer(slot: WorkerSlot): void {
+		if (slot.graceTimer) {
+			clearTimeout(slot.graceTimer);
+			slot.graceTimer = undefined;
 		}
 	}
 
@@ -369,10 +419,7 @@ export class WorkerTaskRunner {
 			this.log(
 				`worker ${slot.id} reported result for missing active task ${response.taskId}; recycling worker`,
 			);
-			if (!slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
-			}
+			this.shutdownSlot(slot);
 			return;
 		}
 
@@ -439,8 +486,7 @@ export class WorkerTaskRunner {
 		if (task.slotId) {
 			const slot = this.workerSlots.get(task.slotId);
 			if (slot && !slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
+				this.shutdownSlot(slot);
 				if (this.hasOutstandingWork()) {
 					this.ensureWorkerCapacity();
 					this.drainQueue();
@@ -458,8 +504,7 @@ export class WorkerTaskRunner {
 		if (task.slotId) {
 			const slot = this.workerSlots.get(task.slotId);
 			if (slot && !slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
+				this.shutdownSlot(slot);
 				if (this.hasOutstandingWork()) {
 					this.ensureWorkerCapacity();
 					this.drainQueue();

--- a/packages/host-service/src/workers/host-worker.ts
+++ b/packages/host-service/src/workers/host-worker.ts
@@ -5,7 +5,9 @@
 import { parentPort } from "node:worker_threads";
 import type { WorkerTaskDefinition } from "./define-worker-task.ts";
 import { gitTasks } from "./tasks/git.ts";
+import { killAndReapTrackedChildren } from "./worker-child-tracker.ts";
 import {
+	isWorkerShutdownRequestMessage,
 	serializeWorkerError,
 	type WorkerTaskRequestMessage,
 } from "./worker-task-protocol.ts";
@@ -38,6 +40,13 @@ function isWorkerTaskRequestMessage(
 }
 
 parentPort.on("message", async (message: unknown) => {
+	if (isWorkerShutdownRequestMessage(message)) {
+		// Cooperative retirement (WorkerTaskRunner.shutdownSlot): reap in-flight
+		// children first — a plain terminate() would strand them as zombies —
+		// then end this thread (process.exit in a worker stops only the thread).
+		await killAndReapTrackedChildren();
+		process.exit(0);
+	}
 	if (!isWorkerTaskRequestMessage(message)) return;
 	const task = message;
 

--- a/packages/host-service/src/workers/test-fixtures/respawning-worker.ts
+++ b/packages/host-service/src/workers/test-fixtures/respawning-worker.ts
@@ -1,0 +1,40 @@
+// Test fixture: the task spawns child A and, from a microtask queued by A's
+// exit event, spawns successor B. That lands B exactly in the window between
+// the reaper observing an empty set and the worker exiting — the still-
+// running-task race from the #6221 review. Every pid is appended to
+// SPAWN_PID_FILE so the test can assert all of them were killed AND reaped.
+import { spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { parentPort } from "node:worker_threads";
+import { killAndReapTrackedChildren } from "../worker-child-tracker.ts";
+import { isWorkerShutdownRequestMessage } from "../worker-task-protocol.ts";
+
+function spawnAndRecord(): ReturnType<typeof spawn> {
+	const child = spawn("sleep", ["30"], { stdio: "ignore" });
+	if (process.env.SPAWN_PID_FILE && child.pid) {
+		appendFileSync(process.env.SPAWN_PID_FILE, `${child.pid}\n`);
+	}
+	return child;
+}
+
+parentPort?.on("message", async (message: unknown) => {
+	if (isWorkerShutdownRequestMessage(message)) {
+		await killAndReapTrackedChildren();
+		process.exit(0);
+	}
+	const first = spawnAndRecord();
+	first.once("exit", () => {
+		// Exactly three microtask hops: this listener runs before the
+		// reaper's resolve (it registered first), and the reaper's
+		// `await Promise.all` adds two reaction layers before its empty-set
+		// re-check — so hops 1-2 land BEFORE the re-check and get reaped even
+		// by a single-pass reaper. Hop 3 is the vulnerable window: after the
+		// re-check, before the worker's process.exit continuation.
+		void Promise.resolve()
+			.then(() => undefined)
+			.then(() => undefined)
+			.then(() => {
+				spawnAndRecord();
+			});
+	});
+});

--- a/packages/host-service/src/workers/test-fixtures/shutdown-ignoring-worker.ts
+++ b/packages/host-service/src/workers/test-fixtures/shutdown-ignoring-worker.ts
@@ -1,0 +1,5 @@
+// Test fixture: a worker that stays alive but never honors shutdown
+// requests, for exercising the grace-period hard-terminate fallback.
+import { parentPort } from "node:worker_threads";
+
+parentPort?.on("message", () => {});

--- a/packages/host-service/src/workers/test-fixtures/spawning-worker.ts
+++ b/packages/host-service/src/workers/test-fixtures/spawning-worker.ts
@@ -1,0 +1,21 @@
+// Test fixture: a worker whose tasks spawn a long-lived child and then never
+// respond, forcing the runner's timeout/abort termination path while a child
+// is in flight. The child's PID is appended to SPAWN_PID_FILE so tests can
+// assert it was killed AND reaped. Honors cooperative shutdown like the real
+// host-worker entry.
+import { spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { parentPort } from "node:worker_threads";
+import { killAndReapTrackedChildren } from "../worker-child-tracker.ts";
+import { isWorkerShutdownRequestMessage } from "../worker-task-protocol.ts";
+
+parentPort?.on("message", async (message: unknown) => {
+	if (isWorkerShutdownRequestMessage(message)) {
+		await killAndReapTrackedChildren();
+		process.exit(0);
+	}
+	const child = spawn("sleep", ["30"], { stdio: "ignore" });
+	if (process.env.SPAWN_PID_FILE) {
+		appendFileSync(process.env.SPAWN_PID_FILE, `${child.pid}\n`);
+	}
+});

--- a/packages/host-service/src/workers/worker-child-tracker.ts
+++ b/packages/host-service/src/workers/worker-child-tracker.ts
@@ -1,0 +1,61 @@
+// Child-process tracking for worker threads, so a cooperative shutdown can
+// SIGKILL + reap in-flight children before the thread exits. Needed because
+// worker.terminate() destroys the thread's libuv process handles: any child
+// still alive (or exited but not yet waited on) at that moment is never
+// reaped and stays <defunct> under host-service until the process dies
+// (issue #6152).
+//
+// Hooks ChildProcess.prototype.spawn — the one funnel every creation path
+// uses (spawn/exec/execFile/fork, simple-git, promisified variants) — rather
+// than the module-level functions, whose call sites capture bindings at
+// import time. No-op on runtimes without that method (bun test).
+
+import { ChildProcess } from "node:child_process";
+
+const liveChildren = new Set<ChildProcess>();
+let shuttingDown = false;
+
+type SpawnFn = (this: ChildProcess, ...args: unknown[]) => unknown;
+
+const proto = ChildProcess.prototype as unknown as { spawn?: SpawnFn };
+const originalSpawn = proto.spawn;
+if (typeof originalSpawn === "function") {
+	proto.spawn = function (this: ChildProcess, ...args: unknown[]): unknown {
+		const result = originalSpawn.apply(this, args);
+		trackChild(this);
+		return result;
+	};
+}
+
+function trackChild(child: ChildProcess): void {
+	// No pid = spawn failed; there is no OS process to reap.
+	if (child.pid === undefined) return;
+	liveChildren.add(child);
+	child.once("exit", () => liveChildren.delete(child));
+	if (shuttingDown) child.kill("SIGKILL");
+}
+
+/**
+ * SIGKILL every live child and resolve once each has been reaped ('exit'
+ * fires after libuv waits on the pid). Children spawned while shutting down
+ * are killed on arrival and picked up by the next loop pass. A child wedged
+ * in uninterruptible sleep can stall this — the runner's grace timeout
+ * hard-terminates the worker in that case.
+ */
+export async function killAndReapTrackedChildren(): Promise<void> {
+	shuttingDown = true;
+	while (liveChildren.size > 0) {
+		await Promise.all(
+			[...liveChildren].map((child) => {
+				if (child.exitCode !== null || child.signalCode !== null) {
+					liveChildren.delete(child);
+					return undefined;
+				}
+				return new Promise<void>((resolve) => {
+					child.once("exit", () => resolve());
+					child.kill("SIGKILL");
+				});
+			}),
+		);
+	}
+}

--- a/packages/host-service/src/workers/worker-child-tracker.ts
+++ b/packages/host-service/src/workers/worker-child-tracker.ts
@@ -44,18 +44,30 @@ function trackChild(child: ChildProcess): void {
  */
 export async function killAndReapTrackedChildren(): Promise<void> {
 	shuttingDown = true;
-	while (liveChildren.size > 0) {
-		await Promise.all(
-			[...liveChildren].map((child) => {
-				if (child.exitCode !== null || child.signalCode !== null) {
-					liveChildren.delete(child);
-					return undefined;
-				}
-				return new Promise<void>((resolve) => {
-					child.once("exit", () => resolve());
-					child.kill("SIGKILL");
-				});
-			}),
-		);
+	// Exit only after two consecutive quiet event-loop turns: the task is
+	// still running, and a killed child's exit/close callbacks can spawn a
+	// successor after the set looks empty (kill-on-arrival doesn't reap it).
+	// setImmediate runs before the same iteration's close callbacks, so one
+	// quiet turn isn't enough. A task spawning later than that (e.g. off a
+	// timer) is inherently uncloseable and bounded by the grace terminate.
+	let quietTurns = 0;
+	while (quietTurns < 2) {
+		while (liveChildren.size > 0) {
+			await Promise.all(
+				[...liveChildren].map((child) => {
+					if (child.exitCode !== null || child.signalCode !== null) {
+						liveChildren.delete(child);
+						return undefined;
+					}
+					return new Promise<void>((resolve) => {
+						child.once("exit", () => resolve());
+						child.kill("SIGKILL");
+					});
+				}),
+			);
+			quietTurns = 0;
+		}
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		quietTurns += 1;
 	}
 }

--- a/packages/host-service/src/workers/worker-task-protocol.ts
+++ b/packages/host-service/src/workers/worker-task-protocol.ts
@@ -16,6 +16,23 @@ export interface WorkerTaskRequestMessage {
 	payload: unknown;
 }
 
+/** Main-thread → worker: SIGKILL + reap any in-flight child processes, then
+ * exit the thread voluntarily. Sent before a hard terminate() so children
+ * don't leak as zombies — see WorkerTaskRunner.shutdownSlot (#6152). */
+export interface WorkerShutdownRequestMessage {
+	kind: "shutdown";
+}
+
+export function isWorkerShutdownRequestMessage(
+	message: unknown,
+): message is WorkerShutdownRequestMessage {
+	return (
+		typeof message === "object" &&
+		message !== null &&
+		(message as { kind?: unknown }).kind === "shutdown"
+	);
+}
+
 export type WorkerTaskResponseMessage =
 	| {
 			kind: "result";

--- a/packages/host-service/src/workers/worker-termination.node-test.ts
+++ b/packages/host-service/src/workers/worker-termination.node-test.ts
@@ -1,0 +1,165 @@
+// Real-process tests for cooperative worker shutdown (issue #6152): retiring
+// a worker with in-flight child processes must SIGKILL and reap them, not
+// strand them as permanent zombies. Runs under Node
+// (`node --experimental-strip-types --test`) because the assertions read real
+// zombie state for this exact process out of `ps`; bun's worker/process
+// internals differ from the production (node/Electron) runtime.
+
+import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, test } from "node:test";
+import { WorkerTaskRunner } from "./WorkerTaskRunner.ts";
+
+const SPAWNING_WORKER = path.resolve(
+	import.meta.dirname,
+	"test-fixtures",
+	"spawning-worker.ts",
+);
+const SHUTDOWN_IGNORING_WORKER = path.resolve(
+	import.meta.dirname,
+	"test-fixtures",
+	"shutdown-ignoring-worker.ts",
+);
+
+const runners: WorkerTaskRunner[] = [];
+function makeRunner(workerScriptPath: string, shutdownGraceMs?: number) {
+	const runner = new WorkerTaskRunner({
+		workerScriptPath,
+		concurrency: 1,
+		name: "termination-test",
+		shutdownGraceMs,
+	});
+	runners.push(runner);
+	return runner;
+}
+
+let pidFile: string | undefined;
+
+afterEach(async () => {
+	await Promise.all(runners.splice(0).map((r) => r.dispose()));
+	if (pidFile) {
+		fs.rmSync(path.dirname(pidFile), { recursive: true, force: true });
+		pidFile = undefined;
+		delete process.env.SPAWN_PID_FILE;
+	}
+});
+
+function makePidFile(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "worker-termination-"));
+	pidFile = path.join(dir, "child-pid");
+	process.env.SPAWN_PID_FILE = pidFile;
+	return pidFile;
+}
+
+/** Zombie children of this process, per ps. A zombie also still answers
+ * kill(pid, 0), so "pid fully gone" below means killed AND reaped. */
+function zombieChildCount(): number {
+	const out = execFileSync("ps", ["-axo", "pid=,ppid=,stat="], {
+		encoding: "utf8",
+	});
+	return out
+		.split("\n")
+		.map((line) => line.trim().split(/\s+/))
+		.filter(
+			(parts) =>
+				parts.length >= 3 &&
+				parts[1] === String(process.pid) &&
+				(parts[2] as string).includes("Z"),
+		).length;
+}
+
+function pidExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitFor(
+	condition: () => boolean,
+	timeoutMs: number,
+	label: string,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	assert.fail(`timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
+async function readSpawnedPid(file: string): Promise<number> {
+	await waitFor(
+		() => fs.existsSync(file) && fs.readFileSync(file, "utf8").includes("\n"),
+		5_000,
+		"fixture to report its child pid",
+	);
+	const pid = Number.parseInt(fs.readFileSync(file, "utf8").trim(), 10);
+	assert.ok(Number.isInteger(pid) && pid > 0);
+	return pid;
+}
+
+describe("WorkerTaskRunner termination", () => {
+	test("task timeout SIGKILLs and reaps the worker's in-flight child", async () => {
+		const file = makePidFile();
+		const runner = makeRunner(SPAWNING_WORKER);
+
+		await assert.rejects(
+			runner.runTask("test/hang", {}, { timeoutMs: 300 }),
+			/timed out after 300ms/,
+		);
+
+		const childPid = await readSpawnedPid(file);
+		// Killed AND reaped: the pid must disappear entirely — a zombie would
+		// still answer signal 0.
+		await waitFor(
+			() => !pidExists(childPid),
+			5_000,
+			`child ${childPid} to be killed and reaped`,
+		);
+		assert.equal(zombieChildCount(), 0);
+	});
+
+	test("task abort SIGKILLs and reaps the worker's in-flight child", async () => {
+		const file = makePidFile();
+		const runner = makeRunner(SPAWNING_WORKER);
+		const controller = new AbortController();
+
+		const task = assert.rejects(
+			runner.runTask("test/hang", {}, { signal: controller.signal }),
+			/aborted/,
+		);
+		const childPid = await readSpawnedPid(file);
+		controller.abort();
+		await task;
+
+		await waitFor(
+			() => !pidExists(childPid),
+			5_000,
+			`child ${childPid} to be killed and reaped`,
+		);
+		assert.equal(zombieChildCount(), 0);
+	});
+
+	test("worker ignoring shutdown is hard-terminated after the grace period", async () => {
+		const runner = makeRunner(SHUTDOWN_IGNORING_WORKER, 300);
+
+		await assert.rejects(
+			runner.runTask("test/hang", {}, { timeoutMs: 200 }),
+			/timed out/,
+		);
+		// dispose() resolves only when the worker exits — here that exit can
+		// only come from the grace-timer terminate() fallback. Without the
+		// fallback this would never settle.
+		const disposed = runner.dispose().then(() => "disposed" as const);
+		const timeout = new Promise<"timeout">((resolve) => {
+			setTimeout(() => resolve("timeout"), 5_000).unref?.();
+		});
+		assert.equal(await Promise.race([disposed, timeout]), "disposed");
+	});
+});

--- a/packages/host-service/src/workers/worker-termination.node-test.ts
+++ b/packages/host-service/src/workers/worker-termination.node-test.ts
@@ -23,6 +23,11 @@ const SHUTDOWN_IGNORING_WORKER = path.resolve(
 	"test-fixtures",
 	"shutdown-ignoring-worker.ts",
 );
+const RESPAWNING_WORKER = path.resolve(
+	import.meta.dirname,
+	"test-fixtures",
+	"respawning-worker.ts",
+);
 
 const runners: WorkerTaskRunner[] = [];
 function makeRunner(workerScriptPath: string, shutdownGraceMs?: number) {
@@ -143,6 +148,40 @@ describe("WorkerTaskRunner termination", () => {
 			5_000,
 			`child ${childPid} to be killed and reaped`,
 		);
+		assert.equal(zombieChildCount(), 0);
+	});
+
+	test("children spawned from a killed child's exit callbacks are reaped too", async () => {
+		const file = makePidFile();
+		const runner = makeRunner(RESPAWNING_WORKER);
+
+		await assert.rejects(
+			runner.runTask("test/hang", {}, { timeoutMs: 300 }),
+			/timed out after 300ms/,
+		);
+
+		// The fixture reports child A at spawn and successor B after A is
+		// killed; both must be fully reaped, not just SIGKILLed on arrival.
+		await waitFor(
+			() =>
+				fs.existsSync(file) &&
+				fs.readFileSync(file, "utf8").trim().split("\n").length >= 2,
+			5_000,
+			"fixture to report the successor child pid",
+		);
+		const pids = fs
+			.readFileSync(file, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => Number.parseInt(line, 10));
+		assert.equal(pids.length, 2);
+		for (const pid of pids) {
+			await waitFor(
+				() => !pidExists(pid),
+				5_000,
+				`child ${pid} to be killed and reaped`,
+			);
+		}
 		assert.equal(zombieChildCount(), 0);
 	});
 


### PR DESCRIPTION
**Links**
- Fixes #6152

## Summary
- `WorkerTaskRunner` no longer hard-`terminate()`s worker threads that have child processes in flight — every termination path (timeout, abort, idle-reap, recycle, dispose) now runs a cooperative shutdown that SIGKILLs **and reaps** the worker's children before the thread exits.
- Fixes the permanent `<defunct>` accumulation under host-service (4722 zombies / `kern.maxprocperuid` exhaustion in the issue report).

## Why / Context
`worker.terminate()` destroys the thread's libuv `uv_process_t` handles. Children spawned by that worker (e.g. the `git status` + `git diff` pair from `gitStatusSnapshotTask`, 15s timeout) remain children of the host-service *process*, but nothing can ever `waitpid` them once the owning thread is gone — JS has no reaping API and the main thread never held the handles. Each timed-out or aborted task therefore leaked its in-flight children as permanent zombies.

## How It Works
- `worker-child-tracker.ts` (worker-side) hooks `ChildProcess.prototype.spawn` — the single funnel that `spawn`/`exec`/`execFile`/`fork`, simple-git, and promisified variants all pass through — to keep a live-children set. Module-function patching was rejected because call sites capture bindings at import time. Guarded no-op on runtimes without that method (bun).
- The runner's new `shutdownSlot()` replaces all five direct `terminate()` call sites: it posts `{kind: "shutdown"}`, the worker SIGKILLs each tracked child and awaits its `exit` event (which fires only after libuv has reaped the pid), then exits its own thread via `process.exit(0)`. A grace timer (`shutdownGraceMs`, default 5s) hard-terminates workers that don't comply.
- Task rejection timing, caller-visible errors, and slot/capacity accounting are unchanged — only the dying worker's teardown moved from "instant terminate" to "cooperate, then terminate by 5s".

## Manual QA Checklist
End-to-end A/B in the real dev desktop app (fix stashed vs. built), driving the real `git.getStatus` tRPC path on a workspace whose repo had a `core.fsmonitor` hook sleeping 60s (deterministically outlives the 15s worker timeout), sampling the host-service child process table every 2s:

- [x] **Before**: every timed-out snapshot leaked both git children — 8 permanent zombies under the host-service pid, alive ~60s then `Z` forever, unaffected by `kill -CHLD`
- [x] **After**: git children SIGKILLed at ~15s (task timeout), zero `Z` states across 140s of sampling, zero zombies at end
- [x] Caller-visible behavior identical both sides (`git.getStatus timed out after 15000ms`, same latency)
- [x] Pool healthy after repeated cooperative shutdowns — once the slow hook was removed, `getStatus` succeeded via the worker path (crash circuit never opened)
- [x] Standalone repros: issue's `repro.mjs` → `zombies: 1`; same counter driving the fixed runner timeout path → `zombies: 0`

Not covered end-to-end: the **abort** path from the app — renderer tRPC query aborts don't propagate into the host worker's `abortTask` for this procedure (client aborted at 3s; the git child still ran to the 15s timeout). Abort is covered by the node-test below with real processes.

## Testing
- `bun run typecheck` / `bun run lint` — exit 0
- New `worker-termination.node-test.ts` (`bun run test:integration:workers`, runs under node like the daemon node-tests since the assertions read real zombie state from `ps`): timeout path, abort path, grace-period hard-terminate fallback. **Mutation-verified**: reverting `shutdownSlot` to bare `terminate()` makes both zombie tests fail. The "pid fully gone" assertion is strict — a zombie still answers `kill(pid, 0)`, so passing means killed *and* reaped. It also canaries the `prototype.spawn` patch point across Node upgrades.
- `bun test src/workers/` + related suites (off-loop, workspace-cleanup, no-native-worker-imports) — 39 pass

## Design Decisions
- **Why cooperative shutdown (issue option 1) instead of "don't terminate slots with children" (option 2)**: option 2 needs the same child tracking just to know a child is in flight, and leaves wedged tasks running forever.
- **Why not delete `terminate()` entirely**: trades the zombie leak for a runaway-process/thread leak.
- **Intended semantic change**: timed-out/aborted work is now actually cancelled — previously a timed-out `git fetch` still completed invisibly and mutated refs after the caller was told it failed. Callers audited; all treat rejection as failure.

## Known Limitations
- A worker wedged in *synchronous* code can't process the shutdown message and is hard-terminated after the grace period — its children can still leak. These git tasks are I/O-bound, so the worker loop is essentially always responsive; this is the bound the issue's option 1 explicitly accepts.
- Tracking is inert under bun (different `ChildProcess` internals); production runs under node/Electron where it's fully active.

## Follow-ups
- Migrating the runner from worker threads to a forked child-process pool would make this failure class structural (`kill(-pgid)` + orphan reparenting to init) and delete the tracker/protocol/grace machinery — deferred so a hot-path transport rewrite isn't coupled to the leak fix; needs its own perf evidence.
- Renderer query aborts not reaching host worker `abortTask` (observed during QA) may deserve its own issue if in-app cancellation is expected to cancel host-side work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking zombie child processes in `host-service` by replacing hard worker termination with a cooperative shutdown that SIGKILLs and reaps worker-spawned children before exit. Also handles children spawned during shutdown (from exit callbacks), preventing `<defunct>` buildup and per-UID process exhaustion. Fixes #6152.

- **Bug Fixes**
  - Track worker-spawned children via a `ChildProcess.prototype.spawn` hook and reap them on shutdown.
  - Add a `shutdown` message and `shutdownSlot()` so all termination paths (timeout, abort, idle, recycle, dispose) request cooperative exit.
  - Workers run `killAndReapTrackedChildren()` until two consecutive quiet event-loop turns to catch late-spawned successors, then `process.exit(0)`; a grace timer (`shutdownGraceMs`, default 5s) falls back to `terminate()` if ignored.
  - No change to caller-facing behavior or task timing; only teardown is different.
  - New Node integration tests cover timeout, abort, successor-from-exit race, and the grace-period hard-terminate fallback; added `test:integration:workers` script.

<sup>Written for commit e4291fc393f9b70f066b9695f3a14cb956093976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful worker shutdown with a configurable grace period before forced termination.
  * Worker shutdown now cleans up child processes to prevent lingering processes and resource leaks.
  * Added a default five-second shutdown grace period.

* **Bug Fixes**
  * Improved cleanup when tasks time out, are aborted, or produce invalid results.
  * Ensured worker disposal waits for worker processes to exit properly.

* **Tests**
  * Added integration coverage for child-process cleanup and forced termination of unresponsive workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->