### PR TITLE
fix(desktop): classify pull/sync conflicts and rejected pushes as typed non-500s

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	isMergeConflictError,
 	isNoPullRequestFoundMessage,
 	isUpstreamMissingError,
 } from "./git-utils";
@@ -34,6 +35,32 @@ describe("git-operations error handling", () => {
 		test("does not falsely detect other errors as upstream deleted", () => {
 			for (const message of otherErrorMessages) {
 				expect(isUpstreamMissingError(message)).toBe(false);
+			}
+		});
+	});
+
+	describe("isMergeConflictError", () => {
+		const mergeConflictMessages = [
+			"CONFLICT (content): Merge conflict in src/file.ts\nAutomatic merge failed; fix conflicts and then commit the result.",
+			"error: could not apply abc1234... my commit\nhint: Resolve all conflicts manually, mark them as resolved with",
+			"CONFLICT (modify/delete): file.ts deleted in HEAD",
+		];
+
+		const otherErrorMessages = [
+			"Your configuration specifies to merge with the ref 'refs/heads/feature-branch' from the remote, but no such ref was fetched.",
+			"error: failed to push some refs to 'origin' (non-fast-forward)",
+			"fatal: not a git repository",
+		];
+
+		test("detects rebase/merge conflict errors", () => {
+			for (const message of mergeConflictMessages) {
+				expect(isMergeConflictError(message)).toBe(true);
+			}
+		});
+
+		test("does not falsely detect other errors as merge conflicts", () => {
+			for (const message of otherErrorMessages) {
+				expect(isMergeConflictError(message)).toBe(false);
 			}
 		});
 	});

--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -4,6 +4,7 @@ import { publicProcedure, router } from "../..";
 import { getCurrentBranch } from "../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import {
+	isMergeConflictError,
 	isNoPullRequestFoundMessage,
 	isUpstreamMissingError,
 } from "./git-utils";
@@ -45,6 +46,49 @@ async function getLocalBranchOrThrow({
 		});
 	}
 	return branch;
