### PR TITLE
fix(host-service): stop hot-looping git spawns on workspaces whose worktree dir is gone

### DIFF
--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { type FSWatcher, watch } from "node:fs";
+import { existsSync, type FSWatcher, watch } from "node:fs";
 import { promisify } from "node:util";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import { isNull } from "drizzle-orm";
@@ -314,6 +314,10 @@ export class GitWatcher {
 		worktreePath: string,
 	): Promise<void> {
 		if (this.closed) return;
+
+		// Deleted-out-from-under worktree: skip the exec attempt; the 30s
+		// rescan re-probes and picks the workspace up when the dir returns.
+		if (!existsSync(worktreePath)) return;
 
 		let gitDir: string;
 		try {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -148,6 +148,7 @@ function createManager(
 		readWorkspaceRefs?: (
 			worktreePath: string,
 		) => Promise<WorkspaceRefsSnapshot>;
+		worktreeExists?: (worktreePath: string) => boolean;
 	} = {},
 ) {
 	return new PullRequestRuntimeManager({
@@ -169,6 +170,9 @@ function createManager(
 			}) as never),
 		gitWatcher: { onChanged: () => () => {} } as never,
 		readWorkspaceRefs: overrides.readWorkspaceRefs,
+		// Seeded worktree paths are fabricated; default the disk gate open so
+		// sync-path tests exercise the git read, not the missing-dir skip.
+		worktreeExists: overrides.worktreeExists ?? (() => true),
 	});
 }
 
