### PR TITLE
fix(host-service): classify missing project directory as NOT_FOUND in workspace-creation git procedures

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/adopt.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/adopt.ts
@@ -7,7 +7,10 @@ import {
 	getWorktreeBranchAtPath,
 	listWorktreeBranches,
 } from "../shared/branch-search";
-import { requireLocalProject } from "../shared/local-project";
+import {
+	requireLocalProject,
+	requireProjectRepoPath,
+} from "../shared/local-project";
 import type { TerminalDescriptor } from "../shared/types";
 
 /**
@@ -21,7 +24,8 @@ export const adopt = protectedProcedure
 	.input(adoptInputSchema)
 	.mutation(async ({ ctx, input }) => {
 		const localProject = requireLocalProject(ctx, input.projectId);
-		await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
+		const repoPath = requireProjectRepoPath(localProject);
+		await ensureMainWorkspace(ctx, input.projectId, repoPath);
 
 		let branch = input.branch.trim();
 		if (!branch) {
@@ -31,7 +35,7 @@ export const adopt = protectedProcedure
 			});
 		}
 
-		const git = await ctx.git(localProject.repoPath);
+		const git = await ctx.git(repoPath);
 
 		let worktreePath: string;
 		if (input.worktreePath) {

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/list-project-worktrees.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/list-project-worktrees.ts
@@ -2,7 +2,10 @@ import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { workspaces } from "../../../../db/schema";
 import { protectedProcedure } from "../../../index";
-import { requireLocalProject } from "../shared/local-project";
+import {
+	requireLocalProject,
+	requireProjectRepoPath,
+} from "../shared/local-project";
 import {
 	listGitWorktrees,
 	normalizeWorktreePath,
@@ -20,7 +23,7 @@ export const listProjectWorktrees = protectedProcedure
 	.input(z.object({ projectId: z.string() }))
 	.query(async ({ ctx, input }) => {
 		const localProject = requireLocalProject(ctx, input.projectId);
-		const git = await ctx.git(localProject.repoPath);
+		const git = await ctx.git(requireProjectRepoPath(localProject));
 		const records = await listGitWorktrees(git);
 
 		// Tracking key is (projectId, branch) — same as searchBranches — but

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
@@ -11,7 +11,10 @@ import {
 	markRefetchRemote,
 	shouldRefetchRemote,
 } from "../shared/branch-search";
-import { findLocalProject } from "../shared/local-project";
+import {
+	findLocalProject,
+	requireProjectRepoPath,
+} from "../shared/local-project";
 import type { BranchRow } from "../shared/types";
 
 type BranchAccum = {
@@ -36,7 +39,7 @@ export const searchBranches = protectedProcedure
 			};
 		}
 
-		const git = await ctx.git(localProject.repoPath);
+		const git = await ctx.git(requireProjectRepoPath(localProject));
 
 		// Honor `refresh` only if TTL elapsed — prevents thrashing `git fetch`
 		// on every keystroke when the client tags first-page requests.

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/local-project.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/local-project.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { projects } from "../../../../db/schema";
 import type { HostServiceContext } from "../../../../types";
@@ -23,4 +25,18 @@ export function requireLocalProject(
 		throw projectNotSetupError(projectId);
 	}
 	return localProject;
+}
+
+// A project directory deleted or moved outside the app is a routine
+// lifecycle state, not a bug — classify it here so simple-git's construct
+// error can't escape a workspace-creation procedure as a reportable 500.
+export function requireProjectRepoPath(localProject: LocalProject): string {
+	if (!existsSync(localProject.repoPath)) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Project directory no longer exists on disk",
+			cause: { kind: "PROJECT_DIR_MISSING", repoPath: localProject.repoPath },
+		});
+	}
+	return localProject.repoPath;
 }


### PR DESCRIPTION
## Problem

Sentry HOST-SERVICE-W (40 events on 1.20.1, regressed): when a project's main repo directory has been deleted or moved outside the app, `workspaceCreation.searchBranches` (and siblings) construct a simple-git instance on `localProject.repoPath` without checking the directory exists. simple-git's constructor throws its `GitConstructError` ("cannot use simple-git on a directory that does not exist"), which escapes as an INTERNAL_SERVER_ERROR 500 on every branch-search batch.

## Root cause

PR #6199 classified this family for the worktree-scoped `git.*` procedures via the shared `resolve-worktree.ts` boundary, but the workspace-creation procedures construct git directly on the project `repoPath` and were left out — so the issue regressed on the 1.20.1 release that ships #6199.

## Fix

Mirror #6199 at the workspace-creation layer: one shared guard, `requireProjectRepoPath()` in `shared/local-project.ts`, that checks `existsSync(repoPath)` before git construction and throws a typed `NOT_FOUND` TRPCError with cause `{ kind: "PROJECT_DIR_MISSING", repoPath }`. Applied at the three procedures that construct git on the project repo path:

- `searchBranches` (the failing frame)
- `listProjectWorktrees`
- `adopt` (guarded before `ensureMainWorkspace` so no workspace row is created for a missing directory)

Behavior is unchanged — the operation still fails when the directory is gone — only the classification changes from an unexpected 500 to a routine typed NOT_FOUND. Genuine unexpected git failures on these paths still surface as 500s.

## Verification

`bunx biome check` on the four changed files:

```
Checked 4 files in 11ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
```

(exited clean, no errors)

No existing tests cover the touched files, so no test run applied.

Refs HOST-SERVICE-W

https://claude.ai/code/session_fb644a69-16aa-40f3-974b-fe2757d6255c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies missing project repo directories as NOT_FOUND in workspace-creation git procedures to stop 500s from `simple-git` constructor errors. Aligns workspace-creation paths with the worktree handlers and reduces HOST-SERVICE-W noise. (Linear: HOST-SERVICE-W)

- **Bug Fixes**
  - Added `requireProjectRepoPath()` to check `existsSync(repoPath)` and throw a typed `TRPCError` with cause `{ kind: "PROJECT_DIR_MISSING", repoPath }`.
  - Applied to `searchBranches`, `listProjectWorktrees`, and `adopt` (before `ensureMainWorkspace`).
  - Behavior unchanged; only error classification changes from 500 to NOT_FOUND. Unexpected git errors still surface as 500s.

<sup>Written for commit 297bda5f7254ec2b90927a3dab36035b69890cf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or invalid local repository paths during workspace creation.
  - Users now receive a clear “not found” error instead of an unexpected filesystem error.
  - Repository operations, including branch search and worktree listing, now validate paths before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->