### PR TITLE
fix(host-service): resync terminal grid on attach to stop TUI ghost artifacts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -932,6 +932,7 @@
         "@t3-oss/env-core": "0.13.11",
         "@trpc/client": "11.16.0",
         "@trpc/server": "11.16.0",
+        "@xterm/addon-serialize": "0.15.0-beta.289",
         "@xterm/headless": "6.1.0-beta.289",
         "better-sqlite3": "12.11.1",
         "drizzle-orm": "0.45.2",

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -60,6 +60,7 @@ const RUNTIME_PACKAGES = [
 	"@duckdb/node-api",
 	"@duckdb/node-bindings",
 	"@xterm/headless",
+	"@xterm/addon-serialize",
 ] as const;
 
 /**

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -86,6 +86,7 @@
 		"@t3-oss/env-core": "0.13.11",
 		"@trpc/client": "11.16.0",
 		"@trpc/server": "11.16.0",
+		"@xterm/addon-serialize": "0.15.0-beta.289",
 		"@xterm/headless": "6.1.0-beta.289",
 		"better-sqlite3": "12.11.1",
 		"drizzle-orm": "0.45.2",

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -57,6 +57,10 @@ type HeadlessInternals = {
 	};
 };
 
+// Scrollback retained by the emulator and emitted by grid resyncs. Bounds the
+// per-attach resync payload; history beyond it is renderer-local only.
+const TRACKER_SCROLLBACK_LINES = 1000;
+
 export function createModeTracker(cols: number, rows: number): ModeTracker {
 	const term = new HeadlessTerminal({
 		cols,
@@ -64,7 +68,7 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		// Retains recent scrollback so `snapshot()` can serve line-mode history,
 		// not just the visible screen. Irrelevant to alt-screen TUIs (no
 		// scrollback), but cheap insurance for plain shell output.
-		scrollback: 1000,
+		scrollback: TRACKER_SCROLLBACK_LINES,
 		allowProposedApi: true,
 	});
 	const serializeAddon = new SerializeAddon();
@@ -166,7 +170,7 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		},
 		snapshot,
 		serialize() {
-			return serializeAddon.serialize({ scrollback: 1000 });
+			return serializeAddon.serialize({ scrollback: TRACKER_SCROLLBACK_LINES });
 		},
 		dispose() {
 			term.dispose();

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -18,6 +18,8 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const { Terminal: HeadlessTerminal } =
 	require("@xterm/headless") as typeof import("@xterm/headless");
+const { SerializeAddon } =
+	require("@xterm/addon-serialize") as typeof import("@xterm/addon-serialize");
 
 export interface ModeTracker {
 	feed(bytes: Uint8Array): void;
@@ -25,6 +27,12 @@ export interface ModeTracker {
 	buildPreamble(): Uint8Array | null;
 	isBracketedPasteActive(): boolean;
 	snapshot(maxLines?: number): TerminalSnapshot;
+	/**
+	 * Full-fidelity VT dump of the emulator buffer (content, colors, cursor,
+	 * alt-screen switch) for grid resync on attach. Escape-sequence string,
+	 * not plain text — write it into a freshly reset xterm.
+	 */
+	serialize(): string;
 	dispose(): void;
 }
 
@@ -59,6 +67,8 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		scrollback: 1000,
 		allowProposedApi: true,
 	});
+	const serializeAddon = new SerializeAddon();
+	term.loadAddon(serializeAddon);
 	const internals = term as unknown as HeadlessInternals;
 
 	// Validate the private surface up front so a future @xterm/headless
@@ -155,6 +165,9 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 			return term.modes.bracketedPasteMode;
 		},
 		snapshot,
+		serialize() {
+			return serializeAddon.serialize({ scrollback: 1000 });
+		},
 		dispose() {
 			term.dispose();
 		},

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -34,7 +34,7 @@ import {
 	createTerminalSessionInternal,
 	disposeSessionAndWait,
 	listTerminalSessions,
-	replayBuffer,
+	sendGridResync,
 } from "./terminal.ts";
 import { __setAccountShellForTesting } from "./user-shell.ts";
 