@@ -953,5 +957,107 @@ describe("workspace-created event trigger", () => {
 
 		expect(refsReads()).toBe(0);
 		expect(getWorkspace(db, "ws-new")?.pullRequestId).toBeNull();
+	});
+});
+
+describe("missing-worktree degraded state", () => {
+	const createdEvent: WorkspaceChangedEvent = {
+		workspaceId: "ws-dead",
+		eventType: "created",
+		workspace: null,
+		occurredAt: 1,
+	};
+
+	function createGatedManager(db: HostDb, disk: { exists: boolean }) {
+		let refsReads = 0;
+		const manager = createManager(db, {
+			execGh: routeGh({
+				"feat/dead": makePrNode({
+					number: 7001,
+					headRef: "feat/dead",
+					headSha: "sha-dead",
+				}),
+			}),
+			readWorkspaceRefs: async () => {
+				refsReads += 1;
+				return {
+					branch: "feat/dead",
+					headSha: "sha-dead",
+					upstream: { owner: REPO.owner, name: REPO.name, branch: "feat/dead" },
+				};
+			},
+			worktreeExists: () => disk.exists,
+		});
+		return { manager, refsReads: () => refsReads };
+	}
+
+	async function withCapturedWarnings<T>(
+		fn: () => Promise<T>,
+	): Promise<{ result: T; warnings: string[] }> {
+		const original = console.warn;
+		const warnings: string[] = [];
+		console.warn = (...args: unknown[]) => {
+			warnings.push(String(args[0]));
+		};
+		try {
+			return { result: await fn(), warnings };
+		} finally {
+			console.warn = original;
+		}
+	}
+
+	test("skips git reads and logs one line while the worktree is missing", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws-dead", branch: "feat/dead" });
+		const disk = { exists: false };
+		const { manager, refsReads } = createGatedManager(db, disk);
+		const bus = createFakeWorkspaceEventBus();
+		manager.subscribeToWorkspaceEvents(bus);
+
+		const { warnings } = await withCapturedWarnings(async () => {
+			bus.emit(createdEvent);
+			await waitFor(() => refsReads() > 0, 100);
+			bus.emit(createdEvent);
+			await waitFor(() => refsReads() > 0, 100);
+		});
+
+		expect(refsReads()).toBe(0);
+		expect(getWorkspace(db, "ws-dead")?.pullRequestId).toBeNull();
+		expect(
+			warnings.filter((w) => w.includes("Worktree missing on disk")),
+		).toHaveLength(1);
+
+		manager.stop();
+	});
+
+	test("resumes sync and logs degraded-exit when the worktree reappears", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws-dead", branch: "feat/dead" });
+		const disk = { exists: false };
+		const { manager, refsReads } = createGatedManager(db, disk);
+		const bus = createFakeWorkspaceEventBus();
+		manager.subscribeToWorkspaceEvents(bus);
+
+		const { warnings } = await withCapturedWarnings(async () => {
+			bus.emit(createdEvent);
+			await waitFor(() => refsReads() > 0, 100);
+			expect(refsReads()).toBe(0);
+
+			disk.exists = true;
+			bus.emit(createdEvent);
+			await waitFor(() => Boolean(getWorkspace(db, "ws-dead")?.pullRequestId));
+		});
+
+		expect(refsReads()).toBeGreaterThan(0);
+		const ws = getWorkspace(db, "ws-dead");
+		expect(ws?.headSha).toBe("sha-dead");
+		expect(ws?.pullRequestId).toBe(getPrByNumber(db, 7001)?.id);
+		expect(
+			warnings.filter((w) => w.includes("Worktree reappeared")),
+		).toHaveLength(1);
+
+		manager.stop();
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import type { Octokit } from "@octokit/rest";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { and, eq, inArray, isNull } from "drizzle-orm";
@@ -58,6 +59,9 @@ const PROJECT_REFRESH_INTERVAL_MS = 5 * 60_000;
 // PROJECT_REFRESH). Otherwise the cache is always stale at poll time and
 // each tick fires fresh GitHub calls for the same upstream branch.
 const REPO_PULL_REQUEST_CACHE_TTL_MS = 60_000;
+// Re-probe cadence for worktrees observed missing on disk. existsSync-only —
+// cheap enough to run every tick; spawning git against a missing dir is not.
+const MISSING_WORKTREE_PROBE_INTERVAL_MS = 30_000;
 // Dedup + link-assignment key. Branch stays case-sensitive: `feature` and
 // `Feature` are distinct branches with distinct PRs, so collapsing them here
 // would mislink. Case drift is tolerated only in the fallback in
@@ -102,6 +106,8 @@ export interface PullRequestRuntimeManagerOptions {
 	 * event loop (app wiring passes a worker-pool-backed reader). Defaults
 	 * to reading in-process via `git`. */
 	readWorkspaceRefs?: (worktreePath: string) => Promise<WorkspaceRefsSnapshot>;
+	/** Test seam for the missing-worktree gate. Defaults to `existsSync`. */
+	worktreeExists?: (worktreePath: string) => boolean;
 }
 
 interface NormalizedRepoIdentity {
@@ -179,6 +185,14 @@ export class PullRequestRuntimeManager {
 	private readonly readWorkspaceRefs: (
 		worktreePath: string,
 	) => Promise<WorkspaceRefsSnapshot>;
+	private readonly worktreeExists: (worktreePath: string) => boolean;
+	// Worktrees deleted out from under us (external `rm`, crashed teardown).
+	// While a workspace is listed here, sync attempts cost one existsSync and
+	// spawn no git; the probe timer re-enters the normal sync path when the
+	// directory reappears. One log line per transition, never per attempt.
+	private readonly missingWorktrees = new Map<string, string>();
+	private missingWorktreeProbeTimer: ReturnType<typeof setInterval> | null =
+		null;
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
 		this.db = options.db;
@@ -189,6 +203,7 @@ export class PullRequestRuntimeManager {
 		this.readWorkspaceRefs =
 			options.readWorkspaceRefs ??
 			(async (worktreePath) => readWorkspaceRefs(await this.git(worktreePath)));
+		this.worktreeExists = options.worktreeExists ?? existsSync;
 	}
 
 	start() {
@@ -245,10 +260,14 @@ export class PullRequestRuntimeManager {
 	stop() {
 		if (this.safetyNetTimer) clearInterval(this.safetyNetTimer);
 		if (this.projectRefreshTimer) clearInterval(this.projectRefreshTimer);
+		if (this.missingWorktreeProbeTimer)
+			clearInterval(this.missingWorktreeProbeTimer);
 		this.unsubscribeFromGitWatcher?.();
 		this.unsubscribeFromWorkspaceEvents?.();
 		this.safetyNetTimer = null;
 		this.projectRefreshTimer = null;
+		this.missingWorktreeProbeTimer = null;
+		this.missingWorktrees.clear();
 		this.unsubscribeFromGitWatcher = null;
 		this.unsubscribeFromWorkspaceEvents = null;
 	}
@@ -479,11 +498,17 @@ export class PullRequestRuntimeManager {
 			.from(workspaces)
 			.where(eq(workspaces.id, workspaceId))
 			.get();
-		if (!workspace) return;
+		if (!workspace) {
+			this.forgetMissingWorktree(workspaceId);
+			return;
+		}
 		// Session workspaces (null projectId) have no remote and no PRs; the
 		// GitWatcher still fires for their repos, so gate here too. Archived
 		// workspaces are frozen tombstones — never resync or relink them.
-		if (workspace.projectId === null || workspace.archivedAt !== null) return;
+		if (workspace.projectId === null || workspace.archivedAt !== null) {
+			this.forgetMissingWorktree(workspaceId);
+			return;
+		}
 
 		const projectId = await this.syncWorkspaceRow(workspace);
 		if (projectId) await this.refreshProject(projectId);
@@ -492,6 +517,14 @@ export class PullRequestRuntimeManager {
 	private async syncWorkspaceRow(
 		workspace: typeof workspaces.$inferSelect,
 	): Promise<string | null> {
+		// A worktree deleted outside the app is a routine lifecycle state, not
+		// an error to retry: skip the git spawn entirely until the directory is
+		// back on disk (external restore, workspace repair).
+		if (!this.worktreeExists(workspace.worktreePath)) {
+			this.noteWorktreeMissing(workspace.id, workspace.worktreePath);
+			return null;
+		}
+		this.noteWorktreePresent(workspace.id);
 		try {
 			const { branch, headSha, upstream } = await this.readWorkspaceRefs(
 				workspace.worktreePath,
@@ -551,6 +584,38 @@ export class PullRequestRuntimeManager {
 				},
 			);
 			return null;
+		}
+	}
+
+	private noteWorktreeMissing(workspaceId: string, worktreePath: string): void {
+		if (this.missingWorktrees.has(workspaceId)) return;
+		this.missingWorktrees.set(workspaceId, worktreePath);
+		console.warn(
+			"[host-service:pull-request-runtime] Worktree missing on disk; pausing branch sync until it reappears",
+			{ workspaceId, worktreePath },
+		);
+		this.missingWorktreeProbeTimer ??= setInterval(() => {
+			for (const [id, path] of this.missingWorktrees) {
+				if (this.worktreeExists(path)) void this.enqueueWorkspaceSync(id);
+			}
+		}, MISSING_WORKTREE_PROBE_INTERVAL_MS);
+	}
+
+	private noteWorktreePresent(workspaceId: string): void {
+		const worktreePath = this.missingWorktrees.get(workspaceId);
+		if (worktreePath === undefined) return;
+		this.forgetMissingWorktree(workspaceId);
+		console.warn(
+			"[host-service:pull-request-runtime] Worktree reappeared; resuming branch sync",
+			{ workspaceId, worktreePath },
+		);
+	}
+
+	private forgetMissingWorktree(workspaceId: string): void {
+		if (!this.missingWorktrees.delete(workspaceId)) return;
+		if (this.missingWorktrees.size === 0 && this.missingWorktreeProbeTimer) {
+			clearInterval(this.missingWorktreeProbeTimer);
+			this.missingWorktreeProbeTimer = null;
 		}
 	}
 
@@ -724,10 +789,13 @@ export class PullRequestRuntimeManager {
 				remoteName: project.remoteName,
 			};
 		} else {
-			const git = await this.git(project.repoPath);
 			const remoteName = "origin";
 			let remoteUrl: string;
+			// The construct sits inside the try: a repoPath that vanished from
+			// disk throws GitConstructError, which is "no repo" here, not a
+			// refresh failure to warn about every sweep.
 			try {
+				const git = await this.git(project.repoPath);
 				const value = await git.remote(["get-url", remoteName]);
 				if (typeof value !== "string") {
 					return null;


### PR DESCRIPTION
## Summary
- Pollers (PR runtime sweeps, git watcher) no longer spawn git forever against workspaces whose worktree directory has been deleted: a cheap `existsSync` gate flips the workspace into a degraded state with one transition log line, and it auto-recovers when the directory reappears.

## Why / Context
A user's host-service log (UI-freeze report, #ext-vori) showed **421/day** `GitConstructError: Cannot use simple-git on a directory that does not exist` — every poll cycle re-spawned git against missing dirs, forever, contributing to the background load starving their pty-daemon (the delivery mechanism of their terminal freezes).

## How It Works
Before constructing simple-git for a workspace poll, check the worktree dir. Missing → mark degraded (log once), skip work; re-probe with `existsSync` each tick (cheap, no spawn). Dir back → exit degraded (log once), full re-sync. Interactive git-status is gated statelessly, so it recovers instantly. Transient git errors on *existing* dirs are untouched.

## Manual QA (10-min A/B windows, same harness, real host-service with 3 deleted-worktree workspaces)
- git spawn attempts: **15 → 0**; recurring error-log groups **15 → 0** (5 one-time transition lines); raw log lines 286 → 41.
- Recovery: restored a worktree dir → "Worktree reappeared" + full row re-sync (branch + headSha) in **20s**.

## Testing
- 2 new degraded-state tests (verified they fail with the gate removed); 20/20 package tests; `bun run typecheck` and `bun run lint` exit 0.

Not addressed (separate, low-frequency): the reporter's `[ensureMainWorkspace]` detached-HEAD retries (~6/day).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `host-service` from repeatedly spawning git when a workspace’s worktree directory is missing. Adds a cheap disk check to pause sync, cut error logs, and auto-recover when the directory returns.

- **Bug Fixes**
  - Gate PR sync on `existsSync`; mark a workspace as degraded, skip git spawns, probe every 30s, and log once on enter/exit.
  - In `git-watcher`, skip the rescan exec when the worktree path is missing to avoid spawn loops.
  - Treat a missing project `repoPath` as “no repo” during refresh to avoid repeated warnings.

<sup>Written for commit e5faa7fe0cfc078e23bf46125a3c59b3d87f81c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unavailable workspace worktrees during pull request synchronization.
  - Prevented unnecessary Git operations when a worktree is missing.
  - Automatically detects when a worktree returns and resumes synchronization.
  - Improved resilience when repository metadata cannot be loaded, avoiding refresh failures.
  - Cleans up missing-worktree monitoring when workspaces are removed, archived, or sessions end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->