### PR TITLE
fix(desktop): classify ETIMEDOUT filesystem errors as TIMEOUT instead of 500

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -16,6 +16,8 @@ const ERRNO_TO_TRPC: Record<FsErrnoCode, TRPCError["code"]> = {
 	EACCES: "FORBIDDEN",
 	EPERM: "FORBIDDEN",
 	ENOSPC: "PRECONDITION_FAILED",
+	// Network-backed/virtual filesystem mounts can time out syscalls
+	ETIMEDOUT: "TIMEOUT",
 };
 
 const PATH_ERROR_TO_TRPC: Record<

--- a/apps/desktop/src/shared/fs-error-types.ts
+++ b/apps/desktop/src/shared/fs-error-types.ts
@@ -9,7 +9,8 @@ export type FsErrnoCode =
 	| "ENOTDIR"
 	| "EACCES"
 	| "EPERM"
-	| "ENOSPC";
+	| "ENOSPC"
+	| "ETIMEDOUT";
 
 export interface FsErrnoCause {
 	kind: "FS_ERRNO";


### PR DESCRIPTION
## Problem

Seven Sentry issues (3+2+1+1+1+1+1 events, release 1.19.0) from a single user environment: `filesystem.listDirectory` fails with `ETIMEDOUT` errno errors (`scandir`/`lstat` timing out) and surfaces them as reported `INTERNAL_SERVER_ERROR` 500s. The user's repository lives on a network-backed/virtual filesystem mount where these syscalls can time out — an environmental failure, not an app bug.

## Root cause

The desktop filesystem router's `withFsErrorTranslation` maps known user-environment errnos to typed non-500 `TRPCError`s via `ERRNO_TO_TRPC`, but `ETIMEDOUT` was not in the map, so it fell through to the rethrow-and-report path.

All seven issues cross this same boundary: every event is tagged `trpc_path: filesystem.listDirectory`. The lstat-on-individual-file variants come from Node's `fs.readdir(..., { withFileTypes: true })`, which falls back to a per-entry `lstat` when the filesystem returns unknown dirent types (typical of virtual/network mounts) — still inside the same translated `listDirectory` call.

## Fix

Classification only (per the PR #6164 contract — no beforeSend filter, no Sentry-side suppression):

- Add `ETIMEDOUT` to `FsErrnoCode` in `apps/desktop/src/shared/fs-error-types.ts`
- Map it to `TIMEOUT` in `ERRNO_TO_TRPC` in `apps/desktop/src/lib/trpc/routers/filesystem/index.ts`

Error messages are preserved verbatim; unrecognized errnos still rethrow and stay reported 500s. Sibling errnos (`ENOTCONN`, `EIO`) were deliberately not added: `EIO` can indicate genuine disk/hardware failure that must keep reporting, and `ENOTCONN` has not been observed — no evidence to justify pre-classifying either.

## Verification

```
$ bunx biome check apps/desktop/src/shared/fs-error-types.ts apps/desktop/src/lib/trpc/routers/filesystem/index.ts
Checked 2 files in 13ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit
(exit 0)
```

No existing tests cover these files; none were touched.

Refs DESKTOP-NT
Refs DESKTOP-NN
Refs DESKTOP-NY
Refs DESKTOP-NS
Refs DESKTOP-NR
Refs DESKTOP-NQ
Refs DESKTOP-NP

https://claude.ai/code/session_48e2c6bd-dc88-43af-8756-7d63377c3318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies `ETIMEDOUT` filesystem errors as `TIMEOUT` in the Desktop filesystem TRPC router instead of 500. This prevents false `INTERNAL_SERVER_ERROR` reports for `filesystem.listDirectory` on network/virtual mounts and aligns with DESKTOP-NT, DESKTOP-NN, DESKTOP-NY, DESKTOP-NS, DESKTOP-NR, DESKTOP-NQ, DESKTOP-NP.

<sup>Written for commit e88e5627baba33c1d90149a2f737d91764d74d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of filesystem timeouts.
  * Network and virtual filesystem timeout errors now display as standard timeout errors instead of generic failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->