### PR TITLE
feat(desktop,host-service): resume v1 pane agent sessions after migration

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -77,6 +77,24 @@ export const createMigrationRouter = () => {
 		}),
 
 		/**
+		 * Latest captured agent session per v1 pane (see V1PaneAgentSession).
+		 * Read at v2 pane-creation time — not frozen into the migration plan —
+		 * because the pane keeps living in v1 (and its agent keeps reporting)
+		 * long after the every-boot migration pass ledgers it.
+		 */
+		readV1PaneAgentSessions: publicProcedure
+			.input(z.object({ paneIds: z.array(z.string().min(1)) }))
+			.query(({ input }) => {
+				const sessions = appState.data.v1AgentSessions ?? {};
+				return Object.fromEntries(
+					input.paneIds.flatMap((paneId) => {
+						const session = sessions[paneId];
+						return session ? [[paneId, session] as const] : [];
+					}),
+				);
+			}),
+
+		/**
 		 * Cross-instance single-flight for the auto-migrator (cf. #5791 for
 		 * host services): one lock file per home dir — instances sharing it
 		 * share local.db, so one runner suffices. Acquisition is atomic (`wx`

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-copilot.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-copilot.ts
@@ -11,7 +11,7 @@ import { HOOKS_DIR } from "./paths";
 export const COPILOT_HOOK_SCRIPT_NAME = "copilot-hook.sh";
 
 const COPILOT_HOOK_SIGNATURE = "# Superset copilot hook";
-const COPILOT_HOOK_VERSION = "v3";
+const COPILOT_HOOK_VERSION = "v4";
 export const COPILOT_HOOK_MARKER = `${COPILOT_HOOK_SIGNATURE} ${COPILOT_HOOK_VERSION}`;
 
 const COPILOT_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
@@ -19,7 +19,7 @@ import { HOOKS_DIR } from "./paths";
 export const CURSOR_HOOK_SCRIPT_NAME = "cursor-hook.sh";
 
 const CURSOR_HOOK_SIGNATURE = "# Superset cursor hook";
-const CURSOR_HOOK_VERSION = "v5";
+const CURSOR_HOOK_VERSION = "v6";
 export const CURSOR_HOOK_MARKER = `${CURSOR_HOOK_SIGNATURE} ${CURSOR_HOOK_VERSION}`;
 
 const CURSOR_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-gemini.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-gemini.ts
@@ -19,7 +19,7 @@ import { HOOKS_DIR } from "./paths";
 export const GEMINI_HOOK_SCRIPT_NAME = "gemini-hook.sh";
 
 const GEMINI_HOOK_SIGNATURE = "# Superset gemini hook";
-const GEMINI_HOOK_VERSION = "v4";
+const GEMINI_HOOK_VERSION = "v5";
 export const GEMINI_HOOK_MARKER = `${GEMINI_HOOK_SIGNATURE} ${GEMINI_HOOK_VERSION}`;
 
 const GEMINI_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -32,7 +32,7 @@ mock.module("shared/env.shared", () => ({
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v6",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v7",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -776,9 +776,9 @@ exit 0
 	});
 
 	it("bumps hook script markers when hook semantics change", () => {
-		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v3");
-		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v5");
-		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v4");
+		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v4");
+		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v6");
+		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v5");
 	});
 
 	it("replaces stale Mastra hook commands from old superset paths", () => {

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -58,7 +58,7 @@ describe("getNotifyScriptContent", () => {
 			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}}}"',
 		);
 		expect(script).toContain(
-			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
+			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
 		);
 		expect(script).toContain('V1_EVENT_TYPE="$EVENT_TYPE"');
 		expect(script).toContain('V1_EVENT_TYPE="Stop"');
@@ -85,6 +85,35 @@ describe("getNotifyScriptContent", () => {
 		expect(script).toContain("terminalId=$SUPERSET_TERMINAL_ID");
 		expect(script).toContain("SUPERSET_TAB_ID");
 		expect(script).toContain("SUPERSET_PANE_ID");
+	});
+
+	it("extracts the codex thread-id as the session id on turn completion", () => {
+		// Exact shape of codex's legacy notify callback (captured from
+		// codex-cli 0.146): the resumable id rides in kebab-case thread-id.
+		const result = runNotifyHook({
+			type: "agent-turn-complete",
+			"thread-id": "019fdecb-edc4-7671-91ba-967a367cda56",
+			"turn-id": "019fdecb-edec-7390-8ccb-50060c49c32f",
+			cwd: "/tmp",
+			"input-messages": ["Reply with exactly: OK"],
+			"last-assistant-message": "OK",
+		});
+
+		expect(result.exitCode).toBe(0);
+		const stderr = result.stderr.toString();
+		expect(stderr).toContain("[notify-hook] event=Stop");
+		expect(stderr).toContain("sessionId=019fdecb-edc4-7671-91ba-967a367cda56");
+	});
+
+	it("prefers an explicit session_id over thread-id", () => {
+		const result = runNotifyHook({
+			hook_event_name: "Stop",
+			session_id: "real-session",
+			"thread-id": "should-not-win",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toContain("sessionId=real-session");
 	});
 
 	it("normalizes Grok permission notifications to PermissionRequest", () => {

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -37,7 +37,7 @@ function runNotifyHook(
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v6");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v7");
 	});
 
 	it("exits silently outside Superset terminals even with a payload session id", () => {

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -4,7 +4,7 @@ import { env } from "shared/env.shared";
 import { HOOKS_DIR } from "./paths";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v6";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v7";
 
 const NOTIFY_SCRIPT_TEMPLATE_PATH = path.join(
 	__dirname,

--- a/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
@@ -62,6 +62,8 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "sessionId=$HOOK_SESSION_ID" \
   --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
   --data-urlencode "eventType=$V1_EVENT_TYPE" \
+  --data-urlencode "rawEventType=$EVENT_TYPE" \
+  --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1

--- a/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
@@ -71,6 +71,8 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "sessionId=$HOOK_SESSION_ID" \
   --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
   --data-urlencode "eventType=$V1_EVENT_TYPE" \
+  --data-urlencode "rawEventType=$EVENT_TYPE" \
+  --data-urlencode "agentId=$AGENT_ID" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1

--- a/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
@@ -61,6 +61,8 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "sessionId=$HOOK_SESSION_ID" \
   --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
   --data-urlencode "eventType=$V1_EVENT_TYPE" \
+  --data-urlencode "rawEventType=$EVENT_TYPE" \
+  --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -27,6 +27,11 @@ if [ -z "$RESOURCE_ID" ]; then
   RESOURCE_ID=$(echo "$INPUT" | grep -oE '"resource_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 fi
 SESSION_ID=${RESOURCE_ID:-$HOOK_SESSION_ID}
+if [ -z "$SESSION_ID" ]; then
+  # Codex's legacy notify callback (agent-turn-complete) carries the
+  # resumable id as thread-id — the same id `codex resume` takes.
+  SESSION_ID=$(echo "$INPUT" | grep -oE '"thread[-_]id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+fi
 
 # Claude/Mastra/Droid/Kimi use "hook_event_name"; Grok uses camelCase
 # "hookEventName" (snake_case values, mapped server-side); Codex uses "type".
@@ -77,7 +82,7 @@ elif [ "$SUPERSET_ENV" = "development" ] || [ "$NODE_ENV" = "development" ]; the
 fi
 
 if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
-  echo "[notify-hook] event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID" >&2
+  echo "[notify-hook] event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID" >&2
 fi
 
 debug_log() {

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -123,6 +123,9 @@ fi
 # v1 fallback: Electron localhost hook server. Kept while v1 terminals exist.
 [ -z "$SUPERSET_TAB_ID" ] && [ -z "$SESSION_ID" ] && [ -z "$SUPERSET_TERMINAL_ID" ] && exit 0
 
+# rawEventType keeps the un-collapsed event (SessionStart/SessionEnd survive)
+# so the app can tell an agent's own goodbye from a turn Stop — the v1 pane
+# agent-session capture needs that to mirror v2 resume-candidate detection.
 if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
   STATUS_CODE=$(curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
     --connect-timeout 1 --max-time 2 \
@@ -134,6 +137,8 @@ if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
     --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
     --data-urlencode "resourceId=$RESOURCE_ID" \
     --data-urlencode "eventType=$V1_EVENT_TYPE" \
+    --data-urlencode "rawEventType=$EVENT_TYPE" \
+    --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
     --data-urlencode "env=$SUPERSET_ENV" \
     --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
     -o /dev/null -w "%{http_code}" 2>/dev/null)
@@ -151,6 +156,8 @@ else
     --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
     --data-urlencode "resourceId=$RESOURCE_ID" \
     --data-urlencode "eventType=$V1_EVENT_TYPE" \
+    --data-urlencode "rawEventType=$EVENT_TYPE" \
+    --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
     --data-urlencode "env=$SUPERSET_ENV" \
     --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
     > /dev/null 2>&1

--- a/apps/desktop/src/main/lib/app-state/index.ts
+++ b/apps/desktop/src/main/lib/app-state/index.ts
@@ -13,11 +13,20 @@ let _appState: AppStateDB | null = null;
  * (e.g., from old electron-store format with keys like "tabs-storage").
  */
 function ensureValidShape(data: Partial<AppState>): AppState {
+	const tabsState = {
+		...defaultAppState.tabsState,
+		...(data.tabsState ?? {}),
+	};
+	// Agent-session captures are keyed by pane id; drop entries whose pane is
+	// gone so the record can't grow past the pane set.
+	const v1AgentSessions = Object.fromEntries(
+		Object.entries(data.v1AgentSessions ?? {}).filter(
+			([paneId]) => tabsState.panes[paneId] !== undefined,
+		),
+	);
 	return {
-		tabsState: {
-			...defaultAppState.tabsState,
-			...(data.tabsState ?? {}),
-		},
+		tabsState,
+		v1AgentSessions,
 		themeState: {
 			...defaultAppState.themeState,
 			...(data.themeState ?? {}),

--- a/apps/desktop/src/main/lib/app-state/index.ts
+++ b/apps/desktop/src/main/lib/app-state/index.ts
@@ -18,10 +18,11 @@ function ensureValidShape(data: Partial<AppState>): AppState {
 		...(data.tabsState ?? {}),
 	};
 	// Agent-session captures are keyed by pane id; drop entries whose pane is
-	// gone so the record can't grow past the pane set.
+	// gone so the record can't grow past the pane set. Optional-chain: legacy
+	// app-state.json variants can carry a null panes map.
 	const v1AgentSessions = Object.fromEntries(
 		Object.entries(data.v1AgentSessions ?? {}).filter(
-			([paneId]) => tabsState.panes[paneId] !== undefined,
+			([paneId]) => tabsState.panes?.[paneId] !== undefined,
 		),
 	);
 	return {

--- a/apps/desktop/src/main/lib/app-state/schemas.ts
+++ b/apps/desktop/src/main/lib/app-state/schemas.ts
@@ -20,10 +20,28 @@ interface LegacyHotkeysState {
 	byPlatform: Record<string, Record<string, string | null>>;
 }
 
+/**
+ * Last known CLI agent session in a v1 terminal pane, captured from the hook
+ * server so the v1→v2 migration can seed a resume candidate for the pane's
+ * recreated terminal. Mirrors host-service terminal_agent_bindings semantics:
+ * `prompted` ↔ progressed past session start (never-prompted sessions have no
+ * persisted conversation), `endedAt` ↔ the agent's own SessionEnd goodbye
+ * (a clean quit, not resumable).
+ */
+export interface V1PaneAgentSession {
+	agentId: string;
+	agentSessionId: string;
+	prompted: boolean;
+	endedAt?: number;
+	updatedAt: number;
+}
+
 export interface AppState {
 	tabsState: BaseTabsState;
 	themeState: ThemeState;
 	hotkeysState: LegacyHotkeysState;
+	/** v1 pane id → last agent session seen there (see V1PaneAgentSession). */
+	v1AgentSessions?: Record<string, V1PaneAgentSession>;
 	/** App version at last launch; a mismatch means an update was just installed */
 	lastRunVersion?: string;
 }

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -8,6 +8,7 @@ import type { AgentLifecycleEvent } from "shared/notification-types";
 import { HOOK_PROTOCOL_VERSION } from "../terminal/env";
 import { mapEventType } from "./map-event-type";
 import { resolvePaneId } from "./resolve-pane-id";
+import { recordV1AgentHookEvent } from "./v1-agent-sessions";
 
 // Re-export types for backwards compatibility
 export type {
@@ -59,6 +60,8 @@ app.get("/hook/complete", (req, res) => {
 		hookSessionId,
 		resourceId,
 		eventType,
+		rawEventType,
+		agentId,
 		env: clientEnv,
 		version,
 	} = req.query;
@@ -97,6 +100,26 @@ app.get("/hook/complete", (req, res) => {
 		workspaceId as string | undefined,
 		sessionId as string | undefined,
 	);
+
+	// v1 pane agent-session capture for the v1→v2 migration's resume seeding.
+	// Needs the un-collapsed event (SessionEnd vs Stop) — only v7+ hook
+	// scripts send it, so absence just means no capture.
+	if (
+		resolvedPaneId &&
+		typeof rawEventType === "string" &&
+		rawEventType.length > 0 &&
+		typeof agentId === "string" &&
+		agentId.length > 0
+	) {
+		recordV1AgentHookEvent(resolvedPaneId, {
+			rawEventType,
+			agentId,
+			...(typeof sessionId === "string" && sessionId.length > 0
+				? { agentSessionId: sessionId }
+				: {}),
+			at: Date.now(),
+		});
+	}
 
 	const event: AgentLifecycleEvent = {
 		paneId: resolvedPaneId,

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+import type { V1PaneAgentSession } from "main/lib/app-state/schemas";
+import {
+	applyV1AgentHookEvent,
+	applyV1TerminalExit,
+} from "./v1-agent-sessions";
+
+const T0 = 1_000_000;
+
+function record(
+	overrides: Partial<V1PaneAgentSession> = {},
+): V1PaneAgentSession {
+	return {
+		agentId: "claude",
+		agentSessionId: "session-a",
+		prompted: true,
+		updatedAt: T0,
+		...overrides,
+	};
+}
+
+describe("applyV1AgentHookEvent", () => {
+	it("starts a fresh un-prompted record on SessionStart", () => {
+		const next = applyV1AgentHookEvent(undefined, {
+			rawEventType: "SessionStart",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0,
+		});
+		expect(next).toEqual({
+			agentId: "claude",
+			agentSessionId: "session-a",
+			prompted: false,
+			updatedAt: T0,
+		});
+	});
+
+	it("ignores a SessionStart without a session id", () => {
+		const next = applyV1AgentHookEvent(undefined, {
+			rawEventType: "SessionStart",
+			agentId: "claude",
+			at: T0,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it("a new session id replaces the record and resets prompted", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "SessionStart",
+			agentId: "claude",
+			agentSessionId: "session-b",
+			at: T0 + 1,
+		});
+		expect(next).toEqual({
+			agentId: "claude",
+			agentSessionId: "session-b",
+			prompted: false,
+			updatedAt: T0 + 1,
+		});
+	});
+
+	it("a same-session SessionStart (resume) keeps prompted and clears the goodbye", () => {
+		const next = applyV1AgentHookEvent(record({ endedAt: T0 }), {
+			rawEventType: "SessionStart",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 60_000,
+		});
+		expect(next?.prompted).toBe(true);
+		expect(next?.endedAt).toBeUndefined();
+	});
+
+	it("marks prompted on the first prompt-class event", () => {
+		const started = applyV1AgentHookEvent(undefined, {
+			rawEventType: "SessionStart",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0,
+		});
+		const next = applyV1AgentHookEvent(started, {
+			rawEventType: "UserPromptSubmit",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 1,
+		});
+		expect(next?.prompted).toBe(true);
+	});
+
+	it("creates a prompted record from a bare Stop when no record exists (agents without session-start hooks)", () => {
+		const next = applyV1AgentHookEvent(undefined, {
+			rawEventType: "Stop",
+			agentId: "codex",
+			agentSessionId: "session-c",
+			at: T0,
+		});
+		expect(next).toEqual({
+			agentId: "codex",
+			agentSessionId: "session-c",
+			prompted: true,
+			updatedAt: T0,
+		});
+	});
+
+	it("records the agent's own SessionEnd as a clean quit", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "SessionEnd",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 5,
+		});
+		expect(next?.endedAt).toBe(T0 + 5);
+	});
+
+	it("ignores a goodbye from a different session", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "SessionEnd",
+			agentId: "claude",
+			agentSessionId: "session-other",
+			at: T0 + 5,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it("a straggler event within the window must not revive a clean quit", () => {
+		const next = applyV1AgentHookEvent(record({ endedAt: T0 }), {
+			rawEventType: "Stop",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 10_000,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it("an event well past the goodbye revives the record", () => {
+		const next = applyV1AgentHookEvent(record({ endedAt: T0 }), {
+			rawEventType: "Stop",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 60_000,
+		});
+		expect(next?.endedAt).toBeUndefined();
+		expect(next?.prompted).toBe(true);
+	});
+
+	it("a different session id right after a goodbye starts a new record", () => {
+		const next = applyV1AgentHookEvent(record({ endedAt: T0 }), {
+			rawEventType: "Stop",
+			agentId: "claude",
+			agentSessionId: "session-b",
+			at: T0 + 1_000,
+		});
+		expect(next).toEqual({
+			agentId: "claude",
+			agentSessionId: "session-b",
+			prompted: true,
+			updatedAt: T0 + 1_000,
+		});
+	});
+
+	it("ignores unknown event types", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "SomethingNew",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 1,
+		});
+		expect(next).toBeUndefined();
+	});
+});
+
+describe("applyV1TerminalExit", () => {
+	it("upgrades a death-gasp goodbye back to resumable", () => {
+		const next = applyV1TerminalExit(record({ endedAt: T0 }), T0 + 5_000);
+		expect(next?.endedAt).toBeUndefined();
+		expect(next?.prompted).toBe(true);
+	});
+
+	it("leaves an old goodbye final — the shell outlived the agent", () => {
+		expect(
+			applyV1TerminalExit(record({ endedAt: T0 }), T0 + 60_000),
+		).toBeUndefined();
+	});
+
+	it("changes nothing when the session never said goodbye", () => {
+		expect(applyV1TerminalExit(record(), T0 + 1)).toBeUndefined();
+		expect(applyV1TerminalExit(undefined, T0 + 1)).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
@@ -157,6 +157,64 @@ describe("applyV1AgentHookEvent", () => {
 		});
 	});
 
+	it("never inherits the session id across an agent change", () => {
+		// claude quit cleanly, then codex (whose v1 events carry no session
+		// id) runs in the same pane well past the straggler window — reviving
+		// would mint a codex candidate pointing at the claude session.
+		const next = applyV1AgentHookEvent(record({ endedAt: T0 }), {
+			rawEventType: "Stop",
+			agentId: "codex",
+			at: T0 + 60_000,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it("a different agent with its own session id replaces the record", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "Stop",
+			agentId: "codex",
+			agentSessionId: "codex-sess",
+			at: T0 + 1,
+		});
+		expect(next).toEqual({
+			agentId: "codex",
+			agentSessionId: "codex-sess",
+			prompted: true,
+			updatedAt: T0 + 1,
+		});
+	});
+
+	it("ignores a goodbye from a different agent", () => {
+		const next = applyV1AgentHookEvent(record(), {
+			rawEventType: "SessionEnd",
+			agentId: "gemini",
+			at: T0 + 5,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it("skips persistence when nothing material changes", () => {
+		// Already prompted, same live session: a Stop stream must not
+		// rewrite app-state.json on every turn.
+		const live = record();
+		expect(
+			applyV1AgentHookEvent(live, {
+				rawEventType: "Stop",
+				agentId: "claude",
+				agentSessionId: "session-a",
+				at: T0 + 1,
+			}),
+		).toBeUndefined();
+		expect(
+			applyV1AgentHookEvent(live, {
+				rawEventType: "SessionStart",
+				agentId: "claude",
+				agentSessionId: "session-a",
+				at: T0 + 1,
+			}),
+		).toBeUndefined();
+	});
+
 	it("ignores unknown event types", () => {
 		const next = applyV1AgentHookEvent(record(), {
 			rawEventType: "SomethingNew",

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
@@ -59,7 +59,8 @@ export function applyV1AgentHookEvent(
 
 	if (SESSION_END_EVENTS.has(rawEventType)) {
 		if (!existing || existing.endedAt !== undefined) return undefined;
-		// A goodbye from some other session must not end this one.
+		// A goodbye from some other agent or session must not end this one.
+		if (agentId !== existing.agentId) return undefined;
 		if (
 			agentSessionId !== undefined &&
 			agentSessionId !== existing.agentSessionId
@@ -71,16 +72,15 @@ export function applyV1AgentHookEvent(
 
 	if (SESSION_START_EVENTS.has(rawEventType)) {
 		if (!agentSessionId) return undefined;
-		if (existing?.agentSessionId === agentSessionId) {
+		if (
+			existing?.agentId === agentId &&
+			existing.agentSessionId === agentSessionId
+		) {
 			// Same session starting again (e.g. resumed in place): the
 			// conversation still exists, so keep `prompted`; it is live again,
-			// so drop any goodbye.
-			return {
-				...existing,
-				agentId,
-				endedAt: undefined,
-				updatedAt: at,
-			};
+			// so drop any goodbye. Nothing material changes otherwise.
+			if (existing.endedAt === undefined) return undefined;
+			return { ...existing, endedAt: undefined, updatedAt: at };
 		}
 		return { agentId, agentSessionId, prompted: false, updatedAt: at };
 	}
@@ -89,12 +89,16 @@ export function applyV1AgentHookEvent(
 	// stop, permission request, tool use) means the session has a message.
 	if (mapEventType(rawEventType) === null) return undefined;
 
-	const startsNewSession =
-		agentSessionId !== undefined &&
+	// Never inherit a session id across an agent or session change (mirrors
+	// the v2 store): a codex event landing on a claude record must not mint
+	// a codex candidate pointing at the claude session.
+	const identityChanged =
 		existing !== undefined &&
-		agentSessionId !== existing.agentSessionId;
+		(agentId !== existing.agentId ||
+			(agentSessionId !== undefined &&
+				agentSessionId !== existing.agentSessionId));
 
-	if (existing === undefined || startsNewSession) {
+	if (existing === undefined || identityChanged) {
 		if (!agentSessionId) return undefined;
 		return { agentId, agentSessionId, prompted: true, updatedAt: at };
 	}
@@ -104,16 +108,13 @@ export function applyV1AgentHookEvent(
 		// curls) — reviving would erase the clean-quit marker. An event well
 		// past the goodbye is a real relaunch without session-start hooks.
 		if (at - existing.endedAt <= END_STRAGGLER_WINDOW_MS) return undefined;
-		return {
-			...existing,
-			agentId,
-			prompted: true,
-			endedAt: undefined,
-			updatedAt: at,
-		};
+		return { ...existing, prompted: true, endedAt: undefined, updatedAt: at };
 	}
 
-	return { ...existing, agentId, prompted: true, updatedAt: at };
+	// Only persist material changes — hook events stream steadily while an
+	// agent works, and each write rewrites all of app-state.json.
+	if (existing.prompted) return undefined;
+	return { ...existing, prompted: true, updatedAt: at };
 }
 
 /**

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
@@ -1,0 +1,161 @@
+import { appState } from "main/lib/app-state";
+import type { V1PaneAgentSession } from "main/lib/app-state/schemas";
+import { mapEventType } from "./map-event-type";
+
+/**
+ * Tracks the last CLI agent session per v1 terminal pane so the v1→v2
+ * migration can seed a resume candidate for the pane's recreated terminal
+ * (same banner + detection as host-service terminal_agent_bindings). Fed by
+ * the hook server's `rawEventType`/`agentId` params — the legacy `eventType`
+ * collapses SessionStart/SessionEnd into Start/Stop and can't distinguish a
+ * clean quit from a turn boundary.
+ *
+ * Detection mirrors host-service persistence:
+ * - never-prompted sessions aren't resumable (no persisted conversation)
+ * - the agent's own SessionEnd goodbye marks a clean quit (not resumable)
+ * - a goodbye within 30s of the pane's terminal death is a death gasp
+ *   (agents run SessionEnd hooks on SIGHUP) and is upgraded back
+ * - a straggler event within 30s of a goodbye must not revive the record
+ */
+
+const SESSION_START_EVENTS = new Set([
+	"SessionStart",
+	"sessionStart",
+	"session_start",
+	"Attached",
+	"attached",
+]);
+
+const SESSION_END_EVENTS = new Set([
+	"SessionEnd",
+	"sessionEnd",
+	"session_end",
+	"Detached",
+	"detached",
+]);
+
+/** Mirrors host-service DEATH_GASP_DETACH_WINDOW_MS. */
+const DEATH_GASP_WINDOW_MS = 30_000;
+
+/** Mirrors host-service END_STRAGGLER_WINDOW_MS. */
+const END_STRAGGLER_WINDOW_MS = 30_000;
+
+export interface V1AgentHookEvent {
+	rawEventType: string;
+	agentId: string;
+	agentSessionId?: string;
+	at: number;
+}
+
+/**
+ * Next record for a pane after a hook event, or undefined when the event
+ * changes nothing. Pure so the transitions are testable.
+ */
+export function applyV1AgentHookEvent(
+	existing: V1PaneAgentSession | undefined,
+	event: V1AgentHookEvent,
+): V1PaneAgentSession | undefined {
+	const { rawEventType, agentId, agentSessionId, at } = event;
+
+	if (SESSION_END_EVENTS.has(rawEventType)) {
+		if (!existing || existing.endedAt !== undefined) return undefined;
+		// A goodbye from some other session must not end this one.
+		if (
+			agentSessionId !== undefined &&
+			agentSessionId !== existing.agentSessionId
+		) {
+			return undefined;
+		}
+		return { ...existing, endedAt: at, updatedAt: at };
+	}
+
+	if (SESSION_START_EVENTS.has(rawEventType)) {
+		if (!agentSessionId) return undefined;
+		if (existing?.agentSessionId === agentSessionId) {
+			// Same session starting again (e.g. resumed in place): the
+			// conversation still exists, so keep `prompted`; it is live again,
+			// so drop any goodbye.
+			return {
+				...existing,
+				agentId,
+				endedAt: undefined,
+				updatedAt: at,
+			};
+		}
+		return { agentId, agentSessionId, prompted: false, updatedAt: at };
+	}
+
+	// Anything else the v1 status pipeline understands (prompt submitted,
+	// stop, permission request, tool use) means the session has a message.
+	if (mapEventType(rawEventType) === null) return undefined;
+
+	const startsNewSession =
+		agentSessionId !== undefined &&
+		existing !== undefined &&
+		agentSessionId !== existing.agentSessionId;
+
+	if (existing === undefined || startsNewSession) {
+		if (!agentSessionId) return undefined;
+		return { agentId, agentSessionId, prompted: true, updatedAt: at };
+	}
+
+	if (existing.endedAt !== undefined) {
+		// Straggler from the ended session (async notify callbacks, in-flight
+		// curls) — reviving would erase the clean-quit marker. An event well
+		// past the goodbye is a real relaunch without session-start hooks.
+		if (at - existing.endedAt <= END_STRAGGLER_WINDOW_MS) return undefined;
+		return {
+			...existing,
+			agentId,
+			prompted: true,
+			endedAt: undefined,
+			updatedAt: at,
+		};
+	}
+
+	return { ...existing, agentId, prompted: true, updatedAt: at };
+}
+
+/**
+ * Next record after the pane's terminal died, or undefined when nothing
+ * changes. A goodbye recorded moments before the death was the agent's
+ * SIGHUP death gasp, not a user quit — clear it so the session stays a
+ * resume candidate (mirrors the host-service detach upgrade).
+ */
+export function applyV1TerminalExit(
+	existing: V1PaneAgentSession | undefined,
+	at: number,
+): V1PaneAgentSession | undefined {
+	if (existing?.endedAt === undefined) return undefined;
+	if (at - existing.endedAt > DEATH_GASP_WINDOW_MS) return undefined;
+	return { ...existing, endedAt: undefined, updatedAt: at };
+}
+
+function persist(paneId: string, next: V1PaneAgentSession): void {
+	appState.data.v1AgentSessions = {
+		...(appState.data.v1AgentSessions ?? {}),
+		[paneId]: next,
+	};
+	void appState.write().catch((err) => {
+		console.error("[v1-agent-sessions] app-state write failed", err);
+	});
+}
+
+export function recordV1AgentHookEvent(
+	paneId: string,
+	event: V1AgentHookEvent,
+): void {
+	const next = applyV1AgentHookEvent(
+		appState.data.v1AgentSessions?.[paneId],
+		event,
+	);
+	if (next) persist(paneId, next);
+}
+
+export function recordV1TerminalExit(paneId: string): void {
+	const next = applyV1TerminalExit(
+		appState.data.v1AgentSessions?.[paneId],
+		Date.now(),
+	);
+	if (next) persist(paneId, next);
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -30,6 +30,7 @@ import {
 	getNotificationTitle,
 	getWorkspaceName,
 } from "../lib/notifications/utils";
+import { recordV1TerminalExit } from "../lib/notifications/v1-agent-sessions";
 import {
 	getInitialWindowBounds,
 	loadWindowState,
@@ -249,6 +250,9 @@ export async function MainWindow() {
 				signal?: number;
 				reason?: "killed" | "exited" | "error";
 			}) => {
+				// A goodbye hook just before this death was the agent's SIGHUP
+				// death gasp — keep the session resumable across migration.
+				recordV1TerminalExit(event.paneId);
 				notificationsEmitter.emit(NOTIFICATION_EVENTS.TERMINAL_EXIT, {
 					paneId: event.paneId,
 					exitCode: event.exitCode,

--- a/apps/desktop/src/renderer/lib/v1-migration/terminals.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/terminals.ts
@@ -7,6 +7,42 @@ export interface V1TerminalPane {
 export interface PendingMigratedTerminal {
 	terminalId: string;
 	cwd: string | null;
+	/**
+	 * Source pane, so pane-creation time can look up the pane's latest
+	 * captured agent session and seed a resume candidate. Null on queue
+	 * entries persisted before this field existed.
+	 */
+	v1PaneId: string | null;
+}
+
+/** Shape of the electron-main V1PaneAgentSession capture the resume check needs. */
+export interface V1PaneAgentSessionSnapshot {
+	agentId: string;
+	agentSessionId: string;
+	prompted: boolean;
+	endedAt?: number;
+}
+
+export interface MigratedPaneResume {
+	agentId: string;
+	agentSessionId: string;
+}
+
+/**
+ * Whether a migrated pane's captured agent session should be offered for
+ * resume. Mirrors host-service findResumeCandidateBinding: a session id was
+ * captured, the session progressed past its first prompt (never-prompted
+ * sessions have no persisted conversation), and the agent never said its own
+ * goodbye (a clean quit is not a resume candidate).
+ */
+export function resolveMigratedPaneResume(
+	session: V1PaneAgentSessionSnapshot | undefined,
+): MigratedPaneResume | null {
+	if (!session) return null;
+	if (!session.agentId || !session.agentSessionId) return null;
+	if (!session.prompted) return null;
+	if (session.endedAt !== undefined) return null;
+	return { agentId: session.agentId, agentSessionId: session.agentSessionId };
 }
 
 export interface TerminalMigrationPlan {
@@ -48,7 +84,7 @@ export function planTerminalMigration({
 		const terminalId = newTerminalId();
 		plan.terminalIdByPaneId.set(pane.paneId, terminalId);
 		const list = plan.pendingByV2WorkspaceId.get(v2WorkspaceId) ?? [];
-		list.push({ terminalId, cwd: pane.cwd });
+		list.push({ terminalId, cwd: pane.cwd, v1PaneId: pane.paneId });
 		plan.pendingByV2WorkspaceId.set(v2WorkspaceId, list);
 	}
 

--- a/apps/desktop/src/renderer/lib/v1-migration/v1-migration.test.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/v1-migration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { resolvePresetImport } from "./presets";
 import { decideProjectImport } from "./projects";
 import { planHostBranchPrefix, planProjectPrefs } from "./settings";
-import { planTerminalMigration } from "./terminals";
+import { planTerminalMigration, resolveMigratedPaneResume } from "./terminals";
 import { planWorkspaceAdoptions } from "./workspaces";
 
 type Candidate = { id: string; source: string };
@@ -262,8 +262,8 @@ describe("planTerminalMigration", () => {
 
 	test("mapped panes queue under their v2 workspace with fresh ids", () => {
 		expect(plan.pendingByV2WorkspaceId.get("v2-ws")).toEqual([
-			{ terminalId: "term-1", cwd: "/repo/feat" },
-			{ terminalId: "term-2", cwd: null },
+			{ terminalId: "term-1", cwd: "/repo/feat", v1PaneId: "pane-1" },
+			{ terminalId: "term-2", cwd: null, v1PaneId: "pane-2" },
 		]);
 		expect(plan.terminalIdByPaneId.get("pane-1")).toBe("term-1");
 	});
@@ -271,6 +271,35 @@ describe("planTerminalMigration", () => {
 	test("panes on unmigrated workspaces defer", () => {
 		expect(plan.deferredPaneIds).toEqual(["pane-3"]);
 		expect(plan.terminalIdByPaneId.has("pane-3")).toBe(false);
+	});
+});
+
+describe("resolveMigratedPaneResume", () => {
+	const session = {
+		agentId: "claude",
+		agentSessionId: "sess-1",
+		prompted: true,
+	};
+
+	test("offers a prompted, un-ended session for resume", () => {
+		expect(resolveMigratedPaneResume(session)).toEqual({
+			agentId: "claude",
+			agentSessionId: "sess-1",
+		});
+	});
+
+	test("never offers a never-prompted session (no persisted conversation)", () => {
+		expect(
+			resolveMigratedPaneResume({ ...session, prompted: false }),
+		).toBeNull();
+	});
+
+	test("never offers a session the agent quit cleanly", () => {
+		expect(resolveMigratedPaneResume({ ...session, endedAt: 123 })).toBeNull();
+	});
+
+	test("handles absent captures", () => {
+		expect(resolveMigratedPaneResume(undefined)).toBeNull();
 	});
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
@@ -1,5 +1,11 @@
-import { workspaceTrpc } from "@superset/workspace-client";
+import { BUILTIN_AGENT_IDS } from "@superset/shared/agent-catalog";
+import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import { useEffect, useRef } from "react";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import {
+	resolveMigratedPaneResume,
+	type V1PaneAgentSessionSnapshot,
+} from "renderer/lib/v1-migration/terminals";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useV2TerminalLauncher } from "../useV2TerminalLauncher";
 
@@ -10,6 +16,13 @@ import { useV2TerminalLauncher } from "../useV2TerminalLauncher";
  * boot). Created entries are removed from the queue; failures stay queued
  * for the next open. Panes come from useAutoAdoptBackgroundSessions once
  * the sessions are running.
+ *
+ * When the source v1 pane had a resumable agent session (captured by the
+ * electron hook server), the fresh terminal is seeded with an ended binding
+ * so the pane surfaces the same resume banner as a killed v2 session. The
+ * capture is read here — not frozen at migration time — because the pane
+ * keeps living in v1 (and its agent keeps reporting) long after the
+ * every-boot migration pass ledgers it.
  */
 export function useCreatePendingMigratedTerminals({
 	workspaceId,
@@ -20,6 +33,7 @@ export function useCreatePendingMigratedTerminals({
 }): void {
 	const collections = useCollections();
 	const launcher = useV2TerminalLauncher();
+	const { trpcClient } = useWorkspaceClient();
 	const utils = workspaceTrpc.useUtils();
 	const runningRef = useRef(false);
 
@@ -32,6 +46,24 @@ export function useCreatePendingMigratedTerminals({
 		runningRef.current = true;
 
 		void (async () => {
+			const paneIds = pending
+				.map((t) => t.v1PaneId)
+				.filter((id): id is string => id !== null);
+			let agentSessions: Record<string, V1PaneAgentSessionSnapshot> = {};
+			if (paneIds.length > 0) {
+				try {
+					agentSessions =
+						await electronTrpcClient.migration.readV1PaneAgentSessions.query({
+							paneIds,
+						});
+				} catch (err) {
+					console.warn("[v1-migration] agent session read failed", {
+						workspaceId,
+						err,
+					});
+				}
+			}
+
 			const created = new Set<string>();
 			for (const terminal of pending) {
 				try {
@@ -44,6 +76,30 @@ export function useCreatePendingMigratedTerminals({
 					created.add(terminal.terminalId);
 				} catch (err) {
 					console.error("[v1-migration] pending terminal create failed", {
+						workspaceId,
+						terminalId: terminal.terminalId,
+						err,
+					});
+					continue;
+				}
+
+				const resume = resolveMigratedPaneResume(
+					terminal.v1PaneId ? agentSessions[terminal.v1PaneId] : undefined,
+				);
+				if (!resume) continue;
+				const agentId = BUILTIN_AGENT_IDS.find((id) => id === resume.agentId);
+				if (!agentId) continue;
+				// Best-effort: a failed seed still leaves a working shell, and
+				// seedResumeCandidate never overwrites a real binding.
+				try {
+					await trpcClient.terminalAgents.seedResumeCandidate.mutate({
+						workspaceId,
+						terminalId: terminal.terminalId,
+						agentId,
+						agentSessionId: resume.agentSessionId,
+					});
+				} catch (err) {
+					console.warn("[v1-migration] resume candidate seed failed", {
 						workspaceId,
 						terminalId: terminal.terminalId,
 						err,
@@ -62,5 +118,5 @@ export function useCreatePendingMigratedTerminals({
 			}
 			runningRef.current = false;
 		})();
-	}, [isLayoutReady, workspaceId, collections, launcher, utils]);
+	}, [isLayoutReady, workspaceId, collections, launcher, trpcClient, utils]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
@@ -46,9 +46,11 @@ export function useCreatePendingMigratedTerminals({
 		runningRef.current = true;
 
 		void (async () => {
+			// Pre-field entries lack v1PaneId; healed rows may surface it as
+			// undefined rather than null, so filter by type, not by !== null.
 			const paneIds = pending
 				.map((t) => t.v1PaneId)
-				.filter((id): id is string => id !== null);
+				.filter((id): id is string => typeof id === "string" && id.length > 0);
 			let agentSessions: Record<string, V1PaneAgentSessionSnapshot> = {};
 			if (paneIds.length > 0) {
 				try {
@@ -57,14 +59,19 @@ export function useCreatePendingMigratedTerminals({
 							paneIds,
 						});
 				} catch (err) {
+					// Without the capture we can't tell which terminals need a
+					// resume seed — clearing them now would drop it permanently.
+					// Leave the whole queue for the next open (creates no-op).
 					console.warn("[v1-migration] agent session read failed", {
 						workspaceId,
 						err,
 					});
+					runningRef.current = false;
+					return;
 				}
 			}
 
-			const created = new Set<string>();
+			const completed = new Set<string>();
 			for (const terminal of pending) {
 				try {
 					// createSession is idempotent by terminalId, so a re-run after
@@ -73,7 +80,6 @@ export function useCreatePendingMigratedTerminals({
 						terminalId: terminal.terminalId,
 						cwd: terminal.cwd ?? undefined,
 					});
-					created.add(terminal.terminalId);
 				} catch (err) {
 					console.error("[v1-migration] pending terminal create failed", {
 						workspaceId,
@@ -86,32 +92,39 @@ export function useCreatePendingMigratedTerminals({
 				const resume = resolveMigratedPaneResume(
 					terminal.v1PaneId ? agentSessions[terminal.v1PaneId] : undefined,
 				);
-				if (!resume) continue;
-				const agentId = BUILTIN_AGENT_IDS.find((id) => id === resume.agentId);
-				if (!agentId) continue;
-				// Best-effort: a failed seed still leaves a working shell, and
-				// seedResumeCandidate never overwrites a real binding.
-				try {
-					await trpcClient.terminalAgents.seedResumeCandidate.mutate({
-						workspaceId,
-						terminalId: terminal.terminalId,
-						agentId,
-						agentSessionId: resume.agentSessionId,
-					});
-				} catch (err) {
-					console.warn("[v1-migration] resume candidate seed failed", {
-						workspaceId,
-						terminalId: terminal.terminalId,
-						err,
-					});
+				const agentId = resume
+					? BUILTIN_AGENT_IDS.find((id) => id === resume.agentId)
+					: undefined;
+				if (resume && agentId) {
+					// A failed seed keeps the entry queued so the next open
+					// retries it (seedResumeCandidate is idempotent and never
+					// overwrites a binding the terminal earned in the meantime).
+					try {
+						await trpcClient.terminalAgents.seedResumeCandidate.mutate({
+							workspaceId,
+							terminalId: terminal.terminalId,
+							agentId,
+							agentSessionId: resume.agentSessionId,
+						});
+					} catch (err) {
+						console.warn("[v1-migration] resume candidate seed failed", {
+							workspaceId,
+							terminalId: terminal.terminalId,
+							err,
+						});
+						continue;
+					}
 				}
+				completed.add(terminal.terminalId);
 			}
-			if (created.size > 0) {
+			if (completed.size > 0) {
 				collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
 					draft.pendingMigratedTerminals = (
 						draft.pendingMigratedTerminals ?? []
-					).filter((t) => !created.has(t.terminalId));
+					).filter((t) => !completed.has(t.terminalId));
 				});
+			}
+			if (pending.length > 0) {
 				// Nudge the session list so auto-adopt builds the panes now
 				// rather than on the next natural refetch.
 				await utils.terminal.listSessions.invalidate({ workspaceId });

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -156,6 +156,9 @@ export const workspaceLocalStateSchema = z.object({
 			z.object({
 				terminalId: z.string(),
 				cwd: z.string().nullable().default(null),
+				// Source v1 pane — lets creation seed the pane's captured agent
+				// session as a resume candidate. Null on pre-existing entries.
+				v1PaneId: z.string().nullable().default(null),
 			}),
 		)
 		.default([]),
@@ -188,6 +191,7 @@ const WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS = {
 	pendingMigratedTerminals: [] as Array<{
 		terminalId: string;
 		cwd: string | null;
+		v1PaneId: string | null;
 	}>,
 };
 

--- a/packages/host-service/src/terminal-agents/persistence.test.ts
+++ b/packages/host-service/src/terminal-agents/persistence.test.ts
@@ -10,6 +10,7 @@ import {
 	findResumeCandidateBinding,
 	markTerminalAgentBindingEnded,
 	SqliteTerminalAgentBindingPersistence,
+	seedEndedTerminalAgentBinding,
 } from "./persistence";
 import { TerminalAgentStore } from "./store";
 
@@ -322,5 +323,96 @@ describe("binding end marking and resume candidates", () => {
 		expect(
 			persistence.listLiveByWorkspace("ws-1").map((b) => b.agentSessionId),
 		).toEqual(["sess-new"]);
+	});
+});
+
+describe("seedEndedTerminalAgentBinding (v1 pane migration)", () => {
+	function seedBareSession(
+		db: HostDb,
+		id: string,
+		workspaceId: string | null = "ws-1",
+	) {
+		db.insert(terminalSessions)
+			.values({
+				id,
+				status: "active",
+				originWorkspaceId: workspaceId,
+				createdAt: 1,
+			})
+			.run();
+	}
+
+	it("seeds a resume candidate for a bindingless terminal", () => {
+		const db = createTestDb();
+		seedBareSession(db, "t-migrated");
+
+		const result = seedEndedTerminalAgentBinding(db, {
+			terminalId: "t-migrated",
+			workspaceId: "ws-1",
+			agentId: "claude" as never,
+			agentSessionId: "sess-v1",
+			seededAt: 1_000,
+		});
+
+		expect(result).toBe("seeded");
+		const candidate = findResumeCandidateBinding(db, "ws-1", "t-migrated");
+		expect(candidate?.agentSessionId).toBe("sess-v1");
+		expect(candidate?.endReason).toBe("terminal-exited");
+		expect(candidate?.lastEventType).toBe("Stop");
+		// The seeded row is ended — it must never surface as a live agent.
+		const persistence = new SqliteTerminalAgentBindingPersistence(db);
+		expect(persistence.listLiveByWorkspace("ws-1")).toEqual([]);
+	});
+
+	it("never overwrites a terminal that already earned a binding", () => {
+		const db = createTestDb();
+		seedBareSession(db, "t1");
+		db.insert(terminalAgentBindings)
+			.values({
+				terminalId: "t1",
+				workspaceId: "ws-1",
+				agentId: "claude",
+				agentSessionId: "sess-real",
+				startedAt: 1,
+				lastEventAt: 2,
+				lastEventType: "Start",
+			})
+			.run();
+
+		const result = seedEndedTerminalAgentBinding(db, {
+			terminalId: "t1",
+			workspaceId: "ws-1",
+			agentId: "claude" as never,
+			agentSessionId: "sess-v1",
+		});
+
+		expect(result).toBe("already-bound");
+		expect(
+			new SqliteTerminalAgentBindingPersistence(db)
+				.listLiveByWorkspace("ws-1")
+				.map((b) => b.agentSessionId),
+		).toEqual(["sess-real"]);
+	});
+
+	it("rejects unknown terminals and workspace mismatches", () => {
+		const db = createTestDb();
+		seedBareSession(db, "t-other-ws", "ws-2");
+
+		expect(
+			seedEndedTerminalAgentBinding(db, {
+				terminalId: "t-missing",
+				workspaceId: "ws-1",
+				agentId: "claude" as never,
+				agentSessionId: "sess-v1",
+			}),
+		).toBe("terminal-not-found");
+		expect(
+			seedEndedTerminalAgentBinding(db, {
+				terminalId: "t-other-ws",
+				workspaceId: "ws-1",
+				agentId: "claude" as never,
+				agentSessionId: "sess-v1",
+			}),
+		).toBe("terminal-not-found");
 	});
 });

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -151,6 +151,65 @@ export function findResumeCandidateBinding(
 	return row ? rowToBinding(row) : undefined;
 }
 
+export type SeedEndedBindingResult =
+	| "seeded"
+	| "already-bound"
+	| "terminal-not-found";
+
+/**
+ * Seed an already-ended binding for a terminal that never hosted the agent —
+ * used by the v1→v2 pane migration to carry a v1 pane's agent session into
+ * the pane's recreated terminal as a resume candidate. `lastEventType` is
+ * "Stop" (not "Attached") because the v1 capture only surfaces sessions that
+ * progressed past their first prompt. Never overwrites: a terminal that
+ * already earned a real binding keeps it ("already-bound").
+ */
+export function seedEndedTerminalAgentBinding(
+	db: HostDb,
+	input: {
+		terminalId: string;
+		workspaceId: string;
+		agentId: TerminalAgentId;
+		agentSessionId: string;
+		definitionId?: AgentDefinitionId;
+		seededAt?: number;
+	},
+): SeedEndedBindingResult {
+	const session = db
+		.select({ originWorkspaceId: terminalSessions.originWorkspaceId })
+		.from(terminalSessions)
+		.where(eq(terminalSessions.id, input.terminalId))
+		.get();
+	if (!session || session.originWorkspaceId !== input.workspaceId) {
+		return "terminal-not-found";
+	}
+
+	const bound = db
+		.select({ terminalId: terminalAgentBindings.terminalId })
+		.from(terminalAgentBindings)
+		.where(eq(terminalAgentBindings.terminalId, input.terminalId))
+		.get();
+	if (bound) return "already-bound";
+
+	const seededAt = input.seededAt ?? Date.now();
+	db.insert(terminalAgentBindings)
+		.values({
+			terminalId: input.terminalId,
+			workspaceId: input.workspaceId,
+			agentId: input.agentId,
+			agentSessionId: input.agentSessionId,
+			definitionId: input.definitionId ?? null,
+			startedAt: seededAt,
+			lastEventAt: seededAt,
+			lastEventType: "Stop",
+			endedAt: seededAt,
+			endReason: "terminal-exited",
+		})
+		.onConflictDoNothing({ target: terminalAgentBindings.terminalId })
+		.run();
+	return "seeded";
+}
+
 export class SqliteTerminalAgentBindingPersistence
 	implements TerminalAgentBindingPersistence
 {

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -12,7 +12,10 @@ import type {
 	TerminalAgentBinding,
 	TerminalAgentId,
 } from "../../../terminal-agents";
-import { findResumeCandidateBinding } from "../../../terminal-agents/persistence";
+import {
+	findResumeCandidateBinding,
+	seedEndedTerminalAgentBinding,
+} from "../../../terminal-agents/persistence";
 import { protectedProcedure, router } from "../../index";
 import { resolveHostAgentConfig } from "../agents/agents";
 
@@ -110,6 +113,34 @@ export const terminalAgentsRouter = router({
 				agentLabel: config?.label ?? binding.agentId,
 				resumeSupported: (config?.resumeArgs.length ?? 0) > 0,
 			};
+		}),
+
+	/**
+	 * Seed a resume candidate for a terminal recreated by the v1→v2 pane
+	 * migration: the v1 pane's captured agent session, stamped ended, so the
+	 * migrated pane surfaces the same resume banner and flows through the
+	 * same `agents.run({resumeSessionId})` path as a killed v2 session.
+	 * No-ops when the terminal already earned a real binding.
+	 */
+	seedResumeCandidate: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				terminalId: z.string(),
+				agentId: terminalAgentIdSchema,
+				agentSessionId: z.string().min(1),
+				definitionId: agentDefinitionIdSchema.optional(),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const result = seedEndedTerminalAgentBinding(ctx.db, input);
+			if (result === "terminal-not-found") {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `No terminal ${input.terminalId} in workspace ${input.workspaceId}`,
+				});
+			}
+			return { seeded: result === "seeded" };
 		}),
 
 	/**


### PR DESCRIPTION
## Summary
- Migrated v1 terminal panes lost their agent entirely — only `{paneId, cwd}` crossed the v1→v2 boundary, so a pane running claude came back as a bare shell. Now the migrated pane surfaces the **same resume banner and detection** as a killed v2 session (#6253) and resumes through the same `agents.run({resumeSessionId})` path.

## Why / Context
#6253 made killed v2 agent sessions resumable by id, but the v1→v2 migration predates it and had nothing to resume from: v1 never recorded which agent session ran in a pane. The hook script's v1 fallback collapsed `SessionStart`/`SessionEnd` into `Start`/`Stop`, dropped `SUPERSET_AGENT_ID`, and the Electron hook server discarded the session id after logging it. This closes that gap so the v1 sunset doesn't strand in-flight agent sessions.

## How It Works
Three stages:

**1. Capture (v1 side, keeps working after the flip)**
- Hook templates (`notify-hook` v7 + cursor/copilot/gemini) send `agentId` and the un-collapsed `rawEventType` on the v1 dispatch.
- New `main/lib/notifications/v1-agent-sessions.ts` records per-pane `{agentId, agentSessionId, prompted, endedAt}` into `app-state.json`, mirroring host-service binding semantics: never-prompted sessions excluded (resume would hit "No conversation found"), the agent's own `SessionEnd` marks a clean quit, a goodbye within 30s of the pane's terminal death is a SIGHUP death gasp and upgrades back to resumable, and 30s stragglers can't revive a clean quit. Entries prune to live pane ids at boot.
- Capture runs in Electron main, so it keeps updating even after the user flips to v2 while v1 daemon sessions live on.

**2. Carry (migration)**
- `pendingMigratedTerminals` queue entries record their `v1PaneId` (nullable; old entries just skip seeding).
- The capture is read **at v2 pane-creation time** via `migration.readV1PaneAgentSessions` — not frozen into the plan — because the migration ledgers panes on every boot while the user is still on v1, and the pane's agent keeps running and reporting long after that.

**3. Seed (v2 side)**
- New `terminalAgents.seedResumeCandidate` mutation inserts an already-ended binding (`endReason: "terminal-exited"`, `lastEventType: "Stop"`) for the recreated terminal, after verifying the terminal belongs to the workspace, and never overwrites a real binding. `useCreatePendingMigratedTerminals` calls it best-effort after each `createSession`; from there the existing `resumeCandidate` query, `TerminalAgentResumeBanner`, and resume flow take over unchanged.

## Manual QA Checklist

### Capture
- [ ] Run claude in a v1 pane, prompt it → `v1AgentSessions` entry in `app-state.json` with `prompted: true`
- [ ] Quit claude cleanly (`/quit` or Ctrl+D on prompt) → entry gains `endedAt`
- [ ] Kill the pane's pty out from under claude → `endedAt` cleared (death gasp upgrade)

### Migration + resume
- [ ] Migrate the workspace, open it in v2 → recreated terminal pane shows "Claude Code was interrupted" banner
- [ ] Resume → claude reopens the v1 conversation in a fresh terminal, pane repoints, old shell disposed
- [ ] Cleanly-quit v1 sessions and never-prompted sessions get no banner
- [ ] Launching a new agent in the migrated terminal before its workspace opens is unaffected (seed no-ops on existing bindings)

## Testing
- `bun run typecheck` (desktop + host-service)
- `bun run lint` (exit 0)
- `bun test`: new transition tests (`v1-agent-sessions.test.ts`), `resolveMigratedPaneResume` + plan tests, `seedEndedTerminalAgentBinding` persistence tests; full sweeps: desktop main (573), host-service trpc (359), all green
- Mutation-verified: removing the `prompted` guard from resume detection makes tests fail
- Manual QA above not yet run end-to-end (needs a real v1 profile); flagging for a CDP pass before merge if desired

## Design Decisions
- **Read capture at creation time instead of plan time**: the terminal-migration ledger is one-shot per pane, but the pane keeps living in v1 after it's ledgered. Freezing agent info into the plan would ship stale (usually empty) sessions; resolving by `v1PaneId` at first v2 open uses the latest state.
- **Seed an ended binding instead of auto-launching `claude --resume`**: keeps the user in control and reuses the shipped banner/detection verbatim rather than a parallel path.

## Known Limitations
- Capture only knows sessions that fire ≥1 hook event after this ships — an agent idle since before the update won't be offered until its next turn. Nothing recoverable; v1 never persisted this.
- Panes already migrated *and* created before this ships have no `v1PaneId` and get no resume.
- Like the v2 resume flow, resume launches at the workspace root — a claude session started in a subdirectory may not be found by `--resume` (claude keys sessions by cwd).
- Codex coverage (verified empirically on codex-cli 0.146): TUI sessions capture via `~/.codex/hooks.json` exactly like claude; the legacy notify callback's `thread-id` is now extracted as a fallback id, so exec-launched and pre-hooks codex builds capture on their first completed turn. Only a codex session killed before any completed turn stays uncapturable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated v1 terminal panes now preserve and resume their agent sessions after moving to v2, showing the standard resume banner and flowing through `agents.run({ resumeSessionId })`. Adds Codex support by deriving the session id from `thread-id`, and hardens seeding against transient failures.

- **New Features**
  - Capture: v7 notify hooks send `rawEventType` and `agentId`; Electron main records per‑pane `{agentId, agentSessionId, prompted, endedAt}` in `app-state.json` and prunes to live panes.
  - Carry: `pendingMigratedTerminals` records `v1PaneId`; `migration.readV1PaneAgentSessions` reads the latest capture at v2 pane creation.
  - Seed: `terminalAgents.seedResumeCandidate` writes an ended binding (`endReason: "terminal-exited"`, `lastEventType: "Stop"`) for the recreated terminal; the renderer seeds this after create.
  - Codex: notify hook falls back to `thread-id` as the session id on turn completion (prefers explicit `session_id`).

- **Bug Fixes**
  - Resume seeding: don’t dequeue until seed succeeds; abort the pass on capture‑read errors so the next open retries.
  - Capture correctness: never inherit a session id across an agent change; ignore goodbyes from a different agent/session; skip app‑state writes when nothing changes.
  - Robustness: filter `v1PaneId` by type; `ensureValidShape` tolerates a legacy null panes map and prunes stale v1 session records.
  - Hooks: bump script markers (`notify` v7, `copilot` v4, `cursor` v6, `gemini` v5).

<sup>Written for commit 6ff1693e5f5f7130ba5adda9128bd2b5231a147b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for v1 agent sessions, including prompts, completion, revival, and terminal exits.
  * Preserved agent-session metadata during terminal migration.
  * Enabled eligible migrated sessions to resume automatically in the new workspace.
  * Added support for safely seeding resumable agent bindings.

* **Bug Fixes**
  * Removed stale session records for panes that no longer exist.
  * Improved session identification, including Codex thread IDs and raw lifecycle events.
  * Updated agent notification hooks for more reliable session tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
