### PR TITLE
fix(cli): make desktop-bundled CLI refuse self-update and explain missing superset-host

### DIFF
--- a/apps/desktop/scripts/build-bundled-cli.ts
+++ b/apps/desktop/scripts/build-bundled-cli.ts
@@ -62,6 +62,7 @@ function run(
 
 function buildCliBuildEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
+	env.SUPERSET_CLI_CHANNEL = "desktop-bundled";
 	const apiUrl =
 		process.env.SUPERSET_API_URL || process.env.NEXT_PUBLIC_API_URL;
 	const webUrl =

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
 			process.env.SUPERSET_WEB_URL ?? "https://app.superset.sh",
 		),
 		"process.env.SUPERSET_VERSION": JSON.stringify(VERSION),
+		"process.env.SUPERSET_CLI_CHANNEL": JSON.stringify(
+			process.env.SUPERSET_CLI_CHANNEL ?? "standalone",
+		),
 	},
 	globals: {
 		json: boolean().desc("Output as JSON (auto-on under CI/agent envs)"),

--- a/packages/cli/src/commands/update/command.test.ts
+++ b/packages/cli/src/commands/update/command.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import updateCommand from "./command";
+
+function invoke() {
+	return updateCommand.run({
+		ctx: {} as never,
+		args: {} as never,
+		options: {} as never,
+		signal: new AbortController().signal,
+	});
+}
+
+afterEach(() => {
+	delete process.env.SUPERSET_CLI_CHANNEL;
+});
+
+describe("update", () => {
+	test("refuses to run from the desktop-bundled CLI", async () => {
+		process.env.SUPERSET_CLI_CHANNEL = "desktop-bundled";
+		await expect(invoke()).rejects.toThrow(
+			/bundled with the Superset desktop app/,
+		);
+	});
+
+	test("standalone dev builds hit the dev-build guard instead", async () => {
+		await expect(invoke()).rejects.toThrow(/only available in built binaries/);
+	});
+});

--- a/packages/cli/src/commands/update/command.test.ts
+++ b/packages/cli/src/commands/update/command.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import cliConfig from "../../../cli.config";
 import updateCommand from "./command";
 
 function invoke() {
@@ -24,5 +26,31 @@ describe("update", () => {
 
 	test("standalone dev builds hit the dev-build guard instead", async () => {
 		await expect(invoke()).rejects.toThrow(/only available in built binaries/);
+	});
+});
+
+// Release binaries get SUPERSET_CLI_CHANNEL via build-time define replacement,
+// not runtime env — assert that wiring statically so a regression can't slip
+// past the runtime-env tests above.
+describe("channel build wiring", () => {
+	test("cli.config.ts bakes SUPERSET_CLI_CHANNEL, defaulting to standalone", () => {
+		expect(cliConfig.define?.["process.env.SUPERSET_CLI_CHANNEL"]).toBe(
+			JSON.stringify("standalone"),
+		);
+	});
+
+	test("desktop bundled-CLI build sets the desktop-bundled channel", () => {
+		// Importing the script would run it (and trips the CLI tsconfig rootDir),
+		// so assert against its source instead.
+		const buildScript = readFileSync(
+			new URL(
+				"../../../../../apps/desktop/scripts/build-bundled-cli.ts",
+				import.meta.url,
+			),
+			"utf8",
+		);
+		expect(buildScript).toMatch(
+			/SUPERSET_CLI_CHANNEL\s*[:=]\s*"desktop-bundled"/,
+		);
 	});
 });

--- a/packages/cli/src/commands/update/command.ts
+++ b/packages/cli/src/commands/update/command.ts
@@ -14,7 +14,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { boolean, CLIError, string } from "@superset/cli-framework";
 import { command } from "../../lib/command";
-import { env } from "../../lib/env";
+import { env, isDesktopBundled } from "../../lib/env";
 
 // `cli-latest` is a rolling GH Release/tag updated by build-cli.yml on every
 // CLI release. Reading from a fixed download path (rather than the global
@@ -137,6 +137,13 @@ export default command({
 		),
 	},
 	run: async ({ options }) => {
+		if (isDesktopBundled()) {
+			throw new CLIError(
+				"This CLI is bundled with the Superset desktop app and updates together with the app.",
+				"For a standalone CLI that updates in place: curl -fsSL https://superset.sh/cli/install.sh | sh",
+			);
+		}
+
 		const target = detectTarget();
 		const currentVersion = getCurrentVersion();
 		if (currentVersion === "0.0.0-dev") {

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -10,3 +10,13 @@ export const env = {
 	SUPERSET_WEB_URL: process.env.SUPERSET_WEB_URL || "https://app.superset.sh",
 	VERSION: process.env.SUPERSET_VERSION || "0.0.0-dev",
 };
+
+/**
+ * True for the CLI compiled into the desktop app bundle (baked at build time
+ * by apps/desktop/scripts/build-bundled-cli.ts). The bundled CLI ships without
+ * superset-host and lives inside the signed .app, so it can neither run the
+ * host service standalone nor update itself in place.
+ */
+export function isDesktopBundled(): boolean {
+	return process.env.SUPERSET_CLI_CHANNEL === "desktop-bundled";
+}

--- a/packages/cli/src/lib/host/spawn.test.ts
+++ b/packages/cli/src/lib/host/spawn.test.ts
@@ -75,6 +75,42 @@ afterAll(() => {
 });
 
 describe("spawnHostService", () => {
+	test("reports missing superset-host with an override hint", async () => {
+		process.env.SUPERSET_HOST_BIN = join(tempHome, "missing-host");
+		try {
+			await expect(
+				spawnHostService({
+					organizationId: "00000000-0000-0000-0000-000000000001",
+					sessionToken: "session-token",
+					api: createApi(),
+					port: 54879,
+					daemon: true,
+				}),
+			).rejects.toThrow(/superset-host binary not found .* SUPERSET_HOST_BIN/);
+		} finally {
+			process.env.SUPERSET_HOST_BIN = hostBin;
+		}
+	});
+
+	test("explains desktop-bundled CLI cannot run the host service", async () => {
+		process.env.SUPERSET_HOST_BIN = join(tempHome, "missing-host");
+		process.env.SUPERSET_CLI_CHANNEL = "desktop-bundled";
+		try {
+			await expect(
+				spawnHostService({
+					organizationId: "00000000-0000-0000-0000-000000000001",
+					sessionToken: "session-token",
+					api: createApi(),
+					port: 54879,
+					daemon: true,
+				}),
+			).rejects.toThrow(/bundled with the Superset desktop app/);
+		} finally {
+			process.env.SUPERSET_HOST_BIN = hostBin;
+			delete process.env.SUPERSET_CLI_CHANNEL;
+		}
+	});
+
 	test("passes SUPERSET_AUTH_CONFIG_PATH when provided", async () => {
 		globalThis.fetch = mock(
 			async () => new Response("ok", { status: 200 }),

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 import type { ApiClient } from "../api-client";
-import { env } from "../env";
+import { env, isDesktopBundled } from "../env";
 import {
 	type HostServiceManifest,
 	hostDbPath,
@@ -94,6 +94,11 @@ export async function spawnHostService(
 ): Promise<SpawnHostResult> {
 	const hostBin = resolveHostBinary();
 	if (!existsSync(hostBin)) {
+		if (isDesktopBundled()) {
+			throw new Error(
+				"`superset start` is not available in the CLI bundled with the Superset desktop app; the app runs the host service itself. For headless use, install the standalone CLI: curl -fsSL https://superset.sh/cli/install.sh | sh",
+			);
+		}
 		throw new Error(
 			`superset-host binary not found at ${hostBin}. Set SUPERSET_HOST_BIN to override.`,
 		);


### PR DESCRIPTION
## Problem

User report: after the 1.18.1 → 1.19.0 auto-update, `superset start` fails with `superset-host binary not found at /Applications/Superset.app/Contents/Resources/resources/bin/superset-host`, and `superset update` can't repair it (already "current").

Root cause chain:
- The desktop bundle has **never** shipped `superset-host` — `build-bundled-cli.ts` compiles only `superset`. The host wrapper ships solely in the standalone CLI tarball.
- `superset update` resolves its install root from `execPath`, so when run from the bundled CLI it `atomicReplace()`d `Superset.app/Contents/Resources/resources` with the full standalone dist — rewriting signed app resources (breaks the code-signature seal) and planting `superset-host` inside the bundle.
- That accidental plant was the only reason `superset start` ever worked from the bundled CLI. It fired whenever a CLI hotfix put `cli-latest` ahead of the bundled version (e.g. 1.18.1 vs 1.18.3). The 1.19.0 release unified versions, so `update` reports up-to-date and never re-extracts, while the auto-update wiped the previously planted files.

## Fix

- Bake a `SUPERSET_CLI_CHANNEL` build-time constant into CLI builds: `desktop-bundled` (set by `apps/desktop/scripts/build-bundled-cli.ts`) vs `standalone` (default).
- `superset update` from the bundled CLI now refuses with install.sh guidance instead of rewriting the signed app bundle.
- `superset start` from the bundled CLI (no `superset-host` sibling) now explains that the desktop app runs the host service itself and points to the standalone install, instead of surfacing a confusing path inside the .app.

## Tests

- `update` guard: refuses under `desktop-bundled`, falls through to the existing dev-build guard otherwise (guard verified to fail when disabled).
- `spawnHostService`: bundled-channel message vs generic `SUPERSET_HOST_BIN` hint.
- `bun run lint` clean; turbo typecheck green for `@superset/cli` + `@superset/desktop`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the desktop-bundled CLI from self-updating and replace confusing `superset-host` errors with clear guidance. Previously, the bundled CLI could rewrite the signed app and occasionally made `superset start` work by accident; now `superset update` refuses in the bundled channel and `superset start` explains the desktop app runs the host service.

- Gate behavior by build-time `SUPERSET_CLI_CHANNEL` (`desktop-bundled` vs `standalone`) and `isDesktopBundled()`. The desktop build sets the bundled channel; `packages/cli/cli.config.ts` defaults to `standalone`.
- `superset update` in the bundled channel errors and points to the standalone install: curl -fsSL https://superset.sh/cli/install.sh | sh
- `superset start` in the bundled channel explains the app runs the host; otherwise, missing host errors include a `SUPERSET_HOST_BIN` override hint.
- Tests cover runtime guards and statically assert the build-time wiring so release builds cannot regress.

<sup>Written for commit 3b928ae183e3f9fb41a45b6230966c00cba34881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of updates for the desktop-bundled CLI with a clear message directing users to the standalone installation.
  * Added a desktop-specific error when the required host binary is unavailable.
  * Preserved existing update behavior for standalone CLI installations.

* **Tests**
  * Added coverage for bundled and standalone CLI update scenarios.
  * Added coverage for missing host binaries and relevant configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->