### PR TITLE
fix(host-service): stop gh open-PR sweep dying on >1MB payloads and hot-looping on failure

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setSystemTime, test } from "bun:test";
 import { resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -615,6 +615,63 @@ describe("PullRequestRuntimeManager refresh", () => {
 		);
 
 		expect(getWorkspace(db, "ws")?.pullRequestId).toBe("pr-existing");
+	});
+
+	// A permanently failing fetch (payload over maxBuffer, revoked auth) must
+	// not respawn gh at full 60s-TTL cadence forever: consecutive failures
+	// double the cached rejection's TTL, and a success resets the streak.
+	test("backs off repeated open-PR sweep failures and resets on success", async () => {
+		const t0 = Date.now();
+		setSystemTime(new Date(t0));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			let attempts = 0;
+			let failing = true;
+			const manager = createManager(db, {
+				execGh: async () => {
+					attempts += 1;
+					if (failing) throw new Error("sweep unavailable");
+					return [];
+				},
+				github: (async () => {
+					throw new Error("octokit unavailable");
+				}) as never,
+			});
+			const repo = {
+				provider: "github" as const,
+				owner: REPO.owner,
+				name: REPO.name,
+				url: `https://github.com/${REPO.owner}/${REPO.name}.git`,
+				remoteName: "origin",
+				defaultBranch: "main",
+			};
+			const sweep = () =>
+				withSilencedWarnings(() =>
+					manager.getCachedOpenPullRequests(repo).catch(() => {}),
+				);
+
+			// Trigger every 20s for 10 minutes. Without backoff the 60s TTL
+			// admits 11 fetches; doubling admits only t=0, 2min, 6min.
+			for (let t = 0; t <= 10 * 60_000; t += 20_000) {
+				setSystemTime(new Date(t0 + t));
+				await sweep();
+			}
+			expect(attempts).toBe(3);
+
+			// The t=6min failure backed off to 8min: retry fires at 14min.
+			failing = false;
+			setSystemTime(new Date(t0 + 14 * 60_000 + 1_000));
+			await sweep();
+			expect(attempts).toBe(4);
+
+			// Success resets the streak: the base 60s TTL applies again.
+			setSystemTime(new Date(t0 + 14 * 60_000 + 1_000 + 61_000));
+			await sweep();
+			expect(attempts).toBe(5);
+		} finally {
+			setSystemTime();
+		}
 	});
 });
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -205,6 +205,22 @@ function makePrNode(pr: {
 	};
 }
 
