### PR TITLE
feat(host-service,desktop): archive-first workspace delete so rows leave the sidebar instantly

### DIFF
--- a/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
+++ b/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
@@ -1,0 +1,84 @@
+# Workspace Delete: Lifecycle, Edge Cases, Failure Modes
+
+Covers the v2 local workspace delete pipeline (`workspaceCleanup.destroy` in
+`packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts`)
+and its renderer contract. Sessions delete through the same pipeline (they are
+workspaces with no project row).
+
+## Pipeline order (archive-first)
+
+| Step | What | On failure |
+|------|------|-----------|
+| 0 | **Archive (commit point)** — tombstone `archivedAt`/`archiveReason`; broadcast drops the row from every list | — |
+| 1 | Preflight dirty-worktree check (skipped when `force`) | CONFLICT → un-archive |
+| 2 | Teardown script (per `teardownMode`) | blocking: PRECONDITION_FAILED → un-archive |
+| 3 | Local cleanup: PTYs, worktree removal | throw → un-archive |
+| 4 | Legacy cloud delete (best-effort, skipped for sessions) | warning only |
+| 5 | Optional branch delete | warning only |
+| 6 | Caches | warning only |
+
+**The archive commit is deliberately FIRST** — before the (potentially slow)
+git preflight and teardown script — so the row leaves the sidebar/board the
+moment the user confirms (~200 ms measured, broadcast-bound). Any failure in
+steps 1–3 un-archives, so the row *reappears* instead of being stuck
+half-deleted. Telemetry fires only after step 6 succeeds.
+
+## Force semantics
+
+`force: true` (the "Delete anyway" paths) skips preflight, double-forces the
+worktree removal, uses `-D` for branch delete — **and skips teardown
+entirely** (interactive contract: force-retry is consent to abandon a failed
+teardown). Non-interactive callers (CLI/SDK/MCP via `workspace.delete`) use
+`teardownMode: "best-effort"` instead: teardown always runs, failures degrade
+to warnings (#6174).
+
+Consequence worth knowing: if the confirm dialog showed *any* warning
+(uncommitted changes / unpushed commits), confirming passes `force: true`, so
+**teardown does not run for warned deletes**.
+
+## Failure modes
+
+| Scenario | Behavior |
+|----------|----------|
+| **Blocking teardown failure** | Row vanishes on confirm → teardown fails → row reappears (un-archive) and the globally-mounted dialog re-opens as "Teardown exited with code N" with the script's output tail. "Delete anyway" force-retries (teardown skipped); Cancel leaves the workspace fully alive. |
+| **Dirty-worktree race** (clean at dialog-open, dirty by destroy time) | Archive → preflight CONFLICT → un-archive → renderer silently retries with `force: true` → re-archive → deleted. The row blips back for ~100 ms; no error is surfaced. The retry is only for `conflict` — never for `in-progress`. |
+| **Indeterminate preflight** (git status timeout/pool failure) | Fails closed (INTERNAL error, un-archive) rather than skipping the dirty check on a destructive path. Retry usually succeeds; `force` is the escape hatch. |
+| **Worktree removal fails** (still registered after `git worktree remove`) | Throw → un-archive; workspace stays visible and retryable rather than orphaning disk state. |
+| **Host crash mid-delete** | The tombstone is the durable delete-intent record. On startup `runArchivedWorkspaceReconcile` finishes interrupted deletes with best-effort teardown. Path-reuse guard: a tombstone whose `worktreePath` is owned by a live row is left alone (`selectStranded`), so re-created branches never get a healthy worktree rm'd. |
+| **Concurrent destroy** | Process-local `destroysInFlight` guard → CONFLICT with `deleteInProgress` cause → renderer shows a toast and does NOT force-retry. Because the row is already gone (archive-first), UI-initiated double-deletes are mostly impossible anyway. |
+| **Main workspace** | BAD_REQUEST, never archived. |
+| **Deleting the viewed workspace** | Renderer navigates away up-front (before the RPC), so the route never 404s; teardown failure still re-opens the global dialog on whatever route the user landed on. |
+| **Repo with no remote** | `rev-list HEAD --not --remotes` counts *every* commit as unpushed → the dialog always warns → confirm becomes `force` → teardown never runs for such projects. Known quirk, predates archive-first. |
+
+## Renderer contract
+
+- **The delete dialog is globally mounted** (`DeleteWorkspaceMount`, driven by
+  `useDeleteWorkspaceIntent`). Never mount `DashboardSidebarDeleteDialog`
+  under a workspace row: archive-first removes the row (and would unmount the
+  dialog) the instant the destroy starts, killing the teardown-failure
+  force-retry prompt. All entry points — sidebar row, board card, palette,
+  ⌘⇧⌫ hotkey, missing-worktree screen — call
+  `useDeleteWorkspaceIntent.getState().request(...)`.
+- The intent store latches: closing the dialog only flips `open`; the target
+  stays mounted so the in-flight destroy can re-open it on failure. The mount
+  keys the dialog by `workspaceId` so state never leaks between targets.
+- `useDeletingWorkspacesStore` marks ids with a destroy in flight; navigation
+  targeting and shortcuts skip them during the pre-broadcast window and the
+  reappear-on-failure case.
+- On success the renderer also drops the row from the host-workspaces cache
+  explicitly (`removeWorkspace`) so the UI never depends on the socket
+  broadcast.
+- Tombstones reach the renderer via a dedicated query key
+  (`host-service/workspaces/archived/...`), never the persisted live-list
+  cache (#6296).
+
+## Verified 2026-08-09 (CDP, real UI input)
+
+- Happy path with 3 s teardown: row removed **276 ms** after confirm; teardown
+  started ~1 s later and finished ~3 s after that; row never returned.
+- Blocking teardown failure: row removed 198 ms after confirm, reappeared
+  ~1.1 s later, failure pane opened with output tail; force-retry deleted with
+  teardown skipped; tombstone row (`archiveReason: "deleted"`) written before
+  the removal broadcast.
+- Dirty race, concurrent-destroy CONFLICT, main-workspace guard, cancel-path
+  restore, and delete-while-viewing navigation all verified as tabled above.

--- a/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
+++ b/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
@@ -25,9 +25,10 @@ half-deleted. Telemetry fires only after step 6 succeeds.
 
 ## Two consent flags (never conflated)
 
-- **`force`** — git-destructive consent only: skips the dirty preflight,
-  double-forces worktree removal, uses `-D` for branch delete. Set by a
-  warned "Delete anyway" confirm and by the silent dirty-race retry.
+- **`force`** — git-destructive consent only: skips the dirty-worktree
+  preflight. (Worktree removal is always double-forced and branch delete
+  always uses `-D` — the deleteBranch checkbox is the consent there.) Set by
+  a warned "Delete anyway" confirm and by the silent dirty-race retry.
   **Teardown still runs.**
 - **`skipTeardown`** — consent to abandon the teardown script. Set ONLY by
   the retry button on the teardown-failed pane (single and bulk).

--- a/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
+++ b/apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md
@@ -23,32 +23,34 @@ moment the user confirms (~200 ms measured, broadcast-bound). Any failure in
 steps 1–3 un-archives, so the row *reappears* instead of being stuck
 half-deleted. Telemetry fires only after step 6 succeeds.
 
-## Force semantics
+## Two consent flags (never conflated)
 
-`force: true` (the "Delete anyway" paths) skips preflight, double-forces the
-worktree removal, uses `-D` for branch delete — **and skips teardown
-entirely** (interactive contract: force-retry is consent to abandon a failed
-teardown). Non-interactive callers (CLI/SDK/MCP via `workspace.delete`) use
+- **`force`** — git-destructive consent only: skips the dirty preflight,
+  double-forces worktree removal, uses `-D` for branch delete. Set by a
+  warned "Delete anyway" confirm and by the silent dirty-race retry.
+  **Teardown still runs.**
+- **`skipTeardown`** — consent to abandon the teardown script. Set ONLY by
+  the retry button on the teardown-failed pane (single and bulk).
+
+These were one flag originally, which meant editing any tracked file (dirty
+worktree → warned confirm → force) silently disabled the user's teardown
+script. Non-interactive callers (CLI/SDK/MCP via `workspace.delete`) use
 `teardownMode: "best-effort"` instead: teardown always runs, failures degrade
 to warnings (#6174).
-
-Consequence worth knowing: if the confirm dialog showed *any* warning
-(uncommitted changes / unpushed commits), confirming passes `force: true`, so
-**teardown does not run for warned deletes**.
 
 ## Failure modes
 
 | Scenario | Behavior |
 |----------|----------|
-| **Blocking teardown failure** | Row vanishes on confirm → teardown fails → row reappears (un-archive) and the globally-mounted dialog re-opens as "Teardown exited with code N" with the script's output tail. "Delete anyway" force-retries (teardown skipped); Cancel leaves the workspace fully alive. |
-| **Dirty-worktree race** (clean at dialog-open, dirty by destroy time) | Archive → preflight CONFLICT → un-archive → renderer silently retries with `force: true` → re-archive → deleted. The row blips back for ~100 ms; no error is surfaced. The retry is only for `conflict` — never for `in-progress`. |
+| **Blocking teardown failure** | Row vanishes on confirm → teardown fails → row reappears (un-archive) and the globally-mounted dialog re-opens as "Teardown exited with code N" with the script's output tail. The retry sets `skipTeardown: true`; Cancel leaves the workspace fully alive. Applies to warned deletes too — `force` no longer bypasses teardown. |
+| **Dirty-worktree race** (clean at dialog-open, dirty by destroy time) | Archive → preflight CONFLICT → un-archive → renderer silently retries with `force: true` (git consent only; teardown still runs) → re-archive → deleted. The row blips back for ~100 ms; no error is surfaced. The retry is only for `conflict` — never for `in-progress`. |
 | **Indeterminate preflight** (git status timeout/pool failure) | Fails closed (INTERNAL error, un-archive) rather than skipping the dirty check on a destructive path. Retry usually succeeds; `force` is the escape hatch. |
 | **Worktree removal fails** (still registered after `git worktree remove`) | Throw → un-archive; workspace stays visible and retryable rather than orphaning disk state. |
 | **Host crash mid-delete** | The tombstone is the durable delete-intent record. On startup `runArchivedWorkspaceReconcile` finishes interrupted deletes with best-effort teardown. Path-reuse guard: a tombstone whose `worktreePath` is owned by a live row is left alone (`selectStranded`), so re-created branches never get a healthy worktree rm'd. |
 | **Concurrent destroy** | Process-local `destroysInFlight` guard → CONFLICT with `deleteInProgress` cause → renderer shows a toast and does NOT force-retry. Because the row is already gone (archive-first), UI-initiated double-deletes are mostly impossible anyway. |
 | **Main workspace** | BAD_REQUEST, never archived. |
 | **Deleting the viewed workspace** | Renderer navigates away up-front (before the RPC), so the route never 404s; teardown failure still re-opens the global dialog on whatever route the user landed on. |
-| **Repo with no remote** | `rev-list HEAD --not --remotes` counts *every* commit as unpushed → the dialog always warns → confirm becomes `force` → teardown never runs for such projects. Known quirk, predates archive-first. |
+| **Repo with no remote** | `rev-list HEAD --not --remotes` counts *every* commit as unpushed → the dialog always warns → confirm becomes `force`. Since the flag split, teardown still runs; the only cost is a skipped preflight. |
 
 ## Renderer contract
 

--- a/apps/desktop/src/renderer/commandPalette/ui/DeleteWorkspaceMount/DeleteWorkspaceMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/DeleteWorkspaceMount/DeleteWorkspaceMount.tsx
@@ -1,25 +1,40 @@
 import { useCallback } from "react";
 import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 
+/**
+ * The single mount for the v2 delete dialog, shared by every entry point
+ * (sidebar rows, board cards, command palette, close-workspace hotkey,
+ * missing-worktree screen). The destroy pipeline archives the row first, so
+ * the row — and anything mounted under it — unmounts the instant the destroy
+ * starts; this mount lives at the dashboard layout level and survives that,
+ * keeping the teardown-failure force-retry pane reachable. Closing the
+ * dialog only flips `open` (the target stays latched) so the in-flight
+ * destroy can re-open it on failure; `key` gives each workspace a fresh
+ * dialog instance so no error/preview state leaks between targets.
+ */
 export function DeleteWorkspaceMount() {
 	const target = useDeleteWorkspaceIntent((s) => s.target);
+	const open = useDeleteWorkspaceIntent((s) => s.open);
+	const setOpen = useDeleteWorkspaceIntent((s) => s.setOpen);
 	const close = useDeleteWorkspaceIntent((s) => s.close);
+	const { removeWorkspaceFromSidebar } = useDashboardSidebarState();
 
-	const handleOpenChange = useCallback(
-		(open: boolean) => {
-			if (!open) close();
-		},
-		[close],
-	);
+	const handleDeleted = useCallback(() => {
+		if (target) removeWorkspaceFromSidebar(target.workspaceId);
+		close();
+	}, [target, removeWorkspaceFromSidebar, close]);
 
 	if (!target) return null;
 	return (
 		<DashboardSidebarDeleteDialog
+			key={target.workspaceId}
 			workspaceId={target.workspaceId}
 			workspaceName={target.workspaceName}
-			open
-			onOpenChange={handleOpenChange}
+			open={open}
+			onOpenChange={setOpen}
+			onDeleted={handleDeleted}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/commandPalette/ui/DeleteWorkspaceMount/DeleteWorkspaceMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/DeleteWorkspaceMount/DeleteWorkspaceMount.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
@@ -21,20 +20,22 @@ export function DeleteWorkspaceMount() {
 	const close = useDeleteWorkspaceIntent((s) => s.close);
 	const { removeWorkspaceFromSidebar } = useDashboardSidebarState();
 
-	const handleDeleted = useCallback(() => {
-		if (target) removeWorkspaceFromSidebar(target.workspaceId);
-		close();
-	}, [target, removeWorkspaceFromSidebar, close]);
-
 	if (!target) return null;
+	// Callbacks bind the rendered target's id: a dialog whose destroy is
+	// still in flight after a new request replaced the target keeps its own
+	// id, so its settle can't touch the new target's dialog.
+	const workspaceId = target.workspaceId;
 	return (
 		<DashboardSidebarDeleteDialog
-			key={target.workspaceId}
-			workspaceId={target.workspaceId}
+			key={workspaceId}
+			workspaceId={workspaceId}
 			workspaceName={target.workspaceName}
 			open={open}
-			onOpenChange={setOpen}
-			onDeleted={handleDeleted}
+			onOpenChange={(next) => setOpen(workspaceId, next)}
+			onDeleted={() => {
+				removeWorkspaceFromSidebar(workspaceId);
+				close(workspaceId);
+			}}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -13,8 +13,8 @@ import {
 
 export interface DestroyWorkspaceInput {
 	deleteBranch?: boolean;
-	/** Git-destructive consent only (skip dirty preflight, force worktree/
-	 * branch removal). Does NOT skip the teardown script. */
+	/** Git-destructive consent only (skips the dirty-worktree preflight).
+	 * Does NOT skip the teardown script. */
 	force?: boolean;
 	/** Consent to abandon the teardown script — only the teardown-failed
 	 * retry sets this. */

--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -13,7 +13,12 @@ import {
 
 export interface DestroyWorkspaceInput {
 	deleteBranch?: boolean;
+	/** Git-destructive consent only (skip dirty preflight, force worktree/
+	 * branch removal). Does NOT skip the teardown script. */
 	force?: boolean;
+	/** Consent to abandon the teardown script — only the teardown-failed
+	 * retry sets this. */
+	skipTeardown?: boolean;
 }
 
 export interface DestroyWorkspaceSuccess {
@@ -72,6 +77,7 @@ export async function destroyWorkspaceAtHost(
 			workspaceId,
 			deleteBranch: input.deleteBranch ?? false,
 			force: input.force ?? false,
+			skipTeardown: input.skipTeardown ?? false,
 		});
 	} catch (error) {
 		throw normalizeDestroyWorkspaceError(error);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/useBulkWorkspaceDelete.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkDeleteDialog/hooks/useBulkWorkspaceDelete/useBulkWorkspaceDelete.ts
@@ -122,10 +122,14 @@ export function useBulkWorkspaceDelete({
 		async ({
 			targets,
 			forceAll,
+			skipTeardown,
 			retainedFailures,
 		}: {
 			targets: DashboardSidebarWorkspace[];
 			forceAll: boolean;
+			/** Only the teardown-failure retry pass abandons teardown; warned
+			 * (forced) deletes still run it. */
+			skipTeardown: boolean;
 			retainedFailures: BulkWorkspaceDeleteFailure[];
 		}) => {
 			if (inFlight.current || targets.length === 0) return;
@@ -174,6 +178,7 @@ export function useBulkWorkspaceDelete({
 						destroyWorkspaceAtHost(targetFor(workspace), {
 							deleteBranch: preferences.deleteLocalBranch,
 							force,
+							skipTeardown,
 						}),
 					onSettled: () => setCompletedCount((count) => count + 1),
 				});
@@ -261,6 +266,7 @@ export function useBulkWorkspaceDelete({
 		await execute({
 			targets: workspaces,
 			forceAll: false,
+			skipTeardown: false,
 			retainedFailures: [],
 		});
 	}, [execute, inspectionSummary.canConfirm, workspaces]);
@@ -276,6 +282,7 @@ export function useBulkWorkspaceDelete({
 		await execute({
 			targets: teardownFailures.map((failure) => failure.workspace),
 			forceAll: true,
+			skipTeardown: true,
 			retainedFailures: failures.filter(
 				(failure) => !teardownWorkspaceIds.has(failure.workspace.id),
 			),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
@@ -53,7 +53,7 @@ export function DashboardSidebarDeleteDialog({
 				open={open}
 				onOpenChange={handleOpenChange}
 				cause={error.cause}
-				onForceDelete={() => run(true)}
+				onForceDelete={() => run({ force: true, skipTeardown: true })}
 			/>
 		);
 	}
@@ -73,7 +73,7 @@ export function DashboardSidebarDeleteDialog({
 			hasUnpushedCommits={hasUnpushedCommits}
 			canConfirm={canConfirm}
 			blockingReason={blockingReason}
-			onConfirm={() => run(hasWarnings)}
+			onConfirm={() => run({ force: hasWarnings })}
 			confirmLabel={confirmLabel}
 		/>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -101,8 +101,9 @@ export function useDestroyDialogState({
 
 			setError(null);
 			onOpenChange(false);
-			// The row stays listed until the archive commit (post-teardown);
-			// mark it so navigation/shortcuts skip it in the meantime.
+			// The archive commit tombstones the row almost immediately, but
+			// until that broadcast lands (and if a failure un-archives it)
+			// navigation/shortcuts must skip it.
 			useDeletingWorkspacesStore.getState().markDeleting(workspaceId);
 			// Navigate up-front: no-ops if the deleted workspace isn't the
 			// active route, so a later user navigation won't be hijacked.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -95,7 +95,17 @@ export function useDestroyDialogState({
 	);
 
 	const run = useCallback(
-		async (force: boolean) => {
+		// Two separate consents, never conflated: `force` covers git
+		// destructiveness (dirty worktree, unpushed commits), `skipTeardown`
+		// covers abandoning the teardown script and is set only by the
+		// teardown-failed retry — a warned "Delete anyway" still runs teardown.
+		async ({
+			force,
+			skipTeardown = false,
+		}: {
+			force: boolean;
+			skipTeardown?: boolean;
+		}) => {
 			if (inFlight.current) return;
 			inFlight.current = true;
 
@@ -117,17 +127,18 @@ export function useDestroyDialogState({
 			try {
 				let result: DestroyWorkspaceSuccess;
 				try {
-					result = await destroy({ deleteBranch, force });
+					result = await destroy({ deleteBranch, force, skipTeardown });
 				} catch (firstErr) {
 					const e = firstErr as DestroyWorkspaceError;
 					// Silent force-retry on the dirty-worktree race: preflight said
 					// clean but the worktree was dirty by destroy time. The user
 					// already confirmed once — don't bounce them back through a
-					// second warning. Do NOT extend this to `in-progress` (that's
-					// a different CONFLICT cause; retrying just races the same
+					// second warning. Git consent only: teardown still runs on the
+					// retry. Do NOT extend this to `in-progress` (that's a
+					// different CONFLICT cause; retrying just races the same
 					// guard).
 					if (e.kind === "conflict" && !force) {
-						result = await destroy({ deleteBranch, force: true });
+						result = await destroy({ deleteBranch, force: true, skipTeardown });
 					} else {
 						throw firstErr;
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -14,7 +14,6 @@ import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSi
 import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
 import type { WorkspaceSelectionEvent } from "../../providers/DashboardSidebarSelectionProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
-import { DashboardSidebarDeleteDialog } from "../DashboardSidebarDeleteDialog";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
 import { DashboardSidebarExpandedWorkspaceRow } from "./components/DashboardSidebarExpandedWorkspaceRow";
 import {
@@ -70,19 +69,17 @@ export function DashboardSidebarWorkspaceItem({
 		handleCopyPath,
 		handleCopyBranchName,
 		handleCreateSection,
-		handleDeleted,
 		handleOpenInFinder,
 		handleRemoveFromSidebar,
 		handleRemovePullRequest,
 		handleTogglePin,
 		handleToggleUnread,
 		isActive,
-		isDeleteDialogOpen,
 		isUnread,
 		isRenaming,
 		moveWorkspaceToSection,
 		renameValue,
-		setIsDeleteDialogOpen,
+		requestDelete,
 		setRenameValue,
 		startRename,
 		submitRename,
@@ -254,9 +251,7 @@ export function DashboardSidebarWorkspaceItem({
 							onRemoveFromSidebar={handleRemoveFromSidebar}
 							onRemovePullRequest={handleRemovePullRequest}
 							onRename={isMainWorkspace ? undefined : startRename}
-							onDelete={
-								isMainWorkspace ? undefined : () => setIsDeleteDialogOpen(true)
-							}
+							onDelete={isMainWorkspace ? undefined : requestDelete}
 							onToggleUnread={handleToggleUnread}
 							onClearStatus={handleClearStatus}
 						>
@@ -265,15 +260,6 @@ export function DashboardSidebarWorkspaceItem({
 					)}
 				</div>
 
-				{!isPending && !isMainWorkspace && (
-					<DashboardSidebarDeleteDialog
-						workspaceId={id}
-						workspaceName={name || branch}
-						open={isDeleteDialogOpen}
-						onOpenChange={setIsDeleteDialogOpen}
-						onDeleted={handleDeleted}
-					/>
-				)}
 				{renameBranchTarget && (
 					<RenameBranchDialog
 						workspaceId={id}
@@ -315,7 +301,7 @@ export function DashboardSidebarWorkspaceItem({
 				onWorkspaceChipsClick={handleWorkspaceChipsClick}
 				onDoubleClick={isPending || isMainWorkspace ? undefined : startRename}
 				onRemoveFromSidebarClick={handleRemoveFromSidebar}
-				onCloseWorkspaceClick={() => setIsDeleteDialogOpen(true)}
+				onCloseWorkspaceClick={requestDelete}
 				onRenameValueChange={setRenameValue}
 				onSubmitRename={submitRename}
 				onCancelRename={cancelRename}
@@ -357,9 +343,7 @@ export function DashboardSidebarWorkspaceItem({
 						onRemoveFromSidebar={handleRemoveFromSidebar}
 						onRemovePullRequest={handleRemovePullRequest}
 						onRename={isMainWorkspace ? undefined : startRename}
-						onDelete={
-							isMainWorkspace ? undefined : () => setIsDeleteDialogOpen(true)
-						}
+						onDelete={isMainWorkspace ? undefined : requestDelete}
 						onToggleUnread={handleToggleUnread}
 						onClearStatus={handleClearStatus}
 					>
@@ -368,15 +352,6 @@ export function DashboardSidebarWorkspaceItem({
 				)}
 			</div>
 
-			{!isPending && !isMainWorkspace && (
-				<DashboardSidebarDeleteDialog
-					workspaceId={id}
-					workspaceName={name || branch}
-					open={isDeleteDialogOpen}
-					onOpenChange={setIsDeleteDialogOpen}
-					onDeleted={handleDeleted}
-				/>
-			)}
 			{renameBranchTarget && (
 				<RenameBranchDialog
 					workspaceId={id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -17,6 +17,7 @@ import { DASHBOARD_SIDEBAR_PULL_REQUEST_QUERY_KEY_PREFIX } from "renderer/routes
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import { useV2NotificationStore } from "renderer/stores/v2-notifications";
 
@@ -56,16 +57,11 @@ export function useDashboardSidebarWorkspaceItemActions({
 		clearManualUnread(workspaceId);
 		markWorkspaceTerminalsSeen();
 	};
-	const {
-		createSection,
-		moveWorkspaceToSection,
-		removeWorkspaceFromSidebar,
-		setWorkspacePinned,
-	} = useDashboardSidebarState();
+	const { createSection, moveWorkspaceToSection, setWorkspacePinned } =
+		useDashboardSidebarState();
 
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
-	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
 	const isActive = !!matchRoute({
 		to: "/v2-workspace/$workspaceId",
@@ -99,8 +95,14 @@ export function useDashboardSidebarWorkspaceItemActions({
 		workspaceActions.renameWorkspace(workspaceId, trimmed);
 	};
 
-	const handleDeleted = () => {
-		removeWorkspaceFromSidebar(workspaceId);
+	// The delete dialog is globally mounted (archive-first tombstoning drops
+	// this row the moment the destroy starts, which would unmount a
+	// row-local dialog mid-flight).
+	const requestDelete = () => {
+		useDeleteWorkspaceIntent.getState().request({
+			workspaceId,
+			workspaceName: workspaceName || branch,
+		});
 	};
 
 	const handleRemoveFromSidebar = () => {
@@ -238,19 +240,17 @@ export function useDashboardSidebarWorkspaceItemActions({
 		handleCopyPath,
 		handleCopyBranchName,
 		handleCreateSection,
-		handleDeleted,
 		handleOpenInFinder,
 		handleRemoveFromSidebar,
 		handleRemovePullRequest,
 		handleTogglePin,
 		handleToggleUnread,
 		isActive,
-		isDeleteDialogOpen,
 		isRenaming,
 		isUnread,
 		moveWorkspaceToSection,
 		renameValue,
-		setIsDeleteDialogOpen,
+		requestDelete,
 		setRenameValue,
 		startRename,
 		submitRename,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -11,13 +11,12 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
-import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
-import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
+import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
@@ -33,26 +32,19 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
 });
 
-type DeleteTarget =
-	| {
-			version: "v1";
-			workspaceId: string;
-			workspaceName: string;
-			workspaceType: "worktree" | "branch";
-	  }
-	| {
-			version: "v2";
-			workspaceId: string;
-			workspaceName: string;
-			open: boolean;
-	  };
+/** v1 only — v2 deletes go through the globally-mounted DeleteWorkspaceMount
+ * (see delete-workspace-intent store). */
+type DeleteTarget = {
+	workspaceId: string;
+	workspaceName: string;
+	workspaceType: "worktree" | "branch";
+};
 
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
-	const { removeWorkspaceFromSidebar } = useDashboardSidebarState();
 	useDevSeedV2Sidebar();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
@@ -132,7 +124,6 @@ function DashboardLayout() {
 					workspaceId: currentWorkspaceId,
 					workspaceName: currentWorkspace.name,
 					workspaceType: currentWorkspace.type,
-					version: "v1",
 				});
 				return;
 			}
@@ -142,11 +133,9 @@ function DashboardLayout() {
 				currentV2Workspace &&
 				currentV2Workspace.type !== "main"
 			) {
-				setDeleteTarget({
+				useDeleteWorkspaceIntent.getState().request({
 					workspaceId: currentV2WorkspaceId,
 					workspaceName: currentV2Workspace.name || currentV2Workspace.branch,
-					version: "v2",
-					open: true,
 				});
 			}
 		},
@@ -248,7 +237,7 @@ function DashboardLayout() {
 			</div>
 			<div id="workspace-right-sidebar-slot" className="flex h-full shrink-0" />
 			<AddRepositoryModals />
-			{deleteTarget?.version === "v1" && (
+			{deleteTarget && (
 				<DeleteWorkspaceDialog
 					workspaceId={deleteTarget.workspaceId}
 					workspaceName={deleteTarget.workspaceName}
@@ -256,22 +245,6 @@ function DashboardLayout() {
 					open={true}
 					onOpenChange={(open) => {
 						if (!open) setDeleteTarget(null);
-					}}
-				/>
-			)}
-			{deleteTarget?.version === "v2" && (
-				<DashboardSidebarDeleteDialog
-					workspaceId={deleteTarget.workspaceId}
-					workspaceName={deleteTarget.workspaceName}
-					open={deleteTarget.open}
-					onOpenChange={(open) => {
-						setDeleteTarget((target) =>
-							target?.version === "v2" ? { ...target, open } : target,
-						);
-					}}
-					onDeleted={() => {
-						removeWorkspaceFromSidebar(deleteTarget.workspaceId);
-						setDeleteTarget(null);
 					}}
 				/>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/stores/deletingWorkspacesStore/deletingWorkspacesStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/stores/deletingWorkspacesStore/deletingWorkspacesStore.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
 
 /**
- * Workspace ids with a destroy in flight. The archive commit point lands
- * AFTER the (potentially slow) teardown script, so for those seconds the
- * rows are still present in every list — navigation targeting and keyboard
- * shortcuts must not send the user into a workspace that is about to
- * vanish. Module-scope store, not a provider: it is written imperatively
+ * Workspace ids with a destroy in flight. The archive commit tombstones the
+ * row almost immediately, but there's still a window before the broadcast
+ * lands (plus the reappear-on-failure case) — navigation targeting and
+ * keyboard shortcuts must not send the user into a workspace that is about
+ * to vanish. Module-scope store, not a provider: it is written imperatively
  * by the destroy flows and read wherever a target is picked.
  */
 interface DeletingWorkspacesState {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
@@ -1,8 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, FolderX, RefreshCw, Trash2 } from "lucide-react";
-import { useState } from "react";
-import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
+import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 
 interface WorkspaceMissingWorktreeStateProps {
 	workspaceId: string;
@@ -21,7 +20,6 @@ export function WorkspaceMissingWorktreeState({
 	onRefresh,
 	isRefreshing = false,
 }: WorkspaceMissingWorktreeStateProps) {
-	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const displayName = workspaceName || branch;
 
 	return (
@@ -66,7 +64,12 @@ export function WorkspaceMissingWorktreeState({
 						size="sm"
 						variant="destructive"
 						className="h-7 gap-1.5 px-2.5 text-[13px]"
-						onClick={() => setDeleteDialogOpen(true)}
+						onClick={() =>
+							useDeleteWorkspaceIntent.getState().request({
+								workspaceId,
+								workspaceName: displayName,
+							})
+						}
 					>
 						<Trash2 className="size-3.5" strokeWidth={2} aria-hidden="true" />
 						Delete workspace
@@ -101,13 +104,6 @@ export function WorkspaceMissingWorktreeState({
 						</Link>
 					</Button>
 				</div>
-
-				<DashboardSidebarDeleteDialog
-					workspaceId={workspaceId}
-					workspaceName={displayName}
-					open={deleteDialogOpen}
-					onOpenChange={setDeleteDialogOpen}
-				/>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceContextMenu/V2WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceContextMenu/V2WorkspaceContextMenu.tsx
@@ -7,15 +7,15 @@ import {
 } from "@superset/ui/context-menu";
 import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
-import { type ReactNode, useCallback, useState } from "react";
+import { type ReactNode, useCallback } from "react";
 import { LuArrowUpRight, LuGitBranch, LuTrash2 } from "react-icons/lu";
 import { RiPushpinFill, RiPushpinLine } from "react-icons/ri";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import type { AccessibleV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 
 export interface V2WorkspaceActions {
 	/** Navigate to the workspace (paywall-gated for remote hosts). */
@@ -45,17 +45,10 @@ export function V2WorkspaceContextMenu({
 }: V2WorkspaceContextMenuProps) {
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
-	const {
-		ensureWorkspaceInSidebar,
-		removeWorkspaceFromSidebar,
-		hideWorkspaceInSidebar,
-	} = useDashboardSidebarState();
+	const { ensureWorkspaceInSidebar, hideWorkspaceInSidebar } =
+		useDashboardSidebarState();
 	const { copyToClipboard } = useCopyToClipboard();
 	const isMainWorkspace = workspace.type === "main";
-	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-	// Latched on first open so the dialog stays mounted through the destroy —
-	// a teardown failure re-opens it to offer force-delete.
-	const [deleteDialogMounted, setDeleteDialogMounted] = useState(false);
 
 	const open = useCallback(() => {
 		const go = () => navigateToV2Workspace(workspace.id, navigate);
@@ -112,80 +105,63 @@ export function V2WorkspaceContextMenu({
 		}
 	}, [copyToClipboard, workspace.branch]);
 
+	// Globally-mounted dialog (DeleteWorkspaceMount): archive-first
+	// tombstoning drops this row the moment the destroy starts, which
+	// would unmount a row-local dialog mid-flight.
 	const openDeleteDialog = useCallback(() => {
-		setDeleteDialogMounted(true);
-		setIsDeleteDialogOpen(true);
-	}, []);
-
-	const handleDeleted = useCallback(() => {
-		setDeleteDialogMounted(false);
-		removeWorkspaceFromSidebar(workspace.id);
-	}, [removeWorkspaceFromSidebar, workspace.id]);
+		useDeleteWorkspaceIntent.getState().request({
+			workspaceId: workspace.id,
+			workspaceName: workspace.name || workspace.branch,
+		});
+	}, [workspace.id, workspace.name, workspace.branch]);
 
 	return (
-		<>
-			<ContextMenu>
-				<ContextMenuTrigger asChild>
-					{children({
-						open,
-						addToSidebar,
-						removeFromSidebar,
-						openDeleteDialog,
-					})}
-				</ContextMenuTrigger>
-				<ContextMenuContent
-					onCloseAutoFocus={(event) => event.preventDefault()}
-				>
-					<ContextMenuItem onSelect={open}>
-						<LuArrowUpRight className="size-4" />
-						Open
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				{children({
+					open,
+					addToSidebar,
+					removeFromSidebar,
+					openDeleteDialog,
+				})}
+			</ContextMenuTrigger>
+			<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
+				<ContextMenuItem onSelect={open}>
+					<LuArrowUpRight className="size-4" />
+					Open
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={handleCopyBranchName}>
+					<LuGitBranch className="size-4" />
+					Copy Branch Name
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				{workspace.isInSidebar ? (
+					<ContextMenuItem
+						onSelect={removeFromSidebar}
+						disabled={isCurrentRoute}
+					>
+						<RiPushpinLine className="size-4" />
+						Unpin from Sidebar
 					</ContextMenuItem>
-					<ContextMenuItem onSelect={handleCopyBranchName}>
-						<LuGitBranch className="size-4" />
-						Copy Branch Name
+				) : (
+					<ContextMenuItem onSelect={addToSidebar}>
+						<RiPushpinFill className="size-4" />
+						Pin to Sidebar
 					</ContextMenuItem>
-					<ContextMenuSeparator />
-					{workspace.isInSidebar ? (
+				)}
+				{!isMainWorkspace ? (
+					<>
+						<ContextMenuSeparator />
 						<ContextMenuItem
-							onSelect={removeFromSidebar}
-							disabled={isCurrentRoute}
+							onSelect={openDeleteDialog}
+							className="text-destructive focus:text-destructive"
 						>
-							<RiPushpinLine className="size-4" />
-							Unpin from Sidebar
+							<LuTrash2 className="size-4 text-destructive" />
+							Delete
 						</ContextMenuItem>
-					) : (
-						<ContextMenuItem onSelect={addToSidebar}>
-							<RiPushpinFill className="size-4" />
-							Pin to Sidebar
-						</ContextMenuItem>
-					)}
-					{!isMainWorkspace ? (
-						<>
-							<ContextMenuSeparator />
-							<ContextMenuItem
-								onSelect={openDeleteDialog}
-								className="text-destructive focus:text-destructive"
-							>
-								<LuTrash2 className="size-4 text-destructive" />
-								Delete
-							</ContextMenuItem>
-						</>
-					) : null}
-				</ContextMenuContent>
-			</ContextMenu>
-			{/* Mount the dialog (and its per-workspace live-query subscription)
-			    only once the user opened it — not idle for every row. The latch
-			    keeps it mounted through the destroy so a teardown-failure can
-			    re-open it to offer force-delete. */}
-			{!isMainWorkspace && deleteDialogMounted ? (
-				<DashboardSidebarDeleteDialog
-					workspaceId={workspace.id}
-					workspaceName={workspace.name || workspace.branch}
-					open={isDeleteDialogOpen}
-					onOpenChange={setIsDeleteDialogOpen}
-					onDeleted={handleDeleted}
-				/>
-			) : null}
-		</>
+					</>
+				) : null}
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/stores/delete-workspace-intent.ts
+++ b/apps/desktop/src/renderer/stores/delete-workspace-intent.ts
@@ -11,14 +11,17 @@ export interface DeleteWorkspaceTarget {
  * workspace row unmounts the moment the destroy starts — every delete entry
  * point requests through this store instead. `open` is tracked separately
  * from `target` so the dialog stays mounted (latched) through an in-flight
- * destroy and can re-open itself on a teardown failure.
+ * destroy and can re-open itself on a teardown failure. `setOpen`/`close`
+ * take the workspaceId so a stale callback from a superseded delete (a new
+ * `request` replaced the target mid-flight) can't close or reopen the new
+ * target's dialog.
  */
 interface DeleteWorkspaceIntentState {
 	target: DeleteWorkspaceTarget | null;
 	open: boolean;
 	request: (target: DeleteWorkspaceTarget) => void;
-	setOpen: (open: boolean) => void;
-	close: () => void;
+	setOpen: (workspaceId: string, open: boolean) => void;
+	close: (workspaceId: string) => void;
 }
 
 export const useDeleteWorkspaceIntent = create<DeleteWorkspaceIntentState>(
@@ -26,7 +29,15 @@ export const useDeleteWorkspaceIntent = create<DeleteWorkspaceIntentState>(
 		target: null,
 		open: false,
 		request: (target) => set({ target, open: true }),
-		setOpen: (open) => set({ open }),
-		close: () => set({ target: null, open: false }),
+		setOpen: (workspaceId, open) =>
+			set((state) =>
+				state.target?.workspaceId === workspaceId ? { open } : state,
+			),
+		close: (workspaceId) =>
+			set((state) =>
+				state.target?.workspaceId === workspaceId
+					? { target: null, open: false }
+					: state,
+			),
 	}),
 );

--- a/apps/desktop/src/renderer/stores/delete-workspace-intent.ts
+++ b/apps/desktop/src/renderer/stores/delete-workspace-intent.ts
@@ -5,16 +5,28 @@ export interface DeleteWorkspaceTarget {
 	workspaceName: string;
 }
 
+/**
+ * Drives the single globally-mounted v2 delete dialog (DeleteWorkspaceMount).
+ * The destroy pipeline archives the row FIRST, so any dialog mounted under a
+ * workspace row unmounts the moment the destroy starts — every delete entry
+ * point requests through this store instead. `open` is tracked separately
+ * from `target` so the dialog stays mounted (latched) through an in-flight
+ * destroy and can re-open itself on a teardown failure.
+ */
 interface DeleteWorkspaceIntentState {
 	target: DeleteWorkspaceTarget | null;
+	open: boolean;
 	request: (target: DeleteWorkspaceTarget) => void;
+	setOpen: (open: boolean) => void;
 	close: () => void;
 }
 
 export const useDeleteWorkspaceIntent = create<DeleteWorkspaceIntentState>(
 	(set) => ({
 		target: null,
-		request: (target) => set({ target }),
-		close: () => set({ target: null }),
+		open: false,
+		request: (target) => set({ target, open: true }),
+		setOpen: (open) => set({ open }),
+		close: () => set({ target: null, open: false }),
 	}),
 );

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -45,7 +45,7 @@ export interface DestroyWorkspaceInput {
 	deleteBranch: boolean;
 	force: boolean;
 	/**
-	 * Teardown (step 1) behavior — deliberately separate from `force`, which
+	 * Teardown (step 2) behavior — deliberately separate from `force`, which
 	 * only carries the destructive git semantics (skip preflight, double-force
 	 * worktree removal):
 	 *   - "blocking":    a failed script throws PRECONDITION_FAILED so an
@@ -147,25 +147,26 @@ export const workspaceCleanupRouter = router({
 	/**
 	 * Destroy a workspace in phases:
 	 *
-	 *   0.   Preflight    — dirty-worktree check (skip if force)
-	 *   1.   Teardown     — run .superset/teardown.sh (per teardownMode)
-	 *   1.5. Archive      ← the commit point: the row tombstones
+	 *   0.   Archive      ← the commit point, FIRST: the row tombstones
 	 *                       (archivedAt/archiveReason) and vanishes from
-	 *                       default lists
-	 *   2.   Local cleanup — PTYs, worktree
-	 *   3.   Best-effort legacy cloud delete (skipped for sessions)
-	 *   4.   Branch delete — optional local branch cleanup
-	 *   5.   Caches
+	 *                       default lists before any slow work, so the
+	 *                       delete feels instant in every client
+	 *   1.   Preflight    — dirty-worktree check (skip if force)
+	 *   2.   Teardown     — run .superset/teardown.sh (per teardownMode)
+	 *   3.   Local cleanup — PTYs, worktree
+	 *   4.   Best-effort legacy cloud delete (skipped for sessions)
+	 *   5.   Branch delete — optional local branch cleanup
+	 *   6.   Caches
 	 *
-	 * A failure in phases 2-5 un-archives the row so the workspace stays
-	 * visible and retryable instead of orphaning disk state; a crash after
-	 * the archive is finished by the startup reconciler
-	 * (runArchivedWorkspaceReconcile).
+	 * ANY failure in phases 1-6 un-archives the row so the workspace
+	 * reappears and stays retryable instead of orphaning disk state; a
+	 * crash after the archive is finished by the startup reconciler
+	 * (runArchivedWorkspaceReconcile) with best-effort teardown.
 	 *
 	 * Force semantics (git only; teardown is governed by teardownMode):
-	 *   - skips preflight (step 0)
-	 *   - step 2b always uses `--force --force`
-	 *   - step 4 always uses `-D` regardless: the `deleteBranch`
+	 *   - skips preflight (step 1)
+	 *   - step 3b always uses `--force --force`
+	 *   - step 5 always uses `-D` regardless: the `deleteBranch`
 	 *     checkbox is the user's consent, so refusing unmerged branches
 	 *     would just silently drop the opt-in.
 	 *
@@ -232,84 +233,16 @@ async function runDestroy(
 	}
 	const { local, project } = main;
 
-	// ─── Step 0: Preflight ─────────────────────────────────────────
-	// Block only on dirty worktree (the common "I forgot to commit"
-	// case). Missing/broken local state is handled by the cleanup phase.
-	// Sessions are standalone repos — the same dirty check applies even
-	// though they have no project row.
-	if (!input.force && local && (project || local.type === "session")) {
-		try {
-			const gitEnv = await cleanupGitOps.resolveGitEnv(ctx, local.worktreePath);
-			const state = await cleanupGitOps.readWorktreeState({
-				worktreePath: local.worktreePath,
-				gitEnv,
-			});
-			if (state.hasChanges) {
-				throw new TRPCError({
-					code: "CONFLICT",
-					message: "Worktree has uncommitted changes",
-				});
-			}
-		} catch (err) {
-			if (err instanceof TRPCError) throw err;
-			if (isIndeterminateGitTaskFailure(err)) {
-				// Timeout/pool failure: dirty-state is UNKNOWN. Fail closed on
-				// this destructive path rather than silently skipping the
-				// dirty-worktree block — a retry usually succeeds (the first
-				// attempt warmed the FS cache), and force skips preflight
-				// entirely as the explicit escape hatch.
-				const message = err instanceof Error ? err.message : String(err);
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: `Couldn't verify worktree state at ${local.worktreePath}: ${message}`,
-				});
-			}
-			// Can't read status (missing worktree dir, etc.) — not a
-			// conflict. Continue; step 3b will skip idempotently.
-		}
-	}
-
-	// ─── Step 1: Teardown ──────────────────────────────────────────
-	// Script is the user's last chance to stop services / flush state
-	// before the workspace goes away. Deliberately BEFORE the archive
-	// commit point: a blocking failure here re-opens the delete dialog
-	// with a force-retry, and that dialog lives under the still-visible
-	// row — archiving first would unmount it mid-prompt.
-	if (input.teardownMode !== "skip" && local && project) {
-		const teardown: TeardownResult = await runTeardown({
-			db: ctx.db,
-			workspaceId: input.workspaceId,
-			worktreePath: local.worktreePath,
-			repoPath: project.repoPath,
-			projectId: project.id,
-		});
-		if (teardown.status === "failed") {
-			if (input.teardownMode === "blocking") {
-				const cause: TeardownFailureCause = {
-					kind: "TEARDOWN_FAILED",
-					exitCode: teardown.exitCode,
-					signal: teardown.signal,
-					timedOut: teardown.timedOut,
-					outputTail: teardown.outputTail,
-				};
-				// Recoverable via force-retry — an expected user-script failure, not a
-				// service bug; must not be reported as a 500.
-				throw new TRPCError({
-					code: "PRECONDITION_FAILED",
-					message: "Teardown script failed",
-					cause,
-				});
-			}
-			warnings.push(formatTeardownWarning(teardown));
-		}
-	}
-
-	// ─── Step 1.5: Archive (the commit point) ──────────────────────
-	// The tombstone is a durable delete-intent record: the row vanishes
-	// from default lists on every device before any physical destruction,
-	// and if the host crashes mid-cleanup the startup reconciler finishes
-	// the job. A cleanup failure below un-archives so the workspace stays
-	// live and retryable. Sessions tombstone too — they're workspaces with
+	// ─── Step 0: Archive (the commit point) ────────────────────────
+	// FIRST, before any slow work (git preflight, teardown script): the
+	// tombstone is a durable delete-intent record, and its broadcast is
+	// what drops the row from every list — archiving up front is what
+	// makes the delete feel instant. If the host crashes mid-cleanup the
+	// startup reconciler finishes the job with best-effort teardown. ANY
+	// failure below un-archives so the workspace reappears live and
+	// retryable. The renderer's delete dialog is globally mounted (not
+	// under the row) so a teardown-failure prompt survives the row
+	// vanishing here. Sessions tombstone too — they're workspaces with
 	// a little missing data (no project, no PRs; reason is always
 	// "deleted"), and session folder names are claimed against ALL rows
 	// including tombstones, so a tombstone's path can't be reused.
@@ -319,6 +252,81 @@ async function runDestroy(
 	}
 
 	try {
+		// ─── Step 1: Preflight ─────────────────────────────────────
+		// Block only on dirty worktree (the common "I forgot to commit"
+		// case). Missing/broken local state is handled by the cleanup phase.
+		// Sessions are standalone repos — the same dirty check applies even
+		// though they have no project row.
+		if (!input.force && local && (project || local.type === "session")) {
+			try {
+				const gitEnv = await cleanupGitOps.resolveGitEnv(
+					ctx,
+					local.worktreePath,
+				);
+				const state = await cleanupGitOps.readWorktreeState({
+					worktreePath: local.worktreePath,
+					gitEnv,
+				});
+				if (state.hasChanges) {
+					throw new TRPCError({
+						code: "CONFLICT",
+						message: "Worktree has uncommitted changes",
+					});
+				}
+			} catch (err) {
+				if (err instanceof TRPCError) throw err;
+				if (isIndeterminateGitTaskFailure(err)) {
+					// Timeout/pool failure: dirty-state is UNKNOWN. Fail closed on
+					// this destructive path rather than silently skipping the
+					// dirty-worktree block — a retry usually succeeds (the first
+					// attempt warmed the FS cache), and force skips preflight
+					// entirely as the explicit escape hatch.
+					const message = err instanceof Error ? err.message : String(err);
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message: `Couldn't verify worktree state at ${local.worktreePath}: ${message}`,
+					});
+				}
+				// Can't read status (missing worktree dir, etc.) — not a
+				// conflict. Continue; step 3b will skip idempotently.
+			}
+		}
+
+		// ─── Step 2: Teardown ──────────────────────────────────────
+		// Script is the user's last chance to stop services / flush state
+		// before the workspace goes away. Runs after the archive so the
+		// (potentially slow) script never delays the row leaving the UI; a
+		// blocking failure throws, the catch below un-archives, and the
+		// globally-mounted dialog re-opens with a force-retry.
+		if (input.teardownMode !== "skip" && local && project) {
+			const teardown: TeardownResult = await runTeardown({
+				db: ctx.db,
+				workspaceId: input.workspaceId,
+				worktreePath: local.worktreePath,
+				repoPath: project.repoPath,
+				projectId: project.id,
+			});
+			if (teardown.status === "failed") {
+				if (input.teardownMode === "blocking") {
+					const cause: TeardownFailureCause = {
+						kind: "TEARDOWN_FAILED",
+						exitCode: teardown.exitCode,
+						signal: teardown.signal,
+						timedOut: teardown.timedOut,
+						outputTail: teardown.outputTail,
+					};
+					// Recoverable via force-retry — an expected user-script failure, not a
+					// service bug; must not be reported as a 500.
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: "Teardown script failed",
+						cause,
+					});
+				}
+				warnings.push(formatTeardownWarning(teardown));
+			}
+		}
+
 		const result = await runDestroyPhases(ctx, input, {
 			local,
 			project,
@@ -372,8 +380,8 @@ async function runDestroyPhases(
 		warnings: string[];
 	},
 ) {
-	// ─── Step 2: Local cleanup ─────────────────────────────────────
-	// 2a. PTYs
+	// ─── Step 3: Local cleanup ─────────────────────────────────────
+	// 3a. PTYs
 	try {
 		const killed = await disposeSessionsByWorkspaceId(
 			input.workspaceId,
@@ -387,7 +395,7 @@ async function runDestroyPhases(
 		warnings.push(`Failed to dispose terminal sessions: ${message}`);
 	}
 
-	// 2b. Worktree. Double-force unlocks the rare locked-worktree case and
+	// 3b. Worktree. Double-force unlocks the rare locked-worktree case and
 	//     clears stale metadata when the directory was manually removed.
 	//     Runs in the worker pool: the removal is a recursive delete of the
 	//     whole worktree directory, which would otherwise stall the loop.
@@ -475,8 +483,8 @@ async function runDestroyPhases(
 		}
 	}
 
-	// ─── Step 3: Legacy cloud cleanup ──────────────────────────────
-	// The row already committed at step 1.5 (archived tombstone). The
+	// ─── Step 4: Legacy cloud cleanup ──────────────────────────────
+	// The row already committed at step 0 (archived tombstone). The
 	// cloud delete is best-effort legacy cleanup for rows mirrored before
 	// workspaces went fully local.
 	let cloudDeleted = false;
@@ -493,7 +501,7 @@ async function runDestroyPhases(
 		}
 	}
 
-	// ─── Step 4: Optional branch delete ────────────────────────────
+	// ─── Step 5: Optional branch delete ────────────────────────────
 	// After the local commit point so a failure here can't block the delete.
 	// An absent ref (renamed, pruned, or never materialized) already
 	// satisfies the goal, so the task skips the delete without a scary
@@ -513,7 +521,7 @@ async function runDestroyPhases(
 		}
 	}
 
-	// ─── Step 5: Caches ────────────────────────────────────────────
+	// ─── Step 6: Caches ────────────────────────────────────────────
 	if (local) {
 		try {
 			invalidateLabelCache(input.workspaceId);

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -188,14 +188,21 @@ export const workspaceCleanupRouter = router({
 				workspaceId: z.string(),
 				deleteBranch: z.boolean().default(false),
 				force: z.boolean().default(false),
+				// Consent to NOT run the teardown script — set only by the
+				// teardown-failed retry. Deliberately a separate flag from
+				// `force`, which carries only the git-destructive consent
+				// (dirty worktree / unpushed commits): a warned "Delete
+				// anyway" must still run teardown, otherwise editing any
+				// tracked file silently disables the user's cleanup script.
+				skipTeardown: z.boolean().default(false),
 			}),
 		)
 		.mutation(async ({ ctx, input }) =>
 			destroyWorkspace(ctx, {
-				...input,
-				// Interactive contract: force-retry is the user's explicit consent
-				// to abandon a failed teardown.
-				teardownMode: input.force ? "skip" : "blocking",
+				workspaceId: input.workspaceId,
+				deleteBranch: input.deleteBranch,
+				force: input.force,
+				teardownMode: input.skipTeardown ? "skip" : "blocking",
 			}),
 		),
 });

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -158,8 +158,11 @@ export const workspaceCleanupRouter = router({
 	 *   5.   Branch delete — optional local branch cleanup
 	 *   6.   Caches
 	 *
-	 * ANY failure in phases 1-6 un-archives the row so the workspace
-	 * reappears and stays retryable instead of orphaning disk state; a
+	 * A thrown failure — preflight conflict, blocking teardown, or the
+	 * unrecoverable parts of step 3 — un-archives the row so the workspace
+	 * reappears and stays retryable instead of orphaning disk state.
+	 * Steps 4-6 (and the tolerated parts of step 3) degrade to warnings on
+	 * a still-successful delete, and telemetry fires on that success. A
 	 * crash after the archive is finished by the startup reconciler
 	 * (runArchivedWorkspaceReconcile) with best-effort teardown.
 	 *

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -236,9 +236,12 @@ describe("workspaceCleanup.destroy integration", () => {
 		// the workspace is live and retryable.
 		expect(remaining[0]?.archivedAt).toBeNull();
 
+		// The teardown-failed retry carries both consents: force (git) and
+		// skipTeardown — force alone would run the failing script again.
 		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
 			workspaceId: scenario.featureWorkspaceId,
 			force: true,
+			skipTeardown: true,
 		});
 		expect(result.success).toBe(true);
 		expect(result.worktreeRemoved).toBe(true);

--- a/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-delete-teardown.integration.test.ts
@@ -136,12 +136,27 @@ describe("workspace delete teardown integration", () => {
 		expect(teardownWarning).toContain("external resources not cleaned");
 	});
 
-	test("workspaceCleanup.destroy with force still skips teardown (interactive force-retry contract)", async () => {
+	test("workspaceCleanup.destroy with force still runs teardown (git consent only)", async () => {
 		const { scenario, markerPath } = await setup("printf ran > {{MARKER}}");
 
 		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
 			workspaceId: scenario.featureWorkspaceId,
 			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(existsSync(markerPath)).toBe(true);
+		expect(existsSync(scenario.worktreePath)).toBe(false);
+	});
+
+	test("workspaceCleanup.destroy with skipTeardown skips the script (teardown-failed retry contract)", async () => {
+		const { scenario, markerPath } = await setup("printf ran > {{MARKER}}");
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+			force: true,
+			skipTeardown: true,
 		});
 
 		expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- Deleting a workspace now tombstones it **first** — before the git preflight and the teardown script — so the row leaves the sidebar/board ~200 ms after confirm instead of waiting seconds for teardown. Any failure un-archives, so the row reappears instead of getting stuck half-deleted.
- Delete consent is now **two flags**: `force` (git-destructive consent: skip dirty preflight, forceful worktree/branch removal) and `skipTeardown` (abandon the teardown script — set only by the teardown-failed retry). Previously one flag, so a warned "Delete anyway" (e.g. any edited tracked file) silently skipped the user's teardown script.
- The v2 delete dialog is now a single globally-mounted instance (`DeleteWorkspaceMount` + latched `useDeleteWorkspaceIntent`); all entry points (sidebar row, board card, palette, ⌘⇧⌫, missing-worktree screen) request through the store.
- New reference doc: `apps/desktop/docs/WORKSPACE_DELETE_LIFECYCLE.md` (pipeline order, consent flags, failure-mode table, renderer contract).

## Why / Context
#6296 deliberately placed the archive commit *after* teardown because a blocking teardown failure re-opens the delete dialog for force-retry, and that dialog was mounted under the workspace's row — archiving first would drop the row and unmount the dialog mid-prompt. The cost was a visible delay: the row sat in the sidebar for the full preflight + teardown duration. This PR reverses the ordering to make delete feel instant, and removes the original blocker by hoisting the dialog out of the row entirely.

The consent split came out of QA on this branch: editing the teardown script inside the worktree (to test failure) dirtied it, which flipped the confirm to "Delete anyway" → `force` → teardown skipped — the workspace deleted cleanly and the failure path never ran. Git consent and teardown consent are different questions; they're now separate flags.

## How It Works
**Host** (`workspace-cleanup.ts`): `archiveLocalWorkspace` moves to step 0, right after the main-workspace check. Preflight, teardown, and the destroy phases now run inside one try/catch whose catch un-archives. `destroy` takes `skipTeardown` (default false) and derives `teardownMode` from it alone — `force` no longer touches teardown. Telemetry still fires only at the true commit. The startup reconciler (`runArchivedWorkspaceReconcile`) already assumed mark-first and resumes crash-interrupted deletes with best-effort teardown — no changes needed there.

**Renderer**: since the row unmounts the instant a destroy starts, `DashboardSidebarDeleteDialog` must never be row-mounted. The intent store gains an `open`/latch split: closing the dialog only flips `open` while the target stays mounted, so the in-flight destroy can re-open it as the teardown-failure pane. `run()` now takes `{force, skipTeardown}`: warned confirm → `{force: true}`, teardown-failed retry → `{force: true, skipTeardown: true}`, dirty-race silent retry stays git-only. Bulk delete threads the same split (`forceTeardownFailures` is the only skip path).

## Manual QA Checklist (verified via CDP against the dev app, real UI input, screenshots captured)
- [x] Happy path (3 s teardown script): row removed **276 ms** after confirm; teardown started ~1 s later and ran entirely after removal; row never returned; worktree removed; tombstone `reason: "deleted"` written before the removal broadcast
- [x] Blocking teardown failure (`exit 1`): row removed at 198 ms → reappeared ~1.1 s later (un-archive) with "Teardown exited with code 1" pane open showing the script's output tail — pane survives the row unmount
- [x] Force-retry from the pane: row gone instantly, teardown skipped (no marker file written), workspace destroyed
- [x] Cancel from the pane: workspace fully alive (`archivedAt: null`), row back, worktree intact
- [x] Dirty-worktree race (dirtied after inspect, before confirm): archive → CONFLICT → un-archive → silent force retry → deleted; row blips ~100 ms; no error surfaced
- [x] Concurrent destroy mid-flight: typed CONFLICT with `deleteInProgress` cause (toast path, no retry)
- [x] Main workspace: BAD_REQUEST, never archived
- [x] Deleting the actively-viewed workspace: navigates away immediately; failure pane still opens on the new route
- [ ] Post-split re-verify: warned "Delete anyway" (dirty worktree) runs teardown; failing teardown restores the row and opens the retry pane (needs a dev-app restart to pick up the new host-service — CDP pass above predates the flag split; recipe: `echo '{ "teardown": ["sleep 3 && exit 1"] }' > <worktree>/.superset/config.local.json`, gitignored so the worktree stays clean)

## Testing
- `bun run typecheck` (+ direct `tsc --noEmit` on desktop and host-service)
- `bun run lint`
- `bun test src/renderer/routes/_authenticated/_dashboard` (262 pass) and host-service reconcile/teardown suites (13 pass)
- No existing tests asserted the pipeline ordering; behavior verified end-to-end via CDP as above

## Design Decisions
- **Global dialog mount instead of optimistic row-hiding**: hiding the row renderer-side would still unmount a row-local dialog and adds a second source of truth; moving the commit point host-side makes every client instant, and the dialog hoist fixes a latent bug where deletes from the layout hotkey/missing-worktree screen could already lose the force-retry prompt.
- **Archive before *preflight*, not just before teardown**: preflight's git status read can be slow on large worktrees; the conflict path un-archives and the renderer's silent force-retry re-archives, so the only cost is a ~100 ms row blip in a rare race.
- **Two consent flags instead of dialog copy**: "teardown will be skipped" text on the warned confirm would keep the surprising behavior and just document it; a dirty worktree is a git question and shouldn't decide whether cleanup scripts run.

## Known Limitations
- Repos with **no remote** always read as having unpushed commits (`rev-list HEAD --not --remotes`) → always-warned confirm. Since the split this only skips preflight; teardown still runs.
- Version skew with remote hosts: an old host ignores `skipTeardown` and still maps `force` → skip; a new host + old renderer re-runs teardown on the failure retry (pane re-opens; Cancel escapes). Desktop and its local host-service ship together, so this only affects mixed-version remote hosts.
- A host crash between archive and teardown means the reconciler finishes the delete with best-effort teardown on next boot (same as any crash-interrupted delete).

## Rollback
Revert the two commits. The tombstone schema is untouched (#6296's migration 0020); only ordering, consent flags, and dialog mounting changed, so old and new builds interoperate on the same host.db.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace deletion now removes workspaces from navigation immediately while cleanup continues.
  - Sidebar, context-menu, and missing-worktree deletion actions use a consistent confirmation experience.
  - Bulk deletion supports retrying cleanup failures while preserving safety controls.

- **Bug Fixes**
  - Failed deletions restore workspaces for retry.
  - Deletion dialogs preserve the selected workspace when closed.
  - Improved navigation handling during cleanup and application interruptions.

- **Documentation**
  - Added documentation covering workspace deletion behavior, recovery, concurrency, and UI timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->