### PR TITLE
fix(host-service): propagate Superset home directory

### DIFF
--- a/packages/cli/src/lib/host/spawn.test.ts
+++ b/packages/cli/src/lib/host/spawn.test.ts
@@ -45,7 +45,7 @@ mock.module("node:child_process", () => ({
 	spawn: spawnMock,
 }));
 
-const { SUPERSET_CONFIG_PATH } = await import("../config");
+const { SUPERSET_CONFIG_PATH, SUPERSET_HOME_DIR } = await import("../config");
 const { spawnHostService } = await import("./spawn");
 
 function createApi(): ApiClient {
@@ -120,19 +120,32 @@ describe("spawnHostService", () => {
 			async () => new Response("ok", { status: 200 }),
 		) as unknown as typeof fetch;
 
-		await spawnHostService({
-			organizationId: "00000000-0000-0000-0000-000000000001",
-			sessionToken: "session-token",
-			authConfigPath: SUPERSET_CONFIG_PATH,
-			api: createApi(),
-			port: 54879,
-			daemon: true,
-		});
+		const inheritedHomeDir = process.env.SUPERSET_HOME_DIR;
+		delete process.env.SUPERSET_HOME_DIR;
+		try {
+			await spawnHostService({
+				organizationId: "00000000-0000-0000-0000-000000000001",
+				sessionToken: "session-token",
+				authConfigPath: SUPERSET_CONFIG_PATH,
+				api: createApi(),
+				port: 54879,
+				daemon: true,
+			});
+		} finally {
+			if (inheritedHomeDir === undefined) {
+				delete process.env.SUPERSET_HOME_DIR;
+			} else {
+				process.env.SUPERSET_HOME_DIR = inheritedHomeDir;
+			}
+		}
 
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 		expect(spawnCalls[0]?.options.env?.SUPERSET_AUTH_CONFIG_PATH).toBe(
 			SUPERSET_CONFIG_PATH,
 		);
 		expect(spawnCalls[0]?.options.env?.AUTH_TOKEN).toBe("session-token");
+		expect(spawnCalls[0]?.options.env?.SUPERSET_HOME_DIR).toBe(
+			SUPERSET_HOME_DIR,
+		);
 	});
 });

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -8,6 +8,7 @@ import {
 	openRotatingLogFd,
 } from "@superset/shared/rotating-log";
 import type { ApiClient } from "../api-client";
