### PR TITLE
fix(desktop): surface automation update errors and make team automations read-only

### DIFF
--- a/apps/desktop/src/renderer/components/EmojiTextInput/EmojiTextInput.tsx
+++ b/apps/desktop/src/renderer/components/EmojiTextInput/EmojiTextInput.tsx
@@ -45,6 +45,8 @@ interface EmojiTextInputProps {
 	className?: string;
 	onEnter?: () => void;
 	onBlur?: (value: string) => void;
+	/** false renders the value read-only. */
+	editable?: boolean;
 }
 
 function getPlainText(
@@ -62,8 +64,10 @@ export function EmojiTextInput({
 	className,
 	onEnter,
 	onBlur,
+	editable = true,
 }: EmojiTextInputProps) {
 	const editor = useEditor({
+		editable,
 		immediatelyRender: false,
 		extensions: [
 			SingleLineDocument,
@@ -94,6 +98,10 @@ export function EmojiTextInput({
 			onBlur?.(getPlainText(e));
 		},
 	});
+
+	useEffect(() => {
+		if (editor && editor.isEditable !== editable) editor.setEditable(editable);
+	}, [editable, editor]);
 
 	useEffect(() => {
 		if (!editor) return;

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -442,7 +442,7 @@ export function MarkdownEditor({
 
 	return (
 		<div className={cn("w-full", className)}>
-			{showBubbleMenu && editor && (
+			{showBubbleMenu && editable && editor && (
 				<BubbleMenu
 					editor={editor}
 					options={{

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -157,6 +157,8 @@ interface MarkdownEditorProps {
 		fileMention?: boolean;
 		bubbleMenu?: boolean;
 	};
+	/** false renders the content read-only. */
+	editable?: boolean;
 }
 
 function getMarkdown(editor: Editor | null): string {
@@ -212,6 +214,7 @@ export function MarkdownEditor({
 	searchFiles,
 	onPasteFiles,
 	features,
+	editable = true,
 }: MarkdownEditorProps) {
 	const showSlashCommand = features?.slashCommand ?? true;
 	const showEmoji = features?.emoji ?? true;
@@ -231,6 +234,7 @@ export function MarkdownEditor({
 	const urlPolicy = useInlineUrlPolicy();
 
 	const editor = useEditor({
+		editable,
 		autofocus: autoFocus === true ? "end" : autoFocus || false,
 		extensions: [
 			Document,
@@ -422,6 +426,10 @@ export function MarkdownEditor({
 		},
 	});
 	editorRef.current = editor;
+
+	useEffect(() => {
+		if (editor && editor.isEditable !== editable) editor.setEditable(editable);
+	}, [editable, editor]);
 
 	useEffect(() => {
 		if (!editor || editor.isFocused) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
@@ -1,4 +1,5 @@
 import type { SelectAutomation } from "@superset/db/schema";
+import { toast } from "@superset/ui/sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { EmojiTextInput } from "renderer/components/EmojiTextInput";
@@ -8,8 +9,10 @@ import { useProjectFileSearch } from "../../../hooks/useProjectFileSearch";
 
 export function AutomationBody({
 	automation,
+	readOnly,
 }: {
 	automation: SelectAutomation;
+	readOnly?: boolean;
 }) {
 	const [name, setName] = useState(automation.name);
 	const [prompt, setPrompt] = useState(automation.prompt);
@@ -26,6 +29,10 @@ export function AutomationBody({
 	const updateMutation = useMutation({
 		mutationFn: (patch: { name?: string }) =>
 			apiTrpcClient.automation.update.mutate({ id: automation.id, ...patch }),
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update automation",
+			),
 	});
 
 	const setPromptMutation = useMutation({
@@ -39,6 +46,10 @@ export function AutomationBody({
 				queryKey: ["automation-versions", automation.id],
 			});
 		},
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update prompt",
+			),
 	});
 
 	const searchFiles = useProjectFileSearch({
@@ -51,7 +62,9 @@ export function AutomationBody({
 			<EmojiTextInput
 				value={name}
 				onChange={setName}
+				editable={!readOnly}
 				onBlur={(next) => {
+					if (readOnly) return;
 					const trimmed = next.trim();
 					if (trimmed && trimmed !== automation.name) {
 						updateMutation.mutate({ name: trimmed });
@@ -63,7 +76,9 @@ export function AutomationBody({
 			<MarkdownEditor
 				content={prompt}
 				onChange={setPrompt}
+				editable={!readOnly}
 				onSave={(next) => {
+					if (readOnly) return;
 					if (next !== automation.prompt) {
 						setPromptMutation.mutate(next);
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
@@ -21,6 +21,8 @@ interface AutomationDetailHeaderProps {
 	toggleDisabled?: boolean;
 	deleteDisabled?: boolean;
 	runNowDisabled?: boolean;
+	/** Hides the actions — they're all owner-gated server-side. */
+	readOnly?: boolean;
 }
 
 export function AutomationDetailHeader({
@@ -34,6 +36,7 @@ export function AutomationDetailHeader({
 	toggleDisabled,
 	deleteDisabled,
 	runNowDisabled,
+	readOnly,
 }: AutomationDetailHeaderProps) {
 	return (
 		<header className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
@@ -54,64 +57,66 @@ export function AutomationDetailHeader({
 			{/* Window-drag leaf standing in for the hidden TopBar. */}
 			<div className="drag h-full min-w-0 flex-1" />
 
-			<div className="flex items-center gap-1">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon-sm"
-							onClick={onOpenHistory}
-							aria-label="Version history"
-						>
-							<LuClock className="size-4" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>Version history</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon-sm"
-							onClick={onToggleEnabled}
-							disabled={toggleDisabled}
-							aria-label={enabled ? "Pause" : "Resume"}
-						>
-							{enabled ? (
-								<LuPause className="size-4" />
-							) : (
-								<LuPlay className="size-4" />
-							)}
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>{enabled ? "Pause" : "Resume"}</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon-sm"
-							onClick={onDelete}
-							disabled={deleteDisabled}
-							aria-label="Delete"
-						>
-							<LuTrash2 className="size-4" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>Delete</TooltipContent>
-				</Tooltip>
-				<div className="mx-1 h-4 w-px bg-border" />
-				<Button
-					variant="outline"
-					size="sm"
-					className="h-8 gap-1.5 px-3"
-					onClick={onRunNow}
-					disabled={runNowDisabled}
-				>
-					<LuPlay className="size-4" />
-					<span>Run now</span>
-				</Button>
-			</div>
+			{!readOnly && (
+				<div className="flex items-center gap-1">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onClick={onOpenHistory}
+								aria-label="Version history"
+							>
+								<LuClock className="size-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Version history</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onClick={onToggleEnabled}
+								disabled={toggleDisabled}
+								aria-label={enabled ? "Pause" : "Resume"}
+							>
+								{enabled ? (
+									<LuPause className="size-4" />
+								) : (
+									<LuPlay className="size-4" />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>{enabled ? "Pause" : "Resume"}</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onClick={onDelete}
+								disabled={deleteDisabled}
+								aria-label="Delete"
+							>
+								<LuTrash2 className="size-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Delete</TooltipContent>
+					</Tooltip>
+					<div className="mx-1 h-4 w-px bg-border" />
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-8 gap-1.5 px-3"
+						onClick={onRunNow}
+						disabled={runNowDisabled}
+					>
+						<LuPlay className="size-4" />
+						<span>Run now</span>
+					</Button>
+				</div>
+			)}
 		</header>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
@@ -3,7 +3,10 @@ import type {
 	SelectAutomationRun,
 } from "@superset/db/schema";
 import { formatDateTimeInTimezone } from "@superset/shared/rrule";
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { useRecentProjects } from "renderer/hooks/host-projects/useRecentProjects";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
@@ -11,6 +14,7 @@ import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { AgentPicker } from "../../../components/AgentPicker";
 import { ProjectPicker } from "../../../components/ProjectPicker";
 import { RelayOfflineNotice } from "../../../components/RelayOfflineNotice";
@@ -26,13 +30,17 @@ import { SectionTitle } from "./components/SectionTitle";
 interface AutomationDetailSidebarProps {
 	automation: SelectAutomation;
 	recentRuns: SelectAutomationRun[];
+	/** Disables every editor — automation updates are owner-gated server-side. */
+	readOnly?: boolean;
 }
 
 export function AutomationDetailSidebar({
 	automation,
 	recentRuns,
+	readOnly,
 }: AutomationDetailSidebarProps) {
 	const recentProjects = useRecentProjects();
+	const collections = useCollections();
 	const { localHostId } = useWorkspaceHostOptions();
 	const selectedProject = recentProjects.find(
 		(p) => p.id === automation.v2ProjectId,
@@ -55,7 +63,23 @@ export function AutomationDetailSidebar({
 			>,
 		) =>
 			apiTrpcClient.automation.update.mutate({ id: automation.id, ...patch }),
+		// The pickers re-render from the Electric-synced row, so a rejected
+		// update silently snaps back without this.
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update automation",
+			),
 	});
+
+	const { data: ownerRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ u: collections.users })
+				.where(({ u }) => eq(u.id, automation.ownerUserId))
+				.select(({ u }) => ({ name: u.name, email: u.email })),
+		[collections.users, automation.ownerUserId],
+	);
+	const ownerName = ownerRows[0]?.name ?? ownerRows[0]?.email ?? null;
 
 	const lastRunAt = recentRuns
 		.map((run) => run.scheduledFor)
@@ -105,108 +129,120 @@ export function AutomationDetailSidebar({
 				</Section>
 
 				<Section title="Details">
-					<Row
-						label="Device"
-						value={
-							<DevicePicker
-								className="-mr-4"
-								hostId={hostId}
-								showLocalOnlineState
-								onSelectHostId={(nextHostId) => {
-									updateMutation.mutate({ targetHostId: nextHostId });
-								}}
-							/>
-						}
-					/>
-					<Row
-						label="Project"
-						value={
-							<ProjectPicker
-								className="-mr-4"
-								selectedProject={selectedProject}
-								recentProjects={recentProjects}
-								onSelectProject={(v2ProjectId) =>
-									updateMutation.mutate({ v2ProjectId })
-								}
-							/>
-						}
-					/>
-					<Row
-						label="Workspace"
-						value={
-							<WorkspacePicker
-								className="-mr-4"
-								hostId={hostId}
-								projectId={automation.v2ProjectId}
-								value={automation.v2WorkspaceId}
-								onChange={(v2WorkspaceId) =>
-									updateMutation.mutate({
-										v2WorkspaceId,
-										// Denormalized pin: the picker is scoped to this
-										// host/project, so send both — the cloud stores them
-										// without a workspace-registry lookup.
-										...(v2WorkspaceId && hostId && automation.v2ProjectId
-											? {
-													targetHostId: hostId,
-													v2ProjectId: automation.v2ProjectId,
-												}
-											: {}),
-									})
-								}
-							/>
-						}
-					/>
-					<Row
-						label="Repeats"
-						value={
-							<SchedulePicker
-								className="-mr-4"
-								rrule={automation.rrule}
-								onRruleChange={(rrule) => updateMutation.mutate({ rrule })}
-							/>
-						}
-					/>
-					<Row
-						label="Agent"
-						value={
-							<AgentPicker
-								className="-mr-4"
-								hostId={hostId}
-								value={automation.agent}
-								onChange={(id) => {
-									// The picker is scoped to `hostId` and emits a preset slug
-									// when unambiguous, falling back to the instance UUID. If
-									// the automation was previously auto-routed (targetHostId
-									// null), pin it to the host this value came from so a
-									// UUID-shaped agent can't be dispatched to a host that's
-									// never seen it.
-									const patch: { agent: string; targetHostId?: string } = {
-										agent: id,
-									};
-									if (!automation.targetHostId && hostId) {
-										patch.targetHostId = hostId;
-									}
-									updateMutation.mutate(patch);
-								}}
-							/>
-						}
-					/>
-					{agentMissing && (
-						<p className="select-text cursor-text text-xs text-amber-600 dark:text-amber-500">
-							This agent no longer exists on the selected device (its agents may
-							have been reset). Runs will fail until you pick a new one.
+					{readOnly && (
+						<p className="select-text cursor-text pb-2 text-xs text-muted-foreground">
+							Owned by {ownerName ?? "a teammate"} — only they can edit this
+							automation.
 						</p>
 					)}
-					<Row
-						label="Timezone"
-						value={
-							<TimezonePicker
-								className="-mr-4"
-								value={automation.timezone}
-								onChange={(timezone) => updateMutation.mutate({ timezone })}
-							/>
-						}
-					/>
+					{/* display:contents keeps the rows in the section's flex column;
+					    disabled propagates to every picker's trigger button. */}
+					<fieldset disabled={readOnly} className="contents">
+						<Row
+							label="Device"
+							value={
+								<DevicePicker
+									className="-mr-4"
+									hostId={hostId}
+									showLocalOnlineState
+									disabled={readOnly}
+									onSelectHostId={(nextHostId) => {
+										updateMutation.mutate({ targetHostId: nextHostId });
+									}}
+								/>
+							}
+						/>
+						<Row
+							label="Project"
+							value={
+								<ProjectPicker
+									className="-mr-4"
+									selectedProject={selectedProject}
+									recentProjects={recentProjects}
+									onSelectProject={(v2ProjectId) =>
+										updateMutation.mutate({ v2ProjectId })
+									}
+								/>
+							}
+						/>
+						<Row
+							label="Workspace"
+							value={
+								<WorkspacePicker
+									className="-mr-4"
+									hostId={hostId}
+									projectId={automation.v2ProjectId}
+									value={automation.v2WorkspaceId}
+									onChange={(v2WorkspaceId) =>
+										updateMutation.mutate({
+											v2WorkspaceId,
+											// Denormalized pin: the picker is scoped to this
+											// host/project, so send both — the cloud stores them
+											// without a workspace-registry lookup.
+											...(v2WorkspaceId && hostId && automation.v2ProjectId
+												? {
+														targetHostId: hostId,
+														v2ProjectId: automation.v2ProjectId,
+													}
+												: {}),
+										})
+									}
+								/>
+							}
+						/>
+						<Row
+							label="Repeats"
+							value={
+								<SchedulePicker
+									className="-mr-4"
+									rrule={automation.rrule}
+									onRruleChange={(rrule) => updateMutation.mutate({ rrule })}
+								/>
+							}
+						/>
+						<Row
+							label="Agent"
+							value={
+								<AgentPicker
+									className="-mr-4"
+									hostId={hostId}
+									disabled={readOnly}
+									value={automation.agent}
+									onChange={(id) => {
+										// The picker is scoped to `hostId` and emits a preset slug
+										// when unambiguous, falling back to the instance UUID. If
+										// the automation was previously auto-routed (targetHostId
+										// null), pin it to the host this value came from so a
+										// UUID-shaped agent can't be dispatched to a host that's
+										// never seen it.
+										const patch: { agent: string; targetHostId?: string } = {
+											agent: id,
+										};
+										if (!automation.targetHostId && hostId) {
+											patch.targetHostId = hostId;
+										}
+										updateMutation.mutate(patch);
+									}}
+								/>
+							}
+						/>
+						{agentMissing && (
+							<p className="select-text cursor-text text-xs text-amber-600 dark:text-amber-500">
+								This agent no longer exists on the selected device (its agents
+								may have been reset). Runs will fail until you pick a new one.
+							</p>
+						)}
+						<Row
+							label="Timezone"
+							value={
+								<TimezonePicker
+									className="-mr-4"
+									value={automation.timezone}
+									onChange={(timezone) => updateMutation.mutate({ timezone })}
+								/>
+							}
+						/>
+					</fieldset>
 					<RelayOfflineNotice hostId={hostId} className="mt-2" />
 				</Section>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -10,6 +10,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { HostOfflineRunDialog } from "../components/HostOfflineRunDialog";
 import { isHostOfflineError } from "../utils/hostOfflineError";
@@ -41,6 +42,8 @@ function AutomationDetailPage() {
 	const { history } = Route.useSearch();
 	const navigate = useNavigate();
 	const collections = useCollections();
+	const { data: session } = authClient.useSession();
+	const currentUserId = session?.user?.id;
 	const [historyOpen, setHistoryOpen] = useState(history ?? false);
 	const [hostOfflineOpen, setHostOfflineOpen] = useState(false);
 
@@ -69,6 +72,10 @@ function AutomationDetailPage() {
 	const setEnabledMutation = useMutation({
 		mutationFn: (enabled: boolean) =>
 			apiTrpcClient.automation.setEnabled.mutate({ id: automationId, enabled }),
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update automation",
+			),
 	});
 
 	const runNowMutation = useMutation({
@@ -103,6 +110,12 @@ function AutomationDetailPage() {
 			</div>
 		);
 	}
+
+	// Every automation mutation is owner-gated server-side; render teammates'
+	// automations read-only instead of letting edits silently bounce. Unknown
+	// session (still loading) stays editable — the server is the enforcement.
+	const readOnly =
+		currentUserId !== undefined && automation.ownerUserId !== currentUserId;
 
 	return (
 		<div className="flex h-full w-full flex-1 overflow-hidden">
@@ -140,14 +153,20 @@ function AutomationDetailPage() {
 					toggleDisabled={setEnabledMutation.isPending}
 					deleteDisabled={deleteMutation.isPending}
 					runNowDisabled={runNowMutation.isPending}
+					readOnly={readOnly}
 				/>
 
-				<AutomationBody key={automation.id} automation={automation} />
+				<AutomationBody
+					key={automation.id}
+					automation={automation}
+					readOnly={readOnly}
+				/>
 			</div>
 
 			<AutomationDetailSidebar
 				automation={automation}
 				recentRuns={recentRuns}
+				readOnly={readOnly}
 			/>
 
 			<HostOfflineRunDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -180,7 +180,9 @@ function AutomationDetailPage() {
 				automationId={automation.id}
 				automationName={automation.name}
 				currentPrompt={automation.prompt}
-				open={historyOpen}
+				// Versions are owner-gated server-side too; the header action is
+				// hidden, but the ?history=true search param could still open it.
+				open={!readOnly && historyOpen}
 				onOpenChange={setHistoryOpen}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
@@ -25,9 +25,9 @@ interface AgentPickerProps {
 	onChange: (next: string) => void;
 	className?: string;
 	/**
-	 * Must be set on the Radix trigger, not just an enclosing fieldset —
-	 * Chrome still fires pointerdown on disabled buttons, which is what
-	 * opens a DropdownMenu.
+	 * Disables opening via the Radix trigger itself. A button disabled only
+	 * through an enclosing <fieldset> still receives pointerdown in Chrome —
+	 * the event that opens a DropdownMenu.
 	 */
 	disabled?: boolean;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
@@ -24,6 +24,12 @@ interface AgentPickerProps {
 	value: string;
 	onChange: (next: string) => void;
 	className?: string;
+	/**
+	 * Must be set on the Radix trigger, not just an enclosing fieldset —
+	 * Chrome still fires pointerdown on disabled buttons, which is what
+	 * opens a DropdownMenu.
+	 */
+	disabled?: boolean;
 }
 
 export function AgentPicker({
@@ -31,6 +37,7 @@ export function AgentPicker({
 	value,
 	onChange,
 	className,
+	disabled,
 }: AgentPickerProps) {
 	const navigate = useNavigate();
 	const hostUrl = useHostUrl(hostId);
@@ -47,7 +54,7 @@ export function AgentPicker({
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
+			<DropdownMenuTrigger asChild disabled={disabled}>
 				<PickerTrigger
 					className={className}
 					icon={

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
@@ -44,6 +44,12 @@ interface DevicePickerProps {
 	 * (automations) goes through the relay, so "local" is not inherently online.
 	 */
 	showLocalOnlineState?: boolean;
+	/**
+	 * Must be set on the Radix trigger, not just an enclosing fieldset —
+	 * Chrome still fires pointerdown on disabled buttons, which is what
+	 * opens a DropdownMenu.
+	 */
+	disabled?: boolean;
 }
 
 function getSelectedLabel(
@@ -70,6 +76,7 @@ export function DevicePicker({
 	onSelectHostId,
 	className,
 	showLocalOnlineState = false,
+	disabled,
 }: DevicePickerProps) {
 	const { machineId } = useLocalHostService();
 	const { currentDeviceName, localHostIsOnline, otherHosts } =
@@ -91,7 +98,7 @@ export function DevicePicker({
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
+			<DropdownMenuTrigger asChild disabled={disabled}>
 				<FormPickerTrigger
 					className={cn("max-w-[140px]", className)}
 					aria-label={`Device: ${selectedLabel}`}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
@@ -45,9 +45,9 @@ interface DevicePickerProps {
 	 */
 	showLocalOnlineState?: boolean;
 	/**
-	 * Must be set on the Radix trigger, not just an enclosing fieldset —
-	 * Chrome still fires pointerdown on disabled buttons, which is what
-	 * opens a DropdownMenu.
+	 * Disables opening via the Radix trigger itself. A button disabled only
+	 * through an enclosing <fieldset> still receives pointerdown in Chrome —
+	 * the event that opens a DropdownMenu.
 	 */
 	disabled?: boolean;
 }


### PR DESCRIPTION
## Problem

Choosing another host on an automation appeared to do nothing — the picker snapped back to the old device with no feedback.

CDP repro (dev app, real UI journey): on a **teammate's** automation (Team tab), picking another device fired `automation.update` which the server rejected with 404 — every automation mutation is owner-gated server-side via `getAutomationForUser`. The sidebar's mutation had no `onError`, and the pickers re-render from the Electric-synced row, so the rejected update silently reverted. Same silent failure applied to every field on the detail page (project, workspace, schedule, agent, timezone, name, prompt) plus the pause toggle.

Owned automations were verified unaffected end-to-end (update 200 → row syncs → picker label updates).

## Fix

- **Detail page renders read-only for non-owners** (matches the list page, which already gates row actions on `isOwner`): pickers disabled, header actions hidden (all owner-gated: pause, delete, run now, version history), name/prompt editors non-editable, plus an "Owned by X — only they can edit this automation" note.
- **Every detail-page mutation now toasts server rejections** (`update`, `setPrompt`, `setEnabled`) so no failure class can be silent again.
- `DevicePicker`/`AgentPicker` gained an explicit `disabled` prop: Chrome still fires `pointerdown` on fieldset-disabled buttons, and that's the event that opens a Radix DropdownMenu — verified with trusted CDP input that the fieldset alone doesn't block them (Popover-based pickers open on `click`, which disabled controls do suppress).
- `MarkdownEditor`/`EmojiTextInput` gained an `editable` prop (TipTap `setEditable`).

## Verification (CDP, dev app from this worktree)

- **Before**: Team tab → "Sentry triage" → pick Town-Hall → request 404s, no toast, picker snaps back (the reported symptom).
- **After**: same journey → ownership note shown, header actions hidden, prompt `contenteditable=false`, Device/Agent pickers don't open under **trusted** CDP clicks.
- **Regression**: owned automation host change Kiets-Spaceship → Town-Hall persists, label updates, and DB row confirms; restored afterwards.

## Open question

If teammates *should* be able to repoint each other's automations (e.g. off a dead host), that's a server-side authorization change (`getAutomationForUser` ownership check) — happy to follow up; this PR makes the current permission model visible instead of silent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make teammate-owned automations read-only and surface server rejections as toasts, fixing silent reverts and clarifying permissions. Also hide editor toolbars in read-only mode and block version history for non-owners.

- **Bug Fixes**
  - Toast on automation mutation failures (update, prompt save, enable/disable) to avoid silent reverts.
  - Prevent device/agent pickers from opening when disabled by enforcing trigger `disabled`.
  - Block Version History for non-owners, including via `?history=true`.

- **New Features**
  - Read-only view for non-owners: disable pickers and editors, hide header actions, and show “Owned by X — only they can edit this automation.”
  - Read-only support: `editable` on `MarkdownEditor`/`EmojiTextInput`; `disabled` on `DevicePicker`/`AgentPicker`. Bubble menu hides when read-only.

<sup>Written for commit 57ca75f6fc38784b6ff63cb8d2738f326f8795a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation details are now read-only when viewed by someone other than the owner.
  * Read-only views display ownership information and disable editing, settings, version history, and action controls.
  * Editors, dropdowns, and selection controls now support disabled and read-only states.

* **Bug Fixes**
  * Added error notifications when automation updates, prompt saves, or enable/disable actions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->