### PR TITLE
fix(desktop): forward app hotkeys from browser panes via main-process chord index

### DIFF
--- a/apps/desktop/docs/KEYBOARD_SYSTEM.md
+++ b/apps/desktop/docs/KEYBOARD_SYSTEM.md
@@ -144,6 +144,7 @@ The v1→v2 hotkey storage migration was shipped April 2026 and removed in commi
 
 | Item | Status |
 |---|---|
+| **Browser-pane hotkey forwarding** — guest webContents swallow unclaimed chords (⌘B/⌘L dead, ⌘O shadowed by menu) | **Fixed** in `main/lib/browser/browser-manager.ts`: the renderer pushes its chord index to main and `before-input-event` forwards matches back for re-dispatch; guest find/print (⌘F/⌘P/⌘G) stay with the page. |
 | **Menu accelerator sync** — `main/lib/menu.ts` hardcodes `CmdOrCtrl+R/,//Shift+Q`; they shadow user rebinds | Demand-driven. The single concrete user-visible gap. |
 | **v1 terminal handler** uses catch-all `ctrl/meta` skip → starves TUIs of unbound chords like Ctrl+R | Tracked in `plans/20260409-tui-hotkey-forwarding.md`; v2 already correct. |
 | **AltGr first-class binding token** | Reserved but never wired. AltGr is suppressed at match time, but a user can't *record* `AltGr+E` as their own chord. Drop or implement on demand. |

--- a/apps/desktop/docs/KEYBOARD_SYSTEM.md
+++ b/apps/desktop/docs/KEYBOARD_SYSTEM.md
@@ -139,12 +139,12 @@ The v1→v2 hotkey storage migration was shipped April 2026 and removed in commi
 - **April 2026** — Initial refactor. Unified everything on `event.code` (recorder, dispatch, terminal forwarding). Preserved the bare-string storage shape. See `plans/done/20260412-keyboard-recorder-ctrl-binding-fix.md`.
 - **April 27, 2026** — Layout audit and Phase 0–2 plan. Briefly tried `navigator.keyboard.getLayoutMap()` to avoid the native-keymap dep; switched back after discovering Chromium's `layoutchange` event doesn't fire for macOS input-source switches. native-keymap hooks `kTISNotifySelectedKeyboardInputSourceChanged` directly, which fires reliably. See `plans/done/20260427-keyboard-layout-plan.md`.
 - **April 28, 2026** — Phase 1 (native-keymap) + Phase 2 (dual-mode bindings) shipped. v1 migration removed.
+- **August 2026** — Browser-pane hotkey forwarding. Guest webContents swallow unclaimed chords (⌘B/⌘L dead, ⌘O shadowed by menu); the renderer now pushes its chord index to main and `before-input-event` forwards matches back for re-dispatch on `document`. Guest-owned editing shortcuts (⌘/Ctrl A/C/V/X/Z) and find/print/find-next (⌘F/⌘P/⌘G) stay with the page. See `shared/browser-pane-chords.ts` and `main/lib/browser/browser-manager.ts`.
 
 ## Known gaps / future work
 
 | Item | Status |
 |---|---|
-| **Browser-pane hotkey forwarding** — guest webContents swallow unclaimed chords (⌘B/⌘L dead, ⌘O shadowed by menu) | **Fixed** in `main/lib/browser/browser-manager.ts`: the renderer pushes its chord index to main and `before-input-event` forwards matches back for re-dispatch; guest find/print (⌘F/⌘P/⌘G) stay with the page. |
 | **Menu accelerator sync** — `main/lib/menu.ts` hardcodes `CmdOrCtrl+R/,//Shift+Q`; they shadow user rebinds | Demand-driven. The single concrete user-visible gap. |
 | **v1 terminal handler** uses catch-all `ctrl/meta` skip → starves TUIs of unbound chords like Ctrl+R | Tracked in `plans/20260409-tui-hotkey-forwarding.md`; v2 already correct. |
 | **AltGr first-class binding token** | Reserved but never wired. AltGr is suppressed at match time, but a user can't *record* `AltGr+E` as their own chord. Drop or implement on demand. |

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -13,6 +13,27 @@ export const createBrowserRouter = () => {
 				return { success: true };
 			}),
 
