### PR TITLE
fix(desktop): stop duplicating backpressured PTY stdin writes

### DIFF
--- a/apps/desktop/src/main/terminal-host/session.test.ts
+++ b/apps/desktop/src/main/terminal-host/session.test.ts
@@ -517,7 +517,7 @@ describe("PtySubprocessFrameDecoder resync", () => {
 		expect(frames[0].payload.toString("utf8")).toBe("hello");
 	});
 
-	it("recovers when the oversized header and a valid frame share one chunk", () => {
+	it("drops the rest of a chunk that trails an oversized header, then recovers on the next chunk", () => {
 		const decoder = new PtySubprocessFrameDecoder();
 
 		const badHeader = Buffer.alloc(5);
@@ -528,11 +528,99 @@ describe("PtySubprocessFrameDecoder resync", () => {
 		const goodPayload = Buffer.from("world");
 		const goodHeader = createFrameHeader(goodType, goodPayload.length);
 
-		expect(() => decoder.push(badHeader)).toThrow(/frame too large/);
+		// A corrupted header has no framing marker to resync against, so bytes
+		// sharing its chunk are unrecoverable: the throw abandons them rather
+		// than guessing where the next frame starts.
+		expect(() =>
+			decoder.push(Buffer.concat([badHeader, goodHeader, goodPayload])),
+		).toThrow(/frame too large/);
+
+		// State must still be clean, so the following chunk decodes normally.
 		const frames = decoder.push(Buffer.concat([goodHeader, goodPayload]));
 
 		expect(frames).toHaveLength(1);
 		expect(frames[0].type).toBe(goodType);
 		expect(frames[0].payload.toString("utf8")).toBe("world");
+	});
+});
+
+describe("Terminal Host Session stdin backpressure", () => {
+	class BackpressuringStdin extends EventEmitter {
+		readonly writes: Buffer[] = [];
+		private buffered = 0;
+
+		constructor(private readonly highWaterMark = 64 * 1024) {
+			super();
+		}
+
+		write(chunk: Buffer | string): boolean {
+			const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8");
+			this.writes.push(buf);
+			this.buffered += buf.length;
+			return this.buffered < this.highWaterMark;
+		}
+
+		drain(): void {
+			this.buffered = 0;
+			this.emit("drain");
+		}
+	}
+
+	class BackpressuringChildProcess extends EventEmitter {
+		readonly stdout = new FakeStdout();
+		readonly stdin = new BackpressuringStdin();
+		pid = 4343;
+		kill(): boolean {
+			return true;
+		}
+	}
+
+	it("writes each queued frame exactly once across drain cycles", () => {
+		const child = new BackpressuringChildProcess();
+		const session = new Session({
+			sessionId: "session-stdin-backpressure",
+			workspaceId: "workspace-1",
+			paneId: "pane-1",
+			tabId: "tab-1",
+			cols: 80,
+			rows: 24,
+			cwd: "/tmp",
+			spawnProcess: () => child as unknown as ChildProcess,
+		});
+
+		session.spawn({
+			cwd: "/tmp",
+			cols: 80,
+			rows: 24,
+			env: { PATH: "/usr/bin" },
+		});
+		child.stdout.emit("data", createFrameHeader(PtySubprocessIpcType.Ready, 0));
+		const spawnedPid = Buffer.allocUnsafe(4);
+		spawnedPid.writeUInt32LE(1234, 0);
+		child.stdout.emit(
+			"data",
+			Buffer.concat([
+				createFrameHeader(PtySubprocessIpcType.Spawned, 4),
+				spawnedPid,
+			]),
+		);
+
+		// Large enough to backpressure the pipe several times over.
+		const pasted = "x".repeat(400_000);
+		session.write(pasted);
+		for (let i = 0; i < 200; i++) child.stdin.drain();
+
+		// A backpressured buffer must not be handed to the stream twice: the
+		// duplicate misaligns the frame stream and the subprocess then reads
+		// payload bytes as a header (#6153).
+		const decoder = new PtySubprocessFrameDecoder();
+		const frames = child.stdin.writes.flatMap((chunk) => decoder.push(chunk));
+		const received = Buffer.concat(
+			frames
+				.filter((frame) => frame.type === PtySubprocessIpcType.Write)
+				.map((frame) => frame.payload),
+		).toString("utf8");
+
+		expect(received).toBe(pasted);
 	});
 });

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -472,7 +472,13 @@ export class Session {
 
 		while (this.subprocessStdinQueue.length > 0) {
 			const buf = this.subprocessStdinQueue[0];
+			// write() buffers the chunk even when it returns false, so the chunk
+			// must leave our queue either way — re-sending it after 'drain'
+			// duplicates bytes and misaligns the frame stream (#6153).
 			const canWrite = this.subprocess.stdin.write(buf);
+			this.subprocessStdinQueue.shift();
+			this.subprocessStdinQueuedBytes -= buf.length;
+
 			if (!canWrite) {
 				if (!this.subprocessStdinDrainArmed) {
 					this.subprocessStdinDrainArmed = true;
@@ -483,9 +489,6 @@ export class Session {
 				}
 				return;
 			}
-
-			this.subprocessStdinQueue.shift();
-			this.subprocessStdinQueuedBytes -= buf.length;
 		}
 	}
 


### PR DESCRIPTION
## What & why

Follow-up to #6184, which fixed the *symptom* of #6153 (a poisoned decoder froze the session forever). This fixes the **source of the corruption**.

`flushSubprocessStdinQueue` (`apps/desktop/src/main/terminal-host/session.ts`) wrote `queue[0]` and, when `stdin.write()` returned `false`, returned **without dequeuing that chunk**. Node buffers the chunk regardless — a `false` return only means the internal buffer passed its high-water mark. So the same chunk was written again on `drain`, injecting duplicate bytes into the framed stdin stream and shifting every following frame boundary. The subprocess then read payload text as a 5-byte header, which is exactly why #6153 reported ASCII-looking lengths: a paste of `x` characters yields `2021161080` = `"xxxx"` as `u32LE`.

The fix dequeues the chunk as soon as `write()` accepts it and uses the return value only to arm the `drain` and stop sending more. The 2 MB memory bound is unchanged (later frames still queue and the cap still drops them), and this matches the sibling `flushNotifyQueue` in `lib/terminal-host/client.ts`, which already shifts before writing — which is why the client path never had this bug.

## How I tested it

End-to-end in the dev desktop app (v1 terminal pane, the surface that routes through `terminal-host`), same 20 × 1.2 MB paste flood each time:

| Build | `frame too large` errors | Session after the flood |
|---|---|---|
| before #6184 | 94, all one identical length | dead — input never echoed again |
| #6184 only | 499 across ~50 distinct lengths | alive |
| #6184 + this | **0** | alive, `echo` executes |

- New regression test `Terminal Host Session stdin backpressure` drives the real `Session` through a backpressuring fake stdin and asserts the reassembled payload equals the original paste byte for byte. It fails without this fix (`PtySubprocess IPC frame too large: 2021161080`) and passes with it.
- Also rewrites the decoder test that #6184's review flagged (CodeRabbit + cubic + Greptile): it claimed to cover an oversized header sharing a chunk with a valid frame, but fed them in separate `push()` calls, duplicating the test above it. It now builds the shared chunk and asserts the real semantics — a corrupted header has no framing marker to resync against, so trailing bytes in that chunk are abandoned and the next chunk decodes normally. That documents the residual behavior Greptile raised; with corruption no longer occurring, the path is not reachable from this bug class.
- `bun test apps/desktop/src/main/terminal-host/` — 40 pass, 0 fail. `bun run lint` clean. `bun run typecheck` — 37/37.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated PTY stdin writes under backpressure in the desktop terminal host, preventing frame corruption and frozen sessions. Each chunk is now sent exactly once, even when `stdin.write()` returns `false`.

- **Bug Fixes**
  - Dequeue the head chunk immediately after `stdin.write()`; use the return value only to pause on `drain`. This stops duplicate bytes that misalign framed stdin (root cause behind #6153; follow-up to #6184).
  - Matches `flushNotifyQueue` behavior; 2 MB queue cap unchanged.
  - Added a regression test for backpressured stdin that verifies byte‑for‑byte integrity, and corrected the decoder test to reflect real recovery semantics.

<sup>Written for commit 45202ab9219fad65d0df58c43c3dc45082ee5165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal input handling under backpressure to prevent queued input from being written more than once.
  * Improved recovery when processing oversized terminal data, ensuring trailing bytes are discarded correctly and subsequent data remains readable.
* **Tests**
  * Added regression coverage for terminal input buffering and oversized data recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->