### PR TITLE
fix(desktop): surface legacy-dashboard banner when v2 is not active

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -16,6 +16,11 @@ Renderer localStorage has one ~10 MB quota, loads synchronously at boot, and key
 
 Guardrail: localStorage is for small singleton UI state. Anything entity-scoped with unbounded cardinality, or payloads beyond a few KB, belongs in the SQLite persistence layer (`createElectronSQLitePersistence`) — localStorage collections re-serialize the whole org blob on every mutation.
 
+### v2 dashboard keys
+
+- **`v2-local-override-v2`** (`stores/v2-local-override.ts`) — singleton `boolean | null` opt-in/opt-out for the v2 dashboard. Bounded: one value, written only from Settings → Experimental. Deletion: `setOptInV2(null)` is never written; the key dies with the v2/legacy split (move to `DEAD_KEYS` then). Loss of this key is the #5498 silent-fallback case — see `V2AvailableBanner`.
+- **`v2-available-banner-v1`** (`stores/v2-available-banner/store.ts`) — singleton `boolean` dismissal flag for the legacy-dashboard banner. Bounded: one value, ~30 bytes. Deletion: reset to `false` automatically whenever v2 becomes active (the banner re-arms so a later silent fallback re-surfaces it). No CLI/machine writes this key; when the banner is removed, move the key to `DEAD_KEYS` in the same PR.
+
 ## Window-drag regions: `drag` on empty leaves only
 
 Never mark a container with interactive children as `drag` and carve the children out with `no-drag`: Chromium loses the carve-outs when they sit inside masked, scrollable, or CSS-zoomed wrappers (OverflowFadeContainer, ZoomStable), which silently deadens every control under the bar. Instead, put `drag` only on dedicated empty leaf elements — traffic-light spacers and flex fillers (see TopBar, DashboardSidebarHeader, packages/panes TabBar). The worst failure mode then is "empty area not draggable" instead of "chrome swallows clicks".

--- a/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
@@ -1,26 +1,44 @@
 import { SidebarCard } from "@superset/ui/sidebar-card";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
+import { useEffect } from "react";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { useV2AvailableBannerStore } from "renderer/stores/v2-available-banner";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 /**
  * Surfaced in the LEGACY (v1) sidebar whenever v2 is not active.
  *
- * Two distinct cases:
- *  - A pre-cutoff user who never opted in (or whose localStorage opt-in was
- *    lost — see #5498): v2 is available but off. The card explains they are
- *    on the legacy dashboard and how to switch back, and is dismissible.
- *  - A v2-only user who explicitly opted out: v2 is *not* available to
- *    return to in Settings → Experimental, so the card is dismissed-free
- *    (it simply states the legacy view).
+ * Two distinct states:
+ *  - **Invitation** (`optInV2 !== false` — pre-cutoff user who never opted
+ *    in, or whose localStorage opt-in was lost, see #5498): v2 is available
+ *    and the card explains they are on the legacy dashboard with a switch
+ *    path (Settings → Experimental). Dismissible — but the dismissal is
+ *    reset whenever v2 becomes active, so a later silent fallback (lost
+ *    override) re-surfaces the warning instead of hiding it forever behind
+ *    a stale dismissal.
+ *  - **Opted out** (`optInV2 === false` — explicit opt-out, including
+ *    v2-only users): the user chose legacy. Card states the legacy view
+ *    without an invitation action and is not dismissible (nothing to
+ *    dismiss — they opted out on purpose).
  */
 export function V2AvailableBanner() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const optedOut = useV2LocalOverrideStore((s) => s.optInV2 === false);
 	const dismissed = useV2AvailableBannerStore((s) => s.dismissed);
 	const dismiss = useV2AvailableBannerStore((s) => s.dismiss);
+	const resetDismiss = useV2AvailableBannerStore((s) => s.resetDismiss);
 	const navigate = useNavigate();
