### PR TITLE
Merge pull request #1 from moshfeu/feat/claude-tab-title-color

### DIFF
--- a/apps/api/src/app/api/auth/[...all]/route.ts
+++ b/apps/api/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,8 @@
 import { auth } from "@superset/auth/server";
+import {
+	DATABASE_UNAVAILABLE_MESSAGE,
+	isDatabaseConnectivityError,
+} from "@superset/shared/db-connectivity-error";
 import { toNextJsHandler } from "better-auth/next-js";
 
 const { GET: _GET, POST: _POST } = toNextJsHandler(auth);
@@ -13,6 +17,35 @@ function normalizeLocalhostUri(uri: string): string {
 	return uri.replace(/^(https?:\/\/)localhost(:\d+)/, "$1127.0.0.1$2");
 }
 
+/**
+ * Better Auth's dispatcher only catches its own `APIError`s (see
+ * `better-auth/dist/api/dispatch.mjs`) — a raw driver failure (DB
+ * unreachable) rethrows past it and becomes an opaque, bodiless 500 from
+ * Next's default uncaught-exception handling. Callers (e.g. the desktop
+ * dev sign-in flow) then have nothing but a status code to show. Detect
+ * this specific, common-in-dev case and return a JSON body so it's
+ * distinguishable from a real auth failure (bad credentials, etc).
+ */
+async function withAuthErrorHandling(
+	handler: Promise<Response>,
+): Promise<Response> {
+	try {
+		return await handler;
+	} catch (error) {
+		if (isDatabaseConnectivityError(error)) {
+			console.error("[auth] Database unreachable:", error);
+			return Response.json(
+				{
+					code: "DATABASE_UNAVAILABLE",
+					message: DATABASE_UNAVAILABLE_MESSAGE,
+				},
+				{ status: 503 },
+			);
+		}
+		throw error;
+	}
+}
+
 const GET = async (req: Request) => {
 	const url = new URL(req.url);
 	if (url.pathname.endsWith("/oauth2/authorize")) {
@@ -21,11 +54,11 @@ const GET = async (req: Request) => {
 			const normalized = normalizeLocalhostUri(redirectUri);
 			if (normalized !== redirectUri) {
 				url.searchParams.set("redirect_uri", normalized);
-				return _GET(new Request(url.toString(), req));
+				return withAuthErrorHandling(_GET(new Request(url.toString(), req)));
 			}
 		}
 	}
-	return _GET(req);
+	return withAuthErrorHandling(_GET(req));
 };
 
 const POST = async (req: Request) => {
@@ -35,12 +68,14 @@ const POST = async (req: Request) => {
 		const body = await cloned.json().catch(() => null);
 		if (body?.redirect_uris && Array.isArray(body.redirect_uris)) {
 			body.redirect_uris = body.redirect_uris.map(normalizeLocalhostUri);
-			return _POST(
-				new Request(req.url, {
-					method: req.method,
-					headers: req.headers,
-					body: JSON.stringify(body),
-				}),
+			return withAuthErrorHandling(
+				_POST(
+					new Request(req.url, {
+						method: req.method,
+						headers: req.headers,
+						body: JSON.stringify(body),
+					}),
+				),
 			);
 		}
 	}
@@ -53,12 +88,14 @@ const POST = async (req: Request) => {
 				const normalized = normalizeLocalhostUri(body.redirect_uri);
 				if (normalized !== body.redirect_uri) {
 					body.redirect_uri = normalized;
-					return _POST(
-						new Request(req.url, {
-							method: req.method,
-							headers: req.headers,
-							body: JSON.stringify(body),
-						}),
+					return withAuthErrorHandling(
+						_POST(
+							new Request(req.url, {
+								method: req.method,
+								headers: req.headers,
+								body: JSON.stringify(body),
+							}),
+						),
 					);
 				}
 			}
@@ -69,18 +106,20 @@ const POST = async (req: Request) => {
 				const normalized = normalizeLocalhostUri(redirectUri);
 				if (normalized !== redirectUri) {
 					params.set("redirect_uri", normalized);
-					return _POST(
-						new Request(req.url, {
-							method: req.method,
-							headers: req.headers,
-							body: params.toString(),
-						}),
+					return withAuthErrorHandling(
+						_POST(
+							new Request(req.url, {
+								method: req.method,
+								headers: req.headers,
+								body: params.toString(),
+							}),
+						),
 					);
 				}
 			}
 		}
 	}
-	return _POST(req);
+	return withAuthErrorHandling(_POST(req));
 };
 
 export { GET, POST };

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -22,6 +22,8 @@ if [ -z "$RESOURCE_ID" ]; then
 fi
 SESSION_ID=${RESOURCE_ID:-$HOOK_SESSION_ID}
 
+CWD=$(echo "$INPUT" | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+
 # Claude/Mastra/Droid/Kimi use "hook_event_name"; Grok uses camelCase
 # "hookEventName" (snake_case values, mapped server-side); Codex uses "type".
 EVENT_TYPE=$(echo "$INPUT" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
@@ -96,7 +98,7 @@ json_escape() {
 }
 
 if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}}}"
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"cwd\":\"$(json_escape "$CWD")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}}}"
 
   STATUS_CODE=$(curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \
     --connect-timeout 2 --max-time 5 \

--- a/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
@@ -22,13 +22,20 @@ export function getTerminalAgentBindingsQueryKey(workspaceId: string) {
 }
 
 /**
- * Map of `terminalId → agent binding` for a workspace, read from the host
- * store and invalidated on `agent:lifecycle` / `terminal:lifecycle` events.
+ * Shared query/invalidation plumbing behind both hooks below. `select` scopes
+ * what a caller re-renders on: React Query's default structural sharing keeps
+ * a `select` result referentially stable across refetches unless the
+ * selected slice itself changed, so `useTerminalAgentBinding` (below) only
+ * re-renders when *its* terminal's binding actually changes, not on every
+ * unrelated binding update in the workspace.
  */
-export function useTerminalAgentBindings(
+function useTerminalAgentBindingsQuery<TData>(
 	workspaceId: string,
-	options?: { enabled?: boolean },
-): Map<string, TerminalAgentBinding> {
+	options: {
+		enabled?: boolean;
+		select: (bindings: TerminalAgentBindings) => TData;
+	},
+): TData | undefined {
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
 	const queryKey = useMemo(
@@ -37,7 +44,7 @@ export function useTerminalAgentBindings(
 	);
 
 	const enabled =
-		(options?.enabled ?? true) && Boolean(workspaceId) && Boolean(hostUrl);
+		(options.enabled ?? true) && Boolean(workspaceId) && Boolean(hostUrl);
 
 	const { data } = useQuery({
 		queryKey,
@@ -52,6 +59,7 @@ export function useTerminalAgentBindings(
 		// staleTime lets focus/remount refetches self-heal any staleness
 		// from events missed while the WS was down (host restart, sleep).
 		staleTime: 30_000,
+		select: options.select,
 	});
 
 	const invalidate = useCallback(() => {
@@ -59,21 +67,49 @@ export function useTerminalAgentBindings(
 	}, [queryClient, queryKey]);
 
 	useWorkspaceEvent("agent:lifecycle", workspaceId, invalidate, enabled);
+	useWorkspaceEvent("agent:meta", workspaceId, invalidate, enabled);
 	useWorkspaceEvent("terminal:lifecycle", workspaceId, invalidate, enabled);
 
-	return useMemo(() => {
-		const map = new Map<string, TerminalAgentBinding>();
-		for (const binding of data ?? []) {
-			map.set(binding.terminalId, binding);
-		}
-		return map;
-	}, [data]);
+	return data;
+}
+
+const EMPTY_BINDINGS_MAP: Map<string, TerminalAgentBinding> = new Map();
+
+const selectAsMap = (
+	bindings: TerminalAgentBindings,
+): Map<string, TerminalAgentBinding> => {
+	const map = new Map<string, TerminalAgentBinding>();
+	for (const binding of bindings) {
+		map.set(binding.terminalId, binding);
+	}
+	return map;
+};
+
+/**
+ * Map of `terminalId → agent binding` for a workspace, read from the host
+ * store and invalidated on `agent:lifecycle` / `agent:meta` /
+ * `terminal:lifecycle` events.
+ */
+export function useTerminalAgentBindings(
+	workspaceId: string,
+	options?: { enabled?: boolean },
+): Map<string, TerminalAgentBinding> {
+	return (
+		useTerminalAgentBindingsQuery(workspaceId, {
+			enabled: options?.enabled,
+			select: selectAsMap,
+		}) ?? EMPTY_BINDINGS_MAP
+	);
 }
 
 export function useTerminalAgentBinding(
 	workspaceId: string,
 	terminalId: string,
 ): TerminalAgentBinding | undefined {
-	const bindings = useTerminalAgentBindings(workspaceId);
-	return bindings.get(terminalId);
+	const select = useCallback(
+		(bindings: TerminalAgentBindings) =>
+			bindings.find((binding) => binding.terminalId === terminalId),
+		[terminalId],
+	);
+	return useTerminalAgentBindingsQuery(workspaceId, { select });
 }

--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceEvent/useWorkspaceEvent.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceEvent/useWorkspaceEvent.ts
@@ -1,5 +1,6 @@
 import {
 	type AgentLifecyclePayload,
+	type AgentMetaPayload,
 	type GitChangedPayload,
 	getEventBus,
 	type PortChangedPayload,
@@ -33,6 +34,12 @@ export function useWorkspaceEvent(
 	enabled?: boolean,
 ): void;
 export function useWorkspaceEvent(
+	type: "agent:meta",
+	workspaceId: string,
+	callback: (payload: AgentMetaPayload) => void,
+	enabled?: boolean,
+): void;
+export function useWorkspaceEvent(
 	type: "terminal:lifecycle",
 	workspaceId: string,
 	callback: (payload: TerminalLifecyclePayload) => void,
@@ -49,6 +56,7 @@ export function useWorkspaceEvent(
 		| "git:changed"
 		| "fs:events"
 		| "agent:lifecycle"
+		| "agent:meta"
 		| "terminal:lifecycle"
 		| "port:changed",
 	workspaceId: string,
@@ -56,6 +64,7 @@ export function useWorkspaceEvent(
 		| ((event: FsWatchEvent) => void)
 		| ((payload: GitChangedPayload) => void)
 		| ((payload: AgentLifecyclePayload) => void)
+		| ((payload: AgentMetaPayload) => void)
 		| ((payload: TerminalLifecyclePayload) => void)
 		| ((payload: PortChangedPayload) => void),
 	enabled = true,
@@ -87,6 +96,15 @@ export function useWorkspaceEvent(
 				workspaceId,
 				(_wid, payload) => {
 					(handler as (payload: AgentLifecyclePayload) => void)(payload);
+				},
+			);
+			cleanups.push(removeListener);
+		} else if (type === "agent:meta") {
+			const removeListener = bus.on(
+				"agent:meta",
+				workspaceId,
+				(_wid, payload) => {
+					(handler as (payload: AgentMetaPayload) => void)(payload);
 				},
 			);
 			cleanups.push(removeListener);

--- a/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
+++ b/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
@@ -1,10 +1,18 @@
+import {
+	DATABASE_UNAVAILABLE_DATA_KEY,
+	type DatabaseUnavailableErrorData,
+} from "@superset/shared/db-connectivity-error";
+import { toast } from "@superset/ui/sonner";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import {
 	defaultShouldDehydrateQuery,
 	focusManager,
+	MutationCache,
+	QueryCache,
 	QueryClient,
 } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { TRPCClientError } from "@trpc/client";
 import { del, get, set } from "idb-keyval";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronReactClient } from "../../lib/trpc-client";
@@ -28,8 +36,39 @@ focusManager.setEventListener((handleFocus) => {
 // Bump when query response shapes change — invalidates the persisted cache.
 const PERSIST_BUSTER = "v1";
 
+// Most query/mutation errors are handled per-call-site (explicit `onError` +
+// toast, or an inline error render) — this only catches the one case that
+// otherwise fails silently everywhere: the DB-connectivity flag set by
+// `packages/trpc`'s errorFormatter (see apps/api's tRPC init) when Postgres/
+// Neon is unreachable, most commonly a forgotten local Docker DB stack.
+const DATABASE_UNAVAILABLE_TOAST_THROTTLE_MS = 10_000;
+let lastDatabaseUnavailableToastAt = 0;
+
+function notifyIfDatabaseUnavailable(error: unknown): void {
+	const isDatabaseUnavailable =
+		error instanceof TRPCClientError &&
+		Boolean(
+			(error.data as DatabaseUnavailableErrorData | null)?.[
+				DATABASE_UNAVAILABLE_DATA_KEY
+			],
+		);
+	if (!isDatabaseUnavailable) return;
+
+	const now = Date.now();
+	if (
+		now - lastDatabaseUnavailableToastAt <
+		DATABASE_UNAVAILABLE_TOAST_THROTTLE_MS
+	)
+		return;
+	lastDatabaseUnavailableToastAt = now;
+
+	toast.error("Database unavailable", { description: error.message });
+}
+
 // Shared QueryClient for tRPC hooks and router loaders
 const queryClient = new QueryClient({
+	queryCache: new QueryCache({ onError: notifyIfDatabaseUnavailable }),
+	mutationCache: new MutationCache({ onError: notifyIfDatabaseUnavailable }),
 	defaultOptions: {
 		queries: {
 			networkMode: "always",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
@@ -2,6 +2,7 @@ import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { getStatusTooltip } from "renderer/screens/main/components/StatusIndicator";
+import { resolveClaudeAgentColor } from "shared/constants/claude-agent-colors";
 import type {
 	DashboardSidebarRunningAgent,
 	RunningAgentStatus,
@@ -38,6 +39,8 @@ export function DashboardSidebarAgentHoverRow({
 
 	const statusLabel =
 		agent.status === "idle" ? "Idle" : getStatusTooltip(agent.status);
+	const displayLabel = agent.title ?? agent.label;
+	const dotColor = resolveClaudeAgentColor(agent.color);
 
 	return (
 		<div className="flex items-center gap-1.5 rounded-sm px-2 py-1 hover:bg-muted">
@@ -47,7 +50,14 @@ export function DashboardSidebarAgentHoverRow({
 				className="flex min-w-0 flex-1 items-center gap-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 			>
 				<DashboardSidebarAgentAvatar agent={agent} />
-				<span className="min-w-0 truncate text-xs">{agent.label}</span>
+				{dotColor ? (
+					<span
+						className="size-1.5 shrink-0 rounded-full"
+						style={{ backgroundColor: dotColor }}
+						aria-hidden="true"
+					/>
+				) : null}
+				<span className="min-w-0 truncate text-xs">{displayLabel}</span>
 			</button>
 			<span
 				className={cn("shrink-0 text-[10px]", STATUS_TEXT_CLASS[agent.status])}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -28,6 +28,13 @@ export interface DashboardSidebarRunningAgent {
 	startedAt: number;
 	/** Agent display name (e.g. "Claude"). */
 	label: string;
+	/**
+	 * Session title/color, when known — derived live from the agent's own
+	 * state (e.g. Claude Code's `/color` and auto-generated title) rather
+	 * than a static catalog value. Falls back to `label` when absent.
+	 */
+	title?: string;
+	color?: string;
 }
 
 /**
@@ -56,6 +63,8 @@ export function useDashboardSidebarWorkspaceRunningAgents(
 				status: statuses.get(binding.terminalId) ?? "idle",
 				startedAt: binding.startedAt,
 				label: AGENT_IDENTITY_LABELS[binding.agentId] ?? binding.agentId,
+				...(binding.title ? { title: binding.title } : {}),
+				...(binding.color ? { color: binding.color } : {}),
 			});
 		}
 		agents.sort((a, b) => a.startedAt - b.startedAt);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalPaneIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalPaneIcon.tsx
@@ -2,25 +2,41 @@ import { AGENT_IDENTITY_LABELS } from "@superset/shared/agent-catalog";
 import { TerminalSquare } from "lucide-react";
 import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { useTerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
+import { resolveClaudeAgentColor } from "shared/constants/claude-agent-colors";
 
 interface TerminalPaneIconProps {
 	workspaceId: string;
 	terminalId: string;
+	/** Off for the tab bar icon, which shows the color as a background tint instead. */
+	showColorDot?: boolean;
 }
 
 /**
  * Pane icon that swaps in the running agent's logo when the host-service
  * `terminalAgents` tracker has detected one in this terminal. Falls back
  * to the generic terminal glyph when no agent is bound or the agent id
- * has no preset icon.
+ * has no preset icon. Adds a corner dot for the agent's own session color
+ * (e.g. Claude Code's `/color`) when known.
  */
 export function TerminalPaneIcon({
 	workspaceId,
 	terminalId,
+	showColorDot = true,
 }: TerminalPaneIconProps) {
 	const binding = useTerminalAgentBinding(workspaceId, terminalId);
 	const agentId = binding?.agentId;
 	const iconSrc = usePresetIcon(agentId ?? "");
+	const dotColor = showColorDot
+		? resolveClaudeAgentColor(binding?.color)
+		: undefined;
+
+	const colorDot = dotColor ? (
+		<span
+			className="-bottom-0.5 -right-0.5 absolute size-1.5 rounded-full ring-1 ring-background"
+			style={{ backgroundColor: dotColor }}
+			aria-hidden="true"
+		/>
+	) : null;
 
 	if (agentId && iconSrc) {
 		const label =
@@ -28,15 +44,23 @@ export function TerminalPaneIcon({
 				AGENT_IDENTITY_LABELS[agentId as keyof typeof AGENT_IDENTITY_LABELS]) ||
 			agentId;
 		return (
-			<img
-				src={iconSrc}
-				alt={label}
-				title={label}
-				className="size-3.5 shrink-0"
-				draggable={false}
-			/>
+			<span className="relative inline-flex shrink-0">
+				<img
+					src={iconSrc}
+					alt={label}
+					title={label}
+					className="size-3.5 shrink-0"
+					draggable={false}
+				/>
+				{colorDot}
+			</span>
 		);
 	}
 
-	return <TerminalSquare className="size-3.5 shrink-0" />;
+	return (
+		<span className="relative inline-flex shrink-0">
+			<TerminalSquare className="size-3.5 shrink-0" />
+			{colorDot}
+		</span>
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalTabContentWrapper.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalTabContentWrapper.tsx
@@ -1,0 +1,59 @@
+import type { Tab } from "@superset/panes";
+import type { ReactNode } from "react";
+import { useTerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
+import { useClaudeTabDecorationEnabled } from "renderer/stores/claude-tab-decoration";
+import { resolveClaudeAgentAccentBackground } from "shared/constants/claude-agent-colors";
+import type { PaneViewerData } from "../../../../../../types";
+import { getSingleTerminalPane } from "./renderTerminalTabIcon";
+
+interface TerminalTabContentWrapperProps {
+	workspaceId: string;
+	terminalId: string;
+	children: ReactNode;
+}
+
+function TerminalTabContentWrapper({
+	workspaceId,
+	terminalId,
+	children,
+}: TerminalTabContentWrapperProps) {
+	const decorationEnabled = useClaudeTabDecorationEnabled();
+	const binding = useTerminalAgentBinding(workspaceId, terminalId);
+	const background = decorationEnabled
+		? resolveClaudeAgentAccentBackground(binding?.color)
+		: undefined;
+	if (!background) return children;
+
+	return (
+		<span
+			className="flex h-full w-full items-center rounded-[5px] p-[3px]"
+			style={{ backgroundColor: background }}
+		>
+			{children}
+		</span>
+	);
+}
+
+/**
+ * Tints a single-pane terminal tab's full width (icon, title, and the
+ * accessory/close-button area) with its agent's session color (e.g. Claude
+ * Code's `/color`) as a background, instead of the small corner dot
+ * `TerminalPaneIcon` shows elsewhere.
+ */
+export function createRenderTerminalTabContentWrapper(workspaceId: string) {
+	return function renderTerminalTabContentWrapper(
+		tab: Tab<PaneViewerData>,
+		children: ReactNode,
+	): ReactNode {
+		const terminal = getSingleTerminalPane(tab);
+		if (!terminal) return children;
+		return (
+			<TerminalTabContentWrapper
+				workspaceId={workspaceId}
+				terminalId={terminal.terminalId}
+			>
+				{children}
+			</TerminalTabContentWrapper>
+		);
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/index.ts
@@ -1,1 +1,3 @@
+export { createRenderTerminalTabIcon } from "./renderTerminalTabIcon";
 export { TerminalPaneIcon } from "./TerminalPaneIcon";
+export { createRenderTerminalTabContentWrapper } from "./TerminalTabContentWrapper";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/renderTerminalTabIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/renderTerminalTabIcon.tsx
@@ -1,0 +1,35 @@
+import type { Tab } from "@superset/panes";
+import type { PaneViewerData, TerminalPaneData } from "../../../../../../types";
+import { TerminalPaneIcon } from "./TerminalPaneIcon";
+
+export function getSingleTerminalPane(
+	tab: Tab<PaneViewerData>,
+): { terminalId: string } | null {
+	const paneIds = Object.keys(tab.panes);
+	if (paneIds.length !== 1) return null;
+	const pane = tab.panes[paneIds[0]];
+	if (pane.kind !== "terminal") return null;
+	return { terminalId: (pane.data as TerminalPaneData).terminalId };
+}
+
+/**
+ * Tab-bar icon for single-pane terminal tabs — same icon as the pane's own
+ * (`TerminalPaneIcon`), so the always-visible tab carries the same signal
+ * as the in-pane one. Multi-pane tabs get no icon, matching
+ * `renderBrowserTabIcon`'s single-pane-only behavior. The agent-color dot
+ * is off here — `createRenderTerminalTabContentWrapper` shows it as a
+ * background tint on the whole tab instead.
+ */
+export function createRenderTerminalTabIcon(workspaceId: string) {
+	return function renderTerminalTabIcon(tab: Tab<PaneViewerData>) {
+		const terminal = getSingleTerminalPane(tab);
+		if (!terminal) return null;
+		return (
+			<TerminalPaneIcon
+				workspaceId={workspaceId}
+				terminalId={terminal.terminalId}
+				showColorDot={false}
+			/>
+		);
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -9,7 +9,7 @@ import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { Circle, GitCompareArrows, Globe, MessageSquare } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import {
 	LuArrowDownToLine,
 	LuClipboard,
@@ -17,6 +17,7 @@ import {
 	LuEraser,
 	LuPower,
 } from "react-icons/lu";
+import { useTerminalAgentBindings } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { FileIcon } from "renderer/lib/fileIcons";
 import { getBaseName } from "renderer/lib/pathBasename";
@@ -28,6 +29,7 @@ import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useClaudeTabDecorationEnabled } from "renderer/stores/claude-tab-decoration";
 import { getV2NotificationSourcesForPane } from "renderer/stores/v2-notifications";
 import type { StoreApi } from "zustand/vanilla";
 import { V2NotificationStatusIndicator } from "../../components/V2NotificationStatusIndicator";
@@ -118,6 +120,12 @@ export function usePaneRegistry({
 }: UsePaneRegistryOptions): PaneRegistry<PaneViewerData> {
 	const { workspace } = useWorkspace();
 	const workspaceId = workspace.id;
+	// Claude Code exposes no live title/rename hook of its own, so this reads
+	// its transcript file directly. It wins below over the PTY's OSC-scanned
+	// title, which only updates whenever Claude Code's TUI happens to next
+	// re-emit its own title escape — always one step stale relative to this.
+	const terminalAgentBindings = useTerminalAgentBindings(workspaceId);
+	const claudeTabDecorationEnabled = useClaudeTabDecorationEnabled();
 	const runAgent = workspaceTrpc.agents.run.useMutation();
 	const collections = useCollections();
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
@@ -163,6 +171,28 @@ export function usePaneRegistry({
 		},
 		[collections.v2WorkspaceLocalState, workspaceId],
 	);
+
+	// A terminal pane's `titleOverride` only ever holds the static label set at
+	// launch (e.g. "Claude") — there's no UI that lets a user set it to a
+	// custom string, so it's always safe to clear once the session has a real
+	// derived title to show instead. (A genuine user rename lives on
+	// `tab.titleOverride`, which this never touches.)
+	useEffect(() => {
+		if (!claudeTabDecorationEnabled) return;
+		const state = store.getState();
+		for (const tab of state.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				if (pane.kind !== "terminal" || !pane.titleOverride) continue;
+				const { terminalId } = pane.data as TerminalPaneData;
+				if (!terminalAgentBindings.get(terminalId)?.title) continue;
+				state.setPaneTitleOverride({
+					tabId: tab.id,
+					paneId: pane.id,
+					titleOverride: undefined,
+				});
+			}
+		}
+	}, [store, terminalAgentBindings, claudeTabDecorationEnabled]);
 
 	const createNewAgentSession = useCallback(
 		async (input: {
@@ -321,9 +351,13 @@ export function usePaneRegistry({
 								instanceId,
 							),
 						getSnapshot: () =>
+							(claudeTabDecorationEnabled
+								? terminalAgentBindings.get(terminalId)?.title
+								: undefined) ||
 							terminalRuntimeRegistry
 								.getTitle(terminalId, instanceId)
-								?.trim() || undefined,
+								?.trim() ||
+							undefined,
 					};
 				},
 				onBeforeClose: (pane) => {
@@ -585,6 +619,8 @@ export function usePaneRegistry({
 			onRevealPath,
 			createNewAgentSession,
 			workspaceTrpcUtils,
+			terminalAgentBindings,
+			claudeTabDecorationEnabled,
 		],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -40,6 +40,10 @@ import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActio
 import { useDefaultPaneActions } from "./hooks/useDefaultPaneActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
+import {
+	createRenderTerminalTabContentWrapper,
+	createRenderTerminalTabIcon,
+} from "./hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon";
 import { useSlotElement } from "./hooks/useSlotElement";
 import { useTabCloseGuard } from "./hooks/useTabCloseGuard";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
@@ -311,7 +315,13 @@ function V2WorkspaceContent() {
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}
-							renderTabIcon={renderBrowserTabIcon}
+							renderTabIcon={(tab) =>
+								renderBrowserTabIcon(tab) ??
+								createRenderTerminalTabIcon(workspaceId)(tab)
+							}
+							renderTabContentWrapper={createRenderTerminalTabContentWrapper(
+								workspaceId,
+							)}
 							renderTabAccessory={(tab) => (
 								<V2NotificationStatusIndicator
 									sources={getV2NotificationSourcesForTab(tab)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
@@ -4,6 +4,7 @@ import {
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { ClaudeTabDecorationSection } from "./components/ClaudeTabDecorationSection";
 import { FontSettingSection } from "./components/FontSettingSection";
 import { MarkdownStyleSection } from "./components/MarkdownStyleSection";
 import { ThemeSection } from "./components/ThemeSection";
@@ -45,6 +46,10 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 		SETTING_ITEM_ID.APPEARANCE_TERMINAL_FONT,
 		visibleItems,
 	);
+	const showClaudeTabDecoration = isItemVisible(
+		SETTING_ITEM_ID.APPEARANCE_CLAUDE_TAB_DECORATION,
+		visibleItems,
+	);
 	const showCustomThemes = isItemVisible(
 		SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES,
 		visibleItems,
@@ -69,6 +74,9 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 						showEditor={showEditorFont}
 						showTerminal={showTerminalFont}
 					/>
+				)}
+				{showClaudeTabDecoration && (
+					<ClaudeTabDecorationSection key="claude-tab-decoration" />
 				)}
 			</SectionList>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ClaudeTabDecorationSection/ClaudeTabDecorationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ClaudeTabDecorationSection/ClaudeTabDecorationSection.tsx
@@ -1,0 +1,30 @@
+import { Label } from "@superset/ui/label";
+import { Switch } from "@superset/ui/switch";
+import {
+	useClaudeTabDecorationEnabled,
+	useClaudeTabDecorationStore,
+} from "renderer/stores/claude-tab-decoration";
+
+export function ClaudeTabDecorationSection() {
+	const enabled = useClaudeTabDecorationEnabled();
+	const setEnabled = useClaudeTabDecorationStore((state) => state.setEnabled);
+
+	return (
+		<div className="flex items-center justify-between gap-6">
+			<div className="min-w-0 flex-1 space-y-0.5">
+				<Label htmlFor="claude-tab-decoration" className="text-sm font-medium">
+					Claude Code session name & color
+				</Label>
+				<p className="text-xs text-muted-foreground">
+					Reflect a Claude Code session's <code>/rename</code> and{" "}
+					<code>/color</code> as the tab's title and background.
+				</p>
+			</div>
+			<Switch
+				id="claude-tab-decoration"
+				checked={enabled}
+				onCheckedChange={setEnabled}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ClaudeTabDecorationSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ClaudeTabDecorationSection/index.ts
@@ -1,0 +1,1 @@
+export { ClaudeTabDecorationSection } from "./ClaudeTabDecorationSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -20,6 +20,7 @@ export const SETTING_ITEM_ID = {
 	APPEARANCE_CUSTOM_THEMES: "appearance-custom-themes",
 	APPEARANCE_EDITOR_FONT: "appearance-editor-font",
 	APPEARANCE_TERMINAL_FONT: "appearance-terminal-font",
+	APPEARANCE_CLAUDE_TAB_DECORATION: "appearance-claude-tab-decoration",
 
 	RINGTONES_NOTIFICATION: "ringtones-notification",
 
@@ -134,6 +135,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES]: "shared",
 	[SETTING_ITEM_ID.APPEARANCE_EDITOR_FONT]: "v2",
 	[SETTING_ITEM_ID.APPEARANCE_TERMINAL_FONT]: "v2",
+	[SETTING_ITEM_ID.APPEARANCE_CLAUDE_TAB_DECORATION]: "v2",
 
 	[SETTING_ITEM_ID.RINGTONES_NOTIFICATION]: "shared",
 
@@ -454,6 +456,24 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"weight",
 			"ligatures",
 			"custom",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.APPEARANCE_CLAUDE_TAB_DECORATION,
+		section: "appearance",
+		title: "Claude Code session name & color",
+		description: "Reflect a Claude Code session's /rename and /color in tabs",
+		keywords: [
+			"appearance",
+			"claude",
+			"claude code",
+			"tab",
+			"tabs",
+			"rename",
+			"color",
+			"title",
+			"session",
+			"decoration",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/stores/claude-tab-decoration.ts
+++ b/apps/desktop/src/renderer/stores/claude-tab-decoration.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+/**
+ * Whether a Claude Code terminal's own `/rename`/`/color` should be
+ * reflected as the tab's title and background tint. On by default; single
+ * source of truth read everywhere via {@link useClaudeTabDecorationEnabled}.
+ */
+interface ClaudeTabDecorationState {
+	enabled: boolean;
+	setEnabled: (enabled: boolean) => void;
+}
+
+export const useClaudeTabDecorationStore = create<ClaudeTabDecorationState>()(
+	devtools(
+		persist(
+			(set) => ({
+				enabled: true,
+				setEnabled: (enabled) => set({ enabled }),
+			}),
+			{ name: "claude-tab-decoration" },
+		),
+		{ name: "ClaudeTabDecorationStore" },
+	),
+);
+
+/** Single read path for the Claude tab name/color decoration setting. */
+export function useClaudeTabDecorationEnabled(): boolean {
+	return useClaudeTabDecorationStore((state) => state.enabled);
+}

--- a/apps/desktop/src/shared/constants/claude-agent-colors.ts
+++ b/apps/desktop/src/shared/constants/claude-agent-colors.ts
@@ -1,0 +1,32 @@
+/**
+ * Claude Code's `/color` command accepts these named colors (see
+ * packages/host-service/src/terminal-agents/claude-transcript.ts for where
+ * the chosen name is read from). Maps each to a concrete CSS value for the
+ * dot/swatch shown on tabs and the agent hover-list.
+ */
+export const CLAUDE_AGENT_COLOR_VALUES: Record<string, string> = {
+	red: "#ef4444",
+	blue: "#3b82f6",
+	green: "#22c55e",
+	yellow: "#eab308",
+	purple: "#a855f7",
+	orange: "#f97316",
+	pink: "#ec4899",
+	cyan: "#06b6d4",
+};
+
+export function resolveClaudeAgentColor(
+	color: string | undefined,
+): string | undefined {
+	if (!color) return undefined;
+	return CLAUDE_AGENT_COLOR_VALUES[color];
+}
+
+/** Low-alpha tint of a resolved agent color, for a background-decoration look. */
+export function resolveClaudeAgentAccentBackground(
+	color: string | undefined,
+): string | undefined {
+	const resolved = resolveClaudeAgentColor(color);
+	if (!resolved) return undefined;
+	return `color-mix(in srgb, ${resolved} 18%, transparent)`;
+}

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -28,6 +28,7 @@ import { PullRequestRuntimeManager } from "./runtime/pull-requests";
 import { runWorkspaceBackfill } from "./runtime/workspace-backfill";
 import { registerWorkspaceTerminalRoute } from "./terminal/terminal";
 import {
+	ClaudeTranscriptWatcher,
 	SqliteTerminalAgentBindingPersistence,
 	TerminalAgentStore,
 } from "./terminal-agents";
@@ -213,6 +214,15 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		);
 	}
 	const terminalAgentStore = new TerminalAgentStore(terminalAgentPersistence);
+	// Claude Code exposes no API/hook/IPC for a session's `/color` or
+	// auto-generated title — this tails the session's own transcript file for
+	// them (see claude-transcript.ts for why). Purely additive: title/color
+	// stay undefined until the watcher finds them.
+	const claudeTranscriptWatcher = new ClaudeTranscriptWatcher(
+		terminalAgentStore,
+		eventBus,
+	);
+	claudeTranscriptWatcher.start();
 
 	// Startup sweeps run in the background so they don't block server
 	// startup. Ordering matters: the backfills fill identity fields on
@@ -322,6 +332,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 			gitWatcher.close();
 		} catch (err) {
 			console.warn("[host-service] gitWatcher.close failed:", err);
+		}
+		try {
+			claudeTranscriptWatcher.close();
+		} catch (err) {
+			console.warn("[host-service] claudeTranscriptWatcher.close failed:", err);
 		}
 		if (ownsDb) {
 			try {

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -175,6 +175,17 @@ export class EventBus {
 	}
 
 	/**
+	 * Fan out a Claude Code binding's live-derived title/color change. Kept
+	 * separate from `broadcastAgentLifecycle` so a meta-only update never
+	 * carries an `eventType` that would trigger the working indicator/chime.
+	 */
+	broadcastAgentMeta(
+		message: Omit<Extract<ServerMessage, { type: "agent:meta" }>, "type">,
+	): void {
+		this.broadcast({ type: "agent:meta", ...message });
+	}
+
+	/**
 	 * Fan out terminal process lifecycle events to renderer clients. Agent hook
 	 * status can otherwise get stuck when a terminal exits while its pane is not
 	 * mounted and therefore cannot observe the terminal websocket `exit` packet.

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -34,6 +34,19 @@ export interface AgentLifecycleMessage {
 	occurredAt: number;
 }
 
+/**
+ * Fired when a Claude Code binding's live-derived `title`/`color` changes
+ * (see `ClaudeTranscriptWatcher`). Deliberately separate from
+ * `agent:lifecycle` — that type's `eventType` drives the working
+ * indicator/completion chime, and a meta-only change must not trigger those.
+ */
+export interface AgentMetaMessage {
+	type: "agent:meta";
+	workspaceId: string;
+	terminalId: string;
+	occurredAt: number;
+}
+
 export interface TerminalLifecycleMessage {
 	type: "terminal:lifecycle";
 	workspaceId: string;
@@ -117,6 +130,7 @@ export type ServerMessage =
 	| FsEventsMessage
 	| GitChangedMessage
 	| AgentLifecycleMessage
+	| AgentMetaMessage
 	| TerminalLifecycleMessage
 	| PortChangedMessage
 	| WorkspaceChangedMessage

--- a/packages/host-service/src/terminal-agents/claude-transcript-watcher.ts
+++ b/packages/host-service/src/terminal-agents/claude-transcript-watcher.ts
@@ -1,0 +1,187 @@
+import { type FSWatcher, watch } from "node:fs";
+import type { EventBus } from "../events/event-bus";
+import {
+	readLatestColorAndTitle,
+	resolveTranscriptPath,
+} from "./claude-transcript";
+import type { TerminalAgentStore } from "./store";
+import type { TerminalAgentBinding } from "./types";
+
+const RESCAN_INTERVAL_MS = 10_000;
+const DEBOUNCE_MS = 300;
+
+/**
+ * Only Claude Code writes the transcript shape `claude-transcript.ts` parses
+ * (`agent-color`/`ai-title` lines) — other agent ids are never watched.
+ */
+const CLAUDE_AGENT_ID = "claude";
+
+interface WatchedTranscript {
+	workspaceId: string;
+	path: string;
+	watcher: FSWatcher;
+}
+
+/**
+ * Tails each active Claude terminal-agent binding's transcript file for
+ * `agent-color`/`ai-title` lines and republishes changes onto
+ * `TerminalAgentStore`'s live-meta overlay (`updateAgentMeta`).
+ *
+ * Modeled on `GitWatcher`: `fs.watch` per target + debounce + periodic
+ * rescan. The rescan does double duty: it discovers newly-eligible bindings
+ * (a binding's `cwd`/`agentSessionId` can arrive after this watcher last
+ * looked, and the transcript file itself may not exist yet — nothing is
+ * written until the session's first message) and it re-checks already-watched
+ * bindings as a fallback against a missed `fs.watch` notification.
+ */
+export class ClaudeTranscriptWatcher {
+	private readonly store: TerminalAgentStore;
+	private readonly eventBus: EventBus;
+	private readonly watched = new Map<string, WatchedTranscript>();
+	private readonly debounceTimers = new Map<
+		string,
+		ReturnType<typeof setTimeout>
+	>();
+	private rescanTimer: ReturnType<typeof setInterval> | null = null;
+	private onStoreChange: (() => void) | null = null;
+	private closed = false;
+
+	constructor(store: TerminalAgentStore, eventBus: EventBus) {
+		this.store = store;
+		this.eventBus = eventBus;
+	}
+
+	start(): void {
+		this.refresh();
+		this.rescanTimer = setInterval(() => this.refresh(), RESCAN_INTERVAL_MS);
+		this.onStoreChange = () => this.refresh();
+		this.store.on("change", this.onStoreChange);
+	}
+
+	close(): void {
+		this.closed = true;
+		if (this.rescanTimer) {
+			clearInterval(this.rescanTimer);
+			this.rescanTimer = null;
+		}
+		if (this.onStoreChange) {
+			this.store.off("change", this.onStoreChange);
+			this.onStoreChange = null;
+		}
+		for (const timer of this.debounceTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.debounceTimers.clear();
+		for (const entry of this.watched.values()) {
+			entry.watcher.close();
+		}
+		this.watched.clear();
+	}
+
+	private refresh(): void {
+		if (this.closed) return;
+
+		const eligible = new Map<string, TerminalAgentBinding>();
+		for (const binding of this.store.list()) {
+			if (binding.agentId !== CLAUDE_AGENT_ID) continue;
+			if (!binding.cwd || !binding.agentSessionId) continue;
+			eligible.set(binding.terminalId, binding);
+		}
+
+		for (const [terminalId, entry] of this.watched) {
+			const binding = eligible.get(terminalId);
+			const expectedPath = binding
+				? resolveTranscriptPath(
+						binding.cwd as string,
+						binding.agentSessionId as string,
+					)
+				: null;
+			if (!binding || expectedPath !== entry.path) {
+				entry.watcher.close();
+				this.watched.delete(terminalId);
+			}
+		}
+
+		for (const [terminalId, binding] of eligible) {
+			if (this.watched.has(terminalId)) {
+				// Belt-and-suspenders re-check: `fs.watch` can silently miss a
+				// notification (e.g. two appends landing in the same debounce
+				// window, or an FSEvents coalescing quirk on macOS), which would
+				// otherwise strand a binding's title/color until some later
+				// unrelated write happens to fire the watcher again.
+				const entry = this.watched.get(terminalId);
+				if (entry) this.checkAndEmit(terminalId, entry.workspaceId, entry.path);
+				continue;
+			}
+			this.watchBinding(binding);
+		}
+	}
+
+	private watchBinding(binding: TerminalAgentBinding): void {
+		if (!binding.cwd || !binding.agentSessionId) return;
+		const { terminalId, workspaceId } = binding;
+		const path = resolveTranscriptPath(binding.cwd, binding.agentSessionId);
+
+		// Check immediately in case the transcript already has lines from
+		// before this watcher started (e.g. host-service restart mid-session).
+		this.checkAndEmit(terminalId, workspaceId, path);
+
+		let watcher: FSWatcher;
+		try {
+			watcher = watch(path, () => {
+				this.scheduleCheck(terminalId, workspaceId, path);
+			});
+		} catch {
+			// Transcript doesn't exist yet — the next rescan retries.
+			return;
+		}
+
+		watcher.on("error", () => {
+			watcher.close();
+			this.watched.delete(terminalId);
+		});
+
+		this.watched.set(terminalId, { workspaceId, path, watcher });
+	}
+
+	private scheduleCheck(
+		terminalId: string,
+		workspaceId: string,
+		path: string,
+	): void {
+		const existing = this.debounceTimers.get(terminalId);
+		if (existing) clearTimeout(existing);
+		this.debounceTimers.set(
+			terminalId,
+			setTimeout(() => {
+				this.debounceTimers.delete(terminalId);
+				this.checkAndEmit(terminalId, workspaceId, path);
+			}, DEBOUNCE_MS),
+		);
+	}
+
+	private checkAndEmit(
+		terminalId: string,
+		workspaceId: string,
+		path: string,
+	): void {
+		const result = readLatestColorAndTitle(path);
+		// Omit undefined keys entirely rather than setting them — the store
+		// merges this object onto prior state, and an explicit `undefined`
+		// value would clobber an already-known title/color.
+		const meta: { title?: string; color?: string } = {
+			...(result.color !== undefined ? { color: result.color } : {}),
+			...(result.title !== undefined ? { title: result.title } : {}),
+		};
+		if (Object.keys(meta).length === 0) return;
+		this.store.updateAgentMeta(terminalId, workspaceId, meta);
+		// The renderer's terminal-agent-bindings query only invalidates on
+		// `agent:lifecycle`/`terminal:lifecycle`/`agent:meta` broadcasts — the
+		// store's own "change" EventEmitter never reaches the renderer.
+		this.eventBus.broadcastAgentMeta({
+			workspaceId,
+			terminalId,
+			occurredAt: Date.now(),
+		});
+	}
+}

--- a/packages/host-service/src/terminal-agents/claude-transcript.test.ts
+++ b/packages/host-service/src/terminal-agents/claude-transcript.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	encodeProjectDirName,
+	readLatestColorAndTitle,
+	resolveTranscriptPath,
+} from "./claude-transcript";
+
+describe("encodeProjectDirName", () => {
+	it("replaces every non-alphanumeric character 1:1 with a dash", () => {
+		expect(
+			encodeProjectDirName(
+				"/Users/moshef/.superset/worktrees/4c931ee0/session-start",
+			),
+		).toBe("-Users-moshef--superset-worktrees-4c931ee0-session-start");
+	});
+});
+
+describe("resolveTranscriptPath", () => {
+	it("joins the encoded cwd and sessionId under ~/.claude/projects", () => {
+		const path = resolveTranscriptPath("/Users/moshef/repo", "abc-123");
+		expect(
+			path.endsWith(".claude/projects/-Users-moshef-repo/abc-123.jsonl"),
+		).toBe(true);
+	});
+});
+
+describe("readLatestColorAndTitle", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "claude-transcript-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("returns {} when the file doesn't exist", () => {
+		expect(readLatestColorAndTitle(join(dir, "missing.jsonl"))).toEqual({});
+	});
+
+	it("returns {} for an empty file", () => {
+		const path = join(dir, "empty.jsonl");
+		writeFileSync(path, "");
+		expect(readLatestColorAndTitle(path)).toEqual({});
+	});
+
+	it("ignores malformed lines and unrelated entry types", () => {
+		const path = join(dir, "malformed.jsonl");
+		writeFileSync(
+			path,
+			[
+				"not json at all",
+				JSON.stringify({ type: "user", message: "hi" }),
+				"",
+			].join("\n"),
+		);
+		expect(readLatestColorAndTitle(path)).toEqual({});
+	});
+
+	it("returns the most recent agent-color and ai-title lines", () => {
+		const path = join(dir, "session.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ type: "agent-color", agentColor: "red" }),
+				JSON.stringify({ type: "ai-title", aiTitle: "First title" }),
+				JSON.stringify({ type: "user", message: "hi" }),
+				JSON.stringify({ type: "agent-color", agentColor: "yellow" }),
+				JSON.stringify({ type: "ai-title", aiTitle: "Second title" }),
+				"",
+			].join("\n"),
+		);
+		expect(readLatestColorAndTitle(path)).toEqual({
+			color: "yellow",
+			title: "Second title",
+		});
+	});
+
+	it("returns only the field type present when the other never appeared", () => {
+		const path = join(dir, "color-only.jsonl");
+		writeFileSync(
+			path,
+			`${JSON.stringify({ type: "agent-color", agentColor: "blue" })}\n`,
+		);
+		expect(readLatestColorAndTitle(path)).toEqual({ color: "blue" });
+	});
+
+	it("reads a user-set title from a custom-title line", () => {
+		const path = join(dir, "custom-title.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ type: "agent-color", agentColor: "red" }),
+				JSON.stringify({ type: "custom-title", customTitle: "my session" }),
+				JSON.stringify({ type: "agent-name", agentName: "my session" }),
+				"",
+			].join("\n"),
+		);
+		expect(readLatestColorAndTitle(path)).toEqual({
+			color: "red",
+			title: "my session",
+		});
+	});
+});

--- a/packages/host-service/src/terminal-agents/claude-transcript.ts
+++ b/packages/host-service/src/terminal-agents/claude-transcript.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Claude Code has no documented API, hook payload field, or IPC channel for
+ * a session's `/color` or auto-generated title — both are only ever appended
+ * as discrete lines into the session's own transcript file:
+ *
+ *   {"type":"agent-color","agentColor":"yellow","sessionId":"..."}
+ *   {"type":"ai-title","aiTitle":"...","sessionId":"..."}
+ *
+ * A user-set title (via `/rename`) instead appends as:
+ *
+ *   {"type":"custom-title","customTitle":"...","sessionId":"..."}
+ *
+ * (also duplicated as a `agent-name`/`agentName` line, which we ignore in
+ * favor of `custom-title` since both carry the same value.)
+ *
+ * This is confirmed by direct empirical testing, not documentation — Claude
+ * Code's own docs warn the transcript format is internal and can change
+ * between versions. All parsing here is defensive: any failure yields
+ * `undefined` fields rather than throwing, so a format change degrades to
+ * "no title/color shown", never a crash.
+ */
+
+/**
+ * Replicates Claude Code's `~/.claude/projects/<encoded-cwd>` directory
+ * naming: every non-alphanumeric character in the absolute cwd (including
+ * `/` and `.`) is replaced 1:1 with `-` (no collapsing of runs).
+ */
+export function encodeProjectDirName(cwd: string): string {
+	return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
+ * sessionId is attacker-influenceable (forwarded verbatim from the
+ * unauthenticated hook payload), so it's constrained to Claude Code's actual
+ * session-id charset (UUID-like: hex digits and hyphens only) before being
+ * interpolated into a filesystem path — never trust it enough to allow `/` or
+ * `..` segments that could traverse out of the project's transcript directory.
+ */
+function sanitizeSessionId(sessionId: string): string {
+	return sessionId.replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+export function resolveTranscriptPath(cwd: string, sessionId: string): string {
+	return join(
+		homedir(),
+		".claude",
+		"projects",
+		encodeProjectDirName(cwd),
+		`${sanitizeSessionId(sessionId)}.jsonl`,
+	);
+}
+
+export interface TranscriptColorAndTitle {
+	color?: string;
+	title?: string;
+}
+
+/**
+ * Scans the transcript for the most recent `agent-color`/`ai-title` lines.
+ * The file is append-only and can grow to the low megabytes over a long
+ * session, so this reads the whole file rather than tracking a byte offset —
+ * simplicity over micro-optimizing a rarely-large, rarely-changing file.
+ */
+export function readLatestColorAndTitle(
+	transcriptPath: string,
+): TranscriptColorAndTitle {
+	let contents: string;
+	try {
+		contents = readFileSync(transcriptPath, "utf8");
+	} catch {
+		return {};
+	}
+
+	let color: string | undefined;
+	let aiTitle: string | undefined;
+	let customTitle: string | undefined;
+
+	for (const line of contents.split("\n")) {
+		if (!line) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (typeof parsed !== "object" || parsed === null) continue;
+		const record = parsed as Record<string, unknown>;
+		if (
+			record.type === "agent-color" &&
+			typeof record.agentColor === "string"
+		) {
+			color = record.agentColor;
+		} else if (
+			record.type === "ai-title" &&
+			typeof record.aiTitle === "string"
+		) {
+			aiTitle = record.aiTitle;
+		} else if (
+			record.type === "custom-title" &&
+			typeof record.customTitle === "string"
+		) {
+			customTitle = record.customTitle;
+		}
+	}
+
+	// A user's `/rename` (custom-title) must always win over Claude's
+	// auto-generated title, regardless of which line appears later in the
+	// file — Claude's auto-titling isn't gated by "user already renamed",
+	// so an ai-title line can land after a custom-title line and would
+	// otherwise clobber the user's explicit rename on the next scan.
+	return { color, title: customTitle ?? aiTitle };
+}

--- a/packages/host-service/src/terminal-agents/index.ts
+++ b/packages/host-service/src/terminal-agents/index.ts
@@ -1,3 +1,4 @@
+export { ClaudeTranscriptWatcher } from "./claude-transcript-watcher";
 export { SqliteTerminalAgentBindingPersistence } from "./persistence";
 export type {
 	TerminalAgentBindingListFilter,

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -377,4 +377,105 @@ describe("TerminalAgentStore", () => {
 		persistentStore.markTerminalExited("t1");
 		expect(persisted.has("t1")).toBe(false);
 	});
+
+	it("overlays cwd from recordEvent and title/color from updateAgentMeta onto every read path", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			occurredAt: 100,
+			cwd: "/repo",
+		});
+		store.updateAgentMeta("t1", WORKSPACE, {
+			title: "My session",
+			color: "blue",
+		});
+
+		const expected = { cwd: "/repo", title: "My session", color: "blue" };
+		expect(store.get("t1")).toMatchObject(expected);
+		expect(store.listByWorkspace(WORKSPACE)[0]).toMatchObject(expected);
+		expect(store.list()[0]).toMatchObject(expected);
+		expect(store.findActive(WORKSPACE, "claude")).toMatchObject(expected);
+	});
+
+	it("overlays live meta on top of DB-backed persistence reads, not just the in-memory map", () => {
+		const persisted: TerminalAgentBinding = {
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			agentId: "claude",
+			startedAt: 100,
+			lastEventAt: 100,
+			lastEventType: "Start",
+		};
+		const persistentStore = new TerminalAgentStore({
+			load: () => [],
+			upsert: () => {},
+			delete: () => {},
+			listLiveByWorkspace: () => [persisted],
+		});
+
+		persistentStore.updateAgentMeta("t1", WORKSPACE, {
+			title: "From transcript",
+			color: "red",
+		});
+
+		expect(persistentStore.listByWorkspace(WORKSPACE)[0]).toMatchObject({
+			title: "From transcript",
+			color: "red",
+		});
+	});
+
+	it("updateAgentMeta merges partial updates without clobbering a previously known field", () => {
+		store.updateAgentMeta("t1", WORKSPACE, { color: "red" });
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			occurredAt: 100,
+		});
+		store.updateAgentMeta("t1", WORKSPACE, { title: "Later title" });
+
+		const binding = store.get("t1");
+		expect(binding?.color).toBe("red");
+		expect(binding?.title).toBe("Later title");
+	});
+
+	it("updateAgentMeta is a no-op (no change event) when nothing actually changed", () => {
+		store.updateAgentMeta("t1", WORKSPACE, { title: "Same", color: "red" });
+
+		const events: string[] = [];
+		store.on("change", (workspaceId: string) => {
+			events.push(workspaceId);
+		});
+		store.updateAgentMeta("t1", WORKSPACE, { title: "Same", color: "red" });
+
+		expect(events).toEqual([]);
+	});
+
+	it("clears live meta when the terminal is deleted", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			occurredAt: 100,
+		});
+		store.updateAgentMeta("t1", WORKSPACE, {
+			title: "Gone soon",
+			color: "red",
+		});
+		store.markTerminalExited("t1");
+
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			occurredAt: 200,
+		});
+		expect(store.get("t1")?.title).toBeUndefined();
+		expect(store.get("t1")?.color).toBeUndefined();
+	});
 });

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -10,6 +10,13 @@ interface RecordEventInput {
 	agentSessionId?: string;
 	definitionId?: AgentDefinitionId;
 	occurredAt: number;
+	cwd?: string;
+}
+
+interface LiveAgentMeta {
+	cwd?: string;
+	title?: string;
+	color?: string;
 }
 
 export interface TerminalAgentBindingListFilter {
@@ -51,6 +58,13 @@ export interface TerminalAgentBindingPersistence {
 export class TerminalAgentStore extends EventEmitter {
 	private readonly byTerminal = new Map<string, TerminalAgentBinding>();
 	private readonly persistence: TerminalAgentBindingPersistence | undefined;
+	/**
+	 * Live-derived metadata (cwd/title/color), keyed by terminalId. Never
+	 * persisted — DB-backed reads (`listLiveByWorkspace` etc.) bypass
+	 * `byTerminal` entirely, so this overlay is applied to every read path
+	 * regardless of whether persistence is configured.
+	 */
+	private readonly liveMeta = new Map<string, LiveAgentMeta>();
 
 	constructor(persistence?: TerminalAgentBindingPersistence) {
 		super();
@@ -70,11 +84,19 @@ export class TerminalAgentStore extends EventEmitter {
 			agentSessionId,
 			definitionId,
 			occurredAt,
+			cwd,
 		} = input;
 
 		if (EXIT_EVENT_TYPES.has(eventType)) {
 			this.deleteTerminal(terminalId);
 			return;
+		}
+
+		if (cwd) {
+			this.liveMeta.set(terminalId, {
+				...this.liveMeta.get(terminalId),
+				cwd,
+			});
 		}
 
 		const existing = this.byTerminal.get(terminalId);
@@ -140,8 +162,34 @@ export class TerminalAgentStore extends EventEmitter {
 		if (changed) this.emit("change", workspaceId);
 	}
 
+	/**
+	 * Called by the transcript watcher when it detects a new `agent-color`
+	 * or `ai-title` line. No-ops (and skips the change event) when neither
+	 * value actually changed, so a rescan tick doesn't cause needless
+	 * cache invalidation.
+	 */
+	updateAgentMeta(
+		terminalId: string,
+		workspaceId: string,
+		meta: { title?: string; color?: string },
+	): void {
+		const existing = this.liveMeta.get(terminalId);
+		if (existing?.title === meta.title && existing?.color === meta.color) {
+			return;
+		}
+		this.liveMeta.set(terminalId, { ...existing, ...meta });
+		this.emit("change", workspaceId);
+	}
+
+	private withLiveMeta(binding: TerminalAgentBinding): TerminalAgentBinding {
+		const meta = this.liveMeta.get(binding.terminalId);
+		if (!meta) return binding;
+		return { ...binding, ...meta };
+	}
+
 	get(terminalId: string): TerminalAgentBinding | undefined {
-		return this.byTerminal.get(terminalId);
+		const binding = this.byTerminal.get(terminalId);
+		return binding ? this.withLiveMeta(binding) : undefined;
 	}
 
 	listByWorkspace(
@@ -149,7 +197,9 @@ export class TerminalAgentStore extends EventEmitter {
 		filter?: TerminalAgentBindingListFilter,
 	): TerminalAgentBinding[] {
 		if (this.persistence?.listLiveByWorkspace) {
-			return this.persistence.listLiveByWorkspace(workspaceId, filter);
+			return this.persistence
+				.listLiveByWorkspace(workspaceId, filter)
+				.map((binding) => this.withLiveMeta(binding));
 		}
 		const out: TerminalAgentBinding[] = [];
 		for (const binding of this.byTerminal.values()) {
@@ -157,16 +207,20 @@ export class TerminalAgentStore extends EventEmitter {
 			if (filter?.agentId && binding.agentId !== filter.agentId) continue;
 			if (filter?.definitionId && binding.definitionId !== filter.definitionId)
 				continue;
-			out.push(binding);
+			out.push(this.withLiveMeta(binding));
 		}
 		return out;
 	}
 
 	list(): TerminalAgentBinding[] {
 		if (this.persistence?.listLive) {
-			return this.persistence.listLive();
+			return this.persistence
+				.listLive()
+				.map((binding) => this.withLiveMeta(binding));
 		}
-		return [...this.byTerminal.values()];
+		return [...this.byTerminal.values()].map((binding) =>
+			this.withLiveMeta(binding),
+		);
 	}
 
 	findActive(
@@ -175,11 +229,12 @@ export class TerminalAgentStore extends EventEmitter {
 		definitionId?: AgentDefinitionId,
 	): TerminalAgentBinding | undefined {
 		if (this.persistence?.findLiveActive) {
-			return this.persistence.findLiveActive(
+			const binding = this.persistence.findLiveActive(
 				workspaceId,
 				agentId,
 				definitionId,
 			);
+			return binding ? this.withLiveMeta(binding) : undefined;
 		}
 		let best: TerminalAgentBinding | undefined;
 		for (const binding of this.byTerminal.values()) {
@@ -191,13 +246,14 @@ export class TerminalAgentStore extends EventEmitter {
 				best = binding;
 			}
 		}
-		return best;
+		return best ? this.withLiveMeta(best) : undefined;
 	}
 
 	private deleteTerminal(terminalId: string): void {
 		const existing = this.byTerminal.get(terminalId);
 		if (!existing) return;
 		this.byTerminal.delete(terminalId);
+		this.liveMeta.delete(terminalId);
 		this.persistence?.delete(terminalId);
 		this.emit("change", existing.workspaceId);
 	}

--- a/packages/host-service/src/terminal-agents/types.ts
+++ b/packages/host-service/src/terminal-agents/types.ts
@@ -19,4 +19,12 @@ export interface TerminalAgentBinding {
 	startedAt: number;
 	lastEventAt: number;
 	lastEventType: string;
+	/**
+	 * Ephemeral, never persisted — derived live from the agent's own local
+	 * state (e.g. a Claude Code transcript file) and re-derivable from
+	 * scratch on host-service restart, so it's kept out of the DB schema.
+	 */
+	cwd?: string;
+	title?: string;
+	color?: string;
 }

--- a/packages/host-service/src/trpc/router/notifications/notifications.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.ts
@@ -18,6 +18,7 @@ const agentIdentityInput = z
 const hookInput = z.object({
 	terminalId: z.string().optional(),
 	eventType: z.string().optional(),
+	cwd: z.string().optional(),
 	agent: agentIdentityInput,
 });
 
@@ -73,6 +74,7 @@ export const notificationsRouter = router({
 
 		const agent = normalizeAgentIdentity(input.agent);
 		const occurredAt = Date.now();
+		const cwd = trimOrUndefined(input.cwd);
 
 		ctx.eventBus.broadcastAgentLifecycle({
 			workspaceId: terminalSession.originWorkspaceId,
@@ -90,6 +92,7 @@ export const notificationsRouter = router({
 			...(agent?.sessionId ? { agentSessionId: agent.sessionId } : {}),
 			...(agent?.definitionId ? { definitionId: agent.definitionId } : {}),
 			occurredAt,
+			...(cwd ? { cwd } : {}),
 		});
 
 		return { success: true, ignored: false as const };

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -15,6 +15,7 @@ export function Workspace<TData>({
 	className,
 	renderTabAccessory,
 	renderTabIcon,
+	renderTabContentWrapper,
 	renderEmptyState,
 	renderAddTabMenu,
 	renderTabBarLeading,
@@ -121,6 +122,7 @@ export function Workspace<TData>({
 					store.getState().movePaneToNewTab({ paneId, toIndex })
 				}
 				renderTabIcon={renderTabIcon}
+				renderTabContentWrapper={renderTabContentWrapper}
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabBarLeading={renderTabBarLeading}
 				renderTabBarTrailing={renderTabBarTrailing}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -32,6 +32,7 @@ interface TabBarProps<TData> {
 	onReorderTab: (tabId: string, toIndex: number) => void;
 	onMovePaneToNewTab: (paneId: string, toIndex: number) => void;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
+	renderTabContentWrapper?: (tab: Tab<TData>, children: ReactNode) => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
 	renderTabBarLeading?: () => ReactNode;
 	renderTabBarTrailing?: () => ReactNode;
@@ -83,6 +84,7 @@ export function TabBar<TData>({
 	onReorderTab,
 	onMovePaneToNewTab,
 	renderTabIcon,
+	renderTabContentWrapper,
 	renderAddTabMenu,
 	renderTabBarLeading,
 	renderTabBarTrailing,
@@ -209,6 +211,7 @@ export function TabBar<TData>({
 								onCloseAll={onCloseAllTabs}
 								onRename={(title) => onRenameTab(tab.id, title)}
 								icon={renderTabIcon?.(tab)}
+								renderContentWrapper={renderTabContentWrapper}
 								accessory={renderTabAccessory?.(tab)}
 							/>
 						</div>

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -32,6 +32,8 @@ interface TabItemProps<TData> {
 	onCloseAll: () => void;
 	onRename: (title: string | undefined) => void;
 	icon?: ReactNode;
+	/** Wraps the tab's full content (icon, title, AND the accessory/close-button area). */
+	renderContentWrapper?: (tab: Tab<TData>, children: ReactNode) => ReactNode;
 	accessory?: ReactNode;
 }
 
@@ -47,6 +49,7 @@ export function TabItem<TData>({
 	onCloseAll,
 	onRename,
 	icon,
+	renderContentWrapper,
 	accessory,
 }: TabItemProps<TData>) {
 	const [isEditing, setIsEditing] = useState(false);
@@ -108,6 +111,56 @@ export function TabItem<TData>({
 		[connectDrag, connectPaneDrop],
 	);
 
+	const tabContent = (
+		<>
+			<Tooltip delayDuration={500} open={isDragging ? false : undefined}>
+				<TooltipTrigger asChild>
+					{/* biome-ignore lint/a11y/noStaticElementInteractions: tab selection is handled by the wrapper's mousedown; this title element is intentionally a non-focusable div so clicking a tab never steals focus from the active pane (issue #4967) */}
+					<div
+						className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
+						onAuxClick={(event) => {
+							if (event.button === 1) {
+								event.preventDefault();
+								onClose();
+							}
+						}}
+						onDoubleClick={startEditing}
+					>
+						{icon && <span className="shrink-0">{icon}</span>}
+						<OverflowFadeText className="flex-1">{title}</OverflowFadeText>
+					</div>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">{title}</TooltipContent>
+			</Tooltip>
+			<div className="relative flex h-full w-7 shrink-0 items-center justify-center">
+				{accessory && (
+					<span className="pointer-events-none absolute inset-0 flex items-center justify-center leading-none opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+						{accessory}
+					</span>
+				)}
+				<Button
+					aria-label="Close tab"
+					className={cn(
+						"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+						isActive ? "hover:bg-muted" : "hover:bg-foreground/10",
+					)}
+					onClick={(event) => {
+						event.stopPropagation();
+						onClose();
+					}}
+					onMouseDown={(event) => {
+						event.stopPropagation();
+					}}
+					size="icon"
+					type="button"
+					variant="ghost"
+				>
+					<XIcon className="size-3.5" />
+				</Button>
+			</div>
+		</>
+	);
+
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
@@ -146,58 +199,7 @@ export function TabItem<TData>({
 							/>
 						</div>
 					) : (
-						<>
-							<Tooltip
-								delayDuration={500}
-								open={isDragging ? false : undefined}
-							>
-								<TooltipTrigger asChild>
-									{/* biome-ignore lint/a11y/noStaticElementInteractions: tab selection is handled by the wrapper's mousedown; this title element is intentionally a non-focusable div so clicking a tab never steals focus from the active pane (issue #4967) */}
-									<div
-										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
-										onAuxClick={(event) => {
-											if (event.button === 1) {
-												event.preventDefault();
-												onClose();
-											}
-										}}
-										onDoubleClick={startEditing}
-									>
-										{icon && <span className="shrink-0">{icon}</span>}
-										<OverflowFadeText className="flex-1">
-											{title}
-										</OverflowFadeText>
-									</div>
-								</TooltipTrigger>
-								<TooltipContent side="bottom">{title}</TooltipContent>
-							</Tooltip>
-							<div className="relative flex h-full w-7 shrink-0 items-center justify-center">
-								{accessory && (
-									<span className="pointer-events-none absolute inset-0 flex items-center justify-center leading-none opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-										{accessory}
-									</span>
-								)}
-								<Button
-									aria-label="Close tab"
-									className={cn(
-										"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-										isActive ? "hover:bg-muted" : "hover:bg-foreground/10",
-									)}
-									onClick={(event) => {
-										event.stopPropagation();
-										onClose();
-									}}
-									onMouseDown={(event) => {
-										event.stopPropagation();
-									}}
-									size="icon"
-									type="button"
-									variant="ghost"
-								>
-									<XIcon className="size-3.5" />
-								</Button>
-							</div>
-						</>
+						(renderContentWrapper?.(tab, tabContent) ?? tabContent)
 					)}
 				</div>
 			</ContextMenuTrigger>

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -103,6 +103,13 @@ export interface WorkspaceProps<TData> {
 	className?: string;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
+	/**
+	 * Wraps the tab's full content — icon, title, and the accessory/close-
+	 * button area — jointly (rather than a separate slot), e.g. for a colored
+	 * accent background spanning the whole tab. Receives the default markup
+	 * as `children`; return it unwrapped to opt out for a given tab.
+	 */
+	renderTabContentWrapper?: (tab: Tab<TData>, children: ReactNode) => ReactNode;
 	renderEmptyState?: () => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
 	/** Rendered at the leading (left) edge of the tab bar row, before the tabs. */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,10 @@
 			"types": "./src/sentry.ts",
 			"default": "./src/sentry.ts"
 		},
+		"./db-connectivity-error": {
+			"types": "./src/db-connectivity-error.ts",
+			"default": "./src/db-connectivity-error.ts"
+		},
 		"./terminal-wheel-handler": {
 			"types": "./src/terminal-wheel-handler/index.ts",
 			"default": "./src/terminal-wheel-handler/index.ts"

--- a/packages/shared/src/db-connectivity-error.test.ts
+++ b/packages/shared/src/db-connectivity-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { isDatabaseConnectivityError } from "./db-connectivity-error";
+
+describe("isDatabaseConnectivityError", () => {
+	it("matches a raw ECONNREFUSED failure", () => {
+		expect(
+			isDatabaseConnectivityError(
+				new Error("connect ECONNREFUSED 127.0.0.1:5432"),
+			),
+		).toBe(true);
+	});
+
+	it("matches a NeonDbError by name", () => {
+		const error = new Error("fetch failed");
+		error.name = "NeonDbError";
+		expect(isDatabaseConnectivityError(error)).toBe(true);
+	});
+
+	it("matches an 'Unable to connect' cause", () => {
+		const error = new Error("query failed", {
+			cause: new Error("Unable to connect to database"),
+		});
+		expect(isDatabaseConnectivityError(error)).toBe(true);
+	});
+
+	it("does not match an unrelated error", () => {
+		expect(isDatabaseConnectivityError(new Error("Validation failed"))).toBe(
+			false,
+		);
+	});
+
+	it("does not match a non-Error value", () => {
+		expect(isDatabaseConnectivityError("some string")).toBe(false);
+		expect(isDatabaseConnectivityError(null)).toBe(false);
+	});
+});

--- a/packages/shared/src/db-connectivity-error.ts
+++ b/packages/shared/src/db-connectivity-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Detects a raw DB-driver connectivity failure (Postgres/Neon proxy
+ * unreachable — the common "forgot to start the local Docker DB stack"
+ * dev-environment mistake) so callers can surface a clear message instead
+ * of an opaque generic error.
+ */
+export function isDatabaseConnectivityError(error: unknown): boolean {
+	const text =
+		error instanceof Error
+			? `${error.name} ${error.message} ${String(error.cause ?? "")}`
+			: String(error);
+	return /ECONNREFUSED|NeonDbError|Unable to connect/i.test(text);
+}
+
+export const DATABASE_UNAVAILABLE_MESSAGE =
+	"Could not reach the database. Is your local dev DB stack (Docker) running?";
+
+/** Key set on tRPC's `errorFormatter` `data` field — shared so the client
+ * doesn't have to re-declare the same shape by hand when reading it back. */
+export const DATABASE_UNAVAILABLE_DATA_KEY = "databaseUnavailable" as const;
+
+export interface DatabaseUnavailableErrorData {
+	[DATABASE_UNAVAILABLE_DATA_KEY]?: boolean;
+}

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -2,6 +2,11 @@ import type { auth, Session } from "@superset/auth/server";
 import { db } from "@superset/db/client";
 import { members } from "@superset/db/schema";
 import { COMPANY, ORGANIZATION_HEADER } from "@superset/shared/constants";
+import {
+	DATABASE_UNAVAILABLE_DATA_KEY,
+	DATABASE_UNAVAILABLE_MESSAGE,
+	isDatabaseConnectivityError,
+} from "@superset/shared/db-connectivity-error";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import superjson from "superjson";
@@ -18,10 +23,18 @@ export const createTRPCContext = (opts: TRPCContext): TRPCContext => opts;
 const t = initTRPC.context<TRPCContext>().create({
 	transformer: superjson,
 	errorFormatter({ shape, error }) {
+		// A raw driver failure (DB unreachable) isn't a `TRPCError`, so it
+		// reaches here as `error.cause` with tRPC's own generic message —
+		// surface something a developer can act on instead.
+		const databaseUnavailable = isDatabaseConnectivityError(error.cause);
 		return {
 			...shape,
+			message: databaseUnavailable
+				? DATABASE_UNAVAILABLE_MESSAGE
+				: shape.message,
 			data: {
 				...shape.data,
+				[DATABASE_UNAVAILABLE_DATA_KEY]: databaseUnavailable,
 				zodError:
 					error.cause instanceof ZodError ? error.cause.flatten() : null,
 			},

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -3,6 +3,7 @@ export { useGitChangeEvents } from "./hooks/useGitChangeEvents";
 export {
 	type AgentIdentity,
 	type AgentLifecyclePayload,
+	type AgentMetaPayload,
 	type EventBusHandle,
 	type GitChangedPayload,
 	getEventBus,

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -13,6 +13,7 @@ type EventType =
 	| "fs:events"
 	| "git:changed"
 	| "agent:lifecycle"
+	| "agent:meta"
 	| "terminal:lifecycle"
 	| "port:changed"
 	| "workspace:changed"
@@ -35,6 +36,11 @@ export interface AgentLifecyclePayload {
 	terminalId: string;
 	// Absent when the hook ran without `SUPERSET_AGENT_ID` set.
 	agent?: AgentIdentity;
+	occurredAt: number;
+}
+
+export interface AgentMetaPayload {
+	terminalId: string;
 	occurredAt: number;
 }
 
@@ -93,15 +99,17 @@ type EventListener<T extends EventType> = T extends "fs:events"
 		? (workspaceId: string, payload: GitChangedPayload) => void
 		: T extends "agent:lifecycle"
 			? (workspaceId: string, payload: AgentLifecyclePayload) => void
-			: T extends "terminal:lifecycle"
-				? (workspaceId: string, payload: TerminalLifecyclePayload) => void
-				: T extends "port:changed"
-					? (workspaceId: string, payload: PortChangedPayload) => void
-					: T extends "workspace:changed"
-						? (workspaceId: string, payload: WorkspaceChangedPayload) => void
-						: T extends "project:changed"
-							? (projectId: string, payload: ProjectChangedPayload) => void
-							: never;
+			: T extends "agent:meta"
+				? (workspaceId: string, payload: AgentMetaPayload) => void
+				: T extends "terminal:lifecycle"
+					? (workspaceId: string, payload: TerminalLifecyclePayload) => void
+					: T extends "port:changed"
+						? (workspaceId: string, payload: PortChangedPayload) => void
+						: T extends "workspace:changed"
+							? (workspaceId: string, payload: WorkspaceChangedPayload) => void
+							: T extends "project:changed"
+								? (projectId: string, payload: ProjectChangedPayload) => void
+								: never;
 
 interface ListenerEntry {
 	type: EventType;
@@ -155,6 +163,7 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 			message.type === "fs:events" ||
 			message.type === "git:changed" ||
 			message.type === "agent:lifecycle" ||
+			message.type === "agent:meta" ||
 			message.type === "terminal:lifecycle" ||
 			message.type === "port:changed" ||
 			message.type === "workspace:changed"
@@ -189,6 +198,11 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 					occurredAt: message.occurredAt,
 				},
 			);
+		} else if (message.type === "agent:meta") {
+			(entry.callback as EventListener<"agent:meta">)(message.workspaceId, {
+				terminalId: message.terminalId,
+				occurredAt: message.occurredAt,
+			});
 		} else if (message.type === "terminal:lifecycle") {
 			(entry.callback as EventListener<"terminal:lifecycle">)(
 				message.workspaceId,


### PR DESCRIPTION
feat(desktop,panes): reflect Claude Code session name/color in tabs

<!--
PR titles become the squash-merge commit subject, so use conventional commit format:
  feat(desktop): add copy-logs button to failed CI checks
  fix(web): guard against missing PR in workspace header
-->

## What & why

<!-- What changed and the problem it solves. Link the issue if there is one (e.g. "fixes #123"). -->

## How I tested it

<!--
What you ran or clicked to verify this works. Screenshots are strongly preferred
for anything user-visible — before/after for bug fixes. See "Capturing screenshots
via CDP" in CONTRIBUTING.md for how to capture them from the dev app.
-->

## Checklist

- [ ] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reflects Claude Code session name and color in terminal tabs, so you can spot and track agent work at a glance. Also adds clear messaging when the database is unreachable.

- New Features
  - Derive Claude session title/color by tailing its transcript and publish changes as `agent:meta`; `TerminalAgentStore` overlays live `cwd`/`title`/`color` on reads.
  - Forward `cwd` from the agent hook so transcript files can be located reliably.
  - Desktop UX: show a small color dot on agent icons, tint single-pane terminal tabs with the session color, and use the session title for the tab. Added an Appearance toggle to enable/disable this.
  - Plumbing: `@superset/panes` supports a tab content wrapper for background accents; terminal tab icon renderer added; React Query bindings now select per-terminal slices and invalidate on `agent:meta`.

- Bug Fixes
  - Surface DB-connectivity failures with a clear message: shared helper in `@superset/shared/db-connectivity-error`, tRPC error formatting in `@superset/trpc`, a 503 JSON body in API auth, and a desktop toast in the Query/Mutation caches.

<sup>Written for commit cda4ab867c5306708d020fe1cc3307558861742a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

