### PR TITLE
feat(cli): add --delete-branch option to workspaces delete

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -698,13 +698,26 @@ superset workspaces create --project prj_… --name "perf-spike" --branch perf/s
 	options={[
 		{ flag: "--host <id>", description: "Host the workspaces live on." },
 		{ flag: "--local", description: "Target this machine (the default)." },
+		{ flag: "--delete-branch", description: "Also delete each workspace's local branch (`git branch -D`). Off by default." },
 	]}
-	output={`{ deleted: string[]; warnings: string[] }`}
+	output={`{ deleted: string[]; branchesDeleted: string[]; warnings: string[] }`}
 >
 Delete one or more workspaces on the target host (default: this machine).
+The worktree is always removed; the local git branch is kept unless you pass
+`--delete-branch`.
+
+Passing the flag is your consent to a forced delete: the branch goes away with
+`git branch -D` even when it is unmerged, so unpushed commits on it are lost.
+Branch deletion runs after the workspace is already gone, so a git failure
+lands in `warnings` instead of failing the delete, and the workspace stays in
+`deleted`. `branchesDeleted` lists the workspaces whose branch cleanup
+succeeded (a branch that was already gone counts as done).
 
 ```bash
 superset workspaces delete ws_a ws_b ws_c
+
+# Delete the workspaces and their local branches
+superset workspaces delete ws_a --delete-branch
 ```
 </Command>
 

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -643,13 +643,26 @@ superset workspaces create \
 	options={[
 		{ flag: "--host <id>", description: "Host the workspaces live on." },
 		{ flag: "--local", description: "Target this machine (the default)." },
+		{ flag: "--delete-branch", description: "Also delete each workspace's local branch (`git branch -D`). Off by default." },
 	]}
-	output={`{ deleted: string[]; warnings: string[] }`}
+	output={`{ deleted: string[]; branchesDeleted: string[]; warnings: string[] }`}
 >
 Delete one or more workspaces on the target host (default: this machine).
+The worktree is always removed; the local git branch is kept unless you pass
+`--delete-branch`.
+
+Passing the flag is your consent to a forced delete: the branch goes away with
+`git branch -D` even when it is unmerged, so unpushed commits on it are lost.
+Branch deletion runs after the workspace is already gone, so a git failure
+lands in `warnings` instead of failing the delete, and the workspace stays in
+`deleted`. `branchesDeleted` lists the workspaces whose branch cleanup
+succeeded (a branch that was already gone counts as done).
 
 ```bash
 superset workspaces delete ws_a ws_b ws_c
+
+# Delete the workspaces and their local branches
+superset workspaces delete ws_a --delete-branch
 ```
 </Command>
 

--- a/packages/cli/src/commands/agents/create/command.test.ts
+++ b/packages/cli/src/commands/agents/create/command.test.ts
@@ -13,8 +13,20 @@ mock.module("../../../lib/host-workspaces", () => ({
 	}),
 }));
 