+
+	// Re-arm the banner whenever v2 is active, so a subsequent silent
+	// fallback to v1 (lost localStorage override, #5498) shows the warning
+	// even if the user dismissed the invitation earlier.
+	useEffect(() => {
+		if (isV2CloudEnabled && dismissed) {
+			resetDismiss();
+		}
+	}, [isV2CloudEnabled, dismissed, resetDismiss]);
 
 	function handleManage() {
 		track("v2_banner_manage_clicked");
@@ -33,6 +51,23 @@ export function V2AvailableBanner() {
 	}
 
 	if (isV2CloudEnabled) return null;
+
+	if (optedOut) {
+		return (
+			<motion.div
+				initial={{ opacity: 0, y: 8 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.2 }}
+				className="px-3 pb-2"
+			>
+				<SidebarCard
+					badge="Legacy"
+					title="You're viewing the legacy dashboard"
+					description="v2 was turned off in Settings → Experimental."
+				/>
+			</motion.div>
+		);
+	}
 
 	return (
 		<AnimatePresence>

--- a/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
@@ -5,6 +5,17 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { useV2AvailableBannerStore } from "renderer/stores/v2-available-banner";
 
+/**
+ * Surfaced in the LEGACY (v1) sidebar whenever v2 is not active.
+ *
+ * Two distinct cases:
+ *  - A pre-cutoff user who never opted in (or whose localStorage opt-in was
+ *    lost — see #5498): v2 is available but off. The card explains they are
+ *    on the legacy dashboard and how to switch back, and is dismissible.
+ *  - A v2-only user who explicitly opted out: v2 is *not* available to
+ *    return to in Settings → Experimental, so the card is dismissed-free
+ *    (it simply states the legacy view).
+ */
 export function V2AvailableBanner() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const dismissed = useV2AvailableBannerStore((s) => s.dismissed);
@@ -34,10 +45,10 @@ export function V2AvailableBanner() {
 					className="px-3 pb-2"
 				>
 					<SidebarCard
-						badge="New"
-						title="Superset v2 is here"
-						description="Try the new cloud workspace experience."
-						actionLabel="Try new version of Superset"
+						badge="Legacy"
+						title="You're viewing the legacy dashboard"
+						description="Superset v2 is available. Switch back in Settings → Experimental."
+						actionLabel="Switch to v2"
 						onAction={handleManage}
 						onDismiss={handleDismiss}
 					/>

--- a/apps/desktop/src/renderer/hooks/deriveIsV2CloudEnabled.test.ts
+++ b/apps/desktop/src/renderer/hooks/deriveIsV2CloudEnabled.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { deriveIsV2CloudEnabled } from "./deriveIsV2CloudEnabled";
+
+describe("deriveIsV2CloudEnabled — silent v1 fallback (#5498)", () => {
+	test("explicit opt-in wins over everything", () => {
+		expect(
+			deriveIsV2CloudEnabled({
+				optInV2: true,
+				isV2OnlyUser: false,
+				isDev: false,
+			}),
+		).toBe(true);
+	});
+
+	test("explicit opt-out wins even for v2-only users and dev", () => {
+		expect(
+			deriveIsV2CloudEnabled({
+				optInV2: false,
+				isV2OnlyUser: true,
+				isDev: true,
+			}),
+		).toBe(false);
+	});
+
+	test("no local preference: v2-only users default to v2", () => {
+		expect(
+			deriveIsV2CloudEnabled({
+				optInV2: null,
+				isV2OnlyUser: true,
+				isDev: false,
+			}),
+		).toBe(true);
+	});
+
+	test("no local preference: dev builds default to v2", () => {
+		expect(
+			deriveIsV2CloudEnabled({
+				optInV2: null,
+				isV2OnlyUser: false,
+				isDev: true,
+			}),
+		).toBe(true);
+	});
+
+	// REPRO for #5498: a pre-cutoff user who opted in has their only source
+	// of truth in renderer localStorage. Losing it reverts optInV2 to null
+	// and silently drops them back to the legacy v1 dashboard.
+	test("REPRO: losing localStorage silently drops a pre-cutoff opt-in to v1", () => {
+		const preCutoff = deriveIsV2CloudEnabled({
+			optInV2: true,
+			isV2OnlyUser: false,
+			isDev: false,
+		});
+		expect(preCutoff).toBe(true);
+
+		const afterWipe = deriveIsV2CloudEnabled({
+			optInV2: null,
+			isV2OnlyUser: false,
+			isDev: false,
+		});
+		expect(afterWipe).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/deriveIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/deriveIsV2CloudEnabled.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure derivation of whether the v2 cloud dashboard is active for a user.
+ *
+ * `optInV2` is the renderer-local override persisted in localStorage
+ * (zustand key `v2-local-override-v2`):
+ *   - `true`  → user explicitly opted in
+ *   - `false` → user explicitly opted out (always wins)
+ *   - `null`  → no local preference recorded (fresh install OR localStorage lost)
+ *
+ * When there is no local preference we fall back to `isV2OnlyUser || isDev`.
+ *
+ * KNOWN LIMITATION (see issue #5498): a pre-cutoff user who opted in has
+ * their only source of truth in localStorage. If that storage is wiped
+ * (quota-recovery wipe, profile corruption, moving machines) `optInV2`
+ * reverts to `null` and this function silently returns `false`, dropping the
+ * user back to the legacy v1 dashboard with no indication anything changed.
+ * The UI compensates by surfacing a legacy-dashboard banner (see
+ * `V2AvailableBanner`) whenever this derivation is false for a pre-cutoff
+ * account.
+ */
+export function deriveIsV2CloudEnabled(params: {
+	optInV2: boolean | null;
+	isV2OnlyUser: boolean;
+	isDev: boolean;
+}): boolean {
+	const { optInV2, isV2OnlyUser, isDev } = params;
+	return optInV2 ?? (isV2OnlyUser || isDev);
+}

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -6,6 +6,7 @@ import {
 	isV1MigrationCompleteAtBoot,
 } from "renderer/lib/v1-migration/completion";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+import { deriveIsV2CloudEnabled } from "./deriveIsV2CloudEnabled";
 
 /**
  * True for accounts created on/after V2_ONLY_USER_CUTOFF — these users
@@ -34,5 +35,9 @@ export function useIsV2CloudEnabled(): boolean {
 		return true;
 	}
 	// Dev builds default to v2; an explicit opt-out (optInV2 === false) still wins.
-	return optInV2 ?? (v2Only || env.NODE_ENV === "development");
+	return deriveIsV2CloudEnabled({
+		optInV2,
+		isV2OnlyUser: v2Only,
+		isDev: env.NODE_ENV === "development",
+	});
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { HiringBanner } from "renderer/components/HiringBanner";
+import { V2AvailableBanner } from "renderer/components/V2AvailableBanner";
 import { useWorkspaceShortcuts } from "renderer/hooks/useWorkspaceShortcuts";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { MultiDragPreview } from "./MultiDragPreview";
@@ -117,6 +118,8 @@ export function WorkspaceSidebar({
 			/>
 
 			<HiringBanner surface="v1" isCollapsed={isCollapsed} />
+
+			{!isCollapsed && <V2AvailableBanner />}
 
 			<WorkspaceSidebarFooter isCollapsed={isCollapsed} />
 			<MultiDragPreview />

--- a/apps/desktop/src/renderer/stores/v2-available-banner/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-available-banner/store.ts
@@ -4,6 +4,7 @@ import { devtools, persist } from "zustand/middleware";
 interface V2AvailableBannerState {
 	dismissed: boolean;
 	dismiss: () => void;
+	resetDismiss: () => void;
 }
 
 export const useV2AvailableBannerStore = create<V2AvailableBannerState>()(
@@ -12,6 +13,7 @@ export const useV2AvailableBannerStore = create<V2AvailableBannerState>()(
 			(set) => ({
 				dismissed: false,
 				dismiss: () => set({ dismissed: true }),
+				resetDismiss: () => set({ dismissed: false }),
 			}),
 			{ name: "v2-available-banner-v1" },
 		),


### PR DESCRIPTION
Fixes #5498

## Bug

For accounts created before `V2_ONLY_USER_CUTOFF`, the v2 dashboard is gated on a **renderer-local-only** flag: `optInV2`, persisted in zustand at localStorage key `v2-local-override-v2`. If localStorage is lost — quota-recovery wipe, profile corruption, moving machines — `optInV2` reverts to `null` and the app **silently drops the user back to the legacy v1 dashboard**. The v1 sidebar shows only legacy `local.db` projects, which presents as "all my worktrees disappeared" — indistinguishable from data loss. Nothing in the UI says "you are on v1".

## Fix

- **`deriveIsV2CloudEnabled.ts`** (new, pure): the `optInV2 ?? (isV2OnlyUser || isDev)` derivation extracted from `useIsV2CloudEnabled` so the fallback semantics are unit-testable, including the exact #5498 repro (opt-in → wipe → silent v1).
- **`V2AvailableBanner`**: rewritten with explicit copy — badge **"Legacy"**, title **"You're viewing the legacy dashboard"**, description pointing to **Settings → Experimental**, action **"Switch to v2"**. Previously the card said "Superset v2 is here / Try new version of Superset", which never told a user already on v2-recovering-from-a-wipe that they had fallen back.
- **`WorkspaceSidebar`** (v1): mounts `<V2AvailableBanner />` (only when not collapsed), so the legacy dashboard actually surfaces the banner — the component previously existed but was mounted nowhere.

The dismissible store is kept for the invitation case; the explicit legacy copy + Settings link addresses the diagnosis cost the issue calls out ("took hours — nothing in the UI or logs says 'you are on v1'").

## Validation

- `bun test` on `deriveIsV2CloudEnabled.test.ts`: **5/5 pass** (opt-in wins, opt-out wins, v2-only default, dev default, and the #5498 repro: opt-in → wipe → silent v1)
- `tsc --noEmit` on apps/desktop: **0 errors**
- Biome: clean
- Manual: on a pre-cutoff account with no v2 opt-in, the v1 sidebar now shows the Legacy card linking to Settings → Experimental.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces a “Legacy dashboard” banner in the v1 sidebar whenever v2 isn’t active so localStorage-loss fallbacks are visible. Previously, losing `v2-local-override-v2` dropped pre‑cutoff users to v1 with no signal; now v1 labels “Legacy” and links to switch back. Explicit opt-outs show an informational card with no action. The banner auto‑re‑arms after v2 usage to catch later fallbacks.

- Mounts `V2AvailableBanner` in the v1 `WorkspaceSidebar` when the sidebar is not collapsed; hidden when v2 is active.
- Invitation state (no explicit opt-out): badge “Legacy”, title “You’re viewing the legacy dashboard”, action “Switch to v2” (Settings → Experimental); dismissible.
- Opt‑out state (`optInV2 === false`): non‑dismissible info card with no action.
- Resets the banner dismissal whenever v2 becomes active (`resetDismiss` in store).
- Extracts pure `deriveIsV2CloudEnabled` and updates `useIsV2CloudEnabled`; adds tests covering opt‑in/out, v2‑only/dev defaults, and the #5498 repro.
- Documents `v2-local-override-v2` and `v2-available-banner-v1` key lifecycles in `AGENTS.md`.

<sup>Written for commit 1e077b7d97c9c7af2db8b083df24c199b5e82d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar banner identifying the legacy dashboard and guiding eligible users to switch to v2 through Experimental settings.
  * Opted-out users now see a persistent informational card without an action.
  * Banner dismissal resets when v2 becomes active.

* **Bug Fixes**
  * Stabilized dashboard version selection for explicit preferences, v2-only users, and development environments.

* **Tests**
  * Added coverage for dashboard preferences, defaults, and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->