### PR TITLE
feat(api,desktop,trpc): client version header + per-procedure telemetry

### DIFF
--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -29,7 +29,7 @@ function getCorsHeaders(origin: string | null, deploymentOrigin: string) {
 		"Access-Control-Allow-Origin": isAllowed ? origin : "",
 		"Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
 		"Access-Control-Allow-Headers":
-			"Content-Type, Authorization, x-trpc-source, trpc-accept, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Closed",
+			"Content-Type, Authorization, x-trpc-source, trpc-accept, x-superset-client, Producer-Id, Producer-Epoch, Producer-Seq, Stream-Closed",
 		"Access-Control-Expose-Headers": [
 			// Durable stream headers
 			"Stream-Next-Offset",

--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { auth, type Session } from "@superset/auth/server";
 import { db } from "@superset/db/client";
 import * as authSchema from "@superset/db/schema/auth";
@@ -85,9 +86,18 @@ export const createContext = async ({
 		session = await sessionFromOAuthBearer(req.headers);
 	}
 
-	return createTRPCContext({
+	const context = createTRPCContext({
 		session,
 		auth,
 		headers: req.headers,
 	});
+
+	if (context.client) {
+		Sentry.setTag(
+			"client",
+			`${context.client.product}/${context.client.version}`,
+		);
+	}
+
+	return context;
 };

--- a/apps/desktop/src/renderer/lib/api-trpc-client.ts
+++ b/apps/desktop/src/renderer/lib/api-trpc-client.ts
@@ -16,12 +16,12 @@ export const apiTrpcClient = createTRPCProxyClient<AppRouter>({
 			transformer: superjson,
 			headers: () => {
 				const token = getAuthToken();
-				if (token) {
-					return {
-						Authorization: `Bearer ${token}`,
-					};
-				}
-				return {};
+				return {
+					...(token ? { Authorization: `Bearer ${token}` } : {}),
+					...(window.App?.appVersion
+						? { "x-superset-client": `desktop/${window.App.appVersion}` }
+						: {}),
+				};
 			},
 		}),
 	],

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -249,7 +249,12 @@ const apiClient = createTRPCProxyClient<AppRouter>({
 			url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
 			headers: () => {
 				const token = getAuthToken();
-				return token ? { Authorization: `Bearer ${token}` } : {};
+				return {
+					...(token ? { Authorization: `Bearer ${token}` } : {}),
+					...(window.App?.appVersion
+						? { "x-superset-client": `desktop/${window.App.appVersion}` }
+						: {}),
+				};
 			},
 			transformer: superjson,
 		}),

--- a/packages/mcp/src/caller.ts
+++ b/packages/mcp/src/caller.ts
@@ -51,5 +51,6 @@ export function createMcpCaller(ctx: McpContext): McpCaller {
 		session,
 		auth,
 		headers,
+		client: null,
 	});
 }

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -6,14 +6,40 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import superjson from "superjson";
 import { ZodError } from "zod";
+import { posthog } from "./lib/analytics";
+
+export interface ApiClientInfo {
+	product: "desktop" | "mobile" | "cli";
+	version: string;
+}
+
+export const CLIENT_VERSION_HEADER = "x-superset-client";
+
+const CLIENT_HEADER_PATTERN =
+	/^(desktop|mobile|cli)\/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)$/;
+
+// Absent or unparseable header = web or a pre-header build, both treated as
+// always-current.
+export function parseClientHeader(headers: Headers): ApiClientInfo | null {
+	const match = headers
+		.get(CLIENT_VERSION_HEADER)
+		?.match(CLIENT_HEADER_PATTERN);
+	const product = match?.[1];
+	const version = match?.[2];
+	if (!product || !version) return null;
+	return { product: product as ApiClientInfo["product"], version };
+}
 
 export type TRPCContext = {
 	session: Session | null;
 	auth: typeof auth;
 	headers: Headers;
+	client: ApiClientInfo | null;
 };
 
