### PR TITLE
chore: add superficial README test edits across packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img width="full" alt="Superset" src="apps/marketing/public/images/readme-hero.png" />
 
-### The Code Editor for AI Agents
+### Hello from a README test — something else entirely
 
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
@@ -35,7 +35,7 @@ Superset orchestrates CLI-based coding agents across isolated git worktrees, wit
 - **Open any workspace where you need it** with one-click handoff to your editor or terminal
 - **Reach your workspaces from anywhere** via remote hosts, the CLI, the SDK, or MCP
 
-Wait less, ship more.
+Wait less, ship more. (readme test note)
 
 ## Features
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,5 +1,7 @@
 # docs
 
+<!-- superficial test change -->
+
 This is a Next.js application generated with
 [Create Fumadocs](https://github.com/fuma-nama/fumadocs).
 

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -2,6 +2,8 @@
 
 How to run 100 agents in parallel without losing your mind, a practical guide.
 
+<!-- superficial test change -->
+
 ## Table of Contents
 
 1. [Why would I want to do this?](#why-would-i-want-to-do-this)

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -2,6 +2,8 @@
 
 Email templates for Superset, built with [React Email](https://react.email).
 
+<!-- superficial test change -->
+
 ## Images in Email
 
 **Critical:** Email clients require absolute URLs for images. All images must be hosted on your production domain.

--- a/packages/panes/README.md
+++ b/packages/panes/README.md
@@ -2,6 +2,8 @@
 
 A generic, headless workspace layout engine. Tabs hold panes arranged in split layouts. The package provides the data model, store, and React components — you provide the pane content.
 
+<!-- superficial test change -->
+
 ## Concepts
 
 ```


### PR DESCRIPTION
## What & why

Adds superficial README wording tweaks across a few packages/docs for testing purposes. No functional code changes.

## How I tested it

- Reviewed the README diffs only (cosmetic edits)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made small, test-only edits to README files in the root and packages (`apps/docs`, `docs/cookbook`, `packages/email`, `packages/panes`). Changes are cosmetic only; no code, build, or behavior impact.

<sup>Written for commit ec4b968b8916ad45edee834feed41ab0e80ce8ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

