### PR TITLE
feat(marketing): add how-it-works, install CTA, security section, and hiring pill to homepage

### DIFF
--- a/apps/marketing/content/compare/best-ai-coding-agents-2026.mdx
+++ b/apps/marketing/content/compare/best-ai-coding-agents-2026.mdx
@@ -62,7 +62,7 @@ These center the editing environment itself:
 
 These tools run and manage multiple agents:
 
-- **Superset** — Local-first workspace that runs 10+ agents in parallel via Git worktrees
+- **Superset** — Local-first workspace that runs 100+ agents in parallel via Git worktrees
 - **Capy** — Hosted parallel-agent platform with isolated environments
 - **Conductor** — macOS app for running Claude Code and Codex in parallel
 
@@ -93,7 +93,7 @@ Most serious workflows now use one tool from more than one layer. The agent does
 
 Superset is the strongest option if your main problem is coordination rather than model quality. It runs AI coding agents in isolated Git worktrees so you can dispatch many tasks at once, review diffs independently, preview local apps in a built-in browser, and merge only what you want. It now also has a first-party chat panel, Superset Chat as a built-in agent option, a file editor, and an MCP server, so it feels less like a thin terminal wrapper and more like a local-first workspace around agents like Claude Code, Codex, OpenCode, or Aider. The shipped product should still be evaluated as local-first today, even if the repo direction clearly suggests future cloud or remote-workspace expansion.
 
-**Best for:** Running 5-10+ agents in parallel, agent-agnostic teams, local reviewable workflows, browser/chat/review in one app
+**Best for:** Running 5-100+ agents in parallel, agent-agnostic teams, local reviewable workflows, browser/chat/review in one app
 
 ### Claude Code
 

--- a/apps/marketing/content/compare/superset-vs-aider.mdx
+++ b/apps/marketing/content/compare/superset-vs-aider.mdx
@@ -24,7 +24,7 @@ Aider is one of the most popular open-source AI pair programmers — a single, f
 |---|---|---|
 | **Category** | Agent orchestration workspace | Terminal AI pair programmer |
 | **AI approach** | Agent-agnostic — runs Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Model-agnostic — Claude, GPT, Gemini, DeepSeek, or local models |
-| **Parallelism** | Core feature — 10+ agents across isolated Git worktrees | One interactive session per terminal |
+| **Parallelism** | Core feature — 100+ agents across isolated Git worktrees | One interactive session per terminal |
 | **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Command-line REPL in your terminal |
 | **Git model** | Isolated worktree per task | Auto-commits to your current branch |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source (Apache-2.0); bring your own API keys |

--- a/apps/marketing/content/compare/superset-vs-claude-code.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-code.mdx
@@ -24,7 +24,7 @@ Claude Code is Anthropic's AI coding agent, with both terminal and desktop app s
 | | **Superset** | **Claude Code** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding agent (CLI + desktop app) |
-| **What it does** | Runs 10+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and debugs code in your terminal or desktop app |
+| **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and debugs code in your terminal or desktop app |
 | **AI approach** | Agent-agnostic — orchestrates Claude Code, Codex, Aider, OpenCode, Superset Chat, and more | Claude models only (Sonnet, Opus, Haiku) via Anthropic API |
 | **Parallelism** | Core feature — many agents on separate branches simultaneously | Single session; requires separate terminal tabs for parallelism |
 | **Isolation** | Automatic Git worktree per task — agents cannot conflict | Shares your working directory — manual worktree setup needed |
@@ -57,7 +57,7 @@ With Claude Code alone, whether from the CLI or the Desktop app, you are still m
 
 ### Automatic Isolation
 
-Running Claude Code directly, it modifies files in your current directory. If you start two Claude Code instances in the same directory, they'll overwrite each other's changes. Superset creates a separate Git worktree per task, giving each Claude Code instance an isolated copy of the repository. This is what makes running 10+ agents at once safe.
+Running Claude Code directly, it modifies files in your current directory. If you start two Claude Code instances in the same directory, they'll overwrite each other's changes. Superset creates a separate Git worktree per task, giving each Claude Code instance an isolated copy of the repository. This is what makes running 100+ agents at once safe.
 
 ### Agent Flexibility
 

--- a/apps/marketing/content/compare/superset-vs-cline.mdx
+++ b/apps/marketing/content/compare/superset-vs-cline.mdx
@@ -25,7 +25,7 @@ Cline is a popular open-source autonomous coding agent that lives inside VS Code
 | **Category** | Agent orchestration workspace | In-editor autonomous agent |
 | **Home** | Standalone desktop app | VS Code (and forks) extension |
 | **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic — Anthropic, OpenRouter, Bedrock, and more via your keys |
