### PR TITLE
feat(desktop): add configurable file tree hiding

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -55,6 +55,11 @@ import {
 	MAX_TERMINAL_PARKED_RUNTIME_CAP,
 	MIN_TERMINAL_PARKED_RUNTIME_CAP,
 } from "shared/constants";
+import {
+	DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+	MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH,
+	MAX_FILE_TREE_HIDDEN_PATTERNS,
+} from "shared/file-tree-patterns";
 import { normalizePresetProjectIds } from "shared/preset-project-targeting";
 import {
 	CUSTOM_RINGTONE_ID,
@@ -949,6 +954,36 @@ export const createSettingsRouter = () => {
 					.onConflictDoUpdate({
 						target: settings.id,
 						set,
+					})
+					.run();
+
+				return { success: true };
+			}),
+
+		getFileTreeHiddenPatterns: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.fileTreeHiddenPatterns ?? DEFAULT_FILE_TREE_HIDDEN_PATTERNS;
+		}),
+
+		setFileTreeHiddenPatterns: publicProcedure
+			.input(
+				z.object({
+					patterns: z
+						.array(z.string().max(MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH))
+						.max(MAX_FILE_TREE_HIDDEN_PATTERNS),
+				}),
+			)
+			.mutation(({ input }) => {
+				const patterns = input.patterns
+					.map((pattern) => pattern.trim())
+					.filter((pattern) => pattern.length > 0);
+
+				localDb
+					.insert(settings)
+					.values({ id: 1, fileTreeHiddenPatterns: patterns })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { fileTreeHiddenPatterns: patterns },
 					})
 					.run();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -282,17 +282,19 @@ export function FilesTab({
 		Boolean(rootPath),
 	);
 
-	if (!rootPath) {
+	if (workspaceQuery.isLoading || hiddenPatternsQuery.isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-				{workspaceQuery.isLoading ? (
-					<>
-						<Loader2 className="size-3.5 animate-spin" />
-						<span>Loading files...</span>
-					</>
-				) : (
-					"Workspace worktree not available"
-				)}
+				<Loader2 className="size-3.5 animate-spin" />
+				<span>Loading files...</span>
+			</div>
+		);
+	}
+
+	if (!rootPath) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				Workspace worktree not available
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -28,12 +28,14 @@ import {
 	usePierreRowClickPolicy,
 	useSidebarFilePolicy,
 } from "renderer/lib/clickPolicy";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useFallthroughIcons } from "renderer/lib/fileIcons";
 import {
 	createPierreTreeStyle,
 	PIERRE_TREE_UNSAFE_CSS,
 } from "renderer/lib/pierreTree";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
+import { DEFAULT_FILE_TREE_HIDDEN_PATTERNS } from "shared/file-tree-patterns";
 import { PierreRowContextMenu } from "../PierreRowContextMenu";
 import { FileMenuItems } from "./components/FileMenuItems";
 import { FilesTabDropOverlay } from "./components/FilesTabDropOverlay";
@@ -146,7 +148,17 @@ export function FilesTab({
 		renderRowDecoration: (ctx) => handlersRef.current.renderRowDecoration(ctx),
 	});
 
