### PR TITLE
fix(host-service): bypass user git hooks for scaffolding initial commits

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -20,6 +20,8 @@ import { join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
 import {
 	cloneRepoInto,
+	cloneTemplateInto,
+	initEmptyRepo,
 	initLocalRepoInPlace,
 	resolveLocalRepo,
 } from "./resolve-repo";
@@ -303,6 +305,102 @@ describe("initLocalRepoInPlace", () => {
 		await expect(initLocalRepoInPlace(file)).rejects.toThrow(
 			/Path is not a directory/,
 		);
+	});
+});
+
+// ── scaffolding commits vs user git hooks ─────────────────────────
+
+describe("scaffolding commits bypass user git hooks", () => {
+	// Simulates a machine-wide `core.hooksPath` whose hooks reject every
+	// commit (e.g. a conventional-commit policy). Our own scaffolding
+	// commits in repos we just created must not be subject to them
+	// (HOST-SERVICE-13).
+	let savedGlobalConfig: string | undefined;
+	let hookedConfig: string;
+	let identityConfig: string;
+
+	beforeEach(() => {
+		const hooksDir = join(workRoot, "global-hooks");
+		mkdirSync(hooksDir);
+		for (const hook of ["pre-commit", "prepare-commit-msg", "commit-msg"]) {
+			// The stderr echo matters: simple-git only fails a raw task on
+			// non-zero exit when stderr is non-empty, and real policy hooks
+			// always print a rejection message.
+			writeFileSync(
+				join(hooksDir, hook),
+				`#!/bin/sh\necho "${hook}: rejected by policy" >&2\nexit 1\n`,
+				{ mode: 0o755 },
+			);
+		}
+		const identity =
+			"[user]\n\tname = test\n\temail = test@example.com\n[commit]\n\tgpgsign = false\n";
+		hookedConfig = join(workRoot, "gitconfig-hooked");
+		writeFileSync(
+			hookedConfig,
+			`[core]\n\thooksPath = ${hooksDir}\n${identity}`,
+		);
+		identityConfig = join(workRoot, "gitconfig-identity");
+		writeFileSync(identityConfig, identity);
+		savedGlobalConfig = process.env.GIT_CONFIG_GLOBAL;
+		process.env.GIT_CONFIG_GLOBAL = hookedConfig;
+	});
+
+	afterEach(() => {
+		if (savedGlobalConfig === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+		else process.env.GIT_CONFIG_GLOBAL = savedGlobalConfig;
+	});
+
+	test("fixture sanity: the rejecting hooks abort a plain commit", async () => {
+		const repo = join(workRoot, "hooked");
+		mkdirSync(repo);
+		const git = simpleGit(repo);
+		await git.init();
+
+		// simple-git's chain object is a thenable, not a Promise —
+		// `expect().rejects` won't unwrap it, so catch manually.
+		let rejected = false;
+		try {
+			await git.raw(["commit", "--allow-empty", "-m", "should be rejected"]);
+		} catch {
+			rejected = true;
+		}
+		expect(rejected).toBe(true);
+	});
+
+	test("initLocalRepoInPlace commits despite rejecting global hooks", async () => {
+		const dir = join(workRoot, "in-place");
+		mkdirSync(dir);
+
+		const resolved = await initLocalRepoInPlace(dir);
+
+		expect(eqRealpath(resolved.repoPath, dir)).toBe(true);
+	});
+
+	test("initEmptyRepo commits despite rejecting global hooks", async () => {
+		const resolved = await initEmptyRepo(workRoot, "fresh");
+
+		expect(eqRealpath(resolved.repoPath, join(workRoot, "fresh"))).toBe(true);
+	});
+
+	test("cloneTemplateInto snapshot commit despite rejecting global hooks", async () => {
+		const template = join(workRoot, "template");
+		mkdirSync(template);
+		writeFileSync(join(template, "README.md"), "template");
+		// Seed the template fixture without the rejecting hooks in effect —
+		// only the code under test may exercise the bypass path.
+		process.env.GIT_CONFIG_GLOBAL = identityConfig;
+		const templateGit = simpleGit(template);
+		await templateGit.init();
+		await templateGit.add(".");
+		await templateGit.raw(["commit", "-m", "seed"]);
+		process.env.GIT_CONFIG_GLOBAL = hookedConfig;
+
+		const resolved = await cloneTemplateInto(template, workRoot, "from-tpl");
+
+		expect(eqRealpath(resolved.repoPath, join(workRoot, "from-tpl"))).toBe(
+			true,
+		);
+		expect(existsSync(join(workRoot, "from-tpl", "README.md"))).toBe(true);
 	});
 });
 

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -142,6 +142,15 @@ function asInitialCommitTrpcError(err: unknown): TRPCError {
 	});
 }
 
