### PR TITLE
fix(desktop): respect repository merge settings in PR merge menus

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.merge.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.merge.test.ts
@@ -106,4 +106,26 @@ describe("changes.mergePR repository settings guard", () => {
 			strategy: "rebase",
 		});
 	});
+
+	test("keeps merge behavior when a capability is unknown", async () => {
+		getRepoMergeSettingsMock.mockResolvedValue({
+			allowRebaseMerge: null,
+			viewerDefaultMergeMethod: "MERGE",
+		});
+
+		await expect(
+			caller.mergePR({
+				worktreePath: "/tmp/merge-settings-test",
+				strategy: "rebase",
+			}),
+		).resolves.toEqual({
+			success: true,
+			mergedAt: "2026-08-07T00:00:00.000Z",
+		});
+
+		expect(mergePullRequestMock).toHaveBeenCalledWith({
+			worktreePath: "/tmp/merge-settings-test",
+			strategy: "rebase",
+		});
+	});
 });

--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.merge.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.merge.test.ts
@@ -1,0 +1,109 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import type { GitHubMergeCapabilities } from "@superset/shared/github-merge-methods";
+
+interface MergeSettings extends GitHubMergeCapabilities {
+	viewerDefaultMergeMethod: string | null;
+}
+
+const getRepoMergeSettingsMock = mock(
+	async (): Promise<MergeSettings | null> => null,
+);
+const getRepoContextMock = mock(async () => null);
+const fetchGitHubPRStatusMock = mock(async () => null);
+const clearGitHubCachesForWorktreeMock = mock(
+	(_worktreePath: string): void => {},
+);
+const mergePullRequestMock = mock(
+	async (_input: unknown): Promise<{ success: boolean; mergedAt: string }> => ({
+		success: true,
+		mergedAt: "2026-08-07T00:00:00.000Z",
+	}),
+);
+const assertRegisteredWorktreeMock = mock((_worktreePath: string): void => {});
+
+mock.module("../workspaces/utils/github", () => ({
+	clearGitHubCachesForWorktree: clearGitHubCachesForWorktreeMock,
+	fetchGitHubPRStatus: fetchGitHubPRStatusMock,
+	getRepoContext: getRepoContextMock,
+	getRepoMergeSettings: getRepoMergeSettingsMock,
+}));
+mock.module("./security/path-validation", () => ({
+	assertRegisteredWorktree: assertRegisteredWorktreeMock,
+}));
+mock.module("./utils/merge-pull-request", () => ({
+	mergePullRequest: mergePullRequestMock,
+}));
+
+let createGitOperationsRouter: typeof import("./git-operations").createGitOperationsRouter;
+
+type GitOperationsRouter = ReturnType<
+	typeof import("./git-operations").createGitOperationsRouter
+>;
+type GitOperationsCaller = ReturnType<GitOperationsRouter["createCaller"]>;
+
+describe("changes.mergePR repository settings guard", () => {
+	let caller: GitOperationsCaller;
+
+	beforeAll(async () => {
+		({ createGitOperationsRouter } = await import("./git-operations"));
+		caller = createGitOperationsRouter().createCaller({});
+	});
+
+	afterAll(() => {
+		mock.restore();
+	});
+
+	beforeEach(() => {
+		getRepoMergeSettingsMock.mockReset();
+		getRepoMergeSettingsMock.mockResolvedValue(null);
+		mergePullRequestMock.mockReset();
+		mergePullRequestMock.mockResolvedValue({
+			success: true,
+			mergedAt: "2026-08-07T00:00:00.000Z",
+		});
+		assertRegisteredWorktreeMock.mockReset();
+	});
+
+	test("rejects an explicitly disabled strategy before merging", async () => {
+		getRepoMergeSettingsMock.mockResolvedValue({
+			allowMergeCommit: true,
+			allowRebaseMerge: true,
+			allowSquashMerge: false,
+			viewerDefaultMergeMethod: "MERGE",
+		});
+
+		await expect(
+			caller.mergePR({
+				worktreePath: "/tmp/merge-settings-test",
+				strategy: "squash",
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		expect(mergePullRequestMock).not.toHaveBeenCalled();
+	});
+
+	test("keeps the existing merge behavior when settings are unavailable", async () => {
+		await expect(
+			caller.mergePR({
+				worktreePath: "/tmp/merge-settings-test",
+				strategy: "rebase",
+			}),
+		).resolves.toEqual({
+			success: true,
+			mergedAt: "2026-08-07T00:00:00.000Z",
+		});
+
+		expect(mergePullRequestMock).toHaveBeenCalledWith({
+			worktreePath: "/tmp/merge-settings-test",
+			strategy: "rebase",
+		});
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -1,3 +1,7 @@
+import {
+	GITHUB_MERGE_METHODS,
+	isGitHubMergeMethodDisabled,
+} from "@superset/shared/github-merge-methods";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
@@ -313,22 +317,15 @@ export const createGitOperationsRouter = () => {
 			.input(
 				z.object({
 					worktreePath: z.string(),
-					strategy: z.enum(["merge", "squash", "rebase"]).default("squash"),
+					strategy: z.enum(GITHUB_MERGE_METHODS).default("squash"),
 				}),
 			)
 			.mutation(
 				async ({ input }): Promise<{ success: boolean; mergedAt?: string }> => {
 					assertRegisteredWorktree(input.worktreePath);
 					const mergeSettings = await getRepoMergeSettings(input.worktreePath);
-					const methodDisabled =
-						(input.strategy === "merge" &&
-							mergeSettings?.allowMergeCommit === false) ||
-						(input.strategy === "squash" &&
-							mergeSettings?.allowSquashMerge === false) ||
-						(input.strategy === "rebase" &&
-							mergeSettings?.allowRebaseMerge === false);
 
-					if (methodDisabled) {
+					if (isGitHubMergeMethodDisabled(mergeSettings, input.strategy)) {
 						throw new TRPCError({
 							code: "BAD_REQUEST",
 							message: `Repository merge settings do not allow ${input.strategy} merges.`,

--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getCurrentBranch } from "../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
+import { getRepoMergeSettings } from "../workspaces/utils/github";
 import {
 	isNoPullRequestFoundMessage,
 	isUpstreamMissingError,
@@ -300,6 +301,13 @@ export const createGitOperationsRouter = () => {
 					}
 				},
 			),
+
+		getMergeSettings: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async ({ input }) => {
+				assertRegisteredWorktree(input.worktreePath);
+				return getRepoMergeSettings(input.worktreePath);
+			}),
 
 		mergePR: publicProcedure
 			.input(

--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -319,6 +319,21 @@ export const createGitOperationsRouter = () => {
 			.mutation(
 				async ({ input }): Promise<{ success: boolean; mergedAt?: string }> => {
 					assertRegisteredWorktree(input.worktreePath);
+					const mergeSettings = await getRepoMergeSettings(input.worktreePath);
+					const methodDisabled =
+						(input.strategy === "merge" &&
+							mergeSettings?.allowMergeCommit === false) ||
+						(input.strategy === "squash" &&
+							mergeSettings?.allowSquashMerge === false) ||
+						(input.strategy === "rebase" &&
+							mergeSettings?.allowRebaseMerge === false);
+
+					if (methodDisabled) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: `Repository merge settings do not allow ${input.strategy} merges.`,
+						});
+					}
 
 					try {
 						return await mergePullRequest(input);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -10,5 +10,6 @@ export {
 	extractNwoFromUrl,
 	getPullRequestRepoArgs,
 	getRepoContext,
+	getRepoMergeSettings,
 	normalizeGitHubUrl,
 } from "./repo-context";

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/repo-context.ts
@@ -1,7 +1,11 @@
 import { execGitWithShellPath } from "../git-client";
 import { execWithShellEnv } from "../shell-env";
 import { getCachedRepoContextState, readCachedRepoContext } from "./cache";
-import { GHRepoResponseSchema, type RepoContext } from "./types";
+import {
+	GHMergeSettingsResponseSchema,
+	GHRepoResponseSchema,
+	type RepoContext,
+} from "./types";
 
 async function refreshRepoContext(
 	worktreePath: string,
@@ -82,6 +86,41 @@ export async function getRepoContext(
 			forceFresh,
 		},
 	);
+}
+
+export async function getRepoMergeSettings(worktreePath: string) {
+	try {
+		const repoContext = await getRepoContext(worktreePath);
+		const { stdout } = await execWithShellEnv(
+			"gh",
+			[
+				"repo",
+				"view",
+				...getPullRequestRepoArgs(repoContext),
+				"--json",
+				"mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,viewerDefaultMergeMethod",
+			],
+			{ cwd: worktreePath },
+		);
+		const result = GHMergeSettingsResponseSchema.safeParse(JSON.parse(stdout));
+		if (!result.success) {
+			console.warn(
+				"[GitHub] Merge settings response validation failed:",
+				result.error,
+			);
+			return null;
+		}
+
+		return {
+			allowMergeCommit: result.data.mergeCommitAllowed,
+			allowRebaseMerge: result.data.rebaseMergeAllowed,
+			allowSquashMerge: result.data.squashMergeAllowed,
+			viewerDefaultMergeMethod: result.data.viewerDefaultMergeMethod ?? null,
+		};
+	} catch (error) {
+		console.warn("[GitHub] Failed to fetch repository merge settings:", error);
+		return null;
+	}
 }
 
 export function shouldRefreshCachedRepoContext({

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -157,6 +157,13 @@ export const GHPRResponseSchema = z.object({
 	reviewRequests: z.array(GHReviewRequestSchema).nullable().optional(),
 });
 
+export const GHMergeSettingsResponseSchema = z.object({
+	mergeCommitAllowed: z.boolean(),
+	squashMergeAllowed: z.boolean(),
+	rebaseMergeAllowed: z.boolean(),
+	viewerDefaultMergeMethod: z.string().nullable().optional(),
+});
+
 export const GHRepoResponseSchema = z.object({
 	url: z.string(),
 	isFork: z.boolean().optional().default(false),

--- a/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.test.ts
+++ b/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { getAvailableMergeMethods } from "./githubMergeMethods";
+
+describe("getAvailableMergeMethods", () => {
+	test("returns the only method allowed by the repository", () => {
+		expect(
+			getAvailableMergeMethods({
+				allowMergeCommit: true,
+				allowRebaseMerge: false,
+				allowSquashMerge: false,
+				viewerDefaultMergeMethod: "MERGE",
+			}),
+		).toEqual(["merge"]);
+	});
+
+	test("puts the repository default first when it is available", () => {
+		expect(
+			getAvailableMergeMethods({
+				allowMergeCommit: true,
+				allowRebaseMerge: true,
+				allowSquashMerge: true,
+				viewerDefaultMergeMethod: "REBASE",
+			}),
+		).toEqual(["rebase", "squash", "merge"]);
+	});
+
+	test("keeps the fallback menu when settings are unavailable", () => {
+		expect(getAvailableMergeMethods(null)).toEqual([
+			"squash",
+			"merge",
+			"rebase",
+		]);
+	});
+
+	test("never returns disabled methods for the merge menu", () => {
+		const methods = getAvailableMergeMethods({
+			allowMergeCommit: true,
+			allowRebaseMerge: true,
+			allowSquashMerge: false,
+			viewerDefaultMergeMethod: "SQUASH",
+		});
+
+		expect(methods).toEqual(["merge", "rebase"]);
+		expect(methods).not.toContain("squash");
+	});
+});

--- a/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.ts
+++ b/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.ts
@@ -1,0 +1,77 @@
+export const MERGE_METHODS = ["squash", "merge", "rebase"] as const;
+
+export type MergeMethod = (typeof MERGE_METHODS)[number];
+
+export interface GitHubMergeSettings {
+	allowMergeCommit?: boolean | null;
+	allowRebaseMerge?: boolean | null;
+	allowSquashMerge?: boolean | null;
+	viewerDefaultMergeMethod?: string | null;
+}
+
+export const MERGE_METHOD_LABELS: Record<MergeMethod, string> = {
+	merge: "Create merge commit",
+	rebase: "Rebase and merge",
+	squash: "Squash and merge",
+};
+
+function hasCompleteMergeSettings(
+	settings: GitHubMergeSettings | null | undefined,
+): settings is GitHubMergeSettings & {
+	allowMergeCommit: boolean;
+	allowRebaseMerge: boolean;
+	allowSquashMerge: boolean;
+} {
+	return (
+		typeof settings?.allowMergeCommit === "boolean" &&
+		typeof settings.allowRebaseMerge === "boolean" &&
+		typeof settings.allowSquashMerge === "boolean"
+	);
+}
+
+function normalizeMergeMethod(
+	value: string | null | undefined,
+): MergeMethod | null {
+	const normalized = value?.toLowerCase();
+	return normalized === "merge" ||
+		normalized === "rebase" ||
+		normalized === "squash"
+		? normalized
+		: null;
+}
+
+/**
+ * Returns the methods that GitHub allows, with the viewer's default first
+ * when it is available. An incomplete response is treated as unavailable so
+ * a transient settings failure never removes the merge menu options.
+ */
+export function getAvailableMergeMethods(
+	settings: GitHubMergeSettings | null | undefined,
+): MergeMethod[] {
+	if (!hasCompleteMergeSettings(settings)) {
+		return [...MERGE_METHODS];
+	}
+
+	const availableMethods = MERGE_METHODS.filter((method) => {
+		switch (method) {
+			case "merge":
+				return settings.allowMergeCommit;
+			case "rebase":
+				return settings.allowRebaseMerge;
+			case "squash":
+				return settings.allowSquashMerge;
+			default:
+				return false;
+		}
+	});
+	const defaultMethod = normalizeMergeMethod(settings.viewerDefaultMergeMethod);
+
+	if (!defaultMethod || !availableMethods.includes(defaultMethod)) {
+		return availableMethods;
+	}
+
+	return [
+		defaultMethod,
+		...availableMethods.filter((method) => method !== defaultMethod),
+	];
+}

--- a/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.ts
+++ b/apps/desktop/src/renderer/lib/githubMergeMethods/githubMergeMethods.ts
@@ -1,11 +1,15 @@
-export const MERGE_METHODS = ["squash", "merge", "rebase"] as const;
+import {
+	GITHUB_MERGE_METHODS,
+	type GitHubMergeCapabilities,
+	type GitHubMergeMethod,
+	isGitHubMergeMethodDisabled,
+} from "@superset/shared/github-merge-methods";
 
-export type MergeMethod = (typeof MERGE_METHODS)[number];
+export const MERGE_METHODS = GITHUB_MERGE_METHODS;
 
-export interface GitHubMergeSettings {
-	allowMergeCommit?: boolean | null;
-	allowRebaseMerge?: boolean | null;
-	allowSquashMerge?: boolean | null;
+export type MergeMethod = GitHubMergeMethod;
+
+export interface GitHubMergeSettings extends GitHubMergeCapabilities {
 	viewerDefaultMergeMethod?: string | null;
 }
 
@@ -53,16 +57,7 @@ export function getAvailableMergeMethods(
 	}
 
 	const availableMethods = MERGE_METHODS.filter((method) => {
-		switch (method) {
-			case "merge":
-				return settings.allowMergeCommit;
-			case "rebase":
-				return settings.allowRebaseMerge;
-			case "squash":
-				return settings.allowSquashMerge;
-			default:
-				return false;
-		}
+		return !isGitHubMergeMethodDisabled(settings, method);
 	});
 	const defaultMethod = normalizeMergeMethod(settings.viewerDefaultMergeMethod);
 

--- a/apps/desktop/src/renderer/lib/githubMergeMethods/index.ts
+++ b/apps/desktop/src/renderer/lib/githubMergeMethods/index.ts
@@ -1,0 +1,6 @@
+export type { GitHubMergeSettings, MergeMethod } from "./githubMergeMethods";
+export {
+	getAvailableMergeMethods,
+	MERGE_METHOD_LABELS,
+	MERGE_METHODS,
+} from "./githubMergeMethods";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/PRStatusGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/PRStatusGroup.tsx
@@ -15,6 +15,11 @@ import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useMemo } from "react";
 import { VscChevronDown, VscGitMerge, VscLoading } from "react-icons/vsc";
+import {
+	getAvailableMergeMethods,
+	MERGE_METHOD_LABELS,
+	type MergeMethod,
+} from "renderer/lib/githubMergeMethods";
 import { PRIcon, type PRState } from "renderer/screens/main/components/PRIcon";
 import { computeChecksRollup } from "../../utils/computeChecksStatus";
 import type { PRFlowState } from "../../utils/getPRFlowState";
@@ -79,6 +84,18 @@ export function PRStatusGroup({
 			toast.error(`Merge failed: ${error.message}`, { id: context?.toastId });
 		},
 	});
+	const repoMergeSettingsQuery = workspaceTrpc.github.getRepo.useQuery(
+		{
+			owner: pr?.repoOwner ?? "",
+			repo: pr?.repoName ?? "",
+		},
+		{
+			enabled: Boolean(
+				pr && pr.state === "open" && !pr.isDraft && pr.repoOwner && pr.repoName,
+			),
+			staleTime: 5 * 60 * 1_000,
+		},
+	);
 
 	const checks = useMemo(
 		() => (pr ? computeChecksRollup(pr.checks) : null),
@@ -100,7 +117,7 @@ export function PRStatusGroup({
 	// Queued PRs are still actively running checks, so keep CI/review indicators.
 	const showIndicators = pr.state === "open" || pr.state === "queued";
 
-	const handleMerge = (mergeMethod: "merge" | "squash" | "rebase") => {
+	const handleMerge = (mergeMethod: MergeMethod) => {
 		mergePRMutation.mutate({
 			owner: pr.repoOwner,
 			repo: pr.repoName,
@@ -108,6 +125,17 @@ export function PRStatusGroup({
 			mergeMethod,
 		});
 	};
+	const mergeMethods = getAvailableMergeMethods(
+		repoMergeSettingsQuery.data
+			? {
+					allowMergeCommit: repoMergeSettingsQuery.data.allow_merge_commit,
+					allowRebaseMerge: repoMergeSettingsQuery.data.allow_rebase_merge,
+					allowSquashMerge: repoMergeSettingsQuery.data.allow_squash_merge,
+					viewerDefaultMergeMethod:
+						repoMergeSettingsQuery.data.viewerDefaultMergeMethod,
+				}
+			: null,
+	);
 
 	const tint = stateTintClasses(linkState);
 
@@ -181,30 +209,17 @@ export function PRStatusGroup({
 							<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
 								Merge
 							</DropdownMenuLabel>
-							<DropdownMenuItem
-								onClick={() => handleMerge("squash")}
-								className="text-xs"
-								disabled={mergePRMutation.isPending}
-							>
-								<VscGitMerge className="size-3.5" />
-								Squash and merge
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								onClick={() => handleMerge("merge")}
-								className="text-xs"
-								disabled={mergePRMutation.isPending}
-							>
-								<VscGitMerge className="size-3.5" />
-								Create merge commit
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								onClick={() => handleMerge("rebase")}
-								className="text-xs"
-								disabled={mergePRMutation.isPending}
-							>
-								<VscGitMerge className="size-3.5" />
-								Rebase and merge
-							</DropdownMenuItem>
+							{mergeMethods.map((method) => (
+								<DropdownMenuItem
+									key={method}
+									onClick={() => handleMerge(method)}
+									className="text-xs"
+									disabled={mergePRMutation.isPending}
+								>
+									<VscGitMerge className="size-3.5" />
+									{MERGE_METHOD_LABELS[method]}
+								</DropdownMenuItem>
+							))}
 						</DropdownMenuContent>
 					</DropdownMenu>
 				</>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -15,6 +15,11 @@ import {
 	VscLoading,
 } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	getAvailableMergeMethods,
+	MERGE_METHOD_LABELS,
+	type MergeMethod,
+} from "renderer/lib/githubMergeMethods";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
 import { useCreateOrOpenPR } from "renderer/screens/main/hooks";
 
@@ -49,6 +54,13 @@ export function PRButton({
 				id: context?.toastId,
 			}),
 	});
+	const mergeSettingsQuery = electronTrpc.changes.getMergeSettings.useQuery(
+		{ worktreePath },
+		{
+			enabled: pr?.state === "open",
+			staleTime: 5 * 60 * 1_000,
+		},
+	);
 
 	const { createOrOpenPR, isPending: isCreateOrOpenPRPending } =
 		useCreateOrOpenPR({
@@ -60,8 +72,10 @@ export function PRButton({
 
 	const handleCreatePR = () => createOrOpenPR();
 
-	const handleMergePR = (strategy: "merge" | "squash" | "rebase") =>
+	const handleMergePR = (strategy: MergeMethod) =>
 		mergePRMutation.mutate({ worktreePath, strategy });
+
+	const mergeMethods = getAvailableMergeMethods(mergeSettingsQuery.data);
 
 	if (isLoading) {
 		return (
@@ -164,30 +178,17 @@ export function PRButton({
 					<DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
 						Merge
 					</DropdownMenuLabel>
-					<DropdownMenuItem
-						onClick={() => handleMergePR("squash")}
-						className="text-xs"
-						disabled={mergePRMutation.isPending}
-					>
-						<VscGitMerge className="size-3.5" />
-						Squash and merge
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => handleMergePR("merge")}
-						className="text-xs"
-						disabled={mergePRMutation.isPending}
-					>
-						<VscGitMerge className="size-3.5" />
-						Create merge commit
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => handleMergePR("rebase")}
-						className="text-xs"
-						disabled={mergePRMutation.isPending}
-					>
-						<VscGitMerge className="size-3.5" />
-						Rebase and merge
-					</DropdownMenuItem>
+					{mergeMethods.map((method) => (
+						<DropdownMenuItem
+							key={method}
+							onClick={() => handleMergePR(method)}
+							className="text-xs"
+							disabled={mergePRMutation.isPending}
+						>
+							<VscGitMerge className="size-3.5" />
+							{MERGE_METHOD_LABELS[method]}
+						</DropdownMenuItem>
+					))}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		</div>

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -1,6 +1,20 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../../index";
 
+const REPOSITORY_MERGE_SETTINGS_QUERY = `
+	query($owner: String!, $name: String!) {
+		repository(owner: $owner, name: $name) {
+			viewerDefaultMergeMethod
+		}
+	}
+`;
+
+interface RepositoryMergeSettingsResult {
+	repository: {
+		viewerDefaultMergeMethod: string | null;
+	} | null;
+}
+
 export const githubRouter = router({
 	getPRStatus: protectedProcedure
 		.input(
@@ -80,7 +94,28 @@ export const githubRouter = router({
 				owner: input.owner,
 				repo: input.repo,
 			});
-			return data;
+
+			let viewerDefaultMergeMethod: string | null = null;
+			try {
+				const result = await octokit.graphql<RepositoryMergeSettingsResult>(
+					REPOSITORY_MERGE_SETTINGS_QUERY,
+					{
+						owner: input.owner,
+						name: input.repo,
+					},
+				);
+				viewerDefaultMergeMethod =
+					result.repository?.viewerDefaultMergeMethod ?? null;
+			} catch (error) {
+				// The REST settings are still useful when GraphQL does not expose
+				// the viewer default (for example, with an older token scope).
+				console.warn(
+					"[github.getRepo] Failed to fetch viewer default merge method:",
+					error,
+				);
+			}
+
+			return { ...data, viewerDefaultMergeMethod };
 		}),
 
 	listDeployments: protectedProcedure

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -1,29 +1,12 @@
+import {
+	GITHUB_MERGE_METHODS,
+	type GitHubMergeCapabilities,
+	isGitHubMergeMethodDisabled,
+	normalizeGitHubRestMergeCapabilities,
+} from "@superset/shared/github-merge-methods";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { protectedProcedure, router } from "../../index";
-
-const MERGE_METHODS = ["merge", "squash", "rebase"] as const;
-type MergeMethod = (typeof MERGE_METHODS)[number];
-
-interface RepositoryMergeCapabilities {
-	allow_merge_commit?: boolean | null;
-	allow_rebase_merge?: boolean | null;
-	allow_squash_merge?: boolean | null;
-}
-
-function isMergeMethodDisabled(
-	repository: RepositoryMergeCapabilities | null,
-	mergeMethod: MergeMethod,
-): boolean {
-	switch (mergeMethod) {
-		case "merge":
-			return repository?.allow_merge_commit === false;
-		case "squash":
-			return repository?.allow_squash_merge === false;
-		case "rebase":
-			return repository?.allow_rebase_merge === false;
-	}
-}
 
 const REPOSITORY_MERGE_SETTINGS_QUERY = `
 	query($owner: String!, $name: String!) {
@@ -196,18 +179,18 @@ export const githubRouter = router({
 				owner: z.string(),
 				repo: z.string(),
 				pullNumber: z.number(),
-				mergeMethod: z.enum(MERGE_METHODS).default("merge"),
+				mergeMethod: z.enum(GITHUB_MERGE_METHODS).default("merge"),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
 			const octokit = await ctx.github();
-			let repository: RepositoryMergeCapabilities | null = null;
+			let repository: GitHubMergeCapabilities | null = null;
 			try {
 				const result = await octokit.repos.get({
 					owner: input.owner,
 					repo: input.repo,
 				});
-				repository = result.data;
+				repository = normalizeGitHubRestMergeCapabilities(result.data);
 			} catch (error) {
 				// Preserve the existing merge behavior when repository settings are
 				// unavailable. Explicitly disabled methods are still rejected below.
@@ -217,7 +200,7 @@ export const githubRouter = router({
 				);
 			}
 
-			if (isMergeMethodDisabled(repository, input.mergeMethod)) {
+			if (isGitHubMergeMethodDisabled(repository, input.mergeMethod)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: `Repository ${input.owner}/${input.repo} does not allow ${input.mergeMethod} merges.`,

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -1,5 +1,29 @@
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { protectedProcedure, router } from "../../index";
+
+const MERGE_METHODS = ["merge", "squash", "rebase"] as const;
+type MergeMethod = (typeof MERGE_METHODS)[number];
+
+interface RepositoryMergeCapabilities {
+	allow_merge_commit?: boolean | null;
+	allow_rebase_merge?: boolean | null;
+	allow_squash_merge?: boolean | null;
+}
+
+function isMergeMethodDisabled(
+	repository: RepositoryMergeCapabilities | null,
+	mergeMethod: MergeMethod,
+): boolean {
+	switch (mergeMethod) {
+		case "merge":
+			return repository?.allow_merge_commit === false;
+		case "squash":
+			return repository?.allow_squash_merge === false;
+		case "rebase":
+			return repository?.allow_rebase_merge === false;
+	}
+}
 
 const REPOSITORY_MERGE_SETTINGS_QUERY = `
 	query($owner: String!, $name: String!) {
@@ -110,7 +134,7 @@ export const githubRouter = router({
 				// The REST settings are still useful when GraphQL does not expose
 				// the viewer default (for example, with an older token scope).
 				console.warn(
-					"[github.getRepo] Failed to fetch viewer default merge method:",
+					`[github.getRepo] Failed to fetch viewer default merge method for ${input.owner}/${input.repo}:`,
 					error,
 				);
 			}
@@ -172,11 +196,34 @@ export const githubRouter = router({
 				owner: z.string(),
 				repo: z.string(),
 				pullNumber: z.number(),
-				mergeMethod: z.enum(["merge", "squash", "rebase"]).default("merge"),
+				mergeMethod: z.enum(MERGE_METHODS).default("merge"),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
 			const octokit = await ctx.github();
+			let repository: RepositoryMergeCapabilities | null = null;
+			try {
+				const result = await octokit.repos.get({
+					owner: input.owner,
+					repo: input.repo,
+				});
+				repository = result.data;
+			} catch (error) {
+				// Preserve the existing merge behavior when repository settings are
+				// unavailable. Explicitly disabled methods are still rejected below.
+				console.warn(
+					`[github.mergePR] Failed to fetch merge settings for ${input.owner}/${input.repo}; continuing:`,
+					error,
+				);
+			}
+
+			if (isMergeMethodDisabled(repository, input.mergeMethod)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Repository ${input.owner}/${input.repo} does not allow ${input.mergeMethod} merges.`,
+				});
+			}
+
 			const { data } = await octokit.pulls.merge({
 				owner: input.owner,
 				repo: input.repo,

--- a/packages/host-service/test/integration/github-mocked.integration.test.ts
+++ b/packages/host-service/test/integration/github-mocked.integration.test.ts
@@ -67,6 +67,10 @@ describe("github router with mocked Octokit", () => {
 				};
 			},
 		},
+		graphql: async (_query: string, args: unknown) => {
+			calls.push({ method: "graphql", args });
+			return { repository: { viewerDefaultMergeMethod: "SQUASH" } };
+		},
 		users: {
 			getAuthenticated: async () => {
 				calls.push({ method: "users.getAuthenticated", args: {} });
@@ -141,7 +145,9 @@ describe("github router with mocked Octokit", () => {
 			repo: "hello",
 		});
 		expect(result.full_name).toBe("octocat/hello");
+		expect(result.viewerDefaultMergeMethod).toBe("SQUASH");
 		expect(calls[0].method).toBe("repos.get");
+		expect(calls[1].method).toBe("graphql");
 	});
 
 	test("listDeployments forwards filters to octokit", async () => {

--- a/packages/host-service/test/integration/github-mocked.integration.test.ts
+++ b/packages/host-service/test/integration/github-mocked.integration.test.ts
@@ -4,6 +4,12 @@ import { createTestHost, type TestHost } from "../helpers/createTestHost";
 describe("github router with mocked Octokit", () => {
 	let host: TestHost;
 	const calls: Array<{ method: string; args: unknown }> = [];
+	let repositoryMergeSettings = {
+		allow_merge_commit: true,
+		allow_rebase_merge: true,
+		allow_squash_merge: true,
+	};
+	let repositorySettingsError: Error | null = null;
 
 	const fakeOctokit = {
 		pulls: {
@@ -45,12 +51,16 @@ describe("github router with mocked Octokit", () => {
 		repos: {
 			get: async (args: unknown) => {
 				calls.push({ method: "repos.get", args });
+				if (repositorySettingsError) {
+					throw repositorySettingsError;
+				}
 				return {
 					data: {
 						id: 1,
 						name: "hello",
 						full_name: "octocat/hello",
 						default_branch: "main",
+						...repositoryMergeSettings,
 					},
 				};
 			},
@@ -81,6 +91,12 @@ describe("github router with mocked Octokit", () => {
 
 	beforeEach(async () => {
 		calls.length = 0;
+		repositoryMergeSettings = {
+			allow_merge_commit: true,
+			allow_rebase_merge: true,
+			allow_squash_merge: true,
+		};
+		repositorySettingsError = null;
 		host = await createTestHost({
 			githubFactory: async () => fakeOctokit,
 		});
@@ -181,7 +197,7 @@ describe("github router with mocked Octokit", () => {
 		expect(result.login).toBe("octocat");
 	});
 
-	test("mergePR forwards mergeMethod to octokit.pulls.merge", async () => {
+	test("mergePR forwards an allowed mergeMethod to octokit.pulls.merge", async () => {
 		const result = await host.trpc.github.mergePR.mutate({
 			owner: "octocat",
 			repo: "hello",
@@ -189,10 +205,45 @@ describe("github router with mocked Octokit", () => {
 			mergeMethod: "squash",
 		});
 		expect(result.merged).toBe(true);
-		expect(calls[0].method).toBe("pulls.merge");
-		expect(calls[0].args).toMatchObject({
+		expect(calls.map(({ method }) => method)).toEqual([
+			"repos.get",
+			"pulls.merge",
+		]);
+		expect(calls[1].args).toMatchObject({
 			pull_number: 42,
 			merge_method: "squash",
 		});
+	});
+
+	test("mergePR does not send a disabled method to GitHub", async () => {
+		repositoryMergeSettings.allow_squash_merge = false;
+
+		await expect(
+			host.trpc.github.mergePR.mutate({
+				owner: "octocat",
+				repo: "hello",
+				pullNumber: 42,
+				mergeMethod: "squash",
+			}),
+		).rejects.toThrow("does not allow squash merges");
+
+		expect(calls.map(({ method }) => method)).toEqual(["repos.get"]);
+	});
+
+	test("mergePR preserves the existing merge when settings are unavailable", async () => {
+		repositorySettingsError = new Error("GitHub settings unavailable");
+
+		const result = await host.trpc.github.mergePR.mutate({
+			owner: "octocat",
+			repo: "hello",
+			pullNumber: 42,
+			mergeMethod: "rebase",
+		});
+
+		expect(result.merged).toBe(true);
+		expect(calls.map(({ method }) => method)).toEqual([
+			"repos.get",
+			"pulls.merge",
+		]);
 	});
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -144,6 +144,10 @@
 			"types": "./src/github-remote.ts",
 			"default": "./src/github-remote.ts"
 		},
+		"./github-merge-methods": {
+			"types": "./src/github-merge-methods.ts",
+			"default": "./src/github-merge-methods.ts"
+		},
 		"./simple-git-options": {
 			"types": "./src/simple-git-options.ts",
 			"default": "./src/simple-git-options.ts"

--- a/packages/shared/src/github-merge-methods.test.ts
+++ b/packages/shared/src/github-merge-methods.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isGitHubMergeMethodDisabled,
+	normalizeGitHubRestMergeCapabilities,
+} from "./github-merge-methods";
+
+describe("GitHub merge method capabilities", () => {
+	test("normalizes REST capability field names", () => {
+		expect(
+			normalizeGitHubRestMergeCapabilities({
+				allow_merge_commit: true,
+				allow_rebase_merge: false,
+				allow_squash_merge: true,
+			}),
+		).toEqual({
+			allowMergeCommit: true,
+			allowRebaseMerge: false,
+			allowSquashMerge: true,
+		});
+	});
+
+	test("only treats an explicitly disabled capability as disabled", () => {
+		const capabilities = normalizeGitHubRestMergeCapabilities({
+			allow_rebase_merge: false,
+		});
+
+		expect(isGitHubMergeMethodDisabled(capabilities, "rebase")).toBe(true);
+		expect(isGitHubMergeMethodDisabled(capabilities, "merge")).toBe(false);
+		expect(isGitHubMergeMethodDisabled(null, "squash")).toBe(false);
+	});
+});

--- a/packages/shared/src/github-merge-methods.ts
+++ b/packages/shared/src/github-merge-methods.ts
@@ -1,0 +1,41 @@
+export const GITHUB_MERGE_METHODS = ["squash", "merge", "rebase"] as const;
+
+export type GitHubMergeMethod = (typeof GITHUB_MERGE_METHODS)[number];
+
+export interface GitHubMergeCapabilities {
+	allowMergeCommit?: boolean | null;
+	allowRebaseMerge?: boolean | null;
+	allowSquashMerge?: boolean | null;
+}
+
+export interface GitHubRestMergeCapabilities {
+	allow_merge_commit?: boolean | null;
+	allow_rebase_merge?: boolean | null;
+	allow_squash_merge?: boolean | null;
+}
+
+export function normalizeGitHubRestMergeCapabilities(
+	capabilities: GitHubRestMergeCapabilities | null | undefined,
+): GitHubMergeCapabilities | null {
+	if (!capabilities) return null;
+
+	return {
+		allowMergeCommit: capabilities.allow_merge_commit,
+		allowRebaseMerge: capabilities.allow_rebase_merge,
+		allowSquashMerge: capabilities.allow_squash_merge,
+	};
+}
+
+export function isGitHubMergeMethodDisabled(
+	capabilities: GitHubMergeCapabilities | null | undefined,
+	method: GitHubMergeMethod,
+): boolean {
+	switch (method) {
+		case "merge":
+			return capabilities?.allowMergeCommit === false;
+		case "rebase":
+			return capabilities?.allowRebaseMerge === false;
+		case "squash":
+			return capabilities?.allowSquashMerge === false;
+	}
+}


### PR DESCRIPTION
## Design

Both pull request merge menus use the same pure merge-method selection logic and the same capability mapping.

- `@superset/shared/github-merge-methods` owns the supported method set, REST-to-canonical capability normalization, and explicit-disabled check.
- The renderer uses that capability check while filtering methods and keeps the viewer default first when it is enabled.
- v2 reads repository capabilities through `github.getRepo`; v1 reads the equivalent fields through `gh repo view`, resolving fork worktrees to their upstream repository.
- Both merge mutations reject a method only when GitHub explicitly reports it as disabled. Missing, incomplete, or failed settings lookups remain fail-open, preserving the existing merge behavior.
- No database schema changes are required.

## Validation

- Shared capability tests: 2 passing
- Merge menu tests: 4 passing
- v1 merge router tests: 3 passing
- GitHub router integration tests: 10 passing
- Existing v1 merge utility tests: 3 passing
- Biome lint and format checks: passing
- Shared and host-service typechecks: passing
- Desktop typecheck remains blocked by the workspace's missing `@sentry/electron/main` and `@sentry/electron/renderer` modules.

Closes #6185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request merge menus now reflect the repository’s enabled merge methods.
  * The viewer’s preferred merge method is prioritized when available.
  * Merge method labels and selections are consistent across pull request interfaces.
  * Unavailable repository settings fall back to standard merge options.

* **Bug Fixes**
  * Disabled merge methods are no longer displayed or accepted for merging.

* **Tests**
  * Added coverage for repository-specific methods, defaults, fallbacks, and disabled options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->