### PR TITLE
fix(desktop): reset seeded new-workspace draft when the modal is dismissed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { NewWorkspaceScreen } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen";
 import { DashboardNewWorkspaceDraftProvider } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext";
 import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-attachments";
+import { resetNewWorkspaceDraftOnRouteLeave } from "renderer/stores/new-workspace-draft";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/new-workspace/",
@@ -14,6 +15,9 @@ export const Route = createFileRoute(
 			typeof search.projectId === "string" ? search.projectId : undefined,
 		session: search.session === true ? true : undefined,
 	}),
+	// The handoff draft stays available for this route's entire lifetime and is
+	// cleared only once navigation actually abandons the create flow.
+	onLeave: resetNewWorkspaceDraftOnRouteLeave,
 	component: NewWorkspacePage,
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -55,7 +55,10 @@ export function DashboardNewWorkspaceModal() {
 	// "+" button, hotkey, onboarding hand-off) redirect to the route instead.
 	useEffect(() => {
 		if (!isScreen || !isOpen) return;
-		closeModal();
+		// Keep the seeded draft (setup-script prompt, linked issue/PR): the
+		// /new-workspace page consumes it after the handoff, so this close
+		// must not run the #5372 dismissal cleanup.
+		closeModal({ resetDraft: false });
 		void navigate({
 			to: "/new-workspace",
 			search: preSelectedSession

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -131,3 +131,8 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 			})),
 	}),
 );
+
+/** Clears any draft preserved for the full-page handoff once that route is left. */
+export function resetNewWorkspaceDraftOnRouteLeave() {
+	useNewWorkspaceDraftStore.getState().resetDraft();
+}

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
@@ -40,4 +40,21 @@ describe("new workspace modal store (#5372)", () => {
 		useNewWorkspaceModalStore.getState().openModal("project-2");
 		expect(useNewWorkspaceDraftStore.getState().prompt).toBe("");
 	});
+
+	test("full-page handoff preserves the seeded draft", () => {
+		// DashboardNewWorkspaceModal test arm: closes the store modal with
+		// { resetDraft: false } before navigating to /new-workspace, where
+		// the destination screen consumes the seeded prompt.
+		const draftStore = useNewWorkspaceDraftStore.getState();
+		draftStore.resetDraft();
+		draftStore.updateDraft({ prompt: SETUP_SCRIPT_PROMPT });
+		useNewWorkspaceModalStore.getState().openModal("project-1");
+
+		useNewWorkspaceModalStore.getState().closeModal({ resetDraft: false });
+
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe(
+			SETUP_SCRIPT_PROMPT,
+		);
+		expect(useNewWorkspaceModalStore.getState().isOpen).toBeFalse();
+	});
 });

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+import {
+	resetNewWorkspaceDraftOnRouteLeave,
+	useNewWorkspaceDraftStore,
+} from "./new-workspace-draft";
 import { useNewWorkspaceModalStore } from "./new-workspace-modal";
 
 const SETUP_SCRIPT_PROMPT = "Write a setup script for this project";
