### PR TITLE
feat(docs): widen sidebar text halo with smooth fade-out

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -249,37 +249,46 @@ html:not([data-anchor-scrolling]) {
 }
 
 /* Dense halo in the page background color: knocks the dither back around text.
-   Tight radii are stacked many times — each repeat multiplies opacity. */
+   Tight radii are stacked many times — each repeat multiplies opacity.
+   Repeat count steps down and outer layers mix toward transparent as the
+   radius grows, so the halo decays smoothly instead of plateauing and
+   cutting off. */
 @utility text-halo {
 	text-shadow:
-		0 0 2px var(--background),
-		0 0 2px var(--background),
-		0 0 2px var(--background),
-		0 0 2px var(--background),
-		0 0 2px var(--background),
-		0 0 2px var(--background),
-		0 0 4px var(--background),
-		0 0 4px var(--background),
-		0 0 4px var(--background),
-		0 0 4px var(--background),
-		0 0 4px var(--background),
-		0 0 4px var(--background),
+		0 0 3px var(--background),
+		0 0 3px var(--background),
+		0 0 3px var(--background),
+		0 0 3px var(--background),
+		0 0 3px var(--background),
 		0 0 6px var(--background),
 		0 0 6px var(--background),
 		0 0 6px var(--background),
 		0 0 6px var(--background),
 		0 0 6px var(--background),
-		0 0 8px var(--background),
-		0 0 8px var(--background),
-		0 0 8px var(--background),
-		0 0 8px var(--background),
+		0 0 9px var(--background),
+		0 0 9px var(--background),
+		0 0 9px var(--background),
+		0 0 9px var(--background),
+		0 0 12px var(--background),
 		0 0 12px var(--background),
 		0 0 12px var(--background),
 		0 0 12px var(--background),
 		0 0 16px var(--background),
 		0 0 16px var(--background),
-		0 0 24px var(--background),
-		0 0 32px var(--background);
+		0 0 16px var(--background),
+		0 0 22px var(--background),
+		0 0 22px var(--background),
+		0 0 22px var(--background),
+		0 0 30px color-mix(in srgb, var(--background) 85%, transparent),
+		0 0 30px color-mix(in srgb, var(--background) 85%, transparent),
+		0 0 40px color-mix(in srgb, var(--background) 65%, transparent),
+		0 0 40px color-mix(in srgb, var(--background) 65%, transparent),
+		0 0 52px color-mix(in srgb, var(--background) 50%, transparent),
+		0 0 52px color-mix(in srgb, var(--background) 50%, transparent),
+		0 0 68px color-mix(in srgb, var(--background) 40%, transparent),
+		0 0 88px color-mix(in srgb, var(--background) 28%, transparent),
+		0 0 112px color-mix(in srgb, var(--background) 18%, transparent),
+		0 0 140px color-mix(in srgb, var(--background) 10%, transparent);
 }
 
 @utility no-scrollbar {


### PR DESCRIPTION
## Summary
- Widen the `text-halo` utility used by the active docs sidebar link so the dither dots are knocked back further around the label
- Replace the plateau-then-cutoff shadow stack with a graduated taper: repeat counts step down as blur radius grows (5× at 3–6px → singles past 68px)
- Outer layers (30px→140px) mix the background color toward transparent (85%→10%) so the halo dissolves into the dither instead of ending at a visible edge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the `text-halo` for the active docs sidebar link and added a smooth fade-out. Repeat counts taper and outer layers mix the background color toward transparent at larger radii, improving legibility and removing the visible edge.

<sup>Written for commit 41ae560cd71c99730d26762984e670ce0c85feef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the `text-halo` visual effect with smoother shadow transitions and a more extended, gradually fading halo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->