### PR TITLE
fix(desktop,host-service): create terminal sessions on WS attach so new panes survive HTTP pool starvation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
@@ -48,11 +48,13 @@ export function useDefaultContextMenuActions({
 				icon: <LuRows2 />,
 				shortcut:
 					splitDownShortcut !== "Unassigned" ? splitDownShortcut : undefined,
-				onSelect: async (ctx) => {
-					const terminalId = await launcher.create();
+				onSelect: (ctx) => {
 					ctx.actions.split("down", {
 						kind: "terminal",
-						data: { terminalId } as TerminalPaneData,
+						data: {
+							terminalId: launcher.mint(),
+							createOnAttach: true,
+						} as TerminalPaneData,
 					});
 				},
 			},
@@ -62,11 +64,13 @@ export function useDefaultContextMenuActions({
 				icon: <LuColumns2 />,
 				shortcut:
 					splitRightShortcut !== "Unassigned" ? splitRightShortcut : undefined,
-				onSelect: async (ctx) => {
-					const terminalId = await launcher.create();
+				onSelect: (ctx) => {
 					ctx.actions.split("right", {
 						kind: "terminal",
-						data: { terminalId } as TerminalPaneData,
+						data: {
+							terminalId: launcher.mint(),
+							createOnAttach: true,
+						} as TerminalPaneData,
 					});
 				},
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
@@ -22,13 +22,15 @@ export function useDefaultPaneActions({
 						<TbLayoutColumns className="size-3.5" />
 					),
 				tooltip: <HotkeyLabel label="Split pane" id="SPLIT_AUTO" />,
-				onClick: async (ctx) => {
+				onClick: (ctx) => {
 					const position =
 						ctx.pane.parentDirection === "horizontal" ? "down" : "right";
-					const terminalId = await launcher.create();
 					ctx.actions.split(position, {
 						kind: "terminal",
-						data: { terminalId } as TerminalPaneData,
+						data: {
+							terminalId: launcher.mint(),
+							createOnAttach: true,
+						} as TerminalPaneData,
 					});
 				},
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -94,6 +94,9 @@ export function TerminalPane({
 	const themedUrl = new URL(baseWebsocketUrl);
 	themedUrl.searchParams.set("workspaceId", workspaceId);
 	themedUrl.searchParams.set("themeType", themeType);
+	if (paneData.createOnAttach) {
+		themedUrl.searchParams.set("create", "1");
+	}
 	const websocketUrl = themedUrl.toString();
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
@@ -137,9 +140,10 @@ export function TerminalPane({
 	//      container back into the live tree, preserving the buffer.
 	//   2. connect() attaches the WebSocket to that terminalId. The socket is
 	//      transport only; it does not carry creation-time intent.
-	// The pane never calls createSession — that's useV2TerminalLauncher's job,
-	// awaited at the call site before the pane is added to the store. By the
-	// time this effect runs, the host-service session already exists.
+	// The pane never calls createSession over HTTP. Optimistically-inserted
+	// panes (`createOnAttach`) let the WS attach create the session; other
+	// panes' sessions were created by useV2TerminalLauncher before the pane
+	// landed in the store.
 	// Deps narrowed to the terminal identity so provider key remount churn
 	// (workspaceId/client briefly flipping while pane data catches up) doesn't
 	// re-run this effect. Mutable inputs are read through refs.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -89,7 +89,6 @@ export function TerminalSessionDropdown({
 	workspaceId,
 }: TerminalSessionDropdownProps) {
 	const [isOpen, setIsOpen] = useState(false);
-	const [isCreatingTerminal, setIsCreatingTerminal] = useState(false);
 	const collections = useCollections();
 	const { terminalId } = context.pane.data as TerminalPaneData;
 	const terminalInstanceId = context.pane.id;
@@ -243,36 +242,26 @@ export function TerminalSessionDropdown({
 		});
 	};
 
-	const handleNewTerminal = async () => {
-		if (isCreatingTerminal) return;
-		setIsCreatingTerminal(true);
-		try {
-			const nextTerminalId = await launcher.create();
-			const state = context.store.getState();
-			const terminalPaneLocations = getTerminalPaneLocations(context);
-			if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
-				markTerminalForBackground(terminalId, workspaceId);
-			}
-			state.setPaneData({
-				paneId: context.pane.id,
-				data: {
-					terminalId: nextTerminalId,
-				} as PaneViewerData,
-			});
-			state.setPaneTitleOverride({
-				tabId: context.tab.id,
-				paneId: context.pane.id,
-				titleOverride: undefined,
-			});
-			void utils.terminal.listSessions.invalidate({ workspaceId });
-			setIsOpen(false);
-		} catch (error) {
-			toast.error("Failed to create terminal", {
-				description: error instanceof Error ? error.message : "Unknown error",
-			});
-		} finally {
-			setIsCreatingTerminal(false);
+	const handleNewTerminal = () => {
+		const state = context.store.getState();
+		const terminalPaneLocations = getTerminalPaneLocations(context);
+		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
+			markTerminalForBackground(terminalId, workspaceId);
 		}
+		state.setPaneData({
+			paneId: context.pane.id,
+			data: {
+				terminalId: launcher.mint(),
+				createOnAttach: true,
+			} as PaneViewerData,
+		});
+		state.setPaneTitleOverride({
+			tabId: context.tab.id,
+			paneId: context.pane.id,
+			titleOverride: undefined,
+		});
+		void utils.terminal.listSessions.invalidate({ workspaceId });
+		setIsOpen(false);
 	};
 
 	const hostTitle =
@@ -322,19 +311,14 @@ export function TerminalSessionDropdown({
 						type="button"
 						aria-label="New terminal"
 						title="New terminal"
-						disabled={isCreatingTerminal}
 						className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 						onClick={(event) => {
 							event.preventDefault();
 							event.stopPropagation();
-							void handleNewTerminal();
+							handleNewTerminal();
 						}}
 					>
-						{isCreatingTerminal ? (
-							<LoaderCircle className="size-3.5 animate-spin" />
-						) : (
-							<Plus className="size-3.5" />
-						)}
+						<Plus className="size-3.5" />
 					</button>
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2TerminalLauncher/useV2TerminalLauncher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2TerminalLauncher/useV2TerminalLauncher.ts
@@ -4,6 +4,10 @@ import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-works
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 
+/** Worst-case legitimate create ≈ daemon bootstrap (5s connect + 15s open) +
+ * shell env probe (8s); anything past this is a wedged transport, not work. */
+const CREATE_SESSION_TIMEOUT_MS = 30_000;
+
 interface CreateOptions {
 	/**
 	 * If provided, the launcher uses this id instead of minting one. Use it
@@ -22,9 +26,17 @@ export interface TerminalLauncher {
 	 * Awaits `terminal.createSession` and returns the terminalId. Callers
 	 * should await this before writing the pane into the store, so the pane's
 	 * WebSocket connect doesn't race ahead of the session existing on
-	 * host-service.
+	 * host-service. Use it when the pane may never mount (background preset
+	 * tabs, migration) — a mounted pane should use `mint()` instead.
 	 */
 	create(options?: CreateOptions): Promise<string>;
+	/**
+	 * Mints a terminalId with no network call, for optimistic pane insertion.
+	 * Pair with `createOnAttach: true` in the pane data: the pane's WS attach
+	 * creates the session host-side, so plain terminal creation can't queue
+	 * behind Chromium's 6-per-origin HTTP socket pool under load.
+	 */
+	mint(): string;
 }
 
 export function useV2TerminalLauncher(): TerminalLauncher {
@@ -39,21 +51,29 @@ export function useV2TerminalLauncher(): TerminalLauncher {
 	const create = useCallback(
 		async (options?: CreateOptions): Promise<string> => {
 			const terminalId = options?.terminalId ?? crypto.randomUUID();
-			await trpcClient.terminal.createSession.mutate({
-				terminalId,
-				workspaceId,
-				themeType,
-				initialCommand: options?.command,
-				cwd: options?.cwd,
-			});
+			// Bounded: this rides the shared 6-per-origin HTTP pool, which can be
+			// starved for minutes under load — without a signal the click hangs
+			// silently forever (the server exempts mutations from its timeout).
+			await trpcClient.terminal.createSession.mutate(
+				{
+					terminalId,
+					workspaceId,
+					themeType,
+					initialCommand: options?.command,
+					cwd: options?.cwd,
+				},
+				{ signal: AbortSignal.timeout(CREATE_SESSION_TIMEOUT_MS) },
+			);
 			return terminalId;
 		},
 		[trpcClient, workspaceId, themeType],
 	);
 
+	const mint = useCallback((): string => crypto.randomUUID(), []);
+
 	// Memoize so the launcher reference is stable across renders — every
 	// consumer lists `launcher` in a deps array (preset hook, hotkeys, pane
 	// actions, context menu, openers), and a fresh object literal each render
 	// would needlessly invalidate all those memos.
-	return useMemo<TerminalLauncher>(() => ({ create }), [create]);
+	return useMemo<TerminalLauncher>(() => ({ create, mint }), [create, mint]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -218,7 +218,7 @@ export function useWorkspaceHotkeys({
 	useHotkey("FOCUS_PANE_UP", () => moveFocusDirectional("up"));
 	useHotkey("FOCUS_PANE_DOWN", () => moveFocusDirectional("down"));
 
-	useHotkey("SPLIT_AUTO", async () => {
+	useHotkey("SPLIT_AUTO", () => {
 		const state = store.getState();
 		const active = state.getActivePane();
 		if (!active) return;
@@ -227,46 +227,52 @@ export function useWorkspaceHotkeys({
 			? getPaneParentDirection(tab.layout, active.pane.id)
 			: null;
 		const position = parentDirection === "horizontal" ? "bottom" : "right";
-		const terminalId = await launcher.create();
 		state.splitPane({
 			tabId: active.tabId,
 			paneId: active.pane.id,
 			position,
 			newPane: {
 				kind: "terminal",
-				data: { terminalId } as TerminalPaneData,
+				data: {
+					terminalId: launcher.mint(),
+					createOnAttach: true,
+				} as TerminalPaneData,
 			},
 		});
 	});
 
-	useHotkey("SPLIT_RIGHT", async () => {
+	useHotkey("SPLIT_RIGHT", () => {
 		const state = store.getState();
 		const active = state.getActivePane();
 		if (!active) return;
-		const terminalId = await launcher.create();
 		state.splitPane({
 			tabId: active.tabId,
 			paneId: active.pane.id,
 			position: "right",
 			newPane: {
 				kind: "terminal",
-				data: { terminalId } as TerminalPaneData,
+				data: {
+					terminalId: launcher.mint(),
+					createOnAttach: true,
+				} as TerminalPaneData,
 			},
 		});
 	});
 
-	useHotkey("SPLIT_DOWN", async () => {
+	useHotkey("SPLIT_DOWN", () => {
 		const state = store.getState();
 		const active = state.getActivePane();
 		if (!active) return;
-		const terminalId = await launcher.create();
 		state.splitPane({
 			tabId: active.tabId,
 			paneId: active.pane.id,
 			position: "bottom",
 			newPane: {
 				kind: "terminal",
-				data: { terminalId } as TerminalPaneData,
+				data: {
+					terminalId: launcher.mint(),
+					createOnAttach: true,
+				} as TerminalPaneData,
 			},
 		});
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -111,13 +111,15 @@ export function useWorkspacePaneOpeners({
 		[store],
 	);
 
-	const addBlankTerminalTab = useCallback(async () => {
-		const terminalId = await launcher.create();
+	const addBlankTerminalTab = useCallback(() => {
 		store.getState().addTab({
 			panes: [
 				{
 					kind: "terminal",
-					data: { terminalId } as TerminalPaneData,
+					data: {
+						terminalId: launcher.mint(),
+						createOnAttach: true,
+					} as TerminalPaneData,
 				},
 			],
 		});
@@ -125,7 +127,7 @@ export function useWorkspacePaneOpeners({
 
 	const addTerminalTab = useCallback(async () => {
 		if (newTabPresets.length === 0) {
-			await addBlankTerminalTab();
+			addBlankTerminalTab();
 			return;
 		}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -8,6 +8,14 @@ export interface FilePaneData {
 
 export interface TerminalPaneData {
 	terminalId: string;
+	/**
+	 * Pane was inserted optimistically; the WS attach creates the session
+	 * (`create=1`) instead of a pre-awaited HTTP mutation, which starves under
+	 * Chromium's 6-per-origin socket pool. Safe to persist: the host only
+	 * honors it when no session row exists at all, so a stale flag can't
+	 * clobber a live or exited session.
+	 */
+	createOnAttach?: boolean;
 }
 
 export interface ChatPaneData {

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -213,7 +213,13 @@ export function seedEndedTerminalAgentBinding(
 export class SqliteTerminalAgentBindingPersistence
 	implements TerminalAgentBindingPersistence
 {
-	constructor(private readonly db: HostDb) {}
+	// No parameter property: this module is on terminal.ts's import chain,
+	// which node --experimental-strip-types test runners load unbundled.
+	private readonly db: HostDb;
+
+	constructor(db: HostDb) {
+		this.db = db;
+	}
 
 	load(): TerminalAgentBinding[] {
 		const rows = this.db

--- a/packages/host-service/src/terminal/terminal.create-on-attach.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.create-on-attach.node-test.ts
@@ -1,0 +1,280 @@
+// create-on-attach: a WS attach carrying `create=1` + `workspaceId` creates
+// the session when no session row exists, so the renderer can insert a
+// terminal pane optimistically instead of pre-awaiting an HTTP mutation that
+// starves in Chromium's 6-per-origin socket pool under load.
+//
+// Harness: real in-process pty-daemon and the real host-service WS route
+// (same shape as terminal.replay-gap.repro.node-test.ts).
+//
+// Run:
+//   cd packages/host-service && node --experimental-strip-types --test \
+//     src/terminal/terminal.create-on-attach.node-test.ts
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import { createNodeWebSocket } from "@hono/node-ws";
+import { Server } from "@superset/pty-daemon";
+import { Hono } from "hono";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, terminalSessions, workspaces } from "../db/schema.ts";
+import type { EventBus } from "../events/index.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import {
+	__resetSessionsForTesting,
+	isLiveTerminalSession,
+	listTerminalSessions,
+	registerWorkspaceTerminalRoute,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(
+	os.tmpdir(),
+	`host-svc-createattach-${process.pid}`,
+);
+const SOCK = path.join(
+	os.tmpdir(),
+	`host-svc-createattach-${process.pid}.sock`,
+);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+let httpPort: number;
+let httpServer: ReturnType<typeof serve>;
+
+type FirstResult =
+	| { kind: "attached" }
+	| { kind: "error"; message: string; code?: string };
+
+/** Dial the terminal WS and resolve with the first protocol outcome. */
+function dial(terminalId: string, query: string): Promise<FirstResult> {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(
+			`ws://127.0.0.1:${httpPort}/terminal/${terminalId}${query}`,
+		);
+		ws.binaryType = "arraybuffer";
+		const timer = setTimeout(() => {
+			ws.close();
+			reject(new Error("attach timeout"));
+		}, 15_000);
+		const done = (result: FirstResult) => {
+			clearTimeout(timer);
+			ws.close();
+			resolve(result);
+		};
+		ws.addEventListener("message", (event) => {
+			const data = (event as MessageEvent).data;
+			if (data instanceof ArrayBuffer) return;
+			const message = JSON.parse(String(data)) as {
+				type: string;
+				message?: string;
+				code?: string;
+			};
+			if (message.type === "attached") done({ kind: "attached" });
+			if (message.type === "error")
+				done({
+					kind: "error",
+					message: message.message ?? "",
+					code: message.code,
+				});
+		});
+		ws.addEventListener("error", () => {
+			clearTimeout(timer);
+			reject(new Error("ws error during connect"));
+		});
+	});
+}
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-createattach-test",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-createattach-test";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting("/bin/sh");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: process.env.HOME ?? TEST_HOME,
+		SHELL: "/bin/sh",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({ id: workspaceId, projectId, worktreePath, branch: "main" })
+		.run();
+
+	const app = new Hono();
+	const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+	registerWorkspaceTerminalRoute({
+		app,
+		db,
+		eventBus: undefined as unknown as EventBus,
+		upgradeWebSocket,
+	});
+	httpPort = await new Promise<number>((resolve) => {
+		httpServer = serve(
+			{ fetch: app.fetch, port: 0, hostname: "127.0.0.1" },
+			(info) => resolve(info.port),
+		);
+	});
+	injectWebSocket(httpServer);
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+test("attach with create=1 creates the session for a brand-new id", async () => {
+	const terminalId = `create-attach-${randomUUID().slice(0, 8)}`;
+	const result = await dial(terminalId, `?workspaceId=${workspaceId}&create=1`);
+	assert.deepEqual(result, { kind: "attached" });
+	assert.ok(isLiveTerminalSession(terminalId));
+
+	// The session now exists like any other: a plain re-attach works.
+	const reattach = await dial(terminalId, `?workspaceId=${workspaceId}`);
+	assert.deepEqual(reattach, { kind: "attached" });
+});
+
+test("attach without create=1 keeps the session-gone contract", async () => {
+	const terminalId = `no-create-${randomUUID().slice(0, 8)}`;
+	const result = await dial(terminalId, `?workspaceId=${workspaceId}`);
+	assert.equal(result.kind, "error");
+	if (result.kind === "error") {
+		assert.equal(result.code, "session-gone");
+	}
+	assert.ok(!isLiveTerminalSession(terminalId));
+});
+
+test("create=1 without workspaceId is refused", async () => {
+	const terminalId = `no-workspace-${randomUUID().slice(0, 8)}`;
+	const result = await dial(terminalId, "?create=1");
+	assert.equal(result.kind, "error");
+	assert.ok(!isLiveTerminalSession(terminalId));
+});
+
+// create-on-attach must only fire when NO session row exists — a stale
+// persisted `createOnAttach` flag on a pane whose session has since exited
+// or been disposed must not silently respawn it.
+test("create=1 against an exited session row keeps session-gone", async () => {
+	const terminalId = `exited-${randomUUID().slice(0, 8)}`;
+	db.insert(terminalSessions)
+		.values({
+			id: terminalId,
+			originWorkspaceId: workspaceId,
+			status: "exited",
+		})
+		.run();
+	const result = await dial(terminalId, `?workspaceId=${workspaceId}&create=1`);
+	assert.equal(result.kind, "error");
+	if (result.kind === "error") {
+		assert.equal(result.code, "session-gone");
+	}
+	assert.ok(!isLiveTerminalSession(terminalId));
+});
+
+test("create=1 against a disposed session row keeps session-gone", async () => {
+	const terminalId = `disposed-${randomUUID().slice(0, 8)}`;
+	db.insert(terminalSessions)
+		.values({
+			id: terminalId,
+			originWorkspaceId: workspaceId,
+			status: "disposed",
+		})
+		.run();
+	const result = await dial(terminalId, `?workspaceId=${workspaceId}&create=1`);
+	assert.equal(result.kind, "error");
+	if (result.kind === "error") {
+		assert.equal(result.code, "session-gone");
+	}
+	assert.ok(!isLiveTerminalSession(terminalId));
+});
+
+test("create=1 with an unknown workspaceId errors instead of attaching", async () => {
+	const terminalId = `bad-workspace-${randomUUID().slice(0, 8)}`;
+	const result = await dial(
+		terminalId,
+		`?workspaceId=${randomUUID()}&create=1`,
+	);
+	assert.equal(result.kind, "error");
+	assert.ok(!isLiveTerminalSession(terminalId));
+});
+
+test("concurrent create=1 dials from different workspaces don't share a shell", async () => {
+	const otherWorkspaceId = randomUUID();
+	const otherWorktree = path.join(TEST_HOME, "worktree-b");
+	fs.mkdirSync(otherWorktree, { recursive: true });
+	const otherProjectId = randomUUID();
+	db.insert(projects)
+		.values({ id: otherProjectId, repoPath: otherWorktree })
+		.run();
+	db.insert(workspaces)
+		.values({
+			id: otherWorkspaceId,
+			projectId: otherProjectId,
+			worktreePath: otherWorktree,
+			branch: "main",
+		})
+		.run();
+
+	const terminalId = `cross-workspace-${randomUUID().slice(0, 8)}`;
+	const results = await Promise.all([
+		dial(terminalId, `?workspaceId=${workspaceId}&create=1`),
+		dial(terminalId, `?workspaceId=${otherWorkspaceId}&create=1`),
+	]);
+	const attached = results.filter((r) => r.kind === "attached");
+	assert.equal(attached.length, 1);
+	const failure = results.find((r) => r.kind === "error");
+	assert.ok(failure);
+	if (failure.kind === "error") {
+		assert.match(failure.message, /belongs to workspace/);
+	}
+});
+
+test("concurrent create=1 attaches share one session", async () => {
+	const terminalId = `concurrent-${randomUUID().slice(0, 8)}`;
+	const query = `?workspaceId=${workspaceId}&create=1`;
+	const results = await Promise.all([
+		dial(terminalId, query),
+		dial(terminalId, query),
+		dial(terminalId, query),
+	]);
+	for (const result of results) {
+		assert.deepEqual(result, { kind: "attached" });
+	}
+	const matching = listTerminalSessions({ workspaceId }).filter(
+		(session) => session.terminalId === terminalId,
+	);
+	assert.equal(matching.length, 1);
+});

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -2075,6 +2075,13 @@ export async function createTerminalSessionInternal({
 	return session;
 }
 
+// Concurrent create-on-attach dials for the same brand-new terminalId must
+// share one spawn instead of racing createTerminalSessionInternal.
+const inflightCreates = new Map<
+	string,
+	Promise<TerminalSession | { error: string }>
+>();
+
 export function registerWorkspaceTerminalRoute({
 	app,
 	db,
@@ -2167,6 +2174,11 @@ export function registerWorkspaceTerminalRoute({
 			const terminalId = c.req.param("terminalId") ?? "";
 			const requestedWorkspaceId = c.req.query("workspaceId") || null;
 			const seqRequest = parseSeqAttachParam(c.req.query("seq"));
+			// Optimistic pane creation: the renderer inserts the pane first and
+			// lets this attach create the session, so plain terminal creation
+			// never queues behind Chromium's 6-per-origin HTTP socket pool.
+			const createRequested = c.req.query("create") === "1";
+			const requestedThemeType = parseThemeType(c.req.query("themeType"));
 			const attachSocketToSession = (
 				session: TerminalSession,
 				ws: TerminalSocket,
@@ -2215,6 +2227,37 @@ export function registerWorkspaceTerminalRoute({
 					.findFirst({ where: eq(terminalSessions.id, terminalId) })
 					.sync();
 				if (!record) {
+					// Only ids with no session row at all qualify for create-on-attach
+					// — exited/disposed records below keep their session-gone answer.
+					if (createRequested && requestedWorkspaceId) {
+						const inflight = inflightCreates.get(terminalId);
+						if (inflight) {
+							const shared = await inflight;
+							if ("error" in shared) return shared;
+							// The shared spawn was created for the FIRST dial's workspace —
+							// validate ownership like every other attach path.
+							const mismatchError = getTerminalWorkspaceMismatchError({
+								terminalId,
+								ownerWorkspaceId: shared.workspaceId,
+								requestedWorkspaceId,
+							});
+							if (mismatchError) return { error: mismatchError };
+							return shared;
+						}
+						const createPromise = createTerminalSessionInternal({
+							terminalId,
+							workspaceId: requestedWorkspaceId,
+							themeType: requestedThemeType,
+							db,
+							eventBus,
+						});
+						inflightCreates.set(terminalId, createPromise);
+						try {
+							return await createPromise;
+						} finally {
+							inflightCreates.delete(terminalId);
+						}
+					}
 					return {
 						error: `Terminal session "${terminalId}" not found; create it before connecting.`,
 						code: "session-gone",
@@ -2246,14 +2289,12 @@ export function registerWorkspaceTerminalRoute({
 					if (mismatchError) return { error: mismatchError };
 				}
 
-				const themeType = parseThemeType(c.req.query("themeType"));
-
 				// Prefer adoption: if the daemon still owns the PTY across a
 				// host-service restart, we keep the live shell + ring buffer.
 				const adopted = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
-					themeType,
+					themeType: requestedThemeType,
 					db,
 					eventBus,
 					adoptOnly: true,
@@ -2284,7 +2325,7 @@ export function registerWorkspaceTerminalRoute({
 				return createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
-					themeType,
+					themeType: requestedThemeType,
 					db,
 					eventBus,
 					restoredNotice: true,


### PR DESCRIPTION
## Summary
- Under load, creating a new terminal pane in v2 silently did nothing until the window was refreshed. Every "new terminal" action awaited a `terminal.createSession` HTTP mutation **before** inserting the pane, with no timeout at any layer — and under load Chromium's 6-connections-per-origin pool to host-service gets pinned by long-running requests, so the mutation never reached the wire.
- This PR inverts the flow for plain terminal creation: insert the pane synchronously and create the session during the pane's WebSocket attach (`create=1`). WebSockets use a separate connection pool, so creation keeps working while HTTP is fully starved.
- Paths that create sessions for panes that may never mount (background preset tabs, v1→v2 migration) keep the HTTP mutation, now bounded by `AbortSignal.timeout(30s)` so they fail visibly instead of hanging forever.

## Why / Context
Reproduced deterministically via CDP against the dev app: pin all 6 HTTP sockets to host-service with slow real requests (stand-in for what sidebar polls + minutes-long `workspaces.create` + 15–60s git/filesystem queries do under real load), then click **+ → Terminal**:

- **Before:** the `createSession` POST — and even its CORS preflight — sat unanswered for 47s. No tab, no spinner, no toast. Releasing the pins (what a refresh does to in-flight fetches) made it complete instantly, which is exactly the reported "can't create terminals until refresh".
- **After:** same wedge, same click — pane visible in **15ms**, shell attached in **401ms** over the `create=1` WebSocket, HTTP probe confirmed still blocked before and after.

The no-timeout stack that made this silent: raw tRPC client (QueryClient retry config doesn't apply to `.mutate()`), no fetch timeout on `httpBatchStreamLink`, and host-service's timeout middleware exempts mutations by design.

## How It Works
- **Renderer:** `TerminalLauncher` gains `mint()` — returns a fresh terminalId, no network. All plain-create surfaces (tab-bar `+`, empty state, split hotkeys/button/context menu, session dropdown) insert the pane immediately with `createOnAttach: true` in `TerminalPaneData`. `TerminalPane` appends `create=1` to the terminal WS URL for flagged panes.
- **Host-service:** the terminal WS attach handler's "no session row" branch calls the existing idempotent `createTerminalSessionInternal` when `create=1` + `workspaceId` are present, deduped through the same in-flight map as respawns. Exited/disposed rows keep answering `session-gone`, so a persisted flag can never resurrect a closed shell.
- **Failure UX:** creation failures now surface as a pane in a disconnected state with the existing diagnosis popover + retry, instead of a click that does nothing.

Also includes two one-line fixes (separate commit): the agent-resume work pulled `terminal-agents/persistence.ts` into terminal.ts's import chain with an extensionless value import and a TS parameter property, which silently broke every terminal `*.node-test.ts` under `node --experimental-strip-types`.

## Manual QA Checklist
All verified via CDP against the dev desktop app with real trusted input (screenshots + WS/network event logs captured):

- [x] Baseline: + → Terminal creates and attaches normally with no load (~500ms, unchanged)
- [x] Wedge: with all 6 HTTP sockets pinned (probe blocked before *and* after), + → Terminal shows the pane in 15ms and attaches in 401ms
- [x] Session dropdown "New Terminal" under the same wedge: attached in 402ms
- [x] Rapid-create spam (3 quick creates): 3 distinct sessions, no duplicates
- [x] Real-keystroke `exit`, then reload: flagged pane re-attaches and replays the exit — dead shell shown, **no respawn**, live session count stable
- [x] Reload + mount every tab: every `create=1` dial resolved to its existing id (attach, never a duplicate); pre-fix unflagged panes still dial `create=0` with the adopt/respawn path intact
- [x] `createOnAttach` persists in the pane layout and is honored safely (only fires when no session row exists at all)

## Testing
- `bun run typecheck`
- `bun run lint`
- `cd packages/host-service && bun test` — 1065 pass, 0 fail
- `node --experimental-strip-types --test src/terminal/terminal.create-on-attach.node-test.ts` — 7 tests against the real WS route + in-process pty-daemon: creates for brand-new ids, session-gone preserved for no-flag/exited-row/disposed-row, unknown workspaceId refused, concurrent attaches deduped to one session. Mutation-checked: disabling the create branch fails the suite.

## Design Decisions
- **Create-on-attach instead of a client timeout + toast**: a timeout converts "silent forever-hang" into "error toast under load" — but creation still fails exactly when users need a terminal to investigate the load. The WS path verifiably keeps working while the HTTP pool is starved (fresh WS handshake: 94ms during full starvation), and it removes the create-before-insert ordering constraint rather than masking it.
- **`createOnAttach` deliberately persists** (not cleared after first attach): the host only honors it when *no* session row exists, so a stale flag can't clobber a live or exited session — and if a row is ever hard-deleted while the pane layout survives, the pane respawns a fresh shell instead of dead-ending.
- **Presets/migration keep HTTP**: background preset tabs intentionally never mount (no WS to carry the create), and keeping commands off the WS URL avoids initial-command re-run semantics on reattach.

## Known Limitations
- Under a *pinned pool*, preset execution into background tabs is still HTTP-bound — it now fails visibly after 30s instead of hanging, but doesn't bypass the pool.
- Relay-fronted hosts verified by inspection only (WS dial preceded by a 3s-bounded `_whoowns` preflight to the relay origin over HTTP/2, which has no 6-connection limit) — no relay workspace on the dev stack to run the wedge harness against.

## Follow-ups
- Batch the unbatched `httpLink` in `renderer/lib/host-service-client.ts` (sidebar polls are the biggest steady-state consumer of the 6 sockets).
- Keep minutes-long `workspaces.create` mutations from squatting pooled sockets.
- `plans/pty-lifecycle-cleanup.md` item 9: park = disconnect, jitter + cap on resume-reconnect fan-out (the separate WS handshake-throttle contributor).
- One-line `finally` hardening for the migration hook's `runningRef` (a throw mid-loop can wedge it for the session; pre-existing, now reachable via the 30s timeout).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create terminal sessions on WebSocket attach so new panes appear instantly and keep working when the HTTP connection pool is saturated. Adds a 30s timeout to remaining HTTP-based creates to avoid silent hangs.

- **Bug Fixes**
  - Renderer: insert panes immediately using `launcher.mint()` + `createOnAttach`; updated all create surfaces (tab “+”, splits, dropdown, hotkeys). The pane’s WS attach appends `create=1`. Failures show a disconnected pane with retry.
  - `host-service`: WS attach creates the session when no row exists and `create=1` + `workspaceId` are provided; exited/disposed rows still return `session-gone`. Concurrent attaches are de-duped. `themeType` honored on attach. Added node tests for create-on-attach.
  - Presets/migration that may never mount still use HTTP, now with `AbortSignal.timeout(30_000)`.
  - Node strip-types compatibility: avoid TS parameter properties and use `.ts` import extensions on the `terminal.ts` chain so `node --experimental-strip-types` tests run.

<sup>Written for commit c60a48a4877e85378b758d76e07076263afb1eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal panes and tabs now open more responsively by preparing sessions during attachment.
  - Added support for creating terminal sessions directly when connecting, including workspace and theme handling.
  - New terminal actions and split-pane shortcuts now respond immediately.

- **Bug Fixes**
  - Improved concurrent terminal creation to prevent duplicate sessions.
  - Added a timeout for terminal session creation requests.
  - Improved handling of missing, exited, or unavailable terminal sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->