### PR TITLE
fix(deps): sync bun.lock with the nanoid 6.0.0 bump from #6104

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -277,7 +277,7 @@
         "lucide-react": "0.563.0",
         "mastracode": "0.18.1",
         "mdast-util-to-string": "4.0.0",
-        "nanoid": "5.1.7",
+        "nanoid": "6.0.0",
         "native-keymap": "3.3.9",
         "node-addon-api": "7.1.1",
         "node-pty": "1.2.0-beta.14",
@@ -1178,7 +1178,7 @@
         "input-otp": "1.4.2",
         "lucide-react": "0.563.0",
         "motion": "12.38.0",
-        "nanoid": "5.1.7",
+        "nanoid": "6.0.0",
         "next-themes": "0.4.6",
         "radix-ui": "1.4.3",
         "react-day-picker": "9.14.0",
@@ -5313,7 +5313,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "nanostores": ["nanostores@1.4.2", "", {}, "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g=="],
 


### PR DESCRIPTION
## Summary
- Dependabot alerts #274 and #275 flagged `nanoid` for [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) (non-secure generators can loop indefinitely with negative size), patched at 5.1.16/3.3.16.
- #6104 bumped `nanoid` to `6.0.0` in `apps/desktop/package.json` and `packages/ui/package.json`, but never regenerated `bun.lock` — Dependabot doesn't update Bun lockfiles. `bun.lock` was still resolving `nanoid` to the vulnerable `5.1.7`.
- This left `main` broken: `bun install --frozen-lockfile` (used by every job in `.github/workflows/*.yml` via `--frozen`) fails with `error: lockfile had changes, but lockfile is frozen` against the current lockfile. Confirmed nanoid@6.0.0 had never actually been installed in this repo until now.
- This PR regenerates `bun.lock` so it matches the already-committed `package.json` pin (3-line diff, `nanoid` only).

## Test plan
- [x] `bun install --frozen-lockfile --dry-run` passes against the updated lockfile (previously failed against main's committed lockfile)
- [x] `turbo typecheck --filter=@superset/desktop --filter=@superset/ui` passes with nanoid 6.0.0 actually installed
- [x] `bun run lint` passes clean
- [x] `turbo test --filter=@superset/desktop --filter=@superset/ui` — 2665 tests pass
- [ ] CI green on this PR (in particular `bun install --frozen --ignore-scripts` steps)

https://claude.ai/code/session_01JpN8KotJPBgXAQN3GKMLuh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced `bun.lock` to resolve `nanoid@6.0.0` as already pinned, replacing the vulnerable `5.1.7`. This unblocks CI by fixing `bun install --frozen-lockfile` and addresses GHSA-28wg-ghj8-5hjv.

<sup>Written for commit c7724c72c9adb98254fb3cca9e662d284bd9a14a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