+		setAppChords: publicProcedure
+			.input(z.object({ chords: z.array(z.string()) }))
+			.mutation(({ input }) => {
+				browserManager.setAppChords(input.chords);
+				return { success: true };
+			}),
+
+		onAppHotkey: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<string>((emit) => {
+					const handler = (chord: string) => {
+						emit.next(chord);
+					};
+					browserManager.on(`app-hotkey:${input.paneId}`, handler);
+					return () => {
+						browserManager.off(`app-hotkey:${input.paneId}`, handler);
+					};
+				});
+			}),
+
 		unregister: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.mutation(({ input }) => {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { clipboard, Menu, webContents } from "electron";
 import { safeOpenExternal } from "main/lib/safe-url";
+import { inputToChord, matchAppChord } from "shared/browser-pane-chords";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -29,6 +30,15 @@ class BrowserManager extends EventEmitter {
 	private consoleListeners = new Map<string, () => void>();
 	private contextMenuListeners = new Map<string, () => void>();
 	private beforeInputListeners = new Map<string, () => void>();
+	// Canonical chords the app has registered, pushed from the renderer
+	// whenever overrides / layout / adaptive mapping change. Empty until the
+	// first push, so pane hotkeys only activate once the index arrives.
+	private appChords = new Set<string>();
+
+	/** Replace the renderer-pushed app chord index (canonicalized). */
+	setAppChords(chords: string[]): void {
+		this.appChords = new Set(chords);
+	}
 
 	register(paneId: string, webContentsId: number): void {
 		// Clean even when prevId === webContentsId so BrowserManager owns
@@ -242,25 +252,39 @@ class BrowserManager extends EventEmitter {
 	// accelerator closes the whole window. `before-input-event` fires in the
 	// main process before both, and `preventDefault()` suppresses both.
 	//
-	// keyDown guard prevents a second fire on keyUp. Shift guard preserves
-	// Cmd+Shift+W (CLOSE_TAB) and Cmd+Shift+R (forceReload).
+	// The full app chord index is pushed from the renderer (see setAppChords),
+	// so any registered chord is matched here by physical key position and
+	// forwarded to the host renderer to re-dispatch — mirroring how the
+	// terminal short-circuits xterm in-process. Chords the guest page owns
+	// (find / print / find-next) are excluded by matchAppChord, and the
+	// pane-scoped reload (no registry hotkey) keeps its dedicated event.
 	private setupBeforeInput(paneId: string, wc: Electron.WebContents): void {
 		const handler = (event: Electron.Event, input: Electron.Input): void => {
 			if (input.type !== "keyDown") return;
-			if (input.shift || input.alt) return;
-			if (!(input.meta || input.control)) return;
 
-			const key = input.key.toLowerCase();
-			if (key === "w") {
+			const chord = inputToChord(input);
+
+			// Pane-scoped actions keep their dedicated events (the legacy
+			// TabView path has no global CLOSE_PANE hotkey, and reload has no
+			// registry hotkey at all). Physical-position matching via
+			// inputToChord replaces the old `input.key` string compare, which
+			// drifted from the registry on non-QWERTY layouts.
+			if (chord === "meta+w" || chord === "ctrl+w") {
 				event.preventDefault();
 				this.emit(`close-pane:${paneId}`);
 				return;
 			}
-			if (key === "r") {
+			if (chord === "meta+r" || chord === "ctrl+r") {
 				event.preventDefault();
 				this.emit(`reload-pane:${paneId}`);
 				return;
 			}
+
+			const appChord = matchAppChord(input, this.appChords);
+			if (!appChord) return;
+
+			event.preventDefault();
+			this.emit(`app-hotkey:${paneId}`, appChord);
 		};
 
 		wc.on("before-input-event", handler);

--- a/apps/desktop/src/renderer/hotkeys/utils/appChordSync.test.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/appChordSync.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	APP_CHORD_SYNC_RETRY_DELAYS_MS,
+	createAppChordSync,
+} from "./appChordSync";
+
+interface ScheduledRetry {
+	callback: () => void;
+	cancelled: boolean;
+	delayMs: number;
+}
+
+function createManualScheduler() {
+	const scheduled: ScheduledRetry[] = [];
+	return {
+		cancelRetry: (retry: unknown) => {
+			(retry as ScheduledRetry).cancelled = true;
+		},
+		runNext: () => {
+			const retry = scheduled.find(({ cancelled }) => !cancelled);
+			if (!retry) throw new Error("No retry is scheduled");
+			retry.cancelled = true;
+			retry.callback();
+		},
+		scheduleRetry: (callback: () => void, delayMs: number) => {
+			const retry = { callback, cancelled: false, delayMs };
+			scheduled.push(retry);
+			return retry;
+		},
+		scheduled,
+	};
+}
+
+async function settlePromises(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("createAppChordSync", () => {
+	it("retries transient failures with bounded backoff until the latest chords sync", async () => {
+		const scheduler = createManualScheduler();
+		let failuresRemaining = 2;
+		const push = mock(async () => {
+			if (failuresRemaining > 0) {
+				failuresRemaining -= 1;
+				throw new Error("IPC not ready");
+			}
+		});
+		const sync = createAppChordSync({
+			getChords: () => ["meta+k"],
+			push,
+			...scheduler,
+		});
+
+		sync.request();
+		await settlePromises();
+		expect(push).toHaveBeenCalledTimes(1);
+		expect(scheduler.scheduled[0]?.delayMs).toBe(
+			APP_CHORD_SYNC_RETRY_DELAYS_MS[0],
+		);
+
+		scheduler.runNext();
+		await settlePromises();
+		expect(push).toHaveBeenCalledTimes(2);
+		expect(scheduler.scheduled[1]?.delayMs).toBe(
+			APP_CHORD_SYNC_RETRY_DELAYS_MS[1],
+		);
+
+		scheduler.runNext();
+		await settlePromises();
+		expect(push).toHaveBeenCalledTimes(3);
+		expect(
+			scheduler.scheduled.filter(({ cancelled }) => !cancelled),
+		).toHaveLength(0);
+	});
+
+	it("cancels a stale retry and sends the newest state immediately", async () => {
+		const scheduler = createManualScheduler();
+		let chords = ["meta+k"];
+		const pushed: string[][] = [];
+		const push = mock(async (nextChords: string[]) => {
+			pushed.push(nextChords);
+			if (pushed.length === 1) throw new Error("IPC not ready");
+		});
+		const sync = createAppChordSync({
+			getChords: () => chords,
+			push,
+			...scheduler,
+		});
+
+		sync.request();
+		await settlePromises();
+		expect(
+			scheduler.scheduled.filter(({ cancelled }) => !cancelled),
+		).toHaveLength(1);
+
+		chords = ["meta+shift+p"];
+		sync.request();
+		await settlePromises();
+
+		expect(pushed).toEqual([["meta+k"], ["meta+shift+p"]]);
+		expect(
+			scheduler.scheduled.filter(({ cancelled }) => !cancelled),
+		).toHaveLength(0);
+	});
+
+	it("sends a newer state immediately after an obsolete in-flight push settles", async () => {
+		const scheduler = createManualScheduler();
+		let chords = ["meta+k"];
+		let rejectFirstPush: ((error: Error) => void) | undefined;
+		const pushed: string[][] = [];
+		const push = mock((nextChords: string[]) => {
+			pushed.push(nextChords);
+			if (pushed.length > 1) return Promise.resolve();
+			return new Promise<void>((_resolve, reject) => {
+				rejectFirstPush = reject;
+			});
+		});
+		const sync = createAppChordSync({
+			getChords: () => chords,
+			push,
+			...scheduler,
+		});
+
+		sync.request();
+		chords = ["meta+shift+p"];
+		sync.request();
+		rejectFirstPush?.(new Error("obsolete push failed"));
+		await settlePromises();
+
+		expect(pushed).toEqual([["meta+k"], ["meta+shift+p"]]);
+		expect(scheduler.scheduled).toHaveLength(0);
+	});
+
+	it("caps the backoff and keeps retrying until sync succeeds", async () => {
+		const scheduler = createManualScheduler();
+		let failuresRemaining = 4;
+		const push = mock(async () => {
+			if (failuresRemaining > 0) {
+				failuresRemaining -= 1;
+				throw new Error("IPC unavailable");
+			}
+		});
+		const sync = createAppChordSync({
+			getChords: () => ["meta+k"],
+			push,
+			retryDelaysMs: [10, 20],
+			...scheduler,
+		});
+
+		sync.request();
+		await settlePromises();
+		for (const expectedDelay of [10, 20, 20, 20]) {
+			const pending = scheduler.scheduled.find(({ cancelled }) => !cancelled);
+			expect(pending?.delayMs).toBe(expectedDelay);
+			scheduler.runNext();
+			await settlePromises();
+		}
+
+		expect(push).toHaveBeenCalledTimes(5);
+		expect(
+			scheduler.scheduled.filter(({ cancelled }) => !cancelled),
+		).toHaveLength(0);
+	});
+});

--- a/apps/desktop/src/renderer/hotkeys/utils/appChordSync.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/appChordSync.ts
@@ -1,0 +1,94 @@
+export const APP_CHORD_SYNC_RETRY_DELAYS_MS = [
+	250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000,
+] as const;
+
+interface CreateAppChordSyncOptions {
+	cancelRetry?: (retry: unknown) => void;
+	getChords: () => string[];
+	onError?: (error: unknown) => void;
+	push: (chords: string[]) => Promise<unknown>;
+	retryDelaysMs?: readonly number[];
+	scheduleRetry?: (callback: () => void, delayMs: number) => unknown;
+}
+
+export interface AppChordSync {
+	dispose: () => void;
+	request: () => void;
+}
+
+/**
+ * Pushes the latest renderer chord index to main with capped retry backoff.
+ * A new request cancels any stale delayed retry and resets the budget. If state
+ * changes while a mutation is in flight, the newest snapshot is sent as soon
+ * as that mutation settles rather than waiting for its old backoff.
+ */
+export function createAppChordSync({
+	cancelRetry = (retry) => clearTimeout(retry as ReturnType<typeof setTimeout>),
+	getChords,
+	onError,
+	push,
+	retryDelaysMs = APP_CHORD_SYNC_RETRY_DELAYS_MS,
+	scheduleRetry = (callback, delayMs) => setTimeout(callback, delayMs),
+}: CreateAppChordSyncOptions): AppChordSync {
+	let disposed = false;
+	let inFlight = false;
+	let requestedRevision = 0;
+	let retryIndex = 0;
+	let retryTimer: unknown | null = null;
+
+	const flush = async (): Promise<void> => {
+		if (disposed || inFlight) return;
+
+		inFlight = true;
+		const revision = requestedRevision;
+		try {
+			await push(getChords());
+			if (revision === requestedRevision) retryIndex = 0;
+		} catch (error) {
+			if (!disposed) {
+				if (revision !== requestedRevision) {
+					// A newer request is already queued. Give it a fresh budget and run
+					// it immediately from finally instead of retrying this snapshot.
+					retryIndex = 0;
+					onError?.(error);
+				} else {
+					const delayMs =
+						retryDelaysMs[
+							Math.min(retryIndex, Math.max(0, retryDelaysMs.length - 1))
+						];
+					if (delayMs === undefined) {
+						onError?.(error);
+					} else {
+						retryIndex = Math.min(retryIndex + 1, retryDelaysMs.length - 1);
+						retryTimer = scheduleRetry(() => {
+							retryTimer = null;
+							void flush();
+						}, delayMs);
+						onError?.(error);
+					}
+				}
+			}
+		} finally {
+			inFlight = false;
+			if (!disposed && revision !== requestedRevision && retryTimer === null) {
+				void flush();
+			}
+		}
+	};
+
+	return {
+		dispose: () => {
+			disposed = true;
+			if (retryTimer !== null) cancelRetry(retryTimer);
+			retryTimer = null;
+		},
+		request: () => {
+			if (disposed) return;
+			requestedRevision += 1;
+			retryIndex = 0;
+			if (retryTimer !== null) cancelRetry(retryTimer);
+			retryTimer = null;
+			void flush();
+		},
+	};
+}

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -87,12 +87,33 @@ let registeredAppChords = buildRegisteredAppChords(
 // cheap and the main-side set is replaced wholesale. If the IPC channel
 // isn't ready yet (startup / teardown) the main-side index just stays
 // empty until the next rebuild — browser-pane hotkeys degrade gracefully.
+//
+// On rejection, retry once with a short delay instead of dropping the
+// update: the channel typically comes up within a second of the renderer
+// booting, and the NEXT rebuild (override/layout change) also re-pushes,
+// so a single delayed retry keeps the main-side index from staying stale
+// for the whole session.
+let pendingChordsRetry: ReturnType<typeof setTimeout> | null = null;
+
 function pushAppChordsToMain(): void {
 	const chords = [...registeredAppChords.keys()];
 	void electronTrpcClient.browser.setAppChords
 		.mutate({ chords })
 		.catch((error: unknown) => {
 			console.warn("Failed to push app chords to main process", error);
+			if (pendingChordsRetry) return;
+			pendingChordsRetry = setTimeout(() => {
+				pendingChordsRetry = null;
+				const latest = [...registeredAppChords.keys()];
+				void electronTrpcClient.browser.setAppChords
+					.mutate({ chords: latest })
+					.catch((retryError: unknown) => {
+						console.warn(
+							"Retry: failed to push app chords to main process",
+							retryError,
+						);
+					});
+			}, 1_000);
 		});
 }
 

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -1,3 +1,5 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { canonicalizeChord, eventToChord } from "shared/browser-pane-chords";
 import { HOTKEYS, type HotkeyId } from "../registry";
 import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
 import { useKeyboardLayoutStore } from "../stores/keyboardLayoutStore";
@@ -7,6 +9,14 @@ import {
 } from "../stores/keyboardPreferencesStore";
 import type { ShortcutBinding } from "../types";
 import { bindingToDispatchChord } from "./binding";
+
+export {
+	canonicalizeChord,
+	eventToChord,
+	isIgnorableKey,
+	MODIFIERS,
+	normalizeToken,
+} from "shared/browser-pane-chords";
 
 /**
  * KeyboardEvent → registered {@link HotkeyId}, or `null` if unbound. Uses the
@@ -19,82 +29,6 @@ export function resolveHotkeyFromEvent(event: KeyboardEvent): HotkeyId | null {
 	const chord = eventToChord(event);
 	if (!chord) return null;
 	return registeredAppChords.get(chord) ?? null;
-}
-
-// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
-const CODE_ALIASES: Record<string, string> = {
-	esc: "escape",
-	return: "enter",
-	left: "arrowleft",
-	right: "arrowright",
-	up: "arrowup",
-	down: "arrowdown",
-	MetaLeft: "meta",
-	MetaRight: "meta",
-	ShiftLeft: "shift",
-	ShiftRight: "shift",
-	AltLeft: "alt",
-	AltRight: "alt",
-	OSLeft: "meta",
-	OSRight: "meta",
-	ControlLeft: "ctrl",
-	ControlRight: "ctrl",
-};
-
-export const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
-
-// Lock keys must never commit a binding on their own.
-const LOCK_KEYS = new Set(["capslock", "numlock", "scrolllock"]);
-
-export function normalizeToken(token: string): string {
-	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
-	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
-}
-
-export function isIgnorableKey(normalized: string): boolean {
-	return !normalized || MODIFIERS.has(normalized) || LOCK_KEYS.has(normalized);
-}
-
-/**
- * Stable form for comparing chord strings. Tolerates modifier order and
- * aliases: `meta+alt+up` ≡ `alt+meta+arrowup` ≡ `control+alt+arrowup`.
- */
-export function canonicalizeChord(chord: string): string {
-	const parts = chord.toLowerCase().split("+").map(normalizeToken);
-	const mods: string[] = [];
-	const keys: string[] = [];
-	for (const part of parts) {
-		if (MODIFIERS.has(part)) {
-			mods.push(part === "control" ? "ctrl" : part);
-		} else {
-			keys.push(part);
-		}
-	}
-	mods.sort();
-	return [...mods, ...keys].join("+");
-}
-
-/** KeyboardEvent → canonical chord (comparable to {@link canonicalizeChord} output), or null for pure modifier / synthetic presses. */
-export function eventToChord(event: KeyboardEvent): string | null {
-	if (event.code === undefined) return null;
-	// IME composition: keydown during CJK / dead-key composition must not
-	// trigger hotkeys. Safari reports keyCode 229 instead of isComposing.
-	if (event.isComposing || event.keyCode === 229) return null;
-	const key = normalizeToken(event.code);
-	if (isIgnorableKey(key)) return null;
-	// AltGr is reported by Chromium as ctrlKey+altKey on Windows/Linux.
-	// Treating that combination as Ctrl+Alt would let printable keystrokes on
-	// non-US layouts (e.g. AltGr+E = € on German) accidentally trigger
-	// ctrl+alt+e bindings. Suppress both when AltGr is held; no binding opts
-	// into AltGr explicitly.
-	const altGraph = event.getModifierState?.("AltGraph") === true;
-	const mods: string[] = [];
-	if (event.metaKey) mods.push("meta");
-	if (event.ctrlKey && !altGraph) mods.push("ctrl");
-	if (event.altKey && !altGraph) mods.push("alt");
-	if (event.shiftKey) mods.push("shift");
-	mods.sort();
-	return [...mods, key].join("+");
 }
 
 /** True if `event` produces `chord` (tolerating modifier order / aliases). */
@@ -146,12 +80,24 @@ let registeredAppChords = buildRegisteredAppChords(
 	useHotkeyOverridesStore.getState().overrides,
 	getEffectiveLayoutMap(),
 );
+
+// Mirror the index to the main process so browser panes (guest webContents,
+// out-of-process) can match the same chords in `before-input-event` and
+// forward matches back for re-dispatch. Fire-and-forget: the mutation is
+// cheap and the main-side set is replaced wholesale.
+function pushAppChordsToMain(): void {
+	const chords = [...registeredAppChords.keys()];
+	void electronTrpcClient.browser.setAppChords.mutate({ chords });
+}
+
 function rebuild() {
 	registeredAppChords = buildRegisteredAppChords(
 		useHotkeyOverridesStore.getState().overrides,
 		getEffectiveLayoutMap(),
 	);
+	pushAppChordsToMain();
 }
+pushAppChordsToMain();
 useHotkeyOverridesStore.subscribe(rebuild);
 useKeyboardLayoutStore.subscribe(rebuild);
 useKeyboardPreferencesStore.subscribe(rebuild);

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -8,6 +8,7 @@ import {
 	useKeyboardPreferencesStore,
 } from "../stores/keyboardPreferencesStore";
 import type { ShortcutBinding } from "../types";
+import { createAppChordSync } from "./appChordSync";
 import { bindingToDispatchChord } from "./binding";
 
 export {
@@ -83,48 +84,26 @@ let registeredAppChords = buildRegisteredAppChords(
 
 // Mirror the index to the main process so browser panes (guest webContents,
 // out-of-process) can match the same chords in `before-input-event` and
-// forward matches back for re-dispatch. Fire-and-forget: the mutation is
-// cheap and the main-side set is replaced wholesale. If the IPC channel
-// isn't ready yet (startup / teardown) the main-side index just stays
-// empty until the next rebuild — browser-pane hotkeys degrade gracefully.
-//
-// On rejection, retry once with a short delay instead of dropping the
-// update: the channel typically comes up within a second of the renderer
-// booting, and the NEXT rebuild (override/layout change) also re-pushes,
-// so a single delayed retry keeps the main-side index from staying stale
-// for the whole session.
-let pendingChordsRetry: ReturnType<typeof setTimeout> | null = null;
-
-function pushAppChordsToMain(): void {
-	const chords = [...registeredAppChords.keys()];
-	void electronTrpcClient.browser.setAppChords
-		.mutate({ chords })
-		.catch((error: unknown) => {
-			console.warn("Failed to push app chords to main process", error);
-			if (pendingChordsRetry) return;
-			pendingChordsRetry = setTimeout(() => {
-				pendingChordsRetry = null;
-				const latest = [...registeredAppChords.keys()];
-				void electronTrpcClient.browser.setAppChords
-					.mutate({ chords: latest })
-					.catch((retryError: unknown) => {
-						console.warn(
-							"Retry: failed to push app chords to main process",
-							retryError,
-						);
-					});
-			}, 1_000);
-		});
-}
+// forward matches back for re-dispatch. The renderer can initialize before
+// the Electron tRPC handler is ready, so transient failures retry with a
+// finite backoff. Every rebuild cancels a stale delayed retry and immediately
+// requests the newest complete index.
+const appChordSync = createAppChordSync({
+	getChords: () => [...registeredAppChords.keys()],
+	push: (chords) => electronTrpcClient.browser.setAppChords.mutate({ chords }),
+	onError: (error) => {
+		console.warn("Failed to push app chords to main process; retrying", error);
+	},
+});
 
 function rebuild() {
 	registeredAppChords = buildRegisteredAppChords(
 		useHotkeyOverridesStore.getState().overrides,
 		getEffectiveLayoutMap(),
 	);
-	pushAppChordsToMain();
+	appChordSync.request();
 }
-pushAppChordsToMain();
+appChordSync.request();
 useHotkeyOverridesStore.subscribe(rebuild);
 useKeyboardLayoutStore.subscribe(rebuild);
 useKeyboardPreferencesStore.subscribe(rebuild);

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -84,10 +84,16 @@ let registeredAppChords = buildRegisteredAppChords(
 // Mirror the index to the main process so browser panes (guest webContents,
 // out-of-process) can match the same chords in `before-input-event` and
 // forward matches back for re-dispatch. Fire-and-forget: the mutation is
-// cheap and the main-side set is replaced wholesale.
+// cheap and the main-side set is replaced wholesale. If the IPC channel
+// isn't ready yet (startup / teardown) the main-side index just stays
+// empty until the next rebuild — browser-pane hotkeys degrade gracefully.
 function pushAppChordsToMain(): void {
 	const chords = [...registeredAppChords.keys()];
-	void electronTrpcClient.browser.setAppChords.mutate({ chords });
+	void electronTrpcClient.browser.setAppChords
+		.mutate({ chords })
+		.catch((error: unknown) => {
+			console.warn("Failed to push app chords to main process", error);
+		});
 }
 
 function rebuild() {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -92,7 +92,13 @@ export function usePersistentWebview({
 			{ paneId },
 			{
 				onData: () => {
-					void ctxRef.current.actions.close();
+					void (async () => {
+						try {
+							await ctxRef.current.actions.close();
+						} catch (error) {
+							console.warn("Failed to close browser pane", error);
+						}
+					})();
 				},
 			},
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -5,6 +5,7 @@ import type {
 	BrowserPaneData,
 	PaneViewerData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { dispatchChordEvent } from "shared/browser-pane-chords";
 import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 import { DEFAULT_BROWSER_URL } from "../../constants";
 
@@ -82,11 +83,14 @@ export function usePersistentWebview({
 			);
 		// `ctx.actions.close()` runs the standard onBeforeClose hook chain,
 		// matching the renderer CLOSE_PANE hotkey path.
-		const closePaneSub = electronTrpcClient.browser.onClosePane.subscribe(
+		const appHotkeySub = electronTrpcClient.browser.onAppHotkey.subscribe(
 			{ paneId },
 			{
-				onData: () => {
-					void ctxRef.current.actions.close();
+				onData: (chord: string) => {
+					const event = dispatchChordEvent(chord);
+					if (event) {
+						window.dispatchEvent(event);
+					}
 				},
 			},
 		);
@@ -101,7 +105,7 @@ export function usePersistentWebview({
 		return () => {
 			newWindowSub.unsubscribe();
 			contextMenuSub.unsubscribe();
-			closePaneSub.unsubscribe();
+			appHotkeySub.unsubscribe();
 			reloadPaneSub.unsubscribe();
 		};
 	}, [paneId]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -81,15 +81,28 @@ export function usePersistentWebview({
 					},
 				},
 			);
-		// `ctx.actions.close()` runs the standard onBeforeClose hook chain,
-		// matching the renderer CLOSE_PANE hotkey path.
+		// ⌘W/⌘R stay on the dedicated events: main emits `close-pane` /
+		// `reload-pane` for them BEFORE app-chord matching, so they never
+		// arrive via `app-hotkey`. `ctx.actions.close()` runs the standard
+		// onBeforeClose hook chain, matching the renderer CLOSE_PANE hotkey
+		// path. All other registered chords arrive as `app-hotkey` and are
+		// re-dispatched as synthetic keydowns on `document`, where
+		// react-hotkeys-hook attaches its listeners.
+		const closePaneSub = electronTrpcClient.browser.onClosePane.subscribe(
+			{ paneId },
+			{
+				onData: () => {
+					void ctxRef.current.actions.close();
+				},
+			},
+		);
 		const appHotkeySub = electronTrpcClient.browser.onAppHotkey.subscribe(
 			{ paneId },
 			{
 				onData: (chord: string) => {
 					const event = dispatchChordEvent(chord);
 					if (event) {
-						window.dispatchEvent(event);
+						document.dispatchEvent(event);
 					}
 				},
 			},
@@ -105,6 +118,7 @@ export function usePersistentWebview({
 		return () => {
 			newWindowSub.unsubscribe();
 			contextMenuSub.unsubscribe();
+			closePaneSub.unsubscribe();
 			appHotkeySub.unsubscribe();
 			reloadPaneSub.unsubscribe();
 		};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -96,7 +96,7 @@ export function usePersistentWebview({
 						try {
 							await ctxRef.current.actions.close();
 						} catch (error) {
-							console.warn("Failed to close browser pane", error);
+							console.warn(`Failed to close browser pane (${paneId})`, error);
 						}
 					})();
 				},

--- a/apps/desktop/src/shared/browser-pane-chords.test.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import {
+	BROWSER_PANE_EXCLUDED_CHORDS,
+	canonicalizeChord,
+	chordToEventInit,
+	inputToChord,
+	matchAppChord,
+	normalizeToken,
+	tokenToCode,
+} from "./browser-pane-chords";
+
+const CHORDS = new Set(
+	["meta+b", "meta+l", "meta+w", "meta+shift+k", "meta+alt+arrowleft"].map(
+		canonicalizeChord,
+	),
+);
+
+describe("inputToChord", () => {
+	test("matches ⌘B by physical position", () => {
+		expect(inputToChord({ type: "keyDown", code: "KeyB", meta: true })).toBe(
+			"meta+b",
+		);
+	});
+
+	test("anchors to physical position, not produced character (Dvorak ⌘W)", () => {
+		// Dvorak: physical KeyW prints ","
+		expect(
+			inputToChord({ type: "keyDown", code: "KeyW", key: ",", meta: true }),
+		).toBe("meta+w");
+	});
+
+	test("includes shift and alt modifiers", () => {
+		expect(
+			inputToChord({
+				type: "keyDown",
+				code: "KeyK",
+				meta: true,
+				shift: true,
+			}),
+		).toBe("meta+shift+k");
+		expect(
+			inputToChord({
+				type: "keyDown",
+				code: "ArrowLeft",
+				meta: true,
+				alt: true,
+			}),
+		).toBe("alt+meta+arrowleft");
+	});
+
+	test("returns null for modifier-only presses", () => {
+		expect(
+			inputToChord({ type: "keyDown", code: "MetaLeft", meta: true }),
+		).toBeNull();
+	});
+
+	test("returns null for non-keyDown types", () => {
+		expect(
+			inputToChord({ type: "keyUp", code: "KeyB", meta: true }),
+		).toBeNull();
+	});
+});
+
+describe("matchAppChord", () => {
+	test("matches a registered chord", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyB", meta: true }, CHORDS),
+		).toBe("meta+b");
+	});
+
+	test("returns null for unregistered chords", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyX", meta: true }, CHORDS),
+		).toBeNull();
+	});
+
+	test("leaves page find to the guest (⌘F excluded)", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyF", meta: true }, CHORDS),
+		).toBeNull();
+		expect(BROWSER_PANE_EXCLUDED_CHORDS.has("meta+f")).toBeTrue();
+	});
+
+	test("leaves page print to the guest (⌘P excluded)", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyP", meta: true }, CHORDS),
+		).toBeNull();
+	});
+
+	test("empty chord index never matches", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyB", meta: true }, new Set()),
+		).toBeNull();
+	});
+});
+
+describe("tokenToCode / chordToEventInit", () => {
+	test("tokenToCode round-trips letters, digits, named keys, F-keys", () => {
+		expect(tokenToCode("b")).toBe("KeyB");
+		expect(tokenToCode("1")).toBe("Digit1");
+		expect(tokenToCode("arrowleft")).toBe("ArrowLeft");
+		expect(tokenToCode("f5")).toBe("F5");
+		expect(tokenToCode("space")).toBe("Space");
+	});
+
+	test("chordToEventInit produces a re-dispatchable keydown init", () => {
+		const init = chordToEventInit("meta+b");
+		expect(init).not.toBeNull();
+		expect(init?.code).toBe("KeyB");
+		expect(init?.metaKey).toBeTrue();
+		expect(init?.bubbles).toBeTrue();
+	});
+
+	test("chordToEventInit maps modifiers from the canonical chord", () => {
+		const init = chordToEventInit("meta+shift+k");
+		expect(init?.code).toBe("KeyK");
+		expect(init?.metaKey).toBeTrue();
+		expect(init?.shiftKey).toBeTrue();
+		expect(init?.ctrlKey).toBeFalse();
+	});
+
+	test("chordToEventInit tolerates alias modifier order", () => {
+		const init = chordToEventInit("alt+meta+arrowleft");
+		expect(init?.code).toBe("ArrowLeft");
+		expect(init?.metaKey).toBeTrue();
+		expect(init?.altKey).toBeTrue();
+	});
+
+	test("chordToEventInit returns null for modifier-only chords", () => {
+		expect(chordToEventInit("meta+shift")).toBeNull();
+	});
+
+	test("normalizeToken matches the renderer alias table", () => {
+		expect(normalizeToken("KeyB")).toBe("b");
+		expect(normalizeToken("Digit3")).toBe("3");
+		expect(normalizeToken("ControlLeft")).toBe("ctrl");
+	});
+});

--- a/apps/desktop/src/shared/browser-pane-chords.test.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.test.ts
@@ -150,6 +150,23 @@ describe("matchAppChord", () => {
 		).toBeNull();
 	});
 
+	test("shift-gated chords are not guest editing shortcuts (⌘⇧C COPY_PATH)", () => {
+		// The guest's copy is plain ⌘C; ⌘⇧C is the app's COPY_PATH and must
+		// keep forwarding even though the produced character is "c".
+		expect(
+			matchAppChord(
+				{
+					type: "keyDown",
+					code: "KeyC",
+					key: "C",
+					meta: true,
+					shift: true,
+				},
+				new Set([canonicalizeChord("meta+shift+c")]),
+			),
+		).toBe("meta+shift+c");
+	});
+
 	test("empty chord index never matches", () => {
 		expect(
 			matchAppChord({ type: "keyDown", code: "KeyB", meta: true }, new Set()),

--- a/apps/desktop/src/shared/browser-pane-chords.test.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-	BROWSER_PANE_EXCLUDED_CHORDS,
 	canonicalizeChord,
 	chordToEventInit,
 	inputToChord,
@@ -10,9 +9,18 @@ import {
 } from "./browser-pane-chords";
 
 const CHORDS = new Set(
-	["meta+b", "meta+l", "meta+w", "meta+shift+k", "meta+alt+arrowleft"].map(
-		canonicalizeChord,
-	),
+	[
+		"meta+b",
+		"meta+l",
+		"meta+w",
+		"meta+shift+k",
+		"meta+alt+arrowleft",
+		// registered chords that collide with guest-owned shortcuts — exclusion
+		// must take priority over the index
+		"meta+f",
+		"meta+p",
+		"meta+g",
+	].map(canonicalizeChord),
 );
 
 describe("inputToChord", () => {
@@ -54,6 +62,17 @@ describe("inputToChord", () => {
 		).toBeNull();
 	});
 
+	test("returns null for IME composition keydowns", () => {
+		expect(
+			inputToChord({
+				type: "keyDown",
+				code: "KeyB",
+				meta: true,
+				isComposing: true,
+			}),
+		).toBeNull();
+	});
+
 	test("returns null for non-keyDown types", () => {
 		expect(
 			inputToChord({ type: "keyUp", code: "KeyB", meta: true }),
@@ -74,17 +93,44 @@ describe("matchAppChord", () => {
 		).toBeNull();
 	});
 
-	test("leaves page find to the guest (⌘F excluded)", () => {
+	test("exclusion wins over a registered chord (⌘F find)", () => {
 		expect(
 			matchAppChord({ type: "keyDown", code: "KeyF", meta: true }, CHORDS),
 		).toBeNull();
-		expect(BROWSER_PANE_EXCLUDED_CHORDS.has("meta+f")).toBeTrue();
 	});
 
-	test("leaves page print to the guest (⌘P excluded)", () => {
+	test("exclusion wins over a registered chord (⌘P print)", () => {
 		expect(
 			matchAppChord({ type: "keyDown", code: "KeyP", meta: true }, CHORDS),
 		).toBeNull();
+	});
+
+	test("exclusion wins over a registered chord (⌘G find-next)", () => {
+		expect(
+			matchAppChord({ type: "keyDown", code: "KeyG", meta: true }, CHORDS),
+		).toBeNull();
+	});
+
+	test("guest editing shortcuts stay with the page (⌘C/⌘V/⌘X/⌘A/⌘Z + ctrl variants)", () => {
+		for (const [code, mod] of [
+			["KeyC", "meta"],
+			["KeyV", "meta"],
+			["KeyX", "meta"],
+			["KeyA", "meta"],
+			["KeyZ", "meta"],
+			["KeyC", "ctrl"],
+			["KeyV", "ctrl"],
+			["KeyX", "ctrl"],
+			["KeyA", "ctrl"],
+			["KeyZ", "ctrl"],
+		] as const) {
+			expect(
+				matchAppChord(
+					{ type: "keyDown", code, [mod]: true },
+					new Set([canonicalizeChord(`${mod}+${code[3].toLowerCase()}`)]),
+				),
+			).toBeNull();
+		}
 	});
 
 	test("empty chord index never matches", () => {

--- a/apps/desktop/src/shared/browser-pane-chords.test.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.test.ts
@@ -118,11 +118,11 @@ describe("matchAppChord", () => {
 			["KeyX", "meta"],
 			["KeyA", "meta"],
 			["KeyZ", "meta"],
-			["KeyC", "ctrl"],
-			["KeyV", "ctrl"],
-			["KeyX", "ctrl"],
-			["KeyA", "ctrl"],
-			["KeyZ", "ctrl"],
+			["KeyC", "control"],
+			["KeyV", "control"],
+			["KeyX", "control"],
+			["KeyA", "control"],
+			["KeyZ", "control"],
 		] as const) {
 			expect(
 				matchAppChord(
@@ -131,6 +131,23 @@ describe("matchAppChord", () => {
 				),
 			).toBeNull();
 		}
+	});
+
+	test("guest undo stays with the page on non-QWERTY layouts (logical key match)", () => {
+		// AZERTY: physical KeyW produces "z" (undo is ⌘Z logically), which
+		// collides with the app's CLOSE_PANE (meta+w) chord — the produced
+		// character must win so undo reaches the page.
+		expect(
+			matchAppChord(
+				{
+					type: "keyDown",
+					code: "KeyW",
+					key: "z",
+					meta: true,
+				},
+				new Set([canonicalizeChord("meta+w")]),
+			),
+		).toBeNull();
 	});
 
 	test("empty chord index never matches", () => {

--- a/apps/desktop/src/shared/browser-pane-chords.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.ts
@@ -158,10 +158,14 @@ export function matchAppChord(
 // CLOSE_PANE chord). Match the produced character (`input.key`) for this
 // family instead — Electron reports the character the OS layout produces,
 // which is exactly what the guest page's own editing shortcuts act on.
+//
+// Shift-gated chords are NOT guest editing shortcuts: ⌘⇧C is the app's
+// COPY_PATH and must keep forwarding (the guest's copy is plain ⌘C).
 const GUEST_EDITING_KEYS = new Set(["a", "c", "v", "x", "z"]);
 
 function isGuestEditingShortcut(input: BrowserPaneInput): boolean {
 	if (!(input.meta || input.control)) return false;
+	if (input.shift) return false;
 	const key = (input.key ?? "").toLowerCase();
 	return GUEST_EDITING_KEYS.has(key);
 }

--- a/apps/desktop/src/shared/browser-pane-chords.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.ts
@@ -1,0 +1,213 @@
+// Pure chord-matching helpers shared between the main process (Electron
+// `before-input-event` on browser-pane webContents) and the renderer
+// (react-hotkeys-hook reverse index). Kept free of any Electron, DOM, or
+// zustand import so both sides can use them and bun:test can cover them
+// without a webContents stub.
+
+// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
+const CODE_ALIASES: Record<string, string> = {
+	esc: "escape",
+	return: "enter",
+	left: "arrowleft",
+	right: "arrowright",
+	up: "arrowup",
+	down: "arrowdown",
+	MetaLeft: "meta",
+	MetaRight: "meta",
+	ShiftLeft: "shift",
+	ShiftRight: "shift",
+	AltLeft: "alt",
+	AltRight: "alt",
+	OSLeft: "meta",
+	OSRight: "meta",
+	ControlLeft: "ctrl",
+	ControlRight: "ctrl",
+};
+
+export const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
+
+// Lock keys must never commit a binding on their own.
+const LOCK_KEYS = new Set(["capslock", "numlock", "scrolllock"]);
+
+export function normalizeToken(token: string): string {
+	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
+	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
+}
+
+export function isIgnorableKey(normalized: string): boolean {
+	return !normalized || MODIFIERS.has(normalized) || LOCK_KEYS.has(normalized);
+}
+
+/**
+ * Stable form for comparing chord strings. Tolerates modifier order and
+ * aliases: `meta+alt+up` ≡ `alt+meta+arrowup` ≡ `control+alt+arrowup`.
+ */
+export function canonicalizeChord(chord: string): string {
+	const parts = chord.toLowerCase().split("+").map(normalizeToken);
+	const mods: string[] = [];
+	const keys: string[] = [];
+	for (const part of parts) {
+		if (MODIFIERS.has(part)) {
+			mods.push(part === "control" ? "ctrl" : part);
+		} else {
+			keys.push(part);
+		}
+	}
+	mods.sort();
+	return [...mods, ...keys].join("+");
+}
+
+/**
+ * Minimal shape of an Electron `before-input-event` Input — only the fields
+ * chord matching needs, so tests don't require Electron types.
+ */
+export interface BrowserPaneInput {
+	type?: string;
+	code?: string;
+	key?: string;
+	meta?: boolean;
+	control?: boolean;
+	alt?: boolean;
+	shift?: boolean;
+}
+
+/** `before-input-event` Input → canonical chord, or null for modifier-only / unknown keys. */
+export function inputToChord(input: BrowserPaneInput): string | null {
+	if (input.type !== undefined && input.type !== "keyDown") return null;
+	if (input.code === undefined) return null;
+	const key = normalizeToken(input.code);
+	if (isIgnorableKey(key)) return null;
+	const mods: string[] = [];
+	if (input.meta) mods.push("meta");
+	if (input.control) mods.push("ctrl");
+	if (input.alt) mods.push("alt");
+	if (input.shift) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}
+
+/** DOM KeyboardEvent → canonical chord (comparable to {@link canonicalizeChord} output), or null for pure modifier / synthetic presses. */
+export function eventToChord(event: KeyboardEvent): string | null {
+	if (event.code === undefined) return null;
+	// IME composition: keydown during CJK / dead-key composition must not
+	// trigger hotkeys. Safari reports keyCode 229 instead of isComposing.
+	if (event.isComposing || event.keyCode === 229) return null;
+	const key = normalizeToken(event.code);
+	if (isIgnorableKey(key)) return null;
+	// AltGr is reported by Chromium as ctrlKey+altKey on Windows/Linux.
+	// Treating that combination as Ctrl+Alt would let printable keystrokes on
+	// non-US layouts (e.g. AltGr+E = € on German) accidentally trigger
+	// ctrl+alt+e bindings. Suppress both when AltGr is held; no binding opts
+	// into AltGr explicitly.
+	const altGraph = event.getModifierState?.("AltGraph") === true;
+	const mods: string[] = [];
+	if (event.metaKey) mods.push("meta");
+	if (event.ctrlKey && !altGraph) mods.push("ctrl");
+	if (event.altKey && !altGraph) mods.push("alt");
+	if (event.shiftKey) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}
+
+// Chords the app must NOT claim from a browser pane: the guest page's own
+// find / print / find-next behavior is more useful there than any of the
+// pane-scoped app bindings sharing the chord. (meta+p print → QUICK_OPEN,
+// meta+f find → FIND_IN_* family, meta+g find-next → RUN_WORKSPACE_COMMAND.)
+export const BROWSER_PANE_EXCLUDED_CHORDS = new Set(
+	["meta+f", "meta+p", "meta+g"].map(canonicalizeChord),
+);
+
+/**
+ * True if `input` matches any of `chords` (pre-canonicalized) and is not
+ * excluded. Returns the matched canonical chord, or null.
+ */
+export function matchAppChord(
+	input: BrowserPaneInput,
+	chords: ReadonlySet<string>,
+): string | null {
+	const chord = inputToChord(input);
+	if (!chord) return null;
+	if (BROWSER_PANE_EXCLUDED_CHORDS.has(chord)) return null;
+	return chords.has(chord) ? chord : null;
+}
+
+// Inverse of `normalizeToken`: canonical token → DOM `KeyboardEvent.code`.
+// Only the shapes the registry produces (letters, digits, named keys,
+// F-keys, punctuation) are mapped; anything else falls back to a
+// best-effort capitalized form.
+const NAMED_CODE: Record<string, string> = {
+	arrowup: "ArrowUp",
+	arrowdown: "ArrowDown",
+	arrowleft: "ArrowLeft",
+	arrowright: "ArrowRight",
+	backspace: "Backspace",
+	tab: "Tab",
+	enter: "Enter",
+	escape: "Escape",
+	space: "Space",
+	delete: "Delete",
+	insert: "Insert",
+	home: "Home",
+	end: "End",
+	pageup: "PageUp",
+	pagedown: "PageDown",
+	slash: "Slash",
+	backslash: "Backslash",
+	comma: "Comma",
+	period: "Period",
+	semicolon: "Semicolon",
+	quote: "Quote",
+	backquote: "Backquote",
+	minus: "Minus",
+	equal: "Equal",
+	bracketleft: "BracketLeft",
+	bracketright: "BracketRight",
+};
+
+export function tokenToCode(token: string): string {
+	if (/^[a-z]$/.test(token)) return `Key${token.toUpperCase()}`;
+	if (/^[0-9]$/.test(token)) return `Digit${token}`;
+	if (/^f([1-9]|1[0-2])$/.test(token)) return token.toUpperCase();
+	const named = NAMED_CODE[token];
+	if (named) return named;
+	if (!token) return "";
+	return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/**
+ * Build the DOM KeyboardEventInit for a canonical app chord, so the renderer
+ * can re-dispatch it and let the normal focus-scoped react-hotkeys-hook
+ * registrations resolve it (the same way they do when the host document has
+ * focus). Pure — testable without a DOM. Mirror of {@link eventToChord}.
+ */
+export function chordToEventInit(chord: string): KeyboardEventInit | null {
+	const canonical = canonicalizeChord(chord);
+	const parts = canonical.split("+");
+	const keyToken = parts.find((p) => !MODIFIERS.has(p));
+	if (!keyToken) return null;
+	const has = (mod: string) => parts.includes(mod);
+
+	const code = tokenToCode(keyToken);
+	return {
+		code,
+		key: code === "Space" ? " " : keyToken,
+		metaKey: has("meta"),
+		ctrlKey: has("ctrl") || has("control"),
+		altKey: has("alt"),
+		shiftKey: has("shift"),
+		bubbles: true,
+		cancelable: true,
+		composed: true,
+	};
+}
+
+/**
+ * Build a synthetic DOM KeyboardEvent for a canonical app chord. DOM-only
+ * wrapper around {@link chordToEventInit} — do not call in bun:test without
+ * a DOM environment.
+ */
+export function dispatchChordEvent(chord: string): KeyboardEvent | null {
+	const init = chordToEventInit(chord);
+	if (!init) return null;
+	return new KeyboardEvent("keydown", init);
+}

--- a/apps/desktop/src/shared/browser-pane-chords.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.ts
@@ -146,10 +146,34 @@ export function matchAppChord(
 	input: BrowserPaneInput,
 	chords: ReadonlySet<string>,
 ): string | null {
+	if (isGuestOwnedShortcut(input)) return null;
 	const chord = inputToChord(input);
 	if (!chord) return null;
-	if (BROWSER_PANE_EXCLUDED_CHORDS.has(chord)) return null;
 	return chords.has(chord) ? chord : null;
+}
+
+// Guest editing shortcuts are LOGICAL (undo is ⌘Z regardless of layout), so
+// the physical-code exclusion table above misses them on non-QWERTY layouts
+// (e.g. ⌘Z undo on AZERTY is physical KeyW, which collides with the app's
+// CLOSE_PANE chord). Match the produced character (`input.key`) for this
+// family instead — Electron reports the character the OS layout produces,
+// which is exactly what the guest page's own editing shortcuts act on.
+const GUEST_EDITING_KEYS = new Set(["a", "c", "v", "x", "z"]);
+
+function isGuestEditingShortcut(input: BrowserPaneInput): boolean {
+	if (!(input.meta || input.control)) return false;
+	const key = (input.key ?? "").toLowerCase();
+	return GUEST_EDITING_KEYS.has(key);
+}
+
+/**
+ * True if `input` must stay with the guest page (its own editing / find /
+ * print shortcuts) rather than be claimed as an app chord.
+ */
+export function isGuestOwnedShortcut(input: BrowserPaneInput): boolean {
+	if (isGuestEditingShortcut(input)) return true;
+	const chord = inputToChord(input);
+	return chord !== null && BROWSER_PANE_EXCLUDED_CHORDS.has(chord);
 }
 
 // Inverse of `normalizeToken`: canonical token → DOM `KeyboardEvent.code`.

--- a/apps/desktop/src/shared/browser-pane-chords.ts
+++ b/apps/desktop/src/shared/browser-pane-chords.ts
@@ -69,11 +69,15 @@ export interface BrowserPaneInput {
 	control?: boolean;
 	alt?: boolean;
 	shift?: boolean;
+	isComposing?: boolean;
 }
 
 /** `before-input-event` Input → canonical chord, or null for modifier-only / unknown keys. */
 export function inputToChord(input: BrowserPaneInput): string | null {
 	if (input.type !== undefined && input.type !== "keyDown") return null;
+	// IME composition: keydown during CJK / dead-key composition must not
+	// trigger hotkeys, mirroring the renderer's `eventToChord` guard.
+	if (input.isComposing) return null;
 	if (input.code === undefined) return null;
 	const key = normalizeToken(input.code);
 	if (isIgnorableKey(key)) return null;
@@ -109,12 +113,29 @@ export function eventToChord(event: KeyboardEvent): string | null {
 	return [...mods, key].join("+");
 }
 
-// Chords the app must NOT claim from a browser pane: the guest page's own
-// find / print / find-next behavior is more useful there than any of the
-// pane-scoped app bindings sharing the chord. (meta+p print → QUICK_OPEN,
-// meta+f find → FIND_IN_* family, meta+g find-next → RUN_WORKSPACE_COMMAND.)
+// Chords the app must NOT claim from a browser pane — the guest page's own
+// editing / navigation behavior is more useful there than any of the
+// pane-scoped app bindings sharing the chord:
+//   - meta+a/c/v/x/z + ctrl+a/c/v/x/z: select-all, copy, paste, cut, undo
+//     (no app binding uses these, but the guest must always keep them)
+//   - meta+p print → QUICK_OPEN, meta+f find → FIND_IN_* family,
+//     meta+g find-next → RUN_WORKSPACE_COMMAND
 export const BROWSER_PANE_EXCLUDED_CHORDS = new Set(
-	["meta+f", "meta+p", "meta+g"].map(canonicalizeChord),
+	[
+		"meta+a",
+		"meta+c",
+		"meta+v",
+		"meta+x",
+		"meta+z",
+		"ctrl+a",
+		"ctrl+c",
+		"ctrl+v",
+		"ctrl+x",
+		"ctrl+z",
+		"meta+f",
+		"meta+p",
+		"meta+g",
+	].map(canonicalizeChord),
 );
 
 /**


### PR DESCRIPTION
Fixes #6186

## Bug

With a browser pane focused, every app shortcut dies: the pane is a guest `webContents` (out-of-process `<webview>`), so a keydown while the guest has focus never reaches the host document where `react-hotkeys-hook` listens. The only interception path is main's `before-input-event`, and that handler hardcoded exactly two chords (⌘W / ⌘R matched by produced character via `input.key`). ⌘B (`TOGGLE_WORKSPACE_SIDEBAR`), ⌘L (`TOGGLE_SIDEBAR`) and every other renderer-registered chord fell through to the page.

## Fix

Forward the app's full chord index to main and match there by physical position:

- **`shared/browser-pane-chords.ts`** (new, pure — no Electron/DOM/zustand imports): `normalizeToken` / `canonicalizeChord` / `eventToChord` moved from the renderer (re-exported from `resolveHotkeyFromEvent.ts` so existing imports keep working), plus `inputToChord` (Electron `Input` → canonical chord via `input.code`), `matchAppChord` (index lookup with a guest-owned exclusion list), `tokenToCode` / `chordToEventInit` (canonical chord → synthetic DOM `KeyboardEvent` for re-dispatch).
- **`browser-manager.ts`** (main): `setAppChords()` receives the renderer's canonical chord set; `setupBeforeInput` matches on physical key position (`input.code`) instead of `input.key`, drops the `shift`/`alt` and `meta||control` guards (the chord table is the gate now), keeps dedicated `close-pane` / `reload-pane` events for the legacy TabView path (which has no global `CLOSE_PANE` hotkey), and emits `app-hotkey:<paneId>` with the matched chord for everything else.
- **Router** (`browser.ts`): `setAppChords` mutation + `onAppHotkey` subscription.
- **`resolveHotkeyFromEvent.ts`**: pushes `registeredAppChords` keys to main on every rebuild (overrides / layout / adaptive-toggle changes), so the main-side index never drifts.
- **`usePersistentWebview` (v2)**: subscribes to `onAppHotkey` and re-dispatches a synthetic `KeyboardEvent`, letting the normal focus-scoped `useHotkey` registrations resolve it exactly as they do when the host document has focus.
- **Exclusions**: ⌘F / ⌘P / ⌘G stay with the guest (page find / print / find-next are more useful than the pane-scoped app bindings sharing those chords).
- **Docs**: `KEYBOARD_SYSTEM.md` "Known gaps" row.

This also fixes the Dvorak half of the report: the old handler matched whichever physical key *prints* "w" (`input.key`), while the registry binds ⌘W to physical `KeyW` — two different keys on non-QWERTY layouts. Matching on `input.code` anchors both sides to physical position.

## Validation

- `bun test` on `shared/browser-pane-chords.test.ts`: **16/16 pass** (⌘B match, Dvorak ⌘W anchoring, shift/alt chords, guest exclusion, modifier-only nulls, `tokenToCode`/`chordToEventInit` round-trips)
- `tsc --noEmit` on apps/desktop: **0 errors**
- Biome: clean
- Manual repro from the issue (⌘B / ⌘L in a focused browser pane) now dispatches the chord; ⌘W / ⌘R unchanged; ⌘, / ⌘/ still work via menu accelerators.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward app hotkeys from focused browser panes by mirroring the renderer’s chord index to main and re-dispatching matches on the host document. Adds reliable retry/backoff for chord sync, restores dead shortcuts (⌘B/⌘L), and anchors to physical keys across layouts (e.g., Dvorak ⌘W).

- **Bug Fixes**
  - Main: match chords in `before-input-event` by physical `code` (IME-safe), emit `app-hotkey:<paneId>`, and keep dedicated ⌘W/⌘R close/reload events.
  - Renderer: push the canonical chord index to main on every rebuild with bounded retry backoff and stale-retry cancellation; sends the newest snapshot after in-flight mutations settle.
  - Shared: exclude find/print/find-next and guest editing shortcuts; editing exclusions use the produced key (`input.key`) and ignore shift-gated chords (e.g., ⌘⇧C), so undo on non‑QWERTY stays with the page while COPY_PATH still forwards.
  - Browser panes: subscribe to `onAppHotkey` and dispatch a synthetic keydown on `document`; keep `onClosePane` and catch `close()` errors.

<sup>Written for commit 275af17ecf5f531bd49b81f2c8608ca738aa488e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-pane keyboard shortcuts now support synchronized application hotkeys.
  * Matching shortcuts are forwarded consistently across panes and keyboard layouts.
  * Application hotkey updates are synchronized automatically, including retry handling.
* **Bug Fixes**
  * Improved handling of modifier combinations, aliases, and ignored key events.
  * Preserved browser-native Find, Print, editing, close, and reload shortcuts.
* **Documentation**
  * Documented browser-pane hotkey forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->