### PR TITLE
perf(desktop,host-service): enqueue workspace creation off pooled sockets and batch the host-service client

### DIFF
--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -1,5 +1,5 @@
 import type { AppRouter } from "@superset/host-service";
-import { createTRPCClient, httpLink } from "@trpc/client";
+import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
 import superjson from "superjson";
 import { getHostServiceHeaders } from "./host-service-auth";
 
@@ -20,7 +20,13 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 
 	const client = createTRPCClient<AppRouter>({
 		links: [
-			httpLink({
+			// Streaming batch link: same-tick calls share one HTTP request and
+			// one CORS preflight, but each result streams as soon as it's ready
+			// — no slowest-in-batch latency (the reason #3879 unbatched the old
+			// buffering httpBatchLink). All renderer clients share Chromium's
+			// 6-connections-per-origin pool with every other host-service
+			// request, so sockets are the scarce resource here.
+			httpBatchStreamLink({
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: () => getHostServiceHeaders(hostUrl),

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -1,9 +1,18 @@
+import {
+	getEventBus,
+	type WorkspaceCreateSettledPayload,
+} from "@superset/workspace-client";
+import { TRPCClientError } from "@trpc/client";
 import { useCallback } from "react";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
+import {
+	getHostServiceClientByUrl,
+	type HostServiceClient,
+} from "renderer/lib/host-service-client";
 import { getHostServiceUnavailableMessage } from "renderer/lib/host-service-unavailable";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -36,6 +45,111 @@ export interface SubmitHandle {
 
 export interface UseWorkspaceCreatesApi {
 	submit: (args: SubmitArgs) => SubmitHandle;
+}
+
+/** Sessions create a folder + git init — quick. A wedged transport must not
+ * hold the pending-create UI forever. */
+const SESSION_CREATE_TIMEOUT_MS = 30_000;
+/** The enqueue call validates and returns — it does none of the git work. */
+const ENQUEUE_TIMEOUT_MS = 15_000;
+/** Backstop for a lost `workspace:create-settled` event (host restart or WS
+ * drop mid-create). Sized for worktree adds on monorepo-scale repos. */
+const CREATE_SETTLE_TIMEOUT_MS = 10 * 60_000;
+
+/** What the completed-create pipeline needs, from either transport. */
+interface CreateOutcome {
+	workspace: { id: string; projectId: string | null };
+	terminals: Array<{ terminalId: string; label?: string }>;
+	agents: Array<
+		| { ok: true; kind: "terminal" | "chat"; sessionId: string; label: string }
+		| { ok: false; error: string }
+	>;
+}
+
+/** Older hosts don't have `workspaces.createEnqueued` yet. */
+function isMissingProcedureError(error: unknown): boolean {
+	return (
+		error instanceof TRPCClientError &&
+		/no procedure found on path/i.test(error.message)
+	);
+}
+
+/**
+ * Enqueue the create and resolve from the `workspace:create-settled` event.
+ * The synchronous `workspaces.create` mutation holds one of Chromium's six
+ * pooled sockets for the whole create (minutes on big repos) and exceeds the
+ * relay's 30s exchange cap outright; the enqueue variant returns immediately
+ * and the result arrives over the eventBus WebSocket instead.
+ */
+async function createViaEnqueue(
+	client: HostServiceClient,
+	hostUrl: string,
+	workspaceId: string,
+	payload: WorkspacesCreateInput,
+): Promise<CreateOutcome> {
+	const bus = getEventBus(hostUrl, () => getHostServiceWsToken(hostUrl));
+	const releaseBus = bus.retain();
+	let unsubscribe: () => void = () => {};
+	try {
+		// Subscribe before enqueueing so the settled event can't slip past.
+		const settled = new Promise<WorkspaceCreateSettledPayload>((resolve) => {
+			unsubscribe = bus.on(
+				"workspace:create-settled",
+				workspaceId,
+				(_workspaceId, eventPayload) => resolve(eventPayload),
+			);
+		});
+
+		try {
+			await client.workspaces.createEnqueued.mutate(payload, {
+				signal: AbortSignal.timeout(ENQUEUE_TIMEOUT_MS),
+			});
+		} catch (error) {
+			if (!isMissingProcedureError(error)) throw error;
+			// Legacy host: fall back to the long-held synchronous create.
+			const result = await client.workspaces.create.mutate(payload);
+			return result;
+		}
+
+		const outcome = await Promise.race([
+			settled,
+			new Promise<"timeout">((resolve) =>
+				setTimeout(() => resolve("timeout"), CREATE_SETTLE_TIMEOUT_MS),
+			),
+		]);
+
+		if (outcome === "timeout") {
+			// The event was lost, not necessarily the create. If the row exists
+			// the workspace is real — recover with an empty pane seed rather
+			// than tearing down a workspace the user can already see.
+			const existing = await client.workspace.get
+				.query({ id: workspaceId })
+				.catch(() => null);
+			if (existing) {
+				return {
+					workspace: { id: workspaceId, projectId: payload.projectId },
+					terminals: [],
+					agents: [],
+				};
+			}
+			throw new Error("Timed out waiting for the host to create the workspace");
+		}
+
+		if (!outcome.ok) {
+			throw new Error(outcome.error ?? "Workspace creation failed");
+		}
+		return {
+			workspace: {
+				id: outcome.canonicalWorkspaceId ?? workspaceId,
+				projectId: outcome.projectId,
+			},
+			terminals: outcome.terminals,
+			agents: outcome.agents,
+		};
+	} finally {
+		unsubscribe();
+		releaseBus();
+	}
 }
 
 export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
@@ -138,14 +252,17 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 			// agent behind the setup commands. On a cold cache the hook value is
 			// still undefined — resolve it directly so an early create can't
 			// silently skip the gate (failures fall back to default-off).
-			const createPromise = (async () => {
+			const createPromise: Promise<CreateOutcome> = (async () => {
 				const client = getHostServiceClientByUrl(hostUrl);
 				if (snapshot.projectId === null) {
-					// Sessions have no setup scripts, so no wait-for-setup gate.
+					// Sessions have no setup scripts, so no wait-for-setup gate —
+					// and no git worktree work, so the synchronous mutation stays.
 					const { projectId: _null, ...sessionInput } = snapshot;
-					const result =
-						await client.workspaces.createSession.mutate(sessionInput);
-					return { ...result, alreadyExists: false };
+					const result = await client.workspaces.createSession.mutate(
+						sessionInput,
+						{ signal: AbortSignal.timeout(SESSION_CREATE_TIMEOUT_MS) },
+					);
+					return result;
 				}
 				let waitForSetup = waitForSetupBeforeAgent;
 				if (waitForSetup === undefined && snapshot.agents?.length) {
@@ -158,7 +275,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					snapshot.agents?.length && waitForSetup
 						? { ...snapshot, waitForSetupBeforeAgents: true }
 						: snapshot;
-				return client.workspaces.create.mutate(payload);
+				return createViaEnqueue(client, hostUrl, workspaceId, payload);
 			})();
 
 			writeWorkspacePaneLayout(

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -74,6 +74,27 @@ function isMissingProcedureError(error: unknown): boolean {
 	);
 }
 
+/** An `AbortSignal.timeout` firing — host reachable but slow, as opposed to
+ * unreachable (network errors reject differently). */
+function isTimeoutAbort(error: unknown): boolean {
+	const cause = error instanceof TRPCClientError ? error.cause : error;
+	return (
+		cause instanceof DOMException &&
+		(cause.name === "TimeoutError" || cause.name === "AbortError")
+	);
+}
+
+/** Bounded row-existence probe: did the host actually create this workspace? */
+async function workspaceRowExists(
+	client: HostServiceClient,
+	workspaceId: string,
+): Promise<boolean> {
+	const existing = await client.workspace.get
+		.query({ id: workspaceId }, { signal: AbortSignal.timeout(15_000) })
+		.catch(() => null);
+	return existing != null;
+}
+
 /**
  * Enqueue the create and resolve from the `workspace:create-settled` event.
  * The synchronous `workspaces.create` mutation holds one of Chromium's six
@@ -105,27 +126,35 @@ async function createViaEnqueue(
 				signal: AbortSignal.timeout(ENQUEUE_TIMEOUT_MS),
 			});
 		} catch (error) {
-			if (!isMissingProcedureError(error)) throw error;
-			// Legacy host: fall back to the long-held synchronous create.
-			const result = await client.workspaces.create.mutate(payload);
-			return result;
+			if (isMissingProcedureError(error)) {
+				// Legacy host: fall back to the long-held synchronous create.
+				const result = await client.workspaces.create.mutate(payload);
+				return result;
+			}
+			// A timed-out enqueue may still have reached the host (reachable but
+			// slow — e.g. a saturated socket pool). Hard-failing here could tear
+			// down a workspace the host is actually creating; fall through and
+			// let the settled event / backstop decide. Anything else (network
+			// error, rejection) is a definitive no-enqueue: fail now.
+			if (!isTimeoutAbort(error)) throw error;
 		}
 
+		let backstopTimer: ReturnType<typeof setTimeout> | undefined;
 		const outcome = await Promise.race([
 			settled,
-			new Promise<"timeout">((resolve) =>
-				setTimeout(() => resolve("timeout"), CREATE_SETTLE_TIMEOUT_MS),
-			),
-		]);
+			new Promise<"timeout">((resolve) => {
+				backstopTimer = setTimeout(
+					() => resolve("timeout"),
+					CREATE_SETTLE_TIMEOUT_MS,
+				);
+			}),
+		]).finally(() => clearTimeout(backstopTimer));
 
 		if (outcome === "timeout") {
 			// The event was lost, not necessarily the create. If the row exists
 			// the workspace is real — recover with an empty pane seed rather
 			// than tearing down a workspace the user can already see.
-			const existing = await client.workspace.get
-				.query({ id: workspaceId })
-				.catch(() => null);
-			if (existing) {
+			if (await workspaceRowExists(client, workspaceId)) {
 				return {
 					workspace: { id: workspaceId, projectId: payload.projectId },
 					terminals: [],
@@ -258,11 +287,28 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					// Sessions have no setup scripts, so no wait-for-setup gate —
 					// and no git worktree work, so the synchronous mutation stays.
 					const { projectId: _null, ...sessionInput } = snapshot;
-					const result = await client.workspaces.createSession.mutate(
-						sessionInput,
-						{ signal: AbortSignal.timeout(SESSION_CREATE_TIMEOUT_MS) },
-					);
-					return result;
+					try {
+						const result = await client.workspaces.createSession.mutate(
+							sessionInput,
+							{ signal: AbortSignal.timeout(SESSION_CREATE_TIMEOUT_MS) },
+						);
+						return result;
+					} catch (error) {
+						// The abort cancels the client, not the host — a slow but
+						// ultimately successful session create must not be recorded
+						// as failed (the row would pop back via workspace:changed).
+						if (
+							isTimeoutAbort(error) &&
+							(await workspaceRowExists(client, workspaceId))
+						) {
+							return {
+								workspace: { id: workspaceId, projectId: null },
+								terminals: [],
+								agents: [],
+							};
+						}
+						throw error;
+					}
 				}
 				let waitForSetup = waitForSetupBeforeAgent;
 				if (waitForSetup === undefined && snapshot.agents?.length) {

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -84,15 +84,47 @@ function isTimeoutAbort(error: unknown): boolean {
 	);
 }
 
-/** Bounded row-existence probe: did the host actually create this workspace? */
-async function workspaceRowExists(
+/**
+ * Bounded row-existence probe: did the host actually create this workspace?
+ * "unknown" means the probe itself failed (transport/auth) — callers must not
+ * treat that as absence.
+ */
+async function probeWorkspaceRow(
 	client: HostServiceClient,
 	workspaceId: string,
-): Promise<boolean> {
-	const existing = await client.workspace.get
-		.query({ id: workspaceId }, { signal: AbortSignal.timeout(15_000) })
-		.catch(() => null);
-	return existing != null;
+): Promise<"exists" | "absent" | "unknown"> {
+	try {
+		const existing = await client.workspace.get.query(
+			{ id: workspaceId },
+			{ signal: AbortSignal.timeout(15_000) },
+		);
+		return existing != null ? "exists" : "absent";
+	} catch (error) {
+		if (error instanceof TRPCClientError && error.data?.code === "NOT_FOUND") {
+			return "absent";
+		}
+		return "unknown";
+	}
+}
+
+/** A few spaced probes: a client-side timeout can race a create that hasn't
+ * inserted its row yet. Resolves "exists" as soon as any probe sees the row. */
+async function probeWorkspaceRowWithRetries(
+	client: HostServiceClient,
+	workspaceId: string,
+	attempts = 3,
+	delayMs = 4_000,
+): Promise<"exists" | "absent" | "unknown"> {
+	let last: "absent" | "unknown" = "absent";
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		if (attempt > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+		const result = await probeWorkspaceRow(client, workspaceId);
+		if (result === "exists") return result;
+		last = result;
+	}
+	return last;
 }
 
 /**
@@ -152,16 +184,23 @@ async function createViaEnqueue(
 
 		if (outcome === "timeout") {
 			// The event was lost, not necessarily the create. If the row exists
-			// the workspace is real — recover with an empty pane seed rather
-			// than tearing down a workspace the user can already see.
-			if (await workspaceRowExists(client, workspaceId)) {
+			// the workspace is real — recover with an EMPTY pane seed rather
+			// than tearing down a workspace the user can already see. Launched
+			// terminals/agents aren't recoverable without the event; the
+			// background-session auto-adopt path surfaces them on open.
+			const row = await probeWorkspaceRow(client, workspaceId);
+			if (row === "exists") {
 				return {
 					workspace: { id: workspaceId, projectId: payload.projectId },
 					terminals: [],
 					agents: [],
 				};
 			}
-			throw new Error("Timed out waiting for the host to create the workspace");
+			throw new Error(
+				row === "unknown"
+					? "Timed out waiting for the host to create the workspace, and the host could not be reached to verify it"
+					: "Timed out waiting for the host to create the workspace",
+			);
 		}
 
 		if (!outcome.ok) {
@@ -297,9 +336,12 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 						// The abort cancels the client, not the host — a slow but
 						// ultimately successful session create must not be recorded
 						// as failed (the row would pop back via workspace:changed).
+						// Spaced probes cover a create that hasn't inserted its row
+						// yet; the empty pane seed is healed by session auto-adopt.
 						if (
 							isTimeoutAbort(error) &&
-							(await workspaceRowExists(client, workspaceId))
+							(await probeWorkspaceRowWithRetries(client, workspaceId)) ===
+								"exists"
 						) {
 							return {
 								workspace: { id: workspaceId, projectId: null },

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -78,6 +78,7 @@ export interface CreateAppResult {
 	injectWebSocket: ReturnType<typeof createNodeWebSocket>["injectWebSocket"];
 	api: ApiClient;
 	db: HostDb;
+	eventBus: EventBus;
 	dispose: () => Promise<void>;
 }
 
@@ -365,5 +366,5 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		}
 	};
 
-	return { app, injectWebSocket, api, db, dispose };
+	return { app, injectWebSocket, api, db, eventBus, dispose };
 }

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -225,6 +225,20 @@ export class EventBus {
 	}
 
 	/**
+	 * Terminal event for an enqueued workspaces.createEnqueued call — carries
+	 * what the synchronous create response used to (canonical id + launched
+	 * terminals/agents), keyed by the client-minted enqueue id.
+	 */
+	broadcastWorkspaceCreateSettled(
+		message: Omit<
+			Extract<ServerMessage, { type: "workspace:create-settled" }>,
+			"type"
+		>,
+	): void {
+		this.broadcast({ type: "workspace:create-settled", ...message });
+	}
+
+	/**
 	 * Fan out project lifecycle changes (create/rename/delete) from the
 	 * host-owned projects table. Broadcast to all clients — list consumers
 	 * subscribe host-wide rather than per-workspace.

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -111,6 +111,36 @@ export interface ProjectChangedMessage {
 	occurredAt: number;
 }
 
+export interface WorkspaceCreateTerminalLaunch {
+	terminalId: string;
+	label?: string;
+}
+
+export type WorkspaceCreateAgentLaunch =
+	| { ok: true; kind: "terminal" | "chat"; sessionId: string; label: string }
+	| { ok: false; error: string };
+
+/**
+ * Terminal event for an enqueued `workspaces.createEnqueued` call. The HTTP
+ * response returns immediately; this carries what the synchronous
+ * `workspaces.create` response used to: the canonical row id (which can
+ * differ from the enqueue id when the create resolved to an existing
+ * workspace) and the launched terminals/agents for the pane-layout seed.
+ */
+export interface WorkspaceCreateSettledMessage {
+	type: "workspace:create-settled";
+	/** The client-minted id from the enqueue call — the correlation key. */
+	workspaceId: string;
+	ok: boolean;
+	canonicalWorkspaceId: string | null;
+	projectId: string | null;
+	terminals: WorkspaceCreateTerminalLaunch[];
+	agents: WorkspaceCreateAgentLaunch[];
+	alreadyExists: boolean;
+	error?: string;
+	occurredAt: number;
+}
+
 export interface EventBusErrorMessage {
 	type: "error";
 	message: string;
@@ -123,6 +153,7 @@ export type ServerMessage =
 	| TerminalLifecycleMessage
 	| PortChangedMessage
 	| WorkspaceChangedMessage
+	| WorkspaceCreateSettledMessage
 	| ProjectChangedMessage
 	| EventBusErrorMessage;
 

--- a/packages/host-service/src/terminal/terminal.create-on-attach.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.create-on-attach.node-test.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { Server } from "@superset/pty-daemon";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { createDb, type HostDb } from "../db/index.ts";
 import { projects, terminalSessions, workspaces } from "../db/schema.ts";
@@ -161,6 +162,15 @@ test("attach with create=1 creates the session for a brand-new id", async () => 
 	const result = await dial(terminalId, `?workspaceId=${workspaceId}&create=1`);
 	assert.deepEqual(result, { kind: "attached" });
 	assert.ok(isLiveTerminalSession(terminalId));
+
+	// The session must be persisted, not just in-memory — the row is what
+	// future attaches (and the session-gone contract) key off after restarts.
+	const row = db.query.terminalSessions
+		.findFirst({ where: eq(terminalSessions.id, terminalId) })
+		.sync();
+	assert.ok(row);
+	assert.equal(row.originWorkspaceId, workspaceId);
+	assert.equal(row.status, "active");
 
 	// The session now exists like any other: a plain re-attach works.
 	const reattach = await dial(terminalId, `?workspaceId=${workspaceId}`);

--- a/packages/host-service/src/trpc/index.ts
+++ b/packages/host-service/src/trpc/index.ts
@@ -98,6 +98,7 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 const baseProcedure = t.procedure.use(sentryMiddleware);
 
 export const router = t.router;
+export const createCallerFactory = t.createCallerFactory;
 export const publicProcedure = baseProcedure;
 
 export const protectedProcedure = baseProcedure.use(async ({ ctx, next }) => {

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -19,7 +19,7 @@ import {
 	insertLocalWorkspace,
 	toCloudShape,
 } from "../../../workspaces/local-workspace-store";
-import { protectedProcedure, router } from "../../index";
+import { createCallerFactory, protectedProcedure, router } from "../../index";
 import {
 	buildTerminalAgentLaunch,
 	isChatAgent,
@@ -1195,6 +1195,63 @@ export const workspacesRouter = router({
 			};
 		}),
 
+	/**
+	 * Enqueue-and-return variant of `create` for renderer clients: the full
+	 * create (worktree add, AI naming, agent dispatch) can run for minutes,
+	 * which would pin one of Chromium's 6-per-origin pooled sockets — and
+	 * relay-fronted hosts hard-cap request exchanges at 30s. Validates
+	 * cheaply, responds immediately, then runs the real `create` in the
+	 * background and broadcasts a `workspace:create-settled` event carrying
+	 * everything the synchronous response used to. CLI/MCP/SDK/automations
+	 * keep calling `create` directly.
+	 */
+	createEnqueued: protectedProcedure
+		.input(createInputSchema)
+		.mutation(({ ctx, input }) => {
+			const workspaceId = input.id;
+			if (!workspaceId) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "createEnqueued requires a client-minted `id`",
+				});
+			}
+			for (const launch of input.agents ?? []) {
+				validateAgentLaunchEffort(ctx.db, launch);
+			}
+			requireLocalProject(ctx, input.projectId);
+
+			void createWorkspacesCaller(ctx)
+				.create(input)
+				.then((result) => {
+					ctx.eventBus.broadcastWorkspaceCreateSettled({
+						workspaceId,
+						ok: true,
+						canonicalWorkspaceId: result.workspace.id,
+						projectId: result.workspace.projectId ?? null,
+						terminals: result.terminals,
+						agents: result.agents,
+						alreadyExists: result.alreadyExists,
+						occurredAt: Date.now(),
+					});
+				})
+				.catch((error) => {
+					console.warn("[workspaces.createEnqueued] create failed", error);
+					ctx.eventBus.broadcastWorkspaceCreateSettled({
+						workspaceId,
+						ok: false,
+						canonicalWorkspaceId: null,
+						projectId: null,
+						terminals: [],
+						agents: [],
+						alreadyExists: false,
+						error: error instanceof Error ? error.message : String(error),
+						occurredAt: Date.now(),
+					});
+				});
+
+			return { workspaceId };
+		}),
+
 	aiRename: protectedProcedure
 		.input(
 			z.object({
@@ -1260,5 +1317,10 @@ export const workspacesRouter = router({
 			return { branchName };
 		}),
 });
+
+// Server-side caller for createEnqueued's background run of the real create.
+// Declared after the router; the resolver closure only dereferences it at
+// request time, long after module init.
+const createWorkspacesCaller = createCallerFactory(workspacesRouter);
 
 export { generateWorkspaceNamesFromPrompt as _aiNamesGenerator };

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -1235,7 +1235,10 @@ export const workspacesRouter = router({
 					});
 				})
 				.catch((error) => {
-					console.warn("[workspaces.createEnqueued] create failed", error);
+					console.warn(
+						`[workspaces.createEnqueued] create failed for workspace ${workspaceId} (project ${input.projectId})`,
+						error,
+					);
 					ctx.eventBus.broadcastWorkspaceCreateSettled({
 						workspaceId,
 						ok: false,

--- a/packages/host-service/test/helpers/createTestHost.ts
+++ b/packages/host-service/test/helpers/createTestHost.ts
@@ -48,6 +48,7 @@ export interface TestHostOptions {
 export interface TestHost {
 	app: CreateAppResult["app"];
 	api: CreateAppResult["api"];
+	eventBus: CreateAppResult["eventBus"];
 	db: HostDb;
 	dispose: () => Promise<void>;
 	psk: string;
@@ -178,6 +179,7 @@ export async function createTestHost(
 	return {
 		app: result.app,
 		api: fakeApi.client,
+		eventBus: result.eventBus,
 		db: db as unknown as HostDb,
 		dispose,
 		psk,

--- a/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { eq } from "drizzle-orm";
+import { workspaces } from "../../src/db/schema";
+import type { ServerMessage } from "../../src/events";
+import { cloudFlows } from "../helpers/cloud-fakes";
+import { createProjectScenario } from "../helpers/scenarios";
+
+type SettledMessage = Extract<
+	ServerMessage,
+	{ type: "workspace:create-settled" }
+>;
+
+/** Capture workspace:create-settled broadcasts without a WebSocket client. */
+function captureSettled(eventBus: {
+	broadcastWorkspaceCreateSettled: (
+		message: Omit<SettledMessage, "type">,
+	) => void;
+}): Array<Omit<SettledMessage, "type">> {
+	const captured: Array<Omit<SettledMessage, "type">> = [];
+	const original = eventBus.broadcastWorkspaceCreateSettled.bind(eventBus);
+	eventBus.broadcastWorkspaceCreateSettled = (message) => {
+		captured.push(message);
+		original(message);
+	};
+	return captured;
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 30_000,
+): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+describe("workspaces.createEnqueued integration", () => {
+	let dispose: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		if (dispose) {
+			await dispose();
+			dispose = undefined;
+		}
+	});
+
+	test("returns immediately, then broadcasts a settled event with the create result", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+		const settled = captureSettled(scenario.host.eventBus);
+
+		const id = randomUUID();
+		const enqueue = await scenario.host.trpc.workspaces.createEnqueued.mutate({
+			projectId: scenario.projectId,
+			name: "enqueued ws",
+			branch: "feature/enqueued",
+			id,
+		});
+		expect(enqueue.workspaceId).toBe(id);
+		// The enqueue response must not wait for the create: no settled
+		// broadcast may have happened synchronously with the mutation.
+		await waitFor(() => settled.length > 0);
+
+		const event = settled[0];
+		expect(event?.workspaceId).toBe(id);
+		expect(event?.ok).toBe(true);
+		expect(event?.canonicalWorkspaceId).toBeTruthy();
+		expect(event?.projectId).toBe(scenario.projectId);
+		expect(event?.alreadyExists).toBe(false);
+
+		const persisted = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, event?.canonicalWorkspaceId ?? ""))
+			.get();
+		expect(persisted?.branch).toBe("feature/enqueued");
+		expect(existsSync(persisted?.worktreePath ?? "")).toBe(true);
+	});
+
+	test("rejects without a client-minted id", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		await expect(
+			scenario.host.trpc.workspaces.createEnqueued.mutate({
+				projectId: scenario.projectId,
+				branch: "feature/no-id",
+			}),
+		).rejects.toThrow(/requires a client-minted/);
+	});
+
+	test("a create that fails after enqueue broadcasts ok:false with the error", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+		const settled = captureSettled(scenario.host.eventBus);
+
+		const id = randomUUID();
+		// ".." is invalid in a git ref, so the worktree add fails mid-create.
+		const enqueue = await scenario.host.trpc.workspaces.createEnqueued.mutate({
+			projectId: scenario.projectId,
+			branch: "feature/bad..ref",
+			id,
+		});
+		expect(enqueue.workspaceId).toBe(id);
+
+		await waitFor(() => settled.length > 0);
+		const event = settled[0];
+		expect(event?.workspaceId).toBe(id);
+		expect(event?.ok).toBe(false);
+		expect(event?.error).toBeTruthy();
+		expect(event?.canonicalWorkspaceId).toBeNull();
+	});
+});

--- a/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
@@ -65,8 +65,10 @@ describe("workspaces.createEnqueued integration", () => {
 			id,
 		});
 		expect(enqueue.workspaceId).toBe(id);
-		// The enqueue response must not wait for the create: no settled
-		// broadcast may have happened synchronously with the mutation.
+		// The enqueue response must not wait for the create: the mutation
+		// round-trip is milliseconds while the worktree add takes hundreds,
+		// so nothing may have settled by the time the response resolves.
+		expect(settled.length).toBe(0);
 		await waitFor(() => settled.length > 0);
 
 		const event = settled[0];

--- a/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
@@ -87,6 +87,37 @@ describe("workspaces.createEnqueued integration", () => {
 		expect(existsSync(persisted?.worktreePath ?? "")).toBe(true);
 	});
 
+	test("resolving to an existing workspace settles with the canonical id and alreadyExists", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		const first = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			name: "original ws",
+			branch: "feature/shared-branch",
+		});
+		const canonicalId = first.workspace.id;
+
+		const settled = captureSettled(scenario.host.eventBus);
+		const enqueueId = randomUUID();
+		await scenario.host.trpc.workspaces.createEnqueued.mutate({
+			projectId: scenario.projectId,
+			branch: "feature/shared-branch",
+			id: enqueueId,
+		});
+		await waitFor(() => settled.length > 0);
+
+		const event = settled[0];
+		// The renderer keys cleanup off this divergence: the optimistic row
+		// under enqueueId is dropped in favor of the canonical workspace.
+		expect(event?.workspaceId).toBe(enqueueId);
+		expect(event?.ok).toBe(true);
+		expect(event?.canonicalWorkspaceId).toBe(canonicalId);
+		expect(event?.alreadyExists).toBe(true);
+	});
+
 	test("rejects without a client-minted id", async () => {
 		const scenario = await createProjectScenario({
 			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -11,6 +11,7 @@ export {
 	type ProjectSnapshotPayload,
 	type TerminalLifecyclePayload,
 	type WorkspaceChangedPayload,
+	type WorkspaceCreateSettledPayload,
 	type WorkspaceSnapshotPayload,
 } from "./lib/eventBus";
 export {

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -16,6 +16,7 @@ type EventType =
 	| "terminal:lifecycle"
 	| "port:changed"
 	| "workspace:changed"
+	| "workspace:create-settled"
 	| "project:changed";
 
 interface FsEventsPayload {
@@ -71,6 +72,16 @@ export interface WorkspaceChangedPayload {
 	occurredAt: number;
 }
 
+type WorkspaceCreateSettledMessage = Extract<
+	ServerMessage,
+	{ type: "workspace:create-settled" }
+>;
+
+export type WorkspaceCreateSettledPayload = Omit<
+	WorkspaceCreateSettledMessage,
+	"type" | "workspaceId"
+>;
+
 type ProjectChangedMessage = Extract<
 	ServerMessage,
 	{ type: "project:changed" }
@@ -99,9 +110,14 @@ type EventListener<T extends EventType> = T extends "fs:events"
 					? (workspaceId: string, payload: PortChangedPayload) => void
 					: T extends "workspace:changed"
 						? (workspaceId: string, payload: WorkspaceChangedPayload) => void
-						: T extends "project:changed"
-							? (projectId: string, payload: ProjectChangedPayload) => void
-							: never;
+						: T extends "workspace:create-settled"
+							? (
+									workspaceId: string,
+									payload: WorkspaceCreateSettledPayload,
+								) => void
+							: T extends "project:changed"
+								? (projectId: string, payload: ProjectChangedPayload) => void
+								: never;
 
 interface ListenerEntry {
 	type: EventType;
@@ -157,7 +173,8 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 			message.type === "agent:lifecycle" ||
 			message.type === "terminal:lifecycle" ||
 			message.type === "port:changed" ||
-			message.type === "workspace:changed"
+			message.type === "workspace:changed" ||
+			message.type === "workspace:create-settled"
 				? message.workspaceId
 				: message.type === "project:changed"
 					? message.projectId
@@ -215,6 +232,12 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 					workspace: message.workspace,
 					occurredAt: message.occurredAt,
 				},
+			);
+		} else if (message.type === "workspace:create-settled") {
+			const { type: _type, workspaceId: _workspaceId, ...payload } = message;
+			(entry.callback as EventListener<"workspace:create-settled">)(
+				message.workspaceId,
+				payload,
 			);
 		} else if (message.type === "project:changed") {
 			(entry.callback as EventListener<"project:changed">)(message.projectId, {


### PR DESCRIPTION
Follow-up to #6299 (terminal create-on-attach). That PR fixed the worst victim of Chromium's 6-per-origin socket pool to host-service; this one reduces the pressure at its two biggest sources. Both changes are proven with before/after CDP measurements against the real dev app.

## Summary
- **`workspaces.create` no longer holds a pooled socket for the whole create.** New `workspaces.createEnqueued` validates, returns immediately, runs the real create in the background, and broadcasts a `workspace:create-settled` eventBus event carrying what the synchronous response used to (canonical workspace id + launched terminals/agents for the pane-layout seed). The desktop renderer switches to it; CLI/MCP/SDK/automations keep the synchronous `create` untouched.
- **The desktop's host-service tRPC client is batched again** — with `httpBatchStreamLink`, which streams each result as it completes, addressing the slowest-in-batch latency that motivated the original unbatching in #3879.
- **Per-case timeout bounds** on the create-flow mutations (enqueue 15s, session create 30s, settled-event backstop 10min with a row-existence check), plus the persisted-row assertion in the create-on-attach test (review follow-up from #6299).

## CDP evidence (real UI journeys, dev desktop app)

**Create hold time — the marquee number.** Same journey both times: New Workspace composer → demo-app project → prompt → submit, with all renderer→host requests timed via CDP Network events:

| | request | held socket for |
|---|---|---|
| before | `POST workspaces.create` | **3,710ms — the entire create** |
| after | `POST workspaces.createEnqueued` | **≤590ms** (max held across *all* 150 requests in the window) |

On demo-app the create is ~4s; on a monorepo it's minutes of `git worktree add` — all of it previously pinning 1 of 6 sockets. On relay-fronted hosts the synchronous create exceeded the relay's 30s exchange cap outright (`apps/relay/src/tunnel.ts:64`), so remote creates of large repos could not succeed at all; the enqueue variant fits comfortably.

**End-to-end UX verified after the change:** workspace appears in the sidebar instantly, navigation lands on it, the AI-generated branch name is applied, and the agent pane is seeded from the settled event and starts executing its prompt (screenshots captured). Scratch workspaces then destroyed cleanly through the same host.

**Batching, dashboard route (6 pollers active), 60s windows:** 72 → 66 requests/min, preflights 36 → 32, with same-tick batches visibly collapsing (`terminalAgents.list,pullRequests.getByWorkspaces` pairs). Honest read: the steady-state win is modest because independent poll intervals rarely share a tick — the real value is same-tick fan-outs (multi-host `useQueries`, boot bursts) and that it removes the per-call socket+preflight floor with no latency downside.

## How It Works
- Host: `createEnqueued` reuses the entire existing `create` procedure via a server-side caller (`createCallerFactory`) — zero changes to the 700-line create body. The settled event goes through a new typed `EventBus.broadcastWorkspaceCreateSettled`, following the existing lifecycle-event shapes.
- Renderer: `useWorkspaceCreates.submit` subscribes to `workspace:create-settled` for the client-minted id *before* enqueueing (no missed-event race), and keeps the existing optimistic flow untouched — sidebar row, empty pane seed, `failedWorkspaceCreates` record, `workspaceTransactions` pending UI all behave exactly as before, now driven by the event payload.
- Degraded paths: hosts without the procedure (version skew) fall back to the legacy synchronous create; a lost settled event (host restart mid-create, WS drop) hits a 10-minute backstop that checks whether the row exists before declaring failure, so a real workspace is never torn down over a missed event.

## Testing
- `bun run typecheck`, `bun run lint`
- `cd packages/host-service && bun test` — 1102 pass, 0 fail, including 3 new integration tests for `createEnqueued` (immediate return + settled event with persisted row; missing-id rejection; mid-create failure broadcasts `ok:false` with the error)
- CDP journeys above, on the built dev app with this branch's host-service bundle

## Known Limitations / Follow-ups
- The `WorkspaceCreatingState` progress UI is still estimate-based; the settled event now provides the terminal signal, and intermediate progress events (worktree add started, agents dispatched) are a natural next step on the same channel.
- Bulk create sites (`toast.promise` over `Promise.all(handles)`) work unchanged — each handle's `completed` now resolves from its event — but weren't individually re-verified beyond the single-create journey.
- Remaining raw-client mutations elsewhere (destroy, rename, etc.) still lack per-case bounds; incremental, per the per-case-bounds decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes workspace creation async and brings back streaming batched tRPC calls to reduce host-service socket pressure and prevent relay timeouts. Adds safer timeout recovery so slow creates and sessions don’t get marked failed.

- **New Features**
  - Added `workspaces.createEnqueued`: validates, returns immediately, runs the real create in the background, and emits `workspace:create-settled` (canonical workspace id, terminals, agents).
  - Desktop switches to the enqueue flow; CLI/MCP/SDK stay synchronous. Sessions remain synchronous with a 30s timeout.
  - Timeouts: enqueue 15s; session create 30s; settle backstop 10m with a bounded row-existence probe. Older hosts fall back to legacy `create`.
  - Desktop tRPC client uses `httpBatchStreamLink` from `@trpc/client` to batch same-tick calls and stream results, reducing preflights and socket usage.
  - Event bus: new `broadcastWorkspaceCreateSettled`; renderer subscribes before enqueue. Types exported via `@superset/workspace-client`.

- **Bug Fixes**
  - Tri-state row probe with spaced retries for timeout recovery: avoids false “failed” creates/sessions; if only the row exists, return with an empty pane seed and rely on auto-adopt to heal panes.
  - A timed-out enqueue now waits for the settled event/backstop instead of failing fast; the probe is bounded and the backstop timer is cleared once settled.

<sup>Written for commit b197d2d484b21aecbabb59c395500bd0a2c39cb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation now returns immediately while completing asynchronously in the background.
  * Added completion updates for successful or failed workspace creation, including workspace, terminal, and agent details.
  * Added client support for receiving workspace creation updates.
  * Improved request batching while streaming individual results.

* **Bug Fixes**
  * Added timeout recovery and compatibility fallback for workspace creation.

* **Tests**
  * Expanded coverage for persisted terminal sessions and asynchronous workspace creation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->