### PR TITLE
refactor(host-service,desktop): consolidate terminal session listing into terminal.list

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
@@ -38,8 +38,7 @@ import { focusOrAddTerminalPane } from "../../utils/focusTerminalPane";
 import {
 	BACKGROUND_TERMINAL_ATTACHMENT_DEBOUNCE_MS,
 	getAttachedTerminalIdsKey,
-	getBackgroundTerminalCountRefetchInterval,
-	getBackgroundTerminalListRefetchInterval,
+	getBackgroundTerminalRefetchInterval,
 	getBackgroundTerminalSessions,
 	getUnattachedTerminalIds,
 	parseAttachedTerminalIdsKey,
@@ -95,37 +94,26 @@ export const BackgroundTerminalsButton = memo(
 			[backgroundMarkerIds, attachedTerminalIds],
 		);
 		const optimisticBackgroundCount = optimisticBackgroundTerminalIds.length;
-		const backgroundCountInput = useMemo(
-			() => ({
-				workspaceId,
-				attachedTerminalIds: debouncedAttachedTerminalIds,
-			}),
-			[workspaceId, debouncedAttachedTerminalIds],
-		);
 		const sessionsInput = useMemo(() => ({ workspaceId }), [workspaceId]);
 		const utils = workspaceTrpc.useUtils();
 		const killSession = workspaceTrpc.terminal.killSession.useMutation();
-		const backgroundCountQuery =
-			workspaceTrpc.terminal.countBackgroundSessions.useQuery(
-				backgroundCountInput,
-				{
-					enabled: !isOpen,
-					notifyOnChangeProps: ["data", "dataUpdatedAt"],
-					refetchInterval: getBackgroundTerminalCountRefetchInterval(isOpen),
-					refetchOnWindowFocus: false,
-					staleTime: 5_000,
-				},
-			);
-		const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
-			sessionsInput,
-			{
-				enabled: isOpen,
-				notifyOnChangeProps: ["data", "isLoading"],
-				refetchInterval: getBackgroundTerminalListRefetchInterval(isOpen),
-				refetchOnWindowFocus: isOpen,
-				staleTime: 1_000,
-			},
-		);
+		const sessionsQuery = workspaceTrpc.terminal.list.useQuery(sessionsInput, {
+			notifyOnChangeProps: ["data", "dataUpdatedAt", "isLoading"],
+			refetchInterval: getBackgroundTerminalRefetchInterval(isOpen),
+			refetchOnWindowFocus: isOpen,
+			staleTime: isOpen ? 1_000 : 5_000,
+		});
+		// The settled count mirrors the server-side background count the closed
+		// state used to poll: computed against the debounced attachment set so a
+		// pane mid-drag doesn't flap the badge. null until the first fetch lands.
+		const settledBackgroundCount = useMemo(() => {
+			const sessions = sessionsQuery.data?.sessions;
+			if (!sessions) return null;
+			return getBackgroundTerminalSessions(
+				sessions,
+				debouncedAttachedTerminalIds,
+			).length;
+		}, [sessionsQuery.data?.sessions, debouncedAttachedTerminalIds]);
 
 		useRenderStressInstrumentation("BackgroundTerminalsButton", {
 			warnAt: 35,
@@ -133,7 +121,7 @@ export const BackgroundTerminalsButton = memo(
 				isOpen,
 				attachedTerminalCount: attachedTerminalIds.length,
 				optimisticBackgroundCount,
-				closedCount: backgroundCountQuery.data?.count ?? null,
+				closedCount: settledBackgroundCount,
 			}),
 		});
 
