### PR TITLE
fix(desktop): confirm the repo root when the picked folder isn't one

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -56,7 +56,12 @@ type OpenNewError = { canceled: false; error: string };
 type OpenNewResult =
 	| OpenNewCanceled
 	| { canceled: false; project: Project }
-	| { canceled: false; needsGitInit: true; selectedPath: string }
+	| {
+			canceled: false;
+			needsGitInit: true;
+			selectedPath: string;
+			enclosingRepoPath?: string;
+	  }
 	| OpenNewError;
 
 /**
@@ -99,7 +104,7 @@ function parsePullRequests(raw: unknown) {
 
 type FolderOutcome =
 	| { status: "success"; project: Project }
-	| { status: "needsGitInit"; selectedPath: string }
+	| { status: "needsGitInit"; selectedPath: string; enclosingRepoPath?: string }
 	| { status: "error"; selectedPath: string; error: string };
 
 type OpenNewMultiResult =
@@ -1095,7 +1100,19 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 
 			for (const selectedPath of result.filePaths) {
 				try {
-					const mainRepoPath = await getGitRoot(selectedPath);
+					const { root: mainRepoPath, isRoot } = await getGitRoot(selectedPath);
+					// The selected folder sits inside a repo but isn't its root, so
+					// opening it means opening the enclosing repo. Let the user
+					// confirm that (or initialize the folder they actually picked)
+					// before anything is written.
+					if (!isRoot) {
+						outcomes.push({
+							status: "needsGitInit",
+							selectedPath,
+							enclosingRepoPath: mainRepoPath,
+						});
+						continue;
+					}
 					const defaultBranch = await getDefaultBranch(mainRepoPath);
 
 					const project = upsertProject(mainRepoPath, defaultBranch);
@@ -1156,7 +1173,18 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 
 				let mainRepoPath: string;
 				try {
-					mainRepoPath = await getGitRoot(selectedPath);
+					const gitRoot = await getGitRoot(selectedPath);
+					// See openNew: a folder nested inside a repo resolves to that
+					// repo, so ask before opening something the user didn't pick.
+					if (!gitRoot.isRoot) {
+						return {
+							canceled: false,
+							needsGitInit: true as const,
+							selectedPath,
+							enclosingRepoPath: gitRoot.root,
+						};
+					}
+					mainRepoPath = gitRoot.root;
 				} catch (error) {
 					if (error instanceof NotGitRepoError) {
 						return {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -1173,6 +1173,20 @@ describe("getGitRoot", () => {
 		expect(result.isRoot).toBe(true);
 	});
 
+	// Git terminates the line with LF and round-trips a trailing CR that is part
+	// of the name, so the terminator strip must not consume it.
+	test("preserves a root whose directory name ends in a carriage return", async () => {
+		const repoPath = createTestRepo("trailing-cr\r");
+		seedCommit(repoPath);
+
+		const result = await getGitRoot(repoPath);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.root.endsWith("\r")).toBe(true);
+		expect(existsSync(result.root)).toBe(true);
+		expect(result.isRoot).toBe(true);
+	});
+
 	// The walk-up is deliberate and stays: a subdirectory still resolves to the
 	// repo it belongs to. Only isRoot tells the caller the user picked something
 	// other than that root.

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -1190,7 +1190,7 @@ describe("getGitRoot", () => {
 		const plainPath = join(TEST_DIR, "plain");
 		mkdirSync(plainPath, { recursive: true });
 
-		expect(getGitRoot(plainPath)).rejects.toBeInstanceOf(NotGitRepoError);
+		await expect(getGitRoot(plainPath)).rejects.toBeInstanceOf(NotGitRepoError);
 	});
 
 	// A worktree root keeps `.git` as a FILE, not a directory, so a filesystem
@@ -1251,14 +1251,16 @@ describe("getGitRoot", () => {
 		mkdirSync(barePath, { recursive: true });
 		execSync("git init --bare", { cwd: barePath, stdio: "ignore" });
 
-		expect(getGitRoot(barePath)).rejects.not.toBeInstanceOf(NotGitRepoError);
+		await expect(getGitRoot(barePath)).rejects.not.toBeInstanceOf(
+			NotGitRepoError,
+		);
 	});
 
 	test("does not classify a .git directory as NotGitRepoError", async () => {
 		const repoPath = createTestRepo("dotgit");
 		seedCommit(repoPath);
 
-		expect(getGitRoot(join(repoPath, ".git"))).rejects.not.toBeInstanceOf(
+		await expect(getGitRoot(join(repoPath, ".git"))).rejects.not.toBeInstanceOf(
 			NotGitRepoError,
 		);
 	});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -1159,6 +1159,20 @@ describe("getGitRoot", () => {
 		expect(result.isRoot).toBe(true);
 	});
 
+	// Guards the untrimmed read of `--show-toplevel`: a directory name may end
+	// in whitespace, and trimming it hands callers a path that doesn't exist.
+	test("preserves a root whose directory name ends in whitespace", async () => {
+		const repoPath = createTestRepo("trailing space ");
+		seedCommit(repoPath);
+
+		const result = await getGitRoot(repoPath);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.root.endsWith(" ")).toBe(true);
+		expect(existsSync(result.root)).toBe(true);
+		expect(result.isRoot).toBe(true);
+	});
+
 	// The walk-up is deliberate and stays: a subdirectory still resolves to the
 	// repo it belongs to. Only isRoot tells the caller the user picked something
 	// other than that root.

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -7,6 +7,7 @@ import {
 	realpathSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -15,9 +16,11 @@ import {
 	branchExistsOnRemote,
 	createWorktree,
 	getCurrentBranch,
+	getGitRoot,
 	getWorktreeCreatedAt,
 	hasUnpushedCommits,
 	isUnbornHeadError,
+	NotGitRepoError,
 	parsePorcelainStatusV2,
 	parsePrUrl,
 } from "./git";
@@ -1132,5 +1135,131 @@ describe("parsePrUrl", () => {
 		expect(
 			parsePrUrl("https://github.com/superset-sh/superset/issues/1781"),
 		).toBe(null);
+	});
+});
+
+describe("getGitRoot", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	test("reports the repo root itself as the root", async () => {
+		const repoPath = createTestRepo("root");
+		seedCommit(repoPath);
+
+		const result = await getGitRoot(repoPath);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.isRoot).toBe(true);
+	});
+
+	// The walk-up is deliberate and stays: a subdirectory still resolves to the
+	// repo it belongs to. Only isRoot tells the caller the user picked something
+	// other than that root.
+	test("walks up from a subdirectory and reports it is not the root", async () => {
+		const repoPath = createTestRepo("subdir");
+		seedCommit(repoPath);
+		const nested = join(repoPath, "packages", "app");
+		mkdirSync(nested, { recursive: true });
+
+		const result = await getGitRoot(nested);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.isRoot).toBe(false);
+	});
+
+	test("reports an untracked folder inside a repo as not the root", async () => {
+		const repoPath = createTestRepo("untracked-child");
+		seedCommit(repoPath);
+		const scratch = join(repoPath, "scratch");
+		mkdirSync(scratch, { recursive: true });
+
+		const result = await getGitRoot(scratch);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.isRoot).toBe(false);
+	});
+
+	test("throws NotGitRepoError when no ancestor is a repo", async () => {
+		const plainPath = join(TEST_DIR, "plain");
+		mkdirSync(plainPath, { recursive: true });
+
+		expect(getGitRoot(plainPath)).rejects.toBeInstanceOf(NotGitRepoError);
+	});
+
+	// A worktree root keeps `.git` as a FILE, not a directory, so a filesystem
+	// check would misclassify it and offer to initialize a repo Superset made.
+	test("treats a linked worktree root as a root", async () => {
+		const repoPath = createTestRepo("worktree-main");
+		seedCommit(repoPath);
+		const worktreePath = join(TEST_DIR, "worktree-linked");
+		execSync(`git worktree add -b wt-branch "${worktreePath}"`, {
+			cwd: repoPath,
+			stdio: "ignore",
+		});
+
+		expect(statSync(join(worktreePath, ".git")).isFile()).toBe(true);
+
+		const result = await getGitRoot(worktreePath);
+
+		expect(result.root).toBe(worktreePath);
+		expect(result.isRoot).toBe(true);
+	});
+
+	test("resolves a subdirectory of a worktree to the worktree", async () => {
+		const repoPath = createTestRepo("worktree-sub-main");
+		seedCommit(repoPath);
+		const worktreePath = join(TEST_DIR, "worktree-sub");
+		execSync(`git worktree add -b wt-sub-branch "${worktreePath}"`, {
+			cwd: repoPath,
+			stdio: "ignore",
+		});
+		const nested = join(worktreePath, "src");
+		mkdirSync(nested, { recursive: true });
+
+		const result = await getGitRoot(nested);
+
+		expect(result.root).toBe(worktreePath);
+		expect(result.isRoot).toBe(false);
+	});
+
+	// Git reports the real path, so a symlinked repo root would fail any
+	// comparison of the requested path against the reported root.
+	test("treats a symlink to a repo root as a root", async () => {
+		const repoPath = createTestRepo("symlink-target");
+		seedCommit(repoPath);
+		const linkPath = join(TEST_DIR, "symlink-to-repo");
+		symlinkSync(repoPath, linkPath);
+
+		const result = await getGitRoot(linkPath);
+
+		expect(result.root).toBe(repoPath);
+		expect(result.isRoot).toBe(true);
+	});
+
+	// Bare repos and `.git` directories fail with "must be run in a work tree",
+	// not "not a git repository". They have no `.git` child, so classifying them
+	// as NotGitRepoError would offer to initialize a repo inside a repo.
+	test("does not classify a bare repo as NotGitRepoError", async () => {
+		const barePath = join(TEST_DIR, "bare.git");
+		mkdirSync(barePath, { recursive: true });
+		execSync("git init --bare", { cwd: barePath, stdio: "ignore" });
+
+		expect(getGitRoot(barePath)).rejects.not.toBeInstanceOf(NotGitRepoError);
+	});
+
+	test("does not classify a .git directory as NotGitRepoError", async () => {
+		const repoPath = createTestRepo("dotgit");
+		seedCommit(repoPath);
+
+		expect(getGitRoot(join(repoPath, ".git"))).rejects.not.toBeInstanceOf(
+			NotGitRepoError,
+		);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -890,10 +890,14 @@ export async function getGitRoot(path: string): Promise<GitRootInfo> {
 		// canonicalizes /tmp to /private/tmp, resolves symlinks to their real
 		// path, and returns the canonical casing on a case-insensitive volume.
 		const output = await git.revparse(["--show-toplevel", "--show-prefix"]);
-		const [root = "", prefix = ""] = output.split("\n");
+		const [rootLine = "", prefixLine = ""] = output.split("\n");
+		// Strip only a trailing CR, never trim: a directory name may legitimately
+		// end in whitespace, and trimming it would hand callers a path that
+		// doesn't exist.
+		const root = rootLine.replace(/\r$/, "");
 		// Emptiness only — `core.quotePath` can C-quote non-ASCII path
 		// components, so the prefix value itself is not safe to parse.
-		return { root: root.trim(), isRoot: prefix.trim() === "" };
+		return { root, isRoot: prefixLine.replace(/\r$/, "") === "" };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.toLowerCase().includes("not a git repository")) {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -884,20 +884,22 @@ export interface GitRootInfo {
 export async function getGitRoot(path: string): Promise<GitRootInfo> {
 	try {
 		const git = await getSimpleGitWithShellPath(path);
+		// Two calls, not one: a directory name may contain a newline, so a single
+		// `rev-parse --show-toplevel --show-prefix` cannot be split back into
+		// its two values unambiguously. `raw` also leaves stdout untrimmed, which
+		// keeps a root whose final directory name ends in whitespace intact —
+		// trimming it would hand callers a path that doesn't exist.
+		const rootOutput = await git.raw(["rev-parse", "--show-toplevel"]);
+		const root = rootOutput.replace(/\r?\n$/, "");
 		// `--show-prefix` is empty exactly when `path` is the work tree root, so
 		// git answers the question in its own terms. Comparing `root` against
 		// `path` would be wrong on macOS three ways: `--show-toplevel`
 		// canonicalizes /tmp to /private/tmp, resolves symlinks to their real
 		// path, and returns the canonical casing on a case-insensitive volume.
-		const output = await git.revparse(["--show-toplevel", "--show-prefix"]);
-		const [rootLine = "", prefixLine = ""] = output.split("\n");
-		// Strip only a trailing CR, never trim: a directory name may legitimately
-		// end in whitespace, and trimming it would hand callers a path that
-		// doesn't exist.
-		const root = rootLine.replace(/\r$/, "");
 		// Emptiness only — `core.quotePath` can C-quote non-ASCII path
 		// components, so the prefix value itself is not safe to parse.
-		return { root, isRoot: prefixLine.replace(/\r$/, "") === "" };
+		const prefix = await git.revparse(["--show-prefix"]);
+		return { root, isRoot: prefix === "" };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.toLowerCase().includes("not a git repository")) {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -890,7 +890,11 @@ export async function getGitRoot(path: string): Promise<GitRootInfo> {
 		// keeps a root whose final directory name ends in whitespace intact —
 		// trimming it would hand callers a path that doesn't exist.
 		const rootOutput = await git.raw(["rev-parse", "--show-toplevel"]);
-		const root = rootOutput.replace(/\r?\n$/, "");
+		// Strip exactly the LF git terminates the line with. Not `\r?\n`: a
+		// directory name may itself end in a carriage return, and git round-trips
+		// that as `<name>\r\n`, so consuming the CR would yield a path that
+		// doesn't exist.
+		const root = rootOutput.replace(/\n$/, "");
 		// `--show-prefix` is empty exactly when `path` is the work tree root, so
 		// git answers the question in its own terms. Comparing `root` against
 		// `path` would be wrong on macOS three ways: `--show-toplevel`

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -872,11 +872,28 @@ export async function removeWorktree(
 	}
 }
 
-export async function getGitRoot(path: string): Promise<string> {
+export interface GitRootInfo {
+	/** Absolute path of the work tree root. Git walks up, so this can be an
+	 *  ancestor of the path that was passed in. */
+	root: string;
+	/** True when the requested path is itself that root: a normal clone root,
+	 *  a `git worktree` root, or a submodule root. */
+	isRoot: boolean;
+}
+
+export async function getGitRoot(path: string): Promise<GitRootInfo> {
 	try {
 		const git = await getSimpleGitWithShellPath(path);
-		const root = await git.revparse(["--show-toplevel"]);
-		return root.trim();
+		// `--show-prefix` is empty exactly when `path` is the work tree root, so
+		// git answers the question in its own terms. Comparing `root` against
+		// `path` would be wrong on macOS three ways: `--show-toplevel`
+		// canonicalizes /tmp to /private/tmp, resolves symlinks to their real
+		// path, and returns the canonical casing on a case-insensitive volume.
+		const output = await git.revparse(["--show-toplevel", "--show-prefix"]);
+		const [root = "", prefix = ""] = output.split("\n");
+		// Emptiness only — `core.quotePath` can C-quote non-ASCII path
+		// components, so the prefix value itself is not safe to parse.
+		return { root: root.trim(), isRoot: prefix.trim() === "" };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.toLowerCase().includes("not a git repository")) {

--- a/apps/desktop/src/renderer/react-query/projects/InitGitDialog.tsx
+++ b/apps/desktop/src/renderer/react-query/projects/InitGitDialog.tsx
@@ -7,13 +7,23 @@ import {
 	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { useGitInitDialogStore } from "renderer/stores/git-init-dialog";
 
 export function InitGitDialog() {
-	const { isOpen, isPending, paths, onConfirm, onCancel } =
+	const { isOpen, isPending, folders, onConfirm, onOpenEnclosing, onCancel } =
 		useGitInitDialogStore();
 
-	const isSingle = paths.length === 1;
+	const isSingle = folders.length === 1;
+	const enclosingRoots = [
+		...new Set(
+			folders
+				.map((folder) => folder.enclosingRepoPath)
+				.filter((root): root is string => !!root),
+		),
+	];
+	const hasEnclosing = enclosingRoots.length > 0;
+	const firstRoot = enclosingRoots[0];
 
 	return (
 		<AlertDialog
@@ -24,16 +34,33 @@ export function InitGitDialog() {
 		>
 			<AlertDialogContent>
 				<AlertDialogHeader>
-					<AlertDialogTitle>Initialize Git Repository?</AlertDialogTitle>
+					<AlertDialogTitle>
+						{hasEnclosing
+							? "Open the enclosing repository?"
+							: "Initialize Git Repository?"}
+					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="space-y-2">
-							{isSingle ? (
-								<p>
-									<span className="font-medium text-foreground">
-										{paths[0]?.split("/").pop()}
-									</span>{" "}
-									is not a git repository. Would you like to initialize one?
-								</p>
+							{isSingle && folders[0] ? (
+								folders[0].enclosingRepoPath ? (
+									<p>
+										<span className="font-medium text-foreground">
+											{getBaseName(folders[0].path)}
+										</span>{" "}
+										isn't a git repository. It's inside{" "}
+										<span className="font-medium text-foreground">
+											{getBaseName(folders[0].enclosingRepoPath)}
+										</span>{" "}
+										({folders[0].enclosingRepoPath}).
+									</p>
+								) : (
+									<p>
+										<span className="font-medium text-foreground">
+											{getBaseName(folders[0].path)}
+										</span>{" "}
+										is not a git repository. Would you like to initialize one?
+									</p>
+								)
 							) : (
 								<>
 									<p>
@@ -41,14 +68,19 @@ export function InitGitDialog() {
 										like to initialize them?
 									</p>
 									<ul className="list-disc pl-4 space-y-1">
-										{paths.map((p) => (
-											<li key={p}>
+										{folders.map((folder) => (
+											<li key={folder.path}>
 												<span className="font-medium text-foreground">
-													{p.split("/").pop()}
+													{getBaseName(folder.path)}
 												</span>
 												<span className="text-xs ml-1 text-muted-foreground">
-													{p}
+													{folder.path}
 												</span>
+												{folder.enclosingRepoPath ? (
+													<span className="text-xs ml-1 text-muted-foreground">
+														inside {getBaseName(folder.enclosingRepoPath)}
+													</span>
+												) : null}
 											</li>
 										))}
 									</ul>
@@ -65,9 +97,20 @@ export function InitGitDialog() {
 					>
 						Cancel
 					</Button>
-					<Button disabled={isPending} onClick={() => onConfirm?.()}>
+					<Button
+						variant={hasEnclosing ? "outline" : "default"}
+						disabled={isPending}
+						onClick={() => onConfirm?.()}
+					>
 						{isPending ? "Initializing..." : "Initialize Git"}
 					</Button>
+					{hasEnclosing ? (
+						<Button disabled={isPending} onClick={() => onOpenEnclosing?.()}>
+							{enclosingRoots.length === 1 && firstRoot
+								? `Open ${getBaseName(firstRoot)}`
+								: "Open enclosing repositories"}
+						</Button>
+					) : null}
 				</AlertDialogFooter>
 			</AlertDialogContent>
 		</AlertDialog>

--- a/apps/desktop/src/renderer/react-query/projects/InitGitDialog.tsx
+++ b/apps/desktop/src/renderer/react-query/projects/InitGitDialog.tsx
@@ -11,18 +11,31 @@ import { getBaseName } from "renderer/lib/pathBasename";
 import { useGitInitDialogStore } from "renderer/stores/git-init-dialog";
 
 export function InitGitDialog() {
-	const { isOpen, isPending, folders, onConfirm, onOpenEnclosing, onCancel } =
-		useGitInitDialogStore();
+	const {
+		isOpen,
+		pendingAction,
+		folders,
+		onConfirm,
+		onOpenEnclosing,
+		onCancel,
+	} = useGitInitDialogStore();
 
+	const isPending = pendingAction !== null;
 	const isSingle = folders.length === 1;
-	const enclosingRoots = [
-		...new Set(
-			folders
-				.map((folder) => folder.enclosingRepoPath)
-				.filter((root): root is string => !!root),
-		),
-	];
-	const hasEnclosing = enclosingRoots.length > 0;
+	// Only offer "open the enclosing repo" when it accounts for every selected
+	// folder. In a mixed selection the plain folders have no enclosing repo, so
+	// opening only the nested ones would silently drop the rest.
+	const enclosingRoots =
+		folders.length > 0 && folders.every((folder) => folder.enclosingRepoPath)
+			? [
+					...new Set(
+						folders
+							.map((folder) => folder.enclosingRepoPath)
+							.filter((root): root is string => !!root),
+					),
+				]
+			: [];
+	const canOpenEnclosing = enclosingRoots.length > 0;
 	const firstRoot = enclosingRoots[0];
 
 	return (
@@ -35,7 +48,7 @@ export function InitGitDialog() {
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>
-						{hasEnclosing
+						{canOpenEnclosing
 							? "Open the enclosing repository?"
 							: "Initialize Git Repository?"}
 					</AlertDialogTitle>
@@ -98,17 +111,19 @@ export function InitGitDialog() {
 						Cancel
 					</Button>
 					<Button
-						variant={hasEnclosing ? "outline" : "default"}
+						variant={canOpenEnclosing ? "outline" : "default"}
 						disabled={isPending}
 						onClick={() => onConfirm?.()}
 					>
-						{isPending ? "Initializing..." : "Initialize Git"}
+						{pendingAction === "init" ? "Initializing..." : "Initialize Git"}
 					</Button>
-					{hasEnclosing ? (
+					{canOpenEnclosing ? (
 						<Button disabled={isPending} onClick={() => onOpenEnclosing?.()}>
-							{enclosingRoots.length === 1 && firstRoot
-								? `Open ${getBaseName(firstRoot)}`
-								: "Open enclosing repositories"}
+							{pendingAction === "openEnclosing"
+								? "Opening..."
+								: enclosingRoots.length === 1 && firstRoot
+									? `Open ${getBaseName(firstRoot)}`
+									: "Open enclosing repositories"}
 						</Button>
 					) : null}
 				</AlertDialogFooter>

--- a/apps/desktop/src/renderer/react-query/projects/useOpenProject.tsx
+++ b/apps/desktop/src/renderer/react-query/projects/useOpenProject.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import type { ElectronRouterOutputs } from "renderer/lib/electron-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { GitInitDialogFolder } from "renderer/stores/git-init-dialog";
 import { useGitInitDialogStore } from "renderer/stores/git-init-dialog";
 import { processOpenNewResults } from "./processOpenNewResults";
 import { useOpenFromPath } from "./useOpenFromPath";
@@ -9,7 +10,7 @@ import { useOpenNew } from "./useOpenNew";
 type Project = ElectronRouterOutputs["projects"]["get"];
 
 interface PendingGitInit {
-	paths: string[];
+	folders: GitInitDialogFolder[];
 	immediateSuccesses: Project[];
 	resolve: (projects: Project[]) => void;
 }
@@ -27,7 +28,7 @@ export function useOpenProject() {
 			pendingRef.current = pending;
 
 			useGitInitDialogStore.getState().open({
-				paths: pending.paths,
+				folders: pending.folders,
 				onConfirm: async () => {
 					const p = pendingRef.current;
 					if (!p) return;
@@ -37,13 +38,53 @@ export function useOpenProject() {
 					const projects: Project[] = [...p.immediateSuccesses];
 
 					try {
-						for (const path of p.paths) {
+						for (const folder of p.folders) {
 							try {
-								const result = await initGitAndOpen.mutateAsync({ path });
+								const result = await initGitAndOpen.mutateAsync({
+									path: folder.path,
+								});
 								projects.push(result.project);
 							} catch (error) {
 								console.error(
 									"[useOpenProject] Failed to init git:",
+									folder.path,
+									error,
+								);
+							}
+						}
+
+						await utils.projects.getRecents.invalidate();
+					} finally {
+						useGitInitDialogStore.getState().close();
+						pendingRef.current = null;
+						p.resolve(projects);
+					}
+				},
+				onOpenEnclosing: async () => {
+					const p = pendingRef.current;
+					if (!p) return;
+
+					useGitInitDialogStore.getState().setIsPending(true);
+
+					const projects: Project[] = [...p.immediateSuccesses];
+					// Each enclosing root is itself a repo root, so re-opening it
+					// resolves cleanly and never prompts again.
+					const roots = [
+						...new Set(
+							p.folders
+								.map((folder) => folder.enclosingRepoPath)
+								.filter((root): root is string => !!root),
+						),
+					];
+
+					try {
+						for (const path of roots) {
+							try {
+								const result = await openFromPathMutation.mutateAsync({ path });
+								if ("project" in result) projects.push(result.project);
+							} catch (error) {
+								console.error(
+									"[useOpenProject] Failed to open enclosing repo:",
 									path,
 									error,
 								);
@@ -67,7 +108,7 @@ export function useOpenProject() {
 				},
 			});
 		},
-		[initGitAndOpen, utils],
+		[initGitAndOpen, openFromPathMutation, utils],
 	);
 
 	const openNew = useCallback((): Promise<Project[]> => {
@@ -93,7 +134,10 @@ export function useOpenProject() {
 
 						if (needsGitInit.length > 0) {
 							showDialog({
-								paths: needsGitInit.map((n) => n.selectedPath),
+								folders: needsGitInit.map((n) => ({
+									path: n.selectedPath,
+									enclosingRepoPath: n.enclosingRepoPath,
+								})),
 								immediateSuccesses: immediateProjects,
 								resolve,
 							});
@@ -127,7 +171,12 @@ export function useOpenProject() {
 
 							if ("needsGitInit" in result && result.needsGitInit) {
 								showDialog({
-									paths: [result.selectedPath],
+									folders: [
+										{
+											path: result.selectedPath,
+											enclosingRepoPath: result.enclosingRepoPath,
+										},
+									],
 									immediateSuccesses: [],
 									resolve: (projects) => resolve(projects[0] ?? null),
 								});

--- a/apps/desktop/src/renderer/react-query/projects/useOpenProject.tsx
+++ b/apps/desktop/src/renderer/react-query/projects/useOpenProject.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useRef } from "react";
 import type { ElectronRouterOutputs } from "renderer/lib/electron-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import type { GitInitDialogFolder } from "renderer/stores/git-init-dialog";
+import type {
+	GitInitDialogAction,
+	GitInitDialogFolder,
+} from "renderer/stores/git-init-dialog";
 import { useGitInitDialogStore } from "renderer/stores/git-init-dialog";
 import { processOpenNewResults } from "./processOpenNewResults";
 import { useOpenFromPath } from "./useOpenFromPath";
@@ -13,6 +16,16 @@ interface PendingGitInit {
 	folders: GitInitDialogFolder[];
 	immediateSuccesses: Project[];
 	resolve: (projects: Project[]) => void;
+}
+
+/** A repo root selected alongside one of its own subfolders resolves to the
+ *  same project twice, so callers would otherwise see it listed more than once. */
+function dedupeProjects(projects: Project[]): Project[] {
+	const byId = new Map<string, Project>();
+	for (const project of projects) {
+		if (!byId.has(project.id)) byId.set(project.id, project);
+	}
+	return [...byId.values()];
 }
 
 export function useOpenProject() {
@@ -27,46 +40,56 @@ export function useOpenProject() {
 		(pending: PendingGitInit) => {
 			pendingRef.current = pending;
 
+			/** Both dialog actions share this settle flow: open one path at a
+			 *  time, keep going past individual failures, then close and resolve
+			 *  with whatever succeeded. */
+			const runAction = async (
+				action: GitInitDialogAction,
+				paths: string[],
+				openPath: (path: string) => Promise<Project | null>,
+			) => {
+				const p = pendingRef.current;
+				if (!p) return;
+
+				useGitInitDialogStore.getState().setPendingAction(action);
+
+				const projects: Project[] = [...p.immediateSuccesses];
+
+				try {
+					for (const path of paths) {
+						try {
+							const project = await openPath(path);
+							if (project) projects.push(project);
+						} catch (error) {
+							console.error(`[useOpenProject] ${action} failed:`, path, error);
+						}
+					}
+
+					await utils.projects.getRecents.invalidate();
+				} finally {
+					useGitInitDialogStore.getState().close();
+					pendingRef.current = null;
+					p.resolve(dedupeProjects(projects));
+				}
+			};
+
 			useGitInitDialogStore.getState().open({
 				folders: pending.folders,
-				onConfirm: async () => {
+				onConfirm: () => {
 					const p = pendingRef.current;
 					if (!p) return;
-
-					useGitInitDialogStore.getState().setIsPending(true);
-
-					const projects: Project[] = [...p.immediateSuccesses];
-
-					try {
-						for (const folder of p.folders) {
-							try {
-								const result = await initGitAndOpen.mutateAsync({
-									path: folder.path,
-								});
-								projects.push(result.project);
-							} catch (error) {
-								console.error(
-									"[useOpenProject] Failed to init git:",
-									folder.path,
-									error,
-								);
-							}
-						}
-
-						await utils.projects.getRecents.invalidate();
-					} finally {
-						useGitInitDialogStore.getState().close();
-						pendingRef.current = null;
-						p.resolve(projects);
-					}
+					void runAction(
+						"init",
+						p.folders.map((folder) => folder.path),
+						async (path) => {
+							const result = await initGitAndOpen.mutateAsync({ path });
+							return result.project;
+						},
+					);
 				},
-				onOpenEnclosing: async () => {
+				onOpenEnclosing: () => {
 					const p = pendingRef.current;
 					if (!p) return;
-
-					useGitInitDialogStore.getState().setIsPending(true);
-
-					const projects: Project[] = [...p.immediateSuccesses];
 					// Each enclosing root is itself a repo root, so re-opening it
 					// resolves cleanly and never prompts again.
 					const roots = [
@@ -76,27 +99,18 @@ export function useOpenProject() {
 								.filter((root): root is string => !!root),
 						),
 					];
-
-					try {
-						for (const path of roots) {
-							try {
-								const result = await openFromPathMutation.mutateAsync({ path });
-								if ("project" in result) projects.push(result.project);
-							} catch (error) {
-								console.error(
-									"[useOpenProject] Failed to open enclosing repo:",
-									path,
-									error,
-								);
-							}
+					void runAction("openEnclosing", roots, async (path) => {
+						const result = await openFromPathMutation.mutateAsync({ path });
+						if ("project" in result) return result.project;
+						if ("error" in result) {
+							console.error(
+								"[useOpenProject] Failed to open enclosing repo:",
+								path,
+								result.error,
+							);
 						}
-
-						await utils.projects.getRecents.invalidate();
-					} finally {
-						useGitInitDialogStore.getState().close();
-						pendingRef.current = null;
-						p.resolve(projects);
-					}
+						return null;
+					});
 				},
 				onCancel: () => {
 					const p = pendingRef.current;

--- a/apps/desktop/src/renderer/stores/git-init-dialog.ts
+++ b/apps/desktop/src/renderer/stores/git-init-dialog.ts
@@ -9,9 +9,12 @@ export interface GitInitDialogFolder {
 	enclosingRepoPath?: string;
 }
 
+/** Which action is running, so each button can label its own progress. */
+export type GitInitDialogAction = "init" | "openEnclosing";
+
 interface GitInitDialogState {
 	isOpen: boolean;
-	isPending: boolean;
+	pendingAction: GitInitDialogAction | null;
 	folders: GitInitDialogFolder[];
 	onConfirm: (() => void) | null;
 	onOpenEnclosing: (() => void) | null;
@@ -22,7 +25,7 @@ interface GitInitDialogState {
 		onOpenEnclosing: () => void;
 		onCancel: () => void;
 	}) => void;
-	setIsPending: (isPending: boolean) => void;
+	setPendingAction: (pendingAction: GitInitDialogAction | null) => void;
 	close: () => void;
 }
 
@@ -30,7 +33,7 @@ export const useGitInitDialogStore = create<GitInitDialogState>()(
 	devtools(
 		(set) => ({
 			isOpen: false,
-			isPending: false,
+			pendingAction: null,
 			folders: [],
 			onConfirm: null,
 			onOpenEnclosing: null,
@@ -39,7 +42,7 @@ export const useGitInitDialogStore = create<GitInitDialogState>()(
 			open: ({ folders, onConfirm, onOpenEnclosing, onCancel }) => {
 				set({
 					isOpen: true,
-					isPending: false,
+					pendingAction: null,
 					folders,
 					onConfirm,
 					onOpenEnclosing,
@@ -47,14 +50,14 @@ export const useGitInitDialogStore = create<GitInitDialogState>()(
 				});
 			},
 
-			setIsPending: (isPending) => {
-				set({ isPending });
+			setPendingAction: (pendingAction) => {
+				set({ pendingAction });
 			},
 
 			close: () => {
 				set({
 					isOpen: false,
-					isPending: false,
+					pendingAction: null,
 					folders: [],
 					onConfirm: null,
 					onOpenEnclosing: null,

--- a/apps/desktop/src/renderer/stores/git-init-dialog.ts
+++ b/apps/desktop/src/renderer/stores/git-init-dialog.ts
@@ -1,15 +1,25 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
+export interface GitInitDialogFolder {
+	path: string;
+	/** Set when `path` is not a repo root but sits inside one. Git resolves
+	 *  such a folder to this enclosing repo, so the user is offered that as
+	 *  an alternative to initializing the folder they picked. */
+	enclosingRepoPath?: string;
+}
+
 interface GitInitDialogState {
 	isOpen: boolean;
 	isPending: boolean;
-	paths: string[];
+	folders: GitInitDialogFolder[];
 	onConfirm: (() => void) | null;
+	onOpenEnclosing: (() => void) | null;
 	onCancel: (() => void) | null;
 	open: (params: {
-		paths: string[];
+		folders: GitInitDialogFolder[];
 		onConfirm: () => void;
+		onOpenEnclosing: () => void;
 		onCancel: () => void;
 	}) => void;
 	setIsPending: (isPending: boolean) => void;
@@ -21,12 +31,20 @@ export const useGitInitDialogStore = create<GitInitDialogState>()(
 		(set) => ({
 			isOpen: false,
 			isPending: false,
-			paths: [],
+			folders: [],
 			onConfirm: null,
+			onOpenEnclosing: null,
 			onCancel: null,
 
-			open: ({ paths, onConfirm, onCancel }) => {
-				set({ isOpen: true, isPending: false, paths, onConfirm, onCancel });
+			open: ({ folders, onConfirm, onOpenEnclosing, onCancel }) => {
+				set({
+					isOpen: true,
+					isPending: false,
+					folders,
+					onConfirm,
+					onOpenEnclosing,
+					onCancel,
+				});
 			},
 
 			setIsPending: (isPending) => {
@@ -37,8 +55,9 @@ export const useGitInitDialogStore = create<GitInitDialogState>()(
 				set({
 					isOpen: false,
 					isPending: false,
-					paths: [],
+					folders: [],
 					onConfirm: null,
+					onOpenEnclosing: null,
 					onCancel: null,
 				});
 			},


### PR DESCRIPTION
## What & why

`getGitRoot` resolves a picked folder with `git rev-parse --show-toplevel`, which walks up the directory tree. If the folder you pick isn't a git repository but any ancestor is, the app silently opens that ancestor instead. `NotGitRepoError` is the only trigger for the existing "Initialize Git Repository?" dialog, and it's only thrown when *no* ancestor is a repo, so you're never asked.

The case that hurts is a home directory tracked as a dotfiles repo. Pick `~/projects/new-thing` in **Add repository → Open project** and Superset adds `~` as a project, named after your home directory, without a prompt. Drag-and-drop does the same thing through `openFromPath`.

**This does not change which repository gets opened.** A subdirectory still resolves to the repo that contains it, and that stays the default action. The only change is that the app no longer makes the choice silently. `plans/20260601-v2-import-git-init-non-git-folder.md:100-102` deferred this case on purpose:

> **Edge — folder nested inside a parent git repo:** `git rev-parse --show-toplevel` succeeds and resolves to the *parent* root, so detection reports "already a git repo" and we never offer init — we import the parent root, which is the current behavior. Leave it unchanged.

That's still the behavior. `getGitRoot` now returns `{ root, isRoot }`, and `openNew` / `openFromPath` show the dialog when `isRoot` is false rather than writing a project row. The dialog gets a third button, `Open <root>`, which is the primary action and produces exactly the project you get today. `Initialize Git` was already wired to `initGitAndOpen`, which inits and upserts the path verbatim, so initializing the folder you actually picked works without a router change — it just wasn't reachable whenever an ancestor repo existed.

The root test is `--show-prefix`, which is empty exactly when the path is the work tree root. That keeps two cases right that a filesystem or string check would get wrong:

- **Worktree and submodule roots.** At a `git worktree` root `.git` is a file, not a directory, so `statSync(join(p, ".git")).isDirectory()` would call it "not a repo" and offer to `git init` a worktree Superset created itself.
- **Path comparison.** Comparing the picked path against `--show-toplevel` fails on macOS three separate ways: `/tmp` and `/var` canonicalize to `/private/...`, symlinks resolve to their realpath, and a case-insensitive volume returns canonical casing.

Bare repos and `.git` directories still fail with "this operation must be run in a work tree" rather than "not a git repository", so they keep falling through as a generic error and are never offered a `git init`. There are tests for both.

Scope is the Electron open-project path only. `packages/host-service` has the same walk-up in `tryRevParseGitRoot` / `findByPath`, but `initLocalRepoInPlace` documents ancestor adoption as intentional idempotence, so offering "initialize here" there needs a new wire flag through `project.create`. That's a separate PR.

## How I tested it

`bun test`, `bun run lint` and `bun run typecheck` on macOS, bun 1.3.5, git 2.50.1.

Nine new cases in `apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts` covering repo root, subdirectory, untracked child folder, no ancestor repo, worktree root, worktree subdirectory, symlinked repo root, bare repo and `.git` directory. `getGitRoot` had no coverage before this.

```
$ cd apps/desktop && bun test src/lib/trpc/routers/workspaces/utils/git.test.ts -t getGitRoot
 9 pass
 0 fail
Ran 9 tests across 1 file.
```

The subdirectory and worktree cases are the regression guards — they assert the walk-up still happens and that a worktree root is still a root.

`packages/host-service` is untouched, and the two tests that lock the walk-up semantics pass unmodified:

```
$ cd packages/host-service && bun test src/trpc/router/project/utils/resolve-repo.test.ts
 30 pass
 0 fail
```

Full desktop suite, `bun run lint` and `bun run typecheck`:

```
$ cd apps/desktop && bun test
 2558 pass
 2 fail
Ran 2560 tests across 267 files.

$ bun run lint          # exit 0
$ bun run typecheck     # Tasks: 37 successful, 37 total
```

The 2 failures are pre-existing. I confirmed they fail identically on a clean `main` (`a316a1f`) with my changes stashed: `Shell Environment > getProcessEnvWithShellPath applies shell PATH and preserves string vars` and `createWorktree hook tolerance > continues when git is killed mid-hook (timeout shape) but worktree is created`. Baseline there is 37 pass / 2 fail in that file; with this change it's 46 pass / 2 fail.

`src/no-main-process-blocking.test.ts` passes with `allowedCounts` unedited (git.ts stays at 21, projects.ts at 6) — the change reuses the existing git client rather than adding one.

I haven't captured screenshots. I don't have a working desktop app to drive over CDP, and I'd rather not put a mocked-up image in a PR description. Happy to add them if you'd like, or the dialog copy is:

- Title: `Open the enclosing repository?`
- Body: **new-thing** isn't a git repository. It's inside **dotfiles** (`/Users/me`).
- Buttons: `Cancel` · `Initialize Git` · **`Open dotfiles`**

When there's no enclosing repo the dialog is unchanged, both copy and buttons.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ask the user to confirm when they pick a folder inside a Git repo. The dialog lets them open the enclosing repo or initialize Git in the selected folder; default stays “open enclosing,” and only shows when all selected folders are nested.

- **Bug Fixes**
  - Desktop: detect non-root selections and show a three-button dialog (Cancel · Initialize Git · Open <root>). Multi-select supported; “Open enclosing” appears only when every folder has an enclosing repo. Track which action is running so each button shows accurate progress; dedupe projects when a repo root and its subfolder are both selected; surface typed error results from `openFromPath`.
  - `getGitRoot` now returns `{ root, isRoot }`; reads `--show-toplevel` and `--show-prefix` in two calls to handle names with newlines; uses `raw` to preserve trailing whitespace and strips only the trailing LF (preserves a trailing CR). Keeps worktrees, submodules, symlinks, and macOS path canonicalization correct.
  - Tests: add cases for roots ending in trailing whitespace and trailing CR, and retain coverage for repo root, subdirectory, untracked child, no ancestor, worktree root/subdir, symlinked root, bare repo, and `.git` directory.

<sup>Written for commit ff12eba2f6ee815c6e4a53424eb04084ad93b829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project opening for folders nested inside existing Git repositories.
  * Added an option to open the enclosing repository directly.
  * Git initialization prompts now distinguish standalone folders from folders within repositories.
  * Preserved selected folder paths for confirmation and initialization.

* **Bug Fixes**
  * Improved repository-root detection for nested, linked, symlinked, and bare repositories.
  * Improved handling of repository paths containing special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->