### PR TITLE
fix(desktop): default new-workspace project to the active workspace's project

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -37,6 +37,7 @@ import {
 	tasksSearchFromFilters,
 	useTasksFilterStore,
 } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import {
 	useOpenEmptyProjectModal,
@@ -100,10 +101,19 @@ export function DashboardSidebarHeader({
 	const matchRoute = useMatchRoute();
 	const { gateFeature } = usePaywall();
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
-	const onV2WorkspaceRoute = !!matchRoute({
+	const v2WorkspaceMatch = matchRoute({
 		to: "/v2-workspace/$workspaceId",
 		fuzzy: true,
 	});
+	const onV2WorkspaceRoute = v2WorkspaceMatch !== false;
+	// Pre-select the viewed workspace's project in the new-workspace modal.
+	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const activeProjectId =
+		v2WorkspaceMatch !== false
+			? (hostWorkspaces.find(
+					(workspace) => workspace.id === v2WorkspaceMatch.workspaceId,
+				)?.projectId ?? undefined)
+			: undefined;
 	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
 	const isPullRequestsOpen = !!matchRoute({
 		to: "/pull-requests",
@@ -188,7 +198,7 @@ export function DashboardSidebarHeader({
 						<TooltipTrigger asChild>
 							<button
 								type="button"
-								onClick={() => openModal()}
+								onClick={() => openModal(activeProjectId)}
 								className="flex size-7 items-center justify-center rounded-md bg-fill-hover/60 [.light_&]:bg-fill-hover text-muted-foreground transition-colors hover:bg-fill-selected [.light_&]:hover:bg-fill-selected"
 							>
 								<div className="flex size-5 items-center justify-center rounded bg-fill-selected">
@@ -388,7 +398,7 @@ export function DashboardSidebarHeader({
 
 			<button
 				type="button"
-				onClick={() => openModal()}
+				onClick={() => openModal(activeProjectId)}
 				className="group flex w-full items-center gap-2 rounded-md bg-fill-hover/60 [.light_&]:bg-fill-hover px-1 py-1 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-fill-selected [.light_&]:hover:bg-fill-selected hover:text-foreground"
 			>
 				<div className="flex size-5 shrink-0 items-center justify-center rounded bg-fill-selected">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -117,7 +117,9 @@ function DashboardLayout() {
 		}
 	});
 	useHotkey("NEW_WORKSPACE", () =>
-		openNewWorkspaceModal(currentWorkspace?.projectId),
+		openNewWorkspaceModal(
+			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
+		),
 	);
 
 	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);


### PR DESCRIPTION
## Summary
- Opening the new-workspace surface (sidebar "New Workspace" button or ⌘N) while viewing a v2 workspace now pre-selects that workspace's project instead of falling back to the last draft / most recent project.

## Why / Context
When you're working inside project X and hit "New Workspace", the modal defaulted to whatever project was selected last — usually wrong, and an easy way to accidentally create a workspace in the wrong repo. All other triggers (project rows, command palette, task/PR pages) already passed an explicit project; only two V2 entry points didn't.

## How It Works
The pre-selection plumbing already existed end-to-end (`openModal(projectId?)` → `preSelectedProjectId` → honored by the modal, the dashboard modal, and the `/new-workspace` page variant via search param). This wires the two missing call sites:

- `DashboardSidebarHeader` (expanded + collapsed "New Workspace" buttons): derives the active workspace from the `/v2-workspace/$workspaceId` route match (fuzzy, so sub-routes count) and looks up its `projectId` via `useHostWorkspaces()`.
- `layout.tsx` NEW_WORKSPACE hotkey: falls back to the current v2 workspace's `projectId` (previously only handled the v1 route).

With no active workspace the value is `undefined`, so existing default behavior is preserved. The selection remains manually changeable — only the initial value changes.

## Manual QA Checklist

Verified end-to-end over CDP against the dev app (real clicks/keystrokes, multiple projects), including a pre-fix baseline:

- [x] Inside a `mastra-superset` workspace → sidebar "New Workspace" → pre-selects mastra-superset (`?projectId=` present)
- [x] Inside a `pi-mono` workspace → sidebar button → pre-selects pi-mono
- [x] Inside an `openclaw` workspace → ⌘N hotkey → pre-selects openclaw
- [x] On `/v2-workspaces` (no active workspace) → no `projectId`, prior default behavior preserved
- [x] Manual re-selection in the project dropdown still works
- [x] Evidence gate: same interaction on pre-fix code (files reverted to HEAD~1) reproducibly lands with no pre-selection

## Testing
- `bun run typecheck`
- `bun run lint`
- `apps/desktop` `bun test` — 2540 pass / 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opening “New Workspace” while viewing a v2 workspace now pre-selects that workspace’s project (sidebar button and ⌘N). This reduces creating workspaces in the wrong project and preserves previous defaults when no workspace is active.

- **Bug Fixes**
  - Sidebar “New Workspace” buttons detect the current `/v2-workspace/$workspaceId` and pass its `projectId` to `openModal`.
  - ⌘N hotkey now falls back to the current v2 workspace’s `projectId` when opening the modal.

<sup>Written for commit c7d4e44c911bf1e2a2c4503a9b01323363dff1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New workspace creation now automatically selects the project associated with the workspace currently being viewed.
  * Updated both sidebar controls and the keyboard shortcut to maintain the correct project selection across workspace versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->