### PR TITLE
feat(desktop,host-service): add a commit graph to the workspace sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ superset-dev-data/
 
 # Local-only plans (not tracked)
 plans/local/
+
+# Bun compile temp artifacts (~60 MB each)
+*.bun-build

--- a/apps/desktop/plans/20260801-1200-git-graph-visual-spec.md
+++ b/apps/desktop/plans/20260801-1200-git-graph-visual-spec.md
@@ -1,0 +1,340 @@
+# Commit Graph — Visual Spec
+
+Design contract for the `Graph` sidebar tab. Covers lane geometry, the lane colour ramp, ref-badge
+treatments, row anatomy at each width, and the empty / loading / truncated states.
+
+Companion to `plans/20260801-commit-graph-sidebar.md` (the implementation plan). This file owns **pixels
+and colour**; that file owns data, algorithm, and wiring.
+
+**Status:** signed off. The three open calls — row tint at 6%/9%, badges inline rather than in a
+gutter, date always-on at the wide breakpoint — were reviewed against the mock and confirmed. The
+components in §8 are landed.
+
+**Ownership:** the files listed in §8 own the presentation. Anything that needs a pixel or a colour
+changed goes through this spec, not through a local override at the call site.
+
+---
+
+## 1. Frame
+
+The graph renders inside the v2 workspace sidebar. Real width range is **240–560px**, with the
+resize hysteresis at `WorkspaceSidebar.tsx:95`:
+
+```ts
+setCompact((prev) => (prev ? width < 280 : width < 260));
+```
+
+So `compact` engages below 260px and releases at 280px. Every number below is derived from that
+range — this is a sidebar component, not a page component, and it never gets a second column.
+
+Three breakpoints:
+
+| Name | Width | `compact` |
+|---|---|---|
+| Compact | < 260px | `true` |
+| Standard | 260–399px | `false` |
+| Wide | ≥ 400px | `false` |
+
+---
+
+## 2. Row geometry
+
+| Token | Standard / Wide | Compact |
+|---|---|---|
+| Row height | 28px | 24px |
+| Ref line height (two-line rows only) | 16px | 14px |
+| Two-line row height | 44px | 38px |
+| Lane pitch | 14px | 12px |
+| Lane centre x | `pitch / 2 + laneIndex * pitch` | same |
+| Node radius | 3.5px | 3px |
+| Node ring | 1.5px, drawn in the lane colour | same |
+| Edge stroke | 1.5px | 1.5px |
+| Elbow radius | 6px | 5px |
+| Visible lane cap | 6 (Standard), 8 (Wide) | 4 |
+| Lane column width | `min(laneCount, cap) * pitch + 4` | same |
+
+At Standard the lane column costs `6 * 14 + 4 = 88px` of 260px. That is the budget ceiling; it is why
+the cap is width-derived rather than a constant.
+
+**Overflow.** Beyond the cap, lanes sharing a parent merge into the last visible lane, and a `+N`
+chip renders at the right edge of the
+lane column. Horizontal scrolling of the lane column is explicitly rejected — it desynchronises from
+the subject text.
+
+### Edge kinds
+
+`assignLanes` emits five edge kinds per row. Geometry, with `y0 = 0`, `y1 = rowHeight`,
+`yc = rowHeight / 2` (the node's y), `e` = elbow radius, `s = sign(xTo - xFrom)`:
+
+| Kind | Meaning | Path |
+|---|---|---|
+| `pass` | Lane crosses the row untouched | `M x,y0 V y1` |
+| `in-straight` | The commit's own lane, entering from above | `M x,y0 V yc` |
+| `in-merge` | Another lane awaiting this commit, closing into the node | `M xFrom,y0 V (yc - e) Q xFrom,yc (xFrom + s·e),yc H xTo` |
+| `out-straight` | First parent inherits the lane | `M x,yc V y1` |
+| `out-fork` | Extra parent leaves toward another lane | `M xFrom,yc H (xTo - s·e) Q xTo,yc xTo,(yc + e) V y1` |
+
+Note the deliberate asymmetry: **merges descend then bend into the node horizontally; forks leave the
+node horizontally then bend down.** That is what distinguishes the two at a 3.5px node, without
+relying on the subject text. Both use the same elbow radius, so a fork and the merge that eventually
+closes it read as one shape. All paths are `fill: none`, `stroke-linecap: round`.
+
+A parent outside the fetch window emits `out-stub` instead of `out-straight`: a dashed segment from
+the node to `0.8 · rowHeight` at 55% opacity. It must render, not throw — it is the normal state of
+the last page.
+
+**Node.** Filled with the row background, ringed in the lane colour — a donut, not a dot. Merge
+commits (`parents.length > 1`) get a filled node instead, so merges are distinguishable at 3.5px
+without relying on the subject text. Root commits (`parents.length === 0`) get a filled node with a
+1px outer gap.
+
+---
+
+## 3. Lane colour ramp
+
+`packages/ui/src/globals.css` ships `--chart-1..5` only, and their hues are **not stable across
+themes** — light `--chart-1` is orange `oklch(0.646 0.222 41.116)`, dark is blue
+`oklch(0.488 0.243 264.376)`. A lane would change colour on a theme switch. So the spec adds a
+dedicated ramp.
+
+**Additive only.** Eight new custom properties in `:root` and `.dark`, plus eight `@theme inline`
+entries. Nothing existing is touched.
+
+Design rules for the ramp:
+
+1. **Fixed hue per index, identical in both themes.** Lane 3 is green in light and green in dark.
+2. **Equal lightness and chroma within a theme.** Lanes are peers; none may shout. This is what makes
+   eight colours read as one family instead of a rainbow.
+3. **Hues at 45° spacing** on the OKLCH wheel, offset so the trunk (lane 1) is not a warning colour.
+4. Values sit inside sRGB at the stated L/C, so no browser gamut-mapping surprises.
+
+```css
+:root {
+  /* Lane ramp — equal L/C, 45° hue spacing, hue held constant across themes. */
+  --graph-lane-1: oklch(0.56 0.125 262); /* indigo — trunk */
+  --graph-lane-2: oklch(0.56 0.125 152); /* green */
+  --graph-lane-3: oklch(0.56 0.125 25);  /* red */
+  --graph-lane-4: oklch(0.56 0.125 197); /* teal */
+  --graph-lane-5: oklch(0.56 0.125 307); /* violet */
+  --graph-lane-6: oklch(0.56 0.125 71);  /* amber */
+  --graph-lane-7: oklch(0.56 0.125 342); /* magenta */
+  --graph-lane-8: oklch(0.56 0.125 117); /* olive */
+}
+
+.dark {
+  --graph-lane-1: oklch(0.75 0.115 262);
+  --graph-lane-2: oklch(0.75 0.115 152);
+  --graph-lane-3: oklch(0.75 0.115 25);
+  --graph-lane-4: oklch(0.75 0.115 197);
+  --graph-lane-5: oklch(0.75 0.115 307);
+  --graph-lane-6: oklch(0.75 0.115 71);
+  --graph-lane-7: oklch(0.75 0.115 342);
+  --graph-lane-8: oklch(0.75 0.115 117);
+}
+```
+
+Index order is deliberately *not* the hue order — adjacent lanes on screen get maximally separated
+hues (262 → 152 → 25 → 197), which matters far more than the ramp reading as a gradient when listed.
+
+**Assignment.** Lane colour is `hash(originatingBranchName) % 8`, not `laneIndex % 8`. A lane keeps
+its colour when the graph refetches and lane indices shift. Fallback for a lane with no branch name:
+`laneIndex % 8`.
+
+**Row tint.** Each row carries a full-bleed wash of its lane's colour:
+
+```css
+background: color-mix(in oklch, var(--graph-lane-N) 6%, transparent);        /* light */
+background: color-mix(in oklch, var(--graph-lane-N) 9%, transparent);        /* dark */
+```
+
+This is the highest-value trick in the row: lane membership stays readable without tracing lines, and it survives lane compression at narrow widths where the lines themselves get
+crowded. Reviewed at 28px with eight hues live and confirmed at 6% / 9%; the mock keeps a tint toggle
+and strength control if the call is ever revisited. Rows inside a selected range use 2× the alpha.
+
+No hardcoded hex anywhere in the components. Everything routes through these tokens plus the existing
+shadcn set.
+
+---
+
+## 4. Ref badges
+
+The lanes are the frame. **The badges are the feature** — the point of this tab is surfacing branches
+and worktrees that exist in git but have no open Superset workspace.
+
+So state is encoded in **texture, not only colour**: fill means claimed, dashes mean stale, a strike
+means broken. That reads at 260px, survives a colourblind viewer, and does not compete with the lane
+ramp for hue.
+
+| `state` | Treatment | Reads as |
+|---|---|---|
+| `open` | Solid chip, lane-coloured background at 18%, lane-coloured 1px border, foreground text, leading dot filled | Yours, live |
+| `detached-worktree` | Transparent, 1px **dashed** border in `--border`, `--muted-foreground` text | On disk, nobody's home |
+| `orphan-branch` | Transparent, **no border**, `--muted-foreground` text, 1px dotted underline | A name with nothing checked out |
+| `prunable` | Transparent, 1px dashed `--destructive` border, name **struck through**, `--destructive` text | Registered, but the path is gone |
+| `merged` | `--muted` background, no border, `--muted-foreground` text at 90% | Landed; safe to forget |
+| `null` (remote / tag / HEAD) | Transparent, 1px solid `--border`, `--muted-foreground` text | Plain decoration |
+
+Shared badge metrics: height 16px (compact 14px), padding `0 5px`, `--radius-sm` (6px), font-size 11px
+(compact 10px), `font-weight: 500`, monospace for the name.
+
+**Type marks.** Two 10px inline SVG glyphs, no emoji: a branch fork for `branch` / `remote`, a tag
+outline for `tag`. `head` gets no glyph — it renders as the literal text `HEAD` in
+`--foreground`, `font-weight: 600`. A `remote` badge shows its full shortname including the remote
+(`origin/main`); it is never string-stripped, per `scripts/check-git-ref-strings.sh`.
+
+**Truncation.** Names ellipsise at `max-width: 12ch` (compact `8ch`) with the full name in `title`.
+`prunable` badges put `pruneReason` in the `title` instead.
+
+**Ordering** within a row, so the eye lands on the same thing every time: `head` → `open` →
+`detached-worktree` → `prunable` → `orphan-branch` → `merged` → remote → tag. At most 3 badges
+render; the rest collapse into a `+N` chip that lists them in its `title`.
+
+**Badges are inline, not in a gutter.** A left gutter joined to the node by a leader line needs a
+~700px graph column; at 260px the gutter would take a third of the width from the subject, and the
+leader lines would cross the lanes they are trying to stay clear of. Badges therefore render
+**inline, immediately right of the lane column**, before the subject. The subject is what
+truncates.
+
+---
+
+## 5. Row anatomy
+
+```
+Wide      ≥400px   [ lanes ][ badges ][ subject ······················ ][ hash ][ date ]
+Standard  260-399  [ lanes ][ badges ][ subject ······················ ][ hash ]
+Compact   <260     [ lanes ][ badges ][ subject ····· ]
+```
+
+- **subject** — single line, ellipsised, `--foreground`. Merge commits (`parents.length > 1`) render
+  at `--muted-foreground`; they are structure, not work. Controlled by the `muteMerges` prop,
+  default on.
+- **hash** — 7-char short hash, monospace, `--muted-foreground`, `tabular-nums`, 11px.
+- **date** — relative (`3h`, `2d`, `Mar 4`), monospace, `--muted-foreground`, right-aligned,
+  `tabular-nums`. **Always on at Wide**, not hover-revealed. *Changed from the plan:* a hover-reveal
+  costs a hover state and a layout shift to save 44px that Wide already has, and it makes the column
+  unscannable — the one thing a date column is for.
+- **author** — dropped at every width. There is no width for it and `CommitDetailPanel` carries it.
+
+Vertical rhythm: the lane SVG, badges, subject, hash and date all centre on the same baseline box.
+Nothing in the row may change height on hover or select — height is a function of the row's index
+alone, which is what lets `estimateSize` stay measurement-free.
+
+### Two-line ref rows (`twoLineRefs`, off by default)
+
+An opt-in that gives refs their own line above the subject:
+
+```
+Two-line   [ lanes ][ badges, untruncated, full width ················· ]
+                   [ subject ······················ ][ hash ][ date ]
+```
+
+- Only rows that **carry refs** grow. A bare commit stays 28px whatever the toggle says, so the
+  virtualizer's estimate is `graphRowHeight({ compact, twoLine: rows[i].commit.refs.length > 0 })`
+  — index-based, no measurement pass, and the same function the row renders itself with. Roughly 15%
+  of rows carry badges, so the added scroll height is small.
+- Badges drop the `max-w-[12ch]` / `max-w-[8ch]` cap (`RefBadge`'s `untrimmed`). The cap exists to
+  stop a long branch name eating the subject; on its own line there is no subject to eat. This is the
+  point of the feature — `fix/tm–…` and `origin/…` truncate today at every sidebar width.
+- No `+N` collapse. The line shows every ref, sorted by the same rank as inline. If they overrun the
+  width the line clips rather than wrapping — wrapping would make height a function of measured
+  content, and the whole estimate would need a measurement pass.
+- **The node tracks the subject, not the row's midpoint.** `GraphLanes` takes a `topOffset` and puts
+  the node at `topOffset + rowHeight / 2` while lanes still span the full height, so edges stay
+  continuous through the badge line and the node still marks the line the commit actually is.
+
+### Interaction states
+
+| State | Treatment |
+|---|---|
+| Hover | `--accent` background over the lane tint |
+| Selected | `--accent` background + lane tint at 16% + 2px left rail in the row's lane colour, full-bleed |
+| Range endpoint (shift-click) | Same as selected |
+| Range interior | Lane tint at 16%, no `--accent` |
+| Unselected | Lane tint at 9% |
+| Keyboard focus | `outline: 2px solid var(--ring); outline-offset: -2px` — inset so it never clips |
+
+**Why selected and range interior share an alpha.** `resolveRowSelection` puts only the two endpoints
+in `selectedSet`; the band between them is `lo+1 … hi-1`. Giving the band a stronger tint than the
+endpoints made the band outrank its own anchors — measured in light theme at ΔL\* 7.7 for the band
+against 5.7 for an endpoint. Equal alphas plus `--accent` on the endpoints alone restores the
+ordering by construction, in both themes, with no per-theme tuning: selection is always tint *and*
+accent, so it is always strictly brighter than tint alone.
+
+The 9% floor stays under `--accent`'s own contribution (≈8.6 ΔL\* on the dark ground), so an
+unselected tinted row never competes with a selected one.
+
+Rows are `<button type="button">` in a `<div role="list">`, so keyboard focus and Enter come free.
+
+---
+
+## 6. Non-row states
+
+- **Loading, no data** — 8 skeleton rows: a lane-width shimmer block plus a subject bar at 60% / 45% /
+  70% alternating widths. Only when there is genuinely nothing to show; per `AGENTS.md` rule 11,
+  existing rows always render even while `isReady` is false.
+- **Empty** — centred, `--muted-foreground`, 12px: **"No commits yet."** / "Commits appear here as
+  work lands on any branch in this project." An empty screen is an invitation, not an apology.
+- **Error** — inline row at the top, `--destructive` text, with a **Retry** button. States what
+  failed: "Couldn't read the commit graph." plus the error message in a `title`.
+- **Truncated** — sticky footer row, 24px, `--muted` background, hairline top border:
+  **"Showing 500 of 12,431 commits"** with a **Load more** button on the right. Numbers use
+  `tabular-nums`. Renders only when `nextCursor !== null`.
+- **Scope control** — the header carries the `refScope` select (`Local refs` / the three
+  not-yet-implemented scopes, disabled). Persisted per project, so it does not belong in the row spec
+  beyond leaving the header 24px.
+
+---
+
+## 7. The seam
+
+```ts
+GraphRow   { row, compact, selected, onSelect, onDoubleClick?, laneCap, showDate,
+             inRange?, muteMerges?, twoLineRefs? }
+GraphLanes { row, compact, laneCap, topOffset? }
+RefBadge   { graphRef, compact, laneColor, untrimmed? }
+```
+
+Everything added after the freeze is optional and defaults to today's behaviour, so the seam widened
+without a single call site changing. `graphRowHeight({ compact, twoLine })` ships beside them as the
+one place row height is defined — the row renders with it and the virtualizer estimates with it, so
+the two cannot drift.
+
+Three deltas from the seam sketched in the implementation plan, all narrowing rather than widening:
+
+1. `GraphRow` no longer takes `refs` separately — it reads `row.commit.refs`. One source, no way for
+   the two to disagree.
+2. `GraphLanes` and `RefBadge` take the whole `GraphRowModel` / `GraphRef` rather than destructured
+   fields. Adding a field later is then not a signature change.
+3. `laneCap` and `showDate` are new, and are the only width-derived inputs. The components never read
+   a width themselves; the tab shell measures once and passes `laneCapForWidth(width)` and
+   `width >= GRAPH_WIDE_BREAKPOINT` down. That keeps every component pure and the breakpoint logic in
+   one file.
+
+**Gotcha for whoever extends these.** `cn` runs tailwind-merge, which reads an arbitrary
+`text-[11px]` as a font-size/line-height pair and drops any earlier `leading-*`. Put `leading-none`
+*after* the size class or the 16px badges silently grow. Caught by the row test, not by review.
+
+## 8. Files this spec owns
+
+- `apps/desktop/.../WorkspaceSidebar/hooks/useGraphTab/types.ts` — the frozen seam
+- `.../hooks/useGraphTab/components/GraphLanes/` — per-row SVG painter
+- `.../hooks/useGraphTab/components/GraphRow/` — row layout, states
+- `.../hooks/useGraphTab/components/RefBadge/` — badge treatments
+- `packages/ui/src/globals.css` — the additive `--graph-lane-1..8` block from §3
+
+Presentational only: no tRPC, no collections, no data fetching, no `useEffect`. Props in, markup out.
+
+## 9. Checked against
+
+Fixtures rendered at 240 / 260 / 320 / 400px in both themes: a linear run, a two-parent merge, a
+three-parent octopus, a root commit, a lane freed and reused, a parent outside the window, and all
+five ref states on one screen. Topology correctness against `git log --graph --oneline --branches` is
+a phase-3 check — with fixtures alone this pass can only verify that the components render what they
+are handed, and it claims nothing more.
+
+The two-line variant and the tint-ordering fix are covered the same way: markup tests assert the
+badge cap is dropped, the `+N` chip is gone, only ref-carrying rows grow, the lane SVG spans the
+taller row with the node pushed down, and the toggle-off render is byte-identical to before. That is
+a fixture-level guarantee. Neither has been seen on the running app yet — the light-theme numbers
+above come from the §5.3 measurement, which was itself synthetic (CSS-toggled, store route
+unexercised).

--- a/apps/desktop/plans/20260801-1200-git-graph-visual-spec.md
+++ b/apps/desktop/plans/20260801-1200-git-graph-visual-spec.md
@@ -3,7 +3,7 @@
 Design contract for the `Graph` sidebar tab. Covers lane geometry, the lane colour ramp, ref-badge
 treatments, row anatomy at each width, and the empty / loading / truncated states.
 
-Companion to `plans/20260801-commit-graph-sidebar.md` (the implementation plan). This file owns **pixels
+Companion to `plans/done/20260801-commit-graph-sidebar.md` (the implementation plan). This file owns **pixels
 and colour**; that file owns data, algorithm, and wiring.
 
 **Status:** signed off. The three open calls — row tint at 6%/9%, badges inline rather than in a
@@ -12,6 +12,14 @@ components in §8 are landed.
 
 **Ownership:** the files listed in §8 own the presentation. Anything that needs a pixel or a colour
 changed goes through this spec, not through a local override at the call site.
+
+**Superseded where it differs from the shipped code.** One thing moved after sign-off: the lane ramp
+is no longer the fixed OKLCH list in §3. Lanes are derived per theme from its own ANSI palette
+(`src/shared/themes/graph-lanes.ts`), with slots 7–8 as `color-mix()` shifts of the first two, because
+a fixed ramp ignored a user-imported theme entirely. The `--graph-lane-1..8` hex in
+`src/renderer/globals.css` is only the pre-hydration fallback. The §3 constraints — one hue per index,
+equal weight within a theme, adjacent lanes maximally separated — still hold; only the source of the
+values changed.
 
 ---
 
@@ -92,7 +100,7 @@ without relying on the subject text. Root commits (`parents.length === 0`) get a
 
 ## 3. Lane colour ramp
 
-`packages/ui/src/globals.css` ships `--chart-1..5` only, and their hues are **not stable across
+`src/renderer/globals.css` ships `--chart-1..5` only, and their hues are **not stable across
 themes** — light `--chart-1` is orange `oklch(0.646 0.222 41.116)`, dark is blue
 `oklch(0.488 0.243 264.376)`. A lane would change colour on a theme switch. So the spec adds a
 dedicated ramp.
@@ -199,11 +207,11 @@ truncates.
 
 ## 5. Row anatomy
 
-```
+```text
 Wide      ≥400px   [ lanes ][ badges ][ subject ······················ ][ hash ][ date ]
 Standard  260-399  [ lanes ][ badges ][ subject ······················ ][ hash ]
 Compact   <260     [ lanes ][ badges ][ subject ····· ]
-```
+```text
 
 - **subject** — single line, ellipsised, `--foreground`. Merge commits (`parents.length > 1`) render
   at `--muted-foreground`; they are structure, not work. Controlled by the `muteMerges` prop,
@@ -223,10 +231,10 @@ alone, which is what lets `estimateSize` stay measurement-free.
 
 An opt-in that gives refs their own line above the subject:
 
-```
+```text
 Two-line   [ lanes ][ badges, untruncated, full width ················· ]
                    [ subject ······················ ][ hash ][ date ]
-```
+```text
 
 - Only rows that **carry refs** grow. A bare commit stays 28px whatever the toggle says, so the
   virtualizer's estimate is `graphRowHeight({ compact, twoLine: rows[i].commit.refs.length > 0 })`

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -58,6 +58,16 @@
 	/* Sidebar row fills: low-opacity foreground washes so they track any theme */
 	--fill-hover: color-mix(in oklab, var(--foreground) 7%, transparent);
 	--fill-selected: color-mix(in oklab, var(--foreground) 10%, transparent);
+	/* Commit-graph lanes: pre-hydration fallback for the bright ANSI set.
+	   The live values come from shared/themes/graph-lanes via applyGraphLaneColors. */
+	--graph-lane-1: #729fcf;
+	--graph-lane-2: #8ae234;
+	--graph-lane-3: #ef2929;
+	--graph-lane-4: #34e2e2;
+	--graph-lane-5: #ad7fa8;
+	--graph-lane-6: #fce94f;
+	--graph-lane-7: color-mix(in oklch, #729fcf 62%, white);
+	--graph-lane-8: color-mix(in oklch, #8ae234 62%, white);
 }
 
 /* Light theme fallback values - applied before hydration if user has light theme saved */
@@ -102,6 +112,15 @@
 	--highlight-foreground: oklch(0.985 0 0);
 	--fill-hover: color-mix(in oklab, var(--foreground) 4%, transparent);
 	--fill-selected: color-mix(in oklab, var(--foreground) 6%, transparent);
+	/* Standard ANSI set — the bright one washes out on a white ground. */
+	--graph-lane-1: #3465a4;
+	--graph-lane-2: #4e9a06;
+	--graph-lane-3: #cc0000;
+	--graph-lane-4: #06989a;
+	--graph-lane-5: #75507b;
+	--graph-lane-6: #c4a000;
+	--graph-lane-7: color-mix(in oklch, #3465a4 62%, black);
+	--graph-lane-8: color-mix(in oklch, #4e9a06 62%, black);
 }
 
 @theme inline {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,15 +1,21 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef, useState } from "react";
-import { LuFile, LuGitCompareArrows } from "react-icons/lu";
+import { LuFile, LuGitBranch, LuGitCompareArrows } from "react-icons/lu";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { GraphSelection } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { useSettings } from "renderer/stores/settings";
 import type { CommentPaneData, DiffFocusSide } from "../../types";
 import { FilesTab } from "./components/FilesTab";
 import { PRActionHeader } from "./components/PRActionHeader";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { useChangesTab } from "./hooks/useChangesTab";
+import { useGraphTab } from "./hooks/useGraphTab";
+import {
+	GRAPH_WIDE_BREAKPOINT,
+	laneCapForWidth,
+} from "./hooks/useGraphTab/components/GraphLanes";
 import { type OpenChatFn, usePRFlowDispatch } from "./hooks/usePRFlowDispatch";
 import { usePRFlowState } from "./hooks/usePRFlowState";
 import { useReviewTab } from "./hooks/useReviewTab";
@@ -20,9 +26,14 @@ import type { SidebarTabDefinition } from "./types";
 // always renders so users can see PR state and merge once a PR exists.
 const CREATE_PR_BUTTON_ENABLED = false;
 
-type SidebarTabId = "changes" | "files" | "review";
+type SidebarTabId = "changes" | "files" | "graph" | "review";
 
-const VALID_TAB_IDS: readonly SidebarTabId[] = ["changes", "files", "review"];
+const VALID_TAB_IDS: readonly SidebarTabId[] = [
+	"changes",
+	"files",
+	"graph",
+	"review",
+];
 
 function isSidebarTabId(tab: string): tab is SidebarTabId {
 	return (VALID_TAB_IDS as readonly string[]).includes(tab);
@@ -43,6 +54,10 @@ interface WorkspaceSidebarProps {
 		changeKey?: string,
 	) => void;
 	onOpenComment?: (comment: CommentPaneData) => void;
+	/** Open a commit/range diff pane for a Graph tab click. */
+	onOpenCommitRef?: (ref: GraphSelection, openInNewTab?: boolean) => void;
+	/** Pin the diff pane a Graph single click just opened (double-click). */
+	onPinCommitPane?: () => void;
 	onOpenChat?: OpenChatFn;
 	onSearch?: () => void;
 	selectedFilePath?: string;
@@ -54,6 +69,8 @@ export function WorkspaceSidebar({
 	onSelectFile,
 	onSelectDiffFile,
 	onOpenComment,
+	onOpenCommitRef,
+	onPinCommitPane,
 	onOpenChat,
 	onSearch,
 	selectedFilePath,
@@ -84,6 +101,11 @@ export function WorkspaceSidebar({
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [compact, setCompact] = useState(false);
+	// Lane cap + date column are width-bucketed, so they only change when the
+	// sidebar crosses a breakpoint — React dedupes the identical state updates
+	// the ResizeObserver fires on every pixel within a bucket.
+	const [laneCap, setLaneCap] = useState(6);
+	const [showDate, setShowDate] = useState(false);
 	useEffect(() => {
 		const el = containerRef.current;
 		if (!el) return;
@@ -93,6 +115,8 @@ export function WorkspaceSidebar({
 			// Hysteresis: expand back to labels only once we're clearly past
 			// the breakpoint, so the labels don't jitter on the edge.
 			setCompact((prev) => (prev ? width < 280 : width < 260));
+			setLaneCap(laneCapForWidth(width));
+			setShowDate(width >= GRAPH_WIDE_BREAKPOINT);
 		});
 		ro.observe(el);
 		return () => ro.disconnect();
@@ -110,6 +134,19 @@ export function WorkspaceSidebar({
 	const changesTab: SidebarTabDefinition = {
 		...changesTabDef,
 		icon: LuGitCompareArrows,
+	};
+
+	const graphTabDef = useGraphTab({
+		workspaceId,
+		compact,
+		laneCap,
+		showDate,
+		onOpenCommitRef,
+		onPinCommitPane,
+	});
+	const graphTab: SidebarTabDefinition = {
+		...graphTabDef,
+		icon: LuGitBranch,
 	};
 
 	const reviewTab = useReviewTab({
@@ -145,7 +182,12 @@ export function WorkspaceSidebar({
 		),
 	};
 
-	const tabs: SidebarTabDefinition[] = [filesTab, changesTab, reviewTab];
+	const tabs: SidebarTabDefinition[] = [
+		filesTab,
+		changesTab,
+		graphTab,
+		reviewTab,
+	];
 	const activeTabDef = tabs.find((t) => t.id === activeTab);
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/GraphHeaderActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/GraphHeaderActions.tsx
@@ -1,0 +1,134 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { ChevronDown, Rows2, Unlink } from "lucide-react";
+import type { GraphRefScope } from "../../types";
+
+/** Scope options, in widening order. Labels are what the strip shows. */
+const SCOPE_LABELS: Array<{ value: GraphRefScope; label: string }> = [
+	{ value: "head", label: "This workspace" },
+	{ value: "open-workspaces", label: "Open workspaces" },
+	{ value: "local", label: "All local branches" },
+	{ value: "remote", label: "Remote" },
+	{ value: "all", label: "Everything" },
+];
+
+/** Shown when a persisted scope predates the list above. Matches the `local`
+ *  default that both the schema and the router fall back to. */
+const FALLBACK_SCOPE_LABEL = "All local branches";
+
+interface GraphHeaderActionsProps {
+	refScope: GraphRefScope;
+	onSelectRefScope: (scope: GraphRefScope) => void;
+	twoLineRefs: boolean;
+	onToggleTwoLineRefs: () => void;
+	unreferencedOnly: boolean;
+	onToggleUnreferencedOnly: () => void;
+}
+
+/**
+ * The graph's scope chooser plus its two toggles. Presentational — props in,
+ * controls out; the persisted fields and write paths live in useGraphTab.
+ *
+ * These live on the graph's own control strip, not in SidebarHeader's `actions`
+ * slot: that slot is a shrink-0 island in a 40px row whose four tab buttons are
+ * each flex-1 with no min-w-0, so anything rendered there clips the last tab
+ * label ("Review") instead of shrinking it.
+ *
+ * Icon-only, sized to sit beside the strip's 10px text rather than to match a
+ * tab button.
+ */
+export function GraphHeaderActions({
+	refScope,
+	onSelectRefScope,
+	twoLineRefs,
+	onToggleTwoLineRefs,
+	unreferencedOnly,
+	onToggleUnreferencedOnly,
+}: GraphHeaderActionsProps) {
+	const scopeLabel =
+		SCOPE_LABELS.find((s) => s.value === refScope)?.label ??
+		FALLBACK_SCOPE_LABEL;
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						aria-label={`Graph scope: ${scopeLabel}`}
+					>
+						{scopeLabel}
+						<ChevronDown className="size-2.5" />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-44">
+					<DropdownMenuRadioGroup
+						value={refScope}
+						onValueChange={(value) => onSelectRefScope(value as GraphRefScope)}
+					>
+						{SCOPE_LABELS.map((scope) => (
+							<DropdownMenuRadioItem key={scope.value} value={scope.value}>
+								{scope.label}
+							</DropdownMenuRadioItem>
+						))}
+					</DropdownMenuRadioGroup>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={onToggleTwoLineRefs}
+						className={cn(
+							"rounded p-0.5 transition-colors hover:bg-accent",
+							twoLineRefs
+								? "text-foreground"
+								: "text-muted-foreground/60 hover:text-muted-foreground",
+						)}
+						aria-pressed={twoLineRefs}
+						aria-label={
+							twoLineRefs
+								? "Show ref badges inline"
+								: "Show ref badges on their own line"
+						}
+					>
+						<Rows2 className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					{twoLineRefs ? "Inline refs" : "Two-line refs"}
+				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={onToggleUnreferencedOnly}
+						className={cn(
+							"rounded p-0.5 transition-colors hover:bg-accent",
+							unreferencedOnly
+								? "text-foreground"
+								: "text-muted-foreground/60 hover:text-muted-foreground",
+						)}
+						aria-pressed={unreferencedOnly}
+						aria-label={
+							unreferencedOnly
+								? "Stop highlighting unreferenced refs"
+								: "Highlight unreferenced refs"
+						}
+					>
+						<Unlink className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Highlight unreferenced</TooltipContent>
+			</Tooltip>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/GraphHeaderActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/GraphHeaderActions.tsx
@@ -127,7 +127,9 @@ export function GraphHeaderActions({
 						<Unlink className="size-3.5" />
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="bottom">Highlight unreferenced</TooltipContent>
+				<TooltipContent side="bottom">
+					{unreferencedOnly ? "Stop highlighting" : "Highlight unreferenced"}
+				</TooltipContent>
 			</Tooltip>
 		</>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphHeaderActions/index.ts
@@ -1,0 +1,1 @@
+export { GraphHeaderActions } from "./GraphHeaderActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/GraphLanes.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/GraphLanes.test.tsx
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { GraphEdge, GraphRowModel } from "../../types";
+import { graphGeometry } from "./constants";
+import { GraphLanes } from "./GraphLanes";
+
+function row(overrides: Partial<GraphRowModel> = {}): GraphRowModel {
+	return {
+		commit: {
+			hash: "aaa",
+			shortHash: "aaa0000",
+			message: "m",
+			author: "Ada",
+			authorEmail: "a@x",
+			date: "2026-07-31T09:00:00Z",
+			parents: ["bbb"],
+			refs: [],
+		},
+		lane: 0,
+		color: 1,
+		isMerge: false,
+		isRoot: false,
+		edges: [],
+		laneCount: 1,
+		...overrides,
+	};
+}
+
+function render(
+	model: GraphRowModel,
+	{ compact = false, laneCap = 6, topOffset = 0 } = {},
+) {
+	return renderToStaticMarkup(
+		<GraphLanes
+			row={model}
+			compact={compact}
+			laneCap={laneCap}
+			topOffset={topOffset}
+		/>,
+	);
+}
+
+/** Count occurrences of a substring (a tag open + attrs match is enough). */
+function count(markup: string, needle: string): number {
+	let n = 0;
+	let i = markup.indexOf(needle);
+	while (i !== -1) {
+		n++;
+		i = markup.indexOf(needle, i + needle.length);
+	}
+	return n;
+}
+
+describe("GraphLanes", () => {
+	it("sizes the SVG to the visible lane count, capped", () => {
+		const geo = graphGeometry(false);
+		// 3 lanes, cap 6 → all visible.
+		expect(render(row({ laneCount: 3 }))).toContain(
+			`width="${3 * geo.pitch + 4}"`,
+		);
+		// 10 lanes, cap 6 → collapsed to 6 visible.
+		expect(render(row({ laneCount: 10 }), { laneCap: 6 })).toContain(
+			`width="${6 * geo.pitch + 4}"`,
+		);
+	});
+
+	it("draws one path per edge", () => {
+		const edges: GraphEdge[] = [
+			{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 },
+			{ kind: "out-straight", fromLane: 0, toLane: 0, color: 1 },
+		];
+		const markup = render(row({ edges, laneCount: 1 }));
+		expect(count(markup, "<path")).toBe(edges.length);
+	});
+
+	it("stubs an out-stub edge dashed and dimmed", () => {
+		const markup = render(
+			row({
+				edges: [{ kind: "out-stub", fromLane: 0, toLane: 0, color: 1 }],
+				laneCount: 1,
+			}),
+		);
+		expect(markup).toContain('stroke-dasharray="2 2"');
+		expect(markup).toContain('opacity="0.55"');
+	});
+
+	it("renders a donut node for a plain commit, a filled node for merges/roots", () => {
+		// Plain commit: one ringed circle (stroke set, no separate fill colour).
+		const plain = render(row({ isMerge: false, isRoot: false }));
+		expect(count(plain, "<circle")).toBe(1);
+		// Merge: filled node.
+		const merge = render(row({ isMerge: true }));
+		expect(count(merge, "<circle")).toBe(1);
+		expect(merge).toContain("var(--graph-lane-1)");
+		// Root: filled node plus an outer ring → two circles.
+		const root = render(row({ isRoot: true }));
+		expect(count(root, "<circle")).toBe(2);
+	});
+
+	it("clamps lanes past the cap onto the last visible lane", () => {
+		// Node on lane 9 with a cap of 6 lands at the x of lane 5, not lane 9.
+		const geo = graphGeometry(false);
+		const clampedX = (5 * geo.pitch + geo.pitch / 2).toString();
+		const markup = render(row({ lane: 9, laneCount: 10, isRoot: true }), {
+			laneCap: 6,
+		});
+		expect(markup).toContain(`cx="${clampedX}"`);
+	});
+
+	it("paints each edge in its own lane colour", () => {
+		const markup = render(
+			row({
+				edges: [
+					{ kind: "pass", fromLane: 0, toLane: 0, color: 2 },
+					{ kind: "in-merge", fromLane: 1, toLane: 0, color: 3 },
+				],
+				laneCount: 2,
+			}),
+		);
+		expect(markup).toContain("var(--graph-lane-2)");
+		expect(markup).toContain("var(--graph-lane-3)");
+	});
+
+	it("emits a recognizable path shape per edge kind", () => {
+		// Geometry is the spec contract; assert each kind's path opens where the
+		// spec says (incoming from the top y=0, outgoing from the node y=rowHeight/2).
+		const geo = graphGeometry(false);
+		const yc = (geo.rowHeight / 2).toString();
+		const incoming = render(
+			row({
+				edges: [{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 }],
+				laneCount: 1,
+			}),
+		);
+		expect(incoming).toContain(`d="M7,0 V${yc}"`);
+		const outgoing = render(
+			row({
+				edges: [{ kind: "out-straight", fromLane: 0, toLane: 0, color: 1 }],
+				laneCount: 1,
+			}),
+		);
+		expect(outgoing).toContain(`d="M7,${yc} V${geo.rowHeight}"`);
+		// A pass edge spans the full row height.
+		const pass = render(
+			row({
+				edges: [{ kind: "pass", fromLane: 0, toLane: 0, color: 1 }],
+				laneCount: 1,
+			}),
+		);
+		expect(pass).toContain(`d="M7,0 V${geo.rowHeight}"`);
+	});
+
+	it("honours compact geometry", () => {
+		const geo = graphGeometry(true);
+		expect(render(row({ laneCount: 2 }), { compact: true })).toContain(
+			`height="${geo.rowHeight}"`,
+		);
+		// Compact rowHeight (24) is smaller than standard (28).
+		expect(geo.rowHeight).toBeLessThan(graphGeometry(false).rowHeight);
+	});
+
+	it("pushes the node down by topOffset while lanes still span the row", () => {
+		const geo = graphGeometry(false);
+		const offset = 16;
+		const markup = render(
+			row({
+				laneCount: 1,
+				edges: [
+					{ kind: "pass", fromLane: 0, toLane: 0, color: 1 },
+					{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 },
+				],
+			}),
+			{ topOffset: offset },
+		);
+
+		const height = geo.rowHeight + offset;
+		const yc = offset + geo.rowHeight / 2;
+
+		expect(markup).toContain(`height="${height}"`);
+		expect(markup).toContain(`viewBox="0 0 18 ${height}"`);
+		// The node tracks the subject line, not the row's midpoint.
+		expect(markup).toContain(`cy="${yc}"`);
+		expect(markup).not.toContain(`cy="${height / 2}"`);
+		// A pass edge still runs edge to edge, so lanes stay continuous.
+		expect(markup).toContain(`d="M7,0 V${height}"`);
+		// An incoming edge stops at the node, which has moved down with it.
+		expect(markup).toContain(`d="M7,0 V${yc}"`);
+	});
+
+	it("keeps the out-stub proportional at any row height", () => {
+		const geo = graphGeometry(false);
+		const stub = {
+			kind: "out-stub",
+			fromLane: 0,
+			toLane: 0,
+			color: 1,
+		} as const;
+		/** 60% of the way from the node down to the bottom edge. */
+		const stubEnd = (offset: number) => {
+			const height = geo.rowHeight + offset;
+			const yc = offset + geo.rowHeight / 2;
+			return yc + (height - yc) * 0.6;
+		};
+
+		// Single-line: still the original 80%-of-row endpoint.
+		expect(stubEnd(0)).toBeCloseTo(geo.rowHeight * 0.8, 6);
+		expect(render(row({ edges: [stub], laneCount: 1 }))).toContain(
+			`V${stubEnd(0)}"`,
+		);
+
+		// Two-line: proportional to the taller row, and still inside it.
+		const offset = 16;
+		const markup = render(row({ edges: [stub], laneCount: 1 }), {
+			topOffset: offset,
+		});
+		expect(markup).toContain(`V${stubEnd(offset)}"`);
+		expect(stubEnd(offset)).toBeLessThan(geo.rowHeight + offset);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/GraphLanes.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/GraphLanes.tsx
@@ -1,0 +1,132 @@
+import type { GraphEdge, GraphRowModel } from "../../types";
+import { graphGeometry } from "./constants";
+
+interface GraphLanesProps {
+	row: GraphRowModel;
+	compact: boolean;
+	/** Visible lanes; see laneCapForWidth. Lanes past this collapse onto the last one. */
+	laneCap: number;
+	/**
+	 * Extra height above the node, added by a two-line row's badge line. Lanes
+	 * span the whole row so edges stay continuous, but the node tracks the
+	 * subject — the line the commit actually is.
+	 */
+	topOffset?: number;
+}
+
+/** Vertical dimensions of one row's lane strip. */
+interface LaneDims {
+	height: number;
+	/** Node centre. Not height/2 once a badge line sits on top. */
+	yc: number;
+	elbowRadius: number;
+}
+
+function laneColor(index: number): string {
+	return `var(--graph-lane-${index})`;
+}
+
+/**
+ * Merges and forks are drawn deliberately asymmetrically: a merge descends
+ * then bends into the node horizontally, a fork leaves the node horizontally
+ * then bends down. That is what tells them apart at a 3.5px node.
+ */
+function edgePath(
+	edge: GraphEdge,
+	dims: LaneDims,
+	x: (lane: number) => number,
+): string {
+	const { height, yc, elbowRadius: e } = dims;
+	const x0 = x(edge.fromLane);
+	const x1 = x(edge.toLane);
+	const dir = Math.sign(x1 - x0) || 1;
+
+	switch (edge.kind) {
+		case "pass":
+			return `M${x0},0 V${height}`;
+		case "in-straight":
+			return `M${x0},0 V${yc}`;
+		case "in-merge":
+			return `M${x0},0 V${yc - e} Q${x0},${yc} ${x0 + dir * e},${yc} H${x1}`;
+		case "out-straight":
+			return `M${x0},${yc} V${height}`;
+		case "out-stub":
+			// 60% of the way from the node to the bottom edge, whatever the height.
+			return `M${x0},${yc} V${yc + (height - yc) * 0.6}`;
+		case "out-fork":
+			return `M${x0},${yc} H${x1 - dir * e} Q${x1},${yc} ${x1},${yc + e} V${height}`;
+	}
+}
+
+/** Per-row inline SVG, sized to this row only, so virtualization stays trivial. */
+export function GraphLanes({
+	row,
+	compact,
+	laneCap,
+	topOffset = 0,
+}: GraphLanesProps) {
+	const geo = graphGeometry(compact);
+	const shownLanes = Math.min(row.laneCount, laneCap);
+	const width = shownLanes * geo.pitch + 4;
+	const height = geo.rowHeight + topOffset;
+	const yc = topOffset + geo.rowHeight / 2;
+	const dims: LaneDims = { height, yc, elbowRadius: geo.elbowRadius };
+
+	// Lanes past the cap collapse onto the last visible one rather than
+	// scrolling sideways, which would desync from the subject column.
+	const x = (lane: number) =>
+		Math.min(lane, laneCap - 1) * geo.pitch + geo.pitch / 2;
+
+	const nodeX = x(row.lane);
+	const nodeColor = laneColor(row.color);
+
+	return (
+		<svg
+			aria-hidden="true"
+			className="shrink-0"
+			width={width}
+			height={height}
+			viewBox={`0 0 ${width} ${height}`}
+		>
+			<title>Commit graph lanes</title>
+			{row.edges.map((edge) => (
+				<path
+					key={`${edge.kind}-${edge.fromLane}-${edge.toLane}`}
+					d={edgePath(edge, dims, x)}
+					fill="none"
+					stroke={laneColor(edge.color)}
+					strokeWidth={geo.strokeWidth}
+					strokeLinecap="round"
+					{...(edge.kind === "out-stub"
+						? { strokeDasharray: "2 2", opacity: 0.55 }
+						: {})}
+				/>
+			))}
+
+			{row.isMerge || row.isRoot ? (
+				<circle cx={nodeX} cy={yc} r={geo.nodeRadius} fill={nodeColor} />
+			) : (
+				<circle
+					cx={nodeX}
+					cy={yc}
+					r={geo.nodeRadius}
+					// Filled with the row's own ground so the ring reads as a donut.
+					className="fill-sidebar"
+					stroke={nodeColor}
+					strokeWidth={1.5}
+				/>
+			)}
+			{row.isRoot && (
+				<circle
+					cx={nodeX}
+					cy={yc}
+					r={geo.nodeRadius + 2}
+					fill="none"
+					stroke={nodeColor}
+					strokeWidth={1}
+					opacity={0.45}
+				/>
+			)}
+		</svg>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/constants.ts
@@ -1,0 +1,67 @@
+// Lane geometry. Every number is derived from the sidebar's real width range
+// (240-560px) and the compact breakpoint in WorkspaceSidebar.tsx.
+// See apps/desktop/plans/20260801-1200-git-graph-visual-spec.md.
+
+export interface GraphGeometry {
+	/** Horizontal distance between lane centres. */
+	pitch: number;
+	rowHeight: number;
+	nodeRadius: number;
+	elbowRadius: number;
+	strokeWidth: number;
+}
+
+export const GRAPH_GEOMETRY: GraphGeometry = {
+	pitch: 14,
+	rowHeight: 28,
+	nodeRadius: 3.5,
+	elbowRadius: 6,
+	strokeWidth: 1.5,
+};
+
+export const GRAPH_GEOMETRY_COMPACT: GraphGeometry = {
+	pitch: 12,
+	rowHeight: 24,
+	nodeRadius: 3,
+	elbowRadius: 5,
+	strokeWidth: 1.5,
+};
+
+export function graphGeometry(compact: boolean): GraphGeometry {
+	return compact ? GRAPH_GEOMETRY_COMPACT : GRAPH_GEOMETRY;
+}
+
+/**
+ * Height of the badge line a two-line row adds above its subject. Matches the
+ * badge's own box (h-4 / h-3.5) so the line costs nothing but the badges.
+ */
+export function refLineHeight(compact: boolean): number {
+	return compact ? 14 : 16;
+}
+
+/**
+ * The virtualizer's `estimateSize(i)`. Index-based, so a two-line row needs no
+ * measurement pass: whether a row carries refs is known before render.
+ */
+export function graphRowHeight(options: {
+	compact: boolean;
+	twoLine: boolean;
+}): number {
+	const { compact, twoLine } = options;
+	return (
+		graphGeometry(compact).rowHeight + (twoLine ? refLineHeight(compact) : 0)
+	);
+}
+
+/**
+ * Visible lanes before the overflow chip takes over. Width-derived because the
+ * lane column is the only element that can starve the subject: at 260px a
+ * 6-lane column already costs 88px.
+ */
+export function laneCapForWidth(width: number): number {
+	if (width < 260) return 4;
+	return width >= 400 ? 8 : 6;
+}
+
+/** Author and date only earn their space at the wide breakpoint. */
+export const GRAPH_WIDE_BREAKPOINT = 400;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphLanes/index.ts
@@ -1,0 +1,11 @@
+export {
+	GRAPH_GEOMETRY,
+	GRAPH_GEOMETRY_COMPACT,
+	GRAPH_WIDE_BREAKPOINT,
+	type GraphGeometry,
+	graphGeometry,
+	graphRowHeight,
+	laneCapForWidth,
+	refLineHeight,
+} from "./constants";
+export { GraphLanes } from "./GraphLanes";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.test.tsx
@@ -226,9 +226,13 @@ describe("GraphRow", () => {
 		});
 
 		it("changes nothing when the toggle is off", () => {
-			expect(render(withRefs, 320)).toBe(render(withRefs, 320, false, {}));
-			expect(render(withRefs, 320)).toContain("+5");
-			expect(render(withRefs, 320)).toContain("max-w-[12ch]");
+			const off = render(withRefs, 320, false, { twoLineRefs: false });
+
+			// Off is the one-line layout: chip and width cap both back.
+			expect(off).toContain("+5");
+			expect(off).toContain("max-w-[12ch]");
+			// And it is a real difference, not two spellings of the same render.
+			expect(off).not.toBe(render(withRefs, 320, false, { twoLineRefs: true }));
 		});
 
 		it("keeps the lane SVG spanning the taller row", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.test.tsx
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { GraphCommit, GraphRef, GraphRowModel } from "../../types";
+import { graphRowHeight, laneCapForWidth } from "../GraphLanes";
+import { GraphRow } from "./GraphRow";
+
+function commit(
+	hash: string,
+	parents: string[],
+	refs: GraphRef[] = [],
+): GraphCommit {
+	return {
+		hash: `${hash}0000000000000000000000000000000000`.slice(0, 40),
+		shortHash: hash.padEnd(7, "0").slice(0, 7),
+		message: `feat(desktop): ${hash} subject that is long enough to need truncating`,
+		author: "Ada",
+		authorEmail: "ada@example.com",
+		date: "2026-07-31T09:00:00Z",
+		parents,
+		refs,
+	};
+}
+
+function row(overrides: Partial<GraphRowModel> = {}): GraphRowModel {
+	return {
+		commit: commit("aaa", ["bbb"]),
+		lane: 0,
+		color: 1,
+		isMerge: false,
+		isRoot: false,
+		edges: [
+			{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 },
+			{ kind: "out-straight", fromLane: 0, toLane: 0, color: 1 },
+		],
+		laneCount: 1,
+		...overrides,
+	};
+}
+
+const ALL_STATES: GraphRef[] = [
+	{ name: "HEAD", type: "head", state: null },
+	{ name: "main", type: "branch", state: "open", worktreeWorkspaceId: "ws_1" },
+	{
+		name: "feat/share-skills",
+		type: "branch",
+		state: "detached-worktree",
+		worktreePath: "/tmp/wt/share-skills",
+	},
+	{ name: "chore/turbo", type: "branch", state: "orphan-branch" },
+	{
+		name: "fix/pty-flake",
+		type: "branch",
+		state: "prunable",
+		pruneReason: "worktree path is gone",
+	},
+	{ name: "docs/release", type: "branch", state: "merged" },
+	{ name: "origin/main", type: "remote", state: null },
+	{ name: "v0.9.2", type: "tag", state: null },
+];
+
+function render(
+	model: GraphRowModel,
+	width: number,
+	selected = false,
+	{ twoLineRefs = false, inRange = false } = {},
+) {
+	const compact = width < 260;
+	return renderToStaticMarkup(
+		<GraphRow
+			row={model}
+			compact={compact}
+			selected={selected}
+			onSelect={() => {}}
+			laneCap={laneCapForWidth(width)}
+			showDate={width >= 400}
+			twoLineRefs={twoLineRefs}
+			inRange={inRange}
+		/>,
+	);
+}
+
+const WIDTHS = [240, 260, 320, 400];
+
+describe("GraphRow", () => {
+	it("renders every topology at every breakpoint without NaN geometry", () => {
+		const models = [
+			row(),
+			row({ commit: commit("mmm", ["p1", "p2"]), isMerge: true, laneCount: 2 }),
+			row({
+				commit: commit("ooo", ["p1", "p2", "p3"]),
+				isMerge: true,
+				laneCount: 4,
+				edges: [
+					{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 },
+					{ kind: "out-straight", fromLane: 0, toLane: 0, color: 1 },
+					{ kind: "out-fork", fromLane: 0, toLane: 1, color: 2 },
+					{ kind: "out-fork", fromLane: 0, toLane: 2, color: 3 },
+				],
+			}),
+			row({
+				commit: commit("rrr", []),
+				isRoot: true,
+				edges: [{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 }],
+			}),
+			row({
+				commit: commit("sss", ["outside-the-window"]),
+				edges: [
+					{ kind: "in-straight", fromLane: 0, toLane: 0, color: 1 },
+					{ kind: "out-stub", fromLane: 0, toLane: 0, color: 1 },
+				],
+			}),
+			row({
+				commit: commit("ccc", ["p1"]),
+				lane: 2,
+				color: 4,
+				laneCount: 3,
+				edges: [
+					{ kind: "pass", fromLane: 0, toLane: 0, color: 1 },
+					{ kind: "pass", fromLane: 1, toLane: 1, color: 2 },
+					{ kind: "in-merge", fromLane: 2, toLane: 0, color: 4 },
+				],
+			}),
+		];
+
+		for (const width of WIDTHS) {
+			for (const model of models) {
+				const markup = render(model, width);
+				expect(markup).not.toContain("NaN");
+				expect(markup).not.toContain("undefined");
+				expect(markup).toContain("<svg");
+			}
+		}
+	});
+
+	it("shows every ref state, ordering HEAD first and collapsing the rest", () => {
+		const markup = render(
+			row({ commit: commit("aaa", ["bbb"], ALL_STATES) }),
+			320,
+		);
+
+		// HEAD, then the open branch, then the detached worktree — the rest collapse.
+		expect(markup.indexOf("HEAD")).toBeLessThan(markup.indexOf("main"));
+		expect(markup.indexOf("main")).toBeLessThan(
+			markup.indexOf("feat/share-skills"),
+		);
+		expect(markup).toContain("+5");
+		// The collapsed names stay reachable through the chip's tooltip.
+		expect(markup).toContain("fix/pty-flake");
+		expect(markup).toContain("v0.9.2");
+	});
+
+	it("puts the prune reason in the badge tooltip", () => {
+		const markup = render(
+			row({
+				commit: commit("aaa", ["bbb"], [ALL_STATES[4] as GraphRef]),
+			}),
+			320,
+		);
+		expect(markup).toContain("fix/pty-flake — worktree path is gone");
+		expect(markup).toContain("line-through");
+	});
+
+	it("drops the hash in compact and the date below the wide breakpoint", () => {
+		const model = row();
+		expect(render(model, 240)).not.toContain(model.commit.shortHash);
+		expect(render(model, 320)).toContain(model.commit.shortHash);
+		expect(render(model, 320)).not.toContain("min-w-10");
+		expect(render(model, 400)).toContain("min-w-10");
+	});
+
+	it("caps visible lanes by width and reports the overflow", () => {
+		const wide = row({ lane: 0, laneCount: 9 });
+		expect(render(wide, 260)).toContain("+3"); // cap 6
+		expect(render(wide, 400)).toContain("+1"); // cap 8
+		expect(render(wide, 240)).toContain("+5"); // cap 4
+	});
+
+	it("marks the selected row with a lane-coloured rail", () => {
+		const markup = render(row({ color: 5 }), 320, true);
+		expect(markup).toContain("bg-accent");
+		expect(markup).toContain("var(--graph-lane-5)");
+	});
+
+	it("keeps a selected endpoint brighter than the range band it anchors", () => {
+		// resolveRowSelection puts endpoints in selectedSet only (the band is
+		// lo+1..hi-1), so equal alphas + --accent is what keeps the ordering.
+		const plain = render(row(), 320);
+		const band = render(row(), 320, false, { inRange: true });
+		const endpoint = render(row(), 320, true);
+
+		expect(plain).toContain("9%, transparent");
+		expect(band).toContain("16%, transparent");
+		expect(endpoint).toContain("16%, transparent");
+		// Anchored on the class boundary: hover:bg-accent is on every row.
+		const bgAccent = /[\s"]bg-accent[\s"]/;
+		expect(endpoint).toMatch(bgAccent);
+		expect(band).not.toMatch(bgAccent);
+	});
+
+	describe("two-line ref rows", () => {
+		const withRefs = row({ commit: commit("aaa", ["bbb"], ALL_STATES) });
+
+		it("shows every badge untruncated instead of collapsing to a chip", () => {
+			const markup = render(withRefs, 320, false, { twoLineRefs: true });
+
+			for (const graphRef of ALL_STATES) {
+				expect(markup).toContain(graphRef.name);
+			}
+			// No "+N" ref chip, and no width cap on the badges.
+			expect(markup).not.toContain("+5");
+			expect(markup).not.toContain("max-w-[12ch]");
+		});
+
+		it("only grows the rows that carry refs", () => {
+			const bare = render(row(), 320, false, { twoLineRefs: true });
+			const decorated = render(withRefs, 320, false, { twoLineRefs: true });
+
+			expect(bare).toContain(
+				`height:${graphRowHeight({ compact: false, twoLine: false })}px`,
+			);
+			expect(decorated).toContain(
+				`height:${graphRowHeight({ compact: false, twoLine: true })}px`,
+			);
+			// The height the virtualizer would reserve is the height rendered.
+			expect(graphRowHeight({ compact: false, twoLine: true })).toBe(44);
+		});
+
+		it("changes nothing when the toggle is off", () => {
+			expect(render(withRefs, 320)).toBe(render(withRefs, 320, false, {}));
+			expect(render(withRefs, 320)).toContain("+5");
+			expect(render(withRefs, 320)).toContain("max-w-[12ch]");
+		});
+
+		it("keeps the lane SVG spanning the taller row", () => {
+			const markup = render(withRefs, 320, false, { twoLineRefs: true });
+			expect(markup).toContain(
+				`height="${graphRowHeight({ compact: false, twoLine: true })}"`,
+			);
+		});
+
+		it("uses the compact badge line at the compact breakpoint", () => {
+			const markup = render(withRefs, 240, false, { twoLineRefs: true });
+			expect(markup).toContain(
+				`height:${graphRowHeight({ compact: true, twoLine: true })}px`,
+			);
+			expect(markup).not.toContain("max-w-[8ch]");
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/GraphRow.tsx
@@ -1,0 +1,203 @@
+import { cn } from "@superset/ui/utils";
+import type { MouseEvent } from "react";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
+import type { GraphRef, GraphRowModel } from "../../types";
+import { GraphLanes, graphGeometry, refLineHeight } from "../GraphLanes";
+import { RefBadge } from "../RefBadge";
+
+interface GraphRowProps {
+	row: GraphRowModel;
+	compact: boolean;
+	selected: boolean;
+	/** Shift-click marks a range; both endpoints render as selected. */
+	onSelect: (event: MouseEvent<HTMLButtonElement>) => void;
+	/** Pin the preview pane a single click just opened. */
+	onDoubleClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+	laneCap: number;
+	/** Only the wide breakpoint has room for a date column. */
+	showDate: boolean;
+	/** Rows between two range endpoints get a stronger wash. */
+	inRange?: boolean;
+	/** Merge subjects are structure, not work — dim them. */
+	muteMerges?: boolean;
+	/**
+	 * Give refs their own line above the subject, untruncated. Only changes
+	 * rows that actually carry refs — the rest stay single-line, which is why
+	 * the virtualizer's estimateSize has to be index-based (graphRowHeight).
+	 */
+	twoLineRefs?: boolean;
+	/**
+	 * Recede under the unreferenced filter. Dimmed rather than removed —
+	 * dropping rows would leave the surviving lane edges dangling.
+	 */
+	dimmed?: boolean;
+}
+
+// Fixed order so the eye lands on the same thing in every row.
+const REF_RANK: Record<string, number> = {
+	head: 0,
+	open: 1,
+	"detached-worktree": 2,
+	prunable: 3,
+	"orphan-branch": 4,
+	merged: 5,
+};
+
+function refRank(graphRef: GraphRef): number {
+	if (graphRef.type === "head") return 0;
+	if (graphRef.type === "remote") return 6;
+	if (graphRef.type === "tag") return 7;
+	return REF_RANK[graphRef.state ?? "merged"] ?? 5;
+}
+
+export function GraphRow({
+	row,
+	compact,
+	selected,
+	onSelect,
+	onDoubleClick,
+	laneCap,
+	showDate,
+	inRange = false,
+	muteMerges = true,
+	twoLineRefs = false,
+	dimmed = false,
+}: GraphRowProps) {
+	const { commit } = row;
+	const laneVar = `var(--graph-lane-${row.color})`;
+
+	const sortedRefs = [...commit.refs].sort((a, b) => refRank(a) - refRank(b));
+	// A ref line has the width to itself, so it shows every badge in full. The
+	// slice + "+N" chip only exist to stop inline badges eating the subject.
+	const ownLine = twoLineRefs && sortedRefs.length > 0;
+	const maxBadges = compact ? 2 : 3;
+	const shownRefs = ownLine ? sortedRefs : sortedRefs.slice(0, maxBadges);
+	const hiddenRefs = ownLine ? [] : sortedRefs.slice(maxBadges);
+
+	const geo = graphGeometry(compact);
+	const refLine = ownLine ? refLineHeight(compact) : 0;
+
+	const laneOverflow = Math.max(0, row.laneCount - laneCap);
+	// Selection has to outrank the range band it anchors: endpoints carry
+	// --accent, the rows between them do not, so giving both the same 16% keeps
+	// the endpoints strictly brighter. 9% elsewhere stays under --accent's own
+	// contribution, so an unselected tinted row never competes with a selected one.
+	const tintAlpha = inRange || selected ? 16 : 9;
+	const tint = `color-mix(in oklch, ${laneVar} ${tintAlpha}%, transparent)`;
+
+	// One strip, two homes: its own line above the subject, or inline ahead of
+	// it. On its own line it clips rather than wrapping, so the row height stays
+	// a function of the index alone.
+	const refStrip =
+		shownRefs.length > 0 ? (
+			<span
+				className={cn(
+					"flex min-w-0 items-center gap-[3px]",
+					ownLine ? "overflow-hidden" : "shrink-0",
+				)}
+				style={ownLine ? { height: refLine } : undefined}
+			>
+				{shownRefs.map((graphRef) => (
+					<RefBadge
+						key={`${graphRef.type}:${graphRef.name}`}
+						graphRef={graphRef}
+						compact={compact}
+						laneColor={row.color}
+						untrimmed={ownLine}
+					/>
+				))}
+				{hiddenRefs.length > 0 && (
+					<span
+						title={hiddenRefs.map((r) => r.name).join(", ")}
+						className={cn(
+							"inline-flex shrink-0 items-center rounded-sm border border-border px-1 font-medium font-mono text-muted-foreground",
+							compact ? "h-3.5 text-[10px]" : "h-4 text-[11px]",
+							"leading-none",
+						)}
+					>
+						+{hiddenRefs.length}
+					</span>
+				)}
+			</span>
+		) : null;
+
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			onDoubleClick={onDoubleClick}
+			title={commit.message}
+			className={cn(
+				"relative flex w-full items-stretch gap-1.5 border-0 pr-2 text-left",
+				"hover:bg-accent focus-visible:outline-2 focus-visible:outline-ring focus-visible:-outline-offset-2",
+				selected && "bg-accent",
+				dimmed && "opacity-40",
+			)}
+			style={{
+				height: geo.rowHeight + refLine,
+				// Lane membership stays readable without tracing lines, and it
+				// survives the lane compression that narrow widths force.
+				//
+				// This is background-*image*, not -color, on purpose: an inline
+				// backgroundColor outranks a class-set one, which silently killed
+				// hover:bg-accent. As an image the tint layers over whatever ground
+				// the hover/selected classes set, and still paints below content.
+				backgroundImage: `linear-gradient(${tint}, ${tint})`,
+			}}
+		>
+			{selected && (
+				<span
+					aria-hidden="true"
+					className="absolute inset-y-0 left-0 w-0.5"
+					style={{ backgroundColor: laneVar }}
+				/>
+			)}
+
+			<GraphLanes
+				row={row}
+				compact={compact}
+				laneCap={laneCap}
+				topOffset={refLine}
+			/>
+
+			<span className="flex min-w-0 flex-1 flex-col">
+				{ownLine && refStrip}
+
+				<span className="flex min-w-0 flex-1 items-center gap-1.5">
+					{laneOverflow > 0 && (
+						<span className="-ml-1 shrink-0 font-mono text-[9px] text-muted-foreground">
+							+{laneOverflow}
+						</span>
+					)}
+
+					{!ownLine && refStrip}
+
+					<span
+						className={cn(
+							"min-w-0 flex-1 truncate",
+							compact ? "text-[11px]" : "text-xs",
+							row.isMerge && muteMerges
+								? "text-muted-foreground"
+								: "text-foreground",
+							// Must follow the text-size class; see RefBadge.
+							"leading-none",
+						)}
+					>
+						{commit.message}
+					</span>
+
+					{!compact && (
+						<span className="shrink-0 font-mono text-[11px] text-muted-foreground tabular-nums">
+							{commit.shortHash}
+						</span>
+					)}
+					{showDate && (
+						<span className="min-w-10 shrink-0 text-right font-mono text-[11px] text-muted-foreground tabular-nums">
+							{formatRelativeTime(Date.parse(commit.date))}
+						</span>
+					)}
+				</span>
+			</span>
+		</button>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphRow/index.ts
@@ -1,0 +1,1 @@
+export { GraphRow } from "./GraphRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.test.ts
@@ -32,12 +32,13 @@ describe("resolveRowSelection", () => {
 		expect(inRangeSet.size).toBe(0);
 	});
 
-	test("commit outside the window is simply absent", () => {
-		const { selectedSet } = resolveRowSelection(commit("zzz"), H);
-		expect(selectedSet.has("zzz")).toBe(true);
-		// Unknown hash still recorded in selectedSet (harmless; GraphRow won't
-		// match it), and nothing else is selected.
-		expect(selectedSet.size).toBe(1);
+	test("commit outside the window highlights no row", () => {
+		const { selectedSet, inRangeSet } = resolveRowSelection(commit("zzz"), H);
+		// The hash is still recorded — harmless, since no rendered row matches
+		// it — and no row in the window is marked.
+		expect([...selectedSet]).toEqual(["zzz"]);
+		expect(H.some((hash) => selectedSet.has(hash))).toBe(false);
+		expect(inRangeSet.size).toBe(0);
 	});
 
 	test("range highlights both endpoints and the rows between", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import { graphRowHeight } from "../GraphLanes";
+import {
+	type GraphSelection,
+	graphRowSizer,
+	hasUnreferencedRef,
+	isTwoLineRow,
+	resolveRowSelection,
+} from "./GraphTabContent";
+
+// Short hashes are enough — the resolver only compares strings.
+const H = ["a", "b", "c", "d", "e", "f"];
+
+const none: GraphSelection = { kind: "none" };
+const commit = (hash: string): GraphSelection => ({ kind: "commit", hash });
+const range = (fromHash: string, toHash: string): GraphSelection => ({
+	kind: "range",
+	fromHash,
+	toHash,
+});
+
+describe("resolveRowSelection", () => {
+	test("none highlights nothing", () => {
+		const { selectedSet, inRangeSet } = resolveRowSelection(none, H);
+		expect(selectedSet.size).toBe(0);
+		expect(inRangeSet.size).toBe(0);
+	});
+
+	test("commit selects exactly that row, with no range wash", () => {
+		const { selectedSet, inRangeSet } = resolveRowSelection(commit("c"), H);
+		expect([...selectedSet]).toEqual(["c"]);
+		expect(inRangeSet.size).toBe(0);
+	});
+
+	test("commit outside the window is simply absent", () => {
+		const { selectedSet } = resolveRowSelection(commit("zzz"), H);
+		expect(selectedSet.has("zzz")).toBe(true);
+		// Unknown hash still recorded in selectedSet (harmless; GraphRow won't
+		// match it), and nothing else is selected.
+		expect(selectedSet.size).toBe(1);
+	});
+
+	test("range highlights both endpoints and the rows between", () => {
+		// a(0) b(1) c(2) d(3) e(4) f(5) — range a..d covers b, c in between
+		const { selectedSet, inRangeSet } = resolveRowSelection(range("a", "d"), H);
+		expect([...selectedSet].sort()).toEqual(["a", "d"]);
+		expect([...inRangeSet].sort()).toEqual(["b", "c"]);
+	});
+
+	test("range works when endpoints are given in reverse display order", () => {
+		// newer-first list; toHash may be the higher index. d(3)..a(0)
+		const { selectedSet, inRangeSet } = resolveRowSelection(range("d", "a"), H);
+		expect([...selectedSet].sort()).toEqual(["a", "d"]);
+		expect([...inRangeSet].sort()).toEqual(["b", "c"]);
+	});
+
+	test("adjacent range endpoints select both with nothing between", () => {
+		const { selectedSet, inRangeSet } = resolveRowSelection(range("c", "d"), H);
+		expect([...selectedSet].sort()).toEqual(["c", "d"]);
+		expect(inRangeSet.size).toBe(0);
+	});
+
+	test("range with one endpoint outside the window selects only the present one", () => {
+		// fromHash "a" present, toHash "zzz" absent → no between-rows computable
+		const { selectedSet, inRangeSet } = resolveRowSelection(
+			range("a", "zzz"),
+			H,
+		);
+		expect([...selectedSet]).toEqual(["a"]);
+		expect(inRangeSet.size).toBe(0);
+	});
+
+	test("range with neither endpoint present selects nothing", () => {
+		const { selectedSet, inRangeSet } = resolveRowSelection(range("x", "z"), H);
+		expect(selectedSet.size).toBe(0);
+		expect(inRangeSet.size).toBe(0);
+	});
+});
+
+describe("isTwoLineRow (§4.2 estimateSize rule)", () => {
+	const refs = (n: number) =>
+		Array.from({ length: n }, () => ({ state: "open" as string | null }));
+
+	test("toggle off is always single-line, even with refs", () => {
+		expect(isTwoLineRow(refs(3), false)).toBe(false);
+	});
+
+	test("toggle on only lifts rows that actually carry refs", () => {
+		expect(isTwoLineRow([], true)).toBe(false);
+		expect(isTwoLineRow(refs(1), true)).toBe(true);
+		expect(isTwoLineRow(refs(3), true)).toBe(true);
+	});
+
+	test("the taller height applies only to ref-carrying rows", () => {
+		// estimateSize feeds isTwoLineRow into graphRowHeight; a ref-less row must
+		// stay at base height, a ref-carrying row must grow.
+		const base = graphRowHeight({ compact: false, twoLine: false });
+		const tall = graphRowHeight({ compact: false, twoLine: true });
+		expect(
+			graphRowHeight({ compact: false, twoLine: isTwoLineRow([], true) }),
+		).toBe(base);
+		expect(
+			graphRowHeight({
+				compact: false,
+				twoLine: isTwoLineRow(refs(1), true),
+			}),
+		).toBe(tall);
+		expect(tall).toBeGreaterThan(base);
+	});
+});
+
+describe("hasUnreferencedRef (§4.3 predicate)", () => {
+	const ref = (state: string | null) => ({ state });
+
+	test("a commit whose only ref is merged is referenced (dims under the filter)", () => {
+		expect(hasUnreferencedRef([ref("merged")])).toBe(false);
+	});
+
+	test("a commit carrying a prunable / orphan / detached-worktree ref is unreferenced (stays bright)", () => {
+		expect(hasUnreferencedRef([ref("prunable")])).toBe(true);
+		expect(hasUnreferencedRef([ref("orphan-branch")])).toBe(true);
+		expect(hasUnreferencedRef([ref("detached-worktree")])).toBe(true);
+	});
+
+	test("an open ref anchors the commit", () => {
+		expect(hasUnreferencedRef([ref("open")])).toBe(false);
+	});
+
+	test("null-state refs (HEAD / remote / tag) never count as a reference", () => {
+		expect(hasUnreferencedRef([ref(null)])).toBe(false);
+		expect(hasUnreferencedRef([])).toBe(false);
+	});
+});
+
+describe("graphRowSizer", () => {
+	const row = (hash: string, refs: Array<{ state: string | null }>) => ({
+		commit: { hash, refs },
+	});
+
+	test("getItemKey(i) returns the hash at i", () => {
+		const rows = [row("a", []), row("b", [{ state: "open" }]), row("c", [])];
+		const sizer = graphRowSizer(rows, { compact: false, twoLineRefs: true });
+		expect(sizer.getItemKey(0)).toBe("a");
+		expect(sizer.getItemKey(1)).toBe("b");
+		expect(sizer.getItemKey(2)).toBe("c");
+	});
+
+	test("the shift invariant: a commit's (key, size) survives a prepend", () => {
+		// Heights differ across these rows: "b" and "d" carry a ref (two-line),
+		// "a" and "c" don't (single-line).
+		const before = [
+			row("a", []),
+			row("b", [{ state: null }]),
+			row("c", []),
+			row("d", [{ state: "open" }]),
+		];
+		const sizerBefore = graphRowSizer(before, {
+			compact: false,
+			twoLineRefs: true,
+		});
+		const snapshotBefore = new Map(
+			before.map((r, i) => [
+				r.commit.hash,
+				[sizerBefore.getItemKey(i), sizerBefore.estimateSize(i)] as const,
+			]),
+		);
+
+		// A refetch prepends a brand-new commit, shifting every prior commit's
+		// index by one.
+		const after = [row("new", []), ...before];
+		const sizerAfter = graphRowSizer(after, {
+			compact: false,
+			twoLineRefs: true,
+		});
+		const snapshotAfter = new Map(
+			after.map((r, i) => [
+				r.commit.hash,
+				[sizerAfter.getItemKey(i), sizerAfter.estimateSize(i)] as const,
+			]),
+		);
+
+		// Every commit present in both lists must keep the same (key, size) pair
+		// — looked up by its own hash, not by the slot it happens to occupy.
+		for (const [hash, pair] of snapshotBefore) {
+			expect(snapshotAfter.get(hash)).toEqual(pair);
+		}
+	});
+
+	test("estimateSize matches graphRowHeight(isTwoLineRow(...)) for both flags", () => {
+		const withRef = row("x", [{ state: "open" }]);
+		const withoutRef = row("y", []);
+		const rows = [withRef, withoutRef];
+
+		for (const compact of [false, true]) {
+			for (const twoLineRefs of [false, true]) {
+				const sizer = graphRowSizer(rows, { compact, twoLineRefs });
+				expect(sizer.estimateSize(0)).toBe(
+					graphRowHeight({
+						compact,
+						twoLine: isTwoLineRow(withRef.commit.refs, twoLineRefs),
+					}),
+				);
+				expect(sizer.estimateSize(1)).toBe(
+					graphRowHeight({
+						compact,
+						twoLine: isTwoLineRow(withoutRef.commit.refs, twoLineRefs),
+					}),
+				);
+			}
+		}
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/GraphTabContent.tsx
@@ -1,0 +1,403 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Clipboard, ExternalLink, FileText, Hash } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import type { GraphCommit, GraphRefScope } from "../../types";
+import { assignLanes } from "../../utils/assignLanes";
+import { GraphHeaderActions } from "../GraphHeaderActions";
+import { graphRowHeight } from "../GraphLanes";
+import { GraphRow } from "../GraphRow";
+
+const OVERSCAN = 10;
+
+// A ref with no open Superset workspace behind it. `open` and `merged` are
+// accounted for; null-state refs (HEAD, remotes, tags) never qualify.
+const UNREFERENCED_STATES = new Set([
+	"detached-worktree",
+	"orphan-branch",
+	"prunable",
+]);
+
+/** A row carries refs onto the two-line layout only when the toggle is on AND
+ *  it actually has refs. Exported so estimateSize and the test share one rule. */
+export function isTwoLineRow(
+	refs: Array<{ state: string | null }>,
+	twoLineRefs: boolean,
+): boolean {
+	return twoLineRefs && refs.length > 0;
+}
+
+/** The virtualizer's size + key derivation, extracted so the invariant that
+ *  broke (a commit's key and height must survive a list shift) is testable
+ *  without a DOM. */
+export function graphRowSizer(
+	rows: Array<{
+		commit: { hash: string; refs: Array<{ state: string | null }> };
+	}>,
+	options: { compact: boolean; twoLineRefs: boolean },
+): { getItemKey: (i: number) => string; estimateSize: (i: number) => number } {
+	const { compact, twoLineRefs } = options;
+	return {
+		getItemKey: (i) => rows[i].commit.hash,
+		estimateSize: (i) =>
+			graphRowHeight({
+				compact,
+				twoLine: isTwoLineRow(rows[i].commit.refs, twoLineRefs),
+			}),
+	};
+}
+
+/** A commit carries an "unreferenced" ref when one of its refs has no open
+ *  workspace behind it (detached-worktree / orphan-branch / prunable). The
+ *  §4.3 filter highlights these and dims the rest, so this is the predicate
+ *  that keeps a row bright. `merged` and `open` count as referenced; null-state
+ *  refs (HEAD, remotes, tags) never qualify. */
+export function hasUnreferencedRef(
+	refs: Array<{ state: string | null }>,
+): boolean {
+	return refs.some((r) => r.state && UNREFERENCED_STATES.has(r.state));
+}
+
+/**
+ * What the graph currently highlights. Derived from the persisted
+ * `graphSelection` (graph-owned, separate from the Changes tab's
+ * changesFilter so the two surfaces don't fight over one selection).
+ */
+export type GraphSelection =
+	| { kind: "none" }
+	| { kind: "commit"; hash: string }
+	| { kind: "range"; fromHash: string; toHash: string };
+
+/**
+ * Resolve a selection to per-row highlight sets, given the loaded window's
+ * commit hashes in display order (newest first). `inRange` covers rows strictly
+ * between the two range endpoints; an endpoint outside the window is simply not
+ * highlighted. Exported for unit testing.
+ */
+export function resolveRowSelection(
+	selection: GraphSelection,
+	hashes: string[],
+): { selectedSet: Set<string>; inRangeSet: Set<string> } {
+	if (selection.kind === "none") {
+		return { selectedSet: new Set<string>(), inRangeSet: new Set<string>() };
+	}
+	const indexByHash = new Map<string, number>();
+	for (let i = 0; i < hashes.length; i++) indexByHash.set(hashes[i], i);
+	if (selection.kind === "commit") {
+		return {
+			selectedSet: new Set([selection.hash]),
+			inRangeSet: new Set<string>(),
+		};
+	}
+	const selected = new Set<string>();
+	const inRange = new Set<string>();
+	const fromIdx = indexByHash.get(selection.fromHash);
+	const toIdx = indexByHash.get(selection.toHash);
+	if (fromIdx !== undefined) selected.add(selection.fromHash);
+	if (toIdx !== undefined) selected.add(selection.toHash);
+	if (fromIdx !== undefined && toIdx !== undefined) {
+		const lo = Math.min(fromIdx, toIdx);
+		const hi = Math.max(fromIdx, toIdx);
+		for (let i = lo + 1; i < hi; i++) inRange.add(hashes[i]);
+	}
+	return { selectedSet: selected, inRangeSet: inRange };
+}
+
+interface GraphTabContentProps {
+	commits: GraphCommit[];
+	totalCommits: number | null;
+	/** A nextCursor was returned — more commits exist beyond the fetched window. */
+	hasMore: boolean;
+	limit: number;
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	error?: unknown;
+	compact: boolean;
+	laneCap: number;
+	showDate: boolean;
+	/** Which refs seed the traversal. Shown in the strip's scope chooser. */
+	refScope?: GraphRefScope;
+	onSelectRefScope?: (scope: GraphRefScope) => void;
+	/** Put ref badges on their own line (§4.2). Drives estimateSize + GraphRow. */
+	twoLineRefs?: boolean;
+	onToggleTwoLineRefs?: () => void;
+	/** Dim referenced commits so unreferenced refs stand out (§4.3). */
+	unreferencedOnly?: boolean;
+	onToggleUnreferencedOnly?: () => void;
+	selection: GraphSelection;
+	onSelectRow: (
+		hash: string,
+		modifiers: { shiftKey: boolean; metaKey: boolean },
+	) => void;
+	/** Pin the preview pane a single click just opened (double-click). */
+	onDoubleClickRow: (hash: string) => void;
+	/** Open a commit diff pane in a new tab/pane (row context menu). */
+	onOpenInNewTab?: (hash: string) => void;
+}
+
+export function GraphTabContent({
+	commits,
+	totalCommits,
+	hasMore,
+	limit: _limit,
+	isLoading,
+	isFetching,
+	isError,
+	error,
+	compact,
+	laneCap,
+	showDate,
+	refScope = "local",
+	onSelectRefScope,
+	twoLineRefs = false,
+	onToggleTwoLineRefs,
+	unreferencedOnly = false,
+	onToggleUnreferencedOnly,
+	selection,
+	onSelectRow,
+	onDoubleClickRow,
+	onOpenInNewTab,
+}: GraphTabContentProps) {
+	const rows = useMemo(() => assignLanes(commits), [commits]);
+	const listRef = useRef<HTMLDivElement>(null);
+	const { copyToClipboard } = useCopyToClipboard();
+
+	// Row context menu: read-only copy actions + open-in-new-tab. Handled by
+	// event delegation on the list (closest [data-hash]) so GraphRow stays a
+	// pure presentational component. A controlled DropdownMenu anchored at the
+	// cursor handles positioning and outside-click, mirroring the file-tree row.
+	const [menu, setMenu] = useState<{
+		commit: GraphCommit;
+		x: number;
+		y: number;
+	} | null>(null);
+	const closeMenu = useCallback(() => setMenu(null), []);
+	const handleContextMenu = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			const target = (event.target as HTMLElement).closest("[data-hash]");
+			const hash = target?.getAttribute("data-hash");
+			if (!hash) return;
+			const row = rows.find((r) => r.commit.hash === hash);
+			if (!row) return;
+			event.preventDefault();
+			setMenu({ commit: row.commit, x: event.clientX, y: event.clientY });
+		},
+		[rows],
+	);
+	const copyValue = useCallback(
+		async (text: string, label: string) => {
+			try {
+				await copyToClipboard(text);
+				toast.success(`${label} copied`);
+			} catch (err: unknown) {
+				toast.error(
+					`Failed to copy: ${err instanceof Error ? err.message : "Unknown error"}`,
+				);
+			}
+		},
+		[copyToClipboard],
+	);
+
+	const sizer = useMemo(
+		() => graphRowSizer(rows, { compact, twoLineRefs }),
+		[rows, compact, twoLineRefs],
+	);
+	const virtualizer = useVirtualizer({
+		count: rows.length,
+		getScrollElement: () => listRef.current,
+		estimateSize: sizer.estimateSize,
+		// Key the size cache by commit, not by index. Refs move while the tab is
+		// open, so a refetch that prepends one commit shifts every index by one —
+		// with the default index key, a two-line row inherits the cached height of
+		// whatever used to sit at its position and either overlaps the row below
+		// (cached too short) or leaves a blank band (cached too tall).
+		getItemKey: sizer.getItemKey,
+		overscan: OVERSCAN,
+	});
+
+	// Row height is a function of (refs, compact, twoLineRefs); the virtualizer
+	// caches sizes, so anything that changes one needs an explicit remeasure or
+	// the list keeps the old offsets. `rows` is in here because a ref landing on
+	// or leaving a commit changes that commit's height at an unchanged hash,
+	// which getItemKey alone cannot catch.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: estimateSize closes over rows/compact/twoLineRefs via graphRowHeight; remeasure when any changes (the effect body only touches virtualizer).
+	useEffect(() => {
+		virtualizer.measure();
+	}, [virtualizer, rows, compact, twoLineRefs]);
+
+	const items = virtualizer.getVirtualItems();
+
+	const hashes = useMemo(() => rows.map((r) => r.commit.hash), [rows]);
+	// Per-row highlight sets (see resolveRowSelection). Memoized on the hash
+	// list + selection so a scroll-only render doesn't recompute.
+	const { selectedSet, inRangeSet } = useMemo(
+		() => resolveRowSelection(selection, hashes),
+		[hashes, selection],
+	);
+
+	// Cache-first (AGENTS rule 11): existing rows keep rendering while a
+	// background refetch is in flight. The status flags only decide what to
+	// show when there is no data yet.
+	const showLoading = rows.length === 0 && isLoading;
+	const showError = rows.length === 0 && isError;
+	const showEmpty = rows.length === 0 && !isLoading && !isError;
+
+	const truncated = totalCommits != null ? totalCommits > rows.length : hasMore;
+	const shownCount = rows.length;
+
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			{/* One control strip: truncation copy on the left, the graph's own
+			    scope chooser + toggles on the right. Deliberately not
+			    SidebarHeader's `actions` slot — see GraphHeaderActions. Rendered
+			    even with zero rows: a scope that returns nothing would otherwise
+			    take its own chooser away and strand the graph empty. */}
+			{onSelectRefScope && onToggleTwoLineRefs && onToggleUnreferencedOnly && (
+				<div className="flex h-6 shrink-0 items-center gap-1 border-b border-border bg-muted/40 px-2">
+					<span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
+						{truncated && shownCount > 0
+							? `Showing first ${shownCount}${totalCommits != null ? ` of ${totalCommits}` : ""} commits`
+							: null}
+					</span>
+					<span className="flex shrink-0 items-center gap-0.5">
+						<GraphHeaderActions
+							refScope={refScope}
+							onSelectRefScope={onSelectRefScope}
+							twoLineRefs={twoLineRefs}
+							onToggleTwoLineRefs={onToggleTwoLineRefs}
+							unreferencedOnly={unreferencedOnly}
+							onToggleUnreferencedOnly={onToggleUnreferencedOnly}
+						/>
+					</span>
+				</div>
+			)}
+			{isFetching && shownCount > 0 && (
+				<div className="shrink-0 bg-muted/30 px-2 py-0.5 text-[10px] text-muted-foreground">
+					Updating…
+				</div>
+			)}
+			{showLoading && (
+				<div className="px-3 py-6 text-center text-xs text-muted-foreground">
+					Loading commits…
+				</div>
+			)}
+			{showError && (
+				<div className="select-text cursor-text px-3 py-6 text-center text-xs text-destructive">
+					{error instanceof Error ? error.message : "Failed to load git graph"}
+				</div>
+			)}
+			{showEmpty && (
+				<div className="px-3 py-6 text-center text-xs text-muted-foreground">
+					No commits yet
+				</div>
+			)}
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: delegated right-click context menu for a virtualized commit list */}
+			<div
+				ref={listRef}
+				className="min-h-0 flex-1 overflow-y-auto"
+				onContextMenu={handleContextMenu}
+			>
+				<div
+					className="relative w-full"
+					style={{ height: virtualizer.getTotalSize() }}
+				>
+					{items.map((virtualRow) => {
+						const row = rows[virtualRow.index];
+						const hash = row.commit.hash;
+						return (
+							<div
+								key={hash}
+								data-index={virtualRow.index}
+								data-hash={hash}
+								className="absolute left-0 w-full"
+								style={{ top: virtualRow.start }}
+							>
+								<GraphRow
+									row={row}
+									compact={compact}
+									selected={selectedSet.has(hash)}
+									inRange={inRangeSet.has(hash)}
+									onSelect={(event) =>
+										onSelectRow(hash, {
+											shiftKey: event.shiftKey,
+											metaKey: event.metaKey || event.ctrlKey,
+										})
+									}
+									onDoubleClick={() => onDoubleClickRow(hash)}
+									laneCap={laneCap}
+									showDate={showDate}
+									twoLineRefs={twoLineRefs}
+									dimmed={
+										unreferencedOnly && !hasUnreferencedRef(row.commit.refs)
+									}
+								/>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+			{menu && (
+				<DropdownMenu open onOpenChange={(open) => !open && closeMenu()}>
+					<DropdownMenuTrigger asChild>
+						<span
+							aria-hidden
+							style={{
+								position: "fixed",
+								left: menu.x,
+								top: menu.y,
+								width: 0,
+								height: 0,
+								pointerEvents: "none",
+							}}
+						/>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent className="w-52" align="start">
+						<DropdownMenuItem
+							onSelect={() => void copyValue(menu.commit.hash, "Hash")}
+						>
+							<Clipboard />
+							Copy Hash
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() =>
+								void copyValue(menu.commit.shortHash, "Short hash")
+							}
+						>
+							<Hash />
+							Copy Short Hash
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => void copyValue(menu.commit.message, "Subject")}
+						>
+							<FileText />
+							Copy Subject
+						</DropdownMenuItem>
+						{onOpenInNewTab && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem
+									onSelect={() => {
+										onOpenInNewTab(menu.commit.hash);
+										closeMenu();
+									}}
+								>
+									<ExternalLink />
+									Open in New Tab
+								</DropdownMenuItem>
+							</>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/GraphTabContent/index.ts
@@ -1,0 +1,5 @@
+export {
+	type GraphSelection,
+	GraphTabContent,
+	resolveRowSelection,
+} from "./GraphTabContent";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/RefBadge.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/RefBadge.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { GraphRef } from "../../types";
+import { RefBadge } from "./RefBadge";
+
+function render(ref: GraphRef, { compact = false, laneColor = 1 } = {}) {
+	return renderToStaticMarkup(
+		<RefBadge graphRef={ref} compact={compact} laneColor={laneColor} />,
+	);
+}
+
+describe("RefBadge", () => {
+	it("renders HEAD as bare text with no glyph", () => {
+		const markup = render({ name: "HEAD", type: "head", state: null });
+		expect(markup).toContain("HEAD");
+		// A head badge carries no lucide icon (branch/tag do, as <svg>).
+		expect(markup).not.toContain("<svg");
+	});
+
+	it("uses a branch glyph for branch and remote, a tag glyph for tag", () => {
+		// branch + remote both use the GitBranch icon; tag uses Tag. All three
+		// render exactly one lucide <svg>.
+		for (const type of ["branch", "remote"] as const) {
+			const markup = render({ name: "main", type, state: null });
+			expect(markup).toMatch(/<svg[^>]*>/);
+		}
+		expect(render({ name: "v1", type: "tag", state: null })).toMatch(
+			/<svg[^>]*>/,
+		);
+	});
+
+	it("tints an open badge with its lane colour", () => {
+		const markup = render(
+			{ name: "main", type: "branch", state: "open" },
+			{ laneColor: 4 },
+		);
+		expect(markup).toContain("var(--graph-lane-4)");
+		expect(markup).toContain("18%");
+		// Non-open badges do not carry the lane tint.
+		const closed = render({
+			name: "main",
+			type: "branch",
+			state: "merged",
+		});
+		expect(closed).not.toContain("var(--graph-lane-");
+	});
+
+	it("strikes and flags a prunable ref, surfacing the prune reason", () => {
+		const markup = render({
+			name: "fix/pty",
+			type: "branch",
+			state: "prunable",
+			pruneReason: "worktree path is gone",
+		});
+		expect(markup).toContain("line-through");
+		expect(markup).toContain("border-destructive");
+		// The prune reason rides in the tooltip, not the visible name.
+		expect(markup).toContain('title="fix/pty — worktree path is gone"');
+	});
+
+	it("mutes a merged ref and underlines an orphan", () => {
+		expect(
+			render({ name: "docs/x", type: "branch", state: "merged" }),
+		).toContain("bg-muted");
+		expect(
+			render({ name: "chore/x", type: "branch", state: "orphan-branch" }),
+		).toContain("underline");
+	});
+
+	it("dashes a detached-worktree border and shows the worktree path", () => {
+		const markup = render({
+			name: "feat/x",
+			type: "branch",
+			state: "detached-worktree",
+			worktreePath: "/tmp/wt/x",
+		});
+		expect(markup).toContain("border-dashed");
+		expect(markup).toContain('title="feat/x — /tmp/wt/x"');
+	});
+
+	it("shrinks the badge in compact mode", () => {
+		const standard = render(
+			{ name: "main", type: "branch", state: "open" },
+			{ compact: false },
+		);
+		const compact = render(
+			{ name: "main", type: "branch", state: "open" },
+			{ compact: true },
+		);
+		expect(standard).toContain("h-4");
+		expect(standard).toContain("text-[11px]");
+		expect(compact).toContain("h-3.5");
+		expect(compact).toContain("text-[10px]");
+	});
+
+	it("shows the full remote shortname without stripping a prefix", () => {
+		// check-git-ref-strings.sh forbids inferring kind from a shortname
+		// prefix; the remote name must render verbatim.
+		const markup = render({ name: "origin/main", type: "remote", state: null });
+		expect(markup).toContain("origin/main");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/RefBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/RefBadge.tsx
@@ -1,0 +1,101 @@
+import { cn } from "@superset/ui/utils";
+import { GitBranch, Tag } from "lucide-react";
+import type { GraphRef, GraphRefState } from "../../types";
+
+interface RefBadgeProps {
+	graphRef: GraphRef;
+	compact: boolean;
+	/** 1-8; only `open` badges tint themselves with their lane's colour. */
+	laneColor: number;
+	/**
+	 * Drop the width cap. Only for a two-line row, where the badge owns the
+	 * line and there is nothing left to starve — inline, the cap is what stops
+	 * a long branch name from eating the subject.
+	 */
+	untrimmed?: boolean;
+}
+
+// State is encoded in texture as well as colour — fill means claimed, dashes
+// mean stale, a strike means broken. That reads at 260px, survives a
+// colourblind viewer, and leaves hue free for lane identity.
+const STATE_CLASSES: Record<GraphRefState, string> = {
+	open: "text-foreground",
+	"detached-worktree": "border-dashed border-border text-muted-foreground",
+	"orphan-branch":
+		"px-0.5 text-muted-foreground underline decoration-dotted underline-offset-[3px]",
+	prunable: "border-dashed border-destructive/60 text-destructive",
+	merged: "bg-muted text-muted-foreground opacity-90",
+};
+
+function tooltip(graphRef: GraphRef): string {
+	if (graphRef.state === "prunable" && graphRef.pruneReason) {
+		return `${graphRef.name} — ${graphRef.pruneReason}`;
+	}
+	if (graphRef.worktreePath)
+		return `${graphRef.name} — ${graphRef.worktreePath}`;
+	return graphRef.name;
+}
+
+export function RefBadge({
+	graphRef,
+	compact,
+	laneColor,
+	untrimmed = false,
+}: RefBadgeProps) {
+	const base = cn(
+		"inline-flex shrink-0 items-center gap-[3px] overflow-hidden text-ellipsis whitespace-nowrap rounded-sm border border-transparent px-[5px] font-medium font-mono text-muted-foreground",
+		compact ? "h-3.5 text-[10px]" : "h-4 text-[11px]",
+		!untrimmed && (compact ? "max-w-[8ch]" : "max-w-[12ch]"),
+		// After the size classes: tailwind-merge treats an arbitrary text-[..]
+		// as a font-size/line-height pair and drops an earlier leading-*.
+		"leading-none",
+	);
+
+	if (graphRef.type === "head") {
+		return (
+			<span className={cn(base, "border-border font-semibold text-foreground")}>
+				HEAD
+			</span>
+		);
+	}
+
+	const Icon = graphRef.type === "tag" ? Tag : GitBranch;
+	const isOpen = graphRef.state === "open";
+
+	return (
+		<span
+			className={cn(
+				base,
+				graphRef.state ? STATE_CLASSES[graphRef.state] : "border-border",
+			)}
+			style={
+				isOpen
+					? {
+							backgroundColor: `color-mix(in oklch, var(--graph-lane-${laneColor}) 18%, transparent)`,
+							borderColor: `color-mix(in oklch, var(--graph-lane-${laneColor}) 55%, transparent)`,
+						}
+					: undefined
+			}
+			title={tooltip(graphRef)}
+		>
+			<Icon
+				className="shrink-0"
+				size={10}
+				strokeWidth={2}
+				style={
+					isOpen
+						? { color: `var(--graph-lane-${laneColor})` }
+						: { opacity: 0.75 }
+				}
+			/>
+			<span
+				className={cn(
+					"overflow-hidden text-ellipsis",
+					graphRef.state === "prunable" && "line-through",
+				)}
+			>
+				{graphRef.name}
+			</span>
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/components/RefBadge/index.ts
@@ -1,0 +1,1 @@
+export { RefBadge } from "./RefBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/index.ts
@@ -1,0 +1,1 @@
+export { useGraphTab } from "./useGraphTab";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/types.ts
@@ -1,0 +1,89 @@
+// Seam between the graph's data/algorithm layer and its presentation layer.
+// `assignLanes` produces GraphRowModel[]; GraphRow / GraphLanes / RefBadge
+// consume it. Nothing here imports React, tRPC, or a collection.
+//
+// Geometry and colour live in apps/desktop/plans/20260801-1200-git-graph-visual-spec.md.
+
+/** How a ref decorates a commit. Classified from a full refname via ResolvedRef — never a shortname prefix. */
+export type GraphRefType = "head" | "branch" | "remote" | "tag";
+
+/** Which refs seed the traversal. Mirrors host-service `GraphRefScope` and the
+ *  persisted `graphRefScope` enum. */
+export type GraphRefScope =
+	| "local"
+	| "open-workspaces"
+	| "remote"
+	| "all"
+	| "head";
+
+/**
+ * Whether a local branch is claimed by an open workspace, sitting on disk
+ * unclaimed, or nothing but a name. Remote refs, tags and HEAD carry `null`.
+ */
+export type GraphRefState =
+	| "open"
+	| "detached-worktree"
+	| "orphan-branch"
+	| "prunable"
+	| "merged";
+
+export interface GraphRef {
+	name: string;
+	type: GraphRefType;
+	state: GraphRefState | null;
+	worktreePath?: string;
+	/** Absent when the worktree has no open Superset workspace. */
+	worktreeWorkspaceId?: string;
+	/** Only on `prunable`; surfaced in the badge's tooltip. */
+	pruneReason?: string;
+}
+
+export interface GraphCommit {
+	hash: string;
+	shortHash: string;
+	message: string;
+	author: string;
+	authorEmail: string;
+	date: string;
+	parents: string[];
+	refs: GraphRef[];
+}
+
+/**
+ * One painted segment in a row's lane column.
+ *
+ * - `pass` — lane crosses the row untouched
+ * - `in-straight` — the commit's own lane, entering from above
+ * - `in-merge` — another lane awaiting this commit, closing into the node
+ * - `out-straight` — first parent inherits the lane
+ * - `out-fork` — an extra parent leaves toward another lane
+ * - `out-stub` — parent lies outside the fetched window; renders dashed and stops short
+ */
+export type GraphEdgeKind =
+	| "pass"
+	| "in-straight"
+	| "in-merge"
+	| "out-straight"
+	| "out-fork"
+	| "out-stub";
+
+export interface GraphEdge {
+	kind: GraphEdgeKind;
+	fromLane: number;
+	toLane: number;
+	/** 1-8, indexing --graph-lane-N. Keyed to the lane's originating branch, not its position. */
+	color: GraphLaneColor;
+}
+
+export type GraphLaneColor = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+export interface GraphRowModel {
+	commit: GraphCommit;
+	lane: number;
+	color: GraphLaneColor;
+	isMerge: boolean;
+	isRoot: boolean;
+	edges: GraphEdge[];
+	/** Lanes live in this row, before the visible-lane cap is applied. */
+	laneCount: number;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/useGraphTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/useGraphTab.tsx
@@ -1,0 +1,224 @@
+import { workspaceTrpc } from "@superset/workspace-client";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback } from "react";
+import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { GraphSelection } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { SidebarTabDefinition } from "../../types";
+import {
+	GraphTabContent,
+	type GraphSelection as GraphTabSelection,
+} from "./components/GraphTabContent";
+import type { GraphRefScope } from "./types";
+
+// One page. The truncation banner in GraphTabContent surfaces when the repo
+// has more history than this; pagination/fetch-next is a phase-6 concern.
+const GRAPH_LIMIT = 500;
+
+export interface UseGraphTabParams {
+	workspaceId: string;
+	compact: boolean;
+	laneCap: number;
+	showDate: boolean;
+	/** Open a commit/range diff pane for a graph click. Wired to the workspace
+	 *  store's ref-carrying diff-pane opener in page.tsx. */
+	onOpenCommitRef?: (ref: GraphSelection, openInNewTab?: boolean) => void;
+	/** Pin the diff pane a single click just opened (double-click). */
+	onPinCommitPane?: () => void;
+}
+
+export function useGraphTab({
+	workspaceId,
+	compact,
+	laneCap,
+	showDate,
+	onOpenCommitRef,
+	onPinCommitPane,
+}: UseGraphTabParams): SidebarTabDefinition {
+	const collections = useCollections();
+	const utils = workspaceTrpc.useUtils();
+	const { ensureProjectInSidebar } = useDashboardSidebarState();
+
+	// Live query so the row highlight re-renders the moment a graph click (or a
+	// selection made elsewhere) updates the persisted graphSelection.
+	const { data: [localState] = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ state: collections.v2WorkspaceLocalState })
+				.where(({ state }) => eq(state.workspaceId, workspaceId)),
+		[collections, workspaceId],
+	);
+
+	const projectId = localState?.sidebarState?.projectId;
+
+	// A live query, not `.get()`. The header toggles below write to this
+	// collection, and `.get()` is a non-reactive snapshot — the row would change
+	// in localStorage while the header kept rendering the stale flag until some
+	// unrelated re-render happened to run, which reads as a multi-second lag on
+	// a write that already completed.
+	const { data: [projectRow] = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ sidebarProject: collections.v2SidebarProjects })
+				.where(({ sidebarProject }) =>
+					eq(sidebarProject.projectId, projectId ?? ""),
+				),
+		[collections, projectId],
+	);
+
+	// Read defensively: project rows pre-dating these fields have them undefined.
+	const graphRefScope = projectRow?.graphRefScope || "local";
+	const twoLineRefs = projectRow?.graphTwoLineRefs ?? false;
+	const unreferencedOnly = projectRow?.graphUnreferencedOnly ?? false;
+
+	const baseBranchQuery = workspaceTrpc.git.getBaseBranch.useQuery(
+		{ workspaceId },
+		{ staleTime: Number.POSITIVE_INFINITY },
+	);
+	const baseBranch = baseBranchQuery.data?.baseBranch ?? null;
+
+	const graphQuery = workspaceTrpc.git.listGraph.useQuery(
+		{
+			workspaceId,
+			baseBranch: baseBranch ?? undefined,
+			refScope: graphRefScope,
+			limit: GRAPH_LIMIT,
+		},
+		{ staleTime: 30_000 },
+	);
+
+	// Invalidate only on broad git state changes. When `paths` is present the
+	// event is a worktree-only edit (file content), which can't move refs, so
+	// the graph is unchanged and we skip the refetch.
+	useWorkspaceEvent("git:changed", workspaceId, (payload) => {
+		if (payload.paths && payload.paths.length > 0) return;
+		void utils.git.listGraph.invalidate();
+	});
+
+	// The graph owns its own selection (graphSelection), separate from the
+	// Changes tab's changesFilter. Clicking around the graph no longer retargets
+	// the Changes tab — the two surfaces no longer fight over one selection.
+	const graphSelection = localState?.sidebarState?.graphSelection ?? null;
+	const selection: GraphTabSelection =
+		graphSelection?.kind === "commit"
+			? { kind: "commit", hash: graphSelection.hash }
+			: graphSelection?.kind === "range"
+				? {
+						kind: "range",
+						fromHash: graphSelection.fromHash,
+						toHash: graphSelection.toHash,
+					}
+				: { kind: "none" };
+
+	// Row click selects a single commit (the new anchor) and opens its diff
+	// pane; shift-click extends from the anchor into a range. cmd/ctrl-click
+	// forces a new pane. The anchor is the last single-commit selection, or the
+	// start of the current range, so repeated shift-clicks keep extending from
+	// the same origin.
+	const handleSelectRow = useCallback(
+		(
+			hash: string,
+			{ shiftKey, metaKey }: { shiftKey: boolean; metaKey: boolean },
+		) => {
+			const current =
+				collections.v2WorkspaceLocalState.get(workspaceId)?.sidebarState
+					?.graphSelection ?? null;
+			const anchor =
+				current?.kind === "commit"
+					? current.hash
+					: current?.kind === "range"
+						? current.fromHash
+						: null;
+			const ref: GraphSelection =
+				shiftKey && anchor && anchor !== hash
+					? { kind: "range", fromHash: anchor, toHash: hash }
+					: { kind: "commit", hash };
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.sidebarState.graphSelection = ref;
+			});
+			onOpenCommitRef?.(ref, metaKey);
+		},
+		[collections, workspaceId, onOpenCommitRef],
+	);
+
+	// Double-click pins the preview pane the first click already opened — the
+	// identical "click an active row to pin" convention the file tree uses. No
+	// debounce: the single click opens immediately, this just flips the pin.
+	const handleDoubleClickRow = useCallback(() => {
+		onPinCommitPane?.();
+	}, [onPinCommitPane]);
+
+	// Row context menu → always a fresh commit pane, never a reuse.
+	const handleOpenInNewTab = useCallback(
+		(hash: string) => {
+			onOpenCommitRef?.({ kind: "commit", hash }, true);
+		},
+		[onOpenCommitRef],
+	);
+
+	// `ensureProjectInSidebar` first, matching useV2ProjectDefaultApp: a project
+	// with no sidebar row yet would otherwise swallow the write entirely. It is
+	// idempotent — an existing row is left untouched.
+	const toggleTwoLineRefs = useCallback(() => {
+		if (!projectId) return;
+		ensureProjectInSidebar(projectId);
+		collections.v2SidebarProjects.update(projectId, (draft) => {
+			draft.graphTwoLineRefs = !draft.graphTwoLineRefs;
+		});
+	}, [collections, ensureProjectInSidebar, projectId]);
+	const selectRefScope = useCallback(
+		(scope: GraphRefScope) => {
+			if (!projectId) return;
+			ensureProjectInSidebar(projectId);
+			collections.v2SidebarProjects.update(projectId, (draft) => {
+				draft.graphRefScope = scope;
+			});
+		},
+		[collections, ensureProjectInSidebar, projectId],
+	);
+	const toggleUnreferencedOnly = useCallback(() => {
+		if (!projectId) return;
+		ensureProjectInSidebar(projectId);
+		collections.v2SidebarProjects.update(projectId, (draft) => {
+			draft.graphUnreferencedOnly = !draft.graphUnreferencedOnly;
+		});
+	}, [collections, ensureProjectInSidebar, projectId]);
+
+	const commits = graphQuery.data?.commits ?? [];
+	const totalCommits = graphQuery.data?.totalCommits ?? null;
+	const hasMore = graphQuery.data?.nextCursor != null;
+
+	const content = (
+		<GraphTabContent
+			commits={commits}
+			totalCommits={totalCommits}
+			hasMore={hasMore}
+			limit={GRAPH_LIMIT}
+			isLoading={graphQuery.isLoading}
+			isFetching={graphQuery.isFetching}
+			isError={graphQuery.isError}
+			error={graphQuery.error}
+			compact={compact}
+			laneCap={laneCap}
+			showDate={showDate}
+			refScope={graphRefScope}
+			onSelectRefScope={selectRefScope}
+			twoLineRefs={twoLineRefs}
+			onToggleTwoLineRefs={toggleTwoLineRefs}
+			unreferencedOnly={unreferencedOnly}
+			onToggleUnreferencedOnly={toggleUnreferencedOnly}
+			selection={selection}
+			onSelectRow={handleSelectRow}
+			onDoubleClickRow={handleDoubleClickRow}
+			onOpenInNewTab={handleOpenInNewTab}
+		/>
+	);
+
+	return {
+		id: "graph",
+		label: "Graph",
+		content,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "bun:test";
+import type {
+	GraphCommit,
+	GraphEdge,
+	GraphLaneColor,
+	GraphRef,
+	GraphRowModel,
+} from "../../types";
+import { assignLanes } from "./assignLanes";
+
+const FULL = "0000000000000000000000000000000000";
+
+/** Pads a short label into a 40-char hash so parent refs match commit hashes. */
+const full = (h: string): string => `${h}${FULL}`.slice(0, 40);
+
+function commit(
+	hash: string,
+	parents: string[],
+	refs: GraphRef[] = [],
+): GraphCommit {
+	return {
+		hash: full(hash),
+		shortHash: hash.padEnd(7, "0").slice(0, 7),
+		message: hash,
+		author: "Ada",
+		authorEmail: "ada@example.com",
+		date: "2026-07-31T09:00:00Z",
+		// Parents are padded too, so `present.has(parent)` resolves correctly.
+		parents: parents.map(full),
+		refs,
+	};
+}
+
+function branch(name: string): GraphRef {
+	return { name, type: "branch", state: null };
+}
+
+function kinds(row: GraphRowModel): GraphEdge["kind"][] {
+	return row.edges.map((e) => e.kind);
+}
+
+/** Geometry snapshot — the computed layout, independent of the commit payload. */
+function geometry(row: GraphRowModel) {
+	return {
+		lane: row.lane,
+		color: row.color,
+		isMerge: row.isMerge,
+		isRoot: row.isRoot,
+		laneCount: row.laneCount,
+		edges: row.edges,
+	};
+}
+
+/** Asserts every edge stays inside [0, laneCount), colours are 1..8, keys unique. */
+function assertValidRows(rows: GraphRowModel[]): void {
+	for (const row of rows) {
+		expect(row.lane, "lane inside laneCount").toBeGreaterThanOrEqual(0);
+		expect(row.lane, "lane inside laneCount").toBeLessThan(row.laneCount);
+		expect(row.color, "colour in 1..8").toBeGreaterThanOrEqual(1);
+		expect(row.color, "colour in 1..8").toBeLessThanOrEqual(8);
+		const seen = new Set<string>();
+		for (const edge of row.edges) {
+			expect(edge.color, "edge colour in 1..8").toBeGreaterThanOrEqual(1);
+			expect(edge.color, "edge colour in 1..8").toBeLessThanOrEqual(8);
+			expect(edge.fromLane, "fromLane inside laneCount").toBeLessThan(
+				row.laneCount,
+			);
+			expect(edge.toLane, "toLane inside laneCount").toBeLessThan(
+				row.laneCount,
+			);
+			const key = `${edge.kind}-${edge.fromLane}-${edge.toLane}`;
+			expect(seen.has(key), `duplicate edge key ${key}`).toBe(false);
+			seen.add(key);
+		}
+	}
+}
+
+function findRow(rows: GraphRowModel[], hash: string): GraphRowModel {
+	const row = rows.find((r) => r.commit.hash.startsWith(hash));
+	if (!row) throw new Error(`no row for ${hash}`);
+	return row;
+}
+
+describe("assignLanes", () => {
+	it("lays a linear chain on one lane with straight edges", () => {
+		const c = commit("c", ["b"], [branch("main")]);
+		const b = commit("b", ["a"]);
+		const a = commit("a", []);
+		const rows = assignLanes([c, b, a]);
+
+		assertValidRows(rows);
+		expect(rows.map((r) => r.lane)).toEqual([0, 0, 0]);
+		// The tip opens its lane here — nothing above it, so no incoming edge.
+		expect(kinds(rows[0])).toEqual(["out-straight"]);
+		expect(kinds(rows[1])).toEqual(["in-straight", "out-straight"]);
+		expect(kinds(rows[2])).toEqual(["in-straight"]); // root: no outgoing edge
+		expect(rows[2].isRoot).toBe(true);
+		// Colour seeded once from the tip's branch and inherited downwards.
+		const color = rows[0].color;
+		expect(rows.map((r) => r.color)).toEqual([color, color, color]);
+	});
+
+	it("forks an extra parent into its own lane on a simple merge", () => {
+		const m = commit("m", ["a", "b"], [branch("main")]);
+		const a = commit("a", ["r"]);
+		const b = commit("b", ["r"]);
+		const r = commit("r", []);
+		const rows = assignLanes([m, a, b, r]);
+
+		assertValidRows(rows);
+		const mRow = findRow(rows, "m");
+		const bRow = findRow(rows, "b");
+		const rRow = findRow(rows, "r");
+
+		expect(mRow.isMerge).toBe(true);
+		expect(mRow.lane).toBe(0);
+		// First parent straight, second parent forks into a new lane.
+		expect(mRow.edges).toContainEqual({
+			kind: "out-straight",
+			fromLane: 0,
+			toLane: 0,
+			color: mRow.color,
+		});
+		const fork = mRow.edges.find((e) => e.kind === "out-fork");
+		if (!fork)
+			throw new Error("expected an out-fork edge to the second parent");
+		expect(fork.fromLane).toBe(0);
+		expect(fork.toLane).toBeGreaterThan(0);
+		expect(bRow.lane).toBe(fork.toLane);
+
+		// Root: one lane is its own (in-straight), the other merges in.
+		const mergesIntoRoot = rRow.edges.filter((e) => e.kind === "in-merge");
+		expect(mergesIntoRoot.length, "one lane converges via in-merge").toBe(1);
+		expect(mergesIntoRoot[0].toLane).toBe(rRow.lane);
+		expect(rRow.laneCount, "both lanes visible at the root").toBe(2);
+	});
+
+	it("emits one out-fork per extra parent on an octopus merge", () => {
+		const o = commit("o", ["a", "b", "c"], [branch("main")]);
+		const a = commit("a", ["r"]);
+		const b = commit("b", ["r"]);
+		const c = commit("c", ["r"]);
+		const r = commit("r", []);
+		const rows = assignLanes([o, a, b, c, r]);
+
+		assertValidRows(rows);
+		const octopus = findRow(rows, "o");
+		expect(octopus.isMerge).toBe(true);
+		expect(octopus.edges.filter((e) => e.kind === "out-straight").length).toBe(
+			1,
+		);
+		const forks = octopus.edges.filter((e) => e.kind === "out-fork");
+		expect(forks.length, "two out-fork edges for the two extra parents").toBe(
+			2,
+		);
+		expect(
+			new Set(forks.map((f) => f.toLane)).size,
+			"each extra parent gets its own lane",
+		).toBe(2);
+	});
+
+	it("survives a criss-cross without invalid lanes or duplicate edges", () => {
+		// Two merges over the same pair of branches — the classic hard case.
+		const r = commit("r", []);
+		const a = commit("a", ["r"]);
+		const b = commit("b", ["r"]);
+		const m1 = commit("m1", ["a", "b"], [branch("feature")]);
+		const m2 = commit("m2", ["a", "b"], [branch("release")]);
+		const rows = assignLanes([m1, m2, a, b, r]);
+
+		assertValidRows(rows);
+		const mergeRows = rows.filter((row) => row.isMerge);
+		expect(mergeRows.length).toBe(2);
+		// Each merge forks its second parent out, regardless of lane reuse above.
+		for (const mergeRow of mergeRows) {
+			expect(mergeRow.edges.filter((e) => e.kind === "out-fork").length).toBe(
+				1,
+			);
+		}
+		expect(findRow(rows, "r").isRoot).toBe(true);
+	});
+
+	it("marks a parentless commit as a root and frees its lane", () => {
+		const a = commit("a", [], [branch("main")]);
+		const rows = assignLanes([a]);
+
+		assertValidRows(rows);
+		expect(rows[0].isRoot).toBe(true);
+		// A lone tip-and-root: nothing above to come from, nothing below to go to.
+		expect(kinds(rows[0])).toEqual([]);
+	});
+
+	it("emits no incoming edge for a branch tip", () => {
+		// Two tips over a shared trunk: c is the graph tip (main), f is a
+		// dangling branch tip (feature). Both open their lane at the top, so
+		// neither has anything above it to draw an incoming edge from. b,
+		// reached by both, still gets its incoming edges — proving the
+		// suppression is specific to lanes opened in their own row.
+		const c = commit("c", ["b"], [branch("main")]);
+		const f = commit("f", ["b"], [branch("feature")]);
+		const b = commit("b", ["a"]);
+		const a = commit("a", []);
+		const rows = assignLanes([c, f, b, a]);
+
+		assertValidRows(rows);
+		const cRow = findRow(rows, "c");
+		const fRow = findRow(rows, "f");
+		const bRow = findRow(rows, "b");
+
+		const incoming = (row: GraphRowModel) =>
+			row.edges.filter(
+				(e) => e.kind === "in-straight" || e.kind === "in-merge",
+			);
+		expect(incoming(cRow), "graph tip has no incoming edge").toEqual([]);
+		expect(incoming(fRow), "dangling tip has no incoming edge").toEqual([]);
+		// b is reached by both tips: one lane continues straight in, the other
+		// merges into the node.
+		expect(bRow.edges.filter((e) => e.kind === "in-straight").length).toBe(1);
+		expect(bRow.edges.filter((e) => e.kind === "in-merge").length).toBe(1);
+	});
+
+	it("reuses a lane freed by a stub for the next unrelated commit", () => {
+		// 'a' stubs off (parent outside the window), freeing lane 0. 'b' is an
+		// unrelated root that should claim the same slot.
+		const a = commit("a", ["outside"], [branch("main")]);
+		const b = commit("b", [], [branch("other")]);
+		const rows = assignLanes([a, b]);
+
+		assertValidRows(rows);
+		expect(kinds(rows[0])).toContain("out-stub");
+		expect(rows[1].lane, "freed lane reused").toBe(0);
+		expect(rows[1].isRoot).toBe(true);
+	});
+
+	it("stubs a first parent that falls outside the window without throwing", () => {
+		const a = commit("a", ["not-present"], [branch("main")]);
+		const rows = assignLanes([a]);
+
+		assertValidRows(rows);
+		expect(kinds(rows[0])).toEqual(["out-stub"]);
+		expect(rows[0].laneCount).toBe(1);
+	});
+
+	it("stubs a forked extra parent outside the window and frees its lane", () => {
+		const m = commit("m", ["a", "gone"], [branch("main")]);
+		const a = commit("a", [], [branch("topic")]);
+		const rows = assignLanes([m, a]);
+
+		assertValidRows(rows);
+		const mRow = findRow(rows, "m");
+		const forks = mRow.edges.filter((e) => e.kind === "out-fork");
+		expect(forks.length, "one fork to the absent second parent").toBe(1);
+		// The absent parent's lane must not linger: the root 'a' reclaims lane 0.
+		expect(findRow(rows, "a").lane).toBe(0);
+		expect(findRow(rows, "a").laneCount).toBe(1);
+	});
+
+	it("keeps older rows geometrically stable when a new tip is prepended", () => {
+		// Realistic growth: the branch ref rides the newest commit, so the lane
+		// colour stays put as history extends. Older rows must not reflow.
+		const base = assignLanes([
+			commit("c", ["b"], [branch("main")]),
+			commit("b", ["a"]),
+			commit("a", []),
+		]);
+		const grown = assignLanes([
+			commit("t", ["c"], [branch("main")]), // new tip takes the ref
+			commit("c", ["b"], []), // ref moved up, as git update-ref would do
+			commit("b", ["a"]),
+			commit("a", []),
+		]);
+
+		expect(grown.length).toBe(base.length + 1);
+		// b and a are reached by the same parent as before, so their geometry —
+		// incoming edges included — is byte-identical.
+		expect(geometry(grown[2])).toEqual(geometry(base[1]));
+		expect(geometry(grown[3])).toEqual(geometry(base[2]));
+		// c was the tip in `base` (no incoming edge). Prepending t makes c a
+		// non-tip, so it gains exactly the incoming straight edge from t — the
+		// one legitimate change. Lane, colour and outgoing edges stay put.
+		const stable = (row: GraphRowModel) => ({
+			lane: row.lane,
+			color: row.color,
+			isMerge: row.isMerge,
+			isRoot: row.isRoot,
+			laneCount: row.laneCount,
+			outgoing: row.edges.filter((e) => e.kind.startsWith("out-")),
+		});
+		expect(stable(grown[1])).toEqual(stable(base[0]));
+		expect(
+			grown[1].edges.some((e) => e.kind === "in-straight"),
+			"former tip gains an incoming edge once a parent appears above it",
+		).toBe(true);
+		expect(
+			base[0].edges.some((e) => e.kind === "in-straight"),
+			"tip has no incoming edge",
+		).toBe(false);
+	});
+
+	it("is deterministic: the same input yields the same output", () => {
+		const a = commit("a", []);
+		const b = commit("b", ["a"]);
+		const m = commit("m", ["a", "b"], [branch("main")]);
+		const once = assignLanes([m, a, b]);
+		const twice = assignLanes([m, a, b]);
+		expect(once).toEqual(twice);
+	});
+
+	it("clamps every emitted colour into the 1..8 palette", () => {
+		// A fan-out heavy enough to exercise many distinct fork seeds.
+		const tips = Array.from({ length: 8 }, (_, i) =>
+			commit(`tip${i}`, ["root"], [branch(`b${i}`)]),
+		);
+		const root = commit("root", []);
+		const rows = assignLanes([...tips, root]);
+
+		assertValidRows(rows);
+		const palette: GraphLaneColor[] = [1, 2, 3, 4, 5, 6, 7, 8];
+		for (const row of rows) {
+			expect(palette).toContain(row.color);
+			for (const edge of row.edges) {
+				expect(palette).toContain(edge.color);
+			}
+		}
+	});
+
+	it("gives parallel lanes distinct colours up to the palette size", () => {
+		// N independent branches over a shared root. Every parent row carries
+		// N lanes live at once (the row's own lane plus N-1 `pass` lanes), which
+		// is the measured defect: two vertical lines side by side painted the
+		// same colour. Up to GRAPH_LANE_COUNT (8) the colours must all differ;
+		// only past the palette size may a collision appear, and it must.
+		const GRAPH_LANE_COUNT = 8;
+
+		const fan = (n: number): GraphRowModel[] => {
+			const tips = Array.from({ length: n }, (_, i) =>
+				commit(`t${i}`, [`p${i}`], [branch(`b${i}`)]),
+			);
+			const parents = Array.from({ length: n }, (_, i) =>
+				commit(`p${i}`, ["root"]),
+			);
+			const root = commit("root", []);
+			return assignLanes([...tips, ...parents, root]);
+		};
+
+		// Colours running side-by-side at a row: the row's own lane plus every
+		// `pass` lane (a vertical line crossing the row untouched).
+		const parallelColours = (row: GraphRowModel): number[] => [
+			row.color,
+			...row.edges.filter((e) => e.kind === "pass").map((e) => e.color),
+		];
+
+		// Within the palette: no row paints two parallel lanes the same colour.
+		// Sanity-check first that the fixture really is N-wide at its busiest row.
+		const within = fan(GRAPH_LANE_COUNT);
+		assertValidRows(within);
+		const widest = Math.max(
+			...within.map((row) => parallelColours(row).length),
+		);
+		expect(widest, "fixture exercises GRAPH_LANE_COUNT concurrent lanes").toBe(
+			GRAPH_LANE_COUNT,
+		);
+		for (const row of within) {
+			const cols = parallelColours(row);
+			expect(
+				new Set(cols).size,
+				`row ${row.commit.shortHash}: parallel lanes must not share a colour`,
+			).toBe(cols.length);
+		}
+
+		// Past the palette: one more lane than colours forces a collision — the
+		// honest ceiling the plan calls out. The duplicate appears only because
+		// there is no ninth hue, never because the picker skipped a free slot.
+		const beyond = fan(GRAPH_LANE_COUNT + 1);
+		assertValidRows(beyond);
+		const collisionRow = beyond.find((row) => {
+			const cols = parallelColours(row);
+			return new Set(cols).size !== cols.length;
+		});
+		expect(
+			collisionRow,
+			"a collision appears only once the palette is exhausted",
+		).toBeDefined();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.test.ts
@@ -255,6 +255,24 @@ describe("assignLanes", () => {
 		expect(findRow(rows, "a").laneCount).toBe(1);
 	});
 
+	it("does not fork an extra parent back onto the lane it just stubbed", () => {
+		// First parent outside the window frees this row's own lane; the second
+		// parent must not reclaim that slot, or the row draws a terminator and a
+		// live edge on one lane.
+		const m = commit("m", ["gone", "b"], [branch("main")]);
+		const b = commit("b", [], [branch("topic")]);
+		const rows = assignLanes([m, b]);
+
+		assertValidRows(rows);
+		const mRow = findRow(rows, "m");
+		const stub = mRow.edges.find((e) => e.kind === "out-stub");
+		expect(stub, "first parent stubs off").toBeDefined();
+		const live = mRow.edges.filter((e) => e.kind !== "out-stub");
+		expect(live.length, "one live edge to the present parent").toBe(1);
+		expect(live[0].toLane, "not the stubbed lane").not.toBe(stub?.toLane);
+		expect(findRow(rows, "b").lane).toBe(live[0].toLane);
+	});
+
 	it("keeps older rows geometrically stable when a new tip is prepended", () => {
 		// Realistic growth: the branch ref rides the newest commit, so the lane
 		// colour stays put as history extends. Older rows must not reflow.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.ts
@@ -1,0 +1,195 @@
+import type {
+	GraphCommit,
+	GraphEdge,
+	GraphLaneColor,
+	GraphRowModel,
+} from "../../types";
+
+/**
+ * Assigns each commit to a lane and emits the painted edges for its row.
+ *
+ * Commits arrive in display order: newest first (the tip), oldest last, as
+ * `git log --topo-order` yields them. An "active lane" awaits a single parent
+ * hash; when that commit is reached the lane either continues down its first
+ * parent or closes into the node as a merge.
+ *
+ * Parents that fall outside the fetched window (older than the oldest row, or
+ * absent from the input entirely) stub out: the row emits a short dashed
+ * `out-stub` edge and the lane is freed, so the branch visibly terminates
+ * instead of trailing on as a solid line.
+ */
+export function assignLanes(commits: GraphCommit[]): GraphRowModel[] {
+	const present = new Set(commits.map((c) => c.hash));
+	// lanes[i] = hash lane i is tracking downwards, or null when the slot is free.
+	const lanes: (string | null)[] = [];
+	const laneColor: GraphLaneColor[] = [];
+	const rows: GraphRowModel[] = [];
+
+	// Rotating colour cursor. A lane opening claims the next palette slot no
+	// live lane is using, so two parallel lanes never share a colour within the
+	// 1..8 ramp. Keying colour to lane index collides the moment a lane closes
+	// and its slot is reused by a still-live neighbour; the cursor + live-skip
+	// avoids that. Past eight simultaneous lanes a clash is unavoidable and the
+	// cursor reuses its slot (the honest ceiling).
+	let colorCursor = 0;
+	const pickColor = (): GraphLaneColor => {
+		const used = new Set<number>();
+		for (let i = 0; i < lanes.length; i++) {
+			if (lanes[i] !== null) used.add(laneColor[i]);
+		}
+		for (let step = 0; step < 8; step++) {
+			const candidate = ((colorCursor + step) % 8) + 1;
+			if (!used.has(candidate)) {
+				colorCursor = (colorCursor + step + 1) % 8;
+				return candidate as GraphLaneColor;
+			}
+		}
+		// Palette exhausted (9+ live lanes): reuse the cursor slot and advance.
+		const reused = (colorCursor % 8) + 1;
+		colorCursor = (colorCursor + 1) % 8;
+		return reused as GraphLaneColor;
+	};
+
+	for (const commit of commits) {
+		// Reuse the lane awaiting this commit, else the first free slot, else extend.
+		let mine = lanes.indexOf(commit.hash);
+		// A lane opened in this row is a branch tip (or the graph tip): nothing
+		// above it awaits or reaches this commit, so it must not draw an incoming
+		// straight edge — that would read as a parent link to a row that isn't
+		// there. Lanes reached via an out-fork take the reuse path below and keep
+		// their in-straight, which correctly meets the fork point.
+		const openedHere = mine === -1;
+		if (mine === -1) {
+			mine = lanes.indexOf(null);
+			if (mine === -1) {
+				mine = lanes.length;
+				lanes.push(null);
+				laneColor.push(1);
+			}
+			// Claim a colour nothing live is using, then occupy the slot.
+			laneColor[mine] = pickColor();
+			lanes[mine] = commit.hash;
+		}
+		const rowColor = laneColor[mine];
+
+		const edges: GraphEdge[] = [];
+
+		// Incoming sweep: lanes awaiting this commit close into the node; the rest
+		// pass through untouched. Several lanes can await one commit when branches
+		// reconverge — all but the chosen one merge in and are freed.
+		for (let j = 0; j < lanes.length; j++) {
+			const awaiting = lanes[j];
+			if (awaiting === commit.hash) {
+				if (j === mine) {
+					if (!openedHere) {
+						edges.push({
+							kind: "in-straight",
+							fromLane: j,
+							toLane: j,
+							color: laneColor[j],
+						});
+					}
+				} else {
+					edges.push({
+						kind: "in-merge",
+						fromLane: j,
+						toLane: mine,
+						color: laneColor[j],
+					});
+					lanes[j] = null;
+				}
+			} else if (awaiting !== null) {
+				edges.push({
+					kind: "pass",
+					fromLane: j,
+					toLane: j,
+					color: laneColor[j],
+				});
+			}
+		}
+
+		// First parent inherits the lane — unless it lies outside the window, in
+		// which case the branch stubs off and the lane is released.
+		const firstParent = commit.parents[0];
+		if (commit.parents.length > 0) {
+			if (present.has(firstParent)) {
+				edges.push({
+					kind: "out-straight",
+					fromLane: mine,
+					toLane: mine,
+					color: rowColor,
+				});
+				lanes[mine] = firstParent;
+			} else {
+				edges.push({
+					kind: "out-stub",
+					fromLane: mine,
+					toLane: mine,
+					color: rowColor,
+				});
+				lanes[mine] = null;
+			}
+		} else {
+			// Root: the lane ends at this node.
+			lanes[mine] = null;
+		}
+
+		// Extra parents fork into their own lanes. A forked lane is seeded with the
+		// parent hash (perturbed by a counter so sibling forks spread across the
+		// palette); when the parent is later reached it inherits that colour.
+		for (let p = 1; p < commit.parents.length; p++) {
+			const parent = commit.parents[p];
+			let k = lanes.indexOf(parent);
+			if (k === -1) {
+				k = lanes.indexOf(null);
+				if (k === -1) {
+					k = lanes.length;
+					lanes.push(null);
+					laneColor.push(1);
+				}
+				laneColor[k] = pickColor();
+			}
+			if (k === mine) {
+				edges.push({
+					kind: "out-straight",
+					fromLane: mine,
+					toLane: k,
+					color: laneColor[k],
+				});
+			} else {
+				edges.push({
+					kind: "out-fork",
+					fromLane: mine,
+					toLane: k,
+					color: laneColor[k],
+				});
+			}
+			// A forked parent outside the window stops here too — no dead lanes.
+			lanes[k] = present.has(parent) ? parent : null;
+		}
+
+		// Drop trailing free slots so the array tracks the active span and freed
+		// interior slots stay available for reuse by later rows.
+		while (lanes.length > 0 && lanes[lanes.length - 1] === null) {
+			lanes.pop();
+			laneColor.pop();
+		}
+
+		let laneCount = Math.max(lanes.length, mine + 1);
+		for (const edge of edges) {
+			laneCount = Math.max(laneCount, edge.fromLane + 1, edge.toLane + 1);
+		}
+
+		rows.push({
+			commit,
+			lane: mine,
+			color: rowColor,
+			isMerge: commit.parents.length > 1,
+			isRoot: commit.parents.length === 0,
+			edges,
+			laneCount,
+		});
+	}
+
+	return rows;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/assignLanes.ts
@@ -141,7 +141,10 @@ export function assignLanes(commits: GraphCommit[]): GraphRowModel[] {
 			const parent = commit.parents[p];
 			let k = lanes.indexOf(parent);
 			if (k === -1) {
-				k = lanes.indexOf(null);
+				// Never reclaim this row's own lane: it was just freed above (root,
+				// or first parent outside the window) and already carries an
+				// out-stub. Reusing it would draw a stub and a live edge on one lane.
+				k = lanes.findIndex((slot, i) => slot === null && i !== mine);
 				if (k === -1) {
 					k = lanes.length;
 					lanes.push(null);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/index.ts
@@ -1,0 +1,1 @@
+export { assignLanes } from "./assignLanes";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
@@ -1,3 +1,4 @@
+import type { CommitMetadata } from "@superset/host-service";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useMemo } from "react";
 import type { FileStatus } from "../../components/StatusIndicator";
@@ -12,6 +13,9 @@ interface UseChangesetArgs {
 
 interface UseChangesetResult {
 	files: ChangesetFile[];
+	/** Commit metadata when `ref` is a commit/range; null otherwise (against-base /
+	 *  uncommitted have no single commit to describe). */
+	commit: CommitMetadata | null;
 	isLoading: boolean;
 	isError: boolean;
 	error: unknown;
@@ -63,6 +67,7 @@ export function useChangeset({
 
 	return {
 		files,
+		commit: commitQuery.data?.commit ?? null,
 		isLoading: activeQuery.isLoading,
 		isError: activeQuery.isError,
 		error: activeQuery.error,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -17,6 +17,7 @@ import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/C
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
 	type ChangesetFile,
+	type DiffRef,
 	getChangesetFileKey,
 	useChangeset,
 } from "../../../useChangeset";
@@ -25,6 +26,7 @@ import { useSidebarDiffRef } from "../../../useSidebarDiffRef";
 import { useViewedFiles } from "../../../useViewedFiles";
 import { AgentCommentComposer } from "./components/AgentCommentComposer";
 import { CommentThread } from "./components/CommentThread";
+import { CommitMetadataHeader } from "./components/CommitMetadataHeader";
 import { DiffHeaderMetadata } from "./components/DiffHeaderMetadata";
 import { DiffHeaderPrefix } from "./components/DiffHeaderPrefix";
 import { DiffSectionBar } from "./components/DiffSectionBar";
@@ -64,7 +66,23 @@ export function DiffPane({
 	const codeViewRef = useRef<CodeViewHandle<DiffAnnotationMetadata>>(null);
 	const searchContainerRef = useRef<HTMLDivElement>(null);
 
-	const ref = useSidebarDiffRef(workspaceId);
+	// A graph-owned pane carries its own commit/range ref; the Changes tab's
+	// follower pane (no ref) falls back to the sidebar changesFilter. The hook
+	// always runs (rules of hooks); its value only feeds the follower path.
+	const sidebarRef = useSidebarDiffRef(workspaceId);
+	const ref = useMemo<DiffRef>(() => {
+		if (data.ref?.kind === "commit") {
+			return { kind: "commit", commitHash: data.ref.hash };
+		}
+		if (data.ref?.kind === "range") {
+			return {
+				kind: "commit",
+				commitHash: data.ref.toHash,
+				fromHash: data.ref.fromHash,
+			};
+		}
+		return sidebarRef;
+	}, [data.ref, sidebarRef]);
 	const scrollStateKey = useMemo(
 		() =>
 			createPaneScrollStateKey({
@@ -79,7 +97,7 @@ export function DiffPane({
 		() => getPaneScrollState(scrollStateKey),
 		[scrollStateKey],
 	);
-	const { files, isLoading } = useChangeset({ workspaceId, ref });
+	const { files, commit, isLoading } = useChangeset({ workspaceId, ref });
 	const { viewedSet, setViewed } = useViewedFiles(workspaceId);
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
 	const threadAnnotationsByPath = useDiffAnnotationsByPath({ workspaceId });
@@ -316,6 +334,7 @@ export function DiffPane({
 
 	return (
 		<div className="flex h-full w-full flex-col">
+			{data.ref && commit ? <CommitMetadataHeader commit={commit} /> : null}
 			{currentSection ? (
 				<DiffSectionBar
 					kind={currentSection.kind}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommitMetadataHeader/CommitMetadataHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommitMetadataHeader/CommitMetadataHeader.tsx
@@ -1,0 +1,67 @@
+import type { CommitMetadata } from "@superset/host-service";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
+
+interface CommitMetadataHeaderProps {
+	commit: CommitMetadata;
+}
+
+/**
+ * Read-only metadata strip at the top of a commit diff pane: short hash,
+ * parents (so a merge reads as one), the full message (subject + body),
+ * authorship, and a relative date. Rendered only when the pane carries a
+ * commit/range ref — the Changes tab's follower pane shows nothing here.
+ */
+export function CommitMetadataHeader({ commit }: CommitMetadataHeaderProps) {
+	const ts = Date.parse(commit.date);
+	const parents = commit.parents.map((p) => p.slice(0, 7));
+	// %B is subject + body; split the first line off as the subject so a long
+	// body doesn't crowd the title row.
+	const newlineIdx = commit.message.indexOf("\n");
+	const subject =
+		newlineIdx === -1 ? commit.message : commit.message.slice(0, newlineIdx);
+	const body =
+		newlineIdx === -1 ? "" : commit.message.slice(newlineIdx + 1).trim();
+
+	return (
+		<div className="shrink-0 border-b border-border px-3 py-2">
+			<div className="flex items-center gap-2 text-[11px]">
+				<span className="font-mono text-muted-foreground tabular-nums">
+					{commit.shortHash}
+				</span>
+				{parents.length > 0 && (
+					<span
+						className="font-mono text-muted-foreground/70 tabular-nums"
+						title={commit.parents.join(", ") || undefined}
+					>
+						← {parents.join(" ")}
+					</span>
+				)}
+				{Number.isNaN(ts) ? null : (
+					<span
+						className="ml-auto font-mono text-muted-foreground tabular-nums"
+						title={commit.date}
+					>
+						{formatRelativeTime(ts)}
+					</span>
+				)}
+			</div>
+			{subject && (
+				<div
+					className="mt-1 truncate text-xs font-medium text-foreground"
+					title={subject}
+				>
+					{subject}
+				</div>
+			)}
+			{body && (
+				<pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[11px] text-muted-foreground">
+					{body}
+				</pre>
+			)}
+			<div className="mt-1 truncate text-[11px] text-muted-foreground">
+				{commit.author}
+				{commit.authorEmail ? ` <${commit.authorEmail}>` : ""}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommitMetadataHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommitMetadataHeader/index.ts
@@ -1,0 +1,1 @@
+export { CommitMetadataHeader } from "./CommitMetadataHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -9,7 +9,13 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { Circle, GitCompareArrows, Globe, MessageSquare } from "lucide-react";
+import {
+	Circle,
+	GitCommitHorizontal,
+	GitCompareArrows,
+	Globe,
+	MessageSquare,
+} from "lucide-react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useMemo } from "react";
 import {
@@ -43,6 +49,7 @@ import type {
 	ChatV3PaneData,
 	CommentPaneData,
 	DevtoolsPaneData,
+	DiffPaneData,
 	FilePaneData,
 	PaneViewerData,
 	TerminalPaneData,
@@ -288,8 +295,19 @@ export function usePaneRegistry({
 					),
 			},
 			diff: {
-				getIcon: () => <GitCompareArrows className="size-3.5" />,
-				getTitle: () => "Changes",
+				getIcon: (ctx: RendererContext<PaneViewerData>) =>
+					(ctx.pane.data as DiffPaneData).ref ? (
+						<GitCommitHorizontal className="size-3.5" />
+					) : (
+						<GitCompareArrows className="size-3.5" />
+					),
+				getTitle: (pane) => {
+					const ref = (pane.data as DiffPaneData).ref;
+					if (ref?.kind === "commit") return ref.hash.slice(0, 7);
+					if (ref?.kind === "range")
+						return `${ref.fromHash.slice(0, 7)}..${ref.toHash.slice(0, 7)}`;
+					return "Changes";
+				},
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<DiffPane
 						context={ctx}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceStore } from "@superset/panes";
 import { useCallback } from "react";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import type { GraphSelection } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import type { StoreApi } from "zustand/vanilla";
 import type {
 	BrowserPaneData,
@@ -13,6 +14,16 @@ import type {
 	TerminalPaneData,
 } from "../../types";
 import type { TerminalLauncher } from "../useV2TerminalLauncher";
+
+/** Structural equality for graph refs, so an already-open commit pane is focused
+ *  instead of duplicated. */
+function sameRef(a: GraphSelection | undefined, b: GraphSelection): boolean {
+	if (!a || a.kind !== b.kind) return false;
+	if (a.kind === "commit" && b.kind === "commit") return a.hash === b.hash;
+	if (a.kind === "range" && b.kind === "range")
+		return a.fromHash === b.fromHash && a.toHash === b.toHash;
+	return false;
+}
 
 export function useWorkspacePaneOpeners({
 	store,
@@ -35,6 +46,8 @@ export function useWorkspacePaneOpeners({
 		side?: DiffFocusSide,
 		changeKey?: string,
 	) => void;
+	openCommitDiffPane: (ref: GraphSelection, openInNewTab?: boolean) => void;
+	pinActiveCommitPane: () => void;
 	addTerminalTab: () => Promise<void>;
 	addChatTab: () => void;
 	addChatV3Tab: () => void;
@@ -198,8 +211,95 @@ export function useWorkspacePaneOpeners({
 		[store],
 	);
 
+	const openCommitDiffPane = useCallback(
+		(ref: GraphSelection, openInNewTab?: boolean) => {
+			const state = store.getState();
+			// A commit pane shows the whole changeset; CodeView renders every file,
+			// so an empty path simply means "no specific file focused".
+			const paneData = {
+				ref,
+				collapsedFiles: [],
+				path: "",
+			} as DiffPaneData;
+
+			// cmd/ctrl-click: always a fresh pane, never a reuse.
+			if (openInNewTab) {
+				state.addTab({ panes: [{ kind: "diff", data: paneData }] });
+				return;
+			}
+
+			// Focus an existing pane already showing this exact ref (any tab)
+			// before reusing or creating — same convention as the file tree.
+			for (const tab of state.tabs) {
+				for (const pane of Object.values(tab.panes)) {
+					if (pane.kind !== "diff") continue;
+					if (sameRef((pane.data as DiffPaneData).ref, ref)) {
+						state.setActiveTab(tab.id);
+						state.setActivePane({ tabId: tab.id, paneId: pane.id });
+						return;
+					}
+				}
+			}
+
+			// Reuse the unpinned ref-carrying diff pane in the active tab; replace
+			// its ref. ONLY ref-carrying panes are eligible — the discriminator
+			// `data.ref === undefined` marks the Changes tab's follower pane, which
+			// a graph click must never hijack.
+			const activeTabId = state.activeTabId;
+			const activeTab = activeTabId
+				? state.tabs.find((t) => t.id === activeTabId)
+				: null;
+			if (activeTab) {
+				const reusable = Object.values(activeTab.panes).find(
+					(p) =>
+						p.kind === "diff" &&
+						!p.pinned &&
+						(p.data as DiffPaneData).ref !== undefined,
+				);
+				if (reusable) {
+					state.replacePane({
+						tabId: activeTab.id,
+						paneId: reusable.id,
+						newPane: { kind: "diff", data: paneData },
+					});
+					return;
+				}
+				// No reusable ref pane: add a new one (split), leaving the Changes
+				// follower pane untouched.
+				state.addPane({
+					tabId: activeTab.id,
+					pane: { kind: "diff", data: paneData },
+				});
+				return;
+			}
+
+			// No active tab: seed one with the commit pane.
+			state.addTab({ panes: [{ kind: "diff", data: paneData }] });
+		},
+		[store],
+	);
+
+	/** Pin the diff pane a single click just opened. No-op unless the active
+	 *  pane is a ref-carrying commit diff (double-clicking the Changes tab's
+	 *  follower pane does nothing). */
+	const pinActiveCommitPane = useCallback(() => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (
+			active?.pane.kind === "diff" &&
+			(active.pane.data as DiffPaneData).ref
+		) {
+			state.setPanePinned({
+				paneId: active.pane.id,
+				pinned: true,
+			});
+		}
+	}, [store]);
+
 	return {
 		openDiffPane,
+		openCommitDiffPane,
+		pinActiveCommitPane,
 		addTerminalTab,
 		addChatTab,
 		addChatV3Tab,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -200,6 +200,8 @@ function V2WorkspaceContent() {
 	});
 	const {
 		openDiffPane,
+		openCommitDiffPane,
+		pinActiveCommitPane,
 		addTerminalTab,
 		addChatTab,
 		addChatV3Tab,
@@ -412,6 +414,8 @@ function V2WorkspaceContent() {
 								onSelectFile={openFilePaneFromTreeClick}
 								onSelectDiffFile={openDiffPane}
 								onOpenComment={openCommentPane}
+								onOpenCommitRef={openCommitDiffPane}
+								onPinCommitPane={pinActiveCommitPane}
 								onSearch={handleQuickOpen}
 								selectedFilePath={selectedFilePath}
 								pendingReveal={pendingReveal}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -1,3 +1,5 @@
+import type { GraphSelection } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+
 export interface FilePaneData {
 	filePath: string;
 	mode: "editor" | "diff" | "preview";
@@ -51,6 +53,12 @@ export interface DiffPaneData {
 	focusLine?: number;
 	focusSide?: DiffFocusSide;
 	focusTick?: number;
+	/** Commit/range ref this pane is bound to. Absent (undefined) marks the
+	 *  follower pane that mirrors sidebar changesFilter (the Changes tab);
+	 *  present marks a graph-owned commit preview. Preview reuse only ever
+	 *  recycles panes that already carry a ref, so a graph click can never
+	 *  hijack the Changes tab's own pane. */
+	ref?: GraphSelection;
 }
 
 export interface CommentPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -13,6 +13,19 @@ export const dashboardSidebarProjectSchema = z.object({
 	isCollapsed: z.boolean().default(false),
 	tabOrder: z.number().int().default(0),
 	defaultOpenInApp: z.string().nullable().default(null),
+	// Which refs the git graph paints for this project's workspaces. Mirrors the
+	// host-service GraphRefScope; written by the graph strip's scope chooser.
+	// Rows pre-dating this field read as undefined and fall back to "local" at
+	// the call site (no heal migration needed — projects have none).
+	graphRefScope: z
+		.enum(["local", "open-workspaces", "remote", "all", "head"])
+		.default("local"),
+	// Put commit-graph ref badges on their own line (full-width, untruncated) —
+	// fixes the 12ch/8ch truncation visible at every sidebar width today.
+	graphTwoLineRefs: z.boolean().default(false),
+	// Dim referenced commits so unreferenced refs (no open workspace behind them)
+	// stand out. Dims, never removes — dropping rows would dangle lane edges.
+	graphUnreferencedOnly: z.boolean().default(false),
 });
 
 const paneWorkspaceStateSchema = z.custom<WorkspaceState<unknown>>();
@@ -97,6 +110,21 @@ const changesFilterSchema = z.discriminatedUnion("kind", [
 
 export type ChangesFilter = z.infer<typeof changesFilterSchema>;
 
+// Graph-owned selection: the commit/range the Graph tab highlights. Lives on
+// sidebarState (not changesFilter) so clicking around the graph never retargets
+// the Changes tab — the two surfaces no longer fight over one piece of state.
+// Persisted per workspace, so a selection survives a tab switch and restart.
+const graphSelectionSchema = z.discriminatedUnion("kind", [
+	z.object({ kind: z.literal("commit"), hash: z.string() }),
+	z.object({
+		kind: z.literal("range"),
+		fromHash: z.string(),
+		toHash: z.string(),
+	}),
+]);
+
+export type GraphSelection = z.infer<typeof graphSelectionSchema>;
+
 export type ChangesViewMode = "folders" | "tree";
 
 const workspaceRunStateSchema = z.enum([
@@ -127,8 +155,11 @@ export const workspaceLocalStateSchema = z.object({
 		tabOrder: z.number().int().default(0),
 		sectionId: z.string().uuid().nullable().default(null),
 		changesFilter: changesFilterSchema.default({ kind: "all" }),
+		graphSelection: graphSelectionSchema.nullable().default(null),
 		changesViewMode: z.enum(["folders", "tree"]).default("folders"),
-		activeTab: z.enum(["changes", "files", "review"]).default("changes"),
+		activeTab: z
+			.enum(["changes", "files", "graph", "review"])
+			.default("changes"),
 		isHidden: z.boolean().default(false),
 		// Epoch ms when the user pinned this workspace to the sidebar's Pinned
 		// section; null = not pinned. Ordering is pinnedAt ascending.
@@ -168,6 +199,7 @@ const SIDEBAR_STATE_DEFAULTS = {
 	tabOrder: 0,
 	sectionId: null,
 	changesFilter: { kind: "all" },
+	graphSelection: null,
 	changesViewMode: "folders",
 	activeTab: "changes",
 	isHidden: false,

--- a/apps/desktop/src/renderer/stores/theme/store.ts
+++ b/apps/desktop/src/renderer/stores/theme/store.ts
@@ -10,7 +10,12 @@ import {
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { trpcThemeStorage } from "../../lib/trpc-storage";
-import { applyUIColors, toXtermTheme, updateThemeClass } from "./utils";
+import {
+	applyGraphLaneColors,
+	applyUIColors,
+	toXtermTheme,
+	updateThemeClass,
+} from "./utils";
 
 /** Special theme ID for system preference (follows OS dark/light mode) */
 export const SYSTEM_THEME_ID = "system";
@@ -138,6 +143,9 @@ function applyTheme(theme: Theme): {
 } {
 	// Apply UI colors to CSS variables
 	applyUIColors(theme.ui);
+
+	// Commit-graph lanes come from the ANSI palette, not from theme.ui
+	applyGraphLaneColors(theme);
 
 	// Update dark/light class
 	updateThemeClass(theme.type);

--- a/apps/desktop/src/renderer/stores/theme/utils/css-variables.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/css-variables.ts
@@ -1,4 +1,5 @@
-import type { UIColors } from "shared/themes/types";
+import { GRAPH_LANE_CSS_VARS, getGraphLanes } from "shared/themes/graph-lanes";
+import type { Theme, UIColors } from "shared/themes/types";
 
 /**
  * Maps UI color keys to CSS variable names
@@ -59,6 +60,24 @@ export function applyUIColors(colors: UIColors): void {
 }
 
 /**
+ * Apply commit-graph lane colours to CSS variables on :root.
+ *
+ * Kept separate from applyUIColors because lanes are derived from the whole
+ * theme (its ANSI palette), not from UIColors — see shared/themes/graph-lanes.
+ */
+export function applyGraphLaneColors(theme: Theme): void {
+	const root = document.documentElement;
+
+	const lanes = getGraphLanes(theme);
+	for (const [index, cssVar] of GRAPH_LANE_CSS_VARS.entries()) {
+		const value = lanes[index];
+		if (value) {
+			root.style.setProperty(cssVar, value);
+		}
+	}
+}
+
+/**
  * Update dark/light mode class based on theme type
  */
 export function updateThemeClass(type: "dark" | "light"): void {
@@ -78,6 +97,9 @@ export function updateThemeClass(type: "dark" | "light"): void {
 export function clearThemeVariables(): void {
 	const root = document.documentElement;
 	for (const cssVar of Object.values(UI_COLOR_TO_CSS_VAR)) {
+		root.style.removeProperty(cssVar);
+	}
+	for (const cssVar of GRAPH_LANE_CSS_VARS) {
 		root.style.removeProperty(cssVar);
 	}
 }

--- a/apps/desktop/src/renderer/stores/theme/utils/index.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/index.ts
@@ -1,4 +1,5 @@
 export {
+	applyGraphLaneColors,
 	applyUIColors,
 	clearThemeVariables,
 	updateThemeClass,

--- a/apps/desktop/src/shared/themes/graph-lanes.test.ts
+++ b/apps/desktop/src/shared/themes/graph-lanes.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { builtInThemes, darkTheme, lightTheme } from "./built-in";
+import {
+	GRAPH_LANE_COUNT,
+	GRAPH_LANE_CSS_VARS,
+	getGraphLanes,
+} from "./graph-lanes";
+import type { Theme } from "./types";
+
+describe("getGraphLanes", () => {
+	it("gives every built-in theme eight distinct lane colors", () => {
+		for (const theme of builtInThemes) {
+			const lanes = getGraphLanes(theme);
+			expect(lanes).toHaveLength(GRAPH_LANE_COUNT);
+			expect(lanes.every(Boolean)).toBe(true);
+			expect(new Set(lanes).size).toBe(GRAPH_LANE_COUNT);
+		}
+	});
+
+	it("still yields eight lanes when a theme has no terminal block", () => {
+		const stripped: Theme = { ...darkTheme, terminal: undefined };
+		const lanes = getGraphLanes(stripped);
+		expect(lanes.every(Boolean)).toBe(true);
+		expect(new Set(lanes).size).toBe(GRAPH_LANE_COUNT);
+	});
+
+	it("keeps eight lanes distinct when a theme sets bright == standard", () => {
+		// Monokai does exactly this, so slots 7-8 cannot be the other brightness.
+		const monokai = builtInThemes.find((theme) => theme.id === "monokai");
+		expect(monokai?.terminal?.brightBlue).toBe(
+			monokai?.terminal?.blue as string,
+		);
+		expect(new Set(getGraphLanes(monokai as Theme)).size).toBe(
+			GRAPH_LANE_COUNT,
+		);
+	});
+
+	it("draws dark themes from the bright set and light themes from the standard set", () => {
+		expect(getGraphLanes(darkTheme)[0]).toBe(
+			darkTheme.terminal?.brightBlue as string,
+		);
+		expect(getGraphLanes(lightTheme)[0]).toBe(
+			lightTheme.terminal?.blue as string,
+		);
+	});
+
+	it("lightens dark-theme overflow lanes toward white, darkens light-theme ones toward black", () => {
+		// Slots 7/8 are lightness-shifted copies of the first two hues — the only
+		// rendering path the live app had never exercised before §5.3. The
+		// direction matters: a dark ground needs the lane brightened (toward
+		// white), a light ground needs it darkened (toward black), or a tinted row
+		// reads the wrong way. Pin both directions and the wrap-around identity.
+		const dark = getGraphLanes(darkTheme);
+		const light = getGraphLanes(lightTheme);
+		expect(dark[6]).toBe(
+			`color-mix(in oklch, ${darkTheme.terminal?.brightBlue} 62%, white)`,
+		);
+		expect(dark[7]).toBe(
+			`color-mix(in oklch, ${darkTheme.terminal?.brightGreen} 62%, white)`,
+		);
+		expect(light[6]).toBe(
+			`color-mix(in oklch, ${lightTheme.terminal?.blue} 62%, black)`,
+		);
+		expect(light[7]).toBe(
+			`color-mix(in oklch, ${lightTheme.terminal?.green} 62%, black)`,
+		);
+		// Slots 7/8 stay distinct from 1–6 and from each other in both themes —
+		// the wrap-around never collapses two live lanes onto one colour.
+		for (const lanes of [dark, light]) {
+			expect(new Set(lanes).size).toBe(GRAPH_LANE_COUNT);
+			expect(lanes[6]).not.toBe(lanes[0]);
+			expect(lanes[7]).not.toBe(lanes[1]);
+			expect(lanes[6]).not.toBe(lanes[7]);
+		}
+	});
+
+	it("names one CSS variable per lane, 1-indexed", () => {
+		expect(GRAPH_LANE_CSS_VARS).toHaveLength(GRAPH_LANE_COUNT);
+		expect(GRAPH_LANE_CSS_VARS[0]).toBe("--graph-lane-1");
+		expect(GRAPH_LANE_CSS_VARS.at(-1)).toBe(`--graph-lane-${GRAPH_LANE_COUNT}`);
+	});
+});

--- a/apps/desktop/src/shared/themes/graph-lanes.ts
+++ b/apps/desktop/src/shared/themes/graph-lanes.ts
@@ -1,0 +1,52 @@
+import { getTerminalColors, type Theme } from "./types";
+
+/** Lanes the commit graph can colour before it has to reuse one. */
+export const GRAPH_LANE_COUNT = 8;
+
+/**
+ * Commit-graph lane colours, derived from the theme rather than stored on it.
+ *
+ * This mirrors `getEditorTheme`: prefer the theme's own ANSI palette, fall back
+ * to the xterm defaults for its type. Lanes are deliberately not part of
+ * `UIColors` — `import.ts` makes every UI colour optional, so eight new
+ * required entries would invalidate every user-imported theme.
+ *
+ * Index order is hue order, not palette order. `assignLanes` hands consecutive
+ * indices to lanes that end up side by side, so neighbours have to sit far
+ * apart on the wheel; blue/green/red/cyan/magenta/yellow keeps every adjacent
+ * pair at least ~120 degrees apart.
+ *
+ * ANSI only offers six chromatic hues, so slots 7 and 8 are lightness-shifted
+ * copies of the first two. The other brightness rank is not usable: Monokai
+ * (and most ports of it) set bright == standard for every hue, which would give
+ * eight lanes only six colours. Those slots only appear once the sidebar is wide
+ * enough for eight lanes (see `laneCapForWidth`).
+ */
+export function getGraphLanes(theme: Theme): string[] {
+	const t = getTerminalColors(theme);
+	// Dark themes read better on the bright ANSI set and light themes on the
+	// standard set — the same split getEditorTheme uses for additions/deletions.
+	const hues =
+		theme.type === "dark"
+			? [
+					t.brightBlue,
+					t.brightGreen,
+					t.brightRed,
+					t.brightCyan,
+					t.brightMagenta,
+					t.brightYellow,
+				]
+			: [t.blue, t.green, t.red, t.cyan, t.magenta, t.yellow];
+
+	const toward = theme.type === "dark" ? "white" : "black";
+	const shift = (color: string) =>
+		`color-mix(in oklch, ${color} 62%, ${toward})`;
+
+	return [...hues, shift(hues[0] as string), shift(hues[1] as string)];
+}
+
+/** CSS custom properties the graph reads, in lane order. */
+export const GRAPH_LANE_CSS_VARS = Array.from(
+	{ length: GRAPH_LANE_COUNT },
+	(_, index) => `--graph-lane-${index + 1}`,
+);

--- a/packages/host-service/src/index.ts
+++ b/packages/host-service/src/index.ts
@@ -27,4 +27,5 @@ export type {
 	TeardownFailureCause,
 } from "./trpc/error-types";
 export type { AppRouter } from "./trpc/router";
+export type { CommitMetadata } from "./trpc/router/git/types";
 export type { ApiClient, HostServiceContext } from "./types";

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -363,9 +363,13 @@ export const gitRouter = router({
 				{
 					timeoutMs: 30_000,
 					strategy: "coalesce",
-					// Scope is part of the key: two scopes are two different
-					// traversals, and coalescing them would serve one the other's rows.
-					dedupeKey: `${input.workspaceId}:graph-log:${input.refScope}`,
+					// Every traversal input is part of the key. Two calls that differ
+					// in scope, base, window size or offset are two different
+					// traversals, and coalescing them serves one the other's rows —
+					// `baseBranch` alone decides the `merged` classification, and the
+					// base resolves a tick after mount, so the first two calls of a
+					// cold open genuinely differ.
+					dedupeKey: `${input.workspaceId}:graph-log:${input.refScope}:${input.baseBranch ?? ""}:${input.limit}:${skip}`,
 				},
 			);
 

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -172,6 +172,15 @@ function assertSafeRelativePath(filePath: string): void {
 	}
 }
 
+/**
+ *  Hash-shaped revisions only. These reach `git show`/`git diff` positionally,
+ *  and git reads a leading `-` as an option — `--output=<path>` on `git show`
+ *  writes an arbitrary file. Callers only ever send real hashes.
+ */
+const commitHashSchema = z
+	.string()
+	.regex(/^[0-9a-f]{4,40}$/i, "Invalid commit hash");
+
 export const gitRouter = router({
 	listBranches: queryProcedure
 		.input(z.object({ workspaceId: z.string() }))
@@ -426,8 +435,10 @@ export const gitRouter = router({
 		.input(
 			z.object({
 				workspaceId: z.string(),
-				commitHash: z.string(),
-				fromHash: z.string().optional(),
+				// `""` is the placeholder the renderer puts in a disabled query's
+				// input while no commit is selected; it never reaches the wire.
+				commitHash: commitHashSchema.or(z.literal("")),
+				fromHash: commitHashSchema.optional(),
 			}),
 		)
 		.query(async ({ ctx, input }) => {
@@ -652,8 +663,8 @@ export const gitRouter = router({
 				path: z.string(),
 				category: z.enum(["against-base", "staged", "unstaged", "commit"]),
 				baseBranch: z.string().optional(),
-				commitHash: z.string().optional(),
-				fromHash: z.string().optional(),
+				commitHash: commitHashSchema.optional(),
+				fromHash: commitHashSchema.optional(),
 			}),
 		)
 		.query(async ({ ctx, input }) => {

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -11,17 +11,27 @@ import { getHostWorkerPool } from "../../../workers/host-worker-pool";
 import {
 	gitCommitFilesTask,
 	gitFetchBaseRefTask,
+	gitGraphLogTask,
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
+import {
+	normalizeWorktreePath,
+	type WorktreeRecord,
+} from "../workspace-creation/shared/worktree-list";
 import type {
 	ChangedFile,
 	CheckConclusionState,
 	CheckRun,
 	CheckStatusState,
 	Commit,
+	CommitMetadata,
+	GraphCommit,
+	GraphRef,
+	GraphRefState,
 	IssueComment,
+	ListGraphResult,
 	MergeableState,
 	PullRequestReviewDecision,
 	PullRequestReviewThread,
@@ -34,6 +44,7 @@ import {
 	resolveBaseComparison,
 } from "./utils/git-helpers";
 import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
+import { worktreeByBranch } from "./utils/graph-log";
 import {
 	type GraphQLThreadsResult,
 	parseGraphQLThreads,
@@ -63,11 +74,14 @@ async function withCommitFilesSlot<T>(fn: () => Promise<T>): Promise<T> {
 // Identical requests share one slot AND one task — deduping outside the
 // semaphore keeps same-commit bursts from consuming both cap slots or
 // re-running a task that finished while they waited for a slot.
-const inFlightCommitFiles = new Map<string, Promise<ChangedFile[]>>();
+const inFlightCommitFiles = new Map<
+	string,
+	Promise<{ files: ChangedFile[]; commit: CommitMetadata | null }>
+>();
 function runCommitFilesDeduped(
 	key: string,
-	fn: () => Promise<ChangedFile[]>,
-): Promise<ChangedFile[]> {
+	fn: () => Promise<{ files: ChangedFile[]; commit: CommitMetadata | null }>,
+): Promise<{ files: ChangedFile[]; commit: CommitMetadata | null }> {
 	const existing = inFlightCommitFiles.get(key);
 	if (existing) return existing;
 	const task = withCommitFilesSlot(fn).finally(() => {
@@ -84,6 +98,56 @@ function resolveGitTaskEnv(
 	worktreePath: string,
 ): Promise<Record<string, string>> {
 	return createGitEnvResolver(ctx.credentials)(worktreePath);
+}
+
+/**
+ * Compute the state for a local-branch ref plus its worktree metadata. State
+ * rules (local branches only; remote/tag/head carry `null`):
+ *   - registered worktree git marks prunable (a deleted worktree directory is
+ *     one: "gitdir file points to non-existent location") → prunable
+ *   - registered worktree, matching workspaces row → open
+ *   - registered worktree, no row → detached-worktree
+ *   - no worktree, contained in base → merged
+ *   - no worktree, not contained → orphan-branch
+ *
+ * Containment comes from `git branch --merged <baseRef>` (reachable from the
+ * base), NOT graph topology — a branch merged before the commit window still
+ * reports "merged".
+ */
+function branchRefState(
+	fullRef: string,
+	name: string,
+	branchWorktree: Map<string, WorktreeRecord>,
+	workspaceByPath: Map<string, string>,
+	mergedSet: Set<string>,
+): Pick<
+	GraphRef,
+	"state" | "worktreePath" | "worktreeWorkspaceId" | "pruneReason"
+> {
+	const wt = branchWorktree.get(name);
+	if (wt) {
+		// `git worktree list --porcelain` already flags a missing directory, so
+		// this no longer stats every branch's worktree on the main thread.
+		if (wt.prunable) {
+			return {
+				state: "prunable",
+				pruneReason: wt.prunable.reason || "worktree path missing",
+			};
+		}
+		const wsId = workspaceByPath.get(normalizeWorktreePath(wt.path));
+		if (wsId) {
+			return {
+				state: "open",
+				worktreeWorkspaceId: wsId,
+				worktreePath: wt.path,
+			};
+		}
+		return { state: "detached-worktree", worktreePath: wt.path };
+	}
+	const state: GraphRefState = mergedSet.has(fullRef)
+		? "merged"
+		: "orphan-branch";
+	return { state };
 }
 
 function assertSafeRelativePath(filePath: string): void {
@@ -234,6 +298,129 @@ export const gitRouter = router({
 			return { commits };
 		}),
 
+	listGraph: queryProcedure
+		.meta({ timeoutMs: 30_000 })
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				baseBranch: z.string().optional(),
+				refScope: z
+					.enum(["local", "open-workspaces", "remote", "all", "head"])
+					.default("local"),
+				limit: z.number().int().min(1).max(2000).default(500),
+				cursor: z.string().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			// Fetch the workspace row once for both path and projectId (sibling
+			// workspaces share the project's git dir).
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+			if (!workspace?.worktreePath) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+			const worktreePath = workspace.worktreePath;
+
+			// The cursor carries the scope it was issued for: `--skip` counts rows
+			// of one traversal, so replaying a local offset against `head` would
+			// window a list that never had those rows. A foreign cursor restarts
+			// at 0 rather than serving a silently wrong page.
+			let skip = 0;
+			if (input.cursor) {
+				const m = /^skip:(\d+):([a-z-]+)$/.exec(input.cursor);
+				if (m && m[2] === input.refScope) {
+					skip = Number.parseInt(m[1] ?? "0", 10);
+				}
+			}
+
+			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+			const result = await getHostWorkerPool().run(
+				gitGraphLogTask,
+				{
+					worktreePath,
+					baseBranch: input.baseBranch,
+					refScope: input.refScope,
+					limit: input.limit,
+					skip,
+					gitEnv,
+				},
+				// ~9 git spawns per call, all in the worker. A `git:changed` storm
+				// during a rebase would fan those out badly; coalesce overlapping
+				// calls for the same workspace onto one in-flight traversal.
+				{
+					timeoutMs: 30_000,
+					strategy: "coalesce",
+					// Scope is part of the key: two scopes are two different
+					// traversals, and coalescing them would serve one the other's rows.
+					dedupeKey: `${input.workspaceId}:graph-log:${input.refScope}`,
+				},
+			);
+
+			const fetched = result.commits;
+			const hasMore = fetched.length > input.limit;
+			const window = hasMore ? fetched.slice(0, input.limit) : fetched;
+			const nextCursor = hasMore
+				? `skip:${skip + input.limit}:${input.refScope}`
+				: null;
+
+			// The worker can't touch the DB, so the path→workspaceId join that
+			// backs the "open" / "detached-worktree" states lives here.
+			const siblings = ctx.db.query.workspaces
+				.findMany({ where: eq(workspaces.projectId, workspace.projectId) })
+				.sync();
+			const workspaceByPath = new Map<string, string>();
+			for (const w of siblings) {
+				workspaceByPath.set(normalizeWorktreePath(w.worktreePath), w.id);
+			}
+
+			const refsBySha = new Map<string, typeof result.refs>();
+			for (const r of result.refs) {
+				const list = refsBySha.get(r.sha);
+				if (list) list.push(r);
+				else refsBySha.set(r.sha, [r]);
+			}
+
+			const branchWorktree = worktreeByBranch(result.worktrees);
+			const mergedSet = new Set(result.mergedBranches);
+
+			const commits: GraphCommit[] = window.map((c) => ({
+				hash: c.hash,
+				shortHash: c.shortHash,
+				message: c.message,
+				author: c.author,
+				authorEmail: c.authorEmail,
+				date: c.date,
+				parents: c.parents,
+				refs: (refsBySha.get(c.hash) ?? []).map((r): GraphRef => {
+					if (r.type !== "branch") {
+						return { name: r.name, type: r.type, state: null };
+					}
+					return {
+						name: r.name,
+						type: r.type,
+						...branchRefState(
+							r.fullRef,
+							r.name,
+							branchWorktree,
+							workspaceByPath,
+							mergedSet,
+						),
+					};
+				}),
+			}));
+
+			const out: ListGraphResult = {
+				commits,
+				nextCursor,
+				totalCommits: result.totalCommits,
+			};
+			return out;
+		}),
+
 	getCommitFiles: queryProcedure
 		.meta({ timeoutMs: 15_000 })
 		.input(
@@ -247,7 +434,7 @@ export const gitRouter = router({
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
 			const dedupeKey = `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`;
-			const files = await runCommitFilesDeduped(dedupeKey, () =>
+			const result = await runCommitFilesDeduped(dedupeKey, () =>
 				getHostWorkerPool().run(
 					gitCommitFilesTask,
 					{
@@ -264,7 +451,7 @@ export const gitRouter = router({
 				),
 			);
 
-			return { files };
+			return result;
 		}),
 
 	getBaseBranch: queryProcedure

--- a/packages/host-service/src/trpc/router/git/types.ts
+++ b/packages/host-service/src/trpc/router/git/types.ts
@@ -133,3 +133,66 @@ export interface Commit {
 	authorEmail: string;
 	date: string;
 }
+
+/** Full metadata for a single commit — subject + body, authorship, parents.
+ *  Returned alongside `getCommitFiles` so a commit diff pane can render a
+ *  metadata header without a second spawn. */
+export interface CommitMetadata {
+	hash: string;
+	shortHash: string;
+	/** Full commit message — subject and body. */
+	message: string;
+	author: string;
+	authorEmail: string;
+	date: string;
+	parents: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Git graph (listGraph) — sidebar topology view
+// ---------------------------------------------------------------------------
+
+export type GraphRefType = "head" | "branch" | "remote" | "tag";
+
+export type GraphRefState =
+	| "open"
+	| "detached-worktree"
+	| "orphan-branch"
+	| "prunable"
+	| "merged";
+
+/** Which refs seed git.listGraph's traversal. See `buildTipSet`. */
+export type GraphRefScope =
+	| "local"
+	| "open-workspaces"
+	| "remote"
+	| "all"
+	| "head";
+
+export interface GraphRef {
+	name: string;
+	type: GraphRefType;
+	state: GraphRefState | null;
+	worktreePath?: string;
+	worktreeWorkspaceId?: string;
+	pruneReason?: string;
+}
+
+export interface GraphCommit {
+	hash: string;
+	shortHash: string;
+	message: string;
+	author: string;
+	authorEmail: string;
+	date: string;
+	parents: string[];
+	refs: GraphRef[];
+}
+
+export interface ListGraphResult {
+	commits: GraphCommit[];
+	nextCursor: string | null;
+	/** Total commits reachable from the tip set (independent of window), or
+	 * null when the count could not be determined. */
+	totalCommits: number | null;
+}

--- a/packages/host-service/src/trpc/router/git/utils/graph-log.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/graph-log.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildTipSet,
+	classifyRefType,
+	parseForEachRef,
+	parseGraphLog,
+	parseMergedBranches,
+	refShortName,
+	worktreeByBranch,
+} from "./graph-log";
+
+describe("classifyRefType", () => {
+	test("classifies heads, tags, remotes, and HEAD", () => {
+		expect(classifyRefType("refs/heads/main")).toBe("branch");
+		expect(classifyRefType("refs/tags/v1.0")).toBe("tag");
+		expect(classifyRefType("refs/remotes/origin/main")).toBe("remote");
+		expect(classifyRefType("HEAD")).toBe("head");
+	});
+
+	test("returns null for unrecognized refs", () => {
+		expect(classifyRefType("refs/stash")).toBeNull();
+		expect(classifyRefType("origin/main")).toBeNull();
+		expect(classifyRefType("main")).toBeNull();
+	});
+});
+
+describe("refShortName", () => {
+	test("strips known prefixes", () => {
+		expect(refShortName("refs/heads/feature/x")).toBe("feature/x");
+		expect(refShortName("refs/tags/v1.0")).toBe("v1.0");
+		expect(refShortName("refs/remotes/origin/main")).toBe("origin/main");
+		expect(refShortName("HEAD")).toBe("HEAD");
+	});
+});
+
+describe("parseForEachRef", () => {
+	test("classifies and drops symbolic remote HEAD", () => {
+		const raw = [
+			"aaa\trefs/heads/main\trefs/remotes/origin/main",
+			"bbb\trefs/heads/feature\t",
+			"aaa\trefs/remotes/origin/HEAD\t", // symbolic — dropped
+			"aaa\trefs/remotes/origin/main\t",
+			"ccc\trefs/tags/v1.0\t",
+		].join("\n");
+		const refs = parseForEachRef(raw);
+		expect(refs).toHaveLength(4);
+		expect(
+			refs.find((r) => r.fullRef === "refs/remotes/origin/HEAD"),
+		).toBeUndefined();
+		const main = refs.find((r) => r.fullRef === "refs/heads/main");
+		expect(main?.type).toBe("branch");
+		expect(main?.upstream).toBe("refs/remotes/origin/main");
+		expect(main?.name).toBe("main");
+		const tag = refs.find((r) => r.fullRef === "refs/tags/v1.0");
+		expect(tag?.type).toBe("tag");
+	});
+
+	test("skips blank / malformed lines", () => {
+		expect(parseForEachRef("")).toEqual([]);
+		expect(parseForEachRef("onlyhash")).toEqual([]);
+	});
+});
+
+describe("parseGraphLog", () => {
+	test("parses 7-field rows and keeps tabs in subject", () => {
+		const raw =
+			"fullhash\tshort\t<p1> <p2>\tAda\tada@x\t2024-01-02T03:04:05Z\tsubject with\ttab";
+		const commits = parseGraphLog(raw);
+		expect(commits).toHaveLength(1);
+		const c = commits[0];
+		if (!c) throw new Error("expected commit");
+		expect(c).toMatchObject({
+			hash: "fullhash",
+			shortHash: "short",
+			author: "Ada",
+			authorEmail: "ada@x",
+			date: "2024-01-02T03:04:05Z",
+			message: "subject with\ttab",
+		});
+		expect(c.parents).toEqual(["<p1>", "<p2>"]);
+	});
+
+	test("root commit has empty parents", () => {
+		const commits = parseGraphLog("h\tsh\t\tA\ta@x\t2024\tmsg");
+		const c = commits[0];
+		if (!c) throw new Error("expected commit");
+		expect(c.parents).toEqual([]);
+	});
+
+	test("skips blank / short rows", () => {
+		expect(parseGraphLog("")).toEqual([]);
+		expect(parseGraphLog("a\tb")).toEqual([]);
+	});
+});
+
+describe("parseMergedBranches", () => {
+	test("keeps only refs/heads lines", () => {
+		const raw = "refs/heads/main\nrefs/heads/merged\n  \nrefs/heads/other";
+		expect(parseMergedBranches(raw).sort()).toEqual([
+			"refs/heads/main",
+			"refs/heads/merged",
+			"refs/heads/other",
+		]);
+	});
+});
+
+describe("buildTipSet", () => {
+	test("dedupes and always includes head", () => {
+		const tips = buildTipSet({
+			head: "HEAD",
+			baseRef: "refs/heads/main",
+			localBranchRefs: ["refs/heads/main", "refs/heads/feature"],
+			detachedWorktreeHeads: ["deadbeef"],
+			upstreamRefs: ["refs/remotes/origin/main"],
+		});
+		expect(tips.sort()).toEqual(
+			[
+				"HEAD",
+				"deadbeef",
+				"refs/heads/feature",
+				"refs/heads/main",
+				"refs/remotes/origin/main",
+			].sort(),
+		);
+	});
+
+	test("works with null base and empty sets", () => {
+		const tips = buildTipSet({
+			head: "HEAD",
+			baseRef: null,
+			localBranchRefs: [],
+			detachedWorktreeHeads: [],
+			upstreamRefs: [],
+		});
+		expect(tips).toEqual(["HEAD"]);
+	});
+
+	test("scopes widen from head to all", () => {
+		const args = {
+			head: "HEAD",
+			baseRef: "refs/heads/main",
+			localBranchRefs: ["refs/heads/main", "refs/heads/feature"],
+			worktreeBranchRefs: ["refs/heads/feature"],
+			detachedWorktreeHeads: ["deadbeef"],
+			upstreamRefs: ["refs/remotes/origin/feature"],
+		};
+		expect(buildTipSet({ ...args, scope: "head" })).toEqual(["HEAD"]);
+		expect(buildTipSet({ ...args, scope: "open-workspaces" }).sort()).toEqual(
+			["HEAD", "deadbeef", "refs/heads/feature", "refs/heads/main"].sort(),
+		);
+		expect(buildTipSet({ ...args, scope: "local" })).toContain(
+			"refs/remotes/origin/feature",
+		);
+		// `remote` is HEAD + one flag: no local branches, no worktree heads.
+		expect(buildTipSet({ ...args, scope: "remote" }).sort()).toEqual(
+			["HEAD", "--remotes"].sort(),
+		);
+		// `all` never enumerates refs — one flag, whatever the tag count.
+		expect(buildTipSet({ ...args, scope: "all" }).sort()).toEqual(
+			[
+				"HEAD",
+				"deadbeef",
+				"refs/heads/main",
+				"--exclude=refs/stash",
+				"--all",
+			].sort(),
+		);
+	});
+});
+
+describe("worktreeByBranch", () => {
+	test("maps non-bare branch worktrees, skips detached/bare", () => {
+		const map = worktreeByBranch([
+			{
+				path: "/a",
+				head: "h1",
+				branch: "main",
+				detached: false,
+				bare: false,
+				locked: null,
+				prunable: null,
+			},
+			{
+				path: "/b",
+				head: "h2",
+				branch: null,
+				detached: true,
+				bare: false,
+				locked: null,
+				prunable: null,
+			},
+			{
+				path: "/c",
+				head: null,
+				branch: null,
+				detached: false,
+				bare: true,
+				locked: null,
+				prunable: null,
+			},
+			{
+				path: "/d",
+				head: "h3",
+				branch: "feature",
+				detached: false,
+				bare: false,
+				locked: null,
+				prunable: null,
+			},
+		]);
+		expect([...map.keys()].sort()).toEqual(["feature", "main"]);
+		expect(map.get("main")?.path).toBe("/a");
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/graph-log.ts
+++ b/packages/host-service/src/trpc/router/git/utils/graph-log.ts
@@ -1,0 +1,212 @@
+// Pure parsers and classifiers for git.listGraph. No git, no DB, no tRPC —
+// everything here operates on raw git stdout strings and is unit-testable.
+// The worker task (workers/tasks/git.ts) spawns git and feeds stdout here; the
+// tRPC coordinator (git.ts listGraph) joins the worker's structured output
+// against DB workspace rows to compute ref state.
+
+import type { WorktreeRecord } from "../../workspace-creation/shared/worktree-list";
+import type { GraphRefScope, GraphRefType } from "../types";
+
+/** Commit as parsed from `git log` (no refs attached yet). */
+export interface RawGraphCommit {
+	hash: string;
+	shortHash: string;
+	parents: string[];
+	author: string;
+	authorEmail: string;
+	date: string;
+	message: string;
+}
+
+/** A ref resolved to its target sha, classified by type. The decoration map
+ * is built from these; the coordinator attaches per-commit and adds state. */
+export interface GraphRefRecord {
+	sha: string;
+	name: string;
+	type: GraphRefType;
+	/** Fully-qualified refname (e.g. `refs/heads/main`), or "HEAD". */
+	fullRef: string;
+}
+
+/** Raw `for-each-ref` row including the upstream column. */
+export interface ParsedRef extends GraphRefRecord {
+	/** Upstream ref (`refs/remotes/<remote>/<branch>`) for local branches, or "". */
+	upstream: string;
+}
+
+/** Output of the git graph worker task. The coordinator post-processes this. */
+export interface GraphLogTaskOutput {
+	commits: RawGraphCommit[];
+	refs: GraphRefRecord[];
+	worktrees: WorktreeRecord[];
+	/** Full refnames (`refs/heads/<name>`) contained in the base ref. */
+	mergedBranches: string[];
+	totalCommits: number | null;
+}
+
+/** Classify a full refname into a graph ref type, or null if unrecognized. */
+export function classifyRefType(fullRef: string): GraphRefType | null {
+	if (fullRef === "HEAD") return "head";
+	if (fullRef.startsWith("refs/heads/")) return "branch";
+	if (fullRef.startsWith("refs/tags/")) return "tag";
+	if (fullRef.startsWith("refs/remotes/")) return "remote";
+	return null;
+}
+
+/** Short display name from a full refname. */
+export function refShortName(fullRef: string): string {
+	if (fullRef.startsWith("refs/heads/"))
+		return fullRef.slice("refs/heads/".length);
+	if (fullRef.startsWith("refs/tags/"))
+		return fullRef.slice("refs/tags/".length);
+	if (fullRef.startsWith("refs/remotes/")) {
+		return fullRef.slice("refs/remotes/".length);
+	}
+	return fullRef;
+}
+
+/**
+ * Parse `git for-each-ref --format=%(objectname)%x09%(refname)%x09%(upstream)`
+ * across refs/heads/, refs/remotes/, refs/tags/. Drops the symbolic remote
+ * HEAD refs (`refs/remotes/<remote>/HEAD`) so the default branch isn't
+ * double-decorated.
+ */
+export function parseForEachRef(raw: string): ParsedRef[] {
+	const records: ParsedRef[] = [];
+	for (const line of raw.split("\n")) {
+		if (!line) continue;
+		const cols = line.split("\t");
+		const sha = cols[0];
+		const fullRef = cols[1] ?? "";
+		const upstream = cols[2] ?? "";
+		if (!sha || !fullRef) continue;
+		const type = classifyRefType(fullRef);
+		if (!type) continue;
+		if (
+			type === "remote" &&
+			fullRef.startsWith("refs/remotes/") &&
+			fullRef.endsWith("/HEAD")
+		) {
+			continue;
+		}
+		records.push({
+			sha,
+			name: refShortName(fullRef),
+			type,
+			fullRef,
+			upstream,
+		});
+	}
+	return records;
+}
+
+/**
+ * Parse `git log --format=%H%x09%h%x09%P%x09%an%x09%ae%x09%aI%x09%s`.
+ * The subject is emitted LAST so a tab inside it cannot shift the structured
+ * fields ahead of it; the first six tabs are authoritative and everything
+ * after the sixth is re-joined as the subject (subjects may contain tabs).
+ */
+export function parseGraphLog(raw: string): RawGraphCommit[] {
+	const commits: RawGraphCommit[] = [];
+	for (const line of raw.split("\n")) {
+		if (!line) continue;
+		const parts = line.split("\t");
+		if (parts.length < 7) continue;
+		const [hash, shortHash, parentsRaw, author, authorEmail, date] = parts;
+		const message = parts.slice(6).join("\t");
+		commits.push({
+			hash: hash ?? "",
+			shortHash: shortHash ?? "",
+			parents: (parentsRaw ?? "").split(" ").filter(Boolean),
+			author: author ?? "",
+			authorEmail: authorEmail ?? "",
+			date: date ?? "",
+			message,
+		});
+	}
+	return commits;
+}
+
+/**
+ * Parse `git branch --merged <baseRef> --format=%(refname)` into a set of full
+ * local-branch refnames contained in the base ref.
+ */
+export function parseMergedBranches(raw: string): string[] {
+	return raw
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.startsWith("refs/heads/"));
+}
+
+/**
+ * Assemble the deduped list of git tips for a ref scope. All inputs are
+ * assumed to exist (the worker validates before calling); duplicate strings
+ * are collapsed and git log deduplicates reachability regardless.
+ *
+ * - `head`: HEAD alone — the checked-out branch's own history.
+ * - `open-workspaces`: HEAD, base, detached worktree heads, and the branches
+ *   actually checked out in a worktree.
+ * - `local` (default): the above plus every local branch and the tracked
+ *   upstream of the current branch. Tags and other remotes decorate only.
+ * - `remote`: HEAD plus every `refs/remotes/*` — what the last fetch saw on
+ *   the server, without local-only branches. Reflects fetch time, not origin
+ *   right now; this never fetches.
+ * - `all`: every ref, via git's own `--all` — a tag-heavy repo would otherwise
+ *   put thousands of refnames on one command line.
+ */
+export function buildTipSet(args: {
+	scope?: GraphRefScope;
+	head: string;
+	baseRef: string | null;
+	localBranchRefs: string[];
+	detachedWorktreeHeads: string[];
+	upstreamRefs: string[];
+	/** `refs/heads/…` checked out in some worktree. Tips under
+	 *  `open-workspaces` only. */
+	worktreeBranchRefs?: string[];
+}): string[] {
+	const scope = args.scope ?? "local";
+	const tips = new Set<string>();
+	tips.add(args.head);
+	if (scope === "head") return [...tips];
+	if (scope === "remote") {
+		// One arg for every `refs/remotes/*`, same argument-count guard as `--all`.
+		// Local branches and detached worktree heads stay out — that is the point
+		// of the scope. HEAD stays so you can see where you sit against them.
+		tips.add("--remotes");
+		return [...tips];
+	}
+	if (args.baseRef) tips.add(args.baseRef);
+	for (const s of args.detachedWorktreeHeads) tips.add(s);
+	if (scope === "open-workspaces") {
+		for (const r of args.worktreeBranchRefs ?? []) tips.add(r);
+		return [...tips];
+	}
+	if (scope === "all") {
+		// Argument-count guard: `--all` is one arg whatever the ref count. The
+		// worktree heads above still have to be named — they are not refs.
+		// `--exclude` must precede the `--all` it filters.
+		tips.add("--exclude=refs/stash");
+		tips.add("--all");
+		return [...tips];
+	}
+	for (const r of args.localBranchRefs) tips.add(r);
+	for (const u of args.upstreamRefs) tips.add(u);
+	return [...tips];
+}
+
+/**
+ * Build a branch-name → worktree map for the non-bare, branch-checked-out
+ * worktrees. A branch can be checked out in at most one worktree (git
+ * enforces this), so the mapping is 1:1.
+ */
+export function worktreeByBranch(
+	worktrees: WorktreeRecord[],
+): Map<string, WorktreeRecord> {
+	const map = new Map<string, WorktreeRecord>();
+	for (const w of worktrees) {
+		if (w.bare || w.detached || !w.branch) continue;
+		if (!map.has(w.branch)) map.set(w.branch, w);
+	}
+	return map;
+}

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -12,11 +12,27 @@ import {
 	readWorkspaceRefs,
 	type WorkspaceRefsSnapshot,
 } from "../../runtime/pull-requests/utils/workspace-refs.ts";
-import type { ChangedFile } from "../../trpc/router/git/types.ts";
+import type {
+	ChangedFile,
+	CommitMetadata,
+	GraphRefScope,
+} from "../../trpc/router/git/types.ts";
 import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-freshness.ts";
-import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
+import {
+	getChangedFilesForDiff,
+	resolveBaseComparison,
+} from "../../trpc/router/git/utils/git-helpers.ts";
 import type { GitStatusSnapshotComputation } from "../../trpc/router/git/utils/git-status.ts";
 import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
+import {
+	buildTipSet,
+	type GraphLogTaskOutput,
+	type GraphRefRecord,
+	parseForEachRef,
+	parseGraphLog,
+	parseMergedBranches,
+	worktreeByBranch,
+} from "../../trpc/router/git/utils/graph-log.ts";
 import {
 	normalizeWorktreePath,
 	parseWorktreeList,
@@ -60,15 +76,48 @@ export const gitCommitFilesTask = defineWorkerTask<
 		fromHash?: string;
 		gitEnv: GitTaskEnv;
 	},
-	ChangedFile[]
+	{ files: ChangedFile[]; commit: CommitMetadata | null }
 >({
 	type: "git/getCommitFiles",
 	handler: async ({ worktreePath, commitHash, fromHash, gitEnv }) => {
 		const git = createUserSimpleGit(worktreePath).env(gitEnv);
 		const from = fromHash ? fromHash : `${commitHash}^`;
-		return getChangedFilesForDiff(git, [from, commitHash]);
+		// Fetch the commit's full metadata alongside the file list — one extra
+		// spawn in the worker, so a diff pane gets its header for free with no
+		// second round-trip. %B is last and may contain tabs, so it is split off
+		// by position rather than by a delimiter it could contain.
+		const format = "%H%x09%h%x09%P%x09%an%x09%ae%x09%aI%x09%B";
+		const [files, metaRaw] = await Promise.all([
+			getChangedFilesForDiff(git, [from, commitHash]),
+			git.raw(["show", "-s", `--format=${format}`, commitHash]).catch(() => ""),
+		]);
+		const commit = parseCommitMetadata(metaRaw, commitHash);
+		return { files, commit };
 	},
 });
+
+/** Parse `git show -s --format=...` output into CommitMetadata. Fields before
+ *  the body are single-token; the body (%B, last) may contain tabs and is split
+ *  off by position so it survives intact. */
+export function parseCommitMetadata(
+	raw: string,
+	fallbackHash: string,
+): CommitMetadata | null {
+	const line = raw.trim();
+	if (!line) return null;
+	const parts = line.split("\t");
+	if (parts.length < 6) return null;
+	const [hash, shortHash, parentsRaw, author, authorEmail, date] = parts;
+	return {
+		hash: hash || fallbackHash,
+		shortHash: shortHash || fallbackHash.slice(0, 7),
+		parents: parentsRaw ? parentsRaw.split(" ").filter(Boolean) : [],
+		author: author ?? "",
+		authorEmail: authorEmail ?? "",
+		date: date ?? "",
+		message: parts.slice(6).join("\t").trim(),
+	};
+}
 
 export const gitWorkspaceRefsTask = defineWorkerTask<
 	{ worktreePath: string; gitEnv: GitTaskEnv },
@@ -165,6 +214,173 @@ export const gitDeleteBranchTask = defineWorkerTask<
 	},
 });
 
+/**
+ * Collect the raw topology material for git.listGraph, at any `refScope`.
+ * Every git spawn lives here so the event loop is freed during traversal;
+ * the tRPC coordinator joins `worktrees` against DB workspace rows to compute
+ * ref `state` (workers cannot touch the DB).
+ *
+ * Spawns: for-each-ref (heads/remotes/tags), worktree list, rev-parse HEAD,
+ * base-resolution helpers (symbolic-ref/config), branch --merged, rev-list
+ * --count, log. Each is tolerant of a missing base / unborn repo so a partial
+ * repo state returns an empty window instead of a 500.
+ */
+export const gitGraphLogTask = defineWorkerTask<
+	{
+		worktreePath: string;
+		baseBranch?: string;
+		refScope: GraphRefScope;
+		limit: number;
+		skip: number;
+		gitEnv: GitTaskEnv;
+	},
+	GraphLogTaskOutput
+>({
+	type: "git/graphLog",
+	handler: async ({
+		worktreePath,
+		baseBranch,
+		refScope,
+		limit,
+		skip,
+		gitEnv,
+	}) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+
+		const [refsRaw, worktreesRaw, headShaRaw] = await Promise.all([
+			git
+				.raw([
+					"for-each-ref",
+					"--format=%(objectname)%09%(refname)%09%(upstream)",
+					"refs/heads/",
+					"refs/remotes/",
+					"refs/tags/",
+				])
+				.catch(() => ""),
+			git.raw(["worktree", "list", "--porcelain"]).catch(() => ""),
+			git.revparse(["HEAD"]).catch(() => ""),
+		]);
+
+		const parsedRefs = parseForEachRef(refsRaw);
+		const worktrees = parseWorktreeList(worktreesRaw);
+		const headSha = headShaRaw.trim();
+
+		// Unborn repo: no commits to graph. Still return refs/worktrees so the
+		// coordinator can decorate the empty state if ever needed.
+		if (!headSha || !/^[0-9a-f]{7,}$/.test(headSha)) {
+			return {
+				commits: [],
+				refs: parsedRefs.map((r) => ({
+					sha: r.sha,
+					name: r.name,
+					type: r.type,
+					fullRef: r.fullRef,
+				})),
+				worktrees,
+				mergedBranches: [],
+				totalCommits: 0,
+			};
+		}
+
+		// Resolve + validate the base ref (it may name a remote that was never
+		// fetched). A missing base means no "merged" classification and no base
+		// tip, but the graph still renders.
+		let baseRef: string | null = null;
+		const base = await resolveBaseComparison(git, baseBranch).catch(() => null);
+		if (base?.baseRef) {
+			const verified = await git
+				.raw(["rev-parse", "--verify", "--quiet", `${base.baseRef}^{commit}`])
+				.catch(() => "");
+			if (/^[0-9a-f]{7,}/.test(verified.trim())) baseRef = base.baseRef;
+		}
+
+		const mergedBranches =
+			baseRef !== null
+				? parseMergedBranches(
+						await git
+							.raw(["branch", "--merged", baseRef, "--format=%(refname)"])
+							.catch(() => ""),
+					)
+				: [];
+
+		// Upstream of the current branch only; consumed by the "local" scope
+		// ("all" returns before reading it — `--all` already covers remotes).
+		// Restricted to refs that exist in this repo so the tip set stays valid.
+		const refFullSet = new Set(parsedRefs.map((r) => r.fullRef));
+		const normWorktree = normalizeWorktreePath(worktreePath);
+		const currentBranch =
+			worktrees.find(
+				(w) =>
+					!w.detached &&
+					!w.bare &&
+					w.branch !== null &&
+					normalizeWorktreePath(w.path) === normWorktree,
+			)?.branch ?? null;
+		const upstreamRefs: string[] = [];
+		if (currentBranch) {
+			const cur = parsedRefs.find(
+				(r) => r.fullRef === `refs/heads/${currentBranch}`,
+			);
+			if (cur?.upstream && refFullSet.has(cur.upstream)) {
+				upstreamRefs.push(cur.upstream);
+			}
+		}
+
+		const tips = buildTipSet({
+			scope: refScope,
+			head: "HEAD",
+			baseRef,
+			localBranchRefs: parsedRefs
+				.filter((r) => r.type === "branch")
+				.map((r) => r.fullRef),
+			// ponytail: "open workspaces" is read off `git worktree list`, not the
+			// workspaces table — the worker has no DB and every Superset workspace
+			// is a worktree. A worktree created outside Superset counts too; join
+			// against DB rows in the coordinator if that ever matters.
+			// Prunable is dropped here, not in `worktreeByBranch`: the coordinator
+			// needs those entries to classify a branch `prunable`, but a worktree
+			// whose directory is gone is not an open workspace.
+			worktreeBranchRefs: [...worktreeByBranch(worktrees)]
+				.filter(([, w]) => !w.prunable)
+				.map(([branch]) => `refs/heads/${branch}`),
+			detachedWorktreeHeads: worktrees
+				.filter((w) => w.detached && !w.bare && w.head !== null)
+				.map((w) => w.head as string),
+			upstreamRefs,
+		});
+
+		const [logRaw, countRaw] = await Promise.all([
+			git
+				.raw([
+					"log",
+					"--topo-order",
+					`--max-count=${limit + 1}`,
+					`--skip=${skip}`,
+					...tips,
+					"--format=%H%x09%h%x09%P%x09%an%x09%ae%x09%aI%x09%s",
+				])
+				.catch(() => ""),
+			git.raw(["rev-list", "--count", ...tips]).catch(() => ""),
+		]);
+
+		const commits = parseGraphLog(logRaw);
+		const trimmed = countRaw.trim();
+		const totalCommits = /^\d+$/.test(trimmed)
+			? Number.parseInt(trimmed, 10)
+			: null;
+
+		const refs: GraphRefRecord[] = parsedRefs.map((r) => ({
+			sha: r.sha,
+			name: r.name,
+			type: r.type,
+			fullRef: r.fullRef,
+		}));
+		refs.push({ sha: headSha, name: "HEAD", type: "head", fullRef: "HEAD" });
+
+		return { commits, refs, worktrees, mergedBranches, totalCommits };
+	},
+});
+
 export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
@@ -174,4 +390,5 @@ export const gitTasks = [
 	gitWorktreeStateTask,
 	gitWorktreeRemoveTask,
 	gitDeleteBranchTask,
+	gitGraphLogTask,
 ];

--- a/packages/host-service/test/integration/git-graph.integration.test.ts
+++ b/packages/host-service/test/integration/git-graph.integration.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
+
+/**
+ * Walks the full commit window of git.listGraph and flattens every ref so
+ * state/tag/head assertions don't depend on which commit a ref decorates.
+ */
+function allBranchStates(result: {
+	commits: Array<{ refs: Array<{ type: string; state: string | null }> }>;
+}) {
+	const states = new Set<string>();
+	for (const c of result.commits) {
+		for (const r of c.refs) {
+			if (r.type === "branch" && r.state) states.add(r.state);
+		}
+	}
+	return states;
+}
+
+describe("git.listGraph", () => {
+	let scenario: BasicScenario;
+	/** Adjacent temp dir holding feature/stale worktrees so dispose() (which
+	 * rms the repo) plus this cleanup leaves nothing behind. */
+	let worktreeBase: string;
+
+	beforeEach(async () => {
+		scenario = await createBasicScenario();
+		worktreeBase = mkdtempSync(join(tmpdir(), "host-service-graph-wt-"));
+	});
+
+	afterEach(async () => {
+		await scenario?.dispose();
+		rmSync(worktreeBase, { recursive: true, force: true });
+	});
+
+	test("returns empty window for a fresh repo with a single commit", async () => {
+		const result = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+		});
+		// HEAD + main + initial commit are reachable; the window has exactly
+		// the one seeded commit, decorated with HEAD + the main branch.
+		expect(result.commits.length).toBeGreaterThanOrEqual(1);
+		expect(result.nextCursor).toBeNull();
+	});
+
+	test("classifies all local ref states and decorates tags/HEAD with parents populated", async () => {
+		const { git } = scenario.repo;
+		// Base ref so resolveBaseComparison + `git branch --merged` resolve.
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+		await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			"refs/remotes/origin/main",
+		]);
+
+		// A branch merged into base via a no-ff merge commit (2 parents).
+		await git.checkoutLocalBranch("merged-prev");
+		await scenario.repo.commit("on merged-prev", { "mp.txt": "x" });
+		await git.checkout("main");
+		await git.raw([
+			"merge",
+			"--no-ff",
+			"merged-prev",
+			"-m",
+			"merge merged-prev into main",
+		]);
+		// Advance base past the merge so merged-prev is contained in base.
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+
+		// An orphan branch: a commit not reachable from base.
+		await git.checkoutLocalBranch("orphan");
+		await scenario.repo.commit("on orphan", { "orphan.txt": "o" });
+		await git.checkout("main");
+
+		// Recent commit on main so the window has content beyond the merge.
+		const taggedSha = await scenario.repo.commit("recent on main", {
+			"recent.txt": "1",
+		});
+		await git.raw(["tag", "v1.0", taggedSha]);
+
+		// A worktree with NO workspaces row → detached-worktree.
+		const featurePath = join(worktreeBase, "feature");
+		await git.raw(["worktree", "add", "-b", "feature", featurePath]);
+
+		// A worktree whose path is deleted from disk → prunable.
+		const stalePath = join(worktreeBase, "stale");
+		await git.raw(["worktree", "add", "-b", "stale", stalePath]);
+		rmSync(stalePath, { recursive: true, force: true });
+
+		const result = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 500,
+		});
+
+		// All five local-branch states are represented.
+		const states = allBranchStates(result);
+		expect(states.has("open")).toBe(true); // main (repo root, has a row)
+		expect(states.has("detached-worktree")).toBe(true); // feature
+		expect(states.has("orphan-branch")).toBe(true); // orphan
+		expect(states.has("prunable")).toBe(true); // stale
+		expect(states.has("merged")).toBe(true); // merged-prev
+
+		// The merge commit carries two parents.
+		const mergeCommit = result.commits.find(
+			(c) => c.message === "merge merged-prev into main",
+		);
+		expect(mergeCommit).toBeDefined();
+		expect(mergeCommit?.parents.length).toBe(2);
+
+		// Tags and HEAD decorate commits.
+		const allRefs = result.commits.flatMap((c) => c.refs);
+		expect(allRefs.some((r) => r.type === "tag" && r.name === "v1.0")).toBe(
+			true,
+		);
+		expect(allRefs.some((r) => r.type === "head" && r.name === "HEAD")).toBe(
+			true,
+		);
+
+		// Remote-tracking decorations are not local-branch states.
+		expect(
+			result.commits.some((c) =>
+				c.refs.some((r) => r.type === "remote" && r.state === null),
+			),
+		).toBe(true);
+
+		// totalCommits is the full reachable set (independent of window).
+		expect(result.totalCommits).toBe(result.commits.length);
+		expect(result.nextCursor).toBeNull();
+	});
+
+	test("pagination via cursor windows the graph without losing totalCommits", async () => {
+		const { git } = scenario.repo;
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+		for (let i = 0; i < 5; i++) {
+			await scenario.repo.commit(`commit ${i}`, { [`f${i}.txt`]: `${i}` });
+		}
+
+		const first = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 2,
+		});
+		expect(first.commits).toHaveLength(2);
+		expect(first.nextCursor).toMatch(/^skip:2:local$/);
+		// totalCommits reflects the full reachable history, not the window.
+		expect(first.totalCommits).toBe(6); // initial + 5
+
+		const second = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 2,
+			cursor: first.nextCursor,
+		});
+		expect(second.commits[0]?.hash).not.toBe(first.commits[0]?.hash);
+		expect(second.nextCursor).toMatch(/^skip:4:local$/);
+
+		// A cursor issued for another scope is dropped, not replayed: page one
+		// again rather than a window of rows that traversal never produced.
+		const foreign = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 2,
+			refScope: "head",
+			cursor: first.nextCursor,
+		});
+		expect(foreign.commits[0]?.hash).toBe(first.commits[0]?.hash);
+		expect(foreign.nextCursor).toMatch(/^skip:2:head$/);
+	});
+
+	test("topo order holds even when author dates are out of chronological order", async () => {
+		const { git } = scenario.repo;
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+
+		// `m2` is authored 2020. `m3` is m2's own child but BACKDATED to 2010,
+		// older than its parent. `--date-order` (mutually exclusive with
+		// `--topo-order`; git keeps only the last) would sort m3 below m2 —
+		// parent before child — which is exactly the non-topological input
+		// `assignLanes` cannot lay out. `--topo-order` alone keeps the child
+		// above its parent regardless of timestamps.
+		git.env({
+			GIT_AUTHOR_DATE: "2020-02-02T12:00:00",
+			GIT_COMMITTER_DATE: "2020-02-02T12:00:00",
+		});
+		await git.commit("m2", undefined, { "--allow-empty": null });
+		git.env({
+			GIT_AUTHOR_DATE: "2010-01-01T12:00:00",
+			GIT_COMMITTER_DATE: "2010-01-01T12:00:00",
+		});
+		await git.commit("m3 (backdated)", undefined, { "--allow-empty": null });
+
+		const result = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 500,
+		});
+
+		// Topological invariant: a parent present in the window always renders
+		// below (older than) its child. `--date-order` would have broken this
+		// for the backdated m3/m2 pair.
+		const indexByHash = new Map(result.commits.map((c, i) => [c.hash, i]));
+		for (const commit of result.commits) {
+			const ci = indexByHash.get(commit.hash);
+			if (ci === undefined) continue;
+			for (const parent of commit.parents) {
+				const pi = indexByHash.get(parent);
+				if (pi === undefined) continue;
+				expect(
+					pi > ci,
+					`parent ${parent.slice(0, 7)} of ${commit.hash.slice(
+						0,
+						7,
+					)} must render after its child`,
+				).toBe(true);
+			}
+		}
+
+		// The backdated child sits above its parent — the exact case date-order
+		// got wrong.
+		const indexOf = (msg: string) =>
+			result.commits.findIndex((c) => c.message === msg);
+		expect(indexOf("m3 (backdated)")).toBeLessThan(indexOf("m2"));
+		expect(indexOf("m2")).toBeLessThan(indexOf("initial commit"));
+	});
+
+	test("refScope narrows and widens the traversal", async () => {
+		const { git } = scenario.repo;
+		// A branch with no worktree, unreachable from HEAD.
+		await git.checkoutLocalBranch("side");
+		await scenario.repo.commit("on side", { "side.txt": "s" });
+		await git.checkout("main");
+		await scenario.repo.commit("on main", { "main.txt": "m" });
+
+		// A worktree checked out on `side` whose directory is then deleted: git
+		// still lists it (prunable), but it is not an open workspace, so
+		// "open-workspaces" must not pick `side` up through it.
+		const stalePath = join(worktreeBase, "stale");
+		await git.raw(["worktree", "add", stalePath, "side"]);
+		rmSync(stalePath, { recursive: true, force: true });
+
+		const subjects = async (refScope: "head" | "open-workspaces" | "local") =>
+			(
+				await scenario.host.trpc.git.listGraph.query({
+					workspaceId: scenario.workspaceId,
+					refScope,
+				})
+			).commits.map((c) => c.message);
+
+		// "side" has no worktree, so only the branch-wide scopes reach it.
+		expect(await subjects("head")).not.toContain("on side");
+		expect(await subjects("open-workspaces")).not.toContain("on side");
+		expect(await subjects("local")).toContain("on side");
+
+		// "remote" walks refs/remotes only. Nothing is pushed here, so the local
+		// work is absent and only HEAD's own history remains.
+		const remote = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			refScope: "remote",
+		});
+		expect(remote.commits.map((c) => c.message)).not.toContain("on side");
+		await git.raw(["update-ref", "refs/remotes/origin/side", "side"]);
+		const fetched = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			refScope: "remote",
+		});
+		expect(fetched.commits.map((c) => c.message)).toContain("on side");
+
+		// "all" adds remotes and tags as tips; it must at least cover local.
+		const all = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			refScope: "all",
+		});
+		expect(all.commits.map((c) => c.message)).toContain("on side");
+	});
+
+	test("merged classification survives a window that drops the merge commit", async () => {
+		const { git } = scenario.repo;
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+		await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			"refs/remotes/origin/main",
+		]);
+
+		// merged-prev: merged into base, tip lands in the graph.
+		await git.checkoutLocalBranch("merged-prev");
+		await scenario.repo.commit("mp tip", { "mp.txt": "x" });
+		await git.checkout("main");
+		await git.raw(["merge", "--no-ff", "merged-prev", "-m", "merge mp"]);
+		await git.raw([
+			"update-ref",
+			"refs/remotes/origin/main",
+			"refs/heads/main",
+		]);
+
+		// Bury the merge under enough commits that a small window excludes it.
+		for (let i = 0; i < 3; i++) {
+			await scenario.repo.commit(`after merge ${i}`, { [`a${i}.txt`]: `${i}` });
+		}
+
+		// Full window: merged-prev tip is visible and classified "merged".
+		const full = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 500,
+		});
+		const mpRef = full.commits
+			.flatMap((c) => c.refs)
+			.find((r) => r.name === "merged-prev");
+		expect(mpRef?.state).toBe("merged");
+
+		// `git branch --merged` is computed independent of the log window: a
+		// paged query that shows fewer commits still reports the same total.
+		const paged = await scenario.host.trpc.git.listGraph.query({
+			workspaceId: scenario.workspaceId,
+			limit: 2,
+		});
+		expect(paged.totalCommits).toBe(full.totalCommits);
+	});
+});

--- a/packages/host-service/test/integration/git-history.integration.test.ts
+++ b/packages/host-service/test/integration/git-history.integration.test.ts
@@ -52,7 +52,7 @@ describe("git history + diff procedures", () => {
 	});
 
 	test("getCommitFiles lists files changed in a commit", async () => {
-		const sha = await scenario.repo.commit("add files", {
+		const sha = await scenario.repo.commit("add files\n\nwith a body line", {
 			"x.txt": "x content",
 			"y.txt": "y content",
 		});
@@ -64,6 +64,15 @@ describe("git history + diff procedures", () => {
 		const paths = result.files.map((f) => f.path).sort();
 		expect(paths).toContain("x.txt");
 		expect(paths).toContain("y.txt");
+
+		// getCommitFiles also returns the commit's full metadata so a diff pane
+		// can render a header without a second spawn — subject, body, author,
+		// date and parents.
+		expect(result.commit).not.toBeNull();
+		expect(result.commit?.hash).toBe(sha);
+		expect(result.commit?.message).toBe("add files\n\nwith a body line");
+		expect(result.commit?.author).toBe("Test Runner");
+		expect(result.commit?.parents).toHaveLength(1);
 	});
 
 	test("getDiff returns staged content for a staged change", async () => {

--- a/packages/host-service/test/integration/git-history.integration.test.ts
+++ b/packages/host-service/test/integration/git-history.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
 
@@ -73,6 +73,18 @@ describe("git history + diff procedures", () => {
 		expect(result.commit?.message).toBe("add files\n\nwith a body line");
 		expect(result.commit?.author).toBe("Test Runner");
 		expect(result.commit?.parents).toHaveLength(1);
+	});
+
+	test("getCommitFiles rejects an option-shaped revision", async () => {
+		// `git show` reads a leading `-` as an option, and `--output=<file>`
+		// writes wherever it points. Only hash-shaped revisions get through.
+		await expect(
+			scenario.host.trpc.git.getCommitFiles.query({
+				workspaceId: scenario.workspaceId,
+				commitHash: `--output=${join(scenario.repo.repoPath, "pwned")}`,
+			}),
+		).rejects.toThrow();
+		expect(existsSync(join(scenario.repo.repoPath, "pwned"))).toBe(false);
 	});
 
 	test("getDiff returns staged content for a staged change", async () => {

--- a/plans/done/20260801-commit-graph-sidebar.md
+++ b/plans/done/20260801-commit-graph-sidebar.md
@@ -1,0 +1,356 @@
+# Visual Commit Graph in the Workspace Sidebar
+
+## Context
+
+Superset's v2 workspace sidebar has three tabs (Files / Changes / Review). Commit history exists only
+as a flat `base..HEAD` dropdown (`CommitFilterDropdown`) — no topology, no ref decorations, no view of
+the branches and worktrees agents create outside the currently-open workspaces. Upstream asks for this
+in #4935 and #5594 (#3849 folded in); no PR has ever attempted graph rendering.
+
+The deliverable is a fourth `Graph` tab rendering a lane-based commit graph. The **primary value is ref
+classification, not lanes**: surfacing branches and worktrees that exist in git but have no open
+Superset workspace (`detached-worktree`, `orphan-branch`, `prunable`, `merged`). Lanes are the frame;
+the state badges are the feature.
+
+Read-only in phase 1. Commit selection reuses the existing diff surface via `changesFilter` — no new
+diff pipeline.
+
+Repo rule: on implementation, copy this doc to `plans/` (cross-cutting) per `AGENTS.md`, never
+`*_PLAN.md` at an app root.
+
+## Verified against HEAD `2d1a792ac`
+
+| Fact | Location |
+|---|---|
+| Tab registry, `SidebarTabId` union, `VALID_TAB_IDS`, `isSidebarTabId` | `WorkspaceSidebar.tsx:23-29,148` |
+| `compact` breakpoint (280/260 hysteresis) | `WorkspaceSidebar.tsx:86-99` |
+| Persisted `activeTab` enum | `dashboardSidebarLocal/schema.ts:131`, defaults `:172` |
+| Per-project persisted row (keyed by projectId) | `dashboardSidebarProjectSchema` `schema.ts:10`, collection `collections.ts:777` |
+| `changesFilter` → `DiffRef` → diff surface | `schema.ts:~90`, `useSidebarDiffRef.ts` |
+| `listCommits` is `base..HEAD`, flat, no parents/refs; consumed by desktop + mobile | `git/git.ts:197` |
+| Worker task pattern + registration array | `workers/tasks/git.ts:22-81` |
+| `resolveBaseComparison` | `git/utils/git-helpers.ts:157` |
+| `ResolvedRef`, `asLocalRef`, `asRemoteRef`, `resolveUpstream` | `runtime/git/refs.ts` |
+| Guardrails: no `origin/` string prefixes, no raw `simpleGit()` | `scripts/check-git-ref-strings.sh`, `scripts/check-simple-git-usage.sh` |
+| Integration harness `createBasicScenario` | `test/helpers/scenarios`, used by `git-history.integration.test.ts` |
+| Worker purity: no `../db`, `../events`, `../daemon`, no native addons | `test/integration/no-native-worker-imports.test.ts` |
+
+**Three corrections to earlier assumptions:**
+
+1. Worktree parsing precedent is **not** `readWorkspaceRefs` (that reads one workspace's
+   branch/head/upstream). It is `parseWorktreeList` / `listGitWorktrees` / `normalizeWorktreePath` in
+   `trpc/router/workspace-creation/shared/worktree-list.ts` — declared single source of truth for
+   `git worktree list --porcelain`. Reuse it; do not re-parse inline.
+2. `git:changed` invalidation for v2 lives in `renderer/hooks/host-service/useGitStatus/useGitStatus.ts:83`,
+   not `useChangesTab.tsx` (which invalidates only on manual refresh / base-branch change).
+3. No healing migration is needed for the new tab id. `WorkspaceSidebar.tsx:72` already guards
+   `activeTab` through `isSidebarTabId` and falls back to `"changes"`; `healWorkspaceLocalState`
+   spreads unknown values through untouched. Adding `"graph"` to the zod enum + the union suffices.
+
+Also worth stating: no 500-commit cap exists in host-service today (the #5890 precedent is not in this
+tree). The cap below is new.
+
+## Contract — `git.listGraph`
+
+```ts
+// input
+{
+  workspaceId: z.string(),
+  baseBranch: z.string().optional(),                                  // same shape as listCommits
+  refScope: z.enum(["local", "open-workspaces", "all", "head"]).default("local"),
+  limit: z.number().int().min(1).max(2000).default(500),
+  cursor: z.string().optional(),
+}
+```
+
+Phase 1 implements `local` only. `open-workspaces` / `all` / `head` throw
+`TRPCError({ code: "NOT_IMPLEMENTED" })` — the enum ships now so the contract does not reopen.
+
+**`local` tip set** (deduped before `git log`), seeded from git's own refs, never from workspace records:
+
+- `HEAD`
+- resolved base ref (`resolveBaseComparison(git, baseBranch)` → `baseRef`; do not re-derive)
+- upstream tracking refs of HEAD and of base (`resolveUpstream`)
+- every local branch (`for-each-ref refs/heads/`)
+- every worktree head (`git worktree list --porcelain`), including worktrees with no Superset workspace
+
+Excluded as tips: all other remote refs, and tags. Tags still decorate commits inside the window.
+In git terms: `--branches` plus explicit tips, not `--all`.
+
+```ts
+// output
+{
+  commits: Array<{
+    hash: string; shortHash: string; message: string;
+    author: string; authorEmail: string; date: string;
+    parents: string[];
+    refs: Array<{
+      name: string;
+      type: "head" | "branch" | "remote" | "tag";
+      state: "open" | "detached-worktree" | "orphan-branch" | "prunable" | "merged" | null;
+      worktreePath?: string;
+      worktreeWorkspaceId?: string;   // absent when the worktree has no open workspace
+      pruneReason?: string;           // from worktree list --porcelain
+    }>;
+  }>;
+  nextCursor: string | null;
+  totalCommits: number | null;        // true count for the truncation banner
+}
+```
+
+State rules (local-branch refs only; remote/tag/HEAD entries carry `state: null`):
+
+| Condition | `state` |
+|---|---|
+| worktree registered, path missing from disk | `prunable` (+ `pruneReason`) |
+| worktree registered, `workspaces` row matches path | `open` (+ `worktreeWorkspaceId`, `worktreePath`) |
+| worktree registered, no `workspaces` row | `detached-worktree` (+ `worktreePath`) |
+| no worktree, contained in base | `merged` |
+| no worktree, not contained | `orphan-branch` |
+
+A detached (branch-less) worktree emits a ref entry named after its directory basename with
+`type: "head"` and the same `detached-worktree` / `prunable` state.
+
+**Containment comes from `git branch --merged <baseRef> --format=%(refname)`, not from graph
+topology** — a branch merged 800 commits back sits outside the window and would misclassify as
+`orphan-branch`.
+
+`cursor` is opaque (`skip:<n>`), applied as `--skip`. Fetch `limit + 1` to detect more; `nextCursor`
+null when exhausted. Documented as best-effort: pages re-anchor when refs move between fetches.
+
+Persistence: `refScope` goes on `dashboardSidebarProjectSchema` (per project, keyed by projectId),
+**not** per workspace and not global.
+
+## Architecture
+
+### (a) Host-service — data
+
+New pure util `packages/host-service/src/trpc/router/git/utils/graph-log.ts`:
+`buildTipSet`, `parseGraphLog`, `classifyRefs` — no tRPC, no DB, unit-testable.
+
+New worker task in `workers/tasks/git.ts` (register in the exported `gitTasks` array):
+
+```ts
+gitGraphLogTask: defineWorkerTask<
+  { worktreePath: string; baseBranch?: string; refScope: "local"; limit: number; skip: number; gitEnv: GitTaskEnv },
+  { commits: RawGraphCommit[]; refs: GraphRefRecord[]; worktrees: WorktreeRecord[]; mergedBranches: string[]; totalCommits: number | null }
+>
+```
+
+Every git spawn happens in the worker (base resolution included — `resolveBaseComparison` is already in
+the worker's import graph via `getGitStatusSnapshot`), so both stdout draining and parsing stay off the
+host event loop. Spawns per call: `for-each-ref` (heads+remotes+tags, one call), `worktree list
+--porcelain`, `branch --merged`, `log`, `rev-list --count`, plus base resolution.
+
+Log format — subject last so embedded tabs can't shift fields:
+
+```
+git log --topo-order --date-order --max-count=<limit+1> --skip=<n> <tips...> \
+  --format=%H%x09%h%x09%P%x09%an%x09%ae%x09%aI%x09%s
+```
+
+**Do not use `%D` for decorations.** Build the sha→refs map from
+`for-each-ref refs/heads/ refs/remotes/ refs/tags/ --format=%(objectname)\t%(refname)\t%(upstream)`
+and classify from the **full refname** into `ResolvedRef` (`runtime/git/refs.ts`). Never infer kind from
+a shortname prefix — `check-git-ref-strings.sh` fails CI on it, and a local branch may legitimately be
+named `origin/foo`.
+
+New procedure `listGraph` in `trpc/router/git/git.ts` (leave `listCommits` untouched — desktop and
+`apps/mobile/.../useWorkspaceCommits` consume its output type). Coordinator responsibilities only:
+`resolveWorktreePath`, `resolveGitTaskEnv`, run the worker, then join worktree paths against
+`ctx.db.query.workspaces` (compare through `normalizeWorktreePath` on both sides — git canonicalizes,
+DB rows may hold symlinked paths) and stamp `state` / `worktreeWorkspaceId`. Workers cannot import
+`../db`; the join must live here.
+
+Output types go in `trpc/router/git/types.ts` beside `Commit`.
+
+### (b) Lane assignment — pure, renderer-side
+
+`.../WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/{assignLanes.ts,assignLanes.test.ts,index.ts}`
+
+`RawGraphCommit[] → GraphRow[]` where `GraphRow = { commit, lane, edges: Array<{fromLane, toLane, kind: "straight"|"fork"|"merge"}>, laneCount }`.
+
+Active-lane sweep over topo-ordered input: lanes keyed by expected-next-hash; a commit takes the
+leftmost lane awaiting it or opens a new one; first parent inherits the lane; extra parents open/close
+lanes and emit merge edges. Lane color = stable hash of the lane's originating branch name (fallback:
+lane index) so colors don't reshuffle on refetch. No React, no tRPC types in this file.
+
+Tests: linear; simple merge; octopus (3+ parents); criss-cross; orphan/root; lane freed then reused;
+parent outside the window (renders a stub edge, must not throw); determinism when commits are appended.
+
+### (c) Renderer — the tab
+
+```
+.../WorkspaceSidebar/hooks/useGraphTab/
+  useGraphTab.tsx          # returns SidebarTabDefinition, mirrors useChangesTab
+  types.ts  index.ts
+  components/
+    GraphTabContent/       # virtualizer + loading/empty/error + truncation banner
+    GraphRow/              # lanes + refs + subject + author + date
+    GraphLanes/            # per-row inline SVG painter
+    RefBadge/              # branch / tag / HEAD / worktree pill, state-colored
+    CommitDetailPanel/     # author, date, full message, changed files (getCommitFiles)
+```
+
+- Fixed row height (~28px) for a cheap `estimateSize`; no per-row measurement.
+  `@tanstack/react-virtual` 3.14.3 is already a desktop dep — pattern to copy:
+  `renderer/screens/main/.../CommitListVirtualized/CommitListVirtualized.tsx` (v1, from merged #2763).
+- Per-row inline SVG of width `laneCount * laneWidth`, not one tall absolutely-positioned canvas —
+  keeps virtualization trivial.
+- Cap the lane column at ~8 visible lanes with an overflow indicator.
+- `compact` (sidebar < 280px): lanes + short hash + subject only; drop author/date.
+- Theme tokens only, no hardcoded hex; lane colors must survive a light/dark switch.
+- **Cache-first rendering** (`AGENTS.md` rule 11): render existing rows whenever `data` is present;
+  `isReady`/`isLoading` only decide the no-data case.
+
+Invalidation: subscribe in `useGraphTab` via
+`renderer/hooks/host-service/useWorkspaceEvent` → `useWorkspaceEvent("git:changed", workspaceId, cb)`.
+Invalidate `git.listGraph` **only when `payload.paths` is absent** (present = worktree-only edit, which
+cannot move refs). No polling — `GitWatcher` is already debounced host-side.
+
+Selection: row click → `collections.v2WorkspaceLocalState.update(workspaceId, draft => { draft.sidebarState.changesFilter = { kind: "commit", hash } })`;
+shift-click a second row → `{ kind: "range", fromHash, toHash }`. `useSidebarDiffRef` reads the
+persisted filter independently of the active tab, so the main diff surface follows without a tab
+switch. Known cosmetic gap: `CommitFilterDropdown`'s label lookup only knows `base..HEAD` commits, so a
+graph-selected commit outside that range shows a sliced hash — acceptable in phase 1.
+
+## Files touched
+
+**New:** `git/utils/graph-log.ts` (+ test), `hooks/useGraphTab/**`, `utils/assignLanes/**`,
+`test/integration/git-graph.integration.test.ts`.
+
+**Edited (6, keep the diff surface minimal — these ship daily upstream; rebase weekly):**
+`packages/ui/src/globals.css` (additive `--graph-lane-1..8`, light + dark) ·
+`workers/tasks/git.ts` (task + `gitTasks` registration) · `trpc/router/git/git.ts` (`listGraph`) ·
+`trpc/router/git/types.ts` (output types) · `WorkspaceSidebar.tsx` (union + `VALID_TAB_IDS` + `graphTab`) ·
+`dashboardSidebarLocal/schema.ts` (`activeTab` enum + `graphRefScope` on the project schema).
+
+## Build order
+
+The visual layer ships **first**, as real code, so the data layer never has to guess at geometry or
+colour and Phase 4 is not a blocker.
+
+**Visual layer:**
+
+- `hooks/useGraphTab/components/GraphLanes/`, `GraphRow/`, `RefBadge/` — presentational only, pure
+  props-in / SVG-and-markup-out, no tRPC, no collections, no data fetching.
+- `apps/desktop/plans/git-graph-visual-spec.md` — lane geometry (lane width, node radius, curve radii,
+  stroke weights), lane color ramp bound to existing theme tokens, `state` → badge treatment table,
+  truncation banner, empty / loading, compact rules, light + dark.
+- A self-contained HTML mock for review before the components land.
+- Storybook-less visual check: render the components against a hand-written `GraphRow[]` fixture
+  (linear, merge, octopus, all five ref states) so they can be eyeballed without the data layer.
+
+**Data layer:** phases 1, 2, 3, 5, 6 — worker task, `listGraph`, `assignLanes`, tab registration,
+virtualizer, selection/diff wiring. Imports the three components as-is. No colour or spacing invented
+locally; a spec gap gets resolved in the spec rather than improvised at the call site.
+
+**Direction inputs for the spec:**
+
+- Rounded elbows over angular ones; a rotating lane palette rather than a per-branch hash; merge rows
+  dimmed by default; local and remote labels for the same branch combined into one badge to cut badge
+  density at 280px.
+- Perf target: 100k+ commits with no scroll lag. The failure mode to avoid is picking one arbitrary
+  branch to straighten in complex trees — a worktree-centric graph cannot do that.
+- The narrow-width fix is **merging lanes that share a parent** to cut horizontal size, rather than
+  scrolling sideways. Adopt for the >8-lane collapse.
+- Collapsing linear runs into a single edge, showing only roots, heads and merge/fork points, is a
+  candidate for compact mode below 260px — noted, not committed.
+
+**Taken for the row treatment:**
+
+- **Per-row background tint in the lane's colour** (~6% alpha, full row width). Lane membership stays
+  readable without tracing lines — the highest-value trick available, and it degrades gracefully when
+  lanes compress at narrow widths.
+- **Rounded elbows**, vertical lanes, filled node with a coloured ring.
+- **Muted, single-line, ellipsised subjects**; relative date right-aligned.
+- **Selected row = full-width lighter band**, not an outline.
+- Explicitly *not* taken: badges in a left gutter joined to the node by a leader line (needs a ~700px
+  graph column), avatar-on-node (needs an avatar cache and network — deferred), and a ~24px lane pitch
+  (too wide for a 280px sidebar).
+
+**Provisional geometry** (fixed in the spec, reviewed via the HTML mock before any TSX lands):
+row 28px / compact 24px · lane pitch 14px · node r 3.5px · stroke 1.5px · elbow radius 6px ·
+lane cap 6 visible (84px of 280px) then merge lanes sharing a parent, then a `+N` overflow chip.
+
+**Palette needs new tokens.** `packages/ui/src/globals.css` ships only `--chart-1..5`, and their hues
+are *not* stable across themes (light `--chart-1` is orange, dark is blue) — a lane would change colour
+on a theme switch. The spec adds `--graph-lane-1..8` (light + dark, equal chroma/lightness so lanes read
+as one family) to that file. That makes a 6th edited file; it is additive and touches nothing existing.
+No hardcoded hex anywhere in the components.
+
+**Seam (frozen before the data layer starts):**
+
+```ts
+GraphRow      { row: GraphRowModel; refs: GraphRef[]; compact: boolean; selected: boolean; onSelect: (e) => void }
+GraphLanes    { lane: number; edges: GraphEdge[]; laneCount: number; compact: boolean }
+RefBadge      { name: string; type: GraphRef["type"]; state: GraphRef["state"]; compact: boolean; pruneReason?: string }
+```
+
+`GraphRowModel` / `GraphEdge` are the `assignLanes` output types from §(b) — declared in
+`hooks/useGraphTab/types.ts` up front so both layers compile against one definition.
+
+## Phases
+
+Each phase ends green on `bun run lint && bun run typecheck && bun test`, separate commit.
+Conventional-commit PR titles (`feat(host-service): add listGraph procedure`).
+
+Phase order changes: **Phase 4 (lane rendering) runs first**, against fixtures. Then 1 → 2 → 3 → 5 → 6
+uninterrupted.
+
+- **0 — Setup.** Branch `feat/git-graph-sidebar`, `bun install`, `bun run dev:desktop` boots, tests pass. Record the forked-from commit. No code.
+- **4 — Lane rendering (first).** `types.ts` seam + `GraphLanes` / `GraphRow` / `RefBadge` + visual spec + HTML mock, verified against fixtures.
+- **1 — Data.** `graph-log.ts` + `gitGraphLogTask` + `listGraph`.
+- **2 — Lanes.** `assignLanes` + tests. No UI.
+- **3 — Tab shell.** Register `graph`, extend both enums, virtualized list wired to the landed components.
+- **5 — Selection & diff wiring.** commit / range filters + `CommitDetailPanel`.
+- **6 — Perf pass.** Profile on a large repo; add a bench beside `packages/host-service/scripts/git-status-large-repo-profile.ts` if marginal.
+
+## Verification
+
+**Phase 1 acceptance (the gate that matters).** Integration test beside
+`test/integration/git-history.integration.test.ts` using `createBasicScenario`. Fixture repo with:
+one open workspace, one worktree with **no** `workspaces` row, one orphan local branch, one prunable
+worktree (path deleted from disk), plus a merge commit, a tag, and a branch merged into base. Assert
+all four ref states are returned correctly, that parents are populated, and that a branch merged
+outside the commit window still reports `merged`. Also assert `bun run lint` passes (it runs both
+guardrail scripts).
+
+**Phase 2:** unit tests per §(b), including determinism across appended commits.
+
+**Phase 3:** tab survives app restart; an old row with `activeTab: "changes"` loads; a corrupt value
+falls back to `"changes"` rather than throwing.
+
+**Phase 4:** components render a hand-written fixture set (linear, merge, octopus, all five ref states)
+at 260px, 400px, full width, in light and dark. HTML mock reviewed before the TSX
+lands. Topology check against `git log --graph --oneline --branches` happens once phase 3 wires real
+data — the components alone can only be checked against fixtures, and the plan says so rather than
+claiming end-to-end proof.
+
+**Phase 5:** a commit selected in the graph shows the same diff as the same commit selected in
+`CommitFilterDropdown`.
+
+**Phase 6:** initial paint < 300ms warm; no dropped frames scrolling 500 rows; host-service event loop
+unblocked during a graph fetch.
+
+CDP checks follow the six-point protocol in `apps/desktop/AGENTS.md` — match the worktree's renderer
+port before testing, capture before/after evidence, and state which checks were end-to-end vs synthetic.
+
+## Deferred
+
+Write actions (checkout, cherry-pick, revert, tag) · author/message filtering · graph on the `local`
+workspace · mobile (iOS-only, out of scope) · `open-workspaces` / `all` / `head` scopes ·
+`git worktree prune` from the graph (state is read-only, surfaced only).
+
+**Queued follow-up:** an "unreferenced only" filter chip in the graph header — branches and worktrees
+with no open workspace. That is the day-to-day view worth opening.
+
+## Risks
+
+1. **Sidebar width.** 280px is tight. If phase 3 already feels cramped, prototype a graph *pane*
+   (`packages/panes`) before committing to phase 4.
+2. **Lane stability.** Pin lane identity to the originating branch / first-parent chain, never array
+   position, or every `git:changed` reshuffles the graph.
+3. **Spawn count.** ~6 git spawns per `listGraph` call. All in the worker, but if `git:changed` storms
+   during a rebase, coalesce by `dedupeKey` like `gitCommitFilesTask` does.
+4. **Divergence.** The 5 edited files are actively developed upstream. Rebase weekly.

--- a/plans/done/20260801-commit-graph-sidebar.md
+++ b/plans/done/20260801-commit-graph-sidebar.md
@@ -144,7 +144,7 @@ host event loop. Spawns per call: `for-each-ref` (heads+remotes+tags, one call),
 
 Log format — subject last so embedded tabs can't shift fields:
 
-```
+```sh
 git log --topo-order --date-order --max-count=<limit+1> --skip=<n> <tips...> \
   --format=%H%x09%h%x09%P%x09%an%x09%ae%x09%aI%x09%s
 ```
@@ -168,7 +168,9 @@ Output types go in `trpc/router/git/types.ts` beside `Commit`.
 
 `.../WorkspaceSidebar/hooks/useGraphTab/utils/assignLanes/{assignLanes.ts,assignLanes.test.ts,index.ts}`
 
-`RawGraphCommit[] → GraphRow[]` where `GraphRow = { commit, lane, edges: Array<{fromLane, toLane, kind: "straight"|"fork"|"merge"}>, laneCount }`.
+`RawGraphCommit[] → GraphRow[]` where `GraphRow = { commit, lane, edges: Array<{fromLane, toLane, kind}>, laneCount }`.
+As built, `kind` is `"pass" | "in-straight" | "in-merge" | "out-straight" | "out-fork" | "out-stub"` —
+each row paints its own half-edges, so incoming and outgoing are separate kinds.
 
 Active-lane sweep over topo-ordered input: lanes keyed by expected-next-hash; a commit takes the
 leftmost lane awaiting it or opens a new one; first parent inherits the lane; extra parents open/close
@@ -180,7 +182,7 @@ parent outside the window (renders a stub edge, must not throw); determinism whe
 
 ### (c) Renderer — the tab
 
-```
+```text
 .../WorkspaceSidebar/hooks/useGraphTab/
   useGraphTab.tsx          # returns SidebarTabDefinition, mirrors useChangesTab
   types.ts  index.ts
@@ -220,7 +222,7 @@ graph-selected commit outside that range shows a sliced hash — acceptable in p
 `test/integration/git-graph.integration.test.ts`.
 
 **Edited (6, keep the diff surface minimal — these ship daily upstream; rebase weekly):**
-`packages/ui/src/globals.css` (additive `--graph-lane-1..8`, light + dark) ·
+`apps/desktop/src/renderer/globals.css` (additive `--graph-lane-1..8`, light + dark) ·
 `workers/tasks/git.ts` (task + `gitTasks` registration) · `trpc/router/git/git.ts` (`listGraph`) ·
 `trpc/router/git/types.ts` (output types) · `WorkspaceSidebar.tsx` (union + `VALID_TAB_IDS` + `graphTab`) ·
 `dashboardSidebarLocal/schema.ts` (`activeTab` enum + `graphRefScope` on the project schema).
@@ -273,7 +275,7 @@ locally; a spec gap gets resolved in the spec rather than improvised at the call
 row 28px / compact 24px · lane pitch 14px · node r 3.5px · stroke 1.5px · elbow radius 6px ·
 lane cap 6 visible (84px of 280px) then merge lanes sharing a parent, then a `+N` overflow chip.
 
-**Palette needs new tokens.** `packages/ui/src/globals.css` ships only `--chart-1..5`, and their hues
+**Palette needs new tokens.** The desktop renderer's `globals.css` ships only `--chart-1..5`, and their hues
 are *not* stable across themes (light `--chart-1` is orange, dark is blue) — a lane would change colour
 on a theme switch. The spec adds `--graph-lane-1..8` (light + dark, equal chroma/lightness so lanes read
 as one family) to that file. That makes a 6th edited file; it is additive and touches nothing existing.
@@ -312,7 +314,7 @@ uninterrupted.
 `test/integration/git-history.integration.test.ts` using `createBasicScenario`. Fixture repo with:
 one open workspace, one worktree with **no** `workspaces` row, one orphan local branch, one prunable
 worktree (path deleted from disk), plus a merge commit, a tag, and a branch merged into base. Assert
-all four ref states are returned correctly, that parents are populated, and that a branch merged
+all five ref states are returned correctly, that parents are populated, and that a branch merged
 outside the commit window still reports `merged`. Also assert `bun run lint` passes (it runs both
 guardrail scripts).
 

--- a/plans/done/20260803-commit-graph-followups.md
+++ b/plans/done/20260803-commit-graph-followups.md
@@ -4,7 +4,7 @@ Follow-up to `plans/` sibling work on the sidebar commit graph. The graph ships 
 this document covers what is left. Every item states the files, the acceptance bar, and why the
 decision went the way it did.
 
-Predecessor plan: `plans/20260801-commit-graph-sidebar.md` (phases 0–6). Phases 0–4 are landed;
+Predecessor plan: `plans/done/20260801-commit-graph-sidebar.md` (phases 0–6). Phases 0–4 are landed;
 phase 5 is **superseded** by §2 below; phase 6 is partially landed.
 
 ## Current state (verified, do not redo)
@@ -40,7 +40,7 @@ Both corrupt what everything downstream renders. Cheap.
 
 `packages/host-service/src/workers/tasks/git.ts:211-212`:
 
-```
+```text
 "--topo-order",
 "--date-order",
 ```
@@ -245,6 +245,8 @@ follow-up; same header slot as 4.1/4.2.
 ## 5. Verification debt
 
 Things believed correct but never actually checked. Each is a place a regression can hide today.
+**§5.6 is the authoritative status**: 5.1–5.5 below are the debt as first written, and 5.6 records
+what has since been run and what is still open.
 
 ### 5.1 Phase 6 perf pass never ran
 

--- a/plans/done/20260803-commit-graph-followups.md
+++ b/plans/done/20260803-commit-graph-followups.md
@@ -1,0 +1,357 @@
+# Commit Graph — Pending Work
+
+Follow-up to `plans/` sibling work on the sidebar commit graph. The graph ships and renders live;
+this document covers what is left. Every item states the files, the acceptance bar, and why the
+decision went the way it did.
+
+Predecessor plan: `plans/20260801-commit-graph-sidebar.md` (phases 0–6). Phases 0–4 are landed;
+phase 5 is **superseded** by §2 below; phase 6 is partially landed.
+
+## Current state (verified, do not redo)
+
+| Thing | Where | State |
+|---|---|---|
+| `listGraph` procedure | `packages/host-service/src/trpc/router/git/git.ts:296` | landed, `local` scope only; other scopes throw `NOT_IMPLEMENTED` |
+| `gitGraphLogTask` | `packages/host-service/src/workers/tasks/git.ts` | landed |
+| Integration test | `packages/host-service/test/integration/git-graph.integration.test.ts` | landed |
+| Large-repo bench | `packages/host-service/scripts/git-graph-large-repo-profile.ts` | ran once, results in §5.1 below; script removed before merge |
+| `assignLanes` | `.../useGraphTab/utils/assignLanes/` | landed, **one defect open** (§1.2) |
+| Graph tab registration | `WorkspaceSidebar.tsx:28,33` | landed |
+| `graphRefScope` persistence | `CollectionsProvider/dashboardSidebarLocal/schema.ts:16-20` | landed, **no UI reads it** beyond the fetch input |
+| Lane colours | `apps/desktop/src/shared/themes/graph-lanes.ts` | landed, verified live |
+| Row tint + hover | `.../GraphRow/GraphRow.tsx` | landed (`f51b2161b`) |
+
+**Do not edit** (design layer, landed and verified): `shared/themes/graph-lanes.ts`,
+`graph-lanes.test.ts`, `.../components/GraphRow/`, `.../components/GraphLanes/`,
+`.../components/RefBadge/`, the `--graph-lane-*` blocks in
+`apps/desktop/src/renderer/globals.css`, and `stores/theme/utils/css-variables.ts`. A gap in the
+visual layer comes back as a question, not a local fix.
+
+Topology was checked end-to-end against `git log --graph --oneline --branches` on a real
+repository: 16/16 sampled rows matched on order, lane assignment, and merge/fork elbows.
+
+---
+
+## 1. Confirmed defects — do these first
+
+Both corrupt what everything downstream renders. Cheap.
+
+### 1.1 `--topo-order` is silently discarded
+
+`packages/host-service/src/workers/tasks/git.ts:211-212`:
+
+```
+"--topo-order",
+"--date-order",
+```
+
+The two are mutually exclusive in git; the last one wins. The log therefore comes back in date
+order, while `assignLanes` assumes topological input. Delete line 212.
+
+**Acceptance:** the integration test gains a case with a branch whose commits are authored out of
+chronological order relative to the trunk; lane assignment stays stable.
+
+### 1.2 Lane colour collision
+
+Two lanes drawn side by side in the same row get the same colour. Measured live: **15 of 42
+rendered rows**, e.g. `--graph-lane-7` painted at both `x=7` and `x=21` within one row.
+
+Not a palette problem — eight distinct lane colours exist and resolve correctly in the renderer
+(verified via computed styles). The colour assignment in `assignLanes` is the cause.
+
+Fix is a rotating counter that advances when a **new lane opens**, skipping any colour currently
+live in another open lane. Not `laneIndex % 8` — lane indices are
+reused as lanes close, so two live lanes collide as soon as the graph is wider than the reuse
+window.
+
+**Acceptance:** a unit test asserting no two concurrently-open lanes share a colour, over a fixture
+with more open lanes than palette entries (forces the wrap-around case). Note the honest ceiling:
+with 8 colours and 9+ simultaneous lanes, collision is unavoidable — the test asserts collisions
+only appear past `GRAPH_LANE_COUNT`, not never.
+
+### 1.3 Phantom tip edge — verify only
+
+An inbound stroke above the newest commit. Appears already fixed in the working tree (graph tip
+renders `["M7,14 V28"]`, no inbound stroke). Confirm with a test rather than re-fixing.
+
+---
+
+## 2. Commit panes — replaces phase 5
+
+Phase 5 as originally written ("reuse `changesFilter` so the main diff surface follows without a
+tab switch") is **cancelled**. It was the cheap version and it conflicts with the decision below.
+
+### Decisions taken
+
+1. **A graph click no longer writes `changesFilter`.** The graph owns its own pane. The Changes tab
+   keeps showing whatever it was showing. Rationale: with one shared piece of state, clicking
+   around the graph silently retargets the Changes tab — two surfaces fighting over one selection.
+2. **Scope for this pass:** preview + pin + range + row context menu. Write actions (checkout,
+   revert, cherry-pick) stay deferred.
+
+### 2.1 Graph-owned selection state
+
+`GraphRow`'s `selected` / `inRange` props are currently derived from `changesFilter`
+(`useGraphTab.tsx:76-86`), and the shift-click anchor is read out of the same field
+(`useGraphTab.tsx:95-110`). Stop writing `changesFilter` and the graph stops highlighting itself.
+
+Add a `graphSelection` field to `sidebarState`
+(`CollectionsProvider/dashboardSidebarLocal/schema.ts:132`), same discriminated shape as
+`changesFilterSchema` minus the `all` case:
+
+```ts
+{ kind: "commit"; hash: string } | { kind: "range"; fromHash: string; toHash: string } | undefined
+```
+
+Selection highlight and the shift-click anchor both read from it. Persisted per workspace, so a
+selection survives a tab switch and an app restart.
+
+This is the first thing the change hits; it is not optional.
+
+### 2.2 Extend the `diff` pane — do **not** add a `commit` pane type
+
+Earlier discussion floated a new `commit` member on `PaneType`. Extending the existing `diff` kind
+is the better call, for two concrete reasons:
+
+- `PaneType` (`apps/desktop/src/shared/tabs-types.ts:11`) is shared between main and renderer and
+  is **persisted inside pane layouts**. A new member is a forward-compat liability someone has to
+  verify against older builds. Extending an existing kind has no such surface.
+- Everything the new kind was going to buy is reachable from the registry context: `getTitle`,
+  `getIcon` and `renderPane` all receive the pane, so a ref-carrying diff pane can title itself
+  with a short hash and render a metadata header.
+
+Today `diff` is a **follower, not a document**: `usePaneRegistry.tsx:285-301` hardcodes
+`getTitle: () => "Changes"`, and `DiffPane` reads `useSidebarDiffRef()` off persisted sidebar state
+rather than off its own pane data. Two diff panes are two views of the same filter.
+
+Changes:
+
+- Pane data gains `ref?: { kind: "commit"; hash } | { kind: "range"; fromHash; toHash }` and
+  `isPinned?: boolean`.
+- `DiffPane` takes an optional ref prop, falling back to `useSidebarDiffRef()` when absent. The
+  Changes tab passes nothing and behaves **identically** — that fallback is what keeps the follower
+  semantics intact.
+- `getTitle`: short hash for a commit ref, `abc1234..def5678` for a range, `"Changes"` when the ref
+  is absent. `getIcon`: `GitCommitHorizontal` when a ref is present, existing `GitCompareArrows`
+  otherwise.
+
+**The discriminator that makes this safe:** `ref === undefined` marks the follower pane. Preview
+reuse (§2.3) must only ever reuse panes that already carry a ref, or a commit click would recycle
+the Changes tab's own pane — exactly what decision 1 forbids.
+
+### 2.3 Preview / pin / open semantics
+
+The convention already exists for files: `isPinned` on `FileViewerState`
+(`stores/tabs/types.ts:94`), preview reuse at `stores/tabs/store.ts:~820-845`, `pinPane` at
+`store.ts:1388`. Commit clicks obey the identical rule — no new concept for the user to learn.
+
+| Input | Behaviour |
+|---|---|
+| single click | reuse the unpinned, ref-carrying diff pane in the active tab; replace its ref. Create one if none. |
+| double click | pin the pane already opened by the first click |
+| shift-click | range from the anchor; same pane, title `abc1234..def5678` |
+| cmd/ctrl-click | new pane regardless of reuse |
+
+`pinPane` currently early-returns unless `pane.fileViewer` exists (`store.ts:1390`); generalise it
+to the diff pane's `isPinned` as well.
+
+**Do not debounce single-click waiting for a double.** Single click opens the preview immediately;
+double-click flips `isPinned` on the pane the first click already opened. A 250ms wait puts dead
+feel on every click in the graph.
+
+**Acceptance:** clicking fifteen rows in a row leaves one pane, not fifteen. Pinning one and
+clicking again leaves two.
+
+### 2.4 Commit metadata header
+
+Rendered inside `DiffPane` when a commit ref is present: full message body, author, date, parents,
+ref badges (reuse the landed `RefBadge`). This absorbs the original plan's `CommitDetailPanel` /
+`CommitDetailStrip` — as a pane header it gets real width, instead of being crammed into a 280px
+sidebar strip. That item is now closed by this one.
+
+**Contract gap:** `listGraph` returns `message` from `%s` — subject only. The header wants the
+body. Two options:
+
+- add `%b` to the log format → body for all 500 rows, most never opened, payload inflates
+- fetch on open → one extra spawn, lazy
+
+**Take the second.** Piggyback the existing `getCommitFiles` call the pane already makes on mount.
+Costs nothing until someone opens a commit.
+
+Opening a file from the commit pane is already supported: `createFileViewerPane` accepts
+`commitHash` (`stores/tabs/utils.ts:198`). No new work there.
+
+### 2.5 Row context menu
+
+Read-only: **Copy Hash**, **Copy Short Hash**, **Copy Subject**, **Open in New Tab**.
+
+Note `contextMenuActions` in the pane registry is the *pane header* menu — a different surface. The
+row menu needs whatever the file tree rows use.
+
+---
+
+## 3. Robustness
+
+### 3.1 `dedupeKey` on `gitGraphLogTask`
+
+Roughly nine git spawns per `listGraph` call, all in the worker. A `git:changed` storm during a
+rebase fans that out badly. Coalesce by `dedupeKey` the way `gitCommitFilesTask` already does.
+Carried over from the original plan's risk 3, still unassigned.
+
+**Acceptance:** the bench script (`scripts/git-graph-large-repo-profile.ts`) shows a flat spawn
+count under a burst of overlapping invalidations.
+
+---
+
+## 4. Header controls
+
+The graph header currently holds only a truncation banner
+(`GraphTabContent.tsx:118-125`). Three chips are queued for that slot. All are optional relative to
+§1–§3; land them in this order.
+
+### 4.1 Ref-scope toggle
+
+The persistence already exists (`graphRefScope`, `schema.ts:16-20`, read at
+`useGraphTab.tsx:45-49`, passed at `:62`) and the enum already ships on the procedure. Only `local`
+is implemented; `open-workspaces` / `all` / `head` throw `NOT_IMPLEMENTED`
+(`git.ts:311-316`). So the toggle needs at least one more scope implemented before it has anything
+to switch to.
+
+**Name the axis correctly in the UI.** This is not local-vs-remote: remote refs are already excluded
+as *tips* while still *decorating* commits inside the window. What the scope changes is **which
+tips seed the log**. Labelling it "Local / Remote" will mislead — the remote branches are visible
+either way.
+
+### 4.2 Two-line ref rows
+
+Toggle that moves ref badges onto their own untrimmed line with the commit subject below it, left
+aligned; hash and relative time stay on the subject's line.
+
+This is the strongest of the three — it fixes real badge truncation at sidebar widths, visible today
+(`fix/tm–…`, `origin/…`).
+
+The obvious objection — "variable row height breaks `estimateSize`" — does not hold.
+`@tanstack/react-virtual` takes an index-based `estimateSize(i)`, and whether a row carries refs is
+known before render, so `estimateSize(i) => rows[i].commit.refs.length ? 44 : 28` needs no
+measurement pass. Roughly 15% of rows carry badges, so the added scroll height is small.
+
+### 4.3 "Unreferenced only" chip
+
+Branches and worktrees with no open Superset workspace. Carried over from the original plan's queued
+follow-up; same header slot as 4.1/4.2.
+
+---
+
+## 5. Verification debt
+
+Things believed correct but never actually checked. Each is a place a regression can hide today.
+
+### 5.1 Phase 6 perf pass never ran
+
+`packages/host-service/scripts/git-graph-large-repo-profile.ts` is landed but has not been run.
+Original acceptance bar, unchanged: initial paint < 300ms warm, no dropped frames scrolling 500
+rows, host-service event loop unblocked during a graph fetch. Run it after §3, since `dedupeKey`
+changes the spawn profile the bench measures.
+
+### 5.2 Missing component tests
+
+Tests exist for `assignLanes`, `GraphRow` and `GraphTabContent`. There are none for `GraphLanes`
+(the SVG painter — elbow geometry, lane cap, merge/fork edge kinds) or `RefBadge` (the five ref
+states × compact). Both are pure props-in/markup-out, so they are cheap to cover and they are
+exactly where a silent visual regression would land.
+
+### 5.3 Light theme is entirely unverified
+
+Every live check so far ran on one dark theme. Two specific consequences:
+
+- Lane slots 7 and 8 are `color-mix(… 62%, black)` in light and `… 62%, white)` in dark
+  (`shared/themes/graph-lanes.ts`). The darkening path has never been rendered.
+- The row tint alphas (9% normal, 16% in-range) were tuned against a **dark** ground measured at
+  L\* 8.04, with `--accent` contributing ≈ 8.6 ΔL\* as the ceiling. On a light ground both the
+  ground lightness and the accent delta are different, so the same alphas may read as too strong,
+  too weak, or may collide with the selected-row band.
+
+Check both themes at 260px, 400px and full width before calling the visual layer done. If the light
+tint needs different alphas, that is a `GraphRow` change and comes back rather than being patched
+locally.
+
+### 5.4 Topology check was narrow
+
+The 16/16 match was one repository, one sidebar width, dark theme. Unexercised on real data: the
+compact breakpoint (< 260px), the 8-lane cap and its `+N` overflow chip, and a repository with more
+concurrent lanes than the palette has entries — which is also the fixture §1.2 needs.
+
+### 5.5 A cosmetic gap closes for free
+
+The original plan accepted that a graph-selected commit outside `base..HEAD` shows a sliced hash in
+`CommitFilterDropdown`, because the graph wrote into the same `changesFilter` the dropdown labels.
+§2.1 stops that write, so the dropdown never sees a hash it cannot label. No work — just do not
+re-introduce the coupling.
+
+### 5.6 Verification results
+
+Re-checked against the live app over CDP (renderer matched to this worktree's `DESKTOP_VITE_PORT`,
+graph driven to render real history). Split by method so a regression can't hide behind a label:
+
+- **§5.2 — covered.** `GraphLanes` and `RefBadge` now have markup tests; the light-theme lane
+  overflow darkening path (`color-mix(… 62%, black)`, never rendered before) is pinned by a unit
+  test beside `graph-lanes.test.ts`.
+- **§5.3 dark — end-to-end.** Live graph rows: `--graph-lane-7/8` resolve to the `62%, white`
+  lightening path, the row tint paints as a `linear-gradient(color-mix(in oklch … 9% …))`, edge
+  strokes and node fills resolve. Verified on the running app, not a fixture.
+- **§5.3 light — synthetic (CSS-toggled; the store's `Theme → UIColors → getGraphLanes` route is
+  still unexercised in light, because `useThemeStore` re-imports `electronTrpcClient` and throws on
+  fresh module eval, so the switch was applied via the pure `applyUIColors`/
+  `applyGraphLaneColors` helpers + globals.css's `:root.light` ramp).** Perceptual lightness (oklch
+  L, ≈ CIELAB L*) on a light ground: ground 98.5, 9% tint 94.2 (Δ 4.3), 16% range 90.8 (Δ 7.7),
+  selected row (accent + 9% tint) 92.8 (Δ 5.7). Both bars hold — the 9% tint is visible (Δ ≥ 3) and
+  a tinted row never reads as prominent as a selected one (Δ tint < Δ selected). **§5.3 closes with
+  no `GraphRow` change.** Caveat noted for a future pass: the 16% range rows read slightly darker
+  (Δ 7.7) than the selected endpoints (Δ 5.7) — not a violation of either bar, but the range/selected
+  prominence ordering is worth an eyeball check once the store's light path renders for real.
+- **§5.4 — partial.** Real history renders with non-degenerate topology (rows carry lane SVGs,
+  lanes assign). The narrow cases still unexercised on live data are the compact breakpoint
+  (< 260px), the 8-lane cap and its `+N` overflow chip, and a window wider than the palette — the
+  same topology-heavy fixture §1.2's test builds synthetically. A topology-heavy repo (or the §1.2
+  fixture rendered live) would close it.
+- **§5.1 — run.** `scripts/git-graph-large-repo-profile.ts` against a synthetic repo (600 trunk
+  commits, 8 merged branches, 2 worktrees, limit 500): median warm fetch **153ms** (< 300ms bar),
+  event-loop delay p99 **1.6ms** / max 1.7ms — and that is with the bench running **inline** (no
+  worker bundle in the harness); production's real worker pool isolates further, so these are a
+  lower bound on unblocking. **9 git spawns per call** (matches the plan's estimate), max 3 active
+  concurrently (the `for-each-ref` / `worktree list` / `rev-parse HEAD` fan-out). Caveat: the bench
+  drives sequential iterations, so §3.1's *burst* coalescing (flat spawn count under overlapping
+  invalidations) is not directly measured here — the dedupeKey path is covered by the worker-pool's
+  own tests; a concurrent-burst variant of the bench would close that last gap.
+
+## Dropped
+
+**Header search bar.** Dropped by decision. For the record, the two traps that killed it: searching
+500 rows out of 2891 loaded silently lies about the result set, and filtering commits destroys the
+lanes because parents vanish from the window (git's own `--graph --grep` degrades to simplified
+history for this reason). If it ever comes back, the shape that works is a server-side
+`git log --grep` returning hashes for **find-and-jump**, not filter.
+
+## Deferred
+
+- Combine local + remote ref badges for the same branch into one pill — offered, not taken.
+- Write actions from the graph: checkout, cherry-pick, revert, tag, `git worktree prune`.
+- `open-workspaces` / `all` / `head` scopes beyond whatever 4.1 needs.
+- Graph on the `local` workspace; mobile (iOS-only, out of scope).
+
+## Risks
+
+1. **§2.1 and §2.2 must land together.** Removing the `changesFilter` write without `graphSelection`
+   in place leaves the graph unable to highlight its own selection.
+2. **Preview reuse must filter on `ref !== undefined`** (§2.2). Getting this wrong makes a graph
+   click hijack the Changes tab — the precise failure decision 1 exists to prevent.
+3. The files under §"do not edit" ship as a set with the theme plumbing; a change to lane colours
+   or row chrome needs the palette derivation in `graph-lanes.ts` re-checked, including the Monokai
+   case where the bright and standard ANSI ranks are identical.
+4. Every phase ends green on `bun run lint && bun run typecheck && bun test`, separate commit,
+   conventional-commit PR title. CI fails on Biome **warnings**, not just errors.
+5. **This branch stays on the fork.** `origin` is the only configured remote and `feat/git-graph-sidebar`
+   has no upstream tracking branch. Keep it that way — do not add an upstream remote or push this
+   branch anywhere but `origin`.
+6. The six files this feature edits ship daily on the upstream project. Rebase weekly; the tab
+   registration in `WorkspaceSidebar.tsx` and the persisted schema are the likeliest conflicts.


### PR DESCRIPTION
## What & why

Adds a fourth **Graph** tab to the v2 workspace sidebar: a lane-based commit graph whose primary value is **ref classification**, not the lanes. The lanes are the frame; what the tab is actually for is surfacing branches and worktrees that exist in git but have no open workspace behind them.

Commit history was only reachable as a flat `base..HEAD` dropdown — no topology, and no view at all of the branches and worktrees that accumulate outside the currently-open workspaces. A branch whose worktree was deleted, or a worktree with no workspace row, was invisible until it caused a problem.

Read-only. No write actions (checkout, cherry-pick, revert, prune) in this PR.

Relates to superset-sh/superset#4935 and superset-sh/superset#5594 (superset-sh/superset#3849 folded in).

### Host service — `git.listGraph`

- New procedure alongside `listCommits`, which is untouched (desktop and mobile both consume its output type). `getCommitFiles` is the one existing procedure that changed: it now also returns the commit's own metadata (subject, body, author, date, parents), so a diff pane opened from the graph renders its header without a second spawn.
- Tip set is seeded from git's own refs, never from workspace records. `refScope` picks how wide it goes, and all five values are served:

  | Scope | Tips | Reads as |
  |---|---|---|
  | `head` | `HEAD` | this workspace's own history |
  | `open-workspaces` | + base ref, worktree branches, detached worktree heads | branches open in other Superset workspaces |
  | `local` (default) | + every local branch, the current branch's upstream | everything on this machine |
  | `remote` | `HEAD` + `--remotes` | what the last fetch saw on the server |
  | `all` | `--exclude=refs/stash --all` | every ref, tags included |

  `remote` and `all` pass one flag rather than enumerating refnames, so a tag-heavy repo can't overflow the command line. Detached worktree heads are still named explicitly — they aren't refs. Under `open-workspaces`, a worktree git marks `prunable` is excluded: its directory is gone, so it is not an open workspace.
- Ref state is classified per local branch: `open` · `detached-worktree` · `prunable` (+ reason) · `merged` · `orphan-branch`. Containment comes from `git branch --merged <baseRef>`, not from graph topology, so a branch merged far outside the window still reports `merged`. `prunable` comes from git's own porcelain flag (`gitdir file points to non-existent location`) rather than a per-branch `existsSync`, so classification costs no synchronous fs calls on the host event loop.
- Every git spawn happens in the worker (`gitGraphLogTask`), including base resolution, so both stdout draining and parsing stay off the host event loop. Decorations are built from `for-each-ref` and resolved through `ResolvedRef` — never from `%D`, never from a shortname prefix.
- Overlapping traversals coalesce, so a `git:changed` storm during a rebase doesn't fan out into duplicate walks.
- The pagination cursor is tagged with the scope it was issued for. `--skip` counts rows of one traversal, so replaying a `local` offset against `head` would window a list that never had those rows; a cursor from another scope restarts at page one instead of serving a silently wrong page. Scope is also part of the coalescing dedupe key, so two scopes never share one walk.

### Renderer

- `assignLanes` — pure, tested, no React or tRPC. Active-lane sweep over topo-ordered input; lane identity is pinned to the originating branch so a refetch doesn't reshuffle the graph.
- Virtualized list, per-row inline SVG (not one tall canvas), so virtualization stays trivial. Row height is derived from the commit's own refs — no measurement pass — and the size cache is keyed by commit hash so it survives refs moving underneath an open tab.
- Lane colours are new additive `--graph-lane-1..8` tokens in both themes, equal chroma/lightness so the lanes read as one family and survive a theme switch. No component hardcodes a colour; the live values come from `shared/themes/graph-lanes` through `applyGraphLaneColors`, and the hex in `globals.css` is only the pre-hydration fallback set.
- Ref badges encode state in texture as well as colour — fill, dashes, strike — so they still read at 260px and for a colourblind viewer, leaving hue free for lane identity.
- Row tint in the lane's colour makes lane membership readable without tracing lines, and survives the lane compression narrow widths force.
- Commit clicks open the existing `diff` pane kind; the graph owns its own persisted selection, separate from the Changes tab's filter, so the two surfaces no longer fight over one piece of state. Shift-click ranges, cmd/ctrl-click forces a new pane, double-click pins — matching the file tree's convention exactly.
- Read-only row context menu (copy hash / subject / open in new tab).
- The tab's own control strip carries a scope chooser and two toggles. The chooser sits left of them and reads **This workspace · Open workspaces · All local branches · Remote · Everything** — plain wording rather than git's, since the audience is people who don't think in refs. The toggles are ref badges on their own untruncated line, and dimming of commits that carry no unreferenced ref. The strip renders even when the window is empty, so a scope that returns nothing can't take away the control that would let you leave it.

### Notable decisions

**The "unreferenced" filter dims, it does not remove.** Lanes and edges are assigned across the whole commit list; dropping rows would leave the surviving edges pointing at rows that aren't there, and filtering before lane assignment yields a graph of disconnected nodes.

**Selected rows and range-interior rows share a tint alpha.** Selection also carries `--accent`; the range interior doesn't. Same alpha therefore keeps an endpoint strictly brighter than the band it anchors, in both themes, with no per-theme numbers.

**The row size cache is keyed by commit hash, not by list index.** Refs move while the tab is open, so a refetch that prepends a commit shifts every index — under the virtualizer's default index key a row inherits the cached height of whatever previously sat in its slot, which in two-line mode misfits by a whole badge line and shows up as overlapping rows or a blank band. Keying by hash lets a cached size travel with its commit; `rows` is also in the remeasure deps for the case the key can't catch, a ref landing on a commit whose hash doesn't change. Only reproduces on a repo with live churn.

**"Open workspaces" is read off `git worktree list`, not the workspaces table.** The worker has no DB access, and every Superset workspace is a worktree, so the worktree list already answers the question. The known ceiling: a worktree created outside Superset counts as an open workspace. Joining against DB rows in the coordinator is the upgrade path if that ever matters.

**The header toggles read through a live query, not `.get()`.** They write to `v2SidebarProjects`, and `.get()` is a non-reactive snapshot — the row changed in localStorage while the header kept rendering the stale flag until some unrelated re-render happened to run, which reads as a multi-second lag on a write that already completed. No spinner: the write is synchronous and local, so a pending indicator would animate over an already-finished state change. The toggles also `ensureProjectInSidebar` first, matching `useV2ProjectDefaultApp` — a project with no sidebar row yet would otherwise swallow the write entirely.

**The strip's controls are not in `SidebarHeader`'s `actions` slot.** That slot is a `shrink-0` island in a fixed 40px row whose four tab buttons are each `flex-1` with no `min-w-0`; anything rendered there clips the last tab label instead of shrinking it. The chooser and toggles live on the graph's own control strip instead.

## How I tested it

| Gate | Result |
|---|---|
| `bun run lint` | 0 (5832 files) |
| `bun run typecheck` | passes except `@superset/ui`, which fails on a duplicate `@types/hast` resolution in `node_modules`. No `packages/ui` file, `package.json`, or `bun.lock` is in this branch's diff, so it is not from here |
| `bun run test` | 14/15 packages green |
| `apps/desktop` tests | 2617 pass, 1 fail — `getProcessEnvWithShellPath`, environment-dependent and untouched by this branch |
| `packages/host-service` tests | 998 pass, 0 fail, 14 skip |

`refScope` has its own integration test: a branch with no worktree is absent under `head` and `open-workspaces` but present under `local` and `all`; a worktree checked out on that branch whose directory is then deleted stays excluded from `open-workspaces`, which fails without the prunable filter; and `remote` excludes the local-only branch until `refs/remotes/origin/side` exists, then includes it. Cursor handling is covered both ways — a `local` cursor pages forward, and the same cursor handed to `head` restarts at page one instead of windowing rows that traversal never produced. `buildTipSet` is unit-tested per scope, including that `all` and `remote` emit a flag rather than a refname list.

Integration test covers all five ref states against a fixture repo (open workspace, worktree with no workspace row, orphan branch, prunable worktree with its path deleted) plus a merge commit, a tag, and a branch merged outside the commit window. Lane assignment is unit-tested for linear / merge / octopus / criss-cross / root / lane reuse / parent outside the window, including determinism when commits are appended.

Rendering was checked against the running app at 260px and 400px sidebar widths, in both toggle states, with the measurements alongside the screenshots (total virtual size, per-row height, badge clipping). The toggle-reactivity fix was verified end-to-end on the running app.

The row-height regression is pinned by a test that prepends a commit to a mixed-height list and asserts every commit present in both lists keeps the same `(key, size)` pair, looked up by hash rather than by slot. It was confirmed red against the pre-fix behaviour: restoring the index key fails it. The size and key derivation was extracted into a pure `graphRowSizer` to make that testable — this repo has no jsdom or testing-library, and adding one for two callbacks wasn't worth the dependency.

It was also verified live: with the Graph tab open on a repo of ~1600 commits, a commit landing on `HEAD` prepended a two-line row and shifted every index by one. Row offsets stayed consistent with rendered heights across the shift and across the subsequent removal — 0 mismatches in both directions, where the pre-fix build produced an overlap at the slot that grew and a blank band at the slot that shrank.

### Screenshots

Captured from the dev app over CDP (`RENDERER_REMOTE_DEBUG_PORT=9222 bun dev`, renderer matched to this workspace's `DESKTOP_VITE_PORT`), driving the real controls with dispatched mouse input. The clip is the sidebar column only; the rest of the window is unchanged by this PR. The branches below `main` are a throwaway topology built for these shots and deleted afterwards — the repo's own history is a straight line, which shows none of the cases the tab exists for.

**Inline refs** (default) — four concurrent lanes, two merges and an octopus. The fork elbow leaves the node horizontally then bends down; the merge descends then bends in, so the two read apart at a 3.5px node. Row tint carries lane membership without tracing the line. The dashed, struck-through red badge is a branch whose worktree directory is gone (`prunable`); badges truncate to fit 260px.

![Commit graph with four lanes, merge and fork elbows, a tag badge, HEAD and main, and a struck-through prunable branch badge](https://raw.githubusercontent.com/acseven/superset/950275a887b1067027812da3e375bb9a608a1a92/.pr-assets/git-graph-sidebar/demo-lanes.png)

**Scope chooser** — the five scopes as the user reads them, `All local branches` selected. Plain wording rather than git's, because the audience is people who don't think in refs.

![Graph tab with the scope menu open, showing This workspace / Open workspaces / All local branches / Remote / Everything](https://raw.githubusercontent.com/acseven/superset/950275a887b1067027812da3e375bb9a608a1a92/.pr-assets/git-graph-sidebar/demo-scopes.png)

**Refs on their own line** (toggle on) — same commits, badges move above the row they decorate and stop truncating: `origin/main` and the long branch names read in full. That is the trade the toggle exists for, and the reason row height has to come from the commit's own refs.

![Same graph with ref badges on their own line above each commit, showing full branch and tag names](https://raw.githubusercontent.com/acseven/superset/950275a887b1067027812da3e375bb9a608a1a92/.pr-assets/git-graph-sidebar/demo-two-line.png)

**Highlight unreferenced** (toggle on) — the point of the tab. Rows carrying a branch or worktree with no open workspace behind it stay bright; everything already accounted for dims. Nothing is removed, so the lanes and edges still connect.

![Same graph dimmed except the rows carrying unreferenced branches, which stay at full contrast](https://raw.githubusercontent.com/acseven/superset/950275a887b1067027812da3e375bb9a608a1a92/.pr-assets/git-graph-sidebar/demo-unreferenced.png)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` passes with 0 output (CI fails on warnings too)
- [ ] `bun run typecheck` — green for every package this PR touches; `@superset/ui` fails on a pre-existing duplicate `@types/hast` resolution, see the table above
- [x] "Allow edits from maintainers" is checked on fork PRs

## Known gaps

- Pagination is best-effort within a scope: the cursor is a `--skip` offset, so pages re-anchor if refs move between fetches. Crossing scopes is handled (the cursor is dropped), moving refs are not. The truncation banner surfaces when a repo has more history than one page.
- `Everything` is now largely `All local branches ∪ Remote ∪ tags`, so it may not earn its slot. Left in for one release to see whether anyone picks it.
- `remote` reflects the last fetch. Nothing in this PR fetches, so a stale remote reads as a stale graph.
- `All local branches` is the longest label and squeezes the "Showing first N of M" text beside it at the narrowest sidebar widths.
- Light theme is covered by unit tests on the pure colour helpers; the store's delivery path was verified in dark only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Git Graph tab to the workspace sidebar with a visual, lane-based commit history.
  * Added reference-scope filtering, pagination, two-line badges, and unreferenced-reference highlighting.
  * Added commit and range selection, diff previews, pane pinning, context-menu actions, and commit metadata.
  * Added responsive layouts and loading, empty, error, and truncated-history states.
  * Added theme-aware lane colors and indicators for branches, tags, HEAD, worktrees, merged, and prunable references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