-	const bridge = useFilesTabBridge({ model, workspaceId, rootPath });
+	const hiddenPatternsQuery =
+		electronTrpc.settings.getFileTreeHiddenPatterns.useQuery();
+	const hiddenPatterns =
+		hiddenPatternsQuery.data ?? DEFAULT_FILE_TREE_HIDDEN_PATTERNS;
+
+	const bridge = useFilesTabBridge({
+		model,
+		workspaceId,
+		rootPath,
+		hiddenPatterns,
+	});
 	const { reveal, startCreating, handleRename, handleDelete, collapseAll } =
 		useFilesTabActions({
 			model,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -156,7 +156,7 @@ export function FilesTab({
 	const bridge = useFilesTabBridge({
 		model,
 		workspaceId,
-		rootPath,
+		rootPath: hiddenPatternsQuery.isLoading ? "" : rootPath,
 		hiddenPatterns,
 	});
 	const { reveal, startCreating, handleRename, handleDelete, collapseAll } =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -1,8 +1,9 @@
 import type { FileTree } from "@pierre/trees";
 import { workspaceTrpc } from "@superset/workspace-client";
 import type { FsWatchEvent } from "@superset/workspace-fs/client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import { createFileTreeHiddenMatcher } from "shared/file-tree-patterns";
 import {
 	asDirectoryHandle,
 	stripTrailingSlash,
@@ -14,6 +15,7 @@ interface UseFilesTabBridgeOptions {
 	model: FileTree;
 	workspaceId: string;
 	rootPath: string;
+	hiddenPatterns: string[];
 }
 
 export interface FilesTabBridge {
@@ -71,9 +73,26 @@ export function useFilesTabBridge({
 	model,
 	workspaceId,
 	rootPath,
+	hiddenPatterns,
 }: UseFilesTabBridgeOptions): FilesTabBridge {
 	const utils = workspaceTrpc.useUtils();
 	const [isRefreshing, setIsRefreshing] = useState(false);
+
+	// Editing the pattern list changes `fetchDir`'s identity, which re-runs the
+	// reset effect below and reloads the tree through the new filter.
+	const matcher = useMemo(
+		() => createFileTreeHiddenMatcher(hiddenPatterns),
+		[hiddenPatterns],
+	);
+	const isHidden = useCallback(
+		(rel: string, isDirectory: boolean) =>
+			matcher({
+				name: rel.split("/").pop() ?? "",
+				relativePath: rel,
+				isDirectory,
+			}),
+		[matcher],
+	);
 
 	// Sets/Maps are mutated in place (clear() on reset, never reassigned) so
 	// consumers can read `bridge.knownPaths` once and trust the reference
@@ -115,6 +134,7 @@ export function useFilesTabBridge({
 					const ops: { type: "add"; path: string }[] = [];
 					for (const entry of result.entries) {
 						const rel = toRel(rootPath, entry.absolutePath);
+						if (isHidden(rel, entry.kind === "directory")) continue;
 						const treePath = entry.kind === "directory" ? `${rel}/` : rel;
 						if (knownPathsRef.current.has(treePath)) continue;
 						knownPathsRef.current.add(treePath);
@@ -150,7 +170,7 @@ export function useFilesTabBridge({
 			});
 			return promise;
 		},
-		[model, rootPath, workspaceId, utils.filesystem.listDirectory],
+		[isHidden, model, rootPath, workspaceId, utils.filesystem.listDirectory],
 	);
 
 	const doRefresh = useCallback(async (): Promise<void> => {
@@ -175,6 +195,7 @@ export function useFilesTabBridge({
 					if (versionRef.current !== startVersion) return;
 					for (const entry of result.entries) {
 						const rel = toRel(rootPath, entry.absolutePath);
+						if (isHidden(rel, entry.kind === "directory")) continue;
 						freshPaths.add(entry.kind === "directory" ? `${rel}/` : rel);
 					}
 					loadedDirsRef.current.add(dir);
@@ -201,7 +222,7 @@ export function useFilesTabBridge({
 		} finally {
 			setIsRefreshing(false);
 		}
-	}, [model, rootPath, workspaceId, utils.filesystem.listDirectory]);
+	}, [isHidden, model, rootPath, workspaceId, utils.filesystem.listDirectory]);
 
 	// Reset + initial load on workspace switch. Bumping versionRef invalidates
 	// any in-flight fetches from the previous workspace.
@@ -292,6 +313,21 @@ export function useFilesTabBridge({
 				const oldKey = matchKnown(knownPathsRef.current, oldRel);
 				const isFolder = event.isDirectory ?? oldKey?.endsWith("/") ?? false;
 				const newKey = isFolder ? `${rel}/` : rel;
+
+				// Renamed into a hidden pattern: drop it rather than move it.
+				if (isHidden(rel, isFolder)) {
+					if (oldKey) {
+						removeKnownPath(model, knownPathsRef.current, oldKey);
+						if (isFolder) {
+							purgeDescendants(
+								knownPathsRef.current,
+								loadedDirsRef.current,
+								stripTrailingSlash(oldKey),
+							);
+						}
+					}
+					return;
+				}
 				if (oldKey && knownPathsRef.current.has(oldKey)) {
 					try {
 						model.move(oldKey, newKey);
@@ -351,6 +387,7 @@ export function useFilesTabBridge({
 
 			if (event.kind === "create") {
 				const isFolder = event.isDirectory ?? false;
+				if (isHidden(rel, isFolder)) return;
 				const key = isFolder ? `${rel}/` : rel;
 				addKnownPath(model, knownPathsRef.current, key);
 				if (isFolder && !loadedDirsRef.current.has(rel)) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -86,11 +86,7 @@ export function useFilesTabBridge({
 	);
 	const isHidden = useCallback(
 		(rel: string, isDirectory: boolean) =>
-			matcher({
-				name: rel.split("/").pop() ?? "",
-				relativePath: rel,
-				isDirectory,
-			}),
+			matcher({ relativePath: rel, isDirectory }),
 		[matcher],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
@@ -4,6 +4,7 @@ import {
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { FileTreeHiddenSection } from "./components/FileTreeHiddenSection";
 import { FontSettingSection } from "./components/FontSettingSection";
 import { MarkdownStyleSection } from "./components/MarkdownStyleSection";
 import { ThemeSection } from "./components/ThemeSection";
@@ -49,6 +50,10 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 		SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES,
 		visibleItems,
 	);
+	const showFileTreeHidden = isItemVisible(
+		SETTING_ITEM_ID.APPEARANCE_FILE_TREE_HIDDEN,
+		visibleItems,
+	);
 	const showThemeSection = showTheme || showCustomThemes;
 
 	return (
@@ -63,6 +68,7 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 			<SectionList>
 				{showThemeSection && <ThemeSection key="theme" />}
 				{showMarkdown && <MarkdownStyleSection key="markdown" />}
+				{showFileTreeHidden && <FileTreeHiddenSection key="file-tree-hidden" />}
 				{(showEditorFont || showTerminalFont) && (
 					<FontSettingSection
 						key="typography"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
 import { RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -32,6 +33,7 @@ export function FileTreeHiddenSection() {
 			onSuccess: () => {
 				void utils.settings.getFileTreeHiddenPatterns.invalidate();
 			},
+			onError: (error) => toast.error(error.message),
 		});
 
 	const [draft, setDraft] = useState<string | null>(null);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
@@ -27,8 +27,11 @@ function toPatterns(text: string): string[] {
 export function FileTreeHiddenSection() {
 	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
-	const { data, isLoading } =
+	const { data, isError, refetch } =
 		electronTrpc.settings.getFileTreeHiddenPatterns.useQuery();
+	// Never edit against an unknown list: saving an empty fallback would wipe
+	// the stored patterns.
+	const isUnavailable = isError || data === undefined;
 	const setPatterns =
 		electronTrpc.settings.setFileTreeHiddenPatterns.useMutation({
 			onSuccess: () => {
@@ -49,7 +52,7 @@ export function FileTreeHiddenSection() {
 	const isDirty = draft !== null && draft !== persisted;
 
 	const commit = () => {
-		if (draft === null) return;
+		if (draft === null || isUnavailable) return;
 		const patterns = toPatterns(draft);
 		if (
 			patterns.some(
@@ -81,16 +84,30 @@ export function FileTreeHiddenSection() {
 				aria-label="Hidden file patterns"
 				className="font-mono text-xs min-h-32"
 				spellCheck={false}
-				disabled={isLoading || setPatterns.isPending}
+				disabled={isUnavailable || setPatterns.isPending}
 				value={value}
 				onChange={(event) => setDraft(event.target.value)}
 			/>
+
+			{isError && (
+				<div className="mt-2 flex items-center gap-2 text-xs text-destructive">
+					<span>Could not load hidden file patterns.</span>
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-7 text-xs"
+						onClick={() => void refetch()}
+					>
+						Retry
+					</Button>
+				</div>
+			)}
 
 			<div className="mt-2 flex items-center gap-2">
 				<Button
 					size="sm"
 					onClick={commit}
-					disabled={!isDirty || isLoading || setPatterns.isPending}
+					disabled={!isDirty || isUnavailable || setPatterns.isPending}
 				>
 					Save patterns
 				</Button>
@@ -98,7 +115,7 @@ export function FileTreeHiddenSection() {
 					variant="ghost"
 					size="sm"
 					className="gap-1.5 text-xs text-muted-foreground"
-					disabled={isLoading || setPatterns.isPending}
+					disabled={isUnavailable || setPatterns.isPending}
 					onClick={() => {
 						setDraft(null);
 						setPatterns.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@superset/ui/button";
+import { Textarea } from "@superset/ui/textarea";
+import { RotateCcw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import {
+	DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+	MAX_FILE_TREE_HIDDEN_PATTERNS,
+} from "shared/file-tree-patterns";
+
+function toText(patterns: string[]): string {
+	return patterns.join("\n");
+}
+
+function toPatterns(text: string): string[] {
+	return text
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.slice(0, MAX_FILE_TREE_HIDDEN_PATTERNS);
+}
+
+export function FileTreeHiddenSection() {
+	const searchQuery = useSettingsSearchQuery();
+	const utils = electronTrpc.useUtils();
+	const { data, isLoading } =
+		electronTrpc.settings.getFileTreeHiddenPatterns.useQuery();
+	const setPatterns =
+		electronTrpc.settings.setFileTreeHiddenPatterns.useMutation({
+			onSuccess: () => {
+				void utils.settings.getFileTreeHiddenPatterns.invalidate();
+			},
+		});
+
+	const [draft, setDraft] = useState<string | null>(null);
+	const persisted = toText(data ?? []);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: drop the local draft when persisted patterns change so a save or reset is reflected in the textarea
+	useEffect(() => {
+		setDraft(null);
+	}, [persisted]);
+
+	const value = draft ?? persisted;
+	const isDirty = draft !== null && draft !== persisted;
+
+	const commit = () => {
+		if (draft === null) return;
+		setPatterns.mutate({ patterns: toPatterns(draft) });
+	};
+
+	return (
+		<section aria-labelledby="file-tree-hidden-title">
+			<h3 id="file-tree-hidden-title" className="text-sm font-medium mb-1">
+				<HighlightText text="Hidden files" query={searchQuery} />
+			</h3>
+			<p className="text-xs text-muted-foreground mb-3">
+				One glob pattern per line. Matching files and folders are hidden from
+				the workspace file tree. A pattern without a slash matches a name at any
+				depth (<code>node_modules</code>), a leading slash anchors it to the
+				workspace root (<code>/output</code>), and a trailing slash limits it to
+				directories (<code>build/</code>).
+			</p>
+
+			<Textarea
+				aria-label="Hidden file patterns"
+				className="font-mono text-xs min-h-32"
+				spellCheck={false}
+				disabled={isLoading}
+				value={value}
+				onChange={(event) => setDraft(event.target.value)}
+				onBlur={commit}
+			/>
+
+			<div className="mt-2 flex items-center gap-2">
+				<Button size="sm" onClick={commit} disabled={!isDirty || isLoading}>
+					Save patterns
+				</Button>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="gap-1.5 text-xs text-muted-foreground"
+					disabled={isLoading}
+					onClick={() => {
+						setDraft(null);
+						setPatterns.mutate({
+							patterns: DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+						});
+					}}
+				>
+					<RotateCcw className="size-3.5" />
+					Reset to defaults
+				</Button>
+			</div>
+		</section>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/FileTreeHiddenSection.tsx
@@ -8,6 +8,7 @@ import { HighlightText } from "renderer/routes/_authenticated/settings/component
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
 	DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+	MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH,
 	MAX_FILE_TREE_HIDDEN_PATTERNS,
 } from "shared/file-tree-patterns";
 
@@ -49,7 +50,18 @@ export function FileTreeHiddenSection() {
 
 	const commit = () => {
 		if (draft === null) return;
-		setPatterns.mutate({ patterns: toPatterns(draft) });
+		const patterns = toPatterns(draft);
+		if (
+			patterns.some(
+				(pattern) => pattern.length > MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH,
+			)
+		) {
+			toast.error(
+				`Patterns must be ${MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH} characters or fewer`,
+			);
+			return;
+		}
+		setPatterns.mutate({ patterns });
 	};
 
 	return (
@@ -69,21 +81,24 @@ export function FileTreeHiddenSection() {
 				aria-label="Hidden file patterns"
 				className="font-mono text-xs min-h-32"
 				spellCheck={false}
-				disabled={isLoading}
+				disabled={isLoading || setPatterns.isPending}
 				value={value}
 				onChange={(event) => setDraft(event.target.value)}
-				onBlur={commit}
 			/>
 
 			<div className="mt-2 flex items-center gap-2">
-				<Button size="sm" onClick={commit} disabled={!isDirty || isLoading}>
+				<Button
+					size="sm"
+					onClick={commit}
+					disabled={!isDirty || isLoading || setPatterns.isPending}
+				>
 					Save patterns
 				</Button>
 				<Button
 					variant="ghost"
 					size="sm"
 					className="gap-1.5 text-xs text-muted-foreground"
-					disabled={isLoading}
+					disabled={isLoading || setPatterns.isPending}
 					onClick={() => {
 						setDraft(null);
 						setPatterns.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FileTreeHiddenSection/index.ts
@@ -1,0 +1,1 @@
+export { FileTreeHiddenSection } from "./FileTreeHiddenSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -20,6 +20,7 @@ export const SETTING_ITEM_ID = {
 	APPEARANCE_CUSTOM_THEMES: "appearance-custom-themes",
 	APPEARANCE_EDITOR_FONT: "appearance-editor-font",
 	APPEARANCE_TERMINAL_FONT: "appearance-terminal-font",
+	APPEARANCE_FILE_TREE_HIDDEN: "appearance-file-tree-hidden",
 
 	RINGTONES_NOTIFICATION: "ringtones-notification",
 
@@ -135,6 +136,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES]: "shared",
 	[SETTING_ITEM_ID.APPEARANCE_EDITOR_FONT]: "v2",
 	[SETTING_ITEM_ID.APPEARANCE_TERMINAL_FONT]: "v2",
+	[SETTING_ITEM_ID.APPEARANCE_FILE_TREE_HIDDEN]: "v2",
 
 	[SETTING_ITEM_ID.RINGTONES_NOTIFICATION]: "shared",
 
@@ -433,6 +435,28 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"upload",
 			"personalize",
 			"customize",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.APPEARANCE_FILE_TREE_HIDDEN,
+		section: "appearance",
+		title: "Hidden Files",
+		description: "Glob patterns hidden from the workspace file tree",
+		keywords: [
+			"appearance",
+			"hidden",
+			"hide",
+			"files",
+			"file tree",
+			"sidebar",
+			"explorer",
+			"ignore",
+			"exclude",
+			"glob",
+			"pattern",
+			"dotfiles",
+			"node_modules",
+			"gitignore",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -21,6 +21,10 @@ import {
 	retargetAbsolutePath,
 	toRelativeWorkspacePath,
 } from "shared/absolute-paths";
+import {
+	createFileTreeHiddenMatcher,
+	DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+} from "shared/file-tree-patterns";
 import type {
 	DirectoryEntry,
 	FileSystemChangeEvent,
@@ -150,6 +154,17 @@ export function FilesView() {
 
 	const [searchTerm, setSearchTerm] = useState("");
 	const projectId = workspace?.project?.id;
+	const hiddenPatternsQuery =
+		electronTrpc.settings.getFileTreeHiddenPatterns.useQuery();
+	const hiddenMatcher = useMemo(
+		() =>
+			createFileTreeHiddenMatcher(
+				hiddenPatternsQuery.data ?? DEFAULT_FILE_TREE_HIDDEN_PATTERNS,
+			),
+		[hiddenPatternsQuery.data],
+	);
+	const hiddenMatcherRef = useRef(hiddenMatcher);
+	hiddenMatcherRef.current = hiddenMatcher;
 
 	// Refs avoid stale closure in dataLoader callbacks
 	const worktreePathRef = useRef(worktreePath);
@@ -215,13 +230,18 @@ export function FilesView() {
 						workspaceId: workspaceId ?? "",
 						absolutePath: dirPath,
 					});
-					const nextEntries = entries.map((entry) => ({
-						id: entry.absolutePath,
-						name: entry.name,
-						path: entry.absolutePath,
-						relativePath: getEntryRelativePath(currentPath, entry.absolutePath),
-						isDirectory: entry.kind === "directory",
-					}));
+					const nextEntries = entries
+						.map((entry) => ({
+							id: entry.absolutePath,
+							name: entry.name,
+							path: entry.absolutePath,
+							relativePath: getEntryRelativePath(
+								currentPath,
+								entry.absolutePath,
+							),
+							isDirectory: entry.kind === "directory",
+						}))
+						.filter((entry) => !hiddenMatcherRef.current(entry));
 					for (const entry of nextEntries) {
 						entryCacheRef.current.set(entry.path, entry);
 					}
@@ -234,6 +254,13 @@ export function FilesView() {
 		},
 		features: [asyncDataLoaderFeature, selectionFeature, expandAllFeature],
 	});
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reload cached tree entries when the matcher changes
+	useEffect(() => {
+		entryCacheRef.current.clear();
+		tree.getItemInstance("root")?.invalidateChildrenIds();
+		void trpcUtils.filesystem.searchFiles.invalidate();
+	}, [hiddenMatcher, tree, trpcUtils.filesystem.searchFiles]);
 
 	const prevWorktreePathRef = useRef(worktreePath);
 	useEffect(() => {
@@ -534,14 +561,16 @@ export function FilesView() {
 	}, [refreshVisibleDirectories]);
 
 	const searchResultEntries = useMemo(() => {
-		return searchResults.map((result) => ({
-			id: result.id,
-			name: result.name,
-			path: result.path,
-			relativePath: result.relativePath,
-			isDirectory: result.isDirectory,
-		}));
-	}, [searchResults]);
+		return searchResults
+			.map((result) => ({
+				id: result.id,
+				name: result.name,
+				path: result.path,
+				relativePath: result.relativePath,
+				isDirectory: result.isDirectory,
+			}))
+			.filter((entry) => !hiddenMatcher(entry));
+	}, [hiddenMatcher, searchResults]);
 
 	if (!worktreePath) {
 		return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -255,13 +255,6 @@ export function FilesView() {
 		features: [asyncDataLoaderFeature, selectionFeature, expandAllFeature],
 	});
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reload cached tree entries when the matcher changes
-	useEffect(() => {
-		entryCacheRef.current.clear();
-		tree.getItemInstance("root")?.invalidateChildrenIds();
-		void trpcUtils.filesystem.searchFiles.invalidate();
-	}, [hiddenMatcher, tree, trpcUtils.filesystem.searchFiles]);
-
 	const prevWorktreePathRef = useRef(worktreePath);
 	useEffect(() => {
 		if (
@@ -285,6 +278,11 @@ export function FilesView() {
 		}
 		void trpcUtils.filesystem.searchFiles.invalidate();
 	}, [tree, trpcUtils]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reload every visible directory when the matcher changes
+	useEffect(() => {
+		refreshVisibleDirectories();
+	}, [hiddenMatcher]);
 
 	const invalidateDirectoryByPath = useCallback(
 		(directoryPath: string) => {

--- a/apps/desktop/src/shared/file-tree-patterns.test.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { createFileTreeHiddenMatcher } from "./file-tree-patterns";
+
+function entry(relativePath: string, isDirectory = false) {
+	const segments = relativePath.split("/");
+	return {
+		name: segments[segments.length - 1] ?? "",
+		relativePath,
+		isDirectory,
+	};
+}
+
+describe("createFileTreeHiddenMatcher", () => {
+	it("hides nothing when no patterns are configured", () => {
+		const isHidden = createFileTreeHiddenMatcher([]);
+		expect(isHidden(entry("node_modules", true))).toBe(false);
+		expect(isHidden(entry("src/index.ts"))).toBe(false);
+	});
+
+	it("matches a separator-free pattern against the basename at any depth", () => {
+		const isHidden = createFileTreeHiddenMatcher(["node_modules"]);
+		expect(isHidden(entry("node_modules", true))).toBe(true);
+		expect(isHidden(entry("packages/ui/node_modules", true))).toBe(true);
+		expect(isHidden(entry("src/node_modules_helper.ts"))).toBe(false);
+	});
+
+	it("anchors patterns that start with a slash to the workspace root", () => {
+		const isHidden = createFileTreeHiddenMatcher(["/output"]);
+		expect(isHidden(entry("output", true))).toBe(true);
+		expect(isHidden(entry("src/output", true))).toBe(false);
+	});
+
+	it("restricts trailing-slash patterns to directories", () => {
+		const isHidden = createFileTreeHiddenMatcher(["build/"]);
+		expect(isHidden(entry("build", true))).toBe(true);
+		expect(isHidden(entry("build"))).toBe(false);
+	});
+
+	it("stops single-star globs at separators", () => {
+		const isHidden = createFileTreeHiddenMatcher(["*.log"]);
+		expect(isHidden(entry("debug.log"))).toBe(true);
+		expect(isHidden(entry("logs/debug.log"))).toBe(true);
+		expect(isHidden(entry("debug.log.txt"))).toBe(false);
+	});
+
+	it("spans separators for double-star globs", () => {
+		const isHidden = createFileTreeHiddenMatcher(["coverage/**"]);
+		expect(isHidden(entry("coverage/lcov.info"))).toBe(true);
+		expect(isHidden(entry("coverage/html/index.html"))).toBe(true);
+		expect(isHidden(entry("coverage"))).toBe(false);
+	});
+
+	it("treats a leading double-star as an optional prefix", () => {
+		const isHidden = createFileTreeHiddenMatcher(["**/__pycache__"]);
+		expect(isHidden(entry("__pycache__", true))).toBe(true);
+		expect(isHidden(entry("src/deep/__pycache__", true))).toBe(true);
+	});
+
+	it("does not let a dot in a pattern match an arbitrary character", () => {
+		const isHidden = createFileTreeHiddenMatcher([".env"]);
+		expect(isHidden(entry(".env"))).toBe(true);
+		expect(isHidden(entry("xenv"))).toBe(false);
+		expect(isHidden(entry("aenv"))).toBe(false);
+	});
+
+	it("does not let regex metacharacters in a pattern alter matching", () => {
+		const isHidden = createFileTreeHiddenMatcher(["a+b(c)"]);
+		expect(isHidden(entry("a+b(c)"))).toBe(true);
+		expect(isHidden(entry("aab"))).toBe(false);
+		expect(isHidden(entry("abc"))).toBe(false);
+	});
+
+	it("ignores blank lines and comments", () => {
+		const isHidden = createFileTreeHiddenMatcher([
+			"   ",
+			"# a comment",
+			"dist",
+		]);
+		expect(isHidden(entry("dist", true))).toBe(true);
+		expect(isHidden(entry("src"))).toBe(false);
+	});
+
+	it("ignores a pattern that compiles to nothing rather than hiding everything", () => {
+		const isHidden = createFileTreeHiddenMatcher(["/", "//"]);
+		expect(isHidden(entry("src"))).toBe(false);
+		expect(isHidden(entry("package.json"))).toBe(false);
+	});
+
+	it("normalizes windows separators before matching path patterns", () => {
+		const isHidden = createFileTreeHiddenMatcher(["target/debug"]);
+		expect(
+			isHidden({
+				...entry("target/debug", true),
+				relativePath: "target\\debug",
+			}),
+		).toBe(true);
+	});
+
+	it("matches an exact nested path without hiding siblings", () => {
+		const isHidden = createFileTreeHiddenMatcher(["packages/ui/dist"]);
+		expect(isHidden(entry("packages/ui/dist", true))).toBe(true);
+		expect(isHidden(entry("packages/core/dist", true))).toBe(false);
+	});
+});

--- a/apps/desktop/src/shared/file-tree-patterns.test.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { createFileTreeHiddenMatcher } from "./file-tree-patterns";
 
 function entry(relativePath: string, isDirectory = false) {
-	const segments = relativePath.split("/");
-	return {
-		name: segments[segments.length - 1] ?? "",
-		relativePath,
-		isDirectory,
-	};
+	return { relativePath, isDirectory };
 }
 
 describe("createFileTreeHiddenMatcher", () => {

--- a/apps/desktop/src/shared/file-tree-patterns.test.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.test.ts
@@ -21,18 +21,23 @@ describe("createFileTreeHiddenMatcher", () => {
 		const isHidden = createFileTreeHiddenMatcher(["node_modules"]);
 		expect(isHidden(entry("node_modules", true))).toBe(true);
 		expect(isHidden(entry("packages/ui/node_modules", true))).toBe(true);
+		expect(isHidden(entry("node_modules/pkg/index.js"))).toBe(true);
+		expect(isHidden(entry("packages/ui/node_modules/pkg/index.js"))).toBe(true);
 		expect(isHidden(entry("src/node_modules_helper.ts"))).toBe(false);
 	});
 
 	it("anchors patterns that start with a slash to the workspace root", () => {
 		const isHidden = createFileTreeHiddenMatcher(["/output"]);
 		expect(isHidden(entry("output", true))).toBe(true);
+		expect(isHidden(entry("output/result.json"))).toBe(true);
 		expect(isHidden(entry("src/output", true))).toBe(false);
+		expect(isHidden(entry("src/output/result.json"))).toBe(false);
 	});
 
 	it("restricts trailing-slash patterns to directories", () => {
 		const isHidden = createFileTreeHiddenMatcher(["build/"]);
 		expect(isHidden(entry("build", true))).toBe(true);
+		expect(isHidden(entry("build/output.js"))).toBe(true);
 		expect(isHidden(entry("build"))).toBe(false);
 	});
 

--- a/apps/desktop/src/shared/file-tree-patterns.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.ts
@@ -108,15 +108,22 @@ export function createFileTreeHiddenMatcher(
 		return () => false;
 	}
 
-	return ({ name, relativePath, isDirectory }) => {
+	return ({ relativePath, isDirectory }) => {
 		const normalizedPath = relativePath.replace(/\\/g, "/");
+		const segments = normalizedPath.split("/").filter(Boolean);
+
 		return compiled.some((pattern) => {
-			if (pattern.directoriesOnly && !isDirectory) {
-				return false;
-			}
-			return pattern.matchesBasename
-				? pattern.regex.test(name)
-				: pattern.regex.test(normalizedPath);
+			return segments.some((segment, index) => {
+				const candidateIsDirectory = index < segments.length - 1 || isDirectory;
+				if (pattern.directoriesOnly && !candidateIsDirectory) {
+					return false;
+				}
+
+				const candidatePath = segments.slice(0, index + 1).join("/");
+				return pattern.matchesBasename
+					? pattern.regex.test(segment)
+					: pattern.regex.test(candidatePath);
+			});
 		});
 	};
 }

--- a/apps/desktop/src/shared/file-tree-patterns.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.ts
@@ -1,0 +1,122 @@
+// Glob patterns hidden from the workspace file tree. Users edit this list in
+// Settings > Appearance; the tree filters against it client-side.
+export const DEFAULT_FILE_TREE_HIDDEN_PATTERNS = [
+	".git",
+	"node_modules",
+	".DS_Store",
+];
+
+export const MAX_FILE_TREE_HIDDEN_PATTERNS = 200;
+export const MAX_FILE_TREE_HIDDEN_PATTERN_LENGTH = 200;
+
+interface CompiledPattern {
+	regex: RegExp;
+	directoriesOnly: boolean;
+	matchesBasename: boolean;
+}
+
+function escapeLiteral(segment: string): string {
+	return segment.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+}
+
+// Translates a gitignore-flavored glob into a regex source string. `**` spans
+// separators, `*` and `?` stop at them.
+function globToRegexSource(pattern: string): string {
+	let source = "";
+	let index = 0;
+
+	while (index < pattern.length) {
+		if (pattern.startsWith("**/", index)) {
+			source += "(?:.*/)?";
+			index += 3;
+			continue;
+		}
+
+		if (pattern.startsWith("**", index)) {
+			source += ".*";
+			index += 2;
+			continue;
+		}
+
+		const character = pattern[index];
+		if (character === "*") {
+			source += "[^/]*";
+		} else if (character === "?") {
+			source += "[^/]";
+		} else {
+			source += escapeLiteral(character);
+		}
+		index += 1;
+	}
+
+	return source;
+}
+
+function compilePattern(rawPattern: string): CompiledPattern | null {
+	let pattern = rawPattern.trim();
+	if (!pattern || pattern.startsWith("#")) {
+		return null;
+	}
+
+	const directoriesOnly = pattern.endsWith("/");
+	if (directoriesOnly) {
+		pattern = pattern.slice(0, -1);
+	}
+
+	// A leading slash anchors the pattern to the workspace root; without one a
+	// separator-free pattern matches a basename at any depth.
+	const isAnchored = pattern.startsWith("/");
+	if (isAnchored) {
+		pattern = pattern.slice(1);
+	}
+
+	if (!pattern) {
+		return null;
+	}
+
+	const matchesBasename = !isAnchored && !pattern.includes("/");
+
+	try {
+		return {
+			regex: new RegExp(`^${globToRegexSource(pattern)}$`),
+			directoriesOnly,
+			matchesBasename,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export interface FileTreeEntryForMatch {
+	name: string;
+	relativePath: string;
+	isDirectory: boolean;
+}
+
+export type FileTreeHiddenMatcher = (entry: FileTreeEntryForMatch) => boolean;
+
+// Returns a matcher that reports whether an entry should be hidden. An empty or
+// fully invalid pattern list yields a matcher that hides nothing.
+export function createFileTreeHiddenMatcher(
+	patterns: string[],
+): FileTreeHiddenMatcher {
+	const compiled = patterns
+		.map(compilePattern)
+		.filter((entry): entry is CompiledPattern => entry !== null);
+
+	if (compiled.length === 0) {
+		return () => false;
+	}
+
+	return ({ name, relativePath, isDirectory }) => {
+		const normalizedPath = relativePath.replace(/\\/g, "/");
+		return compiled.some((pattern) => {
+			if (pattern.directoriesOnly && !isDirectory) {
+				return false;
+			}
+			return pattern.matchesBasename
+				? pattern.regex.test(name)
+				: pattern.regex.test(normalizedPath);
+		});
+	};
+}

--- a/apps/desktop/src/shared/file-tree-patterns.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.ts
@@ -88,7 +88,6 @@ function compilePattern(rawPattern: string): CompiledPattern | null {
 }
 
 export interface FileTreeEntryForMatch {
-	name: string;
 	relativePath: string;
 	isDirectory: boolean;
 }

--- a/apps/desktop/src/shared/file-tree-patterns.ts
+++ b/apps/desktop/src/shared/file-tree-patterns.ts
@@ -111,19 +111,25 @@ export function createFileTreeHiddenMatcher(
 	return ({ relativePath, isDirectory }) => {
 		const normalizedPath = relativePath.replace(/\\/g, "/");
 		const segments = normalizedPath.split("/").filter(Boolean);
+		let candidatePath = "";
+		const candidates = segments.map((segment, index) => {
+			candidatePath = candidatePath ? `${candidatePath}/${segment}` : segment;
+			return {
+				name: segment,
+				path: candidatePath,
+				isDirectory: index < segments.length - 1 || isDirectory,
+			};
+		});
 
-		return compiled.some((pattern) => {
-			return segments.some((segment, index) => {
-				const candidateIsDirectory = index < segments.length - 1 || isDirectory;
-				if (pattern.directoriesOnly && !candidateIsDirectory) {
+		return compiled.some((pattern) =>
+			candidates.some((candidate) => {
+				if (pattern.directoriesOnly && !candidate.isDirectory) {
 					return false;
 				}
-
-				const candidatePath = segments.slice(0, index + 1).join("/");
 				return pattern.matchesBasename
-					? pattern.regex.test(segment)
-					: pattern.regex.test(candidatePath);
-			});
-		});
+					? pattern.regex.test(candidate.name)
+					: pattern.regex.test(candidate.path);
+			}),
+		);
 	};
 }

--- a/packages/local-db/drizzle/0046_add_file_tree_hidden_patterns.sql
+++ b/packages/local-db/drizzle/0046_add_file_tree_hidden_patterns.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `file_tree_hidden_patterns` text;

--- a/packages/local-db/drizzle/meta/0046_snapshot.json
+++ b/packages/local-db/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,1592 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fcaf89b5-a144-4fa0-b072-50dcee40b89e",
+  "prevId": "5cac2d6b-224f-4742-895b-963901ee8f2d",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_permissions_migrated_at": {
+          "name": "agent_preset_permissions_migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wait_for_setup_before_agent": {
+          "name": "wait_for_setup_before_agent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_line_height": {
+          "name": "terminal_line_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_letter_spacing": {
+          "name": "terminal_letter_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_weight": {
+          "name": "terminal_font_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_ligatures": {
+          "name": "terminal_ligatures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_minimum_contrast": {
+          "name": "terminal_minimum_contrast",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_cursor_blink": {
+          "name": "terminal_cursor_blink",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_parked_runtime_cap": {
+          "name": "terminal_parked_runtime_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_line_height": {
+          "name": "editor_line_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_letter_spacing": {
+          "name": "editor_letter_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_weight": {
+          "name": "editor_font_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_ligatures": {
+          "name": "editor_ligatures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_agent_hooks": {
+          "name": "disabled_agent_hooks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_tree_hidden_patterns": {
+          "name": "file_tree_hidden_patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "v1_migration_state": {
+      "name": "v1_migration_state",
+      "columns": {
+        "v1_id": {
+          "name": "v1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v2_id": {
+          "name": "v2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "v1_migration_state_v2_id_idx": {
+          "name": "v1_migration_state_v2_id_idx",
+          "columns": [
+            "v2_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "v1_migration_state_organization_id_v1_id_kind_pk": {
+          "columns": [
+            "organization_id",
+            "v1_id",
+            "kind"
+          ],
+          "name": "v1_migration_state_organization_id_v1_id_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1785347262454,
       "tag": "0045_add_disabled_agent_hooks_setting",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1786388466755,
+      "tag": "0046_add_file_tree_hidden_patterns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -255,6 +255,9 @@ export const settings = sqliteTable("settings", {
 	disabledAgentHooks: text("disabled_agent_hooks", { mode: "json" }).$type<
 		string[]
 	>(),
+	fileTreeHiddenPatterns: text("file_tree_hidden_patterns", {
+		mode: "json",
+	}).$type<string[]>(),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Summary

- add a Settings > Appearance list of gitignore-flavored patterns hidden from the v2 workspace file tree
- default to `.git`, `node_modules`, and `.DS_Store`
- apply filtering to initial directory loads, refreshes, live creates, and renames
- reload the current tree immediately when patterns change

Closes the current request tracked in #5595 and revives the still-applicable behavior from #3153.

## Validation

- `bun test src/shared/file-tree-patterns.test.ts src/renderer/routes/_authenticated/settings/utils/settings-search/`
  - 22 passed, 0 failed
- `bunx turbo typecheck --filter=@superset/desktop --filter=@superset/local-db`
- Biome check on all changed source files
- manually verified on macOS Desktop v1.20.2 against a repository containing dot-directories, caches, nested generated folders, and live file-system changes

## Manual behavior verified

- defaults hide `.git`, `node_modules`, and `.DS_Store`
- adding/removing patterns updates the open Files sidebar
- anchored `/output`, directory-only `build/`, basename, `*`, `?`, and `**` patterns behave as documented
- Reset to defaults restores the shipped list
- terminal and file operations remain unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable hidden-file patterns to Desktop file trees, applied to both the v2 workspace tree and the legacy Files explorer. Patterns are persisted, loaded before first render, and used to filter loads, refreshes, live events, and search results.

- New Features
  - New Settings > Appearance “Hidden files” textarea with Save/Reset; searchable; editing/save/reset are disabled while saving or until patterns load; load failures show a Retry; oversized patterns are rejected with an error.
  - Defaults to `.git`, `node_modules`, and `.DS_Store`; every loaded directory reloads immediately when patterns change; initial load waits for persisted patterns.
  - Filtering covers v2 Files tab and the legacy Files explorer: refresh and live create/rename are filtered (events under hidden ancestors are ignored; renames into hidden drop the entry); search results are filtered; legacy caches invalidate on changes.
  - Glob support: `*`, `?`, `**`, leading `/` to anchor to root, trailing `/` for directories, and basename matches without `/`.
  - TRPC: `getFileTreeHiddenPatterns` and `setFileTreeHiddenPatterns` with input limits; saves are blocked if the pattern list hasn’t loaded.
  - Matcher with unit tests; matches ancestors per path segment derived from the relative path; normalizes Windows separators.

- Migration
  - Adds `settings.file_tree_hidden_patterns` column in `@superset/local-db`; applies via existing migrations, no manual steps.

<sup>Written for commit 69105e1e941913583e4f8db7f07f113c06a3e4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable hidden-file patterns for the workspace file tree.
  - Added a “Hidden Files” section in Appearance settings with editing, saving, reset, search highlighting, and guidance.
  - Supports glob-style patterns for hiding files and folders, including wildcards, directory matching, comments, and rooted paths.
  - Hidden entries are also excluded from file search results.

- **Bug Fixes**
  - Hidden files and directories remain filtered during refreshes, creation, and renames.

- **Tests**
  - Added coverage for pattern matching, path formats, wildcards, comments, and invalid patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->