@@ -168,8 +156,8 @@ export const BackgroundTerminalsButton = memo(
 		useEffect(() => {
 			if (isOpen || optimisticBackgroundTerminalIds.length === 0) return;
 			if (debouncedAttachedTerminalIdsKey !== attachedTerminalIdsKey) return;
-			if (backgroundCountQuery.data?.count !== 0) return;
-			if (backgroundCountQuery.dataUpdatedAt <= markerObservedAtRef.current) {
+			if (settledBackgroundCount !== 0) return;
+			if (sessionsQuery.dataUpdatedAt <= markerObservedAtRef.current) {
 				return;
 			}
 
@@ -178,8 +166,8 @@ export const BackgroundTerminalsButton = memo(
 			}
 		}, [
 			attachedTerminalIdsKey,
-			backgroundCountQuery.data?.count,
-			backgroundCountQuery.dataUpdatedAt,
+			settledBackgroundCount,
+			sessionsQuery.dataUpdatedAt,
 			debouncedAttachedTerminalIdsKey,
 			isOpen,
 			optimisticBackgroundTerminalIds,
@@ -189,10 +177,7 @@ export const BackgroundTerminalsButton = memo(
 		const backgroundCount =
 			isOpen && sessionsQuery.data
 				? backgroundSessions.length
-				: Math.max(
-						backgroundCountQuery.data?.count ?? 0,
-						optimisticBackgroundCount,
-					);
+				: Math.max(settledBackgroundCount ?? 0, optimisticBackgroundCount);
 
 		if (!isOpen && backgroundCount === 0) return null;
 
@@ -203,8 +188,7 @@ export const BackgroundTerminalsButton = memo(
 		const handleAdopt = (terminalId: string) => {
 			clearTerminalBackgroundMarker(workspaceId, terminalId);
 			const result = focusOrAddTerminalPane(store, terminalId);
-			void utils.terminal.listSessions.invalidate({ workspaceId });
-			void utils.terminal.countBackgroundSessions.invalidate({ workspaceId });
+			void utils.terminal.list.invalidate({ workspaceId });
 			logStressEvent("background-terminals.adopt", { result, workspaceId });
 			setIsOpen(false);
 		};
@@ -220,8 +204,7 @@ export const BackgroundTerminalsButton = memo(
 				);
 				toast.error("Failed to close terminal session");
 			} finally {
-				void utils.terminal.listSessions.invalidate({ workspaceId });
-				void utils.terminal.countBackgroundSessions.invalidate({ workspaceId });
+				void utils.terminal.list.invalidate({ workspaceId });
 			}
 		};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.utils.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.utils.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	getAttachedTerminalIdsKey,
-	getBackgroundTerminalCountRefetchInterval,
-	getBackgroundTerminalListRefetchInterval,
+	getBackgroundTerminalRefetchInterval,
 	getBackgroundTerminalSessions,
 	getUnattachedTerminalIds,
 	parseAttachedTerminalIdsKey,
@@ -51,10 +50,8 @@ describe("BackgroundTerminalsButton utils", () => {
 		).toEqual(["term-b"]);
 	});
 
-	test("uses shallow count polling only while closed", () => {
-		expect(getBackgroundTerminalCountRefetchInterval(false)).toBe(10_000);
-		expect(getBackgroundTerminalCountRefetchInterval(true)).toBe(false);
-		expect(getBackgroundTerminalListRefetchInterval(false)).toBe(false);
-		expect(getBackgroundTerminalListRefetchInterval(true)).toBe(2_000);
+	test("polls slowly while closed and fast while open", () => {
+		expect(getBackgroundTerminalRefetchInterval(false)).toBe(10_000);
+		expect(getBackgroundTerminalRefetchInterval(true)).toBe(2_000);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.utils.ts
@@ -1,6 +1,6 @@
 export const BACKGROUND_TERMINAL_ATTACHMENT_DEBOUNCE_MS = 250;
-export const BACKGROUND_TERMINAL_COUNT_REFETCH_INTERVAL_MS = 10_000;
-export const BACKGROUND_TERMINAL_LIST_REFETCH_INTERVAL_MS = 2_000;
+export const BACKGROUND_TERMINAL_CLOSED_REFETCH_INTERVAL_MS = 10_000;
+export const BACKGROUND_TERMINAL_OPEN_REFETCH_INTERVAL_MS = 2_000;
 
 interface TerminalPaneLike {
 	kind: string;
@@ -68,14 +68,8 @@ export function getUnattachedTerminalIds(
 		.sort();
 }
 
-export function getBackgroundTerminalCountRefetchInterval(
-	isOpen: boolean,
-): number | false {
-	return isOpen ? false : BACKGROUND_TERMINAL_COUNT_REFETCH_INTERVAL_MS;
-}
-
-export function getBackgroundTerminalListRefetchInterval(
-	isOpen: boolean,
-): number | false {
-	return isOpen ? BACKGROUND_TERMINAL_LIST_REFETCH_INTERVAL_MS : false;
+export function getBackgroundTerminalRefetchInterval(isOpen: boolean): number {
+	return isOpen
+		? BACKGROUND_TERMINAL_OPEN_REFETCH_INTERVAL_MS
+		: BACKGROUND_TERMINAL_CLOSED_REFETCH_INTERVAL_MS;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
@@ -39,7 +39,7 @@ export function useAutoAdoptBackgroundSessions({
 	workspaceId,
 	isLayoutReady,
 }: UseAutoAdoptBackgroundSessionsArgs): void {
-	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+	const sessionsQuery = workspaceTrpc.terminal.list.useQuery(
 		{ workspaceId },
 		{ enabled: isLayoutReady, refetchOnWindowFocus: false },
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.ts
@@ -31,7 +31,7 @@ export function useConsumeAutomationRunLink({
 }: UseConsumeAutomationRunLinkArgs): void {
 	const consumedRef = useRef<Set<string>>(new Set());
 	const collections = useCollections();
-	const terminalSessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+	const terminalSessionsQuery = workspaceTrpc.terminal.list.useQuery(
 		{ workspaceId },
 		{
 			enabled: terminalId != null,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useCreatePendingMigratedTerminals/useCreatePendingMigratedTerminals.ts
@@ -127,7 +127,7 @@ export function useCreatePendingMigratedTerminals({
 			if (pending.length > 0) {
 				// Nudge the session list so auto-adopt builds the panes now
 				// rather than on the next natural refetch.
-				await utils.terminal.listSessions.invalidate({ workspaceId });
+				await utils.terminal.list.invalidate({ workspaceId });
 			}
 			runningRef.current = false;
 		})();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -105,10 +105,10 @@ export function TerminalPane({
 
 	const workspaceTrpcUtils = workspaceTrpc.useUtils();
 	const invalidateTerminalSessionsRef = useRef(
-		workspaceTrpcUtils.terminal.listSessions.invalidate,
+		workspaceTrpcUtils.terminal.list.invalidate,
 	);
 	invalidateTerminalSessionsRef.current =
-		workspaceTrpcUtils.terminal.listSessions.invalidate;
+		workspaceTrpcUtils.terminal.list.invalidate;
 
 	// useCallback so useSyncExternalStore doesn't re-subscribe every render —
 	// otherwise every keystroke-triggered re-render unsubscribes and

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -95,16 +95,13 @@ export function TerminalSessionDropdown({
 	const utils = workspaceTrpc.useUtils();
 	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
 	const sessionsInput = useMemo(() => ({ workspaceId }), [workspaceId]);
-	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
-		sessionsInput,
-		{
-			enabled: shouldQueryTerminalSessionList(isOpen),
-			notifyOnChangeProps: ["data", "isFetching"],
-			refetchInterval: getTerminalSessionListRefetchInterval(isOpen),
-			refetchOnWindowFocus: false,
-			staleTime: TERMINAL_SESSION_LIST_STALE_MS,
-		},
-	);
+	const sessionsQuery = workspaceTrpc.terminal.list.useQuery(sessionsInput, {
+		enabled: shouldQueryTerminalSessionList(isOpen),
+		notifyOnChangeProps: ["data", "isFetching"],
+		refetchInterval: getTerminalSessionListRefetchInterval(isOpen),
+		refetchOnWindowFocus: false,
+		staleTime: TERMINAL_SESSION_LIST_STALE_MS,
+	});
 	useRenderStressInstrumentation("TerminalSessionDropdown", {
 		warnAt: 30,
 		getDetails: () => ({
@@ -230,7 +227,7 @@ export function TerminalSessionDropdown({
 			});
 			closePanesForTerminal(session.terminalId);
 		} finally {
-			await utils.terminal.listSessions.invalidate({ workspaceId });
+			await utils.terminal.list.invalidate({ workspaceId });
 		}
 	};
 
@@ -260,7 +257,7 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			titleOverride: undefined,
 		});
-		void utils.terminal.listSessions.invalidate({ workspaceId });
+		void utils.terminal.list.invalidate({ workspaceId });
 		setIsOpen(false);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -132,7 +132,7 @@ export function usePaneRegistry({
 		workspaceTrpc.terminal.killSession.useMutation({
 			onSuccess: () => {
 				toast.success("Terminal session killed");
-				void workspaceTrpcUtils.terminal.listSessions.invalidate({
+				void workspaceTrpcUtils.terminal.list.invalidate({
 					workspaceId,
 				});
 			},
@@ -147,7 +147,7 @@ export function usePaneRegistry({
 	const { mutate: killTerminalSessionSilently } =
 		workspaceTrpc.terminal.killSession.useMutation({
 			onSuccess: () => {
-				void workspaceTrpcUtils.terminal.listSessions.invalidate({
+				void workspaceTrpcUtils.terminal.list.invalidate({
 					workspaceId,
 				});
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
@@ -300,7 +300,7 @@ export function useV2WorkspaceRun({
 				state.stopRequestedAt ??= stoppedAt;
 				markStopped(state, stoppedAt, { state: "stopped-by-user" });
 			});
-			await utils.terminal.listSessions.invalidate({ workspaceId });
+			await utils.terminal.list.invalidate({ workspaceId });
 		} catch (error) {
 			if (isTerminalGoneError(error)) {
 				const stoppedAt = Date.now();
@@ -309,7 +309,7 @@ export function useV2WorkspaceRun({
 					if (!state || state.state !== "running") return;
 					markStopped(state, stoppedAt);
 				});
-				await utils.terminal.listSessions.invalidate({ workspaceId });
+				await utils.terminal.list.invalidate({ workspaceId });
 				return;
 			}
 

--- a/apps/mobile/lib/trpc/host-chat-types.ts
+++ b/apps/mobile/lib/trpc/host-chat-types.ts
@@ -73,7 +73,7 @@ interface SessionInput {
  * `TerminalAgentBinding` (packages/host-service/src/terminal-agents/types.ts).
  * Only live agent-bound sessions are returned (dead ones filtered server-side).
  * Requires the agent lifecycle hooks to reach this host, so it can be empty
- * even when PTY terminals exist — we merge it with `terminal.listSessions`. */
+ * even when PTY terminals exist — we merge it with `terminal.list`. */
 export interface TerminalAgentBinding {
 	terminalId: string;
 	workspaceId: string;

--- a/apps/web/src/trpc/host-client.ts
+++ b/apps/web/src/trpc/host-client.ts
@@ -75,7 +75,7 @@ async function hostCall<TOutput>(
 export function listHostTerminals(routingKey: string, workspaceId: string) {
 	return hostCall<{ sessions: HostTerminalSession[] }>(
 		routingKey,
-		"terminal.listSessions",
+		"terminal.list",
 		{ workspaceId },
 		"GET",
 	);

--- a/packages/cli/src/commands/terminals/list/command.ts
+++ b/packages/cli/src/commands/terminals/list/command.ts
@@ -34,7 +34,7 @@ export default command({
 			userJwt: ctx.bearer,
 		});
 
-		const result = await target.client.terminal.listSessions.query({
+		const result = await target.client.terminal.list.query({
 			workspaceId: options.workspace,
 		});
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -630,7 +630,8 @@ export function listTerminalSessions(
 }
 
 /**
- * Workspace session list sourced from truth, not from this process's memory.
+ * Live session list sourced from truth, not from this process's memory —
+ * host-wide by default, narrowed to one workspace when `workspaceId` is set.
  *
  * The in-memory map is attachment plumbing: it empties on every host-service
  * restart while the detached pty-daemon keeps PTYs alive, and it only
@@ -645,10 +646,11 @@ export function listTerminalSessions(
  * only the daemon knows has never been attached in this process's lifetime,
  * hence `attached: false, title: null`.
  */
-export async function listWorkspaceTerminalSessions(
+export async function listLiveTerminalSessions(
 	db: HostDb,
-	workspaceId: string,
+	options: { workspaceId?: string } = {},
 ): Promise<TerminalSessionSummary[]> {
+	const { workspaceId } = options;
 	// `getDaemonClient` gates on the daemon bootstrap (waitForDaemonReady +
 	// supervisor.ensure), so a query racing a host-service restart blocks
 	// until the daemon is adopted instead of observing it as unreachable.
@@ -663,7 +665,7 @@ export async function listWorkspaceTerminalSessions(
 		// view is the whole truth. The dropdowns' polls re-query, so a
 		// transient connection failure self-heals.
 		console.warn(
-			"[terminal] listWorkspaceTerminalSessions: daemon unreachable, serving in-memory view",
+			"[terminal] listLiveTerminalSessions: daemon unreachable, serving in-memory view",
 			{ workspaceId, error },
 		);
 		daemonAliveIds = null;
@@ -691,12 +693,17 @@ export async function listWorkspaceTerminalSessions(
 
 	const merged = [...known];
 	for (const row of rows) {
-		if (row.originWorkspaceId !== workspaceId) continue;
+		// Orphaned rows (workspace deleted → origin nulled) have no home in a
+		// grouped listing and can't be attached through workspace-scoped IO.
+		if (row.originWorkspaceId == null) continue;
+		if (workspaceId !== undefined && row.originWorkspaceId !== workspaceId) {
+			continue;
+		}
 		if (row.status !== "active") continue;
 		if (row.disposeRequestedAt != null) continue;
 		merged.push({
 			terminalId: row.id,
-			workspaceId,
+			workspaceId: row.originWorkspaceId,
 			createdAt: row.createdAt,
 			exited: false,
 			exitCode: 0,

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -8,7 +8,7 @@ import {
 	disposeSessionAndWait,
 	disposeSessionsByWorkspaceId,
 	disposeSessionsByWorktreePath,
-	listWorkspaceTerminalSessions,
+	listLiveTerminalSessions,
 	parseThemeType,
 	sessionHasRunningProcess,
 	snapshotSession,
@@ -134,34 +134,19 @@ export const terminalRouter = router({
 		)
 		.mutation(createTerminalSessionFromInput),
 
-	listSessions: protectedProcedure
+	list: protectedProcedure
 		.input(
-			z.object({
-				workspaceId: z.string(),
-			}),
+			z
+				.object({
+					workspaceId: z.string().optional(),
+				})
+				.optional(),
 		)
 		.query(async ({ ctx, input }) => ({
-			sessions: await listWorkspaceTerminalSessions(ctx.db, input.workspaceId),
-		})),
-
-	countBackgroundSessions: protectedProcedure
-		.input(
-			z.object({
-				workspaceId: z.string(),
-				attachedTerminalIds: z.array(z.string()).default([]),
+			sessions: await listLiveTerminalSessions(ctx.db, {
+				workspaceId: input?.workspaceId,
 			}),
-		)
-		.query(async ({ ctx, input }) => {
-			const sessions = await listWorkspaceTerminalSessions(
-				ctx.db,
-				input.workspaceId,
-			);
-			const attached = new Set(input.attachedTerminalIds);
-			return {
-				count: sessions.filter((session) => !attached.has(session.terminalId))
-					.length,
-			};
-		}),
+		})),
 
 	hasRunningProcess: protectedProcedure
 		.input(

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -55,8 +55,8 @@ describe("terminal router integration", () => {
 		await scenario?.dispose();
 	});
 
-	test("listSessions returns empty when no sessions exist", async () => {
-		const result = await scenario.host.trpc.terminal.listSessions.query({
+	test("list returns empty when no sessions exist", async () => {
+		const result = await scenario.host.trpc.terminal.list.query({
 			workspaceId: scenario.workspaceId,
 		});
 		expect(result.sessions).toEqual([]);
@@ -80,9 +80,9 @@ describe("terminal router integration", () => {
 		).rejects.toBeInstanceOf(TRPCClientError);
 	});
 
-	test("listSessions requires authentication", async () => {
+	test("list requires authentication", async () => {
 		await expect(
-			scenario.host.unauthenticatedTrpc.terminal.listSessions.query({
+			scenario.host.unauthenticatedTrpc.terminal.list.query({
 				workspaceId: scenario.workspaceId,
 			}),
 		).rejects.toBeInstanceOf(TRPCClientError);
@@ -127,20 +127,14 @@ describe("terminal router integration", () => {
 				workspaceId: scenario.workspaceId,
 				terminalId,
 			});
-			const detachedCount =
-				await scenario.host.trpc.terminal.countBackgroundSessions.query({
-					workspaceId: scenario.workspaceId,
-					attachedTerminalIds: [],
-				});
-			const attachedCount =
-				await scenario.host.trpc.terminal.countBackgroundSessions.query({
-					workspaceId: scenario.workspaceId,
-					attachedTerminalIds: [terminalId],
-				});
+			const listed = await scenario.host.trpc.terminal.list.query({
+				workspaceId: scenario.workspaceId,
+			});
 
 			expect(spawned).toHaveLength(1);
-			expect(detachedCount.count).toBe(1);
-			expect(attachedCount.count).toBe(0);
+			expect(listed.sessions.map((session) => session.terminalId)).toEqual([
+				terminalId,
+			]);
 			const [{ meta }] = spawned;
 			expect(meta.shell).toBe(fakeFishPath);
 			expect(meta.argv[0]).toBe("-l");
@@ -386,7 +380,7 @@ describe("terminal router integration", () => {
 		}
 	}, 20_000);
 
-	test("listSessions and countBackgroundSessions see unattached daemon sessions after a host-service restart", async () => {
+	test("list sees unattached daemon sessions after a host-service restart", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "host-service-session-truth-"));
 		const socketPath = join(tmp, "pty-daemon.sock");
 		const terminalId = randomUUID();
@@ -446,7 +440,7 @@ describe("terminal router integration", () => {
 			// no reaper pass, warm-up, or renderer attach in between.
 			__resetSessionsForTesting();
 
-			const listed = await scenario.host.trpc.terminal.listSessions.query({
+			const listed = await scenario.host.trpc.terminal.list.query({
 				workspaceId: scenario.workspaceId,
 			});
 			expect(listed.sessions.map((session) => session.terminalId)).toEqual([
@@ -457,18 +451,13 @@ describe("terminal router integration", () => {
 			expect(restored?.attached).toBe(false);
 			expect(restored?.title).toBeNull();
 
-			const count =
-				await scenario.host.trpc.terminal.countBackgroundSessions.query({
-					workspaceId: scenario.workspaceId,
-					attachedTerminalIds: [],
-				});
-			expect(count.count).toBe(1);
-			const excludedCount =
-				await scenario.host.trpc.terminal.countBackgroundSessions.query({
-					workspaceId: scenario.workspaceId,
-					attachedTerminalIds: [terminalId],
-				});
-			expect(excludedCount.count).toBe(0);
+			// The host-wide (unfiltered) list serves the same daemon-truth view,
+			// with workspaceId recovered from the session's origin row.
+			const listedAll = await scenario.host.trpc.terminal.list.query({});
+			expect(listedAll.sessions.map((session) => session.terminalId)).toEqual([
+				terminalId,
+			]);
+			expect(listedAll.sessions[0]?.workspaceId).toBe(scenario.workspaceId);
 
 			// Listing is read-only: the live PTY must be untouched.
 			const after = await findAlive(terminalId);

--- a/packages/mcp/src/tools/terminals/list.ts
+++ b/packages/mcp/src/tools/terminals/list.ts
@@ -37,7 +37,7 @@ export function register(server: McpServer): void {
 					hostId: input.hostId,
 					jwt: ctx.bearerToken,
 				},
-				"terminal.listSessions",
+				"terminal.list",
 				"query",
 				{ workspaceId: input.workspaceId },
 			);

--- a/packages/sdk/api.md
+++ b/packages/sdk/api.md
@@ -109,7 +109,7 @@ Types:
 Methods:
 
 - <code title="host post /api/trpc/terminal.createSession">client.terminals.<a href="./src/resources/terminals.ts">create</a>({ hostId, workspaceId, command?, cwd? }) -> TerminalCreateResult</code>
-- <code title="host post /api/trpc/terminal.listSessions">client.terminals.<a href="./src/resources/terminals.ts">list</a>({ hostId, workspaceId }) -> TerminalListResult</code>
+- <code title="host post /api/trpc/terminal.list">client.terminals.<a href="./src/resources/terminals.ts">list</a>({ hostId, workspaceId }) -> TerminalListResult</code>
 - <code title="host post /api/trpc/terminal.send">client.terminals.<a href="./src/resources/terminals.ts">send</a>({ hostId, workspaceId, terminalId, text, submit? }) -> TerminalSendResult</code>
 - <code title="host post /api/trpc/terminal.snapshot">client.terminals.<a href="./src/resources/terminals.ts">read</a>({ hostId, workspaceId, terminalId, maxLines? }) -> TerminalReadResult</code>
 - <code title="host post /api/trpc/terminal.killSession">client.terminals.<a href="./src/resources/terminals.ts">close</a>({ hostId, workspaceId, terminalId }) -> TerminalCloseResult</code>

--- a/packages/sdk/src/resources/terminals.ts
+++ b/packages/sdk/src/resources/terminals.ts
@@ -29,7 +29,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostQuery<TerminalListResult>(
 			params.hostId,
-			"terminal.listSessions",
+			"terminal.list",
 			{ workspaceId: params.workspaceId },
 		);
 	}


### PR DESCRIPTION
First PR of the terminal-first mobile push: the host's terminal listing becomes one resource-search endpoint that mobile can call host-wide.

## What changed

- **`terminal.listSessions({workspaceId})` → `terminal.list({workspaceId?})`** — same daemon-truth semantics (in-memory sessions merged with alive daemon PTYs joined to active workspace rows), now host-wide when no filter is passed. Orphaned daemon rows (`originWorkspaceId` nulled by workspace deletion) are skipped in the unfiltered view; each merged row's `workspaceId` comes from its origin row.
- **`terminal.countBackgroundSessions` deleted.** Its only consumer (`BackgroundTerminalsButton`) also queried the session list, so the two polls are merged into one `terminal.list` query (slow interval closed / fast interval open) and the count derives client-side against the debounced attachment set — same badge semantics, one endpoint fewer. The two refetch-interval helpers collapse into `getBackgroundTerminalRefetchInterval`.
- Mechanical rename across all consumers: desktop v2 terminal panes/hooks, web's `listHostTerminals`, CLI `terminals list`, SDK `terminals.list`, MCP terminals tool, host-service integration tests (which now also cover the unfiltered host-wide path).
- `terminal.daemon.listSessions` is untouched — it's the supervisor's daemon-PTY view (terminal settings), a different resource.

## Version-skew note

An older client polling an upgraded host gets `NOT_FOUND` on the removed names during the mismatch window (remote hosts can lag the desktop/CLI). Failure mode is a failed background list/count poll — no crash path. Kept clean rather than shipping deprecated aliases; flagging for reviewer judgment.

## Verification

- `bun run typecheck` — 37/37 tasks pass
- `bun run lint` — clean
- `packages/host-service` terminal integration tests: 9 pass (incl. new host-wide assertion)
- `BackgroundTerminalsButton.utils.test.ts`: 4 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated terminal session listing into `terminal.list({ workspaceId? })`, enabling a host-wide view when omitted. Removed `terminal.countBackgroundSessions`; desktop now derives the background count from the same list and uses a single poll.

- **Refactors**
  - `terminal.listSessions({workspaceId})` → `terminal.list({workspaceId?})` with the same daemon-truth merge; host-wide when unfiltered. Orphaned daemon rows are skipped; each row’s `workspaceId` comes from its origin.
  - Deleted `terminal.countBackgroundSessions`. `BackgroundTerminalsButton` now uses one `terminal.list` query with `getBackgroundTerminalRefetchInterval`.
  - Renamed server helper `listWorkspaceTerminalSessions` → `listLiveTerminalSessions` (behavior unchanged).
  - Updated consumers: desktop terminal panes/hooks (including background/adopt flows), web `listHostTerminals`, CLI `terminals list`, SDK `terminals.list`, MCP terminals tool, and tests/docs. Integration tests now also cover the unfiltered host-wide path.

- **Migration**
  - Replace all usage of `terminal.listSessions` with `terminal.list` and stop calling `terminal.countBackgroundSessions`.
  - Expect temporary `NOT_FOUND` errors on older clients during staggered upgrades; only background polling fails and recovers after update.
  - Desktop constants collapsed to `getBackgroundTerminalRefetchInterval` (single source for open/closed polling).

<sup>Written for commit 3cd6d975476bec8410f01bd3bba8bd702138205c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unified terminal session listings across the desktop app, web, mobile, CLI, SDK, and integrations.
  * Improved background-terminal status updates, with faster refreshes when the panel is open and efficient periodic updates when closed.
  * Terminal sessions are now more reliably associated with their actual workspace, including sessions recovered after a restart.
  * Improved synchronization after adopting, stopping, migrating, or closing terminal sessions.
* **Documentation**
  * Updated terminal listing API documentation and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->