+// `lib/host/spawn.test.ts` replaces `node:child_process` with a spawn-only
+// stub, and bun leaks module mocks across files in the same process, so
+// importing the real host-info (which pulls `execFileSync`) fails at load
+// time. The host is resolved through the mocked host-target below anyway.
+mock.module("@superset/shared/host-info", () => ({
+	getHostId: () => "host-1",
+}));
+
+// Bun leaks module mocks across test files in the same process, so every mock
+// of this barrel must cover its whole surface — a partial one breaks any later
+// file whose command imports the missing export.
 mock.module("../../../lib/host-target", () => ({
 	requireHostTarget: () => "host-1",
+	resolveHostFilter: () => "host-1",
 	resolveHostTarget: () => ({
 		hostId: "host-1",
 		client: {

--- a/packages/cli/src/commands/agents/create/command.test.ts
+++ b/packages/cli/src/commands/agents/create/command.test.ts
@@ -9,8 +9,20 @@ mock.module("../../../lib/host-workspaces", () => ({
 	}),
 }));
 
+// `lib/host/spawn.test.ts` replaces `node:child_process` with a spawn-only
+// stub, and bun leaks module mocks across files in the same process, so
+// importing the real host-info (which pulls `execFileSync`) fails at load
+// time. The host is resolved through the mocked host-target below anyway.
+mock.module("@superset/shared/host-info", () => ({
+	getHostId: () => "host-1",
+}));
+
+// Bun leaks module mocks across test files in the same process, so every mock
+// of this barrel must cover its whole surface — a partial one breaks any later
+// file whose command imports the missing export.
 mock.module("../../../lib/host-target", () => ({
 	requireHostTarget: () => "host-1",
+	resolveHostFilter: () => "host-1",
 	resolveHostTarget: () => ({
 		hostId: "host-1",
 		client: {

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -2,8 +2,11 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 let createInput: Record<string, unknown> | undefined;
 
+// See the note in agents/create/command.test.ts: leaked module mocks make a
+// partial barrel mock break unrelated files, so mirror the full surface.
 mock.module("../../../lib/host-target", () => ({
 	requireHostTarget: () => "host-1",
+	resolveHostFilter: () => "host-1",
 	resolveHostTarget: () => ({
 		hostId: "host-1",
 		client: {

--- a/packages/cli/src/commands/workspaces/delete/command.test.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.test.ts
@@ -78,6 +78,20 @@ describe("workspaces delete", () => {
 		expect(result.message).toBe("Deleted workspace ws_a");
 	});
 
+	test("says what happened to the branch of a single workspace", async () => {
+		// A ratio is noise for one workspace — and "1/1 branches" reads wrong.
+		const deletedBranch = await invoke(["ws_a"], { deleteBranch: true });
+		expect(deletedBranch.message).toBe(
+			"Deleted workspace ws_a (branch deleted)",
+		);
+
+		branchDeletedByInput = () => false;
+		const keptBranch = await invoke(["ws_a"], { deleteBranch: true });
+		expect(keptBranch.message).toBe(
+			"Deleted workspace ws_a (branch not deleted)",
+		);
+	});
+
 	test("forwards --delete-branch to every workspace on the host", async () => {
 		const result = await invoke(["ws_a", "ws_b"], { deleteBranch: true });
 

--- a/packages/cli/src/commands/workspaces/delete/command.test.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let deleteInputs: Record<string, unknown>[] = [];
+let branchDeletedByInput: (input: Record<string, unknown>) => boolean = (
+	input,
+) => input.deleteBranch === true;
+
+// `spawn.test.ts` replaces `node:child_process` with a spawn-only stub and bun
+// leaks module mocks across files in the same process, so importing the real
+// host-info (which pulls `execFileSync`) would break at load time. The host is
+// resolved through the mocked host-target below anyway.
+mock.module("@superset/shared/host-info", () => ({
+	getHostId: () => "host-1",
+}));
+
+// See the note in agents/create/command.test.ts: leaked module mocks make a
+// partial barrel mock break unrelated files, so mirror the full surface.
+mock.module("../../../lib/host-target", () => ({
+	requireHostTarget: () => "host-1",
+	resolveHostFilter: () => "host-1",
+	resolveHostTarget: () => ({
+		hostId: "host-1",
+		client: {
+			workspace: {
+				delete: {
+					mutate: async (input: Record<string, unknown>) => {
+						deleteInputs.push(input);
+						return {
+							success: true,
+							cloudDeleted: true,
+							worktreeRemoved: true,
+							branchDeleted: branchDeletedByInput(input),
+							warnings: [],
+						};
+					},
+				},
+			},
+		},
+	}),
+}));
+
+const { default: deleteWorkspaceCommand } = await import("./command");
+
+/** Narrows the command's `data | array | void` return to the data/message
+ *  shape this command always produces. */
+async function invoke(ids: string[], options: { deleteBranch?: boolean } = {}) {
+	const result = await deleteWorkspaceCommand.run({
+		ctx: {
+			config: { organizationId: "org-1" },
+			bearer: "bearer",
+		} as never,
+		args: { ids } as never,
+		options: { local: true, ...options } as never,
+		signal: new AbortController().signal,
+	});
+	if (!result || Array.isArray(result)) {
+		throw new Error("workspaces delete must return a data/message result");
+	}
+	return result;
+}
+
+afterEach(() => {
+	deleteInputs = [];
+	branchDeletedByInput = (input) => input.deleteBranch === true;
+});
+
+describe("workspaces delete", () => {
+	test("keeps the branch by default", async () => {
+		const result = await invoke(["ws_a"]);
+
+		expect(deleteInputs).toEqual([{ id: "ws_a", deleteBranch: false }]);
+		expect(result.data).toMatchObject({
+			deleted: ["ws_a"],
+			branchesDeleted: [],
+		});
+		// No branch annotation when the flag wasn't passed: "0/1 branches
+		// deleted" would read as a failure.
+		expect(result.message).toBe("Deleted workspace ws_a");
+	});
+
+	test("forwards --delete-branch to every workspace on the host", async () => {
+		const result = await invoke(["ws_a", "ws_b"], { deleteBranch: true });
+
+		expect(deleteInputs).toEqual([
+			{ id: "ws_a", deleteBranch: true },
+			{ id: "ws_b", deleteBranch: true },
+		]);
+		expect(result.data).toMatchObject({
+			deleted: ["ws_a", "ws_b"],
+			branchesDeleted: ["ws_a", "ws_b"],
+		});
+		expect(result.message).toBe("Deleted 2 workspaces (2/2 branches deleted)");
+	});
+
+	test("reports how many branches the host actually deleted", async () => {
+		// Branch cleanup runs after the workspace is already deleted, so a git
+		// failure only clears `branchDeleted` — the workspace still counts as
+		// deleted.
+		branchDeletedByInput = (input) => input.id === "ws_a";
+
+		const result = await invoke(["ws_a", "ws_b"], { deleteBranch: true });
+
+		expect(result.data).toMatchObject({
+			deleted: ["ws_a", "ws_b"],
+			branchesDeleted: ["ws_a"],
+		});
+		expect(result.message).toBe("Deleted 2 workspaces (1/2 branches deleted)");
+	});
+});

--- a/packages/cli/src/commands/workspaces/delete/command.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.ts
@@ -55,7 +55,7 @@ export default command({
 		// Only annotate branches when asked: without --delete-branch the count
 		// is always 0 and would read as a failure.
 		const deleteMessage = deleteBranch
-			? `${deletedSummary} (${branchesDeleted.length}/${deleted.length} branches deleted)`
+			? `${deletedSummary} (${formatBranchNote(branchesDeleted.length, deleted.length)})`
 			: deletedSummary;
 		return {
 			data: { deleted, branchesDeleted, warnings },
@@ -66,3 +66,15 @@ export default command({
 		};
 	},
 });
+
+/** A single workspace has exactly one branch, so the ratio is noise there —
+ *  say what happened to it instead. */
+function formatBranchNote(
+	branchesDeleted: number,
+	workspacesDeleted: number,
+): string {
+	if (workspacesDeleted === 1) {
+		return branchesDeleted === 1 ? "branch deleted" : "branch not deleted";
+	}
+	return `${branchesDeleted}/${workspacesDeleted} branches deleted`;
+}

--- a/packages/cli/src/commands/workspaces/delete/command.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.ts
@@ -9,9 +9,13 @@ export default command({
 	options: {
 		host: string().desc("Host the workspaces live on"),
 		local: boolean().desc("Target this machine (the default)"),
+		deleteBranch: boolean().desc(
+			"Also delete each workspace's local branch (git branch -D; kept by default)",
+		),
 	},
 	run: async ({ ctx, args, options }) => {
 		const ids = args.ids as string[];
+		const deleteBranch = options.deleteBranch ?? false;
 		const organizationId = ctx.config.organizationId;
 		if (!organizationId) {
 			throw new CLIError("No active organization", "Run: superset auth login");
@@ -30,21 +34,31 @@ export default command({
 		});
 
 		const deleted: string[] = [];
+		const branchesDeleted: string[] = [];
 		const warnings: string[] = [];
 		for (const id of ids) {
-			const result = await target.client.workspace.delete.mutate({ id });
+			const result = await target.client.workspace.delete.mutate({
+				id,
+				deleteBranch,
+			});
 			deleted.push(id);
+			if (result.branchDeleted) branchesDeleted.push(id);
 			for (const warning of result.warnings ?? []) {
 				warnings.push(`${id}: ${warning}`);
 			}
 		}
 
-		const deleteMessage =
+		const deletedSummary =
 			deleted.length === 1
 				? `Deleted workspace ${deleted[0]}`
 				: `Deleted ${deleted.length} workspaces`;
+		// Only annotate branches when asked: without --delete-branch the count
+		// is always 0 and would read as a failure.
+		const deleteMessage = deleteBranch
+			? `${deletedSummary} (${branchesDeleted.length}/${deleted.length} branches deleted)`
+			: deletedSummary;
 		return {
-			data: { deleted, warnings },
+			data: { deleted, branchesDeleted, warnings },
 			message:
 				warnings.length > 0
 					? `${deleteMessage}\nWarnings:\n${warnings.map((warning) => `- ${warning}`).join("\n")}`

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -186,7 +186,14 @@ export const workspaceRouter = router({
 		}),
 
 	delete: protectedProcedure
-		.input(z.object({ id: z.string() }))
+		.input(
+			z.object({
+				id: z.string(),
+				// Opt-in: the branch outlives the workspace by default, so an
+				// existing caller that omits the flag keeps its exact behavior.
+				deleteBranch: z.boolean().default(false),
+			}),
+		)
 		.mutation(async ({ ctx, input }) => {
 			// Legacy external surface used by CLI/SDK/MCP. Preserve its
 			// non-interactive contract while reusing the v2 cleanup path:
@@ -195,7 +202,7 @@ export const workspaceRouter = router({
 			// is nobody to prompt for a force-retry (#6174).
 			return destroyWorkspace(ctx, {
 				workspaceId: input.id,
-				deleteBranch: false,
+				deleteBranch: input.deleteBranch,
 				force: true,
 				teardownMode: "best-effort",
 			});

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -176,7 +176,14 @@ export const workspaceRouter = router({
 		}),
 
 	delete: protectedProcedure
-		.input(z.object({ id: z.string() }))
+		.input(
+			z.object({
+				id: z.string(),
+				// Opt-in: the branch outlives the workspace by default, so an
+				// existing caller that omits the flag keeps its exact behavior.
+				deleteBranch: z.boolean().default(false),
+			}),
+		)
 		.mutation(async ({ ctx, input }) => {
 			// Legacy external surface used by CLI/SDK/MCP. Preserve its
 			// non-interactive contract while reusing the v2 cleanup path:
@@ -185,7 +192,7 @@ export const workspaceRouter = router({
 			// is nobody to prompt for a force-retry (#6174).
 			return destroyWorkspace(ctx, {
 				workspaceId: input.id,
-				deleteBranch: false,
+				deleteBranch: input.deleteBranch,
 				force: true,
 				teardownMode: "best-effort",
 			});

--- a/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
@@ -524,6 +524,40 @@ describe("workspace.create + workspace.delete integration", () => {
 		expect(archivedAfter?.archiveReason).toBe("deleted");
 	});
 
+	test("delete() keeps the local branch when deleteBranch is omitted", async () => {
+		const scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+		});
+		expect(result.success).toBe(true);
+		expect(result.branchDeleted).toBe(false);
+
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).toContain(scenario.branch);
+	});
+
+	test("delete() with deleteBranch also removes the local branch", async () => {
+		const scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+			deleteBranch: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.branchDeleted).toBe(true);
+		expect(result.warnings).toEqual([]);
+
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).not.toContain(scenario.branch);
+	});
+
 	test("delete() requires authentication", async () => {
 		const scenario = await createBasicScenario();
 		dispose = scenario.dispose;

--- a/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
@@ -420,6 +420,40 @@ describe("workspace.create + workspace.delete integration", () => {
 		).toBe(true);
 	});
 
+	test("delete() keeps the local branch when deleteBranch is omitted", async () => {
+		const scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+		});
+		expect(result.success).toBe(true);
+		expect(result.branchDeleted).toBe(false);
+
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).toContain(scenario.branch);
+	});
+
+	test("delete() with deleteBranch also removes the local branch", async () => {
+		const scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+			deleteBranch: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.branchDeleted).toBe(true);
+		expect(result.warnings).toEqual([]);
+
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).not.toContain(scenario.branch);
+	});
+
 	test("delete() requires authentication", async () => {
 		const scenario = await createBasicScenario();
 		dispose = scenario.dispose;


### PR DESCRIPTION
## What & why

> Related to #6380 — that issue asks for branch release to become the *default*;
> this PR only makes it *possible* from the CLI, keeping today's behaviour when
> the flag is absent. #6381 proposes flipping the default instead; I've left the
> trade-off (the desktop keeps the branch unless the user ticks the box) as a
> comment there rather than duplicating the discussion here.

`superset workspaces delete` had no way to clean up the workspace's local git
branch. The external delete surface (`workspace.delete`, shared by CLI/SDK/MCP)
hardcoded `deleteBranch: false` when calling the v2 cleanup saga, so the branch
cleanup the desktop delete dialog offers had no non-interactive equivalent —
scripted teardown left a branch behind for every workspace.

This adds it as an **explicit opt-in**, with the current behavior untouched by
default:

- `workspace.delete` now accepts `deleteBranch` (`z.boolean().default(false)`)
  and forwards it to `destroyWorkspace`. Every existing caller that omits the
  field keeps its exact behavior.
- The CLI gains `--delete-branch`, and reports what actually happened in
  `branchesDeleted` plus an `N/M branches deleted` note in the human message.
  The note only appears when the flag was passed — otherwise `0/1` would read
  as a failure.

Branch deletion stays exactly where the saga already runs it (step 4, after the
workspace row is gone), so a git failure surfaces in `warnings` instead of
failing the delete. `--delete-branch` is the user's consent to the saga's
existing forced semantics (`git branch -D`, unmerged branches included); the
docs say so explicitly since there is no confirmation dialog on this path.

Output shape gains one field:
`{ deleted, branchesDeleted, warnings }`.

Docs: `apps/docs/content/docs/cli/cli-reference.mdx`.

## How I tested it

`bun run lint` → exit 0, `bun run typecheck` → 0 errors on the touched
packages (`@superset/cli`, `@superset/host-service`, `@superset/docs`).

**Host cleanup API — real git, not mocks** (`packages/host-service`, 55 pass):
two new integration tests in `workspace-create-delete.integration.test.ts` run
against a real `git worktree add -b` fixture and assert on `git branchLocal()`
afterwards — the branch survives when `deleteBranch` is omitted, and is gone
when it is passed. Verified the second one **fails before the change**
(`branchDeleted: false`) and passes after:

```
(fail) delete() with deleteBranch also removes the local branch   # src reverted
 1 pass 1 fail
→ 14 pass 0 fail                                                  # with the change
```

**CLI** (`packages/cli`, 42 pass): new `workspaces/delete/command.test.ts`
covers the default (`deleteBranch: false` forwarded, no branch note in the
message), the flag forwarded to every id, and a partial result
(`1/2 branches deleted`) when the host reports one branch cleanup as failed.

**Rendered help** — real `bun run dev workspaces delete --help`:

```
Options:
  --host <string>  Host the workspaces live on
  --local          Target this machine (the default)
  --delete-branch  Also delete each workspace's local branch (git branch -D; kept by default)
```

**End-to-end against a live host** — both behaviors in one run:

<img width="2784" height="1519" alt="delete-branch-demo" src="https://github.com/user-attachments/assets/6a5c56fb-fc81-4401-a14c-74949ee9b1ab" />

<sub>Terminal transcript of a real run, rendered with <a
href="https://github.com/charmbracelet/freeze"><code>freeze</code></a>. The
output is captured verbatim (pseudo-TTY, ANSI colors intact); the <code>$
…</code> lines are printed by the demo script with shortened ids rather than
typed, for readability.</sub>

Setup: CLI binary built from this branch (`bun run build` in `packages/cli`)
talking to the dev desktop app's host service, also from this branch
(`./.superset/setup.local.sh` + `bun run dev`). The project is a throwaway git
repo, so no real workspace was harmed. Two workspaces on two branches, then:

| Command | Result | `branchesDeleted` |
| --- | --- | --- |
| `workspaces delete <keep>` | `Deleted workspace <id>` | `[]` — `demo/keep` still in `git branch` |
| `workspaces delete <scratch> --delete-branch` | `Deleted workspace <id> (branch deleted)` | `[<id>]` — `demo/scratch` gone from `git branch` |

The same run in `--json` mode returns `{"deleted":[…],"branchesDeleted":[…],"warnings":[]}`.

## Note on the two unrelated-looking test edits

`agents/create/command.test.ts` and `workspaces/create/command.test.ts` each
gain a mock line. Bun leaks module mocks across test files in one process:

- Their **partial** mock of the `lib/host-target` barrel (no `resolveHostFilter`)
  broke the new delete test at load time, so both now mirror the full surface.
- `lib/host/spawn.test.ts` replaces `node:child_process` with a spawn-only
  stub, which breaks any later file importing the real `host-info`
  (`execFileSync`). This was **already failing `agents/create` on main**
  (`1 fail` before this branch); since I had to touch the file anyway, the
  same one-line mock fixes it and the package is now green. Happy to split it
  out if you'd rather keep this PR to a single change.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--delete-branch` to `superset workspaces delete` to optionally remove each workspace’s local git branch. Keeps current behavior by default and clarifies single-workspace output.

- **New Features**
  - CLI (`@superset/cli`): Added `--delete-branch`; output now includes `branchesDeleted`. With the flag, single deletes show “(branch deleted|not deleted)”; multi deletes show “N/M branches deleted”. No branch note is shown without the flag.
  - Host service (`@superset/host-service`): `workspace.delete` accepts `deleteBranch` (default `false`) and forwards it to `destroyWorkspace`; branch cleanup runs post-delete and git failures become `warnings`.
  - Docs (`@superset/docs`): Updated CLI reference with the new option, output shape, and that it uses `git branch -D`.

- **Bug Fixes**
  - CLI: Fixed single-workspace message to avoid “1/1 branches deleted”; now says “(branch deleted|not deleted)”.

<sup>Written for commit a41a59a80bd70a6dacc1ee8a86297b9037bbb584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--delete-branch` option to `superset workspaces delete`.
  * Worktrees are removed automatically; associated branches are deleted only when explicitly requested.
  * Command results now report deleted branches and include warnings for cleanup failures.

* **Bug Fixes**
  * Branch cleanup failures no longer prevent workspace deletion from being reported as successful.

* **Documentation**
  * Updated the CLI reference with the new option, output fields, and branch cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

