### PR TITLE
fix(cli): route desktop terminals to workspace organization

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -100,6 +100,7 @@ Each terminal session receives these environment variables:
 | `SUPERSET_PANE_ID` | Unique identifier for the terminal pane |
 | `SUPERSET_TAB_ID` | Identifier for the containing tab |
 | `SUPERSET_WORKSPACE_ID` | Identifier for the workspace |
+| `SUPERSET_ORGANIZATION_ID` | Organization that owns the workspace; scopes CLI routing in Desktop-managed terminals |
 | `SUPERSET_WORKSPACE_NAME` | Human-readable workspace name |
 | `SUPERSET_WORKSPACE_PATH` | Filesystem path to the workspace |
 | `SUPERSET_ROOT_PATH` | Root path of the project |

--- a/packages/cli/CLI_SPEC_CURRENT.md
+++ b/packages/cli/CLI_SPEC_CURRENT.md
@@ -156,6 +156,17 @@ The desktop app uses the same host manifest schema and home tree in
 production, so a desktop-started host service and a CLI-started host
 service can discover each other through the same manifest path.
 
+Desktop-managed terminals also set `SUPERSET_ORGANIZATION_ID` to the
+workspace's organization. The CLI prefers that invocation-scoped value over
+the active organization stored in `config.json`, which keeps workspace and
+host routing aligned without changing the user's global CLI selection.
+
+The desktop bundle contains only the `superset` executable, not the standalone
+`superset-host` runtime and its Node/native dependencies. `superset start`
+discovers Desktop's already-running service through the shared manifest; use
+the standalone CLI distribution when a new headless host service must be
+launched.
+
 The standalone install script is separate from runtime state. It installs
 the CLI and host binary under `SUPERSET_HOME` (default `~/superset`) and
 adds `<SUPERSET_HOME>/bin` to the user's shell `PATH`. These locations do

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -15,7 +15,10 @@ export default command({
 	},
 	run: async ({ ctx, options, signal }) => {
 		const orgs = await ctx.api.user.myOrganizations.query();
-		const organization = await resolveOrganization(orgs, options.org);
+		const organization = await resolveOrganization(
+			orgs,
+			options.org ?? process.env.SUPERSET_ORGANIZATION_ID,
+		);
 
 		const existing = readManifest(organization.id);
 		if (existing && isProcessAlive(existing.pid)) {

--- a/packages/cli/src/lib/resolve-auth.test.ts
+++ b/packages/cli/src/lib/resolve-auth.test.ts
@@ -10,7 +10,7 @@ const tempHome = fs.mkdtempSync(
 process.env.SUPERSET_HOME_DIR = tempHome;
 
 const { resolveAuth } = await import("./resolve-auth");
-const { writeConfig } = await import("./config");
+const { readConfig, writeConfig } = await import("./config");
 
 function clearConfig(): void {
 	writeConfig({});
@@ -19,7 +19,9 @@ function clearConfig(): void {
 // Clean baseline: the real dev/CI shell may export SUPERSET_API_KEY, which
 // would leak into every test. Clear it for the suite, restore in afterAll.
 const originalEnvKey = process.env.SUPERSET_API_KEY;
+const originalOrganizationId = process.env.SUPERSET_ORGANIZATION_ID;
 delete process.env.SUPERSET_API_KEY;
+delete process.env.SUPERSET_ORGANIZATION_ID;
 
 afterEach(() => {
 	clearConfig();
@@ -36,6 +38,11 @@ afterAll(() => {
 	}
 	if (originalEnvKey === undefined) delete process.env.SUPERSET_API_KEY;
 	else process.env.SUPERSET_API_KEY = originalEnvKey;
+	if (originalOrganizationId === undefined) {
+		delete process.env.SUPERSET_ORGANIZATION_ID;
+	} else {
+		process.env.SUPERSET_ORGANIZATION_ID = originalOrganizationId;
+	}
 });
 
 describe("resolveAuth", () => {
@@ -118,6 +125,8 @@ describe("resolveAuth", () => {
 		process.env.SUPERSET_ORGANIZATION_ID = "org_env";
 		const result = await resolveAuth(undefined);
 		expect(result.config.organizationId).toBe("org_env");
+		// Invocation-scoped only: the stored config on disk keeps the user's org.
+		expect(readConfig().organizationId).toBe("org_stored");
 	});
 
 	it("keeps the stored org when SUPERSET_ORGANIZATION_ID is unset", async () => {

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -488,6 +488,7 @@ describe("buildV2TerminalEnv", () => {
 		},
 		shell: "/bin/zsh",
 		supersetHomeDir: "/Users/test/.superset",
+		organizationId: "org-1",
 		cwd: "/tmp/workspace",
 		terminalId: "term-1",
 		workspaceId: "ws-1",
@@ -507,6 +508,7 @@ describe("buildV2TerminalEnv", () => {
 			COLORTERM: "truecolor",
 			PWD: "/tmp/workspace",
 			SUPERSET_TERMINAL_ID: "term-1",
+			SUPERSET_ORGANIZATION_ID: "org-1",
 			SUPERSET_WORKSPACE_ID: "ws-1",
 			SUPERSET_WORKSPACE_PATH: "/tmp/workspace",
 			SUPERSET_ROOT_PATH: "/tmp/repo",
@@ -620,6 +622,7 @@ describe("v2 env contract boundary", () => {
 			},
 			shell: "/bin/zsh",
 			supersetHomeDir: "/Users/test/.superset",
+			organizationId: "org-abc",
 			cwd: "/tmp/ws",
 			terminalId: "t-1",
 			workspaceId: "w-1",
@@ -634,6 +637,7 @@ describe("v2 env contract boundary", () => {
 		expect(env.HOST_SERVICE_SECRET).toBeUndefined();
 		expect(env.AUTH_TOKEN).toBeUndefined();
 		expect(env.ORGANIZATION_ID).toBeUndefined();
+		expect(env.SUPERSET_ORGANIZATION_ID).toBe("org-abc");
 		expect(env.NODE_ENV).toBeUndefined();
 		expect(env.VITE_SECRET).toBeUndefined();
 		expect(env.npm_package_name).toBeUndefined();

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -179,6 +179,7 @@ interface BuildV2TerminalEnvParams {
 	baseEnv: Record<string, string>;
 	shell: string;
 	supersetHomeDir: string;
+	organizationId: string;
 	themeType?: "dark" | "light";
 	cwd: string;
 	terminalId: string;
@@ -208,6 +209,7 @@ export function buildV2TerminalEnv(
 		baseEnv,
 		shell,
 		supersetHomeDir,
+		organizationId,
 		themeType,
 		cwd,
 		terminalId,
@@ -247,6 +249,13 @@ export function buildV2TerminalEnv(
 	env.PWD = cwd;
 
 	env.SUPERSET_TERMINAL_ID = terminalId;
+	// Scope CLI commands launched in this terminal to the same organization as
+	// the org-specific host-service that owns the workspace. This is routing
+	// metadata, not a credential; the CLI still uses its own authenticated
+	// session, but no longer consults that session's unrelated active-org choice.
+	if (organizationId) {
+		env.SUPERSET_ORGANIZATION_ID = organizationId;
+	}
 	env.SUPERSET_WORKSPACE_ID = workspaceId;
 	env.SUPERSET_WORKSPACE_PATH = workspacePath;
 	env.SUPERSET_ROOT_PATH = rootPath;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -2466,6 +2466,7 @@ export async function createTerminalSessionInternal({
 			baseEnv,
 			shell,
 			supersetHomeDir,
+			organizationId: process.env.ORGANIZATION_ID || "",
 			themeType,
 			cwd,
 			terminalId,


### PR DESCRIPTION
## Summary

- host-service now exports `SUPERSET_ORGANIZATION_ID` (the workspace's organization) into every Desktop-managed v2 terminal environment
- `superset start` treats that terminal org as the explicit `--org` choice, so it discovers the Desktop-managed host instead of prompting or targeting the wrong org
- add a disk-not-rewritten assertion to the existing CLI org-override test, plus spec/docs for the new env var and the Desktop/standalone packaging boundary

Rebased onto main after #6519 landed the CLI consumer side (the `SUPERSET_ORGANIZATION_ID` override in `resolve-auth`) and the `desktop-bundled` channel bits independently; those halves are dropped from this PR, which now supplies only the missing producer side.

## Root cause

Desktop terminals exposed the workspace ID but not its organization. Workspace commands therefore read the host manifest under the CLI's independently selected global organization and reported the local host as offline when Desktop and CLI selected different organizations. The CLI has honored `SUPERSET_ORGANIZATION_ID` since #6519, but nothing set it in Desktop terminals.

## Verification

- `bun test src/lib/resolve-auth.test.ts` in packages/cli (12 pass)
- `bun test src/terminal/env.test.ts` in packages/host-service (46 pass)
- `turbo typecheck` for @superset/cli + @superset/host-service
- biome check on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Desktop-managed terminals now provide organization context to the CLI automatically.
  - CLI organization routing can use `SUPERSET_ORGANIZATION_ID` when no organization is specified directly.
  - Documented how desktop and standalone CLI distributions discover and launch hosts.

- **Bug Fixes**
  - Environment-based organization routing no longer persists changes to saved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->