### PR TITLE
fix(desktop): retain new-workspace image attachments across navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
@@ -2,6 +2,7 @@ import { PromptInputProvider } from "@superset/ui/ai-elements/prompt-input";
 import { createFileRoute } from "@tanstack/react-router";
 import { NewWorkspaceScreen } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen";
 import { DashboardNewWorkspaceDraftProvider } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext";
+import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-attachments";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/new-workspace/",
@@ -23,7 +24,7 @@ function NewWorkspacePage() {
 	const { projectId } = Route.useSearch();
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={() => {}}>
-			<PromptInputProvider>
+			<PromptInputProvider attachmentsStore={newWorkspaceAttachmentsStore}>
 				<NewWorkspaceScreen isOpen preSelectedProjectId={projectId ?? null} />
 				{/* Window-drag surface replacing the hidden TopBar's drag region.
 				    Stops short of the top-right corner so the screen's naming

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/NewWorkspaceEmptyScreen/NewWorkspaceEmptyScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/NewWorkspaceEmptyScreen/NewWorkspaceEmptyScreen.tsx
@@ -1,6 +1,7 @@
 import { PromptInputProvider } from "@superset/ui/ai-elements/prompt-input";
 import { NewWorkspaceScreen } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen";
 import { DashboardNewWorkspaceDraftProvider } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext";
+import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-attachments";
 
 /**
  * Experiment test arm (new-workspace-screen): replaces the "No workspaces yet"
@@ -12,7 +13,7 @@ import { DashboardNewWorkspaceDraftProvider } from "renderer/routes/_authenticat
 export function NewWorkspaceEmptyScreen() {
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={() => {}}>
-			<PromptInputProvider>
+			<PromptInputProvider attachmentsStore={newWorkspaceAttachmentsStore}>
 				<NewWorkspaceScreen isOpen preSelectedProjectId={null} />
 			</PromptInputProvider>
 		</DashboardNewWorkspaceDraftProvider>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -11,6 +11,7 @@ import {
 } from "@superset/ui/dialog";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
+import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-attachments";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -66,7 +67,7 @@ export function DashboardNewWorkspaceModal() {
 
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
-			<PromptInputProvider>
+			<PromptInputProvider attachmentsStore={newWorkspaceAttachmentsStore}>
 				<PromptInputResetSync />
 				<Dialog
 					modal

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -44,6 +44,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
 import { SupersetIcon } from "renderer/routes/_authenticated/onboarding/providers/components/SupersetIcon";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { newWorkspaceAttachmentPaths } from "renderer/stores/new-workspace-attachments";
 import { useNewWorkspacePromptContext } from "renderer/stores/new-workspace-prompt-context";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../DashboardNewWorkspaceDraftContext";
@@ -118,9 +119,6 @@ export function NewWorkspaceScreen({
 	// case (Esc-cancelled drags, drops outside the window) that an enter/leave
 	// counter gets permanently stuck on.
 	const [isDraggingFiles, setIsDraggingFiles] = useState(false);
-	// Source paths for dropped/picked files, keyed by filename — the attachment
-	// items only keep an object URL, and Finder reveal needs the original path.
-	const attachmentPathsRef = useRef(new Map<string, string>());
 	useEffect(() => {
 		if (!isOpen) return;
 		let timer: number | null = null;
@@ -132,8 +130,8 @@ export function NewWorkspaceScreen({
 					// Attachment items only expose the basename, so the map is
 					// name-keyed; a second same-named file from elsewhere makes the
 					// name ambiguous — poison it so no card reveals the wrong file.
-					const existing = attachmentPathsRef.current.get(file.name);
-					attachmentPathsRef.current.set(
+					const existing = newWorkspaceAttachmentPaths.get(file.name);
+					newWorkspaceAttachmentPaths.set(
 						file.name,
 						existing !== undefined && existing !== path ? "" : path,
 					);
@@ -601,7 +599,7 @@ export function NewWorkspaceScreen({
 							))}
 							{visibleFiles.map((file) => {
 								const sourcePath = file.filename
-									? attachmentPathsRef.current.get(file.filename) || null
+									? newWorkspaceAttachmentPaths.get(file.filename) || null
 									: null;
 								return (
 									<AttachmentCard

--- a/apps/desktop/src/renderer/stores/new-workspace-attachments.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-attachments.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	newWorkspaceAttachmentPaths,
+	newWorkspaceAttachmentsStore,
+} from "./new-workspace-attachments";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+
+const imageFile = {
+	id: "file-1",
+	type: "file" as const,
+	url: "blob:renderer/one",
+	mediaType: "image/png",
+	filename: "one.png",
+};
+
+describe("newWorkspaceAttachmentsStore", () => {
+	beforeEach(() => {
+		newWorkspaceAttachmentsStore.set([]);
+		newWorkspaceAttachmentPaths.clear();
+	});
+
+	it("retains files independent of any mounted provider", () => {
+		newWorkspaceAttachmentsStore.set([imageFile]);
+		expect(newWorkspaceAttachmentsStore.get()).toEqual([imageFile]);
+	});
+
+	it("keeps files across non-reset draft updates", () => {
+		newWorkspaceAttachmentsStore.set([imageFile]);
+		useNewWorkspaceDraftStore.getState().updateDraft({ prompt: "hello" });
+		expect(newWorkspaceAttachmentsStore.get()).toEqual([imageFile]);
+	});
+
+	it("clears files, revokes blob URLs, and drops source paths on draft reset", () => {
+		const revoked: string[] = [];
+		const original = URL.revokeObjectURL;
+		URL.revokeObjectURL = (url: string) => {
+			revoked.push(url);
+		};
+		try {
+			newWorkspaceAttachmentsStore.set([imageFile]);
+			newWorkspaceAttachmentPaths.set("one.png", "/tmp/one.png");
+
+			useNewWorkspaceDraftStore.getState().resetDraft();
+
+			expect(newWorkspaceAttachmentsStore.get()).toEqual([]);
+			expect(revoked).toEqual(["blob:renderer/one"]);
+			expect(newWorkspaceAttachmentPaths.size).toBe(0);
+		} finally {
+			URL.revokeObjectURL = original;
+		}
+	});
+
+	it("notifies subscribers when files change", () => {
+		let calls = 0;
+		const unsubscribe = newWorkspaceAttachmentsStore.subscribe(() => {
+			calls += 1;
+		});
+		newWorkspaceAttachmentsStore.set([imageFile]);
+		expect(calls).toBe(1);
+		unsubscribe();
+		newWorkspaceAttachmentsStore.set([]);
+		expect(calls).toBe(1);
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-attachments.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-attachments.ts
@@ -1,0 +1,26 @@
+import { createPromptInputAttachmentsStore } from "@superset/ui/ai-elements/prompt-input";
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
+
+/**
+ * Module-scoped attachment state for the new-workspace draft. Keeps attached
+ * files alive across navigation the same way the prompt text survives in
+ * useNewWorkspaceDraftStore — the create surfaces mount and unmount, this
+ * store does not.
+ */
+export const newWorkspaceAttachmentsStore = createPromptInputAttachmentsStore();
+
+/**
+ * Source paths for dropped/picked files, keyed by filename — attachment items
+ * only keep an object URL, and Finder reveal needs the original path. Module
+ * scoped so reveal keeps working for attachments restored after navigation.
+ */
+export const newWorkspaceAttachmentPaths = new Map<string, string>();
+
+// A draft reset (successful create or explicit discard) clears attachments
+// with it, even while no create surface is mounted.
+useNewWorkspaceDraftStore.subscribe((state, prevState) => {
+	if (state.resetKey !== prevState.resetKey) {
+		newWorkspaceAttachmentsStore.clear();
+		newWorkspaceAttachmentPaths.clear();
+	}
+});

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -33,6 +33,7 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
 import { isEnterSubmit } from "../../lib/keyboard";
 import { cn } from "../../lib/utils";
@@ -141,8 +142,61 @@ export const useProviderAttachments = () => {
 const useOptionalProviderAttachments = () =>
 	useContext(ProviderAttachmentsContext);
 
+export type PromptInputAttachmentItem = FileUIPart & { id: string };
+
+export interface PromptInputAttachmentsStore {
+	get: () => PromptInputAttachmentItem[];
+	set: (files: PromptInputAttachmentItem[]) => void;
+	subscribe: (listener: () => void) => () => void;
+	/** Revokes all blob URLs and empties the store; safe while no provider is mounted. */
+	clear: () => void;
+}
+
+/**
+ * Module-scoped attachment state for PromptInputProvider. Pass the result as
+ * `attachmentsStore` to make attachments survive provider unmount (e.g. route
+ * navigation). The store then owns the blob URLs' lifetime: they are no longer
+ * revoked on unmount, only by remove/clear/setFiles or store.clear().
+ */
+export function createPromptInputAttachmentsStore(): PromptInputAttachmentsStore {
+	let files: PromptInputAttachmentItem[] = [];
+	const listeners = new Set<() => void>();
+	const notify = () => {
+		for (const listener of listeners) {
+			listener();
+		}
+	};
+	return {
+		get: () => files,
+		set: (next) => {
+			files = next;
+			notify();
+		},
+		subscribe: (listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		clear: () => {
+			for (const f of files) {
+				if (f.url) {
+					URL.revokeObjectURL(f.url);
+				}
+			}
+			files = [];
+			notify();
+		},
+	};
+}
+
+const EMPTY_ATTACHMENTS: PromptInputAttachmentItem[] = [];
+const emptyAttachmentsSubscribe = () => () => {};
+const getEmptyAttachments = () => EMPTY_ATTACHMENTS;
+
 export type PromptInputProviderProps = PropsWithChildren<{
 	initialInput?: string;
+	attachmentsStore?: PromptInputAttachmentsStore;
 }>;
 
 /**
@@ -151,6 +205,7 @@ export type PromptInputProviderProps = PropsWithChildren<{
  */
 export function PromptInputProvider({
 	initialInput: initialTextInput = "",
+	attachmentsStore,
 	children,
 }: PromptInputProviderProps) {
 	// ----- textInput state
@@ -180,41 +235,65 @@ export function PromptInputProvider({
 		focusCallbackRef.current = cb;
 	}, []);
 
-	// ----- attachments state (global when wrapped)
-	const [attachmentFiles, setAttachmentFiles] = useState<
-		(FileUIPart & { id: string })[]
-	>([]);
+	// ----- attachments state (global when wrapped, module-scoped when an
+	// external store is provided)
+	const [localFiles, setLocalFiles] = useState<PromptInputAttachmentItem[]>([]);
+	const storeFiles = useSyncExternalStore(
+		attachmentsStore?.subscribe ?? emptyAttachmentsSubscribe,
+		attachmentsStore?.get ?? getEmptyAttachments,
+	);
+	const attachmentFiles = attachmentsStore ? storeFiles : localFiles;
+	const setAttachmentFiles = useCallback(
+		(
+			updater: (
+				prev: PromptInputAttachmentItem[],
+			) => PromptInputAttachmentItem[],
+		) => {
+			if (attachmentsStore) {
+				attachmentsStore.set(updater(attachmentsStore.get()));
+			} else {
+				setLocalFiles(updater);
+			}
+		},
+		[attachmentsStore],
+	);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const openRef = useRef<() => void>(() => {});
 
-	const add = useCallback((files: File[] | FileList) => {
-		const incoming = Array.from(files);
-		if (incoming.length === 0) {
-			return;
-		}
-
-		setAttachmentFiles((prev) =>
-			prev.concat(
-				incoming.map((file) => ({
-					id: nanoid(),
-					type: "file" as const,
-					url: URL.createObjectURL(file),
-					mediaType: file.type,
-					filename: file.name,
-				})),
-			),
-		);
-	}, []);
-
-	const remove = useCallback((id: string) => {
-		setAttachmentFiles((prev) => {
-			const found = prev.find((f) => f.id === id);
-			if (found?.url) {
-				URL.revokeObjectURL(found.url);
+	const add = useCallback(
+		(files: File[] | FileList) => {
+			const incoming = Array.from(files);
+			if (incoming.length === 0) {
+				return;
 			}
-			return prev.filter((f) => f.id !== id);
-		});
-	}, []);
+
+			setAttachmentFiles((prev) =>
+				prev.concat(
+					incoming.map((file) => ({
+						id: nanoid(),
+						type: "file" as const,
+						url: URL.createObjectURL(file),
+						mediaType: file.type,
+						filename: file.name,
+					})),
+				),
+			);
+		},
+		[setAttachmentFiles],
+	);
+
+	const remove = useCallback(
+		(id: string) => {
+			setAttachmentFiles((prev) => {
+				const found = prev.find((f) => f.id === id);
+				if (found?.url) {
+					URL.revokeObjectURL(found.url);
+				}
+				return prev.filter((f) => f.id !== id);
+			});
+		},
+		[setAttachmentFiles],
+	);
 
 	const clear = useCallback(() => {
 		setAttachmentFiles((prev) => {
@@ -225,38 +304,43 @@ export function PromptInputProvider({
 			}
 			return [];
 		});
-	}, []);
+	}, [setAttachmentFiles]);
 
-	const setFiles = useCallback((files: FileUIPart[]) => {
-		setAttachmentFiles((prev) => {
-			for (const f of prev) {
-				if (f.url) {
-					URL.revokeObjectURL(f.url);
+	const setFiles = useCallback(
+		(files: FileUIPart[]) => {
+			setAttachmentFiles((prev) => {
+				for (const f of prev) {
+					if (f.url) {
+						URL.revokeObjectURL(f.url);
+					}
 				}
-			}
-			return files.map((file) => ({
-				...file,
-				id: nanoid(),
-			}));
-		});
-	}, []);
+				return files.map((file) => ({
+					...file,
+					id: nanoid(),
+				}));
+			});
+		},
+		[setAttachmentFiles],
+	);
 
 	const takeFiles = useCallback(() => {
 		const takenFiles = attachmentsRef.current;
 		attachmentsRef.current = [];
-		setAttachmentFiles([]);
+		setAttachmentFiles(() => []);
 		if (fileInputRef.current) {
 			fileInputRef.current.value = "";
 		}
 		return takenFiles;
-	}, []);
+	}, [setAttachmentFiles]);
 
 	// Keep a ref to attachments for cleanup on unmount (avoids stale closure)
 	const attachmentsRef = useRef(attachmentFiles);
 	attachmentsRef.current = attachmentFiles;
 
-	// Cleanup blob URLs on unmount to prevent memory leaks
+	// Cleanup blob URLs on unmount to prevent memory leaks. With an external
+	// store the files outlive the provider, so their URLs must stay valid.
 	useEffect(() => {
+		if (attachmentsStore) return;
 		return () => {
 			for (const f of attachmentsRef.current) {
 				if (f.url) {
@@ -264,7 +348,7 @@ export function PromptInputProvider({
 				}
 			}
 		};
-	}, []);
+	}, [attachmentsStore]);
 
 	const openFileDialog = useCallback(() => {
 		openRef.current?.();


### PR DESCRIPTION
## Problem

On the v2 new-workspace page (`/new-workspace` route and the empty-dashboard create screen), typed prompt text survives navigating away and back, but attached images vanish.

The text lives in the module-level `useNewWorkspaceDraftStore`; attachments lived in React state inside `PromptInputProvider`, which those surfaces mount **inside the route**. Navigating away unmounts the provider, dropping the file list and revoking every blob URL. The control-arm modal never had the bug only because its provider sits in the always-mounted layout.

## Fix

- **`packages/ui` `prompt-input.tsx`**: `PromptInputProvider` accepts an opt-in `attachmentsStore` (created via `createPromptInputAttachmentsStore()`). When provided, attachment state lives in that module-scoped store and blob URLs are no longer revoked on provider unmount — the store owns their lifetime. Without the prop, behavior is unchanged.
- **`new-workspace-attachments.ts`** (new): singleton store wired into all three create surfaces (route, empty screen, modal — both experiment arms now share one draft, matching the text). A subscription on the draft store's `resetKey` clears attachments + revokes URLs on successful create/discard, even while no create surface is mounted.
- **`NewWorkspaceScreen`**: the filename→source-path map backing "Reveal in Finder" was also component-local; hoisted into the same module and cleared on reset.

Attachment ids survive navigation, so the idempotent upload cache (keyed `(fileId, hostUrl)`) keeps its entries — no re-upload on return, and the per-host visibility filter still matches.

## Testing

- New `new-workspace-attachments.test.ts` (4 cases): persistence, reset clearing + URL revocation, subscriber notification. Verified the reset test fails when the reset handler is mutated.
- Monorepo typecheck, `bun run lint`, and `packages/ui` tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost image attachments on the v2 new-workspace screens. Attachments now persist across navigation and only clear on successful create or discard.

- **Bug Fixes**
  - Store attachments in a module-scoped singleton for the new-workspace draft; all three create surfaces use it, so files survive route changes and modal toggles.
  - Clear attachments and revoke blob URLs on draft reset via a `resetKey` subscription; also hoist and clear the filename→source-path map for “Reveal in Finder.”
  - Preserve attachment IDs to keep the upload cache intact and avoid re-uploads.
  - Added unit tests for persistence, reset behavior, and subscriber notifications.

- **New Features**
  - `PromptInputProvider` in `@superset/ui/ai-elements/prompt-input` accepts an optional `attachmentsStore`.
  - Added `createPromptInputAttachmentsStore()` to hold attachment state outside the provider; blob URLs are not revoked on provider unmount when used. Behavior is unchanged when not provided.

<sup>Written for commit e7a974f5ce9c4d699a7999b8d6b539ba8a6426a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

