### PR TITLE
fix(host-service): heal trustd-degraded pty-daemons so gh works in terminals (x509 -26276)

### DIFF
--- a/apps/desktop/src/main/pty-daemon/index.ts
+++ b/apps/desktop/src/main/pty-daemon/index.ts
@@ -38,6 +38,7 @@ import {
 	Server,
 } from "@superset/pty-daemon";
 import type { HandoffMessage } from "@superset/pty-daemon/protocol";
+import { probeTrustdHealthy } from "@superset/pty-daemon/trustd-probe";
 
 interface CliArgs {
 	socket: string;
@@ -85,6 +86,10 @@ async function runFresh(): Promise<void> {
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Probe AFTER binding so a slow `security` can't delay the socket coming up
+	// (the supervisor has a socket-ready timeout). The value lands before the
+	// supervisor's adoption hello, which happens well after bind.
+	server.setTrustdHealthy(await probeTrustdHealthy());
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion})\n`,
 	);
@@ -169,6 +174,9 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Probe only now: running it earlier would delay the upgrade-ack the
+	// predecessor is waiting on (and the socket bind).
+	server.setTrustdHealthy(await probeTrustdHealthy());
 	log(`bound and listening`);
 
 	clearSnapshot(snapshotPath);

--- a/apps/desktop/src/main/pty-daemon/index.ts
+++ b/apps/desktop/src/main/pty-daemon/index.ts
@@ -86,6 +86,9 @@ async function runFresh(): Promise<void> {
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Signal handlers first: a SIGTERM landing during the (bounded) probe
+	// must still run the PTY teardown drain.
+	wireShutdown(server);
 	// Probe AFTER binding so a slow `security` can't delay the socket coming up
 	// (the supervisor has a socket-ready timeout). The value lands before the
 	// supervisor's adoption hello, which happens well after bind.
@@ -93,7 +96,6 @@ async function runFresh(): Promise<void> {
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion})\n`,
 	);
