### PR TITLE
fix(host-service,pty-daemon): heal bootstrap-degraded pty-daemons so gh/ssh work in terminals

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -136,8 +136,12 @@ export function TerminalConnectionIndicator({
 		!!health &&
 		!health.reachable &&
 		health.unreachableForMs >= DAEMON_UNREACHABLE_WARN_MS;
+	// Broken macOS process context (trustd/opendirectoryd unreachable): every
+	// shell fails `gh`/TLS/user lookups and it never self-heals while shells
+	// exist, so it shows immediately — no stall grace period applies.
+	const daemonDegraded = !!health?.bootstrapDegraded;
 
-	if (connectionHealthy && !daemonUnreachable) {
+	if (connectionHealthy && !daemonUnreachable && !daemonDegraded) {
 		return null;
 	}
 	// First connect hasn't had trouble yet — don't flash a status.
@@ -145,32 +149,39 @@ export function TerminalConnectionIndicator({
 		connectionState === "connecting" &&
 		logs.length === 0 &&
 		!diagnosis &&
-		!daemonUnreachable
+		!daemonUnreachable &&
+		!daemonDegraded
 	) {
 		return null;
 	}
 
-	// Three failure modes so copy + colour name the fix that applies. Amber =
+	// Four failure modes so copy + colour name the fix that applies. Amber =
 	// still working itself out (auto-retry, or a stall that usually self-heals);
 	// red = we've stopped trying and need the user.
 	const gaveUp = diagnosis !== null && connectionState === "closed";
 	const mode = daemonUnreachable
 		? "unresponsive"
-		: gaveUp
-			? "disconnected"
-			: "reconnecting";
+		: daemonDegraded
+			? "degraded"
+			: gaveUp
+				? "disconnected"
+				: "reconnecting";
 	const reconnecting = connectionState === "connecting";
 	const label =
 		mode === "unresponsive"
 			? "Terminals aren't responding"
-			: mode === "disconnected"
-				? "Disconnected"
-				: "Reconnecting…";
+			: mode === "degraded"
+				? "Terminals need a restart"
+				: mode === "disconnected"
+					? "Disconnected"
+					: "Reconnecting…";
 	const StatusIcon = mode === "reconnecting" ? Loader2 : TriangleAlert;
 	const accentClass =
-		mode === "disconnected" ? "text-destructive" : "text-yellow-500";
+		mode === "disconnected" || mode === "degraded"
+			? "text-destructive"
+			: "text-yellow-500";
 	const dotClass =
-		mode === "disconnected"
+		mode === "disconnected" || mode === "degraded"
 			? "bg-destructive"
 			: mode === "unresponsive"
 				? "bg-yellow-500"
@@ -203,6 +214,13 @@ export function TerminalConnectionIndicator({
 						/>
 						<p className="font-medium text-foreground">{label}</p>
 					</div>
+					{mode === "degraded" && (
+						<p className="select-text cursor-text text-xs text-muted-foreground">
+							Terminals lost access to macOS user and security services, so
+							commands like <code>gh</code> and <code>ssh</code> fail.
+							Restarting terminals fixes this.
+						</p>
+					)}
 					{/* Reconnect (solid) leads as the safe primary; Restart (outline)
 					    is distinct but quieter, red only on hover so the destructive path
 					    never looks like the obvious one. Both can apply at once (a wedged
@@ -234,7 +252,7 @@ export function TerminalConnectionIndicator({
 								)}
 							</Button>
 						)}
-						{daemonUnreachable && (
+						{(daemonUnreachable || daemonDegraded) && (
 							<Button
 								variant="outline"
 								className="flex-1 hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive"

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -39,6 +39,7 @@ interface AdoptedForTest {
 	socketPath: string;
 	runningVersion: string;
 	updatePending: boolean;
+	bootstrapHealthy?: boolean;
 }
 
 beforeEach(() => {
@@ -73,6 +74,10 @@ interface FakeDaemonOptions {
 	socketPath?: string;
 	respondWithVersion?: string;
 	daemonPid?: number;
+	/** Included in the hello-ack when defined, like a self-probing daemon. */
+	bootstrapHealthy?: boolean;
+	/** Answer `list` with these sessions. Unset = never answer (wedged list). */
+	sessions?: ReturnType<typeof aliveSession>[];
 	respondRaw?: Buffer;
 	hangUpAfterHello?: boolean;
 	respondWithWrongMessageFirst?: boolean;
@@ -95,6 +100,12 @@ async function startFakeDaemon(opts: FakeDaemonOptions): Promise<{
 			decoder.push(chunk);
 			for (const decoded of decoder.drain()) {
 				const msg = decoded.message as ClientMessage;
+				if (msg.type === "list" && opts.sessions) {
+					sock.write(
+						encodeFrame({ type: "list-reply", sessions: opts.sessions }),
+					);
+					continue;
+				}
 				if (msg.type !== "hello") continue;
 				if (opts.silent) return;
 				if (opts.hangUpAfterHello) {
@@ -122,9 +133,9 @@ async function startFakeDaemon(opts: FakeDaemonOptions): Promise<{
 							protocol: 1,
 							daemonVersion: opts.respondWithVersion,
 							daemonPid: opts.daemonPid,
+							bootstrapHealthy: opts.bootstrapHealthy,
 						}),
 					);
-					return;
 				}
 			}
 		});
@@ -456,6 +467,241 @@ describe("DaemonSupervisor.tryAdopt", () => {
 	}, 15_000);
 });
 
+describe("bootstrap-degraded daemon healing (GH #6127)", () => {
+	let originalHome: string | undefined;
+	let tmpHome: string;
+
+	beforeEach(() => {
+		originalHome = process.env.SUPERSET_HOME_DIR;
+		tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-degraded-"));
+		process.env.SUPERSET_HOME_DIR = tmpHome;
+	});
+
+	afterEach(() => {
+		if (originalHome !== undefined) {
+			process.env.SUPERSET_HOME_DIR = originalHome;
+		} else {
+			delete process.env.SUPERSET_HOME_DIR;
+		}
+		fs.rmSync(tmpHome, { recursive: true, force: true });
+	});
+
+	test("tryAdopt carries the daemon's self-reported bootstrap health", async () => {
+		const orgId = "org-degraded-adopt";
+		const socketPath = ptyDaemonSocketPath(orgId);
+		try {
+			fs.unlinkSync(socketPath);
+		} catch {
+			// best-effort cleanup
+		}
+		const fake = await startFakeDaemon({
+			socketPath,
+			respondWithVersion: "0.3.0",
+			daemonPid: process.pid,
+			bootstrapHealthy: false,
+		});
+		try {
+			const sup = new DaemonSupervisor({
+				scriptPath: "/nonexistent",
+				autoUpdate: false,
+			});
+			const adopted = (await invokeTryAdopt(
+				sup,
+				orgId,
+			)) as AdoptedForTest | null;
+			expect(adopted?.bootstrapHealthy).toBe(false);
+		} finally {
+			await fake.close();
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort
+			}
+		}
+	});
+
+	test("auto-respawns a degraded daemon only when it holds zero sessions", async () => {
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.3.0",
+			sessions: [],
+		});
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			expect(
+				await invokeShouldAutoRespawnDegraded(sup, "org-empty", {
+					...freshInstance(),
+					socketPath: fake.socketPath,
+					bootstrapHealthy: false,
+				}),
+			).toBe(true);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("never kills a degraded daemon that owns live sessions", async () => {
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.3.0",
+			sessions: [aliveSession()],
+		});
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			expect(
+				await invokeShouldAutoRespawnDegraded(sup, "org-live", {
+					...freshInstance(),
+					socketPath: fake.socketPath,
+					bootstrapHealthy: false,
+				}),
+			).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("never kills when the session list can't be read (unknown ≠ empty)", async () => {
+		// Fake answers hello but not list — a daemon whose session state we
+		// can't see may own shells; killing it blind repeats SUPER-833.
+		const fake = await startFakeDaemon({ respondWithVersion: "0.3.0" });
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			expect(
+				await invokeShouldAutoRespawnDegraded(sup, "org-unknown", {
+					...freshInstance(),
+					socketPath: fake.socketPath,
+					bootstrapHealthy: false,
+				}),
+			).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	}, 15_000);
+
+	test("does not respawn a healthy or unknown-health daemon", async () => {
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		expect(
+			await invokeShouldAutoRespawnDegraded(sup, "org-healthy", {
+				...freshInstance(),
+				bootstrapHealthy: true,
+			}),
+		).toBe(false);
+		expect(
+			await invokeShouldAutoRespawnDegraded(sup, "org-preprobe", {
+				...freshInstance(),
+			}),
+		).toBe(false);
+	});
+
+	test("only one automatic respawn attempt per org (no churn loop)", async () => {
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.3.0",
+			sessions: [],
+		});
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			(
+				sup as unknown as { bootstrapHealAttempted: Set<string> }
+			).bootstrapHealAttempted.add("org-once");
+			expect(
+				await invokeShouldAutoRespawnDegraded(sup, "org-once", {
+					...freshInstance(),
+					socketPath: fake.socketPath,
+					bootstrapHealthy: false,
+				}),
+			).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("reachability probe discovers degradation and heals a session-less daemon", async () => {
+		// The reporter's path: an auto-update handoff swaps a pre-probe binary
+		// for a probe-capable one that inherited the same broken context. The
+		// periodic probe must pick the flag up and respawn (nothing to lose).
+		const orgId = "org-poll-heal";
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.3.0",
+			daemonPid: process.pid,
+			bootstrapHealthy: false,
+			sessions: [],
+		});
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		const forceRestartMock = mock(async () => ({ success: true as const }));
+		(sup as unknown as { forceRestart: typeof forceRestartMock }).forceRestart =
+			forceRestartMock;
+		try {
+			seedInstance(sup, orgId, {
+				pid: process.pid,
+				socketPath: fake.socketPath,
+				runningVersion: "0.3.0",
+				expectedVersion: "0.3.0",
+				updatePending: false,
+			});
+			await invokeRefreshReachability(sup, orgId, process.pid);
+			// The heal runs detached from the probe (session list is a real
+			// socket round trip) — poll for it instead of a fixed sleep.
+			const deadline = Date.now() + 3_000;
+			while (
+				forceRestartMock.mock.calls.length === 0 &&
+				Date.now() < deadline
+			) {
+				await new Promise((r) => setTimeout(r, 25));
+			}
+			expect(sup.getHealth(orgId)?.bootstrapDegraded).toBe(true);
+			expect(forceRestartMock).toHaveBeenCalledTimes(1);
+			expect(
+				loggedEvents.some(
+					(e) => e.event === "pty_daemon_bootstrap_degraded_detected",
+				),
+			).toBe(true);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("reachability probe surfaces degradation but leaves live sessions alone", async () => {
+		const orgId = "org-poll-live";
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.3.0",
+			daemonPid: process.pid,
+			bootstrapHealthy: false,
+			sessions: [aliveSession()],
+		});
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		const forceRestartMock = mock(async () => ({ success: true as const }));
+		(sup as unknown as { forceRestart: typeof forceRestartMock }).forceRestart =
+			forceRestartMock;
+		try {
+			seedInstance(sup, orgId, {
+				pid: process.pid,
+				socketPath: fake.socketPath,
+				runningVersion: "0.3.0",
+				expectedVersion: "0.3.0",
+				updatePending: false,
+			});
+			await invokeRefreshReachability(sup, orgId, process.pid);
+			// Give the detached heal path time to complete its session list
+			// (a real socket round trip) before asserting nothing happened.
+			await new Promise((r) => setTimeout(r, 300));
+			// Degraded is visible to the UI (which offers restart)…
+			expect(sup.getHealth(orgId)?.bootstrapDegraded).toBe(true);
+			// …but nothing destructive happened on its own.
+			expect(forceRestartMock).not.toHaveBeenCalled();
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("getHealth reports bootstrapDegraded=false while health is unknown", () => {
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		seedInstance(sup, "org-health-unknown", {
+			runningVersion: "0.1.0",
+			expectedVersion: "0.1.0",
+			updatePending: false,
+		});
+		expect(sup.getHealth("org-health-unknown")?.bootstrapDegraded).toBe(false);
+	});
+});
+
 describe("DaemonSupervisor daemon health", () => {
 	test("returns null when there's no daemon for the org", () => {
 		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
@@ -473,6 +719,7 @@ describe("DaemonSupervisor daemon health", () => {
 		expect(sup.getHealth("org-ok")).toEqual({
 			reachable: true,
 			unreachableForMs: 0,
+			bootstrapDegraded: false,
 		});
 	});
 
@@ -531,6 +778,7 @@ describe("DaemonSupervisor daemon health", () => {
 			expect(sup.getHealth("org-recovers")).toEqual({
 				reachable: true,
 				unreachableForMs: 0,
+				bootstrapDegraded: false,
 			});
 			// And the version we couldn't read at adoption is now resolved.
 			expect(sup.getUpdateStatus("org-recovers")?.running).toBe("0.1.0");
@@ -1282,6 +1530,21 @@ function invokeTryAdopt(
 			tryAdopt: (id: string) => Promise<unknown | null>;
 		}
 	).tryAdopt(organizationId);
+}
+
+function invokeShouldAutoRespawnDegraded(
+	sup: DaemonSupervisor,
+	organizationId: string,
+	instance: ReturnType<typeof freshInstance> & { bootstrapHealthy?: boolean },
+): Promise<boolean> {
+	return (
+		sup as unknown as {
+			shouldAutoRespawnDegraded: (
+				id: string,
+				inst: typeof instance,
+			) => Promise<boolean>;
+		}
+	).shouldAutoRespawnDegraded(organizationId, instance);
 }
 
 /** A live pid that is definitely not a pty-daemon. */

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import { probeBootstrapHealthy } from "@superset/pty-daemon/bootstrap-probe";
 import {
 	isPositiveInteger,
 	signalProcessTreeAndGroups,
@@ -51,6 +52,13 @@ interface DaemonInstance {
 	/** Last failed background update attempt for this still-running daemon. */
 	autoUpdateFailure?: DaemonAutoUpdateFailure;
 	/**
+	 * macOS bootstrap-namespace health the daemon self-reported in its
+	 * hello-ack. `false` = degraded: its terminals hit `gh -26276` and
+	 * `id -un` → bare uid (GH #6127). undefined = pre-probe daemon version
+	 * or not yet probed.
+	 */
+	bootstrapHealthy?: boolean;
+	/**
 	 * When the daemon first stopped answering probes; null while reachable.
 	 * Drives the UI's "terminals aren't responding" state, which waits for a
 	 * sustained silence so a transient stall doesn't prompt a destructive
@@ -63,11 +71,18 @@ export interface DaemonHealth {
 	reachable: boolean;
 	/** 0 while reachable. */
 	unreachableForMs: number;
+	/**
+	 * True when the daemon reported a broken macOS bootstrap namespace —
+	 * its shells can't reach trustd/opendirectoryd (`gh -26276`, `id -un`
+	 * → bare uid). Only a daemon restart fixes it; the UI offers that.
+	 */
+	bootstrapDegraded: boolean;
 }
 
 interface DaemonProbeResult {
 	daemonVersion: string;
 	daemonPid?: number;
+	bootstrapHealthy?: boolean;
 }
 
 export interface DaemonAutoUpdateFailure {
@@ -177,6 +192,12 @@ export interface DaemonSupervisorOptions {
 	 * real handoff.
 	 */
 	autoUpdate?: boolean;
+	/**
+	 * Override for the host-side bootstrap probe (macOS Mach-namespace
+	 * health). Production leaves this unset; tests inject a stub so heal
+	 * decisions are deterministic off darwin.
+	 */
+	probeHostBootstrap?: () => boolean | Promise<boolean>;
 }
 
 export class DaemonSupervisor {
@@ -215,9 +236,30 @@ export class DaemonSupervisor {
 		string,
 		Promise<{ ok: true; successorPid: number } | { ok: false; reason: string }>
 	>();
+	/**
+	 * Orgs whose degraded daemon we already auto-respawned once. A respawn
+	 * that lands degraded again (host context beyond repair) must not loop —
+	 * after one attempt, recovery is the explicit user restart only.
+	 */
+	private readonly bootstrapHealAttempted = new Set<string>();
+	/** Whether host-service itself has an intact bootstrap; probed once, cached. */
+	private hostBootstrapHealthyPromise: Promise<boolean> | null = null;
 
 	constructor(opts: DaemonSupervisorOptions) {
 		this.opts = opts;
+	}
+
+	/**
+	 * Whether host-service's own Mach bootstrap namespace is intact. Decides
+	 * whether a fresh daemon can simply inherit our context or must be
+	 * re-rooted into the user's bootstrap via `launchctl asuser`. Cached —
+	 * a process's bootstrap doesn't change under it.
+	 */
+	private hostBootstrapHealthy(): Promise<boolean> {
+		this.hostBootstrapHealthyPromise ??= Promise.resolve(
+			(this.opts.probeHostBootstrap ?? probeBootstrapHealthy)(),
+		);
+		return this.hostBootstrapHealthyPromise;
 	}
 
 	/**
@@ -603,6 +645,28 @@ export class DaemonSupervisor {
 			return;
 		}
 		current.unreachableSince = null;
+		if (probe.bootstrapHealthy !== undefined) {
+			const wasDegraded = current.bootstrapHealthy === false;
+			current.bootstrapHealthy = probe.bootstrapHealthy;
+			// A daemon can first reveal degradation here rather than at adopt
+			// time: an auto-update handoff replaces a pre-probe binary with a
+			// probe-capable one that inherited the same broken context.
+			if (probe.bootstrapHealthy === false && !wasDegraded) {
+				logEvent("pty_daemon_bootstrap_degraded_detected", {
+					organizationId,
+					pid: current.pid,
+					runningVersion: current.runningVersion,
+				});
+				void this.maybeHealDegradedFromPoll(organizationId, current).catch(
+					(err) => {
+						console.error(
+							`[pty-daemon:${organizationId}] bootstrap heal failed:`,
+							err,
+						);
+					},
+				);
+			}
+		}
 		if (current.runningVersion === "unknown") {
 			current.runningVersion = probe.daemonVersion;
 			current.updatePending = isVersionUpdatePending(probe.daemonVersion);
@@ -626,6 +690,7 @@ export class DaemonSupervisor {
 			reachable: unreachableSince === null,
 			unreachableForMs:
 				unreachableSince === null ? 0 : Date.now() - unreachableSince,
+			bootstrapDegraded: instance.bootstrapHealthy === false,
 		};
 	}
 
@@ -789,8 +854,34 @@ export class DaemonSupervisor {
 			await this.killStaleDaemonForDev(organizationId);
 		}
 
-		const adopted = await this.tryAdopt(organizationId);
+		let adopted = await this.tryAdopt(organizationId);
+		// Heal a bootstrap-degraded daemon: it inherited a Mach namespace that
+		// can't reach trustd/opendirectoryd, so its terminals hit `gh -26276`
+		// and `id -un` → bare uid (GH #6127). Adopting it keeps the breakage —
+		// but only replace it when that destroys nothing: with live sessions we
+		// adopt anyway (their shells are already spawned broken; killing them
+		// gains nothing) and surface the state so the user can restart.
+		if (
+			adopted &&
+			(await this.shouldAutoRespawnDegraded(organizationId, adopted))
+		) {
+			this.bootstrapHealAttempted.add(organizationId);
+			logEvent("pty_daemon_bootstrap_degraded_respawn", {
+				organizationId,
+				pid: adopted.pid,
+				runningVersion: adopted.runningVersion,
+			});
+			await this.killAdoptedDaemon(organizationId, adopted);
+			adopted = null;
+		}
 		if (adopted) {
+			if (adopted.bootstrapHealthy === false) {
+				logEvent("pty_daemon_bootstrap_degraded_adopted", {
+					organizationId,
+					pid: adopted.pid,
+					runningVersion: adopted.runningVersion,
+				});
+			}
 			this.instances.set(organizationId, adopted);
 			console.log(
 				`[pty-daemon:${organizationId}] adopted existing daemon pid=${adopted.pid} runningVersion=${adopted.runningVersion} updatePending=${adopted.updatePending}`,
@@ -815,7 +906,7 @@ export class DaemonSupervisor {
 			return adopted;
 		}
 
-		const instance = await this.spawn(organizationId);
+		const instance = await this.spawnWithBootstrapFallback(organizationId);
 		logEvent("pty_daemon_spawn", {
 			organizationId,
 			pid: instance.pid,
@@ -824,6 +915,91 @@ export class DaemonSupervisor {
 		});
 		this.lastUpdatePendingPair.delete(organizationId);
 		return instance;
+	}
+
+	/**
+	 * Whether a degraded daemon can be replaced automatically. Only when the
+	 * daemon self-reported a broken bootstrap AND it holds zero sessions —
+	 * a session list we can't read (null) counts as "may hold shells", so we
+	 * never kill blind. One attempt per org: if the replacement comes up
+	 * degraded too, looping respawns would just churn.
+	 */
+	private async shouldAutoRespawnDegraded(
+		organizationId: string,
+		instance: DaemonInstance,
+	): Promise<boolean> {
+		if (instance.bootstrapHealthy !== false) return false;
+		if (this.bootstrapHealAttempted.has(organizationId)) return false;
+		const sessions = await listDaemonSessions(instance.socketPath, 1_500);
+		return sessions !== null && sessions.length === 0;
+	}
+
+	/**
+	 * Terminate an adopted daemon so start() can fall through to a fresh
+	 * spawn. An adopted daemon has no child handle or crash-respawn hook
+	 * attached yet, so this just kills its process tree and clears its
+	 * manifest + socket. Callers must have verified it holds no sessions.
+	 */
+	private async killAdoptedDaemon(
+		organizationId: string,
+		instance: DaemonInstance,
+	): Promise<void> {
+		await terminateProcessTreeAndGroups(instance.pid, "SIGTERM");
+		removePtyDaemonManifest(organizationId);
+		try {
+			if (fs.existsSync(instance.socketPath)) {
+				fs.unlinkSync(instance.socketPath);
+			}
+		} catch {
+			// best-effort; the fresh daemon unlinks a stale socket on bind anyway
+		}
+	}
+
+	/**
+	 * Poll-path heal: a running daemon just revealed a degraded bootstrap
+	 * (e.g. an auto-update handoff carried the old context into a
+	 * probe-capable binary). Same safety rules as the adopt-path heal; the
+	 * restart flow (stop → ensure) handles the spawned-vs-adopted plumbing.
+	 */
+	private async maybeHealDegradedFromPoll(
+		organizationId: string,
+		instance: DaemonInstance,
+	): Promise<void> {
+		if (!(await this.shouldAutoRespawnDegraded(organizationId, instance))) {
+			return;
+		}
+		// Re-check identity: the instance can be replaced while we listed sessions.
+		if (this.instances.get(organizationId) !== instance) return;
+		this.bootstrapHealAttempted.add(organizationId);
+		await this.forceRestart(organizationId, {
+			event: "pty_daemon_bootstrap_degraded_respawn",
+			props: { pid: instance.pid, runningVersion: instance.runningVersion },
+		});
+	}
+
+	/**
+	 * Spawn, re-rooting into the user's bootstrap when our own is degraded.
+	 * `launchctl asuser` can fail in exotic contexts (no per-user launchd),
+	 * so fall back to a plain spawn — a daemon with our degraded context
+	 * still serves terminals; it's the pre-heal status quo, not a regression.
+	 */
+	private async spawnWithBootstrapFallback(
+		organizationId: string,
+	): Promise<DaemonInstance> {
+		const viaUserBootstrap =
+			process.platform === "darwin" &&
+			typeof process.getuid === "function" &&
+			!(await this.hostBootstrapHealthy());
+		try {
+			return await this.spawn(organizationId, { viaUserBootstrap });
+		} catch (err) {
+			if (!viaUserBootstrap) throw err;
+			logEvent("pty_daemon_asuser_spawn_failed", {
+				organizationId,
+				reason: (err as Error).message.slice(0, 500),
+			});
+			return await this.spawn(organizationId, { viaUserBootstrap: false });
+		}
 	}
 
 	/**
@@ -898,6 +1074,7 @@ export class DaemonSupervisor {
 			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: isVersionUpdatePending(probe?.daemonVersion ?? null),
+			bootstrapHealthy: probe?.bootstrapHealthy,
 			// Start the clock here when it didn't answer: the liveness poll
 			// clears it the moment it does.
 			unreachableSince: probe ? null : Date.now(),
@@ -962,11 +1139,15 @@ export class DaemonSupervisor {
 			runningVersion: probe.daemonVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: isVersionUpdatePending(probe.daemonVersion),
+			bootstrapHealthy: probe.bootstrapHealthy,
 			unreachableSince: null,
 		};
 	}
 
-	private async spawn(organizationId: string): Promise<DaemonInstance> {
+	private async spawn(
+		organizationId: string,
+		opts: { viaUserBootstrap: boolean } = { viaUserBootstrap: false },
+	): Promise<DaemonInstance> {
 		const dir = ptyDaemonManifestDir(organizationId);
 		if (!fs.existsSync(dir)) {
 			fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -1015,17 +1196,34 @@ export class DaemonSupervisor {
 			// "posix_spawnp failed" (EMFILE). The raised limit is inherited by
 			// handoff successors the daemon spawns from itself.
 			const isWindows = process.platform === "win32";
-			const command = isWindows ? process.execPath : "/bin/sh";
+			const shArgs = [
+				"-c",
+				'ulimit -n 1048576 2>/dev/null || ulimit -n "$(ulimit -Hn)" 2>/dev/null || true; exec "$@"',
+				"sh",
+				process.execPath,
+				this.opts.scriptPath,
+				`--socket=${socketPath}`,
+			];
+			// When host-service's own Mach bootstrap is degraded, a plain child
+			// would inherit the breakage (gh -26276 / `id -un` → uid in every
+			// shell — GH #6127). `launchctl asuser <uid>` re-roots the daemon
+			// into the user's per-user launchd namespace, then execs in place,
+			// so the child pid is still the daemon's pid.
+			const asuser =
+				opts.viaUserBootstrap && typeof process.getuid === "function";
+			if (asuser) {
+				logEvent("pty_daemon_spawn_via_asuser", { organizationId });
+			}
+			const command = isWindows
+				? process.execPath
+				: asuser
+					? "/bin/launchctl"
+					: "/bin/sh";
 			const commandArgs = isWindows
 				? [this.opts.scriptPath, `--socket=${socketPath}`]
-				: [
-						"-c",
-						'ulimit -n 1048576 2>/dev/null || ulimit -n "$(ulimit -Hn)" 2>/dev/null || true; exec "$@"',
-						"sh",
-						process.execPath,
-						this.opts.scriptPath,
-						`--socket=${socketPath}`,
-					];
+				: asuser
+					? ["asuser", String(process.getuid?.()), "/bin/sh", ...shArgs]
+					: shArgs;
 			child = childProcess.spawn(command, commandArgs, {
 				detached: !isDev,
 				stdio,
@@ -1456,6 +1654,7 @@ function probeDaemonHello(
 						cleanup({
 							daemonVersion,
 							daemonPid: msg.daemonPid,
+							bootstrapHealthy: msg.bootstrapHealthy,
 						});
 						return;
 					}

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.2.7",
+	"version": "0.3.0",
 	"private": true,
 	"type": "module",
 	"exports": {
@@ -16,6 +16,10 @@
 			"types": "./dist-types/process-tree.d.ts",
 			"default": "./src/process-tree.ts"
 		},
+		"./bootstrap-probe": {
+			"types": "./dist-types/bootstrap-probe.d.ts",
+			"default": "./src/bootstrap-probe.ts"
+		},
 		"./package.json": "./package.json"
 	},
 	"bin": {
@@ -29,7 +33,7 @@
 		"start": "node --experimental-strip-types src/main.ts",
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts src/no-daemon-loop-blocking.test.ts test/server-fd-lifecycle.test.ts test/no-encoding-hops.test.ts",
+		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts src/bootstrap-probe.test.ts src/no-daemon-loop-blocking.test.ts test/server-fd-lifecycle.test.ts test/no-encoding-hops.test.ts",
 		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts test/fd-lifecycle.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -33,6 +33,8 @@ import {
 export interface ServerOptions {
 	socketPath: string;
 	daemonVersion: string;
+	/** macOS bootstrap-namespace health, probed once at daemon startup; see main.ts. */
+	bootstrapHealthy?: boolean;
 	bufferCap?: number;
 	outboundBufferCap?: number;
 	/** Pause producing PTYs when a subscriber buffers past this (flow control). */
@@ -68,11 +70,24 @@ export class Server {
 	private readonly store: SessionStore;
 	private readonly conns = new Set<ConnState>();
 	private readonly opts: ServerOptions;
+	/**
+	 * macOS bootstrap-namespace health, surfaced in the hello-ack. Mutable so
+	 * the (blocking) probe can run AFTER the socket binds / handoff-ack is sent
+	 * rather than delaying either — see main.ts. Until set, hello-ack omits it
+	 * and the supervisor treats that as "unknown" (no healing).
+	 */
+	private bootstrapHealthy: boolean | undefined;
 
 	constructor(opts: ServerOptions) {
 		this.opts = opts;
+		this.bootstrapHealthy = opts.bootstrapHealthy;
 		this.store = new SessionStore({ bufferCap: opts.bufferCap });
 		this.server = net.createServer((socket) => this.onConnection(socket));
+	}
+
+	/** Update the bootstrap-health value reported in subsequent hello-acks. */
+	setBootstrapHealthy(healthy: boolean): void {
+		this.bootstrapHealthy = healthy;
 	}
 
 	async listen(): Promise<void> {
@@ -424,6 +439,7 @@ export class Server {
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
 				daemonPid: process.pid,
+				bootstrapHealthy: this.bootstrapHealthy,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/bootstrap-probe.test.ts
+++ b/packages/pty-daemon/src/bootstrap-probe.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "bun:test";
+import {
+	probeBootstrapHealthy,
+	probeTrustdReachable,
+	probeUserResolutionHealthy,
+} from "./bootstrap-probe.ts";
+
+const FAKE_BUNDLE = `-----BEGIN CERTIFICATE-----\nMIIFakeCertBytes\n-----END CERTIFICATE-----\n`;
+
+describe("probeTrustdReachable", () => {
+	it("returns true on non-darwin without running anything", async () => {
+		let ran = false;
+		const healthy = await probeTrustdReachable({
+			platform: "linux",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("returns true when verify-cert exits 0 (trustd reachable)", async () => {
+		expect(
+			await probeTrustdReachable({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 0 }),
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when verify-cert exits non-zero (trustd unreachable)", async () => {
+		expect(
+			await probeTrustdReachable({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(false);
+	});
+
+	it("verifies the extracted cert (passes -c <file> to security verify-cert)", async () => {
+		let cmd = "";
+		let args: string[] = [];
+		await probeTrustdReachable({
+			platform: "darwin",
+			readBundle: () => FAKE_BUNDLE,
+			run: (c, a) => {
+				cmd = c;
+				args = a;
+				return { status: 0 };
+			},
+		});
+		expect(cmd).toBe("security");
+		expect(args[0]).toBe("verify-cert");
+		expect(args[1]).toBe("-c");
+		expect(args[2]).toMatch(/superset-trustd-[^/]+\/probe\.pem$/);
+	});
+
+	it("finds the END marker after BEGIN when an earlier PEM type precedes it", async () => {
+		// A "TRUSTED CERTIFICATE" block's END sits before the first plain
+		// "BEGIN CERTIFICATE"; indexOf(END, begin) must skip it.
+		const mixed =
+			"-----BEGIN TRUSTED CERTIFICATE-----\nAAA\n-----END TRUSTED CERTIFICATE-----\n" +
+			"-----BEGIN CERTIFICATE-----\nBBB\n-----END CERTIFICATE-----\n";
+		let seenArgs: string[] = [];
+		await probeTrustdReachable({
+			platform: "darwin",
+			readBundle: () => mixed,
+			run: (_c, a) => {
+				seenArgs = a;
+				return { status: 0 };
+			},
+		});
+		// Reached the run step (didn't bail on a bogus end<begin slice).
+		expect(seenArgs[0]).toBe("verify-cert");
+	});
+
+	it("assumes healthy when the CA bundle has no cert (can't determine)", async () => {
+		let ran = false;
+		const healthy = await probeTrustdReachable({
+			platform: "darwin",
+			readBundle: () => "no certs here",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("assumes healthy when the probe throws (bundle unreadable)", async () => {
+		expect(
+			await probeTrustdReachable({
+				platform: "darwin",
+				readBundle: () => {
+					throw new Error("ENOENT");
+				},
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe times out / errors (inconclusive)", async () => {
+		expect(
+			await probeTrustdReachable({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null, error: new Error("ETIMEDOUT") }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe is killed by a signal (status null)", async () => {
+		expect(
+			await probeTrustdReachable({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null }),
+			}),
+		).toBe(true);
+	});
+});
+
+describe("probeUserResolutionHealthy", () => {
+	it("returns true on non-darwin without looking anything up", () => {
+		let looked = false;
+		const healthy = probeUserResolutionHealthy({
+			platform: "linux",
+			uid: 501,
+			userInfo: () => {
+				looked = true;
+				throw new Error("no entry");
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(looked).toBe(false);
+	});
+
+	it("returns true when the uid resolves to a username", () => {
+		expect(
+			probeUserResolutionHealthy({
+				platform: "darwin",
+				uid: 501,
+				userInfo: () => ({ username: "kiet" }),
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when getpwuid fails (userInfo throws)", () => {
+		// The degraded-bootstrap signature: opendirectoryd unreachable, the
+		// /etc/passwd fallback has no uid-501 entry, getpwuid_r finds nothing.
+		expect(
+			probeUserResolutionHealthy({
+				platform: "darwin",
+				uid: 501,
+				userInfo: () => {
+					throw new Error("ENOENT: no such user");
+				},
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when the username is just the bare uid", () => {
+		// `id -un` printing `501` — the name never resolved.
+		expect(
+			probeUserResolutionHealthy({
+				platform: "darwin",
+				uid: 501,
+				userInfo: () => ({ username: "501" }),
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when the username is empty", () => {
+		expect(
+			probeUserResolutionHealthy({
+				platform: "darwin",
+				uid: 501,
+				userInfo: () => ({ username: "" }),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("probeBootstrapHealthy", () => {
+	const healthyTrustd = {
+		readBundle: () => FAKE_BUNDLE,
+		run: () => ({ status: 0 }),
+	};
+
+	it("is healthy only when both probes pass", async () => {
+		expect(
+			await probeBootstrapHealthy({
+				platform: "darwin",
+				...healthyTrustd,
+				uid: 501,
+				userInfo: () => ({ username: "kiet" }),
+			}),
+		).toBe(true);
+	});
+
+	it("is degraded when trustd is unreachable even if the user resolves", async () => {
+		expect(
+			await probeBootstrapHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 1 }),
+				uid: 501,
+				userInfo: () => ({ username: "kiet" }),
+			}),
+		).toBe(false);
+	});
+
+	it("is degraded when the user doesn't resolve even if trustd answers", async () => {
+		expect(
+			await probeBootstrapHealthy({
+				platform: "darwin",
+				...healthyTrustd,
+				uid: 501,
+				userInfo: () => {
+					throw new Error("no entry");
+				},
+			}),
+		).toBe(false);
+	});
+
+	it("is healthy off darwin", async () => {
+		expect(await probeBootstrapHealthy({ platform: "linux" })).toBe(true);
+	});
+});

--- a/packages/pty-daemon/src/bootstrap-probe.ts
+++ b/packages/pty-daemon/src/bootstrap-probe.ts
@@ -1,0 +1,156 @@
+// Detects whether the current process's macOS Mach bootstrap namespace is
+// intact — i.e. whether per-user XPC services are reachable. A daemon that
+// lost its bootstrap (updater relaunch, dead login-session port after
+// logout/login, launch from a non-Aqua context) spawns PTYs where:
+//
+//  - Security.framework can't reach `com.apple.trustd`, so Go binaries like
+//    `gh` fail TLS with `x509: OSStatus -26276`, and
+//  - libinfo can't reach `opendirectoryd`, so getpwuid() falls back to the
+//    flat /etc/passwd (system accounts only) and `id -un` prints the bare
+//    uid while ssh reports "No user exists for uid 501".
+//
+// Both are the same failure (lost bootstrap), but either service can be
+// individually flaky, so we probe both and report degraded when either is
+// definitively broken. Node/curl can't stand in for the trustd probe: they
+// use their own TLS stacks and succeed even when trustd is unreachable.
+// `security verify-cert` DOES exercise the platform verifier, and
+// os.userInfo() calls getpwuid_r directly — those are the reliable probes.
+//
+// The subprocess probe is async on purpose: the daemon runs it after binding
+// its socket (possibly with live sessions adopted via handoff), and a sync
+// spawn would stall every session's IO — see no-daemon-loop-blocking.test.ts.
+
+import { spawn } from "node:child_process";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const SYSTEM_CERT_BUNDLE = "/etc/ssl/cert.pem";
+const BEGIN = "-----BEGIN CERTIFICATE-----";
+const END = "-----END CERTIFICATE-----";
+
+export interface ProbeRunResult {
+	status: number | null;
+	error?: Error;
+}
+
+export interface BootstrapProbeDeps {
+	platform?: NodeJS.Platform;
+	/** Runs a command; resolves with spawnSync-like status/error. */
+	run?: (
+		cmd: string,
+		args: string[],
+	) => ProbeRunResult | Promise<ProbeRunResult>;
+	/** Reads the system CA bundle (source of a known-good cert to verify). */
+	readBundle?: () => string | Promise<string>;
+	tmpDir?: string;
+	/** getpwuid-backed identity lookup; mirrors os.userInfo(). */
+	userInfo?: () => { username: string };
+	uid?: number;
+}
+
+// Bounded so a wedged `security` can't leave the probe pending forever; a
+// real probe takes tens of milliseconds.
+const PROBE_TIMEOUT_MS = 3_000;
+
+function runCommand(cmd: string, args: string[]): Promise<ProbeRunResult> {
+	return new Promise((resolve) => {
+		const child = spawn(cmd, args, {
+			stdio: "ignore",
+			timeout: PROBE_TIMEOUT_MS,
+		});
+		child.once("error", (error) => resolve({ status: null, error }));
+		// A timeout kill surfaces as exit-by-signal → status null → inconclusive.
+		child.once("exit", (code) => resolve({ status: code }));
+	});
+}
+
+/**
+ * True when the platform verifier (trustd) is reachable. macOS only — other
+ * platforms have no such coupling and always return true. We only report
+ * `false` on a clean non-zero exit from `security verify-cert`; any spawn
+ * error, timeout, or signal death is inconclusive and reported healthy, so a
+ * flaky probe never triggers an unwarranted (session-destroying) respawn.
+ */
+export async function probeTrustdReachable(
+	deps: BootstrapProbeDeps = {},
+): Promise<boolean> {
+	const platform = deps.platform ?? process.platform;
+	if (platform !== "darwin") return true;
+
+	const run = deps.run ?? runCommand;
+
+	let certDir: string | undefined;
+	try {
+		const bundle = deps.readBundle
+			? await deps.readBundle()
+			: await fsp.readFile(SYSTEM_CERT_BUNDLE, "utf8");
+		const begin = bundle.indexOf(BEGIN);
+		// Search for END only from BEGIN onward so a different earlier PEM type
+		// (e.g. "BEGIN TRUSTED CERTIFICATE") whose END sits before the first
+		// "BEGIN CERTIFICATE" can't produce a bogus slice.
+		const end = bundle.indexOf(END, begin);
+		if (begin === -1 || end === -1) return true;
+		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
+		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
+		const cert = `${bundle.slice(begin, end + END.length)}\n`;
+		// mkdtemp gives a fresh 0700 dir, so the cert path is unpredictable and
+		// can't be pre-seeded as a symlink (TOCTOU) or collide across runs.
+		certDir = await fsp.mkdtemp(
+			path.join(deps.tmpDir ?? os.tmpdir(), "superset-trustd-"),
+		);
+		const certPath = path.join(certDir, "probe.pem");
+		await fsp.writeFile(certPath, cert, { mode: 0o600 });
+		const result = await run("security", ["verify-cert", "-c", certPath]);
+		if (result.error) return true; // spawn failed / timed out → inconclusive
+		if (typeof result.status !== "number") return true; // killed by signal
+		return result.status === 0;
+	} catch {
+		return true;
+	} finally {
+		if (certDir) {
+			try {
+				await fsp.rm(certDir, { recursive: true, force: true });
+			} catch {
+				// best-effort
+			}
+		}
+	}
+}
+
+/**
+ * True when getpwuid() resolves our own uid to a username. macOS only. When
+ * opendirectoryd is unreachable, libinfo falls back to /etc/passwd, which has
+ * no uid-501 entry — os.userInfo() then throws (getpwuid_r finds nothing) or,
+ * on some paths, surfaces the bare uid as the name. Either is the exact
+ * condition users see as `id -un` → `501` and ssh's "No user exists for uid".
+ * In-process and syscall-backed, so there's no subprocess to flake.
+ */
+export function probeUserResolutionHealthy(
+	deps: BootstrapProbeDeps = {},
+): boolean {
+	const platform = deps.platform ?? process.platform;
+	if (platform !== "darwin") return true;
+	const uid =
+		deps.uid ??
+		(typeof process.getuid === "function" ? process.getuid() : undefined);
+	try {
+		const info = deps.userInfo ? deps.userInfo() : os.userInfo();
+		if (!info.username) return false;
+		return uid === undefined || info.username !== String(uid);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Combined bootstrap-namespace health: trustd reachable AND our uid resolves
+ * to a username. Reported in the daemon's hello-ack so the supervisor can
+ * heal a degraded daemon. Always true off darwin.
+ */
+export async function probeBootstrapHealthy(
+	deps: BootstrapProbeDeps = {},
+): Promise<boolean> {
+	if (!probeUserResolutionHealthy(deps)) return false;
+	return probeTrustdReachable(deps);
+}

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -17,6 +17,7 @@
 
 import * as os from "node:os";
 import packageJson from "../package.json" with { type: "json" };
+import { probeBootstrapHealthy } from "./bootstrap-probe.ts";
 import { drainPendingKills } from "./Pty/index.ts";
 import type { HandoffMessage } from "./protocol/index.ts";
 import { Server } from "./Server/index.ts";
@@ -79,6 +80,13 @@ async function runFresh(): Promise<void> {
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Probe AFTER binding so a slow `security` can't delay the socket coming up
+	// (the supervisor has a socket-ready timeout). Fire-and-forget: hello-acks
+	// omit the field until the async probe lands, which the supervisor treats
+	// as "unknown"; its periodic reachability probe picks the value up.
+	void probeBootstrapHealthy().then((healthy) =>
+		server.setBootstrapHealthy(healthy),
+	);
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion}, host=${os.hostname()})\n`,
 	);
@@ -182,6 +190,11 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Probe only after binding so it can't delay the upgrade-ack the
+	// predecessor is waiting on. Fire-and-forget, same as the fresh path.
+	void probeBootstrapHealthy().then((healthy) =>
+		server.setBootstrapHealthy(healthy),
+	);
 	log(`bound and listening`);
 	process.stderr.write(
 		`[pty-daemon] (handoff successor) listening on ${socketPath} (v${daemonVersion}, host=${os.hostname()}, sessions=${snapshot.sessions.length})\n`,

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -41,6 +41,14 @@ export interface HelloAckMessage {
 	 * missing or stale.
 	 */
 	daemonPid?: number;
+	/**
+	 * macOS only: whether the daemon's Mach bootstrap namespace is intact —
+	 * trustd reachable (Security-framework TLS) AND getpwuid resolves our uid.
+	 * False means terminals it spawns hit `gh: x509: OSStatus -26276` and
+	 * `id -un` → bare uid; the supervisor heals such a daemon. Absent from
+	 * pre-probe daemon versions and until the post-bind probe completes.
+	 */
+	bootstrapHealthy?: boolean;
 }
 
 // ---------- Client -> Daemon ----------


### PR DESCRIPTION
**Links**
- Fixes #6127

## Root cause

The trustd heal referenced in the issue (`dc7e1b70b`) was **never merged** — it lives only on the unmerged `fix-gh-cli-version` branch. Main's pty-daemon 0.2.7 (`efa6d3c81`) is a bare convergence bump with no probe or heal. So on 1.18.1:

- A daemon that lost its macOS Mach bootstrap namespace (updater relaunch, dead login-session port) can't reach `trustd` or `opendirectoryd` — every shell it spawns hits `gh: x509: OSStatus -26276`, `id -un` prints the bare uid, and ssh reports "No user exists for uid 501".
- Nothing detects it: `tryAdopt`/`tryAdoptFromSocket` adopt any socket that answers, `superset stop` kills only host-service (the detached daemon survives and is re-adopted), auto-update handoffs are spawned *by the predecessor* so the successor inherits the broken context, and the UI only offers Restart when the daemon looks *unreachable* — a degraded daemon is perfectly reachable.
- The existing `SSL_CERT_FILE` fallback is a no-op for `gh` (Go's darwin verifier ignores it) and irrelevant to `id -un`.

## Fix

**pty-daemon 0.3.0** (bump converges wedged 0.2.7 daemons onto the probe-carrying binary via auto-update handoff):
- New `bootstrap-probe.ts`: `security verify-cert` (trustd) **plus** `os.userInfo()`/getpwuid resolution — the exact `id -un → 501` signature. Async (the daemon's blocking-call ratchet forbids `spawnSync` on the session-serving loop); inconclusive results always read healthy so a flaky probe can never trigger a destructive respawn.
- Probes fire-and-forget after socket bind (fresh + handoff paths); result reported as `bootstrapHealthy` in every hello-ack.

**host-service supervisor:**
- Adopt-time and poll-time heal: auto-respawn a degraded daemon **only** when it verifiably holds zero sessions (unknown session list = "may hold shells", never killed blind), one attempt per org to prevent churn loops. With live sessions it adopts and defers — killing them gains nothing since existing shells are already broken.
- `getHealth()` exposes `bootstrapDegraded`; the terminal pane indicator gains a red "Terminals need a restart" mode explaining the breakage and offering the existing confirmed Restart.
- When host-service's own bootstrap is degraded, fresh daemons are spawned via `launchctl asuser <uid>` (execs in place, pid bookkeeping unchanged) with plain-spawn fallback.

## Verification

- Unit: 18 probe tests, 8 new supervisor heal tests (59/59 total); live-session guard mutation-tested — removing it fails exactly the two guard tests. `bun run lint` / `bun run typecheck` exit 0.
- CDP E2E against the real dev app, with a **genuinely degraded daemon** (PATH-shimmed `security` exiting 1, self-reported `bootstrapHealthy:false` on the wire):
  - Degraded daemon holding a live session → adopted, not killed (`pty_daemon_bootstrap_degraded_adopted`); 90s soak across ~18 health polls: zero destructive events.
  - Indicator popover Reconnect → reattaches that pane only; pre-existing shells untouched.
  - "Keep waiting" cancel → nothing killed; confirmed Restart → `pty_daemon_user_restart`, healthy daemon replaces degraded one, indicator clears.
  - Session-less degraded daemon → auto-healed exactly once (`pty_daemon_bootstrap_degraded_respawn`), guard prevents loops.
  - Healthy-path regression: shells survive fd-handoff update, host-service restart + adoption, and renderer reload with identical pids.

Known pre-existing failure (untouched): `DaemonSupervisor.node-test.ts` "auto-update defers when live sessions exist" has failed on main since #5833 removed the defer without updating this node-only test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Heals macOS bootstrap‑degraded pty‑daemons so terminal commands like gh and ssh work again by probing the bootstrap state and safely auto‑respawning when possible. Fixes #6127.

- New Features
  - `@superset/pty-daemon` 0.3.0 self‑probes after binding: verifies trustd via `security verify-cert` and checks `os.userInfo()`; reports `bootstrapHealthy` in hello‑ack without blocking the event loop.
  - `@superset/host-service` auto‑respawns a degraded daemon only when it holds zero sessions (one attempt per org); otherwise adopts and surfaces `bootstrapDegraded` so the UI can prompt a restart.
  - When host‑service’s own bootstrap is degraded, new daemons spawn via `launchctl asuser <uid>` with a plain‑spawn fallback.
  - Terminal UI shows a red “Terminals need a restart” state with a Restart action when degradation is detected.

- Dependencies
  - Bumped `@superset/pty-daemon` to `0.3.0` and added the `./bootstrap-probe` export.

<sup>Written for commit 2bd3a4e6e31aacacb76210455f71f2c3d664d35b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS health detection for terminal processes.
  * Terminal status now clearly indicates when a restart is required and explains potential effects on commands such as `gh` and `ssh`.
  * Restart and reconnect options are available when degraded conditions are detected.
  * Automatic recovery can replace degraded, sessionless terminal processes without interrupting active sessions.

* **Bug Fixes**
  * Improved detection and recovery of terminal connectivity issues across startup, reconnection, and ongoing monitoring.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->