### PR TITLE
fix(host-service): fall back to prompt slug when LLM replies conversationally

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the two module boundaries generateBranchNameFromPrompt crosses:
+// the model provider (getSmallModel) and the chat title generator.
+const getSmallModelMock = mock(async () => ({ id: "small-model" }));
+const generateTitleMock = mock(async () => "feature-branch");
+
+mock.module("@superset/chat-legacy/server/shared", () => ({
+	getSmallModel: getSmallModelMock,
+}));
+
+mock.module("@superset/chat-legacy/server/desktop", () => ({
+	generateTitleFromMessage: generateTitleMock,
+}));
+
+const { generateBranchNameFromPrompt, isPlausibleBranchName, slugifyPrompt } =
+	await import("./ai-branch-name");
+
+describe("isPlausibleBranchName", () => {
+	test("accepts a normal kebab branch name", () => {
+		expect(isPlausibleBranchName("feat-auth-flow")).toBeTrue();
+		expect(isPlausibleBranchName("fix-login")).toBeTrue();
+	});
+
+	test("rejects a conversational reply sanitized to many segments", () => {
+		expect(
+			isPlausibleBranchName(
+				"i-d-be-happy-to-help-you-implement-that-task-but-i-don-t-have-access-to-the-jira-api",
+			),
+		).toBeFalse();
+	});
+});
+
+describe("slugifyPrompt", () => {
+	test("strips URLs and keeps meaningful words (#5288)", () => {
+		expect(
+			slugifyPrompt(
+				"Implement this jira task: https://jira.example.com/TASK-123",
+			),
+		).toBe("jira-task");
+	});
+
+	test("falls back to a default when nothing remains", () => {
+		expect(slugifyPrompt("https://example.com")).toBe("workspace");
+	});
+});
+
+describe("generateBranchNameFromPrompt", () => {
+	afterEach(() => {
+		generateTitleMock.mockClear();
+	});
+
+	test("uses the generated name when it is a plausible branch name", async () => {
+		generateTitleMock.mockImplementation(async () => "feat-auth-flow");
+		expect(await generateBranchNameFromPrompt("add auth flow", [])).toBe(
+			"feat-auth-flow",
+		);
+	});
+
+	test("falls back to a prompt slug when the model replies conversationally (#5288)", async () => {
+		generateTitleMock.mockImplementation(
+			async () =>
+				"I'd be happy to help you implement that task, but I don't have access to the Jira API",
+		);
+		expect(
+			await generateBranchNameFromPrompt(
+				"Implement this jira task: https://jira.example.com/TASK-123",
+				[],
+			),
+		).toBe("jira-task");
+	});
+
+	test("deduplicates the fallback slug against existing branches", async () => {
+		generateTitleMock.mockImplementation(
+			async () =>
+				"I'd be happy to help you implement that task, but I don't have access to the Jira API",
+		);
+		expect(
+			await generateBranchNameFromPrompt(
+				"Implement this jira task: https://jira.example.com/TASK-456",
+				["jira-task"],
+			),
+		).toBe("jira-task-2");
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
@@ -43,6 +43,11 @@ describe("slugifyPrompt", () => {
 	test("falls back to a default when nothing remains", () => {
 		expect(slugifyPrompt("https://example.com")).toBe("workspace");
 	});
+
+	test("applies the branch-length limit to fallback slugs", () => {
+		const long = `implement ${"a".repeat(200)} ${"b".repeat(200)} ${"c".repeat(200)} ${"d".repeat(200)}`;
+		expect(slugifyPrompt(long).length).toBeLessThanOrEqual(100);
+	});
 });
 
 describe("generateBranchNameFromPrompt", () => {
@@ -81,5 +86,12 @@ describe("generateBranchNameFromPrompt", () => {
 				["jira-task"],
 			),
 		).toBe("jira-task-2");
+	});
+
+	test("falls back to a prompt slug when the reply does not sanitize", async () => {
+		generateTitleMock.mockImplementation(async () => "...");
+		expect(await generateBranchNameFromPrompt("Fix the login flow", [])).toBe(
+			"fix-login-flow",
+		);
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
@@ -56,7 +56,10 @@ describe("slugifyPrompt", () => {
 
 describe("generateBranchNameFromPrompt", () => {
 	afterEach(() => {
+		getSmallModelMock.mockClear();
+		getSmallModelMock.mockImplementation(async () => ({ id: "small-model" }));
 		generateTitleMock.mockClear();
+		generateTitleMock.mockImplementation(async () => "feature-branch");
 	});
 
 	test("uses the generated name when it is a plausible branch name", async () => {
@@ -104,8 +107,7 @@ describe("generateBranchNameFromPrompt", () => {
 		expect(await generateBranchNameFromPrompt("add auth flow", [])).toBeNull();
 	});
 
-	test("returns null when generation rejects (timeout)", async () => {
-		getSmallModelMock.mockImplementation(async () => ({ id: "small-model" }));
+	test("returns null when generation rejects", async () => {
 		generateTitleMock.mockImplementation(async () => {
 			throw new Error("timed out after 5000ms");
 		});

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 // Mock the two module boundaries generateBranchNameFromPrompt crosses:
 // the model provider (getSmallModel) and the chat title generator.
-const getSmallModelMock = mock(async () => ({ id: "small-model" }));
+const getSmallModelMock = mock<() => Promise<{ id: string } | null>>(
+	async () => ({
+		id: "small-model",
+	}),
+);
 const generateTitleMock = mock(async () => "feature-branch");
 
 mock.module("@superset/chat-legacy/server/shared", () => ({
@@ -93,5 +97,25 @@ describe("generateBranchNameFromPrompt", () => {
 		expect(await generateBranchNameFromPrompt("Fix the login flow", [])).toBe(
 			"fix-login-flow",
 		);
+	});
+
+	test("returns null when no model is available", async () => {
+		getSmallModelMock.mockImplementation(async () => null);
+		expect(await generateBranchNameFromPrompt("add auth flow", [])).toBeNull();
+	});
+
+	test("returns null when generation rejects (timeout)", async () => {
+		getSmallModelMock.mockImplementation(async () => ({ id: "small-model" }));
+		generateTitleMock.mockImplementation(async () => {
+			throw new Error("timed out after 5000ms");
+		});
+		expect(await generateBranchNameFromPrompt("add auth flow", [])).toBeNull();
+	});
+
+	test("deduplicates a plausible generated name against existing branches", async () => {
+		generateTitleMock.mockImplementation(async () => "feat-auth-flow");
+		expect(
+			await generateBranchNameFromPrompt("add auth flow", ["feat-auth-flow"]),
+		).toBe("feat-auth-flow-2");
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
@@ -7,6 +7,37 @@ const BRANCH_NAME_INSTRUCTIONS =
 
 const MAX_BRANCH_LENGTH = 100;
 const GENERATE_TIMEOUT_MS = 5_000;
+// A real branch name is 2-4 words. An LLM that ignored the instruction and
+// answered conversationally ("I'd be happy to help you implement that task,
+// but I don't have access to…") produces far more — see #5288.
+const MAX_BRANCH_WORDS = 8;
+
+/** Words that carry no branch-naming signal (copied from the renderer's
+ * slugifier conventions). */
+const STOP_WORDS = new Set([
+	"a",
+	"an",
+	"the",
+	"this",
+	"that",
+	"with",
+	"for",
+	"from",
+	"and",
+	"or",
+	"but",
+	"in",
+	"on",
+	"of",
+	"to",
+	"please",
+	"can",
+	"could",
+	"would",
+	"should",
+	"implement",
+	"implementation",
+]);
 
 /**
  * Light sanitizer for AI-generated branch names — lowercase, kebab-case,
@@ -25,6 +56,39 @@ function sanitizeGeneratedBranchName(raw: string): string {
 		.replace(/\.lock$/g, "")
 		.slice(0, MAX_BRANCH_LENGTH)
 		.replace(/^[-.]+|[-.]+$/g, "");
+}
+
+function wordCount(name: string): number {
+	if (!name) return 0;
+	return name.split("-").filter(Boolean).length;
+}
+
+/**
+ * True when the generated string plausibly is a branch name rather than a
+ * conversational reply. The model is instructed to return ONLY a branch
+ * name, but prompts that include a URL (e.g. a Jira task link) reliably
+ * produce "I'd be happy to help you implement that task, but I don't have
+ * access to…" — a long sentence that sanitizes into a long kebab string
+ * with many segments. Treat anything beyond MAX_BRANCH_WORDS segments as
+ * a miss and fall back to a prompt-derived slug (#5288).
+ */
+export function isPlausibleBranchName(candidate: string): boolean {
+	return wordCount(candidate) <= MAX_BRANCH_WORDS;
+}
+
+/**
+ * Derive a branch name from the prompt itself, used when the model's reply
+ * is not a plausible branch name. Strips URLs, keeps the first few
+ * meaningful words, kebab-cases them.
+ */
+export function slugifyPrompt(prompt: string): string {
+	const withoutUrls = prompt.replace(/https?:\/\/\S+/g, " ");
+	const words = withoutUrls
+		.toLowerCase()
+		.replace(/[^a-z0-9\s]/g, " ")
+		.split(/\s+/)
+		.filter((w) => w.length > 0 && !STOP_WORDS.has(w));
+	return words.slice(0, 4).join("-").replace(/-+$/g, "") || "workspace";
 }
 
 export async function generateBranchNameFromPrompt(
@@ -60,5 +124,13 @@ export async function generateBranchNameFromPrompt(
 	if (!generated) return null;
 	const sanitized = sanitizeGeneratedBranchName(generated);
 	if (!sanitized) return null;
-	return deduplicateBranchName(sanitized, existingBranches);
+	// A conversational reply is not a branch name — fall back to a slug of
+	// the prompt so the workspace/branch gets a sensible, deterministic
+	// name (and the same prompt shape no longer yields the identical name
+	// for different URLs, which the deduplicator then can't separate).
+	const branchName = isPlausibleBranchName(sanitized)
+		? sanitized
+		: slugifyPrompt(prompt);
+	if (!branchName) return null;
+	return deduplicateBranchName(branchName, existingBranches);
 }

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
@@ -88,7 +88,10 @@ export function slugifyPrompt(prompt: string): string {
 		.replace(/[^a-z0-9\s]/g, " ")
 		.split(/\s+/)
 		.filter((w) => w.length > 0 && !STOP_WORDS.has(w));
-	return words.slice(0, 4).join("-").replace(/-+$/g, "") || "workspace";
+	// Run the result through the same sanitizer as generated names so the
+	// 100-char branch limit applies to fallback slugs too (#6238).
+	const slug = sanitizeGeneratedBranchName(words.slice(0, 4).join("-"));
+	return slug || "workspace";
 }
 
 export async function generateBranchNameFromPrompt(
@@ -123,14 +126,15 @@ export async function generateBranchNameFromPrompt(
 
 	if (!generated) return null;
 	const sanitized = sanitizeGeneratedBranchName(generated);
-	if (!sanitized) return null;
-	// A conversational reply is not a branch name — fall back to a slug of
-	// the prompt so the workspace/branch gets a sensible, deterministic
-	// name (and the same prompt shape no longer yields the identical name
-	// for different URLs, which the deduplicator then can't separate).
-	const branchName = isPlausibleBranchName(sanitized)
-		? sanitized
-		: slugifyPrompt(prompt);
+	// A conversational reply or un-sanitizable output ("...", emoji-only)
+	// is not a branch name — fall back to a slug of the prompt so the
+	// workspace/branch gets a sensible, deterministic name (and the same
+	// prompt shape no longer yields the identical name for different URLs,
+	// which the deduplicator then can't separate).
+	const branchName =
+		!sanitized || !isPlausibleBranchName(sanitized)
+			? slugifyPrompt(prompt)
+			: sanitized;
 	if (!branchName) return null;
 	return deduplicateBranchName(branchName, existingBranches);
 }


### PR DESCRIPTION
Fixes #5288

## Problem

When the workspace prompt contains a URL (e.g. a Jira task link), the branch-naming model ignores the *"return ONLY the branch name"* instruction and answers conversationally:

> I'd be happy to help you implement that task, but I don't have access to...

Two consequences:

1. The old sanitizer let that **whole sentence** through as a kebab-case branch name (`i-d-be-happy-to-help-you-implement-that-task-...`).
2. Because the model returns the **identical reply regardless of the URL**, distinct prompts produced identical names — and the deduplicator then suffixed them into near-identical branches, which is why de-duplication appeared broken.

## Fix

In `ai-branch-name.ts`:

- **`isPlausibleBranchName(candidate)`** — rejects sanitized replies with more than 8 kebab segments (a real branch name is 2–4 words; a conversational reply is a whole sentence).
- **`slugifyPrompt(prompt)`** — derives a deterministic branch name from the prompt itself: strips URLs, drops stop words, keeps the first 4 meaningful words. `"Implement this jira task: https://jira.example.com/TASK-123"` → `jira-task`.
- `generateBranchNameFromPrompt` falls back to the prompt slug when the model's reply is implausible; the result still runs through the existing `deduplicateBranchName`.

## Validation

`ai-branch-name.test.ts` — 7 unit tests: plausibility gate (accepts `feat-auth-flow`, rejects the conversational reply), slugifier (URL stripping + empty fallback), conversational fallback (exact #5288 repro), and dedup of the fallback slug (`jira-task` → `jira-task-2`).

`tsc --noEmit`: 0 errors · Biome: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents conversational LLM replies from becoming branch names by rejecting implausible outputs and falling back to a prompt-derived slug. Fixes #5288; names are deterministic, deduplicated, and capped at 100 characters.

- Plausibility gate: rejects sanitized candidates with more than 8 kebab segments.
- Prompt slug fallback: strips URLs, drops stop words, keeps the first 4 meaningful words; sanitizes and enforces the 100‑char limit; defaults to "workspace".
- Apply fallback when the generated string is implausible or sanitizes to empty; then pass through existing de-duplication.
- Tests cover null-model, generation timeout/error, long-slug truncation, and dedup on both fallback and plausible names; mocks reset after each test.

<sup>Written for commit 130a4c985c54994033d8dd20b67469d066a11a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved automatic branch-name generation with clearer, more concise names.
  - Added fallback names based on the request when generated names are too long, conversational, or empty.
  - Removes URLs and common filler words from fallback names.
  - Limits fallback names to a practical length and uses “workspace” when no suitable name is available.
  - Prevents duplicate branch names by checking existing branches.

- **Bug Fixes**
  - Rejects implausible generated branch names and applies a reliable fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->