### PR TITLE
fix(trpc): retry chat session insert without v2WorkspaceId on FK violation

### DIFF
--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -7,6 +7,7 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, userError } from "../../trpc";
 import { requireActiveOrgMembership } from "../utils/active-org";
+import { createChatSession } from "./utils/create-chat-session";
 
 // Re-shaped from the canonical catalog in `@superset/shared/agent-models` so
 // the chat API and the workspace-create model picker never drift.
@@ -73,24 +74,11 @@ export const chatRouter = {
 				});
 			}
 
-			const result = await dbWs.transaction(async (tx) => {
-				const [inserted] = await tx
-					.insert(chatSessions)
-					.values({
-						id: input.sessionId,
-						organizationId,
-						createdBy: ctx.session.user.id,
-						v2WorkspaceId: input.v2WorkspaceId,
-					})
-					.onConflictDoNothing()
-					.returning({ id: chatSessions.id });
-
-				if (!inserted) {
-					return { txid: null };
-				}
-
-				const txid = await getCurrentTxid(tx);
-				return { txid };
+			const result = await createChatSession(dbWs, {
+				id: input.sessionId,
+				organizationId,
+				createdBy: ctx.session.user.id,
+				v2WorkspaceId: input.v2WorkspaceId,
 			});
 
 			return {

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -8,6 +8,7 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
 import { requireActiveOrgMembership } from "../utils/active-org";
+import { createChatSession } from "./utils/create-chat-session";
 import { uploadChatAttachment } from "./utils/upload-chat-attachment";
 
 // Re-shaped from the canonical catalog in `@superset/shared/agent-models` so
@@ -74,24 +75,11 @@ export const chatRouter = {
 				});
 			}
 
-			const result = await dbWs.transaction(async (tx) => {
-				const [inserted] = await tx
-					.insert(chatSessions)
-					.values({
-						id: input.sessionId,
-						organizationId,
-						createdBy: ctx.session.user.id,
-						v2WorkspaceId: input.v2WorkspaceId,
-					})
-					.onConflictDoNothing()
-					.returning({ id: chatSessions.id });
-
-				if (!inserted) {
-					return { txid: null };
-				}
-
-				const txid = await getCurrentTxid(tx);
-				return { txid };
+			const result = await createChatSession(dbWs, {
+				id: input.sessionId,
+				organizationId,
+				createdBy: ctx.session.user.id,
+				v2WorkspaceId: input.v2WorkspaceId,
 			});
 
 			return {

--- a/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
@@ -142,7 +142,7 @@ describe("createChatSession", () => {
 		expect(result).toEqual({ txid: null });
 	});
 
-	test("logs and retries exactly once on FK violation", async () => {
+	test("logs a fixed reason and retries exactly once on FK violation", async () => {
 		const warnMock = mock();
 		const originalWarn = console.warn;
 		console.warn = warnMock as never;
@@ -151,9 +151,11 @@ describe("createChatSession", () => {
 			const result = await createChatSession(db as never, BASE_VALUES);
 			expect(result).toEqual({ txid: 42 });
 			expect(warnMock).toHaveBeenCalledTimes(1);
-			const [message, details] = warnMock.mock.calls[0];
+			const [message] = warnMock.mock.calls[0] as [string];
 			expect(message).toContain("without v2WorkspaceId");
-			expect(details.sessionId).toBe(BASE_VALUES.id);
+			// The log must not leak raw session/organization ids (#6231 review).
+			expect(message).not.toContain(BASE_VALUES.id);
+			expect(message).not.toContain(BASE_VALUES.organizationId);
 		} finally {
 			console.warn = originalWarn;
 		}

--- a/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
@@ -13,76 +13,131 @@ const BASE_VALUES = {
 	v2WorkspaceId: "44444444-4444-4444-4444-444444444444",
 };
 
-function makeTx(behavior: { inserts: Array<Record<string, unknown> | Error> }) {
-	const returned = behavior.inserts.map((insert) =>
-		insert instanceof Error ? insert : [insert],
-	);
-	return {
-		insert: () => ({
-			values: (values: Record<string, unknown>) => ({
-				onConflictDoNothing: () => ({
-					returning: async () => {
-						const next = returned.shift();
-						if (next instanceof Error) throw next;
-						return next;
-					},
-				}),
+const RETRY_VALUES = {
+	id: BASE_VALUES.id,
+	organizationId: BASE_VALUES.organizationId,
+	createdBy: BASE_VALUES.createdBy,
+};
+
+type InsertOutcome = Record<string, unknown> | Error | undefined;
+
+/**
+ * Each `transaction()` call gets a FRESH transaction whose inserts are drawn
+ * from the shared outcome queue — so the test can assert that the retry runs
+ * in a new transaction (the original one is dead after Postgres aborts it)
+ * rather than reusing the aborted transaction.
+ */
+function makeDb(inserts: InsertOutcome[]) {
+	const outcomes = [...inserts];
+	const txCalls: number[] = [];
+	const capturedValues: Array<Record<string, unknown>> = [];
+	let txCount = 0;
+
+	const makeTx = () => {
+		const txId = txCount++;
+		return {
+			insert: () => ({
+				values: (values: Record<string, unknown>) => {
+					capturedValues.push({ ...values });
+					return {
+						onConflictDoNothing: () => ({
+							returning: async () => {
+								const next = outcomes.shift();
+								// A failed insert aborts the transaction — any
+								// further insert on the SAME tx must fail too.
+								if (next instanceof Error) {
+									throw new Error(`${next.message} (tx ${txId} aborted)`);
+								}
+								return next === undefined ? [] : [next];
+							},
+						}),
+					};
+				},
 			}),
-		}),
+		};
+	};
+
+	return {
+		db: {
+			transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+				txCalls.push(txCount);
+				return fn(makeTx());
+			},
+		},
+		txCalls,
+		capturedValues,
 	};
 }
 
-function makeDb(behavior: { inserts: Array<Record<string, unknown> | Error> }) {
-	const tx = makeTx(behavior);
-	return {
-		transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> =>
-			fn(tx),
-	};
-}
+const FK_ERROR = new Error(
+	'insert or update on table "chat_sessions" violates foreign key constraint "chat_sessions_v2_workspace_id_v2_workspaces_id_fk"',
+);
 
 describe("createChatSession", () => {
 	test("inserts with v2WorkspaceId on success", async () => {
-		const db = makeDb({ inserts: [BASE_VALUES] });
+		const { db, txCalls, capturedValues } = makeDb([BASE_VALUES]);
 		const result = await createChatSession(db as never, BASE_VALUES);
 		expect(result).toEqual({ txid: 42 });
+		// one transaction, one insert, values passed through untouched
+		expect(txCalls).toEqual([0]);
+		expect(capturedValues).toEqual([BASE_VALUES]);
 	});
 
 	test("retries without v2WorkspaceId on FK violation", async () => {
-		const fkError = new Error(
-			'insert or update on table "chat_sessions" violates foreign key constraint "chat_sessions_v2_workspace_id_v2_workspaces_id_fk"',
-		);
-		const retryValues = {
-			id: BASE_VALUES.id,
-			organizationId: BASE_VALUES.organizationId,
-			createdBy: BASE_VALUES.createdBy,
-		};
-		const db = makeDb({ inserts: [fkError, retryValues] });
+		const { db, txCalls, capturedValues } = makeDb([FK_ERROR, RETRY_VALUES]);
 		const result = await createChatSession(db as never, BASE_VALUES);
 		expect(result).toEqual({ txid: 42 });
+		// retry runs in a SECOND transaction (the first aborted)
+		expect(txCalls).toEqual([0, 1]);
+		expect(capturedValues).toEqual([BASE_VALUES, RETRY_VALUES]);
 	});
 
-	test("retries without v2WorkspaceId on generic foreign key error", async () => {
-		const fkError = new Error('violates foreign key constraint "some_fk"');
-		const retryValues = {
-			id: BASE_VALUES.id,
-			organizationId: BASE_VALUES.organizationId,
-			createdBy: BASE_VALUES.createdBy,
-		};
-		const db = makeDb({ inserts: [fkError, retryValues] });
+	test("retries without v2WorkspaceId on generic v2_workspace_id FK error", async () => {
+		const fkError = new Error(
+			'violates foreign key constraint "v2_workspace_id_fkey"',
+		);
+		const { db, txCalls, capturedValues } = makeDb([fkError, RETRY_VALUES]);
 		const result = await createChatSession(db as never, BASE_VALUES);
 		expect(result).toEqual({ txid: 42 });
+		expect(txCalls).toEqual([0, 1]);
+		expect(capturedValues).toEqual([BASE_VALUES, RETRY_VALUES]);
+	});
+
+	test("does NOT retry on unrelated FK errors", async () => {
+		// A different FK constraint (not v2_workspace_id) must propagate.
+		const otherFk = new Error(
+			'violates foreign key constraint "chat_sessions_organization_id_fkey"',
+		);
+		const { db, txCalls, capturedValues } = makeDb([otherFk]);
+		await expect(createChatSession(db as never, BASE_VALUES)).rejects.toThrow(
+			"chat_sessions_organization_id_fkey",
+		);
+		expect(txCalls).toEqual([0]);
+		expect(capturedValues).toEqual([BASE_VALUES]);
+	});
+
+	test("does NOT retry on unrelated column errors", async () => {
+		// Generic errors mentioning "column" / "does not exist" must NOT
+		// trigger the v2_workspace_id retry path.
+		const colError = new Error('column "v2_workspace_id" does not exist');
+		const { db, txCalls } = makeDb([colError]);
+		await expect(createChatSession(db as never, BASE_VALUES)).rejects.toThrow(
+			"does not exist",
+		);
+		expect(txCalls).toEqual([0]);
 	});
 
 	test("propagates non-FK errors", async () => {
 		const otherError = new Error("connection refused");
-		const db = makeDb({ inserts: [otherError] });
+		const { db, txCalls } = makeDb([otherError]);
 		await expect(createChatSession(db as never, BASE_VALUES)).rejects.toThrow(
 			"connection refused",
 		);
+		expect(txCalls).toEqual([0]);
 	});
 
 	test("returns txid null when insert conflicts (onConflictDoNothing)", async () => {
-		const db = makeDb({ inserts: [undefined] });
+		const { db } = makeDb([undefined]);
 		const result = await createChatSession(db as never, BASE_VALUES);
 		expect(result).toEqual({ txid: null });
 	});
@@ -92,15 +147,7 @@ describe("createChatSession", () => {
 		const originalWarn = console.warn;
 		console.warn = warnMock as never;
 		try {
-			const fkError = new Error(
-				'violates foreign key constraint "chat_sessions_v2_workspace_id_v2_workspaces_id_fk"',
-			);
-			const retryValues = {
-				id: BASE_VALUES.id,
-				organizationId: BASE_VALUES.organizationId,
-				createdBy: BASE_VALUES.createdBy,
-			};
-			const db = makeDb({ inserts: [fkError, retryValues] });
+			const { db } = makeDb([FK_ERROR, RETRY_VALUES]);
 			const result = await createChatSession(db as never, BASE_VALUES);
 			expect(result).toEqual({ txid: 42 });
 			expect(warnMock).toHaveBeenCalledTimes(1);

--- a/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@superset/db/utils", () => ({
+	getCurrentTxid: async () => 42,
+}));
+
+const { createChatSession } = await import("./create-chat-session");
+
+const BASE_VALUES = {
+	id: "11111111-1111-1111-1111-111111111111",
+	organizationId: "22222222-2222-2222-2222-222222222222",
+	createdBy: "33333333-3333-3333-3333-333333333333",
+	v2WorkspaceId: "44444444-4444-4444-4444-444444444444",
+};
+
+function makeTx(behavior: { inserts: Array<Record<string, unknown> | Error> }) {
+	const returned = behavior.inserts.map((insert) =>
+		insert instanceof Error ? insert : [insert],
+	);
+	return {
+		insert: () => ({
+			values: (values: Record<string, unknown>) => ({
+				onConflictDoNothing: () => ({
+					returning: async () => {
+						const next = returned.shift();
+						if (next instanceof Error) throw next;
+						return next;
+					},
+				}),
+			}),
+		}),
+	};
+}
+
+function makeDb(behavior: { inserts: Array<Record<string, unknown> | Error> }) {
+	const tx = makeTx(behavior);
+	return {
+		transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> =>
+			fn(tx),
+	};
+}
+
+describe("createChatSession", () => {
+	test("inserts with v2WorkspaceId on success", async () => {
+		const db = makeDb({ inserts: [BASE_VALUES] });
+		const result = await createChatSession(db as never, BASE_VALUES);
+		expect(result).toEqual({ txid: 42 });
+	});
+
+	test("retries without v2WorkspaceId on FK violation", async () => {
+		const fkError = new Error(
+			'insert or update on table "chat_sessions" violates foreign key constraint "chat_sessions_v2_workspace_id_v2_workspaces_id_fk"',
+		);
+		const retryValues = {
+			id: BASE_VALUES.id,
+			organizationId: BASE_VALUES.organizationId,
+			createdBy: BASE_VALUES.createdBy,
+		};
+		const db = makeDb({ inserts: [fkError, retryValues] });
+		const result = await createChatSession(db as never, BASE_VALUES);
+		expect(result).toEqual({ txid: 42 });
+	});
+
+	test("retries without v2WorkspaceId on generic foreign key error", async () => {
+		const fkError = new Error('violates foreign key constraint "some_fk"');
+		const retryValues = {
+			id: BASE_VALUES.id,
+			organizationId: BASE_VALUES.organizationId,
+			createdBy: BASE_VALUES.createdBy,
+		};
+		const db = makeDb({ inserts: [fkError, retryValues] });
+		const result = await createChatSession(db as never, BASE_VALUES);
+		expect(result).toEqual({ txid: 42 });
+	});
+
+	test("propagates non-FK errors", async () => {
+		const otherError = new Error("connection refused");
+		const db = makeDb({ inserts: [otherError] });
+		await expect(createChatSession(db as never, BASE_VALUES)).rejects.toThrow(
+			"connection refused",
+		);
+	});
+
+	test("returns txid null when insert conflicts (onConflictDoNothing)", async () => {
+		const db = makeDb({ inserts: [undefined] });
+		const result = await createChatSession(db as never, BASE_VALUES);
+		expect(result).toEqual({ txid: null });
+	});
+
+	test("logs and retries exactly once on FK violation", async () => {
+		const warnMock = mock();
+		const originalWarn = console.warn;
+		console.warn = warnMock as never;
+		try {
+			const fkError = new Error(
+				'violates foreign key constraint "chat_sessions_v2_workspace_id_v2_workspaces_id_fk"',
+			);
+			const retryValues = {
+				id: BASE_VALUES.id,
+				organizationId: BASE_VALUES.organizationId,
+				createdBy: BASE_VALUES.createdBy,
+			};
+			const db = makeDb({ inserts: [fkError, retryValues] });
+			const result = await createChatSession(db as never, BASE_VALUES);
+			expect(result).toEqual({ txid: 42 });
+			expect(warnMock).toHaveBeenCalledTimes(1);
+			const [message, details] = warnMock.mock.calls[0];
+			expect(message).toContain("without v2WorkspaceId");
+			expect(details.sessionId).toBe(BASE_VALUES.id);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+});

--- a/packages/trpc/src/router/chat/utils/create-chat-session.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.ts
@@ -16,14 +16,19 @@ function errorMessage(error: unknown): string {
 // cloud `v2_workspaces`. The legacy `chat_sessions.v2_workspace_id` FK then
 // rejects any insert for such a workspace. Mirrors the defensive retry in
 // `apps/api/src/app/api/chat/[sessionId]/route.ts`.
+//
+// Match ONLY the specific constraint (or a v2_workspace_id FK violation) so
+// unrelated errors — "column ... does not exist", generic "foreign key"
+// mentions, network failures — never trigger a silent retry that would hide
+// the real cause.
 function shouldRetryWithoutV2WorkspaceId(error: unknown): boolean {
 	const message = errorMessage(error).toLowerCase();
+	if (message.includes("chat_sessions_v2_workspace_id_v2_workspaces_id_fk")) {
+		return true;
+	}
 	return (
-		message.includes("v2_workspace_id") ||
-		message.includes("chat_sessions_v2_workspace_id_v2_workspaces_id_fk") ||
-		message.includes("foreign key") ||
-		message.includes("column") ||
-		message.includes("does not exist")
+		message.includes("v2_workspace_id") &&
+		message.includes("foreign key constraint")
 	);
 }
 
@@ -41,7 +46,6 @@ export interface ChatSessionCreateResult {
 // biome-ignore lint/suspicious/noExplicitAny: transaction type varies by client (Neon, PostgresJs, etc)
 type ChatSessionTx = PgTransaction<any, any, any>;
 
-// biome-ignore lint/suspicious/noExplicitAny: only the transaction callback shape is needed
 type ChatSessionDb = {
 	transaction: <T>(fn: (tx: ChatSessionTx) => Promise<T>) => Promise<T>;
 };

--- a/packages/trpc/src/router/chat/utils/create-chat-session.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.ts
@@ -1,0 +1,102 @@
+import { chatSessions } from "@superset/db/schema";
+import { getCurrentTxid } from "@superset/db/utils";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
+
+// Workspaces became host-owned/local-first (#5731): the main workspace is
+// minted locally with a fresh UUID on every boot and is never mirrored to
+// cloud `v2_workspaces`. The legacy `chat_sessions.v2_workspace_id` FK then
+// rejects any insert for such a workspace. Mirrors the defensive retry in
+// `apps/api/src/app/api/chat/[sessionId]/route.ts`.
+function shouldRetryWithoutV2WorkspaceId(error: unknown): boolean {
+	const message = errorMessage(error).toLowerCase();
+	return (
+		message.includes("v2_workspace_id") ||
+		message.includes("chat_sessions_v2_workspace_id_v2_workspaces_id_fk") ||
+		message.includes("foreign key") ||
+		message.includes("column") ||
+		message.includes("does not exist")
+	);
+}
+
+export interface ChatSessionInsert {
+	id: string;
+	organizationId: string;
+	createdBy: string;
+	v2WorkspaceId: string;
+}
+
+export interface ChatSessionCreateResult {
+	txid: number | null;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: transaction type varies by client (Neon, PostgresJs, etc)
+type ChatSessionTx = PgTransaction<any, any, any>;
+
+// biome-ignore lint/suspicious/noExplicitAny: only the transaction callback shape is needed
+type ChatSessionDb = {
+	transaction: <T>(fn: (tx: ChatSessionTx) => Promise<T>) => Promise<T>;
+};
+
+async function insertAndGetTxid(
+	tx: ChatSessionTx,
+	values: Omit<ChatSessionInsert, "v2WorkspaceId"> | ChatSessionInsert,
+) {
+	const [inserted] = await tx
+		.insert(chatSessions)
+		.values(values)
+		.onConflictDoNothing()
+		.returning({ id: chatSessions.id });
+
+	if (!inserted) {
+		return { txid: null };
+	}
+
+	const txid = await getCurrentTxid(tx);
+	return { txid };
+}
+
+/**
+ * Insert a chat session, retrying without `v2WorkspaceId` when the legacy
+ * foreign key rejects the insert. Local-first workspaces mint their own
+ * host UUIDs that have no cloud `v2_workspaces` row, so the FK violation is
+ * expected for those workspaces; the session still needs to exist so chat
+ * can run against it. The retry runs in a fresh transaction: a failed insert
+ * aborts the surrounding Postgres transaction, so re-inserting inside the
+ * same one would fail regardless.
+ */
+export async function createChatSession(
+	db: ChatSessionDb,
+	values: ChatSessionInsert,
+): Promise<ChatSessionCreateResult> {
+	try {
+		return await db.transaction((tx) => insertAndGetTxid(tx, values));
+	} catch (error) {
+		if (!shouldRetryWithoutV2WorkspaceId(error)) {
+			throw error;
+		}
+
+		console.warn("[chat] retrying chat session insert without v2WorkspaceId", {
+			sessionId: values.id,
+			organizationId: values.organizationId,
+			v2WorkspaceId: values.v2WorkspaceId,
+			error: errorMessage(error),
+		});
+
+		return db.transaction((tx) =>
+			insertAndGetTxid(tx, {
+				id: values.id,
+				organizationId: values.organizationId,
+				createdBy: values.createdBy,
+			}),
+		);
+	}
+}

--- a/packages/trpc/src/router/chat/utils/create-chat-session.ts
+++ b/packages/trpc/src/router/chat/utils/create-chat-session.ts
@@ -5,7 +5,7 @@ import type { PgTransaction } from "drizzle-orm/pg-core";
 function errorMessage(error: unknown): string {
 	if (error instanceof Error) return error.message;
 	try {
-		return JSON.stringify(error);
+		return JSON.stringify(error) ?? String(error);
 	} catch {
 		return String(error);
 	}
@@ -88,12 +88,11 @@ export async function createChatSession(
 			throw error;
 		}
 
-		console.warn("[chat] retrying chat session insert without v2WorkspaceId", {
-			sessionId: values.id,
-			organizationId: values.organizationId,
-			v2WorkspaceId: values.v2WorkspaceId,
-			error: errorMessage(error),
-		});
+		// Log a fixed retry reason only — never raw session/organization ids
+		// or the raw DB error, which can carry user/workspace correlation data.
+		console.warn(
+			"[chat] retrying chat session insert without v2WorkspaceId (foreign-key constraint)",
+		);
 
 		return db.transaction((tx) =>
 			insertAndGetTxid(tx, {


### PR DESCRIPTION
Fixes #6230

## Bug

Sending a message in a chat pane for a **"local"** entry (the `type: "main"` workspace, i.e. the repo checkout itself) fails with a database error, in every repo. Worktree workspaces work — only "local" entries fail.

## Root cause

`chat.createSession` (`packages/trpc/src/router/chat/chat.ts`) inserted `chat_sessions.v2_workspace_id` directly from the client-supplied `input.v2WorkspaceId`. That column has an FK to cloud `v2_workspaces` (`chat_sessions_v2_workspace_id_v2_workspaces_id_fk`).

Since local-first (#5731), workspaces are host-owned: the main workspace is minted locally with a fresh UUID on every boot (`runMainWorkspaceSweep` → `ensureMainWorkspace`) and is never mirrored to the cloud `v2_workspaces` table. The FK can therefore never be satisfied for those ids, and the insert throws on **every** message — surfacing the raw query in the chat pane.

The legacy REST bootstrap (`apps/api/src/app/api/chat/[sessionId]/route.ts`) already carries a defensive retry-without-workspaceId fallback for this exact failure class; the tRPC path had none.

## Fix

Extract the session insert into `create-chat-session.ts` and retry without `v2WorkspaceId` when the insert fails with a foreign-key error — mirroring the REST route's `shouldRetryWithoutWorkspaceId` behavior. The retry runs in a **fresh** transaction because a failed INSERT aborts the surrounding Postgres transaction (`current transaction is aborted`), so re-inserting inside the same one would fail regardless.

The resulting row keeps `v2WorkspaceId` NULL for local-first workspaces — the same degraded-but-functional state the REST path produces.

## Tests

Added `packages/trpc/src/router/chat/utils/create-chat-session.test.ts` (6 cases):
- insert with `v2WorkspaceId` succeeds and returns the txid
- FK violation → retries without `v2WorkspaceId`
- generic foreign-key error → retries
- non-FK errors are propagated
- `onConflictDoNothing` conflict → `{ txid: null }`
- FK violation logs exactly once

`bun test`: 6 pass, 0 fail. Package typecheck: clean. Biome check: clean.

Note: #5853 (bot draft, #5852) targets the same FK with an up-front existence check; this PR takes the retry approach already established in the REST route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries chat session insert without v2WorkspaceId only when the v2_workspace_id FK rejects it, so messages from the local “main” workspace send. Previously `packages/trpc` wrote the client’s v2WorkspaceId and surfaced FK errors; now it retries in a fresh transaction and stores a null v2WorkspaceId for local sessions, matching the REST route.

- Extracts `createChatSession` in `packages/trpc/src/router/chat/utils/create-chat-session.ts` and uses it from `packages/trpc/src/router/chat/chat.ts`.
- Retries only when the error matches `chat_sessions_v2_workspace_id_v2_workspaces_id_fk` or a v2_workspace_id FK violation; does not retry on unrelated FK or column errors.
- Uses a new transaction for the retry; on conflict, returns `{ txid: null }`.
- Hardens error handling: safe message parsing avoids calling toLowerCase on undefined; retry log emits a fixed reason without raw ids or the DB error.
- Tests cover success, targeted FK retry, no-retry cases, fresh-transaction fallback, conflict handling, and a single sanitized warning.

<sup>Written for commit 668c98891308e55e1b3ce105d9ba5e9dc81518bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat-session creation reliability when legacy workspace references are unavailable.
  * Added targeted retry handling for recognized workspace-reference constraint errors.
  * Improved handling of session conflicts, transaction identifiers, and unrelated database failures.
  * Ensured retries use a fresh transaction and produce clear warning logs.

* **Tests**
  * Added coverage for successful creation, retry behavior, conflicts, transaction isolation, warning logs, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->