### PR TITLE
fix(host-service): send follow-up Enter as a separate delayed write so terminals send submits reliably

### DIFF
--- a/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
@@ -346,9 +346,11 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 			[`\x1b[200~delayed-${id}\x1b[201~`, "\r"],
 			"send must be exactly two writes: framed text, then a bare Enter",
 		);
+		const [textWrite, enterWrite] = writes;
+		assert.ok(textWrite && enterWrite);
 		assert.ok(
-			writes[1].at - writes[0].at >= 400,
-			`Enter must trail the text write, gap was ${writes[1].at - writes[0].at}ms`,
+			enterWrite.at - textWrite.at >= 400,
+			`Enter must trail the text write, gap was ${enterWrite.at - textWrite.at}ms`,
 		);
 		await waitFor(
 			() =>

--- a/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
@@ -288,6 +288,63 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 		await disposeSessionAndWait(terminalId, db);
 	});
 
+	test("submit Enter is a separate write, delayed past the paste burst", async () => {
+		const terminalId = `e2e-enterdelay-${randomUUID().slice(0, 8)}`;
+		const id = randomUUID().slice(0, 6);
+		const captureFile = path.join(TEST_HOME, `enterdelay-${terminalId}`);
+		const doneFile = path.join(TEST_HOME, `enterdelay-done-${terminalId}`);
+
+		// `cat > file` under canonical mode: nothing reaches the file until a
+		// line terminator arrives, so the capture file is the oracle for
+		// whether the Enter has been written yet.
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: `printf '\\033[?2004h'; cat > "${captureFile}"; printf '\\033[?2004l'; echo done > "${doneFile}"`,
+		});
+		assert.ok(!("error" in session));
+		if ("error" in session) return;
+
+		await waitFor(() => session.modeTracker.isBracketedPasteActive(), 5000);
+
+		const pending = writeFramedInputToSession({
+			terminalId,
+			workspaceId,
+			text: `delayed-${id}`,
+			submit: true,
+			db,
+		});
+		// Mid-delay: the text write must not have been submitted yet — a
+		// bundled `text\r` write would have flushed the line already.
+		await new Promise((r) => setTimeout(r, 150));
+		const midDelay = fs.existsSync(captureFile)
+			? fs.readFileSync(captureFile, "latin1")
+			: "";
+		assert.ok(
+			!midDelay.includes(`delayed-${id}`),
+			`Enter must be delayed past the text write, got: ${JSON.stringify(midDelay)}`,
+		);
+
+		const sent = await pending;
+		assert.ok(!("error" in sent));
+		await waitFor(
+			() =>
+				fs.existsSync(captureFile) &&
+				fs
+					.readFileSync(captureFile, "latin1")
+					.includes(`\x1b[200~delayed-${id}\x1b[201~`),
+			5000,
+		);
+
+		const eof = writeInputToSession({ terminalId, workspaceId, data: "\x04" });
+		assert.ok(!("error" in eof));
+		await waitFor(() => fs.existsSync(doneFile), 5000);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
 	test("snapshot reads the alt-screen buffer while a TUI is active", async () => {
 		const terminalId = `e2e-alt-${randomUUID().slice(0, 8)}`;
 		const id = randomUUID().slice(0, 6);

--- a/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
@@ -420,6 +420,70 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 		await disposeSessionAndWait(terminalId, db);
 	});
 
