### PR TITLE
docs: document canary release flow and add /canaryrelease command

### DIFF
--- a/.agents/commands/canaryrelease.md
+++ b/.agents/commands/canaryrelease.md
@@ -1,0 +1,16 @@
+---
+description: Trigger a canary build of the desktop app (rolling internal-testing release, not a versioned stable release)
+allowed-tools: Bash
+---
+
+Trigger the desktop canary release workflow. This is distinct from `bun run release desktop` (which cuts a real versioned stable release) — canary is a rolling, prerelease-tagged internal-testing build (`desktop-canary`) that gets force-rebuilt and replaces the previous one each time.
+
+## Steps
+
+1. Run `bash scripts/release-canary.sh $ARGUMENTS` from the repo root.
+   - With no argument, it triggers `release-desktop-canary.yml` (via `gh workflow run`) against the current default branch.
+   - With a commit SHA/ref argument, it pushes that commit to a temp `canary-release-<sha>` branch first, then triggers the workflow against that branch.
+2. The script prints the GitHub Actions run URL — share it with the user.
+3. Optionally poll `gh run view <run-id>` or check the run URL to confirm the build succeeded and the `desktop-canary` release/tag was updated.
+
+No confirmation is needed before running this — canary is a low-stakes rolling internal build, not a user-facing release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ bun run check:versions     # assert versions are unified
 Cut releases on a dedicated release branch (not `main`); `bun run release desktop
 <version> <commit>` provisions one from a commit. Full runbook: `scripts/release/README.md`.
 
+**Canary release** (separate from the above — a rolling internal-testing build of
+the desktop app, not a versioned stable release): `bash scripts/release-canary.sh
+[commit]` (or `/canaryrelease`). Triggers `release-desktop-canary.yml` via `gh
+workflow run`, which force-builds and replaces the rolling `desktop-canary`
+prerelease/tag on GitHub. Omit `commit` to build off the current default branch;
+pass one to build an arbitrary commit via a temp `canary-release-<sha>` branch.
+This is what "run a canary release" means in this repo — do not confuse it with
+`bun run release desktop`, which cuts a real versioned stable release.
+
 ## Code Quality
 
 **Biome runs at root level** (not per-package) for speed — use `bun run lint:fix` to fix all issues automatically.


### PR DESCRIPTION
## Summary
- Documents the desktop canary release flow (`scripts/release-canary.sh`) in `AGENTS.md`, distinguishing it from `bun run release desktop` (a real versioned stable release).
- Adds a `/canaryrelease` command (`.agents/commands/canaryrelease.md`) that runs the script and reports the triggered workflow run.

## Why / Context
Canary is a rolling internal-testing build (`desktop-canary` prerelease tag), triggered via `gh workflow run release-desktop-canary.yml`. It previously had no documentation or slash command, so "run a canary release" was easy to confuse with cutting a real stable release via `bun run release desktop`.

## Testing
- Docs-only change; no code paths affected.
- Manually triggered `scripts/release-canary.sh` against current `main` prior to this PR — [run succeeded](https://github.com/superset-sh/superset/actions/runs/31056586626).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the desktop canary release flow and adds a `/canaryrelease` command to trigger it. Clarifies that canary is a rolling internal build, not the versioned stable release via `bun run release desktop`.

- **New Features**
  - Added `/canaryrelease` command (`.agents/commands/canaryrelease.md`) to run `scripts/release-canary.sh` and share the Actions run URL.
  - Expanded `AGENTS.md` with canary details: rolling `desktop-canary` prerelease, triggered via `gh workflow run release-desktop-canary.yml`.
  - Supports optional commit ref; defaults to the current default branch.

<sup>Written for commit 3306e11bfbcb3cf5980ddd081a749da2dfb69013. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command for triggering desktop canary releases.
  - Supports optional commit arguments and reports the release workflow status and URL.
  - Can optionally verify the resulting canary release and tag.

- **Documentation**
  - Clarified the differences between rolling desktop canary releases and versioned stable releases.
  - Documented canary release commands, workflow behavior, and optional commit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->