### PR TITLE
feat(desktop,host-service): open ports over https when ports.json declares it

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ports/label-cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/label-cache.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import { join } from "node:path";
 import { workspaces } from "@superset/local-db";
+import type { StaticPortLabel } from "@superset/port-scanner";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { loadStaticPorts } from "main/lib/static-ports";
@@ -8,7 +9,7 @@ import { PORTS_FILE_NAME, PROJECT_SUPERSET_DIR_NAME } from "shared/constants";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
 
 interface LabelCacheEntry {
-	labels: Map<number, string> | null;
+	labels: Map<number, StaticPortLabel> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -44,7 +45,7 @@ function safeGetPortsFileSignature(worktreePath: string): string | null {
 
 function safeLoadLabelsForWorktree(
 	worktreePath: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	try {
 		return loadLabelsForWorktree(worktreePath);
 	} catch (error) {
@@ -57,7 +58,7 @@ function safeLoadLabelsForWorktree(
 }
 
 /**
- * Resolve `ports.json` labels per workspace on demand, then memoize.
+ * Resolve `ports.json` entries per workspace on demand, then memoize.
  *
  * Why memoize: `getAll` runs on every `port:add`/`port:remove` event (the
  * renderer calls `utils.ports.getAll.invalidate()` in usePortsData). A dev
@@ -76,15 +77,15 @@ const labelCache = new Map<string, LabelCacheEntry>();
 
 function loadLabelsForWorktree(
 	worktreePath: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const result = loadStaticPorts(worktreePath);
 	if (!result.exists || result.error || !result.ports) {
 		return null;
 	}
 
-	const labels = new Map<number, string>();
+	const labels = new Map<number, StaticPortLabel>();
 	for (const p of result.ports) {
-		labels.set(p.port, p.label);
+		labels.set(p.port, p);
 	}
 	return labels;
 }
@@ -92,8 +93,8 @@ function loadLabelsForWorktree(
 function setLabelCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, string> | null,
-): Map<number, string> | null {
+	labels: Map<number, StaticPortLabel> | null,
+): Map<number, StaticPortLabel> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
@@ -107,7 +108,7 @@ function setLabelCache(
 
 export function getLabelsForWorkspace(
 	workspaceId: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const cached = labelCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {

--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -16,10 +16,13 @@ export const createPortsRouter = () => {
 		getAll: publicProcedure.query((): EnrichedPort[] => {
 			const detectedPorts = portManager.getAllPorts();
 			return detectedPorts.map((port) => {
-				const labels = getLabelsForWorkspace(port.workspaceId);
+				const staticPort = getLabelsForWorkspace(port.workspaceId)?.get(
+					port.port,
+				);
 				return {
 					...port,
-					label: labels?.get(port.port) ?? null,
+					label: staticPort?.label ?? null,
+					scheme: staticPort?.scheme ?? null,
 					hostUrl: null,
 				};
 			});

--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -1,11 +1,12 @@
+import { buildPortEnrichment } from "@superset/port-scanner";
 import { observable } from "@trpc/server/observable";
 import { portManager } from "main/lib/terminal/port-manager";
 import type { DetectedPort, EnrichedPort } from "shared/types";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
-import { getLabelsForWorkspace } from "./label-cache";
+import { getStaticPortsForWorkspace } from "./static-port-cache";
 
-export { invalidatePortLabelCache } from "./label-cache";
+export { invalidateStaticPortCache } from "./static-port-cache";
 
 type PortEvent =
 	| { type: "add"; port: DetectedPort }
@@ -16,15 +17,10 @@ export const createPortsRouter = () => {
 		getAll: publicProcedure.query((): EnrichedPort[] => {
 			const detectedPorts = portManager.getAllPorts();
 			return detectedPorts.map((port) => {
-				const staticPort = getLabelsForWorkspace(port.workspaceId)?.get(
+				const entry = getStaticPortsForWorkspace(port.workspaceId)?.get(
 					port.port,
 				);
-				return {
-					...port,
-					label: staticPort?.label ?? null,
-					scheme: staticPort?.scheme ?? null,
-					hostUrl: null,
-				};
+				return { ...port, ...buildPortEnrichment(entry), hostUrl: null };
 			});
 		}),
 

--- a/apps/desktop/src/lib/trpc/routers/ports/static-port-cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/static-port-cache.ts
@@ -1,15 +1,15 @@
 import { statSync } from "node:fs";
 import { join } from "node:path";
 import { workspaces } from "@superset/local-db";
-import type { StaticPortLabel } from "@superset/port-scanner";
+import type { StaticPortEntry } from "@superset/port-scanner";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { loadStaticPorts } from "main/lib/static-ports";
 import { PORTS_FILE_NAME, PROJECT_SUPERSET_DIR_NAME } from "shared/constants";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
 
-interface LabelCacheEntry {
-	labels: Map<number, StaticPortLabel> | null;
+interface StaticPortCacheEntry {
+	entries: Map<number, StaticPortEntry> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -35,7 +35,7 @@ function safeGetPortsFileSignature(worktreePath: string): string | null {
 	try {
 		return getPortsFileSignature(worktreePath);
 	} catch (error) {
-		console.warn("[ports] Failed to stat static port labels:", {
+		console.warn("[ports] Failed to stat static port entries:", {
 			worktreePath,
 			error,
 		});
@@ -43,13 +43,13 @@ function safeGetPortsFileSignature(worktreePath: string): string | null {
 	}
 }
 
-function safeLoadLabelsForWorktree(
+function safeLoadEntriesForWorktree(
 	worktreePath: string,
-): Map<number, StaticPortLabel> | null {
+): Map<number, StaticPortEntry> | null {
 	try {
-		return loadLabelsForWorktree(worktreePath);
+		return loadEntriesForWorktree(worktreePath);
 	} catch (error) {
-		console.warn("[ports] Failed to load static port labels:", {
+		console.warn("[ports] Failed to load static port entries:", {
 			worktreePath,
 			error,
 		});
@@ -65,61 +65,61 @@ function safeLoadLabelsForWorktree(
  * server that flaps 5 ports cascades into 5 `getAll` calls × N workspaces of
  * sync SQLite reads on the main thread. Cache once; ports.json rarely changes.
  *
- * `labels: null` with a resolved worktree means "no labels file" — still
+ * `entries: null` with a resolved worktree means "no entries file" — still
  * cached so we don't re-check the filesystem every event. A missing worktree is
  * not cached because workspace hydration can race first reads.
  *
  * Lives in its own module so workspace-delete paths in `workspaces/utils/*`
- * can call `invalidatePortLabelCache` without creating a ports ↔ workspaces
+ * can call `invalidateStaticPortCache` without creating a ports ↔ workspaces
  * import cycle.
  */
-const labelCache = new Map<string, LabelCacheEntry>();
+const staticPortCache = new Map<string, StaticPortCacheEntry>();
 
-function loadLabelsForWorktree(
+function loadEntriesForWorktree(
 	worktreePath: string,
-): Map<number, StaticPortLabel> | null {
+): Map<number, StaticPortEntry> | null {
 	const result = loadStaticPorts(worktreePath);
 	if (!result.exists || result.error || !result.ports) {
 		return null;
 	}
 
-	const labels = new Map<number, StaticPortLabel>();
+	const entries = new Map<number, StaticPortEntry>();
 	for (const p of result.ports) {
-		labels.set(p.port, p);
+		entries.set(p.port, p);
 	}
-	return labels;
+	return entries;
 }
 
-function setLabelCache(
+function setStaticPortCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, StaticPortLabel> | null,
-): Map<number, StaticPortLabel> | null {
+	entries: Map<number, StaticPortEntry> | null,
+): Map<number, StaticPortEntry> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
-	labelCache.set(workspaceId, {
-		labels,
+	staticPortCache.set(workspaceId, {
+		entries,
 		portsFileSignature,
 		worktreePath,
 	});
-	return labels;
+	return entries;
 }
 
-export function getLabelsForWorkspace(
+export function getStaticPortsForWorkspace(
 	workspaceId: string,
-): Map<number, StaticPortLabel> | null {
-	const cached = labelCache.get(workspaceId);
+): Map<number, StaticPortEntry> | null {
+	const cached = staticPortCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {
-			labelCache.delete(workspaceId);
+			staticPortCache.delete(workspaceId);
 		} else {
 			const currentSignature = safeGetPortsFileSignature(cached.worktreePath);
-			if (currentSignature === cached.portsFileSignature) return cached.labels;
-			return setLabelCache(
+			if (currentSignature === cached.portsFileSignature) return cached.entries;
+			return setStaticPortCache(
 				workspaceId,
 				cached.worktreePath,
-				safeLoadLabelsForWorktree(cached.worktreePath),
+				safeLoadEntriesForWorktree(cached.worktreePath),
 			);
 		}
 	}
@@ -134,21 +134,21 @@ export function getLabelsForWorkspace(
 		return null;
 	}
 
-	return setLabelCache(
+	return setStaticPortCache(
 		workspaceId,
 		worktreePath,
-		safeLoadLabelsForWorktree(worktreePath),
+		safeLoadEntriesForWorktree(worktreePath),
 	);
 }
 
 /**
- * Invalidate the label cache. Call when a workspace is deleted. Edits to
+ * Invalidate the static-port cache. Call when a workspace is deleted. Edits to
  * `ports.json` are detected by the cached file signature.
  */
-export function invalidatePortLabelCache(workspaceId?: string): void {
+export function invalidateStaticPortCache(workspaceId?: string): void {
 	if (workspaceId === undefined) {
-		labelCache.clear();
+		staticPortCache.clear();
 	} else {
-		labelCache.delete(workspaceId);
+		staticPortCache.delete(workspaceId);
 	}
 }

--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -27,7 +27,7 @@ import { PROJECT_COLOR_VALUES } from "shared/constants/project-colors";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { resolveDefaultEditor } from "../external";
-import { invalidatePortLabelCache } from "../ports/label-cache";
+import { invalidateStaticPortCache } from "../ports/static-port-cache";
 import {
 	activateProject,
 	getBranchWorkspace,
@@ -1622,7 +1622,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						.delete(workspaces)
 						.where(inArray(workspaces.id, closedWorkspaceIds))
 						.run();
-					for (const id of closedWorkspaceIds) invalidatePortLabelCache(id);
+					for (const id of closedWorkspaceIds) invalidateStaticPortCache(id);
 				}
 
 				localDb

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
@@ -11,7 +11,7 @@ import {
 import { and, desc, eq, isNotNull, isNull } from "drizzle-orm";
 
 import { localDb } from "main/lib/local-db";
-import { invalidatePortLabelCache } from "../../ports/label-cache";
+import { invalidateStaticPortCache } from "../../ports/static-port-cache";
 import { computeNextProjectChildTabOrder } from "./project-children-order";
 
 /**
@@ -243,7 +243,7 @@ export function clearWorkspaceDeletingStatus(workspaceId: string): void {
  */
 export function deleteWorkspace(workspaceId: string): void {
 	localDb.delete(workspaces).where(eq(workspaces.id, workspaceId)).run();
-	invalidatePortLabelCache(workspaceId);
+	invalidateStaticPortCache(workspaceId);
 }
 
 /**

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -35,7 +35,7 @@ describe("loadStaticPorts", () => {
 		const result = loadStaticPorts(WORKTREE_PATH);
 		expect(result).toEqual({
 			exists: true,
-			ports: [{ port: 3000, label: "Frontend" }],
+			ports: [{ port: 3000, label: "Frontend", scheme: "http" }],
 			error: null,
 		});
 	});
@@ -54,9 +54,9 @@ describe("loadStaticPorts", () => {
 		expect(result).toEqual({
 			exists: true,
 			ports: [
-				{ port: 3000, label: "Frontend" },
-				{ port: 8080, label: "API Server" },
-				{ port: 5432, label: "PostgreSQL" },
+				{ port: 3000, label: "Frontend", scheme: "http" },
+				{ port: 8080, label: "API Server", scheme: "http" },
+				{ port: 5432, label: "PostgreSQL", scheme: "http" },
 			],
 			error: null,
 		});
@@ -70,6 +70,34 @@ describe("loadStaticPorts", () => {
 
 		const result = loadStaticPorts(WORKTREE_PATH);
 		expect(result.ports?.[0].label).toBe("Frontend");
+	});
+
+	test("keeps a declared https scheme", () => {
+		const config = {
+			ports: [
+				{ port: 3000, label: "Frontend", scheme: "https" },
+				{ port: 8080, label: "API Server", scheme: "http" },
+			],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports).toEqual([
+			{ port: 3000, label: "Frontend", scheme: "https" },
+			{ port: 8080, label: "API Server", scheme: "http" },
+		]);
+	});
+
+	test("returns error for an unsupported scheme", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Test", scheme: "ws" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
 	});
 
 	test("returns error for invalid JSON syntax", () => {

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -72,34 +72,6 @@ describe("loadStaticPorts", () => {
 		expect(result.ports?.[0].label).toBe("Frontend");
 	});
 
-	test("keeps a declared https scheme", () => {
-		const config = {
-			ports: [
-				{ port: 3000, label: "Frontend", scheme: "https" },
-				{ port: 8080, label: "API Server", scheme: "http" },
-			],
-		};
-		writeFileSync(PORTS_FILE, JSON.stringify(config));
-
-		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result.ports).toEqual([
-			{ port: 3000, label: "Frontend", scheme: "https" },
-			{ port: 8080, label: "API Server", scheme: "http" },
-		]);
-	});
-
-	test("returns error for an unsupported scheme", () => {
-		writeFileSync(
-			PORTS_FILE,
-			JSON.stringify({ ports: [{ port: 3000, label: "Test", scheme: "ws" }] }),
-		);
-
-		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result.exists).toBe(true);
-		expect(result.ports).toBeNull();
-		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
-	});
-
 	test("returns error for invalid JSON syntax", () => {
 		writeFileSync(PORTS_FILE, "{ invalid json }");
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
@@ -30,12 +30,11 @@ function createResult(): HostPortsResult {
 function createPortEvent(
 	eventType: PortChangedPayload["eventType"],
 	overrides: Partial<PortChangedPayload["port"]> = {},
-	scheme: PortChangedPayload["scheme"] = null,
 ): PortChangedPayload {
 	return {
 		eventType,
 		label: "Vite",
-		scheme,
+		scheme: null,
 		occurredAt: 2,
 		port: {
 			port: 5173,
@@ -69,7 +68,7 @@ describe("applyPortEventsToHostPortsResult", () => {
 
 	it("keeps the scheme an add event carries, so the row opens over https", () => {
 		const result = applyPortEventsToHostPortsResult(createResult(), [
-			createPortEvent("add", { port: 3030 }, "https"),
+			{ ...createPortEvent("add", { port: 3030 }), scheme: "https" },
 		]);
 
 		expect(result?.ports.at(-1)).toMatchObject({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
@@ -30,10 +30,12 @@ function createResult(): HostPortsResult {
 function createPortEvent(
 	eventType: PortChangedPayload["eventType"],
 	overrides: Partial<PortChangedPayload["port"]> = {},
+	scheme: PortChangedPayload["scheme"] = null,
 ): PortChangedPayload {
 	return {
 		eventType,
 		label: "Vite",
+		scheme,
 		occurredAt: 2,
 		port: {
 			port: 5173,
@@ -62,6 +64,17 @@ describe("applyPortEventsToHostPortsResult", () => {
 			processName: "vite",
 			address: "0.0.0.0",
 			label: "Vite",
+		});
+	});
+
+	it("keeps the scheme an add event carries, so the row opens over https", () => {
+		const result = applyPortEventsToHostPortsResult(createResult(), [
+			createPortEvent("add", { port: 3030 }, "https"),
+		]);
+
+		expect(result?.ports.at(-1)).toMatchObject({
+			port: 3030,
+			scheme: "https",
 		});
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
@@ -1,6 +1,6 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { PortChangedPayload } from "@superset/workspace-client";
-import type { DetectedPort } from "shared/types";
+import type { DetectedPort, PortScheme } from "shared/types";
 import type { DashboardSidebarWorkspaceHostType } from "../../types";
 
 export interface DashboardSidebarPort extends RemotePort {
@@ -11,6 +11,12 @@ export interface DashboardSidebarPort extends RemotePort {
 
 interface RemotePort extends DetectedPort {
 	label: string | null;
+	/**
+	 * Scheme declared in the workspace's `.superset/ports.json`. Optional because a
+	 * host-service older than the field sends no `scheme` at all; absent and null both
+	 * mean plain http.
+	 */
+	scheme?: PortScheme | null;
 }
 
 export interface DashboardSidebarPortGroup {
@@ -111,7 +117,10 @@ export function applyPortEventsToHostPortsResult(
 		}
 
 		if (event.eventType === "add") {
-			ports = [...portsWithoutEventPort, { ...event.port, label: event.label }];
+			ports = [
+				...portsWithoutEventPort,
+				{ ...event.port, label: event.label, scheme: event.scheme ?? null },
+			];
 			changed = true;
 		} else {
 			ports = portsWithoutEventPort;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
@@ -11,11 +11,7 @@ export interface DashboardSidebarPort extends RemotePort {
 
 interface RemotePort extends DetectedPort {
 	label: string | null;
-	/**
-	 * Scheme declared in the workspace's `.superset/ports.json`. Optional because a
-	 * host-service older than the field sends no `scheme` at all; absent and null both
-	 * mean plain http.
-	 */
+	/** Optional: a host-service older than the field sends no `scheme` at all. */
 	scheme?: PortScheme | null;
 }
 
@@ -119,7 +115,7 @@ export function applyPortEventsToHostPortsResult(
 		if (event.eventType === "add") {
 			ports = [
 				...portsWithoutEventPort,
-				{ ...event.port, label: event.label, scheme: event.scheme ?? null },
+				{ ...event.port, label: event.label, scheme: event.scheme },
 			];
 			changed = true;
 		} else {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/usePortOpenActions/usePortOpenActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/usePortOpenActions/usePortOpenActions.ts
@@ -3,6 +3,7 @@ import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import type { LinkAction } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import { buildPortUrl } from "shared/port-url";
 import { usePortForward } from "../../providers/PortForwardsProvider";
 import type { DashboardSidebarPort } from "../useDashboardSidebarPortsData";
 
@@ -31,7 +32,12 @@ export function usePortOpenActions(
 		forward?.status.state === "active" ? forward.status : null;
 	const canOpenInBrowser =
 		port.hostType === "local-device" || activeForward !== null;
-	const portUrl = `http://localhost:${activeForward?.localPort ?? port.port}`;
+	// The forward changes which port to open, not how the service speaks, so the
+	// declared scheme still applies: a tunnel carries TLS through unchanged.
+	const portUrl = buildPortUrl({
+		port: activeForward?.localPort ?? port.port,
+		scheme: port.scheme,
+	});
 
 	const openExternal = () => {
 		if (!canOpenInBrowser || openUrl.isPending) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -365,7 +365,8 @@ const DEFAULT_FOLDER_LINKS: FolderTierMap = {
 	metaShift: "external",
 };
 
-// Clicking a port badge's open affordance opens http://localhost:<port>.
+// Clicking a port badge's open affordance opens the port's URL: http://
+// unless `.superset/ports.json` declares `"scheme": "https"`.
 // A single action chooses where: "pane" = in-app browser, "newTab" = new
 // in-app tab, "external" = system browser.
 const DEFAULT_PORT_OPEN_ACTION: LinkAction = "external";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -5,6 +5,7 @@ import { LuExternalLink, LuLoaderCircle, LuX } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { buildPortUrl } from "shared/port-url";
 import type { EnrichedPort } from "shared/types";
 import { STROKE_WIDTH } from "../../../constants";
 import { useKillPort } from "../../hooks/useKillPort";
@@ -27,7 +28,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 
 	const handleOpenInBrowser = () => {
 		if (openUrl.isPending) return;
-		const url = `http://localhost:${port.port}`;
+		const url = buildPortUrl(port);
 
 		if (openLinksInApp) {
 			navigateToWorkspace(port.workspaceId, navigate);

--- a/apps/desktop/src/shared/port-url.test.ts
+++ b/apps/desktop/src/shared/port-url.test.ts
@@ -1,23 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { buildPortUrl } from "./port-url";
 
 describe("buildPortUrl", () => {
-	test("defaults to http", () => {
+	it("defaults to http when no scheme is declared", () => {
 		expect(buildPortUrl({ port: 3000, scheme: null })).toBe(
 			"http://localhost:3000",
 		);
 		expect(buildPortUrl({ port: 3000, scheme: "http" })).toBe(
 			"http://localhost:3000",
 		);
+		// Absent entirely — a row from a host-service older than the field.
+		expect(buildPortUrl({ port: 8080 })).toBe("http://localhost:8080");
 	});
 
-	test("uses https when the port declares it", () => {
+	it("uses https when the port declares it", () => {
 		expect(buildPortUrl({ port: 3030, scheme: "https" })).toBe(
 			"https://localhost:3030",
 		);
-	});
-
-	test("treats a missing scheme like http, for rows from an older host-service", () => {
-		expect(buildPortUrl({ port: 8080 })).toBe("http://localhost:8080");
 	});
 });

--- a/apps/desktop/src/shared/port-url.test.ts
+++ b/apps/desktop/src/shared/port-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { buildPortUrl } from "./port-url";
+
+describe("buildPortUrl", () => {
+	test("defaults to http", () => {
+		expect(buildPortUrl({ port: 3000, scheme: null })).toBe(
+			"http://localhost:3000",
+		);
+		expect(buildPortUrl({ port: 3000, scheme: "http" })).toBe(
+			"http://localhost:3000",
+		);
+	});
+
+	test("uses https when the port declares it", () => {
+		expect(buildPortUrl({ port: 3030, scheme: "https" })).toBe(
+			"https://localhost:3030",
+		);
+	});
+
+	test("treats a missing scheme like http, for rows from an older host-service", () => {
+		expect(buildPortUrl({ port: 8080 })).toBe("http://localhost:8080");
+	});
+});

--- a/apps/desktop/src/shared/port-url.ts
+++ b/apps/desktop/src/shared/port-url.ts
@@ -1,24 +1,12 @@
 import type { PortScheme } from "./types/ports";
 
-/** The bits of a port row that decide its URL. */
-interface PortUrlParts {
-	port: number;
-	/**
-	 * Scheme declared in `.superset/ports.json`. Null for a port that isn't declared
-	 * there, and `undefined` when the row came from a host-service too old to send it —
-	 * both mean plain http.
-	 */
-	scheme?: PortScheme | null;
-}
-
 /**
- * The URL a detected port opens at, in the in-app browser or externally.
- *
- * A dev server that only speaks TLS (Next's `--experimental-https`, a Vite `server.https`
- * config, anything behind a local cert) cannot answer an `http://` request at all — the
- * connection dies in the TLS handshake — so those ports declare `"scheme": "https"` and
- * open over https instead.
+ * The URL a detected port opens at, in the in-app browser or externally. A port the
+ * workspace's `.superset/ports.json` doesn't declare a scheme for opens over http.
  */
-export function buildPortUrl(port: PortUrlParts): string {
+export function buildPortUrl(port: {
+	port: number;
+	scheme?: PortScheme | null;
+}): string {
 	return `${port.scheme ?? "http"}://localhost:${port.port}`;
 }

--- a/apps/desktop/src/shared/port-url.ts
+++ b/apps/desktop/src/shared/port-url.ts
@@ -1,0 +1,24 @@
+import type { PortScheme } from "./types/ports";
+
+/** The bits of a port row that decide its URL. */
+interface PortUrlParts {
+	port: number;
+	/**
+	 * Scheme declared in `.superset/ports.json`. Null for a port that isn't declared
+	 * there, and `undefined` when the row came from a host-service too old to send it —
+	 * both mean plain http.
+	 */
+	scheme?: PortScheme | null;
+}
+
+/**
+ * The URL a detected port opens at, in the in-app browser or externally.
+ *
+ * A dev server that only speaks TLS (Next's `--experimental-https`, a Vite `server.https`
+ * config, anything behind a local cert) cannot answer an `http://` request at all — the
+ * connection dies in the TLS handshake — so those ports declare `"scheme": "https"` and
+ * open over https instead.
+ */
+export function buildPortUrl(port: PortUrlParts): string {
+	return `${port.scheme ?? "http"}://localhost:${port.port}`;
+}

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -1,10 +1,11 @@
-export type { DetectedPort } from "@superset/port-scanner";
+export type { DetectedPort, PortScheme } from "@superset/port-scanner";
 
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, PortScheme } from "@superset/port-scanner";
 
 export interface StaticPort {
 	port: number;
 	label: string;
+	scheme: PortScheme;
 	workspaceId: string;
 }
 
@@ -16,6 +17,10 @@ export interface StaticPortsResult {
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	// Scheme declared for this port in `.superset/ports.json`. Null when the port isn't
+	// declared there — and absent entirely from an older host-service, so read it as
+	// `scheme ?? "http"`.
+	scheme: PortScheme | null;
 	// null → port belongs to the local Electron port manager.
 	// string → URL of the remote host-service that owns this port; kill routes there.
 	hostUrl: string | null;

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -1,25 +1,20 @@
 export type { DetectedPort, PortScheme } from "@superset/port-scanner";
 
-import type { DetectedPort, PortScheme } from "@superset/port-scanner";
-
-export interface StaticPort {
-	port: number;
-	label: string;
-	scheme: PortScheme;
-	workspaceId: string;
-}
+import type {
+	DetectedPort,
+	PortScheme,
+	StaticPortEntry,
+} from "@superset/port-scanner";
 
 export interface StaticPortsResult {
 	exists: boolean;
-	ports: Omit<StaticPort, "workspaceId">[] | null;
+	ports: StaticPortEntry[] | null;
 	error: string | null;
 }
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
-	// Scheme declared for this port in `.superset/ports.json`. Null when the port isn't
-	// declared there — and absent entirely from an older host-service, so read it as
-	// `scheme ?? "http"`.
+	// Scheme from the workspace's `.superset/ports.json`; null when undeclared.
 	scheme: PortScheme | null;
 	// null → port belongs to the local Electron port manager.
 	// string → URL of the remote host-service that owns this port; kill routes there.

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -57,8 +57,8 @@ Create `.superset/ports.json` in your repository:
 
 **HTTPS dev servers:**
 
-A dev server that only speaks TLS — Next's `--experimental-https`, Vite's
-`server.https`, anything behind a local certificate — cannot answer a plain
+A dev server that only speaks TLS (Next's `--experimental-https`, Vite's
+`server.https`, anything behind a local certificate) cannot answer a plain
 `http://` request at all: the connection fails inside the TLS handshake, so the
 browser shows a connection error rather than your app. Declare those ports with
 `"scheme": "https"` so the browser action opens the right URL.

--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -24,6 +24,7 @@ configuration file. Useful for:
 
 - Providing meaningful labels for your team
 - Making common dev-server ports easier to scan in the UI
+- Telling Superset which ports are served over HTTPS
 
 Create `.superset/ports.json` in your repository:
 
@@ -31,6 +32,7 @@ Create `.superset/ports.json` in your repository:
 {
   "ports": [
     { "port": 3000, "label": "Frontend Dev Server" },
+    { "port": 8443, "label": "Frontend (HTTPS)", "scheme": "https" },
     { "port": 8080, "label": "API Server" },
     { "port": 5432, "label": "PostgreSQL" }
   ]
@@ -40,6 +42,8 @@ Create `.superset/ports.json` in your repository:
 **Fields:**
 - `port` - Port number (1-65535)
 - `label` - Display text shown in tooltip
+- `scheme` - Optional, `"http"` (default) or `"https"`. The scheme the browser
+  actions open this port with
 
 **Behavior:**
 - Dynamic port discovery is still authoritative
@@ -49,6 +53,15 @@ Create `.superset/ports.json` in your repository:
 - Each workspace reads labels from its own worktree's file
 - Changes are detected automatically
 - Ports can be opened at `localhost:PORT` from the browser action (remote workspace ports are [forwarded to your machine](#remote-access) first)
+- Ports declared with `"scheme": "https"` open at `https://localhost:PORT` instead
+
+**HTTPS dev servers:**
+
+A dev server that only speaks TLS — Next's `--experimental-https`, Vite's
+`server.https`, anything behind a local certificate — cannot answer a plain
+`http://` request at all: the connection fails inside the TLS handshake, so the
+browser shows a connection error rather than your app. Declare those ports with
+`"scheme": "https"` so the browser action opens the right URL.
 
 **Error Handling:**
 

--- a/packages/host-service/src/events/event-bus.test.ts
+++ b/packages/host-service/src/events/event-bus.test.ts
@@ -52,6 +52,7 @@ describe("EventBus port events", () => {
 			eventType: "add",
 			port,
 			label: null,
+			scheme: null,
 		});
 		expect(typeof message.occurredAt).toBe("number");
 
@@ -63,6 +64,7 @@ describe("EventBus port events", () => {
 			eventType: "remove",
 			port,
 			label: null,
+			scheme: null,
 		});
 
 		eventBus.close();

--- a/packages/host-service/src/events/event-bus.test.ts
+++ b/packages/host-service/src/events/event-bus.test.ts
@@ -1,16 +1,20 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { DetectedPort } from "@superset/port-scanner";
 import type { HostDb } from "../db";
 import { portManager } from "../ports/port-manager";
+import { invalidateStaticPortCache } from "../ports/static-ports";
 import type { WorkspaceFilesystemManager } from "../runtime/filesystem";
 import { EventBus } from "./event-bus";
 import type { GitWatcher } from "./git-watcher";
 
-function createEventBus(): EventBus {
+function createEventBus(worktreePath = "/tmp/missing-workspace"): EventBus {
 	return new EventBus({
 		db: {} as unknown as HostDb,
 		filesystem: {
-			resolveWorkspaceRoot: () => "/tmp/missing-workspace",
+			resolveWorkspaceRoot: () => worktreePath,
 		} as unknown as WorkspaceFilesystemManager,
 		gitWatcher: {
 			onChanged: () => () => {},
@@ -18,17 +22,50 @@ function createEventBus(): EventBus {
 	});
 }
 
+/** A worktree whose `.superset/ports.json` declares one port. */
+function createWorktree(entry: Record<string, unknown>): string {
+	const worktreePath = mkdtempSync(join(tmpdir(), "superset-event-bus-"));
+	mkdirSync(join(worktreePath, ".superset"), { recursive: true });
+	writeFileSync(
+		join(worktreePath, ".superset", "ports.json"),
+		JSON.stringify({ ports: [entry] }),
+	);
+	worktreePaths.push(worktreePath);
+	return worktreePath;
+}
+
+/** Collects everything the bus broadcasts to one connected client. */
+function createSocket(): {
+	socket: Parameters<EventBus["handleOpen"]>[0];
+	sent: string[];
+} {
+	const sent: string[] = [];
+	return {
+		socket: {
+			readyState: 1,
+			send(data: string) {
+				sent.push(data);
+			},
+			close() {},
+		},
+		sent,
+	};
+}
+
+const worktreePaths: string[] = [];
+
+afterEach(() => {
+	// The cache is module-level and keyed by workspaceId, so it outlives a test.
+	invalidateStaticPortCache();
+	for (const path of worktreePaths.splice(0)) {
+		rmSync(path, { recursive: true, force: true });
+	}
+});
+
 describe("EventBus port events", () => {
 	it("broadcasts port changes from the shared port manager and removes listeners on close", () => {
 		const eventBus = createEventBus();
-		const sentMessages: string[] = [];
-		const socket = {
-			readyState: 1,
-			send(data: string) {
-				sentMessages.push(data);
-			},
-			close() {},
-		};
+		const { socket, sent: sentMessages } = createSocket();
 		const port: DetectedPort = {
 			port: 5173,
 			pid: 123,
@@ -70,6 +107,38 @@ describe("EventBus port events", () => {
 		eventBus.close();
 		portManager.emit("port:add", port);
 		expect(sentMessages).toHaveLength(2);
+	});
+
+	it("carries the label and scheme declared in ports.json on an add event", () => {
+		const worktreePath = createWorktree({
+			port: 3030,
+			label: "web",
+			scheme: "https",
+		});
+		const eventBus = createEventBus(worktreePath);
+		const { socket, sent: sentMessages } = createSocket();
+
+		eventBus.handleOpen(socket);
+		eventBus.start();
+
+		portManager.emit("port:add", {
+			port: 3030,
+			pid: 321,
+			processName: "next",
+			terminalId: "terminal-2",
+			workspaceId: "workspace-https",
+			detectedAt: 1_700_000_000_001,
+			address: "127.0.0.1",
+		});
+
+		expect(JSON.parse(sentMessages[0] ?? "{}")).toMatchObject({
+			type: "port:changed",
+			eventType: "add",
+			label: "web",
+			scheme: "https",
+		});
+
+		eventBus.close();
 	});
 });
 

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { NodeWebSocket } from "@hono/node-ws";
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, StaticPortLabel } from "@superset/port-scanner";
 import {
 	type FsWatchEvent,
 	watchSingleFile,
@@ -318,17 +318,20 @@ export class EventBus {
 		eventType: "add" | "remove";
 		port: DetectedPort;
 	}): void {
+		const staticPort =
+			eventType === "add" ? this.getStaticPort(port) : undefined;
 		this.broadcast({
 			type: "port:changed",
 			workspaceId: port.workspaceId,
 			eventType,
 			port,
-			label: eventType === "add" ? this.getPortLabel(port) : null,
+			label: staticPort?.label ?? null,
+			scheme: staticPort?.scheme ?? null,
 			occurredAt: Date.now(),
 		});
 	}
 
-	private getPortLabel(port: DetectedPort): string | null {
+	private getStaticPort(port: DetectedPort): StaticPortLabel | undefined {
 		const labels = getLabelsForWorkspace((workspaceId) => {
 			try {
 				return this.filesystem.resolveWorkspaceRoot(workspaceId);
@@ -336,7 +339,7 @@ export class EventBus {
 				return null;
 			}
 		}, port.workspaceId);
-		return labels?.get(port.port) ?? null;
+		return labels?.get(port.port);
 	}
 
 	private startFsWatch(

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import type { NodeWebSocket } from "@hono/node-ws";
-import type { DetectedPort, StaticPortLabel } from "@superset/port-scanner";
+import {
+	buildPortEnrichment,
+	type DetectedPort,
+	type StaticPortEntry,
+} from "@superset/port-scanner";
 import {
 	type FsWatchEvent,
 	watchSingleFile,
@@ -8,7 +12,7 @@ import {
 import type { Hono } from "hono";
 import type { HostDb } from "../db/index.ts";
 import { portManager } from "../ports/port-manager.ts";
-import { getLabelsForWorkspace } from "../ports/static-ports.ts";
+import { getStaticPortsForWorkspace } from "../ports/static-ports.ts";
 import type { WorkspaceFilesystemManager } from "../runtime/filesystem/index.ts";
 import type { GitWatcher } from "./git-watcher.ts";
 import type { ClientMessage, ServerMessage } from "./types.ts";
@@ -325,21 +329,24 @@ export class EventBus {
 			workspaceId: port.workspaceId,
 			eventType,
 			port,
-			label: staticPort?.label ?? null,
-			scheme: staticPort?.scheme ?? null,
+			...buildPortEnrichment(staticPort),
 			occurredAt: Date.now(),
 		});
 	}
 
-	private getStaticPort(port: DetectedPort): StaticPortLabel | undefined {
-		const labels = getLabelsForWorkspace((workspaceId) => {
+	/**
+	 * The workspace's `.superset/ports.json` entry for this port, if it declares one.
+	 * Undefined when the file is missing, malformed, or has no entry for the port.
+	 */
+	private getStaticPort(port: DetectedPort): StaticPortEntry | undefined {
+		const entries = getStaticPortsForWorkspace((workspaceId) => {
 			try {
 				return this.filesystem.resolveWorkspaceRoot(workspaceId);
 			} catch {
 				return null;
 			}
 		}, port.workspaceId);
-		return labels?.get(port.port);
+		return entries?.get(port.port);
 	}
 
 	private startFsWatch(

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -1,4 +1,4 @@
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, PortScheme } from "@superset/port-scanner";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { AgentLifecycleEventType } from "./map-event-type.ts";
@@ -50,6 +50,7 @@ export interface PortChangedMessage {
 	eventType: "add" | "remove";
 	port: DetectedPort;
 	label: string | null;
+	scheme: PortScheme | null;
 	occurredAt: number;
 }
 

--- a/packages/host-service/src/ports/static-ports.ts
+++ b/packages/host-service/src/ports/static-ports.ts
@@ -1,12 +1,15 @@
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { parseStaticPortsConfig } from "@superset/port-scanner";
+import {
+	parseStaticPortsConfig,
+	type StaticPortLabel,
+} from "@superset/port-scanner";
 
 const PROJECT_SUPERSET_DIR_NAME = ".superset";
 const PORTS_FILE_NAME = "ports.json";
 
 interface LabelCacheEntry {
-	labels: Map<number, string> | null;
+	labels: Map<number, StaticPortLabel> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -51,7 +54,9 @@ function readPortsFile(worktreePath: string): string | null {
 	}
 }
 
-function safeLoadLabels(worktreePath: string): Map<number, string> | null {
+function safeLoadLabels(
+	worktreePath: string,
+): Map<number, StaticPortLabel> | null {
 	try {
 		return loadLabels(worktreePath);
 	} catch (error) {
@@ -64,20 +69,20 @@ function safeLoadLabels(worktreePath: string): Map<number, string> | null {
 }
 
 /**
- * Read `<worktree>/.superset/ports.json` and return a `port → label` map.
+ * Read `<worktree>/.superset/ports.json` and return a `port → entry` map.
  * Returns null if the file is missing or malformed — this endpoint is a
  * best-effort label hint, not a validator, so parse errors are silent.
  */
-function loadLabels(worktreePath: string): Map<number, string> | null {
+function loadLabels(worktreePath: string): Map<number, StaticPortLabel> | null {
 	const content = readPortsFile(worktreePath);
 	if (content === null) return null;
 
 	const parsed = parseStaticPortsConfig(content);
 	if (parsed.ports === null) return null;
 
-	const labels = new Map<number, string>();
+	const labels = new Map<number, StaticPortLabel>();
 	for (const port of parsed.ports) {
-		labels.set(port.port, port.label);
+		labels.set(port.port, port);
 	}
 	return labels;
 }
@@ -94,8 +99,8 @@ const labelCache = new Map<string, LabelCacheEntry>();
 function setLabelCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, string> | null,
-): Map<number, string> | null {
+	labels: Map<number, StaticPortLabel> | null,
+): Map<number, StaticPortLabel> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
@@ -110,7 +115,7 @@ function setLabelCache(
 export function getLabelsForWorkspace(
 	resolveWorktreePath: (workspaceId: string) => string | null,
 	workspaceId: string,
-): Map<number, string> | null {
+): Map<number, StaticPortLabel> | null {
 	const cached = labelCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {

--- a/packages/host-service/src/ports/static-ports.ts
+++ b/packages/host-service/src/ports/static-ports.ts
@@ -2,14 +2,14 @@ import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
 	parseStaticPortsConfig,
-	type StaticPortLabel,
+	type StaticPortEntry,
 } from "@superset/port-scanner";
 
 const PROJECT_SUPERSET_DIR_NAME = ".superset";
 const PORTS_FILE_NAME = "ports.json";
 
-interface LabelCacheEntry {
-	labels: Map<number, StaticPortLabel> | null;
+interface StaticPortCacheEntry {
+	entries: Map<number, StaticPortEntry> | null;
 	portsFileSignature: string | null;
 	worktreePath: string | null;
 }
@@ -37,7 +37,7 @@ function safeGetPortsFileSignature(worktreePath: string): string | null {
 	try {
 		return getPortsFileSignature(worktreePath);
 	} catch (error) {
-		console.warn("[ports] Failed to stat static port labels:", {
+		console.warn("[ports] Failed to stat static port entries:", {
 			worktreePath,
 			error,
 		});
@@ -54,13 +54,13 @@ function readPortsFile(worktreePath: string): string | null {
 	}
 }
 
-function safeLoadLabels(
+function safeLoadEntries(
 	worktreePath: string,
-): Map<number, StaticPortLabel> | null {
+): Map<number, StaticPortEntry> | null {
 	try {
-		return loadLabels(worktreePath);
+		return loadEntries(worktreePath);
 	} catch (error) {
-		console.warn("[ports] Failed to load static port labels:", {
+		console.warn("[ports] Failed to load static port entries:", {
 			worktreePath,
 			error,
 		});
@@ -71,62 +71,64 @@ function safeLoadLabels(
 /**
  * Read `<worktree>/.superset/ports.json` and return a `port → entry` map.
  * Returns null if the file is missing or malformed — this endpoint is a
- * best-effort label hint, not a validator, so parse errors are silent.
+ * best-effort hint, not a validator, so parse errors are silent.
  */
-function loadLabels(worktreePath: string): Map<number, StaticPortLabel> | null {
+function loadEntries(
+	worktreePath: string,
+): Map<number, StaticPortEntry> | null {
 	const content = readPortsFile(worktreePath);
 	if (content === null) return null;
 
 	const parsed = parseStaticPortsConfig(content);
 	if (parsed.ports === null) return null;
 
-	const labels = new Map<number, StaticPortLabel>();
+	const entries = new Map<number, StaticPortEntry>();
 	for (const port of parsed.ports) {
-		labels.set(port.port, port);
+		entries.set(port.port, port);
 	}
-	return labels;
+	return entries;
 }
 
 /**
- * Memoize label lookups per workspaceId. Called by host port snapshots and
+ * Memoize entry lookups per workspaceId. Called by host port snapshots and
  * add-event enrichment, so the workspace-root + fs reads would otherwise repeat
- * needlessly. `labels: null` with a resolved worktree means "no labels file" —
+ * needlessly. `entries: null` with a resolved worktree means "no entries file" —
  * that negative can stick until the file signature changes. A missing
  * worktreePath is not cached because workspace hydration can race first reads.
  */
-const labelCache = new Map<string, LabelCacheEntry>();
+const staticPortCache = new Map<string, StaticPortCacheEntry>();
 
-function setLabelCache(
+function setStaticPortCache(
 	workspaceId: string,
 	worktreePath: string | null,
-	labels: Map<number, StaticPortLabel> | null,
-): Map<number, StaticPortLabel> | null {
+	entries: Map<number, StaticPortEntry> | null,
+): Map<number, StaticPortEntry> | null {
 	const portsFileSignature = worktreePath
 		? safeGetPortsFileSignature(worktreePath)
 		: null;
-	labelCache.set(workspaceId, {
-		labels,
+	staticPortCache.set(workspaceId, {
+		entries,
 		portsFileSignature,
 		worktreePath,
 	});
-	return labels;
+	return entries;
 }
 
-export function getLabelsForWorkspace(
+export function getStaticPortsForWorkspace(
 	resolveWorktreePath: (workspaceId: string) => string | null,
 	workspaceId: string,
-): Map<number, StaticPortLabel> | null {
-	const cached = labelCache.get(workspaceId);
+): Map<number, StaticPortEntry> | null {
+	const cached = staticPortCache.get(workspaceId);
 	if (cached) {
 		if (cached.worktreePath === null) {
-			labelCache.delete(workspaceId);
+			staticPortCache.delete(workspaceId);
 		} else {
 			const currentSignature = safeGetPortsFileSignature(cached.worktreePath);
-			if (currentSignature === cached.portsFileSignature) return cached.labels;
-			return setLabelCache(
+			if (currentSignature === cached.portsFileSignature) return cached.entries;
+			return setStaticPortCache(
 				workspaceId,
 				cached.worktreePath,
-				safeLoadLabels(cached.worktreePath),
+				safeLoadEntries(cached.worktreePath),
 			);
 		}
 	}
@@ -134,10 +136,14 @@ export function getLabelsForWorkspace(
 	const worktreePath = resolveWorktreePath(workspaceId);
 	if (!worktreePath) return null;
 
-	return setLabelCache(workspaceId, worktreePath, safeLoadLabels(worktreePath));
+	return setStaticPortCache(
+		workspaceId,
+		worktreePath,
+		safeLoadEntries(worktreePath),
+	);
 }
 
-export function invalidateLabelCache(workspaceId?: string): void {
-	if (workspaceId === undefined) labelCache.clear();
-	else labelCache.delete(workspaceId);
+export function invalidateStaticPortCache(workspaceId?: string): void {
+	if (workspaceId === undefined) staticPortCache.clear();
+	else staticPortCache.delete(workspaceId);
 }

--- a/packages/host-service/src/trpc/router/ports/ports.ts
+++ b/packages/host-service/src/trpc/router/ports/ports.ts
@@ -1,7 +1,11 @@
-import type { DetectedPort, PortScheme } from "@superset/port-scanner";
+import {
+	buildPortEnrichment,
+	type DetectedPort,
+	type PortScheme,
+} from "@superset/port-scanner";
 import { z } from "zod";
 import { portManager } from "../../../ports/port-manager";
-import { getLabelsForWorkspace } from "../../../ports/static-ports";
+import { getStaticPortsForWorkspace } from "../../../ports/static-ports";
 import { protectedProcedure, router } from "../../index";
 
 export interface EnrichedPort extends DetectedPort {
@@ -27,29 +31,24 @@ export const portsRouter = router({
 				try {
 					return ctx.runtime.filesystem.resolveWorkspaceRoot(workspaceId);
 				} catch {
-					// Workspace deleted or unknown — no labels for this row.
+					// Workspace deleted or unknown — no entries for this row.
 					return null;
 				}
 			};
-			const labelsByWorkspace = new Map<
+			const entriesByWorkspace = new Map<
 				string,
-				ReturnType<typeof getLabelsForWorkspace>
+				ReturnType<typeof getStaticPortsForWorkspace>
 			>();
 			return portManager
 				.getAllPorts()
 				.filter((port) => requestedWorkspaceIds.has(port.workspaceId))
 				.map((port) => {
-					let labels = labelsByWorkspace.get(port.workspaceId);
-					if (!labelsByWorkspace.has(port.workspaceId)) {
-						labels = getLabelsForWorkspace(resolve, port.workspaceId);
-						labelsByWorkspace.set(port.workspaceId, labels);
+					let entries = entriesByWorkspace.get(port.workspaceId);
+					if (!entriesByWorkspace.has(port.workspaceId)) {
+						entries = getStaticPortsForWorkspace(resolve, port.workspaceId);
+						entriesByWorkspace.set(port.workspaceId, entries);
 					}
-					const staticPort = labels?.get(port.port);
-					return {
-						...port,
-						label: staticPort?.label ?? null,
-						scheme: staticPort?.scheme ?? null,
-					};
+					return { ...port, ...buildPortEnrichment(entries?.get(port.port)) };
 				});
 		}),
 

--- a/packages/host-service/src/trpc/router/ports/ports.ts
+++ b/packages/host-service/src/trpc/router/ports/ports.ts
@@ -1,4 +1,4 @@
-import type { DetectedPort } from "@superset/port-scanner";
+import type { DetectedPort, PortScheme } from "@superset/port-scanner";
 import { z } from "zod";
 import { portManager } from "../../../ports/port-manager";
 import { getLabelsForWorkspace } from "../../../ports/static-ports";
@@ -6,6 +6,8 @@ import { protectedProcedure, router } from "../../index";
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	/** Scheme from `.superset/ports.json`; null when the port isn't declared there. */
+	scheme: PortScheme | null;
 }
 
 export type PortEvent =
@@ -42,7 +44,12 @@ export const portsRouter = router({
 						labels = getLabelsForWorkspace(resolve, port.workspaceId);
 						labelsByWorkspace.set(port.workspaceId, labels);
 					}
-					return { ...port, label: labels?.get(port.port) ?? null };
+					const staticPort = labels?.get(port.port);
+					return {
+						...port,
+						label: staticPort?.label ?? null,
+						scheme: staticPort?.scheme ?? null,
+					};
 				});
 		}),
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -5,7 +5,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { pullRequests } from "../../../db/schema";
-import { invalidateLabelCache } from "../../../ports/static-ports";
+import { invalidateStaticPortCache } from "../../../ports/static-ports";
 import { coercePullRequestState } from "../../../runtime/pull-requests/utils/pull-request-mappers";
 import { runTeardown, type TeardownResult } from "../../../runtime/teardown";
 import { disposeSessionsByWorkspaceId } from "../../../terminal/terminal";
@@ -563,10 +563,10 @@ async function runDestroyPhases(
 	// ─── Step 5: Caches ────────────────────────────────────────────
 	if (local) {
 		try {
-			invalidateLabelCache(input.workspaceId);
+			invalidateStaticPortCache(input.workspaceId);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			warnings.push(`Failed to invalidate label cache: ${message}`);
+			warnings.push(`Failed to invalidate static-port cache: ${message}`);
 		}
 	}
 

--- a/packages/port-scanner/src/index.ts
+++ b/packages/port-scanner/src/index.ts
@@ -9,9 +9,10 @@ export {
 	type PortInfo,
 } from "./scanner.ts";
 export {
+	buildPortEnrichment,
 	type PortScheme,
 	parseStaticPortsConfig,
-	type StaticPortLabel,
+	type StaticPortEntry,
 	type StaticPortsParseResult,
 } from "./static-ports.ts";
 export type { DetectedPort } from "./types.ts";

--- a/packages/port-scanner/src/index.ts
+++ b/packages/port-scanner/src/index.ts
@@ -9,6 +9,7 @@ export {
 	type PortInfo,
 } from "./scanner.ts";
 export {
+	type PortScheme,
 	parseStaticPortsConfig,
 	type StaticPortLabel,
 	type StaticPortsParseResult,

--- a/packages/port-scanner/src/static-ports.test.ts
+++ b/packages/port-scanner/src/static-ports.test.ts
@@ -1,18 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { parseStaticPortsConfig } from "./static-ports.ts";
 
-describe("parseStaticPortsConfig scheme", () => {
-	test("defaults to http when an entry omits it", () => {
-		const result = parseStaticPortsConfig(
-			JSON.stringify({ ports: [{ port: 3000, label: "Frontend" }] }),
-		);
+function parseEntry(entry: Record<string, unknown>) {
+	return parseStaticPortsConfig(JSON.stringify({ ports: [entry] }));
+}
 
-		expect(result.ports).toEqual([
+describe("parseStaticPortsConfig scheme", () => {
+	it("defaults to http when an entry omits it", () => {
+		expect(parseEntry({ port: 3000, label: "Frontend" }).ports).toEqual([
 			{ port: 3000, label: "Frontend", scheme: "http" },
 		]);
 	});
 
-	test("keeps http and https as declared", () => {
+	it("keeps http and https as declared", () => {
 		const result = parseStaticPortsConfig(
 			JSON.stringify({
 				ports: [
@@ -28,21 +28,11 @@ describe("parseStaticPortsConfig scheme", () => {
 		]);
 	});
 
-	test("rejects any other scheme", () => {
-		const result = parseStaticPortsConfig(
-			JSON.stringify({ ports: [{ port: 3000, label: "Web", scheme: "ws" }] }),
-		);
-
-		expect(result.ports).toBeNull();
-		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
-	});
-
-	test("rejects a non-string scheme", () => {
-		const result = parseStaticPortsConfig(
-			JSON.stringify({ ports: [{ port: 3000, label: "Web", scheme: true }] }),
-		);
-
-		expect(result.ports).toBeNull();
-		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
+	it("rejects any other scheme", () => {
+		for (const scheme of ["ws", "HTTPS", "", true]) {
+			const result = parseEntry({ port: 3000, label: "Web", scheme });
+			expect(result.ports).toBeNull();
+			expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
+		}
 	});
 });

--- a/packages/port-scanner/src/static-ports.test.ts
+++ b/packages/port-scanner/src/static-ports.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { parseStaticPortsConfig } from "./static-ports.ts";
+
+describe("parseStaticPortsConfig scheme", () => {
+	test("defaults to http when an entry omits it", () => {
+		const result = parseStaticPortsConfig(
+			JSON.stringify({ ports: [{ port: 3000, label: "Frontend" }] }),
+		);
+
+		expect(result.ports).toEqual([
+			{ port: 3000, label: "Frontend", scheme: "http" },
+		]);
+	});
+
+	test("keeps http and https as declared", () => {
+		const result = parseStaticPortsConfig(
+			JSON.stringify({
+				ports: [
+					{ port: 3000, label: "Web", scheme: "https" },
+					{ port: 8080, label: "API", scheme: "http" },
+				],
+			}),
+		);
+
+		expect(result.ports).toEqual([
+			{ port: 3000, label: "Web", scheme: "https" },
+			{ port: 8080, label: "API", scheme: "http" },
+		]);
+	});
+
+	test("rejects any other scheme", () => {
+		const result = parseStaticPortsConfig(
+			JSON.stringify({ ports: [{ port: 3000, label: "Web", scheme: "ws" }] }),
+		);
+
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
+	});
+
+	test("rejects a non-string scheme", () => {
+		const result = parseStaticPortsConfig(
+			JSON.stringify({ ports: [{ port: 3000, label: "Web", scheme: true }] }),
+		);
+
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe('ports[0].scheme must be "http" or "https"');
+	});
+});

--- a/packages/port-scanner/src/static-ports.ts
+++ b/packages/port-scanner/src/static-ports.ts
@@ -1,24 +1,36 @@
+export const PORT_SCHEMES = ["http", "https"] as const;
+
 /** URL scheme a port is served over. */
-export type PortScheme = "http" | "https";
+export type PortScheme = (typeof PORT_SCHEMES)[number];
 
-const PORT_SCHEMES: PortScheme[] = ["http", "https"];
-
+/** Whether a raw `ports.json` value is a scheme this config accepts. */
 function isPortScheme(value: unknown): value is PortScheme {
-	return PORT_SCHEMES.some((scheme) => scheme === value);
+	return (
+		typeof value === "string" &&
+		(PORT_SCHEMES as readonly string[]).includes(value)
+	);
 }
 
-export interface StaticPortLabel {
+export interface StaticPortEntry {
 	port: number;
 	label: string;
-	/**
-	 * Scheme the browser actions open this port with. Always set once parsed —
-	 * an entry that omits it means `http`.
-	 */
+	/** Always set once parsed; an entry that omits it means `http`. */
 	scheme: PortScheme;
 }
 
+/**
+ * The `ports.json`-derived fields of a detected port row. Null for a port the file
+ * doesn't declare — which every consumer reads as an unlabelled `http` port.
+ */
+export function buildPortEnrichment(entry: StaticPortEntry | undefined): {
+	label: string | null;
+	scheme: PortScheme | null;
+} {
+	return { label: entry?.label ?? null, scheme: entry?.scheme ?? null };
+}
+
 export type StaticPortsParseResult =
-	| { ports: StaticPortLabel[]; error: null }
+	| { ports: StaticPortEntry[]; error: null }
 	| { ports: null; error: string };
 
 function validatePortEntry(
@@ -70,8 +82,6 @@ function validatePortEntry(
 		return { valid: false, error: `ports[${index}].label cannot be empty` };
 	}
 
-	// Optional: a dev server that only speaks TLS is declared `"scheme": "https"`, so the
-	// browser actions open it over https instead of failing in the TLS handshake.
 	if (scheme !== undefined && !isPortScheme(scheme)) {
 		return {
 			valid: false,
@@ -83,7 +93,7 @@ function validatePortEntry(
 		valid: true,
 		port,
 		label: label.trim(),
-		scheme: scheme === undefined ? "http" : scheme,
+		scheme: scheme ?? "http",
 	};
 }
 
@@ -114,7 +124,7 @@ export function parseStaticPortsConfig(
 		return { ports: null, error: "'ports' field must be an array" };
 	}
 
-	const ports: StaticPortLabel[] = [];
+	const ports: StaticPortEntry[] = [];
 	const seenPorts = new Set<number>();
 	for (let index = 0; index < portsField.length; index++) {
 		const result = validatePortEntry(portsField[index], index);

--- a/packages/port-scanner/src/static-ports.ts
+++ b/packages/port-scanner/src/static-ports.ts
@@ -1,6 +1,20 @@
+/** URL scheme a port is served over. */
+export type PortScheme = "http" | "https";
+
+const PORT_SCHEMES: PortScheme[] = ["http", "https"];
+
+function isPortScheme(value: unknown): value is PortScheme {
+	return PORT_SCHEMES.some((scheme) => scheme === value);
+}
+
 export interface StaticPortLabel {
 	port: number;
 	label: string;
+	/**
+	 * Scheme the browser actions open this port with. Always set once parsed —
+	 * an entry that omits it means `http`.
+	 */
+	scheme: PortScheme;
 }
 
 export type StaticPortsParseResult =
@@ -11,7 +25,7 @@ function validatePortEntry(
 	entry: unknown,
 	index: number,
 ):
-	| { valid: true; port: number; label: string }
+	| { valid: true; port: number; label: string; scheme: PortScheme }
 	| { valid: false; error: string } {
 	if (typeof entry !== "object" || entry === null) {
 		return { valid: false, error: `ports[${index}] must be an object` };
@@ -31,7 +45,11 @@ function validatePortEntry(
 		};
 	}
 
-	const { port, label } = entry as { port: unknown; label: unknown };
+	const { port, label, scheme } = entry as {
+		port: unknown;
+		label: unknown;
+		scheme: unknown;
+	};
 
 	if (typeof port !== "number" || !Number.isInteger(port)) {
 		return { valid: false, error: `ports[${index}].port must be an integer` };
@@ -52,7 +70,21 @@ function validatePortEntry(
 		return { valid: false, error: `ports[${index}].label cannot be empty` };
 	}
 
-	return { valid: true, port, label: label.trim() };
+	// Optional: a dev server that only speaks TLS is declared `"scheme": "https"`, so the
+	// browser actions open it over https instead of failing in the TLS handshake.
+	if (scheme !== undefined && !isPortScheme(scheme)) {
+		return {
+			valid: false,
+			error: `ports[${index}].scheme must be "http" or "https"`,
+		};
+	}
+
+	return {
+		valid: true,
+		port,
+		label: label.trim(),
+		scheme: scheme === undefined ? "http" : scheme,
+	};
 }
 
 export function parseStaticPortsConfig(
@@ -96,7 +128,11 @@ export function parseStaticPortsConfig(
 			};
 		}
 		seenPorts.add(result.port);
-		ports.push({ port: result.port, label: result.label });
+		ports.push({
+			port: result.port,
+			label: result.label,
+			scheme: result.scheme,
+		});
 	}
 
 	return { ports, error: null };

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -55,6 +55,7 @@ export interface PortChangedPayload {
 	eventType: PortChangedMessage["eventType"];
 	port: PortChangedMessage["port"];
 	label: PortChangedMessage["label"];
+	scheme: PortChangedMessage["scheme"];
 	occurredAt: number;
 }
 
@@ -285,6 +286,8 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 				eventType: message.eventType,
 				port: message.port,
 				label: message.label,
+				// Absent from an older host-service; consumers read `scheme ?? "http"`.
+				scheme: message.scheme ?? null,
 				occurredAt: message.occurredAt,
 			});
 		} else if (message.type === "workspace:changed") {


### PR DESCRIPTION
## Problem

A dev server that only speaks TLS cannot be opened from the PORTS panel at all.

Next's `--experimental-https`, Vite's `server.https`, anything behind a local mkcert certificate — the badge's open affordance builds `http://localhost:<port>`, the plaintext request dies inside the TLS handshake, and the browser shows a bare connection error instead of the app. Every open route hits it: system browser, in-app pane, and new in-app tab.

There was no way to configure around it, because `.superset/ports.json` accepted only `port` and `label`.

## Root cause

Two hardcoded strings, and a config file with nowhere to put the answer.

- `usePortOpenActions.ts:27` — `` const portUrl = `http://localhost:${port.port}` ``
- `MergedPortBadge.tsx:31` — `` const url = `http://localhost:${port.port}` ``

`validatePortEntry` in `packages/port-scanner/src/static-ports.ts` validates `port` and `label` and ignores every other key, so a workspace could not declare that a port is served over TLS. And nothing *inside* an HTTPS server can fix this from the other end: the handshake fails before any HTTP layer exists, so there is no request for a redirect to answer.

## Fix

**1. `ports.json` entries take an optional `scheme`** (port-scanner). `"scheme": "http" | "https"`, validated against the same hand-rolled validator as the other fields and defaulted to `http` at parse time, so no consumer has to branch:

```json
{
  "ports": [
    { "port": 3000, "label": "Frontend Dev Server" },
    { "port": 8443, "label": "Frontend (HTTPS)", "scheme": "https" }
  ]
}
```

**2. The static-port caches carry the whole parsed entry** (host-service, desktop). Both label caches were `Map<number, string>`; they are now `Map<number, StaticPortEntry>`, and `buildPortEnrichment(entry)` produces the `{ label, scheme }` pair at all three enrichment sites — `ports.getAll` on each side and the `port:changed` broadcast. The next `ports.json` attribute is a field on one object rather than another parameter threaded through five contracts.

**3. Both open sites build their URL from it** (desktop). One `buildPortUrl` helper in `shared/`, used by the workspace sidebar badge and the dashboard sidebar port row, so external-open and both in-app-browser targets agree.

`scheme` is nullable on the wire and read as `scheme ?? "http"`. desktop ↔ host-service is a cross-version contract: a host-service older than this field sends no `scheme` at all, so a required field would be a break. `RemotePort.scheme` is optional for the same reason.

## Testing

Empirical confirmation that this is the failure and that the new URL is the fix — a TLS-only server on a random port, with both URLs built by this PR's own `buildPortUrl`:

```
TLS-only dev server listening on :50724

BEFORE — scheme undeclared (today's hardcoded http://):
  http://localhost:50724
  -> curl exit 52 — connection failed

AFTER  — ports.json declares "scheme": "https":
  https://localhost:50724
  -> HTTP 200
```

(curl exit 52 = empty reply; the server never speaks plaintext.)

- **New tests.** `packages/port-scanner/src/static-ports.test.ts` — `scheme` defaulted, kept, and rejected for anything else. `apps/desktop/src/shared/port-url.test.ts` — null / declared / absent. `event-bus.test.ts` — a real `.superset/ports.json` declaring `"scheme": "https"` driven through the broadcast path. `useDashboardSidebarPortsData.test.ts` — a `port:changed` add event carries `scheme` into the patched row, which is the freshly-detected-port path that would otherwise open over http until the next refetch.
- **Mutation-checked**, not just green: the event-bus test fails when the emitter stops threading `scheme` and passes when it is restored, so it tests the contract rather than the fixture.
- `bun run lint` clean, `bun run typecheck` 37/37 tasks.
- **Full `bun test`**: this environment has pre-existing failures (missing `electronTRPC` global, git-integration tests). Rather than trust the count, I diffed failing test *names* against clean `upstream/main` — the branch's set is a strict subset, zero failures unique to this branch.

**What I have not done:** I did not build and run the desktop app, so there are no CDP screenshots of the badge itself. The evidence above is protocol-level plus unit tests. Happy to provision a local stack and capture proper before/after captures if you want them before merging.

## Behavior notes

- Additive and backward compatible. An older host-service sends no `scheme`; every consumer reads it as `http`, which is exactly today's behavior.
- A malformed `scheme` voids the whole file, the same way a malformed `label` already does. This widens that surface by one field rather than introducing it.
- `StaticPortLabel` → `StaticPortEntry`, and the caches built on it follow (`getStaticPortsForWorkspace`, `invalidateStaticPortCache`, `label-cache.ts` → `static-port-cache.ts`). Once the type carried a scheme it was an entry, not a label. This is the only part touching files outside the feature — `projects.ts`, `db-helpers.ts`, `workspace-cleanup.ts`, one import line each. Say the word and I will drop the rename.
- Deleted `StaticPort` from `shared/types/ports.ts`: with `scheme` added it was a field-for-field copy of `StaticPortEntry`, referenced only by its own `Omit`.
- Docs: `apps/docs/content/docs/ports.mdx` gains the field, an example, and a short note on why an HTTPS-only dev server can't be opened over `http://`.

**Considered and rejected:** a full `"url"` field (more expressive, but invites hostnames and paths the panel's kill/attribution logic doesn't model), and probing the port for a TLS handshake at click time (no config needed, but adds per-click latency, cannot work for remote-host ports, and guesses where a declaration is unambiguous). Glad to switch if you'd prefer either.

**Deliberate follow-ups, not in this PR:**

- `browser-manager.ts:26` forces `http://` onto a bare `localhost`/`127.0.0.1` typed into the in-app address bar. URLs from `buildPortUrl` short-circuit on the `^https?://` branch above it, so port opens are unaffected — but hand-typing `localhost:3030` still hits the original failure. Fixing it properly needs a scheme hint at that entry point, not a second hardcoded default.
- Port tooltips still render `localhost:{port}` without a scheme.
- Remote-workspace ports are untouched (the docs already note `localhost:PORT` doesn't reach those).

## Related

Extends #683 (added `.superset/ports.json`, closing #603) with one more field on the same entry.

Two closed requests want the same thing along a different axis — the URL the badge builds isn't right for their setup, and the config file has nowhere to say so:

- #2368 — a `host` field, so `3000` opens at `app1.localhost:3000` (`enhancement`, +1 from a second user)
- #3470 — full URLs with variable interpolation, for portless-style domain routing

Both were closed in the July 2026 stale-issue sweep rather than on the merits.

**These compose rather than compete**, which is why I kept `scheme` narrow. `scheme` and a future `host` are independent fields on the same entry (`{ port, label, scheme, host }`) and `buildPortUrl` already has the one seam where a hostname would land — it hardcodes `localhost` in a single template. A `url` field as in #3470 would supersede both, so if that's the direction you want, say so and I'll close this: it would be the wrong foundation to build on. I don't think it is — a full URL invites hostnames, paths and ports that the panel's kill/attribution logic doesn't model, and it decouples the entry from the detected port it's meant to describe — but that call is yours, and it's the one thing that would make this PR wasted work rather than a stepping stone.

https://claude.ai/code/session_0193w9zPQL4i7U39yYf8HdNz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port configurations now support HTTP and HTTPS schemes.
  * HTTPS ports open using `https://localhost:PORT`; unspecified schemes default to HTTP.
  * Port labels and schemes are preserved across detected-port updates and events.
* **Bug Fixes**
  * Port links now consistently use the configured scheme.
  * Invalid port schemes are rejected with clear configuration errors.
* **Documentation**
  * Added guidance for configuring HTTPS development servers and scheme behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->