-| **Parallelism** | Core feature — 10+ agents across isolated Git worktrees | One agent per editor window/session |
+| **Parallelism** | Core feature — 100+ agents across isolated Git worktrees | One agent per editor window/session |
 | **Isolation** | Git worktree per task | Works in your open workspace folder |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source; bring your own API keys |
 
@@ -51,7 +51,7 @@ Cline is embedded in VS Code — its context is your open editor window. Superse
 
 ### One Agent vs Many in Parallel
 
-Cline runs one agent session per editor window. Superset is built to run 10+ agents at once, each isolated in its own Git worktree, so parallel tasks never collide over the same files or branch. That is the difference between an in-editor assistant and a multi-agent orchestrator.
+Cline runs one agent session per editor window. Superset is built to run 100+ agents at once, each isolated in its own Git worktree, so parallel tasks never collide over the same files or branch. That is the difference between an in-editor assistant and a multi-agent orchestrator.
 
 ### Worktree Isolation
 

--- a/apps/marketing/content/compare/superset-vs-codex.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex.mdx
@@ -24,7 +24,7 @@ Codex CLI is OpenAI's terminal-based coding agent, but it now sits inside a broa
 | | **Superset** | **Codex CLI** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding agent (terminal-native) |
-| **What it does** | Runs 10+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and executes code via OpenAI models |
+| **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and executes code via OpenAI models |
 | **AI approach** | Agent-agnostic — works with Codex, Claude Code, Aider, OpenCode, Superset Chat, and more | OpenAI's Codex model family and related OpenAI coding workflows |
 | **Parallelism** | Core feature — many agents on separate branches simultaneously | Single session; cloud Codex runs tasks remotely |
 | **Isolation** | Automatic Git worktree per task | Sandbox modes (network-disabled, full-auto) per session |

--- a/apps/marketing/content/compare/superset-vs-github-copilot.mdx
+++ b/apps/marketing/content/compare/superset-vs-github-copilot.mdx
@@ -24,7 +24,7 @@ GitHub Copilot is an AI pair programmer that lives inside your editor, offering 
 | | **Superset** | **GitHub Copilot** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI pair programmer (editor extension) |
-| **What it does** | Runs 10+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Inline code completions, chat, and Copilot Agent mode in your editor |
+| **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Inline code completions, chat, and Copilot Agent mode in your editor |
 | **AI approach** | Agent-agnostic — orchestrates any CLI agent | Multiple frontier models (Claude, GPT, Gemini) via GitHub |
 | **Parallelism** | Core feature — many agents on separate branches simultaneously | In-editor agent mode; cloud coding agent runs on a branch and opens a PR |
 | **Editor** | Works alongside any editor | VS Code, JetBrains, Visual Studio, Neovim (extension) |

--- a/apps/marketing/content/compare/superset-vs-opencode.mdx
+++ b/apps/marketing/content/compare/superset-vs-opencode.mdx
@@ -23,7 +23,7 @@ OpenCode is a coding agent -- a single AI assistant that reads, writes, and debu
 | | **Superset** | **OpenCode** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding agent (terminal-native) |
-| **What it does** | Runs 10+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant for writing, debugging, and refactoring code |
+| **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant for writing, debugging, and refactoring code |
 | **AI approach** | Agent-agnostic -- orchestrates external agents plus Superset Chat | Model-agnostic -- 75+ providers including local models |
 | **Parallelism** | Core feature -- many agents on separate branches | Single-session; multi-session recently added |
 | **Pricing** | Free tier + Pro $20/seat/mo, source-available (ELv2) | Free, open source (MIT); pay for API usage or use Zen |

--- a/apps/marketing/content/compare/superset-vs-openhands.mdx
+++ b/apps/marketing/content/compare/superset-vs-openhands.mdx
@@ -25,7 +25,7 @@ OpenHands (formerly OpenDevin) is an open-source platform for autonomous AI soft
 | **Category** | Agent orchestration workspace | Autonomous agent platform |
 | **Execution** | Local Git worktrees on your machine | Sandboxed runtime (Docker) or OpenHands Cloud |
 | **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic agent framework (via LiteLLM) |
-| **Parallelism** | Core feature — 10+ agents across isolated worktrees | Multiple sessions, typically one sandbox per task |
+| **Parallelism** | Core feature — 100+ agents across isolated worktrees | Multiple sessions, typically one sandbox per task |
 | **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Web UI / CLI over a sandboxed agent |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Open source (MIT) to self-host; Cloud is usage-based |
 