+import { SUPERSET_HOME_DIR } from "../config";
 import { env, isDesktopBundled } from "../env";
 import {
 	ensureManifestDir,
@@ -144,6 +145,7 @@ export async function spawnHostService(
 			HOST_SERVICE_SECRET: secret,
 			HOST_DB_PATH: hostDbPath(options.organizationId),
 			HOST_MIGRATIONS_FOLDER: migrationsFolder,
+			SUPERSET_HOME_DIR,
 		},
 	});
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, writeFileSync } from "node:fs";
 import { readdir, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, isAbsolute, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import type { NodeWebSocket } from "@hono/node-ws";
@@ -2452,7 +2452,8 @@ export async function createTerminalSessionInternal({
 	// wait for it here before the first PTY needs the snapshot.
 	await waitForTerminalBaseEnv();
 	const baseEnv = getTerminalBaseEnv();
-	const supersetHomeDir = process.env.SUPERSET_HOME_DIR || "";
+	const supersetHomeDir =
+		process.env.SUPERSET_HOME_DIR || join(homedir(), ".superset");
 	const shell = resolveLaunchShell(baseEnv);
 	const shellArgs = getShellLaunchArgs({ shell, supersetHomeDir });
 	const ptyEnv = buildV2TerminalEnv({


### PR DESCRIPTION
## summary

* pass the CLI's resolved `SUPERSET_HOME_DIR` into the host-service child environment
* fall back to `~/.superset` when host-service is launched directly without the variable
* add a regression assertion covering a CLI launch with no inherited `SUPERSET_HOME_DIR`

Refs #6254 — this is **Defect 1 only** of the two defects diagnosed there. Defect 2 (headless
hosts never get `notify.sh` or the managed agent hook entries, because `agent-setup` lives under
`apps/desktop/`) is **not** addressed here and still blocks the reported symptom end-to-end.

## why

CLI-started host services previously inherited no `SUPERSET_HOME_DIR`. Terminal creation then passed an empty home directory into the PTY environment, which disabled the managed agent hook command and also prevented shell bootstrap path resolution.

The CLI already resolves the canonical directory in `packages/cli/src/lib/config.ts`; this makes the child process receive that value. The host-service fallback also protects direct launchers such as systemd or containers.

## the deployment this actually fixes

`packages/cli/src/lib/host/spawn.ts` is the right layer, confirmed against the machine that
reported #6254 — a self-hosted remote host running under systemd:

```
[Service]
Type=exec
EnvironmentFile=/etc/superset/env
ExecStart=/opt/superset/current/bin/superset start --org <redacted> --port 8420
```

The unit invokes the **CLI**, so the host-service is a child of `spawnHostService()` and the
`spawn.ts` half of this change is what reaches it. The `terminal.ts` fallback is defence in depth
for launchers that exec the host binary directly.

## validation

Run on this branch, against a real checkout:

* `bun test packages/cli/src/lib/host/spawn.test.ts` → 1 pass / 4 expect
* `bun test packages/host-service/src/terminal/env.test.ts` → 46 pass / 119 expect
* `bunx biome check packages/cli/src/lib/host/spawn.ts packages/cli/src/lib/host/spawn.test.ts packages/host-service/src/terminal/terminal.ts`
* `git diff --check`

**The new assertion is a genuine regression test**, verified by reverting only the one-line
`spawn.ts` change and re-running:

```
expect(received).toBe(expected)
Expected: ".../superset-cli-spawn-6WpnQR"
Received: undefined
(fail) spawnHostService > passes SUPERSET_AUTH_CONFIG_PATH when provided
```

It fails without the fix and passes with it. `spawn.ts` spreads `...process.env` and the test
deletes `SUPERSET_HOME_DIR` before the call, so the only path to a defined value is the explicit
key this PR adds.

**Not run here:** package typecheck (`tsc` unavailable in the environment that authored the
commit) and the `*.node-test.ts` files (they need Node ≥ 22 for `--experimental-strip-types`;
the local toolchain is Node 20, and `better-sqlite3` fails to build under it). Both are worth a
CI confirmation.

## known follow-up, not done here

This change makes `terminal.ts:1401` the **sixth** copy of the same resolution:

| file | form |
|---|---|
| `packages/cli/src/lib/config.ts:27` | `?? join(homedir(), ".superset")` |
| `packages/host-service/src/daemon/manifest.ts:34` | `\|\| join(homedir(), ".superset")` |
| `packages/host-service/src/terminal/terminal.ts:1401` | `\|\| join(homedir(), ".superset")` ← added here |
| `packages/host-service/src/providers/model-providers/utils/anthropic-runtime-env/anthropic-runtime-env.ts:94` | `?.trim() \|\|` |
| `packages/chat-legacy/src/server/desktop/chat-service/anthropic-env-config.ts:88` | `?.trim() \|\|` |
| `apps/desktop/src/main/lib/agent-setup/templates/pi-extension.template.ts:35` | `\|\| join(homedir(), ".superset")` |

Exporting one resolver and calling it from all six would both remove the duplication and make the
fallback trivially unit-testable — which is the cleanest answer to the review note about
`terminal.ts` lacking direct coverage. Happy to do that here or in a follow-up, whichever the
maintainers prefer; I left it out to keep this diff to the fix.

Minor: `config.ts` uses `??` while the rest use `||`, so they disagree when `SUPERSET_HOME_DIR` is
set but **empty** — `??` keeps `""`, `||` falls back. Not a live bug on this path (the
`terminal.ts` `||` catches it), but it is the exact empty-string case that produced #6254.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host services now consistently receive the configured Superset home directory when launched.
  * Added a default home directory of `~/.superset` when no custom directory is provided.
  * Improved handling of inherited environment settings during host service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->