### PR TITLE
feat(marketing): add and refresh compare pages

### DIFF
--- a/apps/marketing/content/compare/agent-orchestrator-alternative.mdx
+++ b/apps/marketing/content/compare/agent-orchestrator-alternative.mdx
@@ -1,0 +1,99 @@
+---
+title: "Best Agent Orchestrator Alternatives in 2026"
+description: "The best alternatives to Agent Orchestrator (AO) for running parallel AI coding agents, including Superset, Orca, Emdash, Conductor, and Gas Town."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - agent-orchestrator
+  - orca
+  - emdash
+  - conductor
+  - gastown
+keywords:
+  - agent orchestrator alternative
+  - ao alternative
+  - aoagents alternative
+  - ai coding agent fleet
+  - parallel coding agents
+---
+
+Agent Orchestrator (AO, from Untrivial AI) is an Apache-2.0 desktop app that runs fleets of coding agents in isolated worktrees and automatically routes CI failures, review comments, and merge conflicts back to the responsible agent. Its reactions system is best-in-class; its edges are elsewhere -- no maintained CLI or API, no scheduling, no remote or team story, and diff inspection defers to the Git host. Here are the best Agent Orchestrator alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Full workspace with automations and scriptable surfaces | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Free desktop ADE with the biggest community | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Emdash** | Open-source ADE with tracker intake and cron | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Conductor** | Focused, polished Mac app | macOS | Proprietary |
+| **Gas Town** | Sustained autonomous fleets with a merge queue | CLI/tmux (macOS, Linux) | Open source (MIT) |
+
+## Why Look for an Agent Orchestrator Alternative?
+
+AO automates the PR feedback loop brilliantly, but the rest of the workflow leans on other tools: reviewing diffs happens on GitHub or GitLab, there is no built-in diff editor, the CLI is deprecated with no API or MCP surface, automation is limited to PR-event reactions (no cron or scheduled runs), and remote access means reverse-proxying a dashboard with no authentication. Teams also get no plans, roles, or enterprise controls.
+
+## The Best Alternatives
+
+### Superset
+
+Superset pairs the same worktree-per-task core with the workspace AO lacks: a built-in diff/file editor, an in-app browser, port management, and persistent daemon-backed terminals -- plus the surfaces AO retired or never had: a maintained CLI, an MCP server, a TypeScript SDK, a Slack bot, and scheduled automations. PR status, review threads, and CI checks surface in the workspace, and remote and cloud workspaces extend it across your devices with team plans behind it.
+
+For the direct comparison, see [Superset vs Agent Orchestrator](/compare/superset-vs-agent-orchestrator).
+
+### Orca
+
+Orca (~39,000 stars, MIT) is the community heavyweight: fleets of agents in parallel worktrees, split terminals, per-task browser tabs, Design Mode, diff annotation, SSH/VPS worktrees, and shipped mobile apps. No packaged CI-fix loop, but the broadest free feature set in the category.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) matches AO's license and adds what it lacks: real diff review with push-and-create-PR, CI-check monitoring in-app, cron automations, an in-app browser, and intake from a dozen issue trackers.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Conductor
+
+Conductor is a proprietary, polished macOS app for Claude Code, Codex, and Cursor agents in parallel worktrees -- less automation than AO, more polish per session.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Gas Town
+
+If AO's automation is why you are here and you want more of it, Gas Town goes further: an AI coordinator dispatching a git-backed work ledger to 20-30 agents, watchdog recovery, and a bisecting merge queue that lands green batches. Terminal machinery for committed operators.
+
+See [Superset vs Gas Town](/compare/superset-vs-gastown).
+
+## How To Choose
+
+- For the complete workspace with scheduling and scriptable surfaces, choose **Superset**.
+- For the biggest free open-source ADE, choose **Orca**.
+- For an Apache-2.0 app with diff review and tracker intake, choose **Emdash**.
+- For a focused Mac app, choose **Conductor**.
+- For autonomy beyond AO's loops, choose **Gas Town**.
+
+## Verdict
+
+AO's reactions system deserves its reputation -- if automatic CI-failure routing is your top requirement, it may be the right call. For everything around that loop -- review, browsing, scheduling, scripting, remote reach, teams -- Superset is the strongest alternative, with Orca and Emdash as the leading open-source options. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Agent Orchestrator alternative?
+
+For most teams, Superset: the same worktree fleet model with a full workspace, scheduled automations, CLI/MCP/SDK surfaces, and remote/cloud workspaces.
+
+### Is there an open-source Agent Orchestrator alternative?
+
+Yes. Orca (MIT), Emdash (Apache-2.0), and Gas Town (MIT) are open source, like AO itself. Superset is source-available under ELv2 with a free tier.
+
+### Which alternatives automate CI-failure fixes like AO?
+
+None package it quite like AO's reactions. Gas Town's watchdogs and merge queue automate recovery and landing; Emdash surfaces CI checks in-app; Superset surfaces CI status in the workspace and lets agents be re-dispatched with the failure context.
+
+### Does AO support GitLab, and do the alternatives?
+
+AO supports GitHub and GitLab. Emdash pulls issues from GitLab; super.engineering supports GitLab forges natively; Superset and Orca are GitHub-centric today.

--- a/apps/marketing/content/compare/bb-alternative.mdx
+++ b/apps/marketing/content/compare/bb-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best bb Alternatives in 2026"
+description: "The best alternatives to bb (the agentic IDE that builds itself) for orchestrating AI coding agents, including Superset, Orca, Emdash, and Herdr."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - bb
+  - orca
+  - emdash
+  - herdr
+  - conductor
+keywords:
+  - bb alternative
+  - bb alternatives
+  - getbb alternative
+  - bb agentic ide
+  - agentic ide
+  - ai agent orchestration
+---
+
+bb is the open-source "IDE that builds itself": agents run in live threads you can steer or hand off, and most features -- crons, previews, even remote access -- are plugins that bb's own agents wrote. It is free, MIT-licensed, and genuinely novel. It is also young: a largely single-maintainer project, in active development by its own description, with worktree isolation optional rather than default and no team or support story. Here are the best bb alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | A complete, supported workspace out of the box | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Free cross-platform desktop ADE, huge community | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Emdash** | Open-source ADE with tracker intake and cron automations | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Herdr** | Terminal-native runtime, deeply scriptable | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **Conductor** | Focused, polished Mac app | macOS | Proprietary |
+
+## Why Look for a bb Alternative?
+
+bb optimizes for moldability: agents as first-class operators, a plugin store, full CLI/HTTP-API parity with the UI. You might want an alternative if you want the workflow to exist on day one instead of assembling it, prefer worktree isolation as the default for every task, need a maintained product with a team behind it, or want built-in review, browser, and scheduling rather than plugin equivalents.
+
+## The Best Alternatives
+
+### Superset
+
+Superset ships what bb expects you to grow: automatic Git worktree isolation per task, persistent terminals, a diff/file editor, an in-app browser, port management, and scheduled automations with a TypeScript SDK and Slack bot -- plus remote and cloud workspaces across your own devices. It keeps the scriptability bb fans care about through its CLI and MCP server, but as a supported product rather than a substrate. If you liked bb's ambition but want fewer moving parts, this is the alternative.
+
+For the direct comparison, see [Superset vs bb](/compare/superset-vs-bb).
+
+### Orca
+
+Orca is the most popular open-source project in the category (~39,000 stars, MIT): fleets of agents in parallel worktrees, split terminals, per-task browser tabs, Design Mode, SSH/VPS worktrees, and mobile companions. Where bb is a substrate with a small community, Orca is a finished free app with a very large one.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) gives every task its own branch and worktree by default, auto-detects 30+ agent CLIs, pulls work from a dozen issue trackers, and includes diff review, an in-app browser, and cron automations -- the built-in versions of several things bb does via plugins.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Herdr
+
+If what drew you to bb was agents driving the tool itself, Herdr scratches the same itch in the terminal: an open-source runtime with a JSON socket API that agents can drive from inside their own panes, plus a 500-plugin marketplace and worktree management in the CLI.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### Conductor
+
+Conductor is the opposite trade from bb: a proprietary, focused macOS app for Claude Code, Codex, and Cursor agents in parallel worktrees. No self-extension, no API surface -- just a polished loop.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+## How To Choose
+
+- For a complete, supported workspace with automations and remote reach, choose **Superset**.
+- For a free, community-heavy desktop ADE, choose **Orca**.
+- For open-source with tracker intake and scheduling built in, choose **Emdash**.
+- For agent-scriptable terminal infrastructure, choose **Herdr**.
+- For a simple polished Mac app, choose **Conductor**.
+
+## Verdict
+
+bb is one of the most interesting experiments in this space, and tinkerers should absolutely try it. If you need the same thread-spawning, agent-orchestrating power with the workspace already built -- review, browser, automations, worktrees by default, and a team behind it -- Superset is the strongest alternative, with Orca and Emdash as the leading open-source picks. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best bb alternative?
+
+For most developers, Superset: the same parallel-agent orchestration with worktrees, review, browser, and automations built in and supported as a product. Orca and Emdash are the strongest open-source alternatives.
+
+### Is there an open-source bb alternative?
+
+Yes -- bb itself is MIT, and so are Orca and Crystal/Nimbalyst; Emdash and Herdr are Apache-2.0. Superset is source-available under ELv2 with a free tier.
+
+### Do these alternatives support agents driving the tool, like bb?
+
+Superset exposes a CLI, an MCP server, and a TypeScript SDK that agents can use to create workspaces and launch other agents. Herdr's socket API is designed for agents to drive it from inside panes. Orca has a CLI plus experimental agent-to-agent orchestration.
+
+### Does bb use Git worktrees?
+
+Yes, optionally -- a bb thread's environment can be backed by a fresh worktree. Superset, Orca, Emdash, and Conductor make a worktree per task the default.

--- a/apps/marketing/content/compare/buzz-alternative.mdx
+++ b/apps/marketing/content/compare/buzz-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Buzz Alternatives in 2026"
+description: "The best alternatives to Buzz by Block for working with AI coding agents, including Superset, Orca, Emdash, and OpenHands — from agent workspaces to self-hosted platforms."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - buzz
+  - orca
+  - emdash
+  - openhands
+  - conductor
+keywords:
+  - buzz alternative
+  - buzz alternatives
+  - buzz by block alternative
+  - buzz.xyz alternative
+  - ai agent collaboration
+  - ai agent workspace
+---
+
+Buzz is Block's open-source workspace where humans and AI agents collaborate as teammates -- channels, threads, repos, and workflows on a Nostr relay you can own, with agents holding their own cryptographic identities. It is a genuinely new idea, but it is early: Git integration is young by Block's own description, there is no per-task isolation or terminal orchestration, and mobile clients are still in development. If what you actually need is agents shipping code, here are the best Buzz alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Running coding agents in parallel with worktrees, review, and automations | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Free cross-platform desktop ADE with mobile companions | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Emdash** | Open-source ADE with issue-tracker intake | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **OpenHands** | Self-hostable autonomous agents in the cloud | Self-hosted / cloud | Open source (MIT) |
+| **Conductor** | Focused Mac app for parallel worktree agents | macOS | Proprietary |
+
+## Why Look for a Buzz Alternative?
+
+Buzz is a collaboration layer: agents and humans share rooms, patches land as signed events, and workflows fire on messages and schedules. You might want an alternative if your goal is the execution layer -- running many coding agents against real repos with isolation and reviewable diffs -- or if you need mature Git tooling, embedded terminals, or a product that works without running (or trusting) a relay.
+
+## The Best Alternatives
+
+### Superset
+
+Superset is the execution-layer counterpart to Buzz's team layer: it runs Claude Code, Codex, OpenCode, and any CLI agent in parallel, each task in its own Git worktree with persistent terminals, a diff/file editor, an in-app browser, and scheduled automations driven by a TypeScript SDK and a Slack bot. If Buzz drew you in with "agents as team members" but your team already lives in Slack and your work lives in GitHub, Superset delivers the agent workflow on the tools you have.
+
+For the direct comparison, see [Superset vs Buzz](/compare/superset-vs-buzz).
+
+### Orca
+
+Orca is a free, MIT-licensed agent development environment (~39,000 stars) that runs fleets of agents in parallel worktrees with terminals, browser tabs, and diff annotation, on macOS, Windows, and Linux with shipped mobile apps. It has none of Buzz's protocol ambitions -- it just runs coding agents very well.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) is an open-source ADE with a worktree per task, 30+ agent providers, diff review, an in-app browser, cron automations, and intake from a dozen issue trackers. A strong pick if your "team of agents" is fed by tickets rather than chat.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### OpenHands
+
+OpenHands is an open-source platform for autonomous coding agents that you can self-host -- closer to Buzz's self-hosted, agents-do-the-work spirit than a desktop app, with agents running tasks end to end in sandboxed environments.
+
+See [Superset vs OpenHands](/compare/superset-vs-openhands).
+
+### Conductor
+
+Conductor is a polished, proprietary macOS app for running Claude Code, Codex, and Cursor in parallel worktrees. No collaboration layer at all -- purely the coding loop, done well.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+## How To Choose
+
+- For parallel coding agents with worktrees, review, and automations, choose **Superset**.
+- For a free, open-source desktop ADE, choose **Orca** or **Emdash**.
+- For self-hosted autonomous agents, choose **OpenHands**.
+- For a simple Mac app, choose **Conductor**.
+- If agent identity, relay ownership, and human-agent channels are the point, Buzz itself has no real substitute yet.
+
+## Verdict
+
+Buzz is less replaceable than most tools on this list because it is trying something different: a decentralized team workspace where agents are members. But most teams evaluating Buzz actually need agents that ship code today, and for that Superset is the strongest alternative -- with Orca and Emdash as the open-source desktop picks and OpenHands for self-hosted autonomy. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Buzz alternative?
+
+It depends on which half of Buzz you want. For the coding-agent half, Superset: parallel agents in isolated worktrees with review and automations. For the collaboration half, Superset's Slack bot covers agent-in-the-channel workflows on the chat platform most teams already use.
+
+### Is there an open-source Buzz alternative?
+
+Buzz itself is Apache-2.0. Orca (MIT), Emdash (Apache-2.0), and OpenHands (MIT) are open-source alternatives on the execution side. Superset is source-available under ELv2.
+
+### Can Buzz and these alternatives be used together?
+
+Conceptually yes -- Buzz as the coordination layer, a workspace like Superset as the execution layer. There is no built-in integration between them today.
+
+### Does Buzz run coding agents in Git worktrees?
+
+No. Buzz projects work against a single local clone, and its Git integration is early by Block's own description. Superset, Orca, Emdash, and Conductor all isolate each task in its own worktree.

--- a/apps/marketing/content/compare/cindy-alternative.mdx
+++ b/apps/marketing/content/compare/cindy-alternative.mdx
@@ -1,0 +1,101 @@
+---
+title: "Best Cindy Alternatives in 2026"
+description: "The best alternatives to Cindy for running AI coding agents in parallel, including Superset, Orca, Emdash, and Conductor — purpose-built developer workspaces."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - cindy
+  - orca
+  - emdash
+  - conductor
+  - herdr
+keywords:
+  - cindy alternative
+  - cindy alternatives
+  - cindy ai agent alternative
+  - makecindy alternative
+  - ai agent orchestration
+  - parallel coding agents
+---
+
+Cindy is an open-source, general-purpose AI agent app that wraps Claude Code and Codex in a continuous workspace with memory, a planner/workers/reviewer team model, mobile apps, and Telegram intake. It is one of the fastest-moving projects in the space -- which is also the caveat: it launched in July 2026, ships multiple releases per day, and is a general agent first rather than an engineering tool. If you need a purpose-built workspace for coding agents, here are the best Cindy alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Git-native parallel agents with review and automations | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Free desktop ADE with shipped mobile apps | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Emdash** | Open-source ADE with tracker intake | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Conductor** | Focused, stable Mac app | macOS | Proprietary |
+| **Herdr** | Terminal-native persistent runtime | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+
+## Why Look for a Cindy Alternative?
+
+Cindy's coding runs happen in its own workspace model with change capture and undo -- useful, but not branch-level Git isolation. There is no worktree per task, no PR-centric review flow, and the release churn of a weeks-old project cuts both ways. Developers who want agents working on real branches with real diffs, or teams that need stability and enterprise controls, usually want a purpose-built tool.
+
+## The Best Alternatives
+
+### Superset
+
+Superset is the engineering-grade version of what Cindy sketches: every task gets its own Git worktree and branch with persistent terminals, a diff/file editor, an in-app browser, and port management, and the whole thing is programmable -- scheduled automations, a TypeScript SDK, an MCP server, and a Slack bot. It runs Claude Code and Codex like Cindy does, plus OpenCode, Cursor, Copilot, Gemini, and any CLI agent. If your agents ship code, this is the alternative.
+
+For the direct comparison, see [Superset vs Cindy](/compare/superset-vs-cindy).
+
+### Orca
+
+Orca matches Cindy's strongest cards -- free, open source, mobile apps -- while being a dedicated developer environment: fleets of agents in parallel worktrees, split terminals, Design Mode, and SSH/VPS remote worktrees, with roughly 39,000 GitHub stars behind it.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) gives each task a branch and worktree, auto-detects 30+ agent CLIs, reviews diffs with push-and-create-PR, and pulls work from a dozen issue trackers with cron automations. The open-source pick when tickets, not chats, feed your agents.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Conductor
+
+Conductor is a stable, proprietary macOS app for Claude Code, Codex, and Cursor agents in parallel worktrees -- the calm, focused counterpoint to Cindy's velocity.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Herdr
+
+Herdr is an open-source terminal runtime that keeps agent sessions alive through disconnects and restarts, with worktree management in its CLI. For developers who want persistence and scriptability rather than an app.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+## How To Choose
+
+- For Git-native parallel agents with review, automations, and teams, choose **Superset**.
+- For free and open source with mobile apps, choose **Orca**.
+- For open source with issue-tracker intake, choose **Emdash**.
+- For a focused Mac app, choose **Conductor**.
+- For terminal-native persistence, choose **Herdr**.
+- If you want one agent for general tasks beyond code, Cindy itself remains an interesting pick.
+
+## Verdict
+
+Cindy is worth watching -- its planner/workers/reviewer model and mobile-first reach are genuinely fresh. But for engineering work, purpose-built beats general-purpose: Superset is the strongest alternative for parallel coding agents on real branches, with Orca and Emdash as the leading open-source options. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Cindy alternative for coding?
+
+Superset: worktree-per-task isolation, diff review, an in-app browser, scheduled automations, and CLI/MCP/SDK surfaces, running Claude Code, Codex, and any other CLI agent.
+
+### Is there an open-source Cindy alternative?
+
+Cindy itself is Apache-2.0. On the developer-workspace side, Orca (MIT), Emdash (Apache-2.0), and Herdr (Apache-2.0) are open source; Superset is source-available under ELv2.
+
+### Which alternatives have mobile apps like Cindy?
+
+Orca ships iOS and Android companions today. Superset's mobile app is on its roadmap; its remote story today is cloud workspaces plus a Slack bot.
+
+### Does Cindy use Git worktrees?
+
+No. Cindy tracks workspace changes per turn with undo/reapply, which is capture rather than isolation. Superset, Orca, Emdash, and Conductor isolate each task in its own Git worktree and branch.

