### PR TITLE
fix(api): dispatch the terminal slot of bounded automations instead of silently dropping it

### DIFF
--- a/apps/api/src/app/api/automations/dispatch/[id]/route.test.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/env", () => ({
+	env: {
+		QSTASH_CURRENT_SIGNING_KEY: "sk-current",
+		QSTASH_NEXT_SIGNING_KEY: "sk-next",
+		NEXT_PUBLIC_API_URL: "http://localhost",
+		RELAY_URL: "http://relay.localhost",
+	},
+}));
+
+mock.module("@upstash/qstash", () => ({
+	Receiver: class {
+		verify = mock(async () => true);
+	},
+}));
+
+const dispatchAutomation = mock(async () => ({
+	status: "dispatched",
+	runId: "run-1",
+}));
+mock.module("@superset/trpc/automation-dispatch", () => ({
+	dispatchAutomation,
+}));
+
+let automationRow: Record<string, unknown> | null = null;
+const insertedRuns: Record<string, unknown>[] = [];
+mock.module("@superset/db/client", () => ({
+	dbWs: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: async () => (automationRow ? [automationRow] : []),
+				}),
+			}),
+		}),
+		insert: () => ({
+			values: (values: Record<string, unknown>) => ({
+				onConflictDoNothing: async () => {
+					insertedRuns.push(values);
+				},
+			}),
+		}),
+	},
+}));
+
+const { POST } = await import("./route");
+
+const AUTOMATION_ID = "6b1f0f5e-8c2a-4f9f-9a3e-1c2d3e4f5a6b";
+// evaluate enqueues scheduledFor floored to the minute; next_run_at keeps
+// its seconds.
+const SLOT = "2026-08-02T18:46:00.000Z";
+const NEXT_RUN_AT = new Date("2026-08-02T18:46:16.613Z");
+
+function makeAutomation(overrides: Record<string, unknown> = {}) {
+	return {
+		id: AUTOMATION_ID,
+		organizationId: "0d9f6a2b-1c3d-4e5f-8a7b-9c0d1e2f3a4b",
+		name: "daily report",
+		enabled: true,
+		nextRunAt: NEXT_RUN_AT,
+		...overrides,
+	};
+}
+
+function callRoute(body: Record<string, unknown>) {
+	const request = new Request(
+		`http://localhost/api/automations/dispatch/${AUTOMATION_ID}`,
+		{
+			method: "POST",
+			headers: { "upstash-signature": "sig" },
+			body: JSON.stringify(body),
+		},
+	);
+	return POST(request, { params: Promise.resolve({ id: AUTOMATION_ID }) });
+}
+
+describe("automations dispatch route", () => {
+	beforeEach(() => {
+		dispatchAutomation.mockClear();
+		insertedRuns.length = 0;
+		automationRow = null;
+	});
+
+	test("dispatches an enabled automation", async () => {
+		automationRow = makeAutomation();
+
+		const response = await callRoute({
+			automationId: AUTOMATION_ID,
+			scheduledFor: SLOT,
+		});
+
+		expect(response.status).toBe(200);
+		expect(dispatchAutomation).toHaveBeenCalledTimes(1);
+		expect(insertedRuns).toHaveLength(0);
+	});
+
+	test("dispatches the terminal slot of a bounded rule after evaluate disabled it", async () => {
+		automationRow = makeAutomation({ enabled: false });
+
+		const response = await callRoute({
+			automationId: AUTOMATION_ID,
+			scheduledFor: SLOT,
+			terminal: true,
+		});
+
+		expect(response.status).toBe(200);
+		const json = (await response.json()) as { outcome?: { status: string } };
+		expect(json.outcome?.status).toBe("dispatched");
+		expect(dispatchAutomation).toHaveBeenCalledTimes(1);
+		expect(insertedRuns).toHaveLength(0);
+	});
+
+	test("skips a disabled automation and records the dropped slot", async () => {
+		automationRow = makeAutomation({ enabled: false });
+
+		const response = await callRoute({
+			automationId: AUTOMATION_ID,
+			scheduledFor: SLOT,
+		});
+
+		expect(response.status).toBe(200);
+		const json = (await response.json()) as { skipped?: string };
+		expect(json.skipped).toBe("disabled");
+		expect(dispatchAutomation).not.toHaveBeenCalled();
+		expect(insertedRuns).toHaveLength(1);
+		expect(insertedRuns[0]).toMatchObject({
+			automationId: AUTOMATION_ID,
+			status: "dispatch_failed",
+			scheduledFor: new Date(SLOT),
+		});
+	});
+
+	test("skips a stale terminal replay whose slot no longer matches next_run_at", async () => {
+		automationRow = makeAutomation({
+			enabled: false,
+			nextRunAt: new Date("2026-08-03T18:46:00.000Z"),
+		});
+
+		const response = await callRoute({
+			automationId: AUTOMATION_ID,
+			scheduledFor: SLOT,
+			terminal: true,
+		});
+
+		expect(response.status).toBe(200);
+		const json = (await response.json()) as { skipped?: string };
+		expect(json.skipped).toBe("disabled");
+		expect(dispatchAutomation).not.toHaveBeenCalled();
+		expect(insertedRuns).toHaveLength(1);
+	});
+});

