### PR TITLE
fix(desktop): use bun:test in deriveBranchName test

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/utils/deriveBranchName/deriveBranchName.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/utils/deriveBranchName/deriveBranchName.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { deriveBranchName } from "./deriveBranchName";
 
 describe("deriveBranchName", () => {


### PR DESCRIPTION
The vitest import in `deriveBranchName.test.ts` broke the Typecheck job on main after #6286 merged — vitest is not a desktop dependency (it resolved locally only via an ad-hoc `bunx vitest` install). Desktop tests run under `bun test`; this switches the import to `bun:test`.

Verified: `bun test` 5/5 passing, `tsc --noEmit` clean in apps/desktop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `vitest` with `bun:test` in the `deriveBranchName` test to match the desktop runner. Fixes CI typecheck failures and keeps `bun test` passing.

<sup>Written for commit 32bd0ee9d9bab639c058c4d2b18aa7b27ec03d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

