### PR TITLE
feat(chat): fork-on-send — switch harness mid-conversation via linked sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/ChatV3Pane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/ChatV3Pane.tsx
@@ -34,6 +34,20 @@ export function ChatV3Pane({
 		[wiring.transport, workspaceId, harness, onSessionIdChange],
 	);
 
+	const forkAndSend = useCallback(
+		async (content: UserContent[], nextHarness: HarnessId) => {
+			if (!sessionId) return;
+			const forked = await wiring.transport.forkSession({
+				commandId: crypto.randomUUID(),
+				sessionId,
+				harness: nextHarness,
+			});
+			setPendingFirstPrompt(content);
+			onSessionIdChange(forked.sessionId);
+		},
+		[sessionId, wiring.transport, onSessionIdChange],
+	);
+
 	const picker = (
 		<SessionPicker
 			activeSessionId={sessionId}
@@ -62,6 +76,9 @@ export function ChatV3Pane({
 			headerLeft={picker}
 			key={sessionId}
 			onFirstPromptSent={() => setPendingFirstPrompt(null)}
+			onForkSend={(content, nextHarness) =>
+				void forkAndSend(content, nextHarness)
+			}
 			pendingFirstPrompt={pendingFirstPrompt}
 			sessionId={sessionId}
 		/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionHeader/SessionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionHeader/SessionHeader.tsx
@@ -1,8 +1,10 @@
 import type { StreamStatus } from "@superset/chat/client";
 import type { SessionState, SessionStatus } from "@superset/chat/protocol";
 import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
 import type { ReactNode } from "react";
+import { HARNESSES, type HarnessId } from "../NewSessionView";
 
 const STATUS_LABELS: Record<SessionStatus, string> = {
 	starting: "Starting",
@@ -23,6 +25,8 @@ const CONNECTION_LABELS: Record<StreamStatus, string> = {
 export function SessionHeader({
 	connection,
 	left,
+	onHarnessSelect,
+	pendingHarness,
 	right,
 	session,
 }: {
@@ -30,15 +34,35 @@ export function SessionHeader({
 	connection: StreamStatus;
 	left?: ReactNode;
 	right?: ReactNode;
+	pendingHarness?: HarnessId | null;
+	onHarnessSelect?: (harness: HarnessId) => void;
 }) {
 	const status = session?.status ?? null;
 	return (
 		<div className="flex items-center gap-2 border-b border-border px-3 py-2">
 			{left}
-			{session?.harness && (
+			{session?.harness && !onHarnessSelect && (
 				<Badge className="font-mono" variant="outline">
 					{session.harness}
 				</Badge>
+			)}
+			{session?.harness && onHarnessSelect && (
+				<div className="flex items-center gap-1">
+					{HARNESSES.map((candidate) => {
+						const selected = candidate === (pendingHarness ?? session.harness);
+						return (
+							<Button
+								className="h-6 px-2 font-mono text-xs"
+								key={candidate}
+								onClick={() => onHarnessSelect(candidate)}
+								size="sm"
+								variant={selected ? "secondary" : "ghost"}
+							>
+								{candidate}
+							</Button>
+						);
+					})}
+				</div>
 			)}
 			{status && (
 				<Badge

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionPicker/SessionPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionPicker/SessionPicker.tsx
@@ -59,6 +59,11 @@ export function SessionPicker({
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start">
+				<DropdownMenuItem onSelect={onNewSession}>
+					<Plus className="mr-1 size-3.5" />
+					New session
+				</DropdownMenuItem>
+				{sessions.length > 0 && <DropdownMenuSeparator />}
 				{sessions.map((session) => (
 					<DropdownMenuItem
 						key={session.sessionId}
@@ -68,13 +73,13 @@ export function SessionPicker({
 						<span className="ml-2 font-mono text-xs text-muted-foreground">
 							{session.harness}
 						</span>
+						{session.forkedFromSessionId && (
+							<span className="ml-2 text-xs text-muted-foreground">
+								forked from {session.forkedFromSessionId.slice(0, 8)}
+							</span>
+						)}
 					</DropdownMenuItem>
 				))}
-				{sessions.length > 0 && <DropdownMenuSeparator />}
-				<DropdownMenuItem onSelect={onNewSession}>
-					<Plus className="mr-1 size-3.5" />
-					New session
-				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionView/SessionView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/SessionView/SessionView.tsx
@@ -7,14 +7,16 @@ import {
 } from "@superset/chat/react";
 import { Loader } from "@superset/ui/ai-elements/loader";
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Composer } from "../Composer";
+import type { HarnessId } from "../NewSessionView";
 import { SessionHeader } from "../SessionHeader";
 import { Transcript } from "../Transcript";
 
 export function SessionView({
 	client,
 	headerLeft,
+	onForkSend,
 	pendingFirstPrompt,
 	onFirstPromptSent,
 	sessionId,
@@ -24,8 +26,10 @@ export function SessionView({
 	headerLeft?: ReactNode;
 	pendingFirstPrompt: UserContent[] | null;
 	onFirstPromptSent: () => void;
+	onForkSend?: (content: UserContent[], harness: HarnessId) => void;
 }) {
 	const session = useChatSession({ client });
+	const [pendingHarness, setPendingHarness] = useState<HarnessId | null>(null);
 	const timeline = useTimeline(session.snapshot);
 	const approvals = useApprovals(session.snapshot);
 
@@ -50,6 +54,17 @@ export function SessionView({
 			<SessionHeader
 				connection={session.connection}
 				left={headerLeft}
+				onHarnessSelect={
+					onForkSend
+						? (harness) =>
+								setPendingHarness(
+									harness === session.snapshot.session?.harness
+										? null
+										: harness,
+								)
+						: undefined
+				}
+				pendingHarness={pendingHarness}
 				session={session.snapshot.session}
 			/>
 			{session.status === "loading" ? (
@@ -71,13 +86,26 @@ export function SessionView({
 					snapshot={session.snapshot}
 				/>
 			)}
+			{pendingHarness && (
+				<div className="border-t border-border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground">
+					Next message continues in{" "}
+					<span className="font-mono">{pendingHarness}</span> — a new linked
+					session seeded with this transcript.
+				</div>
+			)}
 			<Composer
 				disabled={session.status !== "ready"}
 				draftKey={`chat-v3-draft:${sessionId}`}
 				onCancelTurn={
 					runningTurnId ? () => void session.cancelTurn(runningTurnId) : null
 				}
-				onSend={(content) => session.sendPrompt(content)}
+				onSend={(content) => {
+					if (pendingHarness && onForkSend) {
+						onForkSend(content, pendingHarness);
+						return null;
+					}
+					return session.sendPrompt(content);
+				}}
 				outbox={session.outbox}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/hooks/useSessionClient/useSessionClient.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/hooks/useSessionClient/useSessionClient.ts
@@ -30,6 +30,7 @@ export function useChatWiring(): ChatWiring {
 		});
 		const transport: ChatTransport = {
 			createSession: (input) => client.createSession.mutate(input),
+			forkSession: (input) => client.forkSession.mutate(input),
 			prompt: (input) => client.prompt.mutate(input),
 			cancelTurn: (input) => client.cancelTurn.mutate(input),
 			respondToApproval: (input) => client.respondToApproval.mutate(input),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -6,6 +6,8 @@ import {
 	type WorkspaceProps,
 	type WorkspaceStore,
 } from "@superset/panes";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
@@ -15,6 +17,7 @@ import type { StoreApi } from "zustand";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
+	ChatV3PaneData,
 	DiffPaneData,
 	PaneViewerData,
 	TerminalPaneData,
@@ -56,6 +59,8 @@ export function useWorkspaceHotkeys({
 		[setRightSidebarOpen],
 	);
 
+	const isChatV3Enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3) ?? false;
+
 	// --- Tab creation ---
 
 	useHotkey("NEW_GROUP", async () => {
@@ -63,6 +68,14 @@ export function useWorkspaceHotkeys({
 	});
 
 	useHotkey("NEW_CHAT", () => {
+		if (isChatV3Enabled) {
+			store.getState().addTab({
+				panes: [
+					{ kind: "chat-v3", data: { sessionId: null } as ChatV3PaneData },
+				],
+			});
+			return;
+		}
 		store.getState().addTab({
 			panes: [{ kind: "chat", data: { sessionId: null } as ChatPaneData }],
 		});

--- a/packages/chat-runtime/src/commands/commands/commands.ts
+++ b/packages/chat-runtime/src/commands/commands/commands.ts
@@ -11,6 +11,7 @@ import type {
 import {
 	cancelTurnInputSchema,
 	createSessionInputSchema,
+	forkSessionInputSchema,
 	getItemsInputSchema,
 	getSessionInputSchema,
 	listSessionsInputSchema,
@@ -23,8 +24,12 @@ import type { ChatDb, ChatSessionRow } from "../../db";
 import type { ChatJournal } from "../../journal";
 import type { ChatSessionStore } from "../../projection";
 import type { PageResult } from "../../replay";
-import { readPage } from "../../replay";
+import { readPage, readSince } from "../../replay";
 import type { LiveSessionRegistry, PromptResult } from "../../sessions";
+import {
+	composeHandoffPreamble,
+	projectTranscriptForHandoff,
+} from "../handoff";
 
 export const createSessionCommandSchema = createSessionInputSchema
 	.omit({ workspaceId: true })
@@ -40,6 +45,11 @@ export type ListSessionsCommandInput = z.input<
 	typeof listSessionsCommandSchema
 >;
 
+export const forkSessionCommandSchema = forkSessionInputSchema.extend({
+	cwd: z.string().min(1),
+});
+export type ForkSessionCommandInput = z.input<typeof forkSessionCommandSchema>;
+
 export type CreateSessionResult = {
 	sessionId: string;
 	epoch: string;
@@ -52,6 +62,7 @@ export type GetSessionResult = {
 
 export type ChatCommands = {
 	createSession(input: CreateSessionCommandInput): CreateSessionResult;
+	forkSession(input: ForkSessionCommandInput): CreateSessionResult;
 	prompt(input: PromptInput): PromptResult;
 	cancelTurn(input: CancelTurnInput): void;
 	respondToApproval(input: RespondToApprovalInput): void;
@@ -72,6 +83,7 @@ export type CommandsOptions = {
 
 export function createCommands(options: CommandsOptions): ChatCommands {
 	const mintSessionId = options.mintSessionId ?? randomUUID;
+	const pendingSeeds = new Map<string, string>();
 
 	const listSessions = (input: ListSessionsCommandInput): ChatSessionRow[] => {
 		const parsed = listSessionsCommandSchema.parse(input);
@@ -111,13 +123,66 @@ export function createCommands(options: CommandsOptions): ChatCommands {
 			});
 		},
 
+		forkSession(input) {
+			const parsed = forkSessionCommandSchema.parse(input);
+			return options.dedupe.run(`forkSession:${parsed.commandId}`, () => {
+				const source = options.sessions.get(parsed.sessionId);
+				if (!source) {
+					throw new Error(`chat session ${parsed.sessionId} is not running`);
+				}
+				const harness = parsed.harness ?? source.harness;
+				if (!options.live.supports(harness)) {
+					throw new Error(`unknown harness ${harness}`);
+				}
+				const replay = readSince(options.db, parsed.sessionId, {
+					epoch: source.epoch,
+					seq: 0,
+				});
+				const seed = replay.ok
+					? projectTranscriptForHandoff(replay.envelopes, {
+							untilItemId: parsed.fromItemId,
+						})
+					: "";
+				const sessionId = mintSessionId();
+				const opened = options.journal.open({
+					sessionId,
+					scopeId: source.scopeId,
+					harness,
+					forkedFromSessionId: source.sessionId,
+				});
+				try {
+					options.live.create({
+						sessionId,
+						scopeId: source.scopeId,
+						harness,
+						cwd: parsed.cwd,
+					});
+				} catch (error) {
+					options.journal.discard(sessionId);
+					throw error;
+				}
+				if (seed !== "") pendingSeeds.set(sessionId, seed);
+				return { sessionId, epoch: opened.epoch };
+			});
+		},
+
 		prompt(input) {
 			const parsed: PromptInput = promptInputSchema.parse(input);
-			return options.dedupe.run(`prompt:${parsed.commandId}`, () =>
-				options.live
+			return options.dedupe.run(`prompt:${parsed.commandId}`, () => {
+				const seed = pendingSeeds.get(parsed.sessionId);
+				let content = parsed.content;
+				const first = content[0];
+				if (seed !== undefined && first?.type === "text") {
+					pendingSeeds.delete(parsed.sessionId);
+					content = [
+						{ ...first, text: composeHandoffPreamble(seed, first.text) },
+						...content.slice(1),
+					];
+				}
+				return options.live
 					.require(parsed.sessionId)
-					.prompt(parsed.content, parsed.clientId),
-			);
+					.prompt(content, parsed.clientId);
+			});
 		},
 
 		cancelTurn(input) {

--- a/packages/chat-runtime/src/commands/handoff/handoff.test.ts
+++ b/packages/chat-runtime/src/commands/handoff/handoff.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createTestRuntime,
+	FAKE_HARNESS,
+	fakeHarnessRegistry,
+} from "../../testing";
+import { agentMessage, turn } from "../../testing/fixtures";
+import { projectTranscriptForHandoff } from "./handoff";
+
+function turnScript(id: string, text: string) {
+	return [
+		{ kind: "turn" as const, turn: turn(id) },
+		{ kind: "item" as const, item: agentMessage(`${id}-a`, text), turnId: id },
+		{
+			kind: "turn" as const,
+			turn: turn(id, { status: "completed" as const, completedAtMs: 2 }),
+		},
+		{ kind: "session" as const, session: { status: "idle" as const } },
+	];
+}
+
+function boot() {
+	const { harnesses } = fakeHarnessRegistry({
+		turns: [
+			turnScript("t1", "four"),
+			turnScript("t2", "fine"),
+			turnScript("t3", "sure"),
+		],
+	});
+	return createTestRuntime({ harnesses });
+}
+
+describe("forkSession", () => {
+	test("fork inherits scope, records lineage, and seeds the first prompt only", async () => {
+		const runtime = boot();
+		const created = runtime.commands.createSession({
+			commandId: crypto.randomUUID(),
+			scopeId: "ws-1",
+			harness: FAKE_HARNESS,
+			cwd: "/tmp/w",
+		});
+		runtime.commands.prompt({
+			commandId: crypto.randomUUID(),
+			sessionId: created.sessionId,
+			clientId: "c1",
+			content: [{ type: "text", text: "what is 2+2" }],
+		});
+		await Bun.sleep(30);
+
+		const fork = runtime.commands.forkSession({
+			commandId: crypto.randomUUID(),
+			sessionId: created.sessionId,
+			cwd: "/tmp/w",
+		});
+		const row = runtime.sessions.get(fork.sessionId);
+		expect(row?.scopeId).toBe("ws-1");
+		expect(row?.forkedFromSessionId).toBe(created.sessionId);
+
+		runtime.commands.prompt({
+			commandId: crypto.randomUUID(),
+			sessionId: fork.sessionId,
+			clientId: "c2",
+			content: [{ type: "text", text: "continue" }],
+		});
+		await Bun.sleep(30);
+		const page = runtime.commands.getItems({
+			sessionId: fork.sessionId,
+			limit: 50,
+		});
+		if (!page.ok) throw new Error("page not ok");
+		const userTexts = page.envelopes
+			.filter(
+				(e) => e.event.type === "item" && e.event.item.kind === "user_message",
+			)
+			.map((e) =>
+				JSON.stringify(e.event.type === "item" ? e.event.item : null),
+			);
+		expect(userTexts[0]).toContain("prior_conversation");
+		expect(userTexts[0]).toContain("what is 2+2");
+		expect(userTexts[0]).toContain("continue");
+
+		runtime.commands.prompt({
+			commandId: crypto.randomUUID(),
+			sessionId: fork.sessionId,
+			clientId: "c3",
+			content: [{ type: "text", text: "again" }],
+		});
+		await Bun.sleep(30);
+		const page2 = runtime.commands.getItems({
+			sessionId: fork.sessionId,
+			limit: 50,
+		});
+		if (!page2.ok) throw new Error("page2 not ok");
+		const seededIds = new Set(
+			page2.envelopes
+				.filter(
+					(e) =>
+						e.event.type === "item" &&
+						JSON.stringify(e.event.item).includes("prior_conversation"),
+				)
+				.map((e) => (e.event.type === "item" ? e.event.item.id : "")),
+		);
+		expect(seededIds.size).toBe(1);
+		await runtime.dispose();
+	});
+});
+
+describe("projectTranscriptForHandoff", () => {
+	test("tail-truncates with a marker", () => {
+		const events = Array.from({ length: 40 }, (_, i) => ({
+			v: 1 as const,
+			sessionId: "s",
+			ts: i,
+			cursor: { epoch: "e", seq: i + 1 },
+			event: {
+				type: "item" as const,
+				turnId: "t",
+				item: {
+					kind: "agent_message" as const,
+					id: `m${i}`,
+					text: "x".repeat(2000),
+					startedAtMs: i,
+				},
+			},
+		}));
+		const out = projectTranscriptForHandoff(events, { maxChars: 5000 });
+		expect(out.startsWith("[earlier conversation truncated]")).toBe(true);
+		expect(out.length).toBeLessThan(6000);
+	});
+});

--- a/packages/chat-runtime/src/commands/handoff/handoff.ts
+++ b/packages/chat-runtime/src/commands/handoff/handoff.ts
@@ -1,0 +1,38 @@
+import type { DurableEnvelope } from "@superset/chat/protocol";
+import { isKnownItem } from "@superset/chat/protocol";
+
+const MAX_CHARS = 30_000;
+
+export function projectTranscriptForHandoff(
+	events: readonly DurableEnvelope[],
+	options?: { untilItemId?: string; maxChars?: number },
+): string {
+	const lines: string[] = [];
+	for (const envelope of events) {
+		const event = envelope.event;
+		if (event.type !== "item") continue;
+		const item = event.item;
+		if (!isKnownItem(item)) continue;
+		if (item.kind === "user_message") {
+			const text = item.content
+				.map((part) => (part.type === "text" ? part.text : `[${part.type}]`))
+				.join(" ");
+			lines.push(`User: ${text}`);
+		} else if (item.kind === "agent_message") {
+			lines.push(`Assistant: ${item.text}`);
+		} else if (item.kind === "tool_call") {
+			lines.push(`[tool] ${item.toolKind} ${item.title} (${item.status})`);
+		}
+		if (options?.untilItemId && item.id === options.untilItemId) break;
+	}
+	let text = lines.join("\n\n");
+	const maxChars = options?.maxChars ?? MAX_CHARS;
+	if (text.length > maxChars) {
+		text = `[earlier conversation truncated]\n\n${text.slice(text.length - maxChars)}`;
+	}
+	return text;
+}
+
+export function composeHandoffPreamble(seed: string, userText: string): string {
+	return `<prior_conversation>\n${seed}\n</prior_conversation>\n\n${userText}`;
+}

--- a/packages/chat-runtime/src/commands/handoff/index.ts
+++ b/packages/chat-runtime/src/commands/handoff/index.ts
@@ -1,0 +1,1 @@
+export { composeHandoffPreamble, projectTranscriptForHandoff } from "./handoff";

--- a/packages/chat-runtime/src/db/drizzle/0001_third_warlock.sql
+++ b/packages/chat-runtime/src/db/drizzle/0001_third_warlock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chat_sessions_local` ADD `forked_from_session_id` text;

--- a/packages/chat-runtime/src/db/drizzle/meta/0001_snapshot.json
+++ b/packages/chat-runtime/src/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,161 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9e9326e0-e4cd-49e0-8fb7-da567f0deeb8",
+  "prevId": "0c9aa8ad-c478-45be-a2a7-661fae258042",
+  "tables": {
+    "chat_journal": {
+      "name": "chat_journal",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_json": {
+          "name": "event_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_journal_session_id_epoch_seq_pk": {
+          "columns": [
+            "session_id",
+            "epoch",
+            "seq"
+          ],
+          "name": "chat_journal_session_id_epoch_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_sessions_local": {
+      "name": "chat_sessions_local",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forked_from_session_id": {
+          "name": "forked_from_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_session_id": {
+          "name": "harness_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_sessions_local_scope_id_idx": {
+          "name": "chat_sessions_local_scope_id_idx",
+          "columns": [
+            "scope_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/chat-runtime/src/db/drizzle/meta/_journal.json
+++ b/packages/chat-runtime/src/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1785962456515,
       "tag": "0000_natural_wolverine",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1785973283401,
+      "tag": "0001_third_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/chat-runtime/src/db/schema/schema.ts
+++ b/packages/chat-runtime/src/db/schema/schema.ts
@@ -27,6 +27,7 @@ export const chatSessionsLocal = sqliteTable(
 	{
 		sessionId: text("session_id").primaryKey(),
 		scopeId: text("scope_id").notNull(),
+		forkedFromSessionId: text("forked_from_session_id"),
 		harness: text().notNull(),
 		harnessSessionId: text("harness_session_id"),
 		epoch: text().notNull(),

--- a/packages/chat-runtime/src/journal/epoch/epoch.ts
+++ b/packages/chat-runtime/src/journal/epoch/epoch.ts
@@ -14,6 +14,7 @@ export type ChatSessionInit = {
 	harnessSessionId?: string | null;
 	status?: string;
 	title?: string | null;
+	forkedFromSessionId?: string | null;
 };
 
 export type OpenedEpoch = {
@@ -35,6 +36,7 @@ export function openEpoch(db: ChatDb, init: ChatSessionInit): OpenedEpoch {
 			scopeId: init.scopeId,
 			harness: init.harness,
 			harnessSessionId: init.harnessSessionId ?? null,
+			forkedFromSessionId: init.forkedFromSessionId ?? null,
 			epoch,
 			status: init.status ?? "starting",
 			title: init.title ?? null,

--- a/packages/chat-runtime/src/router/router/router.ts
+++ b/packages/chat-runtime/src/router/router/router.ts
@@ -1,6 +1,7 @@
 import {
 	cancelTurnInputSchema,
 	createSessionInputSchema,
+	forkSessionInputSchema,
 	getItemsInputSchema,
 	getSessionInputSchema,
 	listSessionsInputSchema,
@@ -69,6 +70,20 @@ export function createChatRouter(
 						cwd,
 					}),
 				);
+			}),
+
+		forkSession: t.procedure
+			.input(forkSessionInputSchema)
+			.mutation(async ({ input }) => {
+				const source = runtime.sessions.get(input.sessionId);
+				if (!source) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `chat session ${input.sessionId} is not running`,
+					});
+				}
+				const cwd = await options.resolveCwd(source.scopeId);
+				return guarded(() => runtime.commands.forkSession({ ...input, cwd }));
 			}),
 
 		prompt: t.procedure


### PR DESCRIPTION
Implements protocol §7 forkSession end to end, per the design ratified in plans/chat-harness-adapters.md §4b.

**Runtime**: forkSession creates a new session inheriting scope/cwd with forkedFromSessionId lineage (additive 0001 migration); the source journal projects to markdown (projectTranscriptForHandoff, tail-truncating at 30k chars) and rides as a <prior_conversation> preamble on the fork's first prompt only — composed above the adapters, which stay ignorant. Router resolves cwd from the source session's scope. 138 runtime tests green.

**Pane**: the harness chip is now a live picker — selecting the other harness arms the composer with a visible hint ("next message continues in codex — a new linked session seeded with this transcript"); send forks, routes the prompt through the existing first-prompt handoff, and follows to the new session. SessionPicker shows "forked from <id>" lineage and moves + New session to the top; ⌘⇧T opens chat-v3 when the chat-v3 flag is on. 124 desktop v2-workspace tests green.

Honest-handoff semantics per design: the fork seeds the *account* of the conversation (rendered transcript), never the source model's working memory — no harness can read another's native store. Same primitive later powers edit-a-message and regenerate.

Known nit: on fork-send the source session's composer draft isn't cleared (you navigate away; the draft remains under the old session's key). IOU-ledger item.

https://claude.ai/code/session_01XRFCEPsfmJHu2SenDKYJ2h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable fork-on-send: switch harness mid-chat by forking a linked session that inherits scope/cwd and seeds only the next message with a tail‑truncated transcript. Updates the Chat V3 UI to pick a harness, show a hint, and auto-follow to the new session.

- **New Features**
  - Runtime: adds `forkSession` to create a new session with `forkedFromSessionId`; projects the source transcript to markdown (30k char tail) and injects it as a `<prior_conversation>` preamble on the first prompt only; router resolves `cwd` from the source session; adapters stay unchanged.
  - Desktop: harness chip becomes a picker that arms the composer and shows a “continues in …” hint; Send forks, routes the prompt via the existing first-prompt handoff, and navigates to the fork; SessionPicker shows lineage (“forked from …”); ⌘⇧T opens Chat V3 when `FEATURE_FLAGS.CHAT_V3` is on.

- **Migration**
  - Add `forked_from_session_id` to `chat_sessions_local` (run DB migration 0001).

<sup>Written for commit 3a605c8edb46465db24a6360e8da55be2981d0fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fork an active chat into a new session while selecting a different harness.
  * Carry relevant conversation context into forked sessions and continue with a new prompt.
  * View which session a fork originated from in the session picker.
  * Choose the target harness directly from the session header.
  * The new-chat shortcut opens the updated chat experience when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->