### PR TITLE
fix(desktop): wire the Quick Create Workspace hotkey handler

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -98,6 +98,12 @@ function DashboardLayout() {
 		isCollapsed: isWorkspaceSidebarCollapsed,
 	} = useWorkspaceSidebarStore();
 
+	// Open the new-workspace modal preselected on the current project.
+	const openNewWorkspaceForCurrentProject = () =>
+		openNewWorkspaceModal(
+			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
+		);
+
 	// Global hotkeys for dashboard
 	useHotkey("OPEN_SETTINGS", () => navigate({ to: "/settings/account" }));
 	useHotkey("SHOW_HOTKEYS", () => navigate({ to: "/settings/keyboard" }));
@@ -108,19 +114,11 @@ function DashboardLayout() {
 			toggleWorkspaceSidebarCollapsed();
 		}
 	});
-	useHotkey("NEW_WORKSPACE", () =>
-		openNewWorkspaceModal(
-			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
-		),
-	);
+	useHotkey("NEW_WORKSPACE", openNewWorkspaceForCurrentProject);
 	// Quick Create (meta+shift+n) targets the current project, same as the
 	// regular New Workspace hotkey — the registry declares it but no handler
 	// was wired, so it silently did nothing in v2 (#6041).
-	useHotkey("QUICK_CREATE_WORKSPACE", () =>
-		openNewWorkspaceModal(
-			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
-		),
-	);
+	useHotkey("QUICK_CREATE_WORKSPACE", openNewWorkspaceForCurrentProject);
 
 	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -113,6 +113,14 @@ function DashboardLayout() {
 			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
 		),
 	);
+	// Quick Create (meta+shift+n) targets the current project, same as the
+	// regular New Workspace hotkey — the registry declares it but no handler
+	// was wired, so it silently did nothing in v2 (#6041).
+	useHotkey("QUICK_CREATE_WORKSPACE", () =>
+		openNewWorkspaceModal(
+			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
+		),
+	);
 
 	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 


### PR DESCRIPTION
Fixes #6041

## Problem

In Superset v2, the **Quick Create Workspace** hotkey (`meta+shift+n` on macOS, `ctrl+shift+n` on Windows/Linux) does nothing. The regular **New Workspace** hotkey (`meta+n`) works, but the quick-create variant silently no-ops.

## Root cause

`QUICK_CREATE_WORKSPACE` is declared in the hotkeys registry (`apps/desktop/src/renderer/hotkeys/registry.ts`) but was **never wired to a handler**. `NEW_WORKSPACE` has a `useHotkey("NEW_WORKSPACE", ...)` handler in the dashboard layout, but the quick-create variant was left without one — so the key chord is recognized but nothing dispatches. (Introduced in the same PR that added the registry entry; the handler was simply omitted.)

## Fix

Add a `useHotkey("QUICK_CREATE_WORKSPACE", ...)` handler in the dashboard layout that opens the new-workspace modal preselected on the **current project**, matching the behavior of the regular New Workspace hotkey:

```ts
useHotkey("QUICK_CREATE_WORKSPACE", () =>
	openNewWorkspaceModal(
		currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
	),
);
```

This both makes the hotkey do something (the reported bug) and preselects the project the user is focused on rather than "the last project used".

## Tests

No component test harness exists for React route layouts in this repo (the hotkey handlers are wired via `useHotkey` inside the layout component). Verified by:
- `tsc --noEmit` on apps/desktop — 0 errors;
- biome check — clean;
- existing hotkeys `registry.test.ts` + `display.test.ts` — 23/23 pass (shape unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Quick Create Workspace hotkey (`meta+shift+n` / `ctrl+shift+n`) to open the new-workspace modal for the current project, and refactored to share the open callback with `NEW_WORKSPACE`. Fixes #6041.

- **Bug Fixes**
  - Added `useHotkey("QUICK_CREATE_WORKSPACE", openNewWorkspaceForCurrentProject)` in the dashboard layout and reused the same callback for `NEW_WORKSPACE`.

<sup>Written for commit a873287b46010fda1506af94f6e178a30d569f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut for quickly opening the new workspace modal from the dashboard.
  * The shortcut automatically targets the active workspace project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->