@@ -81,7 +81,7 @@ OpenHands is open source under MIT, so self-hosting is free apart from the model
 
 **Choose Superset if you:**
 - Want to run your existing CLI agents locally, in isolated Git worktrees
-- Need 10+ agents in parallel with no container runtime to manage
+- Need 100+ agents in parallel with no container runtime to manage
 - Want a desktop workspace with diff review, chat, browser preview, and MCP
 - Prefer agent choice and editor independence over one autonomous engine
 

--- a/apps/marketing/content/compare/superset-vs-t3-chat.mdx
+++ b/apps/marketing/content/compare/superset-vs-t3-chat.mdx
@@ -23,7 +23,7 @@ T3 Chat and Superset both help developers work with AI, but they sit at differen
 | | **Superset** | **T3 Chat** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | Multi-model AI chat app |
-| **What it does** | Runs 10+ coding agents in parallel with Git worktrees, built-in chat, diff/file review, and browser preview | Lets you chat with multiple frontier models from one hosted interface |
+| **What it does** | Runs 100+ coding agents in parallel with Git worktrees, built-in chat, diff/file review, and browser preview | Lets you chat with multiple frontier models from one hosted interface |
 | **AI approach** | Agent-agnostic orchestration plus Superset Chat and MCP tools | Hosted chat surface with model switching, search, attachments, and profiles |
 | **Execution model** | Local agents can read, edit, and run code in your repo | Chat-first workflow; useful for questions, planning, and pasted context |
 | **Parallelism** | Core feature — many agents across isolated worktrees | Conversation-based, not agent orchestration |

--- a/apps/marketing/content/compare/superset-vs-warp.mdx
+++ b/apps/marketing/content/compare/superset-vs-warp.mdx
@@ -33,7 +33,7 @@ Superset and Warp both help developers work with AI around the command line, but
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. You spin up 10+ agents on separate tasks simultaneously, each in its own Git worktree with a dedicated branch and working directory. Around that core, Superset adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. Superset ships no required model layer — you can bring Claude Code, Codex, Aider, OpenCode, or other agents, and you can review inside Superset or jump into your editor of choice. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. You spin up 100+ agents on separate tasks simultaneously, each in its own Git worktree with a dedicated branch and working directory. Around that core, Superset adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. Superset ships no required model layer — you can bring Claude Code, Codex, Aider, OpenCode, or other agents, and you can review inside Superset or jump into your editor of choice. Source-available under Elastic License 2.0 (ELv2).
 
 ---
 

--- a/apps/marketing/src/app/components/CTASection/CTASection.tsx
+++ b/apps/marketing/src/app/components/CTASection/CTASection.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { COMPANY } from "@superset/shared/constants";
 import { useState } from "react";
+import { FaGithub } from "react-icons/fa";
 import { DownloadButton } from "../DownloadButton";
 import { WaitlistModal } from "../WaitlistModal";
