### PR TITLE
fix(cli): drive a single /authorize request per OAuth login

### DIFF
--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -115,7 +115,7 @@ export function ConsentForm({
 					{ accept, data },
 				);
 				setError(
-					"Could not complete authorization. Please close this window and run superset auth login again.",
+					"Could not complete authorization. Please close this window and restart authorization from the application.",
 				);
 				setIsLoading(false);
 			}

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -105,6 +105,19 @@ export function ConsentForm({
 
 			if (data?.url) {
 				window.location.href = data.url;
+			} else {
+				// No redirect URL and no error: the pending authorization request
+				// could not be resolved (e.g. it was clobbered by a competing
+				// /authorize for the same login — see superset-cli #6310). Surface
+				// it instead of leaving the button stuck on "Authorizing…" forever.
+				console.error(
+					"[oauth/consent] consent() resolved without a redirect URL",
+					{ accept, data },
+				);
+				setError(
+					"Could not complete authorization. Please close this window and run superset auth login again.",
+				);
+				setIsLoading(false);
 			}
 		} catch (err) {
 			console.error("[oauth/consent] Error:", err);

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -14,6 +14,10 @@ describe("login /authorize (single request)", () => {
 		const printed: string[] = [];
 
 		const controller = new AbortController();
+		let notifyAuthUrl!: () => void;
+		const authUrlEmitted = new Promise<void>((resolve) => {
+			notifyAuthUrl = resolve;
+		});
 		const loginPromise = login(controller.signal, {
 			// A loopback port is "bound" — but we never let the fake server
 			// actually receive a code; the test only asserts on the URL(s).
@@ -27,12 +31,14 @@ describe("login /authorize (single request)", () => {
 			},
 			onAuthorizationUrl: (url) => {
 				printed.push(url);
+				notifyAuthUrl();
 			},
-			// Never resolve: we only assert on the URLs emitted up front.
+			// Not reached in the loopback path, but keep it a never-resolving
+			// stub so the login promise stays pending if it is mis-reached.
 			promptForPastedCode: () => new Promise<string>(() => {}),
 		});
 
-		await new Promise((r) => setTimeout(r, 20));
+		await authUrlEmitted;
 
 		expect(printed).toHaveLength(1);
 		expect(opened).toEqual(printed);
@@ -52,6 +58,10 @@ describe("login /authorize (single request)", () => {
 		const printed: string[] = [];
 
 		const controller = new AbortController();
+		let notifyAuthUrl!: () => void;
+		const authUrlEmitted = new Promise<void>((resolve) => {
+			notifyAuthUrl = resolve;
+		});
 		const loginPromise = login(controller.signal, {
 			bindLoopbackServer: async () => null, // no port bound
 			shouldOpenBrowser: () => true,
@@ -60,11 +70,12 @@ describe("login /authorize (single request)", () => {
 			},
 			onAuthorizationUrl: (url) => {
 				printed.push(url);
+				notifyAuthUrl();
 			},
 			promptForPastedCode: () => new Promise<string>(() => {}),
 		});
 
-		await new Promise((r) => setTimeout(r, 20));
+		await authUrlEmitted;
 
 		expect(printed).toHaveLength(1);
 		expect(opened).toHaveLength(0);

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -1,11 +1,138 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { CLIError } from "@superset/cli-framework";
-import { refreshAccessToken } from "./auth";
+import { login, refreshAccessToken, resolveAuthorizeUrl } from "./auth";
 
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+});
+
+describe("login /authorize (single request)", () => {
+	test("opens and prints the SAME url (one /authorize) when loopback is used", async () => {
+		const opened: string[] = [];
+		const printed: string[] = [];
+
+		const controller = new AbortController();
+		const loginPromise = login(controller.signal, {
+			// A loopback port is "bound" — but we never let the fake server
+			// actually receive a code; the test only asserts on the URL(s).
+			bindLoopbackServer: async () => ({
+				server: { close: () => {} } as never,
+				port: 51789,
+			}),
+			shouldOpenBrowser: () => true,
+			openBrowser: async (url) => {
+				opened.push(url);
+			},
+			onAuthorizationUrl: (url) => {
+				printed.push(url);
+			},
+			// Never resolve: we only assert on the URLs emitted up front.
+			promptForPastedCode: () => new Promise<string>(() => {}),
+		});
+
+		await new Promise((r) => setTimeout(r, 20));
+
+		expect(printed).toHaveLength(1);
+		expect(opened).toEqual(printed);
+		// Exactly one authorize request, redirecting to the loopback callback.
+		const url = new URL(printed[0]!);
+		expect(url.pathname).toBe("/api/auth/oauth2/authorize");
+		expect(url.searchParams.get("redirect_uri")).toBe(
+			"http://127.0.0.1:51789/callback",
+		);
+
+		controller.abort();
+		await loginPromise.catch(() => {});
+	});
+
+	test("prints the paste URL and opens nothing when loopback is unavailable", async () => {
+		const opened: string[] = [];
+		const printed: string[] = [];
+
+		const controller = new AbortController();
+		const loginPromise = login(controller.signal, {
+			bindLoopbackServer: async () => null, // no port bound
+			shouldOpenBrowser: () => true,
+			openBrowser: async (url) => {
+				opened.push(url);
+			},
+			onAuthorizationUrl: (url) => {
+				printed.push(url);
+			},
+			promptForPastedCode: () => new Promise<string>(() => {}),
+		});
+
+		await new Promise((r) => setTimeout(r, 20));
+
+		expect(printed).toHaveLength(1);
+		expect(opened).toHaveLength(0);
+		const url = new URL(printed[0]!);
+		expect(url.searchParams.get("redirect_uri")).toBe(
+			"https://app.superset.sh/cli/auth/code",
+		);
+
+		controller.abort();
+		await loginPromise.catch(() => {});
+	});
+});
+
+describe("resolveAuthorizeUrl", () => {
+	const base = {
+		apiUrl: "https://api.superset.test",
+		webUrl: "https://app.superset.test",
+		codeChallenge: "challenge",
+		state: "state-123",
+	};
+
+	test("uses loopback when a port bound and the browser opens", () => {
+		const { authorizeUrl, useLoopback, redirectUri } = resolveAuthorizeUrl({
+			...base,
+			loopbackRedirectUri: "http://127.0.0.1:51789/callback",
+			shouldOpenBrowser: true,
+		});
+		expect(useLoopback).toBe(true);
+		expect(redirectUri).toBe("http://127.0.0.1:51789/callback");
+		expect(new URL(authorizeUrl).searchParams.get("redirect_uri")).toBe(
+			"http://127.0.0.1:51789/callback",
+		);
+	});
+
+	test("falls back to the paste URL when the browser is not opened", () => {
+		const { authorizeUrl, useLoopback, redirectUri } = resolveAuthorizeUrl({
+			...base,
+			loopbackRedirectUri: "http://127.0.0.1:51789/callback",
+			shouldOpenBrowser: false, // SSH / non-TTY / CI
+		});
+		expect(useLoopback).toBe(false);
+		expect(redirectUri).toBe("https://app.superset.test/cli/auth/code");
+		expect(new URL(authorizeUrl).searchParams.get("redirect_uri")).toBe(
+			"https://app.superset.test/cli/auth/code",
+		);
+	});
+
+	test("falls back to the paste URL when no loopback port bound", () => {
+		const { useLoopback, redirectUri } = resolveAuthorizeUrl({
+			...base,
+			loopbackRedirectUri: null,
+			shouldOpenBrowser: true,
+		});
+		expect(useLoopback).toBe(false);
+		expect(redirectUri).toBe("https://app.superset.test/cli/auth/code");
+	});
+
+	test("a single /authorize URL is always produced (#6310)", () => {
+		const { authorizeUrl } = resolveAuthorizeUrl({
+			...base,
+			loopbackRedirectUri: "http://127.0.0.1:51789/callback",
+			shouldOpenBrowser: true,
+		});
+		const url = new URL(authorizeUrl);
+		expect(url.pathname).toBe("/api/auth/oauth2/authorize");
+		expect(url.searchParams.get("client_id")).toBe("superset-cli");
+		expect(url.searchParams.get("state")).toBe("state-123");
+	});
 });
 
 describe("refreshAccessToken", () => {

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -411,15 +411,20 @@ export async function login(
 							resolve({ code, redirectUri });
 						});
 					},
-					() => {
+					(error) => {
 						// The loopback flow is the only one offered; surface its
 						// failure instead of leaving the command waiting forever.
+						// Preserve the underlying reason (denial vs timeout vs CSRF)
+						// so the user can tell a suspicious callback apart from a
+						// normal failure.
 						settle(() => {
 							pasteController.abort();
 							reject(
 								new CLIError(
-									"Browser login did not complete",
-									"Run `superset auth login` again, or use --no-browser to sign in via the paste URL.",
+									error instanceof Error
+										? error.message
+										: "Browser login did not complete",
+									"Run `superset auth login` again, or run it in a non-interactive terminal (no browser) to use the paste flow instead.",
 								),
 							);
 						});

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -391,59 +391,72 @@ export async function login(
 			};
 			signal.addEventListener("abort", onOuterAbort);
 
+			// Drive only the flow whose URL was presented. When the loopback
+			// flow is active, no paste URL was shown, so running the paste prompt
+			// lets an accidental/invalid paste abort a valid browser login and a
+			// browser denial leaves the command waiting indefinitely. When the
+			// paste flow is active, the browser was never opened, so only pasting
+			// can complete it. Either way the code is exchanged with the single
+			// chosen redirect_uri (#6310).
 			if (loopback && useLoopback) {
 				waitForCallback({
 					server: loopback.server,
 					port: loopback.port,
 					expectedState: state,
 					signal: callbackController.signal,
-				})
-					.then((code) => {
+				}).then(
+					(code) => {
 						settle(() => {
 							pasteController.abort();
 							resolve({ code, redirectUri });
 						});
-					})
-					.catch(() => {
-						// Loopback failed (timeout, CSRF, our own cancel). Don't take
-						// down the paste flow — the user can still complete login by
-						// pasting. If paste also fails, that error will surface instead.
-					});
-			}
-
-			// When the loopback flow is active it is the only URL presented; the
-			// paste prompt is a fallback only when the paste URL was shown. Either
-			// way the code is exchanged with the single chosen redirect_uri.
-			callbacks
-				.promptForPastedCode(pasteController.signal)
-				.then((pasted) => {
-					if (pasteController.signal.aborted) return;
-					try {
-						const { code, state: returnedState } = parsePastedCode(pasted);
-						if (returnedState !== state) {
-							throw new CLIError(
-								"State mismatch",
-								"The pasted code does not match this login attempt. Run `superset auth login` again.",
-							);
-						}
+					},
+					() => {
+						// The loopback flow is the only one offered; surface its
+						// failure instead of leaving the command waiting forever.
 						settle(() => {
-							callbackController.abort();
-							resolve({ code, redirectUri });
+							pasteController.abort();
+							reject(
+								new CLIError(
+									"Browser login did not complete",
+									"Run `superset auth login` again, or use --no-browser to sign in via the paste URL.",
+								),
+							);
 						});
-					} catch (err) {
+					},
+				);
+			} else {
+				callbacks
+					.promptForPastedCode(pasteController.signal)
+					.then((pasted) => {
+						if (pasteController.signal.aborted) return;
+						try {
+							const { code, state: returnedState } = parsePastedCode(pasted);
+							if (returnedState !== state) {
+								throw new CLIError(
+									"State mismatch",
+									"The pasted code does not match this login attempt. Run `superset auth login` again.",
+								);
+							}
+							settle(() => {
+								callbackController.abort();
+								resolve({ code, redirectUri });
+							});
+						} catch (err) {
+							settle(() => {
+								callbackController.abort();
+								reject(err);
+							});
+						}
+					})
+					.catch((err) => {
+						if (pasteController.signal.aborted) return;
 						settle(() => {
 							callbackController.abort();
 							reject(err);
 						});
-					}
-				})
-				.catch((err) => {
-					if (pasteController.signal.aborted) return;
-					settle(() => {
-						callbackController.abort();
-						reject(err);
 					});
-				});
+			}
 		});
 
 		return await exchangeCodeForToken({

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -19,6 +19,17 @@ export interface LoginResult {
 export interface LoginCallbacks {
 	onAuthorizationUrl?: (url: string) => void;
 	promptForPastedCode: (signal: AbortSignal) => Promise<string>;
+	/**
+	 * Injectable hooks so the OAuth flow can be unit-tested without spawning a
+	 * browser, a real TTY, or a real loopback server. Default to the real
+	 * implementations when omitted.
+	 */
+	openBrowser?: (url: string) => Promise<void>;
+	shouldOpenBrowser?: () => boolean;
+	bindLoopbackServer?: () => Promise<{
+		server: Server;
+		port: number;
+	} | null>;
 }
 
 function base64url(buffer: Buffer): string {
@@ -198,6 +209,41 @@ function buildAuthorizeUrl({
 	return url;
 }
 
+/**
+ * Pick the single redirect_uri for a login and build the ONE `/authorize` URL
+ * to present. The loopback and paste flows must share a redirect_uri — if they
+ * differ, the second `/authorize` clobbers the first on the provider's side and
+ * the consent step can resolve the wrong (or already-consumed) pending request,
+ * so Authorize returns without a redirect URL (#6310).
+ *
+ * Loopback is used only when a port bound AND we're opening a local browser;
+ * otherwise (SSH, non-TTY, CI, or bind failed) the paste URL is used. Returns
+ * the URL and whether the loopback flow is active so the caller can open the
+ * browser for exactly the same URL it prints.
+ */
+export function resolveAuthorizeUrl(opts: {
+	apiUrl: string;
+	webUrl: string;
+	loopbackRedirectUri: string | null;
+	codeChallenge: string;
+	state: string;
+	shouldOpenBrowser: boolean;
+}): { authorizeUrl: string; useLoopback: boolean; redirectUri: string } {
+	const pasteRedirectUri = new URL(PASTE_REDIRECT_PATH, opts.webUrl).toString();
+	const useLoopback =
+		opts.loopbackRedirectUri !== null && opts.shouldOpenBrowser;
+	const redirectUri = useLoopback
+		? opts.loopbackRedirectUri!
+		: pasteRedirectUri;
+	const authorizeUrl = buildAuthorizeUrl({
+		apiUrl: opts.apiUrl,
+		redirectUri,
+		codeChallenge: opts.codeChallenge,
+		state: opts.state,
+	}).toString();
+	return { authorizeUrl, useLoopback, redirectUri };
+}
+
 async function exchangeCodeForToken({
 	apiUrl,
 	code,
@@ -292,32 +338,28 @@ export async function login(
 	const codeChallenge = generateCodeChallenge(codeVerifier);
 	const state = generateState();
 
-	const loopback = await bindLoopbackServer();
+	const loopback = await (callbacks.bindLoopbackServer ?? bindLoopbackServer)();
 	const loopbackRedirectUri = loopback
 		? `http://127.0.0.1:${loopback.port}/callback`
 		: null;
-	const pasteRedirectUri = new URL(PASTE_REDIRECT_PATH, webUrl).toString();
+	const openBrowserImpl = callbacks.openBrowser ?? openBrowser;
+	const shouldOpenBrowserImpl =
+		callbacks.shouldOpenBrowser ?? shouldOpenBrowser;
 
-	const pasteAuthorizeUrl = buildAuthorizeUrl({
+	// Drive exactly ONE `/authorize` request per login — see `resolveAuthorizeUrl`.
+	const { authorizeUrl, useLoopback, redirectUri } = resolveAuthorizeUrl({
 		apiUrl,
-		redirectUri: pasteRedirectUri,
+		webUrl,
+		loopbackRedirectUri,
 		codeChallenge,
 		state,
-	}).toString();
+		shouldOpenBrowser: shouldOpenBrowserImpl(),
+	});
 
-	const browserAuthorizeUrl = loopbackRedirectUri
-		? buildAuthorizeUrl({
-				apiUrl,
-				redirectUri: loopbackRedirectUri,
-				codeChallenge,
-				state,
-			}).toString()
-		: pasteAuthorizeUrl;
+	callbacks.onAuthorizationUrl?.(authorizeUrl);
 
-	callbacks.onAuthorizationUrl?.(pasteAuthorizeUrl);
-
-	if (shouldOpenBrowser()) {
-		void openBrowser(browserAuthorizeUrl);
+	if (useLoopback) {
+		void openBrowserImpl(authorizeUrl);
 	}
 
 	if (signal.aborted) {
@@ -349,7 +391,7 @@ export async function login(
 			};
 			signal.addEventListener("abort", onOuterAbort);
 
-			if (loopback && loopbackRedirectUri) {
+			if (loopback && useLoopback) {
 				waitForCallback({
 					server: loopback.server,
 					port: loopback.port,
@@ -359,7 +401,7 @@ export async function login(
 					.then((code) => {
 						settle(() => {
 							pasteController.abort();
-							resolve({ code, redirectUri: loopbackRedirectUri });
+							resolve({ code, redirectUri });
 						});
 					})
 					.catch(() => {
@@ -369,6 +411,9 @@ export async function login(
 					});
 			}
 
+			// When the loopback flow is active it is the only URL presented; the
+			// paste prompt is a fallback only when the paste URL was shown. Either
+			// way the code is exchanged with the single chosen redirect_uri.
 			callbacks
 				.promptForPastedCode(pasteController.signal)
 				.then((pasted) => {
@@ -383,7 +428,7 @@ export async function login(
 						}
 						settle(() => {
 							callbackController.abort();
-							resolve({ code, redirectUri: pasteRedirectUri });
+							resolve({ code, redirectUri });
 						});
 					} catch (err) {
 						settle(() => {


### PR DESCRIPTION
Fixes #6310

## Problem

`superset auth login` opens the OAuth consent screen, but clicking **Authorize** does nothing — the page never navigates to `/cli/auth/code`, and the CLI never receives a code.

## Root cause

The CLI built **two** `/authorize` URLs for the same login: a loopback URL (`http://127.0.0.1:PORT/callback`, auto-opened in the browser) and a paste URL (`https://app.superset.sh/cli/auth/code`, printed in the terminal). They shared the same `state`/`code_challenge` but used **different `redirect_uri` values**, and the terminal UI explicitly invited the user to open the printed (paste) URL while the browser had already auto-opened the loopback one.

On the provider side the second `/authorize` for the same login clobbers the first (single pending-request slot), so the pending request the consent step resolves can be the wrong — or already-consumed — one. Consent then returns **without a redirect URL**, and the consent form had no branch for that case: no navigation, no error, spinner stuck on "Authorizing…" forever.

## Fix

**CLI — one `/authorize` request per login.** New `resolveAuthorizeUrl()` picks a **single** `redirect_uri` up front and builds exactly one authorize URL:
- loopback when a port bound **AND** a local browser is being opened;
- paste otherwise (SSH, non-TTY, CI, or bind failed).

`login()` now prints and auto-opens the **same** URL, and the code is exchanged with that same `redirect_uri` on both the loopback and paste completion paths. The paste prompt remains as a fallback only when the paste URL was the one presented.

**Web — never fail silently.** `ConsentForm` now handles the case where `consent()` resolves without an error and without a redirect URL: it logs the full response, surfaces a clear message, and stops the loading state, instead of leaving the button stuck forever. This is the diagnostic branch that was missing regardless of root cause.

## Tests

`packages/cli/src/lib/auth.test.ts` (7 cases total, +6 new):
- `resolveAuthorizeUrl` unit tests: loopback chosen when port bound + browser opens; paste fallback when browser not opened; paste fallback when no port bound; single authorize URL always produced with the right params.
- `login` integration tests with injectable `openBrowser`/`shouldOpenBrowser`/`bindLoopbackServer` hooks: asserts the printed and auto-opened URLs are **identical** (the core of the bug), and that nothing is opened when loopback is unavailable.

`ConsentForm.tsx` has no component test harness in this repo (no jsdom/testing-library), so the web-side change is verified by typecheck + biome only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth login by issuing a single /authorize request per login and running only the presented flow, so the consent page redirects and the CLI gets the code. Adds a client‑neutral safeguard in the web consent form to prevent silent failures. Fixes #6310.

- **Bug Fixes**
  - Use one redirect_uri per login via resolveAuthorizeUrl; CLI opens and prints the same authorize URL, and both loopback and paste flows exchange the code with that same redirect_uri.
  - Drive only the presented flow: loopback-only when active (surface failures instead of hanging); paste-only otherwise.
  - Consent form shows a client‑neutral error and stops loading when consent returns without a redirect URL.
  - Preserve the loopback failure reason and update the recovery hint to suggest re-running in a non-interactive terminal to use the paste flow.

<sup>Written for commit cde65eee383adcfb897fe313b73bf2a64a5c249f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consent flows that return without a redirect URL so they now show an authorization error and stop loading instead of becoming stuck.

* **CLI Improvements**
  * Improved login behavior across browser-based, loopback, and paste-code authentication flows.
  * Added more reliable redirect handling and authorization URL selection.
  * Added fallback support when a local loopback connection is unavailable.
  * Improved handling of loopback connection failures during login.
  * Expanded coverage for login and authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->