--- a/apps/marketing/content/compare/emdash-alternative.mdx
+++ b/apps/marketing/content/compare/emdash-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Emdash Alternatives in 2026"
+description: "The best alternatives to Emdash for running parallel AI coding agents in Git worktrees, including Superset, Orca, Conductor, Herdr, and Crystal."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - emdash
+  - orca
+  - conductor
+  - herdr
+  - crystal
+keywords:
+  - emdash alternative
+  - emdash alternatives
+  - emdash competitors
+  - emdash vs superset
+  - agentic development environment
+  - parallel ai coding agents
+---
+
+Emdash is a well-built open-source agentic development environment (YC W26): a worktree per task, 30+ agent providers, a dozen issue-tracker integrations, diff review, an in-app browser, and cron automations, all free under Apache-2.0. Its limits are surfaces and teams: there is no CLI, SDK, or API, automation is cron-only inside the app, and there is no team or enterprise offering. Here are the best Emdash alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Scriptable surfaces (CLI/MCP/SDK/Slack) and teams | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Biggest open-source community, mobile apps | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Conductor** | Focused, polished Mac app | macOS | Proprietary |
+| **Herdr** | Terminal-native runtime with persistence | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **Crystal (Nimbalyst)** | Lean open-source Claude Code + Codex app | macOS, Windows, Linux | Open source (MIT) |
+
+## Why Look for an Emdash Alternative?
+
+Emdash covers the desktop loop well. You might want an alternative if you need to drive orchestration from scripts, CI, or other agents (Emdash has no CLI or API), want automations that compose into pipelines rather than fire on cron, need team plans or enterprise controls, or want reach beyond the desktop -- cloud workspaces or mobile monitoring.
+
+## The Best Alternatives
+
+### Superset
+
+Superset matches Emdash's core -- any CLI agent in an isolated worktree with diff review, browser, and scheduled runs -- and adds the surfaces Emdash lacks: a CLI, an MCP server so agents and tools can drive the workspace, a TypeScript SDK for building pipelines, and a Slack bot for team workflows, plus remote and cloud workspaces across your own devices. If Emdash's ceiling is "what the app's UI offers," Superset is the programmable version.
+
+For the direct comparison, see [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Orca
+
+Orca is the most popular project in the category (~39,000 stars, MIT): fleets of agents in parallel worktrees, split terminals, Design Mode for UI work, SSH/VPS worktrees, and shipped iOS and Android companions. It lacks Emdash's scheduler, but the community and release velocity are unmatched.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Conductor
+
+Conductor is a proprietary macOS app running Claude Code, Codex, and Cursor agents in parallel worktrees. Narrower agent support and macOS only, but polished and stable -- a good pick if Emdash's breadth is more than you use.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Herdr
+
+Herdr is an open-source terminal runtime rather than a desktop app: an always-on server that keeps agent terminals alive through disconnects, with worktree management in the CLI, a JSON socket API, and a plugin marketplace. The opposite trade from Emdash -- all persistence and scriptability, no built-in review UI.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### Crystal (now Nimbalyst)
+
+Crystal is a lean, MIT-licensed app for running Claude Code and Codex in parallel worktrees with solid in-app Git operations, continuing development under the Nimbalyst name. Less surface area than Emdash, but simple and cross-platform.
+
+See [Superset vs Crystal](/compare/superset-vs-crystal).
+
+## How To Choose
+
+- For programmable orchestration and team features, choose **Superset**.
+- For the biggest open-source community and mobile companions, choose **Orca**.
+- For a focused Mac app, choose **Conductor**.
+- For terminal-native persistence and scripting, choose **Herdr**.
+- For a lean open-source two-agent app, choose **Crystal (Nimbalyst)**.
+
+## Verdict
+
+Emdash is one of the best free ADEs available, and if the desktop app covers your workflow there is little reason to leave. The moment you need to script it, schedule beyond cron, or roll it out to a team, Superset is the strongest alternative, with Orca as the leading open-source option. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Emdash alternative?
+
+For most teams, Superset: the same worktree-per-task model plus a CLI, MCP server, TypeScript SDK, Slack bot, and remote/cloud workspaces. Orca is the strongest open-source alternative.
+
+### Is there an open-source Emdash alternative?
+
+Yes. Orca (MIT), Herdr (Apache-2.0), and Crystal/Nimbalyst (MIT) are all open source, like Emdash itself. Superset is source-available under ELv2 with a free tier.
+
+### Which alternatives support as many agents as Emdash?
+
+Emdash lists 30+ providers. Orca lists 25+ named agents plus any CLI agent, and Superset runs any terminal agent. In practice all three cover the mainstream agents; the long tails differ.
+
+### Do these alternatives integrate with issue trackers?
+
+Emdash's 12-tracker intake is the broadest. Superset integrates GitHub and Linear (plus tasks over MCP/SDK). Orca integrates GitHub, Linear, and Jira. If Asana, Monday, or Trello intake is essential, Emdash keeps an edge.

--- a/apps/marketing/content/compare/firstmate-alternative.mdx
+++ b/apps/marketing/content/compare/firstmate-alternative.mdx
@@ -1,0 +1,99 @@
+---
+title: "Best Firstmate Alternatives in 2026"
+description: "The best alternatives to Firstmate for orchestrating a crew of parallel coding agents, including Superset, Claude Squad, Herdr, Orca, and Gas Town."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - firstmate
+  - claude-squad
+  - herdr
+  - orca
+  - gastown
+keywords:
+  - firstmate alternative
+  - firstmate alternatives
+  - agent distro alternative
+  - multi agent workflow
+  - parallel coding agents tmux
+---
+
+Firstmate is the MIT-licensed "agent distro": a cloned repo of instructions, skills, and scripts that turns a terminal agent into an orchestrator, spawning crewmates in tmux windows and disposable Git worktrees. It is free, transparent, and clever -- and everything visual is bring-your-own: no review UI, no dashboard, no scheduling, and the reliability surface of prompts plus shell scripts. Here are the best Firstmate alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | The same delegation pattern with a real workspace around it | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Claude Squad** | Simple terminal-native parallel agents | macOS, Linux | Open source (AGPL) |
+| **Herdr** | Persistent runtime under your agents | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **Orca** | Free desktop ADE with fan-out workflows | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Gas Town** | Autonomous 20-30 agent fleets with a merge queue | CLI/tmux (macOS, Linux) | Open source (MIT) |
+
+## Why Look for a Firstmate Alternative?
+
+Firstmate assumes you bring the environment: tmux (or Herdr/cmux/Orca as backends), your own review habits, and your own triggers for recurring work. Instruction drift across agent versions and tmux quirks are your problem to debug. If you want the crew pattern with visibility, review, and scheduling built in -- or autonomous supervision beyond one conversation -- these are the alternatives.
+
+## The Best Alternatives
+
+### Superset
+
+Superset delivers Firstmate's core promise -- one instruction fans out to a crew of isolated agents -- as a product. Agents launch into automatic Git worktrees with persistent terminals; an orchestrating agent can spawn and steer workers through the CLI and MCP server; and you watch everything in one workspace with diff review, a browser, and port management. Scheduled automations with a TypeScript SDK and Slack bot handle the recurring work Firstmate leaves to your own wiring.
+
+For the direct comparison, see [Superset vs Firstmate](/compare/superset-vs-firstmate).
+
+### Claude Squad
+
+Claude Squad is the simplest neighboring tool: an open-source terminal app managing multiple agents in separate worktrees over tmux. Less ambitious than Firstmate's supervisor model -- there is no orchestrating first mate -- but fewer moving parts to trust.
+
+See [Superset vs Claude Squad](/compare/superset-vs-claude-squad).
+
+### Herdr
+
+Herdr is one of Firstmate's own optional backends, and for some users the runtime alone is enough: an always-on server that keeps agent terminals alive with worktree management in the CLI and a JSON socket API agents can drive. Persistence and scriptability without the distro layer.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### Orca
+
+Orca (another supported Firstmate backend) is the free, MIT-licensed desktop ADE with ~39,000 stars: fan a prompt across agents in parallel worktrees, compare results, and merge the winner -- the fan-out workflow with a full visual environment attached.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Gas Town
+
+Gas Town is Steve Yegge's MIT-licensed orchestrator for running fleets of 20-30 agents: an AI "Mayor" dispatches work from a git-backed ledger, watchdogs recover stuck agents, and a bisecting merge queue lands the results. Much heavier machinery than Firstmate, for much bigger fleets.
+
+See [Superset vs Gas Town](/compare/superset-vs-gastown).
+
+## How To Choose
+
+- For the crew pattern with a workspace, review, and automations built in, choose **Superset**.
+- For minimal terminal-native parallelism, choose **Claude Squad**.
+- For a persistent runtime you script yourself, choose **Herdr**.
+- For a free visual fan-out environment, choose **Orca**.
+- For autonomous fleets at 20-30 agents, choose **Gas Town**.
+
+## Verdict
+
+Firstmate is the best pure expression of the DIY delegation idea, and tinkerers should read its source regardless of what they run. For daily shipping, the pattern works better with infrastructure under it: Superset is the strongest alternative, with Herdr and Orca as open-source picks that Firstmate itself can even sit on top of. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Firstmate alternative?
+
+For most developers, Superset: the same one-conversation-to-many-agents delegation via its CLI and MCP server, plus worktrees, review, a browser, and scheduled automations as a supported product.
+
+### Is there an open-source Firstmate alternative?
+
+Firstmate is MIT and free. Claude Squad (AGPL), Herdr (Apache-2.0), Orca (MIT), and Gas Town (MIT) are open-source alternatives; Superset is source-available under ELv2.
+
+### Can these alternatives spawn agents from one conversation like Firstmate?
+
+Yes, in different ways. Superset agents orchestrate workers through its CLI/MCP surfaces. Gas Town's Mayor dispatches autonomously. Herdr's socket API lets an agent drive it from inside a pane. Orca has experimental agent-to-agent orchestration.
+
+### Do these alternatives use Git worktrees like Firstmate?
+
+Superset and Orca create a worktree per task automatically; Claude Squad and Herdr manage worktrees for their sessions; Gas Town's "hooks" are git worktree-backed persistent work state.

--- a/apps/marketing/content/compare/gastown-alternative.mdx
+++ b/apps/marketing/content/compare/gastown-alternative.mdx
@@ -1,0 +1,99 @@
+---
+title: "Best Gas Town Alternatives in 2026"
+description: "The best alternatives to Gas Town for orchestrating fleets of AI coding agents, including Superset, Agent Orchestrator, Herdr, Firstmate, and Symphony."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - gastown
+  - agent-orchestrator
+  - herdr
+  - firstmate
+  - symphony
+keywords:
+  - gas town alternative
+  - gastown alternatives
+  - steve yegge gas town
+  - multi agent orchestration
+  - ai agent fleet
+---
+
+Gas Town is Steve Yegge's MIT-licensed orchestrator for running 20-30 coding agents on a sustained, autonomous basis: an AI Mayor dispatches work from a git-backed ledger, watchdogs recover stuck agents, and a bisecting merge queue lands the results. It is also heavy machinery -- Go, Dolt, tmux, and Beads to operate, a single-operator model, an admittedly steep bar, and token costs its author warns about outright. Here are the best Gas Town alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Fleet-scale parallel agents with visibility, review, and automations | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Agent Orchestrator** | Automatic CI/review feedback loops per session | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Herdr** | Persistent terminal runtime for many agents | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **Firstmate** | Lightweight crew delegation, nothing to install | Terminal (macOS, Linux) | Open source (MIT) |
+| **Symphony** | Tracker-driven autonomous Codex runs | Headless daemon | Open source (Apache-2.0) |
+
+## Why Look for a Gas Town Alternative?
+
+Gas Town optimizes for maximum autonomy per operator, and the costs follow: real infrastructure to run, a terminal-and-tmux workflow with no desktop app or diff-review surface, no teams or multi-host story, and sustained token spend from always-running loops. Most engineers want fleet-scale parallelism with more visibility and less machinery.
+
+## The Best Alternatives
+
+### Superset
+
+Superset scales to large agent fleets while keeping humans usefully in the loop: any CLI agent in automatic worktree isolation, every terminal and diff visible in one workspace, orchestrating agents that spawn workers through the CLI and MCP server, and scheduled automations with a TypeScript SDK and Slack bot for the unattended slice. It installs as a desktop app, works across your machines via remote and cloud workspaces, and has team plans -- the fleet without the factory floor.
+
+For the direct comparison, see [Superset vs Gas Town](/compare/superset-vs-gastown).
+
+### Agent Orchestrator
+
+Agent Orchestrator (Apache-2.0, from Untrivial AI) packages Gas Town's most valuable behavior -- agents that respond to CI failures, review comments, and merge conflicts automatically -- as config-driven "reactions" in a cross-platform desktop app, without the Dolt/tmux operational stack.
+
+See [Superset vs Agent Orchestrator](/compare/superset-vs-agent-orchestrator).
+
+### Herdr
+
+Herdr covers the runtime layer: an always-on server that keeps dozens of agent terminals alive with status visualization, worktree management in the CLI, and a JSON socket API. You bring the coordination; it brings the persistence.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### Firstmate
+
+Firstmate is the featherweight take on Gas Town's delegation idea: an MIT "agent distro" where one agent you talk to spawns and supervises crewmates in tmux windows and disposable worktrees. No daemon, no database -- just instructions and scripts.
+
+See [Superset vs Firstmate](/compare/superset-vs-firstmate).
+
+### Symphony
+
+Symphony, OpenAI's open-source spec and reference daemon, shares Gas Town's unattended ethos with a simpler control plane: your issue tracker. Tickets become isolated autonomous Codex runs that end in PRs. Codex-only and an engineering preview, but far less machinery.
+
+See [Superset vs Symphony](/compare/superset-vs-symphony).
+
+## How To Choose
+
+- For fleet-scale agents with visibility, review, and team features, choose **Superset**.
+- For packaged CI/review feedback loops, choose **Agent Orchestrator**.
+- For terminal persistence under your own coordination, choose **Herdr**.
+- For the lightest possible crew model, choose **Firstmate**.
+- For tracker-driven full autonomy on Codex, choose **Symphony**.
+
+## Verdict
+
+Gas Town is the boldest autonomy experiment in the category and its ideas -- the work ledger, the merge queue -- will outlive any single tool. But its own author frames the operator bar and costs honestly. For most engineers and teams that want many agents shipping real work, Superset is the strongest alternative, with Agent Orchestrator as the open-source pick for automated feedback loops. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Gas Town alternative?
+
+For most teams, Superset: fleet-scale parallel agents in worktrees with visibility, review, automations, and multi-device reach, without operating a daemon stack. Agent Orchestrator is the closest open-source alternative for automated PR feedback loops.
+
+### Is there a Gas Town alternative with a GUI?
+
+Yes -- that is most of this list. Superset and Agent Orchestrator are desktop apps; Gas Town is CLI/tmux with a TUI feed and a local web dashboard.
+
+### Which alternatives support agents besides Claude Code?
+
+All of them except Symphony (Codex-only). Gas Town itself also ships presets for Codex, Gemini, Copilot, Cursor, and others, with Claude Code as the deepest integration.
+
+### Can any alternative match Gas Town's merge queue?
+
+Not directly. Agent Orchestrator automates CI-fix and review loops but never auto-merges; Superset routes work through normal PR review. Gas Town's bisecting Refinery remains unique -- and remains the part that demands the most trust.

--- a/apps/marketing/content/compare/herdr-alternative.mdx
+++ b/apps/marketing/content/compare/herdr-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Herdr Alternatives in 2026"
+description: "The best alternatives to Herdr for running AI coding agents, including Superset, Orca, Emdash, cmux, and Claude Squad — from full workspaces to terminal-native tools."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - herdr
+  - orca
+  - emdash
+  - cmux
+  - claude-squad
+keywords:
+  - herdr alternative
+  - herdr alternatives
+  - herdr competitors
+  - herdr vs superset
+  - tmux for ai agents
+  - ai agent orchestration
+---
+
+Herdr is an open-source, terminal-native runtime for AI coding agents -- an always-on server that keeps agent terminals alive through disconnects, with tmux-style attach/detach and a plugin ecosystem. It is excellent at persistence, but it is deliberately minimal everywhere else: no GUI, no built-in diff review, no scheduling, and mobile means an SSH client on your phone. If you want more of the loop built in, here are the best Herdr alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | The full loop: worktrees, review, browser, automations | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Orca** | Free cross-platform desktop ADE with mobile apps | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **Emdash** | Open-source ADE with broad tracker integrations | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Claude Squad** | Terminal-native parallel agents, like Herdr but simpler | macOS, Linux | Open source (AGPL) |
+| **cmux** | Native macOS terminal for agent sessions | macOS | Open source (GPL) |
+
+## Why Look for a Herdr Alternative?
+
+Herdr's own comparison page is honest about what it is: a runtime, not an app. It keeps agents alive and observable, and expects you to bring your own review flow, editor, browser, and scheduling. You might want an alternative if you prefer a GUI over a TUI, want diff review and a browser next to your agents, need scheduled or unattended runs, or want worktree isolation as the default rather than a CLI command.
+
+## The Best Alternatives
+
+### Superset
+
+Superset covers everything Herdr deliberately leaves out while keeping the parts that matter: persistent terminal sessions backed by a daemon that survives app restarts, automatic Git worktree isolation per task, a built-in diff/file editor, an in-app browser, port management, and scheduled automations with a TypeScript SDK and Slack bot. It runs any CLI agent and extends across your own devices through remote and cloud workspaces. If Herdr's persistence hooked you but you keep reaching for other tools to review and schedule, Superset is the single-workspace answer.
+
+For the direct comparison, see [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### Orca
+
+Orca is a free, MIT-licensed desktop agent development environment with roughly 39,000 GitHub stars. It runs a fleet of agents in parallel worktrees with split WebGL terminals, per-task browser tabs, Design Mode for UI work, and SSH/remote worktrees for running agents on a VPS -- with iOS and Android companions for monitoring. It trades Herdr's terminal purity for a much bigger visual surface.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26) is an open-source agentic development environment that gives each task its own branch and worktree, auto-detects 30+ agent CLIs, pulls tasks from a dozen issue trackers, and adds diff review, CI monitoring, an in-app browser, and cron automations. It even has tmux support for long-running sessions, giving you some of Herdr's persistence in a desktop app.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Claude Squad
+
+Claude Squad manages multiple agents in separate worktrees over tmux -- the closest philosophical cousin to Herdr on this list. It is leaner than Herdr (no plugin marketplace, no socket API) but if your need is simply parallel terminal agents in worktrees, it does that with less machinery.
+
+See [Superset vs Claude Squad](/compare/superset-vs-claude-squad).
+
+### cmux
+
+cmux is a native macOS terminal built around agent sessions, keeping many agents organized in panes and tabs. Like Herdr it is a terminal-first tool without worktree orchestration as the centerpiece; unlike Herdr it is a GUI app rather than a client-server runtime.
+
+See [Superset vs cmux](/compare/superset-vs-cmux).
+
+## How To Choose
+
+- For the full workspace -- worktrees, review, browser, automations, remote hosts -- choose **Superset**.
+- For a free, open-source desktop ADE with mobile companions, choose **Orca**.
+- For open-source with deep issue-tracker intake, choose **Emdash**.
+- To stay terminal-native with less machinery than Herdr, choose **Claude Squad**.
+- For a polished native Mac terminal for agents, choose **cmux**.
+
+## Verdict
+
+Herdr is the best pure runtime in the category, and if agents surviving disconnects is your whole problem, it may be all you need. Most developers eventually want the rest of the loop -- review, browsing, scheduling, isolation by default -- and that is where Superset is the strongest alternative, with Orca and Emdash as the leading open-source desktop options. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Herdr alternative?
+
+For most developers, Superset: it keeps persistent agent sessions but adds automatic worktree isolation, diff review, an in-app browser, scheduled automations, and remote/cloud workspaces. Orca and Emdash are strong open-source alternatives.
+
+### Is there an open-source Herdr alternative?
+
+Yes. Orca (MIT), Emdash (Apache-2.0), Claude Squad (AGPL), and cmux (GPL) are all open source. Herdr itself is Apache-2.0; Superset is source-available under ELv2.
+
+### Do these alternatives keep agents running like Herdr does?
+
+Superset's terminals are held by a background daemon, so sessions survive app restarts and updates. Emdash persists terminal state and supports tmux. Claude Squad and Herdr both lean on tmux-style detach. Orca persists scrollback across restarts.
+
+### Does Herdr have diff review?
+
+No -- Herdr's own comparison page notes it pairs with external tools for review. Superset, Orca, and Emdash all build diff review in.

--- a/apps/marketing/content/compare/mux-alternative.mdx
+++ b/apps/marketing/content/compare/mux-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Mux Alternatives in 2026"
+description: "The best alternatives to Mux (by Coder) for parallel agentic development, including Superset, Orca, Emdash, Sculptor, and Conductor."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - mux
+  - orca
+  - emdash
+  - sculptor
+  - conductor
+keywords:
+  - mux alternative
+  - mux alternatives
+  - coder mux alternative
+  - coding agent multiplexer
+  - parallel agentic development
+---
+
+Mux, from Coder, is an open-source "coding agent multiplexer": parallel sessions of its own agent loop across six isolation runtimes -- local, worktree, SSH, Docker, devcontainer, and Coder workspaces -- with budgets, best-of-N attempts, and headless runs. The catch is in "its own agent loop": Mux does not run Claude Code, Codex, or any external CLI agent, so adopting it means adopting its agent and API-key billing. If you want your existing agents and subscriptions, here are the best Mux alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Agents | License |
+|---|---|---|---|
+| **Superset** | Running the agents you already use, in one workspace | Any CLI agent | Source-available (ELv2) |
+| **Orca** | Free desktop ADE, 25+ agents, mobile apps | Any CLI agent | Open source (MIT) |
+| **Emdash** | Open-source ADE with tracker intake | 30+ providers | Open source (Apache-2.0) |
+| **Sculptor** | Container-isolated parallel agents | Claude Code | Open source |
+| **Conductor** | Focused Mac app | Claude Code, Codex, Cursor | Proprietary |
+
+## Why Look for a Mux Alternative?
+
+The main reason is agent lock-in: Mux's loop is capable, but it cannot run the vendor CLIs your team already uses, which also means Claude Max and ChatGPT subscription pricing does not apply -- everything bills as API tokens. Secondary reasons: review flows lean on manual git commands beyond the diff pane, there is no scheduled-automation product, remote access requires self-hosting a server, and the project is pre-1.0 under AGPL.
+
+## The Best Alternatives
+
+### Superset
+
+Superset is the agent-agnostic version of the same idea: Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, and any CLI agent, each in an automatic Git worktree with persistent terminals, a diff/file editor, an in-app browser, and port management. Your agents keep their configs, skills, and subscription billing. Orchestration is scriptable through a CLI, MCP server, and TypeScript SDK, automations run scheduled sessions, and remote and cloud workspaces extend across your devices.
+
+For the direct comparison, see [Superset vs Mux](/compare/superset-vs-mux).
+
+### Orca
+
+Orca (~39,000 stars, MIT) runs any CLI agent in parallel worktrees with split terminals, browser tabs, Design Mode, SSH/VPS worktrees, and mobile companions -- the biggest free alternative that preserves your agent choices.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) auto-detects 30+ agent CLIs, isolates each task in a worktree, and adds diff review, CI monitoring, cron automations, and intake from a dozen issue trackers.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Sculptor
+
+If Mux's Docker runtime is what attracted you, Sculptor (from Imbue) runs each Claude Code agent in its own container -- container isolation with a mainstream agent instead of a proprietary loop.
+
+See [Superset vs Sculptor](/compare/superset-vs-sculptor).
+
+### Conductor
+
+Conductor is a polished, proprietary macOS app for Claude Code, Codex, and Cursor agents in parallel worktrees -- the simple choice if you want vendor agents with minimal machinery.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+## How To Choose
+
+- For any agent on its existing subscription, with a full workspace and automations, choose **Superset**.
+- For free and open source with the largest community, choose **Orca**.
+- For tracker-driven open source, choose **Emdash**.
+- For container isolation with Claude Code, choose **Sculptor**.
+- For a focused Mac app, choose **Conductor**.
+- If you specifically want Coder-governed infrastructure and are fine with Mux's own agent, Mux remains coherent.
+
+## Verdict
+
+Mux is well-engineered, and its budgets and runtime matrix are real contributions. But its structural choice -- its own agent loop instead of yours -- is the deciding factor for most teams. Superset is the strongest alternative that preserves your agents and subscriptions while adding the workspace, automations, and team surfaces around them, with Orca and Emdash as the open-source picks. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Mux alternative?
+
+For most teams, Superset: parallel worktree isolation like Mux's worktree runtime, but running Claude Code, Codex, and any CLI agent on their existing subscriptions, with diff review, automations, and remote/cloud workspaces.
+
+### Can any alternative run agents in containers like Mux?
+
+Sculptor runs Claude Code agents in Docker containers. Herdr's Vercel Sandbox plugin runs agents in cloud microVMs. Superset and Orca isolate via worktrees on machines you control.
+
+### Is Mux open source?
+
+Yes, AGPL-3.0, free, from Coder Technologies. Orca (MIT), Emdash (Apache-2.0), and Sculptor are open source too; Superset is source-available under ELv2.
+
+### Why does the agent model matter for cost?
+
+Mux's built-in loop bills per API token. Vendor CLIs like Claude Code and Codex can run on flat-rate subscriptions (Claude Max, ChatGPT plans). Orchestrators that run vendor CLIs -- Superset, Orca, Emdash, Conductor -- inherit that pricing; Mux cannot.

--- a/apps/marketing/content/compare/orca-alternative.mdx
+++ b/apps/marketing/content/compare/orca-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Orca Alternatives in 2026"
+description: "The best alternatives to Orca (the open-source ADE) for running parallel AI coding agents, including Superset, Conductor, Emdash, Herdr, and super.engineering."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - orca
+  - conductor
+  - emdash
+  - herdr
+  - super-engineering
+keywords:
+  - orca alternative
+  - orca alternatives
+  - orca ade alternative
+  - orca competitors
+  - orca vs superset
+  - parallel ai coding agents
+---
+
+Orca is the most popular open-source agent development environment -- roughly 39,000 GitHub stars, MIT licensed, running fleets of agents in parallel worktrees on macOS, Windows, and Linux with mobile companions. It is a strong default. But it has no scheduler, its programmatic surfaces are young (a CLI plus experimental orchestration), it moves fast enough that near-daily releases can mean churn, and there is no team or enterprise track behind it. Here are the best Orca alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Automations, CLI/MCP/SDK surfaces, teams | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Emdash** | Open-source ADE with 12 issue-tracker integrations | macOS, Windows, Linux | Open source (Apache-2.0) |
+| **Conductor** | Polished, focused Mac app | macOS | Proprietary |
+| **Herdr** | Terminal-native runtime; agents survive disconnects | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **super.engineering** | Native Rust performance, keyboard-driven | macOS (Apple Silicon) | Proprietary (alpha) |
+
+## Why Look for an Orca Alternative?
+
+Orca nails interactive parallel work: fan a prompt across agents, compare, merge the winner. You might want an alternative if you need agents to run on a schedule without external wiring, want deeper scriptability (SDK, MCP server) for pipelines, need team features and enterprise controls, prefer a calmer release cadence, or simply want a different interface model -- terminal-native or natively rendered.
+
+## The Best Alternatives
+
+### Superset
+
+Superset shares Orca's foundation -- any CLI agent, one Git worktree per task, diff review, an in-app browser -- and extends it where Orca stops. Automations run agent sessions on a schedule, a TypeScript SDK and MCP server make the orchestration programmable, a Slack bot brings it to team channels, and remote and cloud workspaces carry whole workspaces across your own devices. It is the alternative for making parallel agents a dependable workflow rather than an interactive session.
+
+For the direct comparison, see [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) is the closest open-source swap: worktree per task, 30+ auto-detected agent CLIs, diff review with push-and-create-PR, an in-app browser, cron automations, and intake from a dozen trackers including Jira, Asana, Notion, and Trello. If Orca's licence and price are why you chose it, Emdash keeps both and adds scheduling.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Conductor
+
+Conductor is a polished, proprietary macOS app for running Claude Code, Codex, and Cursor agents in parallel worktrees. It supports fewer agents and fewer platforms than Orca, but it is focused and stable -- a good fit if you found Orca's surface area more than you need.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Herdr
+
+Herdr flips the model: instead of a desktop workspace, it is an open-source terminal runtime whose server keeps agent sessions alive through disconnects and restarts, with worktree management in the CLI and a plugin marketplace. Pick it if you live in the terminal and want persistence more than UI.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### super.engineering
+
+super.engineering (formerly Superconductor) is a closed-source native macOS orchestrator written in Rust with a GPU-rendered terminal and a keyboard-driven, unlimited-parallel-agents pitch. It is in alpha with nightly-only releases, but if Orca's Electron-style app feels heavy, it is the performance-purist alternative.
+
+See [Superset vs super.engineering](/compare/superset-vs-super-engineering).
+
+## How To Choose
+
+- For scheduled automations, programmable surfaces, and team features, choose **Superset**.
+- For a like-for-like open-source ADE with tracker intake and cron scheduling, choose **Emdash**.
+- For a focused, polished Mac app, choose **Conductor**.
+- For terminal-native persistence, choose **Herdr**.
+- For native performance on a Mac, watch **super.engineering**.
+
+## Verdict
+
+Orca earns its popularity, and for free interactive parallel work it is hard to beat. The gaps show when parallel agents become infrastructure: scheduling, scripting, teams. That is where Superset is the strongest alternative, with Emdash as the best open-source swap. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Orca alternative?
+
+For most teams, Superset: the same agent-agnostic worktree model plus scheduled automations, a TypeScript SDK, an MCP server, a Slack bot, and remote/cloud workspaces. Emdash is the closest open-source alternative.
+
+### Is there a free, open-source Orca alternative?
+
+Yes. Emdash (Apache-2.0) is the most direct one, and Herdr (Apache-2.0) covers the terminal-native angle. Superset has a free tier and is source-available under ELv2.
+
+### Do these alternatives use Git worktrees like Orca?
+
+Superset, Emdash, and Conductor all isolate each task in its own worktree. Herdr manages worktrees through its CLI. super.engineering creates a worktree per task as well.
+
+### Which alternative has mobile apps like Orca?
+
+None of these match Orca's shipped iOS and Android companions today; Superset's mobile app is on its roadmap. If mobile monitoring is a hard requirement, that is a real Orca advantage.

--- a/apps/marketing/content/compare/paperclip-alternative.mdx
+++ b/apps/marketing/content/compare/paperclip-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Paperclip Alternatives in 2026"
+description: "The best alternatives to Paperclip for managing AI agents, including Superset, Gas Town, Symphony, OpenHands, and Agent Orchestrator."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - paperclip
+  - gastown
+  - symphony
+  - openhands
+  - agent-orchestrator
+keywords:
+  - paperclip alternative
+  - paperclip alternatives
+  - paperclip ai agents
+  - agent orchestration platform
+  - manage ai agents
+---
+
+Paperclip is the most-starred agent-management project on GitHub: an MIT-licensed, self-hosted platform that runs AI agents like a company -- goals, tickets, org charts, token budgets, governance, and heartbeat-driven headless execution. It is also a specific bet: a Node/Postgres server you operate, agents you monitor rather than work with, and by its own words "not a code review tool." If your agents ship code, or you want to work alongside them rather than manage them from a dashboard, here are the best Paperclip alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Form factor | License |
+|---|---|---|---|
+| **Superset** | Developers working with parallel coding agents | Desktop app + CLI/MCP/SDK | Source-available (ELv2) |
+| **Gas Town** | Autonomous 20-30 agent fleets with a merge queue | CLI/tmux + daemon | Open source (MIT) |
+| **Symphony** | Tracker tickets becoming autonomous Codex runs | Headless daemon | Open source (Apache-2.0) |
+| **OpenHands** | Self-hosted autonomous coding agents | Self-hosted platform | Open source (MIT) |
+| **Agent Orchestrator** | Sessions with automatic CI/review loops | Desktop app | Open source (Apache-2.0) |
+
+## Why Look for a Paperclip Alternative?
+
+Paperclip is built for operators of large autonomous fleets -- it says itself that with one agent you probably don't need it. You might want an alternative if you are a developer who works interactively with coding agents, need diff review and a PR flow built in (Paperclip explicitly defers review), don't want to run a Node/Postgres server, or find the company metaphor -- boards, budgets, performance reviews -- heavier than your actual problem.
+
+## The Best Alternatives
+
+### Superset
+
+Superset is the developer-side counterpart: instead of managing agents from a dashboard, you work with them -- live terminals in isolated Git worktrees, a diff/file editor, an in-app browser, and port management, with scheduled automations, a TypeScript SDK, an MCP server, and a Slack bot covering the orchestration and unattended slices. It installs as a desktop app with no server to operate, and agents run on your existing subscriptions. If your agents' output is code you review and merge, this is the alternative.
+
+For the direct comparison, see [Superset vs Paperclip](/compare/superset-vs-paperclip).
+
+### Gas Town
+
+Gas Town shares Paperclip's autonomy ambitions with a git-native design: work lives in a git-backed ledger, an AI Mayor dispatches to 20-30 workers, and a bisecting merge queue lands results. Terminal-and-tmux machinery for a single operator, MIT licensed.
+
+See [Superset vs Gas Town](/compare/superset-vs-gastown).
+
+### Symphony
+
+Symphony (OpenAI, Apache-2.0) reduces the management plane to the tool you already have: the issue tracker. A daemon turns active tickets into isolated autonomous Codex runs ending in PRs. Codex-only and an engineering preview, but conceptually the leanest version of Paperclip's promise.
+
+See [Superset vs Symphony](/compare/superset-vs-symphony).
+
+### OpenHands
+
+OpenHands is the established self-hosted platform for autonomous coding agents, running tasks end to end in sandboxed environments. Closer to Paperclip's self-hosted, headless model than a desktop workspace, with a coding-specific focus.
+
+See [Superset vs OpenHands](/compare/superset-vs-openhands).
+
+### Agent Orchestrator
+
+Agent Orchestrator (Apache-2.0) sits between the camps: a desktop app where sessions run in worktrees and a daemon automatically routes CI failures and review comments back to agents -- automated supervision without the company abstraction.
+
+See [Superset vs Agent Orchestrator](/compare/superset-vs-agent-orchestrator).
+
+## How To Choose
+
+- For working with coding agents interactively, with review built in, choose **Superset**.
+- For maximum-autonomy fleets with git-native machinery, choose **Gas Town**.
+- For tracker-driven Codex autonomy, choose **Symphony**.
+- For self-hosted autonomous coding runs, choose **OpenHands**.
+- For automated CI/review loops in a desktop app, choose **Agent Orchestrator**.
+- If you truly are running an agent company against budgets and goals, Paperclip remains the most complete tool for that job.
+
+## Verdict
+
+Paperclip earned its stars by taking agent management seriously -- budgets, governance, and audit trails nobody else has. But most developers evaluating it actually need the layer below: agents shipping code they can see, review, and merge. That is Superset's job, with Gas Town and Symphony as the open-source autonomy bets and OpenHands for self-hosted execution. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Paperclip alternative?
+
+Depends on the layer. For interactive parallel coding agents with review, Superset. For autonomous fleet orchestration, Gas Town or Symphony. For self-hosted autonomous coding, OpenHands.
+
+### Is there a Paperclip alternative that does code review?
+
+Yes -- that gap is the point of switching. Paperclip is explicitly "not a code review tool." Superset builds in a diff/file editor and PR flow; Agent Orchestrator routes review comments back to agents automatically.
+
+### Are these alternatives free?
+
+Gas Town, Symphony, OpenHands, and Agent Orchestrator are free and open source, like Paperclip. Superset has a free tier with Pro at $20/seat/month.
+
+### Do any alternatives have Paperclip's budget controls?
+
+Not at its depth. Mux (by Coder) enforces dollar budgets on headless runs, and providers offer their own spend limits, but Paperclip's per-agent/project/goal token budgets with hard stops remain unique.

--- a/apps/marketing/content/compare/solo-alternative.mdx
+++ b/apps/marketing/content/compare/solo-alternative.mdx
@@ -1,0 +1,100 @@
+---
+title: "Best Solo Alternatives in 2026"
+description: "The best alternatives to Solo (soloterm.com) for managing AI coding agents and dev processes, including Superset, Herdr, cmux, Warp, and Orca."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - solo
+  - herdr
+  - cmux
+  - warp
+  - orca
+keywords:
+  - solo alternative
+  - solo alternatives
+  - soloterm alternative
+  - dev process dashboard
+  - ai agent workspace
+---
+
+Solo is Aaron Francis's native desktop workspace for agents and your dev stack: processes grouped by project with one-click startup, auto-restart, crash alerts, and a 40-tool MCP surface agents use to coordinate. It is deliberately not an orchestrator -- one shared checkout, no worktrees, no diff review, no branch management, by its own description. If you need agents isolated, reviewed, and orchestrated -- or just different trade-offs around the terminal -- here are the best Solo alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Parallel agents in worktrees with review and automations | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Herdr** | Persistent terminal runtime for agents | macOS, Linux, Windows (beta) | Open source (Apache-2.0) |
+| **cmux** | Native macOS terminal organized around agents | macOS | Open source (GPL) |
+| **Warp** | AI-native terminal with built-in agents | macOS, Windows, Linux | Proprietary |
+| **Orca** | Free desktop ADE with worktree fan-out | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+
+## Why Look for a Solo Alternative?
+
+Solo keeps your environment healthy; it does not manage the work. Parallel agents share one checkout and can collide, finished work has no diff review or PR flow, agent interaction is monitoring-level (running, crashed, idle), and everything is strictly local -- no remote hosts or multi-device story. If any of those are your actual problem, you want a different category of tool.
+
+## The Best Alternatives
+
+### Superset
+
+Superset manages what Solo deliberately does not: each task gets its own Git worktree and branch with persistent terminals, a diff/file editor, an in-app browser, and port management, so parallel agents never collide and every change is reviewable. Dev-stack needs are covered by run scripts with a restartable dev-server pane, setup/teardown scripts, and port detection -- and the whole thing is programmable through a CLI, MCP server, and TypeScript SDK, with scheduled automations and remote/cloud workspaces beyond the desktop.
+
+For the direct comparison, see [Superset vs Solo](/compare/superset-vs-solo).
+
+### Herdr
+
+Herdr covers Solo's keep-things-running instinct for the agent side specifically: an always-on server that holds agent terminals open through disconnects and restarts, with status visualization, worktree management in the CLI, and a JSON socket API. No process supervision for your dev stack, but stronger persistence for agents.
+
+See [Superset vs Herdr](/compare/superset-vs-herdr).
+
+### cmux
+
+cmux is a native macOS terminal built around agent sessions -- panes and tabs organized by agent, GPU-fast, open source. Closest to Solo's "native terminal workspace" feel, without the process-supervision layer.
+
+See [Superset vs cmux](/compare/superset-vs-cmux).
+
+### Warp
+
+Warp is the AI-native terminal: built-in agents, blocks, and workflows in a polished cross-platform app. If Solo appealed as a better terminal with AI in it, Warp is the mainstream version of that bet.
+
+See [Superset vs Warp](/compare/superset-vs-warp).
+
+### Orca
+
+Orca (~39,000 stars, MIT) is the free desktop ADE: fan prompts across agents in parallel worktrees, compare results, review diffs, and merge -- with per-task browser tabs and mobile companions. The full orchestration counterpoint to Solo's environment focus.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+## How To Choose
+
+- For isolated, reviewable parallel agent work, choose **Superset**.
+- For agent-terminal persistence you script yourself, choose **Herdr**.
+- For a native Mac agent terminal, choose **cmux**.
+- For an AI-native terminal with agents built in, choose **Warp**.
+- For a free worktree ADE, choose **Orca**.
+- If supervised dev processes are genuinely your problem, Solo remains the best at exactly that -- and pairs fine with the tools above.
+
+## Verdict
+
+Solo is excellent at its chosen job, and its own comparison pages are honest that the job is not orchestration. Most developers hit the wall at parallel work: shared checkouts collide and unreviewed changes pile up. That is where Superset is the strongest alternative -- isolation, review, and automations around the same agents -- with Herdr and Orca as open-source picks depending on whether you want a runtime or a full ADE. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Solo alternative?
+
+Depends on the job. For parallel agent work with isolation and review, Superset. For agent-session persistence, Herdr. For a native agent terminal, cmux. Solo itself stays best-in-class for supervised dev processes.
+
+### Does Solo manage Git worktrees?
+
+No -- it says so itself. If you create worktrees by hand, Solo's linked checkouts share todos and scratchpads across them, but it will not create, isolate, or review them. Superset and Orca manage worktrees automatically.
+
+### Is Solo open source?
+
+The desktop app is proprietary (free tier, Pro $99/year). Herdr, cmux, and Orca are open source; Superset is source-available under ELv2.
+
+### Can Solo and Superset be used together?
+
+Practically, yes -- they manage different layers. Solo supervises your dev stack; Superset isolates and reviews agent work. There is no built-in integration, but nothing conflicts.

--- a/apps/marketing/content/compare/super-engineering-alternative.mdx
+++ b/apps/marketing/content/compare/super-engineering-alternative.mdx
@@ -1,0 +1,99 @@
+---
+title: "Best super.engineering Alternatives in 2026"
+description: "The best alternatives to super.engineering (formerly Superconductor) for running parallel AI coding agents, including Superset, Conductor, Orca, and cmux."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - super-engineering
+  - conductor
+  - orca
+  - cmux
+  - emdash
+keywords:
+  - super.engineering alternative
+  - superconductor alternative
+  - super engineering alternatives
+  - native ai agent orchestrator
+  - parallel coding agents mac
+---
+
+super.engineering (formerly Superconductor) is the performance purist's agent orchestrator: a native macOS app written entirely in Rust with a Metal GPU-rendered terminal, worktree isolation, and an unlimited-parallel-agents pitch. It is also an alpha -- closed source, nightly-only releases, Apple Silicon only, no pricing, and no scheduling, API, or MCP surfaces. If you like the idea but need something you can depend on, here are the best super.engineering alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | A shipping product with automations, SDK/MCP, and teams | macOS now; Windows and Linux coming | Source-available (ELv2) |
+| **Conductor** | Polished, stable Mac app | macOS | Proprietary |
+| **Orca** | Free cross-platform desktop ADE | macOS, Windows, Linux + iOS/Android | Open source (MIT) |
+| **cmux** | Native macOS terminal for agents | macOS | Open source (GPL) |
+| **Emdash** | Open-source ADE with tracker intake | macOS, Windows, Linux | Open source (Apache-2.0) |
+
+## Why Look for a super.engineering Alternative?
+
+The native engineering is real, but so are the alpha caveats: nightly is the only release channel, there is no published pricing, Intel Macs, Windows, and Linux are unsupported, and recurring or scripted work means driving its local `sc` CLI yourself -- there is no scheduler, webhook, HTTP API, SDK, or MCP support. Teams also get no accounts, no collaboration backend, and "email us" enterprise.
+
+## The Best Alternatives
+
+### Superset
+
+Superset trades some native chrome for a complete product: any CLI agent in automatic worktree isolation, persistent daemon-backed terminals, diff review, an in-app browser, port management, and -- the parts super.engineering lacks entirely -- scheduled automations, a TypeScript SDK, an MCP server, a Slack bot, and remote and cloud workspaces. It has published pricing, team plans, and an enterprise tier. If you want parallel agents as dependable infrastructure rather than an alpha experiment, this is the alternative.
+
+For the direct comparison, see [Superset vs super.engineering](/compare/superset-vs-super-engineering).
+
+### Conductor
+
+Conductor is the closest like-for-like: a proprietary, polished macOS app running Claude Code, Codex, and Cursor agents in parallel worktrees. Fewer agents than super.engineering's fifteen-provider matrix, but stable and shipping.
+
+See [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Orca
+
+Orca is the free, MIT-licensed heavyweight (~39,000 stars): fleets of agents in parallel worktrees, split WebGL terminals, Design Mode, SSH/VPS worktrees, and mobile companions, on all three desktop platforms. Not native Rust, but the community and feature velocity are unmatched at the price.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### cmux
+
+If what you liked about super.engineering was mainly the native terminal feel, cmux is a native macOS terminal built for agent sessions -- leaner scope, open source, no worktree orchestration core.
+
+See [Superset vs cmux](/compare/superset-vs-cmux).
+
+### Emdash
+
+Emdash (YC W26, Apache-2.0) covers the desktop loop -- worktree per task, 30+ providers, diff review, browser, cron automations -- with intake from a dozen issue trackers. A strong open-source option if tickets feed your agents.
+
+See [Superset vs Emdash](/compare/superset-vs-emdash).
+
+## How To Choose
+
+- For a dependable product with automations, programmable surfaces, and teams, choose **Superset**.
+- For a stable, focused Mac app, choose **Conductor**.
+- For free and cross-platform with mobile apps, choose **Orca**.
+- For just a great native agent terminal, choose **cmux**.
+- For open source with tracker intake, choose **Emdash**.
+
+## Verdict
+
+super.engineering may become a serious contender once it leaves alpha -- the native architecture is genuinely impressive. Today, if you need parallel worktree agents that your team can rely on, Superset is the strongest alternative, with Conductor as the stable Mac-native pick and Orca as the open-source one. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best super.engineering alternative?
+
+For most developers, Superset: the same worktree orchestration with review built in, plus scheduled automations, a TypeScript SDK, an MCP server, remote and cloud workspaces, and published pricing with team plans.
+
+### Is there an open-source super.engineering alternative?
+
+super.engineering is closed source. Orca (MIT), Emdash (Apache-2.0), and cmux (GPL) are open source; Superset is source-available under ELv2 with a free tier.
+
+### Which alternatives work beyond Apple Silicon Macs?
+
+super.engineering requires macOS 14+ on Apple Silicon. Orca and Emdash run on macOS, Windows, and Linux today; Superset ships on macOS with Windows and Linux planned.
+
+### Does super.engineering have scheduling or an API?
+
+No -- no scheduler, webhooks, HTTP API, SDK, or MCP support as of August 2026; automation means scripting its local `sc` CLI. Superset ships automations with an SDK, MCP server, and Slack bot; Emdash has cron automations.

--- a/apps/marketing/content/compare/superset-vs-agent-orchestrator.mdx
+++ b/apps/marketing/content/compare/superset-vs-agent-orchestrator.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Agent Orchestrator (2026): Two Agent IDEs for Parallel Fleets"
+description: "Compare Superset and Agent Orchestrator (AO) for running fleets of AI coding agents — worktree workspaces, CI-failure loops, review routing, and automation surfaces."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - agent-orchestrator
+keywords:
+  - superset vs agent orchestrator
+  - agent orchestrator alternative
+  - ao agents
+  - aoagents.dev
+  - ai coding agent fleet
+  - ci fix automation
+---
+
+Superset and Agent Orchestrator (AO, from Untrivial AI) are two of the closest head-to-heads in this space: both are desktop apps that run fleets of CLI coding agents in isolated Git worktrees. The centers of gravity differ. AO's signature is the autonomous PR feedback loop -- CI failures, review comments, and merge conflicts are routed back to the responsible agent as configurable "reactions." Superset's is the workspace and its surfaces -- diff review, browser, persistent terminals, plus a CLI, MCP server, SDK, Slack bot, and scheduled automations around the same core.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Agent Orchestrator (AO)** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Supervises parallel agents in worktrees with automatic CI/review/conflict feedback loops |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Open-source agent IDE with an orchestrator agent |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | 23 harnesses (Claude Code, Codex, aider, OpenCode, Cursor, Copilot, Goose, and more) |
+| **Isolation** | Automatic Git worktree per task | Worktree per session (or full clone); tmux/process runtimes |
+| **Signature feature** | Full workspace + automations/SDK/MCP surfaces | Reactions: CI-failed, changes-requested, agent-stuck, approved-and-green |
+| **Forges** | GitHub, plus Linear integration | GitHub and GitLab (polling via gh/glab); Linear tracker plugin |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local-only; DIY reverse proxy, dashboard has no built-in auth |
+| **Scheduling** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Event-driven reactions only; no cron or API |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Agent Orchestrator?
+
+Agent Orchestrator is an Apache-2.0 "agentic IDE" from Untrivial AI (~8,900 GitHub stars) whose pitch is "stop babysitting agents, start merging real work." Each task becomes a session in its own worktree (or full clone) running any of 23 agent harnesses; a local daemon then watches PRs and session state and reacts: CI failures send the agent structured fix prompts with retries, cooldowns, and escalation; requested changes replay review comments as `path:line` prompts; stuck agents are detected; and "approved and green" signals ready-to-merge -- AO never auto-merges. An orchestrator session can plan and spawn workers, a separate reviewer-agent role runs review passes into a Reviews tab, and an in-app browser previews the session's app. It ships as a desktop app for macOS, Windows, and Linux (the npm CLI is legacy/frozen), integrates GitHub and GitLab by polling through your authenticated `gh`/`glab`, tracks per-session agent cost, and is entirely free.
+
+## Key Differences
+
+### The Feedback Loop vs the Workspace
+
+AO's reactions system is the best-engineered PR feedback loop in the category: config-driven CI-failure routing with `maxRetries` and cooldowns, review-comment replay, bot-comment handling, and stuck-agent detection -- no prompting required. Superset covers the same ground differently: PR status, review threads, and CI checks surface in the workspace and diff viewer, and agents can be steered or re-dispatched from there, but the automatic retry loop is not a packaged primitive. In exchange, Superset's workspace is deeper: a real diff/file editor (AO defers diff inspection to the PR on GitHub), persistent daemon-backed terminals, port management, and cross-workspace search.
+
+### Surfaces and Scheduling
+
+AO is desktop-only by design: its CLI is deprecated, there is no public API or MCP surface, and automation means PR-event reactions -- no cron, no scheduled runs. Superset ships a maintained CLI, an MCP server other agents can drive, a TypeScript SDK, a Slack bot, and scheduled automations. If your parallel-agent workflow needs to be scripted, embedded, or run unattended on a schedule, that whole layer exists only on one side.
+
+### Remote and Team
+
+AO is local-first with no multi-device story: remote access means reverse-proxying a dashboard that has no built-in authentication, and there are no team plans. Superset has remote and cloud workspaces across your own devices, host sharing with teammates, and paid tiers with enterprise controls (SSO, audit logs). AO counters with GitLab support (Superset is GitHub-centric today) and per-session cost tracking in the dashboard.
+
+### Openness
+
+AO is fully open source under Apache-2.0. Superset is source-available under ELv2 with free and paid tiers. Both run agents on your own subscriptions; neither proxies your model traffic.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Agent Orchestrator is free and open source with no paid tier as of August 2026. Both are bring-your-own-agent for model costs.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want the full workspace: diff editor, browser, persistent terminals, port management
+- Need scheduled automations and scriptable surfaces (CLI, MCP, SDK, Slack)
+- Want remote/cloud workspaces and team or enterprise features
+- Review inside the tool rather than on the GitHub PR page
+
+**Choose Agent Orchestrator if you:**
+
+- Want automatic CI-failure and review-comment loops as packaged, config-driven behavior
+- Use GitLab, or want a dedicated reviewer-agent role with a Reviews tab
+- Prefer a fully open-source (Apache-2.0) tool
+- Work single-player on one machine and merge on the Git host
+
+**Verdict:** AO is a serious, well-designed competitor, and its reactions system points where the whole category is heading -- agents that fix their own CI failures without a human relaying logs. Superset is the more complete environment around the same worktree core: deeper review, more surfaces, scheduling, remote reach, and a team story. If the feedback loop is your whole problem, try AO; if parallel agents are becoming how your team ships, Superset covers more of the job.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Agent Orchestrator both use Git worktrees?
+
+Yes. Superset creates a worktree per task automatically; AO creates one per session, with a full-clone option for tooling that dislikes shared `.git` directories.
+
+### What are AO's "reactions"?
+
+Config-driven responses to PR and session events: CI failures route structured fix prompts to the agent with retries and cooldowns, requested changes replay as `path:line` prompts, stuck agents get flagged, and approved-and-green marks sessions ready to merge. AO never auto-merges.
+
+### Is Agent Orchestrator open source?
+
+Yes, Apache-2.0, free, with roughly 8,900 GitHub stars. Superset is source-available under ELv2 with a free tier and paid plans.
+
+### Which supports more agents?
+
+AO lists 23 worker harnesses; Superset runs any CLI agent, with first-class integrations for the mainstream ones. In practice both cover Claude Code, Codex, Cursor, OpenCode, Copilot, and the rest of the common set.

--- a/apps/marketing/content/compare/superset-vs-bb.mdx
+++ b/apps/marketing/content/compare/superset-vs-bb.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs bb (2026): Agent Workspace vs the IDE That Builds Itself"
+description: "Compare Superset and bb for orchestrating AI coding agents. See how a full agent workspace differs from bb's self-extending, thread-based agentic IDE."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - bb
+keywords:
+  - superset vs bb
+  - bb alternative
+  - getbb alternative
+  - bb agentic ide
+  - agentic ide
+  - ai agent orchestration
+---
+
+Superset and bb both orchestrate multiple AI coding agents on your own machine, and both reach for Git worktrees as the isolation primitive. The philosophies differ. Superset is a product: a desktop workspace with orchestration, diff review, chat, a browser, automations, and remote workspaces built in. bb is a substrate: an open-source, MIT-licensed "IDE that builds itself," where threads are the core unit and most features -- crons, previews, side chat, even remote access -- are plugins that bb's own agents wrote.
+
+---
+
+## At a Glance
+
+| | **Superset** | **bb** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Orchestrates coding agents in live threads you can follow, steer, or hand off |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Self-extending agentic IDE ("the IDE that builds itself") |
+| **Core unit** | Workspace (worktree + terminals + review) | Thread (agent run in an environment, optionally a worktree) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Claude Code, Codex, Cursor, Pi, OpenCode, Grok, omp, Hermes, plus any ACP agent |
+| **Isolation** | Automatic Git worktree per task | Optional Git worktree per environment |
+| **Surfaces** | Desktop app, CLI, MCP server | Desktop app, web app, CLI, HTTP API |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | bb Connect tunnel + multi-machine enrollment |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Crons and external triggers, shipped as plugins |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is bb?
+
+bb is an open-source agentic IDE whose pitch is that it can control, customize, and automate itself. Work happens in threads: an agent runs in a thread, you follow it live, steer it mid-run, or hand it to another agent, and agents can spawn and babysit other agents' threads. Threads run in environments that can be backed by fresh Git worktrees. The distinctive part is the plugin system -- provider-agnostic workflows, crons, inline previews, side chat, and remote access were all built by bb's own agents as plugins, and a plugin store lets you install what other users' agents have built. bb ships as a macOS desktop app, a web app, a CLI, and an HTTP API, supports a wide harness matrix including any Agent Client Protocol (ACP) agent, and is MIT licensed and free.
+
+## Key Differences
+
+### Product vs Substrate
+
+Superset ships a finished workspace: worktree orchestration, diff review, chat, an in-app browser, port management, and automations are built in and maintained as a product, with a team and an enterprise track behind it. bb ships a core -- threads, environments, and a plugin system -- and expects you (or your agents) to extend it. That makes bb remarkably moldable: users have built task managers, tiling window management, and automated PR review inside it. It also means more assembly. If you want the workflow to exist on day one, Superset has more out of the box; if you want to grow your own tooling, bb is designed for exactly that.
+
+### Threads vs Workspaces
+
+bb's core unit is the thread: a live agent run you can watch, interrupt, or hand off, with worktree isolation as an option per environment. Superset's core unit is the workspace: a worktree with persistent terminals, diffs, and review attached, designed so every task is isolated by default. The models overlap heavily in practice; the difference shows up in defaults. Superset assumes every task deserves its own branch and worktree. bb leaves the isolation choice to the thread.
+
+### Agents as Operators
+
+bb treats agents as first-class operators of the IDE itself: the CLI and HTTP API have parity with the UI, so an agent can script bb, spawn threads, and even write new bb plugins mid-conversation. Superset exposes automation differently -- through scheduled automations, a TypeScript SDK, an MCP server, and a Slack bot -- aimed at recurring and unattended work rather than self-modification. Both are scriptable; bb optimizes for agents driving the tool, Superset for agents doing scheduled and orchestrated work inside it.
+
+### Maturity and Support
+
+Superset is a commercial product with a free tier, paid plans, and enterprise features like SOC 2 and team workflows. bb is a young open-source project (the repo started in early 2026) that describes itself as in active development, with workflows and surfaces still evolving. For personal use that trade is often worth it; for a team standardizing its agent workflow, it matters.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. bb is free and MIT-licensed, with agents running on your own subscriptions and API keys. In both cases you still pay the underlying providers for Claude Code, Codex, or any compatible agent.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want orchestration, review, browser, and automations working out of the box
+- Need remote and cloud workspaces with a supported product behind them
+- Run scheduled or unattended agent sessions through automations and an SDK
+- Care about team and enterprise features like SOC 2
+
+**Choose bb if you:**
+
+- Want an MIT-licensed, free, self-extending IDE you can mold with plugins
+- Like the thread model where agents spawn, steer, and hand off other agents
+- Want a web app and HTTP API with full parity to the desktop UI
+- Enjoy building your own workflow tooling with the agent's help
+
+**Verdict:** bb is one of the most interesting projects in the agent-orchestration space -- a free, open-source IDE that extends itself through agent-written plugins. Superset is the better fit if you want a complete, supported workspace where parallel worktree agents, review, automations, and remote hosts already work together. If you want a substrate to build your own software factory on, bb is worth a serious look.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and bb both use Git worktrees?
+
+Yes, with different defaults. Superset creates an isolated worktree for every task automatically. bb can back a thread's environment with a fresh worktree on its own branch, and cleans up the worktree when the threads using it are archived.
+
+### Is bb open source?
+
+Yes. bb is MIT licensed end to end and free to use. Superset is source-available under the Elastic License 2.0, with a free tier and paid Pro.
+
+### Which agents does each support?
+
+Both are agent-agnostic. Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents. bb supports Claude Code, Codex, Cursor, Pi, OpenCode, Grok, omp, and Hermes, plus any agent that speaks the Agent Client Protocol.
+
+### Can either run agents on another machine?
+
+Yes. Superset has remote and cloud workspaces that run across your own network devices. bb offers bb Connect, a managed tunnel to your own server, plus machine enrollment for dispatching threads across several machines. Execution stays on your hardware in both cases.

--- a/apps/marketing/content/compare/superset-vs-bb.mdx
+++ b/apps/marketing/content/compare/superset-vs-bb.mdx
@@ -37,7 +37,7 @@ Superset and bb both orchestrate multiple AI coding agents on your own machine, 
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is bb?
 
@@ -59,7 +59,7 @@ bb treats agents as first-class operators of the IDE itself: the CLI and HTTP AP
 
 ### Maturity and Support
 
-Superset is a commercial product with a free tier, paid plans, and enterprise features like SOC 2 and team workflows. bb is a young open-source project (the repo started in early 2026) that describes itself as in active development, with workflows and surfaces still evolving. For personal use that trade is often worth it; for a team standardizing its agent workflow, it matters.
+Superset is a commercial product with a free tier, paid plans, and enterprise features like SSO and audit logs. bb is a young open-source project (the repo started in early 2026) that describes itself as in active development, with workflows and surfaces still evolving. For personal use that trade is often worth it; for a team standardizing its agent workflow, it matters.
 
 ---
 
@@ -76,7 +76,7 @@ Superset offers a free tier and Pro at $20/seat/month. bb is free and MIT-licens
 - Want orchestration, review, browser, and automations working out of the box
 - Need remote and cloud workspaces with a supported product behind them
 - Run scheduled or unattended agent sessions through automations and an SDK
-- Care about team and enterprise features like SOC 2
+- Care about team and enterprise features like SSO and audit logs
 
 **Choose bb if you:**
 

--- a/apps/marketing/content/compare/superset-vs-buzz.mdx
+++ b/apps/marketing/content/compare/superset-vs-buzz.mdx
@@ -37,7 +37,7 @@ Superset and Buzz both put AI agents to work alongside developers, but they answ
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Buzz?
 

--- a/apps/marketing/content/compare/superset-vs-buzz.mdx
+++ b/apps/marketing/content/compare/superset-vs-buzz.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Buzz (2026): Agent Workspace vs Block's Human-Agent Collaboration Platform"
+description: "Compare Superset and Buzz by Block. See how a parallel coding-agent workspace differs from a Nostr-based collaboration platform where humans and AI agents share rooms."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - buzz
+keywords:
+  - superset vs buzz
+  - buzz alternative
+  - buzz by block
+  - buzz.xyz
+  - block buzz agents
+  - ai agent collaboration
+---
+
+Superset and Buzz both put AI agents to work alongside developers, but they answer different questions. Superset answers "how do I run many coding agents in parallel on my machines and review what they produce?" Buzz, an open-source platform from Block launched in July 2026, answers "where do humans and agents work together as a team?" It is closer to a Slack-plus-GitHub hybrid built on Nostr, where agents are cryptographically identified members of your channels, than to a parallel-agent coding environment.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Buzz** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | A shared workspace (channels, threads, repos, workflows) where humans and agents collaborate |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Collaboration platform for human-agent teams, built on Nostr |
+| **Core unit** | Workspace (worktree + terminals + review) | Community on a relay (channels, threads, git events) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Agent-agnostic via ACP/MCP (goose, Codex, Claude Code); agents hold their own Nostr keys |
+| **Isolation** | Automatic Git worktree per task | Single local clone per project; no per-task worktrees |
+| **Code review** | Built-in diff/file editor per worktree | Patches (NIP-34 events) reviewed in channels; Git integration self-described as early |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | YAML workflows with message/reaction/schedule/webhook triggers |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Linux, Windows alpha), hosted beta at buzz.xyz, self-host; mobile in development |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Buzz?
+
+Buzz is Block's free, open-source collaboration workspace where humans and AI agents work together, launched in July 2026. Every participant -- human or agent -- holds their own cryptographic keypair on the Nostr protocol, so agents are members with their own channel memberships and audit trails rather than bots behind an API key. A community lives on a relay you can self-host, and it bundles channels, threads, DMs, voice huddles, canvases, git repositories, patch review as signed events, and YAML workflows triggered by messages, reactions, schedules, or webhooks. Agents can be powered by any LLM or harness, including Claude Code, Codex, and Block's goose, and Buzz's own agent stack runs headless coding sessions over ACP with an MCP-provided shell. It ships as a desktop app for macOS, Linux, and Windows (alpha), a hosted beta at buzz.xyz, and a self-hostable stack, all Apache-2.0.
+
+## Key Differences
+
+### Coding Environment vs Team Workspace
+
+Superset is where the coding work happens: agents run in terminals inside isolated worktrees, you watch diffs accumulate, review, and merge. Buzz is where the team coordinates: agents and humans share channels, patches land as signed events in the room, CI posts results, and the merge decision happens next to the discussion. Buzz's own framing is replacing "chat, forges, bots, CI dashboards... and a pile of glue code" with one workspace. They are less substitutes than different layers -- but if the question is which tool runs and manages your parallel coding agents day to day, that is Superset's job, not Buzz's.
+
+### Isolation and Parallelism
+
+Superset creates a Git worktree per task automatically, so a dozen agents can work the same repo on separate branches without collisions, each with persistent terminals and reviewable diffs. Buzz projects work against a single local clone, and its desktop terminal button opens your OS terminal at the checkout rather than orchestrating embedded sessions. You can run many agents behind Buzz at the protocol level, but coordination is channel-centric and its Git integration is, in Block's own words, still early.
+
+### Identity and Decentralization
+
+Buzz's most distinctive idea is agent identity: every agent holds a portable Nostr keypair, so its history and reputation travel across any Nostr-compatible system, and teams that self-host a relay own all their data. Superset's model is more conventional -- your machines, your repos, your provider subscriptions -- with the novelty spent on orchestration depth rather than protocol-level identity. If cryptographic agent identity and relay ownership matter to you, Buzz is genuinely different from everything else in this space.
+
+### Automation
+
+Both automate. Superset schedules agent sessions as automations with a TypeScript SDK and a Slack bot, aimed at recurring coding work like nightly dependency bumps or triage. Buzz uses YAML workflows triggered by messages, reactions, schedules, or webhooks, aimed at team processes in the workspace. Superset's automations produce worktrees and diffs you review; Buzz's workflows produce activity in channels.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Buzz is free and open source (Apache-2.0), with a hosted beta at buzz.xyz and no paid plans announced as of August 2026. In both cases you pay the underlying model providers for agent usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to run many coding agents in parallel with worktree isolation and reviewable diffs
+- Need persistent terminals, an in-app browser, and a diff editor around your agents
+- Run scheduled coding automations with an SDK and Slack integration
+- Want remote and cloud workspaces on your own devices
+
+**Choose Buzz if you:**
+
+- Want a shared workspace where agents are team members, not tools
+- Care about portable, cryptographic agent identity and self-hosted data via Nostr
+- Want channels, threads, voice, canvases, repos, and workflows in one open-source platform
+- Are building human-agent team processes rather than a parallel coding pipeline
+
+**Verdict:** These tools solve different problems and can genuinely coexist: Buzz as the team layer where humans and agents communicate and decide, Superset as the execution layer where coding agents actually run in parallel and produce reviewable work. If you have to pick one for AI-assisted software development today, Superset covers the coding workflow end to end; Buzz is the more experimental bet on what human-agent teams look like.
+
+---
+
+## Frequently Asked Questions
+
+### Is Buzz a coding-agent orchestrator like Superset?
+
+Not primarily. Buzz is a collaboration workspace -- channels, threads, repos, and workflows shared by humans and agents. It can host headless agent coding sessions, but it does not provide per-task Git worktree isolation or embedded terminal orchestration the way Superset does.
+
+### Is Buzz open source?
+
+Yes. Buzz is Apache-2.0 and self-hostable, with a hosted beta at buzz.xyz. Superset is source-available under the Elastic License 2.0 with a free tier and paid Pro.
+
+### Can they be used together?
+
+There is no built-in integration, but they occupy different layers: teams could coordinate in Buzz while individual engineers run their parallel agents in Superset. Superset's Slack bot plays a similar coordination role for Slack-based teams.
+
+### Does Buzz support Claude Code and Codex?
+
+Yes. Buzz is model- and harness-agnostic: agents can be powered by Claude Code, Codex, goose, or any LLM, connected over ACP with MCP-provided tools. Superset runs those same agents as interactive terminal sessions inside isolated worktrees.

--- a/apps/marketing/content/compare/superset-vs-cindy.mdx
+++ b/apps/marketing/content/compare/superset-vs-cindy.mdx
@@ -37,7 +37,7 @@ Superset and Cindy overlap on one job -- running Claude Code and Codex sessions 
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Cindy?
 
@@ -59,7 +59,7 @@ Cindy ships real mobile apps (iOS, iPadOS, Android) and ingests tasks from Teleg
 
 ### Maturity
 
-Cindy's repo appeared in late July 2026 and is iterating at multiple releases per day -- impressive velocity, with the churn that implies. Superset has been shipping longer, has enterprise features (SOC 2, SSO, audit logs), and offers a stability contract teams can adopt. Fast-moving and exciting versus established and supported is a real axis here.
+Cindy's repo appeared in late July 2026 and is iterating at multiple releases per day -- impressive velocity, with the churn that implies. Superset has been shipping longer, has enterprise features (SSO, audit logs), and offers a stability contract teams can adopt. Fast-moving and exciting versus established and supported is a real axis here.
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-cindy.mdx
+++ b/apps/marketing/content/compare/superset-vs-cindy.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Cindy (2026): Agent Workspace vs the General-Purpose AI Agent App"
+description: "Compare Superset and Cindy for running AI coding agents in parallel. See how a developer agent workspace differs from Cindy's cross-platform general-purpose agent app."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - cindy
+keywords:
+  - superset vs cindy
+  - cindy alternative
+  - cindy ai agent
+  - makecindy
+  - ai agent orchestration
+  - parallel coding agents
+---
+
+Superset and Cindy overlap on one job -- running Claude Code and Codex sessions in parallel with tracked, reviewable changes -- but they come from different directions. Superset is a developer workspace: worktrees, terminals, diffs, automations, built for shipping code. Cindy is an open-source general-purpose AI agent app ("consider it done") that happens to be strong at coding: it wraps agent harnesses in a continuous workspace with memory and tools, adds multi-agent planner/worker/reviewer collaboration, and ships on desktop and mobile.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Cindy** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | General-purpose AI agent that runs tasks locally, including parallel coding via Claude Code and Codex |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Open-source general-purpose agent app |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Claude Code and Codex harnesses; models incl. Claude, GPT, Grok, Gemini, DeepSeek, Kimi, Qwen, local endpoints |
+| **Multi-agent** | Parallel worktree workspaces; orchestrate via CLI/MCP/SDK | Built-in planner + parallel workers + reviewer collaboration on one task |
+| **Isolation / review** | Automatic Git worktree per task, built-in diff editor | Workspace change tracking with per-turn file changes, undo/reapply |
+| **Platforms** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | macOS, Windows, Linux + iOS, iPadOS, Android |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Telegram ingestion, plugins; task-centric rather than scheduled |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free BYO keys; Plus $20/mo managed models |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Cindy?
+
+Cindy is an open-source (Apache-2.0) AI agent app whose tagline is "consider it done." It runs locally on macOS, Windows, and Linux, with companion apps for iOS, iPadOS, and Android, and wraps agent harnesses -- Claude Code and Codex today -- in a continuous workspace with memory and tools, letting you switch harness or model mid-task. Its multi-agent feature assigns one task a planner, multiple parallel workers (each a different model/harness combination), and an independent reviewer, with collaborative runs exportable and importable across devices. Workspace change tracking shows exact per-turn file changes with undo and reapply, a split view shows up to eight task panes, Telegram groups can feed tasks in, and a plugin ecosystem extends it. Cindy is free with your own API keys or subscriptions, with a $20/month Plus tier for managed model access. It launched in July 2026 and is evolving very quickly.
+
+## Key Differences
+
+### Developer Workspace vs General Agent
+
+Superset is built for one audience: developers shipping code with parallel agents, so everything orbits Git -- worktrees, branches, diffs, PRs. Cindy is a general agent that does files, browsing, and connected apps, with coding as a headline use case. That makes Cindy more versatile for mixed personal automation, and Superset deeper for engineering: worktree-per-task isolation on real branches, persistent terminals, port management, and one-click handoff to your IDE. Cindy's change tracking (per-turn diffs with undo) is genuinely useful, but it is workspace-level capture, not branch-level Git isolation.
+
+### Multi-Agent Models
+
+Cindy builds team structure into a single task: a planner decomposes the work, parallel workers on different models attack it, and an independent reviewer checks the result -- all managed inside the app, shareable as a package. Superset's parallelism is workspace-shaped: many agents on many tasks, each isolated in a worktree, orchestrated interactively or programmatically through the CLI, MCP server, and SDK. Cindy's model is compelling for one hard task; Superset's for a portfolio of tasks moving in parallel.
+
+### Mobile and Messaging
+
+Cindy ships real mobile apps (iOS, iPadOS, Android) and ingests tasks from Telegram groups. Superset's mobile app is on its roadmap, and its chat-ops surface is a Slack bot aimed at team workflows. If steering agents from your phone today is a hard requirement, Cindy delivers it now.
+
+### Maturity
+
+Cindy's repo appeared in late July 2026 and is iterating at multiple releases per day -- impressive velocity, with the churn that implies. Superset has been shipping longer, has enterprise features (SOC 2, SSO, audit logs), and offers a stability contract teams can adopt. Fast-moving and exciting versus established and supported is a real axis here.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Cindy is free with your own API keys, local models, or existing Claude/Codex subscriptions, with a Plus tier at $20/month for its managed model service and team/enterprise plans announced as coming. Model usage is your own cost under both tools' BYO options.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Ship code and want Git-native isolation: worktree per task, branches, diffs, PRs
+- Run scheduled or unattended agent sessions through automations and an SDK
+- Want CLI and MCP surfaces plus remote and cloud workspaces
+- Need team and enterprise features
+
+**Choose Cindy if you:**
+
+- Want one agent app for general tasks -- files, browsing, connected apps -- plus coding
+- Like the planner/workers/reviewer structure on a single hard task
+- Want native mobile apps and Telegram integration today
+- Prefer Apache-2.0 open source with an optional managed-model subscription
+
+**Verdict:** Cindy is one of the fastest-moving projects in the agent space and its planner/worker/reviewer collaboration is a genuinely fresh take. But it is a general-purpose agent app with coding features, while Superset is a purpose-built engineering workspace. For running a fleet of coding agents against real repositories with isolation, review, and automation, Superset is the deeper tool; keep an eye on Cindy, especially if your agent needs extend beyond code.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Cindy compete directly?
+
+Partially. Both run Claude Code and Codex in parallel with tracked changes. Superset is developer-focused with Git worktree isolation per task; Cindy is a general-purpose agent app whose multi-agent coding runs happen inside its own workspace model.
+
+### Is Cindy open source?
+
+Yes, Apache-2.0, free with your own keys, with a $20/month Plus tier for managed models. Superset is source-available under the Elastic License 2.0 with a free tier and paid Pro.
+
+### Which supports more coding agents?
+
+Superset runs any terminal agent -- Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom CLIs. Cindy wraps Claude Code and Codex harnesses today (with more planned), across a wide range of models including local endpoints.
+
+### Does either work from a phone?
+
+Cindy has native iOS, iPadOS, and Android apps and can take tasks from Telegram. Superset's mobile app is on its public roadmap; today its remote workflows run through cloud workspaces and its Slack bot.

--- a/apps/marketing/content/compare/superset-vs-codex-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex-app.mdx
@@ -39,7 +39,7 @@ For the terminal-focused comparison, see [Superset vs Codex CLI](/compare/supers
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is the Codex App?
 

--- a/apps/marketing/content/compare/superset-vs-codex-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex-app.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Superset vs Codex App (2026): Local Worktrees vs Cloud Coding Agents"
-description: "Compare Superset and the OpenAI Codex app for parallel AI coding. See how local Git worktree orchestration differs from Codex's cloud task environments."
+title: "Superset vs Codex App (2026): Agent-Agnostic Workspace vs OpenAI's Coding Surface"
+description: "Compare Superset and the OpenAI Codex app for parallel AI coding. See how an agent-agnostic worktree workspace differs from Codex inside the ChatGPT desktop app."
 date: 2026-07-13
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-07
 type: "1v1"
 competitors:
   - codex-app
@@ -11,11 +11,11 @@ keywords:
   - codex app alternative
   - codex app
   - openai codex app
+  - codex worktrees
   - codex cloud agents
-  - conductor vs codex app
 ---
 
-Codex is OpenAI's coding agent, offered as one product across a terminal CLI, an editor extension, a cloud service, a desktop app, and a web experience that all share one account and usage limits. When people say "the Codex app," they usually mean the desktop and cloud experience that runs coding tasks in parallel cloud environments. Superset takes a different approach: it runs agents in parallel on your own machine, each in an isolated Git worktree. This page compares those two models.
+Codex is OpenAI's coding agent, offered as one product across a terminal CLI, IDE extensions, a cloud service, and -- since July 2026 -- a dedicated coding surface inside the unified ChatGPT desktop app on macOS and Windows. The Codex app now runs parallel chats in local Git worktrees as well as cloud task environments, which makes it a closer comparison to Superset than it used to be. The remaining difference is the biggest one: Codex runs OpenAI's agent; Superset runs all of them.
 
 For the terminal-focused comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
 
@@ -25,42 +25,43 @@ For the terminal-focused comparison, see [Superset vs Codex CLI](/compare/supers
 
 | | **Superset** | **Codex App** |
 |---|---|---|
-| **Category** | Local-first agent orchestration workspace | OpenAI's Codex coding suite (app + cloud) |
-| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs Codex coding tasks across CLI, editor, desktop, web, and cloud |
-| **Parallelism** | Many agents on separate branches on your machine | Multiple tasks in parallel cloud environments |
-| **Isolation** | Automatic local Git worktree per task | Isolated cloud environments per task |
-| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | OpenAI Codex |
-| **Where code runs** | Your local machine (and your own remote/cloud hosts) | OpenAI-managed cloud sandboxes (plus local CLI/editor) |
-| **Pricing** | Free tier + Pro $20/seat/mo | Included with ChatGPT plans; usage scales by tier |
+| **Category** | Local-first agent orchestration workspace | OpenAI's coding surface in the ChatGPT desktop app |
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs parallel Codex chats in local worktrees plus cloud task environments |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | OpenAI Codex (GPT-5.6 Sol, Terra, Luna) |
+| **Isolation** | Automatic local Git worktree per task | Worktree mode per chat (Codex-managed checkouts) or per-task cloud environments |
+| **Where code runs** | Your local machine (and your own remote/cloud hosts) | Your machine, or OpenAI-managed cloud sandboxes |
+| **Platforms** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | macOS and Windows desktop, CLI, IDE extensions, web |
+| **Scheduling** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Scheduled tasks on background worktrees or in cloud |
+| **Pricing** | Free tier + Pro $20/seat/mo | Included with all ChatGPT plans (Free and up); usage scales by tier |
 | **License** | Source-available (ELv2) | Proprietary (Codex CLI is open source) |
 
 ---
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is the Codex App?
 
-Codex is OpenAI's agentic coding system, delivered as one product across several surfaces that share a single account, configuration, and usage limits: a terminal CLI, an editor extension, a cloud agent, a desktop app, and a web experience, plus ChatGPT integration. The cloud experience is the distinctive part: you describe a task, Codex clones your repo into an isolated cloud environment, works in the background without using your local machine, and returns a diff and logs to review before you merge. You can start multiple tasks in parallel this way. Codex is included with ChatGPT plans, and usage scales with the plan tier.
+Codex is OpenAI's agentic coding system, delivered as one product with a shared account, configuration, and usage limits: a terminal CLI, IDE extensions for VS Code, JetBrains, and Xcode, a cloud agent, and a web experience. In July 2026, the standalone Codex desktop app merged into the unified ChatGPT desktop app, where Codex is a dedicated coding surface you can set as the default view, available on every ChatGPT plan including Free. On desktop, each chat started in Worktree mode gets its own Codex-managed local checkout, so multiple chats work the same project in parallel without interference, and Handoff moves a chat between local, worktree, and remote execution. Cloud tasks still run in per-task OpenAI-managed environments, scheduled tasks can run on background worktrees or in the cloud, and code review spans inline diff editing, PR side panels, and multi-repository review. Current models are the GPT-5.6 family (Sol, Terra, Luna).
 
 ## Key Differences
 
-### Where the Work Runs
-
-This is the core difference. The Codex app's flagship parallelism is cloud-hosted: your repository is cloned into OpenAI-managed environments, and tasks run remotely so your machine can be off. Superset runs agents locally, each in a Git worktree on your own disk, using your real environment, dependencies, and services. Cloud execution is convenient for fire-and-forget tasks; local execution keeps everything on your machine and works without a round-trip to a hosted sandbox. Superset also lets you run on your own remote hosts when you want that, but the default is local and under your control.
-
 ### One Vendor's Suite vs Agent-Agnostic
 
-Codex runs OpenAI's Codex agent. Superset is agent-agnostic: it can run Codex itself as one of many agents, alongside Claude Code, OpenCode, Cursor, Gemini, and others, all in the same workspace. If you want to standardize on OpenAI's suite, the Codex app is cohesive. If you want to mix agents or avoid tying your workflow to one vendor, Superset is built for that.
+This is now the core difference. The Codex app runs OpenAI's Codex agent on OpenAI's models. Superset is agent-agnostic: it runs Codex itself as one of many agents, alongside Claude Code, OpenCode, Cursor, Gemini, and others, all in the same workspace -- fan one task across different agents and compare results, or pick the best agent per job. If you want to standardize on OpenAI's stack, the Codex app is cohesive and deeply integrated with ChatGPT. If you want to mix agents or avoid tying your workflow to one vendor, that is exactly what Superset is built for.
+
+### Worktrees on Both Sides Now
+
+Earlier versions of this comparison could say "local worktrees vs cloud environments." That is no longer accurate: the Codex desktop app runs parallel chats in Codex-managed local worktrees, keeps a rolling set of recent ones, and can hand sessions off between machines. Superset's worktree model remains broader in one specific way -- worktrees are ordinary checkouts of your repo that any agent, terminal, or editor can enter, with persistent terminal sessions, an in-app browser, and port management attached, rather than checkouts managed around a single vendor's chats.
 
 ### Review and Environment
 
-With the Codex app's cloud tasks, you configure the environment once (dependencies, variables), then review the returned diff and logs. With Superset, each agent runs in your existing checkout as a worktree, so the environment is whatever your machine already has, and you review in the built-in diff editor or jump straight into your own IDE. Teams with complex local setups, private services, or offline constraints often prefer keeping the loop local.
+With Codex cloud tasks, you configure the environment once and review returned diffs and logs; on desktop, review happens in the app's diff and PR panels. With Superset, each agent runs in your existing checkout as a worktree, so the environment is whatever your machine already has -- private services, local databases, real dependencies -- and you review in the built-in diff editor or jump into your own IDE. Teams with complex local setups or offline constraints tend to prefer keeping the loop local; Codex's cloud tasks remain the better fire-and-forget story when your machine is off.
 
 ### Pricing Model
 
-The Codex app is included with ChatGPT plans, and usage scales with your tier. Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers -- including OpenAI -- so spend on models stays with those providers.
+Codex is included with every ChatGPT plan, from Free up through Plus, Pro, Business, and Enterprise, with usage limits that scale by tier. Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers -- including OpenAI -- so model spend stays with those providers.
 
 ---
 
@@ -68,36 +69,36 @@ The Codex app is included with ChatGPT plans, and usage scales with your tier. S
 
 **Choose Superset if you:**
 
-- Want agents to run locally in isolated Git worktrees on your own machine
 - Run more than one agent, or want to avoid locking into a single vendor
+- Want worktrees that are plain checkouts any tool can enter, with terminals and a browser attached
 - Need your real local environment, private services, or offline work
-- Want review and orchestration in one workspace across many agents
+- Want orchestration, automations, and review for a mixed-agent fleet in one workspace
 
 **Choose the Codex App if you:**
 
-- Are standardized on OpenAI and want a cohesive Codex suite
-- Like fire-and-forget cloud tasks that run while your machine is off
-- Already pay for a ChatGPT plan and want Codex bundled in
-- Prefer OpenAI-managed environments over local setup
+- Are standardized on OpenAI and want a cohesive Codex + ChatGPT experience
+- Like cloud tasks that run while your machine is off
+- Already pay for a ChatGPT plan (or want to start free) with Codex bundled in
+- Want scheduled tasks and code review inside OpenAI's own surfaces
 
-**Verdict:** The Codex app is a strong choice if you live in OpenAI's ecosystem and like cloud tasks that run in the background. Superset is the better fit if you want local, worktree-isolated agents on your own machine, the freedom to run Codex alongside other agents, and a single workspace to orchestrate and review them all.
+**Verdict:** The Codex app has become a genuinely strong parallel-coding environment -- local worktrees, scheduled tasks, and cloud delegation, bundled with every ChatGPT plan. What it cannot be is neutral: it runs one vendor's agent. Superset is the better fit if you want Codex as one option among many, running in ordinary worktrees on your own machines, with agent-agnostic orchestration, review, and automations around the whole fleet.
 
 ---
 
 ## Frequently Asked Questions
 
-### Is the Codex app the same as Codex CLI?
+### Is the Codex app still a separate desktop app?
 
-They are surfaces of the same product. Codex CLI runs in your terminal; the app and cloud experience add a desktop app, a web experience, and parallel cloud task environments. For the CLI-specific comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+No. In July 2026 the standalone Codex app merged into the unified ChatGPT desktop app on macOS and Windows, where Codex is a dedicated coding surface you can set as your default view. The previous ChatGPT app was renamed ChatGPT Classic.
 
 ### Does the Codex app use Git worktrees?
 
-The Codex app's parallel tasks run in isolated cloud environments, not local Git worktrees. Superset makes a local worktree per task the default so agents run on your own machine.
+Yes, as of 2026. Chats started in Worktree mode get their own Codex-managed local checkout, and parallel chats can work the same project without interference. Cloud tasks still run in OpenAI-managed per-task environments. Superset's worktrees are ordinary repo checkouts usable by any agent or tool, not just one vendor's chats.
 
 ### Can Superset run Codex?
 
-Yes. Superset is agent-agnostic and can run the Codex CLI as one of many agents, each in its own worktree, alongside Claude Code, OpenCode, Cursor, Gemini, and others.
+Yes. Superset is agent-agnostic and runs the Codex CLI as one of many agents, each in its own worktree, alongside Claude Code, OpenCode, Cursor, Gemini, and others.
 
 ### Which is cheaper?
 
-It depends on usage. The Codex app is bundled with ChatGPT plans and scales with your tier. Superset has a free tier and Pro at $20/seat/month, and you pay OpenAI directly for model usage.
+It depends on usage. Codex is bundled with all ChatGPT plans, including a free tier, with usage limits that scale by plan. Superset has a free tier and Pro at $20/seat/month, and you pay OpenAI directly for model usage.

--- a/apps/marketing/content/compare/superset-vs-emdash.mdx
+++ b/apps/marketing/content/compare/superset-vs-emdash.mdx
@@ -37,7 +37,7 @@ Superset and Emdash are two of the closest comparisons in the agent-orchestratio
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Emdash?
 
@@ -79,7 +79,7 @@ Superset offers a free tier and Pro at $20/seat/month. Emdash is free and open s
 
 - Want CLI, MCP server, SDK, and Slack surfaces around the same orchestration core
 - Need automations that compose programmatically, not just fire on a schedule
-- Want cloud workspaces and team/enterprise features (SSO, audit logs, SOC 2)
+- Want cloud workspaces and team/enterprise features (SSO, audit logs)
 - Prefer a supported commercial product
 
 **Choose Emdash if you:**

--- a/apps/marketing/content/compare/superset-vs-emdash.mdx
+++ b/apps/marketing/content/compare/superset-vs-emdash.mdx
@@ -1,0 +1,112 @@
+---
+title: "Superset vs Emdash (2026): Two Agentic Development Environments Compared"
+description: "Compare Superset and Emdash for running AI coding agents in parallel Git worktrees. See how these agentic development environments differ in surfaces, automation, and team features."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - emdash
+keywords:
+  - superset vs emdash
+  - emdash alternative
+  - emdash ade
+  - agentic development environment
+  - ai agent orchestration
+  - worktree agent workspace
+---
+
+Superset and Emdash are two of the closest comparisons in the agent-orchestration space. Both are desktop apps that run many CLI coding agents in parallel, both isolate every task in its own Git worktree, and both wrap the core with diff review, an in-app browser, and scheduled automations. Emdash (YC W26) is open source under Apache-2.0 and leans into breadth -- 30+ agent providers and a dozen issue-tracker integrations. Superset leans into surfaces and teams: CLI, MCP server, TypeScript SDK, Slack bot, cloud workspaces, and an enterprise track.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Emdash** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs multiple coding agents in parallel, each task in its own branch and worktree |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Open-source agentic development environment (ADE) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | 30+ providers (Claude Code, Codex, Cursor, Copilot, Amp, Droid, OpenCode, Goose, Kimi, and more) |
+| **Isolation** | Automatic Git worktree per task | Automatic Git worktree per task |
+| **Issue trackers** | GitHub and Linear integrations | 12 integrations (Linear, GitHub, Jira, GitLab, Asana, Notion, Trello, and more) |
+| **Remote** | Remote and cloud workspaces across your network devices | SSH remote projects and ephemeral remote tasks |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Scheduled (cron) automations with run history |
+| **Surfaces** | Desktop app, CLI, MCP server | Desktop app (macOS, Windows, Linux) |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Emdash?
+
+Emdash is an open-source agentic development environment from General Action (YC W26). Each task gets its own Git branch and worktree, keeping the branch, terminal, conversation, and review state together, with tmux support for long-running sessions and terminal state that survives restarts. It auto-detects 30+ installed agent CLIs, pulls tasks in from a dozen issue trackers, and wraps the loop with a diff view (unified and split, staging, in-place edits, push-and-create-PR), CI-check monitoring, an in-app browser with isolated per-task profiles, a prompts/skills library, MCP-server management for agents, and cron-scheduled automations. It runs on macOS, Windows, and Linux, supports SSH remote projects and ephemeral per-task remote workspaces, and is free under Apache-2.0.
+
+## Key Differences
+
+### Overlap First, Honestly
+
+The core loop is nearly identical: pick a task, get a worktree, run your agent of choice, watch the diff, review, push a PR. Both have in-app browsers, both schedule recurring agent runs, both handle multiple GitHub accounts, and both persist sessions across restarts. Choosing between them is about the edges, not the center.
+
+### Breadth of Integrations vs Breadth of Surfaces
+
+Emdash's edge is intake: 30+ agent providers auto-detected, and issues flowing in from Linear, GitHub, Jira, GitLab, Asana, Monday, Notion, Trello, Plane, Featurebase, Plain, and Forgejo. If your work arrives from many trackers and your team runs exotic agents, Emdash probably supports it today. Superset's edge is output surfaces: beyond the desktop app there is a CLI, an MCP server, a TypeScript SDK, and a Slack bot, so the same orchestration can be scripted, embedded in other tools, and driven from chat. Emdash has no CLI, SDK, or public API; its automation is what the app's UI offers.
+
+### Automation Depth
+
+Both schedule agent runs. Emdash's automations are cron-based with a clean run history and a convert-run-to-task flow. Superset's automations add programmatic control -- a TypeScript SDK for building agent pipelines, an MCP server so other agents can drive Superset, and Slack triggers -- which matters when scheduled runs need to compose into larger workflows rather than fire independently.
+
+### Remote and Team
+
+Emdash covers remote work with SSH: persistent remote projects and ephemeral per-task remote workspaces provisioned by your own scripts. Superset's remote and cloud workspaces move whole workspaces across your own devices and network, with the same UI local or remote. On teams, Emdash is a free single-player tool; Superset has unlimited-user Pro plans, Slack-based team workflows, and an enterprise tier with SSO and audit logs.
+
+### Licensing
+
+Emdash is Apache-2.0, fully open source and free, with no paid tiers as of August 2026. Superset is source-available under ELv2 with free and paid plans. If a permissive OSS license is a hard requirement, Emdash has the cleaner answer; if you want a vendor with a support contract, that is Superset's model.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Emdash is free and open source with no paid tiers. Both are bring-your-own-agent: you pay Anthropic, OpenAI, or other providers for the underlying agents either way.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want CLI, MCP server, SDK, and Slack surfaces around the same orchestration core
+- Need automations that compose programmatically, not just fire on a schedule
+- Want cloud workspaces and team/enterprise features (SSO, audit logs, SOC 2)
+- Prefer a supported commercial product
+
+**Choose Emdash if you:**
+
+- Want a free, Apache-2.0 open-source ADE
+- Pull tasks from trackers like Jira, Asana, Notion, or Trello that Superset does not integrate
+- Run niche agent CLIs that Emdash already auto-detects
+- Only need the desktop app and are happy with cron automations
+
+**Verdict:** Emdash is one of the strongest open-source options in this category -- broad provider support, real diff review, an in-app browser, and scheduled automations, all free. Superset is the better fit when the desktop app is not enough: scriptable surfaces (CLI, MCP, SDK, Slack), cloud workspaces, and team features turn the same worktree-orchestration core into something a whole engineering org can standardize on.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Emdash both use Git worktrees?
+
+Yes. Both create an isolated branch and worktree per task automatically. The isolation model is effectively the same; the differences are in surfaces, integrations, and team features.
+
+### Is Emdash open source?
+
+Yes. Emdash is Apache-2.0 licensed and free, developed by General Action (YC W26). Superset is source-available under the Elastic License 2.0 with a free tier and paid plans.
+
+### Which supports more agents?
+
+Emdash's docs list 30+ auto-detected providers, from Claude Code and Codex to Goose, Droid, and Kimi. Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and any custom terminal agent. In practice both run the mainstream agents; Emdash enumerates a longer tail.
+
+### Can both schedule recurring agent runs?
+
+Yes. Emdash has cron-scheduled automations with run history inside the app. Superset's automations add a TypeScript SDK, an MCP server, and a Slack bot, so scheduled sessions can be scripted and integrated into larger pipelines.

--- a/apps/marketing/content/compare/superset-vs-firstmate.mdx
+++ b/apps/marketing/content/compare/superset-vs-firstmate.mdx
@@ -37,7 +37,7 @@ Superset and Firstmate both answer "how do I get one conversation to fan out int
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Firstmate?
 

--- a/apps/marketing/content/compare/superset-vs-firstmate.mdx
+++ b/apps/marketing/content/compare/superset-vs-firstmate.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Firstmate (2026): Agent Workspace vs the DIY Agent Distro"
+description: "Compare Superset and Firstmate for orchestrating parallel coding agents. A purpose-built desktop workspace vs an open-source agent distro that runs on tmux."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - firstmate
+keywords:
+  - superset vs firstmate
+  - firstmate alternative
+  - firstmate agent distro
+  - agent orchestration tmux
+  - parallel coding agents
+  - multi agent workflow
+---
+
+Superset and Firstmate both answer "how do I get one conversation to fan out into a crew of parallel coding agents?" -- with almost opposite ingredients. Superset is an app: a desktop workspace with worktree isolation, diff review, automations, and remote hosts built in. Firstmate is not an app at all. It is an MIT-licensed "agent distro": a portable directory of instructions, skills, scripts, and conventions that turns a terminal agent you already run into an orchestrator that spawns and supervises crewmates in tmux windows and disposable Git worktrees.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Firstmate** |
+|---|---|---|
+| **What it is** | Desktop workspace that runs 100+ AI agents in parallel with worktree isolation, chat, review, and browser | An "agent distro": instructions, skills, and scripts that make one agent orchestrate a crew |
+| **Form factor** | App (desktop, CLI, MCP server) | A cloned Git repo; nothing to install |
+| **Core model** | Workspace per task (worktree + terminals + review) | "First mate" agent spawns crewmate sessions, each in its own tmux window and worktree |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Claude Code, Codex, OpenCode, Pi, Grok, Kimi |
+| **Isolation** | Automatic Git worktree per task | Disposable Git worktree per crewmate |
+| **Session backend** | Built-in persistent terminals | tmux (or experimental Herdr/Zellij/cmux/Orca backends) |
+| **Remote** | Remote and cloud workspaces across your network devices | Persistent "secondmates" on local or SSH-reachable hosts |
+| **Review / UI** | Built-in diff/file editor, browser, chat | None -- output is PRs, local merges, or reports; you review in your own tools |
+| **License** | Source-available (ELv2) | Open source (MIT), free |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Firstmate?
+
+Firstmate is an open-source "agent distro" -- its own words: "talk to one agent, ship with a crew." There is no app, CLI, or server; the cloned repository is the product. You point a terminal agent (Claude Code, Codex, OpenCode, Pi, Grok, or Kimi) at its AGENTS.md, bundled skills, helper scripts, and policies, and that agent becomes a "first mate" that spawns autonomous crewmates -- each in its own visible tmux window (or experimental Herdr, Zellij, cmux, or Orca backend) and its own disposable Git worktree -- supervises them through a zero-token event-driven watcher, and returns finished PRs, approved local merges, or investigation reports. Optional persistent "secondmates" run from isolated homes on local or SSH-reachable remote hosts, and project modes (no-mistakes, direct-PR, local-only) set the guardrails. It is MIT-licensed, free, and has picked up thousands of GitHub stars since mid-2026.
+
+## Key Differences
+
+### App vs Distro
+
+This is the whole comparison in one line: Superset is software you run; Firstmate is behavior you install into an agent. Firstmate's approach is remarkably portable -- it works anywhere tmux and your agent CLI work, composes with other tools (it can even use Orca or Herdr as its session backend), and you can read every line of what it does. The cost is that everything visual is BYO: no diff review, no dashboard, no browser, no port management. Superset builds the environment; Firstmate assumes you already have one.
+
+### Supervision Models
+
+Both fan work out to isolated worktrees. Firstmate's first mate supervises crewmates conversationally -- you talk to one agent, it manages the rest and reports back with PRs or summaries. Superset gives you direct visibility instead: every agent's terminal, diff, and status is a click away, and orchestration can be interactive or programmatic through the CLI, MCP server, and SDK. Delegation-through-conversation versus a control room -- some developers genuinely prefer the former's simplicity.
+
+### Reliability Surface
+
+A distro built on prompts and shell scripts inherits the failure modes of both: agent instructions drift across harness versions, tmux quirks surface, and there is no vendor to file a ticket with. It also inherits their transparency -- nothing is hidden. Superset owns its stack end to end (terminals, worktree lifecycle, review, automations) and carries a product team, support, and enterprise compliance behind it. For personal experimentation the distro trade is often fine; for a team's daily workflow, owned infrastructure matters.
+
+### Automation
+
+Firstmate runs when you talk to your agent; recurring work means wiring your own triggers, though its secondmates give it a persistent-worker story on remote hosts. Superset ships automations -- scheduled agent sessions with a TypeScript SDK and a Slack bot -- so nightly dependency bumps or triage runs happen without you in the loop.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Firstmate is free and MIT-licensed with no company behind it. Both are bring-your-own-agent: model costs go to Anthropic, OpenAI, or your other providers either way.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want the crew visible: terminals, diffs, and status for every agent in one workspace
+- Need built-in review, browser, automations, and remote/cloud workspaces
+- Want scheduled unattended runs without wiring your own triggers
+- Prefer a supported product for a team workflow
+
+**Choose Firstmate if you:**
+
+- Live in the terminal and like "talk to one agent, ship with a crew"
+- Want a free, MIT, fully-inspectable setup with nothing to install
+- Already have tmux (or Herdr/cmux/Orca) and your own review habits
+- Enjoy customizing the orchestration logic itself -- it is all readable text
+
+**Verdict:** Firstmate is the best expression of the DIY end of this space: a clever, transparent, free distro that turns any capable terminal agent into an orchestrator. But it deliberately stops at spawning and supervising -- environment, review, scheduling, and visibility are your problem. Superset is the purpose-built version of the same idea: parallel worktree agents with the workspace, review, automations, and remote reach already around them. Tinkerers should try Firstmate; teams shipping with agents every day will get further in Superset.
+
+---
+
+## Frequently Asked Questions
+
+### Is Firstmate an app like Superset?
+
+No. Firstmate is a repository of instructions, skills, and scripts -- an "agent distro" -- that an agent like Claude Code or Codex reads to become an orchestrator. Superset is a desktop workspace with the orchestration, terminals, and review built in as software.
+
+### Do both use Git worktrees?
+
+Yes. Firstmate gives each crewmate a disposable worktree (or delegates worktree management to Orca when used as a backend). Superset creates an isolated worktree per task automatically and attaches persistent terminals and diff review to it.
+
+### Can Firstmate and Superset be used together?
+
+Not as an integrated pair -- Firstmate's supported backends are tmux, and experimentally Herdr, Zellij, cmux, and Orca. Conceptually, though, Superset's own orchestration (agents launching agents through its CLI and MCP server) covers the same delegation pattern inside the workspace.
+
+### Is Firstmate free?
+
+Yes -- MIT-licensed, no paid tier, no company. Superset has a free tier and Pro at $20/seat/month, with enterprise plans for teams.

--- a/apps/marketing/content/compare/superset-vs-gastown.mdx
+++ b/apps/marketing/content/compare/superset-vs-gastown.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Gas Town (2026): Agent Workspace vs Autonomous Agent Fleet"
+description: "Compare Superset and Gas Town (Steve Yegge's multi-agent orchestrator) for running AI coding agents — a desktop workspace vs an autonomous 20-30 agent fleet."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - gastown
+keywords:
+  - superset vs gas town
+  - gastown alternative
+  - gas town orchestrator
+  - steve yegge gas town
+  - multi agent orchestration
+  - ai agent fleet
+---
+
+Superset and Gas Town both orchestrate many coding agents, but they sit at different points on the autonomy curve. Superset is a desktop workspace: you (or your automations) launch agents into isolated worktrees, watch them, review diffs, and merge. Gas Town -- Steve Yegge's MIT-licensed orchestrator -- is an autonomous fleet: an AI "Mayor" dispatches work from a git-backed ledger to 20-30 worker agents, watchdogs recover the stuck ones, and a bisecting merge queue lands the results. One is a workspace you drive; the other is a factory you supervise.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Gas Town** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Coordinates fleets of 20-30 agents with an AI coordinator, work ledger, and merge queue |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Autonomous multi-agent orchestration system |
+| **Interface** | Desktop GUI, CLI, MCP server | CLI (`gt`) + tmux + TUI feed + local web dashboard |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Claude Code (deepest), plus Codex, Gemini, Copilot, Cursor, Amp, OpenCode, Pi, and more |
+| **Work model** | Task → worktree workspace → agent → review | Beads (git-backed work ledger) → Mayor dispatches → polecats execute → Refinery merges |
+| **Isolation** | Automatic Git worktree per task | Git worktree-backed "hooks" persisting agent work |
+| **Merging** | You review and merge (diff editor, PR flow) | Bors-style bisecting merge queue; workers never push to main |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Autonomous dispatch loop + watchdog recovery; no time-based scheduler |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Gas Town?
+
+Gas Town is Steve Yegge's MIT-licensed multi-agent orchestration system, built to run 20-30 coding agents "productively, on a sustained basis." You talk to the Mayor, an AI coordinator with full context; it creates work in Beads, a git-backed ledger (Dolt-based since v1.0), and dispatches it to "polecats" -- worker agents with persistent identity whose work survives crashes in worktree-backed "hooks." A watchdog chain (Witness, Deacon, Dogs) detects and recovers stuck agents, and each project's Refinery runs a Bors-style bisecting merge queue so workers never push directly to main. It is CLI- and tmux-centric with a TUI activity feed and a local web dashboard, supports Claude Code most deeply plus Codex, Gemini, Copilot, Cursor, and others, and is free and open source. Yegge's own framing sets expectations: it is powerful, experimental in spirit, expensive to run at full tilt, and aimed at operators comfortable deep in the terminal.
+
+## Key Differences
+
+### Supervised Workspace vs Autonomous Factory
+
+Superset keeps a human in the loop by design: agents work in parallel, but you see every terminal, review every diff, and merge deliberately -- with automations covering the scheduled, unattended slice. Gas Town inverts that: the Mayor plans and dispatches, GUPP (its propulsion rule: if work is on your hook, you must run it) keeps agents moving, and the Refinery merges green batches autonomously. Gas Town is the more radical bet on autonomy; Superset is the more practical bet that engineers still want to see and steer the work.
+
+### The Merge Queue
+
+Gas Town's Refinery is its most distinctive engineering: a bisecting merge queue that batches worker output, verifies it, and isolates failures automatically. Superset has no merge queue -- diffs land as PRs that humans review, with the diff editor and GitHub integration smoothing the loop. If you dream of dozens of agents landing code with minimal human gating, the Refinery is genuinely novel; if your team requires human review anyway, the machinery matters less.
+
+### Operator Bar and Machinery
+
+Gas Town requires Go, Dolt, tmux, and Beads, runs a daemon plus per-project watchdogs, and its author describes the operator bar bluntly -- it is for people already running many agents who can handle industrial machinery. It is also single-operator: one human Overseer per town, no teams, auth, or multi-host story. Superset is an installable desktop app with onboarding, team plans, and enterprise controls. The honest comparison: Gas Town scales autonomy per operator; Superset scales adoption across a team.
+
+### Cost and Model
+
+Gas Town's sustained 20-30 agent loops consume tokens aggressively -- Yegge warns about the spend outright, and rate limits push toward multiple provider accounts. Superset's interactive-plus-scheduled model tends to track what you actually review. Both are bring-your-own-subscription; the difference is how hard the architecture pushes the meter.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Gas Town is free and MIT-licensed with no pricing at all -- but its always-running fleet model makes provider token costs the real line item. Both use your own agent subscriptions and API keys.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to see and review what agents do in one workspace with diffs, terminals, and a browser
+- Need scheduled automations, an SDK/MCP surface, and Slack workflows
+- Want team plans, enterprise controls, and remote/cloud workspaces
+- Prefer an installable product over operating a daemon-and-tmux stack
+
+**Choose Gas Town if you:**
+
+- Want to run 20-30 agents on a sustained, autonomous basis
+- Like the Mayor/ledger/merge-queue model and are comfortable operating it
+- Live in the terminal and want MIT-licensed machinery you can inspect
+- Accept the token spend that full-throttle autonomy implies
+
+**Verdict:** Gas Town is the most ambitious autonomy experiment in the space, and its ledger and merge-queue ideas will influence everything that comes after it. Most engineers and teams, though, want parallel agents with visibility, review, and predictable operations -- and that is Superset's territory: the same fleet-scale parallelism with a workspace, automations, and a team story around it. Run Gas Town if you are the kind of operator it was built for; run Superset if you want the fleet without the factory floor.
+
+---
+
+## Frequently Asked Questions
+
+### Is Gas Town only for Claude Code?
+
+No. Claude Code is the default and deepest integration, but Gas Town ships presets for Codex, Gemini, Copilot, Cursor, Amp, OpenCode, Pi, and others. Superset is similarly agent-agnostic across CLI agents.
+
+### Do Superset and Gas Town both use Git worktrees?
+
+Yes. Superset creates an isolated worktree per task. Gas Town's "hooks" persist each agent's work in git worktree-backed storage so it survives crashes and restarts.
+
+### Does Gas Town have a GUI?
+
+Not a desktop app. It is CLI- and tmux-first, with a TUI activity feed (`gt feed`) and a local web dashboard. Superset is a desktop workspace with a CLI and MCP server alongside.
+
+### Can Superset run an autonomous fleet like Gas Town?
+
+Superset supports orchestration -- an agent can spawn and coordinate workers through the CLI and MCP server, and automations run scheduled unattended sessions -- but it does not ship an autonomous coordinator or merge queue. That trade (human-visible review vs autonomous landing) is the core difference.

--- a/apps/marketing/content/compare/superset-vs-herdr.mdx
+++ b/apps/marketing/content/compare/superset-vs-herdr.mdx
@@ -37,7 +37,7 @@ Superset and Herdr both solve "I have more coding agents than terminals," but fr
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Herdr?
 

--- a/apps/marketing/content/compare/superset-vs-herdr.mdx
+++ b/apps/marketing/content/compare/superset-vs-herdr.mdx
@@ -1,0 +1,112 @@
+---
+title: "Superset vs Herdr (2026): Agent Workspace vs Agent Runtime"
+description: "Compare Superset and Herdr for running AI coding agents. See how a desktop agent workspace differs from Herdr's terminal-native runtime that keeps agents alive anywhere."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - herdr
+keywords:
+  - superset vs herdr
+  - herdr alternative
+  - herdr.dev
+  - agent runtime
+  - tmux for ai agents
+  - ai agent orchestration
+---
+
+Superset and Herdr both solve "I have more coding agents than terminals," but from opposite ends. Superset is a desktop workspace: a GUI where agents run in isolated Git worktrees with diff review, chat, a browser, and automations around them. Herdr (YC F26) is a runtime: an always-running background server with a terminal UI that holds real terminals open so agents survive your laptop lid closing, your SSH connection dropping, or every client quitting. Herdr's own compare page names Superset directly and frames the distinction as "apps manage the herd. Herdr runs it."
+
+---
+
+## At a Glance
+
+| | **Superset** | **Herdr** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Persistent runtime for agents: sessions, workspaces, tabs, and panes that outlive clients |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Terminal-native agent runtime (TUI + CLI + socket API) |
+| **Interface** | Desktop GUI | Terminal UI with tmux-style keybindings; no GUI |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | 19 agents auto-detected (Claude Code, Codex, Cursor, OpenCode, Amp, Copilot, Droid, and more) |
+| **Isolation** | Automatic Git worktree per task | Worktree-per-workspace via CLI; Vercel Sandbox plugin for full VM isolation |
+| **Persistence** | Persistent terminal sessions | Server-owned terminals; detach anywhere, agents keep running |
+| **Diff review** | Built-in diff/file editor | None built in; pairs with external tools, sandbox changes return as Git patches |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | JSON socket API, agent-automation CLI, 500+ plugins; no built-in scheduling |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Herdr?
+
+Herdr is an open-source runtime for AI coding agents -- in its own words, "the runtime your coding agents live on: laptop, desktop, or a box you rent." It is a single Rust binary running an always-on server that owns real terminal sessions, organized as sessions, workspaces, tabs, and panes, with a TUI client you attach and detach like tmux. It auto-detects 19 agent CLIs and visualizes their state (working, blocked, done) up through the sidebar. Worktree management is built into the CLI, a newline-delimited JSON socket API makes everything scriptable (agents can drive Herdr from inside their own panes), and a marketplace hosts 500+ plugins -- including a first-party Vercel Sandbox plugin that runs each agent in an isolated cloud microVM and returns changes as Git patches. Herdr runs on macOS, Linux, and Windows (beta), joined Y Combinator's F26 batch, and its runtime is Apache-2.0 and free.
+
+## Key Differences
+
+### Workspace vs Runtime
+
+Superset is the place you work: launch agents, watch diffs, review, browse, merge -- one app for the whole loop. Herdr is the layer agents run on: it keeps their terminals alive and observable, and expects you to bring your own review flow, editor, and browser. Herdr's compare page is explicit that it pairs with manager apps rather than replacing the review experience. If you want one tool for the full loop, that is Superset. If you want a persistence layer under whatever tools you already use, that is Herdr.
+
+### GUI vs Terminal
+
+Superset is a desktop GUI with a terminal inside it. Herdr is terminal-native: TUI, tmux-style prefix keys, SSH-friendly, and "mobile support" means an SSH client on your phone. Developers who live in the terminal and want zero Electron will feel at home in Herdr; developers who want visual diff review, a browser pane, and clickable orchestration will prefer Superset.
+
+### Review and the Rest of the Loop
+
+Herdr has no built-in diff review -- agent status tells you something finished, and then you review in your editor or an external tool; its Vercel Sandbox flow returns raw Git patches you apply manually. Superset builds the review step in: a diff/file editor per worktree, plus one-click handoff to VS Code, Cursor, or JetBrains. Herdr also has no built-in scheduling; its automation story is the socket API and plugins, which are powerful but assume you script the recurring parts yourself. Superset ships automations with a TypeScript SDK and a Slack bot.
+
+### Persistence and Remote
+
+This is Herdr's home turf. The server owns the terminals, so agents keep working when every client disconnects, and a thin client can attach to a remote server over SSH with the UI streaming locally. Superset covers similar ground differently -- persistent terminal sessions plus remote and cloud workspaces that move whole worktree-isolated workspaces across your devices with the full GUI. Herdr's model is leaner and more composable; Superset's carries the entire workspace, review surface included.
+
+### Sandboxing
+
+Herdr's Vercel Sandbox plugin is genuinely distinctive: each agent runs in an isolated Firecracker microVM, nothing touches your machine, uploads are reviewed before they happen, and deletion requires typing DELETE. Superset's isolation is Git worktrees on machines you control, which keeps your real environment, services, and dependencies available to agents. Stronger containment versus higher-fidelity environments -- which one wins depends on the task.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Herdr's runtime is free and Apache-2.0; the YC announcement says the runtime stays open, with commercial features to be built on top later (none priced as of August 2026). Vercel Sandbox usage bills at Vercel's standard rates. Both are bring-your-own-agent for model costs.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want the full loop -- orchestration, diff review, browser, chat -- in one workspace
+- Prefer a GUI over a terminal multiplexer
+- Run scheduled or unattended agent sessions through automations and an SDK
+- Want team and enterprise features behind the tool
+
+**Choose Herdr if you:**
+
+- Live in the terminal and want a tmux-grade, Electron-free runtime
+- Care most about agents surviving disconnects, lid-closes, and client restarts
+- Want to script everything over a JSON socket API or extend via plugins
+- Want per-agent cloud microVM isolation via the Vercel Sandbox plugin
+
+**Verdict:** Herdr is the best-in-class answer to "keep my agents alive anywhere I can SSH," and its runtime-not-app framing is honest -- it deliberately leaves review, browsing, and scheduling to other tools. Superset is the better fit if you want those other tools built in: worktree orchestration, diff review, browser, automations, and remote workspaces as one product. Plenty of terminal-first developers will run Herdr; teams standardizing an agent workflow end to end will get further with Superset.
+
+---
+
+## Frequently Asked Questions
+
+### Is Herdr a Superset alternative?
+
+Partially. Both orchestrate parallel coding agents, and Herdr's own comparison page lists Superset. But Herdr is a terminal runtime that deliberately excludes diff review, a browser, and scheduling, while Superset is a full workspace that includes them. Some developers use a runtime like Herdr underneath other tools.
+
+### Do both support Git worktrees?
+
+Yes. Superset creates a worktree per task automatically. Herdr manages worktrees through its CLI, where creating a worktree creates a workspace, though it leaves the merge and review flow to you.
+
+### Is Herdr open source?
+
+Yes. Herdr's runtime is Apache-2.0 and free, and the team has said it stays open after joining Y Combinator. Superset is source-available under the Elastic License 2.0 with a free tier and paid Pro.
+
+### What is Herdr's Vercel Sandbox integration?
+
+A first-party plugin that runs each agent in an isolated Vercel Sandbox microVM instead of on your machine, with reviewed file uploads, changes returned as Git patches, and human-confirmed deletion. It is the strongest isolation story in the terminal-runtime category; Superset instead runs agents in worktrees on your own local, remote, or cloud machines.

--- a/apps/marketing/content/compare/superset-vs-mux.mdx
+++ b/apps/marketing/content/compare/superset-vs-mux.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Mux (2026): Agent-Agnostic Workspace vs Coder's Agent Multiplexer"
+description: "Compare Superset and Mux by Coder for parallel agentic development — running any CLI agent in worktrees vs Mux's built-in agent loop with container and Coder runtimes."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - mux
+keywords:
+  - superset vs mux
+  - mux alternative
+  - coder mux
+  - coding agent multiplexer
+  - parallel agentic development
+  - ai agent workspace
+---
+
+Superset and Mux (by Coder, the company behind the self-hosted dev-environment platform) both run parallel agent sessions in isolated workspaces from a desktop app. The structural difference decides everything downstream: Superset orchestrates the agents you already use -- Claude Code, Codex, OpenCode, any CLI -- while Mux ships its own agent loop that talks to model APIs directly. That makes Mux a coding agent with a multiplexer around it, and Superset a multiplexer for every agent, including the ones your team already pays for.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Mux** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Plans and executes tasks with parallel sessions of its own agent loop |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Open-source "coding agent multiplexer" (desktop + self-hosted server) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Its own agent loop only (BYO API keys: Anthropic, OpenAI, xAI, Ollama, OpenRouter) |
+| **Subscriptions** | Reuses your Claude Max / ChatGPT plans via vendor CLIs | API-key billing (plus subsidized Mux Gateway credits) |
+| **Isolation** | Automatic Git worktree per task | Six runtimes: local, worktree, SSH, Docker, devcontainer, Coder |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Self-hosted `mux server` (browser/mobile web), SSH, Coder workspaces |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Headless `mux run` with goals/budgets, JS workflow files, GitHub Actions |
+| **Editor reach** | Open in VS Code, Cursor, Windsurf, JetBrains, Zed | ACP bridge into Zed, Neovim, JetBrains; VS Code extension |
+| **License** | Source-available (ELv2) | Open source (AGPL-3.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Mux?
+
+Mux is Coder's open-source (AGPL-3.0) desktop and browser app for parallel agentic development -- "coding agent multiplexer." Each workspace is an isolated session of Mux's own agent loop (UX inspired by Claude Code: plan/exec modes, compaction, vim inputs), talking directly to Anthropic, OpenAI, xAI, Ollama, or OpenRouter models with your API keys. Isolation is pluggable across six runtimes -- shared local directory, git worktree, SSH host, Docker container, devcontainer, or a Coder workspace -- with a dashboard showing git divergence across sessions, best-of-N parallel attempts, workspace forking, and an integrated code-review pane. It runs headlessly too: `mux run` with goal auto-continuation and dollar budgets, durable JavaScript workflows, and a GitHub Actions guide, plus an ACP bridge that exposes the agent inside Zed, Neovim, and JetBrains. It is free, pre-1.0, with a self-hosted server mode for browser and mobile-web access, and an optional Mux Gateway offering subsidized evaluation credits.
+
+## Key Differences
+
+### Whose Agent Runs
+
+This is the fork in the road. Mux does not run Claude Code, Codex, or any external CLI agent -- you use Mux's loop with API-key billing. That buys deep integration (budgets, compaction, tool policies, best-of-N) but means giving up the agents your team knows and, importantly, the Claude Max or ChatGPT subscriptions you already pay for -- API tokens bill separately. Superset orchestrates vendor CLIs directly, so agents keep their own configs, skills, and subscription pricing, and you can mix brands per task.
+
+### Isolation Options
+
+Mux's runtime matrix is broader: beyond worktrees it offers Docker containers, devcontainers, and Coder-managed workspaces -- attractive for platform teams that want containment or already run Coder. Superset standardizes on worktrees across local, remote, and cloud workspaces, keeping agents in your real environment with your services and dependencies. Containment versus fidelity, again -- but if containers are a requirement, Mux has them today.
+
+### Governance and Enterprise Posture
+
+Mux comes from Coder and inherits its self-hosted, regulated-industry framing -- pair it with Coder's platform and you get governed infrastructure for agent fleets, all AGPL open source. Superset's enterprise story is product-led: team plans, SSO and audit logs, remote hosts shared across teammates, and a Slack bot in the flow of work. Platform teams may prefer Mux's posture; engineering teams adopting a tool usually prefer a product.
+
+### Budgets and Headless Runs
+
+Credit where due: Mux's cost controls are first-class -- per-session and per-goal dollar budgets on `mux run`, token tracking, and subsidized gateway credits. Superset's automations cover scheduled unattended sessions with an SDK and Slack triggers, but does not enforce dollar caps per run; costs live with your providers. If hard spend limits on autonomous runs matter, Mux thought about it first.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month, with agents running on your existing subscriptions or keys. Mux is free and AGPL-3.0; you pay model APIs directly (or draw on Mux Gateway's evaluation credits). Note the billing-model difference: Superset can reuse Claude Max / ChatGPT plans through vendor CLIs, while Mux's own loop requires API-key usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to run the agents you already use -- Claude Code, Codex, Cursor, OpenCode -- on their existing subscriptions
+- Want a full workspace: diff editor, browser, port management, persistent terminals
+- Need scheduled automations, MCP/SDK surfaces, and team features
+- Prefer worktrees in your real environment over containers
+
+**Choose Mux if you:**
+
+- Are happy with one built-in agent loop and API-key billing
+- Want container/devcontainer isolation or run Coder already
+- Need dollar-budgeted headless runs and durable JS workflows
+- Want AGPL open source with a self-hosted browser/mobile-web server
+
+**Verdict:** Mux is a thoughtful, well-engineered take -- but it is structurally an agent with a multiplexer, and adopting it means adopting its loop and its billing. Superset is the multiplexer for the agents you already trust, with the workspace, automations, and team surfaces to make a fleet of them a daily workflow. If Coder-style self-hosted governance or container isolation is the requirement, evaluate Mux; otherwise Superset preserves your agent choices and your subscriptions.
+
+---
+
+## Frequently Asked Questions
+
+### Can Mux run Claude Code or Codex?
+
+No. Mux uses its own agent loop against model APIs (Anthropic, OpenAI, xAI, Ollama, OpenRouter) with your keys. Superset runs the vendor CLIs themselves -- Claude Code, Codex, Cursor, OpenCode, and any terminal agent -- on their own subscriptions.
+
+### Do both use Git worktrees?
+
+Both offer them. Worktree is one of Mux's six runtimes alongside local, SSH, Docker, devcontainer, and Coder workspaces. Superset makes a worktree per task the default across local, remote, and cloud workspaces.
+
+### Is Mux open source?
+
+Yes, AGPL-3.0, free, from Coder Technologies (~2,000 GitHub stars). Superset is source-available under ELv2 with a free tier and paid plans.
+
+### Which is better for teams?
+
+Different angles: Mux plus the Coder platform suits platform teams wanting self-hosted governed infrastructure; Superset ships team plans, SSO/audit logs, shared remote hosts, and a Slack bot as product features. For most engineering teams adopting a tool directly, Superset is the shorter path.

--- a/apps/marketing/content/compare/superset-vs-orca.mdx
+++ b/apps/marketing/content/compare/superset-vs-orca.mdx
@@ -37,7 +37,7 @@ Superset and Orca are unusually close in design. Both are desktop workspaces tha
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is Orca?
 
@@ -55,7 +55,7 @@ Superset includes Automations: you can schedule agent sessions like cron jobs, d
 
 ### Where Each Is Ahead
 
-Orca's standouts: Design Mode is the best click-the-UI-tell-the-agent flow in the category, mobile companions are real shipped apps with live agent status and chat, and usage/rate-limit tracking across Claude and Codex accounts is genuinely handy. Superset's standouts: scheduled automations with an SDK, an MCP server so other tools and agents can drive the workspace, a Slack bot for team workflows, cloud workspaces, and an enterprise track (SOC 2, SSO, audit logs). Day to day the core loop feels similar; the edges serve different users -- Orca leans solo-developer breadth, Superset leans workflow depth and teams.
+Orca's standouts: Design Mode is the best click-the-UI-tell-the-agent flow in the category, mobile companions are real shipped apps with live agent status and chat, and usage/rate-limit tracking across Claude and Codex accounts is genuinely handy. Superset's standouts: scheduled automations with an SDK, an MCP server so other tools and agents can drive the workspace, a Slack bot for team workflows, cloud workspaces, and an enterprise track (SSO, audit logs). Day to day the core loop feels similar; the edges serve different users -- Orca leans solo-developer breadth, Superset leans workflow depth and teams.
 
 ### Licensing
 
@@ -76,7 +76,7 @@ Superset offers a free tier and Pro at $20/seat/month. Orca is free and open sou
 - Need scheduled or unattended agent runs through automations and an SDK
 - Want CLI and MCP server surfaces around the same orchestration
 - Want cloud workspaces alongside remote ones
-- Care about enterprise features like SOC 2 and team workflows
+- Care about enterprise features like SSO and audit logs
 
 **Choose Orca if you:**
 

--- a/apps/marketing/content/compare/superset-vs-orca.mdx
+++ b/apps/marketing/content/compare/superset-vs-orca.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Superset vs Orca (2026): Comparing Worktree-Based Agent Workspaces"
-description: "Compare Superset and Orca for running AI coding agents in parallel Git worktrees. See how these agent development environments differ in remote workflows, automation, and scope."
+description: "Compare Superset and Orca for running AI coding agents in parallel Git worktrees. See how these agent development environments differ in automation, remote workflows, and scope."
 date: 2026-07-13
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-07
 type: "1v1"
 competitors:
   - orca
@@ -15,7 +15,7 @@ keywords:
   - worktree agent workspace
 ---
 
-Superset and Orca are unusually close in design. Both are desktop workspaces that run many AI coding agents in parallel, give each task its own Git worktree, and add diff review and an in-app browser around the orchestration core. The differences are not about the core idea -- they are about scope, remote and cloud workflows, automation, and how far each product extends beyond a single machine.
+Superset and Orca are unusually close in design. Both are desktop workspaces that run many AI coding agents in parallel, give each task its own Git worktree, and add diff review and an in-app browser around the orchestration core. The differences are not about the core idea -- they are about automation, surfaces, mobile, and how each product is built and licensed.
 
 ---
 
@@ -23,13 +23,14 @@ Superset and Orca are unusually close in design. Both are desktop workspaces tha
 
 | | **Superset** | **Orca** |
 |---|---|---|
-| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs multiple AI agents in parallel with Git worktree isolation and per-task browser tabs |
-| **Category** | Local-first agent workspace with remote/cloud hosts | Local agent development environment (ADE) |
-| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Agent-agnostic (25+ CLI agents, including Claude Code, Codex, OpenCode, Cursor CLI, Gemini) |
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs a fleet of parallel agents with worktree isolation, per-task browser tabs, and design mode |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Open-source agent development environment (ADE) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | 25+ named agents, plus any CLI agent |
 | **Isolation** | Automatic Git worktree per task | Automatic Git worktree per task |
-| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop, plus iOS and Android companion apps |
-| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Focused on interactive parallel runs |
-| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) + mobile companions |
+| **Remote** | Remote and cloud workspaces across your network devices | SSH/remote worktrees on your own machines or a VPS |
+| **Mobile** | Mobile app on the roadmap | iOS app (App Store) and Android APK companions |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Orca CLI and experimental agent-to-agent orchestration; no scheduling |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) + mobile companions + CLI |
 | **License** | Source-available (ELv2) | Open source (MIT) |
 
 ---
@@ -40,21 +41,21 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Orca?
 
-Orca is a free, open-source desktop "agent development environment" from Stably. It runs multiple coding agents in parallel, giving every task its own Git worktree, its own agent terminal, and its own browser tab, with a unified UI for diffs, pull request and CI inspection, file browsing, and agent-status tracking. Its pitch is to fan one prompt across several agents, compare the results, and merge the winner. Orca is agent-agnostic, supports 25+ CLI agents, ships on macOS, Windows, and Linux, and offers iOS and Android companion apps. It is MIT licensed.
+Orca is a free, open-source "agent development environment" from Stably (YC-backed), and one of the most popular projects in the category at roughly 39,000 GitHub stars as of August 2026. It runs a fleet of coding agents in parallel, giving every task its own Git worktree, terminal, and browser tab, and its pitch is fan-out: one prompt across several agents, compare the results, merge the winner. Around that core it has grown quickly: Design Mode (click an element in the embedded browser and send its HTML/CSS and a screenshot into the agent prompt), diff annotation, GitHub, Linear, and Jira integration, WebGL-rendered split terminals, SSH/remote worktrees for running agents on a VPS, an Orca CLI, and experimental agent-to-agent orchestration with a coordinator inbox. It ships on macOS, Windows, and Linux with an iOS companion app and an Android APK, supports 25+ named agents plus any CLI agent, and is MIT licensed with near-daily releases.
 
 ## Key Differences
 
-### Same Worktree Model, Different Reach
+### Same Worktree Model, Overlapping Reach
 
-Both products make one Git worktree per task the default primitive, so this is not where they diverge. The difference is reach. Superset extends past the local desktop into remote and cloud workspaces that run on your own network devices, so you can start a task on one machine and pick it up from another. Orca is a local desktop environment with mobile companion apps for monitoring and control. If your work stays on one machine, both feel similar. If you want to move work across machines or run agents on a remote host, Superset covers more of that surface.
+Both products make one Git worktree per task the default primitive, and as of mid-2026 both extend beyond a single desktop: Superset through remote and cloud workspaces that move whole workspaces across your network devices, Orca through SSH/remote worktrees that run agents on another machine or a VPS with port forwarding and auto-reconnect. The practical difference is the workflow around it -- Superset treats a remote workspace as the same first-class thing as a local one, while Orca's remote story centers on worktrees you reach over SSH, monitored from desktop or phone.
 
 ### Automation and Scheduling
 
-Superset includes Automations: you can schedule agent sessions like cron jobs, drive them with a TypeScript SDK, and trigger or receive them through a Slack bot. That makes it suited to recurring or unattended work such as nightly dependency bumps, scheduled test runs, or triage. Orca is centered on interactive parallel runs where you launch, compare, and merge in the moment. If you want agents to run on a schedule or as part of a larger pipeline, Superset has more built in.
+Superset includes Automations: you can schedule agent sessions like cron jobs, drive them with a TypeScript SDK, and trigger or receive them through a Slack bot. That suits recurring or unattended work such as nightly dependency bumps, scheduled test runs, or triage. Orca has grown programmatic surfaces of its own -- a headless CLI and experimental agent-to-agent orchestration where a coordinator dispatches work to workers -- but it has no scheduler, so recurring runs still need external wiring. If you want agents on a schedule out of the box, Superset has more built in.
 
-### Breadth of Surfaces
+### Where Each Is Ahead
 
-Beyond the desktop app, Superset is also available as a command-line interface and an MCP server, so the same orchestration can be scripted or embedded into other tools. Orca focuses on its desktop ADE plus mobile companions. Both are agent-agnostic and both give each task a browser, so day to day they overlap heavily; Superset simply exposes more entry points around the same core.
+Orca's standouts: Design Mode is the best click-the-UI-tell-the-agent flow in the category, mobile companions are real shipped apps with live agent status and chat, and usage/rate-limit tracking across Claude and Codex accounts is genuinely handy. Superset's standouts: scheduled automations with an SDK, an MCP server so other tools and agents can drive the workspace, a Slack bot for team workflows, cloud workspaces, and an enterprise track (SOC 2, SSO, audit logs). Day to day the core loop feels similar; the edges serve different users -- Orca leans solo-developer breadth, Superset leans workflow depth and teams.
 
 ### Licensing
 
@@ -72,19 +73,19 @@ Superset offers a free tier and Pro at $20/seat/month. Orca is free and open sou
 
 **Choose Superset if you:**
 
-- Want remote and cloud workspaces, not just a single local desktop
 - Need scheduled or unattended agent runs through automations and an SDK
 - Want CLI and MCP server surfaces around the same orchestration
+- Want cloud workspaces alongside remote ones
 - Care about enterprise features like SOC 2 and team workflows
 
 **Choose Orca if you:**
 
-- Want a free, MIT-licensed desktop ADE for parallel agents
-- Mostly work on one machine and value the fan-out-and-compare workflow
-- Want mobile companion apps to monitor runs
+- Want a free, MIT-licensed desktop ADE with a huge community
+- Value the fan-out-and-compare workflow and Design Mode for UI work
+- Want shipped mobile apps to monitor and chat with your fleet
 - Prefer a fully permissive open-source license
 
-**Verdict:** Orca and Superset share the same foundation, so you will not go wrong with either for local parallel agent work. Orca is a clean, free, open-source choice if your work lives on one machine. Superset is the better fit if you want the orchestration to extend across remote and cloud hosts, run on a schedule, and expose CLI and MCP surfaces for larger workflows.
+**Verdict:** Orca and Superset share the same foundation, and Orca has become the most popular open-source expression of it -- fast-moving, free, and excellent for solo developers, especially on UI-heavy work. Superset is the better fit if you want the orchestration to run on a schedule, expose CLI/MCP/SDK surfaces for larger workflows, and come with team and enterprise features behind it.
 
 ---
 
@@ -92,16 +93,16 @@ Superset offers a free tier and Pro at $20/seat/month. Orca is free and open sou
 
 ### Do Superset and Orca both use Git worktrees?
 
-Yes. Both create an isolated Git worktree for each task, giving every agent its own branch and working directory. The isolation mechanism is the same; the products differ in reach, automation, and surfaces.
+Yes. Both create an isolated Git worktree for each task, giving every agent its own branch and working directory. The isolation mechanism is the same; the products differ in automation, surfaces, and team features.
 
 ### Is Orca open source?
 
-Yes. Orca is MIT licensed and free to use. Superset is source-available under the Elastic License 2.0 and offers a free tier plus paid Pro.
+Yes. Orca is MIT licensed, free to use, and sits around 39,000 GitHub stars as of August 2026. Superset is source-available under the Elastic License 2.0 and offers a free tier plus paid Pro.
 
 ### Can both run agents other than Claude Code?
 
-Yes. Both are agent-agnostic. Orca lists 25+ supported CLI agents, and Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents.
+Yes. Both are agent-agnostic. Orca lists 25+ named agents and runs any CLI agent, and Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents.
 
 ### Which one works across multiple machines?
 
-Superset adds remote and cloud workspaces that run across your own network devices, so a task can move between machines. Orca is a local desktop environment with iOS and Android companion apps for monitoring and control.
+Both, differently. Superset's remote and cloud workspaces move whole workspaces across your own network devices. Orca runs agents in SSH/remote worktrees on another machine or VPS, with iOS and Android companions for monitoring and chat.

--- a/apps/marketing/content/compare/superset-vs-paperclip.mdx
+++ b/apps/marketing/content/compare/superset-vs-paperclip.mdx
@@ -1,0 +1,107 @@
+---
+title: "Superset vs Paperclip (2026): Agent Workspace vs the Agent Company"
+description: "Compare Superset and Paperclip for managing AI agents — a developer workspace for parallel coding agents vs an open-source platform that runs agents like a company."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - paperclip
+keywords:
+  - superset vs paperclip
+  - paperclip alternative
+  - paperclip ai agents
+  - agent orchestration platform
+  - manage ai agents
+---
+
+Superset and Paperclip both answer "how do I manage a lot of AI agents?", at different altitudes. Superset is a developer workspace: coding agents in parallel Git worktrees with terminals, diffs, and automations, on your machines. Paperclip -- one of the most-starred projects in the space -- is a self-hosted platform that runs agents like a company: org charts, budgets, governance, and a ticket system where agents claim work via checkout locks. Its own tagline draws the line: "manage business goals, not pull requests."
+
+---
+
+## At a Glance
+
+| | **Superset** | **Paperclip** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Orchestrates a team of agents against goals with tickets, org charts, budgets, and governance |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Self-hosted agent-company platform (Node server + web UI) |
+| **Primary user** | Developers shipping code with agents | Anyone running many agents against business goals |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Adapters for Claude Code, Codex, Cursor/CLI agents, HTTP bots (OpenClaw), plugins |
+| **Work model** | Task → worktree workspace → interactive agent → review | Goal → tickets → agents claim via checkout locks → heartbeat runs |
+| **Interaction** | Live terminals, chat, diff review | Headless heartbeat runs; threaded ticket conversations |
+| **Isolation** | Automatic Git worktree per task on your machines | Server-side worktrees/branches; cloud sandboxes (e2b, Modal, Daytona, Kubernetes) |
+| **Code review** | Built-in diff/file editor, PR flow | Explicitly "not a code review tool" -- bring your own |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Paperclip?
+
+Paperclip, from Paperclip Labs, is an MIT-licensed, self-hosted platform for orchestrating teams of AI agents -- "if OpenClaw is an employee, Paperclip is the company." You define goals, "hire" agent employees into an org chart with roles and reporting lines, set token budgets with hard stops, and let a heartbeat system wake agents on schedules and events to claim tickets through atomic checkout locks so no two agents do the same work. Governance is first-class: approval gates, review stages, config rollback, and an immutable audit log. Agents run headlessly via adapters (Claude Code, Codex, CLI agents, HTTP bots) in server-side worktrees or cloud sandboxes (e2b, Modal, Daytona, Kubernetes), with routines triggered by cron, webhooks, or API. It is a Node.js server with a React web UI you deploy yourself -- there is no desktop app or hosted offering yet -- and it is entirely free, with roughly 75,000 GitHub stars as of August 2026.
+
+## Key Differences
+
+### Workspace vs Company
+
+Superset is where a developer works with agents: live terminals you can type into, diffs you review, a browser for the dev server. Paperclip is where an operator manages agents: goals decompose into tickets, agents claim and execute them headlessly, and you monitor threads, costs, and approvals from a dashboard. Paperclip says it plainly -- if you have one agent you probably don't need it; if you have twenty you might. The two barely overlap in daily experience even though both "manage agents."
+
+### Interactive Coding vs Headless Execution
+
+Superset's agents are interactive terminal sessions in real worktrees on machines you control -- you steer mid-run, open the app being built, and hand off to your IDE. Paperclip's agents wake on heartbeats, do their run, and report back; there are no live terminals to attach to, and it is explicitly not a code review tool -- diffs exist as a workspace viewer, but the PR lifecycle is yours to bring. For shipping code with review, Superset covers the loop; Paperclip orchestrates work above it.
+
+### Governance and Budgets
+
+Paperclip's standout is the management layer nobody else has: per-agent and per-project token budgets enforced atomically with hard stops, board-style approvals, execution policies, config revisioning with rollback, and a full audit trail with actor attribution. Superset's controls are workspace-grade -- permissions, enterprise SSO and audit logs on paid plans -- not budget-enforced agent governance. If you are running dozens of autonomous agents against a budget, Paperclip took that problem seriously first.
+
+### Operations
+
+Superset installs as a desktop app; the CLI, MCP server, and SDK come along free of server operations. Paperclip is infrastructure you run: Node 20+, Postgres in production, deployment, upgrades -- with a web UI usable from your phone once hosted. There is no cloud offering yet on either side beyond what you host; Superset's remote and cloud workspaces stay on your own devices.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Paperclip is entirely free and MIT-licensed with no paid tier or SaaS -- you pay for the infrastructure you host it on and the model tokens your agents burn (which its budget system exists to cap). Both are bring-your-own-provider.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Are a developer running coding agents you watch, steer, and review
+- Want worktrees, terminals, diff review, and a browser in one app
+- Need scheduled automations with an SDK, MCP server, and Slack bot
+- Want a product, not a server deployment
+
+**Choose Paperclip if you:**
+
+- Run many autonomous agents and need budgets, governance, and audit trails
+- Want a ticket system where agents claim work without double-doing it
+- Are comfortable self-hosting a Node/Postgres platform
+- Manage agent work beyond code, framed as goals rather than PRs
+
+**Verdict:** These tools live at different layers and could genuinely coexist: Paperclip as the management plane for a large autonomous fleet, Superset as the workspace where engineers actually build with agents and review the results. For software teams whose agents ship code through PRs, Superset is the tool for the job -- Paperclip itself tells you it is not a code review tool. For operators running an agent "company" against budgets and goals, Paperclip has no direct equal.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Paperclip compete?
+
+Less than their star counts suggest. Superset is a developer workspace for interactive parallel coding agents; Paperclip is a self-hosted management platform for autonomous agent teams. The overlap is "many agents, one dashboard" -- the daily experience is very different.
+
+### Is Paperclip free?
+
+Yes -- MIT-licensed, self-hosted, no paid tier or hosted offering as of August 2026. Superset has a free tier and Pro at $20/seat/month.
+
+### Does Paperclip run agents in Git worktrees?
+
+Yes, as server-side plumbing: project workspaces use worktrees and operator branches, plus optional cloud sandboxes. Superset's worktrees are human-facing workspaces on your own machines, with terminals and review attached.
+
+### Can Paperclip review code like Superset?
+
+No -- its README is explicit: "Not a code review tool... Bring your own review process." Superset builds diff review in and integrates the PR flow with GitHub.

--- a/apps/marketing/content/compare/superset-vs-solo.mdx
+++ b/apps/marketing/content/compare/superset-vs-solo.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Solo (2026): Agent Workspace vs Process Dashboard"
+description: "Compare Superset and Solo (soloterm.com) — parallel coding agents in Git worktrees vs Aaron Francis's native dashboard for agents and your dev stack."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - solo
+keywords:
+  - superset vs solo
+  - solo alternative
+  - soloterm
+  - solo terminal
+  - dev process dashboard
+  - ai agent workspace
+---
+
+Superset and Solo both put your coding agents in one window, but they manage different things. Superset manages the work: each task gets a Git worktree, an agent, diffs, and review. Solo -- Aaron Francis's native terminal workspace -- manages the environment: your dev servers, databases, queue workers, and agents run as supervised processes with auto-restart, crash notifications, and a rich MCP surface agents use to coordinate. Solo's own compare pages say it plainly: it is "not a git-worktree orchestrator," and it positions itself as complementary to tools like Superset rather than a replacement.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Solo** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs agents and your whole dev stack as supervised processes in one native window |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Native process dashboard / terminal workspace (Tauri, "not an IDE. On purpose.") |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Claude Code, Codex, Gemini CLI, Amp, OpenCode, Aider, Goose, Copilot, Kimi, custom |
+| **Isolation** | Automatic Git worktree per task | None -- one shared checkout ("not a git-worktree orchestrator") |
+| **Process management** | Run scripts, port detection, restartable dev-server pane | Stack auto-detection, one-click start, auto-restart, crash alerts, CPU/memory tracking |
+| **Agent coordination** | CLI, MCP server, SDK; orchestrating agents spawn workers | 40+ MCP tools: shared todos, scratchpads, locks, timers, agent spawning |
+| **Diff review / PRs** | Built-in diff/file editor, PR flow | None -- does not review code or manage branches |
+| **Platforms** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | macOS and Windows (Linux coming); local only |
+| **License / pricing** | Source-available (ELv2); free tier + Pro $20/seat/mo | Proprietary; free (4 projects) / Pro $99/yr / Team $69-99/seat/yr |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Solo?
+
+Solo is a native desktop terminal workspace from Aaron Francis -- "the workspace for your agents and dev stack," and deliberately "not an IDE." Projects group processes: Solo auto-detects your stack (Laravel, Next, Django, Rails-style setups, and a dozen more) so one click starts everything, then supervises it -- auto-restarting crashed trusted commands, sending crash notifications, tracking CPU and memory, and restarting on file changes. Agents are first-class managed processes with working/waiting status detection and one-click MCP setup; its MCP server exposes 40+ tools so agents can read process output, wait for dev servers, restart services, and coordinate through shared todos, scratchpads, lease-based locks, timers, and even spawn other agents -- a documented lead-agent/worker pattern. Configuration is a committable `solo.yml`. It is a GPU-accelerated Tauri app for macOS and Windows, proprietary, with a free tier (4 projects), Pro at $99/year, and team plans. By its own framing it does not do worktrees, diff review, branches, or PRs.
+
+## Key Differences
+
+### Work Isolation vs Environment Health
+
+Superset's unit is the task: worktree, branch, agent, diff, merge -- parallel agents cannot collide because each has its own checkout. Solo's unit is the process: everything runs in one shared checkout, kept healthy by supervision. Solo is upfront that parallel agents in the same project share the working tree unless you hand-create worktrees (its "linked checkouts" then share todos across them, but Solo will not create or manage the checkouts). For parallel agent coding, that is the decisive difference.
+
+### The Review Gap
+
+Solo does not read agent conversations, review code changes, or manage branches -- by design. When an agent finishes, you review in your editor and handle git yourself. Superset builds the review loop in: a diff/file editor per worktree, PR creation, review threads, and CI status. If "what did the agent actually change?" is the question you ask most, only one of these answers it.
+
+### Where Solo Shines
+
+Solo's process supervision is genuinely better than anything in the orchestrator category: stack auto-detection with one-click start, auto-restart with crash alerts, resource tracking, and a committable `solo.yml` that describes the whole stack for the team. Its MCP coordination surface -- shared todos with blockers, scratchpads, locks, timers that wake idle agents -- is also the richest agent-to-agent toolkit shipped by any tool here. Superset covers the adjacent ground differently: run scripts with a restartable dev-server pane, port detection with jump-to-terminal, and setup/teardown scripts in `.superset/config.json`, with coordination flowing through its CLI, MCP server, and SDK.
+
+### Complement, Not Substitute
+
+Solo's own comparison pages describe it as a layer around your existing tools, coexisting with worktree orchestrators. That is accurate: you could supervise your dev stack in Solo while Superset runs the parallel agents and review. The choice becomes either/or only if you want one window -- in which case pick by primary job: shipping parallel agent work (Superset) or keeping a busy local stack healthy (Solo).
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Solo is free for up to 4 projects with all features, then Pro at $99/year or Team at $69-99/seat/year. Both are bring-your-own-agent: model costs stay with your providers.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Run multiple coding agents in parallel and need them isolated in worktrees
+- Want diff review, PR flow, and a browser around agent work
+- Need scheduled automations, SDK/MCP surfaces, and remote/cloud workspaces
+- Ask "what did the agent change?" more than "is my dev server up?"
+
+**Choose Solo if you:**
+
+- Want your dev servers, databases, workers, and agents supervised in one native window
+- Value auto-restart, crash alerts, and one-click stack startup
+- Want agents coordinating through shared todos, locks, and timers via MCP
+- Work in one shared checkout and review code in your own editor
+
+**Verdict:** Solo is the best process dashboard a developer running agents can buy, and its MCP coordination toolkit deserves the attention it gets. But it manages the environment, not the work -- no isolation, no review, no branches, by its own description. For parallel agent development, Superset is the tool for the job, and plenty of developers will happily run both.
+
+---
+
+## Frequently Asked Questions
+
+### Is Solo a Superset alternative?
+
+Only partially -- Solo itself says it is not a git-worktree orchestrator and positions against editors and terminals, not orchestrators. It supervises processes; Superset orchestrates isolated agent work. They overlap in "agents in one window" and complement each other beyond that.
+
+### Does Solo support Git worktrees?
+
+It does not create or manage them. If you make worktrees yourself, Solo's "linked checkouts" share project todos and scratchpads across them. Superset creates and manages a worktree per task automatically.
+
+### Which agents does each support?
+
+Solo runs Claude Code, Codex, Gemini CLI, Amp, OpenCode, Aider, Goose, Copilot, Kimi, and custom agents as managed processes with status detection. Superset runs any CLI agent with orchestration, worktrees, and review attached.
+
+### Is Solo open source?
+
+The desktop app is proprietary (the MIT `soloterm/solo` repo on GitHub is the original Laravel package, not the app). Superset is source-available under ELv2.

--- a/apps/marketing/content/compare/superset-vs-super-engineering.mdx
+++ b/apps/marketing/content/compare/superset-vs-super-engineering.mdx
@@ -37,7 +37,7 @@ Superset and super.engineering (formerly Superconductor) are direct competitors:
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
 
 ## What Is super.engineering?
 
@@ -59,7 +59,7 @@ super.engineering is in alpha: nightly is the only release channel, the product 
 
 ### Forges and Review
 
-Credit where due: super.engineering supports GitLab (including self-managed) alongside GitHub, and its review panel -- line-anchored comment threads that dispatch to agents, plus the adaptive Git action button -- is a thoughtful flow. Superset's review is its built-in diff/file editor plus one-click handoff to VS Code, Cursor, Windsurf, JetBrains, or Xcode, with GitHub and Linear integration. If GitLab is your forge, super.engineering covers it natively today.
+Credit where due: super.engineering supports GitLab (including self-managed) alongside GitHub, and its review panel -- line-anchored comment threads that dispatch to agents, plus the adaptive Git action button -- is a thoughtful flow. Superset's review is its built-in diff/file editor plus one-click handoff to VS Code, Cursor, Windsurf, JetBrains, or Zed, with GitHub and Linear integration. If GitLab is your forge, super.engineering covers it natively today.
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-super-engineering.mdx
+++ b/apps/marketing/content/compare/superset-vs-super-engineering.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs super.engineering (2026): Agent Workspace vs Native Rust Orchestrator"
+description: "Compare Superset and super.engineering (formerly Superconductor) for running parallel AI coding agents in Git worktrees. Native Rust performance vs a full agent workspace."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - super-engineering
+keywords:
+  - superset vs super.engineering
+  - super.engineering alternative
+  - superconductor alternative
+  - native ai agent orchestrator
+  - agentic ide
+  - parallel coding agents mac
+---
+
+Superset and super.engineering (formerly Superconductor) are direct competitors: both are desktop apps that orchestrate Claude Code, Codex, and other CLI agents in isolated Git worktrees with diff review built in. The split is architectural and philosophical. super.engineering is a closed-source, keyboard-driven native macOS app written entirely in Rust with a GPU-rendered terminal, currently in alpha with nightly-only releases. Superset is a shipping product with automations, an SDK, an MCP server, cloud workspaces, and a team and enterprise track.
+
+---
+
+## At a Glance
+
+| | **Superset** | **super.engineering** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs unlimited parallel CLI agents in worktrees from one keyboard-driven native interface |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Native macOS agent orchestrator (alpha) |
+| **Architecture** | Desktop app | 100% Rust, Metal GPU-rendered terminal, no Electron |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | 15 listed providers (7 stable, incl. Claude Code, Codex, Cursor, OpenCode, Pi, Grok), plus any CLI agent |
+| **Isolation** | Automatic Git worktree per task | Worktree per task (workspace → project → worktree → tab) |
+| **Forges** | GitHub, plus Linear integration | GitHub, GitHub Enterprise, GitLab, self-managed GitLab |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Experimental SSH remote workspaces (Ubuntu hosts) |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | `sc` CLI + experimental 1-8 agent teams; no scheduling |
+| **License / status** | Source-available (ELv2), shipping product | Closed source, alpha, nightly releases only |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is super.engineering?
+
+super.engineering, formerly Superconductor, is a native macOS app for running parallel AI coding agents, built entirely in Rust with a Metal GPU-rendered terminal and a sub-50ms startup claim. Its pitch: web-technology tools cap you at a handful of parallel agents, while a native app runs unlimited agents, scaling with your hardware. Each task gets its own worktree with tabs for chat, terminal, files, diffs, and browser; a review panel supports line-anchored comment threads that can be dispatched back to an agent; and an adaptive Git button walks each branch through commit, PR, CI fixes, and merge on both GitHub and GitLab. A bundled `sc` CLI exposes the app to scripts and agents, including experimental cross-provider agent teams of up to eight roles. It is keyboard-driven and deeply customizable (layouts, themes, picture-in-picture tabs), runs agents as local subprocesses on your own subscriptions with no accounts and no proxying, and is currently a closed-source alpha distributed as a free nightly download for Apple Silicon Macs.
+
+## Key Differences
+
+### Native Performance vs Product Surface
+
+super.engineering's identity is the native build: 100% Rust, GPU terminal, no Electron, unlimited parallel agents. If raw UI speed and terminal fidelity are your top criteria, it is the most aggressive engineering effort in this category. Superset spends its effort on surface area instead: an in-app browser, port management, chat, MCP tooling, automations, and remote/cloud workspaces are all part of the product today. Fast chrome versus more product -- that is the core trade.
+
+### Automation and Scheduling
+
+super.engineering has a genuinely good local CLI (`sc`) with JSON output, and experimental orchestrated agent teams. But it has no scheduling, no webhooks, no HTTP API, no SDK, and no MCP support -- recurring work means scripting `sc` yourself. Superset ships automations that run agent sessions on a schedule, a TypeScript SDK to compose them, an MCP server so agents and tools can drive Superset, and a Slack bot for triggering and receiving runs. For unattended or recurring agent work, Superset has the built-in story.
+
+### Maturity, License, and Team
+
+super.engineering is in alpha: nightly is the only release channel, the product is closed source with no public repo or changelog page, there is no pricing yet, and Enterprise is "email us." Superset is source-available under ELv2, has published free and Pro pricing, and carries team features (unlimited users on Pro, Slack workflows) and an enterprise tier with SSO and audit logs. Individual early adopters may not care; teams standardizing a workflow will.
+
+### Forges and Review
+
+Credit where due: super.engineering supports GitLab (including self-managed) alongside GitHub, and its review panel -- line-anchored comment threads that dispatch to agents, plus the adaptive Git action button -- is a thoughtful flow. Superset's review is its built-in diff/file editor plus one-click handoff to VS Code, Cursor, Windsurf, JetBrains, or Xcode, with GitHub and Linear integration. If GitLab is your forge, super.engineering covers it natively today.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. super.engineering has no pricing page as of August 2026: the alpha is a free download with no account required, and its terms anticipate paid licensing that has not been announced. Both are bring-your-own-agent -- you pay Anthropic, OpenAI, and other providers directly.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want scheduled automations, a TypeScript SDK, an MCP server, and a Slack bot around your agents
+- Need remote and cloud workspaces, team plans, or enterprise features
+- Prefer a shipping product with published pricing over an alpha
+- Want an in-app browser and port management in the loop
+
+**Choose super.engineering if you:**
+
+- Prioritize native performance: Rust, GPU-rendered terminal, no Electron
+- Are keyboard-driven and want deep layout, theme, and keybinding customization
+- Use GitLab (including self-managed) as your forge
+- Are happy riding an alpha on nightly builds
+
+**Verdict:** super.engineering is the performance purist's take on this category, and the native engineering is real. But it is an alpha: closed source, nightly-only, no pricing, no scheduling or API surfaces, and macOS-only. Superset delivers the same worktree-orchestration core as a complete product -- automations, SDK, MCP, browser, remote and cloud workspaces, and team features included. Try super.engineering if the native feel excites you; standardize on Superset if you need the workflow to be dependable today.
+
+---
+
+## Frequently Asked Questions
+
+### Is super.engineering the same as Superconductor?
+
+Yes. Superconductor rebranded to super.engineering; developer-facing names like the `sc` command and `.superconductor/config.json` remain during the transition.
+
+### Do both use Git worktrees?
+
+Yes. Both create an isolated worktree per task. super.engineering organizes them as workspace → project → worktree → tab; Superset attaches persistent terminals, diffs, and review to each worktree-backed workspace.
+
+### Is super.engineering open source?
+
+No. It is closed-source proprietary software, currently free during its alpha, with no published pricing. Superset is source-available under the Elastic License 2.0 with free and paid tiers.
+
+### Which platforms do they run on?
+
+Both are macOS-first today. super.engineering requires macOS 14+ on Apple Silicon, with Windows and Linux planned. Superset ships on macOS with Windows and Linux coming, and additionally offers a CLI, an MCP server, and remote/cloud workspaces.

--- a/apps/marketing/content/compare/superset-vs-symphony.mdx
+++ b/apps/marketing/content/compare/superset-vs-symphony.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs Symphony (2026): Agent Workspace vs OpenAI's Tracker-Driven Orchestration"
+description: "Compare Superset and OpenAI's Symphony — an interactive workspace for parallel coding agents vs an open-source spec that turns tickets into autonomous Codex runs."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "1v1"
+competitors:
+  - symphony
+keywords:
+  - superset vs symphony
+  - openai symphony
+  - symphony alternative
+  - codex orchestration
+  - autonomous coding agents
+  - issue tracker agents
+---
+
+Superset and Symphony both scale coding agents past one-at-a-time, from opposite directions. Superset is an interactive workspace: agents in parallel worktrees with terminals, diffs, and a browser, plus automations for the scheduled slice. Symphony is OpenAI's open-source answer to "stop supervising agents entirely": a headless daemon that continuously reads tickets from your issue tracker, creates an isolated workspace per issue, and runs a Codex session in each until the ticket is done -- "manage work instead of supervising coding agents." It ships as a spec first, with an Elixir reference implementation OpenAI labels an engineering preview.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Symphony** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Turns tracker tickets into isolated, autonomous Codex implementation runs |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Headless orchestration daemon (spec + reference implementation) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Codex only (app-server protocol) |
+| **Control plane** | Workspace UI, CLI, MCP server, SDK | Your issue tracker (Linear, GitHub, Jira, Asana, GitLab) |
+| **Interaction** | Live terminals, chat, steering mid-run | None -- fully unattended; status dashboard is read-only |
+| **Isolation** | Git worktree per task on your machines | Git clone per issue in a contained workspace root |
+| **Review** | Built-in diff/file editor, PR flow | On GitHub PRs; agents can land approved PRs themselves |
+| **Parallelism** | Many interactive agents at once | Concurrency caps per state (default 10 concurrent runs) |
+| **License / status** | Source-available (ELv2), shipping product | Apache-2.0; "low-key engineering preview" (v0.0.2) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Zed. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Symphony?
+
+Symphony is OpenAI's open-source (Apache-2.0) orchestration project for Codex. A long-running daemon polls your issue tracker -- Linear, GitHub, Jira, Asana, or GitLab -- and for each active ticket clones the repo into an isolated per-issue workspace and runs a multi-turn Codex session (app-server mode) that plans on the ticket itself, implements, opens a PR, and moves the ticket through states; after human approval, the agent lands the PR. Policy lives in a repo-owned, hot-reloadable `WORKFLOW.md`, with concurrency caps, stall detection, retries, and workspace cleanup specified. It is deliberately spec-first: OpenAI recommends teams implement their own hardened version from SPEC.md, and calls the Elixir reference implementation a preview for trusted environments. There is no GUI beyond an optional read-only status dashboard, and it is Codex-only.
+
+## Key Differences
+
+### The Tracker Is the UI
+
+Symphony's radical simplification is that assigning work is the entire interface: move a ticket to an active state and an agent picks it up; review happens on the PR and the ticket. There are no terminals to watch and no way to steer mid-run. Superset assumes the opposite -- that engineers want to see agents work, interrupt them, run the app in a browser pane, and review diffs before anything lands. Superset's automations and MCP surface cover unattended work too, but the center of gravity is interactive.
+
+### One Agent vs Any Agent
+
+Symphony speaks the Codex app-server protocol and nothing else -- no Claude Code, no Gemini, no adapter layer. If your org standardizes on OpenAI, that is coherent; if you want to fan a task across different agents or pick per-job, it is disqualifying. Superset is agent-agnostic by design, running Codex alongside Claude Code, OpenCode, Cursor, and any CLI agent.
+
+### Product vs Spec
+
+Superset is a shipping product with onboarding, support, and team plans. Symphony is an engineering preview whose README's first install option is telling your coding agent to build Symphony from the spec -- powerful for teams that want to own a hardened implementation, but you are signing up to operate (or write) infrastructure, with full-auto approval policies in the sample config that demand real trust in your sandboxing.
+
+### Autonomy Model
+
+Symphony bets on full autonomy bounded by ticket states: agents work unattended, humans gate at review, agents land the merge. Superset bets on graduated autonomy: interactive when you are present, scheduled automations with an SDK and Slack bot when you are not, and orchestrating agents that spawn workers through the CLI and MCP server -- with humans reviewing in the workspace either way.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Symphony is free and Apache-2.0; you run the daemon on your own infrastructure and pay for Codex usage under your OpenAI plan or API keys. Both are bring-your-own-provider.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to see, steer, and review agent work in one workspace
+- Run multiple agent brands, not just Codex
+- Want automations, an SDK/MCP surface, and team features in a supported product
+- Prefer installing an app over operating (or building) a daemon
+
+**Choose Symphony if you:**
+
+- Are all-in on Codex and want tickets to become PRs with zero supervision
+- Have a disciplined tracker workflow and strong CI as the safety net
+- Are comfortable running preview infrastructure, or hardening your own from the spec
+- Manage work at the board level and rarely need to steer mid-run
+
+**Verdict:** Symphony is the clearest statement yet of the fully-autonomous thesis -- the ticket board as the only interface -- and its spec is worth reading whatever you run. But it is Codex-only, headless, and a preview by its own label. Superset delivers parallel agent leverage today with the visibility engineers actually want, across any agent, with automations covering the unattended slice. Many teams will eventually want both patterns; Superset is the one you can adopt this afternoon.
+
+---
+
+## Frequently Asked Questions
+
+### Is Symphony a product like Superset?
+
+Not exactly. Symphony is an open-source spec plus a reference implementation that OpenAI calls a "low-key engineering preview" -- teams are encouraged to build their own hardened version. Superset is a shipping desktop product with a CLI, MCP server, and SDK.
+
+### Does Symphony work with Claude Code or other agents?
+
+No. Symphony drives Codex through its app-server protocol exclusively. Superset runs Codex, Claude Code, OpenCode, Cursor, Copilot, Gemini, and any CLI agent.
+
+### Does Symphony use Git worktrees?
+
+No -- it clones the repo into an isolated workspace per issue, contained within a workspace root. Superset uses a Git worktree per task, which shares the repository's object store and is cheaper to create.
+
+### Can Superset do tracker-driven autonomous runs?
+
+Partially. Superset's tasks integrate GitHub Issues and Linear, its automations run scheduled unattended sessions, and its SDK/MCP surfaces support building tracker-driven pipelines -- but it does not ship Symphony's poll-dispatch-land loop as a turnkey daemon. The inverse gap is larger: Symphony has no interactive workspace at all.

--- a/apps/marketing/content/compare/symphony-alternative.mdx
+++ b/apps/marketing/content/compare/symphony-alternative.mdx
@@ -1,0 +1,99 @@
+---
+title: "Best Symphony Alternatives in 2026"
+description: "The best alternatives to OpenAI's Symphony for orchestrating coding agents, including Superset, Agent Orchestrator, Gas Town, OpenHands, and Paperclip."
+date: 2026-08-07
+lastUpdated: 2026-08-07
+type: "roundup"
+competitors:
+  - symphony
+  - agent-orchestrator
+  - gastown
+  - openhands
+  - paperclip
+keywords:
+  - symphony alternative
+  - openai symphony alternative
+  - codex orchestration
+  - autonomous coding agents
+  - tracker driven agents
+---
+
+Symphony is OpenAI's open-source orchestration spec and reference daemon: tickets in your issue tracker become isolated, autonomous Codex runs that end in PRs -- "manage work instead of supervising coding agents." The constraints are equally clear: Codex only, headless only, and a self-described "low-key engineering preview" that OpenAI suggests you harden or reimplement yourself. Here are the best Symphony alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Agents | License |
+|---|---|---|---|
+| **Superset** | Parallel agents with visibility, review, and automations | Any CLI agent | Source-available (ELv2) |
+| **Agent Orchestrator** | Automated CI/review loops in a desktop app | 23 harnesses | Open source (Apache-2.0) |
+| **Gas Town** | Sustained autonomous fleets with a merge queue | Claude Code + presets | Open source (MIT) |
+| **OpenHands** | Self-hosted end-to-end autonomous runs | Own agent | Open source (MIT) |
+| **Paperclip** | Managing agent teams against goals and budgets | Adapter-based | Open source (MIT) |
+
+## Why Look for a Symphony Alternative?
+
+Three reasons come up. Agent choice: Symphony drives Codex exclusively -- no Claude Code, no mixing. Visibility: it is fully headless with a read-only dashboard; you cannot watch or steer a run. Maturity: it is a preview whose sample config runs full auto-approval, and OpenAI recommends building your own hardened implementation -- which is a project, not an install.
+
+## The Best Alternatives
+
+### Superset
+
+Superset flips Symphony's trade: any agent (Codex included), full visibility, and graduated autonomy. Tasks flow in from GitHub Issues and Linear, agents work in isolated worktrees with terminals and diffs you can actually see, and the unattended slice runs through scheduled automations with a TypeScript SDK, MCP server, and Slack bot. You get most of the leverage without betting the workflow on unattended runs -- and you can dial autonomy up per task instead of all at once.
+
+For the direct comparison, see [Superset vs Symphony](/compare/superset-vs-symphony).
+
+### Agent Orchestrator
+
+Agent Orchestrator (Apache-2.0) automates the part of Symphony most teams actually want -- agents that respond to CI failures and review comments without a human relaying logs -- as config-driven reactions in a desktop app, across 23 agent harnesses, while leaving merging to you.
+
+See [Superset vs Agent Orchestrator](/compare/superset-vs-agent-orchestrator).
+
+### Gas Town
+
+Gas Town is the maximalist unattended bet: an AI Mayor dispatching a git-backed work ledger to 20-30 agents with watchdog recovery and a bisecting merge queue. More machinery than Symphony, more agent choice, same appetite for autonomy.
+
+See [Superset vs Gas Town](/compare/superset-vs-gastown).
+
+### OpenHands
+
+OpenHands runs autonomous coding tasks end to end in sandboxed environments, self-hosted or in its cloud -- a mature, agent-included alternative to running Symphony's preview daemon.
+
+See [Superset vs OpenHands](/compare/superset-vs-openhands).
+
+### Paperclip
+
+Paperclip generalizes the idea beyond code: agents claim tickets from a goal-driven ledger under budgets and governance, on a self-hosted platform. Heavier than Symphony's daemon, but a shipped management layer rather than a spec.
+
+See [Superset vs Paperclip](/compare/superset-vs-paperclip).
+
+## How To Choose
+
+- For agent-agnostic parallel work with review and scheduled autonomy, choose **Superset**.
+- For packaged CI/review feedback loops, choose **Agent Orchestrator**.
+- For maximum sustained autonomy with a merge queue, choose **Gas Town**.
+- For self-hosted autonomous runs today, choose **OpenHands**.
+- For governed agent teams against goals, choose **Paperclip**.
+
+## Verdict
+
+Symphony's spec is worth reading regardless of what you run -- the ticket-board-as-interface idea is here to stay. But as a tool it is Codex-only, headless, and preview-grade by its own label. Superset is the strongest alternative for teams that want the leverage with visibility and agent choice; Agent Orchestrator and Gas Town are the open-source picks at increasing levels of autonomy. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Symphony alternative?
+
+For most teams, Superset: tracker-fed tasks, any agent, isolated worktrees with review, and scheduled automations -- adoptable today without hardening a preview daemon.
+
+### Is there a Symphony alternative that works with Claude Code?
+
+All of them. Superset, Agent Orchestrator, and Gas Town run Claude Code alongside other agents; Symphony is the only Codex-exclusive tool in the set.
+
+### Can any alternative land PRs autonomously like Symphony?
+
+Gas Town's Refinery merge queue comes closest, landing verified batches automatically. Agent Orchestrator deliberately never auto-merges; Superset routes work through normal PR review.
+
+### Is Symphony production-ready?
+
+By OpenAI's own framing, no -- it is "a low-key engineering preview for testing in trusted environments," with the recommendation to implement a hardened version from the spec.


### PR DESCRIPTION
## What's in here

- **13 new head-to-head compare pages** under `/compare`, covering tools that come up frequently in brand monitoring, community roundups, and user conversations. All content researched fresh from each product's official site, docs, repo, and changelog (2026-08-07) — no model-memory claims.
- **14 new "Best X Alternatives" roundup pages** — the inverse framing for alternative-seeking search queries, following the existing alternatives-page template with cross-links into the head-to-head pages.
- **2 existing pages refreshed** where products had shipped meaningful changes since 2026-07-13; stale framing and numbers corrected, unverifiable claims softened or removed.
- Copy claims cross-checked against our own docs; two unsupported claims in the new pages were corrected as part of the review.

## Validation

- `bun run --cwd apps/marketing typecheck` — clean
- Compare loader smoke test: all 66 slugs parse and resolve
- `bun run lint` — clean
- Every new/updated page rendered via headless Chrome (CDP): tables, headings, FAQ blocks render correctly; no raw markdown artifacts; every internal `/compare/*` cross-link returns 200

## Possible follow-up

- The 2026 roundup page (last touched March) doesn't yet reflect the current landscape; out of scope here.
- Pre-existing site quirks noticed during verification (not from this change): doubled site-name suffix in `<title>`, and "Last updated" renders one day behind the frontmatter date (UTC/PT off-by-one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comparison guides for Superset and numerous coding-agent platforms, covering features, workflows, integrations, pricing, licensing, and use cases.
  * Added roundup guides for alternatives to popular agent orchestration and coding tools.
  * Included selection guidance, verdicts, comparison links, and FAQs to help readers evaluate each option.
* **Content Updates**
  * Refreshed existing comparisons with current capabilities, platform support, automation, remote workflows, and pricing.
  * Improved SEO metadata and comparison tables across the guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->