+// Typed handle on the private per-repo sweep entrypoint under test; keeps
+// tsc (no private dot-access) and biome (no bracket-access) both satisfied.
+function openPullRequestsSweeper(manager: PullRequestRuntimeManager) {
+	const accessible = manager as unknown as {
+		getCachedOpenPullRequests(repo: {
+			provider: "github";
+			owner: string;
+			name: string;
+			url: string;
+			remoteName: string;
+			defaultBranch: string | null;
+		}): Promise<unknown[]>;
+	};
+	return accessible.getCachedOpenPullRequests.bind(accessible);
+}
+
 // Silences the expected warnings the manager logs on handled failures.
 async function withSilencedWarnings<T>(fn: () => Promise<T>): Promise<T> {
 	const original = console.warn;
@@ -646,10 +662,9 @@ describe("PullRequestRuntimeManager refresh", () => {
 				remoteName: "origin",
 				defaultBranch: "main",
 			};
+			const fetchOpenPrs = openPullRequestsSweeper(manager);
 			const sweep = () =>
-				withSilencedWarnings(() =>
-					manager.getCachedOpenPullRequests(repo).catch(() => {}),
-				);
+				withSilencedWarnings(() => fetchOpenPrs(repo).catch(() => {}));
 
 			// Trigger every 20s for 10 minutes. Without backoff the 60s TTL
 			// admits 11 fetches; doubling admits only t=0, 2min, 6min.
@@ -669,6 +684,67 @@ describe("PullRequestRuntimeManager refresh", () => {
 			setSystemTime(new Date(t0 + 14 * 60_000 + 1_000 + 61_000));
 			await sweep();
 			expect(attempts).toBe(5);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	// A fetch that out-lives its own backoff window before rejecting must
+	// anchor the backoff at the rejection, not the fetch start — otherwise
+	// the cached rejection is born expired and the next trigger refetches
+	// immediately, so slow failures never back off.
+	test("anchors failure backoff at rejection time for slow failures", async () => {
+		const t0 = Date.now();
+		setSystemTime(new Date(t0));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			let attempts = 0;
+			let rejectInFlight: ((error: Error) => void) | undefined;
+			const manager = createManager(db, {
+				execGh: () => {
+					attempts += 1;
+					if (attempts === 1) {
+						return new Promise((_, reject) => {
+							rejectInFlight = reject;
+						});
+					}
+					return Promise.reject(new Error("sweep unavailable"));
+				},
+				github: (async () => {
+					throw new Error("octokit unavailable");
+				}) as never,
+			});
+			const repo = {
+				provider: "github" as const,
+				owner: REPO.owner,
+				name: REPO.name,
+				url: `https://github.com/${REPO.owner}/${REPO.name}.git`,
+				remoteName: "origin",
+				defaultBranch: "main",
+			};
+			const fetchOpenPrs = openPullRequestsSweeper(manager);
+			const sweep = () =>
+				withSilencedWarnings(() => fetchOpenPrs(repo).catch(() => {}));
+
+			// The fetch hangs past its own post-failure window (120s after the
+			// first failure) and only then rejects.
+			const slow = sweep();
+			expect(attempts).toBe(1);
+			setSystemTime(new Date(t0 + 130_000));
+			rejectInFlight?.(new Error("slow failure"));
+			await slow;
+
+			// Anchored at fetch start the window would already be consumed and
+			// this trigger would refetch; anchored at the rejection it holds.
+			setSystemTime(new Date(t0 + 131_000));
+			await sweep();
+			expect(attempts).toBe(1);
+
+			// The full window measured from the failure elapses: retry admitted.
+			setSystemTime(new Date(t0 + 130_000 + 121_000));
+			await sweep();
+			expect(attempts).toBe(2);
 		} finally {
 			setSystemTime();
 		}

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -1,6 +1,8 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, setSystemTime, test } from "bun:test";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
@@ -53,13 +55,14 @@ function seedWorkspace(
 		upstreamRepo?: string | null;
 		upstreamBranch?: string | null;
 		pullRequestId?: string | null;
+		worktreePath?: string;
 	},
 ) {
 	db.insert(schema.workspaces)
 		.values({
 			id: w.id,
 			projectId: PROJECT_ID,
-			worktreePath: `/repo/.worktrees/${w.id}`,
+			worktreePath: w.worktreePath ?? `/repo/.worktrees/${w.id}`,
 			branch: w.branch,
 			createdAt: Date.now(),
 			headSha: w.headSha ?? null,
@@ -1192,5 +1195,72 @@ describe("missing-worktree degraded state", () => {
 		).toHaveLength(1);
 
 		manager.stop();
+	});
+
+	// Constructed WITHOUT worktreeExists: pins the `?? existsSync` production
+	// default against a real directory, which every other test stubs out.
+	test("default disk gate uses the real filesystem when nothing is injected", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		const dir = mkdtempSync(join(tmpdir(), "prm-default-gate-"));
+		seedWorkspace(db, {
+			id: "ws-real",
+			branch: "feat/real",
+			worktreePath: dir,
+		});
+		let refsReads = 0;
+		const manager = new PullRequestRuntimeManager({
+			db,
+			execGh: routeGh({
+				"feat/real": makePrNode({
+					number: 7002,
+					headRef: "feat/real",
+					headSha: "sha-real",
+				}),
+			}) as never,
+			git: (async () => {
+				throw new Error("git should not be used");
+			}) as never,
+			github: (async () => {
+				throw new Error("octokit should not be used");
+			}) as never,
+			gitWatcher: { onChanged: () => () => {} } as never,
+			readWorkspaceRefs: async () => {
+				refsReads += 1;
+				return {
+					branch: "feat/real",
+					headSha: "sha-real",
+					upstream: { owner: REPO.owner, name: REPO.name, branch: "feat/real" },
+				};
+			},
+		});
+		const bus = createFakeWorkspaceEventBus();
+		manager.subscribeToWorkspaceEvents(bus);
+		const event: WorkspaceChangedEvent = {
+			workspaceId: "ws-real",
+			eventType: "created",
+			workspace: null,
+			occurredAt: 1,
+		};
+
+		try {
+			bus.emit(event);
+			await waitFor(() => refsReads > 0);
+			expect(refsReads).toBeGreaterThan(0);
+
+			const seen = refsReads;
+			rmSync(dir, { recursive: true, force: true });
+			const { warnings } = await withCapturedWarnings(async () => {
+				bus.emit(event);
+				await waitFor(() => refsReads > seen, 100);
+			});
+			expect(refsReads).toBe(seen);
+			expect(
+				warnings.filter((w) => w.includes("Worktree missing on disk")),
+			).toHaveLength(1);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+			manager.stop();
+		}
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -1024,6 +1024,9 @@ export class PullRequestRuntimeManager {
 				entry.consecutiveFailures = 0;
 			},
 			() => {
+				// Re-anchor at the failure: a fetch that out-lives its own backoff
+				// window before rejecting must not be retried immediately.
+				entry.fetchedAt = Date.now();
 				entry.consecutiveFailures += 1;
 			},
 		);

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -59,6 +59,10 @@ const PROJECT_REFRESH_INTERVAL_MS = 5 * 60_000;
 // PROJECT_REFRESH). Otherwise the cache is always stale at poll time and
 // each tick fires fresh GitHub calls for the same upstream branch.
 const REPO_PULL_REQUEST_CACHE_TTL_MS = 60_000;
+// A fetch that keeps failing (payload over maxBuffer, revoked auth, …) must
+// not respawn `gh` at full cadence forever: each consecutive failure doubles
+// the effective TTL of the cached rejection, capped here.
+const REPO_PULL_REQUEST_CACHE_MAX_TTL_MS = 30 * 60_000;
 // Re-probe cadence for worktrees observed missing on disk. existsSync-only —
 // cheap enough to run every tick; spawning git against a missing dir is not.
 const MISSING_WORKTREE_PROBE_INTERVAL_MS = 30_000;
@@ -176,11 +180,19 @@ export class PullRequestRuntimeManager {
 	>();
 	private readonly pullRequestHeadCache = new Map<
 		string,
-		{ promise: Promise<GitHubPullRequestNode | null>; fetchedAt: number }
+		{
+			promise: Promise<GitHubPullRequestNode | null>;
+			fetchedAt: number;
+			consecutiveFailures: number;
+		}
 	>();
 	private readonly openPullRequestsCache = new Map<
 		string,
-		{ promise: Promise<GitHubPullRequestNode[]>; fetchedAt: number }
+		{
+			promise: Promise<GitHubPullRequestNode[]>;
+			fetchedAt: number;
+			consecutiveFailures: number;
+		}
 	>();
 	private readonly readWorkspaceRefs: (
 		worktreePath: string,
@@ -979,28 +991,44 @@ export class PullRequestRuntimeManager {
 	// retried, hit the same 403, and re-evicted. Network blips heal at the
 	// next TTL boundary instead.
 	private cachedGitHubFetch<T>(
-		cache: Map<string, { promise: Promise<T>; fetchedAt: number }>,
+		cache: Map<
+			string,
+			{ promise: Promise<T>; fetchedAt: number; consecutiveFailures: number }
+		>,
 		cacheKey: string,
 		options: { bypassCache?: boolean },
 		fetcher: () => Promise<T>,
 	): Promise<T> {
-		if (!options.bypassCache) {
-			const cached = cache.get(cacheKey);
-			if (
-				cached &&
-				Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
-			) {
+		const cached = cache.get(cacheKey);
+		if (!options.bypassCache && cached) {
+			const ttl = Math.min(
+				REPO_PULL_REQUEST_CACHE_TTL_MS * 2 ** cached.consecutiveFailures,
+				REPO_PULL_REQUEST_CACHE_MAX_TTL_MS,
+			);
+			if (Date.now() - cached.fetchedAt < ttl) {
 				return cached.promise;
 			}
 		}
 
-		const fetchedAt = Date.now();
-		const promise = fetcher();
-		// Observer to silence unhandledRejection warnings; real consumers
-		// observe the rejection via their own await on the cached promise.
-		promise.catch(() => {});
-		cache.set(cacheKey, { promise, fetchedAt });
-		return promise;
+		// Carry the failure streak forward so an in-flight retry keeps the
+		// backed-off TTL until it actually resolves.
+		const entry = {
+			promise: fetcher(),
+			fetchedAt: Date.now(),
+			consecutiveFailures: cached?.consecutiveFailures ?? 0,
+		};
+		// The rejection observer also silences unhandledRejection warnings;
+		// real consumers observe it via their own await on the cached promise.
+		entry.promise.then(
+			() => {
+				entry.consecutiveFailures = 0;
+			},
+			() => {
+				entry.consecutiveFailures += 1;
+			},
+		);
+		cache.set(cacheKey, entry);
+		return entry.promise;
 	}
 
 	private async getCachedPullRequestByHead(

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -245,6 +245,8 @@ describe("GitHub pull request REST queries", () => {
 					"direction=desc",
 					"-f",
 					"per_page=100",
+					"--jq",
+					expect.stringContaining("html_url"),
 				],
 			},
 		]);

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -250,6 +250,26 @@ describe("GitHub pull request REST queries", () => {
 				],
 			},
 		]);
+		// The projection must keep every field normalizePullRequest reads;
+		// dropping one silently discards PRs from the sweep.
+		const jqExpression = calls[0]?.args.at(-1) ?? "";
+		for (const field of [
+			"number",
+			"title",
+			"html_url",
+			"state",
+			"merged_at",
+			"draft",
+			"updated_at",
+			".head.ref",
+			".head.sha",
+			".head.repo.name",
+			".head.repo.owner.login",
+			".head.user.login",
+			".base.repo.full_name",
+		]) {
+			expect(jqExpression).toContain(field);
+		}
 	});
 
 	test("derives review decision from latest REST reviews by author", async () => {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -253,6 +253,13 @@ export async function fetchPullRequestByHead(
 	return normalizePullRequestCandidates(response.data, head);
 }
 
+// 100 full PR objects (bodies included) routinely exceed exec's stdout
+// buffer, so project down to exactly what normalizePullRequest reads before
+// the payload leaves gh. jq's null-indexing keeps absent nests as nulls,
+// which normalizePullRequest already rejects the same way as missing keys.
+const OPEN_PULL_REQUESTS_JQ =
+	'if type == "array" then [.[] | select(type == "object") | {number, title, html_url, state, merged_at, draft, updated_at, head: {ref: .head.ref, sha: .head.sha, repo: {name: .head.repo.name, owner: {login: .head.repo.owner.login}}, user: {login: .head.user.login}}, base: {repo: {full_name: .base.repo.full_name}}}] else . end';
+
 // GitHub's `head=` filter is case-sensitive on the branch (verified), so a
 // drifted-case lookup returns nothing. This repo-wide sweep lets the caller
 // match heads case-insensitively. Open PRs only — `state=all` is unbounded.
@@ -276,6 +283,8 @@ export async function fetchOpenPullRequestsFromGh(
 		"direction=desc",
 		"-f",
 		"per_page=100",
+		"--jq",
+		OPEN_PULL_REQUESTS_JQ,
 	]);
 
 	return asArray(raw)

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
@@ -27,6 +27,9 @@ export const execGh: ExecGh = async (args, options) => {
 	const { stdout } = await execFileAsync("gh", args, {
 		encoding: "utf8",
 		timeout: options?.timeout ?? 10_000,
+		// Node's 1MB default dies on large REST payloads (open-PR sweeps of
+		// busy repos exceed it even paginated).
+		maxBuffer: 10 * 1024 * 1024,
 		cwd: options?.cwd,
 		env,
 	});

--- a/packages/host-service/test/pull-requests-scaling.test.ts
+++ b/packages/host-service/test/pull-requests-scaling.test.ts
@@ -108,6 +108,9 @@ async function runSync(workspaceCount: number) {
 		git: git as never,
 		github: async () => ({}) as never,
 		gitWatcher: { onChanged: () => () => {} } as never,
+		// Fixture worktree paths are fabricated; open the missing-dir gate
+		// so the scaling assertions still count real git-factory calls.
+		worktreeExists: () => true,
 	});
 
 	// `syncWorkspaceBranches` calls `refreshProject` only for changed projects;

--- a/packages/host-service/test/pull-requests.test.ts
+++ b/packages/host-service/test/pull-requests.test.ts
@@ -51,6 +51,9 @@ describe("PullRequestRuntimeManager branch sync", () => {
 			git: git as never,
 			github: async () => ({}) as never,
 			gitWatcher: { onChanged: () => () => {} } as never,
+			// Fixture worktree paths are fabricated; open the missing-dir gate
+			// so the sync path under test reaches the mocked git factory.
+			worktreeExists: () => true,
 		});
 		const refreshProjectMock = mock(async () => undefined);
 		(
@@ -133,6 +136,9 @@ describe("PullRequestRuntimeManager branch sync", () => {
 			git: git as never,
 			github: async () => ({}) as never,
 			gitWatcher: { onChanged: () => () => {} } as never,
+			// Fixture worktree paths are fabricated; open the missing-dir gate
+			// so the sync path under test reaches the mocked git factory.
+			worktreeExists: () => true,
 		});
 		const refreshProjectMock = mock(async () => undefined);
 		(


### PR DESCRIPTION
## Summary
- The open-PR sweep (`gh api repos/<o>/<r>/pulls per_page=100`) now slims the response with `--jq` to only the fields consumers read (2.1MB → 48KB on a real 100-PR repo), so it no longer dies on Node's 1MB exec `maxBuffer`.
- `execGh` gets an explicit 10MiB `maxBuffer` as belt-and-braces (also covers the un-slimmed per-head lookup).
- Repeated sweep failures now back off exponentially (60s → 30min cap, reset on success) instead of retrying at full cadence forever.

## Why / Context
A user's host-service log (UI-freeze report, #ext-vori) showed **148/day** `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` from this sweep — for repos with ~100 open PRs it has been completely non-functional and endlessly re-spawning `gh`. Note `superset-sh/superset` itself exceeds 1MB of open-PR JSON, so the sweep was broken for our own repo too.

## Manual QA (fake `gh` shim emitting a real captured 2.1MB pulls payload; 10-min A/B windows)
- BEFORE: 11 spawns, 31 errors, **0 successful parses**. AFTER: 11 spawns, 0 errors, **100/100 PRs parsed**.
- Parsed output **byte-identical** between raw and `--jq`-slimmed responses across all 100 real PRs.
- Persistently failing shim (exit 1): spawns **61 → 6 per hour** (10.2×) via backoff.
- `--jq` expression validated read-only against real GitHub via real `gh`.

## Testing
- New unit test pins the backoff schedule + reset-on-success (fails against pre-fix code); 34/34 pull-requests tests; `bun run typecheck` and `bun run lint` exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the open-PR sweep from crashing on >1MB responses and from retrying in a tight loop. Busy repos now parse reliably and reduce unnecessary `gh` spawns; slow failures now back off correctly.

- **Bug Fixes**
  - Slimmed the sweep response with `gh --jq` to only needed fields (2.1MB → 48KB) and added tests to keep the projection correct; updated the test harness to pin the default `worktreeExists` gate with a real directory.
  - Set `execGh` `maxBuffer` to 10MiB for safety.
  - Added exponential backoff on repeated failures, anchored at rejection time so slow failures don’t immediately refetch (TTL doubles up to 30 min; resets on success).

<sup>Written for commit 49bad6596ec6c7175f6c461ccfea6932921e3e13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added exponential backoff when fetching open pull requests fails, reducing repeated requests and restoring normal refresh timing after a successful fetch.
  * Improved handling of larger GitHub responses to help prevent command failures.
  * Streamlined open pull-request queries to retrieve only the information needed for processing, improving request efficiency and reliability.
  * Improved retry timing by anchoring failed refreshes to the time of failure and preserving consistent request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->