### PR TITLE
fix(host-service): resolve Against-base diff to local branch when origin/<branch> missing

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
@@ -190,10 +190,11 @@ describe("resolveBaseComparison (integration)", () => {
 			baseRef: "feature/parent",
 			fetchTarget: null,
 		});
+		if (!base) throw new Error("expected base comparison");
 
 		// The "Against base" view: diff the base ref against HEAD. This is
 		// the exact pipeline that rendered empty before the fix.
-		const files = await getChangedFilesForDiff(git, [`${base!.baseRef}..HEAD`]);
+		const files = await getChangedFilesForDiff(git, [`${base.baseRef}..HEAD`]);
 		expect(files.map((f) => f.path)).toEqual(["child.md"]);
 	});
 
@@ -201,6 +202,22 @@ describe("resolveBaseComparison (integration)", () => {
 		await git.raw(["update-ref", "refs/remotes/origin/feature", "HEAD"]);
 		await git.raw(["checkout", "-b", "feature"]);
 		await commitFile(git, repo, "feature.md", "x", "feature work");
+		expect(await resolveBaseComparison(git, "feature")).toEqual({
+			branchName: "feature",
+			baseRef: "origin/feature",
+			fetchTarget: { remote: "origin", branch: "feature" },
+		});
+	});
+
+	test("prefers origin when both origin and upstream have the branch", async () => {
+		// Put upstream first in git's configured remote order so origin's
+		// priority cannot depend on whichever remote happens to be listed first.
+		await git.raw(["remote", "remove", "origin"]);
+		await git.raw(["remote", "add", "upstream", "https://example.com/up.git"]);
+		await git.raw(["remote", "add", "origin", "https://example.com/repo.git"]);
+		await git.raw(["update-ref", "refs/remotes/upstream/feature", "HEAD"]);
+		await git.raw(["update-ref", "refs/remotes/origin/feature", "HEAD"]);
+
 		expect(await resolveBaseComparison(git, "feature")).toEqual({
 			branchName: "feature",
 			baseRef: "origin/feature",

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
@@ -119,6 +119,7 @@ describe("resolveBaseComparison (integration)", () => {
 		// Simulate a remote so origin/HEAD can be set. We don't need an
 		// actual remote to fetch from — `symbolic-ref` on the remote HEAD
 		// is all getDefaultBranchName reads.
+		await git.raw(["remote", "add", "origin", "https://example.com/repo.git"]);
 		await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
 		await git.raw([
 			"symbolic-ref",
@@ -173,18 +174,27 @@ describe("resolveBaseComparison (integration)", () => {
 		});
 	});
 
-	test("falls back to the local branch when origin/<branch> does not exist (#5298)", async () => {
-		// Stacked workspace: base is another LOCAL branch that was never
-		// pushed, so refs/remotes/origin/feature exists nowhere. The
-		// "Against base" diff must resolve to the local branch, not to a
-		// missing remote ref (which silently renders an empty Changes tab).
-		await git.raw(["checkout", "-b", "feature/stacked"]);
-		await commitFile(git, repo, "stacked.md", "x", "stacked work");
-		expect(await resolveBaseComparison(git, "feature/stacked")).toEqual({
-			branchName: "feature/stacked",
-			baseRef: "feature/stacked",
+	test("local-only stacked base renders a real diff, not an empty Changes tab (#5298)", async () => {
+		// The actual #5298 scenario: a stacked workspace whose base is
+		// another LOCAL branch that was never pushed. Create the local
+		// parent, then a child branch off it with committed work, and
+		// assert the full chain (resolve → diff) returns the work.
+		await git.raw(["checkout", "-b", "feature/parent"]);
+		await commitFile(git, repo, "parent.md", "p", "parent work");
+		await git.raw(["checkout", "-b", "feature/child"]);
+		await commitFile(git, repo, "child.md", "c", "child work");
+
+		const base = await resolveBaseComparison(git, "feature/parent");
+		expect(base).toEqual({
+			branchName: "feature/parent",
+			baseRef: "feature/parent",
 			fetchTarget: null,
 		});
+
+		// The "Against base" view: diff the base ref against HEAD. This is
+		// the exact pipeline that rendered empty before the fix.
+		const files = await getChangedFilesForDiff(git, [`${base!.baseRef}..HEAD`]);
+		expect(files.map((f) => f.path)).toEqual(["child.md"]);
 	});
 
 	test("prefers origin/<branch> when both remote and local refs exist", async () => {
@@ -195,6 +205,18 @@ describe("resolveBaseComparison (integration)", () => {
 			branchName: "feature",
 			baseRef: "origin/feature",
 			fetchTarget: { remote: "origin", branch: "feature" },
+		});
+	});
+
+	test("finds the base ref on a non-origin remote (fork workflow)", async () => {
+		// Remote named `upstream`, branch exists only there (no local
+		// tracking): the remote-ref probe must not hardcode `origin`.
+		await git.raw(["remote", "add", "upstream", "https://example.com/up.git"]);
+		await git.raw(["update-ref", "refs/remotes/upstream/feature", "HEAD"]);
+		expect(await resolveBaseComparison(git, "feature")).toEqual({
+			branchName: "feature",
+			baseRef: "upstream/feature",
+			fetchTarget: { remote: "upstream", branch: "feature" },
 		});
 	});
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
@@ -173,6 +173,31 @@ describe("resolveBaseComparison (integration)", () => {
 		});
 	});
 
+	test("falls back to the local branch when origin/<branch> does not exist (#5298)", async () => {
+		// Stacked workspace: base is another LOCAL branch that was never
+		// pushed, so refs/remotes/origin/feature exists nowhere. The
+		// "Against base" diff must resolve to the local branch, not to a
+		// missing remote ref (which silently renders an empty Changes tab).
+		await git.raw(["checkout", "-b", "feature/stacked"]);
+		await commitFile(git, repo, "stacked.md", "x", "stacked work");
+		expect(await resolveBaseComparison(git, "feature/stacked")).toEqual({
+			branchName: "feature/stacked",
+			baseRef: "feature/stacked",
+			fetchTarget: null,
+		});
+	});
+
+	test("prefers origin/<branch> when both remote and local refs exist", async () => {
+		await git.raw(["update-ref", "refs/remotes/origin/feature", "HEAD"]);
+		await git.raw(["checkout", "-b", "feature"]);
+		await commitFile(git, repo, "feature.md", "x", "feature work");
+		expect(await resolveBaseComparison(git, "feature")).toEqual({
+			branchName: "feature",
+			baseRef: "origin/feature",
+			fetchTarget: { remote: "origin", branch: "feature" },
+		});
+	});
+
 	test("returns null when no default branch can be resolved", async () => {
 		const emptyRepo = mkTmp();
 		try {

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
@@ -2,12 +2,73 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { SimpleGit } from "simple-git";
 import type { ChangedFile } from "../types";
 import {
 	countUntrackedFileLines,
 	parseNameStatus,
 	parseNumstat,
+	resolveBaseComparison,
 } from "./git-helpers";
+
+function createRemoteProbeGit(
+	remotes: string[],
+	existingRefs: Set<string>,
+): { git: SimpleGit; getMaxConcurrentProbes: () => number } {
+	let activeProbes = 0;
+	let maxConcurrentProbes = 0;
+	const git = {
+		getRemotes: async () => remotes.map((name) => ({ name })),
+		raw: async (args: string[]) => {
+			if (args[0] === "config") {
+				throw new Error("no configured upstream");
+			}
+			const ref = args[2] ?? "";
+			if (args[0] === "rev-parse" && ref.startsWith("refs/remotes/")) {
+				activeProbes++;
+				maxConcurrentProbes = Math.max(maxConcurrentProbes, activeProbes);
+				try {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					if (!existingRefs.has(ref)) throw new Error("missing ref");
+					return ref;
+				} finally {
+					activeProbes--;
+				}
+			}
+			throw new Error("unexpected git command");
+		},
+	} as unknown as SimpleGit;
+	return { git, getMaxConcurrentProbes: () => maxConcurrentProbes };
+}
+
+describe("resolveBaseComparison", () => {
+	test("probes remotes in parallel but deterministically prioritizes origin", async () => {
+		const { git, getMaxConcurrentProbes } = createRemoteProbeGit(
+			["upstream", "backup", "origin"],
+			new Set(["refs/remotes/upstream/feature", "refs/remotes/origin/feature"]),
+		);
+
+		expect(await resolveBaseComparison(git, "feature")).toEqual({
+			branchName: "feature",
+			baseRef: "origin/feature",
+			fetchTarget: { remote: "origin", branch: "feature" },
+		});
+		expect(getMaxConcurrentProbes()).toBe(3);
+	});
+
+	test("selects a non-origin remote when origin lacks the branch", async () => {
+		const { git } = createRemoteProbeGit(
+			["origin", "upstream"],
+			new Set(["refs/remotes/upstream/feature"]),
+		);
+
+		expect(await resolveBaseComparison(git, "feature")).toEqual({
+			branchName: "feature",
+			baseRef: "upstream/feature",
+			fetchTarget: { remote: "upstream", branch: "feature" },
+		});
+	});
+});
 
 describe("parseNumstat", () => {
 	test("regular file entry", () => {

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
@@ -28,7 +28,7 @@ function createRemoteProbeGit(
 				activeProbes++;
 				maxConcurrentProbes = Math.max(maxConcurrentProbes, activeProbes);
 				try {
-					await new Promise((resolve) => setTimeout(resolve, 10));
+					await Promise.resolve();
 					if (!existingRefs.has(ref)) throw new Error("missing ref");
 					return ref;
 				} finally {

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -188,22 +188,34 @@ export async function resolveBaseComparison(
 	// branch when no remote ref exists — e.g. a stacked workspace whose
 	// base is another LOCAL branch that has never been pushed — instead of
 	// leaving the "Against base" diff silently empty (#5298).
-	const remotes = await git
+	const remotes: string[] = await git
 		.getRemotes()
 		.then((rs) => rs.map((r) => r.name))
 		.catch(() => []);
-	for (const remote of remotes) {
-		const remoteRefExists = await git
-			.raw(["rev-parse", "--verify", `refs/remotes/${remote}/${branchName}`])
-			.then(() => true)
-			.catch(() => false);
-		if (remoteRefExists) {
-			return {
-				branchName,
-				baseRef: `${remote}/${branchName}`,
-				fetchTarget: { remote, branch: branchName },
-			};
-		}
+	// Preserve the documented origin fallback regardless of git's remote
+	// listing order. Probe every remote concurrently, but choose the first
+	// successful result from this deterministic priority order rather than
+	// whichever subprocess happens to finish first.
+	const prioritizedRemotes = [
+		...(remotes.includes("origin") ? ["origin"] : []),
+		...remotes.filter((remote) => remote !== "origin"),
+	];
+	const remoteRefMatches = await Promise.all(
+		prioritizedRemotes.map(async (remote) => {
+			const exists = await git
+				.raw(["rev-parse", "--verify", `refs/remotes/${remote}/${branchName}`])
+				.then(() => true)
+				.catch(() => false);
+			return exists ? remote : null;
+		}),
+	);
+	const matchedRemote = remoteRefMatches.find((remote) => remote !== null);
+	if (matchedRemote) {
+		return {
+			branchName,
+			baseRef: `${matchedRemote}/${branchName}`,
+			fetchTarget: { remote: matchedRemote, branch: branchName },
+		};
 	}
 	const localRefExists = await git
 		.raw(["rev-parse", "--verify", `refs/heads/${branchName}`])

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -182,21 +182,28 @@ export async function resolveBaseComparison(
 					},
 				};
 	}
-	// No configured upstream. Prefer `origin/<branch>` (the common case),
-	// but when that remote ref does not exist — e.g. a stacked workspace
-	// whose base is another LOCAL branch that has never been pushed — fall
-	// back to the local branch instead of leaving the "Against base" diff
-	// silently empty (#5298).
-	const remoteRefExists = await git
-		.raw(["rev-parse", "--verify", `refs/remotes/origin/${branchName}`])
-		.then(() => true)
-		.catch(() => false);
-	if (remoteRefExists) {
-		return {
-			branchName,
-			baseRef: `origin/${branchName}`,
-			fetchTarget: { remote: "origin", branch: branchName },
-		};
+	// No configured upstream. Prefer the branch's remote ref on whatever
+	// remote actually has it (usually `origin`, but fork workflows and
+	// differently-named remotes are supported), falling back to the local
+	// branch when no remote ref exists — e.g. a stacked workspace whose
+	// base is another LOCAL branch that has never been pushed — instead of
+	// leaving the "Against base" diff silently empty (#5298).
+	const remotes = await git
+		.getRemotes()
+		.then((rs) => rs.map((r) => r.name))
+		.catch(() => []);
+	for (const remote of remotes) {
+		const remoteRefExists = await git
+			.raw(["rev-parse", "--verify", `refs/remotes/${remote}/${branchName}`])
+			.then(() => true)
+			.catch(() => false);
+		if (remoteRefExists) {
+			return {
+				branchName,
+				baseRef: `${remote}/${branchName}`,
+				fetchTarget: { remote, branch: branchName },
+			};
+		}
 	}
 	const localRefExists = await git
 		.raw(["rev-parse", "--verify", `refs/heads/${branchName}`])

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -182,6 +182,29 @@ export async function resolveBaseComparison(
 					},
 				};
 	}
+	// No configured upstream. Prefer `origin/<branch>` (the common case),
+	// but when that remote ref does not exist — e.g. a stacked workspace
+	// whose base is another LOCAL branch that has never been pushed — fall
+	// back to the local branch instead of leaving the "Against base" diff
+	// silently empty (#5298).
+	const remoteRefExists = await git
+		.raw(["rev-parse", "--verify", `refs/remotes/origin/${branchName}`])
+		.then(() => true)
+		.catch(() => false);
+	if (remoteRefExists) {
+		return {
+			branchName,
+			baseRef: `origin/${branchName}`,
+			fetchTarget: { remote: "origin", branch: branchName },
+		};
+	}
+	const localRefExists = await git
+		.raw(["rev-parse", "--verify", `refs/heads/${branchName}`])
+		.then(() => true)
+		.catch(() => false);
+	if (localRefExists) {
+		return { branchName, baseRef: branchName, fetchTarget: null };
+	}
 	return {
 		branchName,
 		baseRef: `origin/${branchName}`,


### PR DESCRIPTION
Fixes #5298

## Problem

For a **stacked workspace** whose base is another **local branch that has never been pushed**, the **Changes** tab rendered empty — even though a real, committed, non-empty diff existed against that base.

`resolveBaseComparison` resolved the "Against base" view via the remote ref `origin/<base>` and, when no upstream was configured, silently fell through to `origin/<branch>` — a ref that does not exist for an unpushed local base. The diff against a missing ref is empty, so the UI showed nothing.

## Fix

In `resolveBaseComparison`, when no upstream is configured:

1. if `refs/remotes/origin/<branch>` exists → `baseRef: origin/<branch>` + fetch target (unchanged behavior);
2. **new** — if the remote ref is absent but `refs/heads/<branch>` exists (local-only base) → `baseRef: <branch>` with `fetchTarget: null` (there is nothing to fetch for a local branch);
3. otherwise → unchanged fallback.

## Validation

Two integration tests against real on-disk repos (same suite as the existing `resolveBaseComparison` tests):

- **local-only base** (exact #5298 repro): base branch checked out locally, never pushed → resolves to `baseRef: "feature/stacked"`, `fetchTarget: null`;
- **remote + local coexistence**: `refs/remotes/origin/feature` exists → still prefers `origin/feature` with its fetch target.

`bun test` on git-helpers.integration.test.ts: **22/22 pass** · `tsc --noEmit`: 0 errors · Biome: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an empty Changes tab for stacked workspaces by resolving the “Against base” diff to a real ref when `origin/<branch>` is missing. Previously we fell back to `origin/<branch>` and showed an empty diff; now we probe remotes and use a remote match (prefer `origin`), otherwise the local branch, so the diff shows actual changes. Addresses #5298.

- Updated `resolveBaseComparison`: probe all remotes in parallel; deterministically prioritize `origin` regardless of remote order; if no remote ref exists but `refs/heads/<branch>` does, return the local branch with `fetchTarget: null`.
- Supports non-`origin` remotes (fork workflows) and retains preference for `origin/<branch>` when both remote and local refs exist.
- Tests: integration covers the full #5298 pipeline (base→diff returns committed work), coexistence and fork cases; unit tests verify parallel probing without wall-clock delays and `origin` priority.

<sup>Written for commit b4ff1eb6e5d7f135a9bd4496111d8d64fae29b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch comparison across multiple configured remotes.
  * Prioritizes the standard remote when multiple matching branches are available.
  * Detects branches hosted on other remotes when the standard remote lacks them.
  * Supports local-only branches without unnecessary fetching.
  * Retains the standard fallback when no local or remote branch is available.

* **Tests**
  * Added coverage for local, standard-remote, and alternate-remote branch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->