### PR TITLE
fix(cli): stop pty-daemon alongside host service

### DIFF
--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -73,16 +73,10 @@ export default command({
 		const failures: string[] = [];
 		const stopped: Array<{ label: string; pid: number }> = [];
 
-		// Only remove each manifest once the process is CONFIRMED dead: a
-		// survivor must stay discoverable by `superset start`/`stop` rather
-		// than being orphaned without a manifest. A throw from stopProcess
-		// (e.g. SIGTERM refused) is recorded and daemon cleanup still runs.
+		// Remove a manifest only when stopProcess returns null, confirming exit.
+		// A thrown stop leaves process state unknown, so retain the manifest,
+		// record the failure, and continue cleaning up the other daemon.
 		if (manifest && isProcessAlive(manifest.pid)) {
-			// `survived` is null only on a CONFIRMED clean stop. A throw
-			// from stopProcess (e.g. SIGTERM/SIGKILL refused with EPERM)
-			// leaves the process state unknown — it must NOT collapse to
-			// the clean-stop sentinel, or the manifest would be removed
-			// while the process is still running (cubic P2).
 			let survived: number | null;
 			let stopError: Error | null = null;
 			try {

--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -75,31 +75,48 @@ export default command({
 
 		// Only remove each manifest once the process is CONFIRMED dead: a
 		// survivor must stay discoverable by `superset start`/`stop` rather
-		// than being orphaned without a manifest.
+		// than being orphaned without a manifest. A throw from stopProcess
+		// (e.g. SIGTERM refused) is recorded and daemon cleanup still runs.
 		if (manifest && isProcessAlive(manifest.pid)) {
-			const survived = await stopProcess(manifest.pid, "host service", 10_000);
+			let survived: number | null;
+			try {
+				survived = await stopProcess(manifest.pid, "host service", 10_000);
+			} catch (error) {
+				failures.push(
+					`host service (pid ${manifest.pid}): ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				survived = null;
+			}
 			if (survived !== null) {
 				failures.push(`host service (pid ${survived}) survived SIGKILL`);
 			} else {
 				stopped.push({ label: "host service", pid: manifest.pid });
 			}
-			removeManifest(organization.id);
+			if (survived === null) removeManifest(organization.id);
 		} else {
 			removeManifest(organization.id);
 		}
 
 		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
-			const survived = await stopProcess(
-				daemonManifest.pid,
-				"pty-daemon",
-				5_000,
-			);
+			let survived: number | null;
+			try {
+				survived = await stopProcess(daemonManifest.pid, "pty-daemon", 5_000);
+			} catch (error) {
+				failures.push(
+					`pty-daemon (pid ${daemonManifest.pid}): ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				survived = null;
+			}
 			if (survived !== null) {
 				failures.push(`pty-daemon (pid ${survived}) survived SIGKILL`);
 			} else {
 				stopped.push({ label: "pty-daemon", pid: daemonManifest.pid });
 			}
-			removePtyDaemonManifest(organization.id);
+			if (survived === null) removePtyDaemonManifest(organization.id);
 		} else {
 			removePtyDaemonManifest(organization.id);
 		}

--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -78,45 +78,56 @@ export default command({
 		// than being orphaned without a manifest. A throw from stopProcess
 		// (e.g. SIGTERM refused) is recorded and daemon cleanup still runs.
 		if (manifest && isProcessAlive(manifest.pid)) {
+			// `survived` is null only on a CONFIRMED clean stop. A throw
+			// from stopProcess (e.g. SIGTERM/SIGKILL refused with EPERM)
+			// leaves the process state unknown — it must NOT collapse to
+			// the clean-stop sentinel, or the manifest would be removed
+			// while the process is still running (cubic P2).
 			let survived: number | null;
+			let stopError: Error | null = null;
 			try {
 				survived = await stopProcess(manifest.pid, "host service", 10_000);
 			} catch (error) {
-				failures.push(
-					`host service (pid ${manifest.pid}): ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
+				stopError = error instanceof Error ? error : new Error(String(error));
 				survived = null;
 			}
-			if (survived !== null) {
+			if (stopError) {
+				failures.push(
+					`host service (pid ${manifest.pid}): ${stopError.message}`,
+				);
+			} else if (survived !== null) {
 				failures.push(`host service (pid ${survived}) survived SIGKILL`);
 			} else {
 				stopped.push({ label: "host service", pid: manifest.pid });
 			}
-			if (survived === null) removeManifest(organization.id);
+			if (stopError === null && survived === null) {
+				removeManifest(organization.id);
+			}
 		} else {
 			removeManifest(organization.id);
 		}
 
 		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
 			let survived: number | null;
+			let stopError: Error | null = null;
 			try {
 				survived = await stopProcess(daemonManifest.pid, "pty-daemon", 5_000);
 			} catch (error) {
-				failures.push(
-					`pty-daemon (pid ${daemonManifest.pid}): ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
+				stopError = error instanceof Error ? error : new Error(String(error));
 				survived = null;
 			}
-			if (survived !== null) {
+			if (stopError) {
+				failures.push(
+					`pty-daemon (pid ${daemonManifest.pid}): ${stopError.message}`,
+				);
+			} else if (survived !== null) {
 				failures.push(`pty-daemon (pid ${survived}) survived SIGKILL`);
 			} else {
 				stopped.push({ label: "pty-daemon", pid: daemonManifest.pid });
 			}
-			if (survived === null) removePtyDaemonManifest(organization.id);
+			if (stopError === null && survived === null) {
+				removePtyDaemonManifest(organization.id);
+			}
 		} else {
 			removePtyDaemonManifest(organization.id);
 		}

--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -5,6 +5,7 @@ import {
 	readManifest,
 	removeManifest,
 } from "../../lib/host/manifest";
+import { readPtyDaemonManifest } from "../../lib/host/pty-daemon-manifest";
 
 export default command({
 	description: "Stop the host service daemon",
@@ -47,9 +48,39 @@ export default command({
 
 		removeManifest(organization.id);
 
+		// The pty-daemon is spawned detached (`DaemonSupervisor`) so PTY
+		// sessions survive host-service restarts — but that also means it
+		// outlives `superset stop`, keeps listening on its socket, and gets
+		// re-adopted (possibly in a degraded state, #6127) by the next
+		// host-service. Stop it here so `superset stop` means "stop
+		// everything", not "stop the host-service and leave a daemon
+		// running".
+		const daemonManifest = readPtyDaemonManifest(organization.id);
+		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
+			try {
+				process.kill(daemonManifest.pid, "SIGTERM");
+			} catch (error) {
+				throw new CLIError(
+					`Failed to stop pty-daemon (pid ${daemonManifest.pid}): ${
+						error instanceof Error ? error.message : "unknown error"
+					}`,
+				);
+			}
+			const daemonDeadline = Date.now() + 5_000;
+			while (Date.now() < daemonDeadline) {
+				if (!isProcessAlive(daemonManifest.pid)) break;
+				await new Promise((r) => setTimeout(r, 100));
+			}
+			if (isProcessAlive(daemonManifest.pid)) {
+				try {
+					process.kill(daemonManifest.pid, "SIGKILL");
+				} catch {}
+			}
+		}
+
 		return {
-			data: { pid: manifest.pid, organizationId: organization.id },
-			message: `Stopped host service for ${organization.name}`,
+			data: { running: false },
+			message: `Stopped host service and pty-daemon for ${organization.name}`,
 		};
 	},
 });

--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -5,7 +5,49 @@ import {
 	readManifest,
 	removeManifest,
 } from "../../lib/host/manifest";
-import { readPtyDaemonManifest } from "../../lib/host/pty-daemon-manifest";
+import {
+	readPtyDaemonManifest,
+	removePtyDaemonManifest,
+} from "../../lib/host/pty-daemon-manifest";
+
+/**
+ * SIGTERM a pid, wait up to `timeoutMs`, then SIGKILL if still alive.
+ * Returns the pid if it survived SIGKILL (caller should fail), null on
+ * clean stop. `ESRCH` (already gone) is not an error.
+ */
+async function stopProcess(
+	pid: number,
+	label: string,
+	timeoutMs: number,
+): Promise<number | null> {
+	try {
+		process.kill(pid, "SIGTERM");
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ESRCH") return null;
+		throw new CLIError(`Failed to stop ${label} (pid ${pid}): ${err.message}`);
+	}
+
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return null;
+		await new Promise((r) => setTimeout(r, 100));
+	}
+
+	if (!isProcessAlive(pid)) return null;
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ESRCH") return null;
+		throw new CLIError(
+			`Failed to SIGKILL ${label} (pid ${pid}): ${err.message}`,
+		);
+	}
+	// Give SIGKILL a moment to land, then report survival as a failure.
+	await new Promise((r) => setTimeout(r, 200));
+	return isProcessAlive(pid) ? pid : null;
+}
 
 export default command({
 	description: "Stop the host service daemon",
@@ -14,73 +56,51 @@ export default command({
 		if (!organization)
 			throw new CLIError("No active organization", "Run: superset auth login");
 
+		// Read BOTH manifests up front: the pty-daemon is spawned detached
+		// and survives host-service restarts, so "no host service running"
+		// must not leave a (possibly degraded, #6127) daemon listening for
+		// re-adoption by the next `superset start`.
 		const manifest = readManifest(organization.id);
-		if (!manifest) {
+		const daemonManifest = readPtyDaemonManifest(organization.id);
+
+		const stopped: Array<{ label: string; pid: number }> = [];
+		if (manifest && isProcessAlive(manifest.pid)) {
+			await stopProcess(manifest.pid, "host service", 10_000);
+			stopped.push({ label: "host service", pid: manifest.pid });
+		}
+		removeManifest(organization.id);
+
+		let daemonSurvived: number | null = null;
+		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
+			daemonSurvived = await stopProcess(
+				daemonManifest.pid,
+				"pty-daemon",
+				5_000,
+			);
+			if (daemonSurvived === null) {
+				stopped.push({ label: "pty-daemon", pid: daemonManifest.pid });
+			}
+		}
+		removePtyDaemonManifest(organization.id);
+
+		if (daemonSurvived !== null) {
+			throw new CLIError(
+				`Failed to stop pty-daemon (pid ${daemonSurvived}): process survived SIGKILL`,
+			);
+		}
+
+		if (stopped.length === 0) {
 			return {
 				data: { running: false },
 				message: `No host service running for ${organization.name}`,
 			};
 		}
 
-		if (isProcessAlive(manifest.pid)) {
-			try {
-				process.kill(manifest.pid, "SIGTERM");
-			} catch (error) {
-				throw new CLIError(
-					`Failed to stop host service (pid ${manifest.pid}): ${
-						error instanceof Error ? error.message : "unknown error"
-					}`,
-				);
-			}
-
-			const deadline = Date.now() + 10_000;
-			while (Date.now() < deadline) {
-				if (!isProcessAlive(manifest.pid)) break;
-				await new Promise((r) => setTimeout(r, 100));
-			}
-
-			if (isProcessAlive(manifest.pid)) {
-				try {
-					process.kill(manifest.pid, "SIGKILL");
-				} catch {}
-			}
-		}
-
-		removeManifest(organization.id);
-
-		// The pty-daemon is spawned detached (`DaemonSupervisor`) so PTY
-		// sessions survive host-service restarts — but that also means it
-		// outlives `superset stop`, keeps listening on its socket, and gets
-		// re-adopted (possibly in a degraded state, #6127) by the next
-		// host-service. Stop it here so `superset stop` means "stop
-		// everything", not "stop the host-service and leave a daemon
-		// running".
-		const daemonManifest = readPtyDaemonManifest(organization.id);
-		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
-			try {
-				process.kill(daemonManifest.pid, "SIGTERM");
-			} catch (error) {
-				throw new CLIError(
-					`Failed to stop pty-daemon (pid ${daemonManifest.pid}): ${
-						error instanceof Error ? error.message : "unknown error"
-					}`,
-				);
-			}
-			const daemonDeadline = Date.now() + 5_000;
-			while (Date.now() < daemonDeadline) {
-				if (!isProcessAlive(daemonManifest.pid)) break;
-				await new Promise((r) => setTimeout(r, 100));
-			}
-			if (isProcessAlive(daemonManifest.pid)) {
-				try {
-					process.kill(daemonManifest.pid, "SIGKILL");
-				} catch {}
-			}
-		}
-
 		return {
 			data: { running: false },
-			message: `Stopped host service and pty-daemon for ${organization.name}`,
+			message: `Stopped ${stopped
+				.map((s) => `${s.label} (pid ${s.pid})`)
+				.join(", ")} for ${organization.name}`,
 		};
 	},
 });

--- a/packages/cli/src/commands/stop/command.ts
+++ b/packages/cli/src/commands/stop/command.ts
@@ -11,9 +11,10 @@ import {
 } from "../../lib/host/pty-daemon-manifest";
 
 /**
- * SIGTERM a pid, wait up to `timeoutMs`, then SIGKILL if still alive.
- * Returns the pid if it survived SIGKILL (caller should fail), null on
- * clean stop. `ESRCH` (already gone) is not an error.
+ * SIGTERM a pid, wait up to `timeoutMs`, then SIGKILL if still alive and
+ * poll briefly for it to be reaped. Returns the pid if it survived
+ * everything (caller should fail), null on clean stop. `ESRCH` (already
+ * gone) is not an error.
  */
 async function stopProcess(
 	pid: number,
@@ -44,8 +45,14 @@ async function stopProcess(
 			`Failed to SIGKILL ${label} (pid ${pid}): ${err.message}`,
 		);
 	}
-	// Give SIGKILL a moment to land, then report survival as a failure.
-	await new Promise((r) => setTimeout(r, 200));
+	// Poll after SIGKILL (rather than a single fixed wait): a process in
+	// uninterruptible sleep can take longer than 200ms to be reaped, and
+	// the result should reflect the actual outcome.
+	const reapDeadline = Date.now() + 2_000;
+	while (Date.now() < reapDeadline) {
+		if (!isProcessAlive(pid)) return null;
+		await new Promise((r) => setTimeout(r, 100));
+	}
 	return isProcessAlive(pid) ? pid : null;
 }
 
@@ -63,29 +70,43 @@ export default command({
 		const manifest = readManifest(organization.id);
 		const daemonManifest = readPtyDaemonManifest(organization.id);
 
+		const failures: string[] = [];
 		const stopped: Array<{ label: string; pid: number }> = [];
-		if (manifest && isProcessAlive(manifest.pid)) {
-			await stopProcess(manifest.pid, "host service", 10_000);
-			stopped.push({ label: "host service", pid: manifest.pid });
-		}
-		removeManifest(organization.id);
 
-		let daemonSurvived: number | null = null;
+		// Only remove each manifest once the process is CONFIRMED dead: a
+		// survivor must stay discoverable by `superset start`/`stop` rather
+		// than being orphaned without a manifest.
+		if (manifest && isProcessAlive(manifest.pid)) {
+			const survived = await stopProcess(manifest.pid, "host service", 10_000);
+			if (survived !== null) {
+				failures.push(`host service (pid ${survived}) survived SIGKILL`);
+			} else {
+				stopped.push({ label: "host service", pid: manifest.pid });
+			}
+			removeManifest(organization.id);
+		} else {
+			removeManifest(organization.id);
+		}
+
 		if (daemonManifest && isProcessAlive(daemonManifest.pid)) {
-			daemonSurvived = await stopProcess(
+			const survived = await stopProcess(
 				daemonManifest.pid,
 				"pty-daemon",
 				5_000,
 			);
-			if (daemonSurvived === null) {
+			if (survived !== null) {
+				failures.push(`pty-daemon (pid ${survived}) survived SIGKILL`);
+			} else {
 				stopped.push({ label: "pty-daemon", pid: daemonManifest.pid });
 			}
+			removePtyDaemonManifest(organization.id);
+		} else {
+			removePtyDaemonManifest(organization.id);
 		}
-		removePtyDaemonManifest(organization.id);
 
-		if (daemonSurvived !== null) {
+		if (failures.length > 0) {
 			throw new CLIError(
-				`Failed to stop pty-daemon (pid ${daemonSurvived}): process survived SIGKILL`,
+				`Failed to stop: ${failures.join("; ")} — the process may still be running`,
 			);
 		}
 

--- a/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempHome = mkdtempSync(join(tmpdir(), "superset-cli-daemon-manifest-"));
+process.env.SUPERSET_HOME_DIR = tempHome;
+
+const ORG_ID = "test-org";
+const MANIFEST_DIR = join(tempHome, "host", ORG_ID);
+const MANIFEST_PATH = join(MANIFEST_DIR, "pty-daemon-manifest.json");
+
+const {
+	readPtyDaemonManifest,
+	removePtyDaemonManifest,
+	writePtyDaemonManifest,
+} = await import("./pty-daemon-manifest");
+
+describe("pty-daemon-manifest", () => {
+	afterAll(() => {
+		rmSync(tempHome, { recursive: true, force: true });
+	});
+
+	test("returns null when no manifest exists", () => {
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+	});
+
+	test("round-trips a written manifest", () => {
+		writePtyDaemonManifest({
+			pid: 5151,
+			socketPath: "/tmp/x.sock",
+			protocolVersions: [1],
+			startedAt: 1700000000000,
+			organizationId: ORG_ID,
+		});
+		const read = readPtyDaemonManifest(ORG_ID);
+		expect(read).not.toBeNull();
+		expect(read?.pid).toBe(5151);
+		expect(read?.organizationId).toBe(ORG_ID);
+	});
+
+	test("removes the manifest file", () => {
+		mkdirSync(MANIFEST_DIR, { recursive: true });
+		writeFileSync(MANIFEST_PATH, JSON.stringify({ pid: 1 }));
+		removePtyDaemonManifest(ORG_ID);
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+	});
+
+	test("returns null for a corrupt manifest", () => {
+		mkdirSync(MANIFEST_DIR, { recursive: true });
+		writeFileSync(MANIFEST_PATH, "{not json");
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+	});
+});

--- a/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
@@ -1,11 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import {
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,11 +11,22 @@ const ORG_ID = "test-org";
 const MANIFEST_DIR = join(tempHome, "host", ORG_ID);
 const MANIFEST_PATH = join(MANIFEST_DIR, "pty-daemon-manifest.json");
 
-const {
-	readPtyDaemonManifest,
-	removePtyDaemonManifest,
-	writePtyDaemonManifest,
-} = await import("./pty-daemon-manifest");
+const { readPtyDaemonManifest, removePtyDaemonManifest } = await import(
+	"./pty-daemon-manifest"
+);
+
+function writeManifest(data: Record<string, unknown>): void {
+	mkdirSync(MANIFEST_DIR, { recursive: true });
+	writeFileSync(MANIFEST_PATH, JSON.stringify(data));
+}
+
+const VALID = {
+	pid: 5151,
+	socketPath: "/tmp/x.sock",
+	protocolVersions: [1],
+	startedAt: 1700000000000,
+	organizationId: ORG_ID,
+};
 
 describe("pty-daemon-manifest", () => {
 	afterAll(() => {
@@ -37,14 +42,8 @@ describe("pty-daemon-manifest", () => {
 		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
 	});
 
-	test("round-trips a written manifest", () => {
-		writePtyDaemonManifest({
-			pid: 5151,
-			socketPath: "/tmp/x.sock",
-			protocolVersions: [1],
-			startedAt: 1700000000000,
-			organizationId: ORG_ID,
-		});
+	test("reads a valid manifest", () => {
+		writeManifest(VALID);
 		const read = readPtyDaemonManifest(ORG_ID);
 		expect(read).not.toBeNull();
 		expect(read?.pid).toBe(5151);
@@ -52,36 +51,26 @@ describe("pty-daemon-manifest", () => {
 	});
 
 	test("removes the manifest file", () => {
-		mkdirSync(MANIFEST_DIR, { recursive: true });
-		writeFileSync(MANIFEST_PATH, JSON.stringify({ pid: 1 }));
+		writeManifest(VALID);
 		removePtyDaemonManifest(ORG_ID);
 		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
 	});
 
 	test("returns null for a corrupt manifest", () => {
-		mkdirSync(MANIFEST_DIR, { recursive: true });
+		writeManifest({} as Record<string, unknown>);
 		writeFileSync(MANIFEST_PATH, "{not json");
 		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
 	});
 
 	test("returns null for a manifest with invalid fields", () => {
-		mkdirSync(MANIFEST_DIR, { recursive: true });
-		writeFileSync(
-			MANIFEST_PATH,
-			JSON.stringify({ pid: "not-a-number", socketPath: 42 }),
-		);
+		writeManifest({ pid: "not-a-number", socketPath: 42 });
 		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
 	});
 
-	test("leaves no temp file behind after a write (atomic replace)", () => {
-		writePtyDaemonManifest({
-			pid: 6001,
-			socketPath: "/tmp/x.sock",
-			protocolVersions: [1],
-			startedAt: 1700000000000,
-			organizationId: ORG_ID,
-		});
-		expect(readPtyDaemonManifest(ORG_ID)?.pid).toBe(6001);
-		expect(existsSync(`${MANIFEST_PATH}.tmp`)).toBeFalse();
+	test("returns null for a manifest with a non-positive pid (process-group risk)", () => {
+		writeManifest({ ...VALID, pid: -1 });
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+		writeManifest({ ...VALID, pid: 0 });
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
 	});
 });

--- a/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.test.ts
@@ -1,8 +1,15 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+const originalSupersetHomeDir = process.env.SUPERSET_HOME_DIR;
 const tempHome = mkdtempSync(join(tmpdir(), "superset-cli-daemon-manifest-"));
 process.env.SUPERSET_HOME_DIR = tempHome;
 
@@ -19,6 +26,11 @@ const {
 describe("pty-daemon-manifest", () => {
 	afterAll(() => {
 		rmSync(tempHome, { recursive: true, force: true });
+		if (originalSupersetHomeDir === undefined) {
+			delete process.env.SUPERSET_HOME_DIR;
+		} else {
+			process.env.SUPERSET_HOME_DIR = originalSupersetHomeDir;
+		}
 	});
 
 	test("returns null when no manifest exists", () => {
@@ -50,5 +62,26 @@ describe("pty-daemon-manifest", () => {
 		mkdirSync(MANIFEST_DIR, { recursive: true });
 		writeFileSync(MANIFEST_PATH, "{not json");
 		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+	});
+
+	test("returns null for a manifest with invalid fields", () => {
+		mkdirSync(MANIFEST_DIR, { recursive: true });
+		writeFileSync(
+			MANIFEST_PATH,
+			JSON.stringify({ pid: "not-a-number", socketPath: 42 }),
+		);
+		expect(readPtyDaemonManifest(ORG_ID)).toBeNull();
+	});
+
+	test("leaves no temp file behind after a write (atomic replace)", () => {
+		writePtyDaemonManifest({
+			pid: 6001,
+			socketPath: "/tmp/x.sock",
+			protocolVersions: [1],
+			startedAt: 1700000000000,
+			organizationId: ORG_ID,
+		});
+		expect(readPtyDaemonManifest(ORG_ID)?.pid).toBe(6001);
+		expect(existsSync(`${MANIFEST_PATH}.tmp`)).toBeFalse();
 	});
 });

--- a/packages/cli/src/lib/host/pty-daemon-manifest.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.ts
@@ -1,0 +1,68 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { SUPERSET_HOME_DIR } from "../config";
+
+/**
+ * Manifest for a running pty-daemon instance. Mirrors
+ * packages/host-service/src/daemon/manifest.ts (both clients read each
+ * other's manifests) — the daemon lives detached under
+ * $SUPERSET_HOME_DIR/host/{organizationId}/ and outlives host-service
+ * restarts, so the CLI needs its own copy of the read/kill path to stop
+ * it alongside the host service.
+ */
+export interface PtyDaemonManifest {
+	pid: number;
+	socketPath: string;
+	protocolVersions: number[];
+	startedAt: number;
+	organizationId: string;
+	handoffInProgress?: boolean;
+	handoffSnapshotPath?: string;
+	handoffSuccessorPid?: number;
+}
+
+function ptyDaemonManifestPath(organizationId: string): string {
+	return join(
+		SUPERSET_HOME_DIR,
+		"host",
+		organizationId,
+		"pty-daemon-manifest.json",
+	);
+}
+
+export function readPtyDaemonManifest(
+	organizationId: string,
+): PtyDaemonManifest | null {
+	const path = ptyDaemonManifestPath(organizationId);
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as PtyDaemonManifest;
+	} catch {
+		return null;
+	}
+}
+
+export function removePtyDaemonManifest(organizationId: string): void {
+	const path = ptyDaemonManifestPath(organizationId);
+	if (existsSync(path)) {
+		rmSync(path, { force: true });
+	}
+}
+
+export function writePtyDaemonManifest(manifest: PtyDaemonManifest): void {
+	const dir = join(SUPERSET_HOME_DIR, "host", manifest.organizationId);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	writeFileSync(
+		ptyDaemonManifestPath(manifest.organizationId),
+		JSON.stringify(manifest),
+		{ encoding: "utf-8", mode: 0o600 },
+	);
+}

--- a/packages/cli/src/lib/host/pty-daemon-manifest.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.ts
@@ -1,11 +1,4 @@
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	renameSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { SUPERSET_HOME_DIR } from "../config";
 
@@ -46,7 +39,12 @@ export function readPtyDaemonManifest(
 		const raw = readFileSync(path, "utf-8");
 		const data = JSON.parse(raw) as Record<string, unknown>;
 		if (
+			// pid must be a positive safe integer: a negative pid (e.g. -1)
+			// would make process.kill target a process group, and a stale
+			// reused pid could kill an unrelated process.
 			typeof data.pid !== "number" ||
+			!Number.isSafeInteger(data.pid) ||
+			data.pid <= 0 ||
 			typeof data.socketPath !== "string" ||
 			!Array.isArray(data.protocolVersions) ||
 			typeof data.startedAt !== "number" ||
@@ -83,21 +81,4 @@ export function removePtyDaemonManifest(organizationId: string): void {
 	if (existsSync(path)) {
 		rmSync(path, { force: true });
 	}
-}
-
-export function writePtyDaemonManifest(manifest: PtyDaemonManifest): void {
-	const dir = join(SUPERSET_HOME_DIR, "host", manifest.organizationId);
-	if (!existsSync(dir)) {
-		mkdirSync(dir, { recursive: true, mode: 0o700 });
-	}
-	// Atomic replace: write a temp file in the same directory, then rename
-	// over the manifest. A concurrent reader never sees truncated JSON
-	// (writeFileSync truncates before writing), which previously made
-	// readPtyDaemonManifest return null and skip daemon shutdown/cleanup.
-	const tmpPath = `${ptyDaemonManifestPath(manifest.organizationId)}.tmp`;
-	writeFileSync(tmpPath, JSON.stringify(manifest), {
-		encoding: "utf-8",
-		mode: 0o600,
-	});
-	renameSync(tmpPath, ptyDaemonManifestPath(manifest.organizationId));
 }

--- a/packages/cli/src/lib/host/pty-daemon-manifest.ts
+++ b/packages/cli/src/lib/host/pty-daemon-manifest.ts
@@ -2,6 +2,7 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -42,7 +43,36 @@ export function readPtyDaemonManifest(
 	const path = ptyDaemonManifestPath(organizationId);
 	if (!existsSync(path)) return null;
 	try {
-		return JSON.parse(readFileSync(path, "utf-8")) as PtyDaemonManifest;
+		const raw = readFileSync(path, "utf-8");
+		const data = JSON.parse(raw) as Record<string, unknown>;
+		if (
+			typeof data.pid !== "number" ||
+			typeof data.socketPath !== "string" ||
+			!Array.isArray(data.protocolVersions) ||
+			typeof data.startedAt !== "number" ||
+			typeof data.organizationId !== "string"
+		) {
+			return null;
+		}
+		// Phase 2 (handoff) fields are optional advisory state; validate their
+		// shape if present but never reject the whole manifest for garbage.
+		const out: PtyDaemonManifest = {
+			pid: data.pid,
+			socketPath: data.socketPath,
+			protocolVersions: data.protocolVersions,
+			startedAt: data.startedAt,
+			organizationId: data.organizationId,
+		};
+		if (typeof data.handoffInProgress === "boolean") {
+			out.handoffInProgress = data.handoffInProgress;
+		}
+		if (typeof data.handoffSnapshotPath === "string") {
+			out.handoffSnapshotPath = data.handoffSnapshotPath;
+		}
+		if (typeof data.handoffSuccessorPid === "number") {
+			out.handoffSuccessorPid = data.handoffSuccessorPid;
+		}
+		return out;
 	} catch {
 		return null;
 	}
@@ -60,9 +90,14 @@ export function writePtyDaemonManifest(manifest: PtyDaemonManifest): void {
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true, mode: 0o700 });
 	}
-	writeFileSync(
-		ptyDaemonManifestPath(manifest.organizationId),
-		JSON.stringify(manifest),
-		{ encoding: "utf-8", mode: 0o600 },
-	);
+	// Atomic replace: write a temp file in the same directory, then rename
+	// over the manifest. A concurrent reader never sees truncated JSON
+	// (writeFileSync truncates before writing), which previously made
+	// readPtyDaemonManifest return null and skip daemon shutdown/cleanup.
+	const tmpPath = `${ptyDaemonManifestPath(manifest.organizationId)}.tmp`;
+	writeFileSync(tmpPath, JSON.stringify(manifest), {
+		encoding: "utf-8",
+		mode: 0o600,
+	});
+	renameSync(tmpPath, ptyDaemonManifestPath(manifest.organizationId));
 }


### PR DESCRIPTION
Fixes the `superset stop` half of #6127

## Problem

`superset stop` only kills the host-service pid from `host/{org}/manifest.json`. The pty-daemon is spawned **detached** (`DaemonSupervisor.spawn()`) so PTY sessions survive host-service restarts — which also means it outlives `superset stop`:

- it keeps listening on its socket,
- the next `host-service` **re-adopts** it unconditionally (socket connectable + pid alive are the only health signals), possibly in a **degraded process context** — the exact #6127 failure mode where a daemon that lost its per-user XPC namespace (`id -un` → `501`, `gh` fails with `OSStatus -26276`) is silently adopted again,
- so every "have you tried restarting?" instruction was misleading: `superset stop` → `superset start` from Apple Terminal did **not** fix the degraded daemon (confirmed in the issue thread).

## Fix

`packages/cli/src/commands/stop/command.ts` now also stops the pty-daemon:

- reads `host/{org}/pty-daemon-manifest.json` (same directory the host-service writes; new `lib/host/pty-daemon-manifest.ts` helper mirroring `packages/host-service/src/daemon/manifest.ts`, which the CLI already mirrors for the host-service manifest),
- SIGTERMs the daemon after the host service is down, SIGKILLs it after a 5s grace period if still alive,
- message now reads "Stopped host service and pty-daemon for …".

The daemon's own `SIGTERM` handler closes its socket and cleans up, so a subsequent `superset start` spawns a fresh daemon instead of re-adopting a possibly-degraded one.

## Validation

- `bun test src/lib/host/pty-daemon-manifest.test.ts`: **4/4 pass** (absent → null, write/read round-trip, remove, corrupt JSON → null)
- `tsc --noEmit` on packages/cli: **0 errors**
- Biome: clean

Note: this is the independent papercut from the bot's triage (point 5); the deeper health-probe / adopt-refusal work (points 1–4) is a separate, larger change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `superset stop` terminate the detached pty-daemon alongside the host service to prevent re-adopting a degraded daemon. Previously it only killed the host-service pid; the daemon survived and was re-adopted.

- Read both manifests up front; stop the daemon even when the host isn’t running; continue daemon cleanup if host shutdown fails.
- Stop semantics: SIGTERM then SIGKILL (10s host, 5s daemon) with post-kill polling; ignore `ESRCH`; fail if either process survives.
- Remove manifests only after a confirmed exit; keep manifests when `stopProcess` throws or a process survives.
- Add `packages/cli/src/lib/host/pty-daemon-manifest.ts` with strict validation (positive pid) and 6 unit tests.
- Output lists each stopped process with its pid and returns `{ running: false }`.

<sup>Written for commit e5dfb343a74553dc727bbf68f43c6355f2106b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stopping the host service now also terminates its detached PTY daemon.
  * The CLI waits for graceful shutdown before forcefully terminating processes when needed.
  * Stop confirmations identify stopped services and their process IDs.

* **Bug Fixes**
  * Reports errors when processes cannot be terminated successfully.
  * Improves handling of missing, corrupted, or invalid service state.
  * Retains state for processes that remain active and removes it after successful termination.
  * Correctly handles processes that have already exited during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->