### PR TITLE
fix(desktop): toast swallowed mutation errors in billing, api keys, secrets, and base branch picker

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -97,6 +97,10 @@ export function useChangesTab({
 			void utils.git.listCommits.invalidate({ workspaceId });
 			void utils.git.getDiff.invalidate({ workspaceId });
 		},
+		// The picker re-renders from getBaseBranch, so a rejected change
+		// silently snaps back without this.
+		onError: (error) =>
+			toast.error(error.message || "Failed to change base branch"),
 	});
 
 	const setBaseBranch = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
@@ -77,6 +77,9 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 			}
 		} catch (error) {
 			console.error("[api-keys] Failed to generate API key:", error);
+			toast.error(
+				error instanceof Error ? error.message : "Failed to generate API key",
+			);
 		} finally {
 			setIsGenerating(false);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/BillingDetails/BillingDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/BillingDetails/BillingDetails.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
 import { useEffect, useState } from "react";
 import stripeLinkIcon from "renderer/assets/stripe-link.png";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
@@ -70,8 +71,12 @@ export function BillingDetails() {
 			if (result?.url) {
 				openUrl.mutate(result.url);
 			}
-		} catch {
-			// Silently handle
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to open the billing portal",
+			);
 		} finally {
 			setOpeningPortal(null);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/SecretsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/SecretsSettings.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiOutlineCloud } from "react-icons/hi2";
@@ -101,6 +102,9 @@ export function SecretsSettings({ projectId }: SecretsSettingsProps) {
 			});
 		} catch (err) {
 			console.error("[project-settings] Failed to create cloud project:", err);
+			toast.error(
+				err instanceof Error ? err.message : "Failed to create cloud project",
+			);
 		} finally {
 			setIsCreatingCloud(false);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/components/EnvironmentVariablesList/components/SecretRow/SecretRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/components/SecretsSettings/components/EnvironmentVariablesList/components/SecretRow/SecretRow.tsx
@@ -6,6 +6,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
@@ -57,6 +58,9 @@ export function SecretRow({
 			onDeleted();
 		} catch (err) {
 			console.error("[secrets/delete] Failed to delete:", err);
+			toast.error(
+				err instanceof Error ? err.message : "Failed to delete secret",
+			);
 		} finally {
 			setIsDeleting(false);
 		}


### PR DESCRIPTION
Follow-up to #6276. A sweep of `apps/desktop/src/renderer` for the same silent-failure class (cloud/host mutations whose errors were caught with empty or console-only handlers, leaving controls that spin and then do nothing) found five reachable instances; this fixes all of them by surfacing the server error as a toast.

| Surface | Before | Failure the user hits |
|---|---|---|
| Billing portal (`BillingDetails.tsx`) | `catch { // Silently handle }` | Stripe/network failure: Edit buttons spin, portal never opens. (Owner-gating isn't needed here — `billing.details` is gated by the same `requireOwnerWithCustomer`, so non-owners never see the component.) |
| API key generation (`ApiKeysSettings.tsx`) | console-only | Generate spins, dialog stays open with the name still typed in. Revoke in the same file already toasts. |
| Cloud secret delete (`SecretRow.tsx`) | console-only | Confirm dialog → spinner clears → row still there. Sibling add/edit dialogs already toast. |
| Cloud project create (`SecretsSettings.tsx`) | console-only | "Create cloud project" spins and the secrets UI stays unlinked with no explanation. |
| Base branch picker (`useChangesTab.tsx`) | no `onError` | Structural twin of the #6276 device picker: the dropdown re-renders from `getBaseBranch`, so a failed change silently snaps back. `handleRenameBranch` in the same file already uses `toast.promise`. |

The sweep also cleared ~60 look-alikes as already handled (call-site try/catch + toast, `toast.promise`, or the centralized `useOptimisticCollectionActions` error toast), so with #6276 this closes out the pattern in the renderer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show toast errors for failed mutations in billing, API keys, secrets, and the base branch picker to fix silent failures that looked like no-ops. Users now get clear error messages instead of a spinner clearing with nothing happening.

- **Bug Fixes**
  - Billing portal: toast on open failure (e.g., Stripe/network) instead of silent catch.
  - API key generation: toast on failure; dialog no longer just sits.
  - Cloud secret delete: toast on failure; row no longer silently remains.
  - Cloud project create (secrets): toast on failure; clearer unlinked state.
  - Base branch picker: added mutation onError; failed changes now toast instead of snapping back.

<sup>Written for commit 081a9d84818b77aa0cfbf01b00c83c77dc0c3387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notifications when changing a base branch fails.
  * API key generation failures now show a descriptive error message.
  * Billing portal access failures now provide user-facing feedback.
  * Cloud project creation errors now display a notification.
  * Secret deletion failures now show an error message instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->