### PR TITLE
fix(desktop): stop the file tree truncating names that fit

### DIFF
--- a/apps/desktop/src/renderer/lib/pierreTree/createPierreTreeStyle.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/createPierreTreeStyle.ts
@@ -1,30 +1,16 @@
 import type { CSSProperties } from "react";
 
 /**
- * Pierre decides "does this name overflow?" entirely in CSS: alongside the
- * visible single-line label it lays out a hidden `word-break: break-all` copy,
- * then reveals the middle-truncation marker — the `…` + fade that paints over
- * the name, in the row's own background color — via
- * `@container measure (height > 1lh)` on the marker cell.
+ * Pierre detects overflow in pure CSS: a hidden `word-break: break-all` copy of
+ * the label sits beside the visible one, and `@container measure (height > 1lh)`
+ * on the marker cell reveals the middle-truncation marker — the `…` + fade that
+ * paints over the name. A name that fits measures exactly `1lh`, so the test has
+ * no margin: any sub-pixel rounding of the line box marks every row as
+ * overflowing and hides ~3 characters mid-name at every sidebar width.
  *
- * That comparison ships with **zero margin**. On a 28px row a name that fits
- * measures exactly 28.00px against a `1lh` of exactly 28px, and only the strict
- * `>` keeps the marker hidden. Anything that rounds the used line box up by any
- * amount — sub-pixel snapping under fractional page zoom, a display scale that
- * doesn't divide evenly, a future font metric change — flips *every* row to
- * "overflowing" at once. The marker then hides ~3 characters mid-name at any
- * sidebar width, which reads as the tree ignoring the width it has rather than
- * as truncation (the text underneath is still laid out at full width).
- *
- * Measured in the running app: nudging the line box by 0.53% (28.147px, the
- * size of a one-device-pixel snap at zoom ~1.31 on a 1x display) turns the
- * marker on for 23 of 23 rows; with the slack below, 0 of 23, while a name too
- * long for the lane still truncates.
- *
- * So give the query 1.5 lines of slack: rounding can't reach it, and a genuine
- * second line (2lh) still trips it. The marker's own box is sized in `lh` too,
- * so pin that back to a single row or it grows with the inflated line-height
- * when it is legitimately shown.
+ * Give the query 1.5 lines of slack — out of reach of rounding, still tripped by
+ * a real second line. The marker's own box is sized in `lh` too, so pin it back
+ * to one row.
  */
 const MIDDLE_TRUNCATE_ZOOM_CSS = `
 	[data-truncate-marker-cell] {

--- a/apps/desktop/src/renderer/lib/pierreTree/createPierreTreeStyle.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/createPierreTreeStyle.ts
@@ -1,6 +1,41 @@
 import type { CSSProperties } from "react";
 
 /**
+ * Pierre decides "does this name overflow?" entirely in CSS: alongside the
+ * visible single-line label it lays out a hidden `word-break: break-all` copy,
+ * then reveals the middle-truncation marker — the `…` + fade that paints over
+ * the name, in the row's own background color — via
+ * `@container measure (height > 1lh)` on the marker cell.
+ *
+ * That comparison ships with **zero margin**. On a 28px row a name that fits
+ * measures exactly 28.00px against a `1lh` of exactly 28px, and only the strict
+ * `>` keeps the marker hidden. Anything that rounds the used line box up by any
+ * amount — sub-pixel snapping under fractional page zoom, a display scale that
+ * doesn't divide evenly, a future font metric change — flips *every* row to
+ * "overflowing" at once. The marker then hides ~3 characters mid-name at any
+ * sidebar width, which reads as the tree ignoring the width it has rather than
+ * as truncation (the text underneath is still laid out at full width).
+ *
+ * Measured in the running app: nudging the line box by 0.53% (28.147px, the
+ * size of a one-device-pixel snap at zoom ~1.31 on a 1x display) turns the
+ * marker on for 23 of 23 rows; with the slack below, 0 of 23, while a name too
+ * long for the lane still truncates.
+ *
+ * So give the query 1.5 lines of slack: rounding can't reach it, and a genuine
+ * second line (2lh) still trips it. The marker's own box is sized in `lh` too,
+ * so pin that back to a single row or it grows with the inflated line-height
+ * when it is legitimately shown.
+ */
+const MIDDLE_TRUNCATE_ZOOM_CSS = `
+	[data-truncate-marker-cell] {
+		line-height: calc(var(--trees-row-height) * 1.5);
+	}
+	[data-truncate-marker] {
+		line-height: var(--trees-row-height);
+	}
+`;
+
+/**
  * `unsafeCSS` for the file trees. Pierre keeps an empty decoration lane
  * (`flex: 1 1 0`) on every row whenever the git lane is active but the row has
  * no custom decoration (every file in the Files-tab explorer, plus any change
@@ -17,6 +52,7 @@ export const PIERRE_TREE_UNSAFE_CSS = `
 	[data-item-section="decoration"] {
 		flex: 0 1 auto;
 	}
