### PR TITLE
fix(desktop): classify detached-HEAD main-repo open as typed BAD_REQUEST

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -745,7 +745,12 @@ export const createCreateProcedures = () => {
 				const branch =
 					input.branch || (await getCurrentBranch(project.mainRepoPath));
 				if (!branch) {
-					throw new Error("Could not determine current branch");
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							"Cannot open this repository from detached HEAD. Please checkout a branch and try again.",
+						cause: { kind: "DETACHED_HEAD" },
+					});
 				}
 
 				if (input.branch) {


### PR DESCRIPTION
## Problem

Opening a project's main repository as a workspace (`workspaces.openMainRepoWorkspace`) throws a plain `Error("Could not determine current branch")` when the repo has no current branch. The tRPC `sentryMiddleware` reports this as an `INTERNAL_SERVER_ERROR`, so an expected user-repo state shows up in Sentry as a 500 (DESKTOP-JM, 3 events on 1.15.1).

## Root cause

When the main repo is on a detached HEAD (or an unborn branch), `getCurrentBranch` returns nothing and the guard at the top of `openMainRepoWorkspace` throws an untyped `Error`. Per the classification contract (#6164), expected domain states must be translated into non-500 `TRPCError`s at the throw site — this one never was.

## Fix

Replace the plain throw with a typed `TRPCError`:

- `code: "BAD_REQUEST"` — matching the existing detached-HEAD classification in `getLocalBranchOrThrow` (`routers/changes/git-operations.ts`), whose message style this also follows.
- `cause: { kind: "DETACHED_HEAD" }` — a plain-object, kind-discriminated cause that the existing `errorFormatter` in `src/lib/trpc/index.ts` already forwards to the renderer.
- User-actionable message: "Cannot open this repository from detached HEAD. Please checkout a branch and try again."

No filter, no middleware change — genuine unexpected failures on this path still reach Sentry as before.

## Verification

- `bunx biome check apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts`
  ```
  Checked 1 file in 19ms. No fixes applied.
  ```
- `cd apps/desktop && bun run typecheck`
  ```
  $ tsr generate
  $ tsc --noEmit
  exit=0
  ```
- No existing tests cover the changed guard (the adjacent `external-worktree-import.test.ts` tests `utils/git` only), so no test run applies.

Refs DESKTOP-JM

https://claude.ai/code/session_2bf90175-44a5-44e3-be07-aeed3182571a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat opening the main repo on a detached HEAD as a BAD_REQUEST instead of a 500, with a clear action message. Aligns with DESKTOP-JM and keeps this expected state out of Sentry server errors.

<sup>Written for commit 2315ab67356b29a5e989661ad8a0d3e6b9f614fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when opening a workspace from a detached Git HEAD.
  * Displays a clear, user-facing message instead of a generic error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->