### PR TITLE
fix(desktop): reclaim leaked input modes after terminal session restore

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	clearAllTerminalState,
+	hasPersistedBuffer,
 	pruneExpiredTerminalState,
 	reclaimTerminalStateForQuota,
 	removeTerminalStatePersistedAt,
@@ -191,5 +192,27 @@ describe("persisted-at index maintenance", () => {
 		touchTerminalStatePersistedAt("t1", storage, NOW);
 
 		expect(readIndex(values)).toEqual({ t1: NOW });
+	});
+});
+
+describe("hasPersistedBuffer", () => {
+	test("reports true only when a buffer snapshot exists", () => {
+		const { values, storage } = createFakeStorage();
+		expect(hasPersistedBuffer("t1", storage)).toBe(false);
+
+		values.set(`${TERMINAL_BUFFER_KEY_PREFIX}t1`, "scrollback");
+		expect(hasPersistedBuffer("t1", storage)).toBe(true);
+	});
+
+	test("treats an empty snapshot as absent (matches restoreBuffer)", () => {
+		const { values, storage } = createFakeStorage();
+		values.set(`${TERMINAL_BUFFER_KEY_PREFIX}t1`, "");
+		expect(hasPersistedBuffer("t1", storage)).toBe(false);
+	});
+
+	test("ignores a terminal that only has dims persisted", () => {
+		const { values, storage } = createFakeStorage();
+		values.set(`${TERMINAL_DIMS_KEY_PREFIX}t1`, "120x32");
+		expect(hasPersistedBuffer("t1", storage)).toBe(false);
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-buffer-gc.ts
@@ -52,6 +52,22 @@ export function touchTerminalStatePersistedAt(
 	writeIndex(storage, index);
 }
 
+/** Whether a non-empty persisted buffer snapshot exists for a terminal id. */
+export function hasPersistedBuffer(
+	terminalId: string,
+	storage: Storage = localStorage,
+): boolean {
+	try {
+		// Mirrors `restoreBuffer`'s truthy-write guard: an empty snapshot would
+		// be read back as "no content", so it does not count as a restore.
+		return Boolean(
+			storage.getItem(`${TERMINAL_BUFFER_KEY_PREFIX}${terminalId}`),
+		);
+	} catch {
+		return false;
+	}
+}
+
 export function removeTerminalStatePersistedAt(
 	terminalId: string,
 	storage: Storage = localStorage,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -6,6 +6,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
+import type { LeakedInputModeReclaimer } from "shared/leaked-input-mode-reclaim";
 import {
 	applyTerminalFontFamilyCssVariable,
 	type TerminalAppearance,
@@ -20,6 +21,7 @@ import {
 } from "./parser-idle-gate";
 import { loadAddons } from "./terminal-addons";
 import {
+	hasPersistedBuffer,
 	removeTerminalStatePersistedAt,
 	TERMINAL_BUFFER_KEY_PREFIX,
 	TERMINAL_DIMS_KEY_PREFIX,
@@ -82,6 +84,7 @@ function createTerminal(
 	terminal: XTerm;
 	fitAddon: FitAddon;
 	serializeAddon: SerializeAddon;
+	inputModeReclaimer: LeakedInputModeReclaimer;
 } {
 	const fitAddon = new FitAddon();
 	const serializeAddon = new SerializeAddon();
@@ -109,8 +112,8 @@ function createTerminal(
 	// Disarm TUI-only input modes (kitty keyboard / mouse / focus) leaked into a
 	// live shell prompt by a TUI killed while attached (#4949). The parser
 	// handlers are owned by the terminal and cleaned up on terminal.dispose().
-	installInputModeReclaimer(terminal);
-	return { terminal, fitAddon, serializeAddon };
+	const { reclaimer: inputModeReclaimer } = installInputModeReclaimer(terminal);
+	return { terminal, fitAddon, serializeAddon, inputModeReclaimer };
 }
 
 function persistBuffer(
@@ -118,7 +121,17 @@ function persistBuffer(
 	serializeAddon: SerializeAddon,
 ): boolean {
 	try {
-		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
+		// Exclude terminal modes (DECSET ?1000/?1002/?1003 mouse tracking,
+		// ?1004 focus, kitty keyboard) from the persisted snapshot. A restored
+		// snapshot is scrollback belonging to a session that may well be dead;
+		// replaying its input modes into whatever pty the pane lands on next is
+		// wrong by construction (#6308/#6343). Live mode continuity across a
+		// reattach is handled server-side by the host's `buildPreamble()`, so
+		// stripping modes here does not regress mode replay. Mirrors VSCode.
+		const data = serializeAddon.serialize({
+			scrollback: SERIALIZE_SCROLLBACK,
+			excludeModes: true,
+		});
 		localStorage.setItem(`${STORAGE_KEY_PREFIX}${terminalId}`, data);
 		touchTerminalStatePersistedAt(terminalId);
 		return true;
@@ -304,11 +317,8 @@ export function createRuntime(
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
 
-	const { terminal, fitAddon, serializeAddon } = createTerminal(
-		cols,
-		rows,
-		appearance,
-	);
+	const { terminal, fitAddon, serializeAddon, inputModeReclaimer } =
+		createTerminal(cols, rows, appearance);
 
 	const gate = createParserIdleGate();
 	terminal.write = wrapWrite(gate, terminal.write.bind(terminal));
@@ -329,10 +339,22 @@ export function createRuntime(
 	});
 	let initialContent: TerminalRuntime["initialContent"] = "none";
 	if (options.initialBuffer !== undefined) {
+		if (options.initialBuffer.length > 0) {
+			initialContent = "seeded";
+			// The seed is a sibling's serialize — it may carry input modes the
+			// originating session armed. Those must be reclaimable, not exempted
+			// as shell-init-owned, so tell the reclaimer before the bytes land.
+			inputModeReclaimer.noteRestoreAttach();
+		}
 		terminal.write(options.initialBuffer);
-		if (options.initialBuffer.length > 0) initialContent = "seeded";
-	} else if (restoreBuffer(terminalId, terminal)) {
+	} else if (hasPersistedBuffer(terminalId)) {
 		initialContent = "restored";
+		// Same as seeding: a restored snapshot is scrollback of a possibly-dead
+		// session and may carry its armed input modes. Flag the reclaimer before
+		// the replay writes them, so the next shell-ready marker reclaims them
+		// instead of grandfathering them as shell-owned forever (#6308/#6343).
+		inputModeReclaimer.noteRestoreAttach();
+		restoreBuffer(terminalId, terminal);
 	}
 	if (initialContent !== "none") {
 		// SerializeAddon snapshots bake in whatever input-reporting modes were

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
@@ -33,6 +33,34 @@ describe("createLeakedInputModeReclaimer", () => {
 		expect(r.collectDisarm()).toBe("");
 	});
 
+	it("reclaims modes carried over by a restored attach (#6308/#6343)", () => {
+		const r = createLeakedInputModeReclaimer();
+		// Restore: the persisted snapshot / host preamble re-arms the dead
+		// TUI's mouse mode into a fresh xterm before any shell-ready marker.
+		r.noteRestoreAttach();
+		r.noteArm("mouse", true);
+		// Shell reprompts (Claude is gone) → the leaked mode must be reclaimed.
+		r.noteShellReady();
+		expect(r.collectDisarm()).toContain("\x1b[?1003l");
+	});
+
+	it("reclaims modes already armed before noteRestoreAttach is signalled", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteArm("mouse", true); // replay bytes parsed first
+		r.noteRestoreAttach(); // transport then flags the restore
+		r.noteShellReady();
+		expect(r.collectDisarm()).toContain("\x1b[?1003l");
+	});
+
+	it("still keeps live modes on a restored runtime that re-arms before the flush", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteRestoreAttach();
+		r.noteArm("mouse", true);
+		r.noteShellReady(); // marks mouse leaked
+		r.noteArm("mouse", true); // a live TUI grabs it before the flush
+		expect(r.collectDisarm()).toBe("");
+	});
+
 	it("suppresses the disarm when a TUI re-arms before collection", () => {
 		const r = createLeakedInputModeReclaimer();
 		r.noteShellReady();

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
@@ -1,5 +1,6 @@
 import {
 	createLeakedInputModeReclaimer,
+	type LeakedInputModeReclaimer,
 	SHELL_READY_MARKER_PAYLOAD,
 	SHELL_READY_OSC_ID,
 } from "@superset/shared/leaked-input-mode-reclaim";
@@ -24,7 +25,14 @@ import type { IDisposable, Terminal } from "@xterm/xterm";
  * keeps its modes. The decision logic lives in the shared module so a host-side
  * surface can reuse it later.
  */
-export function installInputModeReclaimer(terminal: Terminal): IDisposable {
+export interface InputModeReclaimerHandle {
+	reclaimer: LeakedInputModeReclaimer;
+	dispose(): void;
+}
+
+export function installInputModeReclaimer(
+	terminal: Terminal,
+): InputModeReclaimerHandle {
 	const reclaimer = createLeakedInputModeReclaimer();
 	const parser = terminal.parser;
 	const disposables: IDisposable[] = [];
@@ -102,6 +110,7 @@ export function installInputModeReclaimer(terminal: Terminal): IDisposable {
 	);
 
 	return {
+		reclaimer,
 		dispose(): void {
 			disposed = true;
 			for (const d of disposables) d.dispose();

--- a/packages/shared/src/leaked-input-mode-reclaim.ts
+++ b/packages/shared/src/leaked-input-mode-reclaim.ts
@@ -79,6 +79,15 @@ export interface LeakedInputModeReclaimer {
 	 */
 	noteShellReady(): void;
 	/**
+	 * Mark this runtime as restored/seeded rather than freshly booted. Input
+	 * modes observed before the first shell-ready marker on a restored runtime
+	 * were carried over from a possibly-dead session (a persisted snapshot or
+	 * the host reattach preamble), NOT armed by a fresh shell — so the
+	 * shell-ownership exemption must not apply to them. They stay reclaimable
+	 * at the next marker. Shells never arm these modes, so reclaiming is safe.
+	 */
+	noteRestoreAttach(): void;
+	/**
 	 * Disarm bytes for modes leaked at the last marker and not re-armed since — so
 	 * a live/suspended/racing TUI that owns the foreground keeps its modes.
 	 * Consumes the pending set; returns "" when nothing leaked.
@@ -102,6 +111,10 @@ export function createLeakedInputModeReclaimer(): LeakedInputModeReclaimer {
 		]),
 	);
 	let sawMarker = false;
+	// True once `noteRestoreAttach` runs: this xterm was seeded from a persisted
+	// snapshot / sibling serialize / host reattach preamble rather than a fresh
+	// shell boot, so pre-marker arms are program-sourced, not shell-init-owned.
+	let restoreSourced = false;
 
 	return {
 		noteArm(mode, armed) {
@@ -111,10 +124,21 @@ export function createLeakedInputModeReclaimer(): LeakedInputModeReclaimer {
 			if (armed) {
 				// A re-arm cancels a pending reclaim — the mode is live again.
 				s.pending = false;
-				// Armed before the first marker → shell init owns it.
-				if (!sawMarker) s.shellOwned = true;
+				// Armed before the first marker → shell init owns it. On a
+				// restored/seeded runtime the arms came from the dead session,
+				// not shell init, so they stay reclaimable (#6308/#6343).
+				if (!sawMarker && !restoreSourced) s.shellOwned = true;
 			} else {
 				s.shellOwned = false;
+			}
+		},
+		noteRestoreAttach() {
+			restoreSourced = true;
+			// Any mode that arrived before this point on a restore was the dead
+			// session's — undo the shell-ownership exemption so the next marker
+			// reclaims it instead of grandfathering it forever.
+			for (const s of state.values()) {
+				if (s.armed) s.shellOwned = false;
 			}
 		},
 		noteShellReady() {


### PR DESCRIPTION
Fixes #6308
Fixes #6343

## Problem

When a TUI (Claude Code) is killed while attached — e.g. by quitting the IDE and rebooting — it never writes its DECSET restore bytes. On reopen, the desktop cold-restores the persisted terminal snapshot into a **fresh** xterm. Two things then conspire to leak input modes into the prompt:

1. **The persisted snapshot carries the dead session's modes.** `persistBuffer` serialized with `serializeAddon.serialize({ scrollback })`, and xterm's SerializeAddon appends mode-restore DECSETs (`\x1b[?1002h` / `?1003h`, `?1004h`, kitty keyboard) after the buffer content by default. So the localStorage snapshot keeps "mouse tracking on".
2. **The leaked-input-mode reclaimer misclassifies them as shell-owned.** The reclaimer (`shared/leaked-input-mode-reclaim.ts`) treats any mode armed *before the first `OSC 777;superset-shell-ready` marker* as armed by shell init, and never reclaims it. On a restored runtime the replay bytes (and the host reattach preamble, `#6343`) land in the fresh xterm before any marker, so the leaked modes are exempted forever.

**Result:** mouse movement/clicking sprays mouse-report escape sequences (`34M65;56`, `35M35`, …) into the shell prompt as visible text; the terminal fills up with junk and never self-heals.

## Fix

Two-part, both in the renderer terminal path:

1. **`persistBuffer` now serializes with `excludeModes: true`** (`terminal-runtime.ts`). A persisted snapshot is scrollback belonging to a session that may well be dead; replaying its input modes into whatever pty the pane lands on next is wrong by construction. This mirrors VSCode's documented behavior (see `plans/20260507-terminal-mode-replay.md:24`). Live mode continuity across a *reattach* is already handled server-side by the host's `buildPreamble()`, so stripping modes here does not regress mode replay.
2. **`noteRestoreAttach()` on the reclaimer** (`shared/leaked-input-mode-reclaim.ts`), called from `createRuntime` when a runtime is seeded or restored. This tells the decision core that pre-marker arms are **program-sourced** (a dead session's snapshot / sibling serialize / host preamble), not shell init — so they stay reclaimable at the next shell-ready marker instead of being exempted forever. It also undoes the exemption for any mode that arrived before the signal.

Because `persistBuffer` now strips modes, freshly-written snapshots won't re-arm the bug; `noteRestoreAttach` covers already-poisoned snapshots already sitting on user profiles, plus the host reattach-preamble path.

## Tests

- `terminalInputModeReclaimer.test.ts`: 3 new cases — restored attach reclaims carried-over modes; modes armed *before* `noteRestoreAttach` is signalled are still reclaimed; a live re-arm before the flush still suppresses the disarm. (All 12 pass.)
- `terminal-buffer-gc.test.ts`: 3 new cases for the new `hasPersistedBuffer` helper — true only with content, empty snapshot treated as absent (matches `restoreBuffer`'s truthy guard), dims-only ignored. (All 15 pass.)

## Notes

- A **known follow-up** (out of scope, larger change): the host-side `terminal-mode-tracker` also carries the stale armed state across a host restart (`terminal.ts` reclaims only while `shellReadyState === "pending"`), so a client that attaches *later* could still see a stale preamble. This PR fixes the renderer path that reproduces both reported issues; the durable host-side reclaim is a separate change.
- Manual repro confirmed by the two issues' triage bots (`#6308`, `#6343`) — no maintainer-adjacent duplicates, no existing PR for either issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaked terminal input modes after session restore so the prompt stays clean. Previously, restore/reattach replay re-armed mouse/focus/kitty modes before the first shell-ready marker and the reclaimer exempted them; now we strip those bytes and reclaim them at the next marker. Fixes #6308 and #6343.

- Persisted snapshots serialize with `excludeModes: true` via `@xterm/addon-serialize`, so restores no longer re-arm a dead session’s modes.
- On seeded/restored runtimes, we call noteRestoreAttach() before writing any seed/restore bytes and gate restores with hasPersistedBuffer; restoreBuffer runs after the flag so pre-marker modes are reclaimed.
- The input-mode reclaimer install now returns a handle exposing the `reclaimer` for createRuntime; tests cover restored attach behavior and hasPersistedBuffer.

<sup>Written for commit 2bd9d9c4beb95e0aad65c67433b2be5d43c64a78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of terminal sessions with persisted scrollback.
  * Prevented stale mouse and input modes from remaining active after restoring a terminal.
  * Preserved input modes that are intentionally re-enabled by a live terminal application.
  * More accurately detects whether saved terminal content is available before replaying it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->