### PR TITLE
feat(desktop): built-in "Superset CLI" preset in the v2 preset bar

### DIFF
--- a/apps/desktop/plans/20260807-builtin-cli-preset.md
+++ b/apps/desktop/plans/20260807-builtin-cli-preset.md
@@ -1,0 +1,101 @@
+# Built-in "Superset CLI" preset
+
+Ship a synthetic, app-provided preset in every user's preset bar that opens a terminal and
+runs `superset --help`. Goal: teach users the CLI exists at the place they already launch
+things — point-of-use discovery, not an announcement. No agent session, no prompt injection;
+just show the command surface in a real terminal they can keep typing into.
+
+Works out of the box because the bundled CLI shim (`~/.superset/bin/superset`) is already on
+PATH inside every Superset-spawned terminal.
+
+Competitive context: Orca (stablyai) promotes its CLI in 8+ in-app surfaces; our CLI is on
+PATH in every Superset terminal but nothing in the app ever uses or mentions it.
+
+## UX
+
+Preset bar (`V2PresetsBar`), after the user's own presets:
+
+```
+[ ⌘1 claude ] [ ⌘2 codex ] [ ⌘3 run ] │ [ >_ Superset CLI · Built-in ]
+```
+
+- Chip shows a new `superset-cli` icon (terminal glyph) + "Built-in" micro-badge. No numbered
+  hotkey (built-ins sit outside the `OPEN_PRESET_1..9` index).
+- Tooltip: "Script workspaces, agents, and automations from any terminal — agents can use it
+  too."
+- Click → new terminal tab running `superset --help`. The user lands in a live shell with the
+  full command tree printed, cursor ready.
+- Manage dropdown (existing Eye/EyeOff rows): built-in row gets the same visibility toggle,
+  backed by user preferences instead of the preset row (see Data).
+
+Command choice: `superset --help` for v1. Alternatives considered — bare `superset` (same
+output), `superset status` (assumes host running). A follow-on nicety: append one hint line,
+e.g. `superset --help && echo '→ agents in Superset terminals can run these commands too'` —
+decide at implementation.
+
+## Architecture decisions
+
+1. **Synthetic, merged at read time — never a persisted row.** Precedent: the `superset` chat
+   agent in `useV2AgentChoices` (`renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts`).
+   Seeding a real `v2TerminalPresets` row is rejected: it would trip
+   `useDefaultV2TerminalPresets`'s `existingPresets.length > 0` init guard, existing users
+   (already initialized) would never get it, it would be deletable-forever, and the command
+   couldn't be updated later. Merge-at-read also respects the 20260505 learnings doc (no
+   `kind` discriminator on rows — the synthetic never touches the schema).
+2. **Slug id `"superset-cli"`.** Slugs and UUIDs must not collide (`resolveHostAgentConfig`,
+   `portableAgentValue` depend on it).
+3. **Plain command preset — existing launch path.** `commands: ["superset --help"]`, no
+   `agentId`, so `resolvePresetLaunchCommands` uses the command string as-is and
+   `useV2PresetExecution` → `terminal.createSession({ initialCommand })` does the rest. No
+   host-service changes, no agent dependency of any kind.
+
+## Data changes
+
+- `v2UserPreferencesSchema` (+ `DEFAULT_V2_USER_PREFERENCES`), in
+  `CollectionsProvider/dashboardSidebarLocal/schema.ts`: add
+  `hiddenBuiltinPresetIds: string[]` (default `[]`). Bounded (known slug set), singleton —
+  satisfies the localStorage policy. `pinnedToBar` can't be used: `v2TerminalPresets.update()`
+  throws on a row that doesn't exist in the collection.
+- New module `renderer/lib/builtin-presets/` exporting
+  `BUILTIN_CLI_PRESET = { id: "superset-cli", name: "Superset CLI", description,
+  commands: ["superset --help"] }` and `useBuiltinPresets()` (applies feature flag +
+  hidden ids).
+- Icon: new `superset-cli` light/dark SVG in `packages/ui/src/assets/icons/preset-icons/` +
+  key in `PRESET_ICONS`; `resolveV2PresetIconKey` recognizes the synthetic id.
+
+## Edge cases
+
+- **Project-targeted presets:** merge the synthetic AFTER `filterMatchingPresetsForProject`,
+  so it never shadows or suppresses project-scoped auto-apply presets.
+- **v1→v2 migration ledger:** untouched — no row exists, no `agentId`/name collision possible.
+- **Shim missing (`bundled-cli.ts` returned `missing`/`skipped`):** `superset --help` prints
+  command-not-found. Acceptable for v1 — the terminal error is at least honest. The
+  Settings/CLI status surface (separate plan) is the real fix; once that tRPC status exists,
+  the chip can hide or warn when the shim is absent.
+- **Hotkey/sequential code paths:** built-ins are excluded from `getPresetLaunchPlan`
+  sequencing and hotkey indexing; exactly one behavior (click → launch).
+
+## Rollout & telemetry
+
+- Gate on a PostHog flag `BUILTIN_CLI_PRESET` (`FEATURE_FLAGS` in
+  `packages/shared/src/constants.ts`), ramp like `V1_AUTO_MIGRATION`. Experimental-settings
+  toggle rejected: opt-in defeats the discovery purpose.
+- Events: `builtin_preset_launched` (presetId), `builtin_preset_hidden` /
+  `builtin_preset_unhidden`.
+
+## Out of scope (separate plans)
+
+- Settings → CLI section, onboarding "get more" step, desktop notice, Automations-banner
+  dismissal fix (CLI surfacing plan).
+- "Created via CLI" workspace provenance badge.
+- An agent-driven "Orchestrator" built-in preset (launch an agent primed with
+  `superset:orchestrate`) — considered, deferred; requires prompt injection via `agents.run`
+  and an installed-agent dependency. This CLI preset is the v1.
+
+## Build order
+
+1. `hiddenBuiltinPresetIds` preference + `builtin-presets` module + feature flag plumbing.
+2. Icon assets + `resolveV2PresetIconKey` case.
+3. `V2PresetsBar` merge + chip + badge + manage-dropdown visibility row.
+4. Telemetry events; tests (merge logic, hidden ids, no hotkey index shift, project-filter
+   non-interference).

