### PR TITLE
feat(host-service,desktop): re-assert client focus state to the PTY on terminal attach

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -640,6 +640,13 @@ function attachSocketListeners(
 			transport._bytesSinceAttach = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
+			// Re-assert current keyboard focus so the running program's focus
+			// state can't stay stale across the reattach. In-band xterm focus
+			// reports can't cover this: a rebuilt xterm learns focus-reporting
+			// mode from the preamble only after its focus has already settled,
+			// and a focus-out sent while disconnected never arrived. The host
+			// forwards it only when the program enabled mode 1004.
+			sendFocusState(transport);
 			return;
 		}
 
@@ -799,6 +806,17 @@ export function getPersistableSeqAnchor(
 		return { ...transport.seqAnchor };
 	}
 	return null;
+}
+
+function sendFocusState(transport: TerminalTransport) {
+	const socket = transport._socket;
+	if (!socket || socket.readyState !== WebSocket.OPEN) return;
+	const textarea = transport._terminal?.textarea ?? null;
+	const focused =
+		textarea !== null &&
+		document.hasFocus() &&
+		document.activeElement === textarea;
+	socket.send(JSON.stringify({ type: "focus", focused }));
 }
 
 export function sendResize(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -640,13 +640,6 @@ function attachSocketListeners(
 			transport._bytesSinceAttach = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
-			// Re-assert current keyboard focus so the running program's focus
-			// state can't stay stale across the reattach. In-band xterm focus
-			// reports can't cover this: a rebuilt xterm learns focus-reporting
-			// mode from the preamble only after its focus has already settled,
-			// and a focus-out sent while disconnected never arrived. The host
-			// forwards it only when the program enabled mode 1004.
-			sendFocusState(transport);
 			return;
 		}
 
@@ -654,6 +647,18 @@ function attachSocketListeners(
 			transport.seqAnchor = { epoch: message.epoch, seq: message.seq };
 			transport._seqCounting = true;
 			transport._seqEverSynced = true;
+			// Re-assert current keyboard focus so the running program's focus
+			// state can't stay stale across the reattach (tmux does the same on
+			// client attach). xterm's own DECSET-1004 self-report fires while
+			// the preamble parses, but on a rebuilt pane it can read the focus
+			// class before pane focus settles and report the wrong state — so
+			// this must land at the PTY *after* that report. `synced` arrives
+			// behind the preamble frame: flush it into xterm, then queue an
+			// empty write whose callback runs once the preamble (and any
+			// self-report it triggered) has parsed. The host forwards the state
+			// only when the program enabled mode 1004.
+			transport._writeCoalescer?.flushSync();
+			terminal.write("", () => sendFocusState(transport));
 			return;
 		}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -158,6 +158,13 @@ export interface TerminalTransport {
 	/** Internal: bound resume handler shared by the online/focus/visibility
 	 * listeners, so they can be removed on teardown. */
 	_resumeListener: (() => void) | null;
+	/**
+	 * Internal: removes the textarea focus/blur listeners that keep the
+	 * host's declared focus state current. The host aggregates the declared
+	 * state across sockets, so it must track live focus changes — xterm's
+	 * in-band \x1b[I/\x1b[O reports bypass that aggregation.
+	 */
+	_disposeFocusListeners: (() => void) | null;
 }
 
 const MAX_LOG_ENTRIES = 200;
@@ -334,6 +341,7 @@ export function createTransport(
 		_livenessTimer: null,
 		_lastLivenessTick: 0,
 		_resumeListener: null,
+		_disposeFocusListeners: null,
 	};
 }
 
