### PR TITLE
fix(host-service): classify missing chat credentials as PRECONDITION_FAILED instead of 500

### DIFF
--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -202,6 +202,15 @@ export interface ChatRuntimeManagerOptions {
 	runtimeResolver: ModelProviderRuntimeResolver;
 }
 
+// Expected user state (no provider signed in), not a server fault — the chat
+// router maps this by name to a non-500 TRPCError.
+export class NoModelProviderCredentialsError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "NoModelProviderCredentialsError";
+	}
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
@@ -447,7 +456,9 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		workspaceId: string,
 	): Promise<RuntimeSession> {
 		if (!(await this.runtimeResolver.hasUsableRuntimeEnv())) {
-			throw new Error("No model provider credentials available");
+			throw new NoModelProviderCredentialsError(
+				"No model provider credentials available",
+			);
 		}
 
 		const workspace = this.db.query.workspaces

--- a/packages/host-service/src/trpc/router/chat/chat.ts
+++ b/packages/host-service/src/trpc/router/chat/chat.ts
@@ -1,5 +1,30 @@
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { protectedProcedure, router } from "../../index";
+
+/**
+ * Missing model provider credentials is an expected user state (nothing signed
+ * in yet), not a server fault — map it to a typed non-500 at the boundary so
+ * it isn't reported to Sentry. Name-checked, not instanceof, per the error
+ * classification contract. Anything else rethrows and stays a reported 500.
+ */
+async function withRuntimeErrorMapping<T>(fn: () => Promise<T>): Promise<T> {
+	try {
+		return await fn();
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			error.name === "NoModelProviderCredentialsError"
+		) {
+			throw new TRPCError({
+				code: "PRECONDITION_FAILED",
+				message: error.message,
+				cause: { kind: "NO_MODEL_PROVIDER_CREDENTIALS" },
+			});
+		}
+		throw error;
+	}
+}
 
 const thinkingLevelSchema = z.enum(["off", "low", "medium", "high", "xhigh"]);
 
@@ -39,19 +64,23 @@ export const chatRouter = router({
 	getDisplayState: protectedProcedure
 		.input(sessionInput)
 		.query(({ ctx, input }) => {
-			return ctx.runtime.chat.getDisplayState(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.getDisplayState(input),
+			);
 		}),
 
 	listMessages: protectedProcedure
 		.input(sessionInput)
 		.query(({ ctx, input }) => {
-			return ctx.runtime.chat.listMessages(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.listMessages(input),
+			);
 		}),
 
 	getSnapshot: protectedProcedure
 		.input(sessionInput)
 		.query(({ ctx, input }) => {
-			return ctx.runtime.chat.getSnapshot(input);
+			return withRuntimeErrorMapping(() => ctx.runtime.chat.getSnapshot(input));
 		}),
 
 	sendMessage: protectedProcedure
@@ -62,7 +91,9 @@ export const chatRouter = router({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			const result = await ctx.runtime.chat.sendMessage(input);
+			const result = await withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.sendMessage(input),
+			);
 			// Fire-and-forget cloud lastActiveAt update so the session selector
 			// keeps reordering after activity. Failures here must not block the
 			// turn — the user already sees their message land via the snapshot.
@@ -88,11 +119,13 @@ export const chatRouter = router({
 			}),
 		)
 		.mutation(({ ctx, input }) => {
-			return ctx.runtime.chat.restartFromMessage(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.restartFromMessage(input),
+			);
 		}),
 
 	stop: protectedProcedure.input(sessionInput).mutation(({ ctx, input }) => {
-		return ctx.runtime.chat.stop(input);
+		return withRuntimeErrorMapping(() => ctx.runtime.chat.stop(input));
 	}),
 
 	respondToApproval: protectedProcedure
@@ -104,7 +137,9 @@ export const chatRouter = router({
 			}),
 		)
 		.mutation(({ ctx, input }) => {
-			return ctx.runtime.chat.respondToApproval(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.respondToApproval(input),
+			);
 		}),
 
 	respondToQuestion: protectedProcedure
@@ -117,7 +152,9 @@ export const chatRouter = router({
 			}),
 		)
 		.mutation(({ ctx, input }) => {
-			return ctx.runtime.chat.respondToQuestion(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.respondToQuestion(input),
+			);
 		}),
 
 	respondToPlan: protectedProcedure
@@ -133,7 +170,9 @@ export const chatRouter = router({
 			}),
 		)
 		.mutation(({ ctx, input }) => {
-			return ctx.runtime.chat.respondToPlan(input);
+			return withRuntimeErrorMapping(() =>
+				ctx.runtime.chat.respondToPlan(input),
+			);
 		}),
 
 	getSlashCommands: protectedProcedure


### PR DESCRIPTION
## Problem

Opening the chat pane without any model provider credentials configured reports an INTERNAL_SERVER_ERROR to Sentry — once per chat open for every credential-less user (HOST-SERVICE-11, 5 events on 1.20.0).

## Root cause

`ChatRuntimeManager.createRuntime` guards the expected no-credentials precondition by throwing a plain `Error("No model provider credentials available")`. Every chat router procedure that lazily creates a runtime (`chat.getSnapshot` in the events) surfaces it as an unclassified 500, which the Sentry middleware captures.

## Fix

Classification only — guard and message are unchanged:

- `runtime/chat/chat.ts`: the guard now throws a named `NoModelProviderCredentialsError` (name-checkable plain error class in the owning package).
- `trpc/router/chat/chat.ts`: one shared boundary helper (`withRuntimeErrorMapping`) name-checks it and maps to `TRPCError` `PRECONDITION_FAILED` with cause `{ kind: "NO_MODEL_PROVIDER_CREDENTIALS" }`, message preserved verbatim. All nine procedures that reach `getOrCreateRuntime` (getDisplayState, listMessages, getSnapshot, sendMessage, restartFromMessage, stop, respondToApproval, respondToQuestion, respondToPlan) go through it.

Genuine unexpected failures in `createRuntime` (workspace lookup, runtime boot) rethrow unchanged and keep reporting as 500s.

## Verification

`bunx biome check packages/host-service/src/runtime/chat/chat.ts packages/host-service/src/trpc/router/chat/chat.ts`:

```
Checked 2 files in 13ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
```

(clean exit, no diagnostics)

No existing tests cover the changed files, so no test run applied.

Refs HOST-SERVICE-11

https://claude.ai/code/session_26b85581-d9e3-4a25-9234-c1e277e606d1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies missing chat model provider credentials as PRECONDITION_FAILED (not 500) so expected user state doesn’t get reported to Sentry. Addresses HOST-SERVICE-11 by aligning errors with the issue’s requirement.

- **Bug Fixes**
  - Added `NoModelProviderCredentialsError` in the chat runtime and throw it when no provider credentials are available.
  - Introduced `withRuntimeErrorMapping` in the chat TRPC router to map the named error to `TRPCError` `PRECONDITION_FAILED` with cause `{ kind: "NO_MODEL_PROVIDER_CREDENTIALS" }` (message preserved). Uses `@trpc/server`.
  - Applied the mapping to all chat procedures that create a runtime.
  - Other runtime failures still bubble up as 500s and are reported.

<sup>Written for commit 87127ff383537a40889890e44f207382c1c2781d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when model provider credentials are missing or unusable.
  * Chat operations now return a clear, structured precondition error instead of a generic failure.
  * Other unexpected errors continue to be reported without alteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->