-export const createTRPCContext = (opts: TRPCContext): TRPCContext => opts;
+export const createTRPCContext = (
+	opts: Omit<TRPCContext, "client">,
+): TRPCContext => ({ ...opts, client: parseClientHeader(opts.headers) });
 
 const t = initTRPC.context<TRPCContext>().create({
 	transformer: superjson,
@@ -33,9 +59,29 @@ export const createTRPCRouter = t.router;
 
 export const createCallerFactory = t.createCallerFactory;
 
-export const publicProcedure = t.procedure;
+const API_CALL_SAMPLE_RATE = 0.01;
+
+// Per-procedure, per-client-version usage telemetry: the evidence source for
+// deprecating procedures once no in-window client version still calls them.
+const clientTelemetry = t.middleware(async ({ ctx, path, next }) => {
+	if (ctx.client && Math.random() < API_CALL_SAMPLE_RATE) {
+		posthog.capture({
+			distinctId: ctx.session?.user.id ?? "api-unauthenticated",
+			event: "api_procedure_called",
+			properties: {
+				procedure: path,
+				client_product: ctx.client.product,
+				client_version: ctx.client.version,
+			},
+		});
+	}
+	return next();
+});
+
+export const publicProcedure = t.procedure.use(clientTelemetry);
 
 export const protectedProcedure = t.procedure
+	.use(clientTelemetry)
 	.use(async ({ ctx, next }) => {
 		if (!ctx.session) {
 			throw new TRPCError({
@@ -88,69 +134,74 @@ function resolveActiveOrganizationId(
 	return requestedOrganizationId;
 }
 
-export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
-	const authHeader = ctx.headers.get("authorization");
-	const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-	const headerOrgId = ctx.headers.get(ORGANIZATION_HEADER)?.trim() || null;
+export const jwtProcedure = t.procedure
+	.use(clientTelemetry)
+	.use(async ({ ctx, next }) => {
+		const authHeader = ctx.headers.get("authorization");
+		const bearer = authHeader?.startsWith("Bearer ")
+			? authHeader.slice(7)
+			: null;
+		const headerOrgId = ctx.headers.get(ORGANIZATION_HEADER)?.trim() || null;
 
-	if (bearer) {
-		try {
-			const { payload } = await ctx.auth.api.verifyJWT({
-				body: { token: bearer },
-			});
-			if (payload?.sub) {
-				const organizationIds = Array.isArray(payload.organizationIds)
-					? payload.organizationIds.filter(
-							(id): id is string => typeof id === "string",
-						)
-					: [];
-				return next({
-					ctx: {
-						userId: payload.sub,
-						email: (payload.email as string) ?? "",
-						organizationIds,
-						activeOrganizationId: resolveActiveOrganizationId(
-							organizationIds,
-							headerOrgId,
-						),
-					},
+		if (bearer) {
+			try {
+				const { payload } = await ctx.auth.api.verifyJWT({
+					body: { token: bearer },
 				});
+				if (payload?.sub) {
+					const organizationIds = Array.isArray(payload.organizationIds)
+						? payload.organizationIds.filter(
+								(id): id is string => typeof id === "string",
+							)
+						: [];
+					return next({
+						ctx: {
+							userId: payload.sub,
+							email: (payload.email as string) ?? "",
+							organizationIds,
+							activeOrganizationId: resolveActiveOrganizationId(
+								organizationIds,
+								headerOrgId,
+							),
+						},
+					});
+				}
+			} catch (error) {
+				// A live session is the legit fallback for an unverifiable token
+				// (expired/missing). A TRPCError from verifyJWT is an explicit
+				// rejection (revoked/forged) — surface it instead of laundering
+				// it into session auth.
+				if (error instanceof TRPCError) throw error;
 			}
-		} catch (error) {
-			// A live session is the legit fallback for an unverifiable token
-			// (expired/missing). A TRPCError from verifyJWT is an explicit
-			// rejection (revoked/forged) — surface it instead of laundering
-			// it into session auth.
-			if (error instanceof TRPCError) throw error;
 		}
-	}
 
-	if (ctx.session) {
-		const userId = ctx.session.user.id;
-		const memberRows = await db.query.members.findMany({
-			where: eq(members.userId, userId),
-			columns: { organizationId: true },
-		});
-		const organizationIds = memberRows.map((row) => row.organizationId);
-		return next({
-			ctx: {
-				userId,
-				email: ctx.session.user.email ?? "",
-				organizationIds,
-				activeOrganizationId: headerOrgId
-					? resolveActiveOrganizationId(organizationIds, headerOrgId)
-					: (ctx.session.session.activeOrganizationId ??
-						organizationIds[0] ??
-						null),
-			},
-		});
-	}
+		if (ctx.session) {
+			const userId = ctx.session.user.id;
+			const memberRows = await db.query.members.findMany({
+				where: eq(members.userId, userId),
+				columns: { organizationId: true },
+			});
+			const organizationIds = memberRows.map((row) => row.organizationId);
+			return next({
+				ctx: {
+					userId,
+					email: ctx.session.user.email ?? "",
+					organizationIds,
+					activeOrganizationId: headerOrgId
+						? resolveActiveOrganizationId(organizationIds, headerOrgId)
+						: (ctx.session.session.activeOrganizationId ??
+							organizationIds[0] ??
+							null),
+				},
+			});
+		}
 
-	throw new TRPCError({
-		code: "UNAUTHORIZED",
-		message: "Not authenticated. Provide a bearer JWT, x-api-key, or session.",
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message:
+				"Not authenticated. Provide a bearer JWT, x-api-key, or session.",
+		});
 	});
-});
 
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 	if (!ctx.session.user.email.endsWith(COMPANY.EMAIL_DOMAIN)) {


### PR DESCRIPTION
Desktop cloud tRPC clients now send `x-superset-client: desktop/<appVersion>`; the API parses it into `ctx.client`, tags Sentry, and a sampled (1%) middleware on the shared procedure builders emits `api_procedure_called` with procedure + client product + version.

This is PR A of the API compatibility plan: it starts accumulating the per-procedure, per-client-version usage evidence that the CI contract gate and min-version floor (follow-up PRs) consume, and that the electric-proxy teardown will use as its adoption-drain signal.

Notes:
- Absent/unparseable header = web or pre-header build, treated as always-current; `ctx.client` is null and nothing changes.
- `x-superset-client` added to the API's CORS allow-list (renderer preflights).
- Mobile/CLI headers intentionally deferred (mobile not in use; CLI needs version-embedding survey) — the parser already accepts `mobile/…` and `cli/…`.
- No behavior branches on version anywhere; this PR is purely observational.

https://claude.ai/code/session_01Rq18Ske93pkaTqTHByebtq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Desktop tRPC calls now include `x-superset-client: desktop/<version>`. The API parses it into `ctx.client`, tags Sentry, and samples per-procedure telemetry to track usage by client version.

- **New Features**
  - Desktop renderer sends `x-superset-client: desktop/<appVersion>` on API requests.
  - API: CORS allows `x-superset-client`; parse into `ctx.client`; set `@sentry/nextjs` tag `client=<product>/<version>`.
  - `packages/trpc`: middleware (1% sample) emits `api_procedure_called` to `posthog` with `procedure`, `client_product`, `client_version`.
  - Parser accepts `desktop|mobile|cli`; missing/unparseable treated as web/pre-header (`ctx.client` null). No behavior changes.

<sup>Written for commit 35425e08429977c0f7c00bf14b8302778d604fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved API request compatibility for desktop clients by supporting client identification headers during browser security checks.
  - Desktop requests now consistently include authentication and app version information when available.
  - Added more complete client and version context to support troubleshooting and service performance monitoring.
  - Improved consistency for API calls from command-line integrations and other clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->