### PR TITLE
fix(web): guard MeshGradient against missing WebGL context

### DIFF
--- a/packages/ui/src/components/mesh-gradient.tsx
+++ b/packages/ui/src/components/mesh-gradient.tsx
@@ -26,6 +26,15 @@ interface GradientInstance {
 	};
 }
 
+function supportsWebgl(): boolean {
+	try {
+		const probe = document.createElement("canvas");
+		return Boolean(probe.getContext("webgl2") || probe.getContext("webgl"));
+	} catch {
+		return false;
+	}
+}
+
 export function MeshGradient({
 	colors,
 	className = "",
@@ -37,18 +46,11 @@ export function MeshGradient({
 
 	useEffect(() => {
 		const canvas = canvasRef.current;
-		if (!canvas) return;
+		if (!canvas || !supportsWebgl()) return;
 
 		const gradient = new Gradient() as GradientInstance;
-		gradient.initGradient(`#${canvasId}`);
 
-		setTimeout(() => {
-			if (gradient?.uniforms?.u_global?.value?.noiseSpeed) {
-				gradient.uniforms.u_global.value.noiseSpeed.value = speed;
-			}
-		}, 100);
-
-		return () => {
+		const teardown = () => {
 			if (gradient.pause) {
 				gradient.pause();
 			}
@@ -65,6 +67,23 @@ export function MeshGradient({
 				gradient.disconnect();
 			}
 		};
+
+		// Guard scoped to init only: the library dereferences a null WebGL
+		// context when creation fails despite the probe above.
+		try {
+			gradient.initGradient(`#${canvasId}`);
+		} catch {
+			teardown();
+			return;
+		}
+
+		setTimeout(() => {
+			if (gradient?.uniforms?.u_global?.value?.noiseSpeed) {
+				gradient.uniforms.u_global.value.noiseSpeed.value = speed;
+			}
+		}, 100);
+
+		return teardown;
 	}, [canvasId, speed]);
 
 	return (


### PR DESCRIPTION
## Problem

Unhandled TypeErrors from the shared `MeshGradient` component in two apps: `Cannot read properties of null (reading 'uniformMatrix4fv')` in the web app (/integrations, /agents) and `Argument 1 ('program') ... must be an instance of WebGLProgram` on the marketing homepage. Triggered on browsers that cannot provide a WebGL context (GPU blocklisted, headless, software rendering, or context-creation failure). The gradient is purely decorative; the page is otherwise fine.

## Root cause

`packages/ui/src/components/mesh-gradient.tsx` initializes `stripe-gradient` unconditionally in its mount effect. When `canvas.getContext("webgl"/"webgl2")` returns null, the library proceeds with the null context and dereferences it, throwing from library internals.

## Fix

Fix at the failure site in the shared component (no Sentry-side suppression):

- Feature-detect WebGL on a throwaway canvas (`webgl2 || webgl`) before constructing the gradient; bail out and leave the static background when unavailable.
- Wrap the `initGradient` call in a try/catch scoped to initialization only — on failure, run the existing teardown (pause + decoy-element disconnect) and bail. Errors after successful init are not swallowed.

Behaviour for users with working WebGL is unchanged.

## Verification

`bunx biome check packages/ui/src/components/mesh-gradient.tsx`:
```
Checked 1 file in 27ms. No fixes applied.
```

`cd packages/ui && bun run typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
exit=0
```

Refs WEB-1W
Refs MARKETING-3E

https://claude.ai/code/session_4d58b950-d21f-466c-ba7a-bb20bf855a26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the shared MeshGradient against missing WebGL to stop runtime errors and leave a static background when WebGL isn’t available. Prevents crashes on web app integrations/agents and the marketing homepage; addresses WEB-1W and MARKETING-3E.

- **Bug Fixes**
  - Detect WebGL via a probe canvas; skip gradient init when unsupported.
  - Wrap `initGradient` in try/catch; on failure, teardown (pause + disconnect) and exit. Behavior is unchanged when WebGL works.

<sup>Written for commit 7da800bcda8341d1b028c90b1fd8b36c6c964bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh gradient stability by checking WebGL support before initialization.
  * Added safer handling when gradient setup fails.
  * Ensured gradients are properly paused and disconnected during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->