### PR TITLE
docs(skills): lead skills page with installation

### DIFF
--- a/apps/docs/content/docs/orchestration.mdx
+++ b/apps/docs/content/docs/orchestration.mdx
@@ -15,7 +15,7 @@ The coordinator can be Claude Code or Codex; the workers can be any mix of agent
 
 ## Install
 
-The desktop app [ships this skill automatically](/skills) — if you use Superset, your agents already have it. For standalone agents:
+The desktop app [ships this skill automatically](/skills), so if you use Superset, your agents already have it. For standalone agents:
 
 ```bash
 npx skills add superset-sh/skills

--- a/apps/docs/content/docs/recipes/agent-driven-superset.mdx
+++ b/apps/docs/content/docs/recipes/agent-driven-superset.mdx
@@ -1,20 +1,20 @@
 ---
 title: Drive Superset from Your Agent
-description: Delegate work in parallel, then make it recurring with the automate skill — without leaving the conversation
+description: Delegate work in parallel, then make it recurring with the automate skill, without leaving the conversation
 ---
 
 <Callout type="info" title="Use when">
-	you're mid-conversation with an agent and the next step is a Superset action — fan this work out in parallel, or make it recur on a schedule — and you'd rather say so than click through the app.
+	you're mid-conversation with an agent and the next step is a Superset action (fan this work out in parallel, or make it recur on a schedule) and you'd rather say so than click through the app.
 </Callout>
 
 ## The Idea
 
-Superset ships [skills](/skills) to your coding agents automatically, so the agent in front of you already knows how to run Superset itself. `superset:orchestrate` makes it a coordinator of parallel workers — that has [its own page](/orchestration). This recipe is about the move that follows: `superset:automate` turns anything you've asked for twice into a scheduled [automation](/automations), in the same conversation.
+Superset ships [skills](/skills) to your coding agents automatically, so the agent in front of you already knows how to run Superset itself. `superset:orchestrate` makes it a coordinator of parallel workers; that has [its own page](/orchestration). This recipe is about the move that follows: `superset:automate` turns anything you've asked for twice into a scheduled [automation](/automations), in the same conversation.
 
 ## Steps
 
-1. Delegate something splittable to the agent you're talking to — "split this migration into independent slices and run a worker on each" ([Agent Orchestration](/orchestration) covers what to ask for and how the coordination works). Review each workspace's diff as it lands.
-2. When the job turns out to be recurring — a dependency sweep, a triage pass, a weekly cleanup — promote it without switching surfaces:
+1. Delegate something splittable to the agent you're talking to: "split this migration into independent slices and run a worker on each" ([Agent Orchestration](/orchestration) covers what to ask for and how the coordination works). Review each workspace's diff as it lands.
+2. When the job turns out to be recurring (a dependency sweep, a triage pass, a weekly cleanup), promote it without switching surfaces:
 
 ```text
 That worked. Make it a Superset automation that runs every Monday at 7am
@@ -27,4 +27,4 @@ on this project, and walk me through the first run.
 
 - **Catch up instead of fan out**: "what did my agents do overnight?" gets you a standup digest of finished, blocked, and needs-review work
 - **When Superset itself misbehaves**: "diagnose why this host shows offline" has the agent fix it instead of you reading logs
-- The full list of shipped skills — and how they're delivered and updated — is on the [Skills](/skills) page
+- The full list of shipped skills, and how they're delivered and updated, is on the [Skills](/skills) page

--- a/apps/docs/content/docs/setup-teardown-scripts.mdx
+++ b/apps/docs/content/docs/setup-teardown-scripts.mdx
@@ -177,7 +177,7 @@ When teardown fails:
 2. Click "Delete Anyway" to force-delete immediately
 3. Or click "View Logs" to review the failure, then force-delete from the dialog
 
-Deleting a workspace through the CLI, SDK, or MCP also runs teardown. Since there's no one to prompt on those surfaces, a teardown failure doesn't block the delete — it's reported in the response's `warnings` instead.
+Deleting a workspace through the CLI, SDK, or MCP also runs teardown. Since there's no one to prompt on those surfaces, a teardown failure doesn't block the delete; it's reported in the response's `warnings` instead.
 
 ## Tips
 

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -3,19 +3,19 @@ title: Skills
 description: Superset abilities your coding agents get automatically — orchestration, automations, feedback, diagnostics, and more
 ---
 
