### PR TITLE
fix(desktop): match workspace pane tab borders to right sidebar tabs

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -178,7 +178,7 @@ export function TabBar<TData>({
 			className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-muted/45 dark:bg-muted/35"
 		>
 			{renderTabBarLeading && (
-				<div className="flex h-full shrink-0 items-stretch">
+				<div className="flex h-full shrink-0 items-stretch border-b border-border">
 					{renderTabBarLeading()}
 				</div>
 			)}
@@ -219,23 +219,23 @@ export function TabBar<TData>({
 							style={{ left: insertLineLeft }}
 						/>
 					)}
-					<div className="flex h-full w-10 shrink-0 items-center justify-center">
+					<div className="flex h-full w-10 shrink-0 items-center justify-center border-b border-border">
 						{!hasHorizontalOverflow && (
 							<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 						)}
 					</div>
 					{/* Empty space to the right of the tabs (collapses to 0 when the
 					    tabs overflow); the bar's only window-drag region. */}
-					<div className="drag h-full flex-1" />
+					<div className="drag h-full flex-1 border-b border-border" />
 				</div>
 			</OverflowFadeContainer>
 			{hasHorizontalOverflow && (
-				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center">
+				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center border-b border-border">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 			)}
 			{renderTabBarTrailing && (
-				<div className="no-drag flex h-full shrink-0 items-center px-1">
+				<div className="no-drag flex h-full shrink-0 items-center px-1 border-b border-border">
 					{renderTabBarTrailing()}
 				</div>
 			)}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -116,16 +116,16 @@ export function TabItem<TData>({
 				<div
 					ref={setRef}
 					className={cn(
-						// The bar carries a bottom border and the inactive-tab shade. The
-						// active tab has NO bottom border (only left/right/top) and takes an
+						// Inverted scheme matching the right sidebar tabs: the active tab is
+						// outlined on left/right/top with a transparent bottom border and an
 						// opaque fill, so it flows straight into the content below. Inactive
 						// tabs keep a 1px border on all sides (transparent except the bottom
 						// line) so the bar's line runs unbroken beneath them and tabs don't
 						// shift when switching.
 						"group relative flex h-full w-full items-center transition-colors",
 						isActive
-							? "border-x border-t border-border bg-background text-foreground"
-							: "border border-transparent text-muted-foreground/70 hover:bg-border/20 hover:text-muted-foreground",
+							? "border border-border border-b-transparent bg-background text-foreground"
+							: "border border-transparent border-b-border text-muted-foreground/70 hover:bg-border/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}


### PR DESCRIPTION
## Summary
- Workspace pane tabs now use the same inverted border scheme as the right sidebar's Files/Changes/Review tabs: the active tab is outlined on top/left/right with a transparent bottom border and opaque fill so it flows into the content below, while inactive tabs and the rest of the bar carry an unbroken bottom border line.

## How It Works
- `TabItem.tsx`: active tab gets `border border-border border-b-transparent bg-background`; inactive tabs get `border border-transparent border-b-border`. All states keep a 1px border on every side so tabs don't shift when switching.
- `TabBar.tsx`: every non-tab region (leading chrome, add-tab button slot, drag filler, overflow add button, trailing controls) carries `border-b border-border` so the line spans the full bar width. The border lives on each region rather than the bar root, because a root-level `border-b` would draw a line under the active tab and break the blend-into-content effect.

## Testing
- `bun run lint` (clean)
- `tsc --noEmit` in `packages/panes` (clean)
- Manual: verified end-to-end over CDP in the dev desktop app — opened a workspace with two terminal tabs and captured zoomed screenshots of both the pane tab bar and the sidebar tabs; the active tab blends into the content below and the bottom border line runs unbroken under inactive tabs, the + button, and the filler, matching the sidebar treatment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match workspace pane tab borders to the right sidebar style. Active tabs now flow into content; the bottom border stays continuous under inactive tabs and non-tab regions.

- **Bug Fixes**
  - In `TabItem.tsx`, active tabs use `border border-border border-b-transparent bg-background`; inactive tabs use `border border-transparent border-b-border` to avoid layout shift.
  - In `TabBar.tsx`, add `border-b border-border` to non-tab regions (leading area, add-tab slots, drag filler, overflow add button, trailing controls) so the bottom line spans the full width.

<sup>Written for commit 780924e0566a4898e257b3efd0483b14b80624cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