--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -1,5 +1,9 @@
 import { dbWs } from "@superset/db/client";
-import { automations } from "@superset/db/schema";
+import {
+	automationRuns,
+	automations,
+	type SelectAutomation,
+} from "@superset/db/schema";
 import { dispatchAutomation } from "@superset/trpc/automation-dispatch";
 import { Receiver } from "@upstash/qstash";
 import { eq } from "drizzle-orm";
@@ -18,7 +22,17 @@ const receiver = new Receiver({
 const payloadSchema = z.object({
 	automationId: z.string().uuid(),
 	scheduledFor: z.string().datetime(),
+	// Marks the terminal occurrence of a bounded (COUNT/UNTIL) rule, whose
+	// evaluate tick disables the automation in the same request that enqueues
+	// this message.
+	terminal: z.boolean().default(false),
 });
+
+function bucketToMinute(d: Date): Date {
+	const copy = new Date(d.getTime());
+	copy.setUTCSeconds(0, 0);
+	return copy;
+}
 
 export async function POST(
 	request: Request,
@@ -55,15 +69,54 @@ export async function POST(
 	if (!automation) {
 		return Response.json({ ok: true, skipped: "deleted" });
 	}
+
+	const scheduledFor = new Date(parsed.data.scheduledFor);
 	if (!automation.enabled) {
-		return Response.json({ ok: true, skipped: "disabled" });
+		// evaluate disables an exhausted bounded rule in the same tick that
+		// enqueues its final occurrence, and that UPDATE can beat QStash
+		// delivery. A terminal payload whose slot still matches next_run_at is
+		// that final occurrence, not a user pause — dispatch it (#6128).
+		// next_run_at moves on any other transition (advance, pause/resume
+		// recompute), so a stale terminal replay can't match.
+		const isTerminalSlot =
+			parsed.data.terminal &&
+			bucketToMinute(automation.nextRunAt).getTime() === scheduledFor.getTime();
+		if (!isTerminalSlot) {
+			await recordDisabledSkip(automation, scheduledFor);
+			return Response.json({ ok: true, skipped: "disabled" });
+		}
 	}
 
 	const outcome = await dispatchAutomation({
 		automation,
-		scheduledFor: new Date(parsed.data.scheduledFor),
+		scheduledFor,
 		relayUrl: env.RELAY_URL,
 	});
 
 	return Response.json({ ok: true, outcome });
+}
+
+/**
+ * A slot that reaches this handler already consumed its occurrence
+ * (evaluate advanced next_run_at when it enqueued), so dropping it on the
+ * disabled guard must leave a row — otherwise the loss is indistinguishable
+ * from a healthy finished series.
+ */
+async function recordDisabledSkip(
+	automation: SelectAutomation,
+	scheduledFor: Date,
+): Promise<void> {
+	await dbWs
+		.insert(automationRuns)
+		.values({
+			automationId: automation.id,
+			organizationId: automation.organizationId,
+			title: automation.name,
+			scheduledFor,
+			status: "dispatch_failed",
+			error: "automation disabled before dispatch delivery",
+		})
+		.onConflictDoNothing({
+			target: [automationRuns.automationId, automationRuns.scheduledFor],
+		});
 }

--- a/apps/api/src/app/api/automations/evaluate/route.test.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/env", () => ({
+	env: {
+		QSTASH_TOKEN: "test-token",
+		QSTASH_URL: "http://qstash.localhost",
+		QSTASH_CURRENT_SIGNING_KEY: "sk-current",
+		QSTASH_NEXT_SIGNING_KEY: "sk-next",
+		NEXT_PUBLIC_API_URL: "http://localhost",
+	},
+}));
+
+type BatchMessage = {
+	body: { automationId: string; scheduledFor: string; terminal: boolean };
+	deduplicationId: string;
+};
+
+const batches: BatchMessage[][] = [];
+mock.module("@upstash/qstash", () => ({
+	Client: class {
+		batchJSON = async (messages: BatchMessage[]) => {
+			batches.push(messages);
+		};
+	},
+	Receiver: class {
+		verify = mock(async () => true);
+	},
+}));
+
+let dueRows: Record<string, unknown>[] = [];
+const updates: Record<string, unknown>[] = [];
+mock.module("@superset/db/client", () => ({
+	dbWs: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					orderBy: () => ({
+						limit: async () => dueRows,
+					}),
+				}),
+			}),
+		}),
+		update: () => ({
+			set: (patch: Record<string, unknown>) => ({
+				where: async () => {
+					updates.push(patch);
+				},
+			}),
+		}),
+	},
+}));
+
+const { POST } = await import("./route");
+
+const SLOT = new Date("2026-08-02T18:46:00.000Z");
+
+function makeAutomation(rrule: string, id: string) {
+	return {
+		id,
+		rrule,
+		dtstart: SLOT,
+		timezone: "UTC",
+		nextRunAt: SLOT,
+	};
+}
+
+function callRoute() {
+	const request = new Request("http://localhost/api/automations/evaluate", {
+		method: "POST",
+		headers: { "upstash-signature": "sig" },
+		body: "{}",
+	});
+	return POST(request);
+}
+
+describe("automations evaluate route", () => {
+	beforeEach(() => {
+		batches.length = 0;
+		updates.length = 0;
+		dueRows = [];
+	});
+
+	test("marks the terminal occurrence of a bounded rule and disables it", async () => {
+		dueRows = [makeAutomation("FREQ=DAILY;COUNT=1", "a-count-1")];
+
+		const response = await callRoute();
+
+		expect(response.status).toBe(200);
+		expect(batches).toHaveLength(1);
+		expect(batches[0]?.[0]?.body).toMatchObject({
+			automationId: "a-count-1",
+			scheduledFor: SLOT.toISOString(),
+			terminal: true,
+		});
+		expect(updates).toEqual([{ enabled: false }]);
+	});
+
+	test("non-terminal occurrences enqueue with terminal=false and advance next_run_at", async () => {
+		dueRows = [
+			makeAutomation("FREQ=DAILY", "a-unbounded"),
+			makeAutomation("FREQ=MINUTELY;COUNT=2", "a-count-2"),
+		];
+
+		const response = await callRoute();
+
+		expect(response.status).toBe(200);
+		expect(batches[0]?.map((m) => m.body.terminal)).toEqual([false, false]);
+		expect(updates).toHaveLength(2);
+		for (const patch of updates) {
+			expect(patch.enabled).toBeUndefined();
+			expect(patch.nextRunAt).toBeInstanceOf(Date);
+			expect((patch.nextRunAt as Date).getTime()).toBeGreaterThan(
+				SLOT.getTime(),
+			);
+		}
+	});
+
+	test("an unparseable rrule still enqueues without terminal and reports an advance failure", async () => {
+		dueRows = [makeAutomation("NOT-A-RULE", "a-broken")];
+
+		const response = await callRoute();
+
+		expect(response.status).toBe(200);
+		const json = (await response.json()) as {
+			enqueued: number;
+			advanceFailed: number;
+		};
+		expect(json).toMatchObject({ enqueued: 1, advanceFailed: 1 });
+		expect(batches[0]?.[0]?.body.terminal).toBe(false);
+		expect(updates).toHaveLength(0);
+	});
+});