@@ -506,6 +514,20 @@ export function connect(
 	transport.currentUrl = wsUrl;
 	transport._localToken = extractToken(wsUrl);
 	transport._terminal = terminal;
+	// Keep the host's declared focus state current across live focus changes,
+	// not just at attach — the host writes the aggregate across all attached
+	// clients, so a pane whose focus only travelled in-band would be invisible
+	// to it and an unfocused sibling could clobber the program's state.
+	if (!transport._disposeFocusListeners && terminal.textarea) {
+		const textarea = terminal.textarea;
+		const send = () => sendFocusState(transport);
+		textarea.addEventListener("focus", send);
+		textarea.addEventListener("blur", send);
+		transport._disposeFocusListeners = () => {
+			textarea.removeEventListener("focus", send);
+			textarea.removeEventListener("blur", send);
+		};
+	}
 	transport._terminated = false;
 	transport._diagnosisLogged = false;
 	transport.lastDiagnosis = null;
@@ -779,6 +801,8 @@ export function reconnect(transport: TerminalTransport) {
 
 export function disconnect(transport: TerminalTransport) {
 	teardownLiveness(transport);
+	transport._disposeFocusListeners?.();
+	transport._disposeFocusListeners = null;
 	if (transport._socket) {
 		transport._socket.close();
 		transport._socket = null;
@@ -850,6 +874,8 @@ export function sendDispose(transport: TerminalTransport) {
 
 export function disposeTransport(transport: TerminalTransport) {
 	teardownLiveness(transport);
+	transport._disposeFocusListeners?.();
+	transport._disposeFocusListeners = null;
 	if (transport._socket) {
 		transport._socket.close();
 		transport._socket = null;

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -24,6 +24,7 @@ export interface ModeTracker {
 	resize(cols: number, rows: number): void;
 	buildPreamble(): Uint8Array | null;
 	isBracketedPasteActive(): boolean;
+	isFocusReportingActive(): boolean;
 	snapshot(maxLines?: number): TerminalSnapshot;
 	dispose(): void;
 }
@@ -153,6 +154,9 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		buildPreamble,
 		isBracketedPasteActive() {
 			return term.modes.bracketedPasteMode;
+		},
+		isFocusReportingActive() {
+			return term.modes.sendFocusMode;
 		},
 		snapshot,
 		dispose() {

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -157,11 +157,13 @@ const FOCUS_SCRIPT = String.raw`
 stty -echo
 if [ "$1" = "on" ]; then printf '\033[?1004h'; fi
 printf 'READY-FOCUS\n'
+n=0
 while IFS= read -r line; do
+  n=$((n+1))
   case $line in
-    *"[I"*) printf 'SAW-FOCUS-IN\n' ;;
-    *"[O"*) printf 'SAW-FOCUS-OUT\n' ;;
-    *) printf 'LINE-OK\n' ;;
+    *"[I"*) printf 'EVT %03d SAW-FOCUS-IN\n' "$n" ;;
+    *"[O"*) printf 'EVT %03d SAW-FOCUS-OUT\n' "$n" ;;
+    *) printf 'EVT %03d LINE-OK\n' "$n" ;;
   esac
   case $line in *stop*) exit 0 ;; esac
 done
@@ -937,12 +939,36 @@ test(
 				renderer.sendFocus(true);
 				renderer.sendInput("ping\n");
 				if (mode === "on") {
-					await renderer.waitVisible("SAW-FOCUS-IN");
-					renderer.sendFocus(false);
-					renderer.sendInput("ping\n");
-					await renderer.waitVisible("SAW-FOCUS-OUT");
+					await renderer.waitVisible("EVT 001 SAW-FOCUS-IN");
+					// An unfocused duplicate pane must not clobber the focused
+					// pane's state: the program sees the aggregate (still
+					// focused), never a bare focus-out.
+					const second = new SeqRenderer();
+					try {
+						await second.connect(terminalId, { autoResize: false });
+						await second.waitSynced();
+						second.sendFocus(false);
+						// Separate sockets: give the focus write time to land in the
+						// PTY input queue before the probe line flushes it.
+						await sleep(400);
+						renderer.sendInput("ping\n");
+						await renderer.waitVisible("EVT 002");
+						await renderer.drain();
+						assert.ok(
+							visibleText(renderer.term).includes("EVT 002 SAW-FOCUS-IN"),
+							"an unfocused duplicate pane must not report focus-out while the focused pane is attached",
+						);
+						// Once the focused pane blurs too, focus-out flows.
+						renderer.sendFocus(false);
+						await sleep(400);
+						renderer.sendInput("ping\n");
+						await renderer.waitVisible("EVT 003 SAW-FOCUS-OUT");
+					} finally {
+						await second.disconnect().catch(() => {});
+						second.dispose();
+					}
 				} else {
-					await renderer.waitVisible("LINE-OK");
+					await renderer.waitVisible("EVT 001 LINE-OK");
 					await renderer.drain();
 					assert.ok(
 						!visibleText(renderer.term).includes("SAW-FOCUS-IN"),

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -150,6 +150,23 @@ while :; do
 done
 `;
 
+// Echo-free line reader that reports focus escapes. Focus sequences arrive
+// with no newline, so they surface glued to the front of the next input
+// line — the pattern match catches them there. `$1 = on` enables mode 1004.
+const FOCUS_SCRIPT = String.raw`
+stty -echo
+if [ "$1" = "on" ]; then printf '\033[?1004h'; fi
+printf 'READY-FOCUS\n'
+while IFS= read -r line; do
+  case $line in
+    *"[I"*) printf 'SAW-FOCUS-IN\n' ;;
+    *"[O"*) printf 'SAW-FOCUS-OUT\n' ;;
+    *) printf 'LINE-OK\n' ;;
+  esac
+  case $line in *stop*) exit 0 ;; esac
+done
+`;
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -293,6 +310,14 @@ class SeqRenderer {
 		this.ws?.send(JSON.stringify({ type: "resize", cols, rows }));
 	}
 
+	sendFocus(focused: boolean): void {
+		this.ws?.send(JSON.stringify({ type: "focus", focused }));
+	}
+
+	sendInput(data: string): void {
+		this.ws?.send(JSON.stringify({ type: "input", data }));
+	}
+
 	disconnect(): Promise<void> {
 		return new Promise((resolve) => {
 			const ws = this.ws;
@@ -381,6 +406,7 @@ before(async () => {
 	const worktreePath = path.join(TEST_HOME, "worktree");
 	fs.mkdirSync(worktreePath, { recursive: true });
 	fs.writeFileSync(path.join(TEST_HOME, "tui.sh"), TUI_SCRIPT);
+	fs.writeFileSync(path.join(TEST_HOME, "focus.sh"), FOCUS_SCRIPT);
 
 	server = new Server({
 		socketPath: SOCK,
@@ -883,5 +909,53 @@ test(
 			term.dispose();
 			await disposeSessionAndWait(terminalId, db).catch(() => {});
 		}
+	},
+);
+
+test(
+	"attach-time focus state reaches the PTY only when the program enabled mode 1004",
+	{ timeout: 90_000 },
+	async () => {
+		const run = async (mode: "on" | "off") => {
+			const terminalId = `seq-focus-${mode}-${randomUUID().slice(0, 8)}`;
+			const session = await createTerminalSessionInternal({
+				terminalId,
+				workspaceId,
+				db,
+				listed: true,
+				cols: COLS,
+				rows: ROWS,
+				initialCommand: `exec bash '${path.join(TEST_HOME, "focus.sh")}' ${mode}`,
+			});
+			if ("error" in session) assert.fail(session.error);
+			const renderer = new SeqRenderer();
+			try {
+				await renderer.connect(terminalId);
+				await renderer.waitVisible("READY-FOCUS");
+				// The transport sends the client focus state on every attach;
+				// the host must forward it iff the program asked for it.
+				renderer.sendFocus(true);
+				renderer.sendInput("ping\n");
+				if (mode === "on") {
+					await renderer.waitVisible("SAW-FOCUS-IN");
+					renderer.sendFocus(false);
+					renderer.sendInput("ping\n");
+					await renderer.waitVisible("SAW-FOCUS-OUT");
+				} else {
+					await renderer.waitVisible("LINE-OK");
+					await renderer.drain();
+					assert.ok(
+						!visibleText(renderer.term).includes("SAW-FOCUS-IN"),
+						"focus escapes must not reach a program that never enabled mode 1004",
+					);
+				}
+			} finally {
+				await renderer.disconnect().catch(() => {});
+				renderer.dispose();
+				await disposeSessionAndWait(terminalId, db).catch(() => {});
+			}
+		};
+		await run("on");
+		await run("off");
 	},
 );

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -155,6 +155,13 @@ function getHostAgentHookUrl(): string {
 type TerminalClientMessage =
 	| { type: "input"; data: string }
 	| { type: "resize"; cols: number; rows: number }
+	// The client's current keyboard-focus state, sent on every attach. A
+	// reattaching client may hold focus the program last heard it lost (or
+	// vice versa) — a fresh xterm can't self-report because focus-reporting
+	// mode only reaches it via the preamble after its focus already settled.
+	// The host forwards it as \x1b[I / \x1b[O only when the program actually
+	// enabled focus reporting (mode 1004), which the tracker knows.
+	| { type: "focus"; focused: boolean }
 	| { type: "dispose" };
 
 // PTY output bytes travel as binary WebSocket frames — the renderer pipes
@@ -2317,6 +2324,13 @@ export function registerWorkspaceTerminalRoute({
 
 					if (message.type === "input") {
 						session.pty.write(message.data);
+						return;
+					}
+
+					if (message.type === "focus") {
+						if (session.modeTracker.isFocusReportingActive()) {
+							session.pty.write(message.focused ? "\x1b[I" : "\x1b[O");
+						}
 						return;
 					}
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -440,6 +440,13 @@ interface TerminalSession {
 	pendingRepaintNudge: ReturnType<typeof setTimeout> | null;
 	/** Bumped on every client resize; guards the nudge's delayed restore. */
 	resizeGeneration: number;
+	/**
+	 * Sockets whose client currently holds keyboard focus. The PTY receives
+	 * the AGGREGATE (any focused socket) — so an unfocused duplicate pane
+	 * attaching can't tell the program the focused pane lost focus (tmux's
+	 * client-focus ownership model).
+	 */
+	focusedSockets: Set<TerminalSocket>;
 
 	/**
 	 * Tail of the in-flight follow-up send (writeFramedInputToSession).
@@ -1025,6 +1032,20 @@ function nudgeRepaint(session: TerminalSession) {
  * lets delayed nudge timers no-op instead of poking a dead PTY. */
 function isCurrentLiveSession(session: TerminalSession): boolean {
 	return !session.exited && sessions.get(session.terminalId) === session;
+}
+
+/**
+ * Write the aggregate client focus state to the PTY when the program asked
+ * for focus reports (mode 1004). Written unconditionally rather than
+ * edge-triggered: the program's belief can drift via in-band reports from
+ * individual xterms, so every focus event re-asserts the aggregate truth —
+ * a redundant \x1b[I is idempotent to the program.
+ */
+function syncPtyFocus(session: TerminalSession) {
+	if (session.exited) return;
+	if (!session.modeTracker.isFocusReportingActive()) return;
+	const aggregate = session.focusedSockets.size > 0;
+	session.pty.write(aggregate ? "\x1b[I" : "\x1b[O");
 }
 
 /**
@@ -1947,6 +1968,7 @@ export async function createTerminalSessionInternal({
 		retainedStartSeq: 0,
 		pendingRepaintNudge: null,
 		resizeGeneration: 0,
+		focusedSockets: new Set(),
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
@@ -2328,9 +2350,12 @@ export function registerWorkspaceTerminalRoute({
 					}
 
 					if (message.type === "focus") {
-						if (session.modeTracker.isFocusReportingActive()) {
-							session.pty.write(message.focused ? "\x1b[I" : "\x1b[O");
+						if (message.focused) {
+							session.focusedSockets.add(ws);
+						} else {
+							session.focusedSockets.delete(ws);
 						}
+						syncPtyFocus(session);
 						return;
 					}
 
@@ -2364,12 +2389,18 @@ export function registerWorkspaceTerminalRoute({
 
 				onClose: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					session?.sockets.delete(ws);
+					if (!session) return;
+					session.sockets.delete(ws);
+					// A departing focused client may hand focus-out to the program
+					// (unless another attached client still holds focus).
+					if (session.focusedSockets.delete(ws)) syncPtyFocus(session);
 				},
 
 				onError: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					session?.sockets.delete(ws);
+					if (!session) return;
+					session.sockets.delete(ws);
+					if (session.focusedSockets.delete(ws)) syncPtyFocus(session);
 				},
 			};
 		}),


### PR DESCRIPTION
## Summary

Stacked on #6298 (uses its `synced` message; retarget to `main` after it merges).

A revealed/reattached terminal pane can leave the running TUI (Claude Code enables focus reporting, mode 1004) with a **stale focus state** — dimmed/unfocused UI in a pane the user is actively typing into.

## Why the "VS Code mechanism" alone is not enough — verified against sources and live

VS Code has **no side-channel for focus** (verified: zero hits for `sendFocus`/`1004`/`\x1b[I` in `terminalInstance.ts`, `ptyService.ts`, `terminalProcess.ts`). It relies on:
1. `@xterm/addon-serialize` emitting `\x1b[?1004h` in replayed state, and
2. xterm.js ≥4.15 (PR xtermjs/xterm.js#3506) self-reporting the *current* focus when an app enables 1004.

Our mode-preamble replay already triggers that exact mechanism — but it's **race-prone in a pane-parking architecture**, and we reproduced the failure live: on a parked-runtime rebuild of a *focused* pane, the self-report read the focus class before pane focus settled and delivered `\x1b[O` with no corrective `\x1b[I` ever following. The program is left wrong until the user clicks away and back. VS Code never hits this because its revives happen at window reload, when nothing is focused yet.

The right precedent is **tmux**, which treats attach as an explicit focus edge: on client attach it writes `\033[I`/`\033[O` into panes, gated on the app having enabled the mode (`MODE_FOCUSON`, `window_pane_update_focus()` in `window.c`).

## How it works (tmux's model, race-free)

- **Renderer**: on `synced`, flush the coalescer (the preamble frame precedes `synced`) and queue `{type:"focus", focused}` behind an empty `terminal.write("")` callback — guaranteeing it reaches the host **after** the preamble parse and any xterm self-report it triggered. The renderer's actual state always gets the last word.
- **Host**: forwards `\x1b[I`/`\x1b[O` to the PTY **only when the ModeTracker says the program enabled mode 1004** — plain shells never see stray escapes.
- Version skew safe: old hosts ignore the unknown message; old renderers never send it.

## Verification

- Node regression test: focus escapes reach the program **iff** it enabled 1004 (both polarities asserted).
- Live CDP on the dev desktop, OS window genuinely focused (AppleScript):
  - **Pre-fix build**: eviction rebuild of a focused pane → program received `\x1b[O` only, left wrong (the reported bug, reproduced).
  - **Fixed build**: same journey → program converges on `\x1b[I` (raw byte capture: `^[[I` last); a real window blur afterwards delivered a truthful `^[[O`.
- Full suite green (3/3 seq tests, host-service 1065, desktop 319), lint + typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reasserts client focus to the PTY on attach, tracks live focus changes, and aggregates focus across panes. Fixes stale or clobbered focus after reattaches and in duplicate panes, so TUIs with focus reporting get the correct state without extra clicks.

- **Bug Fixes**
  - `desktop`: on `synced`, flush the preamble and queue a `{type:"focus"}` behind an empty `terminal.write("")` so it lands after any xterm self-report; also send focus on textarea focus/blur to keep the host’s declared state current (listeners removed on teardown).
  - `host-service`: accept `focus` messages and forward `\x1b[I`/`\x1b[O` only when mode 1004 is active via `ModeTracker.isFocusReportingActive()`.
  - `host-service`: track focus per socket and write the aggregate (any focused client) to the PTY; recompute on client disconnect/error so unfocused duplicates can’t clobber a focused pane.
  - tests: add seq tests for 1004 gating and multi-client aggregate semantics.

<sup>Written for commit 0dcb5f60a0665aabe5c946d8cf6eca75e3913bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal focus-state reporting over WebSocket connections.
  * Terminal applications can receive focus-in and focus-out events when focus reporting is enabled.
  * Focus state remains synchronized across multiple connected terminal views.

* **Bug Fixes**
  * Improved focus synchronization when views connect, disconnect, lose focus, or encounter connection errors.
  * Prevented focus events from being sent when focus reporting is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->