--- a/apps/desktop/plans/20260807-builtin-cli-preset.md
+++ b/apps/desktop/plans/20260807-builtin-cli-preset.md
@@ -14,16 +14,18 @@ beyond one banner on the Automations page.
 Preset bar (`V2PresetsBar`), after the user's own presets:
 
 ```
-[ ⌘1 claude ] [ ⌘2 codex ] [ ⌘3 run ] │ [ >_ Superset CLI · Built-in ]
+[ ⌘1 claude ] [ ⌘2 codex ] [ ⌘3 run ] [ >_ Superset CLI ]
 ```
 
-- Chip shows a new `superset-cli` icon (terminal glyph) + "Built-in" micro-badge. No numbered
-  hotkey (built-ins sit outside the `OPEN_PRESET_1..9` index).
+- Chip looks like any other preset (superset icon + name) — deliberately no "Built-in" badge
+  or divider; it's just a little thing users can remove. No numbered hotkey (built-ins sit
+  outside the `OPEN_PRESET_1..9` index).
 - Tooltip: "Script workspaces, agents, and automations from any terminal — agents can use it
   too."
 - Click → new terminal tab running `superset --help`. The user lands in a live shell with the
   full command tree printed, cursor ready.
-- Manage dropdown (existing Eye/EyeOff rows): built-in row gets the same visibility toggle,
+- Context menu: "Run preset" / "Remove preset" — remove persists to user preferences. The
+  manage dropdown (existing Eye/EyeOff rows) shows the same toggle and can restore it,
   backed by user preferences instead of the preset row (see Data).
 
 Command choice: `superset --help` for v1. Alternatives considered — bare `superset` (same

--- a/apps/desktop/plans/20260807-builtin-cli-preset.md
+++ b/apps/desktop/plans/20260807-builtin-cli-preset.md
@@ -58,8 +58,8 @@ decide at implementation.
   throws on a row that doesn't exist in the collection.
 - New hook `renderer/hooks/useBuiltinPresets/` exporting
   `BUILTIN_CLI_PRESET = { id: "superset-cli", name: "Superset CLI", description,
-  commands: ["superset --help"] }` and `useBuiltinPresets()` (applies feature flag +
-  hidden ids; hidden entries are still returned so manage surfaces can un-hide).
+  commands: ["superset --help"] }` and `useBuiltinPresets()` (applies hidden ids;
+  hidden entries are still returned so manage surfaces can un-hide).
 - Icon: reuse the existing `superset` key in `PRESET_ICONS` via `getPresetIcon("superset",
   isDark)` — no new assets needed.
 
@@ -77,9 +77,11 @@ decide at implementation.
 
 ## Rollout & telemetry
 
-- Gate on a PostHog flag `BUILTIN_CLI_PRESET` (`FEATURE_FLAGS` in
-  `packages/shared/src/constants.ts`), ramp like `V1_AUTO_MIGRATION`. Experimental-settings
-  toggle rejected: opt-in defeats the discovery purpose.
+- Always-on, no feature flag. Considered and rejected: the blast radius is a small hideable
+  chip whose dismissal persists (that IS the per-user rollback), a flag adds create/cleanup
+  overhead, and flag-unloaded-means-hidden would hide a discovery feature from offline users
+  in a local-first product. Global rollback = one-line revert. An experimental-settings
+  toggle was also rejected: opt-in defeats the discovery purpose.
 - Events: `builtin_preset_launched` (presetId), `builtin_preset_hidden` /
   `builtin_preset_unhidden`.
 
@@ -94,7 +96,7 @@ decide at implementation.
 
 ## Build order
 
-1. `hiddenBuiltinPresetIds` preference + `builtin-presets` module + feature flag plumbing.
+1. `hiddenBuiltinPresetIds` preference + `builtin-presets` module.
 2. Icon assets + `resolveV2PresetIconKey` case.
 3. `V2PresetsBar` merge + chip + badge + manage-dropdown visibility row.
 4. Telemetry events; tests (merge logic, hidden ids, no hotkey index shift, project-filter

--- a/apps/desktop/plans/20260807-builtin-cli-preset.md
+++ b/apps/desktop/plans/20260807-builtin-cli-preset.md
@@ -6,10 +6,8 @@ things — point-of-use discovery, not an announcement. No agent session, no pro
 just show the command surface in a real terminal they can keep typing into.
 
 Works out of the box because the bundled CLI shim (`~/.superset/bin/superset`) is already on
-PATH inside every Superset-spawned terminal.
-
-Competitive context: Orca (stablyai) promotes its CLI in 8+ in-app surfaces; our CLI is on
-PATH in every Superset terminal but nothing in the app ever uses or mentions it.
+PATH inside every Superset-spawned terminal — yet nothing in the app ever uses or mentions it
+beyond one banner on the Automations page.
 
 ## UX
 
@@ -56,12 +54,12 @@ decide at implementation.
   `hiddenBuiltinPresetIds: string[]` (default `[]`). Bounded (known slug set), singleton —
   satisfies the localStorage policy. `pinnedToBar` can't be used: `v2TerminalPresets.update()`
   throws on a row that doesn't exist in the collection.
-- New module `renderer/lib/builtin-presets/` exporting
+- New hook `renderer/hooks/useBuiltinPresets/` exporting
   `BUILTIN_CLI_PRESET = { id: "superset-cli", name: "Superset CLI", description,
   commands: ["superset --help"] }` and `useBuiltinPresets()` (applies feature flag +
-  hidden ids).
-- Icon: new `superset-cli` light/dark SVG in `packages/ui/src/assets/icons/preset-icons/` +
-  key in `PRESET_ICONS`; `resolveV2PresetIconKey` recognizes the synthetic id.
+  hidden ids; hidden entries are still returned so manage surfaces can un-hide).
+- Icon: reuse the existing `superset` key in `PRESET_ICONS` via `getPresetIcon("superset",
+  isDark)` — no new assets needed.
 
 ## Edge cases
 

--- a/apps/desktop/plans/20260807-builtin-cli-preset.md
+++ b/apps/desktop/plans/20260807-builtin-cli-preset.md
@@ -96,8 +96,9 @@ decide at implementation.
 
 ## Build order
 
-1. `hiddenBuiltinPresetIds` preference + `builtin-presets` module.
-2. Icon assets + `resolveV2PresetIconKey` case.
-3. `V2PresetsBar` merge + chip + badge + manage-dropdown visibility row.
-4. Telemetry events; tests (merge logic, hidden ids, no hotkey index shift, project-filter
-   non-interference).
+1. `hiddenBuiltinPresetIds` preference (heal-time pruning against
+   `KNOWN_BUILTIN_PRESET_IDS`) + `builtin-presets` module.
+2. `V2PresetsBar` merge + chip (existing `superset` icon via `getPresetIcon`) +
+   manage-dropdown visibility row.
+3. Telemetry events; tests (merge logic, hidden ids, heal pruning, no hotkey index shift,
+   project-filter non-interference).

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/index.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/index.ts
@@ -1,0 +1,1 @@
+export * from "./useBuiltinPresets";

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.test.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import {
+	BUILTIN_CLI_PRESET,
+	BUILTIN_CLI_PRESET_ID,
+	getBuiltinPresetEntries,
+} from "./useBuiltinPresets";
+
+describe("getBuiltinPresetEntries", () => {
+	it("returns nothing when the flag is off or not yet loaded", () => {
+		expect(getBuiltinPresetEntries(false, [])).toEqual([]);
+		expect(getBuiltinPresetEntries(undefined, [])).toEqual([]);
+	});
+
+	it("returns the CLI preset as visible when not hidden", () => {
+		const entries = getBuiltinPresetEntries(true, []);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].preset.id).toBe(BUILTIN_CLI_PRESET_ID);
+		expect(entries[0].isVisible).toBe(true);
+	});
+
+	it("keeps hidden presets in the list but marks them not visible", () => {
+		const entries = getBuiltinPresetEntries(true, [BUILTIN_CLI_PRESET_ID]);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].isVisible).toBe(false);
+	});
+
+	it("ignores unrelated hidden ids", () => {
+		const entries = getBuiltinPresetEntries(true, ["some-other-id"]);
+		expect(entries[0].isVisible).toBe(true);
+	});
+});
+
+describe("BUILTIN_CLI_PRESET", () => {
+	it("is a plain command preset with no agent link", () => {
+		// No agentId: resolvePresetLaunchCommands must fall back to `commands`,
+		// and preset-icon resolution must not bind it to a host agent config.
+		expect(BUILTIN_CLI_PRESET.agentId).toBeUndefined();
+		expect(BUILTIN_CLI_PRESET.commands).toEqual(["superset --help"]);
+		expect(BUILTIN_CLI_PRESET.executionMode).toBe("new-tab");
+	});
+
+	it("uses a slug id outside the UUID namespace of user rows", () => {
+		expect(BUILTIN_CLI_PRESET.id).toBe("superset-cli");
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.test.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.test.ts
@@ -6,26 +6,21 @@ import {
 } from "./useBuiltinPresets";
 
 describe("getBuiltinPresetEntries", () => {
-	it("returns nothing when the flag is off or not yet loaded", () => {
-		expect(getBuiltinPresetEntries(false, [])).toEqual([]);
-		expect(getBuiltinPresetEntries(undefined, [])).toEqual([]);
-	});
-
 	it("returns the CLI preset as visible when not hidden", () => {
-		const entries = getBuiltinPresetEntries(true, []);
+		const entries = getBuiltinPresetEntries([]);
 		expect(entries).toHaveLength(1);
 		expect(entries[0].preset.id).toBe(BUILTIN_CLI_PRESET_ID);
 		expect(entries[0].isVisible).toBe(true);
 	});
 
 	it("keeps hidden presets in the list but marks them not visible", () => {
-		const entries = getBuiltinPresetEntries(true, [BUILTIN_CLI_PRESET_ID]);
+		const entries = getBuiltinPresetEntries([BUILTIN_CLI_PRESET_ID]);
 		expect(entries).toHaveLength(1);
 		expect(entries[0].isVisible).toBe(false);
 	});
 
 	it("ignores unrelated hidden ids", () => {
-		const entries = getBuiltinPresetEntries(true, ["some-other-id"]);
+		const entries = getBuiltinPresetEntries(["some-other-id"]);
 		expect(entries[0].isVisible).toBe(true);
 	});
 });

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
@@ -1,0 +1,58 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useMemo } from "react";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+
+export const BUILTIN_CLI_PRESET_ID = "superset-cli";
+
+// Synthetic app-shipped preset merged into the preset bar at read time — never
+// inserted into the v2TerminalPresets collection, so it can't trip the
+// first-run seeding guard or the agent→preset dedupe, and it stays updatable
+// across releases. Slug-shaped id: user preset rows use UUIDs, so the
+// namespaces can't collide.
+export const BUILTIN_CLI_PRESET: V2TerminalPresetRow = {
+	id: BUILTIN_CLI_PRESET_ID,
+	name: "Superset CLI",
+	description:
+		"Script workspaces, agents, and automations from any terminal — agents in Superset terminals can use it too.",
+	cwd: "",
+	commands: ["superset --help"],
+	projectIds: null,
+	executionMode: "new-tab",
+	tabOrder: Number.MAX_SAFE_INTEGER,
+	createdAt: new Date(0),
+};
+
+export interface BuiltinPresetEntry {
+	preset: V2TerminalPresetRow;
+	isVisible: boolean;
+}
+
+export function getBuiltinPresetEntries(
+	flagEnabled: boolean | undefined,
+	hiddenBuiltinPresetIds: readonly string[],
+): BuiltinPresetEntry[] {
+	if (!flagEnabled) return [];
+	return [
+		{
+			preset: BUILTIN_CLI_PRESET,
+			isVisible: !hiddenBuiltinPresetIds.includes(BUILTIN_CLI_PRESET_ID),
+		},
+	];
+}
+
+/**
+ * Built-in presets to render alongside user presets. Hidden entries are still
+ * returned (isVisible: false) so manage surfaces can offer un-hiding; bar
+ * surfaces should filter on isVisible.
+ */
+export function useBuiltinPresets(): BuiltinPresetEntry[] {
+	const flagEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.BUILTIN_CLI_PRESET);
+	const { preferences } = useV2UserPreferences();
+	return useMemo(
+		() =>
+			getBuiltinPresetEntries(flagEnabled, preferences.hiddenBuiltinPresetIds),
+		[flagEnabled, preferences.hiddenBuiltinPresetIds],
+	);
+}

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
@@ -1,8 +1,13 @@
 import { useMemo } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import type { KNOWN_BUILTIN_PRESET_IDS } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
-export const BUILTIN_CLI_PRESET_ID = "superset-cli";
+// Membership in KNOWN_BUILTIN_PRESET_IDS is compile-checked: the preference
+// heal prunes hidden ids against that list, so an id missing from it would
+// have its hidden state silently dropped.
+export const BUILTIN_CLI_PRESET_ID =
+	"superset-cli" satisfies (typeof KNOWN_BUILTIN_PRESET_IDS)[number];
 
 // Synthetic app-shipped preset merged into the preset bar at read time — never
 // inserted into the v2TerminalPresets collection, so it can't trip the

--- a/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
+++ b/apps/desktop/src/renderer/hooks/useBuiltinPresets/useBuiltinPresets.ts
@@ -1,5 +1,3 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
@@ -30,10 +28,8 @@ export interface BuiltinPresetEntry {
 }
 
 export function getBuiltinPresetEntries(
-	flagEnabled: boolean | undefined,
 	hiddenBuiltinPresetIds: readonly string[],
 ): BuiltinPresetEntry[] {
-	if (!flagEnabled) return [];
 	return [
 		{
 			preset: BUILTIN_CLI_PRESET,
@@ -48,11 +44,9 @@ export function getBuiltinPresetEntries(
  * surfaces should filter on isVisible.
  */
 export function useBuiltinPresets(): BuiltinPresetEntry[] {
-	const flagEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.BUILTIN_CLI_PRESET);
 	const { preferences } = useV2UserPreferences();
 	return useMemo(
-		() =>
-			getBuiltinPresetEntries(flagEnabled, preferences.hiddenBuiltinPresetIds),
-		[flagEnabled, preferences.hiddenBuiltinPresetIds],
+		() => getBuiltinPresetEntries(preferences.hiddenBuiltinPresetIds),
+		[preferences.hiddenBuiltinPresetIds],
 	);
 }

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -213,7 +213,9 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 				? prev.includes(presetId)
 					? prev
 					: [...prev, presetId]
-				: prev.filter((id) => id !== presetId);
+				: prev.includes(presetId)
+					? prev.filter((id) => id !== presetId)
+					: prev;
 			if (next === prev) return;
 			if (!existing) {
 				collections.v2UserPreferences.insert({

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -24,6 +24,7 @@ export interface V2UserPreferencesApi {
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean | ((prev: boolean) => boolean)) => void;
 	toggleShowPresetsBar: () => void;
+	setBuiltinPresetHidden: (presetId: string, hidden: boolean) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -200,6 +201,34 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setShowPresetsBar((prev) => !prev);
 	}, [setShowPresetsBar]);
 
+	const setBuiltinPresetHidden = useCallback(
+		(presetId: string, hidden: boolean) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			const prev =
+				existing?.hiddenBuiltinPresetIds ??
+				DEFAULT_V2_USER_PREFERENCES.hiddenBuiltinPresetIds;
+			const next = hidden
+				? prev.includes(presetId)
+					? prev
+					: [...prev, presetId]
+				: prev.filter((id) => id !== presetId);
+			if (next === prev) return;
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					hiddenBuiltinPresetIds: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.hiddenBuiltinPresetIds = next;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -212,5 +241,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setDeleteLocalBranch,
 		setShowPresetsBar,
 		toggleShowPresetsBar,
+		setBuiltinPresetHidden,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -308,9 +308,6 @@ export function V2PresetsBar({
 								)}
 								<span className="min-w-0 flex-1 truncate">{preset.name}</span>
 								<div className="ml-auto flex items-center gap-2">
-									<span className="text-[10px] text-muted-foreground/70">
-										Built-in
-									</span>
 									{isVisible ? (
 										<Eye className="size-3.5 text-foreground" />
 									) : (
@@ -358,9 +355,6 @@ export function V2PresetsBar({
 				);
 			})}
 			{/* Built-ins render after user presets, outside the hotkey index. */}
-			{visibleBuiltinPresets.length > 0 && visiblePresets.length > 0 ? (
-				<div className="h-4 w-px shrink-0 bg-border" />
-			) : null}
 			{visibleBuiltinPresets.map(({ preset }) => (
 				<BuiltinPresetBarItem
 					key={preset.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -12,14 +12,21 @@ import { useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff, Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiMiniCommandLine } from "react-icons/hi2";
-import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
+import { useBuiltinPresets } from "renderer/hooks/useBuiltinPresets";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import type { HotkeyId } from "renderer/hotkeys";
+import { posthog } from "renderer/lib/posthog";
 import { resolveV2PresetIcon } from "renderer/lib/preset-icon";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { BuiltinPresetBarItem } from "./components/BuiltinPresetBarItem";
 import { V2PresetBarItem } from "./components/V2PresetBarItem";
 
 interface V2PresetsBarProps {
@@ -74,6 +81,8 @@ export function V2PresetsBar({
 	const collections = useCollections();
 	const { activeHostUrl } = useLocalHostService();
 	const { data: agents } = useV2AgentConfigs(activeHostUrl);
+	const builtinPresets = useBuiltinPresets();
+	const { setBuiltinPresetHidden } = useV2UserPreferences();
 
 	const [localVisiblePresetIds, setLocalVisiblePresetIds] = useState<string[]>(
 		() => getVisiblePresetOrder(matchedPresets),
@@ -124,6 +133,11 @@ export function V2PresetsBar({
 				]),
 			),
 		[visiblePresets],
+	);
+
+	const visibleBuiltinPresets = useMemo(
+		() => builtinPresets.filter((entry) => entry.isVisible),
+		[builtinPresets],
 	);
 
 	const handleEditPreset = useCallback(
@@ -192,6 +206,27 @@ export function V2PresetsBar({
 		[collections.v2TerminalPresets],
 	);
 
+	// Built-in presets have no collection row: visibility lives in user
+	// preferences, and launches are worth tracking to measure discovery.
+	const handleToggleBuiltinVisibility = useCallback(
+		(presetId: string, nextVisible: boolean) => {
+			setBuiltinPresetHidden(presetId, !nextVisible);
+			posthog.capture(
+				nextVisible ? "builtin_preset_unhidden" : "builtin_preset_hidden",
+				{ presetId },
+			);
+		},
+		[setBuiltinPresetHidden],
+	);
+
+	const handleExecuteBuiltinPreset = useCallback(
+		(preset: V2TerminalPresetRow) => {
+			posthog.capture("builtin_preset_launched", { presetId: preset.id });
+			void executePreset(preset);
+		},
+		[executePreset],
+	);
+
 	return (
 		<div
 			className="flex h-10 min-w-0 shrink-0 items-center gap-1.5 overflow-x-auto overflow-y-hidden bg-background px-2"
@@ -251,6 +286,40 @@ export function V2PresetsBar({
 							</DropdownMenuItem>
 						);
 					})}
+					{builtinPresets.map(({ preset, isVisible }) => {
+						const builtinIcon = getPresetIcon("superset", isDark);
+						return (
+							<DropdownMenuItem
+								key={preset.id}
+								className="gap-2"
+								onSelect={(event) => {
+									event.preventDefault();
+									handleToggleBuiltinVisibility(preset.id, !isVisible);
+								}}
+							>
+								{builtinIcon ? (
+									<img
+										src={builtinIcon}
+										alt=""
+										className="size-4 object-contain"
+									/>
+								) : (
+									<HiMiniCommandLine className="size-4" />
+								)}
+								<span className="min-w-0 flex-1 truncate">{preset.name}</span>
+								<div className="ml-auto flex items-center gap-2">
+									<span className="text-[10px] text-muted-foreground/70">
+										Built-in
+									</span>
+									{isVisible ? (
+										<Eye className="size-3.5 text-foreground" />
+									) : (
+										<EyeOff className="size-3.5 text-muted-foreground/60" />
+									)}
+								</div>
+							</DropdownMenuItem>
+						);
+					})}
 					<DropdownMenuSeparator />
 					<DropdownMenuCheckboxItem
 						checked={showPresetsBar}
@@ -288,6 +357,19 @@ export function V2PresetsBar({
 					/>
 				);
 			})}
+			{/* Built-ins render after user presets, outside the hotkey index. */}
+			{visibleBuiltinPresets.length > 0 && visiblePresets.length > 0 ? (
+				<div className="h-4 w-px shrink-0 bg-border" />
+			) : null}
+			{visibleBuiltinPresets.map(({ preset }) => (
+				<BuiltinPresetBarItem
+					key={preset.id}
+					preset={preset}
+					isDark={isDark}
+					onExecutePreset={handleExecuteBuiltinPreset}
+					onHide={(presetId) => handleToggleBuiltinVisibility(presetId, false)}
+				/>
+			))}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/BuiltinPresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/BuiltinPresetBarItem.tsx
@@ -19,8 +19,8 @@ interface BuiltinPresetBarItemProps {
 }
 
 // Built-in presets have no v2TerminalPresets row, so unlike V2PresetBarItem
-// they are not draggable (nothing to persist), not editable, and hide via
-// user preferences instead of the row's pinnedToBar.
+// they are not draggable (nothing to persist), not editable, and "Remove"
+// persists to user preferences instead of the row's pinnedToBar.
 export function BuiltinPresetBarItem({
 	preset,
 	isDark,
@@ -38,7 +38,7 @@ export function BuiltinPresetBarItem({
 							<Button
 								variant="ghost"
 								size="sm"
-								className="h-6 max-w-44 min-w-0 shrink-0 gap-1.5 rounded-md px-1.5 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+								className="h-6 max-w-32 min-w-0 shrink-0 gap-1.5 rounded-md px-1.5 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
 								onClick={() => onExecutePreset(preset)}
 							>
 								{icon ? (
@@ -51,9 +51,6 @@ export function BuiltinPresetBarItem({
 									<HiMiniCommandLine className="size-3.5 shrink-0" />
 								)}
 								<span className="min-w-0 truncate">{preset.name}</span>
-								<span className="shrink-0 rounded border border-border px-1 text-[9px] leading-3.5 text-muted-foreground/70">
-									Built-in
-								</span>
 							</Button>
 						</TooltipTrigger>
 						{preset.description ? (
@@ -70,7 +67,7 @@ export function BuiltinPresetBarItem({
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem onSelect={() => onHide(preset.id)}>
-					Hide from bar
+					Remove preset
 				</ContextMenuItem>
 			</ContextMenuContent>
 		</ContextMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/BuiltinPresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/BuiltinPresetBarItem.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@superset/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { HiMiniCommandLine } from "react-icons/hi2";
+import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+
+interface BuiltinPresetBarItemProps {
+	preset: V2TerminalPresetRow;
+	isDark: boolean;
+	onExecutePreset: (preset: V2TerminalPresetRow) => void;
+	onHide: (presetId: string) => void;
+}
+
+// Built-in presets have no v2TerminalPresets row, so unlike V2PresetBarItem
+// they are not draggable (nothing to persist), not editable, and hide via
+// user preferences instead of the row's pinnedToBar.
+export function BuiltinPresetBarItem({
+	preset,
+	isDark,
+	onExecutePreset,
+	onHide,
+}: BuiltinPresetBarItemProps) {
+	const icon = getPresetIcon("superset", isDark);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<div>
+					<Tooltip delayDuration={700}>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-6 max-w-44 min-w-0 shrink-0 gap-1.5 rounded-md px-1.5 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+								onClick={() => onExecutePreset(preset)}
+							>
+								{icon ? (
+									<img
+										src={icon}
+										alt=""
+										className="size-3.5 shrink-0 object-contain opacity-90"
+									/>
+								) : (
+									<HiMiniCommandLine className="size-3.5 shrink-0" />
+								)}
+								<span className="min-w-0 truncate">{preset.name}</span>
+								<span className="shrink-0 rounded border border-border px-1 text-[9px] leading-3.5 text-muted-foreground/70">
+									Built-in
+								</span>
+							</Button>
+						</TooltipTrigger>
+						{preset.description ? (
+							<TooltipContent side="bottom" className="max-w-64">
+								{preset.description}
+							</TooltipContent>
+						) : null}
+					</Tooltip>
+				</div>
+			</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItem onSelect={() => onExecutePreset(preset)}>
+					Run preset
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={() => onHide(preset.id)}>
+					Hide from bar
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/BuiltinPresetBarItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./BuiltinPresetBarItem";

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -340,10 +340,15 @@ export const v2UserPreferencesSchema = z.object({
 	showPresetsBar: z.boolean().default(true),
 	// Built-in (synthetic, app-shipped) presets the user hid from the preset
 	// bar. Synthetic presets have no v2TerminalPresets row, so visibility can't
-	// live on the row's pinnedToBar like user presets. Bounded by the fixed set
-	// of built-in preset ids.
+	// live on the row's pinnedToBar like user presets. Pruned against
+	// KNOWN_BUILTIN_PRESET_IDS at heal time so retired ids can't persist.
 	hiddenBuiltinPresetIds: z.array(z.string()).default([]),
 });
+
+// The fixed set of built-in preset ids. Consumers derive their id constants
+// from this list (compile-checked via `satisfies`) so the heal-time pruning
+// below can never drop an id that is still in use.
+export const KNOWN_BUILTIN_PRESET_IDS = ["superset-cli"] as const;
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
 
@@ -430,6 +435,13 @@ export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
 		sidebarFileLinks: shouldMigrateLegacySidebarFileLinks
 			? DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks
 			: sidebarFileLinks,
+		// Prune retired/stray built-in ids so the array stays bounded.
+		hiddenBuiltinPresetIds: (Array.isArray(r.hiddenBuiltinPresetIds)
+			? r.hiddenBuiltinPresetIds
+			: []
+		).filter((id) =>
+			(KNOWN_BUILTIN_PRESET_IDS as readonly string[]).includes(id),
+		),
 	};
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -338,6 +338,11 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	// Built-in (synthetic, app-shipped) presets the user hid from the preset
+	// bar. Synthetic presets have no v2TerminalPresets row, so visibility can't
+	// live on the row's pinnedToBar like user presets. Bounded by the fixed set
+	// of built-in preset ids.
+	hiddenBuiltinPresetIds: z.array(z.string()).default([]),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -356,6 +361,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	hiddenBuiltinPresetIds: [],
 };
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
@@ -288,3 +288,21 @@ describe("withReadHeal end-to-end via real localStorageCollectionOptions", () =>
 		expect(row?.sidebarState.isHidden).toBe(false);
 	});
 });
+
+describe("healV2UserPreferences hiddenBuiltinPresetIds pruning", () => {
+	it("drops ids that are not known built-in presets", () => {
+		const healed = healV2UserPreferences({
+			id: "preferences",
+			hiddenBuiltinPresetIds: ["superset-cli", "retired-preset"],
+		});
+		expect(healed.hiddenBuiltinPresetIds).toEqual(["superset-cli"]);
+	});
+
+	it("defaults a malformed value to an empty array", () => {
+		const healed = healV2UserPreferences({
+			id: "preferences",
+			hiddenBuiltinPresetIds: "superset-cli",
+		});
+		expect(healed.hiddenBuiltinPresetIds).toEqual([]);
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -123,6 +123,13 @@ export const FEATURE_FLAGS = {
 	 */
 	V1_AUTO_MIGRATION: "v1-auto-migration",
 	/**
+	 * Shows the built-in "Superset CLI" preset in the v2 preset bar — a
+	 * synthetic preset that opens a terminal running `superset --help` so users
+	 * discover the bundled CLI. Percentage ramp; off, unloaded, or offline all
+	 * mean "don't show".
+	 */
+	BUILTIN_CLI_PRESET: "builtin-cli-preset",
+	/**
 	 * Shows the "We're Hiring" card in the dashboard sidebar. Targets a static
 	 * PostHog cohort of users who have created 10+ workspaces all-time, which is
 	 * the only place that history exists — workspace rows are hard-deleted, so a

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -123,13 +123,6 @@ export const FEATURE_FLAGS = {
 	 */
 	V1_AUTO_MIGRATION: "v1-auto-migration",
 	/**
-	 * Shows the built-in "Superset CLI" preset in the v2 preset bar — a
-	 * synthetic preset that opens a terminal running `superset --help` so users
-	 * discover the bundled CLI. Percentage ramp; off, unloaded, or offline all
-	 * mean "don't show".
-	 */
-	BUILTIN_CLI_PRESET: "builtin-cli-preset",
-	/**
 	 * Shows the "We're Hiring" card in the dashboard sidebar. Targets a static
 	 * PostHog cohort of users who have created 10+ workspaces all-time, which is
 	 * the only place that history exists — workspace rows are hard-deleted, so a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in **Superset CLI** preset to the workspace preset bar.
  * Launches `superset --help` in a terminal without requiring an agent or hotkey.
  * Built-in presets can be hidden or restored through user preferences.
  * Added tooltips and launch actions for built-in presets.
  * Built-in presets remain separate from user-created presets and cannot be edited or rearranged.

* **Bug Fixes**
  * Preset visibility preferences are saved reliably and preserved across sessions.
  * Invalid preset visibility settings are automatically cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->