+}
+
+type ExpectedGitFailureKind =
+	| "MERGE_CONFLICT"
+	| "PUSH_REJECTED"
+	| "UPSTREAM_MISSING";
+
+function classifyExpectedGitFailure(
+	message: string,
+): { kind: ExpectedGitFailureKind; message: string } | null {
+	if (isMergeConflictError(message)) {
+		return { kind: "MERGE_CONFLICT", message };
+	}
+	if (isNonFastForwardPushError(message)) {
+		return { kind: "PUSH_REJECTED", message };
+	}
+	if (isUpstreamMissingError(message)) {
+		return {
+			kind: "UPSTREAM_MISSING",
+			message:
+				"No upstream branch to pull from. The remote branch may have been deleted.",
+		};
+	}
+	return null;
+}
+
+// Conflicts, rejected pushes and deleted upstreams live in the user's repo,
+// not in our code — surface them as typed non-500s so they aren't reported,
+// while genuinely unexpected git failures keep escaping as 500s.
+function rethrowClassifiedGitError(error: unknown): never {
+	if (error instanceof TRPCError) {
+		throw error;
+	}
+	const message = error instanceof Error ? error.message : String(error);
+	const expected = classifyExpectedGitFailure(message);
+	if (expected) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: expected.message,
+			cause: { kind: expected.kind },
+		});
+	}
+	throw error;
 }
 
 export const createGitOperationsRouter = () => {
@@ -133,14 +177,7 @@ export const createGitOperationsRouter = () => {
 				try {
 					await git.pull(["--rebase"]);
 				} catch (error) {
-					const message =
-						error instanceof Error ? error.message : String(error);
-					if (isUpstreamMissingError(message)) {
-						throw new Error(
-							"No upstream branch to pull from. The remote branch may have been deleted.",
-						);
-					}
-					throw error;
+					rethrowClassifiedGitError(error);
 				}
 				clearStatusCacheForWorktree(input.worktreePath);
 				return { success: true };
@@ -161,32 +198,40 @@ export const createGitOperationsRouter = () => {
 				} catch (error) {
 					const message =
 						error instanceof Error ? error.message : String(error);
-					if (isUpstreamMissingError(message)) {
-						const localBranch = await getLocalBranchOrThrow({
-							worktreePath: input.worktreePath,
-							action: "push",
-						});
+					if (!isUpstreamMissingError(message)) {
+						rethrowClassifiedGitError(error);
+					}
+					const localBranch = await getLocalBranchOrThrow({
+						worktreePath: input.worktreePath,
+						action: "push",
+					});
+					try {
 						await pushWithResolvedUpstream({
 							git,
 							worktreePath: input.worktreePath,
 							localBranch,
 						});
-						await fetchCurrentBranch(git, input.worktreePath);
-						clearStatusCacheForWorktree(input.worktreePath);
-						return { success: true };
+					} catch (pushError) {
+						rethrowClassifiedGitError(pushError);
 					}
-					throw error;
+					await fetchCurrentBranch(git, input.worktreePath);
+					clearStatusCacheForWorktree(input.worktreePath);
+					return { success: true };
 				}
 
 				const localBranch = await getLocalBranchOrThrow({
 					worktreePath: input.worktreePath,
 					action: "push",
 				});
-				await pushCurrentBranch({
-					git,
-					worktreePath: input.worktreePath,
-					localBranch,
-				});
+				try {
+					await pushCurrentBranch({
+						git,
+						worktreePath: input.worktreePath,
+						localBranch,
+					});
+				} catch (error) {
+					rethrowClassifiedGitError(error);
+				}
 				await fetchCurrentBranch(git, input.worktreePath);
 				clearStatusCacheForWorktree(input.worktreePath);
 				return { success: true };

--- a/apps/desktop/src/lib/trpc/routers/changes/git-utils.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-utils.ts
@@ -10,6 +10,19 @@ export function isUpstreamMissingError(message: string): boolean {
 	);
 }
 
+/**
+ * Check if the error message indicates a rebase/merge conflict — an expected
+ * outcome of pulling into a branch with divergent local commits
+ */
+export function isMergeConflictError(message: string): boolean {
+	return (
+		message.includes("CONFLICT (") ||
+		message.includes("Merge conflict in") ||
+		message.includes("could not apply") ||
+		message.includes("Resolve all conflicts manually")
+	);
+}
+
 export function isNoPullRequestFoundMessage(message: string): boolean {
 	return message.toLowerCase().includes("no pull request");
 }


### PR DESCRIPTION
## Problem

Three Sentry issues (1 event each) from the desktop changes router: DESKTOP-M7 (`changes.pull`, 1.16.0), DESKTOP-MG (`changes.sync` pull leg, 1.15.0), DESKTOP-JK (`changes.sync` push leg, 1.15.0). All are expected user-repo outcomes — a rebase merge conflict during `git pull --rebase`, and a push rejected by the remote (non-fast-forward / repository rules) — escaping as `INTERNAL_SERVER_ERROR` and getting reported. Because the raw simple-git error message is git's full stderr transcript, the issue titles also embed remote branch listings and third-party repository URLs.

## Root cause

`changes.push` got a classification catch in #6190, but `changes.pull`'s catch only handled the upstream-missing case (and rethrew it as a plain `Error`, itself a reportable 500), rethrowing everything else raw. `changes.sync` called `pushCurrentBranch` / `pushWithResolvedUpstream` entirely outside any try, and its pull leg rethrew non-upstream-missing errors raw.

## Fix

Classification only — no behavior change, no Sentry-side filtering (per the #6164 contract, classify at throw sites):

- New `isMergeConflictError` matcher in `git-utils.ts` alongside the existing matchers.
- Shared `rethrowClassifiedGitError` helper in `git-operations.ts`: passes `TRPCError` through, wraps expected git outcomes in `TRPCError` `PRECONDITION_FAILED` with a plain-object cause and git's original message text preserved for the UI, and rethrows anything unexpected raw so genuine bugs still report as 500s.
  - rebase/merge conflicts → `cause: { kind: "MERGE_CONFLICT" }`
  - rejected / non-fast-forward / rule-declined pushes (reuses `isNonFastForwardPushError`) → `cause: { kind: "PUSH_REJECTED" }`
  - missing upstream → `cause: { kind: "UPSTREAM_MISSING" }`, keeping pull's existing "No upstream branch to pull from…" message (previously a plain `Error`)
- `pull` routes its catch through the helper; `sync` routes its pull leg and both push paths (`pushCurrentBranch` and the upstream-missing `pushWithResolvedUpstream` fallback) through it.
- Sync's upstream-missing → push-with-set-upstream fallback behavior is unchanged.

Matchers are message-based (worker boundary strips prototypes, so no `instanceof` on git errors). Added unit tests for `isMergeConflictError`.

## Verification

`bunx biome check` on the three changed files:

```
Checked 3 files in 11ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ tsc --noEmit
exit=0
```

`bun test apps/desktop/src/lib/trpc/routers/changes/git-operations.test.ts`:

```
 20 pass
 0 fail
 35 expect() calls
Ran 20 tests across 1 file. [67.00ms]
```

Refs DESKTOP-M7
Refs DESKTOP-MG
Refs DESKTOP-JK

https://claude.ai/code/session_0d966f97-3e8a-4239-ae1b-b1c2e539b359

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies expected git outcomes in the desktop changes router (merge conflicts, rejected pushes, missing upstream) as typed non-500 `TRPCError`s to stop false 500s and avoid leaking git stderr details. No functional behavior changes to pull/push/sync behavior.

- **Bug Fixes**
  - Added `isMergeConflictError` in `git-utils.ts` with unit tests.
  - Introduced `rethrowClassifiedGitError` to map expected failures to `PRECONDITION_FAILED` with `cause` kinds: `MERGE_CONFLICT`, `PUSH_REJECTED`, `UPSTREAM_MISSING`.
  - Routed error handling in `pull`, `sync` pull leg, `pushCurrentBranch`, and `pushWithResolvedUpstream` through the classifier; unexpected errors still surface as 500s.
  - Preserves git message text for the UI; keeps the existing upstream-missing message.

<sup>Written for commit 7437c9cc1707f32cf2a79e4ed4119edb98c06590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

