### PR TITLE
feat(cli): print workspace, agent, and terminal ids in create command output

### DIFF
--- a/packages/cli/src/commands/agents/create/command.ts
+++ b/packages/cli/src/commands/agents/create/command.ts
@@ -70,7 +70,8 @@ export default command({
 				? `chat session ${result.sessionId}`
 				: `terminal ${result.sessionId}`;
 		return {
-			data: result,
+			// Top-level id so --quiet resolves to the session id.
+			data: { id: result.sessionId, ...result },
 			message: `Launched ${result.label} (${sessionDescriptor}) in workspace ${options.workspace}`,
 		};
 	},

--- a/packages/cli/src/commands/projects/create/command.ts
+++ b/packages/cli/src/commands/projects/create/command.ts
@@ -70,9 +70,18 @@ export default command({
 			mode,
 		});
 
+		const lines = [
+			`Created project "${options.name}" on host ${target.hostId}`,
+			"",
+			`project        ${result.projectId}`,
+			`mainWorkspace  ${result.mainWorkspaceId}`,
+			`repoPath       ${result.repoPath}`,
+		];
+
 		return {
-			data: result,
-			message: `Created project "${options.name}" on host ${target.hostId}`,
+			// Top-level id so --quiet resolves to the project id.
+			data: { id: result.projectId, ...result },
+			message: lines.join("\n"),
 		};
 	},
 });

--- a/packages/cli/src/commands/terminals/create/command.ts
+++ b/packages/cli/src/commands/terminals/create/command.ts
@@ -47,7 +47,8 @@ export default command({
 		});
 
 		return {
-			data: result,
+			// Top-level id so --quiet resolves to the terminal id.
+			data: { id: result.terminalId, ...result },
 			message: `Created terminal ${result.terminalId} in workspace ${options.workspace}`,
 		};
 	},

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -12,7 +12,20 @@ mock.module("../../../lib/host-target", () => ({
 					mutate: async (input: Record<string, unknown>) => {
 						createInput = input;
 						return {
-							workspace: { name: "agent-effort" },
+							workspace: {
+								id: "ws-1",
+								name: "agent-effort",
+								branch: "agent/effort",
+							},
+							agents: [
+								{
+									ok: true,
+									kind: "terminal",
+									sessionId: "session-1",
+									label: "Claude",
+								},
+							],
+							terminals: [{ terminalId: "terminal-1", label: "Setup" }],
 							alreadyExists: false,
 						};
 					},
@@ -69,6 +82,21 @@ describe("workspaces create", () => {
 				},
 			],
 		});
+	});
+
+	test("surfaces workspace, agent session, and terminal ids in the message", async () => {
+		const result = (await invoke({
+			agent: "claude",
+			prompt: "Implement the feature",
+		})) as { data: { id: string }; message: string };
+
+		expect(result.message).toContain("workspace  ws-1");
+		expect(result.message).toContain("branch     agent/effort");
+		expect(result.message).toContain(
+			"agent      Claude — terminal session session-1",
+		);
+		expect(result.message).toContain("terminal   terminal-1 (Setup)");
+		expect(result.data.id).toBe("ws-1");
 	});
 
 	test("rejects effort when no agent is selected", async () => {

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -108,11 +108,31 @@ export default command({
 			command: options.command ?? undefined,
 		});
 
-		return {
-			data: result,
-			message: result.alreadyExists
+		const lines = [
+			result.alreadyExists
 				? `Reused existing workspace "${result.workspace.name}" on host ${target.hostId}`
 				: `Created workspace "${result.workspace.name}" on host ${target.hostId}`,
+			"",
+			`workspace  ${result.workspace.id}`,
+			`branch     ${result.workspace.branch}`,
+		];
+		for (const agent of result.agents ?? []) {
+			lines.push(
+				agent.ok
+					? `agent      ${agent.label} — ${agent.kind} session ${agent.sessionId}`
+					: `agent      failed: ${agent.error}`,
+			);
+		}
+		for (const terminal of result.terminals ?? []) {
+			lines.push(
+				`terminal   ${terminal.terminalId}${terminal.label ? ` (${terminal.label})` : ""}`,
+			);
+		}
+
+		return {
+			// Top-level id so --quiet resolves to the workspace id.
+			data: { id: result.workspace.id, ...result },
+			message: lines.join("\n"),
 		};
 	},
 });


### PR DESCRIPTION
## Summary

`superset workspaces create` (and the other create commands) only printed a confirmation sentence — the IDs an agent or script needs next (workspace ID, agent session ID, terminal ID) were only reachable via `--json`.

Default output now surfaces them readably:

```
Created workspace "fix-login-bug" on host <hostId>

workspace  0198f3a2-…
branch     fix/login-bug
agent      Claude — terminal session 0198f3b1-…
terminal   0198f3c0-… (Setup)
```

- **workspaces create**: prints workspace id, branch, per-agent session ids (failed launches print their error instead of being dropped), and setup/command terminal ids
- **projects create**: prints `projectId`, `mainWorkspaceId`, `repoPath` (previously none were shown — the project id is required for `workspaces create --project`)
- **agents create / terminals create**: already printed their ids inline; unchanged in default mode
- **`--quiet` fix**: all four commands now expose a top-level `id` in their data payload, so `--quiet` prints the primary id (workspace/project/session/terminal) instead of dumping a one-line JSON blob (`extractIds` only looks at `data.id`)

`--json` output is unchanged apart from the additive top-level `id` field.

## Testing

- Added a test asserting the workspaces create message contains workspace, agent session, and terminal ids, and that `data.id` is the workspace id
- `bun test packages/cli/src/commands` (14 pass), `tsc --noEmit` clean, Biome clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve create command output to show the IDs you need (workspace, agent session, terminal, project) without requiring --json. Also standardize --quiet to print the primary id.

- **New Features**
  - workspaces create: prints workspace id, branch, per-agent session ids (failed launches show their error), and setup/command terminal ids.
  - projects create: prints projectId, mainWorkspaceId, and repoPath.

- **Bug Fixes**
  - --quiet now prints the primary id for workspaces/projects/agents/terminals by exposing data.id.
  - --json output is unchanged except for the additive top-level id field.

<sup>Written for commit 7e83248bdae03c68eeb1f41512a4364a7b6a174d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved creation command results for agents, projects, terminals, and workspaces with easy-to-access IDs.
  * Project creation now displays the project ID, main workspace ID, and repository path.
  * Workspace creation now reports workspace, branch, agent, and terminal details in a clearer status summary.

* **Tests**
  * Added coverage verifying workspace creation details and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->