### PR TITLE
feat(desktop): add Resources menu with Cmd+Shift+U shortcut

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/menu.ts
+++ b/apps/desktop/src/lib/trpc/routers/menu.ts
@@ -11,7 +11,8 @@ type MenuEvent =
 	| { type: "open-settings"; data: OpenSettingsEvent }
 	| { type: "open-workspace"; data: OpenWorkspaceEvent }
 	| { type: "open-project" }
-	| { type: "toggle-presets-bar" };
+	| { type: "toggle-presets-bar" }
+	| { type: "check-resources" };
 
 export const createMenuRouter = () => {
 	return router({
@@ -33,16 +34,22 @@ export const createMenuRouter = () => {
 					emit.next({ type: "toggle-presets-bar" });
 				};
 
+				const onCheckResources = () => {
+					emit.next({ type: "check-resources" });
+				};
+
 				menuEmitter.on("open-settings", onOpenSettings);
 				menuEmitter.on("open-workspace", onOpenWorkspace);
 				menuEmitter.on("open-project", onOpenProject);
 				menuEmitter.on("toggle-presets-bar", onTogglePresetsBar);
+				menuEmitter.on("check-resources", onCheckResources);
 
 				return () => {
 					menuEmitter.off("open-settings", onOpenSettings);
 					menuEmitter.off("open-workspace", onOpenWorkspace);
 					menuEmitter.off("open-project", onOpenProject);
 					menuEmitter.off("toggle-presets-bar", onTogglePresetsBar);
+					menuEmitter.off("check-resources", onCheckResources);
 				};
 			});
 		}),

