### PR TITLE
feat(desktop): add pan, pinch, and zoom to the image file pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
@@ -1,12 +1,48 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { getImageMimeType } from "shared/file-types";
 import type { ViewProps } from "../../types";
 
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 16;
+const DEFAULT_TRANSFORM = { scale: 1, x: 0, y: 0 };
+
+interface Transform {
+	scale: number;
+	x: number;
+	y: number;
+}
+
+function zoomAtPoint(
+	prev: Transform,
+	nextScale: number,
+	pointX: number,
+	pointY: number,
+): Transform {
+	const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, nextScale));
+	const ratio = scale / prev.scale;
+	return {
+		scale,
+		x: pointX - (pointX - prev.x) * ratio,
+		y: pointY - (pointY - prev.y) * ratio,
+	};
+}
+
 export function ImageView({ document, filePath }: ViewProps) {
 	const [objectUrl, setObjectUrl] = useState<string | null>(null);
+	const [transform, setTransform] = useState<Transform>(DEFAULT_TRANSFORM);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const dragRef = useRef<{
+		pointerId: number;
+		startX: number;
+		startY: number;
+		originX: number;
+		originY: number;
+	} | null>(null);
+	const [isDragging, setIsDragging] = useState(false);
 
 	useEffect(() => {
+		setTransform(DEFAULT_TRANSFORM);
 		if (document.content.kind !== "bytes") {
 			setObjectUrl(null);
 			return;
@@ -19,27 +55,113 @@ export function ImageView({ document, filePath }: ViewProps) {
 		return () => URL.revokeObjectURL(url);
 	}, [document.content, filePath]);
 
-	if (!objectUrl) {
-		return null;
-	}
+	// Native non-passive listener: React's onWheel can't preventDefault,
+	// and trackpad pinch arrives as a wheel event with ctrlKey set.
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+		const handleWheel = (event: WheelEvent) => {
+			event.preventDefault();
+			if (event.ctrlKey || event.metaKey) {
+				const rect = container.getBoundingClientRect();
+				const pointX = event.clientX - rect.left - rect.width / 2;
+				const pointY = event.clientY - rect.top - rect.height / 2;
+				setTransform((prev) =>
+					zoomAtPoint(
+						prev,
+						prev.scale * Math.exp(-event.deltaY * 0.01),
+						pointX,
+						pointY,
+					),
+				);
+			} else {
+				setTransform((prev) => ({
+					...prev,
+					x: prev.x - event.deltaX,
+					y: prev.y - event.deltaY,
+				}));
+			}
+		};
+		container.addEventListener("wheel", handleWheel, { passive: false });
+		return () => container.removeEventListener("wheel", handleWheel);
+	}, []);
+
+	const isTransformed =
+		transform.scale !== 1 || transform.x !== 0 || transform.y !== 0;
 
 	return (
-		<div className="flex h-full items-center justify-center overflow-auto bg-background p-4">
-			<div
-				className="inline-block max-h-full max-w-full"
-				style={{
-					backgroundImage:
-						"conic-gradient(color-mix(in srgb, var(--color-foreground) 10%, transparent) 25%, transparent 0 50%, color-mix(in srgb, var(--color-foreground) 10%, transparent) 0 75%, transparent 0)",
-					backgroundSize: "16px 16px",
-				}}
-			>
-				<img
-					src={objectUrl}
-					alt={getBaseName(filePath)}
-					className="block max-h-full max-w-full object-contain"
-					draggable={false}
-				/>
-			</div>
+		// biome-ignore lint/a11y/noStaticElementInteractions: pointer-driven pan/zoom surface
+		<div
+			ref={containerRef}
+			className={`relative flex h-full touch-none items-center justify-center overflow-hidden bg-background p-4 ${
+				isDragging ? "cursor-grabbing" : "cursor-grab"
+			}`}
+			onPointerDown={(event) => {
+				if (event.button !== 0) {
+					return;
+				}
+				event.currentTarget.setPointerCapture(event.pointerId);
+				dragRef.current = {
+					pointerId: event.pointerId,
+					startX: event.clientX,
+					startY: event.clientY,
+					originX: transform.x,
+					originY: transform.y,
+				};
+				setIsDragging(true);
+			}}
+			onPointerMove={(event) => {
+				const drag = dragRef.current;
+				if (!drag || drag.pointerId !== event.pointerId) {
+					return;
+				}
+				setTransform((prev) => ({
+					...prev,
+					x: drag.originX + event.clientX - drag.startX,
+					y: drag.originY + event.clientY - drag.startY,
+				}));
+			}}
+			onPointerUp={() => {
+				dragRef.current = null;
+				setIsDragging(false);
+			}}
+			onPointerCancel={() => {
+				dragRef.current = null;
+				setIsDragging(false);
+			}}
+			onDoubleClick={() => setTransform(DEFAULT_TRANSFORM)}
+		>
+			{objectUrl && (
+				<div
+					className="inline-block max-h-full max-w-full"
+					style={{
+						transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+						backgroundImage:
+							"conic-gradient(color-mix(in srgb, var(--color-foreground) 10%, transparent) 25%, transparent 0 50%, color-mix(in srgb, var(--color-foreground) 10%, transparent) 0 75%, transparent 0)",
+						backgroundSize: "16px 16px",
+					}}
+				>
+					<img
+						src={objectUrl}
+						alt={getBaseName(filePath)}
+						className="block max-h-full max-w-full select-none object-contain"
+						draggable={false}
+					/>
+				</div>
+			)}
+			{isTransformed && (
+				<button
+					type="button"
+					className="absolute right-2 bottom-2 rounded-md border border-border bg-background/80 px-2 py-0.5 font-mono text-muted-foreground text-xs backdrop-blur hover:text-foreground"
+					onPointerDown={(event) => event.stopPropagation()}
+					onClick={() => setTransform(DEFAULT_TRANSFORM)}
+					title="Reset zoom"
+				>
+					{Math.round(transform.scale * 100)}%
+				</button>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
@@ -1,48 +1,22 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { getImageMimeType } from "shared/file-types";
 import type { ViewProps } from "../../types";
-
-const MIN_SCALE = 0.25;
-const MAX_SCALE = 16;
-const DEFAULT_TRANSFORM = { scale: 1, x: 0, y: 0 };
-
-interface Transform {
-	scale: number;
-	x: number;
-	y: number;
-}
-
-function zoomAtPoint(
-	prev: Transform,
-	nextScale: number,
-	pointX: number,
-	pointY: number,
-): Transform {
-	const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, nextScale));
-	const ratio = scale / prev.scale;
-	return {
-		scale,
-		x: pointX - (pointX - prev.x) * ratio,
-		y: pointY - (pointY - prev.y) * ratio,
-	};
-}
+import { usePanZoom } from "./hooks/usePanZoom";
 
 export function ImageView({ document, filePath }: ViewProps) {
 	const [objectUrl, setObjectUrl] = useState<string | null>(null);
-	const [transform, setTransform] = useState<Transform>(DEFAULT_TRANSFORM);
-	const containerRef = useRef<HTMLDivElement>(null);
-	const dragRef = useRef<{
-		pointerId: number;
-		startX: number;
-		startY: number;
-		originX: number;
-		originY: number;
-	} | null>(null);
-	const [isDragging, setIsDragging] = useState(false);
+	const {
+		containerRef,
+		transform,
+		isDragging,
+		isTransformed,
+		reset,
+		handlers,
+	} = usePanZoom();
 
 	useEffect(() => {
-		setTransform(DEFAULT_TRANSFORM);
+		reset();
 		if (document.content.kind !== "bytes") {
 			setObjectUrl(null);
 			return;
@@ -53,85 +27,15 @@ export function ImageView({ document, filePath }: ViewProps) {
 		);
 		setObjectUrl(url);
 		return () => URL.revokeObjectURL(url);
-	}, [document.content, filePath]);
-
-	// Native non-passive listener: React's onWheel can't preventDefault,
-	// and trackpad pinch arrives as a wheel event with ctrlKey set.
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) {
-			return;
-		}
-		const handleWheel = (event: WheelEvent) => {
-			event.preventDefault();
-			if (event.ctrlKey || event.metaKey) {
-				const rect = container.getBoundingClientRect();
-				const pointX = event.clientX - rect.left - rect.width / 2;
-				const pointY = event.clientY - rect.top - rect.height / 2;
-				setTransform((prev) =>
-					zoomAtPoint(
-						prev,
-						prev.scale * Math.exp(-event.deltaY * 0.01),
-						pointX,
-						pointY,
-					),
-				);
-			} else {
-				setTransform((prev) => ({
-					...prev,
-					x: prev.x - event.deltaX,
-					y: prev.y - event.deltaY,
-				}));
-			}
-		};
-		container.addEventListener("wheel", handleWheel, { passive: false });
-		return () => container.removeEventListener("wheel", handleWheel);
-	}, []);
-
-	const isTransformed =
-		transform.scale !== 1 || transform.x !== 0 || transform.y !== 0;
+	}, [document.content, filePath, reset]);
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: pointer-driven pan/zoom surface
 		<div
 			ref={containerRef}
 			className={`relative flex h-full touch-none items-center justify-center overflow-hidden bg-background p-4 ${
 				isDragging ? "cursor-grabbing" : "cursor-grab"
 			}`}