-	wireShutdown(server);
 }
 
 async function runHandoffReceiver(): Promise<void> {
@@ -174,13 +176,15 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Signal handlers first: a SIGTERM landing during the (bounded) probe
+	// must still run the PTY teardown drain for the adopted sessions.
+	wireShutdown(server);
 	// Probe only now: running it earlier would delay the upgrade-ack the
 	// predecessor is waiting on (and the socket bind).
 	server.setTrustdHealthy(await probeTrustdHealthy());
 	log(`bound and listening`);
 
 	clearSnapshot(snapshotPath);
-	wireShutdown(server);
 }
 
 function wireShutdown(server: Server): void {

--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -953,6 +953,58 @@ describe("trustd-degraded daemon heal", () => {
 		},
 	);
 
+	test(
+		"crash-relaunch chain: degraded boot adopts untouched, next healthy launch heals",
+		darwinOnly,
+		async () => {
+			// The confirmed field vector (#6127): a machine crash relaunches the
+			// app in a degraded login context, so host-service AND the daemon it
+			// spawns are both trustd-broken. That generation must not thrash
+			// (heal suppressed). The daemon then outlives the app quit, and the
+			// NEXT launch — a fresh, healthy host-service — must adopt the
+			// surviving self-reported-degraded daemon and replace it.
+			const orgId = "org-trustd-crash-relaunch";
+			const socketPath = socketPathFor(orgId);
+			const degradedPid = spawnDegradedDaemon(socketPath);
+			assert.equal(await waitForSocket(socketPath, 5000), true);
+			await waitForTrustdReport(socketPath);
+			seedManifest(orgId, degradedPid, socketPath);
+
+			// Generation 1: the crash-relaunched, degraded host-service.
+			const degradedBoot = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+				hostTrustdProbe: async () => false,
+			});
+			const adopted = await degradedBoot.ensure(orgId);
+			assert.equal(adopted.pid, degradedPid, "degraded boot must adopt");
+			assert.equal(isAlive(degradedPid), true, "no heal from a degraded host");
+
+			// App quit: supervisor state dies with the process, daemon survives.
+			dropSupervisorInstance(degradedBoot, orgId);
+
+			// Generation 2: the next normal launch, healthy context (real probe).
+			const healthyLaunch = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup: healthyLaunch, orgId });
+			const healed = await healthyLaunch.ensure(orgId);
+
+			assert.notEqual(
+				healed.pid,
+				degradedPid,
+				"healthy launch must replace the surviving degraded daemon",
+			);
+			const deadline = Date.now() + 3000;
+			while (isAlive(degradedPid) && Date.now() < deadline) {
+				await new Promise((r) => setTimeout(r, 50));
+			}
+			assert.equal(isAlive(degradedPid), false, "degraded daemon still alive");
+			assert.equal(isAlive(healed.pid), true, "fresh daemon not running");
+		},
+	);
+
 	test("adopts (never kills) a pre-probe daemon whose hello-ack lacks trustdHealthy", async () => {
 		// Pre-0.3.0 daemons don't probe — their hello-ack has no trustdHealthy.
 		// Unknown must not be treated as degraded: those daemons hold real

--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -1014,6 +1014,62 @@ describe("trustd-degraded daemon heal", () => {
 		}
 	});
 
+	test("adopts the probed daemon when the manifest pid is stale (recycled)", async () => {
+		// The socket answers with a daemonPid that differs from manifest.pid —
+		// the manifest pid may be recycled onto an unrelated process. Adoption
+		// must land on the probed pid (reusing the SAME probe — a transient
+		// re-probe failure must not demote a confirmed-live daemon to a fresh
+		// spawn), and nothing may be killed.
+		const orgId = "org-trustd-pid-mismatch";
+		const socketPath = socketPathFor(orgId);
+		const realDaemon = childProcess.spawn("sleep", ["60"], {
+			stdio: "ignore",
+		});
+		const recycled = childProcess.spawn("sleep", ["60"], { stdio: "ignore" });
+		const server = net.createServer((sock) => {
+			const decoder = new FrameDecoder();
+			sock.on("data", (chunk: Buffer) => {
+				decoder.push(chunk);
+				for (const { message } of decoder.drain()) {
+					if ((message as { type?: string }).type === "hello") {
+						sock.write(
+							encodeFrame({
+								type: "hello-ack",
+								protocol: CURRENT_PROTOCOL_VERSION,
+								daemonVersion: EXPECTED_DAEMON_VERSION,
+								daemonPid: realDaemon.pid,
+							}),
+						);
+					}
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+		try {
+			// Manifest points at the recycled (unrelated, live) pid.
+			seedManifest(orgId, recycled.pid as number, socketPath);
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const adopted = await sup.ensure(orgId);
+
+			assert.equal(adopted.pid, realDaemon.pid, "must adopt the probed pid");
+			assert.equal(
+				isAlive(recycled.pid as number),
+				true,
+				"recycled pid untouched",
+			);
+			assert.equal(isAlive(realDaemon.pid as number), true, "daemon untouched");
+		} finally {
+			server.close();
+			realDaemon.kill("SIGKILL");
+			recycled.kill("SIGKILL");
+		}
+	});
+
 	test("heals when a daemon adopted before its probe landed later reports degraded", async () => {
 		// The daemon binds before probeTrustdHealthy() completes, so an
 		// adoption in that window sees no trustdHealthy. The liveness poll's

--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -17,6 +17,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
+import {
+	CURRENT_PROTOCOL_VERSION,
+	encodeFrame,
+	FrameDecoder,
+} from "@superset/pty-daemon/protocol";
 import { DaemonSupervisor } from "./DaemonSupervisor.ts";
 import {
 	type PtyDaemonManifest,
@@ -770,6 +775,219 @@ describe("DaemonSupervisor.update (Phase 2 fd-handoff)", () => {
 		assert.equal(result.ok, false);
 		if (!result.ok) {
 			assert.match(result.reason, /no daemon running/);
+		}
+	});
+});
+
+describe("trustd-degraded daemon heal", () => {
+	// The daemon's startup probe runs `security verify-cert` via PATH, so a
+	// PATH-shimmed `security` that exits 1 (exactly what the real binary does
+	// when trustd is unreachable) makes a real daemon self-report degraded.
+	// The probe is darwin-only; on other platforms it always reports healthy.
+	const darwinOnly = { skip: process.platform !== "darwin" };
+
+	function socketPathFor(orgId: string): string {
+		const socketPath = path.join(
+			os.tmpdir(),
+			`superset-ptyd-${crypto
+				.createHash("sha256")
+				.update(orgId)
+				.digest("hex")
+				.slice(0, 12)}.sock`,
+		);
+		try {
+			fs.unlinkSync(socketPath);
+		} catch {}
+		return socketPath;
+	}
+
+	function seedManifest(orgId: string, pid: number, socketPath: string): void {
+		fs.mkdirSync(ptyDaemonManifestDir(orgId), { recursive: true, mode: 0o700 });
+		const manifest: PtyDaemonManifest = {
+			pid,
+			socketPath,
+			protocolVersions: [CURRENT_PROTOCOL_VERSION],
+			startedAt: Date.now(),
+			organizationId: orgId,
+		};
+		writePtyDaemonManifest(manifest);
+	}
+
+	function spawnDegradedDaemon(socketPath: string): number {
+		const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "trustd-shim-"));
+		fs.writeFileSync(path.join(shimDir, "security"), "#!/bin/sh\nexit 1\n", {
+			mode: 0o755,
+		});
+		const child = childProcess.spawn(
+			process.execPath,
+			[DAEMON_BUNDLE, `--socket=${socketPath}`],
+			{
+				detached: true,
+				stdio: "ignore",
+				env: { ...process.env, PATH: `${shimDir}:${process.env.PATH}` },
+			},
+		);
+		child.unref();
+		return child.pid as number;
+	}
+
+	/**
+	 * The daemon probes AFTER binding (so a slow `security` can't delay the
+	 * socket), so right after bind its hello-ack briefly omits trustdHealthy.
+	 * Real adoptions happen long after daemon start; tests must wait for the
+	 * self-report or they race it.
+	 */
+	async function waitForTrustdReport(socketPath: string): Promise<void> {
+		const deadline = Date.now() + 5000;
+		while (Date.now() < deadline) {
+			const reported = await new Promise<boolean>((resolve) => {
+				const sock = net.createConnection({ path: socketPath });
+				const decoder = new FrameDecoder();
+				const timer = setTimeout(() => {
+					sock.destroy();
+					resolve(false);
+				}, 500);
+				sock.once("connect", () =>
+					sock.write(
+						encodeFrame({
+							type: "hello",
+							protocols: [CURRENT_PROTOCOL_VERSION],
+							clientVersion: "test-trustd-wait",
+						}),
+					),
+				);
+				sock.on("data", (chunk: Buffer) => {
+					decoder.push(chunk);
+					for (const { message } of decoder.drain()) {
+						const m = message as { type?: string; trustdHealthy?: boolean };
+						if (m.type === "hello-ack") {
+							clearTimeout(timer);
+							sock.end();
+							resolve(m.trustdHealthy !== undefined);
+							return;
+						}
+					}
+				});
+				sock.once("error", () => {
+					clearTimeout(timer);
+					resolve(false);
+				});
+			});
+			if (reported) return;
+			await new Promise((r) => setTimeout(r, 50));
+		}
+		throw new Error("daemon never reported trustdHealthy in its hello-ack");
+	}
+
+	test(
+		"kills a self-reported degraded daemon and respawns fresh",
+		darwinOnly,
+		async () => {
+			const orgId = "org-trustd-heal";
+			const socketPath = socketPathFor(orgId);
+			const degradedPid = spawnDegradedDaemon(socketPath);
+			assert.equal(await waitForSocket(socketPath, 5000), true);
+			await waitForTrustdReport(socketPath);
+			seedManifest(orgId, degradedPid, socketPath);
+
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const instance = await sup.ensure(orgId);
+
+			assert.notEqual(
+				instance.pid,
+				degradedPid,
+				"degraded daemon must be replaced, not adopted",
+			);
+			const deadline = Date.now() + 3000;
+			while (isAlive(degradedPid) && Date.now() < deadline) {
+				await new Promise((r) => setTimeout(r, 50));
+			}
+			assert.equal(isAlive(degradedPid), false, "degraded daemon still alive");
+			assert.equal(isAlive(instance.pid), true, "fresh daemon not running");
+		},
+	);
+
+	test(
+		"adopts (never kills) a degraded daemon when host-service is degraded too",
+		darwinOnly,
+		async () => {
+			const orgId = "org-trustd-suppress";
+			const socketPath = socketPathFor(orgId);
+			const degradedPid = spawnDegradedDaemon(socketPath);
+			assert.equal(await waitForSocket(socketPath, 5000), true);
+			await waitForTrustdReport(socketPath);
+			seedManifest(orgId, degradedPid, socketPath);
+
+			// A degraded host can't spawn a healthier daemon than the one it
+			// has — killing sessions would be pure loss. Inject the host probe:
+			// the real one can't be staged without breaking this process.
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+				hostTrustdProbe: async () => false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const instance = await sup.ensure(orgId);
+
+			assert.equal(instance.pid, degradedPid, "should adopt, not respawn");
+			assert.equal(isAlive(degradedPid), true, "daemon must be left alive");
+		},
+	);
+
+	test("adopts (never kills) a pre-probe daemon whose hello-ack lacks trustdHealthy", async () => {
+		// Pre-0.3.0 daemons don't probe — their hello-ack has no trustdHealthy.
+		// Unknown must not be treated as degraded: those daemons hold real
+		// sessions, and the version-bump auto-update is their migration path.
+		// Fake the daemon with a live placeholder pid + a socket that speaks
+		// just enough protocol to answer the supervisor's version probe.
+		const orgId = "org-trustd-unknown";
+		const socketPath = socketPathFor(orgId);
+		const placeholder = childProcess.spawn("sleep", ["60"], {
+			stdio: "ignore",
+		});
+		const server = net.createServer((sock) => {
+			const decoder = new FrameDecoder();
+			sock.on("data", (chunk: Buffer) => {
+				decoder.push(chunk);
+				for (const { message } of decoder.drain()) {
+					if ((message as { type?: string }).type === "hello") {
+						sock.write(
+							encodeFrame({
+								type: "hello-ack",
+								protocol: CURRENT_PROTOCOL_VERSION,
+								daemonVersion: "0.2.7",
+								daemonPid: placeholder.pid,
+							}),
+						);
+					}
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+		try {
+			seedManifest(orgId, placeholder.pid as number, socketPath);
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const instance = await sup.ensure(orgId);
+
+			assert.equal(instance.pid, placeholder.pid, "should adopt by pid");
+			assert.equal(instance.updatePending, true, "0.2.7 < expected");
+			assert.equal(
+				isAlive(placeholder.pid as number),
+				true,
+				"must be left alive",
+			);
+		} finally {
+			server.close();
+			placeholder.kill("SIGKILL");
 		}
 	});
 });

--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -787,6 +787,19 @@ describe("trustd-degraded daemon heal", () => {
 	// The probe is darwin-only; on other platforms it always reports healthy.
 	const darwinOnly = { skip: process.platform !== "darwin" };
 
+	// Detached daemons spawned by a test that fails before registering its
+	// supervisor would outlive the run — reap them unconditionally.
+	const strayPids: number[] = [];
+	afterEach(() => {
+		for (const pid of strayPids.splice(0)) {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				// already dead
+			}
+		}
+	});
+
 	function socketPathFor(orgId: string): string {
 		const socketPath = path.join(
 			os.tmpdir(),
@@ -829,6 +842,7 @@ describe("trustd-degraded daemon heal", () => {
 			},
 		);
 		child.unref();
+		strayPids.push(child.pid as number);
 		return child.pid as number;
 	}
 

--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -23,6 +23,7 @@ import {
 	FrameDecoder,
 } from "@superset/pty-daemon/protocol";
 import { DaemonSupervisor } from "./DaemonSupervisor.ts";
+import { EXPECTED_DAEMON_VERSION } from "./expected-version.ts";
 import {
 	type PtyDaemonManifest,
 	ptyDaemonManifestDir,
@@ -984,6 +985,74 @@ describe("trustd-degraded daemon heal", () => {
 				isAlive(placeholder.pid as number),
 				true,
 				"must be left alive",
+			);
+			// A permanently absent field must stay non-destructive across the
+			// liveness poll's later hello probes too, not just at adoption.
+			await new Promise((r) => setTimeout(r, 2_600));
+			assert.equal(
+				isAlive(placeholder.pid as number),
+				true,
+				"must survive poll re-probes",
+			);
+		} finally {
+			server.close();
+			placeholder.kill("SIGKILL");
+		}
+	});
+
+	test("heals when a daemon adopted before its probe landed later reports degraded", async () => {
+		// The daemon binds before probeTrustdHealthy() completes, so an
+		// adoption in that window sees no trustdHealthy. The liveness poll's
+		// hello probe must pick up the late self-report and apply the same
+		// guarded heal the adopt path would have.
+		const orgId = "org-trustd-late-report";
+		const socketPath = socketPathFor(orgId);
+		const placeholder = childProcess.spawn("sleep", ["60"], {
+			stdio: "ignore",
+		});
+		let reportDegraded = false;
+		const server = net.createServer((sock) => {
+			const decoder = new FrameDecoder();
+			sock.on("data", (chunk: Buffer) => {
+				decoder.push(chunk);
+				for (const { message } of decoder.drain()) {
+					if ((message as { type?: string }).type === "hello") {
+						sock.write(
+							encodeFrame({
+								type: "hello-ack",
+								protocol: CURRENT_PROTOCOL_VERSION,
+								daemonVersion: EXPECTED_DAEMON_VERSION,
+								daemonPid: placeholder.pid,
+								...(reportDegraded ? { trustdHealthy: false } : {}),
+							}),
+						);
+					}
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+		try {
+			seedManifest(orgId, placeholder.pid as number, socketPath);
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const adopted = await sup.ensure(orgId);
+			assert.equal(adopted.pid, placeholder.pid, "adopted while unknown");
+
+			// Startup probe "lands": subsequent hello-acks self-report degraded.
+			reportDegraded = true;
+
+			const deadline = Date.now() + 10_000;
+			while (isAlive(placeholder.pid as number) && Date.now() < deadline) {
+				await new Promise((r) => setTimeout(r, 100));
+			}
+			assert.equal(
+				isAlive(placeholder.pid as number),
+				false,
+				"late degraded report must trigger the heal",
 			);
 		} finally {
 			server.close();

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -25,6 +25,7 @@ import {
 	type ServerMessage,
 	type SessionInfo,
 } from "@superset/pty-daemon/protocol";
+import { probeTrustdHealthy } from "@superset/pty-daemon/trustd-probe";
 import semver from "semver";
 import { DaemonClient } from "../terminal/DaemonClient/index.ts";
 import { EXPECTED_DAEMON_VERSION } from "./expected-version.ts";
@@ -57,6 +58,11 @@ interface DaemonInstance {
 	 * restart of shells that were about to come back.
 	 */
 	unreachableSince: number | null;
+	/**
+	 * macOS trustd reachability the daemon self-reported. `false` = degraded
+	 * (its terminals hit `gh -26276`); undefined = pre-probe daemon version.
+	 */
+	trustdHealthy?: boolean;
 }
 
 export interface DaemonHealth {
@@ -68,6 +74,7 @@ export interface DaemonHealth {
 interface DaemonProbeResult {
 	daemonVersion: string;
 	daemonPid?: number;
+	trustdHealthy?: boolean;
 }
 
 export interface DaemonAutoUpdateFailure {
@@ -215,9 +222,45 @@ export class DaemonSupervisor {
 		string,
 		Promise<{ ok: true; successorPid: number } | { ok: false; reason: string }>
 	>();
+	/** Whether host-service itself can reach trustd; probed once, cached. */
+	private hostTrustdHealthyCache: boolean | null = null;
 
 	constructor(opts: DaemonSupervisorOptions) {
 		this.opts = opts;
+	}
+
+	/**
+	 * Whether host-service's own Mach bootstrap can reach com.apple.trustd. Used
+	 * to gate healing a trustd-degraded daemon: only worth respawning from here
+	 * if we're healthy. Cached — a process's bootstrap doesn't change under it.
+	 */
+	private hostTrustdHealthy(): boolean {
+		if (this.hostTrustdHealthyCache === null) {
+			this.hostTrustdHealthyCache = probeTrustdHealthy();
+		}
+		return this.hostTrustdHealthyCache;
+	}
+
+	/**
+	 * Terminate an adopted daemon so ensure() can respawn a fresh one. An
+	 * adopted daemon has no child handle or crash-respawn hook attached yet, so
+	 * this just kills its process tree and clears its manifest + socket. Its PTY
+	 * sessions are lost — acceptable, since a trustd-degraded daemon's shells are
+	 * already broken for `gh`/TLS.
+	 */
+	private async killAdoptedDaemon(
+		organizationId: string,
+		instance: DaemonInstance,
+	): Promise<void> {
+		await terminateProcessTreeAndGroups(instance.pid, "SIGTERM");
+		removePtyDaemonManifest(organizationId);
+		try {
+			if (fs.existsSync(instance.socketPath)) {
+				fs.unlinkSync(instance.socketPath);
+			}
+		} catch {
+			// best-effort; the fresh daemon unlinks a stale socket on bind anyway
+		}
 	}
 
 	/**
@@ -789,7 +832,26 @@ export class DaemonSupervisor {
 			await this.killStaleDaemonForDev(organizationId);
 		}
 
-		const adopted = await this.tryAdopt(organizationId);
+		let adopted = await this.tryAdopt(organizationId);
+		// Heal a trustd-degraded daemon: it inherited a Mach bootstrap that can't
+		// reach com.apple.trustd, so its terminals hit `gh: x509: OSStatus -26276`.
+		// Adopting it keeps the breakage — if WE (host-service) can reach trustd,
+		// kill it and respawn fresh from our healthy context below. If we're also
+		// degraded, a respawn wouldn't help; adopt and let the next healthy launch
+		// heal it.
+		if (
+			adopted &&
+			adopted.trustdHealthy === false &&
+			this.hostTrustdHealthy()
+		) {
+			logEvent("pty_daemon_trustd_degraded_respawn", {
+				organizationId,
+				pid: adopted.pid,
+				runningVersion: adopted.runningVersion,
+			});
+			await this.killAdoptedDaemon(organizationId, adopted);
+			adopted = null;
+		}
 		if (adopted) {
 			this.instances.set(organizationId, adopted);
 			console.log(
@@ -901,6 +963,7 @@ export class DaemonSupervisor {
 			// Start the clock here when it didn't answer: the liveness poll
 			// clears it the moment it does.
 			unreachableSince: probe ? null : Date.now(),
+			trustdHealthy: probe?.trustdHealthy,
 		};
 	}
 
@@ -963,6 +1026,7 @@ export class DaemonSupervisor {
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: isVersionUpdatePending(probe.daemonVersion),
 			unreachableSince: null,
+			trustdHealthy: probe.trustdHealthy,
 		};
 	}
 
@@ -1154,6 +1218,9 @@ export class DaemonSupervisor {
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: false,
 			unreachableSince: null,
+			// A freshly spawned daemon inherits host-service's bootstrap, so its
+			// trustd reachability matches ours.
+			trustdHealthy: this.hostTrustdHealthy(),
 		};
 		this.instances.set(organizationId, instance);
 		// Reachability only — `child.on("exit")` above owns death + respawn.
@@ -1456,6 +1523,7 @@ function probeDaemonHello(
 						cleanup({
 							daemonVersion,
 							daemonPid: msg.daemonPid,
+							trustdHealthy: msg.trustdHealthy,
 						});
 						return;
 					}

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -662,6 +662,36 @@ export class DaemonSupervisor {
 				this.kickoffAutoUpdate(organizationId, current);
 			}
 		}
+		// The daemon probes trustd AFTER binding, so a daemon adopted right
+		// after it started may not have self-reported yet. Fill in the value
+		// only while unknown — the reported value never changes after startup,
+		// so this can complete adoption-time triage late but can never turn
+		// into a mid-life kill of a long-adopted daemon.
+		if (
+			current.trustdHealthy === undefined &&
+			probe.trustdHealthy !== undefined
+		) {
+			current.trustdHealthy = probe.trustdHealthy;
+			if (probe.trustdHealthy === false && (await this.hostTrustdHealthy())) {
+				logEvent("pty_daemon_trustd_degraded_respawn", {
+					organizationId,
+					pid: current.pid,
+					runningVersion: current.runningVersion,
+					lateReport: true,
+				});
+				this.stopHealthPoll(organizationId);
+				await this.killAdoptedDaemon(organizationId, current);
+				if (this.instances.get(organizationId)?.pid === pid) {
+					this.instances.delete(organizationId);
+				}
+				void this.ensure(organizationId).catch((err) => {
+					console.error(
+						`[pty-daemon:${organizationId}] respawn after late degraded report failed:`,
+						err,
+					);
+				});
+			}
+		}
 	}
 
 	/**

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -223,7 +223,7 @@ export class DaemonSupervisor {
 		Promise<{ ok: true; successorPid: number } | { ok: false; reason: string }>
 	>();
 	/** Whether host-service itself can reach trustd; probed once, cached. */
-	private hostTrustdHealthyCache: boolean | null = null;
+	private hostTrustdHealthyCache: Promise<boolean> | null = null;
 
 	constructor(opts: DaemonSupervisorOptions) {
 		this.opts = opts;
@@ -234,10 +234,8 @@ export class DaemonSupervisor {
 	 * to gate healing a trustd-degraded daemon: only worth respawning from here
 	 * if we're healthy. Cached — a process's bootstrap doesn't change under it.
 	 */
-	private hostTrustdHealthy(): boolean {
-		if (this.hostTrustdHealthyCache === null) {
-			this.hostTrustdHealthyCache = probeTrustdHealthy();
-		}
+	private hostTrustdHealthy(): Promise<boolean> {
+		this.hostTrustdHealthyCache ??= probeTrustdHealthy();
 		return this.hostTrustdHealthyCache;
 	}
 
@@ -842,7 +840,7 @@ export class DaemonSupervisor {
 		if (
 			adopted &&
 			adopted.trustdHealthy === false &&
-			this.hostTrustdHealthy()
+			(await this.hostTrustdHealthy())
 		) {
 			logEvent("pty_daemon_trustd_degraded_respawn", {
 				organizationId,
@@ -1220,7 +1218,7 @@ export class DaemonSupervisor {
 			unreachableSince: null,
 			// A freshly spawned daemon inherits host-service's bootstrap, so its
 			// trustd reachability matches ours.
-			trustdHealthy: this.hostTrustdHealthy(),
+			trustdHealthy: await this.hostTrustdHealthy(),
 		};
 		this.instances.set(organizationId, instance);
 		// Reachability only — `child.on("exit")` above owns death + respawn.

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -673,6 +673,10 @@ export class DaemonSupervisor {
 		) {
 			current.trustdHealthy = probe.trustdHealthy;
 			if (probe.trustdHealthy === false && (await this.hostTrustdHealthy())) {
+				// Re-check after the await: a concurrent restart can have
+				// replaced the instance, and killing `current` then would
+				// unlink the successor's socket and manifest under it.
+				if (this.instances.get(organizationId) !== current) return;
 				logEvent("pty_daemon_trustd_degraded_respawn", {
 					organizationId,
 					pid: current.pid,
@@ -1004,9 +1008,20 @@ export class DaemonSupervisor {
 				socketPath: manifest.socketPath,
 			});
 			removePtyDaemonManifest(organizationId);
-			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
-				reason: "manifest_pid_mismatch",
-			});
+			// Reuse the probe we already have — re-probing would let a
+			// transient failure demote this confirmed-live daemon to a fresh
+			// spawn. Fall back to a socket adopt only if the probed pid died.
+			return (
+				this.adoptFromProbe(
+					organizationId,
+					manifest.socketPath,
+					probe,
+					"manifest_pid_mismatch",
+				) ??
+				this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+					reason: "manifest_pid_mismatch",
+				})
+			);
 		}
 		const runningVersion = probe?.daemonVersion ?? "unknown";
 		return {
@@ -1045,13 +1060,34 @@ export class DaemonSupervisor {
 			return null;
 		}
 
+		return this.adoptFromProbe(
+			organizationId,
+			socketPath,
+			probe,
+			context.reason,
+		);
+	}
+
+	/**
+	 * Build an adoption from an already-successful hello probe: validate the
+	 * probed pid, recover the manifest, and return the instance. Split out so
+	 * callers that HAVE a good probe (e.g. the manifest-pid-mismatch path)
+	 * don't re-probe — a transient failure of a second probe would turn a
+	 * confirmed live daemon into a fresh spawn that unlinks its socket.
+	 */
+	private adoptFromProbe(
+		organizationId: string,
+		socketPath: string,
+		probe: DaemonProbeResult,
+		sourceReason: string,
+	): DaemonInstance | null {
 		const resolvedPid = probe.daemonPid;
 		if (!isPositiveInteger(resolvedPid) || !isProcessAlive(resolvedPid)) {
 			logEvent("pty_daemon_socket_adopt_rejected", {
 				organizationId,
 				socketPath,
 				reason: "pid_unavailable",
-				sourceReason: context.reason,
+				sourceReason,
 				probedPid: resolvedPid,
 			});
 			return null;
@@ -1070,7 +1106,7 @@ export class DaemonSupervisor {
 			organizationId,
 			pid: resolvedPid,
 			socketPath,
-			sourceReason: context.reason,
+			sourceReason,
 			runningVersion: probe.daemonVersion,
 		});
 

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -988,6 +988,26 @@ export class DaemonSupervisor {
 				reason: "manifest_socket_unreachable",
 			});
 		}
+		if (
+			probe &&
+			isPositiveInteger(probe.daemonPid) &&
+			probe.daemonPid !== manifest.pid
+		) {
+			// The socket answers, but a DIFFERENT daemon serves it — the
+			// manifest pid is stale (recycled, or lost a bind race). Adopting
+			// manifest.pid would aim any later destructive action (trustd heal,
+			// user restart) at an unrelated process tree. Trust the socket.
+			logEvent("pty_daemon_manifest_pid_mismatch", {
+				organizationId,
+				manifestPid: manifest.pid,
+				probedPid: probe.daemonPid,
+				socketPath: manifest.socketPath,
+			});
+			removePtyDaemonManifest(organizationId);
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_pid_mismatch",
+			});
+		}
 		const runningVersion = probe?.daemonVersion ?? "unknown";
 		return {
 			pid: manifest.pid,
@@ -1067,6 +1087,10 @@ export class DaemonSupervisor {
 	}
 
 	private async spawn(organizationId: string): Promise<DaemonInstance> {
+		// Resolve before spawning the child: an await between the spawn and
+		// instances.set would let a crashing child's exit handler run against
+		// a not-yet-registered instance.
+		const hostTrustdHealthy = await this.hostTrustdHealthy();
 		const dir = ptyDaemonManifestDir(organizationId);
 		if (!fs.existsSync(dir)) {
 			fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -1256,7 +1280,7 @@ export class DaemonSupervisor {
 			unreachableSince: null,
 			// A freshly spawned daemon inherits host-service's bootstrap, so its
 			// trustd reachability matches ours.
-			trustdHealthy: await this.hostTrustdHealthy(),
+			trustdHealthy: hostTrustdHealthy,
 		};
 		this.instances.set(organizationId, instance);
 		// Reachability only — `child.on("exit")` above owns death + respawn.

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -184,6 +184,12 @@ export interface DaemonSupervisorOptions {
 	 * real handoff.
 	 */
 	autoUpdate?: boolean;
+	/**
+	 * Override for host-service's own trustd probe. Tests inject this to
+	 * exercise the degraded-host branch (heal suppressed), which can't be
+	 * staged for real without breaking the test process's own bootstrap.
+	 */
+	hostTrustdProbe?: () => Promise<boolean>;
 }
 
 export class DaemonSupervisor {
@@ -235,7 +241,9 @@ export class DaemonSupervisor {
 	 * if we're healthy. Cached — a process's bootstrap doesn't change under it.
 	 */
 	private hostTrustdHealthy(): Promise<boolean> {
-		this.hostTrustdHealthyCache ??= probeTrustdHealthy();
+		this.hostTrustdHealthyCache ??= (
+			this.opts.hostTrustdProbe ?? probeTrustdHealthy
+		)();
 		return this.hostTrustdHealthyCache;
 	}
 

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.2.7",
+	"version": "0.3.0",
 	"private": true,
 	"type": "module",
 	"exports": {
@@ -16,6 +16,10 @@
 			"types": "./dist-types/process-tree.d.ts",
 			"default": "./src/process-tree.ts"
 		},
+		"./trustd-probe": {
+			"types": "./dist-types/trustd-probe.d.ts",
+			"default": "./src/trustd-probe.ts"
+		},
 		"./package.json": "./package.json"
 	},
 	"bin": {
@@ -29,7 +33,7 @@
 		"start": "node --experimental-strip-types src/main.ts",
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts src/no-daemon-loop-blocking.test.ts test/server-fd-lifecycle.test.ts test/no-encoding-hops.test.ts",
+		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/trustd-probe.test.ts src/process-tree.test.ts src/no-daemon-loop-blocking.test.ts test/server-fd-lifecycle.test.ts test/no-encoding-hops.test.ts",
 		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts test/fd-lifecycle.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -70,11 +70,24 @@ export class Server {
 	private readonly store: SessionStore;
 	private readonly conns = new Set<ConnState>();
 	private readonly opts: ServerOptions;
+	/**
+	 * macOS trustd reachability, surfaced in the hello-ack. Mutable so the
+	 * (blocking) probe can run AFTER the socket binds / handoff-ack is sent
+	 * rather than delaying either — see main.ts. Until set, hello-ack omits it
+	 * and the supervisor treats that as "unknown" (no respawn).
+	 */
+	private trustdHealthy: boolean | undefined;
 
 	constructor(opts: ServerOptions) {
 		this.opts = opts;
+		this.trustdHealthy = opts.trustdHealthy;
 		this.store = new SessionStore({ bufferCap: opts.bufferCap });
 		this.server = net.createServer((socket) => this.onConnection(socket));
+	}
+
+	/** Update the trustd-health value reported in subsequent hello-acks. */
+	setTrustdHealthy(healthy: boolean): void {
+		this.trustdHealthy = healthy;
 	}
 
 	async listen(): Promise<void> {
@@ -426,7 +439,7 @@ export class Server {
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
 				daemonPid: process.pid,
-				trustdHealthy: this.opts.trustdHealthy,
+				trustdHealthy: this.trustdHealthy,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -72,9 +72,9 @@ export class Server {
 	private readonly opts: ServerOptions;
 	/**
 	 * macOS trustd reachability, surfaced in the hello-ack. Mutable so the
-	 * (blocking) probe can run AFTER the socket binds / handoff-ack is sent
-	 * rather than delaying either — see main.ts. Until set, hello-ack omits it
-	 * and the supervisor treats that as "unknown" (no respawn).
+	 * probe can run AFTER the socket binds / handoff-ack is sent rather than
+	 * delaying either — see main.ts. Until set, hello-ack omits it and the
+	 * supervisor treats that as "unknown" (no respawn).
 	 */
 	private trustdHealthy: boolean | undefined;
 

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -33,6 +33,8 @@ import {
 export interface ServerOptions {
 	socketPath: string;
 	daemonVersion: string;
+	/** macOS trustd reachability, probed once at daemon startup; see main.ts. */
+	trustdHealthy?: boolean;
 	bufferCap?: number;
 	outboundBufferCap?: number;
 	/** Pause producing PTYs when a subscriber buffers past this (flow control). */
@@ -424,6 +426,7 @@ export class Server {
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
 				daemonPid: process.pid,
+				trustdHealthy: this.opts.trustdHealthy,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -83,7 +83,7 @@ async function runFresh(): Promise<void> {
 	// Probe AFTER binding so a slow `security` can't delay the socket coming up
 	// (the supervisor has a socket-ready timeout). The value lands before the
 	// supervisor's adoption hello, which happens well after bind.
-	server.setTrustdHealthy(probeTrustdHealthy());
+	server.setTrustdHealthy(await probeTrustdHealthy());
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion}, host=${os.hostname()})\n`,
 	);
@@ -187,9 +187,9 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
-	// Probe only now: it's a blocking spawnSync, and running it earlier would
-	// delay the upgrade-ack the predecessor is waiting on (and the socket bind).
-	server.setTrustdHealthy(probeTrustdHealthy());
+	// Probe only now: running it earlier would delay the upgrade-ack the
+	// predecessor is waiting on (and the socket bind).
+	server.setTrustdHealthy(await probeTrustdHealthy());
 	log(`bound and listening`);
 	process.stderr.write(
 		`[pty-daemon] (handoff successor) listening on ${socketPath} (v${daemonVersion}, host=${os.hostname()}, sessions=${snapshot.sessions.length})\n`,

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -80,6 +80,9 @@ async function runFresh(): Promise<void> {
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Signal handlers first: a SIGTERM landing during the (bounded) probe
+	// must still run the PTY teardown drain.
+	wireShutdown(server);
 	// Probe AFTER binding so a slow `security` can't delay the socket coming up
 	// (the supervisor has a socket-ready timeout). The value lands before the
 	// supervisor's adoption hello, which happens well after bind.
@@ -87,7 +90,6 @@ async function runFresh(): Promise<void> {
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion}, host=${os.hostname()})\n`,
 	);
-	wireShutdown(server);
 }
 
 /**
@@ -187,6 +189,9 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Signal handlers first: a SIGTERM landing during the (bounded) probe
+	// must still run the PTY teardown drain for the adopted sessions.
+	wireShutdown(server);
 	// Probe only now: running it earlier would delay the upgrade-ack the
 	// predecessor is waiting on (and the socket bind).
 	server.setTrustdHealthy(await probeTrustdHealthy());
@@ -196,7 +201,6 @@ async function runHandoffReceiver(): Promise<void> {
 	);
 
 	clearSnapshot(snapshotPath);
-	wireShutdown(server);
 }
 
 function wireShutdown(server: Server): void {

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -21,6 +21,7 @@ import { drainPendingKills } from "./Pty/index.ts";
 import type { HandoffMessage } from "./protocol/index.ts";
 import { Server } from "./Server/index.ts";
 import { clearSnapshot, readSnapshot } from "./SessionStore/index.ts";
+import { probeTrustdHealthy } from "./trustd-probe.ts";
 
 const DAEMON_VERSION: string = packageJson.version;
 
@@ -76,6 +77,7 @@ async function runFresh(): Promise<void> {
 	const server = new Server({
 		socketPath: args.socket,
 		daemonVersion,
+		trustdHealthy: probeTrustdHealthy(),
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
@@ -137,7 +139,11 @@ async function runHandoffReceiver(): Promise<void> {
 		return;
 	}
 	log(`read snapshot: sessions=${snapshot.sessions.length}`);
-	const server = new Server({ socketPath, daemonVersion });
+	const server = new Server({
+		socketPath,
+		daemonVersion,
+		trustdHealthy: probeTrustdHealthy(),
+	});
 
 	try {
 		log(`adopting ${snapshot.sessions.length} sessions`);

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -77,10 +77,13 @@ async function runFresh(): Promise<void> {
 	const server = new Server({
 		socketPath: args.socket,
 		daemonVersion,
-		trustdHealthy: probeTrustdHealthy(),
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Probe AFTER binding so a slow `security` can't delay the socket coming up
+	// (the supervisor has a socket-ready timeout). The value lands before the
+	// supervisor's adoption hello, which happens well after bind.
+	server.setTrustdHealthy(probeTrustdHealthy());
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion}, host=${os.hostname()})\n`,
 	);
@@ -139,11 +142,7 @@ async function runHandoffReceiver(): Promise<void> {
 		return;
 	}
 	log(`read snapshot: sessions=${snapshot.sessions.length}`);
-	const server = new Server({
-		socketPath,
-		daemonVersion,
-		trustdHealthy: probeTrustdHealthy(),
-	});
+	const server = new Server({ socketPath, daemonVersion });
 
 	try {
 		log(`adopting ${snapshot.sessions.length} sessions`);
@@ -188,6 +187,9 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Probe only now: it's a blocking spawnSync, and running it earlier would
+	// delay the upgrade-ack the predecessor is waiting on (and the socket bind).
+	server.setTrustdHealthy(probeTrustdHealthy());
 	log(`bound and listening`);
 	process.stderr.write(
 		`[pty-daemon] (handoff successor) listening on ${socketPath} (v${daemonVersion}, host=${os.hostname()}, sessions=${snapshot.sessions.length})\n`,

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -41,6 +41,13 @@ export interface HelloAckMessage {
 	 * missing or stale.
 	 */
 	daemonPid?: number;
+	/**
+	 * macOS only: whether the daemon's Mach bootstrap can reach `com.apple.trustd`
+	 * (Security-framework TLS trust evaluation). False means terminals it spawns
+	 * hit `gh: x509: OSStatus -26276`; the supervisor respawns such a daemon from
+	 * its own healthy context. Absent from pre-probe daemon versions.
+	 */
+	trustdHealthy?: boolean;
 }
 
 // ---------- Client -> Daemon ----------

--- a/packages/pty-daemon/src/trustd-probe.test.ts
+++ b/packages/pty-daemon/src/trustd-probe.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { probeTrustdHealthy } from "./trustd-probe.ts";
+
+const FAKE_BUNDLE = `-----BEGIN CERTIFICATE-----\nMIIFakeCertBytes\n-----END CERTIFICATE-----\n`;
+
+describe("probeTrustdHealthy", () => {
+	it("returns true on non-darwin without running anything", () => {
+		let ran = false;
+		const healthy = probeTrustdHealthy({
+			platform: "linux",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("returns true when verify-cert exits 0 (trustd reachable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 0 }),
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when verify-cert exits non-zero (trustd unreachable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(false);
+	});
+
+	it("verifies the extracted cert (passes -c <file> to security verify-cert)", () => {
+		let cmd = "";
+		let args: string[] = [];
+		probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => FAKE_BUNDLE,
+			pid: 999,
+			run: (c, a) => {
+				cmd = c;
+				args = a;
+				return { status: 0 };
+			},
+		});
+		expect(cmd).toBe("security");
+		expect(args[0]).toBe("verify-cert");
+		expect(args[1]).toBe("-c");
+		expect(args[2]).toMatch(/superset-trustd-probe-999\.pem$/);
+	});
+
+	it("assumes healthy when the CA bundle has no cert (can't determine)", () => {
+		let ran = false;
+		const healthy = probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => "no certs here",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("assumes healthy when the probe throws (bundle unreadable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => {
+					throw new Error("ENOENT");
+				},
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe times out / errors (inconclusive)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null, error: new Error("ETIMEDOUT") }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe is killed by a signal (status null)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null }),
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/pty-daemon/src/trustd-probe.test.ts
+++ b/packages/pty-daemon/src/trustd-probe.test.ts
@@ -43,7 +43,6 @@ describe("probeTrustdHealthy", () => {
 		probeTrustdHealthy({
 			platform: "darwin",
 			readBundle: () => FAKE_BUNDLE,
-			pid: 999,
 			run: (c, a) => {
 				cmd = c;
 				args = a;
@@ -53,7 +52,26 @@ describe("probeTrustdHealthy", () => {
 		expect(cmd).toBe("security");
 		expect(args[0]).toBe("verify-cert");
 		expect(args[1]).toBe("-c");
-		expect(args[2]).toMatch(/superset-trustd-probe-999\.pem$/);
+		expect(args[2]).toMatch(/superset-trustd-[^/]+\/probe\.pem$/);
+	});
+
+	it("finds the END marker after BEGIN when an earlier PEM type precedes it", () => {
+		// A "TRUSTED CERTIFICATE" block's END sits before the first plain
+		// "BEGIN CERTIFICATE"; indexOf(END, begin) must skip it.
+		const mixed =
+			"-----BEGIN TRUSTED CERTIFICATE-----\nAAA\n-----END TRUSTED CERTIFICATE-----\n" +
+			"-----BEGIN CERTIFICATE-----\nBBB\n-----END CERTIFICATE-----\n";
+		let seenArgs: string[] = [];
+		probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => mixed,
+			run: (_c, a) => {
+				seenArgs = a;
+				return { status: 0 };
+			},
+		});
+		// Reached the run step (didn't bail on a bogus end<begin slice).
+		expect(seenArgs[0]).toBe("verify-cert");
 	});
 
 	it("assumes healthy when the CA bundle has no cert (can't determine)", () => {

--- a/packages/pty-daemon/src/trustd-probe.test.ts
+++ b/packages/pty-daemon/src/trustd-probe.test.ts
@@ -4,9 +4,9 @@ import { probeTrustdHealthy } from "./trustd-probe.ts";
 const FAKE_BUNDLE = `-----BEGIN CERTIFICATE-----\nMIIFakeCertBytes\n-----END CERTIFICATE-----\n`;
 
 describe("probeTrustdHealthy", () => {
-	it("returns true on non-darwin without running anything", () => {
+	it("returns true on non-darwin without running anything", async () => {
 		let ran = false;
-		const healthy = probeTrustdHealthy({
+		const healthy = await probeTrustdHealthy({
 			platform: "linux",
 			run: () => {
 				ran = true;
@@ -17,9 +17,9 @@ describe("probeTrustdHealthy", () => {
 		expect(ran).toBe(false);
 	});
 
-	it("returns true when verify-cert exits 0 (trustd reachable)", () => {
+	it("returns true when verify-cert exits 0 (trustd reachable)", async () => {
 		expect(
-			probeTrustdHealthy({
+			await probeTrustdHealthy({
 				platform: "darwin",
 				readBundle: () => FAKE_BUNDLE,
 				run: () => ({ status: 0 }),
@@ -27,9 +27,9 @@ describe("probeTrustdHealthy", () => {
 		).toBe(true);
 	});
 
-	it("returns false when verify-cert exits non-zero (trustd unreachable)", () => {
+	it("returns false when verify-cert exits non-zero (trustd unreachable)", async () => {
 		expect(
-			probeTrustdHealthy({
+			await probeTrustdHealthy({
 				platform: "darwin",
 				readBundle: () => FAKE_BUNDLE,
 				run: () => ({ status: 1 }),
@@ -37,10 +37,10 @@ describe("probeTrustdHealthy", () => {
 		).toBe(false);
 	});
 
-	it("verifies the extracted cert (passes -c <file> to security verify-cert)", () => {
+	it("verifies the extracted cert (passes -c <file> to security verify-cert)", async () => {
 		let cmd = "";
 		let args: string[] = [];
-		probeTrustdHealthy({
+		await probeTrustdHealthy({
 			platform: "darwin",
 			readBundle: () => FAKE_BUNDLE,
 			run: (c, a) => {
@@ -55,14 +55,14 @@ describe("probeTrustdHealthy", () => {
 		expect(args[2]).toMatch(/superset-trustd-[^/]+\/probe\.pem$/);
 	});
 
-	it("finds the END marker after BEGIN when an earlier PEM type precedes it", () => {
+	it("finds the END marker after BEGIN when an earlier PEM type precedes it", async () => {
 		// A "TRUSTED CERTIFICATE" block's END sits before the first plain
 		// "BEGIN CERTIFICATE"; indexOf(END, begin) must skip it.
 		const mixed =
 			"-----BEGIN TRUSTED CERTIFICATE-----\nAAA\n-----END TRUSTED CERTIFICATE-----\n" +
 			"-----BEGIN CERTIFICATE-----\nBBB\n-----END CERTIFICATE-----\n";
 		let seenArgs: string[] = [];
-		probeTrustdHealthy({
+		await probeTrustdHealthy({
 			platform: "darwin",
 			readBundle: () => mixed,
 			run: (_c, a) => {
@@ -74,9 +74,9 @@ describe("probeTrustdHealthy", () => {
 		expect(seenArgs[0]).toBe("verify-cert");
 	});
 
-	it("assumes healthy when the CA bundle has no cert (can't determine)", () => {
+	it("assumes healthy when the CA bundle has no cert (can't determine)", async () => {
 		let ran = false;
-		const healthy = probeTrustdHealthy({
+		const healthy = await probeTrustdHealthy({
 			platform: "darwin",
 			readBundle: () => "no certs here",
 			run: () => {
@@ -88,9 +88,9 @@ describe("probeTrustdHealthy", () => {
 		expect(ran).toBe(false);
 	});
 
-	it("assumes healthy when the probe throws (bundle unreadable)", () => {
+	it("assumes healthy when the probe throws (bundle unreadable)", async () => {
 		expect(
-			probeTrustdHealthy({
+			await probeTrustdHealthy({
 				platform: "darwin",
 				readBundle: () => {
 					throw new Error("ENOENT");
@@ -100,9 +100,19 @@ describe("probeTrustdHealthy", () => {
 		).toBe(true);
 	});
 
-	it("assumes healthy when the probe times out / errors (inconclusive)", () => {
+	it("assumes healthy when the run promise rejects (inconclusive)", async () => {
 		expect(
-			probeTrustdHealthy({
+			await probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => Promise.reject(new Error("spawn failed")),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe times out / errors (inconclusive)", async () => {
+		expect(
+			await probeTrustdHealthy({
 				platform: "darwin",
 				readBundle: () => FAKE_BUNDLE,
 				run: () => ({ status: null, error: new Error("ETIMEDOUT") }),
@@ -110,9 +120,9 @@ describe("probeTrustdHealthy", () => {
 		).toBe(true);
 	});
 
-	it("assumes healthy when the probe is killed by a signal (status null)", () => {
+	it("assumes healthy when the probe is killed by a signal (status null)", async () => {
 		expect(
-			probeTrustdHealthy({
+			await probeTrustdHealthy({
 				platform: "darwin",
 				readBundle: () => FAKE_BUNDLE,
 				run: () => ({ status: null }),

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -1,0 +1,89 @@
+// Detects whether the current process's macOS Mach bootstrap can reach
+// `com.apple.trustd` — i.e. whether Security-framework TLS trust evaluation
+// works. When it can't (a degraded bootstrap: updater relaunch, a dead
+// login-session port after logout/login, etc.), Go binaries like `gh` fail
+// with `x509: OSStatus -26276` and headless Chromium aborts with
+// `bootstrap_check_in error 141`.
+//
+// Node/curl can't detect this: they use their own TLS stack, not Secure
+// Transport, so they succeed even when trustd is unreachable. `security
+// verify-cert` DOES exercise the platform verifier — exit 0 when trustd is
+// reachable, non-zero when it isn't — so it's the reliable probe.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const SYSTEM_CERT_BUNDLE = "/etc/ssl/cert.pem";
+const BEGIN = "-----BEGIN CERTIFICATE-----";
+const END = "-----END CERTIFICATE-----";
+
+export interface TrustdProbeResult {
+	status: number | null;
+	error?: Error;
+}
+
+export interface TrustdProbeDeps {
+	platform?: NodeJS.Platform;
+	/** Runs a command; mirrors spawnSync's status/error. */
+	run?: (cmd: string, args: string[]) => TrustdProbeResult;
+	/** Reads the system CA bundle (source of a known-good cert to verify). */
+	readBundle?: () => string;
+	tmpDir?: string;
+	pid?: number;
+}
+
+// Bounded so a wedged `security` can't stall daemon startup (the probe runs
+// before the socket binds). Comfortably under the supervisor's socket-ready
+// timeout; a real probe takes tens of milliseconds.
+const PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * True when the platform verifier (trustd) is reachable. macOS only — other
+ * platforms have no such coupling and always return true. We only report
+ * `false` on a clean non-zero exit from `security verify-cert`; any spawn
+ * error, timeout, or signal death is inconclusive and reported healthy, so a
+ * flaky probe never triggers an unwarranted (session-destroying) respawn.
+ */
+export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
+	const platform = deps.platform ?? process.platform;
+	if (platform !== "darwin") return true;
+
+	const run =
+		deps.run ??
+		((cmd: string, args: string[]) =>
+			spawnSync(cmd, args, { timeout: PROBE_TIMEOUT_MS }));
+
+	let certPath: string | undefined;
+	try {
+		const bundle = deps.readBundle
+			? deps.readBundle()
+			: fs.readFileSync(SYSTEM_CERT_BUNDLE, "utf8");
+		const begin = bundle.indexOf(BEGIN);
+		const end = bundle.indexOf(END);
+		if (begin === -1 || end === -1 || end < begin) return true;
+		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
+		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
+		const cert = `${bundle.slice(begin, end + END.length)}\n`;
+		certPath = path.join(
+			deps.tmpDir ?? os.tmpdir(),
+			`superset-trustd-probe-${deps.pid ?? process.pid}.pem`,
+		);
+		fs.writeFileSync(certPath, cert, { mode: 0o600 });
+		const result = run("security", ["verify-cert", "-c", certPath]);
+		if (result.error) return true; // spawn failed / timed out → inconclusive
+		if (typeof result.status !== "number") return true; // killed by signal
+		return result.status === 0;
+	} catch {
+		return true;
+	} finally {
+		if (certPath) {
+			try {
+				fs.unlinkSync(certPath);
+			} catch {
+				// best-effort
+			}
+		}
+	}
+}

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -31,7 +31,6 @@ export interface TrustdProbeDeps {
 	/** Reads the system CA bundle (source of a known-good cert to verify). */
 	readBundle?: () => string;
 	tmpDir?: string;
-	pid?: number;
 }
 
 // Bounded so a wedged `security` can't stall daemon startup (the probe runs
@@ -55,21 +54,26 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 		((cmd: string, args: string[]) =>
 			spawnSync(cmd, args, { timeout: PROBE_TIMEOUT_MS }));
 
-	let certPath: string | undefined;
+	let certDir: string | undefined;
 	try {
 		const bundle = deps.readBundle
 			? deps.readBundle()
 			: fs.readFileSync(SYSTEM_CERT_BUNDLE, "utf8");
 		const begin = bundle.indexOf(BEGIN);
-		const end = bundle.indexOf(END);
-		if (begin === -1 || end === -1 || end < begin) return true;
+		// Search for END only from BEGIN onward so a different earlier PEM type
+		// (e.g. "BEGIN TRUSTED CERTIFICATE") whose END sits before the first
+		// "BEGIN CERTIFICATE" can't produce a bogus slice.
+		const end = bundle.indexOf(END, begin);
+		if (begin === -1 || end === -1) return true;
 		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
 		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
 		const cert = `${bundle.slice(begin, end + END.length)}\n`;
-		certPath = path.join(
-			deps.tmpDir ?? os.tmpdir(),
-			`superset-trustd-probe-${deps.pid ?? process.pid}.pem`,
+		// mkdtemp gives a fresh 0700 dir, so the cert path is unpredictable and
+		// can't be pre-seeded as a symlink (TOCTOU) or collide across runs.
+		certDir = fs.mkdtempSync(
+			path.join(deps.tmpDir ?? os.tmpdir(), "superset-trustd-"),
 		);
+		const certPath = path.join(certDir, "probe.pem");
 		fs.writeFileSync(certPath, cert, { mode: 0o600 });
 		const result = run("security", ["verify-cert", "-c", certPath]);
 		if (result.error) return true; // spawn failed / timed out → inconclusive
@@ -78,9 +82,9 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 	} catch {
 		return true;
 	} finally {
-		if (certPath) {
+		if (certDir) {
 			try {
-				fs.unlinkSync(certPath);
+				fs.rmSync(certDir, { recursive: true, force: true });
 			} catch {
 				// best-effort
 			}

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -10,8 +10,8 @@
 // verify-cert` DOES exercise the platform verifier — exit 0 when trustd is
 // reachable, non-zero when it isn't — so it's the reliable probe.
 
-import { spawnSync } from "node:child_process";
-import * as fs from "node:fs";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -26,17 +26,39 @@ export interface TrustdProbeResult {
 
 export interface TrustdProbeDeps {
 	platform?: NodeJS.Platform;
-	/** Runs a command; mirrors spawnSync's status/error. */
-	run?: (cmd: string, args: string[]) => TrustdProbeResult;
+	/** Runs a command; status = exit code, null when it never exited cleanly. */
+	run?: (
+		cmd: string,
+		args: string[],
+	) => TrustdProbeResult | Promise<TrustdProbeResult>;
 	/** Reads the system CA bundle (source of a known-good cert to verify). */
-	readBundle?: () => string;
+	readBundle?: () => string | Promise<string>;
 	tmpDir?: string;
 }
 
-// Bounded so a wedged `security` can't stall daemon startup (the probe runs
-// before the socket binds). Comfortably under the supervisor's socket-ready
-// timeout; a real probe takes tens of milliseconds.
+// Bounded so a wedged `security` can't leave the hello-ack reporting
+// "unknown" forever; a real probe takes tens of milliseconds.
 const PROBE_TIMEOUT_MS = 3_000;
+
+/** Async execFile mirrored into spawnSync-style {status, error}. */
+function runCommand(cmd: string, args: string[]): Promise<TrustdProbeResult> {
+	return new Promise((resolve) => {
+		execFile(cmd, args, { timeout: PROBE_TIMEOUT_MS }, (error) => {
+			if (!error) {
+				resolve({ status: 0 });
+				return;
+			}
+			// Clean non-zero exit carries a numeric code; a spawn failure carries
+			// a string code (e.g. ENOENT) and a timeout/signal death sets killed.
+			const { code } = error as { code?: number | string };
+			if (typeof code === "number" && !error.killed) {
+				resolve({ status: code });
+				return;
+			}
+			resolve({ status: null, error });
+		});
+	});
+}
 
 /**
  * True when the platform verifier (trustd) is reachable. macOS only — other
@@ -45,20 +67,19 @@ const PROBE_TIMEOUT_MS = 3_000;
  * error, timeout, or signal death is inconclusive and reported healthy, so a
  * flaky probe never triggers an unwarranted (session-destroying) respawn.
  */
-export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
+export async function probeTrustdHealthy(
+	deps: TrustdProbeDeps = {},
+): Promise<boolean> {
 	const platform = deps.platform ?? process.platform;
 	if (platform !== "darwin") return true;
 
-	const run =
-		deps.run ??
-		((cmd: string, args: string[]) =>
-			spawnSync(cmd, args, { timeout: PROBE_TIMEOUT_MS }));
+	const run = deps.run ?? runCommand;
 
 	let certDir: string | undefined;
 	try {
 		const bundle = deps.readBundle
-			? deps.readBundle()
-			: fs.readFileSync(SYSTEM_CERT_BUNDLE, "utf8");
+			? await deps.readBundle()
+			: await fs.readFile(SYSTEM_CERT_BUNDLE, "utf8");
 		const begin = bundle.indexOf(BEGIN);
 		// Search for END only from BEGIN onward so a different earlier PEM type
 		// (e.g. "BEGIN TRUSTED CERTIFICATE") whose END sits before the first
@@ -70,12 +91,12 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 		const cert = `${bundle.slice(begin, end + END.length)}\n`;
 		// mkdtemp gives a fresh 0700 dir, so the cert path is unpredictable and
 		// can't be pre-seeded as a symlink (TOCTOU) or collide across runs.
-		certDir = fs.mkdtempSync(
+		certDir = await fs.mkdtemp(
 			path.join(deps.tmpDir ?? os.tmpdir(), "superset-trustd-"),
 		);
 		const certPath = path.join(certDir, "probe.pem");
-		fs.writeFileSync(certPath, cert, { mode: 0o600 });
-		const result = run("security", ["verify-cert", "-c", certPath]);
+		await fs.writeFile(certPath, cert, { mode: 0o600 });
+		const result = await run("security", ["verify-cert", "-c", certPath]);
 		if (result.error) return true; // spawn failed / timed out → inconclusive
 		if (typeof result.status !== "number") return true; // killed by signal
 		return result.status === 0;
@@ -83,11 +104,8 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 		return true;
 	} finally {
 		if (certDir) {
-			try {
-				fs.rmSync(certDir, { recursive: true, force: true });
-			} catch {
-				// best-effort
-			}
+			// best-effort
+			await fs.rm(certDir, { recursive: true, force: true }).catch(() => {});
 		}
 	}
 }

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -40,6 +40,18 @@ export interface TrustdProbeDeps {
 // "unknown" forever; a real probe takes tens of milliseconds.
 const PROBE_TIMEOUT_MS = 3_000;
 
+/**
+ * An inconclusive probe fails open (healthy) so it can never trigger a
+ * session-destroying respawn — but persistent breakage (missing CA bundle,
+ * unspawnable `security`) must not be silently indistinguishable from a
+ * healthy system in logs.
+ */
+function warnInconclusive(detail: string): void {
+	process.stderr.write(
+		`[trustd-probe] inconclusive, failing open as healthy: ${detail}\n`,
+	);
+}
+
 /** Async execFile mirrored into spawnSync-style {status, error}. */
 function runCommand(cmd: string, args: string[]): Promise<TrustdProbeResult> {
 	return new Promise((resolve) => {
@@ -85,7 +97,10 @@ export async function probeTrustdHealthy(
 		// (e.g. "BEGIN TRUSTED CERTIFICATE") whose END sits before the first
 		// "BEGIN CERTIFICATE" can't produce a bogus slice.
 		const end = bundle.indexOf(END, begin);
-		if (begin === -1 || end === -1) return true;
+		if (begin === -1 || end === -1) {
+			warnInconclusive("no certificate found in system CA bundle");
+			return true;
+		}
 		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
 		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
 		const cert = `${bundle.slice(begin, end + END.length)}\n`;
@@ -97,10 +112,19 @@ export async function probeTrustdHealthy(
 		const certPath = path.join(certDir, "probe.pem");
 		await fs.writeFile(certPath, cert, { mode: 0o600 });
 		const result = await run("security", ["verify-cert", "-c", certPath]);
-		if (result.error) return true; // spawn failed / timed out → inconclusive
-		if (typeof result.status !== "number") return true; // killed by signal
+		if (result.error) {
+			// spawn failed / timed out → inconclusive
+			warnInconclusive(`security did not run cleanly: ${result.error.message}`);
+			return true;
+		}
+		if (typeof result.status !== "number") {
+			// killed by signal
+			warnInconclusive("security was killed by a signal");
+			return true;
+		}
 		return result.status === 0;
-	} catch {
+	} catch (err) {
+		warnInconclusive((err as Error).message);
 		return true;
 	} finally {
 		if (certDir) {


### PR DESCRIPTION
**Links**
- Fixes #6127
- Supersedes #5450 (same fix, revived + completed; that PR predates the daemon-loop blocking ratchet and misses the desktop entry)

## Summary
- The pty-daemon self-probes macOS trustd reachability (`security verify-cert`) at startup and reports it in its hello-ack; the supervisor kills a self-reported-degraded adopted daemon and respawns it from host-service's healthy Mach bootstrap context.
- Fixes the field failure where every terminal in the app gets `gh: ... tls: failed to verify certificate: x509: OSStatus -26276` (and headless Chromium `bootstrap_check_in error 141`) until the user manually restarts the daemon.

## Why / Context
A child inherits its parent's Mach bootstrap port. The pty-daemon deliberately outlives host-service (session persistence via adoption), so a daemon born from a degraded bootstrap — updater relaunch, dead session port after logout/login — permanently breaks Secure-Transport TLS (gh, Chromium) in every shell it spawns, and adoption preserves the broken daemon forever. `curl`/`node` don't use Secure Transport, so nothing else notices. Only a full daemon respawn from a healthy context (what Settings → Restart daemon does manually) heals it; this PR automates exactly that, gated so it never fires spuriously.

## How It Works
- `packages/pty-daemon/src/trustd-probe.ts`: async `probeTrustdHealthy()` — verifies a known-good cert from `/etc/ssl/cert.pem` via `security verify-cert` (the platform verifier). Only a clean non-zero exit ⇒ degraded; spawn errors/timeouts/signals ⇒ healthy (fail-open, so a flaky probe can never cause a session-destroying respawn). Async (`execFile` + `fs/promises`) so it can't stall the daemon loop — matters during fd-handoff, where the successor probes while live sessions stream.
- Daemon runs the probe **after** binding (both fresh-spawn and handoff paths, in both the package entry and the desktop entry shim) and reports `trustdHealthy` in the hello-ack.
- `DaemonSupervisor.start()`: after adoption, if the daemon self-reports `trustdHealthy === false` **and** host-service's own probe is healthy → kill the adopted daemon + fall through to a fresh spawn (`pty_daemon_trustd_degraded_respawn`). If the host is also degraded, adopt untouched (a respawn couldn't do better; next healthy app launch heals). `trustdHealthy` absent (pre-probe daemon) ⇒ unknown ⇒ adopt untouched.
- Migration: pty-daemon 0.2.7 → 0.3.0. Existing daemons auto-update via the normal fd-handoff (sessions preserved); a degraded one's successor re-probes at startup, self-reports, and gets healed on the next adoption. No forced mass session loss.

## Manual QA (all verified end-to-end over CDP against the dev desktop, before/after)
- [x] **Before (main @ 871b02b43):** staged a genuinely trustd-denied daemon (`sandbox-exec` denying `com.apple.trustd.agent`); host-service adopted it silently; `gh auth login -h github.com -p https -w` in a real workspace terminal failed with the exact reported error (screenshot captured).
- [x] **After (this branch):** same staging → adoption logs `pty_daemon_trustd_degraded_respawn`, degraded daemon replaced, same command reaches the one-time-code screen; `gh api` returns normally in new terminals.
- [x] **No false heal:** healthy daemon re-adopted across a host-service restart — same daemon pid, live session survived with same shell pid.
- [x] **Unknown ≠ degraded:** real pre-fix 0.2.7 daemon (no `trustdHealthy` in hello-ack), genuinely degraded, with a live session → adopted untouched, `updatePending` armed.
- [x] **Full migration chain:** degraded 0.2.7 → fd-handoff auto-update (session survived two handoffs) → 0.3.0 successor self-reported `trustdHealthy:false` → healed on next adoption → `gh` working.
- [x] Degraded daemon's sessions are killed by the heal (by design — they're already TLS-broken; same trade-off as the manual Restart daemon button).

## Testing
- `bun run typecheck`, `bun run lint`
- pty-daemon: 79 unit (incl. probe suite) + 56 integration
- host-service: unit suite + `test:integration:daemon` — includes new **"trustd-degraded daemon heal"** tests using real daemons made genuinely degraded via a PATH-shimmed `security` (darwin): degraded → kill+respawn; degraded host → adopt untouched (via injected host probe); pre-probe unknown → adopt untouched.
- Pre-existing on main, unrelated: `auto-update defers when live sessions exist` fails locally at the base commit too.

## Design Decisions
- **Heal at adoption only, never mid-session:** killing a live daemon under a user destroys running shells without consent; adoption points (app launch, hs restart, Restart button, post-update) are where a respawn is already expected.
- **Fail-open probe:** an inconclusive probe must never kill sessions; only `security verify-cert` cleanly exiting non-zero counts as degraded. Verified on macOS 26 that the probe still detects the condition (the trustd Mach service is now `com.apple.trustd.agent`; the probe never hardcoded a name, so it's unaffected).
- **`hostTrustdProbe` option on `DaemonSupervisorOptions`:** DI seam for the degraded-host branch, which cannot be staged in tests without breaking the test process's own bootstrap (same precedent as the existing `autoUpdate` test seam).
- **Desktop entry shim probed separately:** `apps/desktop/src/main/pty-daemon/index.ts` is a hand-mirrored copy of the package's `main.ts`; without that commit the shipped app never probes at all (gap in #5450).

## Known Limitations
- The probe runs once at daemon startup. A daemon that degrades mid-life (logout/login while running) keeps reporting its startup value and only heals via the Restart button or the next version-bump handoff.

## Follow-ups
- Surface `trustdHealthy` through `daemon.getHealth` + inline terminal banner with a Restart action (actionable-error UX for the live-session window).
- Spike: tmux-style per-user-namespace reattach at daemon startup (`bootstrap_get_root` → `bootstrap_look_up_per_user` → `task_set_bootstrap_port`) — verified the sequence works from a healthy process on macOS 26 and provably cannot rescue an already-dead port, so it's prevention that composes with (not replaces) this heal. Needs native code + a logout-survival test.
- Prefer fresh spawn over adoption when the adopted daemon holds zero sessions (free bootstrap freshness when there's nothing to preserve).

## Rollback
Revert the branch. The daemon version bump is forward-compatible: 0.3.0 daemons under a reverted (pre-probe) supervisor just have their extra hello-ack field ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically heals macOS terminals that hit `gh` TLS failures (x509 OSStatus -26276) by detecting trustd‑degraded `@superset/pty-daemon` instances and respawning them from a healthy `host-service`. Also heals if the daemon reports degradation shortly after startup during the liveness poll.

- **Bug Fixes**
  - `@superset/pty-daemon` probes `com.apple.trustd` via `security verify-cert` after socket bind and reports `trustdHealthy` in the hello‑ack (desktop entry does the same); daemon version bumped to 0.3.0.
  - `host-service`: on adoption, if the daemon reports `trustdHealthy:false` and the host probe is healthy, kill and respawn; if the host is degraded or the value is missing (pre‑probe/early bind), adopt unchanged.
  - Late heal: the liveness poll fills in `trustdHealthy` if it was unknown and applies the same gated respawn when it later reports `false`; it re-checks instance identity after awaiting the host probe to avoid unlinking a concurrent restart; known values are never overwritten, so long‑running sessions aren’t killed mid‑life.
  - Robustness: wire signal handlers before the probe so SIGTERM still drains PTY teardown; resolve the host trustd probe before spawning to avoid a spawn/registration race; if hello‑ack `daemonPid` disagrees with the manifest pid, drop the manifest and adopt from the socket (reusing the successful probe to avoid a demoting re‑probe); inconclusive trustd probes now warn but still fail open.
  - Crash‑relaunch chain: a degraded host launch adopts a degraded daemon without thrash; the next healthy launch heals the surviving degraded daemon automatically.

- **Migration**
  - No manual steps. Existing daemons auto‑update via fd‑handoff; if a degraded daemon is healed, its sessions are terminated.

<sup>Written for commit 61eef9464c593b82ad48766c77e3009ca6aded5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS certificate-service health checks during PTY daemon startup and handoff.
  * Daemons now report certificate-service health during readiness checks.
  * Added automatic recovery for daemons with unhealthy certificate services.
* **Bug Fixes**
  * Improved daemon adoption and handoff health tracking.
  * Preserved compatibility with older daemons that do not report health status.
* **Tests**
  * Added coverage for successful, failed, timed-out, and unsupported-platform health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->