--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -16,6 +16,10 @@ export function createApplicationMenu() {
 	const closeAccelerator = "CmdOrCtrl+Shift+Q";
 	const showHotkeysAccelerator = "CmdOrCtrl+/";
 	const openSettingsAccelerator = "CmdOrCtrl+,";
+	// Matches the CHECK_RESOURCES entry in renderer/hotkeys/registry.ts — windows/linux
+	// add Alt to avoid a common IME/OS binding on ctrl+shift+u.
+	const checkResourcesAccelerator =
+		process.platform === "darwin" ? "Cmd+Shift+U" : "Ctrl+Shift+Alt+U";
 
 	const template: Electron.MenuItemConstructorOptions[] = [
 		{
@@ -95,6 +99,18 @@ export function createApplicationMenu() {
 				{ role: "zoom" },
 				{ type: "separator" },
 				{ role: "close", accelerator: closeAccelerator },
+			],
+		},
+		{
+			label: "Resources",
+			submenu: [
+				{
+					label: "Check Resources",
+					accelerator: checkResourcesAccelerator,
+					click: () => {
+						menuEmitter.emit("check-resources");
+					},
+				},
 			],
 		},
 		{

--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -16,10 +16,6 @@ export function createApplicationMenu() {
 	const closeAccelerator = "CmdOrCtrl+Shift+Q";
 	const showHotkeysAccelerator = "CmdOrCtrl+/";
 	const openSettingsAccelerator = "CmdOrCtrl+,";
-	// Matches the CHECK_RESOURCES entry in renderer/hotkeys/registry.ts — windows/linux
-	// add Alt to avoid a common IME/OS binding on ctrl+shift+u.
-	const checkResourcesAccelerator =
-		process.platform === "darwin" ? "Cmd+Shift+U" : "Ctrl+Shift+Alt+U";
 
 	const template: Electron.MenuItemConstructorOptions[] = [
 		{
@@ -104,9 +100,13 @@ export function createApplicationMenu() {
 		{
 			label: "Resources",
 			submenu: [
+				// No accelerator here: on macOS, a menu accelerator is always live
+				// and would bypass the renderer's user-customizable CHECK_RESOURCES
+				// binding (Settings > Keyboard). The default shortcut stays
+				// discoverable via the command palette and keyboard settings, both
+				// of which reflect the user's actual current/overridden binding.
 				{
 					label: "Check Resources",
-					accelerator: checkResourcesAccelerator,
 					click: () => {
 						menuEmitter.emit("check-resources");
 					},

--- a/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
+++ b/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect } from "react";
 import { useHotkey } from "renderer/hotkeys";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { CommandContextProvider } from "./core/ContextProvider";
 import { useFrameStackStore } from "./core/frames";
 import { registerAllModules } from "./modules";
@@ -34,10 +35,19 @@ function CommandPaletteTrigger() {
 	const reset = useFrameStackStore((s) => s.reset);
 	const pushFrame = useFrameStackStore((s) => s.pushFrame);
 	useHotkey("OPEN_COMMAND_PALETTE", () => setOpen(true));
-	useHotkey("CHECK_RESOURCES", () => {
-		setOpen(true);
-		reset();
-		pushFrame(checkResourcesCommand);
+
+	// CHECK_RESOURCES fires via the native "Resources" menu accelerator (see
+	// main/lib/menu.ts) rather than a renderer-side useHotkey binding, so the
+	// same Cmd+Shift+U shortcut also reaches the app when a menu accelerator
+	// would otherwise shadow a DOM keydown listener.
+	electronTrpc.menu.subscribe.useSubscription(undefined, {
+		onData: (event) => {
+			if (event.type !== "check-resources") return;
+			setOpen(true);
+			reset();
+			pushFrame(checkResourcesCommand);
+		},
 	});
+
 	return null;
 }

--- a/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
+++ b/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
@@ -36,16 +36,23 @@ function CommandPaletteTrigger() {
 	const pushFrame = useFrameStackStore((s) => s.pushFrame);
 	useHotkey("OPEN_COMMAND_PALETTE", () => setOpen(true));
 
-	// CHECK_RESOURCES fires via the native "Resources" menu accelerator (see
-	// main/lib/menu.ts) rather than a renderer-side useHotkey binding, so the
-	// same Cmd+Shift+U shortcut also reaches the app when a menu accelerator
-	// would otherwise shadow a DOM keydown listener.
+	const openResources = () => {
+		setOpen(true);
+		reset();
+		pushFrame(checkResourcesCommand);
+	};
+
+	// Keeps CHECK_RESOURCES on the renderer's own hotkey binding (rather than a
+	// native menu accelerator) so it stays user-customizable/disable-able via
+	// Settings > Keyboard — see main/lib/menu.ts for why the "Resources" menu
+	// item has no accelerator.
+	useHotkey("CHECK_RESOURCES", openResources);
+
+	// The native "Resources" menu item's click still opens the same view.
 	electronTrpc.menu.subscribe.useSubscription(undefined, {
 		onData: (event) => {
 			if (event.type !== "check-resources") return;
-			setOpen(true);
-			reset();
-			pushFrame(checkResourcesCommand);
+			openResources();
 		},
 	});
 


### PR DESCRIPTION
## Summary
- Add a top-level **Resources** menu (alongside File/Edit/View/Window/Help) with a "Check Resources" item that opens the existing resource usage (CPU/RAM) view — for mouse-driven discoverability of the feature.
- The **⇧⌘U** shortcut that already opened this view continues to be owned by the renderer's user-customizable hotkey system (Settings > Keyboard), unchanged by this PR.

## Why / Context
Cmd+Shift+U already opened the resource monitor via a renderer `useHotkey` binding, but "Resources" wasn't discoverable anywhere in the UI (menu or otherwise) for users who don't know the shortcut.

An earlier version of this PR also added the shortcut as a native Electron menu `accelerator`. Cubic's review correctly flagged that as a regression: `CHECK_RESOURCES` is rebindable/disable-able via Settings > Keyboard (`hotkeyOverridesStore`, persisted in renderer `localStorage`, no main-process access), and a native accelerator is unconditionally live on macOS — it would fire and ignore a user's override or disable. That's been reverted; the renderer's `useHotkey` remains the sole source of truth for the actual keybinding, matching what the command palette already displays.

## How It Works
- `main/lib/menu.ts`: new "Resources" → "Check Resources" menu item, no accelerator. Click emits a `check-resources` event via the shared `menuEmitter`.
- `lib/trpc/routers/menu.ts`: added `check-resources` to the `MenuEvent` union and wired it into the existing `observable` subscription.
- `renderer/commandPalette/CommandPaletteHost.tsx`: `useHotkey("CHECK_RESOURCES", ...)` still owns the keyboard shortcut (override-aware); a new subscription to the `check-resources` menu event triggers the same action when the menu item is clicked.

## Manual QA Checklist
- [ ] "Resources" menu appears in the app menu bar between Window and Help
- [ ] Clicking Resources → Check Resources opens the resource usage view in the command palette
- [ ] Cmd+Shift+U still opens the same view
- [ ] Rebinding or disabling `CHECK_RESOURCES` in Settings > Keyboard changes/disables the shortcut, and the command palette hint reflects it (menu click still works regardless)
- [ ] Behavior verified after app restart (native menu is main-process, not renderer-hot-reloaded)

## Testing
- `bun run lint:fix` (clean)
- `bun run typecheck --filter=@superset/desktop` (passes)
- Not yet verified end-to-end against a running app — no dev instance was running for this worktree, and native OS menu chrome isn't inspectable via CDP. Flagging for reviewer/manual QA per the checklist above.

## Known Limitations
- No automated test coverage added; this is a small, mechanical menu/IPC wiring change consistent with existing untested sibling menu items (Settings, Keyboard Shortcuts).
- The menu item doesn't display the shortcut hint text — Electron accelerators are unconditionally live on macOS, so showing one would reintroduce the override-bypass bug above. The shortcut is discoverable via the command palette and Settings > Keyboard instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Resources** section to the application menu with a **Check Resources** option.
  * Selecting **Check Resources** opens the resource-checking command palette.
  * Native menu actions now use the same resource-checking workflow as the configurable keyboard shortcut.
  * Existing keyboard shortcuts for opening resource checks remain available and customizable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->