+	test("concurrent sends racing a fresh adoption share one session and serialize", async () => {
+		const terminalId = `e2e-adoptrace-${randomUUID().slice(0, 8)}`;
+		const id = randomUUID().slice(0, 6);
+		const captureFile = path.join(TEST_HOME, `adoptrace-${terminalId}`);
+		const doneFile = path.join(TEST_HOME, `adoptrace-done-${terminalId}`);
+
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: `printf '\\033[?2004h'; cat > "${captureFile}"; printf '\\033[?2004l'; echo done > "${doneFile}"`,
+		});
+		assert.ok(!("error" in session));
+		if ("error" in session) return;
+		await waitFor(() => session.modeTracker.isBracketedPasteActive(), 5000);
+
+		// Simulate a host-service restart: memory empties, daemon lives. Both
+		// sends below then race the adoption; without in-flight dedup they get
+		// separate TerminalSession objects whose write chains interleave, and
+		// the draft rides the first send's Enter.
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+
+		const [first, second] = await Promise.all([
+			writeFramedInputToSession({
+				terminalId,
+				workspaceId,
+				text: `submit-${id}`,
+				submit: true,
+				db,
+			}),
+			writeFramedInputToSession({
+				terminalId,
+				workspaceId,
+				text: `draft-${id}`,
+				submit: false,
+				db,
+			}),
+		]);
+		assert.ok(!("error" in first), JSON.stringify(first));
+		assert.ok(!("error" in second), JSON.stringify(second));
+
+		// First ^D flushes the staged draft line to cat, second at line start
+		// is EOF.
+		writeInputToSession({ terminalId, workspaceId, data: "\x04" });
+		writeInputToSession({ terminalId, workspaceId, data: "\x04" });
+		await waitFor(() => fs.existsSync(doneFile), 5000);
+
+		const captured = fs.readFileSync(captureFile, "latin1");
+		const submitIndex = captured.indexOf(`submit-${id}`);
+		const draftIndex = captured.indexOf(`draft-${id}`);
+		assert.ok(
+			submitIndex >= 0 && draftIndex > submitIndex,
+			`expected submit before draft, got: ${JSON.stringify(captured)}`,
+		);
+		assert.ok(
+			captured.slice(submitIndex, draftIndex).includes("\n"),
+			`Enter must land between the submitted text and the draft, got: ${JSON.stringify(captured)}`,
+		);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
 	test("snapshot reads the alt-screen buffer while a TUI is active", async () => {
 		const terminalId = `e2e-alt-${randomUUID().slice(0, 8)}`;
 		const id = randomUUID().slice(0, 6);

--- a/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.send-snapshot.node-test.ts
@@ -309,6 +309,17 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 
 		await waitFor(() => session.modeTracker.isBracketedPasteActive(), 5000);
 
+		// Record pty writes so the assertion is on the write layer itself: a
+		// delayed-but-bundled `text\r` write would still pass a file-content
+		// check, but not a two-writes-with-a-gap check.
+		const writes: Array<{ data: string; at: number }> = [];
+		const pty = session.pty as unknown as { write(data: string): void };
+		const originalWrite = pty.write.bind(session.pty);
+		pty.write = (data: string) => {
+			writes.push({ data, at: Date.now() });
+			originalWrite(data);
+		};
+
 		const pending = writeFramedInputToSession({
 			terminalId,
 			workspaceId,
@@ -328,7 +339,17 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 		);
 
 		const sent = await pending;
+		pty.write = originalWrite;
 		assert.ok(!("error" in sent));
+		assert.deepEqual(
+			writes.map((w) => w.data),
+			[`\x1b[200~delayed-${id}\x1b[201~`, "\r"],
+			"send must be exactly two writes: framed text, then a bare Enter",
+		);
+		assert.ok(
+			writes[1].at - writes[0].at >= 400,
+			`Enter must trail the text write, gap was ${writes[1].at - writes[0].at}ms`,
+		);
 		await waitFor(
 			() =>
 				fs.existsSync(captureFile) &&
@@ -341,6 +362,58 @@ describe("writeFramedInputToSession / snapshotSession", () => {
 		const eof = writeInputToSession({ terminalId, workspaceId, data: "\x04" });
 		assert.ok(!("error" in eof));
 		await waitFor(() => fs.existsSync(doneFile), 5000);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
+	test("concurrent sends serialize: a staged draft cannot ride another send's Enter", async () => {
+		const terminalId = `e2e-serialize-${randomUUID().slice(0, 8)}`;
+		const id = randomUUID().slice(0, 6);
+
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+		});
+		assert.ok(!("error" in session));
+		if ("error" in session) return;
+
+		const writes: string[] = [];
+		const pty = session.pty as unknown as { write(data: string): void };
+		const originalWrite = pty.write.bind(session.pty);
+		pty.write = (data: string) => {
+			writes.push(data);
+			originalWrite(data);
+		};
+
+		// Fire a submitting send and a submit: false draft concurrently. The
+		// draft must not land inside the first send's text→Enter window, or
+		// the Enter would submit it too.
+		const [first, second] = await Promise.all([
+			writeFramedInputToSession({
+				terminalId,
+				workspaceId,
+				text: `: submit-${id}`,
+				submit: true,
+				db,
+			}),
+			writeFramedInputToSession({
+				terminalId,
+				workspaceId,
+				text: `: draft-${id}`,
+				submit: false,
+				db,
+			}),
+		]);
+		pty.write = originalWrite;
+		assert.ok(!("error" in first));
+		assert.ok(!("error" in second));
+		assert.deepEqual(
+			writes,
+			[`: submit-${id}`, "\r", `: draft-${id}`],
+			"draft text must come after the first send's Enter",
+		);
 
 		await disposeSessionAndWait(terminalId, db);
 	});

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -635,6 +635,14 @@ async function waitForAdoptionReplay(session: TerminalSession): Promise<void> {
 }
 
 /**
+ * In-flight headless adoptions by terminal id. Concurrent callers racing an
+ * adoption would each build their own TerminalSession (independent
+ * followUpWriteChain, duplicate daemon subscriptions) — sharing the leader's
+ * attempt keeps session identity unique per terminal.
+ */
+const adoptionsInFlight = new Map<string, Promise<unknown>>();
+
+/**
  * Resolve a session for headless IO. The in-memory map empties on every
  * host-service restart while the detached daemon keeps PTYs alive, so a
  * miss is not "gone" — recover it the same way pane auto-adoption does.
@@ -650,25 +658,44 @@ async function getOrAdoptSession({
 	db: HostDb;
 	eventBus?: EventBus;
 }): Promise<TerminalSession | { error: string }> {
-	const existing = sessions.get(terminalId);
-	if (existing) {
-		if (existing.workspaceId !== workspaceId) {
-			return { error: "Terminal session does not belong to this workspace" };
+	for (;;) {
+		const existing = sessions.get(terminalId);
+		if (existing) {
+			if (existing.workspaceId !== workspaceId) {
+				return { error: "Terminal session does not belong to this workspace" };
+			}
+			return existing;
 		}
-		return existing;
+
+		// Another caller is mid-adoption: wait it out, then re-resolve so
+		// this caller runs its own workspace check (or leads a fresh attempt
+		// if the leader failed).
+		const pending = adoptionsInFlight.get(terminalId);
+		if (pending) {
+			await pending.catch(() => {});
+			continue;
+		}
+
+		const attempt = (async () => {
+			const adopted = await createTerminalSessionInternal({
+				terminalId,
+				workspaceId,
+				db,
+				eventBus,
+				adoptOnly: true,
+			});
+			if ("error" in adopted) return adopted;
+
+			await waitForAdoptionReplay(adopted);
+			return adopted;
+		})();
+		adoptionsInFlight.set(terminalId, attempt);
+		try {
+			return await attempt;
+		} finally {
+			adoptionsInFlight.delete(terminalId);
+		}
 	}
-
-	const adopted = await createTerminalSessionInternal({
-		terminalId,
-		workspaceId,
-		db,
-		eventBus,
-		adoptOnly: true,
-	});
-	if ("error" in adopted) return adopted;
-
-	await waitForAdoptionReplay(adopted);
-	return adopted;
 }
 
 /**

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -332,6 +332,13 @@ interface TerminalSession {
 	 * paste, focus, mouse, etc. that the FIFO can't restore on its own.
 	 */
 	modeTracker: ModeTracker;
+
+	/**
+	 * Tail of the in-flight follow-up send (writeFramedInputToSession).
+	 * Serializes text + delayed-Enter sequences so concurrent sends can't
+	 * interleave inside another send's Enter window.
+	 */
+	followUpWriteChain?: Promise<void>;
 }
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
@@ -696,22 +703,38 @@ export async function writeFramedInputToSession({
 		return { error: "Terminal session has exited" };
 	}
 
-	const framed = session.modeTracker.isBracketedPasteActive()
-		? `\x1b[200~${text}\x1b[201~`
-		: text;
-	if (!submit) {
-		session.pty.write(framed);
-		return { success: true };
-	}
-	if (text.length > 0) {
-		session.pty.write(framed);
-		await new Promise((r) => setTimeout(r, FOLLOW_UP_ENTER_DELAY_MS));
-		if (session.exited) {
-			return { error: "Terminal session has exited" };
-		}
-	}
-	session.pty.write("\r");
-	return { success: true };
+	// Serialize sends per session: the delayed Enter opens a window where a
+	// concurrent send's text (even a submit: false draft) would land between
+	// this text and its Enter and get submitted by it.
+	const previous = session.followUpWriteChain ?? Promise.resolve();
+	const task = previous.then(
+		async (): Promise<{ success: true } | { error: string }> => {
+			if (session.exited) {
+				return { error: "Terminal session has exited" };
+			}
+			const framed = session.modeTracker.isBracketedPasteActive()
+				? `\x1b[200~${text}\x1b[201~`
+				: text;
+			if (!submit) {
+				session.pty.write(framed);
+				return { success: true };
+			}
+			if (text.length > 0) {
+				session.pty.write(framed);
+				await new Promise((r) => setTimeout(r, FOLLOW_UP_ENTER_DELAY_MS));
+				if (session.exited) {
+					return { error: "Terminal session has exited" };
+				}
+			}
+			session.pty.write("\r");
+			return { success: true };
+		},
+	);
+	session.followUpWriteChain = task.then(
+		() => undefined,
+		() => undefined,
+	);
+	return task;
 }
 
 /**

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -230,6 +230,15 @@ const SHELL_READY_TIMEOUT_MS = 15_000;
 const INITIAL_COMMAND_ENTER_DELAY_MS = 500;
 
 /**
+ * Gap between a follow-up send's text and the Enter that submits it. TUI
+ * agents treat bytes arriving together as one paste burst, so an Enter
+ * bundled with the text can be swallowed into the draft instead of
+ * submitting it when the session is busy or slow (#6243). The delay puts
+ * the Enter in its own read, where it can only be a keypress.
+ */
+const FOLLOW_UP_ENTER_DELAY_MS = 500;
+
+/**
  * Byte ceiling for typing an initialCommand directly into the PTY. The
  * shell-ready marker fires from precmd, before the line editor switches the
  * TTY to raw mode; input written in that gap queues under the kernel's
@@ -690,7 +699,18 @@ export async function writeFramedInputToSession({
 	const framed = session.modeTracker.isBracketedPasteActive()
 		? `\x1b[200~${text}\x1b[201~`
 		: text;
-	session.pty.write(submit ? `${framed}\r` : framed);
+	if (!submit) {
+		session.pty.write(framed);
+		return { success: true };
+	}
+	if (text.length > 0) {
+		session.pty.write(framed);
+		await new Promise((r) => setTimeout(r, FOLLOW_UP_ENTER_DELAY_MS));
+		if (session.exited) {
+			return { error: "Terminal session has exited" };
+		}
+	}
+	session.pty.write("\r");
 	return { success: true };
 }
 


### PR DESCRIPTION
## Summary

Fixes #6243: `superset terminals send` to a busy/laggy Claude Code session typed the text into the agent's input box but left it as an unsubmitted draft, while the CLI reported `submitted: true`. Multi-line text (bracketed paste) was the biggest trigger.

**Cause:** `writeFramedInputToSession` bundled the submit Enter into the same PTY write as the pasted text (`\x1b[200~text\x1b[201~\r`). TUI agents aggregate bytes that arrive together into one paste burst, so on a slow session the trailing `\r` gets folded into the draft instead of acting as a keypress.

**Fix:** write the framed text first, then the Enter as its own write `FOLLOW_UP_ENTER_DELAY_MS` (500ms) later — the same class of fix as #6026's `INITIAL_COMMAND_ENTER_DELAY_MS` for initial commands. In its own read, a `\r` can only be an Enter keypress. If the session exits during the gap, the send now returns an error instead of pretending. `--no-submit` and bare-Enter (empty text) behavior unchanged. All callers (CLI, MCP tool, SDK) inherit the fix through the `terminal.send` mutation.

## Tests

- New node test **"submit Enter is a separate write, delayed past the paste burst"** in `terminal.send-snapshot.node-test.ts` — uses canonical-mode `cat > file` line buffering as the oracle for whether the Enter has been written. Verified it fails against the old bundled write (delay mutated to 0 → fail) and passes with the fix.
- Full send/snapshot suite green: 13/13 under Electron-as-Node.

## E2E verification (dev desktop + real CLI + live Claude Code, driven over CDP)

- Multi-line idle send → submitted, answered.
- Multi-line send into a busy mid-turn session → queued, auto-submitted after the turn, answered.
- Single-line, 8KB payload, and boot-race sends → all submit.

Known limitation (unchanged by this PR, tracked in #6243's remaining asks): if the agent process is dead or suspended, bytes go to whatever owns the pty and `submitted: true` still only means "bytes written" — programmatic submission verification is a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reliably submit text in `host-service` by sending Enter as a separate delayed write, serializing follow-up sends per session, and deduping in-flight adoptions so concurrent sends share one session. Fixes #6243 where multi-line sends could stay as drafts while the CLI reported submitted.

- **Bug Fixes**
  - In `writeFramedInputToSession`, write framed text first, then send `\r` after 500ms (`FOLLOW_UP_ENTER_DELAY_MS`) when `submit: true`, so TUIs treat it as a keypress.
  - Return an error if the session exits during the delay; `--no-submit` and empty-text behavior are unchanged.
  - Serialize follow-up sends per session so text + Enter are atomic; a draft cannot ride another send’s Enter.
  - Dedupe in-flight headless adoptions in `getOrAdoptSession` so racing sends after a restart share one `TerminalSession` and respect send serialization.

<sup>Written for commit 7ffd678c6b7eb6a783debfb48897290b26e553bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal command submission by separating text input from the Enter key.
  * Added a brief delay before submitting commands to ensure terminal input is processed reliably.
  * Non-submitting terminal writes remain immediate.
  * Improved handling of concurrent terminal actions to preserve command order and prevent staged text from being submitted unexpectedly.
  * Added safeguards to ensure terminal actions are sent only while the session remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->