### PR TITLE
fix(host-service): force tunnel reconnect on inbound silence without waiting for onclose

### DIFF
--- a/packages/host-service/src/tunnel/tunnel-client.test.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+// Minimal fake WebSocket implementing only what TunnelClient touches.
+class FakeWebSocket {
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+
+	readyState = FakeWebSocket.OPEN;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+	closeCalls: Array<{ code: number; reason: string }> = [];
+
+	close(code?: number, reason?: string): void {
+		this.closeCalls.push({ code: code ?? 1000, reason: reason ?? "" });
+		// A blackholed TCP path: the closing handshake never completes, so
+		// onclose is NEVER called — the exact #6229 failure.
+	}
+}
+
+// Stub global WebSocket with the fake.
+const originalWebSocket = globalThis.WebSocket;
+(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket;
+
+const { TunnelClient } = await import("./tunnel-client");
+
+// Speed up the watchdog for tests: reach into the module via the constants
+// is not possible (not exported), so we drive the timer manually by
+// stubbing timers.
+function makeClient() {
+	const client = new TunnelClient({
+		relayUrl: "https://relay.example.com",
+		hostId: "host-1",
+		getAuthToken: async () => "token",
+		localPort: 4000,
+		hostServiceSecret: "secret",
+	});
+	return client as unknown as {
+		connect: () => Promise<void>;
+		socket: FakeWebSocket | null;
+		reconnectAttempts: number;
+		closed: boolean;
+		lastInboundAt: number;
+		startWatchdog: () => void;
+		stopWatchdog: () => void;
+		forceReconnect: (s: FakeWebSocket, code: number, reason: string) => void;
+		watchdogTimer: ReturnType<typeof setInterval> | null;
+		dispose: () => void;
+	};
+}
+
+describe("TunnelClient watchdog (#6229)", () => {
+	afterEach(() => {
+		(globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+	});
+
+	test("forceReconnect schedules a reconnect without waiting for onclose", () => {
+		const client = makeClient();
+		const sock = new FakeWebSocket();
+		// Simulate an established socket
+		(client as unknown as { socket: FakeWebSocket }).socket = sock;
+		client.reconnectAttempts = 0;
+
+		// Patch scheduleReconnect to observe the call.
+		let scheduled = 0;
+		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
+			() => {
+				scheduled++;
+			};
+
+		client.forceReconnect(sock, 4002, "Inbound silence timeout");
+
+		expect(sock.closeCalls).toEqual([
+			{ code: 4002, reason: "Inbound silence timeout" },
+		]);
+		// The stale socket is orphaned immediately — onclose (which never
+		// fires on a blackholed path) is not the trigger.
+		expect(client.socket).toBeNull();
+		expect(scheduled).toBe(1);
+	});
+
+	test("forceReconnect ignores a stale socket that is no longer current", () => {
+		const client = makeClient();
+		const stale = new FakeWebSocket();
+		(client as unknown as { socket: FakeWebSocket }).socket = stale;
+		let scheduled = 0;
+		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
+			() => {
+				scheduled++;
+			};
+
+		// A newer socket replaced the stale one before the watchdog fired.
+		const current = new FakeWebSocket();
+		(client as unknown as { socket: FakeWebSocket }).socket = current;
+		client.forceReconnect(stale, 4002, "Inbound silence timeout");
+
+		// Stale socket must not be torn down or scheduled.
+		expect(client.socket).toBe(current);
+		expect(scheduled).toBe(0);
+		expect(stale.closeCalls).toEqual([]);
+	});
+
+	test("forceReconnect is a no-op after close()", () => {
+		const client = makeClient();
+		const sock = new FakeWebSocket();
+		(client as unknown as { socket: FakeWebSocket }).socket = sock;
+		let scheduled = 0;
+		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
+			() => {
+				scheduled++;
+			};
+		(client as unknown as { closed: boolean }).closed = true;
+
+		client.forceReconnect(sock, 4002, "Inbound silence timeout");
+		expect(scheduled).toBe(0);
+	});
+});

--- a/packages/host-service/src/tunnel/tunnel-client.test.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.test.ts
@@ -3,10 +3,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 // Minimal fake WebSocket implementing only what TunnelClient touches.
 class FakeWebSocket {
 	static OPEN = 1;
+	static CONNECTING = 0;
 	static CLOSING = 2;
 	static CLOSED = 3;
 
-	readyState = FakeWebSocket.OPEN;
+	readyState = FakeWebSocket.CONNECTING;
 	onopen: (() => void) | null = null;
 	onmessage: ((event: { data: unknown }) => void) | null = null;
 	onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
@@ -19,6 +20,13 @@ class FakeWebSocket {
 		// onclose is NEVER called — the exact #6229 failure.
 	}
 }
+
+// Registered BEFORE the module import: TunnelClient resolves `WebSocket`
+// at module-evaluation time, so the fake must be in place first. Needed
+// by the late-messages test, which drives the real connect() path to get
+// the guarded handlers; restored in afterEach.
+const originalWebSocket = globalThis.WebSocket;
+(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket;
 
 const { TunnelClient } = await import("./tunnel-client");
 
@@ -48,7 +56,7 @@ function makeClient() {
 
 describe("TunnelClient watchdog (#6229)", () => {
 	afterEach(() => {
-		// nothing to restore — tests never touch globalThis.WebSocket
+		(globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
 	});
 
 	test("forceReconnect schedules a reconnect without waiting for onclose", () => {
@@ -112,19 +120,32 @@ describe("TunnelClient watchdog (#6229)", () => {
 		expect(scheduled).toBe(0);
 	});
 
-	test("late messages from an orphaned socket are ignored", () => {
+	test("late messages from an orphaned socket are ignored", async () => {
 		const client = makeClient();
-		const stale = new FakeWebSocket();
-		client.socket = stale;
+		// Stub scheduleReconnect so the forceReconnect call below doesn't
+		// leave a real reconnect timer that could fire after the test.
+		let scheduled = 0;
+		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
+			() => {
+				scheduled++;
+			};
 		client.lastInboundAt = 1_000;
 
-		// Orphan the stale socket exactly as forceReconnect does.
+		// connect() assigns the REAL guarded handlers on the socket.
+		await client.connect();
+		const stale = client.socket;
+		expect(stale?.onmessage).not.toBeNull();
+		if (!stale) throw new Error("expected a connected socket");
+
+		// Orphan the socket exactly as the watchdog does.
 		client.forceReconnect(stale, 4002, "Inbound silence timeout");
 		expect(client.socket).toBeNull();
 
 		// A late inbound from the orphaned socket must not touch state.
 		const before = client.lastInboundAt;
-		stale.onmessage?.({ data: "late-frame" });
+		stale?.onmessage?.({ data: "late-frame" });
 		expect(client.lastInboundAt).toBe(before);
+		// reconnect was scheduled exactly once by forceReconnect.
+		expect(scheduled).toBe(1);
 	});
 });

--- a/packages/host-service/src/tunnel/tunnel-client.test.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.test.ts
@@ -147,5 +147,10 @@ describe("TunnelClient watchdog (#6229)", () => {
 		expect(client.lastInboundAt).toBe(before);
 		// reconnect was scheduled exactly once by forceReconnect.
 		expect(scheduled).toBe(1);
+
+		// close() marks the client closed so connect()'s 20s deadline (still
+		// pending on the fake socket, which never opened) becomes a no-op
+		// instead of firing after the test.
+		client.close();
 	});
 });

--- a/packages/host-service/src/tunnel/tunnel-client.test.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.test.ts
@@ -20,15 +20,11 @@ class FakeWebSocket {
 	}
 }
 
-// Stub global WebSocket with the fake.
-const originalWebSocket = globalThis.WebSocket;
-(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket;
-
 const { TunnelClient } = await import("./tunnel-client");
 
-// Speed up the watchdog for tests: reach into the module via the constants
-// is not possible (not exported), so we drive the timer manually by
-// stubbing timers.
+// Tests exercise forceReconnect / socket identity directly rather than the
+// watchdog timer (which needs real 10s intervals); the module's other
+// constants are not exported, so timers are not driven here.
 function makeClient() {
 	const client = new TunnelClient({
 		relayUrl: "https://relay.example.com",
@@ -46,21 +42,20 @@ function makeClient() {
 		startWatchdog: () => void;
 		stopWatchdog: () => void;
 		forceReconnect: (s: FakeWebSocket, code: number, reason: string) => void;
-		watchdogTimer: ReturnType<typeof setInterval> | null;
-		dispose: () => void;
+		close: () => void;
 	};
 }
 
 describe("TunnelClient watchdog (#6229)", () => {
 	afterEach(() => {
-		(globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+		// nothing to restore — tests never touch globalThis.WebSocket
 	});
 
 	test("forceReconnect schedules a reconnect without waiting for onclose", () => {
 		const client = makeClient();
 		const sock = new FakeWebSocket();
 		// Simulate an established socket
-		(client as unknown as { socket: FakeWebSocket }).socket = sock;
+		client.socket = sock;
 		client.reconnectAttempts = 0;
 
 		// Patch scheduleReconnect to observe the call.
@@ -84,7 +79,7 @@ describe("TunnelClient watchdog (#6229)", () => {
 	test("forceReconnect ignores a stale socket that is no longer current", () => {
 		const client = makeClient();
 		const stale = new FakeWebSocket();
-		(client as unknown as { socket: FakeWebSocket }).socket = stale;
+		client.socket = stale;
 		let scheduled = 0;
 		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
 			() => {
@@ -93,7 +88,7 @@ describe("TunnelClient watchdog (#6229)", () => {
 
 		// A newer socket replaced the stale one before the watchdog fired.
 		const current = new FakeWebSocket();
-		(client as unknown as { socket: FakeWebSocket }).socket = current;
+		client.socket = current;
 		client.forceReconnect(stale, 4002, "Inbound silence timeout");
 
 		// Stale socket must not be torn down or scheduled.
@@ -105,15 +100,31 @@ describe("TunnelClient watchdog (#6229)", () => {
 	test("forceReconnect is a no-op after close()", () => {
 		const client = makeClient();
 		const sock = new FakeWebSocket();
-		(client as unknown as { socket: FakeWebSocket }).socket = sock;
+		client.socket = sock;
 		let scheduled = 0;
 		(client as unknown as { scheduleReconnect: () => void }).scheduleReconnect =
 			() => {
 				scheduled++;
 			};
-		(client as unknown as { closed: boolean }).closed = true;
+		client.close();
 
 		client.forceReconnect(sock, 4002, "Inbound silence timeout");
 		expect(scheduled).toBe(0);
+	});
+
+	test("late messages from an orphaned socket are ignored", () => {
+		const client = makeClient();
+		const stale = new FakeWebSocket();
+		client.socket = stale;
+		client.lastInboundAt = 1_000;
+
+		// Orphan the stale socket exactly as forceReconnect does.
+		client.forceReconnect(stale, 4002, "Inbound silence timeout");
+		expect(client.socket).toBeNull();
+
+		// A late inbound from the orphaned socket must not touch state.
+		const before = client.lastInboundAt;
+		stale.onmessage?.({ data: "late-frame" });
+		expect(client.lastInboundAt).toBe(before);
 	});
 });

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -381,13 +381,44 @@ export class TunnelClient {
 				console.warn(
 					`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
 				);
-				try {
-					this.socket.close(4002, "Inbound silence timeout");
-				} catch {
-					// already closed
-				}
+				this.forceReconnect(this.socket, 4002, "Inbound silence timeout");
 			}
 		}, WATCHDOG_INTERVAL_MS);
+	}
+
+	/**
+	 * Tear down a stale socket and schedule a reconnect WITHOUT waiting for
+	 * the WebSocket `close` event. `socket.close()` performs a graceful
+	 * closing handshake whose completion fires `onclose`; on a blackholed
+	 * TCP path (packets dropped, not reset — a stuck ESTAB with a growing
+	 * send queue) the close frame is never flushed, the handshake never
+	 * completes, and `onclose` never fires. Every reconnect was previously
+	 * scheduled only from `onclose`, so the client parked in CLOSING
+	 * forever while the process stayed alive but unreachable (#6229).
+	 *
+	 * The connect-timeout path already used this pattern (close + null +
+	 * scheduleReconnect); the watchdog now does too. Setting `this.socket =
+	 * null` BEFORE the late `onclose` arrives makes the identity guard at the
+	 * top of the handler (`if (this.socket !== socket) return`) ignore the
+	 * stale socket's eventual close, so we never double-schedule.
+	 */
+	private forceReconnect(
+		socket: WebSocket,
+		code: number,
+		reason: string,
+	): void {
+		if (this.closed) return;
+		if (this.socket !== socket) return;
+		try {
+			socket.close(code, reason);
+		} catch {
+			// already closed
+		}
+		this.socket = null;
+		this.connecting = false;
+		this.stopWatchdog();
+		this.cleanupChannels();
+		this.scheduleReconnect();
 	}
 
 	private stopWatchdog(): void {

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -105,6 +105,7 @@ export class TunnelClient {
 			this.lastInboundAt = Date.now();
 
 			socket.onopen = () => {
+				if (this.socket !== socket) return;
 				clearTimeout(deadline);
 				this.reconnectAttempts = 0;
 				this.connecting = false;
@@ -116,6 +117,7 @@ export class TunnelClient {
 			};
 
 			socket.onmessage = (event) => {
+				if (this.socket !== socket) return;
 				this.lastInboundAt = Date.now();
 				void this.handleMessage(event.data);
 			};
@@ -156,6 +158,7 @@ export class TunnelClient {
 			};
 
 			socket.onerror = (event) => {
+				if (this.socket !== socket) return;
 				console.error("[host-service:tunnel] socket error:", event);
 			};
 		} catch (error) {


### PR DESCRIPTION
Fixes #6229

## Bug

A persistent Linux host repeatedly goes offline in the Superset control plane while the VPS, network, host-service process, and terminals all stay running. The host logs `no inbound traffic for 77s, forcing reconnect` — and then never reconnects until `systemctl --user restart superset-host`.

Root cause (confirmed by the triage bot and a contributor in the issue thread):

`tunnel-client.ts` detects relay silence via a watchdog, but its **only recovery mechanism was a graceful `WebSocket.close(4002, …)`** — and every reconnect after an established connection was scheduled **exclusively from the `onclose` handler**. On a blackholed TCP path (packets dropped rather than reset — the stuck `ESTAB` with a ~39 KB unacked send queue seen in the report), the close frame can never be flushed, the closing handshake never completes, `onclose` never fires, and `scheduleReconnect()` is never called. The client parks in `CLOSING` forever.

## Fix

`forceReconnect(socket, code, reason)` in `tunnel-client.ts`:

- orphans the stale socket **immediately** — `this.socket = null`, `connecting = false`, `stopWatchdog()`, `cleanupChannels()` — and calls `scheduleReconnect()` directly, **without waiting for `onclose`**;
- mirrors the existing connect-timeout path (`connect()`'s deadline already did close + null + scheduleReconnect);
- the watchdog now calls it instead of the bare `socket.close()`;
- the identity guard at the top of `onclose` (`if (this.socket !== socket) return`) means the stale socket's late close (if it ever arrives) is ignored — no double-scheduling, no teardown of a newer socket.

## Validation

- `bun test` on `tunnel-client.test.ts`: **3/3 pass** using a fake `WebSocket` whose `close()` **never fires `onclose`** (the #6229 failure mode) — forceReconnect schedules the reconnect anyway; stale-socket and post-close no-op cases covered.
- `tsc --noEmit` on packages/host-service: **0 errors**
- Biome: clean

Note: `tunnel-client-v2.ts` may share the pattern; this PR scopes to the v1 client the report and triage identified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force reconnects the tunnel on inbound silence and ignores events from orphaned sockets. Previously the watchdog waited for onclose after close(4002); on blackholed TCP, onclose never fired and the client stayed in CLOSING.

- Adds forceReconnect() to orphan the current socket, stop the watchdog, clean channels, and scheduleReconnect() immediately; the watchdog now calls this on inbound silence.
- Guards onopen, onmessage, onerror, and onclose by socket identity so late events from orphaned sockets don’t touch state or double-schedule.
- Adds tests that drive the real connect() path with a global FakeWebSocket, stub scheduleReconnect to avoid timer leaks, verify reconnect without onclose, ignore stale sockets and late messages, and close the client to suppress the pending connect deadline.

<sup>Written for commit 1b873b0fc7974531a4e707c14f0736a07585f733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic reconnection when a WebSocket becomes unresponsive.
  * Replaced stale connections promptly, even when the close handshake does not complete.
  * Prevented outdated connections from interfering with active sessions or reconnection attempts.
  * Ensured cleanup is skipped after the client has been closed.

* **Tests**
  * Added regression coverage for unresponsive WebSockets, stale callbacks, reconnect scheduling, and late messages from orphaned connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->