+import { InstallCommand } from "./components/InstallCommand";
 
 export function CTASection() {
 	const [isWaitlistOpen, setIsWaitlistOpen] = useState(false);
@@ -14,9 +17,23 @@ export function CTASection() {
 					<h2 className="text-3xl sm:text-4xl lg:text-5xl font-medium tracking-tight leading-[1.1] text-foreground mb-8">
 						Try Superset now.
 					</h2>
-					<div>
+					<div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
 						<DownloadButton onJoinWaitlist={() => setIsWaitlistOpen(true)} />
+						<button
+							type="button"
+							className="px-4 py-2.5 sm:px-6 sm:py-3 text-sm sm:text-base font-normal bg-background border border-border text-foreground hover:bg-muted transition-colors flex items-center gap-2"
+							onClick={() => window.open(COMPANY.GITHUB_URL, "_blank")}
+							aria-label="Star on GitHub"
+						>
+							Star on GitHub
+							<FaGithub className="size-4" />
+						</button>
 					</div>
+					<p className="mt-10 mb-4 text-sm text-muted-foreground">
+						Or install the CLI — paste the agent tab into Claude Code and it
+						installs itself.
+					</p>
+					<InstallCommand />
 				</div>
 			</section>
 			<WaitlistModal

--- a/apps/marketing/src/app/components/CTASection/components/InstallCommand/InstallCommand.tsx
+++ b/apps/marketing/src/app/components/CTASection/components/InstallCommand/InstallCommand.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { DEFAULT_INSTALL_TAB, INSTALL_TABS } from "./constants";
+
+export function InstallCommand() {
+	const [activeTabId, setActiveTabId] = useState(DEFAULT_INSTALL_TAB.id);
+	const [copied, setCopied] = useState(false);
+
+	const activeTab =
+		INSTALL_TABS.find((tab) => tab.id === activeTabId) ?? DEFAULT_INSTALL_TAB;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(activeTab.command);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// Clipboard unavailable (e.g. insecure context) — ignore
+		}
+	};
+
+	return (
+		<div className="w-full max-w-xl border border-border rounded-[2px] bg-foreground/[0.03] text-left">
+			<div className="flex items-center justify-between border-b border-border px-2">
+				<div className="flex items-center">
+					{INSTALL_TABS.map((tab) => (
+						<button
+							key={tab.id}
+							type="button"
+							onClick={() => {
+								setActiveTabId(tab.id);
+								setCopied(false);
+							}}
+							className={`px-3 py-2 text-xs font-mono transition-colors ${
+								tab.id === activeTabId
+									? "text-foreground border-b border-brand -mb-px"
+									: "text-muted-foreground hover:text-foreground"
+							}`}
+						>
+							{tab.label}
+						</button>
+					))}
+				</div>
+				<button
+					type="button"
+					onClick={handleCopy}
+					className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+					aria-label="Copy to clipboard"
+				>
+					{copied ? (
+						<Check className="size-3.5 text-brand" />
+					) : (
+						<Copy className="size-3.5" />
+					)}
+				</button>
+			</div>
+			<div className="flex items-start gap-2 px-4 py-3.5 font-mono text-sm overflow-x-auto">
+				{activeTab.shell && (
+					<span className="text-muted-foreground select-none">$</span>
+				)}
+				<code className="text-foreground whitespace-nowrap">
+					{activeTab.command}
+				</code>
+			</div>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/components/CTASection/components/InstallCommand/constants.ts
+++ b/apps/marketing/src/app/components/CTASection/components/InstallCommand/constants.ts
@@ -1,0 +1,30 @@
+export interface InstallTab {
+	id: string;
+	label: string;
+	command: string;
+	/** Shell commands get a `$` prompt prefix; agent prompts do not. */
+	shell: boolean;
+}
+
+export const DEFAULT_INSTALL_TAB: InstallTab = {
+	id: "brew",
+	label: "brew",
+	command: "brew install superset-sh/tap/superset",
+	shell: true,
+};
+
+export const INSTALL_TABS: InstallTab[] = [
+	DEFAULT_INSTALL_TAB,
+	{
+		id: "curl",
+		label: "curl",
+		command: "curl -fsSL https://superset.sh/cli/install.sh | sh",
+		shell: true,
+	},
+	{
+		id: "agent",
+		label: "agent",
+		command: "Install the Superset CLI: https://superset.sh/llms.txt",
+		shell: false,
+	},
+];

--- a/apps/marketing/src/app/components/CTASection/components/InstallCommand/index.ts
+++ b/apps/marketing/src/app/components/CTASection/components/InstallCommand/index.ts
@@ -1,0 +1,1 @@
+export { InstallCommand } from "./InstallCommand";

--- a/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
+++ b/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
 import { useState } from "react";
 import { HiPlus } from "react-icons/hi2";
 import type { FAQItem } from "./constants";
@@ -40,9 +41,19 @@ function FAQAccordionItem({
 						transition={{ duration: 0.2, ease: "easeInOut" }}
 						className="overflow-hidden"
 					>
-						<p className="pb-6 text-base text-muted-foreground leading-relaxed pr-12">
-							{item.answer}
-						</p>
+						<div className="pb-6 pr-12 space-y-3">
+							<p className="text-base text-muted-foreground leading-relaxed">
+								{item.answer}
+							</p>
+							{item.link && (
+								<Link
+									href={item.link.href}
+									className="inline-block text-base text-brand hover:text-brand-light transition-colors"
+								>
+									{item.link.label} →
+								</Link>
+							)}
+						</div>
 					</motion.div>
 				)}
 			</AnimatePresence>

--- a/apps/marketing/src/app/components/FAQSection/constants.ts
+++ b/apps/marketing/src/app/components/FAQSection/constants.ts
@@ -1,9 +1,23 @@
 export interface FAQItem {
 	question: string;
 	answer: string;
+	link?: {
+		href: string;
+		label: string;
+	};
 }
 
 export const FAQ_ITEMS: FAQItem[] = [
+	{
+		question:
+			"How is Superset different from just running Claude Code in a terminal?",
+		answer:
+			"Claude Code, Codex, and OpenCode are the agents — Superset is where you run many of them at once. Each task gets its own isolated Git worktree, so ten agents can work on ten branches simultaneously while you monitor, review, and merge from one place.",
+		link: {
+			href: "/compare",
+			label: "See how Superset compares to other tools",
+		},
+	},
 	{
 		question: "I already use an IDE like Cursor, is this for me?",
 		answer:

--- a/apps/marketing/src/app/components/FeaturesSection/FeaturesSection.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/FeaturesSection.tsx
@@ -16,7 +16,7 @@ const DEMO_COMPONENTS = [
 
 export function FeaturesSection() {
 	return (
-		<section className="relative py-24 sm:py-32">
+		<section id="features" className="relative py-24 sm:py-32">
 			<div className="max-w-7xl mx-auto px-6 sm:px-8">
 				{/* Feature Rows */}
 				<div className="space-y-24 sm:space-y-32">

--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -32,6 +32,15 @@ interface FooterLink {
 	external?: boolean;
 }
 
+const PRODUCT_LINKS: FooterLink[] = [
+	{ href: "/download", label: "Download" },
+	{ href: "/#how-it-works", label: "How it works" },
+	{ href: "/#features", label: "Features" },
+	{ href: "/#security", label: "Security" },
+	{ href: "/marketplace", label: "Marketplace" },
+	{ href: "/compare", label: "Compare" },
+];
+
 const COMPANY_LINKS: FooterLink[] = [
 	{ href: "/team", label: "About" },
 	{ href: "/contact", label: "Contact" },
@@ -68,7 +77,7 @@ export function Footer() {
 				transition={{ duration: 0.5 }}
 				className="max-w-7xl mx-auto px-6 sm:px-8 py-14 sm:py-20"
 			>
-				<div className="grid grid-cols-2 gap-10 md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:gap-x-20">
+				<div className="grid grid-cols-2 gap-10 md:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto] md:gap-x-16">
 					<div className="col-span-2 flex flex-col gap-6 md:col-span-1">
 						<Link
 							href="/"
@@ -82,6 +91,7 @@ export function Footer() {
 						</p>
 					</div>
 
+					<FooterColumn title="Product" links={PRODUCT_LINKS} />
 					<FooterColumn title="Company" links={COMPANY_LINKS} />
 					<FooterColumn title="Resources" links={RESOURCE_LINKS} />
 					<FooterColumn title="Legal" links={LEGAL_LINKS} />

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { COMPANY } from "@superset/shared/constants";
+import Link from "next/link";
 import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { DownloadButton } from "../DownloadButton";
@@ -31,6 +32,19 @@ export function HeroSection() {
 				<BoidsBackground />
 				<div className="relative w-full max-w-7xl mx-auto px-6 sm:px-8">
 					<div className="flex flex-col items-center text-center">
+						<Link
+							href="/join-us"
+							className="group mb-6 inline-flex items-center gap-2 rounded-[2px] border border-border bg-background/80 px-3 py-1.5 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/[0.2]"
+						>
+							<span className="text-brand shrink-0">●</span>
+							<span>
+								We&apos;re hiring engineers
+								<span className="hidden sm:inline"> in San Francisco</span>
+							</span>
+							<span className="shrink-0 transition-transform group-hover:translate-x-0.5">
+								→
+							</span>
+						</Link>
 						<div className="space-y-4 sm:space-y-6">
 							<h1
 								className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] text-foreground relative max-w-6xl mx-auto"

--- a/apps/marketing/src/app/components/HowItWorksSection/HowItWorksSection.tsx
+++ b/apps/marketing/src/app/components/HowItWorksSection/HowItWorksSection.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { HOW_IT_WORKS_STEPS } from "./constants";
+
+export function HowItWorksSection() {
+	return (
+		<section id="how-it-works" className="relative py-24 sm:py-32">
+			<div className="max-w-7xl mx-auto px-6 sm:px-8">
+				<motion.div
+					className="mb-16 sm:mb-20 space-y-4"
+					initial={{ opacity: 0, y: 20 }}
+					whileInView={{ opacity: 1, y: 0 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.5 }}
+				>
+					<span className="text-sm font-mono uppercase tracking-widest text-brand">
+						How it works
+					</span>
+					<h2 className="text-3xl sm:text-4xl lg:text-5xl font-medium tracking-tight leading-[1.1] text-foreground">
+						Ship your whole backlog,
+						<br />
+						not one prompt at a time.
+					</h2>
+				</motion.div>
+
+				<div className="grid grid-cols-1 md:grid-cols-3 gap-10 md:gap-8 lg:gap-12">
+					{HOW_IT_WORKS_STEPS.map((step, index) => (
+						<motion.div
+							key={step.number}
+							className="space-y-4 border-t border-border pt-6"
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							viewport={{ once: true }}
+							transition={{ duration: 0.5, delay: 0.1 * index }}
+						>
+							<span className="text-sm font-mono text-brand">
+								{step.number}
+							</span>
+							<h3 className="text-xl sm:text-2xl font-medium tracking-tight text-foreground">
+								{step.title}
+							</h3>
+							<p className="text-base text-muted-foreground leading-relaxed">
+								{step.description}
+							</p>
+						</motion.div>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/marketing/src/app/components/HowItWorksSection/constants.ts
+++ b/apps/marketing/src/app/components/HowItWorksSection/constants.ts
@@ -1,0 +1,26 @@
+export interface HowItWorksStep {
+	number: string;
+	title: string;
+	description: string;
+}
+
+export const HOW_IT_WORKS_STEPS: HowItWorksStep[] = [
+	{
+		number: "01",
+		title: "Start a task.",
+		description:
+			"Describe what you want built. Superset spins up a workspace in an isolated Git worktree, so every task starts on a clean branch.",
+	},
+	{
+		number: "02",
+		title: "Agents do the work.",
+		description:
+			"Run Claude Code, Codex, or any CLI agent in parallel, each in its own workspace. No conflicts, no waiting on a single session.",
+	},
+	{
+		number: "03",
+		title: "Review and ship.",
+		description:
+			"Jump in when an agent needs you. Review the changes, open them in your IDE, and commit, push, and merge PRs without leaving the app.",
+	},
+];

--- a/apps/marketing/src/app/components/HowItWorksSection/index.ts
+++ b/apps/marketing/src/app/components/HowItWorksSection/index.ts
@@ -1,0 +1,1 @@
+export { HowItWorksSection } from "./HowItWorksSection";

--- a/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
+++ b/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
@@ -21,9 +21,9 @@ const SECURITY_FEATURES: {
 	},
 	{
 		icon: <HiOutlineServerStack className="w-5 h-5 text-foreground/70" />,
-		title: "Offline First",
+		title: "Local First",
 		description:
-			"Your code stays on your machine. Work without an internet connection. All processing happens locally.",
+			"Repos, worktrees, terminal output, and agent sessions stay on your machine. Cloud sync covers account and organization metadata only.",
 	},
 	{
 		icon: <HiOutlineSignal className="w-5 h-5 text-foreground/70" />,
@@ -35,25 +35,28 @@ const SECURITY_FEATURES: {
 
 export function SecuritySection() {
 	return (
-		<section className="relative py-24 px-8 lg:px-[30px]">
-			<div className="max-w-7xl mx-auto">
+		<section id="security" className="relative py-24 sm:py-32">
+			<div className="max-w-7xl mx-auto px-6 sm:px-8">
 				{/* Heading */}
 				<motion.div
-					className="mb-16"
+					className="mb-16 space-y-4"
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
 					viewport={{ once: true }}
 					transition={{ duration: 0.5 }}
 				>
-					<div className="space-y-1">
-						<h2 className="text-2xl sm:text-3xl font-mono tracking-[-0.01em] text-foreground">
-							Private by default
-						</h2>
-						<h2 className="text-lg sm:text-xl font-light tracking-[-0.03em] text-muted-foreground max-w-[700px]">
-							Your code stays local by default, with explicit control over
-							connected services.
-						</h2>
-					</div>
+					<span className="text-sm font-mono uppercase tracking-widest text-brand">
+						Security
+					</span>
+					<h2 className="text-3xl sm:text-4xl lg:text-5xl font-medium tracking-tight leading-[1.1] text-foreground">
+						Private by default.
+						<br />
+						You&apos;re in control.
+					</h2>
+					<p className="text-base sm:text-lg font-light text-muted-foreground max-w-[700px]">
+						Your code stays local by default, with explicit control over
+						connected services.
+					</p>
 				</motion.div>
 
 				{/* Features Grid */}
@@ -67,13 +70,13 @@ export function SecuritySection() {
 					{SECURITY_FEATURES.map((feature, index) => (
 						<motion.div
 							key={feature.title}
-							className="relative p-6 rounded-2xl border border-border bg-card/50 backdrop-blur-sm"
+							className="relative p-6 rounded-[2px] border border-foreground/[0.1] bg-foreground/[0.03]"
 							initial={{ opacity: 0, y: 20 }}
 							whileInView={{ opacity: 1, y: 0 }}
 							viewport={{ once: true }}
 							transition={{ duration: 0.5, delay: 0.1 * index }}
 						>
-							<div className="mb-4 inline-flex items-center justify-center w-10 h-10 rounded-lg bg-muted border border-border">
+							<div className="mb-4 inline-flex items-center justify-center w-10 h-10 rounded-[2px] bg-muted border border-border">
 								{feature.icon}
 							</div>
 							<h3 className="text-lg font-medium text-foreground/90 mb-2">

--- a/apps/marketing/src/app/index.md/route.ts
+++ b/apps/marketing/src/app/index.md/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
 	const docsUrl = COMPANY.DOCS_URL;
 
 	const lines: string[] = [
-		`# ${COMPANY.NAME} — Run 10+ parallel coding agents on your machine`,
+		`# ${COMPANY.NAME} — Run 100+ parallel coding agents on your machine`,
 		"",
 		PRODUCT_SUMMARY,
 		"",

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -48,12 +48,12 @@ const pixelifySans = Pixelify_Sans({
 });
 
 const siteDescription =
-	"Run 10+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish. Quickly switch between tasks as they need your attention.";
+	"Run 100+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish. Quickly switch between tasks as they need your attention.";
 
 export const metadata: Metadata = {
 	metadataBase: new URL(COMPANY.MARKETING_URL),
 	title: {
-		default: `${COMPANY.NAME} - Run 10+ parallel coding agents on your machine`,
+		default: `${COMPANY.NAME} - Run 100+ parallel coding agents on your machine`,
 		template: `%s | ${COMPANY.NAME}`,
 	},
 	description: siteDescription,
@@ -75,9 +75,9 @@ export const metadata: Metadata = {
 		locale: "en_US",
 		url: COMPANY.MARKETING_URL,
 		siteName: COMPANY.NAME,
-		title: `${COMPANY.NAME} - Run 10+ parallel coding agents on your machine`,
+		title: `${COMPANY.NAME} - Run 100+ parallel coding agents on your machine`,
 		description:
-			"Run 10+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish.",
+			"Run 100+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish.",
 		images: [
 			{
 				url: "/og-image.png",
@@ -89,9 +89,9 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: `${COMPANY.NAME} - Run 10+ parallel coding agents on your machine`,
+		title: `${COMPANY.NAME} - Run 100+ parallel coding agents on your machine`,
 		description:
-			"Run 10+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish.",
+			"Run 100+ parallel coding agents on your machine. Spin up new coding tasks while waiting for your current agent to finish.",
 		images: ["/og-image.png"],
 		creator: "@superset_sh",
 	},

--- a/apps/marketing/src/app/llms-full.txt/route.ts
+++ b/apps/marketing/src/app/llms-full.txt/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 		[
 			`# ${COMPANY.NAME}`,
 			"",
-			"> Run 10+ parallel coding agents on your machine",
+			"> Run 100+ parallel coding agents on your machine",
 			"",
 			PRODUCT_SUMMARY,
 			"",

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -13,11 +13,17 @@ import { HeroSection } from "./components/HeroSection";
 const TrustedBySection = dynamic(() =>
 	import("./components/TrustedBySection").then((mod) => mod.TrustedBySection),
 );
+const HowItWorksSection = dynamic(() =>
+	import("./components/HowItWorksSection").then((mod) => mod.HowItWorksSection),
+);
 const FeaturesSection = dynamic(() =>
 	import("./components/FeaturesSection").then((mod) => mod.FeaturesSection),
 );
 const WallOfLoveSection = dynamic(() =>
 	import("./components/WallOfLoveSection").then((mod) => mod.WallOfLoveSection),
+);
+const SecuritySection = dynamic(() =>
+	import("./components/SecuritySection").then((mod) => mod.SecuritySection),
 );
 const FAQSection = dynamic(() =>
 	import("./components/FAQSection").then((mod) => mod.FAQSection),
@@ -40,8 +46,10 @@ export default function Home() {
 			<ServiceJsonLd />
 			<HeroSection />
 			<TrustedBySection />
+			<HowItWorksSection />
 			<FeaturesSection />
 			<WallOfLoveSection />
+			<SecuritySection />
 			<FAQSection />
 			<CTASection />
 		</main>

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -7,7 +7,7 @@ import { PricingTiers } from "./components/PricingTiers";
 
 export const metadata: Metadata = {
 	title: "Pricing",
-	description: `Simple pricing for every team. Free for individuals, $15/user/month for teams, custom for enterprise. Run 10+ parallel coding agents with ${COMPANY.NAME}.`,
+	description: `Simple pricing for every team. Free for individuals, $15/user/month for teams, custom for enterprise. Run 100+ parallel coding agents with ${COMPANY.NAME}.`,
 	alternates: {
 		canonical: `${COMPANY.MARKETING_URL}/pricing`,
 	},

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -37,7 +37,7 @@ export function OrganizationJsonLd() {
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
 		logo: `${COMPANY.MARKETING_URL}/logo.png`,
-		description: "Run 10+ parallel coding agents on your machine",
+		description: "Run 100+ parallel coding agents on your machine",
 		email: supportEmail,
 		contactPoint: {
 			"@type": "ContactPoint",
@@ -77,7 +77,7 @@ export function SoftwareApplicationJsonLd() {
 			price: "0",
 			priceCurrency: "USD",
 		},
-		description: "Run 10+ parallel coding agents on your machine",
+		description: "Run 100+ parallel coding agents on your machine",
 		url: COMPANY.MARKETING_URL,
 	};
 
@@ -214,7 +214,7 @@ export function HomeWebPageJsonLd() {
 		"@type": "WebPage",
 		"@id": COMPANY.MARKETING_URL,
 		url: COMPANY.MARKETING_URL,
-		name: `${COMPANY.NAME} — Run 10+ parallel coding agents on your machine`,
+		name: `${COMPANY.NAME} — Run 100+ parallel coding agents on your machine`,
 		isPartOf: {
 			"@type": "WebSite",
 			name: COMPANY.NAME,

--- a/apps/marketing/src/lib/llms.ts
+++ b/apps/marketing/src/lib/llms.ts
@@ -28,7 +28,7 @@ export function buildLlmsHeader(): string[] {
 	return [
 		`# ${COMPANY.NAME}`,
 		"",
-		"> Run 10+ parallel coding agents on your machine",
+		"> Run 100+ parallel coding agents on your machine",
 		"",
 		PRODUCT_SUMMARY,
 	];


### PR DESCRIPTION
Homepage improvements inspired by a gap analysis against paperclip.ing.

## Changes
- **How it works**: new 3-step narrative section (start a task → agents work in parallel worktrees → review and merge PRs) between the logo wall and features
- **Install CTA**: the final CTA now shows the CLI install commands with `brew` / `curl` / `agent` tabs and a copy button, plus a Star on GitHub button. The agent tab is a paste-into-Claude-Code prompt pointing at `superset.sh/llms.txt` — verified end-to-end with a headless Claude Code dry run (it finds and picks the brew command)
- **Security section**: mounted the previously unreferenced `SecuritySection`, restyled to the site's design system; copy corrected to match the docs privacy FAQ (local-first, metadata-only cloud sync)
- **FAQ**: new first entry answering "how is this different from just running Claude Code in a terminal", linking to /compare
- **Hero pill**: "We're hiring engineers in San Francisco →" linking to /join-us (location hidden on mobile widths)
- **Footer**: new Product column (Download / How it works / Features / Security / Marketplace / Compare) with matching section anchors
- **Claim consistency**: unified the parallel-agent number to 100+ (was a 10+/100+ mix) across metadata, JSON-LD, llms routes, pricing, and compare pages; left the vibe-kanban page's "10+ coding agents" (describes their agent support) and archived posts untouched

All copy claims were verified against the product: in-app PR merge exists (v1 PRButton + v2 PRStatusGroup), ELv2 license and public repo confirmed, install endpoints (brew tap, install.sh → cli-latest release) checked live.

Lint + typecheck green; homepage smoke-tested via dev server (all sections render).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the homepage with a new “How it works” narrative, an install-focused CTA, a mounted Security section, and a hiring pill. Also standardizes the “100+ parallel agents” claim across the site for consistency and SEO.

- **New Features**
  - Added a 3-step “How it works” section between the logo wall and features.
  - Updated the final CTA with CLI install tabs (`brew` / `curl` / `agent`) + copy button and “Star on GitHub.”
  - Mounted and restyled the Security section; copy matches docs (local-first, metadata-only cloud sync).
  - Added FAQ entry on “How is this different from Claude Code?” linking to /compare.
  - Added a hero hiring pill linking to /join-us (location hidden on mobile).
  - Updated footer with a Product column (Download, How it works, Features, Security, Marketplace, Compare) and section anchors.

- **Copy & SEO**
  - Unified the parallel-agent claim to “100+” across metadata, JSON-LD, `llms` routes, pricing, and compare pages.

<sup>Written for commit 1a4bb14633028ddf10bfeefe34a2f66c11267e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added installation guidance with Homebrew, curl, and agent setup options, plus copy-to-clipboard support.
  - Added a “Star on GitHub” CTA and expanded product navigation in the footer.
  - Added “How it works” and security sections to the homepage.
  - Added a hiring announcement and linked FAQ content.
- **Documentation**
  - Updated marketing and comparison content to highlight support for 100+ parallel coding agents.
  - Refreshed security messaging to emphasize local-first operation and limited cloud synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->