+/**
+ * Scaffolding commits are authored by us in repos we just created — the
+ * user's global git hooks (e.g. a `core.hooksPath` commit-msg policy) must
+ * not be able to reject them. `--no-verify` skips pre-commit/commit-msg;
+ * the empty `core.hooksPath` override covers the rest (a failing
+ * prepare-commit-msg still aborts a `--no-verify` commit).
+ */
+const scaffoldCommitArgs = ["-c", "core.hooksPath=", "commit", "--no-verify"];
+
 /** `git init --initial-branch=main` with a fallback for older git versions. */
 async function gitInitMainBranch(targetPath: string): Promise<void> {
 	const git = createUserSimpleGit(targetPath);
@@ -225,7 +234,7 @@ export async function initLocalRepoInPlace(
 	await gitInitMainBranch(repoPath);
 	try {
 		await createUserSimpleGit(repoPath).raw([
-			"commit",
+			...scaffoldCommitArgs,
 			"--allow-empty",
 			"-m",
 			"Initial commit",
@@ -301,7 +310,7 @@ export async function initEmptyRepo(
 		await gitInitMainBranch(targetPath);
 		try {
 			await createUserSimpleGit(targetPath).raw([
-				"commit",
+				...scaffoldCommitArgs,
 				"--allow-empty",
 				"-m",
 				"Initial commit",
@@ -353,7 +362,7 @@ export async function cloneTemplateInto(
 		const git = createUserSimpleGit(targetPath);
 		await git.add(".");
 		try {
-			await git.raw(["commit", "-m", "Initial commit"]);
+			await git.raw([...scaffoldCommitArgs, "-m", "Initial commit"]);
 		} catch (err) {
 			throw asInitialCommitTrpcError(err);
 		}


### PR DESCRIPTION
## Problem

Creating a session (`workspaces.createSession` → `initEmptyRepo`) initializes a fresh repo under the sessions root and makes a scaffolding "Initial commit". If the user has global git hooks configured (e.g. a `core.hooksPath` commit-msg hook enforcing a commit-message policy), the hook runs against our scaffolding commit and rejects it — session creation deterministically fails as INTERNAL_SERVER_ERROR for any user with such a hook (2 events on 1.20.0).

## Root cause

The scaffolding "Initial commit" invocations in `resolve-repo.ts` (`initEmptyRepo`, `initLocalRepoInPlace`, `cloneTemplateInto`) run plain `git commit`, so the user's machine-wide hooks apply to commits we author in repos we just created. `asInitialCommitTrpcError` types git-user-not-configured but a hook rejection falls through to a 500.

## Fix

Run all three scaffolding commits with hooks bypassed: `-c core.hooksPath= commit --no-verify`. Both parts are needed — `--no-verify` skips pre-commit/commit-msg, and the empty `core.hooksPath` override covers hooks `--no-verify` doesn't (verified empirically: a failing `prepare-commit-msg` still aborts a `--no-verify` commit). `createUserSimpleGit` already enables `allowUnsafeHooksPath`, so simple-git permits the override.

Decision on the `cloneTemplateInto` snapshot path (commits the user's template files into a repo we just initialized): bypass there too. The user does not author that commit invocation either, and a rejecting global hook fails template creation identically — same failure mode, same fix.

`asInitialCommitTrpcError` classification is kept unchanged for what can still fail (git identity not configured, disk errors). No hook-rejection classification was added since the bypass covers every scaffolding path — there is no remaining path where a hook can reject these commits.

Precedent: #6168 (hook tolerance in workspace setup).

Also fixed a latent test-fixture hazard found along the way: simple-git only fails a raw task on non-zero exit when stderr is non-empty, so the regression tests' rejecting hooks print to stderr like real policy hooks do (a silent `exit 1` hook is swallowed by simple-git — noted in the test comment).

## Verification

`bunx biome check` on both changed files:
```
Checked 2 files in 14ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
(clean exit)
```

`bun test packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts`:
```
 34 pass
 0 fail
 65 expect() calls
Ran 34 tests across 1 file. [7.00s]
```

Mutation check — with the bypass reverted to plain `git commit`, the three new regression tests fail; restored, all 34 pass:
```
(fail) scaffolding commits bypass user git hooks > initLocalRepoInPlace commits despite rejecting global hooks
(fail) scaffolding commits bypass user git hooks > initEmptyRepo commits despite rejecting global hooks
(fail) scaffolding commits bypass user git hooks > cloneTemplateInto snapshot commit despite rejecting global hooks
 31 pass / 3 fail
```

Refs HOST-SERVICE-13

https://claude.ai/code/session_1a228bdc-29c4-4d4e-8e63-7bb4acf54aaf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass user git hooks for scaffolding “Initial commit” during session repo setup to prevent 500s when global hooks reject commits. Aligns with HOST-SERVICE-13 by ensuring session creation doesn’t depend on user git hook policies.

- **Bug Fixes**
  - Run scaffolding commits with `-c core.hooksPath=` and `--no-verify` in `initEmptyRepo`, `initLocalRepoInPlace`, and `cloneTemplateInto`.
  - Keep existing error mapping; hooks can no longer block these commits.
  - Add regression tests that simulate rejecting global hooks and ensure `simple-git` surfaces failures via stderr.

<sup>Written for commit 355a72f43667386f4636d3596a3365a93cffd7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository scaffolding now succeeds even when global Git hooks would otherwise reject initial commits.
  * Standard user commits continue to respect and enforce configured Git hooks.
  * Applied consistent hook handling when creating repositories in place, initializing empty repositories, or cloning templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->