-			onPointerDown={(event) => {
-				if (event.button !== 0) {
-					return;
-				}
-				event.currentTarget.setPointerCapture(event.pointerId);
-				dragRef.current = {
-					pointerId: event.pointerId,
-					startX: event.clientX,
-					startY: event.clientY,
-					originX: transform.x,
-					originY: transform.y,
-				};
-				setIsDragging(true);
-			}}
-			onPointerMove={(event) => {
-				const drag = dragRef.current;
-				if (!drag || drag.pointerId !== event.pointerId) {
-					return;
-				}
-				setTransform((prev) => ({
-					...prev,
-					x: drag.originX + event.clientX - drag.startX,
-					y: drag.originY + event.clientY - drag.startY,
-				}));
-			}}
-			onPointerUp={() => {
-				dragRef.current = null;
-				setIsDragging(false);
-			}}
-			onPointerCancel={() => {
-				dragRef.current = null;
-				setIsDragging(false);
-			}}
-			onDoubleClick={() => setTransform(DEFAULT_TRANSFORM)}
+			{...handlers}
 		>
 			{objectUrl && (
 				<div
@@ -156,7 +60,7 @@ export function ImageView({ document, filePath }: ViewProps) {
 					type="button"
 					className="absolute right-2 bottom-2 rounded-md border border-border bg-background/80 px-2 py-0.5 font-mono text-muted-foreground text-xs backdrop-blur hover:text-foreground"
 					onPointerDown={(event) => event.stopPropagation()}
-					onClick={() => setTransform(DEFAULT_TRANSFORM)}
+					onClick={reset}
 					title="Reset zoom"
 				>
 					{Math.round(transform.scale * 100)}%

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
@@ -32,7 +32,11 @@ export function ImageView({ document, filePath }: ViewProps) {
 	return (
 		<div
 			ref={containerRef}
-			className={`relative flex h-full touch-none items-center justify-center overflow-hidden bg-background p-4 ${
+			role="application"
+			aria-label={`Image preview of ${getBaseName(filePath)}. Zoom with plus and minus, pan with arrow keys, press 0 to reset.`}
+			// biome-ignore lint/a11y/noNoninteractiveTabindex: focus is required for the keyboard pan/zoom handlers
+			tabIndex={0}
+			className={`relative flex h-full touch-none items-center justify-center overflow-hidden bg-background p-4 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
 				isDragging ? "cursor-grabbing" : "cursor-grab"
 			}`}
 			{...handlers}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/index.ts
@@ -1,0 +1,1 @@
+export { usePanZoom } from "./usePanZoom";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/usePanZoom.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/usePanZoom.ts
@@ -1,4 +1,5 @@
 import {
+	type KeyboardEvent as ReactKeyboardEvent,
 	type PointerEvent as ReactPointerEvent,
 	useCallback,
 	useEffect,
@@ -82,14 +83,17 @@ export function usePanZoom() {
 		return () => container.removeEventListener("wheel", handleWheel);
 	}, []);
 
-	const endDrag = () => {
+	const endDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+		if (dragRef.current?.pointerId !== event.pointerId) {
+			return;
+		}
 		dragRef.current = null;
 		setIsDragging(false);
 	};
 
 	const handlers = {
 		onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => {
-			if (event.button !== 0) {
+			if (event.button !== 0 || dragRef.current) {
 				return;
 			}
 			event.currentTarget.setPointerCapture(event.pointerId);
@@ -116,6 +120,28 @@ export function usePanZoom() {
 		onPointerUp: endDrag,
 		onPointerCancel: endDrag,
 		onDoubleClick: reset,
+		onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => {
+			const KEYBOARD_PAN_STEP = 50;
+			const actions: Record<string, () => Transform> = {
+				"+": () => zoomAtPoint(transform, transform.scale * 1.25, 0, 0),
+				"=": () => zoomAtPoint(transform, transform.scale * 1.25, 0, 0),
+				"-": () => zoomAtPoint(transform, transform.scale / 1.25, 0, 0),
+				"0": () => DEFAULT_TRANSFORM,
+				ArrowLeft: () => ({ ...transform, x: transform.x + KEYBOARD_PAN_STEP }),
+				ArrowRight: () => ({
+					...transform,
+					x: transform.x - KEYBOARD_PAN_STEP,
+				}),
+				ArrowUp: () => ({ ...transform, y: transform.y + KEYBOARD_PAN_STEP }),
+				ArrowDown: () => ({ ...transform, y: transform.y - KEYBOARD_PAN_STEP }),
+			};
+			const action = actions[event.key];
+			if (!action || event.ctrlKey || event.metaKey || event.altKey) {
+				return;
+			}
+			event.preventDefault();
+			setTransform(action());
+		},
 	};
 
 	const isTransformed =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/usePanZoom.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/hooks/usePanZoom/usePanZoom.ts
@@ -1,0 +1,132 @@
+import {
+	type PointerEvent as ReactPointerEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 16;
+const DEFAULT_TRANSFORM: Transform = { scale: 1, x: 0, y: 0 };
+
+export interface Transform {
+	scale: number;
+	x: number;
+	y: number;
+}
+
+function zoomAtPoint(
+	prev: Transform,
+	nextScale: number,
+	pointX: number,
+	pointY: number,
+): Transform {
+	const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, nextScale));
+	const ratio = scale / prev.scale;
+	return {
+		scale,
+		x: pointX - (pointX - prev.x) * ratio,
+		y: pointY - (pointY - prev.y) * ratio,
+	};
+}
+
+/**
+ * Pan/pinch/zoom gestures for a container element. The container must be
+ * mounted for the lifetime of the hook so the wheel listener attaches.
+ */
+export function usePanZoom() {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [transform, setTransform] = useState<Transform>(DEFAULT_TRANSFORM);
+	const [isDragging, setIsDragging] = useState(false);
+	const dragRef = useRef<{
+		pointerId: number;
+		startX: number;
+		startY: number;
+		originX: number;
+		originY: number;
+	} | null>(null);
+
+	const reset = useCallback(() => setTransform(DEFAULT_TRANSFORM), []);
+
+	// Native non-passive listener: React's onWheel can't preventDefault,
+	// and trackpad pinch arrives as a wheel event with ctrlKey set.
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+		const handleWheel = (event: WheelEvent) => {
+			event.preventDefault();
+			if (event.ctrlKey || event.metaKey) {
+				const rect = container.getBoundingClientRect();
+				const pointX = event.clientX - rect.left - rect.width / 2;
+				const pointY = event.clientY - rect.top - rect.height / 2;
+				setTransform((prev) =>
+					zoomAtPoint(
+						prev,
+						prev.scale * Math.exp(-event.deltaY * 0.01),
+						pointX,
+						pointY,
+					),
+				);
+			} else {
+				setTransform((prev) => ({
+					...prev,
+					x: prev.x - event.deltaX,
+					y: prev.y - event.deltaY,
+				}));
+			}
+		};
+		container.addEventListener("wheel", handleWheel, { passive: false });
+		return () => container.removeEventListener("wheel", handleWheel);
+	}, []);
+
+	const endDrag = () => {
+		dragRef.current = null;
+		setIsDragging(false);
+	};
+
+	const handlers = {
+		onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => {
+			if (event.button !== 0) {
+				return;
+			}
+			event.currentTarget.setPointerCapture(event.pointerId);
+			dragRef.current = {
+				pointerId: event.pointerId,
+				startX: event.clientX,
+				startY: event.clientY,
+				originX: transform.x,
+				originY: transform.y,
+			};
+			setIsDragging(true);
+		},
+		onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => {
+			const drag = dragRef.current;
+			if (!drag || drag.pointerId !== event.pointerId) {
+				return;
+			}
+			setTransform((prev) => ({
+				...prev,
+				x: drag.originX + event.clientX - drag.startX,
+				y: drag.originY + event.clientY - drag.startY,
+			}));
+		},
+		onPointerUp: endDrag,
+		onPointerCancel: endDrag,
+		onDoubleClick: reset,
+	};
+
+	const isTransformed =
+		transform.scale !== 1 || transform.x !== 0 || transform.y !== 0;
+
+	return {
+		containerRef,
+		transform,
+		isDragging,
+		isTransformed,
+		reset,
+		handlers,
+	};
+}


### PR DESCRIPTION
## Summary
- The v2 image file pane (`FilePane` registry `ImageView`) now supports pinch-to-zoom, scroll/drag panning, and double-click reset, instead of a fixed fit-to-pane image.

## Why / Context
Images opened in a workspace pane were locked to a fitted view with no way to inspect details (screenshots, diagrams, dense UI captures). This adds standard image-viewer navigation gestures.

## How It Works
- A `{scale, x, y}` transform is applied to the image wrapper; zoom is anchored at the cursor (`zoomAtPoint`), clamped to 25%–1600%.
- Pinch: Chromium delivers trackpad pinch as a `wheel` event with `ctrlKey` set, so ctrl/cmd+wheel zooms. The listener is attached natively as non-passive because React's `onWheel` can't `preventDefault` (needed to stop scroll chaining/page zoom).
- Pan: plain two-finger scroll pans via wheel deltas; click-drag pans via pointer capture (survives leaving the pane mid-drag).
- Reset: double-click, or a zoom-percentage badge that appears bottom-right whenever the view is zoomed/panned.
- The transform resets when the pane switches to a different file, and the container div now always mounts (the previous `objectUrl` early return would have left the once-mounted wheel listener unattached).

Only the v2 pane registry view is changed; the sunsetting v1 `FileViewerPane` is untouched.

## Manual QA Checklist
- [ ] Open an image file in a workspace pane; it renders fitted as before
- [ ] Trackpad pinch zooms around the cursor; ctrl/cmd + mouse wheel does the same
- [ ] Two-finger scroll pans; click-drag pans with grab cursor
- [ ] Zoom badge appears when zoomed; clicking it or double-clicking resets to fit
- [ ] Switching the pane to another image resets the view
- [ ] Drag released outside the pane doesn't leave panning stuck

## Testing
- `bun run lint`
- `bun run typecheck` (desktop)
- Not manually QA'd in the running app — gesture behavior (pinch/pan/reset) needs a trackpad pass per the checklist above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pan, pinch-to-zoom, keyboard zoom/pan, and quick reset to the desktop image file pane so you can inspect screenshots and diagrams in place. Also extracts a reusable `usePanZoom` hook for future viewers.

- New Features
  - Pinch or Ctrl/Cmd + wheel zooms at the cursor (25%–1600%).
  - Two-finger scroll and click-drag to pan, with grab cursor.
  - Double-click or use the zoom badge to reset to fit.
  - View resets when switching files.
  - Applies to the v2 `FilePane` `ImageView` only.

- Bug Fixes
  - Keyboard pan/zoom now works with focus (+/− to zoom, arrows to pan, 0 to reset) and adds aria hints.
  - Ensures single-pointer drag ownership and prevents reset-badge clicks from starting a drag.
  - Container always mounts so the non-passive wheel listener attaches reliably.
  - Uses pointer capture to avoid stuck panning when the pointer leaves the pane.
  - Prevents scroll chaining and browser zoom via preventDefault on wheel.

<sup>Written for commit 4717c1e885dc3e74e6021e033e2c9cff38951867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive image zooming with bounded controls.
  * Added pointer-based panning and support for wheel and trackpad pinch gestures.
  * Added keyboard controls for zooming, panning, and resetting the view.
  * Added controls to reset the image transform and zoom percentage.
  * Added double-click support to reset the image view.
  * Added visual drag-state feedback while moving images.
  * Image positioning now resets automatically when viewing a different document or file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->