### PR TITLE
chore(desktop): bump version to 1.20.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.19.0",
+	"version": "1.20.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -114,7 +114,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@ai-sdk/anthropic": "3.0.64",
@@ -814,7 +814,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -909,7 +909,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",
@@ -1041,7 +1041,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.19.0",
+	"version": "1.20.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.19.0",
+	"version": "1.20.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the desktop app to 1.20.0 and syncs internal packages for the DMG release build. Updates the lockfile to reflect these versions.

- **Dependencies**
  - `@superset/desktop`: 1.19.0 -> 1.20.0
  - `@superset/cli`: 1.19.0 -> 1.20.0
  - `@superset/host-service`: 1.19.0 -> 1.20.0
  - `@superset/pty-daemon`: 0.2.7 -> 0.3.0 (lockfile)

<sup>Written for commit 984ef5e6c77cc816ec82b15254e190223ca78061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop application, command-line interface, and host service to version 1.20.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->