### PR TITLE
chore(desktop): bump version to 1.20.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.20.1",
+	"version": "1.20.2",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -114,7 +114,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@ai-sdk/anthropic": "3.0.64",
@@ -277,7 +277,7 @@
         "lucide-react": "0.563.0",
         "mastracode": "0.18.1",
         "mdast-util-to-string": "4.0.0",
-        "nanoid": "5.1.7",
+        "nanoid": "6.0.0",
         "native-keymap": "3.3.9",
         "node-addon-api": "7.1.1",
         "node-pty": "1.2.0-beta.14",
@@ -814,7 +814,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -909,7 +909,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",
@@ -1178,7 +1178,7 @@
         "input-otp": "1.4.2",
         "lucide-react": "0.563.0",
         "motion": "12.38.0",
-        "nanoid": "5.1.7",
+        "nanoid": "6.0.0",
         "next-themes": "0.4.6",
         "radix-ui": "1.4.3",
         "react-day-picker": "9.14.0",
@@ -5313,7 +5313,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "nanostores": ["nanostores@1.4.2", "", {}, "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.20.1",
+	"version": "1.20.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.20.1",
+	"version": "1.20.2",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@superset/desktop`, `@superset/cli`, and `@superset/host-service` to 1.20.2 for the 1.20.2 draft release. Syncs workspace versions and updates the lockfile.

- **Dependencies**
  - Lockfile updates, including `nanoid` from 5.1.7 to 6.0.0.

<sup>Written for commit 85efee49c202e18a79edd68bf2a6a8a7843a268a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop application, CLI, and host service to version 1.20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->