### PR TITLE
feat(host-service,desktop): sequence-numbered exactly-once terminal output with gap-only catch-up

### DIFF
--- a/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
+++ b/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
@@ -25,6 +25,7 @@ export const PERSISTED_KEY_REGISTRY: ReadonlyArray<
 		"src/renderer/lib/terminal/terminal-runtime.ts",
 		["terminal-buffer:*", "terminal-dims:*"],
 	],
+	["src/renderer/lib/terminal/terminal-seq-anchor.ts", ["terminal-seq:*"]],
 	[
 		"src/renderer/lib/terminal/terminal-buffer-gc.ts",
 		["terminal-buffer-persisted-at"],

--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
@@ -1,5 +1,7 @@
 export const TERMINAL_BUFFER_KEY_PREFIX = "terminal-buffer:";
 export const TERMINAL_DIMS_KEY_PREFIX = "terminal-dims:";
+/** Stream position paired with the buffer snapshot — see terminal-seq-anchor.ts. */
+export const TERMINAL_SEQ_KEY_PREFIX = "terminal-seq:";
 /** Single JSON map of terminalId -> epoch ms of the last persist/restore. */
 export const TERMINAL_PERSISTED_AT_KEY = "terminal-buffer-persisted-at";
 
@@ -60,13 +62,14 @@ export function removeTerminalStatePersistedAt(
 	writeIndex(storage, index);
 }
 
-/** Removes a terminal's buffer + dims keys, reporting how many existed. */
+/** Removes a terminal's buffer + dims + seq keys, reporting how many existed. */
 function removeTerminalState(storage: Storage, terminalId: string): number {
 	let removed = 0;
 	try {
 		for (const key of [
 			`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`,
 			`${TERMINAL_DIMS_KEY_PREFIX}${terminalId}`,
+			`${TERMINAL_SEQ_KEY_PREFIX}${terminalId}`,
 		]) {
 			if (storage.getItem(key) !== null) {
 				storage.removeItem(key);
@@ -86,6 +89,8 @@ function collectTerminalIds(storage: Storage): Set<string> {
 			ids.add(key.slice(TERMINAL_BUFFER_KEY_PREFIX.length));
 		} else if (key.startsWith(TERMINAL_DIMS_KEY_PREFIX)) {
 			ids.add(key.slice(TERMINAL_DIMS_KEY_PREFIX.length));
+		} else if (key.startsWith(TERMINAL_SEQ_KEY_PREFIX)) {
+			ids.add(key.slice(TERMINAL_SEQ_KEY_PREFIX.length));
 		}
 	}
 	return ids;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
@@ -280,6 +280,7 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 				serializeAddon: { serialize: () => "serialized scrollback" },
 				lastCols: 120,
 				lastRows: 32,
+				gate: { pending: 0 },
 			},
 			transport: {},
 			linkManager: null,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -23,11 +23,16 @@ import {
 	selectRuntimesToEvict,
 } from "./terminal-runtime-eviction";
 import {
+	loadPersistedSeqAnchor,
+	persistSeqAnchor,
+} from "./terminal-seq-anchor";
+import {
 	type ConnectionState,
 	clearLogs,
 	connect,
 	createTransport,
 	disposeTransport,
+	getPersistableSeqAnchor,
 	reconnect,
 	sendDispose,
 	sendInput,
@@ -188,6 +193,19 @@ class TerminalRuntimeRegistryImpl {
 			entry.runtime = createRuntime(terminalId, appearance, {
 				initialBuffer: this.serializeExistingRuntime(terminalId, instanceId),
 			});
+			// Pair the transport's stream position with what the fresh xterm
+			// actually contains: the persisted anchor belongs to the persisted
+			// snapshot only; sibling-seeded content has no known position.
+			if (!entry.transport._hasReceivedBytes) {
+				entry.transport._xtermHadContent =
+					entry.runtime.initialContent !== "none";
+				if (
+					entry.transport.seqAnchor === null &&
+					entry.runtime.initialContent === "restored"
+				) {
+					entry.transport.seqAnchor = loadPersistedSeqAnchor(terminalId);
+				}
+			}
 			this.observeBufferChanges(entry);
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
 			if (entry.pendingLinkHandlers) {
@@ -296,7 +314,11 @@ class TerminalRuntimeRegistryImpl {
 		if (!entry?.runtime) return;
 
 		entry.lastUsedAt = ++this.useSeq;
+		// Land any frame-pending output in xterm before the buffer snapshot,
+		// so the persisted snapshot matches the persisted stream position.
+		entry.transport._writeCoalescer?.flushSync();
 		detachFromContainer(entry.runtime);
+		persistSeqAnchor(terminalId, getPersistableSeqAnchor(entry.transport));
 		// detachFromContainer persists unconditionally; a dead session's snapshot
 		// must not outlive the PTY.
 		if (entry.transport.sessionEnded) {
@@ -356,6 +378,10 @@ class TerminalRuntimeRegistryImpl {
 				this.warnPersistFailureOnce(entry.terminalId);
 				continue;
 			}
+			persistSeqAnchor(
+				entry.terminalId,
+				getPersistableSeqAnchor(entry.transport),
+			);
 			this.clearPersistFailureWarning(entry.terminalId);
 			// tryPersistRuntimeState already wrote the snapshot. Preserve it while
 			// disposing instead of serializing and writing the same buffer twice.
@@ -426,10 +452,16 @@ class TerminalRuntimeRegistryImpl {
 				this.disposeEntry(entry, { persistedState: "clear" });
 				continue;
 			}
+			// Land frame-pending output first so snapshot and anchor agree.
+			entry.transport._writeCoalescer?.flushSync();
 			if (entry.runtime && !tryPersistRuntimeState(entry.runtime)) {
 				this.warnPersistFailureOnce(entry.terminalId);
 				continue;
 			}
+			persistSeqAnchor(
+				entry.terminalId,
+				getPersistableSeqAnchor(entry.transport),
+			);
 			this.clearPersistFailureWarning(entry.terminalId);
 			// Persistence succeeded before any runtime or transport cleanup began.
 			this.disposeEntry(entry, { persistedState: "preserve" });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -317,8 +317,18 @@ class TerminalRuntimeRegistryImpl {
 		// Land any frame-pending output in xterm before the buffer snapshot,
 		// so the persisted snapshot matches the persisted stream position.
 		entry.transport._writeCoalescer?.flushSync();
-		detachFromContainer(entry.runtime);
-		persistSeqAnchor(terminalId, getPersistableSeqAnchor(entry.transport));
+		const snapshotPersisted = detachFromContainer(entry.runtime);
+		// The anchor is only meaningful paired with the snapshot it was counted
+		// against: skip it when the snapshot write failed, and when the parser
+		// still holds unrendered bytes the anchor already counted (the snapshot
+		// would restore short and catch-up would never refill the gap). No
+		// anchor degrades to the safe reanchor path.
+		persistSeqAnchor(
+			terminalId,
+			snapshotPersisted && entry.runtime.gate.pending === 0
+				? getPersistableSeqAnchor(entry.transport)
+				: null,
+		);
 		// detachFromContainer persists unconditionally; a dead session's snapshot
 		// must not outlive the PTY.
 		if (entry.transport.sessionEnded) {
@@ -458,9 +468,13 @@ class TerminalRuntimeRegistryImpl {
 				this.warnPersistFailureOnce(entry.terminalId);
 				continue;
 			}
+			// Anchor only when the snapshot can actually contain every counted
+			// byte — a busy parser means the serialize ran short of the count.
 			persistSeqAnchor(
 				entry.terminalId,
-				getPersistableSeqAnchor(entry.transport),
+				(entry.runtime?.gate.pending ?? 0) === 0
+					? getPersistableSeqAnchor(entry.transport)
+					: null,
 			);
 			this.clearPersistFailureWarning(entry.terminalId);
 			// Persistence succeeded before any runtime or transport cleanup began.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -391,8 +391,10 @@ export function attachToContainer(
 	}
 }
 
-export function detachFromContainer(runtime: TerminalRuntime) {
-	persistBuffer(runtime.terminalId, runtime.serializeAddon);
+/** Returns whether the buffer snapshot was persisted, so callers can keep
+ * paired state (the seq anchor) coherent with it. */
+export function detachFromContainer(runtime: TerminalRuntime): boolean {
+	const persisted = persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime._disposeResizeObserver?.();
 	runtime._disposeResizeObserver = null;
@@ -403,6 +405,7 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	// see getTerminalParkingContainer.
 	getTerminalParkingContainer().appendChild(runtime.wrapper);
 	runtime.container = null;
+	return persisted;
 }
 
 export function updateRuntimeAppearance(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -27,6 +27,7 @@ import {
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
+import { persistSeqAnchor } from "./terminal-seq-anchor";
 import { installInputModeReclaimer } from "./terminalInputModeReclaimer";
 
 const SERIALIZE_SCROLLBACK = 1000;
@@ -54,6 +55,13 @@ export interface TerminalRuntime {
 	_setLigaturesEnabled: ((enabled: boolean) => void) | null;
 	ligaturesEnabled: boolean;
 	_disposeImagePasteFallback: (() => void) | null;
+	/**
+	 * How this runtime's xterm was seeded: from the persisted localStorage
+	 * snapshot (its seq anchor pairs with it), from a sibling instance's
+	 * serialize (content of unknown stream position), or empty. Drives the
+	 * transport's `?seq=` attach mode.
+	 */
+	initialContent: "restored" | "seeded" | "none";
 }
 
 function createTerminal(
@@ -109,15 +117,17 @@ function persistBuffer(
 	}
 }
 
-function restoreBuffer(terminalId: string, terminal: XTerm) {
+function restoreBuffer(terminalId: string, terminal: XTerm): boolean {
 	try {
 		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${terminalId}`);
 		if (data) {
 			terminal.write(data);
 			// Restored-but-never-detached terminals must stay fresh for boot GC.
 			touchTerminalStatePersistedAt(terminalId);
+			return true;
 		}
 	} catch {}
+	return false;
 }
 
 /**
@@ -183,6 +193,7 @@ function clearPersistedDimensions(terminalId: string) {
 export function clearPersistedRuntimeState(terminalId: string): void {
 	clearPersistedBuffer(terminalId);
 	clearPersistedDimensions(terminalId);
+	persistSeqAnchor(terminalId, null);
 	removeTerminalStatePersistedAt(terminalId);
 }
 
@@ -306,10 +317,12 @@ export function createRuntime(
 	const addonsResult = loadAddons(terminal, {
 		ligatures: appearance.ligatures,
 	});
+	let initialContent: TerminalRuntime["initialContent"] = "none";
 	if (options.initialBuffer !== undefined) {
 		terminal.write(options.initialBuffer);
-	} else {
-		restoreBuffer(terminalId, terminal);
+		if (options.initialBuffer.length > 0) initialContent = "seeded";
+	} else if (restoreBuffer(terminalId, terminal)) {
+		initialContent = "restored";
 	}
 
 	const disposeImagePasteFallback = installImagePasteFallback(
@@ -335,6 +348,7 @@ export function createRuntime(
 		_setLigaturesEnabled: addonsResult.setLigaturesEnabled,
 		ligaturesEnabled: appearance.ligatures,
 		_disposeImagePasteFallback: disposeImagePasteFallback,
+		initialContent,
 	};
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-seq-anchor.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-seq-anchor.ts
@@ -24,7 +24,15 @@ export function persistSeqAnchor(
 		} else {
 			localStorage.removeItem(key);
 		}
-	} catch {}
+	} catch {
+		// A failed write (quota) must not leave a STALE anchor paired with a
+		// newer snapshot — the next attach would skip bytes the pane never
+		// got. No anchor degrades safely to the reanchor path; removeItem
+		// works even under quota pressure.
+		try {
+			localStorage.removeItem(key);
+		} catch {}
+	}
 }
 
 export function loadPersistedSeqAnchor(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-seq-anchor.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-seq-anchor.ts
@@ -1,0 +1,54 @@
+import { TERMINAL_SEQ_KEY_PREFIX } from "./terminal-buffer-gc";
+
+/**
+ * Position in the host's PTY output stream, paired with the persisted buffer
+ * snapshot: "this snapshot contains every byte of `epoch` up to `seq`". On
+ * reattach the host sends exactly the missing suffix (see `?seq=` in
+ * host-service terminal.ts), so a rebuilt runtime converges without replay
+ * duplication or resets. Bounded by the buffer snapshot's own lifecycle —
+ * always written/cleared alongside it and swept by the same GC.
+ */
+export interface TerminalSeqAnchor {
+	epoch: string;
+	seq: number;
+}
+
+export function persistSeqAnchor(
+	terminalId: string,
+	anchor: TerminalSeqAnchor | null,
+): void {
+	const key = `${TERMINAL_SEQ_KEY_PREFIX}${terminalId}`;
+	try {
+		if (anchor) {
+			localStorage.setItem(key, JSON.stringify(anchor));
+		} else {
+			localStorage.removeItem(key);
+		}
+	} catch {}
+}
+
+export function loadPersistedSeqAnchor(
+	terminalId: string,
+): TerminalSeqAnchor | null {
+	try {
+		const raw = localStorage.getItem(`${TERMINAL_SEQ_KEY_PREFIX}${terminalId}`);
+		if (!raw) return null;
+		const parsed: unknown = JSON.parse(raw);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof (parsed as TerminalSeqAnchor).epoch === "string" &&
+			typeof (parsed as TerminalSeqAnchor).seq === "number" &&
+			Number.isSafeInteger((parsed as TerminalSeqAnchor).seq) &&
+			(parsed as TerminalSeqAnchor).seq >= 0
+		) {
+			return {
+				epoch: (parsed as TerminalSeqAnchor).epoch,
+				seq: (parsed as TerminalSeqAnchor).seq,
+			};
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -34,7 +34,17 @@ type TerminalServerMessage =
 	// destroyed (not found / disposed / exited), not a transient attach failure.
 	| { type: "error"; message: string; code?: string }
 	| { type: "exit"; exitCode: number; signal: number }
-	| { type: "title"; title: string | null };
+	| { type: "title"; title: string | null }
+	// Stream-position anchor from a seq-aware host. Arrives after any
+	// host-synthesized bytes (mode preamble/notice) and before catch-up/live
+	// PTY bytes; sets our counter and arms per-frame counting so the next
+	// dial can request exactly the bytes we missed. Old hosts never send it.
+	| {
+			type: "synced";
+			epoch: string;
+			seq: number;
+			mode: "exact" | "tail" | "reanchor";
+	  };
 
 export interface TerminalTransport {
 	connectionState: ConnectionState;
@@ -111,6 +121,32 @@ export interface TerminalTransport {
 	 * with no output still gets replay on the next connect.
 	 */
 	_hasReceivedBytes: boolean;
+	/**
+	 * Position in the host's output stream: every byte of `epoch` up to `seq`
+	 * has been written into this xterm. Seeded from the persisted anchor on
+	 * runtime rebuild, re-anchored by each `synced` message, advanced by every
+	 * counted binary frame. Sent as `?seq=` on each dial so the host can
+	 * deliver exactly the missed bytes.
+	 */
+	seqAnchor: { epoch: string; seq: number } | null;
+	/**
+	 * Armed by `synced`, disarmed on attach/close. While disarmed, binary
+	 * frames are host-synthesized (mode preamble/notice) or from a pre-seq
+	 * host and must not advance the anchor.
+	 */
+	_seqCounting: boolean;
+	/**
+	 * True once any connection on this transport delivered a `synced` — i.e.
+	 * the host speaks seq and every PTY byte since has been counted. Decides
+	 * whether the anchor survives persistence (see getPersistableSeqAnchor).
+	 */
+	_seqEverSynced: boolean;
+	/**
+	 * True when the xterm was born with content (restored snapshot or seeded
+	 * from a sibling instance). Without an anchor, such an xterm must never
+	 * request the ring tail (`seq=new`) — it would double-paint.
+	 */
+	_xtermHadContent: boolean;
 	/** Internal: wall-clock-gap watchdog for laptop sleep/wake detection. */
 	_livenessTimer: ReturnType<typeof setInterval> | null;
 	/** Internal: Date.now() at the last watchdog tick. */
@@ -286,6 +322,10 @@ export function createTransport(
 		_localToken: null,
 		_terminated: false,
 		_hasReceivedBytes: false,
+		seqAnchor: null,
+		_seqCounting: false,
+		_seqEverSynced: false,
+		_xtermHadContent: false,
 		_livenessTimer: null,
 		_lastLivenessTick: 0,
 		_resumeListener: null,
@@ -484,10 +524,22 @@ export function connect(
 		// buildUrl/getToken read transport state live, so a URL swap or token
 		// rotation is picked up on the next dial without recreating the socket.
 		buildUrl: () => {
-			const current = stripToken(transport.currentUrl ?? base);
-			return transport._hasReceivedBytes
-				? appendQueryParam(current, "replay", "0")
-				: current;
+			let current = stripToken(transport.currentUrl ?? base);
+			// Legacy replay suppression — read by pre-seq hosts only.
+			if (transport._hasReceivedBytes) {
+				current = appendQueryParam(current, "replay", "0");
+			}
+			// Stream position for seq-aware hosts: exact anchor when we have
+			// one; "new" (dump the tail) only for a genuinely virgin xterm;
+			// "none" (reanchor, send nothing) when the xterm has content of
+			// unknown position. Pre-seq hosts ignore the param.
+			const anchor = transport.seqAnchor;
+			const seqValue = anchor
+				? `${anchor.epoch}:${anchor.seq}`
+				: transport._xtermHadContent || transport._hasReceivedBytes
+					? "none"
+					: "new";
+			return appendQueryParam(current, "seq", seqValue);
 		},
 		getToken: () =>
 			isRelayHostUrl(transport.currentUrl)
@@ -544,9 +596,12 @@ function attachSocketListeners(
 			// Queue PTY bytes; the coalescer batches them into one xterm.write per
 			// animation frame. There's no output ACK back to host-service:
 			// back-pressure lives entirely on the host side, which bounds this
-			// socket's send buffer and drops us (we reconnect and replay) if we
-			// fall hopelessly behind. A slow renderer can never wedge the shell —
-			// it just loses some scrollback.
+			// socket's send buffer and drops us (we reconnect and catch up by
+			// seq) if we fall hopelessly behind. A slow renderer can never wedge
+			// the shell.
+			if (transport._seqCounting && transport.seqAnchor) {
+				transport.seqAnchor.seq += data.byteLength;
+			}
 			transport._writeCoalescer?.push(new Uint8Array(data));
 			transport._hasReceivedBytes = true;
 			return;
@@ -572,8 +627,19 @@ function attachSocketListeners(
 			// A successful attach means the session exists again (re-created or
 			// respawned under the same id) — its scrollback is worth keeping.
 			transport.sessionEnded = false;
+			// Counting stays disarmed until this attach's `synced` arrives —
+			// bytes before it are host-synthesized (preamble/notice) or from a
+			// pre-seq host, and neither advances the stream position.
+			transport._seqCounting = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
+			return;
+		}
+
+		if (message.type === "synced") {
+			transport.seqAnchor = { epoch: message.epoch, seq: message.seq };
+			transport._seqCounting = true;
+			transport._seqEverSynced = true;
 			return;
 		}
 
@@ -615,6 +681,9 @@ function attachSocketListeners(
 		// Render whatever arrived before the close instead of holding it for a
 		// frame that may never come (e.g. hidden window).
 		transport._writeCoalescer?.flushSync();
+		// The stream is broken; the anchor keeps its last-counted position and
+		// the next attach's `synced` re-arms counting.
+		transport._seqCounting = false;
 		setConnectionState(transport, "closed");
 		// Deliberate/terminal closes (PTY exit, fatal error, cleanup) don't
 		// reconnect — partysocket won't re-dial after close(). Synthetic
@@ -699,6 +768,23 @@ export function disconnect(transport: TerminalTransport) {
 	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
 	setConnectionState(transport, "disconnected");
+}
+
+/**
+ * The anchor worth persisting next to the buffer snapshot, or null when it
+ * can't be trusted: a pre-seq host advanced the xterm without ever sending
+ * `synced` (`_hasReceivedBytes` without `_seqEverSynced`), so a stale value
+ * would make a future exact catch-up re-deliver bytes already painted. A
+ * restored anchor with no bytes received since restore is still valid.
+ */
+export function getPersistableSeqAnchor(
+	transport: TerminalTransport,
+): { epoch: string; seq: number } | null {
+	if (!transport.seqAnchor) return null;
+	if (transport._seqEverSynced || !transport._hasReceivedBytes) {
+		return { ...transport.seqAnchor };
+	}
+	return null;
 }
 
 export function sendResize(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -141,6 +141,10 @@ export interface TerminalTransport {
 	 * whether the anchor survives persistence (see getPersistableSeqAnchor).
 	 */
 	_seqEverSynced: boolean;
+	/** Binary frames arrived on the current connection (reset on `attached`).
+	 * With `_seqCounting` still false at close time, it means a pre-seq host
+	 * fed the xterm uncounted bytes — the anchor is invalidated. */
+	_bytesSinceAttach: boolean;
 	/**
 	 * True when the xterm was born with content (restored snapshot or seeded
 	 * from a sibling instance). Without an anchor, such an xterm must never
@@ -325,6 +329,7 @@ export function createTransport(
 		seqAnchor: null,
 		_seqCounting: false,
 		_seqEverSynced: false,
+		_bytesSinceAttach: false,
 		_xtermHadContent: false,
 		_livenessTimer: null,
 		_lastLivenessTick: 0,
@@ -604,6 +609,7 @@ function attachSocketListeners(
 			}
 			transport._writeCoalescer?.push(new Uint8Array(data));
 			transport._hasReceivedBytes = true;
+			transport._bytesSinceAttach = true;
 			return;
 		}
 
@@ -631,6 +637,7 @@ function attachSocketListeners(
 			// bytes before it are host-synthesized (preamble/notice) or from a
 			// pre-seq host, and neither advances the stream position.
 			transport._seqCounting = false;
+			transport._bytesSinceAttach = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
 			return;
@@ -681,8 +688,15 @@ function attachSocketListeners(
 		// Render whatever arrived before the close instead of holding it for a
 		// frame that may never come (e.g. hidden window).
 		transport._writeCoalescer?.flushSync();
-		// The stream is broken; the anchor keeps its last-counted position and
-		// the next attach's `synced` re-arms counting.
+		// A connection that delivered bytes but never a `synced` was a pre-seq
+		// host (downgrade skew): those bytes advanced the xterm without
+		// advancing the anchor, so the anchor is poisoned — drop it rather
+		// than let a later exact catch-up re-deliver painted bytes.
+		if (transport._bytesSinceAttach && !transport._seqCounting) {
+			transport.seqAnchor = null;
+		}
+		// Otherwise the anchor keeps its last-counted position and the next
+		// attach's `synced` re-arms counting.
 		transport._seqCounting = false;
 		setConnectionState(transport, "closed");
 		// Deliberate/terminal closes (PTY exit, fatal error, cleanup) don't

--- a/packages/host-service/scripts/test-e2e.ts
+++ b/packages/host-service/scripts/test-e2e.ts
@@ -1,10 +1,14 @@
-// Runs the host-service end-to-end adoption test under Electron-as-Node.
+// Runs the host-service end-to-end terminal tests under Electron-as-Node.
 //
 // Why Electron and not raw `node`: host-service uses better-sqlite3, whose
 // native module is compiled against the Electron bundled Node ABI for
-// production. Running the test under Electron-as-Node ensures the same
+// production. Running the tests under Electron-as-Node ensures the same
 // native-module ABI as production. Raw `node` would fail with
 // NODE_MODULE_VERSION mismatch.
+//
+// Why the tsx loader and not --experimental-strip-types: the import chain
+// (terminal.ts → terminal-agents/persistence.ts) uses TypeScript parameter
+// properties, which strip-only mode rejects; tsx transforms them.
 //
 // Usage: bun run test:e2e
 
@@ -16,11 +20,11 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "../../..");
 
-// Resolve the Electron binary from the workspace's node_modules. Bun's flat
-// .bun/<pkg>@<version>/node_modules/<pkg> layout makes this a glob.
-function findElectronBinary(): string {
+// Resolve a binary from the workspace's node_modules. Bun's flat
+// .bun/<pkg>@<version>/node_modules/<pkg> layout makes these globs.
+function findInNodeModules(pattern: string, label: string): string {
 	const candidates = childProcess
-		.execSync("find . -path '*/electron/dist/*.app/Contents/MacOS/Electron'", {
+		.execSync(`find . -path '${pattern}'`, {
 			cwd: repoRoot,
 			encoding: "utf-8",
 		})
@@ -29,27 +33,43 @@ function findElectronBinary(): string {
 	const first = candidates[0];
 	if (!first) {
 		throw new Error(
-			"Electron binary not found. Run `bun install` from the repo root first.",
+			`${label} not found. Run \`bun install\` from the repo root first.`,
 		);
 	}
 	return path.join(repoRoot, first);
 }
 
-const electronBin = findElectronBinary();
-const testFile = path.resolve(
-	__dirname,
-	"..",
-	"src/terminal/terminal.adoption.node-test.ts",
+const electronBin = findInNodeModules(
+	"*/electron/dist/*.app/Contents/MacOS/Electron",
+	"Electron binary",
+);
+const tsxLoader = findInNodeModules(
+	"*/node_modules/tsx/dist/loader.mjs",
+	"tsx loader",
 );
 
-if (!fs.existsSync(testFile)) {
-	console.error(`Test file missing: ${testFile}`);
-	process.exit(1);
+const testFiles = [
+	"src/terminal/terminal.adoption.node-test.ts",
+	"src/terminal/terminal.seq-catchup.node-test.ts",
+].map((file) => path.resolve(__dirname, "..", file));
+
+for (const testFile of testFiles) {
+	if (!fs.existsSync(testFile)) {
+		console.error(`Test file missing: ${testFile}`);
+		process.exit(1);
+	}
 }
 
 const result = childProcess.spawnSync(
 	electronBin,
-	["--experimental-strip-types", "--test", "--test-reporter=spec", testFile],
+	[
+		"--import",
+		tsxLoader,
+		"--test",
+		"--test-force-exit",
+		"--test-reporter=spec",
+		...testFiles,
+	],
 	{
 		stdio: "inherit",
 		env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },

--- a/packages/host-service/src/terminal-agents/daemon-loss-sweep.ts
+++ b/packages/host-service/src/terminal-agents/daemon-loss-sweep.ts
@@ -2,7 +2,7 @@ import type { HostDb } from "../db";
 import {
 	getTerminalAgentBindingSessionId,
 	markTerminalAgentBindingEnded,
-} from "./persistence";
+} from "./persistence.ts";
 
 const DAEMON_LOSS_SWEEP_ATTEMPTS = 5;
 const DAEMON_LOSS_SWEEP_DELAY_MS = 2_000;

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -1,7 +1,7 @@
 import type { AgentDefinitionId } from "@superset/shared/agent-catalog";
 import { and, desc, eq, inArray, isNotNull, isNull, ne, or } from "drizzle-orm";
 import type { HostDb } from "../db";
-import { terminalAgentBindings, terminalSessions } from "../db/schema";
+import { terminalAgentBindings, terminalSessions } from "../db/schema.ts";
 import type {
 	TerminalAgentBindingListFilter,
 	TerminalAgentBindingPersistence,

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -22,9 +22,9 @@
 // records the authoritative byte stream so catch-up payloads can be compared
 // byte-for-byte, not just by final grid state.
 //
-// Run:
-//   cd packages/host-service && node --experimental-strip-types --test \
-//     src/terminal/terminal.seq-catchup.node-test.ts
+// Run: `bun run test:e2e` from packages/host-service (Electron-as-Node with
+// the tsx loader — see scripts/test-e2e.ts for why neither plain node nor
+// strip-types works here).
 
 import { strict as assert } from "node:assert";
 import { randomUUID } from "node:crypto";

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -513,8 +513,8 @@ test(
 			// ── Phase 1: two virgin clients attach (tail), streaming keeps them in step
 			await witness.connect(terminalId);
 			await renderer.connect(terminalId);
-			assert.equal(witness.lastSynced?.mode, "tail");
-			assert.equal(renderer.lastSynced?.mode, "tail");
+			assert.equal((await witness.waitSynced()).mode, "tail");
+			assert.equal((await renderer.waitSynced()).mode, "tail");
 			await waitForTrackerText(terminalId, "TUI READY");
 			sendCommand(terminalId, "frames 20");
 			sendCommand(terminalId, "setH 6");
@@ -559,7 +559,7 @@ test(
 			await sleep(300);
 			await renderer.connect(terminalId);
 			assert.equal(
-				renderer.lastSynced?.mode,
+				(await renderer.waitSynced()).mode,
 				"exact",
 				"phase 2: a gapless anchored reattach must be an exact sync",
 			);
@@ -587,9 +587,10 @@ test(
 			await witness.waitVisible("INPUT 000085");
 			const w3t1 = await truthQuiesced();
 			await renderer.connect(terminalId);
-			assert.equal(renderer.lastSynced?.mode, "exact");
+			const synced3 = await renderer.waitSynced();
+			assert.equal(synced3.mode, "exact");
 			assert.equal(
-				renderer.lastSynced?.seq,
+				synced3.seq,
 				gapStart,
 				"phase 3: exact sync must anchor at the client's position",
 			);
@@ -637,7 +638,7 @@ test(
 			const w4t1 = await truthQuiesced();
 			await renderer.connect(terminalId);
 			assert.equal(
-				renderer.lastSynced?.mode,
+				(await renderer.waitSynced()).mode,
 				"exact",
 				"phase 4: a ~105KB gap fits the 2MiB ring and must catch up exactly",
 			);

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -1,0 +1,886 @@
+// Regression tests for sequence-numbered exactly-once terminal output
+// delivery (the re-fix for #6269 after the #6279 grid-resync revert, #6290).
+//
+// Protocol under test: every session tags its output stream with a per-object
+// `epoch` and byte offset. A seq-aware client presents `?seq=<epoch>:<n>` on
+// attach and receives exactly the bytes it missed from the catch-up ring
+// (`synced` mode "exact"), the ring tail when it attaches empty ("tail"), or
+// nothing at all plus a repaint nudge when its position is unknowable
+// ("reanchor": epoch mismatch after a host restart, gap beyond the ring).
+//
+// The two invariants that killed #6279 are asserted directly:
+//   1. The host must NEVER reset or overwrite a client's existing screen —
+//      no `\x1bc` (RIS) may ever appear on the wire, and a reanchor attach
+//      must deliver zero content bytes.
+//   2. A reattach spanning a host-service restart (tracker knows LESS than
+//      the renderer) must leave the renderer's grid intact and converge via
+//      a PTY SIGWINCH repaint, not host-synthesized content.
+//
+// Harness: real in-process pty-daemon, real /bin/sh PTY running a scripted
+// incremental-repaint TUI (Ink-style), the real host-service WS route, and
+// @xterm/headless renderer stand-ins. A continuously-attached "witness"
+// records the authoritative byte stream so catch-up payloads can be compared
+// byte-for-byte, not just by final grid state.
+//
+// Run:
+//   cd packages/host-service && node --experimental-strip-types --test \
+//     src/terminal/terminal.seq-catchup.node-test.ts
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import { createNodeWebSocket } from "@hono/node-ws";
+import { Server } from "@superset/pty-daemon";
+import { Hono } from "hono";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import type { EventBus } from "../events/index.ts";
+import {
+	disposeDaemonClient,
+	getDaemonClient,
+} from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+	registerWorkspaceTerminalRoute,
+	snapshotSession,
+	writeInputToSession,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const require = (await import("node:module")).createRequire(import.meta.url);
+const { Terminal: HeadlessTerminal } =
+	require("@xterm/headless") as typeof import("@xterm/headless");
+type Headless = InstanceType<typeof HeadlessTerminal>;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-seqcatchup-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-seqcatchup-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+
+const COLS = 80;
+const ROWS = 24;
+const RIS = "\x1bc";
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+let httpPort: number;
+let httpServer: ReturnType<typeof serve>;
+
+// Ink-style incremental-repaint TUI (same shape as the #6279 repro): a
+// bottom "input box" redrawn cursor-relative; `ticks` are region-only
+// spinner repaints; SIGWINCH triggers a full clear+repaint; `blob` floods
+// N KiB fast to blow past the catch-up ring.
+const TUI_SCRIPT = String.raw`
+stty -echo
+frame=0
+H=3
+FILLER='................................................'
+draw_box() {
+  bh=$1
+  printf '+==================================+\n'
+  i=1
+  while [ "$i" -le "$((bh - 2))" ]; do
+    printf '| INPUT %06d line %d              |\n' "$frame" "$i"
+    i=$((i + 1))
+  done
+  printf '+==================================+'
+}
+on_winch() {
+  printf '\033[2J\033[H'
+  printf 'FULL-REDRAW at frame %06d\n' "$frame"
+  draw_box "$H"
+}
+trap on_winch WINCH
+frames() {
+  n=$1
+  k=0
+  while [ "$k" -lt "$n" ]; do
+    frame=$((frame + 1))
+    if [ "$(((frame / 7) % 2))" -eq 0 ]; then newH=3; else newH=6; fi
+    printf '\r\033[%dA\033[0J' "$((H - 1))"
+    printf 'transcript %06d %s\n' "$frame" "$FILLER"
+    draw_box "$newH"
+    H=$newH
+    k=$((k + 1))
+  done
+}
+ticks() {
+  n=$1
+  k=0
+  while [ "$k" -lt "$n" ]; do
+    frame=$((frame + 1))
+    printf '\r\033[%dA\033[0J' "$((H - 1))"
+    draw_box "$H"
+    k=$((k + 1))
+  done
+}
+setH() {
+  printf '\r\033[%dA\033[0J' "$((H - 1))"
+  H=$1
+  draw_box "$H"
+}
+blob() {
+  kb=$1
+  dd if=/dev/zero bs=1024 count="$kb" 2>/dev/null | tr '\0' 'x'
+  printf '\nBLOB-DONE %06d\n' "$frame"
+  draw_box "$H"
+}
+printf '\033[2J\033[H'
+printf 'TUI READY\n'
+draw_box "$H"
+while :; do
+  IFS= read -r cmd || { sleep 0.02; continue; }
+  set -- $cmd
+  case $1 in
+    frames) frames "$2" ;;
+    ticks) ticks "$2" ;;
+    setH) setH "$2" ;;
+    blob) blob "$2" ;;
+    quit) exit 0 ;;
+  esac
+done
+`;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+	fn: () => boolean | Promise<boolean>,
+	timeoutMs: number,
+	label: string,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (await fn()) return;
+		await sleep(50);
+	}
+	throw new Error(`Timed out waiting for: ${label}`);
+}
+
+function visibleText(term: Headless): string {
+	const buf = term.buffer.active;
+	const start = Math.max(0, buf.length - term.rows);
+	const lines: string[] = [];
+	for (let y = start; y < buf.length; y++) {
+		lines.push(buf.getLine(y)?.translateToString(true) ?? "");
+	}
+	while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+	return lines.join("\n");
+}
+
+async function trackerVisible(terminalId: string): Promise<string> {
+	const snap = await snapshotSession({
+		terminalId,
+		workspaceId,
+		maxLines: ROWS,
+		db,
+	});
+	if ("error" in snap) throw new Error(`snapshot failed: ${snap.error}`);
+	return snap.text;
+}
+
+interface SyncedMessage {
+	type: "synced";
+	epoch: string;
+	seq: number;
+	mode: "exact" | "tail" | "reanchor";
+}
+
+/**
+ * Renderer stand-in speaking the seq protocol like terminal-ws-transport.ts:
+ * `?seq=` on dial, counting armed by `synced`, every counted binary frame
+ * recorded at its absolute stream position for byte-level comparison.
+ */
+class SeqRenderer {
+	term: Headless;
+	anchor: { epoch: string; seq: number } | null = null;
+	lastSynced: SyncedMessage | null = null;
+	/** Counted (post-synced) chunks at absolute positions, across all attaches. */
+	recorded: Array<{ start: number; bytes: Uint8Array }> = [];
+	countedThisAttach = 0;
+	/** Every binary frame ever received (counted or not), for RIS scanning. */
+	allBinary: Uint8Array[] = [];
+	private counting = false;
+	private ws: WebSocket | null = null;
+	private writeChain: Promise<void> = Promise.resolve();
+
+	constructor() {
+		this.term = new HeadlessTerminal({
+			cols: COLS,
+			rows: ROWS,
+			scrollback: 1000,
+			allowProposedApi: true,
+		});
+	}
+
+	/**
+	 * `seqOverride` forces the dial-time `?seq=` value (e.g. "new"/"none").
+	 * `autoResize: false` suppresses the on-attach resize so the pre-nudge
+	 * attach state is observable (the host's forced repaint nudge waits for
+	 * the client resize, or a 2s fallback).
+	 */
+	connect(
+		terminalId: string,
+		options: { seqOverride?: string; autoResize?: boolean } = {},
+	): Promise<void> {
+		const seqValue =
+			options.seqOverride ??
+			(this.anchor ? `${this.anchor.epoch}:${this.anchor.seq}` : "new");
+		return new Promise((resolve, reject) => {
+			const ws = new WebSocket(
+				`ws://127.0.0.1:${httpPort}/terminal/${terminalId}?seq=${encodeURIComponent(seqValue)}`,
+			);
+			ws.binaryType = "arraybuffer";
+			this.ws = ws;
+			this.counting = false;
+			this.countedThisAttach = 0;
+			this.lastSynced = null;
+			const timer = setTimeout(
+				() => reject(new Error("attach timeout")),
+				10_000,
+			);
+			ws.addEventListener("message", (event) => {
+				const data = (event as MessageEvent).data;
+				if (data instanceof ArrayBuffer) {
+					const bytes = new Uint8Array(data);
+					this.allBinary.push(bytes);
+					if (this.counting && this.anchor) {
+						this.recorded.push({ start: this.anchor.seq, bytes });
+						this.anchor.seq += bytes.byteLength;
+						this.countedThisAttach += bytes.byteLength;
+					}
+					this.writeChain = this.writeChain.then(
+						() => new Promise<void>((r) => this.term.write(bytes, r)),
+					);
+					return;
+				}
+				const message = JSON.parse(String(data)) as
+					| SyncedMessage
+					| { type: string };
+				if (message.type === "attached") {
+					if (options.autoResize !== false) {
+						this.sendResize(this.term.cols, this.term.rows);
+					}
+					clearTimeout(timer);
+					resolve();
+					return;
+				}
+				if (message.type === "synced") {
+					const synced = message as SyncedMessage;
+					this.lastSynced = synced;
+					this.anchor = { epoch: synced.epoch, seq: synced.seq };
+					this.counting = true;
+				}
+			});
+			ws.addEventListener("error", () => {
+				clearTimeout(timer);
+				reject(new Error("ws error during connect"));
+			});
+		});
+	}
+
+	sendResize(cols: number, rows: number): void {
+		this.ws?.send(JSON.stringify({ type: "resize", cols, rows }));
+	}
+
+	disconnect(): Promise<void> {
+		return new Promise((resolve) => {
+			const ws = this.ws;
+			this.ws = null;
+			this.counting = false;
+			if (!ws || ws.readyState === WebSocket.CLOSED) return resolve();
+			ws.addEventListener("close", () => resolve());
+			ws.close();
+		});
+	}
+
+	async drain(): Promise<void> {
+		await this.writeChain;
+	}
+
+	/** Counted stream bytes covering [from, to), concatenated. */
+	streamBytes(from: number, to: number): Buffer {
+		const parts: Buffer[] = [];
+		for (const { start, bytes } of this.recorded) {
+			const end = start + bytes.byteLength;
+			if (end <= from || start >= to) continue;
+			const sliceFrom = Math.max(from, start) - start;
+			const sliceTo = Math.min(to, end) - start;
+			parts.push(Buffer.from(bytes.subarray(sliceFrom, sliceTo)));
+		}
+		return Buffer.concat(parts);
+	}
+
+	assertNoReset(label: string): void {
+		for (const bytes of this.allBinary) {
+			assert.ok(
+				!Buffer.from(bytes).includes(RIS),
+				`${label}: a full-reset (\\x1bc) must never be sent to a client`,
+			);
+		}
+	}
+
+	async waitSynced(timeoutMs = 5_000): Promise<SyncedMessage> {
+		await waitFor(
+			() => this.lastSynced !== null,
+			timeoutMs,
+			"synced message to arrive",
+		);
+		return this.lastSynced as SyncedMessage;
+	}
+
+	async waitVisible(marker: string, timeoutMs = 15_000): Promise<void> {
+		await waitFor(
+			async () => {
+				await this.drain();
+				return visibleText(this.term).includes(marker);
+			},
+			timeoutMs,
+			`renderer to show "${marker}"`,
+		);
+	}
+
+	dispose(): void {
+		this.term.dispose();
+	}
+}
+
+function sendCommand(terminalId: string, command: string): void {
+	const result = writeInputToSession({
+		terminalId,
+		workspaceId,
+		data: `${command}\n`,
+	});
+	assert.ok(!("error" in result), JSON.stringify(result));
+}
+
+async function waitForTrackerText(
+	terminalId: string,
+	marker: string,
+	timeoutMs = 30_000,
+): Promise<void> {
+	await waitFor(
+		async () => (await trackerVisible(terminalId)).includes(marker),
+		timeoutMs,
+		`tracker to show "${marker}"`,
+	);
+}
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+	fs.writeFileSync(path.join(TEST_HOME, "tui.sh"), TUI_SCRIPT);
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-seqcatchup-e2e",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-seqcatchup-e2e";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting("/bin/sh");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: process.env.HOME ?? TEST_HOME,
+		SHELL: "/bin/sh",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({ id: workspaceId, projectId, worktreePath, branch: "main" })
+		.run();
+
+	const app = new Hono();
+	const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+	registerWorkspaceTerminalRoute({
+		app,
+		db,
+		eventBus: undefined as unknown as EventBus,
+		upgradeWebSocket,
+	});
+	httpPort = await new Promise<number>((resolve) => {
+		httpServer = serve(
+			{ fetch: app.fetch, port: 0, hostname: "127.0.0.1" },
+			(info) => resolve(info.port),
+		);
+	});
+	injectWebSocket(httpServer);
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+test(
+	"seq catch-up: gapless, in-ring, beyond-ring, and restart-spanning reattaches",
+	{ timeout: 240_000 },
+	async () => {
+		const terminalId = `seq-e2e-${randomUUID().slice(0, 8)}`;
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: COLS,
+			rows: ROWS,
+			initialCommand: `exec bash '${path.join(TEST_HOME, "tui.sh")}'`,
+		});
+		if ("error" in session) assert.fail(session.error);
+
+		// Ground truth: a direct daemon subscription, bypassing host-service
+		// entirely. Comparisons are window-based (quiescent point to quiescent
+		// point), so no absolute alignment with the recorder is needed —
+		// client-vs-client comparison alone is blind to a systematic
+		// off-by-one that shifts every client identically.
+		const daemon = await getDaemonClient();
+		const truthChunks: Uint8Array[] = [];
+		let truthLen = 0;
+		const unsubTruth = daemon.subscribe(
+			terminalId,
+			{ replay: false },
+			{
+				onOutput(chunk) {
+					truthChunks.push(Uint8Array.from(chunk));
+					truthLen += chunk.byteLength;
+				},
+				onExit() {},
+			},
+		);
+		const truthBytes = (from: number, to: number): Buffer => {
+			const parts: Buffer[] = [];
+			let pos = 0;
+			for (const chunk of truthChunks) {
+				const end = pos + chunk.byteLength;
+				if (end > from && pos < to) {
+					parts.push(
+						Buffer.from(
+							chunk.subarray(
+								Math.max(from, pos) - pos,
+								Math.min(to, end) - pos,
+							),
+						),
+					);
+				}
+				pos = end;
+			}
+			return Buffer.concat(parts);
+		};
+		const truthQuiesced = async (): Promise<number> => {
+			let seen = -1;
+			await waitFor(
+				() => {
+					if (truthLen === seen) return true;
+					seen = truthLen;
+					return false;
+				},
+				15_000,
+				"daemon truth stream to quiesce",
+			);
+			return truthLen;
+		};
+
+		const witness = new SeqRenderer();
+		const renderer = new SeqRenderer();
+		try {
+			// ── Phase 1: two virgin clients attach (tail), streaming keeps them in step
+			await witness.connect(terminalId);
+			await renderer.connect(terminalId);
+			assert.equal(witness.lastSynced?.mode, "tail");
+			assert.equal(renderer.lastSynced?.mode, "tail");
+			await waitForTrackerText(terminalId, "TUI READY");
+			sendCommand(terminalId, "frames 20");
+			sendCommand(terminalId, "setH 6");
+			await renderer.waitVisible("INPUT 000020");
+			await witness.waitVisible("INPUT 000020");
+			await sleep(200);
+			await Promise.all([renderer.drain(), witness.drain()]);
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"phase 1: attached streaming must keep the grid in step with the tracker",
+			);
+			assert.equal(
+				renderer.anchor?.seq,
+				witness.anchor?.seq,
+				"phase 1: both clients must agree on the stream position",
+			);
+			// Window check: a quiescent stretch of live output must land in the
+			// client byte-for-byte and count-for-count against the daemon truth.
+			const w1t0 = await truthQuiesced();
+			const w1a0 = witness.anchor?.seq ?? 0;
+			sendCommand(terminalId, "ticks 5");
+			await witness.waitVisible("INPUT 000025");
+			const w1t1 = await truthQuiesced();
+			await witness.drain();
+			const w1a1 = witness.anchor?.seq ?? 0;
+			assert.equal(
+				w1a1 - w1a0,
+				w1t1 - w1t0,
+				"phase 1: the client must count exactly the daemon's true bytes",
+			);
+			assert.equal(
+				Buffer.compare(witness.streamBytes(w1a0, w1a1), truthBytes(w1t0, w1t1)),
+				0,
+				"phase 1: live window must be byte-identical to the daemon truth",
+			);
+			console.log("PHASE 1 attached streaming ✓");
+
+			// ── Phase 2: gapless reattach delivers ZERO content bytes ────────────
+			const gridBeforeGapless = visibleText(renderer.term);
+			await renderer.disconnect();
+			await sleep(300);
+			await renderer.connect(terminalId);
+			assert.equal(
+				renderer.lastSynced?.mode,
+				"exact",
+				"phase 2: a gapless anchored reattach must be an exact sync",
+			);
+			await sleep(300);
+			await renderer.drain();
+			assert.equal(
+				renderer.countedThisAttach,
+				0,
+				"phase 2: no output was missed, so no bytes may be re-delivered",
+			);
+			assert.equal(
+				visibleText(renderer.term),
+				gridBeforeGapless,
+				"phase 2: the grid must be untouched by a gapless reattach",
+			);
+			console.log("PHASE 2 gapless reattach: zero bytes ✓");
+
+			// ── Phase 3: gap within the ring → exactly the missed bytes ──────────
+			await renderer.disconnect();
+			await sleep(300);
+			const gapStart = renderer.anchor?.seq ?? 0;
+			const w3t0 = await truthQuiesced();
+			sendCommand(terminalId, "ticks 60");
+			await waitForTrackerText(terminalId, "INPUT 000085");
+			await witness.waitVisible("INPUT 000085");
+			const w3t1 = await truthQuiesced();
+			await renderer.connect(terminalId);
+			assert.equal(renderer.lastSynced?.mode, "exact");
+			assert.equal(
+				renderer.lastSynced?.seq,
+				gapStart,
+				"phase 3: exact sync must anchor at the client's position",
+			);
+			await renderer.waitVisible("INPUT 000085");
+			await sleep(200);
+			await Promise.all([renderer.drain(), witness.drain()]);
+			const gapEnd = witness.anchor?.seq ?? 0;
+			assert.ok(gapEnd > gapStart, "phase 3: the gap must be non-empty");
+			assert.equal(
+				Buffer.compare(
+					renderer.streamBytes(gapStart, gapEnd),
+					witness.streamBytes(gapStart, gapEnd),
+				),
+				0,
+				"phase 3: catch-up must deliver byte-for-byte what the witness saw live",
+			);
+			const catchup3 = renderer.streamBytes(gapStart, gapStart + (w3t1 - w3t0));
+			assert.equal(
+				catchup3.length,
+				w3t1 - w3t0,
+				"phase 3: the catch-up must cover exactly the daemon's true gap length",
+			);
+			assert.equal(
+				Buffer.compare(catchup3, truthBytes(w3t0, w3t1)),
+				0,
+				"phase 3: catch-up must match the daemon's true stream",
+			);
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"phase 3: grids must converge after catch-up",
+			);
+			console.log("PHASE 3 in-ring gap: exact byte catch-up ✓");
+
+			// ── Phase 4: the #6269 repro shape (~105 KB gap), healed by catch-up ─
+			await renderer.disconnect();
+			await sleep(300);
+			const bigGapStart = renderer.anchor?.seq ?? 0;
+			const w4t0 = await truthQuiesced();
+			sendCommand(terminalId, "frames 200");
+			sendCommand(terminalId, "setH 3");
+			sendCommand(terminalId, "ticks 1500");
+			await waitForTrackerText(terminalId, "INPUT 001785", 60_000);
+			await witness.waitVisible("INPUT 001785", 60_000);
+			const w4t1 = await truthQuiesced();
+			await renderer.connect(terminalId);
+			assert.equal(
+				renderer.lastSynced?.mode,
+				"exact",
+				"phase 4: a ~105KB gap fits the 2MiB ring and must catch up exactly",
+			);
+			await renderer.waitVisible("INPUT 001785");
+			await sleep(200);
+			await Promise.all([renderer.drain(), witness.drain()]);
+			const bigGapEnd = witness.anchor?.seq ?? 0;
+			assert.equal(
+				Buffer.compare(
+					renderer.streamBytes(bigGapStart, bigGapEnd),
+					witness.streamBytes(bigGapStart, bigGapEnd),
+				),
+				0,
+				"phase 4: the large catch-up must be byte-identical to the live stream",
+			);
+			const catchup4 = renderer.streamBytes(
+				bigGapStart,
+				bigGapStart + (w4t1 - w4t0),
+			);
+			assert.equal(
+				catchup4.length,
+				w4t1 - w4t0,
+				"phase 4: the catch-up must cover exactly the daemon's true gap length",
+			);
+			assert.equal(
+				Buffer.compare(catchup4, truthBytes(w4t0, w4t1)),
+				0,
+				"phase 4: the large catch-up must match the daemon's true stream",
+			);
+			const grid4 = visibleText(renderer.term);
+			assert.equal(
+				grid4,
+				await trackerVisible(terminalId),
+				"phase 4: grids must converge after the large catch-up",
+			);
+			assert.ok(
+				!grid4.includes("INPUT 000085"),
+				"phase 4: no ghost of the pre-gap input box may survive",
+			);
+			console.log("PHASE 4 #6269 repro gap: healed by exact catch-up ✓");
+
+			// The witness has served its purpose; the blob would take it seconds
+			// to parse and its own gap handling isn't under test here.
+			await witness.disconnect();
+
+			// ── Phase 5: gap beyond the ring → reanchor, screen preserved, nudge heals
+			await renderer.disconnect();
+			await sleep(300);
+			const gridBeforeBlob = visibleText(renderer.term);
+			sendCommand(terminalId, "blob 3072"); // 3 MiB > 2 MiB ring
+			await waitForTrackerText(terminalId, "BLOB-DONE", 60_000);
+			// Suppress the on-attach resize so the host's forced nudge (which
+			// waits for it) can't repaint before the attach state is asserted.
+			await renderer.connect(terminalId, { autoResize: false });
+			const synced5 = await renderer.waitSynced();
+			assert.equal(
+				synced5.mode,
+				"reanchor",
+				"phase 5: a gap beyond the ring must reanchor, not guess",
+			);
+			await sleep(400);
+			await renderer.drain();
+			assert.ok(
+				!renderer
+					.streamBytes(synced5.seq, renderer.anchor?.seq ?? synced5.seq)
+					.includes("x".repeat(64)),
+				"phase 5: reanchor must not deliver the missed blob content",
+			);
+			assert.equal(
+				visibleText(renderer.term),
+				gridBeforeBlob,
+				"phase 5: the client's stale-but-real screen must be preserved (the #6290 regression)",
+			);
+			// The client resize matches the PTY dims, so the host must force the
+			// repaint nudge; the TUI's WINCH handler then repaints everything.
+			renderer.sendResize(COLS, ROWS);
+			await renderer.waitVisible("FULL-REDRAW", 15_000);
+			await sleep(300);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"phase 5: the nudge-triggered repaint must converge the visible grid",
+			);
+			console.log("PHASE 5 beyond-ring gap: reanchor + nudge ✓");
+
+			// ── Phase 6: host-service restart (epoch loss) — the #6290 case ──────
+			const preRestartEpoch = renderer.anchor?.epoch;
+			await renderer.disconnect();
+			__resetSessionsForTesting();
+			const gridBeforeRestart = visibleText(renderer.term);
+			// Adoption path: the daemon still owns the PTY, the fresh session's
+			// tracker knows almost nothing — exactly the state that made #6279
+			// blank panes. The old-epoch anchor must reanchor.
+			await renderer.connect(terminalId, { autoResize: false });
+			const synced6 = await renderer.waitSynced();
+			assert.equal(
+				synced6.mode,
+				"reanchor",
+				"phase 6: an old-epoch anchor after a host restart must reanchor",
+			);
+			assert.notEqual(
+				synced6.epoch,
+				preRestartEpoch,
+				"phase 6: the adopted session must mint a fresh epoch",
+			);
+			await sleep(400);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				gridBeforeRestart,
+				"phase 6: a restart-spanning reattach must NEVER blank or overwrite the grid (the #6290 regression)",
+			);
+			renderer.sendResize(COLS, ROWS);
+			await renderer.waitVisible("FULL-REDRAW", 15_000);
+			await sleep(300);
+			await renderer.drain();
+			assert.equal(
+				visibleText(renderer.term),
+				await trackerVisible(terminalId),
+				"phase 6: post-restart nudge repaint must converge the visible grid",
+			);
+			console.log("PHASE 6 restart-spanning reattach: preserved + healed ✓");
+
+			renderer.assertNoReset("whole run");
+			witness.assertNoReset("whole run");
+		} finally {
+			try {
+				unsubTruth();
+			} catch {}
+			await renderer.disconnect().catch(() => {});
+			await witness.disconnect().catch(() => {});
+			renderer.dispose();
+			witness.dispose();
+			await disposeSessionAndWait(terminalId, db).catch(() => {});
+		}
+	},
+);
+
+test(
+	"legacy clients (no ?seq=) keep the pre-seq contract",
+	{ timeout: 60_000 },
+	async () => {
+		const terminalId = `seq-legacy-${randomUUID().slice(0, 8)}`;
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: COLS,
+			rows: ROWS,
+			initialCommand: `exec bash '${path.join(TEST_HOME, "tui.sh")}'`,
+		});
+		if ("error" in session) assert.fail(session.error);
+
+		const term = new HeadlessTerminal({
+			cols: COLS,
+			rows: ROWS,
+			scrollback: 1000,
+			allowProposedApi: true,
+		});
+		let sawSynced = false;
+		let writeChain: Promise<void> = Promise.resolve();
+		let ws: WebSocket | null = null;
+
+		const connectLegacy = () =>
+			new Promise<void>((resolve, reject) => {
+				const socket = new WebSocket(
+					`ws://127.0.0.1:${httpPort}/terminal/${terminalId}`,
+				);
+				socket.binaryType = "arraybuffer";
+				ws = socket;
+				const timer = setTimeout(
+					() => reject(new Error("attach timeout")),
+					10_000,
+				);
+				socket.addEventListener("message", (event) => {
+					const data = (event as MessageEvent).data;
+					if (data instanceof ArrayBuffer) {
+						const bytes = new Uint8Array(data);
+						writeChain = writeChain.then(
+							() => new Promise<void>((r) => term.write(bytes, r)),
+						);
+						return;
+					}
+					const message = JSON.parse(String(data)) as { type: string };
+					if (message.type === "synced") sawSynced = true;
+					if (message.type === "attached") {
+						clearTimeout(timer);
+						resolve();
+					}
+				});
+				socket.addEventListener("error", () => {
+					clearTimeout(timer);
+					reject(new Error("ws error during connect"));
+				});
+			});
+		const disconnectLegacy = () =>
+			new Promise<void>((resolve) => {
+				const socket = ws as WebSocket | null;
+				ws = null;
+				if (!socket || socket.readyState === WebSocket.CLOSED) {
+					return resolve();
+				}
+				socket.addEventListener("close", () => resolve());
+				socket.close();
+			});
+
+		try {
+			await connectLegacy();
+			await waitForTrackerText(terminalId, "TUI READY");
+			await waitFor(
+				async () => {
+					await writeChain;
+					return visibleText(term).includes("TUI READY");
+				},
+				15_000,
+				"legacy client to render the TUI",
+			);
+
+			// Zero-socket output lands in the legacy FIFO and replays on reattach.
+			await disconnectLegacy();
+			await sleep(300);
+			sendCommand(terminalId, "ticks 10");
+			await waitForTrackerText(terminalId, "INPUT 000010");
+			await connectLegacy();
+			await waitFor(
+				async () => {
+					await writeChain;
+					return visibleText(term).includes("INPUT 000010");
+				},
+				15_000,
+				"legacy FIFO replay to arrive",
+			);
+			assert.equal(
+				sawSynced,
+				false,
+				"legacy clients must never receive seq-protocol messages",
+			);
+		} finally {
+			await disconnectLegacy().catch(() => {});
+			term.dispose();
+			await disposeSessionAndWait(terminalId, db).catch(() => {});
+		}
+	},
+);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -206,7 +206,9 @@ type SeqAttachRequest =
 function parseSeqAttachParam(
 	value: string | null | undefined,
 ): SeqAttachRequest {
-	if (!value) return { kind: "legacy" };
+	// Absent means a pre-seq client; an explicitly empty value is a malformed
+	// seq-aware dial and falls through to the safe reanchor below.
+	if (value === null || value === undefined) return { kind: "legacy" };
 	if (value === "new") return { kind: "new" };
 	if (value === "none") return { kind: "none" };
 	const sep = value.indexOf(":");
@@ -1000,9 +1002,10 @@ function deliverOutput(session: TerminalSession, bytes: Uint8Array) {
 function nudgeRepaint(session: TerminalSession) {
 	if (!isCurrentLiveSession(session)) return;
 	const { cols, rows } = session;
-	if (rows <= MIN_TERMINAL_ROWS) return;
+	// Shrink by a row, growing instead when already at the minimum.
+	const toggledRows = rows > MIN_TERMINAL_ROWS ? rows - 1 : rows + 1;
 	const generation = session.resizeGeneration;
-	session.pty.resize(cols, rows - 1);
+	session.pty.resize(cols, toggledRows);
 	setTimeout(() => {
 		// A real client resize landed mid-nudge; it owns the dims now.
 		if (!isCurrentLiveSession(session)) return;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -345,9 +345,12 @@ interface TerminalSession {
 	unsubscribeDaemon: (() => void) | null;
 	sockets: Set<TerminalSocket>;
 	/**
-	 * Buffered PTY output retained for replay on (re)attach. Bytes, not
-	 * strings — keeping this byte-aligned with the wire frees us from the
-	 * per-chunk UTF-8 decoding that used to mangle TUIs.
+	 * Legacy replay FIFO for clients that attach without `?seq=` (pre-seq
+	 * renderers, raw WS consumers): fills only while zero sockets are
+	 * attached, drained by replayBuffer(). Seq-aware clients are served from
+	 * the `retained` catch-up ring instead. Delete once the renderer floor
+	 * speaks seq. Bytes, not strings — byte-aligned with the wire so
+	 * per-chunk UTF-8 decoding can't mangle TUIs.
 	 */
 	buffer: Uint8Array[];
 	bufferBytes: number;
@@ -1091,41 +1094,46 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 	return sent;
 }
 
-export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
-	// sendBytes below no-ops on a non-open socket — bail before clearing the
-	// buffer/notice so the next attach can still replay them.
-	if (socket.readyState !== SOCKET_OPEN) return;
-	// Preamble first, then the restored notice, then FIFO. Mode-setting
-	// escapes (kitty keyboard, bracketed paste, focus, …) are typically
-	// emitted once at startup and broadcast away rather than buffered, so a
-	// fresh xterm needs them re-asserted on every attach — even when the
-	// FIFO is empty.
+/**
+ * Host-synthesized attach bytes: the mode preamble plus (at most once) the
+ * restored notice. Mode-setting escapes (kitty keyboard, bracketed paste,
+ * focus, …) are typically emitted once at program startup and broadcast away
+ * rather than buffered, so a fresh xterm needs them re-asserted on every
+ * attach. Consumes the pending notice — only call when actually delivering
+ * to an open socket. Returns null when there is nothing to synthesize.
+ */
+function takeSynthesizedAttachBytes(
+	session: TerminalSession,
+): Uint8Array | null {
 	const preamble = session.modeTracker.buildPreamble();
 	const notice = session.restoredNoticePending ? SESSION_RESTORED_NOTICE : null;
-	let bufferTotal = 0;
-	for (const b of session.buffer) bufferTotal += b.byteLength;
-	const preambleLen = preamble?.byteLength ?? 0;
-	const noticeLen = notice?.byteLength ?? 0;
-	if (preambleLen === 0 && noticeLen === 0 && bufferTotal === 0) return;
-
-	const combined = new Uint8Array(preambleLen + noticeLen + bufferTotal);
-	let offset = 0;
-	if (preamble) {
-		combined.set(preamble, offset);
-		offset += preamble.byteLength;
-	}
-	if (notice) {
-		combined.set(notice, offset);
-		offset += notice.byteLength;
-	}
-	for (const b of session.buffer) {
-		combined.set(b, offset);
-		offset += b.byteLength;
-	}
 	session.restoredNoticePending = false;
+	if (!preamble && !notice) return null;
+	const combined = new Uint8Array(
+		(preamble?.byteLength ?? 0) + (notice?.byteLength ?? 0),
+	);
+	if (preamble) combined.set(preamble, 0);
+	if (notice) combined.set(notice, preamble?.byteLength ?? 0);
+	return combined;
+}
+
+export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
+	// Bail before consuming the notice/FIFO on a non-open socket so the next
+	// attach can still replay them.
+	if (socket.readyState !== SOCKET_OPEN) return;
+	const synthesized = takeSynthesizedAttachBytes(session);
+	if (synthesized) sendBytes(socket, synthesized);
+	if (session.bufferBytes > 0) {
+		const fifo = new Uint8Array(session.bufferBytes);
+		let offset = 0;
+		for (const b of session.buffer) {
+			fifo.set(b, offset);
+			offset += b.byteLength;
+		}
+		sendBytes(socket, fifo);
+	}
 	session.buffer.length = 0;
 	session.bufferBytes = 0;
-	sendBytes(socket, combined);
 }
 
 /**
@@ -1144,17 +1152,8 @@ function sendSeqAttach(
 ) {
 	if (socket.readyState !== SOCKET_OPEN) return;
 
-	const preamble = session.modeTracker.buildPreamble();
-	const notice = session.restoredNoticePending ? SESSION_RESTORED_NOTICE : null;
-	if (preamble || notice) {
-		const synthesized = new Uint8Array(
-			(preamble?.byteLength ?? 0) + (notice?.byteLength ?? 0),
-		);
-		if (preamble) synthesized.set(preamble, 0);
-		if (notice) synthesized.set(notice, preamble?.byteLength ?? 0);
-		sendBytes(socket, synthesized);
-	}
-	session.restoredNoticePending = false;
+	const synthesized = takeSynthesizedAttachBytes(session);
+	if (synthesized) sendBytes(socket, synthesized);
 
 	const exact =
 		request.kind === "anchor" &&

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -169,9 +169,77 @@ type TerminalServerMessage =
 	// plain errors leave it unset and the renderer keeps its snapshot.
 	| { type: "error"; message: string; code?: "session-gone" }
 	| { type: "exit"; exitCode: number; signal: number }
-	| { type: "title"; title: string | null };
+	| { type: "title"; title: string | null }
+	// Sequence anchor for seq-aware clients (`?seq=` on the attach URL). Sent
+	// once per attach, AFTER any host-synthesized bytes (mode preamble,
+	// restored notice) and BEFORE catch-up/live PTY bytes. The client sets its
+	// byte counter to `seq` and counts every subsequent binary frame, so both
+	// sides agree on stream position without per-frame headers.
+	// - `exact`:    client's anchor was inside the catch-up ring — the binary
+	//               bytes that follow are exactly the missed suffix.
+	// - `tail`:     client attached empty — whatever ring content exists
+	//               follows as a best-effort scrollback restore.
+	// - `reanchor`: the client's position is unknown or unrecoverable (epoch
+	//               mismatch after a host restart, gap beyond the ring). No
+	//               content bytes are sent — the client's screen is presumed
+	//               better than anything we could synthesize (see #6290) — and
+	//               a repaint nudge asks the running program to redraw itself.
+	| { type: "synced"; epoch: string; seq: number; mode: SyncedMode };
+
+type SyncedMode = "exact" | "tail" | "reanchor";
+
+/**
+ * Parsed `?seq=` attach param.
+ * - absent  → legacy client: byte-identical pre-seq behavior (preamble + FIFO).
+ * - "new"   → seq-aware client with a virgin xterm: wants the ring tail.
+ * - "none"  → seq-aware client with restored content but no trustworthy
+ *             anchor (persisted by an older build, multi-instance seed):
+ *             reanchor without dumping bytes into its existing screen.
+ * - "<epoch>:<n>" → anchored client: exact catch-up when possible.
+ */
+type SeqAttachRequest =
+	| { kind: "legacy" }
+	| { kind: "new" }
+	| { kind: "none" }
+	| { kind: "anchor"; epoch: string; seq: number };
+
+function parseSeqAttachParam(
+	value: string | null | undefined,
+): SeqAttachRequest {
+	if (!value) return { kind: "legacy" };
+	if (value === "new") return { kind: "new" };
+	if (value === "none") return { kind: "none" };
+	const sep = value.indexOf(":");
+	if (sep > 0) {
+		const epoch = value.slice(0, sep);
+		const seq = Number(value.slice(sep + 1));
+		if (epoch && Number.isSafeInteger(seq) && seq >= 0) {
+			return { kind: "anchor", epoch, seq };
+		}
+	}
+	// Malformed → safest degraded mode: reanchor, never dump bytes.
+	return { kind: "none" };
+}
 
 const MAX_BUFFER_BYTES = 64 * 1024;
+/**
+ * Catch-up ring cap per session. Sized so that a renderer that missed output
+ * (laptop sleep, back-pressure drop, parked-runtime eviction) can almost
+ * always be caught up with the exact missed bytes instead of a lossy
+ * reanchor — the deterministic ghost repro from #6279 was ~105 KB of missed
+ * TUI repaints; 2 MiB gives ~20x margin while staying far under the 8 MiB
+ * per-socket send cap. Memory is bounded per session and only holds bytes
+ * actually emitted.
+ */
+const CATCHUP_RING_CAP_BYTES = 2 * 1024 * 1024;
+/**
+ * How long after a reanchor attach to wait for the renderer's own resize
+ * (which fires a natural SIGWINCH when dims changed) before forcing the
+ * repaint nudge anyway.
+ */
+const REPAINT_NUDGE_FALLBACK_MS = 2_000;
+/** Gap between the nudge's shrink and restore resizes. */
+const REPAINT_NUDGE_RESTORE_MS = 60;
 // Dim separator delivered ahead of a respawned shell's output so users can
 // tell restored scrollback from the fresh session (cf. VS Code's "History
 // restored" line).
@@ -332,6 +400,34 @@ interface TerminalSession {
 	 * paste, focus, mouse, etc. that the FIFO can't restore on its own.
 	 */
 	modeTracker: ModeTracker;
+
+	/**
+	 * Stream identity for seq-aware clients. Fresh per TerminalSession object
+	 * (create, adopt, respawn) — a client anchored to a different epoch has an
+	 * unknowable position (the byte counter restarted) and gets a reanchor.
+	 */
+	epoch: string;
+	/** Absolute count of PTY output bytes emitted since this session object was created. */
+	outputSeq: number;
+	/**
+	 * Catch-up ring: the retained tail of the output stream, so a reattaching
+	 * seq-aware client receives exactly the bytes it missed (exactly-once
+	 * delivery, Eternal-Terminal style) instead of a lossy tail dump. Unlike
+	 * the legacy FIFO (`buffer`), this retains regardless of attached sockets.
+	 */
+	retained: Uint8Array[];
+	retainedBytes: number;
+	/** Absolute seq of the first byte still in `retained`. */
+	retainedStartSeq: number;
+	/**
+	 * Armed on a reanchor attach: the client may have missed output we can't
+	 * re-deliver, so once its resize arrives (or the fallback timer fires),
+	 * force a SIGWINCH repaint so the running program redraws itself — the
+	 * only party that always knows the full screen truth.
+	 */
+	pendingRepaintNudge: ReturnType<typeof setTimeout> | null;
+	/** Bumped on every client resize; guards the nudge's delayed restore. */
+	resizeGeneration: number;
 
 	/**
 	 * Tail of the in-flight follow-up send (writeFramedInputToSession).
@@ -837,6 +933,107 @@ function bufferOutput(session: TerminalSession, data: Uint8Array) {
 	}
 }
 
+function retainOutput(session: TerminalSession, data: Uint8Array) {
+	session.retained.push(data);
+	session.retainedBytes += data.byteLength;
+	session.outputSeq += data.byteLength;
+	while (
+		session.retainedBytes > CATCHUP_RING_CAP_BYTES &&
+		session.retained.length > 1
+	) {
+		const removed = session.retained.shift();
+		if (removed) {
+			session.retainedBytes -= removed.byteLength;
+			session.retainedStartSeq += removed.byteLength;
+		}
+	}
+}
+
+/** Concatenate the retained stream from absolute seq `from` to the present. */
+function readRetainedFrom(session: TerminalSession, from: number): Uint8Array {
+	let skip = from - session.retainedStartSeq;
+	const parts: Uint8Array[] = [];
+	let total = 0;
+	for (const chunk of session.retained) {
+		if (skip >= chunk.byteLength) {
+			skip -= chunk.byteLength;
+			continue;
+		}
+		const part = skip > 0 ? chunk.subarray(skip) : chunk;
+		skip = 0;
+		parts.push(part);
+		total += part.byteLength;
+	}
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.byteLength;
+	}
+	return out;
+}
+
+/**
+ * Single choke point for PTY output: mode tracker, catch-up ring, then
+ * broadcast (falling back to the legacy zero-socket FIFO). Every byte that
+ * counts toward `outputSeq` MUST flow through here and nowhere else, or
+ * seq-aware clients drift out of sync.
+ */
+function deliverOutput(session: TerminalSession, bytes: Uint8Array) {
+	session.modeTracker.feed(bytes);
+	retainOutput(session, bytes);
+	if (broadcastBytes(session, bytes) === 0) {
+		bufferOutput(session, bytes);
+	}
+}
+
+/**
+ * Force the running program to repaint by toggling the PTY one row smaller
+ * and back — two real SIGWINCHes (a same-dims resize emits none). Used after
+ * a reanchor attach, where the renderer may hold a stale frame that only the
+ * program itself can faithfully redraw (the v1 terminal-host's proven
+ * recipe; never synthesize screen content the tracker may not have — #6290).
+ */
+function nudgeRepaint(session: TerminalSession) {
+	if (!isCurrentLiveSession(session)) return;
+	const { cols, rows } = session;
+	if (rows <= MIN_TERMINAL_ROWS) return;
+	const generation = session.resizeGeneration;
+	session.pty.resize(cols, rows - 1);
+	setTimeout(() => {
+		// A real client resize landed mid-nudge; it owns the dims now.
+		if (!isCurrentLiveSession(session)) return;
+		if (session.resizeGeneration !== generation) return;
+		session.pty.resize(cols, rows);
+	}, REPAINT_NUDGE_RESTORE_MS);
+}
+
+/** False once the session exited or was disposed/replaced in the map —
+ * lets delayed nudge timers no-op instead of poking a dead PTY. */
+function isCurrentLiveSession(session: TerminalSession): boolean {
+	return !session.exited && sessions.get(session.terminalId) === session;
+}
+
+/**
+ * Arm the nudge after a reanchor attach. Wait for the client's own resize
+ * first: if its dims differ from the PTY's, that resize already delivers a
+ * natural SIGWINCH and the nudge is unnecessary; if they match, nudge. The
+ * fallback timer covers clients that never send a resize.
+ */
+function schedulePendingRepaintNudge(session: TerminalSession) {
+	if (session.pendingRepaintNudge !== null) return;
+	session.pendingRepaintNudge = setTimeout(() => {
+		session.pendingRepaintNudge = null;
+		nudgeRepaint(session);
+	}, REPAINT_NUDGE_FALLBACK_MS);
+}
+
+function clearPendingRepaintNudge(session: TerminalSession) {
+	if (session.pendingRepaintNudge === null) return;
+	clearTimeout(session.pendingRepaintNudge);
+	session.pendingRepaintNudge = null;
+}
+
 function normalizeTerminalDimension(
 	value: number | null | undefined,
 	min: number,
@@ -931,6 +1128,82 @@ export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
 	sendBytes(socket, combined);
 }
 
+/**
+ * Attach delivery for seq-aware clients. Wire order matters:
+ *   1. binary: host-synthesized bytes (mode preamble, restored notice) —
+ *      NOT part of the PTY stream, so they go out before the anchor and the
+ *      client does not count them;
+ *   2. json `synced`: sets the client's counter and arms counting;
+ *   3. binary: catch-up bytes — pure PTY-stream bytes the client counts.
+ * After this returns, live output broadcast keeps both counters in step.
+ */
+function sendSeqAttach(
+	session: TerminalSession,
+	socket: TerminalSocket,
+	request: Exclude<SeqAttachRequest, { kind: "legacy" }>,
+) {
+	if (socket.readyState !== SOCKET_OPEN) return;
+
+	const preamble = session.modeTracker.buildPreamble();
+	const notice = session.restoredNoticePending ? SESSION_RESTORED_NOTICE : null;
+	if (preamble || notice) {
+		const synthesized = new Uint8Array(
+			(preamble?.byteLength ?? 0) + (notice?.byteLength ?? 0),
+		);
+		if (preamble) synthesized.set(preamble, 0);
+		if (notice) synthesized.set(notice, preamble?.byteLength ?? 0);
+		sendBytes(socket, synthesized);
+	}
+	session.restoredNoticePending = false;
+
+	const exact =
+		request.kind === "anchor" &&
+		request.epoch === session.epoch &&
+		request.seq >= session.retainedStartSeq &&
+		request.seq <= session.outputSeq;
+
+	if (exact) {
+		sendMessage(socket, {
+			type: "synced",
+			epoch: session.epoch,
+			seq: request.seq,
+			mode: "exact",
+		});
+		if (request.seq < session.outputSeq) {
+			sendBytes(socket, readRetainedFrom(session, request.seq));
+		}
+		return;
+	}
+
+	if (request.kind === "new") {
+		// Virgin client: best-effort scrollback restore from the ring tail.
+		sendMessage(socket, {
+			type: "synced",
+			epoch: session.epoch,
+			seq: session.retainedStartSeq,
+			mode: "tail",
+		});
+		if (session.retainedBytes > 0) {
+			sendBytes(socket, readRetainedFrom(session, session.retainedStartSeq));
+		}
+		return;
+	}
+
+	// Unknown/unrecoverable position ("none", epoch mismatch, gap beyond the
+	// ring). The client's existing screen beats anything we could synthesize —
+	// never overwrite it (#6290). Re-anchor at the live head and ask the
+	// program to repaint itself.
+	sendMessage(socket, {
+		type: "synced",
+		epoch: session.epoch,
+		seq: session.outputSeq,
+		mode: "reanchor",
+	});
+	if (!session.exited) {
+		schedulePendingRepaintNudge(session);
+	}
+}
+
 function clearShellReadyTimeout(session: TerminalSession): void {
 	if (session.shellReadyTimeoutId) {
 		clearTimeout(session.shellReadyTimeoutId);
@@ -952,10 +1225,7 @@ function resolveShellReady(
 		const heldBytes = Uint8Array.from(session.scanState.heldBytes);
 		session.scanState.heldBytes.length = 0;
 		session.scanState.matchPos = 0;
-		session.modeTracker.feed(heldBytes);
-		if (broadcastBytes(session, heldBytes) === 0) {
-			bufferOutput(session, heldBytes);
-		}
+		deliverOutput(session, heldBytes);
 	}
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
@@ -1483,12 +1753,15 @@ export async function createTerminalSessionInternal({
 	}
 
 	const cwd = resolveTerminalCwd(cwdOverride, workspace.worktreePath);
-	const cols = normalizeTerminalDimension(
+	// Adoption overrides these with the PTY's live dims below: the session's
+	// belief must match the kernel's, or the reanchor repaint logic misjudges
+	// whether a client resize will deliver a real SIGWINCH.
+	let cols = normalizeTerminalDimension(
 		requestedCols,
 		MIN_TERMINAL_COLS,
 		DEFAULT_TERMINAL_COLS,
 	);
-	const rows = normalizeTerminalDimension(
+	let rows = normalizeTerminalDimension(
 		requestedRows,
 		MIN_TERMINAL_ROWS,
 		DEFAULT_TERMINAL_ROWS,
@@ -1535,6 +1808,8 @@ export async function createTerminalSessionInternal({
 			}
 			openResult = { pid: found.pid };
 			isAdopted = true;
+			cols = normalizeTerminalDimension(found.cols, MIN_TERMINAL_COLS, cols);
+			rows = normalizeTerminalDimension(found.rows, MIN_TERMINAL_ROWS, rows);
 			console.log(
 				`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
 			);
@@ -1561,6 +1836,16 @@ export async function createTerminalSessionInternal({
 					if (!found) throw err;
 					openResult = { pid: found.pid };
 					isAdopted = true;
+					cols = normalizeTerminalDimension(
+						found.cols,
+						MIN_TERMINAL_COLS,
+						cols,
+					);
+					rows = normalizeTerminalDimension(
+						found.rows,
+						MIN_TERMINAL_ROWS,
+						rows,
+					);
 					console.log(
 						`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
 					);
@@ -1646,6 +1931,13 @@ export async function createTerminalSessionInternal({
 		launchShellName: basename(shell),
 		portHintDecoder: new StringDecoder("utf8"),
 		modeTracker: createModeTracker(cols, rows),
+		epoch: randomBytes(8).toString("hex"),
+		outputSeq: 0,
+		retained: [],
+		retainedBytes: 0,
+		retainedStartSeq: 0,
+		pendingRepaintNudge: null,
+		resizeGeneration: 0,
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
@@ -1695,13 +1987,7 @@ export async function createTerminalSessionInternal({
 				// — the chunk is still output and must refresh the idle clock.
 				portManager.checkOutputForHint(terminalId, hintText);
 
-				// Feed the tracker on every byte — broadcast skips the FIFO,
-				// so this is the only path that catches startup mode escapes.
-				session.modeTracker.feed(bytes);
-
-				if (broadcastBytes(session, bytes) === 0) {
-					bufferOutput(session, bytes);
-				}
+				deliverOutput(session, bytes);
 			},
 			onExit({ code, signal }) {
 				session.exited = true;
@@ -1849,6 +2135,7 @@ export function registerWorkspaceTerminalRoute({
 		upgradeWebSocket((c) => {
 			const terminalId = c.req.param("terminalId") ?? "";
 			const requestedWorkspaceId = c.req.query("workspaceId") || null;
+			const seqRequest = parseSeqAttachParam(c.req.query("seq"));
 			const attachSocketToSession = (
 				session: TerminalSession,
 				ws: TerminalSocket,
@@ -1863,7 +2150,11 @@ export function registerWorkspaceTerminalRoute({
 					.run();
 
 				sendMessage(ws, { type: "title", title: session.title });
-				replayBuffer(session, ws);
+				if (seqRequest.kind === "legacy") {
+					replayBuffer(session, ws);
+				} else {
+					sendSeqAttach(session, ws, seqRequest);
+				}
 				if (session.exited) {
 					sendMessage(ws, {
 						type: "exit",
@@ -1935,8 +2226,13 @@ export function registerWorkspaceTerminalRoute({
 					db,
 					eventBus,
 					adoptOnly: true,
-					// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
-					replayOnAdoption: c.req.query("replay") !== "0",
+					// Only a client with an empty xterm wants the daemon ring
+					// dumped at it. Anchored/reanchor clients keep their own
+					// (better) copy; legacy clients signal via `?replay=0`.
+					replayOnAdoption:
+						seqRequest.kind === "legacy"
+							? c.req.query("replay") !== "0"
+							: seqRequest.kind === "new",
 				});
 				if (!("error" in adopted)) return adopted;
 
@@ -2033,10 +2329,20 @@ export function registerWorkspaceTerminalRoute({
 							MIN_TERMINAL_ROWS,
 							DEFAULT_TERMINAL_ROWS,
 						);
+						session.resizeGeneration += 1;
+						// A reanchor attach waits for this first client resize:
+						// changed dims deliver the repaint SIGWINCH naturally;
+						// unchanged dims need the forced nudge.
+						const needsForcedNudge =
+							session.pendingRepaintNudge !== null &&
+							cols === session.cols &&
+							rows === session.rows;
+						clearPendingRepaintNudge(session);
 						session.pty.resize(cols, rows);
 						session.modeTracker.resize(cols, rows);
 						session.cols = cols;
 						session.rows = rows;
+						if (needsForcedNudge) nudgeRepaint(session);
 					}
 				},
 


### PR DESCRIPTION
## Summary

Re-fix for #6269 (TUI ghost artifacts from at-most-once output delivery) that makes both known failure modes structurally impossible — the ghosts #6279 targeted **and** the blank panes that forced its revert (#6290).

Design follows what established terminals do (VS Code ptyService revive, wezterm per-pane seqnos, Eternal Terminal catch-up, zellij attach redraw): **never reset a live, populated client and replay synthesized state into it.** Instead, make the byte stream exactly-once and reconcile only when bytes were actually lost.

## How it works

**Host (`packages/host-service/src/terminal/terminal.ts`)**
- Each session gets an `epoch` (fresh per session object) + absolute byte offset + a 2 MiB catch-up ring retaining the output tail regardless of attached sockets.
- Clients dial with `?seq=`:
  - `<epoch>:<n>` in-ring → **exact**: precisely the missed suffix. No gap → zero bytes; pane switches are wire-silent.
  - `new` (virgin xterm) → **tail**: ring contents as best-effort restore.
  - epoch mismatch / beyond ring / `none` → **reanchor**: *no content bytes at all* — the client's stale-but-real screen always beats anything the host could synthesize (the #6279 lesson). A **repaint nudge** (PTY rows−1 toggle → two real SIGWINCHes, the v1 terminal-host recipe) makes the running program redraw itself; it fires only if the client's attach resize wouldn't deliver a natural SIGWINCH.
- Wire order: synthesized bytes (mode preamble/notice, uncounted) → `synced` (arms counting) → pure PTY bytes (counted). Adoption now takes live daemon dims so the nudge logic can't misjudge.
- Legacy clients (no `?seq=`) keep the pre-seq contract byte-for-byte — version skew is safe both ways.

**Renderer (`apps/desktop`)**
- Transport counts bytes into a `seqAnchor` armed by `synced`, persists it next to the buffer snapshot (`terminal-seq:*`, registered + GC'd with the buffer keys), and restores it on runtime rebuild — so a parked-runtime eviction reattach converges exactly.

## Why the tests would have caught #6279
- Regression test **spans a host-service restart** (`__resetSessionsForTesting`) — tracker knows *less* than the renderer, the exact case #6279's suite never modeled — and asserts the grid is never blanked or overwritten and no `\x1bc` ever hits the wire.
- Catch-up payloads verified byte-for-byte against a **direct daemon subscription** (client-vs-client comparison alone is provably blind to self-consistent shifts).
- Mutation-checked: seq-accounting drift and a reintroduced destructive reanchor both fail loudly.

## Verification
- `terminal.seq-catchup.node-test.ts`: 6 phases + legacy contract, all green (run from `packages/host-service` under Electron-as-Node with the tsx loader).
- Full host-service suite 1065 pass; adoption e2e 20/20; desktop persisted-key + terminal tests 319 pass; lint + typecheck clean.
- **CDP end-to-end on the dev desktop** (real UI journeys, before/after screenshots):
  - Workspace switch with output flowing while away → full transcript, no blanking, anchor continuous.
  - **Host-service restart under a live TUI and under real Claude Code v2.1.226** (the #6290 scenario, via `hostServiceCoordinator.restart` + daemon adoption): zero blank frames across continuous 150–200 ms sampling, scrollback preserved, fresh epoch, nudge repaint converged (`FULL-REDRAW` / intact Claude UI).
  - Parked-runtime eviction → localStorage restore (`terminal-seq:*` round-trip) → exact catch-up of frames produced while the xterm didn't exist.
  - Socket killed mid-flood → reattach → seq 3,929 → 53,015 caught up, visible transcript contiguous, zero holes.
  - 3 MiB beyond-ring gap + full app reload → reanchor at live head **without delivering the blob** (no `x…` runs in the buffer), screen preserved, nudge healed.
  - Synthetic steps are noted as such (socket close as gap generator; focus-event dispatch standing in for window refocus, a known headless-drive quirk).

## Rollout note
Revert candidate rules: if reattach regressions appear (garbled grids, blank panes, scrollback loss), revert this single squash commit — legacy clients and old hosts are unaffected by design, and the revert restores today's FIFO behavior cleanly.

Fixes #6269. Context: #6279 (reverted in #6290), SUPER-1791, SUPER-859.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements sequence-numbered, exactly-once terminal output with gap-only catch-up and attach-time repaint, and hardens persistence/edge paths to avoid stale anchors and regressions. Adds a seq catch-up e2e suite and runs host-service tests under Electron-as-Node via the `tsx` loader.

- **Bug Fixes**
  - `apps/desktop`: Persist the stream anchor only when the buffer snapshot succeeded and the parser is idle; flush coalesced writes before snapshot. Drop the anchor if a connection delivered bytes without ever sending `synced` (pre-seq host downgrade). Compute `?seq=` as `<epoch>:<n>` / `new` (virgin xterm) / `none` (xterm already has content), and persist/load anchors next to the buffer (`terminal-seq:*`) with GC support. Failed anchor writes clear the key to avoid stale state.
  - `packages/host-service`: Treat an empty `?seq=` as malformed and safely reanchor. Always send host-synthesized bytes (mode preamble/notice) first, then `synced {epoch,seq,mode}`, then PTY bytes. Improve the repaint nudge after reanchor: wait for client resize or fire after a fallback; toggle rows downward, or upward at minimum height. Adoption uses live daemon dims to avoid misjudging repaint triggers. Added `terminal.seq-catchup.node-test.ts` asserting no RIS resets and byte-exact catch-up; `scripts/test-e2e.ts` now uses the `tsx` loader and runs both adoption and seq suites.

<sup>Written for commit 4a7494d085cd1419dc834c16b7bfc9ffa5cc6e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal synchronization across reconnects, preserving output and screen state more reliably.
  * Added precise catch-up for missed terminal output after temporary disconnections.
  * Improved terminal focus handling when reconnecting or restoring sessions.
  * Added compatibility for both modern sequence-aware and legacy terminal connections.

* **Bug Fixes**
  * Reduced duplicated, missing, or out-of-order terminal output during reconnects.
  * Improved terminal restoration across app restarts and session handoffs.
  * Prevented unnecessary screen resets while synchronizing terminal content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

