### PR TITLE
fix(desktop): open Xcode by bundle id so version-suffixed installs launch

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -47,10 +47,10 @@ describe("getAppCommand", () => {
 		]);
 	});
 
-	test("returns single-element array for xcode", () => {
+	test("returns bundle-id command for xcode (name may be version-suffixed)", () => {
 		const result = getAppCommand("xcode", "/path/to/file");
 		expect(result).toEqual([
-			{ command: "open", args: ["-a", "Xcode", "/path/to/file"] },
+			{ command: "open", args: ["-b", "com.apple.dt.Xcode", "/path/to/file"] },
 		]);
 	});
 

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -11,7 +11,7 @@ const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
 	antigravity: "Antigravity",
 	devin: "Devin",
 	zed: null, // Multi-channel, uses bundle IDs (stable/preview/nightly/dev)
-	xcode: "Xcode",
+	xcode: null, // Uses bundle ID — Many developers use Xcodes to install and switch between multiple versions of Xcode - this uses a different app name structure (e.g. "Xcode-16.2.app")
 	iterm: "iTerm",
 	warp: "Warp",
 	terminal: "Terminal",
@@ -44,6 +44,7 @@ const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
 const BUNDLE_ID_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
 	intellij: ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"],
 	pycharm: ["com.jetbrains.pycharm", "com.jetbrains.pycharm.ce"],
+	xcode: ["com.apple.dt.Xcode"],
 	// Zed release channels, most-common first. A user typically installs one
 	// channel; trying stable → preview → nightly → dev launches whichever exists.
 	zed: [


### PR DESCRIPTION
## Fixes
- https://github.com/superset-sh/superset/issues/4688

## What & why

"Open in Xcode" failed for developers who manage multiple Xcode versions (e.g. via [Xcodes](https://github.com/XcodesOrg/Xcodes)). Those installs have version-suffixed bundles like `Xcode-16.2.app`, whose display name is `Xcode-16.2` — so the launcher's `open -a "Xcode"` (resolve-by-name) found nothing and failed.

Fix: launch Xcode by **bundle id** instead. Moved `xcode` from `MACOS_APP_NAMES` to `BUNDLE_ID_CANDIDATES` (`com.apple.dt.Xcode`), so `getAppCommand` emits `open -b com.apple.dt.Xcode <path>`, which resolves regardless of the `.app` display name. Mirrors the existing Zed / JetBrains multi-variant handling in the same file.

## How I tested it

- `bun test apps/desktop/src/lib/trpc/routers/external/helpers.test.ts` — updated the Xcode assertion to expect the bundle-id command; 113 pass.
- `bun run lint`, `bun run typecheck` — clean.
- Manually tested (I use Xcode everyday)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Open in Xcode" on macOS by launching via bundle id `com.apple.dt.Xcode` instead of app name, so version-suffixed installs like `Xcode-16.2.app` open correctly. Moves `xcode` from `MACOS_APP_NAMES` to `BUNDLE_ID_CANDIDATES` and updates the test to expect `open -b`.

<sup>Written for commit c050d4a493164c0924f96300f9e1a5464e76a233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS Xcode launching by identifying the app through its bundle ID.
  * Ensures compatibility with Xcode installations whose application names include version suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->