### PR TITLE
fix(host-service): heal orphaned terminal refs and baseline the post-migration FK check

### DIFF
--- a/packages/host-service/drizzle/0021_heal_orphaned_terminal_session_workspace_refs.sql
+++ b/packages/host-service/drizzle/0021_heal_orphaned_terminal_session_workspace_refs.sql
@@ -1,0 +1,9 @@
+-- Heal legacy orphaned terminal_sessions.origin_workspace_id references.
+-- Long-lived host DBs accumulated rows pointing at workspaces deleted while
+-- FK enforcement was not in effect on the deleting connection. The FK is
+-- ON DELETE SET NULL, so apply the action enforcement would have taken.
+-- Without this, the post-migration foreign_key_check in createDb fails and
+-- the host service crash-loops on startup (canary 2026-08-10 incident).
+UPDATE `terminal_sessions` SET `origin_workspace_id` = NULL
+WHERE `origin_workspace_id` IS NOT NULL
+  AND `origin_workspace_id` NOT IN (SELECT `id` FROM `workspaces`);

--- a/packages/host-service/drizzle/meta/0021_snapshot.json
+++ b/packages/host-service/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1025 @@
+{
+  "id": "bc4a7872-de9c-4ac9-868d-17fd449b9f67",
+  "prevId": "a59bfd1c-4dd6-44ae-a9f5-e7220c85d2a8",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "acp_sessions": {
+      "name": "acp_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stop_reason": {
+          "name": "last_stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "acp_sessions_workspace_id_idx": {
+          "name": "acp_sessions_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "tableTo": "terminal_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_cloud_deletes": {
+      "name": "workspace_cloud_deletes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_synced_at": {
+          "name": "cloud_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "where": "type = 'main'",
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "tableTo": "pull_requests",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "tableTo": "pull_requests",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1786297592534,
       "tag": "0020_overrated_dreaming_celestial",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1786380983362,
+      "tag": "0021_heal_orphaned_terminal_session_workspace_refs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/db.ts
+++ b/packages/host-service/src/db/db.ts
@@ -7,6 +7,28 @@ import * as schema from "./schema.ts";
 
 export type HostDb = ReturnType<typeof createDb>;
 
+/**
+ * `foreign_key_check` rows keyed by `child table → parent table → fk index`,
+ * with per-constraint row counts. Rowids are deliberately excluded: a drizzle
+ * table rebuild reassigns them, so rowid-level comparison would misread a
+ * surviving pre-existing violation as a new one.
+ */
+function violationCountsByConstraint(
+	sqlite: InstanceType<typeof Database>,
+): Map<string, number> {
+	const rows = sqlite.pragma("foreign_key_check") as {
+		table: string;
+		parent: string;
+		fkid: number;
+	}[];
+	const counts = new Map<string, number>();
+	for (const row of rows) {
+		const key = `${row.table}→${row.parent}#${row.fkid}`;
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return counts;
+}
+
 export function createDb(dbPath: string, migrationsFolder: string) {
 	mkdirSync(dirname(dbPath), { recursive: true });
 
@@ -29,12 +51,25 @@ export function createDb(dbPath: string, migrationsFolder: string) {
 	// generated SQL behave as written; foreign_key_check then catches any
 	// violation a migration actually introduced.
 	sqlite.pragma("foreign_keys = OFF");
+	// Snapshot violations before migrating: long-lived DBs can carry legacy
+	// orphans (e.g. rows written/deleted by connections that never enabled
+	// enforcement). Failing startup on those bricks a DB that worked on the
+	// previous version — only violations a migration introduces are fatal.
+	const before = violationCountsByConstraint(sqlite);
 	// Let a failed migration throw — never serve a half-migrated DB.
 	migrate(db, { migrationsFolder });
-	const violations = sqlite.pragma("foreign_key_check") as unknown[];
-	if (violations.length > 0) {
+	const after = violationCountsByConstraint(sqlite);
+	const introduced = [...after.entries()].filter(
+		([constraint, count]) => count > (before.get(constraint) ?? 0),
+	);
+	if (introduced.length > 0) {
 		throw new Error(
-			`[host-service:db] Migration at ${dbPath} left ${violations.length} foreign key violation(s): ${JSON.stringify(violations.slice(0, 5))}`,
+			`[host-service:db] Migration at ${dbPath} introduced foreign key violation(s): ${JSON.stringify(introduced)}`,
+		);
+	}
+	if (after.size > 0) {
+		console.error(
+			`[host-service:db] Pre-existing foreign key violation(s) survive at ${dbPath} (not introduced by migration, serving anyway): ${JSON.stringify([...after.entries()])}`,
 		);
 	}
 	sqlite.pragma("foreign_keys = ON");

--- a/packages/host-service/test/migration-0021-heals-orphaned-terminal-refs.test.ts
+++ b/packages/host-service/test/migration-0021-heals-orphaned-terminal-refs.test.ts
@@ -1,0 +1,115 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	cpSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import * as schema from "../src/db/schema";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "drizzle");
+
+/**
+ * Long-lived host DBs carry terminal_sessions rows whose
+ * origin_workspace_id points at workspaces deleted while FK enforcement was
+ * not in effect on the deleting connection. The post-migration
+ * foreign_key_check in createDb made those legacy orphans fatal, crash-looping
+ * the host service on upgrade (canary 2026-08-10). Migration 0021 heals them
+ * by applying the FK's own ON DELETE SET NULL action retroactively.
+ *
+ * createDb uses better-sqlite3, which Bun can't load, so this reproduces the
+ * identical drizzle-migrator semantics on bun:sqlite (same approach as the
+ * 0019 test).
+ */
+describe("migration 0021 upgrade", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function seedPre0021DbWithOrphan(): { dbPath: string } {
+		const dir = mkdtempSync(join(tmpdir(), "host-migration-0021-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "host.db");
+
+		// A migrations folder truncated to 0020 — the pre-heal schema.
+		const isPre0021 = (tag: string) => Number(tag.slice(0, 4)) < 21;
+		const oldMigrations = join(dir, "drizzle-pre-0021");
+		cpSync(MIGRATIONS_DIR, oldMigrations, { recursive: true });
+		const journalPath = join(oldMigrations, "meta", "_journal.json");
+		const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+			entries: Array<{ tag: string }>;
+		};
+		const removed = journal.entries.filter((entry) => !isPre0021(entry.tag));
+		expect(removed.length).toBeGreaterThanOrEqual(1);
+		journal.entries = journal.entries.filter((entry) => isPre0021(entry.tag));
+		writeFileSync(journalPath, JSON.stringify(journal));
+		for (const file of readdirSync(oldMigrations)) {
+			if (/^\d{4}/.test(file) && !isPre0021(file)) {
+				unlinkSync(join(oldMigrations, file));
+			}
+		}
+
+		const sqlite = new BunDatabase(dbPath, { create: true, readwrite: true });
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: oldMigrations });
+		sqlite.exec(
+			"insert into projects (id, repo_path, created_at) values ('p1', '/tmp/repo', 0)",
+		);
+		sqlite.exec(
+			"insert into workspaces (id, project_id, worktree_path, branch, created_at) values ('w1', 'p1', '/tmp/repo/wt', 'main', 0)",
+		);
+		sqlite.exec(
+			"insert into terminal_sessions (id, origin_workspace_id, created_at) values ('t-linked', 'w1', 0)",
+		);
+		// The legacy corruption: a session whose workspace is long gone.
+		// Enforcement is off on this connection, mirroring how the orphans
+		// were written in the wild.
+		sqlite.exec("PRAGMA foreign_keys = OFF");
+		sqlite.exec(
+			"insert into terminal_sessions (id, origin_workspace_id, created_at) values ('t-orphan', 'w-deleted-long-ago', 0)",
+		);
+		sqlite.close();
+		return { dbPath };
+	}
+
+	test("heals legacy orphans so the post-migration foreign_key_check passes", () => {
+		const { dbPath } = seedPre0021DbWithOrphan();
+
+		const sqlite = new BunDatabase(dbPath, { create: false, readwrite: true });
+		sqlite.exec("PRAGMA foreign_keys = OFF");
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: MIGRATIONS_DIR });
+		const violations = sqlite
+			.query("PRAGMA foreign_key_check")
+			.all() as unknown[];
+		sqlite.exec("PRAGMA foreign_keys = ON");
+
+		expect(violations).toEqual([]);
+		const orphan = sqlite
+			.query(
+				"select origin_workspace_id from terminal_sessions where id = 't-orphan'",
+			)
+			.get() as { origin_workspace_id: string | null } | null;
+		const linked = sqlite
+			.query(
+				"select origin_workspace_id from terminal_sessions where id = 't-linked'",
+			)
+			.get() as { origin_workspace_id: string | null } | null;
+		sqlite.close();
+
+		// The orphan gets the FK's ON DELETE SET NULL action retroactively;
+		// live links are untouched.
+		expect(orphan?.origin_workspace_id).toBeNull();
+		expect(linked?.origin_workspace_id).toBe("w1");
+	});
+});


### PR DESCRIPTION
## Problem

The 2026-08-10 canary bricks the host service for users with long-lived host DBs. #6274 added a fatal `PRAGMA foreign_key_check` after migrations in `createDb`, but the check has no baseline — it fails on **pre-existing** violations too, not just ones a migration introduced. My org's `host.db` had 75 dangling `terminal_sessions.origin_workspace_id` refs dating to April–May (workspaces deleted by a connection without FK enforcement), so the service exited 1 on every spawn until the coordinator gave up after 8 attempts: "The Superset host service stopped unexpectedly and could not be restarted automatically."

Slack report: https://superset-sh.slack.com/archives/C09QCU3M612/p1786380808759459

## Fix

1. **Migration 0021** (`drizzle-kit generate --custom`): retroactively applies the FK's own `ON DELETE SET NULL` action to orphaned `origin_workspace_id` refs. (Dropping the column instead is not an option — the reaper treats `origin_workspace_id IS NULL` as kill-eligible, notifications key lifecycle events on it, and port-scan attribution maps terminals to workspaces through it.)
2. **Baseline the check**: `createDb` snapshots `foreign_key_check` before migrating and only throws when a constraint's violation count *grows*. Counts are compared per constraint (child table → parent table → fk index), not per rowid, because table rebuilds reassign rowids. Surviving pre-existing violations are logged and non-fatal — a DB that served fine yesterday shouldn't refuse to boot today.

## Verification

- New regression test seeds a pre-0021 DB with an orphaned ref (FKs off, mirroring how the corruption happened in the wild), runs the full migration chain with the db.ts FK-off discipline, and asserts the orphan is nulled, live links survive, and `foreign_key_check` is clean. Existing 0019 preserves-terminal-links test still passes.
- Replayed the migration chain against a copy of my actual bricked DB: 75 violations before → 0 after, valid links untouched.
- `tsc --noEmit` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hCEGgTMxthwHnTAkbZdFp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `host-service` startup crash loops by healing orphaned terminal-to-workspace references and making the FK check only fail on new violations. Long‑lived host DBs now boot cleanly while preserving valid links.

- Bug Fixes
  - Added migration 0021: set `terminal_sessions.origin_workspace_id` to NULL when the workspace no longer exists (retroactive ON DELETE SET NULL).
  - Updated `createDb` FK check: snapshot `PRAGMA foreign_key_check` before migrations and only fail if a constraint’s violation count increases; log pre-existing violations.
  - Added regression test to verify orphans are healed and live links remain intact.

<sup>Written for commit 8b91d2f0aa9d96652e3658ac7c29ffc79b6bc3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

