### PR TITLE
fix(desktop): route project/session selection through single draft-store writers

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -44,6 +44,9 @@ function PullRequestDetailPage() {
 	} = useProjectHost(projectId);
 	const hostUrl = useHostUrl(hostId ?? undefined);
 	const updateDraft = useNewWorkspaceDraftStore((state) => state.updateDraft);
+	const selectProject = useNewWorkspaceDraftStore(
+		(state) => state.selectProject,
+	);
 	const resetDraft = useNewWorkspaceDraftStore((state) => state.resetDraft);
 	const openModal = useOpenNewWorkspaceModal();
 
@@ -96,11 +99,8 @@ function PullRequestDetailPage() {
 			state: normalizePRState(data.state, data.isDraft),
 		};
 		resetDraft();
-		updateDraft({
-			selectedProjectId: projectId,
-			hostId,
-			linkedPR,
-		});
+		selectProject(projectId);
+		updateDraft({ hostId, linkedPR });
 		openModal(projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
@@ -49,6 +49,7 @@ export function PullRequestsContent({
 	const debouncedQuery = useDebouncedValue(searchQuery, 300);
 	const navigate = useNavigate();
 	const updateDraft = useNewWorkspaceDraftStore((s) => s.updateDraft);
+	const selectProject = useNewWorkspaceDraftStore((s) => s.selectProject);
 	const resetDraft = useNewWorkspaceDraftStore((s) => s.resetDraft);
 	const openModal = useOpenNewWorkspaceModal();
 
@@ -111,11 +112,8 @@ export function PullRequestsContent({
 			state: normalizePRState(pr.state, pr.isDraft),
 		};
 		resetDraft();
-		updateDraft({
-			selectedProjectId: pr.projectId,
-			hostId: pr.hostId,
-			linkedPR,
-		});
+		selectProject(pr.projectId);
+		updateDraft({ hostId: pr.hostId, linkedPR });
 		openModal(pr.projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
@@ -57,6 +57,7 @@ export function GitHubIssuesContent({
 	const debouncedQuery = useDebouncedValue(searchQuery, 300);
 	const navigate = useNavigate();
 	const updateDraft = useNewWorkspaceDraftStore((s) => s.updateDraft);
+	const selectProject = useNewWorkspaceDraftStore((s) => s.selectProject);
 	const resetDraft = useNewWorkspaceDraftStore((s) => s.resetDraft);
 	const openModal = useOpenNewWorkspaceModal();
 
@@ -149,11 +150,8 @@ export function GitHubIssuesContent({
 			state: issue.state.toLowerCase() === "closed" ? "closed" : "open",
 		};
 		resetDraft();
-		updateDraft({
-			selectedProjectId: issue.projectId,
-			hostId: issue.hostId,
-			linkedIssues: [linkedIssue],
-		});
+		selectProject(issue.projectId);
+		updateDraft({ hostId: issue.hostId, linkedIssues: [linkedIssue] });
 		openModal(issue.projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
@@ -38,6 +38,9 @@ function IssueDetailPage() {
 	} = useProjectHost(projectId);
 	const hostUrl = useHostUrl(hostId ?? undefined);
 	const updateDraft = useNewWorkspaceDraftStore((state) => state.updateDraft);
+	const selectProject = useNewWorkspaceDraftStore(
+		(state) => state.selectProject,
+	);
 	const resetDraft = useNewWorkspaceDraftStore((state) => state.resetDraft);
 	const openModal = useOpenNewWorkspaceModal();
 
@@ -95,11 +98,8 @@ function IssueDetailPage() {
 			state: data.state.toLowerCase() === "closed" ? "closed" : "open",
 		};
 		resetDraft();
-		updateDraft({
-			selectedProjectId: projectId,
-			hostId,
-			linkedIssues: [linkedIssue],
-		});
+		selectProject(projectId);
+		updateDraft({ hostId, linkedIssues: [linkedIssue] });
 		openModal(projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
@@ -72,12 +72,20 @@ export function useDashboardNewWorkspaceDraft() {
 		})),
 	);
 	const updateDraft = useNewWorkspaceDraftStore((store) => store.updateDraft);
+	const selectProject = useNewWorkspaceDraftStore(
+		(store) => store.selectProject,
+	);
+	const selectSession = useNewWorkspaceDraftStore(
+		(store) => store.selectSession,
+	);
 	const resetDraft = useNewWorkspaceDraftStore((store) => store.resetDraft);
 	const resetKey = useNewWorkspaceDraftStore((store) => store.resetKey);
 
 	return {
 		draft,
 		updateDraft,
+		selectProject,
+		selectSession,
 		resetDraft,
 		resetKey,
 		closeModal: ctx.closeModal,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
@@ -25,7 +25,8 @@ export function DashboardNewWorkspaceModalContent({
 	preSelectedProjectId,
 	preSelectedSession = false,
 }: DashboardNewWorkspaceModalContentProps) {
-	const { draft, updateDraft } = useDashboardNewWorkspaceDraft();
+	const { draft, updateDraft, selectProject, selectSession } =
+		useDashboardNewWorkspaceDraft();
 	const setLastProjectId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.setLastProjectId,
 	);
@@ -74,15 +75,7 @@ export function DashboardNewWorkspaceModalContent({
 
 		if (preSelectedSession && !hasInitializedSelectionRef.current) {
 			hasInitializedSelectionRef.current = true;
-			// Same clears as the manual "No project" path — a leftover
-			// project draft's PR/base-branch would fail at submit.
-			updateDraft({
-				selectedProjectId: null,
-				isSession: true,
-				linkedPR: null,
-				baseBranch: null,
-				baseBranchSource: null,
-			});
+			selectSession();
 			return;
 		}
 
@@ -99,15 +92,7 @@ export function DashboardNewWorkspaceModalContent({
 			if (hasPreSelectedProject) {
 				appliedPreSelectionRef.current = preSelectedProjectId;
 				hasInitializedSelectionRef.current = true;
-				if (
-					preSelectedProjectId !== draft.selectedProjectId ||
-					draft.isSession
-				) {
-					updateDraft({
-						selectedProjectId: preSelectedProjectId,
-						isSession: false,
-					});
-				}
+				selectProject(preSelectedProjectId);
 				return;
 			}
 		}
@@ -145,6 +130,8 @@ export function DashboardNewWorkspaceModalContent({
 		preSelectedProjectId,
 		preSelectedSession,
 		recentProjects,
+		selectProject,
+		selectSession,
 		updateDraft,
 	]);
 
@@ -161,19 +148,11 @@ export function DashboardNewWorkspaceModalContent({
 				isSessionSelected={draft.isSession}
 				onSelectProject={(selectedProjectId) => {
 					if (selectedProjectId === null) {
-						// Sessions can't check out a PR or fork a branch — clear
-						// the repo-scoped inputs instead of failing at submit.
-						updateDraft({
-							selectedProjectId: null,
-							isSession: true,
-							linkedPR: null,
-							baseBranch: null,
-							baseBranchSource: null,
-						});
+						selectSession();
 						return;
 					}
 					setLastProjectId(selectedProjectId);
-					updateDraft({ selectedProjectId, isSession: false });
+					selectProject(selectedProjectId);
 				}}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -96,8 +96,14 @@ export function NewWorkspaceScreen({
 	const navigate = useNavigate();
 	const [promptSeed, setPromptSeed] = useState(0);
 	const openInFinderMutation = electronTrpc.external.openInFinder.useMutation();
-	const { closeModal, draft, updateDraft, resetKey } =
-		useDashboardNewWorkspaceDraft();
+	const {
+		closeModal,
+		draft,
+		updateDraft,
+		selectProject,
+		selectSession,
+		resetKey,
+	} = useDashboardNewWorkspaceDraft();
 	const attachments = useProviderAttachments();
 	const hostService = useLocalHostService();
 	const { activeHostUrl, machineId } = hostService;
@@ -207,18 +213,13 @@ export function NewWorkspaceScreen({
 		if (!preSelectedSession) appliedSessionPreselectionRef.current = false;
 	}, [preSelectedSession]);
 	useEffect(() => {
+		if (!preSelectedProjectId) appliedPreSelectionRef.current = null;
+	}, [preSelectedProjectId]);
+	useEffect(() => {
 		if (!isOpen || !areProjectsReady) return;
 		if (preSelectedSession && !appliedSessionPreselectionRef.current) {
 			appliedSessionPreselectionRef.current = true;
-			// Same clears as the manual "No project" path — a leftover
-			// project draft's PR/base-branch would fail at submit.
-			updateDraft({
-				selectedProjectId: null,
-				isSession: true,
-				linkedPR: null,
-				baseBranch: null,
-				baseBranchSource: null,
-			});
+			selectSession();
 			return;
 		}
 		const isValid = (id: string | null | undefined) =>
@@ -229,9 +230,7 @@ export function NewWorkspaceScreen({
 			isValid(preSelectedProjectId)
 		) {
 			appliedPreSelectionRef.current = preSelectedProjectId;
-			if (draft.selectedProjectId !== preSelectedProjectId) {
-				updateDraft({ selectedProjectId: preSelectedProjectId });
-			}
+			selectProject(preSelectedProjectId);
 			return;
 		}
 		// An explicit "No project" (session) choice must survive project-list
@@ -252,6 +251,8 @@ export function NewWorkspaceScreen({
 		draft.selectedProjectId,
 		draft.isSession,
 		projects,
+		selectProject,
+		selectSession,
 		updateDraft,
 	]);
 
@@ -784,19 +785,11 @@ export function NewWorkspaceScreen({
 							isSessionSelected={draft.isSession}
 							onSelectProject={(selectedProjectId) => {
 								if (selectedProjectId === null) {
-									// Sessions can't check out a PR or fork a branch —
-									// clear repo-scoped inputs instead of failing at submit.
-									updateDraft({
-										selectedProjectId: null,
-										isSession: true,
-										linkedPR: null,
-										baseBranch: null,
-										baseBranchSource: null,
-									});
+									selectSession();
 									return;
 								}
 								setLastProjectId(selectedProjectId);
-								updateDraft({ selectedProjectId, isSession: false });
+								selectProject(selectedProjectId);
 							}}
 						/>
 						{draft.linkedPR ? (

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -56,6 +56,8 @@ export interface NewWorkspaceDraft {
 interface NewWorkspaceDraftState extends NewWorkspaceDraft {
 	resetKey: number;
 	updateDraft: (patch: Partial<NewWorkspaceDraft>) => void;
+	selectProject: (projectId: string) => void;
+	selectSession: () => void;
 	addAttachment: (attachment: DraftAttachment) => void;
 	updateAttachment: (localId: string, patch: Partial<DraftAttachment>) => void;
 	removeAttachment: (localId: string) => void;
@@ -87,6 +89,21 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 		...buildInitialDraft(),
 		resetKey: 0,
 		updateDraft: (patch) => set((state) => ({ ...state, ...patch })),
+		// The only writers of the selectedProjectId/isSession pair — a project
+		// selection that leaves isSession behind makes submit reject PR
+		// checkouts while the picker shows the project as selected.
+		selectProject: (projectId) =>
+			set({ selectedProjectId: projectId, isSession: false }),
+		// Sessions can't check out a PR or fork a branch — clear the
+		// repo-scoped inputs instead of failing at submit.
+		selectSession: () =>
+			set({
+				selectedProjectId: null,
+				isSession: true,
+				linkedPR: null,
+				baseBranch: null,
+				baseBranchSource: null,
+			}),
 		addAttachment: (attachment) =>
 			set((state) => ({
 				...state,
@@ -106,15 +123,11 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 					(entry) => entry.localId !== localId,
 				),
 			})),
+		// set() merges, so the store's actions survive the reset.
 		resetDraft: () =>
 			set((state) => ({
 				...buildInitialDraft(),
 				resetKey: state.resetKey + 1,
-				updateDraft: state.updateDraft,
-				addAttachment: state.addAttachment,
-				updateAttachment: state.updateAttachment,
-				removeAttachment: state.removeAttachment,
-				resetDraft: state.resetDraft,
 			})),
 	}),
 );


### PR DESCRIPTION
## Problem

Clicking sidebar **Sessions "+"** and then a project's **"+"** left the new-workspace draft in a stale state: the picker showed the project (e.g. Superset) but `isSession` stayed `true`, so submitting with a linked PR failed with **"Checking out a PR requires a project"** until the project was re-picked from the dropdown.

## Root cause

The `selectedProjectId`/`isSession` pair in `new-workspace-draft.ts` had four copy-pasted writers (picker callback + preselection effect, in both the screen and modal variants) that must stay in sync, and they drifted: the screen's project-preselection branch set the id without clearing `isSession`. The pill renders the project name whenever the id resolves, so the inconsistency was invisible until submit.

## Fix

- Add `selectProject(projectId)` / `selectSession()` actions to the draft store — the only writers of the pair. Selecting a project always leaves session mode; selecting a session always clears the repo-scoped inputs (linked PR, base branch).
- Convert all call sites: both variants' pickers and preselection effects, plus the four PR/issue "Add to workspace" pages.
- Re-arm the screen's preselection ref when the `projectId` search param clears: the screen stays mounted across search-param changes (unlike the modal, which resets refs on close), so Sessions "+" → the **same** project "+" previously skipped re-applying and stayed stuck in session mode.
- Simplify `resetDraft` to rely on zustand's merge semantics instead of hand-preserving each action.

## CDP verification (dev app from this worktree, real mouse/keyboard input, evidence gate)

| Case | Before fix | After fix |
|---|---|---|
| Sessions "+" → project "+" → link PR → submit | ❌ toast "Checking out a PR requires a project", draft `{selectedProjectId: set, isSession: true}` | ✅ creates PR-checkout workspace under the project, navigates to it |
| Sessions "+" → **same** project "+" (re-arm) | stuck in session mode | ✅ `{p: set, sess: false}`, pill shows project |
| Dropdown "No project" with PR linked | — | ✅ clears linked PR + base branch, PR pill disappears |
| Session create (Sessions "+" → prompt → submit) | — | ✅ project-less session workspace created, no toast |
| Manual project switch after "+" preselect | — | ✅ no snap-back after 2s (ref guard intact) |
| PR list "Add to workspace" | — | ✅ draft `{p: set, sess: false, pr: 8883}`, `resetDraft` cleared prior prompt |

Not UI-tested: the modal (control) variant — it's behind the `new-workspace-screen` experiment (test arm active in dev); its call sites got the identical mechanical conversion. Test workspaces created during verification were deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale draft when creating a workspace where the picker showed a project but the draft stayed in session mode, causing PR checkout to fail with "Checking out a PR requires a project." All project/session selection now goes through single store actions to keep state consistent across the screen, modal, and "Add to workspace" flows.

- **Bug Fixes**
  - Centralized selection with `selectProject(projectId)` and `selectSession()` to keep `selectedProjectId`/`isSession` in sync and clear repo-scoped inputs when choosing a session.
  - Updated all pickers and preselection effects; re-arms project preselection when the `projectId` search param clears so Sessions "+" → same project "+" applies correctly.

- **Refactors**
  - Simplified `resetDraft` using `zustand` merge semantics so actions persist across resets.
  - Replaced ad-hoc updates with the new actions across the screen, modal, and PR/issue "Add to workspace" pages.

<sup>Written for commit 4f5a79a8d52a8292873f52ea07f672ba3ed5f14e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved new workspace setup when starting from pull requests or issues.
  * Project and session selections now update consistently and automatically clear conflicting workspace details.
  * Switching between project and session modes now prevents stale pull request, branch, or repository information from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->