### PR TITLE
docs(recipes): add command-your-fleet recipe and CLI variations to existing recipes

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -12,6 +12,7 @@
 		"recipes/pr-feedback",
 		"recipes/fan-out-refactor",
 		"recipes/nightly-audit",
+		"recipes/command-your-fleet",
 		"recipes/agent-driven-superset",
 		"orchestration",
 		"---Core Features---",

--- a/apps/docs/content/docs/recipes/command-your-fleet.mdx
+++ b/apps/docs/content/docs/recipes/command-your-fleet.mdx
@@ -11,6 +11,8 @@ description: Read every agent's screen and broadcast follow-ups across workspace
 
 Every terminal Superset runs is addressable from the [CLI](/cli/getting-started): `terminals list`, `read`, and `send`. Compose them with `workspaces list` and one shell loop sweeps a whole project — every agent's screen in one scroll, or one instruction delivered to all of them.
 
+Workspaces are host-owned, and these loops target the machine you run them on. If your fleet spans hosts, add `--host <id>` to each command to sweep a remote host's share of it.
+
 ## Read the Whole Fleet
 
 Print the last few lines of every terminal in every workspace of a project:

--- a/apps/docs/content/docs/recipes/command-your-fleet.mdx
+++ b/apps/docs/content/docs/recipes/command-your-fleet.mdx
@@ -1,0 +1,60 @@
+---
+title: Command Your Fleet from the CLI
+description: Read every agent's screen and broadcast follow-ups across workspaces with two shell loops
+---
+
+<Callout type="info" title="Use when">
+	several agents are running across workspaces — from a fan-out, a race, or a busy day — and you want status or course-corrections without clicking through panes.
+</Callout>
+
+## The Idea
+
+Every terminal Superset runs is addressable from the [CLI](/cli/getting-started): `terminals list`, `read`, and `send`. Compose them with `workspaces list` and one shell loop sweeps a whole project — every agent's screen in one scroll, or one instruction delivered to all of them.
+
+## Read the Whole Fleet
+
+Print the last few lines of every terminal in every workspace of a project:
+
+```bash
+superset workspaces list --project my-app --quiet | while read ws; do
+  superset terminals list --workspace "$ws" --json 2>/dev/null \
+    | jq -r '.sessions[].terminalId' | while read t; do
+      echo "=== $ws / $t ==="
+      superset terminals read --workspace "$ws" --terminal "$t" --max-lines 5 --json | jq -r '.text'
+  done
+done
+```
+
+`--quiet` prints one workspace ID per line; the inner loop asks each workspace for its live sessions. Raise `--max-lines` when you want more than a glance.
+
+## Broadcast a Follow-Up
+
+Send the same instruction to every running agent in the project:
+
+```bash
+superset workspaces list --project my-app --quiet | while read ws; do
+  superset terminals list --workspace "$ws" --json 2>/dev/null \
+    | jq -r '.sessions[].terminalId' | while read t; do
+      superset terminals send --workspace "$ws" --terminal "$t" \
+        --text "Status check: summarize what you have done and what remains in 2 sentences."
+  done
+done
+```
+
+Follow with the read loop a minute later to collect the answers.
+
+One caveat: `send` delivers to *every* terminal, including plain shells, where the text just lands at the prompt. Broadcast when the fleet is all agents, or filter by workspace name first (`workspaces list --search worker- --quiet`).
+
+## Clean Up When You're Done
+
+```bash
+superset workspaces list --project my-app --quiet | xargs -L1 superset workspaces delete
+```
+
+Deletes every listed workspace (the project's `main` workspace is not deletable). Filter with `--search` to target only the fleet you launched.
+
+## Variations
+
+- **Scope by name**: prefix fleet workspaces (`worker-1`, `race-claude`) at creation, then drive only them with `workspaces list --search worker- --quiet`
+- **Let an agent do this**: the [`superset:orchestrate` skill](/orchestration) runs these same loops for you — monitoring workers and delivering follow-ups is exactly how it coordinates
+- **Watch continuously**: wrap the read loop in `watch -n 30` for a poor-man's fleet dashboard

--- a/apps/docs/content/docs/recipes/fan-out-refactor.mdx
+++ b/apps/docs/content/docs/recipes/fan-out-refactor.mdx
@@ -45,3 +45,13 @@ Two agents editing the same file on different branches means merge conflicts, an
 
 - **Race the risky slice**: if one slice is much harder than the rest, [race two agents on it](/recipes/race-agents) while the easy slices run
 - **Rolling fan-out**: for very large migrations, keep 2-3 slice workspaces active and start the next slice as each PR merges, instead of opening all of them at once
+- **From the CLI**: once the plan names the slices, launch every worker in one paste:
+
+```bash
+for slice in api cli web; do
+  superset workspaces create --project <projectId> \
+    --name "migrate-$slice" --branch "migrate/$slice" --local \
+    --agent claude \
+    --prompt "Migrate the $slice slice from moment to date-fns, per plan.md. Only touch files in your slice. Run the affected tests before finishing."
+done
+```

--- a/apps/docs/content/docs/recipes/nightly-audit.mdx
+++ b/apps/docs/content/docs/recipes/nightly-audit.mdx
@@ -48,3 +48,12 @@ superset automations create --name "Nightly audit" \
   --project <projectId> --prompt-file prompt.md --agent claude
 superset automations run <id>
 ```
+
+Or create it and fire the first run in one pipe:
+
+```bash
+superset automations create --name "Nightly audit" \
+  --rrule "FREQ=DAILY;BYHOUR=3;BYMINUTE=0" \
+  --project <projectId> --prompt-file prompt.md --agent claude \
+  --json | jq -r '.id' | xargs -I{} superset automations run {}
+```

--- a/apps/docs/content/docs/recipes/race-agents.mdx
+++ b/apps/docs/content/docs/recipes/race-agents.mdx
@@ -41,3 +41,12 @@ and any tradeoffs you made.
 
 - **Two agents, two approaches**: same agent, but prompt one toward each design ("use middleware" vs "use a decorator") when you're unsure which is right
 - **Best-of-N on hard bugs**: for a bug that has resisted one agent, three fresh attempts beat continuing a stuck session
+- **From the CLI**: write the prompt to `prompt.md`, then start the whole race in one paste — one workspace per agent, same prompt each:
+
+```bash
+for agent in claude codex opencode; do
+  superset workspaces create --project <projectId> \
+    --name "race-$agent" --branch "race/$agent" --local \
+    --agent "$agent" --prompt "$(cat prompt.md)"
+done
+```


### PR DESCRIPTION
## Summary
- New recipe **Command Your Fleet from the CLI** (`recipes/command-your-fleet`): read every agent's terminal across a project, broadcast a follow-up to all of them, and clean up — three composable shell loops over `workspaces list` + `terminals list/read/send`.
- Added "From the CLI" variations to existing recipes: one-paste agent race loop (`race-agents`), one-worker-per-slice loop (`fan-out-refactor`), and a create-and-fire-in-one-pipe automation variant (`nightly-audit`).
- Registered the new page in `meta.json` after `nightly-audit`.

## Why / Context
The recipes were UI-first (⌘N flows) with almost no CLI presence, while the CLI docs cover commands individually but never compose them. These loops came out of scripting a CLI walkthrough video: the fleet read/broadcast patterns weren't documented anywhere, and the race/fan-out recipes had no copy-paste path for CLI users.

## Testing
- `bun run lint` passes (docs-only change)
- The fleet read/broadcast loops were run for real against a local demo project (multiple workspaces, live agent sessions) and produce the documented output; race/fan-out loops use the same verified `workspaces create --agent` invocation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the "Command Your Fleet from the CLI" recipe and CLI one-paste variations to race-agents, fan-out-refactor, and nightly-audit. Documents fleet read/broadcast/cleanup loops, now with a note that loops are host-scoped and support `--host <id>` for remote hosts.

- **New Features**
  - New recipe: Command Your Fleet from the CLI — sweep terminal logs, broadcast follow-ups, and clean up with shell loops using `workspaces list` + `terminals list/read/send`; note host-scoped behavior and remote sweep via `--host <id>`.
  - Added "From the CLI" snippets:
    - race-agents: start a multi-agent race in one loop
    - fan-out-refactor: launch one worker per slice
    - nightly-audit: create and run an automation in one pipe
  - Registered the new page in `meta.json`.

<sup>Written for commit 81faaa78a161f0369dd53a7d14620b179dafe971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a recipe for managing multiple agent workspaces, including viewing output, sending follow-up instructions, deleting workspaces, filtering fleets, targeting hosts, and monitoring agents.
  * Added examples for running parallel migration refactors across separate workspaces and branches.
  * Added a nightly audit automation workflow with JSON output and immediate execution.
  * Added a workflow for launching multiple agents from a shared prompt.
  * Updated documentation navigation to include the new fleet management recipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->