### PR TITLE
fix(desktop): bump @xterm/addon-webgl to 0.20.0-beta.297 for atlas page eviction

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -161,7 +161,7 @@
 		"@xterm/addon-search": "0.17.0-beta.289",
 		"@xterm/addon-serialize": "0.15.0-beta.289",
 		"@xterm/addon-unicode11": "0.10.0-beta.289",
-		"@xterm/addon-webgl": "0.20.0-beta.288",
+		"@xterm/addon-webgl": "0.20.0-beta.297",
 		"@xterm/headless": "6.1.0-beta.289",
 		"@xterm/xterm": "6.1.0-beta.289",
 		"ai": "6.0.235",

--- a/bun.lock
+++ b/bun.lock
@@ -239,7 +239,7 @@
         "@xterm/addon-search": "0.17.0-beta.289",
         "@xterm/addon-serialize": "0.15.0-beta.289",
         "@xterm/addon-unicode11": "0.10.0-beta.289",
-        "@xterm/addon-webgl": "0.20.0-beta.288",
+        "@xterm/addon-webgl": "0.20.0-beta.297",
         "@xterm/headless": "6.1.0-beta.289",
         "@xterm/xterm": "6.1.0-beta.289",
         "ai": "6.0.235",
@@ -3547,7 +3547,7 @@
 
     "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.10.0-beta.289", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.289" } }, "sha512-wZ1eQ3bakATnttLmO4Ys+wFPV6Ajl38c5RS2cGK1ihaqjC/6GoW0Iga9CVS3fNOk9yvIcLioVnxn5eH8jo2zUQ=="],
 
-    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.20.0-beta.288", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.289" } }, "sha512-4Jp7+SjFm8RWQwGX54RRNPmhV5F9kZ3o9+DYGGrj9RmJ2rJEqzfG861QJUynlTz11Ni634MwXxxIoSC1yQkLgw=="],
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.20.0-beta.297", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.300" } }, "sha512-XWnYnI36ynIdI2nzC9QTlbQis9+W5PgosjBfKYsXy1EJfxyopkcTxctq9YwfaQJ9X1cGsevfNg7gXfj4hpUpUA=="],
 
     "@xterm/headless": ["@xterm/headless@6.1.0-beta.289", "", {}, "sha512-2O36sJvUsDVMitxVSBP+74RncxhsnI+K9M7OhgX39ok2Y71MOi1wWvdl6A/IYwaXEUl+lz2htU8RypWlpzdXvQ=="],
 


### PR DESCRIPTION
## Summary

Bumps `@xterm/addon-webgl` 0.20.0-beta.288 → 0.20.0-beta.297 to pick up xterm.js [PR #6043](https://github.com/xtermjs/xterm.js/pull/6043) (shipped in beta.289 — we missed it by one release), which adds `_evictAllPages()` so the glyph texture atlas evicts instead of allocating pages past the renderer's texture capacity. This also removes the version skew where every other `@xterm/*` package was on the `.289` build line but addon-webgl was on `.288`.

Part of the SUPER-1793 GPU-process memory leak investigation.

## What this fixes — and what it doesn't

Repro (from the SUPER-1793 investigation): high-cardinality truecolor output (e.g. Claude Code's animated gradient shimmer) makes the xterm WebGL glyph atlas churn; each distinct (glyph, fg-color) rasterizes a new atlas entry. Measured on an M5 Max dev build with `while true; do printf '\e[38;2;%d;%d;%dmx' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)); done`-class workloads:

- **beta.288 (before)**: unbounded GPU-process growth, 434 MB → 27 GB in 14 min (IOAccelerator 21 GB / 1,517 regions), no reclaim until the GPU process dies. Pages could exceed `maxAtlasPages` via the merge fall-through, which upstream also ties to garbled rendering (xtermjs/xterm.js#6038, microsoft/vscode#322756).
- **beta.297 (after)**: same workload plateaus at ~15.8 GB instead of growing unboundedly, and the unbindable-page rendering corruption class is fixed.

The plateau equals `maxAtlasPages` (16 on Metal) × 1 GiB (merged pages still grow to `deviceMaxTextureSize` 16384² RGBA), so this bump alone does **not** close SUPER-1793 on low-RAM machines — the remaining work is an upstream cap on merged page *size* and/or an app-side `clearTextureAtlas()` memory-pressure mitigation. Filed separately.

## Verification

- Real app launch from this branch's dev build (guarding against the known ligatures-addon boot-crash failure mode): boots clean, WebGL renderer active, terminals render and stream normally.
- Truecolor stress run on the patched build confirms the eviction behavior change described above (`/tmp/gpu-samples.log` phases `fix297-*` in the investigation workspace).
- `bun run lint` and `apps/desktop` typecheck pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@xterm/addon-webgl` to 0.20.0-beta.297 to enable glyph atlas page eviction and stop unbounded GPU memory growth under high-cardinality output. Part of SUPER-1793.

- **Bug Fixes**
  - Evicts glyph atlas pages instead of allocating past texture capacity, preventing runaway GPU-process memory and fixing the unbindable-page rendering issue.
  - Stress tests now plateau at the atlas page limit (~16 GiB on Metal); further reduction will need an upstream merged-page size cap or an app-side atlas clear.

- **Dependencies**
  - Update `@xterm/addon-webgl` 0.20.0-beta.288 → 0.20.0-beta.297.

<sup>Written for commit c17f4792140777c5e6115b62af41cace8f7577da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the terminal rendering component to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->