### PR TITLE
feat(docs,marketing): brand-orange text selection and denser sidebar active halo

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -165,7 +165,7 @@
 		@apply border-border outline-ring/50;
 	}
 	body {
-		@apply overscroll-none bg-background text-foreground selection:bg-foreground selection:text-background;
+		@apply overscroll-none bg-background text-foreground selection:bg-brand selection:text-black;
 	}
 }
 
@@ -246,6 +246,40 @@ html:not([data-anchor-scrolling]) {
 		0 0 2px var(--background),
 		0 0 2px var(--background),
 		0 1px 4px var(--background);
+}
+
+/* Dense halo in the page background color: knocks the dither back around text.
+   Tight radii are stacked many times — each repeat multiplies opacity. */
+@utility text-halo {
+	text-shadow:
+		0 0 2px var(--background),
+		0 0 2px var(--background),
+		0 0 2px var(--background),
+		0 0 2px var(--background),
+		0 0 2px var(--background),
+		0 0 2px var(--background),
+		0 0 4px var(--background),
+		0 0 4px var(--background),
+		0 0 4px var(--background),
+		0 0 4px var(--background),
+		0 0 4px var(--background),
+		0 0 4px var(--background),
+		0 0 6px var(--background),
+		0 0 6px var(--background),
+		0 0 6px var(--background),
+		0 0 6px var(--background),
+		0 0 6px var(--background),
+		0 0 8px var(--background),
+		0 0 8px var(--background),
+		0 0 8px var(--background),
+		0 0 8px var(--background),
+		0 0 12px var(--background),
+		0 0 12px var(--background),
+		0 0 12px var(--background),
+		0 0 16px var(--background),
+		0 0 16px var(--background),
+		0 0 24px var(--background),
+		0 0 32px var(--background);
 }
 
 @utility no-scrollbar {

--- a/apps/docs/src/components/AsideLink/AsideLink.tsx
+++ b/apps/docs/src/components/AsideLink/AsideLink.tsx
@@ -30,7 +30,11 @@ export const AsideLink = ({
 			className={cn(
 				"flex w-full min-w-0 items-center gap-x-2.5 rounded-md px-2 py-1.5 text-sm transition-colors",
 				isActive
-					? cn("bg-dither text-accent-foreground", activeClassName)
+					? cn(
+							"bg-dither text-accent-foreground",
+							"[&>span]:text-halo",
+							activeClassName,
+						)
 					: "text-muted-foreground hover:text-foreground",
 				className,
 			)}

--- a/apps/marketing/src/app/globals.css
+++ b/apps/marketing/src/app/globals.css
@@ -24,6 +24,11 @@
 	[role="button"]:not([aria-disabled="true"]) {
 		cursor: pointer;
 	}
+
+	::selection {
+		background-color: var(--brand);
+		color: #000;
+	}
 }
 
 @utility scrollbar-hide {


### PR DESCRIPTION
## What

- **Docs + marketing: brand-orange text selection.** Drag-selecting text now highlights in the brand orange (`#d25611`) with black text instead of the white/default highlight (docs previously used `selection:bg-foreground`, marketing had no `::selection` rule at all).
- **Docs sidebar: denser halo on the active link.** The active item's label gets a new `text-halo` utility — a stacked `text-shadow` in the page background color that knocks the dither dots back around the glyphs so the label stays readable over the `bg-dither` pattern. Tight radii are repeated many times since each repeat multiplies opacity.

## Why

The active sidebar item's label was hard to read on top of the orange dither dots, and the white selection highlight clashed with the brand look.

## Verification

- Verified end-to-end in headless Chrome via CDP against the dev servers from this worktree (dark mode): computed `::selection` is `rgb(210, 86, 17)` / black text, screenshot confirms the orange highlight; sidebar halo iterated visually on `/recipes/fan-out-refactor`.
- `bun run lint` and docs `tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds brand-orange text selection across docs and marketing, and a dense text halo on the active docs sidebar link for better readability over the dither background.

- New Features
  - Unified text selection: orange (`#d25611`) background with black text in both `apps/docs` and `apps/marketing`.
  - Docs sidebar: added a text-halo utility (stacked text-shadow) and applied it to the active link label.

<sup>Written for commit 4055d2359947acdd698682608c90f251933dbb19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text selection styling across documentation and marketing pages with brand-colored highlights and improved contrast.
  * Added a text halo effect to reduce visual dithering around selected or highlighted text.
  * Improved the appearance of active navigation links with the new text treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->