-Superset ships a set of skills to the coding agents you already use. In Claude Code they appear under the `superset:` namespace; other agents that read skills (Codex, Kimi, Vibe, Grok) get the same skills with a `superset-` prefix, and the in-app chat exposes the most common ones as slash commands.
+Skills teach the coding agents you already use how to drive Superset — orchestrate parallel agents, create automations, diagnose problems, and more.
 
 ## Installation
 
-**Using the Superset desktop app?** The skills are already installed. The app provisions them automatically at launch — no install step — and keeps them updated as the app updates. Skip ahead to [What You Get](#what-you-get).
+**Using the Superset desktop app?** Skills are already installed — the app provisions them at launch and keeps them updated.
 
-Without the desktop app, install them directly:
+Otherwise, install them directly:
 
 ```bash
 npx skills add superset-sh/skills
 ```
 
-Claude Code users can also use the plugin marketplace:
+Or, in Claude Code, via the plugin marketplace:
 
 ```text
 /plugin marketplace add superset-sh/superset
@@ -42,13 +42,11 @@ You usually don't invoke them — agents pick the right skill from context:
 - "what did my agents do overnight?" → `superset:standup`
 - "run these three refactors in parallel" → `superset:orchestrate`
 
-To invoke one explicitly, use `/superset:feedback` in Claude Code, or `/superset/feedback` in the in-app chat.
+To invoke one explicitly: `/superset:feedback` in Claude Code, or `/superset/feedback` in the in-app chat. Other agents that read skills (Codex, Kimi, Vibe, Grok) see the same skills with a `superset-` prefix.
 
 ## How They're Delivered
 
-The desktop app writes managed copies into the standard discovery locations at launch: `~/.claude/skills/superset/` (loaded by Claude Code as a plugin, which is where the `superset:` namespace comes from), `~/.agents/skills/`, and `~/.agents/commands/`.
+At launch, the desktop app writes managed copies into the standard discovery locations: `~/.claude/skills/superset/` (loaded by Claude Code as a plugin — hence the `superset:` namespace), `~/.agents/skills/`, and `~/.agents/commands/`.
 
-Two rules keep this safe:
-
-- **Your files are never touched.** Anything Superset manages carries a marker; a skill or command you authored yourself at the same path is left alone.
-- **Updates and removals are automatic.** Managed skills are refreshed on every app launch, and ones that no longer ship are cleaned up.
+- **Your files are never touched.** Managed files carry a marker; a skill or command you authored at the same path is left alone.
+- **Updates are automatic.** Managed skills refresh on every app launch, and ones that no longer ship are cleaned up.

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -1,13 +1,13 @@
 ---
 title: Skills
-description: Superset abilities your coding agents get automatically — orchestration, automations, feedback, diagnostics, and more
+description: Superset abilities your coding agents get automatically. Orchestration, automations, feedback, diagnostics, and more
 ---
 
-Skills teach the coding agents you already use how to drive Superset — orchestrate parallel agents, create automations, diagnose problems, and more.
+Skills teach the coding agents you already use how to drive Superset: orchestrate parallel agents, create automations, diagnose problems, and more.
 
 ## Installation
 
-**Using the Superset desktop app?** Skills are already installed — the app provisions them at launch and keeps them updated.
+**Using the Superset desktop app?** Skills are already installed. The app provisions them at launch and keeps them updated.
 
 Otherwise, install them directly:
 
@@ -25,18 +25,18 @@ Or, in Claude Code, via the plugin marketplace:
 
 | Skill | What it does |
 |:------|:-------------|
-| `superset:setup` | Makes a repo Superset-ready — authors `.superset/config.json` and setup scripts, then verifies with a real workspace |
-| `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents — see [Agent Orchestration](/orchestration) |
+| `superset:setup` | Makes a repo Superset-ready: authors `.superset/config.json` and setup scripts, then verifies with a real workspace |
+| `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
-| `superset:doctor` | Diagnoses Superset problems — expired auth, offline hosts, stale versions — and fixes them one step at a time |
+| `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |
 | `superset:10x` | Audits how you use Superset and teaches the advanced features you're not using yet |
 | `superset:contribute` | Sets up a Superset open-source contribution end to end, following the repo's contribution rules |
 
 ## Using Skills
 
-You usually don't invoke them — agents pick the right skill from context:
+You usually don't invoke them; agents pick the right skill from context:
 
 - "report this bug to the superset team" → `superset:feedback`
 - "what did my agents do overnight?" → `superset:standup`
@@ -46,7 +46,7 @@ To invoke one explicitly: `/superset:feedback` in Claude Code, or `/superset/fee
 
 ## How They're Delivered
 
-At launch, the desktop app writes managed copies into the standard discovery locations: `~/.claude/skills/superset/` (loaded by Claude Code as a plugin — hence the `superset:` namespace), `~/.agents/skills/`, and `~/.agents/commands/`.
+At launch, the desktop app writes managed copies into the standard discovery locations: `~/.claude/skills/superset/` (loaded by Claude Code as a plugin, hence the `superset:` namespace), `~/.agents/skills/`, and `~/.agents/commands/`.
 
 - **Your files are never touched.** Managed files carry a marker; a skill or command you authored at the same path is left alone.
 - **Updates are automatic.** Managed skills refresh on every app launch, and ones that no longer ship are cleaned up.

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -3,7 +3,23 @@ title: Skills
 description: Superset abilities your coding agents get automatically — orchestration, automations, feedback, diagnostics, and more
 ---
 
-Superset ships a set of skills to the coding agents you already use. The desktop app provisions them automatically at launch — no install step — and keeps them updated as the app updates. In Claude Code they appear under the `superset:` namespace; other agents that read skills (Codex, Kimi, Vibe, Grok) get the same skills with a `superset-` prefix, and the in-app chat exposes the most common ones as slash commands.
+Superset ships a set of skills to the coding agents you already use. In Claude Code they appear under the `superset:` namespace; other agents that read skills (Codex, Kimi, Vibe, Grok) get the same skills with a `superset-` prefix, and the in-app chat exposes the most common ones as slash commands.
+
+## Installation
+
+**Using the Superset desktop app?** The skills are already installed. The app provisions them automatically at launch — no install step — and keeps them updated as the app updates. Skip ahead to [What You Get](#what-you-get).
+
+Without the desktop app, install them directly:
+
+```bash
+npx skills add superset-sh/skills
+```
+
+Claude Code users can also use the plugin marketplace:
+
+```text
+/plugin marketplace add superset-sh/superset
+```
 
 ## What You Get
 
@@ -36,17 +52,3 @@ Two rules keep this safe:
 
 - **Your files are never touched.** Anything Superset manages carries a marker; a skill or command you authored yourself at the same path is left alone.
 - **Updates and removals are automatic.** Managed skills are refreshed on every app launch, and ones that no longer ship are cleaned up.
-
-## Without the Desktop App
-
-Standalone agents can install the skills directly:
-
-```bash
-npx skills add superset-sh/skills
-```
-
-Claude Code users can also use the plugin marketplace:
-
-```text
-/plugin marketplace add superset-sh/superset
-```

--- a/apps/docs/content/docs/workspaces.mdx
+++ b/apps/docs/content/docs/workspaces.mdx
@@ -17,7 +17,7 @@ Press **⌘N** or click "New Workspace". Create from:
 - **Existing branch** - Continue work on a branch
 - **Pull request** - Review or continue a PR
 
-In the prompt-first workspace flow, **Link pull request** lets you search by title or PR number, or paste the full PR URL to match it directly. The prompt box also keeps a searchable history of your previous prompts — click the history icon to reuse one.
+In the prompt-first workspace flow, **Link pull request** lets you search by title or PR number, or paste the full PR URL to match it directly. The prompt box also keeps a searchable history of your previous prompts; click the history icon to reuse one.
 
 If you type a workspace name yourself, the branch name is derived from it (slugified to kebab-case). Otherwise Superset generates a name from your prompt.
 


### PR DESCRIPTION
## Summary
- Restructure the skills docs page to lead with an **Installation** section: desktop app users learn skills are already provisioned, everyone else gets the `npx skills add` / plugin-marketplace commands up front (previously buried at the bottom as "Without the Desktop App").
- Tighten the prose throughout: one-line intro, namespace details moved into "Using Skills", trimmed "How They're Delivered".
- Remove all em dashes across docs content (21 occurrences in 5 files), rewriting each with appropriate punctuation.

## Testing
- `bun run lint`
- Docs-only change; verified `grep '—' apps/docs/content` returns nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified skills installation options, including automatic desktop-app provisioning, direct CLI installation, and marketplace installation.
  * Added invocation syntax for Claude Code, in-app chat, and other supported agents.
  * Documented managed skill locations, preservation of authored files, and cleanup of obsolete managed files.
  * Improved wording and punctuation across orchestration, workspace, setup/teardown, and recipe guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->