--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -53,30 +53,42 @@ export async function POST(request: Request): Promise<Response> {
 		return Response.json({ enqueued: 0 });
 	}
 
-	await qstash.batchJSON(
-		due.map((automation) => {
-			const scheduledFor = bucketToMinute(automation.nextRunAt);
-			return {
-				url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${automation.id}`,
-				body: {
-					automationId: automation.id,
-					scheduledFor: scheduledFor.toISOString(),
-				},
-				deduplicationId: `${automation.id}_${scheduledFor.getTime()}`,
-				retries: 2,
-				failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
-			};
-		}),
-	);
-
-	const advanceResults = await Promise.allSettled(
-		due.map((automation) => {
+	const plans = due.map((automation) => {
+		const scheduledFor = bucketToMinute(automation.nextRunAt);
+		try {
 			const next = nextOccurrenceAfter({
 				rrule: automation.rrule,
 				dtstart: automation.dtstart,
 				timezone: automation.timezone,
 				after: automation.nextRunAt,
 			});
+			return { automation, scheduledFor, next, computeError: null };
+		} catch (err) {
+			return { automation, scheduledFor, next: null, computeError: err };
+		}
+	});
+
+	await qstash.batchJSON(
+		plans.map(({ automation, scheduledFor, next, computeError }) => ({
+			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${automation.id}`,
+			body: {
+				automationId: automation.id,
+				scheduledFor: scheduledFor.toISOString(),
+				// Terminal occurrence of a bounded rule: this tick also flips
+				// enabled=false, and that UPDATE can land before QStash delivers.
+				// The flag tells the dispatch handler the disable is exhaustion,
+				// not a user pause, so the final slot still runs (#6128).
+				terminal: computeError === null && next === null,
+			},
+			deduplicationId: `${automation.id}_${scheduledFor.getTime()}`,
+			retries: 2,
+			failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
+		})),
+	);
+
+	const advanceResults = await Promise.allSettled(
+		plans.map(({ automation, next, computeError }) => {
+			if (computeError) return Promise.reject(computeError);
 			return dbWs
 				.update(automations)
 				.set(next ? { nextRunAt: next } : { enabled: false })
@@ -89,7 +101,7 @@ export async function POST(request: Request): Promise<Response> {
 	// hide itself without this log.
 	const advanceFailures = advanceResults.flatMap((result, index) => {
 		if (result.status !== "rejected") return [];
-		const automation = due[index];
+		const automation = plans[index]?.automation;
 		return [{ automationId: automation?.id, reason: result.reason }];
 	});
 	if (advanceFailures.length > 0) {

--- a/plans/6128-scheduled-dispatch-loss.md
+++ b/plans/6128-scheduled-dispatch-loss.md
@@ -1,0 +1,77 @@
+# #6128: scheduled dispatch silently lost on the terminal slot of bounded rules
+
+## Root cause (fixed in this branch)
+
+Race between the two halves of the scheduled path, no host/relay involvement:
+
+1. `apps/api/src/app/api/automations/evaluate/route.ts` enqueues the QStash
+   dispatch job, then advances `next_run_at` — or, when the rrule is exhausted
+   (`COUNT`/`UNTIL`), sets `enabled = false`. The disable UPDATE reliably lands
+   before QStash's outbound HTTP delivery.
+2. `apps/api/src/app/api/automations/dispatch/[id]/route.ts` reloaded the row
+   and returned 200 `{skipped: "disabled"}` for any `enabled = false`
+   automation — it couldn't tell "user paused" from "we just disabled this
+   because of the very slot being delivered".
+
+So the **terminal occurrence of every bounded rule** was dropped: no run row
+(every row-writing path lives inside `dispatchAutomation`, downstream of the
+guard), no `workspaces.create`, and QStash saw a 200 so retries and the
+`run-failed` failure callback never fired. `FREQ=DAILY;COUNT=1` can never fire.
+Run-now works because `runNow` (`packages/trpc/src/router/automation/automation.ts`)
+calls `dispatchAutomation` directly with no `enabled` check.
+
+The earlier Mac-host losses in the report (`skipped_offline`,
+`Tunnel disconnected`) are a separate, genuine host-availability class — those
+did write rows. Relay-presence accuracy is tracked in #6014/#6160.
+
+## Fix shipped here
+
+- `evaluate` computes the next occurrence before enqueueing and sends
+  `terminal: true` on the payload when the rule is exhausted.
+- `dispatch` lets a disabled automation through when the payload is terminal
+  AND `bucketToMinute(next_run_at)` still equals `scheduledFor` (the disable
+  path leaves `next_run_at` at the terminal occurrence; any other transition
+  moves it, so stale replays can't match).
+- Any delivery still dropped on the disabled guard now persists a
+  `dispatch_failed` run row (`automation disabled before dispatch delivery`)
+  instead of vanishing.
+
+Regression tests: `evaluate/route.test.ts`, `dispatch/[id]/route.test.ts`.
+
+## E2E verification (2026-08-06, local stack)
+
+Real QStash enqueue→deliver (QStash dev server on :8080), real `next dev`
+API on :4721, workspace's isolated Neon branch DB. Seeded automations owned
+by kiet@superset.sh with a nonexistent `targetHostId` (so a dispatch attempt
+records `skipped_offline` rather than touching a host). Before/after gate:
+
+| Scenario | Pre-fix (stashed) | Post-fix |
+|---|---|---|
+| `FREQ=DAILY;COUNT=1` terminal slot | dispatch handler hit, returned 200 `skipped:"disabled"`; **0 run rows**, `enabled:false` — bug reproduced | run row `skipped_offline` persisted, `enabled:false` |
+| `FREQ=MINUTELY;COUNT=2` | (not run — slot 1 was already known-good) | slot 1 AND terminal slot 2 both persisted rows across two ticks, then clean disable |
+| Late delivery to a paused automation (`terminal:false`) | silent 200, no row | `dispatch_failed` row "automation disabled before dispatch delivery" |
+
+Not exercised e2e: the happy path through relay→`workspaces.create`→agent
+(no live host/relay in the local stack). That path is `dispatchAutomation`,
+which is byte-identical for scheduled and manual runs and unchanged by this
+fix; manual runs prove it in production. Test rows were deleted from the
+branch DB afterwards; the evaluate ticks also swept other due automations
+seeded in the branch copy (branch-local writes only).
+
+## Remaining product/infra decisions (not done here)
+
+1. **Stop overloading `enabled` for exhaustion.** A finished series and a
+   paused automation are indistinguishable (`packages/db/src/schema/schema.ts`
+   has only the boolean). A `completedAt` timestamp or status enum would let
+   the UI say "completed" vs "paused" and would remove the need for the
+   `terminal` flag entirely. Needs a migration + UI work.
+2. **Retry/backfill for missed slots.** `evaluate` advances `next_run_at`
+   unconditionally, and `skipped_offline` is terminal in
+   `packages/trpc/src/router/automation/dispatch.ts` — a missed minute is gone
+   forever. Options: bounded re-enqueue on `skipped_offline`, or a catch-up
+   sweep re-selecting recent slots that lack a successful run row. Interacts
+   with hosts that are asleep on purpose (do users want a burst on wake?).
+3. **Relay presence accuracy** (`v2Hosts.isOnline`) — #6014 shows the daemon
+   healthy while the cloud sees it offline. Separate failure class; needs its
+   own investigation of relay check-in/tunnel state, plus a CLI diagnostic
+   exposing the cloud's view of host presence.


### PR DESCRIPTION
## Summary

Fixes #6128 — the terminal occurrence of every bounded (`COUNT`/`UNTIL`) automation was silently lost: `evaluate` flips `enabled:false` for an exhausted rule in the same tick that enqueues its final dispatch, the disable UPDATE beats QStash's HTTP delivery, and the dispatch handler bailed on `enabled=false` with a 200. Result: no run row, no `workspaces.create`, no retry/failure callback, and an automation that reads like a cleanly finished series. `FREQ=DAILY;COUNT=1` could never fire. Run-now was unaffected because `runNow` calls `dispatchAutomation` directly with no enabled check.

## Changes

- `evaluate` computes the next occurrence **before** enqueueing and sets `terminal: true` on the payload when the rule is exhausted (unparseable rrules keep today's behavior: enqueue non-terminal + log the advance failure).
- `dispatch/[id]` lets a disabled automation through when the payload is terminal **and** `bucketToMinute(next_run_at)` still equals `scheduledFor` — exhaustion leaves `next_run_at` at the terminal occurrence while every other transition moves it, so stale replays can't match.
- Any delivery still dropped on the disabled guard now persists a `dispatch_failed` run row (`automation disabled before dispatch delivery`) instead of vanishing.

## Verification

- Unit: 7 route tests (mocked QStash/db), mutation-tested — reverting the guard or the flag makes exactly the terminal-slot tests fail.
- E2E (local QStash dev server + `next dev` + isolated Neon branch, real enqueue→signed delivery):
  - **pre-fix** `COUNT=1`: handler hit, 200 `skipped:"disabled"`, 0 run rows, `enabled:false` — bug reproduced;
  - **post-fix** `COUNT=1`: terminal slot persists a run row, then clean disable;
  - **post-fix** `COUNT=2` (MINUTELY, two ticks): both slots persist rows incl. the terminal one;
  - late delivery to a paused automation: `dispatch_failed` row persisted.
- `bun run lint` and `bun run typecheck` exit 0.

Not exercised e2e: relay→`workspaces.create` happy path (no live host locally); that's `dispatchAutomation`, shared byte-for-byte with the proven manual path and unchanged here.

Remaining product decisions (status enum instead of overloading `enabled`, retry/backfill for missed slots, relay presence accuracy #6014/#6160) are written up in `plans/6128-scheduled-dispatch-loss.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6128 by ensuring the terminal slot of bounded (`COUNT`/`UNTIL`) automations is dispatched instead of being dropped, and by recording a run when a disabled guard stops delivery. This restores expected behavior for cases like `FREQ=DAILY;COUNT=1`.

- **Bug Fixes**
  - Evaluate: compute the next occurrence before enqueueing and send `terminal: true` when the rule is exhausted; unparseable rrules still enqueue with `terminal: false` and log the advance failure. Uses `@upstash/qstash` batch enqueue.
  - Dispatch: allow a disabled automation through when the payload is terminal and `bucketToMinute(next_run_at)` equals `scheduledFor`; otherwise persist a `dispatch_failed` run row (“automation disabled before dispatch delivery”) instead of silently dropping. Calls `@superset/trpc/automation-dispatch`.

<sup>Written for commit 73d281c6dd166986fe494bf559f0a665257854e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the final scheduled occurrence of bounded automations from being dropped when the automation becomes disabled.
  * Recorded skipped deliveries from disabled automations for improved run history and visibility.
  * Improved handling of stale or invalid scheduled deliveries.

* **Documentation**
  * Added documentation covering the scheduled-dispatch race, resolution, testing, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->