@@ -444,49 +444,67 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
-	test("restoredNotice delivers the separator ahead of shell output on first replay only", async () => {
+	test("restoredNotice is part of the tracked grid: present in every resync, ahead of shell output", async () => {
 		const terminalId = `e2e-notice-${randomUUID().slice(0, 8)}`;
+		const marker = `notice-order-${randomUUID().slice(0, 6)}`;
 		const result = await createTerminalSessionInternal({
 			terminalId,
 			workspaceId,
 			db,
 			listed: true,
 			restoredNotice: true,
+			initialCommand: `printf '%s\\n' "${marker}"`,
 		});
 		assert.ok(!("error" in result));
 		if ("error" in result) return;
 
+		await waitFor(() => sessionBufferText(result).includes(marker), 15_000);
+
+		// Respawn-created attach appends (no reset) so the renderer's restored
+		// scrollback stays painted above the fresh shell.
 		const first = makeCaptureSocket();
-		replayBuffer(result, first.socket);
-		assert.match(
-			first.received(),
-			/Session Contents Restored/,
-			"first replay should carry the restored-session separator",
+		sendGridResync(result, first.socket, { reset: false });
+		const firstPayload = first.received();
+		assert.ok(
+			!firstPayload.startsWith("\x1bc"),
+			"reset: false must not wipe the peer",
+		);
+		const noticeIndex = firstPayload.indexOf("Session Contents Restored");
+		assert.ok(noticeIndex >= 0, "resync should carry the separator");
+		assert.ok(
+			noticeIndex < firstPayload.indexOf(marker),
+			"separator should precede the shell output",
 		);
 
+		// Later reattaches reset the peer and rebuild it from the emulator —
+		// the separator is buffer content now, so it survives.
 		const second = makeCaptureSocket();
-		replayBuffer(result, second.socket);
-		assert.doesNotMatch(
-			second.received(),
+		sendGridResync(result, second.socket, { reset: true });
+		const secondPayload = second.received();
+		assert.ok(
+			secondPayload.startsWith("\x1bc"),
+			"reset: true must prefix a full terminal reset",
+		);
+		assert.match(
+			secondPayload,
 			/Session Contents Restored/,
-			"separator should not repeat on later replays",
+			"separator persists across resyncs as part of the grid",
 		);
 
 		await disposeSessionAndWait(terminalId, db);
 	});
 
-	test("restoredNotice survives FIFO eviction when the shell floods output before attach", async () => {
-		const terminalId = `e2e-notice-flood-${randomUUID().slice(0, 8)}`;
+	test("resync after an unattached output flood delivers the emulator tail, newest output included", async () => {
+		const terminalId = `e2e-flood-resync-${randomUUID().slice(0, 8)}`;
 		const suffix = randomUUID().slice(0, 6);
 		const result = await createTerminalSessionInternal({
 			terminalId,
 			workspaceId,
 			db,
 			listed: true,
-			restoredNotice: true,
-			// > MAX_BUFFER_BYTES (64 KiB) so the FIFO drops its oldest chunks
-			// before any socket attaches. The marker is assembled by printf so
-			// the PTY echo of the command line doesn't match it.
+			// Far more output than any bounded replay could hold, produced with
+			// no socket attached. The marker is assembled by printf so the PTY
+			// echo of the command line doesn't match it.
 			initialCommand: `head -c 200000 /dev/zero | tr '\\0' x; printf 'flood-done-%s\\n' "${suffix}"`,
 		});
 		assert.ok(!("error" in result));
@@ -498,13 +516,11 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		);
 
 		const capture = makeCaptureSocket();
-		replayBuffer(result, capture.socket);
+		sendGridResync(result, capture.socket, { reset: true });
 		const replayed = capture.received();
-		const noticeIndex = replayed.indexOf("Session Contents Restored");
-		assert.ok(noticeIndex >= 0, "separator should survive buffer eviction");
 		assert.ok(
-			noticeIndex < replayed.indexOf("xxxx"),
-			"separator should precede the flooded shell output",
+			replayed.includes(`flood-done-${suffix}`),
+			"resync must contain the newest output no matter how much was produced while detached",
 		);
 
 		await disposeSessionAndWait(terminalId, db);
@@ -534,7 +550,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		if ("error" in second) return;
 
 		const capture = makeCaptureSocket();
-		replayBuffer(second, capture.socket);
+		sendGridResync(second, capture.socket, { reset: true });
 		assert.doesNotMatch(
 			capture.received(),
 			/Session Contents Restored/,
@@ -728,14 +744,13 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
-	test("replayOnAdoption: false suppresses ring-buffer replay on reconnect", async () => {
-		// Regression for the duplicated-output-on-daemon-swap bug: when the
-		// renderer's xterm scrollback survives the WS reconnect (which it
-		// does), replaying the daemon's ring buffer rewrites bytes the user
-		// has already seen and the conversation appears doubled. This test
-		// drives the createTerminalSessionInternal layer that the WS upgrade
-		// handler maps to.
-		const terminalId = `e2e-noreplay-${randomUUID().slice(0, 8)}`;
+	test("adoption replays the daemon ring into the mode tracker, so resyncs carry prior output", async () => {
+		// The daemon ring is what rebuilds the fresh ModeTracker after a
+		// host-service restart — grid resyncs are built from it, and the
+		// attach-time reset makes renderer duplication impossible (the old
+		// duplicated-output-on-daemon-swap failure mode that `replayOnAdoption:
+		// false` used to paper over).
+		const terminalId = `e2e-ringreplay-${randomUUID().slice(0, 8)}`;
 
 		const first = await createTerminalSessionInternal({
 			terminalId,
@@ -746,9 +761,8 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		assert.ok(!("error" in first));
 		if ("error" in first) return;
 
-		// Seed the daemon's ring buffer with a sentinel — that's what would
-		// be replayed on a normal adoption.
-		const SENTINEL = `noreplay-sentinel-${randomUUID().slice(0, 6)}`;
+		// Seed the daemon's ring buffer with a sentinel — replayed on adoption.
+		const SENTINEL = `ringreplay-sentinel-${randomUUID().slice(0, 6)}`;
 		first.pty.write(`echo ${SENTINEL}\n`);
 		await waitForOutput(first.pty, SENTINEL, 3000);
 
@@ -762,7 +776,6 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			workspaceId,
 			db,
 			listed: true,
-			replayOnAdoption: false,
 		});
 		assert.ok(!("error" in second));
 		if ("error" in second) return;
@@ -772,29 +785,23 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			"adopted session should have same shell pid",
 		);
 
-		// The shell may still produce live prompt bytes after reconnect, but
-		// the daemon ring-buffer sentinel from the previous host lifetime must
-		// not be replayed when replayOnAdoption=false.
-		await new Promise((r) => setTimeout(r, 500));
-
-		const bufferedAfterAdoption = Buffer.concat(
-			second.buffer.map((b) => Buffer.from(b)),
-		).toString("utf8");
-		assert.equal(
-			bufferedAfterAdoption.includes(SENTINEL),
-			false,
-			`adopted session replayed prior output despite replayOnAdoption=false: ${JSON.stringify(bufferedAfterAdoption.slice(0, 200))}`,
+		// Ring replay arrives asynchronously; the sentinel must land in the
+		// fresh tracker so the next grid resync can deliver it.
+		await waitFor(() => sessionBufferText(second).includes(SENTINEL), 5000);
+		const capture = makeCaptureSocket();
+		sendGridResync(second, capture.socket, { reset: true });
+		assert.ok(
+			capture.received().includes(SENTINEL),
+			"resync after adoption should carry the prior lifetime's output",
 		);
 
 		// Sanity check: live output still flows post-reattach.
 		const LIVE_SENTINEL = `live-after-reattach-${randomUUID().slice(0, 6)}`;
 		second.pty.write(`echo ${LIVE_SENTINEL}\n`);
-		await waitFor(() => {
-			const text = Buffer.concat(
-				second.buffer.map((b) => Buffer.from(b)),
-			).toString("utf8");
-			return text.includes(LIVE_SENTINEL);
-		}, 3000);
+		await waitFor(
+			() => sessionBufferText(second).includes(LIVE_SENTINEL),
+			3000,
+		);
 
 		await disposeSessionAndWait(terminalId, db);
 	});
@@ -933,8 +940,10 @@ async function waitForOutput(
 	}
 }
 
-function sessionBufferText(session: { buffer: Uint8Array[] }): string {
-	return Buffer.concat(session.buffer).toString("utf8");
+function sessionBufferText(session: {
+	modeTracker: { snapshot(): { text: string } };
+}): string {
+	return session.modeTracker.snapshot().text;
 }
 
 function makeCaptureSocket() {

--- a/packages/host-service/src/terminal/terminal.replay-gap.repro.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.replay-gap.repro.node-test.ts
@@ -1,0 +1,553 @@
+// Regression test for the "TUI artifacts until resize" bug
+// (fix-tui-resize-artifacts).
+//
+// The terminal wire protocol is at-most-once: half-open sockets (sleep/wake)
+// and back-pressure drops lose output bytes without the host knowing. A TUI
+// that repaints incrementally in the normal buffer (Claude Code) relies on
+// the terminal grid containing exactly what it last drew — a lost byte range
+// left permanent ghost content (a stranded copy of the old input box) that
+// only a real dimension change could clear, because a same-dims resize
+// produces no SIGWINCH.
+//
+// The fix: every attach sends a grid resync — full reset + the ModeTracker's
+// serialized buffer + mode preamble — so a reattaching renderer converges on
+// the emulator's authoritative state no matter how much output it missed.
+// This test detaches, streams far more output than any bounded replay could
+// hold (ending in a shrunken repaint region, the shape that used to strand
+// ghosts), reattaches, and asserts the grids are identical with no resize.
+//
+// Harness: real in-process pty-daemon, real bash PTY running a scripted
+// incremental-repaint TUI (Ink-style: cursor-up + erase + redraw of a bottom
+// box whose height varies), the real host-service WS route, and a real
+// @xterm/headless instance standing in for the renderer's grid. Ground truth
+// is the session's own ModeTracker (fed every byte). The renderer stand-in is
+// synthetic; the transport, resync, and PTY layers are the real code.
+//
+// Run:
+//   cd packages/host-service && node --experimental-strip-types --test \
+//     src/terminal/terminal.replay-gap.repro.node-test.ts
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import { createNodeWebSocket } from "@hono/node-ws";
+import { Server } from "@superset/pty-daemon";
+import { Hono } from "hono";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import type { EventBus } from "../events/index.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+	registerWorkspaceTerminalRoute,
+	snapshotSession,
+	writeInputToSession,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const require = (await import("node:module")).createRequire(import.meta.url);
+const { Terminal: HeadlessTerminal } =
+	require("@xterm/headless") as typeof import("@xterm/headless");
+type Headless = InstanceType<typeof HeadlessTerminal>;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-replaygap-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-replaygap-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+
+const COLS = 80;
+const ROWS = 24;
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+let httpPort: number;
+let httpServer: ReturnType<typeof serve>;
+
+// Ink-style incremental-repaint TUI. Owns a bottom "input box" whose height
+// alternates (3 vs 6 rows). Each frame moves the cursor up over its own
+// region, erases to end of screen, prints one transcript line, and redraws
+// the box — all cursor-relative, exactly like Ink's log-update rendering.
+// On SIGWINCH it clears the screen and repaints fully, like Ink on resize.
+const TUI_SCRIPT = String.raw`
+stty -echo
+frame=0
+H=3
+FILLER='................................................'
+draw_box() {
+  bh=$1
+  printf '+==================================+\n'
+  i=1
+  while [ "$i" -le "$((bh - 2))" ]; do
+    printf '| INPUT %06d line %d              |\n' "$frame" "$i"
+    i=$((i + 1))
+  done
+  printf '+==================================+'
+}
+on_winch() {
+  printf '\033[2J\033[H'
+  printf 'FULL-REDRAW at frame %06d\n' "$frame"
+  draw_box "$H"
+}
+trap on_winch WINCH
+frames() {
+  n=$1
+  k=0
+  while [ "$k" -lt "$n" ]; do
+    frame=$((frame + 1))
+    if [ "$(((frame / 7) % 2))" -eq 0 ]; then newH=3; else newH=6; fi
+    printf '\r\033[%dA\033[0J' "$((H - 1))"
+    printf 'transcript %06d %s\n' "$frame" "$FILLER"
+    draw_box "$newH"
+    H=$newH
+    k=$((k + 1))
+  done
+}
+# Spinner-style repaint: rewrite only the box region, no transcript, no scroll.
+ticks() {
+  n=$1
+  k=0
+  while [ "$k" -lt "$n" ]; do
+    frame=$((frame + 1))
+    printf '\r\033[%dA\033[0J' "$((H - 1))"
+    draw_box "$H"
+    k=$((k + 1))
+  done
+}
+# The app resizes its own region (erases the old extent, draws the new one).
+setH() {
+  printf '\r\033[%dA\033[0J' "$((H - 1))"
+  H=$1
+  draw_box "$H"
+}
+printf '\033[2J\033[H'
+printf 'TUI READY\n'
+draw_box "$H"
+while :; do
+  IFS= read -r cmd || { sleep 0.02; continue; }
+  set -- $cmd
+  case $1 in
+    frames) frames "$2" ;;
+    ticks) ticks "$2" ;;
+    setH) setH "$2" ;;
+    quit) exit 0 ;;
+  esac
+done
+`;
+
+function progress(msg: string): void {
+	process.stderr.write(`[repro] ${msg}\n`);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+	fn: () => boolean | Promise<boolean>,
+	timeoutMs: number,
+	label: string,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (await fn()) return;
+		await sleep(50);
+	}
+	throw new Error(`Timed out waiting for: ${label}`);
+}
+
+/** Last `rows` grid rows, right-trimmed, trailing blank rows dropped — the
+ * same extraction ModeTracker.snapshot(maxLines) uses. */
+function visibleText(term: Headless): string {
+	const buf = term.buffer.active;
+	const start = Math.max(0, buf.length - term.rows);
+	const lines: string[] = [];
+	for (let y = start; y < buf.length; y++) {
+		lines.push(buf.getLine(y)?.translateToString(true) ?? "");
+	}
+	while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+	return lines.join("\n");
+}
+
+/** Ground truth: what the app actually drew, per the session's ModeTracker
+ * (fed every PTY byte regardless of socket state). */
+async function trackerVisible(terminalId: string): Promise<string> {
+	const snap = await snapshotSession({
+		terminalId,
+		workspaceId,
+		maxLines: ROWS,
+		db,
+	});
+	assert.ok(!("error" in snap), `snapshot failed: ${JSON.stringify(snap)}`);
+	if ("error" in snap) throw new Error("unreachable");
+	return snap.text;
+}
+
+/**
+ * The renderer stand-in: a real WebSocket client feeding a real xterm parser,
+ * mirroring terminal-ws-transport.ts behavior (binary frames → xterm.write,
+ * resize sent on "attached", same-URL reconnects).
+ */
+class RendererStandIn {
+	term: Headless;
+	private ws: WebSocket | null = null;
+	private writeChain: Promise<void> = Promise.resolve();
+
+	constructor() {
+		this.term = new HeadlessTerminal({
+			cols: COLS,
+			rows: ROWS,
+			scrollback: 1000,
+			allowProposedApi: true,
+		});
+	}
+
+	connect(terminalId: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const ws = new WebSocket(
+				`ws://127.0.0.1:${httpPort}/terminal/${terminalId}`,
+			);
+			ws.binaryType = "arraybuffer";
+			this.ws = ws;
+			const timer = setTimeout(
+				() => reject(new Error("attach timeout")),
+				10_000,
+			);
+			ws.addEventListener("message", (event) => {
+				const data = (event as MessageEvent).data;
+				if (data instanceof ArrayBuffer) {
+					const bytes = new Uint8Array(data);
+					this.writeChain = this.writeChain.then(
+						() => new Promise<void>((r) => this.term.write(bytes, r)),
+					);
+					return;
+				}
+				const message = JSON.parse(String(data)) as { type: string };
+				if (message.type === "attached") {
+					// Mirrors terminal-ws-transport.ts: resize sent on every attach
+					// with the renderer's current (often unchanged) dimensions.
+					this.sendResize(this.term.cols, this.term.rows);
+					clearTimeout(timer);
+					resolve();
+				}
+			});
+			ws.addEventListener("error", () => {
+				clearTimeout(timer);
+				reject(new Error("ws error during connect"));
+			});
+		});
+	}
+
+	sendResize(cols: number, rows: number): void {
+		this.ws?.send(JSON.stringify({ type: "resize", cols, rows }));
+	}
+
+	disconnect(): Promise<void> {
+		return new Promise((resolve) => {
+			const ws = this.ws;
+			this.ws = null;
+			if (!ws || ws.readyState === WebSocket.CLOSED) return resolve();
+			ws.addEventListener("close", () => resolve());
+			ws.close();
+		});
+	}
+
+	async drain(): Promise<void> {
+		await this.writeChain;
+	}
+
+	async waitForFrame(frame: number, timeoutMs = 10_000): Promise<void> {
+		const marker = `INPUT ${String(frame).padStart(6, "0")}`;
+		await waitFor(
+			async () => {
+				await this.drain();
+				return visibleText(this.term).includes(marker);
+			},
+			timeoutMs,
+			`renderer to show frame ${frame}`,
+		);
+	}
+}
+
+async function waitForTrackerFrame(
+	terminalId: string,
+	frame: number,
+	timeoutMs = 15_000,
+): Promise<void> {
+	const marker = `INPUT ${String(frame).padStart(6, "0")}`;
+	await waitFor(
+		async () => (await trackerVisible(terminalId)).includes(marker),
+		timeoutMs,
+		`tracker to show frame ${frame}`,
+	);
+}
+
+function sendCommand(terminalId: string, command: string): void {
+	const result = writeInputToSession({
+		terminalId,
+		workspaceId,
+		data: `${command}\n`,
+	});
+	assert.ok(!("error" in result), JSON.stringify(result));
+}
+
+function runFrames(terminalId: string, count: number): void {
+	sendCommand(terminalId, `frames ${count}`);
+}
+
+function gridDiff(expected: string, actual: string): string {
+	const exp = expected.split("\n");
+	const act = actual.split("\n");
+	const out: string[] = [];
+	const max = Math.max(exp.length, act.length);
+	for (let i = 0; i < max; i++) {
+		const e = exp[i] ?? "<missing>";
+		const a = act[i] ?? "<missing>";
+		out.push(e === a ? `  ${a}` : `- ${e}\n+ ${a}`);
+	}
+	return out.join("\n");
+}
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+	fs.writeFileSync(path.join(TEST_HOME, "tui.sh"), TUI_SCRIPT);
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-replaygap-repro",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-replaygap-repro";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting("/bin/sh");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: process.env.HOME ?? TEST_HOME,
+		SHELL: "/bin/sh",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({ id: workspaceId, projectId, worktreePath, branch: "main" })
+		.run();
+
+	const app = new Hono();
+	const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+	registerWorkspaceTerminalRoute({
+		app,
+		db,
+		// Only used for optional lifecycle broadcasts; not exercised here.
+		eventBus: undefined as unknown as EventBus,
+		upgradeWebSocket,
+	});
+	httpPort = await new Promise<number>((resolve) => {
+		httpServer = serve(
+			{ fetch: app.fetch, port: 0, hostname: "127.0.0.1" },
+			(info) => resolve(info.port),
+		);
+	});
+	injectWebSocket(httpServer);
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+test(
+	"reattach resyncs the grid after any output gap — no artifacts, no resize needed",
+	{ timeout: 180_000 },
+	async () => {
+		progress("test start");
+		const terminalId = `repro-gap-${randomUUID().slice(0, 8)}`;
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: COLS,
+			rows: ROWS,
+			initialCommand: `exec bash '${path.join(TEST_HOME, "tui.sh")}'`,
+		});
+		if ("error" in session) assert.fail(session.error);
+
+		progress("session created");
+		const renderer = new RendererStandIn();
+		// Optional grid dump for visual reporting (REPLAYGAP_EVIDENCE_PATH).
+		const evidence: Record<string, unknown> = {};
+		try {
+			await renderer.connect(terminalId);
+			progress("renderer attached");
+
+			// ── Phase 0/1: attached streaming keeps the grids identical ──────────────
+			await waitForTrackerFrame(terminalId, 0, 15_000).catch(() => {});
+			await waitFor(
+				async () => (await trackerVisible(terminalId)).includes("TUI READY"),
+				15_000,
+				"TUI to boot",
+			);
+			progress("TUI booted");
+			let totalFrames = 20;
+			runFrames(terminalId, 20);
+			// Grow the region to 6 rows while attached — both grids see it. This is the
+			// tall spinner/input state the renderer will be stranded on during the gap.
+			sendCommand(terminalId, "setH 6");
+			await waitForTrackerFrame(terminalId, totalFrames);
+			await renderer.waitForFrame(totalFrames);
+			await sleep(200);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"harness fidelity: attached grids must match",
+			);
+			progress("PHASE 1 done");
+			console.log("PHASE 1 attached streaming: grids identical ✓");
+
+			// ── Phase 2: short detach, then reattach resyncs the grid ────────────────
+			await renderer.disconnect();
+			await sleep(300); // let the route's onClose detach the socket server-side
+			sendCommand(terminalId, "ticks 60"); // a small detached burst
+			totalFrames += 60;
+			await waitForTrackerFrame(terminalId, totalFrames);
+			await renderer.connect(terminalId);
+			await renderer.waitForFrame(totalFrames);
+			await sleep(200);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"short detached output must be resynced on reattach",
+			);
+			progress("PHASE 2 done");
+			console.log(
+				"PHASE 2 short detach: resynced on reattach, grids identical ✓",
+			);
+
+			// ── Phase 3: long detach, way past any bounded replay, then reattach ─────
+			// While detached, the app scrolls some transcript, shrinks its region from
+			// 6 to 3 rows, then spends a long time on region-only spinner repaints —
+			// the shape of a Claude Code session finishing work while the pane is
+			// away, and exactly the byte pattern that used to strand a ghost copy of
+			// the pre-gap 6-row box above the live one. The attach-time grid resync
+			// must converge the renderer regardless.
+			const preGapBoxFrame = totalFrames;
+			await renderer.disconnect();
+			await sleep(300);
+			sendCommand(terminalId, "frames 200");
+			totalFrames += 200;
+			sendCommand(terminalId, "setH 3");
+			sendCommand(terminalId, "ticks 1500"); // ≈105 KB of pure region repaints
+			totalFrames += 1500;
+			await waitForTrackerFrame(terminalId, totalFrames, 60_000);
+			await renderer.connect(terminalId);
+			await renderer.waitForFrame(totalFrames, 15_000);
+			await sleep(200);
+			await renderer.drain();
+
+			const rendererGrid = visibleText(renderer.term);
+			const truthGrid = await trackerVisible(terminalId);
+			evidence.phase3 = { renderer: rendererGrid, truth: truthGrid };
+			if (rendererGrid !== truthGrid) {
+				console.log(
+					"\nPHASE 3 reattach after huge gap — app truth (-) vs renderer grid (+):",
+				);
+				console.log(gridDiff(truthGrid, rendererGrid));
+			}
+			assert.equal(
+				rendererGrid,
+				truthGrid,
+				"reattach after an output gap must resync the grid — artifacts mean the resync failed",
+			);
+			// No stranded copy of the pre-gap box (the old failure signature).
+			const staleMarker = `INPUT ${String(preGapBoxFrame).padStart(6, "0")}`;
+			assert.ok(
+				!rendererGrid.includes(staleMarker),
+				`ghost of the pre-gap box ("${staleMarker}") must not survive the resync`,
+			);
+			progress("PHASE 3 done");
+			console.log(
+				"PHASE 3 reattach after >100KB gap: grid resynced, no ghost, no resize needed ✓",
+			);
+
+			// ── Phase 4: same-dimensions resize stays clean (nothing to heal) ────────
+			renderer.sendResize(COLS, ROWS);
+			await sleep(500);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"grid must stay in sync across a same-dims resize",
+			);
+			evidence.phase4 = { renderer: visibleText(renderer.term) };
+			progress("PHASE 4 done");
+			console.log("PHASE 4 same-dims resize: grids still identical ✓");
+
+			// ── Phase 5: a REAL resize forces SIGWINCH → full repaint → healed ───────
+			renderer.term.resize(COLS + 1, ROWS);
+			renderer.sendResize(COLS + 1, ROWS);
+			await waitFor(
+				async () => {
+					await renderer.drain();
+					return visibleText(renderer.term).includes("FULL-REDRAW");
+				},
+				10_000,
+				"SIGWINCH full repaint to arrive",
+			);
+			// Let the repaint finish flowing, then compare.
+			await sleep(300);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"grids must stay in sync across a real resize (SIGWINCH repaint)",
+			);
+			evidence.phase5 = {
+				renderer: visibleText(renderer.term),
+				truth: await trackerVisible(terminalId),
+			};
+			if (process.env.REPLAYGAP_EVIDENCE_PATH) {
+				fs.writeFileSync(
+					process.env.REPLAYGAP_EVIDENCE_PATH,
+					JSON.stringify(evidence, null, 2),
+				);
+			}
+			progress("PHASE 5 done");
+			console.log(
+				"PHASE 5 real resize (+1 col): SIGWINCH full repaint, grids identical ✓",
+			);
+		} finally {
+			// A live bash loop wedges daemon/server teardown in after() — always
+			// dispose, even when a phase assertion throws.
+			await renderer.disconnect().catch(() => {});
+			renderer.term.dispose();
+			await disposeSessionAndWait(terminalId, db).catch(() => {});
+		}
+	},
+);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1391,12 +1391,13 @@ export async function createTerminalSessionInternal({
 	}
 
 	const cwd = resolveTerminalCwd(cwdOverride, workspace.worktreePath);
-	const cols = normalizeTerminalDimension(
+	// Adoption overrides these with the live PTY's dimensions below.
+	let cols = normalizeTerminalDimension(
 		requestedCols,
 		MIN_TERMINAL_COLS,
 		DEFAULT_TERMINAL_COLS,
 	);
-	const rows = normalizeTerminalDimension(
+	let rows = normalizeTerminalDimension(
 		requestedRows,
 		MIN_TERMINAL_ROWS,
 		DEFAULT_TERMINAL_ROWS,
@@ -1443,6 +1444,10 @@ export async function createTerminalSessionInternal({
 			}
 			openResult = { pid: found.pid };
 			isAdopted = true;
+			// The ring replay must be parsed at the width the app drew at, so
+			// the tracker takes the live PTY's dimensions, not caller defaults.
+			cols = normalizeTerminalDimension(found.cols, MIN_TERMINAL_COLS, cols);
+			rows = normalizeTerminalDimension(found.rows, MIN_TERMINAL_ROWS, rows);
 			console.log(
 				`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
 			);
@@ -1469,6 +1474,16 @@ export async function createTerminalSessionInternal({
 					if (!found) throw err;
 					openResult = { pid: found.pid };
 					isAdopted = true;
+					cols = normalizeTerminalDimension(
+						found.cols,
+						MIN_TERMINAL_COLS,
+						cols,
+					);
+					rows = normalizeTerminalDimension(
+						found.rows,
+						MIN_TERMINAL_ROWS,
+						rows,
+					);
 					console.log(
 						`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
 					);
@@ -1856,8 +1871,13 @@ export function registerWorkspaceTerminalRoute({
 					eventBus,
 					adoptOnly: true,
 				});
-				if (!("error" in adopted))
+				if (!("error" in adopted)) {
+					// The ring replay streams in asynchronously and rebuilds the
+					// fresh tracker. Let it quiesce so the attach resync carries the
+					// prior content instead of a reset + near-empty grid.
+					await waitForAdoptionReplay(adopted);
 					return { session: adopted, respawned: false };
+				}
 
 				// Active row but daemon no longer owns the PTY (laptop sleep,
 				// daemon restart, machine reboot). Respawn rather than dead-end
@@ -1873,6 +1893,10 @@ export function registerWorkspaceTerminalRoute({
 						error,
 					);
 				}
+				// A concurrent attach may have created the session while we awaited
+				// the adopt attempt — only the attach that actually creates the
+				// respawn may skip the reset.
+				const createdByThisAttach = !sessions.has(terminalId);
 				const respawned = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
@@ -1882,7 +1906,7 @@ export function registerWorkspaceTerminalRoute({
 					restoredNotice: true,
 				});
 				if ("error" in respawned) return respawned;
-				return { session: respawned, respawned: true };
+				return { session: respawned, respawned: createdByThisAttach };
 			};
 
 			return {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -171,19 +171,23 @@ type TerminalServerMessage =
 	| { type: "exit"; exitCode: number; signal: number }
 	| { type: "title"; title: string | null };
 
-const MAX_BUFFER_BYTES = 64 * 1024;
-// Dim separator delivered ahead of a respawned shell's output so users can
-// tell restored scrollback from the fresh session (cf. VS Code's "History
-// restored" line).
+// Dim separator fed into the emulator ahead of a respawned shell's output so
+// users can tell restored scrollback from the fresh session (cf. VS Code's
+// "History restored" line). Part of the tracked buffer, so it survives into
+// every grid resync.
 const SESSION_RESTORED_NOTICE = new TextEncoder().encode(
 	"\r\n\x1b[90m─── Session Contents Restored ───\x1b[0m\r\n\r\n",
 );
+// Full terminal reset (RIS). Prefixed to a grid resync so the renderer's
+// buffer is rebuilt from the emulator state alone, regardless of what the
+// previous socket delivered.
+const TERMINAL_FULL_RESET = new TextEncoder().encode("\x1bc");
 // Cap on a single renderer socket's unflushed WebSocket send buffer. With no
 // ACK flow control, a renderer that stops draining (slow paint, pinned main
 // thread, dead tab) would let this buffer grow without bound → host OOM (the
 // risk #4868 was about). Once a socket blows past this, we drop it; the
-// renderer auto-reconnects and replays the bounded tail buffer. Crucially the
-// PTY is never paused, so a stalled renderer can't wedge the shell. Matches the
+// renderer auto-reconnects and gets a full grid resync. Crucially the PTY is
+// never paused, so a stalled renderer can't wedge the shell. Matches the
 // daemon's own 8 MB outbound socket cap.
 const WS_SEND_BUFFER_CAP_BYTES = 8 * 1024 * 1024;
 const SOCKET_OPEN = 1;
@@ -268,18 +272,10 @@ interface TerminalSession {
 	unsubscribeDaemon: (() => void) | null;
 	sockets: Set<TerminalSocket>;
 	/**
-	 * Buffered PTY output retained for replay on (re)attach. Bytes, not
-	 * strings — keeping this byte-aligned with the wire frees us from the
-	 * per-chunk UTF-8 decoding that used to mangle TUIs.
+	 * Total PTY-output bytes fed to the mode tracker. Monotonic; used to
+	 * detect when an adoption ring replay has quiesced.
 	 */
-	buffer: Uint8Array[];
-	bufferBytes: number;
-	/**
-	 * Deliver SESSION_RESTORED_NOTICE ahead of the next replay. Kept out of
-	 * the FIFO so MAX_BUFFER_BYTES eviction can't drop it before a client
-	 * attaches. Cleared on first replay.
-	 */
-	restoredNoticePending: boolean;
+	outputByteCount: number;
 	createdAt: number;
 	exited: boolean;
 	exitCode: number;
@@ -603,15 +599,14 @@ export function writeInputToSession({
 // Ring-buffer replay after adoption arrives asynchronously over the daemon
 // socket, and it is what rebuilds the mode tracker (bracketed paste, screen
 // content). Protocol v2 has no replay-complete signal, so watch the replayed
-// bytes accumulate — they land in session.buffer, since no renderer is
-// attached right after adoption — and return once they quiesce.
+// bytes accumulate in the tracker's counter and return once they quiesce.
 const ADOPTION_REPLAY_WAIT_MS = 500;
 
 async function waitForAdoptionReplay(session: TerminalSession): Promise<void> {
 	const deadline = Date.now() + ADOPTION_REPLAY_WAIT_MS;
 	let seen = -1;
 	while (Date.now() < deadline) {
-		const count = session.bufferBytes;
+		const count = session.outputByteCount;
 		if (count > 0 && count === seen) return;
 		seen = count;
 		await new Promise((resolve) => setTimeout(resolve, 25));
@@ -757,16 +752,6 @@ function setSessionTitle(session: TerminalSession, title: string | null) {
 	broadcastMessage(session, { type: "title", title });
 }
 
-function bufferOutput(session: TerminalSession, data: Uint8Array) {
-	session.buffer.push(data);
-	session.bufferBytes += data.byteLength;
-
-	while (session.bufferBytes > MAX_BUFFER_BYTES && session.buffer.length > 1) {
-		const removed = session.buffer.shift();
-		if (removed) session.bufferBytes -= removed.byteLength;
-	}
-}
-
 function normalizeTerminalDimension(
 	value: number | null | undefined,
 	min: number,
@@ -824,40 +809,45 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 	return sent;
 }
 
-export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
-	// sendBytes below no-ops on a non-open socket — bail before clearing the
-	// buffer/notice so the next attach can still replay them.
+/**
+ * Bring an attaching socket's grid to the emulator's authoritative state:
+ * full reset, then the tracker's serialized buffer (content, colors, cursor,
+ * alt-screen), then the mode preamble (RIS cleared the modes).
+ *
+ * The wire protocol is at-most-once — half-open sockets (sleep/wake) and
+ * back-pressure drops lose bytes without the host knowing — and an
+ * incremental-repaint TUI never recovers from a gap on its own, leaving
+ * ghost content until a real resize forces a repaint. Rebuilding the grid
+ * from the emulator on every attach makes reattach independent of delivery
+ * history (VS Code's ptyService revive model).
+ *
+ * `reset: false` skips the wipe and appends instead — used when the session
+ * was respawned by this very attach, so the renderer's restored scrollback
+ * from the dead PTY stays painted above the fresh shell.
+ */
+export function sendGridResync(
+	session: TerminalSession,
+	socket: TerminalSocket,
+	{ reset }: { reset: boolean },
+) {
 	if (socket.readyState !== SOCKET_OPEN) return;
-	// Preamble first, then the restored notice, then FIFO. Mode-setting
-	// escapes (kitty keyboard, bracketed paste, focus, …) are typically
-	// emitted once at startup and broadcast away rather than buffered, so a
-	// fresh xterm needs them re-asserted on every attach — even when the
-	// FIFO is empty.
+	const content = new TextEncoder().encode(session.modeTracker.serialize());
 	const preamble = session.modeTracker.buildPreamble();
-	const notice = session.restoredNoticePending ? SESSION_RESTORED_NOTICE : null;
-	let bufferTotal = 0;
-	for (const b of session.buffer) bufferTotal += b.byteLength;
-	const preambleLen = preamble?.byteLength ?? 0;
-	const noticeLen = notice?.byteLength ?? 0;
-	if (preambleLen === 0 && noticeLen === 0 && bufferTotal === 0) return;
 
-	const combined = new Uint8Array(preambleLen + noticeLen + bufferTotal);
+	const parts: Uint8Array[] = [];
+	if (reset) parts.push(TERMINAL_FULL_RESET);
+	if (content.byteLength > 0) parts.push(content);
+	if (preamble) parts.push(preamble);
+	if (parts.length === 0) return;
+
+	let total = 0;
+	for (const p of parts) total += p.byteLength;
+	const combined = new Uint8Array(total);
 	let offset = 0;
-	if (preamble) {
-		combined.set(preamble, offset);
-		offset += preamble.byteLength;
+	for (const p of parts) {
+		combined.set(p, offset);
+		offset += p.byteLength;
 	}
-	if (notice) {
-		combined.set(notice, offset);
-		offset += notice.byteLength;
-	}
-	for (const b of session.buffer) {
-		combined.set(b, offset);
-		offset += b.byteLength;
-	}
-	session.restoredNoticePending = false;
-	session.buffer.length = 0;
-	session.bufferBytes = 0;
 	sendBytes(socket, combined);
 }
 
@@ -883,9 +873,8 @@ function resolveShellReady(
 		session.scanState.heldBytes.length = 0;
 		session.scanState.matchPos = 0;
 		session.modeTracker.feed(heldBytes);
-		if (broadcastBytes(session, heldBytes) === 0) {
-			bufferOutput(session, heldBytes);
-		}
+		session.outputByteCount += heldBytes.byteLength;
+		broadcastBytes(session, heldBytes);
 	}
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
@@ -1302,16 +1291,9 @@ interface CreateTerminalSessionOptions {
 	/** Only recover an already-live daemon session; never spawn a new PTY. */
 	adoptOnly?: boolean;
 	/**
-	 * Replay the daemon's ring buffer on subscribe. Default true. Pass false
-	 * when the renderer's xterm already has the scrollback — replaying then
-	 * doubles the visible output. Tradeoff: bytes the PTY produced during
-	 * the WS-down window are dropped (sub-second on a daemon swap).
-	 */
-	replayOnAdoption?: boolean;
-	/**
-	 * Deliver a "session restored" separator ahead of the first replay. Set on
-	 * the cold-restore respawn path, where the renderer paints stale scrollback
-	 * above a brand-new shell.
+	 * Feed a "session restored" separator into the emulator ahead of the
+	 * shell's output. Set on the cold-restore respawn path, where the renderer
+	 * paints stale scrollback above a brand-new shell.
 	 */
 	restoredNotice?: boolean;
 }
@@ -1360,7 +1342,6 @@ export async function createTerminalSessionInternal({
 	cols: requestedCols,
 	rows: requestedRows,
 	adoptOnly = false,
-	replayOnAdoption = true,
 	restoredNotice = false,
 }: CreateTerminalSessionOptions): Promise<TerminalSession | { error: string }> {
 	const existing = sessions.get(terminalId);
@@ -1546,10 +1527,7 @@ export async function createTerminalSessionInternal({
 		rows,
 		unsubscribeDaemon: null,
 		sockets: new Set(),
-		buffer: [],
-		bufferBytes: 0,
-		// Adopted sessions kept a live shell — nothing was restored.
-		restoredNoticePending: restoredNotice && !isAdopted,
+		outputByteCount: 0,
 		createdAt,
 		exited: false,
 		exitCode: 0,
@@ -1577,6 +1555,13 @@ export async function createTerminalSessionInternal({
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
 
+	// Adopted sessions kept a live shell — nothing was restored. Feeding the
+	// separator into the emulator (before any PTY output arrives) makes it
+	// part of the tracked buffer, so it survives into every grid resync.
+	if (restoredNotice && !isAdopted) {
+		session.modeTracker.feed(SESSION_RESTORED_NOTICE);
+	}
+
 	if (session.shellReadyState === "pending") {
 		session.shellReadyTimeoutId = setTimeout(() => {
 			resolveShellReady(session, "timed_out");
@@ -1585,7 +1570,11 @@ export async function createTerminalSessionInternal({
 
 	session.unsubscribeDaemon = daemon.subscribe(
 		terminalId,
-		{ replay: replayOnAdoption },
+		// Always replay the daemon's ring buffer: on adoption it repopulates
+		// the fresh ModeTracker (the source grid resyncs are built from), and
+		// on a new spawn the ring is empty-to-tiny. Renderer duplication is
+		// impossible — attach resets the peer before the resync.
+		{ replay: true },
 		{
 			onOutput(chunk) {
 				// Bytes flow daemon → host → xterm without UTF-8 decoding;
@@ -1622,13 +1611,12 @@ export async function createTerminalSessionInternal({
 				// — the chunk is still output and must refresh the idle clock.
 				portManager.checkOutputForHint(terminalId, hintText);
 
-				// Feed the tracker on every byte — broadcast skips the FIFO,
-				// so this is the only path that catches startup mode escapes.
+				// Feed the tracker on every byte — it is the authoritative
+				// buffer state that grid resyncs on attach are built from.
 				session.modeTracker.feed(bytes);
+				session.outputByteCount += bytes.byteLength;
 
-				if (broadcastBytes(session, bytes) === 0) {
-					bufferOutput(session, bytes);
-				}
+				broadcastBytes(session, bytes);
 			},
 			onExit({ code, signal }) {
 				session.exited = true;
@@ -1779,6 +1767,7 @@ export function registerWorkspaceTerminalRoute({
 			const attachSocketToSession = (
 				session: TerminalSession,
 				ws: TerminalSocket,
+				{ reset }: { reset: boolean },
 			): boolean => {
 				if (session.sockets.has(ws)) return false;
 				session.sockets.add(ws);
@@ -1790,7 +1779,7 @@ export function registerWorkspaceTerminalRoute({
 					.run();
 
 				sendMessage(ws, { type: "title", title: session.title });
-				replayBuffer(session, ws);
+				sendGridResync(session, ws, { reset });
 				if (session.exited) {
 					sendMessage(ws, {
 						type: "exit",
@@ -1801,7 +1790,8 @@ export function registerWorkspaceTerminalRoute({
 				return true;
 			};
 			const resolveSessionForAttach = async (): Promise<
-				TerminalSession | { error: string; code?: "session-gone" }
+				| { session: TerminalSession; respawned: boolean }
+				| { error: string; code?: "session-gone" }
 			> => {
 				const existing = sessions.get(terminalId);
 				if (existing) {
@@ -1813,7 +1803,7 @@ export function registerWorkspaceTerminalRoute({
 						});
 						if (mismatchError) return { error: mismatchError };
 					}
-					return existing;
+					return { session: existing, respawned: false };
 				}
 
 				const record = db.query.terminalSessions
@@ -1855,6 +1845,9 @@ export function registerWorkspaceTerminalRoute({
 
 				// Prefer adoption: if the daemon still owns the PTY across a
 				// host-service restart, we keep the live shell + ring buffer.
+				// (The daemon ring replays into the fresh ModeTracker and streams
+				// to the socket after the reset — legacy `?replay=0` renderers
+				// need no special-casing since the reset prevents duplication.)
 				const adopted = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
@@ -1862,10 +1855,9 @@ export function registerWorkspaceTerminalRoute({
 					db,
 					eventBus,
 					adoptOnly: true,
-					// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
-					replayOnAdoption: c.req.query("replay") !== "0",
 				});
-				if (!("error" in adopted)) return adopted;
+				if (!("error" in adopted))
+					return { session: adopted, respawned: false };
 
 				// Active row but daemon no longer owns the PTY (laptop sleep,
 				// daemon restart, machine reboot). Respawn rather than dead-end
@@ -1881,7 +1873,7 @@ export function registerWorkspaceTerminalRoute({
 						error,
 					);
 				}
-				return createTerminalSessionInternal({
+				const respawned = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
 					themeType,
@@ -1889,6 +1881,8 @@ export function registerWorkspaceTerminalRoute({
 					eventBus,
 					restoredNotice: true,
 				});
+				if ("error" in respawned) return respawned;
+				return { session: respawned, respawned: true };
 			};
 
 			return {
@@ -1899,18 +1893,23 @@ export function registerWorkspaceTerminalRoute({
 					}
 
 					void (async () => {
-						const session = await resolveSessionForAttach();
-						if ("error" in session) {
+						const resolved = await resolveSessionForAttach();
+						if ("error" in resolved) {
 							sendMessage(ws, {
 								type: "error",
-								message: session.error,
-								code: session.code,
+								message: resolved.error,
+								code: resolved.code,
 							});
-							ws.close(1011, session.error);
+							ws.close(1011, resolved.error);
 							return;
 						}
 						if (ws.readyState !== SOCKET_OPEN) return;
-						attachSocketToSession(session, ws);
+						// A respawn was created by this very attach: skip the reset so
+						// the renderer's restored scrollback from the dead PTY stays
+						// painted above the fresh shell.
+						attachSocketToSession(resolved.session, ws, {
+							reset: !resolved.respawned,
+						});
 					})().catch((error) => {
 						console.error("[terminal] unexpected error during attach", error);
 						if (ws.readyState !== SOCKET_OPEN) return;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -324,6 +324,16 @@ interface TerminalSession {
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
 const sessions = new Map<string, TerminalSession>();
 
+/**
+ * Respawns triggered by a WS attach, keyed by terminalId, so concurrent
+ * attaches share one creation and exactly one of them owns the
+ * skip-the-reset resync (the others hold stale grids and must be reset).
+ */
+const inflightRespawns = new Map<
+	string,
+	Promise<TerminalSession | { error: string }>
+>();
+
 // When the daemon disconnects, close every WS socket so the renderer's
 // existing exponential-backoff reconnect kicks in. On reconnect, host-service
 // rebuilds the DaemonClient (next getDaemonClient() call), and the adoption-
@@ -1893,11 +1903,16 @@ export function registerWorkspaceTerminalRoute({
 						error,
 					);
 				}
-				// A concurrent attach may have created the session while we awaited
-				// the adopt attempt — only the attach that actually creates the
-				// respawn may skip the reset.
-				const createdByThisAttach = !sessions.has(terminalId);
-				const respawned = await createTerminalSessionInternal({
+				// Concurrent attaches for the same id must share one respawn, and
+				// only the attach that owns it may skip the reset — the others'
+				// renderers hold stale grids that need the full resync.
+				const inflight = inflightRespawns.get(terminalId);
+				if (inflight) {
+					const shared = await inflight;
+					if ("error" in shared) return shared;
+					return { session: shared, respawned: false };
+				}
+				const respawnPromise = createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
 					themeType,
@@ -1905,8 +1920,14 @@ export function registerWorkspaceTerminalRoute({
 					eventBus,
 					restoredNotice: true,
 				});
-				if ("error" in respawned) return respawned;
-				return { session: respawned, respawned: createdByThisAttach };
+				inflightRespawns.set(terminalId, respawnPromise);
+				try {
+					const respawned = await respawnPromise;
+					if ("error" in respawned) return respawned;
+					return { session: respawned, respawned: true };
+				} finally {
+					inflightRespawns.delete(terminalId);
+				}
 			};
 
 			return {


### PR DESCRIPTION
## Summary
- Fixes the long-standing "Claude Code pane shows ghost/stale content until you resize the window" bug in v2 terminals.
- Root cause: the terminal wire protocol was at-most-once — output was buffered for reattach replay only while **zero** sockets were attached, in a 64 KB FIFO. Half-open sockets (laptop sleep/wake), the 8 MiB back-pressure drop, and FIFO overflow all lost bytes silently.
- Fix: every WS attach now sends a **grid resync** — full reset + the session ModeTracker's serialized buffer + mode preamble — so a reattaching renderer converges on the emulator's authoritative state no matter how much output it missed.

## Why / Context
Incremental-repaint TUIs (Claude Code/Ink) trust that the terminal grid contains exactly what they last drew. When bytes are lost, their cursor-relative erase/redraw sequences land on the wrong rows and strand ghost content — classically the top half of an old input box sitting above the live one. Nothing heals it: a same-dims resize produces no SIGWINCH (and Node suppresses `'resize'` for unchanged dims), so only a real window resize forced the full repaint that cleared it.

Reproduced deterministically before writing the fix: detach → ~105 KB of TUI output ending in a shrunken repaint region (the shape of a session finishing work while the pane is away) → reattach. The 64 KB tail replay left a ghost box + stale transcript that survived a same-dims resize and only cleared on a real resize.

## How It Works
- `ModeTracker` (the headless xterm already fed every PTY byte) gains `serialize()` via `@xterm/addon-serialize` (same beta line as `@xterm/headless`).
- `sendGridResync` (replaces `replayBuffer`) sends `\x1bc` (RIS) + serialized buffer (content, colors, cursor, alt-screen switch) + the existing mode preamble as one binary frame. This is VS Code's ptyService revive model — the pattern the mode tracker already cited.
- **In-band bytes only: renderers need zero changes**, so desktop↔host-service version skew is safe in both directions (old renderers just parse the reset; new renderers against old hosts keep today's behavior).
- The FIFO, `replayOnAdoption`, and `restoredNoticePending` are deleted. The "Session Contents Restored" separator is fed into the emulator itself, so it's part of the tracked grid. Adoption always replays the daemon ring (it repopulates the fresh tracker; the reset makes the old `?replay=0` duplication hack unnecessary). Adoption-replay quiescence now watches a monotonic `outputByteCount` instead of FIFO size.
- One preserved nuance: a respawn created by the attach itself skips the reset (`reset: false`), so the renderer's restored scrollback from the dead PTY stays painted above the fresh shell — existing UX.

## Manual QA Checklist
Validation so far is harness-level (real pty-daemon, real bash PTY running an Ink-style incremental-repaint TUI, real host-service WS route, `@xterm/headless` as the renderer grid) — not the live desktop app. Recommended before release:
- [ ] Terminal spawns, streams, resizes normally in the dev desktop app
- [ ] Claude Code pane: sleep laptop mid-stream (or toggle Wi-Fi) for ~30 s, wake, reveal without resizing → no ghost artifacts
- [ ] Terminal persists across workspace switches; reattach after parked-runtime eviction (>12 hidden terminals) shows correct content
- [ ] Alt-screen TUI (vim/htop) reattach after reconnect renders correctly
- [ ] Kill host-service while a terminal streams; on restart, adoption restores content without duplication
- [ ] Cold-restore respawn still shows the "Session Contents Restored" separator with old scrollback above

## Testing
- New regression test `terminal.replay-gap.repro.node-test.ts`: 5 phases (attached streaming · short detach · >100 KB gap · same-dims resize · real resize), all asserting renderer grid ≡ emulator state with no resize needed. Pre-fix, the same harness reproduced the ghost-box artifact; post-fix all phases pass.
- `terminal.adoption.node-test.ts` 20/20 (three tests rewritten to the new semantics), `terminal.send-snapshot.node-test.ts` 12/12, `bun test src/terminal` 115/115, `bun test test/integration/terminal.integration.test.ts` 9/9
- `bun run typecheck`, `bun run lint` clean
- Node-tests run via Electron-as-Node (better-sqlite3 is built for the Electron ABI): `ELECTRON_RUN_AS_NODE=1 <electron> --import tsx --test --test-force-exit <file>`

## Design Decisions
- **Snapshot-on-attach instead of sequence numbers/acks (Eternal Terminal model)**: sequencing still needs an unbounded buffer or a snapshot fallback for large gaps; snapshot alone makes attach idempotent with a much smaller change, and the tracker infrastructure already existed.
- **In-band RIS instead of a new protocol message**: keeps the fix host-only and version-skew safe; a renderer-cooperative protocol could later preserve local-only scrollback, deferred.

## Known Limitations
- A reattach truncates renderer scrollback to the tracker's window (1,000 lines — same bound the renderer's localStorage persistence already used) and jumps the viewport to bottom. Reattaches only happen after disconnects (sleep, network drop, eviction), where correctness beats history.
- After a huge detached flood, the restored-notice can scroll out of the 1,000-line window like any old line (previously it was pinned outside the FIFO). Natural scrollback semantics now.
- Resync payload is bounded by the tracker window (~100–300 KB worst case per attach), sent once per attach.

## Risks / Rollout
- **⚠️ Revert candidate**: this changes the attach path of every v2 terminal. If we see reattach misbehavior in the wild (garbled grids on reconnect, blank terminals after sleep/wake, scrollback complaints beyond the documented truncation), revert first and re-diagnose — a clean single-revert restores the FIFO replay path wholesale. Admin-merged to get dogfooding signal; treat any terminal-rendering regression report in the next releases as potentially this PR.
- Risk: worst plausible failure is a visual glitch on reattach (mitigated by the reset+rewrite arriving as one coalesced frame).
- Rollout: ships with host-service; no renderer or protocol coordination needed.
- Rollback: `git revert` both commits (31c885b14, faecdbd53) — the FIFO replay path returns wholesale.

## Review follow-ups (second commit)
- Ship `@xterm/addon-serialize` in the CLI dist `RUNTIME_PACKAGES` (CLI smoke test caught the missing runtime module)
- Adopt at the live PTY's dimensions from `daemon.list()` so ring replay parses at the correct width (cubic P1)
- Await ring-replay quiesce before attaching an adopted session (cubic)
- Only the attach that created a respawn skips the reset (CodeRabbit race)
- Tracker scrollback bound shared as one constant

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every terminal attach now sends a full grid resync (RIS reset + serialized emulator grid + mode preamble) to eliminate TUI ghost artifacts after reconnects, sleep/wake, or back-pressure drops. Reattach is independent of missed bytes and needs no renderer changes.

- **Bug Fixes**
  - On attach, send RIS + serialized grid + mode preamble so the renderer converges on the emulator state.
  - Deduped concurrent attach respawns with an in-flight map; only the attach that created the respawn skips the reset, all others get a full resync.
  - On adoption, use the live PTY’s cols/rows and wait for the daemon ring replay to quiesce so the first resync carries prior content at the correct width.
  - The restored-session notice is fed into the emulator buffer, so it persists across resyncs and precedes new shell output.

- **Refactors**
  - Replaced FIFO replay with `sendGridResync`; removed `replayBuffer` and `replayOnAdoption`. Adoption always replays the daemon ring; quiescence now watches `outputByteCount`.
  - Added `ModeTracker.serialize()` via `@xterm/addon-serialize` and included it in the CLI `RUNTIME_PACKAGES`.
  - Shared a single tracker scrollback bound and added a regression test (`terminal.replay-gap.repro.node-test.ts`) asserting reattach matches the emulator with no resize.

<sup>Written for commit 3b7ed460a14d8c05a0174b415dc55f6db10861c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal restoration after disconnects and reconnects, preserving screen state and recent scrollback.
  * Fixed stale or ghost content appearing after WebSocket gaps, including during terminal resizing and incremental UI updates.
  * Improved session adoption and respawn behavior, including restored-session notices and uninterrupted live output.
* **Tests**
  * Added comprehensive coverage for terminal synchronization, output floods, detach/reattach gaps, resizing, and session restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