+	${MIDDLE_TRUNCATE_ZOOM_CSS}
 `;
 
 interface PierreTreeStyleOptions {


### PR DESCRIPTION
## What & why

The Files tab (and the Changes tab's section trees) middle-truncate names that comfortably fit — `CLAUDE.md` renders as `CLAUD…d`, `.github` as `….thub` — and widening the sidebar changes nothing, which is the tell that this isn't a layout problem.

Nothing is actually being truncated. The text underneath is laid out at its full natural width; Pierre's middle-truncation **marker** (the `…` + fade, painted in the row's own background colour) is being drawn over the middle of it. I measured a user-reported screenshot pixel by pixel: every row's on-screen text width was exactly its natural width × the page-zoom factor, long names and short names alike. Nothing was shrunk — ~3 characters were simply covered up.

The cause is that Pierre detects overflow entirely in CSS. It lays out a hidden `word-break: break-all` copy of the label beside the visible one and reveals the marker via `@container measure (height > 1lh)` on the marker cell. **That comparison ships with zero margin**: on a 28px row a name that fits measures exactly `28.00px` against a `1lh` of exactly `28px`, and only the strict `>` keeps the marker hidden. Anything that rounds the used line box up by any amount — sub-pixel snapping under fractional page zoom, a display scale that doesn't divide evenly — flips *every* row at once.

The fix gives the query 1.5 lines of slack, so rounding can't reach it while a genuine second line (`2lh`) still trips it. The marker's own box is sized in `lh` too, so it's pinned back to one row or it grows with the inflated line-height when legitimately shown. Two rules, in the existing shared `PIERRE_TREE_UNSAFE_CSS`, so both the Files tab and the Changes trees get it and the threshold scales with each tree's row height.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/aiwebb/superset/pr-assets-sidebar-truncation/pr-assets/sidebar-truncation-before.png) | ![after](https://raw.githubusercontent.com/aiwebb/superset/pr-assets-sidebar-truncation/pr-assets/sidebar-truncation-after.png) |

## How I tested it

Drove the dev desktop app over CDP (renderer on this workspace's `DESKTOP_VITE_PORT` 3005, target identity confirmed against `/json/list` before testing — another worktree's app was live on the port I first tried), signed in, opened a workspace pointed at this repo, and navigated to Files → `.github/workflows` with real clicks. The screenshots above are that session, cropped to the panel with `Page.captureScreenshot`'s `clip`.

**How the before/after was produced — please read this before trusting the pair.** The failure did not reproduce spontaneously on my machine: at Electron page zoom 1.3145 on a 2× display the tree measured `cellH 28.00` against `1lh 28px` and the markers stayed off, i.e. it sat exactly on the knife edge without falling off it. Emulating DPR 1 over CDP wasn't enough to tip it either. So rather than claim a native repro, I measured the margin directly: I nudged the line box by **0.53%** — `28.147px`, the size of a one-device-pixel snap at zoom ~1.31 on a 1× display, which is where the original report came from — and captured both states under that identical nudge.

- **Before** (fix stashed, nudge applied): 59 of 59 rows show markers. Matches the reported screenshot exactly, down to `….thub` and `claud……ills`.
- **After** (fix applied, same nudge): 0 of 59.
- A name genuinely too long for the lane still truncates, marker and all — checked with a 110-character filename.
- At the default zoom with no nudge, both builds are identical; this changes nothing in the common case.

I also built a standalone harness around the shipped `@pierre/trees@1.0.0-beta.5` CSS and row markup to sweep the threshold independently. There, CSS `zoom` *does* trip the real thing without any nudge — broken at 0.9 / 1.3 / 1.3145, fine at 1.0 / 1.2 / 1.25 / 1.44 / 1.728 — and the fix is correct at every factor tested. Note that CSS `zoom` and Electron page zoom are different mechanisms, so I'm citing that as evidence the threshold is genuinely reachable, not as the trigger.

Gates: `bun run lint` clean, `bun run typecheck` 37/37, `bun run test` 2551 pass / 0 fail.

Not verified: the exact environmental condition that tips a real user's machine over the line. I know the margin is zero and that a 0.53% nudge is enough; I could not reproduce the tip natively on my hardware.

## Authorship

Written by Claude (Claude Code, Opus 5) running in a Superset workspace, prompted and reviewed by @aiwebb. Claude diagnosed the bug from a screenshot, wrote the fix, ran the gates, drove the CDP verification, and captured the screenshots. @aiwebb reported it, confirmed the fix in the running dev app, and directed the screenshots be taken against this repo rather than their own codebase. Claude's first root-cause explanation was wrong — it blamed page-zoom rounding based on the standalone harness, then disproved that in the real app and corrected both the code comment and this description. The commit carries a `Co-Authored-By: Claude` trailer.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect middle‑truncation in the Files and Changes trees when names actually fit. Gives the overflow check slack and pins the marker to one row so only real overflows are truncated.

- **Bug Fixes**
  - Root cause: zero‑margin `@container (height > 1lh)` let rounding show markers over names that fit.
  - Change: add 1.5 `lh` slack and pin the marker box to `1lh`, shipped via `PIERRE_TREE_UNSAFE_CSS` for both trees; also trimmed the inline comment to the core rationale.

<sup>Written for commit 3cd6ddd3bd18fe0bc7f51f02a7f75d8b4e050891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of overflowing tree labels that use middle truncation.
  * Prevented false overflow indicators caused by sub-pixel rendering differences.
  * Preserved consistent marker sizing while supporting multi-line content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->