@@ -56,5 +59,18 @@ describe("new workspace modal store (#5372)", () => {
 			SETUP_SCRIPT_PROMPT,
 		);
 		expect(useNewWorkspaceModalStore.getState().isOpen).toBeFalse();
+	});
+
+	test("leaving the full-page flow clears the preserved handoff draft", () => {
+		const draftStore = useNewWorkspaceDraftStore.getState();
+		draftStore.updateDraft({ prompt: SETUP_SCRIPT_PROMPT });
+		useNewWorkspaceModalStore.getState().openModal("project-1");
+		useNewWorkspaceModalStore.getState().closeModal({ resetDraft: false });
+
+		resetNewWorkspaceDraftOnRouteLeave();
+
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe("");
+		useNewWorkspaceModalStore.getState().openModal("project-2");
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe("");
 	});
 });

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+import { useNewWorkspaceModalStore } from "./new-workspace-modal";
+
+const SETUP_SCRIPT_PROMPT = "Write a setup script for this project";
+
+describe("new workspace modal store (#5372)", () => {
+	afterEach(() => {
+		// Leave both stores in a clean state for the next test.
+		useNewWorkspaceModalStore.getState().closeModal();
+		useNewWorkspaceDraftStore.getState().resetDraft();
+	});
+
+	test("dismissing the modal clears a seeded draft prompt", () => {
+		// Mirrors V2SetupScriptCard.handleConfigure: seed the draft with the
+		// setup-script prompt, then open the modal.
+		const draftStore = useNewWorkspaceDraftStore.getState();
+		draftStore.resetDraft();
+		draftStore.updateDraft({ prompt: SETUP_SCRIPT_PROMPT });
+		useNewWorkspaceModalStore.getState().openModal("project-1");
+
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe(
+			SETUP_SCRIPT_PROMPT,
+		);
+
+		// Esc / outside click → closeModal (the dismiss path).
+		useNewWorkspaceModalStore.getState().closeModal();
+
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe("");
+		expect(useNewWorkspaceModalStore.getState().isOpen).toBeFalse();
+	});
+
+	test("a fresh open after dismiss shows no leftover prompt", () => {
+		const draftStore = useNewWorkspaceDraftStore.getState();
+		draftStore.updateDraft({ prompt: SETUP_SCRIPT_PROMPT });
+		useNewWorkspaceModalStore.getState().openModal("project-1");
+		useNewWorkspaceModalStore.getState().closeModal();
+
+		// The next "New Workspace" click (no seed) must start empty.
+		useNewWorkspaceModalStore.getState().openModal("project-2");
+		expect(useNewWorkspaceDraftStore.getState().prompt).toBe("");
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
 
 interface PendingWorkspace {
 	id: string;
@@ -76,6 +77,13 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 					preSelectedProjectId: null,
 					preSelectedSession: false,
 				});
+				// #5372: a seeded draft (e.g. the Setup-scripts prompt written
+				// by V2SetupScriptCard) must not survive dismissing the modal —
+				// otherwise the next "New Workspace" opens pre-filled with a
+				// prompt the user never asked for. Every seed path calls
+				// resetDraft() before updateDraft(), so resetting here is safe
+				// and makes the dismiss the single cleanup point.
+				useNewWorkspaceDraftStore.getState().resetDraft();
 			},
 
 			setPendingWorkspace: (workspace: PendingWorkspace | null) => {

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -34,7 +34,7 @@ interface NewWorkspaceModalState {
 	stashedDraft: StashedDraft | null;
 	openModal: (projectId?: string) => void;
 	openSessionModal: () => void;
-	closeModal: () => void;
+	closeModal: (options?: { resetDraft?: boolean }) => void;
 	setPendingWorkspace: (workspace: PendingWorkspace | null) => void;
 	clearPendingWorkspace: (id: string) => void;
 	setPendingWorkspaceStatus: (
@@ -71,7 +71,7 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 				});
 			},
 
-			closeModal: () => {
+			closeModal: (options?: { resetDraft?: boolean }) => {
 				set({
 					isOpen: false,
 					preSelectedProjectId: null,
@@ -83,7 +83,14 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 				// prompt the user never asked for. Every seed path calls
 				// resetDraft() before updateDraft(), so resetting here is safe
 				// and makes the dismiss the single cleanup point.
-				useNewWorkspaceDraftStore.getState().resetDraft();
+				//
+				// The full-page handoff (DashboardNewWorkspaceModal test arm)
+				// closes the store modal BEFORE navigating to /new-workspace,
+				// where the destination consumes the seeded draft — so it opts
+				// out with { resetDraft: false } (greptile/cubic P1).
+				if (options?.resetDraft !== false) {
+					useNewWorkspaceDraftStore.getState().resetDraft();
+				}
 			},
 
 			setPendingWorkspace: (workspace: PendingWorkspace | null) => {


### PR DESCRIPTION
Fixes #5372

## Problem

Clicking **Configure** on the "Setup scripts" sidebar card opens the New Workspace modal **seeded with a setup-script prompt**. If you dismiss the modal (Esc / outside click) without creating a workspace, that prompt stays in the draft. The next time you click **+ / New Workspace**, the composer still opens pre-filled with it — even though you never asked to configure setup scripts.

## Root cause

Every seed path (`V2SetupScriptCard`, GitHub issue/PR flows) does `resetDraft()` + `updateDraft(...)` before opening the modal — but the **dismiss** path (`closeModal`) only flipped `isOpen`. The seeded prompt remained in the draft store, so the next plain "New Workspace" open consumed it as if the user had typed it.

## Fix

`closeModal` now also resets the draft store. Since every seed path already resets before seeding, the dismiss becomes the **single cleanup point**:

- Esc / outside click / any close → draft wiped
- seeded flows (Configure, issue, PR) are unaffected — they re-seed after their own reset
- a plain "New Workspace" always opens empty, as before 1.17.0

## Validation

`new-workspace-modal.test.ts` — 2 unit tests:
- dismissing the modal clears a seeded draft prompt (exact #5372 repro);
- a fresh open after dismiss starts with an empty prompt.

`bun test`: 2/2 pass · `tsc --noEmit`: 0 errors · Biome: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears any seeded New Workspace draft on modal dismiss and preserves it only during the `/new-workspace` handoff. Previously dismiss left the seed in place; now dismiss wipes it, handoff keeps it, and leaving `/new-workspace` clears it (fixes #5372).

- **Changes**
  - `closeModal(options?: { resetDraft?: boolean })` now resets the draft by default; pass `resetDraft: false` for the `/new-workspace` handoff (used by `DashboardNewWorkspaceModal` before navigation).
  - Adds `resetNewWorkspaceDraftOnRouteLeave` and hooks it to the `/new-workspace` route `onLeave` to clear the preserved seed on route leave.
  - Adds tests for dismiss cleanup, empty reopen, handoff preservation, and route-leave cleanup.

<sup>Written for commit 2809a52e429f68f7857255eabb3d7e8089cbb574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the new workspace modal now clears previously entered setup prompts.
  * Reopening the modal starts with an empty draft.
  * Moving from the modal to the full-page workspace setup preserves the entered prompt.
  * Drafts are cleared after leaving the full-page workspace setup flow.

* **Tests**
  * Added coverage for draft clearing, reopening behavior, and prompt preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->