### PR TITLE
feat(cli): branded help and interactive command browser with guided flag prompts

### DIFF
--- a/packages/cli-framework/src/build.ts
+++ b/packages/cli-framework/src/build.ts
@@ -31,6 +31,7 @@ await run({
 	version: config.version,
 	tree: { commands, groups, middleware },
 	globals: config.globals,
+	help: config.help,
 });
 `,
 	);

--- a/packages/cli-framework/src/config.ts
+++ b/packages/cli-framework/src/config.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from "node:path";
+import type { HelpBranding } from "./help";
 import type { GenericBuilderInternals } from "./option";
 
 export interface CliConfig {
@@ -12,6 +13,8 @@ export interface CliConfig {
 	define?: Record<string, string>;
 	/** Global option builders (shown on every command). */
 	globals?: Record<string, GenericBuilderInternals>;
+	/** Branding/curation for the root help screen and interactive browser. */
+	help?: HelpBranding;
 }
 
 export function defineConfig(config: CliConfig): CliConfig {

--- a/packages/cli-framework/src/dev.ts
+++ b/packages/cli-framework/src/dev.ts
@@ -58,5 +58,6 @@ export async function runDev(argv: string[]): Promise<void> {
 		version: config.version,
 		tree: { commands, groups, middleware },
 		globals: config.globals,
+		help: config.help,
 	});
 }

--- a/packages/cli-framework/src/help.ts
+++ b/packages/cli-framework/src/help.ts
@@ -10,52 +10,137 @@ export type CommandNode = {
 	args?: ProcessedBuilderConfig[];
 };
 
+/** Optional branding/curation for the root help screen. */
+export interface HelpBranding {
+	/** One-line pitch printed under the wordmark. */
+	tagline?: string;
+	/** Curated sections; listed command names come from the command tree. */
+	sections?: Array<{ title: string; commands: string[] }>;
+	/** Copy-paste examples shown before the command list. */
+	examples?: Array<{ cmd: string; desc: string }>;
+	docsUrl?: string;
+	/** One-line closing tip. */
+	tip?: string;
+}
+
+const useColor = () =>
+	process.stdout.isTTY === true && process.env.NO_COLOR === undefined;
+
+type Paint = (s: string) => string;
+const ansi =
+	(open: string, close = "\x1b[0m"): Paint =>
+	(s) =>
+		useColor() ? `${open}${s}${close}` : s;
+
+export const paint = {
+	bold: ansi("\x1b[1m"),
+	dim: ansi("\x1b[2m"),
+	cyan: ansi("\x1b[36m"),
+	green: ansi("\x1b[32m"),
+	yellow: ansi("\x1b[33m"),
+	magenta: ansi("\x1b[35m"),
+	heading: ansi("\x1b[1m\x1b[4m"),
+	invert: ansi("\x1b[7m"),
+};
+
+function visibleRootEntries(root: CommandNode): Array<[string, CommandNode]> {
+	return [...root.children.entries()]
+		.filter(([, node]) => node.children.size > 0 || node.hasCommand)
+		.sort(([a], [b]) => a.localeCompare(b));
+}
+
+function commandLabel(name: string, node: CommandNode): string {
+	const aliasStr = node.aliases?.length ? ` (${node.aliases.join(", ")})` : "";
+	return `${name}${aliasStr}`;
+}
+
 export function generateRootHelp(
 	name: string,
 	version: string,
 	root: CommandNode,
 	globals?: Record<string, ProcessedBuilderConfig>,
+	branding?: HelpBranding,
 ): string {
 	const lines: string[] = [];
-	lines.push(`${name} v${version}`);
+	lines.push(`${paint.bold(paint.cyan(name))} ${paint.dim(`v${version}`)}`);
+	if (branding?.tagline) {
+		lines.push(paint.dim(branding.tagline));
+	}
 	lines.push("");
-	lines.push(`Usage: ${name} <command> [options]`);
+	lines.push(
+		`${paint.heading("Usage")}  ${name} ${paint.cyan("<command>")} ${paint.dim("[options]")}`,
+	);
 	lines.push("");
 
-	if (root.children.size > 0) {
-		lines.push("Commands:");
-		const entries = [...root.children.entries()]
-			.filter(([, node]) => node.children.size > 0 || node.hasCommand)
-			.sort(([a], [b]) => a.localeCompare(b));
+	const entries = visibleRootEntries(root);
 
-		const maxLen = Math.max(
-			...entries.map(([name]) => {
-				const node = root.children.get(name)!;
-				const aliasStr = node.aliases?.length
-					? ` (${node.aliases.join(", ")})`
-					: "";
-				return name.length + aliasStr.length;
-			}),
-		);
-
-		for (const [cmdName, node] of entries) {
-			const aliasStr = node.aliases?.length
-				? ` (${node.aliases.join(", ")})`
-				: "";
-			const label = `${cmdName}${aliasStr}`.padEnd(maxLen + 2);
-			lines.push(`  ${label}${node.description ?? ""}`);
+	if (branding?.examples?.length) {
+		lines.push(paint.heading("Examples"));
+		for (const example of branding.examples) {
+			lines.push(`  ${paint.dim("$")} ${paint.green(example.cmd)}`);
+			lines.push(`    ${paint.dim(example.desc)}`);
 		}
 		lines.push("");
 	}
 
+	if (entries.length > 0) {
+		const maxLen = Math.max(
+			...entries.map(([n, node]) => commandLabel(n, node).length),
+		);
+		const renderEntry = ([cmdName, node]: [string, CommandNode]) => {
+			const label = commandLabel(cmdName, node).padEnd(maxLen + 2);
+			return `  ${paint.cyan(label)}${node.description ?? ""}`;
+		};
+
+		if (branding?.sections?.length) {
+			lines.push(paint.heading("Commands"));
+			const byName = new Map(entries);
+			const seen = new Set<string>();
+			for (const section of branding.sections) {
+				const sectionEntries = section.commands.flatMap((n) => {
+					const node = byName.get(n);
+					if (!node) return [];
+					seen.add(n);
+					return [[n, node] as [string, CommandNode]];
+				});
+				if (sectionEntries.length === 0) continue;
+				lines.push(`  ${paint.bold(section.title)}`);
+				for (const entry of sectionEntries)
+					lines.push(`  ${renderEntry(entry)}`);
+			}
+			const rest = entries.filter(([n]) => !seen.has(n));
+			if (rest.length > 0) {
+				lines.push(`  ${paint.bold("Other")}`);
+				for (const entry of rest) lines.push(`  ${renderEntry(entry)}`);
+			}
+			lines.push("");
+		} else {
+			lines.push(paint.heading("Commands"));
+			for (const entry of entries) lines.push(renderEntry(entry));
+			lines.push("");
+		}
+	}
+
 	if (globals) {
-		lines.push("Global options:");
+		lines.push(paint.heading("Global options"));
 		lines.push(...formatOptions(globals));
 		lines.push("");
 	}
 
-	lines.push("  --help, -h       Show help");
-	lines.push("  --version, -v    Show version");
+	lines.push(`  ${paint.cyan("--help, -h".padEnd(17))}Show help`);
+	lines.push(`  ${paint.cyan("--version, -v".padEnd(17))}Show version`);
+
+	const footer: string[] = [];
+	if (branding?.docsUrl) {
+		footer.push(`  ${paint.dim("Docs")}  ${paint.cyan(branding.docsUrl)}`);
+	}
+	if (branding?.tip) {
+		footer.push(`  ${paint.dim("Tip")}   ${branding.tip}`);
+	}
+	if (footer.length > 0) {
+		lines.push("");
+		lines.push(...footer);
+	}
 
 	return lines.join("\n");
 }

--- a/packages/cli-framework/src/help.ts
+++ b/packages/cli-framework/src/help.ts
@@ -121,7 +121,7 @@ export function generateRootHelp(
 		}
 	}
 
-	if (globals) {
+	if (globals && Object.keys(globals).length > 0) {
 		lines.push(paint.heading("Global options"));
 		lines.push(...formatOptions(globals));
 		lines.push("");

--- a/packages/cli-framework/src/interactive-help.test.ts
+++ b/packages/cli-framework/src/interactive-help.test.ts
@@ -72,6 +72,21 @@ describe("collectRequiredFields", () => {
 		expect(collectRequiredFields(node)).toEqual([]);
 	});
 
+	it("preserves enum values on required positionals", () => {
+		const fields = collectRequiredFields(
+			leaf({
+				args: [
+					option({
+						name: "level",
+						isRequired: true,
+						enumVals: ["low", "high"],
+					}),
+				],
+			}),
+		);
+		expect(fields[0]?.enumVals).toEqual(["low", "high"]);
+	});
+
 	it("puts required positionals before flags", () => {
 		const node = leaf({
 			args: [option({ name: "id", isRequired: true })],
@@ -97,15 +112,51 @@ describe("buildRunArgs", () => {
 		).toEqual(["tasks", "update", "t-1", "--name", "New title"]);
 	});
 
-	it("emits boolean flags only when true", () => {
+	it("emits --flag for true and --no-flag for false booleans", () => {
 		const fields = [
 			{ kind: "flag", name: "force", type: "boolean" } as const,
 			{ kind: "flag", name: "dry-run", type: "boolean" } as const,
 		];
+		// A required boolean must appear either way; the parser supports
+		// --no-<flag> negation.
 		expect(buildRunArgs(["ws", "rm"], [...fields], [true, false])).toEqual([
 			"ws",
 			"rm",
 			"--force",
+			"--no-dry-run",
+		]);
+	});
+
+	it("expands a variadic positional from one space-separated line", () => {
+		const fields = collectRequiredFields(
+			leaf({
+				args: [option({ name: "ids", isRequired: true, isVariadic: true })],
+			}),
+		);
+		expect(fields[0]?.variadic).toBe(true);
+		expect(buildRunArgs(["tasks", "delete"], fields, ["a-1  b-2 c-3"])).toEqual(
+			["tasks", "delete", "a-1", "b-2", "c-3"],
+		);
+	});
+
+	it("repeats a variadic flag once per value", () => {
+		const fields = [
+			{
+				kind: "flag",
+				name: "attachment",
+				type: "string",
+				variadic: true,
+			} as const,
+		];
+		expect(
+			buildRunArgs(["agents", "create"], [...fields], ["a.png b.png"]),
+		).toEqual([
+			"agents",
+			"create",
+			"--attachment",
+			"a.png",
+			"--attachment",
+			"b.png",
 		]);
 	});
 });

--- a/packages/cli-framework/src/interactive-help.test.ts
+++ b/packages/cli-framework/src/interactive-help.test.ts
@@ -4,6 +4,7 @@ import {
 	buildRunArgs,
 	collectRequiredFields,
 	formatAssembledCommand,
+	runInteractiveHelp,
 } from "./interactive-help";
 import type { ProcessedBuilderConfig } from "./option";
 
@@ -158,6 +159,21 @@ describe("buildRunArgs", () => {
 			"--attachment",
 			"b.png",
 		]);
+	});
+});
+
+describe("runInteractiveHelp", () => {
+	it("resolves immediately when the signal is already aborted", async () => {
+		const ac = new AbortController();
+		ac.abort();
+		const result = await runInteractiveHelp({
+			name: "test",
+			version: "0.0.0",
+			root: { name: "test", children: new Map(), hasCommand: false },
+			populateLeaf: () => {},
+			signal: ac.signal,
+		});
+		expect(result).toEqual({});
 	});
 });
 

--- a/packages/cli-framework/src/interactive-help.test.ts
+++ b/packages/cli-framework/src/interactive-help.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import type { CommandNode } from "./help";
+import {
+	buildRunArgs,
+	collectRequiredFields,
+	formatAssembledCommand,
+} from "./interactive-help";
+import type { ProcessedBuilderConfig } from "./option";
+
+function option(
+	partial: Partial<ProcessedBuilderConfig> & { name: string },
+): ProcessedBuilderConfig {
+	return {
+		type: "string",
+		aliases: [],
+		isRequired: false,
+		isHidden: false,
+		isVariadic: false,
+		...partial,
+	} as ProcessedBuilderConfig;
+}
+
+function leaf(config: {
+	options?: Record<string, ProcessedBuilderConfig>;
+	args?: ProcessedBuilderConfig[];
+}): CommandNode {
+	return {
+		name: "cmd",
+		children: new Map(),
+		hasCommand: true,
+		options: config.options,
+		args: config.args,
+	};
+}
+
+describe("collectRequiredFields", () => {
+	it("returns nothing for a command with no required inputs", () => {
+		const node = leaf({
+			options: { limit: option({ name: "limit", type: "number" }) },
+		});
+		expect(collectRequiredFields(node)).toEqual([]);
+	});
+
+	it("picks required flags and keeps enum values", () => {
+		const node = leaf({
+			options: {
+				type: option({
+					name: "type",
+					isRequired: true,
+					enumVals: ["bug", "feature", "general"],
+				}),
+				title: option({ name: "title", isRequired: true }),
+				body: option({ name: "body" }),
+			},
+		});
+		const fields = collectRequiredFields(node);
+		expect(fields.map((f) => f.name)).toEqual(["type", "title"]);
+		expect(fields[0]?.enumVals).toEqual(["bug", "feature", "general"]);
+	});
+
+	it("treats required-with-default as not required", () => {
+		const node = leaf({
+			options: {
+				port: option({
+					name: "port",
+					type: "number",
+					isRequired: true,
+					default: 8080,
+				}),
+			},
+		});
+		expect(collectRequiredFields(node)).toEqual([]);
+	});
+
+	it("puts required positionals before flags", () => {
+		const node = leaf({
+			args: [option({ name: "id", isRequired: true })],
+			options: { force: option({ name: "force", isRequired: true }) },
+		});
+		expect(collectRequiredFields(node).map((f) => f.kind)).toEqual([
+			"positional",
+			"flag",
+		]);
+	});
+});
+
+describe("buildRunArgs", () => {
+	it("assembles path, positionals, then flag pairs", () => {
+		const fields = collectRequiredFields(
+			leaf({
+				args: [option({ name: "id", isRequired: true })],
+				options: { name: option({ name: "name", isRequired: true }) },
+			}),
+		);
+		expect(
+			buildRunArgs(["tasks", "update"], fields, ["t-1", "New title"]),
+		).toEqual(["tasks", "update", "t-1", "--name", "New title"]);
+	});
+
+	it("emits boolean flags only when true", () => {
+		const fields = [
+			{ kind: "flag", name: "force", type: "boolean" } as const,
+			{ kind: "flag", name: "dry-run", type: "boolean" } as const,
+		];
+		expect(buildRunArgs(["ws", "rm"], [...fields], [true, false])).toEqual([
+			"ws",
+			"rm",
+			"--force",
+		]);
+	});
+});
+
+describe("formatAssembledCommand", () => {
+	it("quotes values with spaces for display", () => {
+		const fields = collectRequiredFields(
+			leaf({ options: { title: option({ name: "title", isRequired: true }) } }),
+		);
+		expect(
+			formatAssembledCommand("superset", ["tasks", "create"], fields, [
+				"fix flaky tests",
+			]),
+		).toBe('superset tasks create --title "fix flaky tests"');
+	});
+});

--- a/packages/cli-framework/src/interactive-help.ts
+++ b/packages/cli-framework/src/interactive-help.ts
@@ -1,0 +1,463 @@
+import {
+	type CommandNode,
+	generateCommandHelp,
+	type HelpBranding,
+	paint,
+} from "./help";
+import type { ProcessedBuilderConfig } from "./option";
+
+/**
+ * EXPERIMENT: interactive help browser shown when the CLI is invoked bare on a
+ * TTY. Arrow keys walk the command tree; Enter drills in. Leaves with no
+ * required inputs run immediately; leaves that need input walk the user
+ * through each required field (text input, enum selector, yes/no) and then
+ * run the assembled command.
+ *
+ * Zero-dep on purpose: raw-mode stdin + ANSI, so it works in the compiled
+ * binary without pulling ink/clack into the framework.
+ */
+
+interface Row {
+	name: string;
+	node: CommandNode;
+}
+
+export interface FormField {
+	kind: "positional" | "flag";
+	/** kebab-case flag name (without --) or positional name. */
+	name: string;
+	description?: string;
+	type: "string" | "number" | "boolean";
+	enumVals?: string[];
+	variadic?: boolean;
+}
+
+export interface InteractiveResult {
+	/** Args to execute after the browser exits (e.g. ["workspaces","list"]). */
+	runArgs?: string[];
+}
+
+const ESC = "\x1b";
+const hide = `${ESC}[?25l`;
+const show = `${ESC}[?25h`;
+
+function rows(node: CommandNode): Row[] {
+	return [...node.children.entries()]
+		.filter(([, n]) => n.children.size > 0 || n.hasCommand)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([name, n]) => ({ name, node: n }));
+}
+
+function isRequired(c: ProcessedBuilderConfig): boolean {
+	return c.isRequired === true && c.default === undefined;
+}
+
+/** Required inputs for a leaf, positionals first, in declaration order. */
+export function collectRequiredFields(node: CommandNode): FormField[] {
+	const fields: FormField[] = [];
+	for (const arg of node.args ?? []) {
+		if (!isRequired(arg)) continue;
+		fields.push({
+			kind: "positional",
+			name: arg.name ?? "arg",
+			description: arg.description,
+			type: arg.type === "number" ? "number" : "string",
+			variadic: arg.isVariadic,
+		});
+	}
+	for (const config of Object.values(node.options ?? {})) {
+		if (config.type === "positional" || config.isHidden) continue;
+		if (!isRequired(config)) continue;
+		fields.push({
+			kind: "flag",
+			name: config.name,
+			description: config.description,
+			type:
+				config.type === "number"
+					? "number"
+					: config.type === "boolean"
+						? "boolean"
+						: "string",
+			enumVals: config.enumVals,
+		});
+	}
+	return fields;
+}
+
+/** Assemble argv for execute(): path, then positionals, then --flag value. */
+export function buildRunArgs(
+	path: string[],
+	fields: FormField[],
+	values: Array<string | boolean>,
+): string[] {
+	const args = [...path];
+	for (const [i, field] of fields.entries()) {
+		const value = values[i];
+		if (field.kind === "positional") {
+			if (typeof value === "string" && value !== "") args.push(value);
+			continue;
+		}
+		if (field.type === "boolean") {
+			if (value === true) args.push(`--${field.name}`);
+			continue;
+		}
+		if (typeof value === "string" && value !== "") {
+			args.push(`--${field.name}`, value);
+		}
+	}
+	return args;
+}
+
+export function formatAssembledCommand(
+	name: string,
+	path: string[],
+	fields: FormField[],
+	values: Array<string | boolean>,
+): string {
+	const parts = [name, ...buildRunArgs(path, fields, values)].map((part) =>
+		/[\s"']/.test(part) ? JSON.stringify(part) : part,
+	);
+	return parts.join(" ");
+}
+
+function render(
+	name: string,
+	version: string,
+	branding: HelpBranding | undefined,
+	path: string[],
+	list: Row[],
+	selected: number,
+): string {
+	const out: string[] = [];
+	out.push(`${paint.bold(paint.cyan(name))} ${paint.dim(`v${version}`)}`);
+	if (branding?.tagline) out.push(paint.dim(branding.tagline));
+	out.push("");
+	const crumbs = [name, ...path].join(" › ");
+	out.push(`${paint.dim("›")} ${paint.bold(crumbs)}`);
+	out.push("");
+	for (const [i, row] of list.entries()) {
+		const isGroup = row.node.children.size > 0;
+		const label = `${row.name}${row.node.aliases?.length ? ` (${row.node.aliases.join(", ")})` : ""}`;
+		const suffix = isGroup ? paint.dim(" ›") : "";
+		const desc = row.node.description
+			? paint.dim(`  ${row.node.description}`)
+			: "";
+		out.push(
+			i === selected
+				? paint.invert(
+						`❯ ${label}${isGroup ? " ›" : ""}  ${row.node.description ?? ""}`,
+					)
+				: `  ${label}${suffix}${desc}`,
+		);
+	}
+	out.push("");
+	const hints = [
+		`${paint.bold("↑↓")} move`,
+		`${paint.bold("enter")} open`,
+		path.length > 0 ? `${paint.bold("←")} back` : undefined,
+		`${paint.bold("q")} quit`,
+	].filter(Boolean);
+	out.push(paint.dim(hints.join("   ")));
+	if (branding?.docsUrl) out.push(paint.dim(`docs: ${branding.docsUrl}`));
+	return out.join("\n");
+}
+
+function renderLeaf(
+	name: string,
+	path: string[],
+	node: CommandNode,
+	globals: Record<string, ProcessedBuilderConfig> | undefined,
+	fieldCount: number,
+): string {
+	const out: string[] = [];
+	out.push(generateCommandHelp(name, path, node, globals));
+	out.push("");
+	if (fieldCount === 0) {
+		out.push(paint.green(`$ ${[name, ...path].join(" ")}`));
+		out.push(
+			paint.dim(
+				`${paint.bold("enter")} run it now   ${paint.bold("←")} back   ${paint.bold("q")} quit`,
+			),
+		);
+	} else {
+		out.push(
+			paint.green(`$ ${[name, ...path].join(" ")} …`) +
+				paint.dim(
+					`  (${fieldCount} required input${fieldCount === 1 ? "" : "s"})`,
+				),
+		);
+		out.push(
+			paint.dim(
+				`${paint.bold("enter")} fill in & run   ${paint.bold("←")} back   ${paint.bold("q")} quit`,
+			),
+		);
+	}
+	return out.join("\n");
+}
+
+interface FormState {
+	fields: FormField[];
+	values: Array<string | boolean>;
+	index: number;
+	buffer: string;
+	enumIndex: number;
+	confirming: boolean;
+}
+
+function renderForm(name: string, path: string[], form: FormState): string {
+	const out: string[] = [];
+	const crumbs = [name, ...path].join(" › ");
+	out.push(`${paint.dim("›")} ${paint.bold(crumbs)}`);
+	out.push("");
+
+	// Completed fields
+	for (let i = 0; i < form.index; i++) {
+		const field = form.fields[i];
+		if (!field) continue;
+		const value = form.values[i];
+		const label = field.kind === "flag" ? `--${field.name}` : `<${field.name}>`;
+		out.push(
+			`  ${paint.green("✓")} ${paint.dim(label)}  ${typeof value === "boolean" ? (value ? "yes" : "no") : value}`,
+		);
+	}
+
+	if (form.confirming) {
+		out.push("");
+		out.push(`  ${paint.bold("Ready:")}`);
+		out.push(
+			`  ${paint.green(`$ ${formatAssembledCommand(name, path, form.fields, form.values)}`)}`,
+		);
+		out.push("");
+		out.push(
+			paint.dim(
+				`${paint.bold("enter")} run   ${paint.bold("←")} edit last   ${paint.bold("esc")} cancel`,
+			),
+		);
+		return out.join("\n");
+	}
+
+	const field = form.fields[form.index];
+	if (!field) return out.join("\n");
+	const label = field.kind === "flag" ? `--${field.name}` : `<${field.name}>`;
+	out.push("");
+	out.push(
+		`  ${paint.cyan(label)}${field.description ? paint.dim(`  ${field.description}`) : ""}  ${paint.dim(`(${form.index + 1}/${form.fields.length})`)}`,
+	);
+
+	if (field.enumVals?.length) {
+		for (const [i, value] of field.enumVals.entries()) {
+			out.push(
+				i === form.enumIndex
+					? `  ${paint.invert(`❯ ${value}`)}`
+					: `    ${value}`,
+			);
+		}
+		out.push("");
+		out.push(
+			paint.dim(
+				`${paint.bold("↑↓")} choose   ${paint.bold("enter")} select   ${paint.bold("esc")} cancel`,
+			),
+		);
+	} else if (field.type === "boolean") {
+		out.push(`  ${paint.bold("y")}es / ${paint.bold("n")}o`);
+		out.push("");
+		out.push(paint.dim(`${paint.bold("esc")} cancel`));
+	} else {
+		out.push(`  ${paint.bold("›")} ${form.buffer}${paint.invert(" ")}`);
+		out.push("");
+		out.push(
+			paint.dim(
+				`${paint.bold("enter")} next   ${paint.bold("esc")} cancel   type to edit`,
+			),
+		);
+	}
+	return out.join("\n");
+}
+
+export async function runInteractiveHelp(opts: {
+	name: string;
+	version: string;
+	root: CommandNode;
+	globals?: Record<string, ProcessedBuilderConfig>;
+	branding?: HelpBranding;
+	populateLeaf: (path: string[], node: CommandNode) => void;
+}): Promise<InteractiveResult> {
+	const { name, version, root, globals, branding, populateLeaf } = opts;
+	const stdin = process.stdin;
+	const stdout = process.stdout;
+
+	let path: string[] = [];
+	let stack: CommandNode[] = [root];
+	let selected = 0;
+	let leaf: CommandNode | null = null;
+	let leafFields: FormField[] = [];
+	let form: FormState | null = null;
+	let lastLineCount = 0;
+
+	const paintFrame = (frame: string) => {
+		// Repaint in place: move to frame top, clear below, rewrite.
+		if (lastLineCount > 0) stdout.write(`${ESC}[${lastLineCount}A`);
+		stdout.write(`${ESC}[0J`);
+		stdout.write(`${frame}\n`);
+		lastLineCount = frame.split("\n").length;
+	};
+
+	const draw = () => {
+		const current = stack[stack.length - 1] ?? root;
+		const frame = form
+			? renderForm(name, path, form)
+			: leaf
+				? renderLeaf(name, path, leaf, globals, leafFields.length)
+				: render(name, version, branding, path, rows(current), selected);
+		paintFrame(frame);
+	};
+
+	stdin.setRawMode?.(true);
+	stdin.resume();
+	stdout.write(hide);
+
+	const cleanup = () => {
+		stdin.setRawMode?.(false);
+		stdin.pause();
+		stdout.write(show);
+	};
+
+	return new Promise<InteractiveResult>((resolvePromise) => {
+		const finish = (result: InteractiveResult) => {
+			cleanup();
+			stdin.off("data", onData);
+			resolvePromise(result);
+		};
+
+		const closeLeaf = () => {
+			leaf = null;
+			leafFields = [];
+			path = path.slice(0, -1);
+		};
+
+		const commitFormValue = (value: string | boolean) => {
+			if (!form) return;
+			form.values[form.index] = value;
+			form.index++;
+			form.buffer = "";
+			form.enumIndex = 0;
+			if (form.index >= form.fields.length) form.confirming = true;
+		};
+
+		const handleFormKey = (key: string): InteractiveResult | undefined => {
+			if (!form) return;
+			if (key === "\x03") return {};
+			if (key === ESC) {
+				form = null;
+				return undefined;
+			}
+
+			if (form.confirming) {
+				if (key === "\r") {
+					return { runArgs: buildRunArgs(path, form.fields, form.values) };
+				}
+				if (key === `${ESC}[D` || key === "\x7f") {
+					// Edit the last field again.
+					form.confirming = false;
+					form.index = Math.max(0, form.index - 1);
+					const prev = form.values[form.index];
+					form.buffer = typeof prev === "string" ? prev : "";
+				}
+				return undefined;
+			}
+
+			const field = form.fields[form.index];
+			if (!field) return undefined;
+			if (field.enumVals?.length) {
+				const n = field.enumVals.length;
+				if (key === `${ESC}[A`) form.enumIndex = (form.enumIndex - 1 + n) % n;
+				else if (key === `${ESC}[B`) form.enumIndex = (form.enumIndex + 1) % n;
+				else if (key === "\r") {
+					const value = field.enumVals[form.enumIndex];
+					if (value !== undefined) commitFormValue(value);
+				}
+				return undefined;
+			}
+			if (field.type === "boolean") {
+				if (key === "y" || key === "Y") commitFormValue(true);
+				else if (key === "n" || key === "N") commitFormValue(false);
+				return undefined;
+			}
+			// Text input
+			if (key === "\r") {
+				if (form.buffer.trim() !== "") commitFormValue(form.buffer.trim());
+				return undefined;
+			}
+			if (key === "\x7f") {
+				form.buffer = form.buffer.slice(0, -1);
+				return undefined;
+			}
+			// Printable chars only (skip other escape sequences).
+			if (!key.startsWith(ESC) && key >= " ") form.buffer += key;
+			return undefined;
+		};
+
+		const onData = (data: Buffer) => {
+			const key = data.toString();
+
+			if (form) {
+				const result = handleFormKey(key);
+				if (result) return finish(result);
+				draw();
+				return;
+			}
+
+			const current = stack[stack.length - 1] ?? root;
+			const list = rows(current);
+
+			if (key === "\x03" || key === "q") return finish({});
+			if (key === `${ESC}[A` || key === "k") {
+				if (!leaf) selected = (selected - 1 + list.length) % list.length;
+			} else if (key === `${ESC}[B` || key === "j") {
+				if (!leaf) selected = (selected + 1) % list.length;
+			} else if (key === `${ESC}[D` || key === "\x7f" || key === ESC) {
+				if (leaf) {
+					closeLeaf();
+				} else if (stack.length > 1) {
+					stack = stack.slice(0, -1);
+					path = path.slice(0, -1);
+					selected = 0;
+				} else {
+					return finish({});
+				}
+			} else if (key === "\r" || key === `${ESC}[C`) {
+				if (leaf) {
+					if (key !== "\r") return;
+					if (leafFields.length === 0) {
+						return finish({ runArgs: [...path] });
+					}
+					form = {
+						fields: leafFields,
+						values: [],
+						index: 0,
+						buffer: "",
+						enumIndex: 0,
+						confirming: false,
+					};
+				} else {
+					const row = list[selected];
+					if (!row) return;
+					if (row.node.children.size > 0) {
+						stack = [...stack, row.node];
+						path = [...path, row.name];
+						selected = 0;
+					} else {
+						path = [...path, row.name];
+						populateLeaf(path, row.node);
+						leaf = row.node;
+						leafFields = collectRequiredFields(row.node);
+					}
+				}
+			}
+			draw();
+		};
+
+		stdin.on("data", onData);
+		draw();
+	});
+}

--- a/packages/cli-framework/src/interactive-help.ts
+++ b/packages/cli-framework/src/interactive-help.ts
@@ -452,13 +452,15 @@ export async function runInteractiveHelp(opts: {
 			return undefined;
 		};
 
-		const onData = (data: Buffer) => {
+		// Hoisted: teardown() references onData, and the already-aborted branch
+		// above runs teardown before this point in the source.
+		function onData(data: Buffer) {
 			try {
 				handleKey(data.toString());
 			} catch (error) {
 				fail(error);
 			}
-		};
+		}
 
 		const handleKey = (key: string) => {
 			if (form) {

--- a/packages/cli-framework/src/interactive-help.ts
+++ b/packages/cli-framework/src/interactive-help.ts
@@ -62,6 +62,7 @@ export function collectRequiredFields(node: CommandNode): FormField[] {
 			name: arg.name ?? "arg",
 			description: arg.description,
 			type: arg.type === "number" ? "number" : "string",
+			enumVals: arg.enumVals,
 			variadic: arg.isVariadic,
 		});
 	}
@@ -79,9 +80,15 @@ export function collectRequiredFields(node: CommandNode): FormField[] {
 						? "boolean"
 						: "string",
 			enumVals: config.enumVals,
+			variadic: config.isVariadic,
 		});
 	}
 	return fields;
+}
+
+/** Variadic fields accept one space-separated line and expand to many argv. */
+function splitVariadic(value: string): string[] {
+	return value.trim().split(/\s+/).filter(Boolean);
 }
 
 /** Assemble argv for execute(): path, then positionals, then --flag value. */
@@ -94,15 +101,27 @@ export function buildRunArgs(
 	for (const [i, field] of fields.entries()) {
 		const value = values[i];
 		if (field.kind === "positional") {
-			if (typeof value === "string" && value !== "") args.push(value);
+			if (typeof value === "string" && value !== "") {
+				if (field.variadic) args.push(...splitVariadic(value));
+				else args.push(value);
+			}
 			continue;
 		}
 		if (field.type === "boolean") {
+			// A required boolean must appear either way; the parser supports
+			// --no-<flag> negation.
 			if (value === true) args.push(`--${field.name}`);
+			else if (value === false) args.push(`--no-${field.name}`);
 			continue;
 		}
 		if (typeof value === "string" && value !== "") {
-			args.push(`--${field.name}`, value);
+			if (field.variadic) {
+				for (const part of splitVariadic(value)) {
+					args.push(`--${field.name}`, part);
+				}
+			} else {
+				args.push(`--${field.name}`, value);
+			}
 		}
 	}
 	return args;
@@ -263,7 +282,13 @@ function renderForm(name: string, path: string[], form: FormState): string {
 		out.push("");
 		out.push(paint.dim(`${paint.bold("esc")} cancel`));
 	} else {
-		out.push(`  ${paint.bold("›")} ${form.buffer}${paint.invert(" ")}`);
+		const inputHints = [
+			field.type === "number" ? "number" : undefined,
+			field.variadic ? "space-separated for multiple" : undefined,
+		].filter(Boolean);
+		out.push(
+			`  ${paint.bold("›")} ${form.buffer}${paint.invert(" ")}${inputHints.length > 0 ? `  ${paint.dim(`(${inputHints.join(", ")})`)}` : ""}`,
+		);
 		out.push("");
 		out.push(
 			paint.dim(
@@ -281,8 +306,9 @@ export async function runInteractiveHelp(opts: {
 	globals?: Record<string, ProcessedBuilderConfig>;
 	branding?: HelpBranding;
 	populateLeaf: (path: string[], node: CommandNode) => void;
+	signal?: AbortSignal;
 }): Promise<InteractiveResult> {
-	const { name, version, root, globals, branding, populateLeaf } = opts;
+	const { name, version, root, globals, branding, populateLeaf, signal } = opts;
 	const stdin = process.stdin;
 	const stdout = process.stdout;
 
@@ -316,18 +342,41 @@ export async function runInteractiveHelp(opts: {
 	stdin.resume();
 	stdout.write(hide);
 
+	// The terminal must be restored on EVERY exit path — normal finish, an
+	// exception inside the key handler, SIGINT/SIGTERM (via the runner's
+	// abort signal), or process exit — or the user's shell is left in raw
+	// mode with a hidden cursor.
+	let cleaned = false;
 	const cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
 		stdin.setRawMode?.(false);
 		stdin.pause();
 		stdout.write(show);
 	};
+	process.on("exit", cleanup);
 
-	return new Promise<InteractiveResult>((resolvePromise) => {
-		const finish = (result: InteractiveResult) => {
+	return new Promise<InteractiveResult>((resolvePromise, rejectPromise) => {
+		const teardown = () => {
 			cleanup();
 			stdin.off("data", onData);
+			process.off("exit", cleanup);
+			signal?.removeEventListener("abort", onAbort);
+		};
+		const finish = (result: InteractiveResult) => {
+			teardown();
 			resolvePromise(result);
 		};
+		const fail = (error: unknown) => {
+			teardown();
+			rejectPromise(error);
+		};
+		const onAbort = () => finish({});
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) {
+			finish({});
+			return;
+		}
 
 		const closeLeaf = () => {
 			leaf = null;
@@ -385,7 +434,13 @@ export async function runInteractiveHelp(opts: {
 			}
 			// Text input
 			if (key === "\r") {
-				if (form.buffer.trim() !== "") commitFormValue(form.buffer.trim());
+				const trimmed = form.buffer.trim();
+				if (trimmed === "") return undefined;
+				// Numbers fail fast here instead of after the browser closes.
+				if (field.type === "number" && Number.isNaN(Number(trimmed))) {
+					return undefined;
+				}
+				commitFormValue(trimmed);
 				return undefined;
 			}
 			if (key === "\x7f") {
@@ -398,8 +453,14 @@ export async function runInteractiveHelp(opts: {
 		};
 
 		const onData = (data: Buffer) => {
-			const key = data.toString();
+			try {
+				handleKey(data.toString());
+			} catch (error) {
+				fail(error);
+			}
+		};
 
+		const handleKey = (key: string) => {
 			if (form) {
 				const result = handleFormKey(key);
 				if (result) return finish(result);
@@ -412,9 +473,10 @@ export async function runInteractiveHelp(opts: {
 
 			if (key === "\x03" || key === "q") return finish({});
 			if (key === `${ESC}[A` || key === "k") {
-				if (!leaf) selected = (selected - 1 + list.length) % list.length;
+				if (!leaf && list.length > 0)
+					selected = (selected - 1 + list.length) % list.length;
 			} else if (key === `${ESC}[B` || key === "j") {
-				if (!leaf) selected = (selected + 1) % list.length;
+				if (!leaf && list.length > 0) selected = (selected + 1) % list.length;
 			} else if (key === `${ESC}[D` || key === "\x7f" || key === ESC) {
 				if (leaf) {
 					closeLeaf();

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -226,6 +226,7 @@ async function execute(
 			root,
 			globals: globalConfigs,
 			branding: opts.help,
+			signal,
 			populateLeaf: (path, node) => {
 				const cmd = commandMap.get(path.join("/"));
 				if (cmd) populateNodeForHelp(node, cmd);
@@ -283,7 +284,9 @@ async function execute(
 	}
 
 	if (commandPath.length === 0) {
-		console.log(generateRootHelp(name, version, root, globalConfigs));
+		console.log(
+			generateRootHelp(name, version, root, globalConfigs, opts.help),
+		);
 		return;
 	}
 

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -4,7 +4,9 @@ import {
 	generateCommandHelp,
 	generateGroupHelp,
 	generateRootHelp,
+	type HelpBranding,
 } from "./help";
+import { runInteractiveHelp } from "./interactive-help";
 import type { MiddlewareFn } from "./middleware";
 import type { GenericBuilderInternals, ProcessedBuilderConfig } from "./option";
 import { formatOutput } from "./output";
@@ -27,6 +29,7 @@ export interface RunOptions {
 	version: string;
 	tree: CommandTree;
 	globals?: Record<string, GenericBuilderInternals>;
+	help?: HelpBranding;
 }
 
 export async function run(opts: RunOptions): Promise<void> {
@@ -201,12 +204,39 @@ async function execute(
 	opts: RunOptions,
 	loaded: CommandTree,
 	signal: AbortSignal,
+	argsOverride?: string[],
 ): Promise<void> {
-	const args = process.argv.slice(2);
+	const args = argsOverride ?? process.argv.slice(2);
 	const { name, version } = opts;
 	const { middleware } = loaded;
 	const globalConfigs = processGlobals(opts.globals);
 	const { root, commandMap } = buildTree(loaded.groups, loaded.commands);
+
+	// EXPERIMENT: bare invocation on a TTY opens the interactive help browser
+	// instead of dumping static help. Agents/CI keep the static output.
+	if (
+		args.length === 0 &&
+		process.stdin.isTTY === true &&
+		process.stdout.isTTY === true &&
+		!isAgentMode()
+	) {
+		const result = await runInteractiveHelp({
+			name,
+			version,
+			root,
+			globals: globalConfigs,
+			branding: opts.help,
+			populateLeaf: (path, node) => {
+				const cmd = commandMap.get(path.join("/"));
+				if (cmd) populateNodeForHelp(node, cmd);
+			},
+		});
+		if (result.runArgs) {
+			console.log("");
+			return execute(opts, loaded, signal, result.runArgs);
+		}
+		return;
+	}
 
 	// Help
 	if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
@@ -214,7 +244,9 @@ async function execute(
 		const { segments } = splitArgsForRouting(cleanArgs, globalConfigs);
 		const routeResult = routeCommand(root, segments);
 		if (routeResult.commandPath.length === 0) {
-			console.log(generateRootHelp(name, version, root, globalConfigs));
+			console.log(
+				generateRootHelp(name, version, root, globalConfigs, opts.help),
+			);
 			return;
 		}
 		const cmd = commandMap.get(routeResult.commandPath.join("/"));

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
 		],
 		examples: [
 			{
-				cmd: 'superset ws create --project <id> --name fix-tests --agent claude --prompt "fix the flaky tests"',
+				cmd: 'superset ws create --project <id> --name fix-tests --branch fix-tests --agent claude --prompt "fix the flaky tests"',
 				desc: "Spin up an isolated workspace and put an agent to work",
 			},
 			{
@@ -56,7 +56,7 @@ export default defineConfig({
 				desc: "Peek at what an agent is doing right now",
 			},
 			{
-				cmd: 'superset automations create --name nightly-audit --rrule "FREQ=DAILY" --prompt "audit deps"',
+				cmd: 'superset automations create --name nightly-audit --project <id> --rrule "FREQ=DAILY" --prompt "audit deps"',
 				desc: "Schedule a recurring agent run",
 			},
 		],

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -27,4 +27,38 @@ export default defineConfig({
 			.env("SUPERSET_API_KEY")
 			.desc("Use a Superset API key (sk_live_…) instead of OAuth login"),
 	},
+	help: {
+		tagline: "Command your fleet of coding agents from any shell.",
+		docsUrl: "https://docs.superset.sh/cli",
+		tip: "Agents in Superset terminals already have `superset` on PATH — tell them to use it.",
+		sections: [
+			{
+				title: "Workspaces & agents",
+				commands: ["workspaces", "agents", "terminals"],
+			},
+			{ title: "Tasks & automations", commands: ["tasks", "automations"] },
+			{
+				title: "Hosts & projects",
+				commands: ["hosts", "projects", "start", "status", "stop"],
+			},
+			{
+				title: "Account",
+				commands: ["auth", "organization", "update", "feedback"],
+			},
+		],
+		examples: [
+			{
+				cmd: 'superset ws create --project <id> --name fix-tests --agent claude --prompt "fix the flaky tests"',
+				desc: "Spin up an isolated workspace and put an agent to work",
+			},
+			{
+				cmd: "superset terminals read --workspace <id> --terminal <id>",
+				desc: "Peek at what an agent is doing right now",
+			},
+			{
+				cmd: 'superset automations create --name nightly-audit --rrule "FREQ=DAILY" --prompt "audit deps"',
+				desc: "Schedule a recurring agent run",
+			},
+		],
+	},
 });


### PR DESCRIPTION
## Summary
- `superset --help` becomes a branded, colored help screen: tagline, copy-paste **Examples**, commands grouped into curated sections (Workspaces & agents / Tasks & automations / Hosts & projects / Account), and a Docs + Tip footer. Colors auto-disable on non-TTY or `NO_COLOR`.
- Bare `superset` on a TTY opens an **interactive command browser**: arrow-key navigation over the whole command tree, per-command flag docs, and one-key execution. Commands with required inputs get a guided form — text inputs, enum selectors (↑↓), yes/no — ending in a "Ready:" screen that shows the exact assembled command before running it.
- Agents and CI are untouched: the browser only opens when stdin+stdout are TTYs **and** `isAgentMode()` is false (same env-var detection that drives auto-JSON), so any environment that gets JSON output still gets static help.

## Why / Context
The CLI is bundled with the desktop app and on PATH in every Superset terminal, but discovering what it can do requires reading docs. This makes bare `superset` a self-guided tour: browse → read flags → fill in required inputs → run — and the confirm screen teaches the real command syntax as a side effect. Companion to the built-in "Superset CLI" preset (#6270), which opens a terminal in the app; this is what users see when they get there.

## How It Works
- `cli-framework/src/help.ts`: new optional `HelpBranding` (`tagline`, `sections`, `examples`, `docsUrl`, `tip`) + ANSI `paint` helper; `generateRootHelp` renders the branded layout when branding is configured. Group/command help unchanged.
- `cli-framework/src/interactive-help.ts` (new): zero-dependency raw-mode browser — arrow-key escape-sequence parsing, in-place frame repainting, tree navigation, `collectRequiredFields()` (required args/flags, positionals first, required-with-default excluded), form state machine (text/enum/boolean), `buildRunArgs()` assembling argv.
- `cli-framework/src/runner.ts`: bare-args + TTY + `!isAgentMode()` gate; on "run", re-enters `execute()` with the assembled argv so middleware/auth/output behave exactly as if typed.
- `config.ts`/`dev.ts`/`build.ts`: plumb `help` from `cli.config.ts` into `run()` (dev mode and compiled binary).
- `packages/cli/cli.config.ts`: the Superset-specific branding content. The framework stays generic — any CLI built on it opts in with its own `help:` block.

Zero new dependencies (no ink/clack in the framework); works in the compiled binary.

## Manual QA (dev CLI in Ghostty + Superset terminal via CDP, screenshots captured)
- [x] `bun run dev --help` renders branded static help; piping strips colors
- [x] Bare `bun run dev` in a TTY opens the browser; agent-env shells still get static help
- [x] Navigation: groups drill in, breadcrumbs update, ← backs out, q quits, raw mode restored
- [x] Leaf with no required inputs (`status`): "enter run it now" executes through normal middleware (auth error surfaces normally against a dev API without login)
- [x] Leaf with required inputs (`feedback submit`): enum selector for `--type`, text input for `--title`, confirm screen shows `superset feedback submit --type feature --title "…"`, ← edits last field, esc cancels
- [ ] Windows terminal key handling (untested — known gap)

## Testing
- `bun test packages/cli-framework/src/interactive-help.test.ts` (7 tests: required-field collection incl. enum/default/positional ordering, argv assembly, boolean flags, display quoting)
- `bun turbo run typecheck --filter=@superset/cli-framework --filter=@superset/cli`
- `bun run lint`

## Known Limitations / Follow-ups
- Guided form covers required inputs only; optional flags still typed by hand
- No pick-lists from live data yet (e.g. selecting `--project` from `projects list --json`) — the natural next step
- No type-to-filter search in the browser; Windows key handling unverified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a branded help screen and an interactive command browser to the `superset` CLI for easier command discovery and execution. Fixes an early-abort case and ensures the terminal is always restored; CI/agents still get static help.

- **New Features**
  - Branded root help: tagline, curated sections, copy‑paste examples, and docs/tip footer; colors auto‑disable on non‑TTY or `NO_COLOR`.
  - Bare `superset` in a TTY opens a browser with arrow‑key navigation, per‑command flag docs, and one‑key run. Guided form gathers required inputs (text, enum picker, yes/no, variadic), then shows a quoted “Ready” command; booleans support `--no-<flag>` when false.
  - TTY + `!isAgentMode()` gate; execution re‑enters the normal runner with the assembled argv so middleware/auth/output behave the same.

- **Bug Fixes**
  - Always restore terminal state (raw mode and cursor) on quit, errors, signal aborts, and when the abort signal was already fired before startup.
  - Better key handling (arrows/backspace/esc/ctrl‑c) and variadic input splitting for flags and positionals.

<sup>Written for commit c7637fe88c2875e8fe7981c31bde11ac7ec27c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive help browser for navigating commands and entering required options.
  - Added customizable help branding, including taglines, command sections, examples, documentation links, and tips.
  - Improved root help output with styled headers, grouped commands, usage details, and examples.
  - Added branded help content and practical command examples to the CLI.
  - Bare interactive terminal launches can now guide users through command selection and required inputs.

- **Tests**
  - Added coverage for interactive command selection, argument handling, flags, defaults, and display formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->