### PR TITLE
fix(desktop): stop chat panes polling the transcript while inactive

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -195,6 +195,7 @@ export function ChatPaneInterface({
 	organizationId,
 	cwd,
 	isFocused,
+	isActive,
 	getOrCreateSession,
 	onResetSession,
 	onUserMessageSubmitted,
@@ -294,6 +295,7 @@ export function ChatPaneInterface({
 		sessionId,
 		workspaceId,
 		enabled: Boolean(sessionId),
+		isActive,
 	});
 	const {
 		commands,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
@@ -13,6 +13,12 @@ export interface ChatPaneInterfaceProps {
 	organizationId: string | null;
 	cwd: string;
 	isFocused: boolean;
+	/**
+	 * True while this chat pane is the focused/active tab. Gates background
+	 * chat polling so idle/background panes stop refetching the full
+	 * transcript on a timer (#6339).
+	 */
+	isActive?: boolean;
 	getOrCreateSession: () => Promise<string>;
 	onResetSession: () => Promise<void>;
 	onUserMessageSubmitted?: (message: string) => void;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
@@ -9,6 +9,14 @@ interface UseChatDisplayOptions {
 	workspaceId: string;
 	enabled?: boolean;
 	fps?: number;
+	/**
+	 * True while this chat pane is the focused/active tab. Idle panes in the
+	 * background keep polling the full transcript on a timer even when nothing
+	 * is running — that serialize/parse work scales with transcript length and
+	 * adds up across several open panes (#6339). Gate background polling on
+	 * this so hidden panes don't refetch until they become active again.
+	 */
+	isActive?: boolean;
 }
 
 // Retention window for an inactive session's cached snapshot (full message
@@ -117,7 +125,13 @@ function getLegacyImagePayload(
 }
 
 export function useChatDisplay(options: UseChatDisplayOptions) {
-	const { sessionId, workspaceId, enabled = true, fps = 4 } = options;
+	const {
+		sessionId,
+		workspaceId,
+		enabled = true,
+		fps = 4,
+		isActive = true,
+	} = options;
 	const [commandError, setCommandError] = useState<unknown>(null);
 	const queryInput =
 		sessionId === null ? undefined : { sessionId, workspaceId };
@@ -125,8 +139,13 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 	const refetchIntervalMs = toRefetchIntervalMs(fps);
 	const queryOptions = {
 		enabled: isQueryEnabled && queryInput !== undefined,
-		refetchInterval: refetchIntervalMs,
-		refetchIntervalInBackground: true,
+		// Only poll while this pane is the active tab. Idle/background panes
+		// otherwise refetch the whole transcript on a timer forever, and that
+		// serialize/parse cost scales with conversation length — it adds up
+		// across several open panes and degrades responsiveness (#6339). The
+		// cached snapshot stays mounted, so returning to the pane resumes fresh.
+		refetchInterval: isActive ? refetchIntervalMs : false,
+		refetchIntervalInBackground: isActive,
 		refetchOnWindowFocus: false,
 		gcTime: CHAT_QUERY_GC_TIME_MS,
 	} as const;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -518,6 +518,7 @@ export function usePaneRegistry({
 						<ChatPane
 							workspaceId={workspaceId}
 							sessionId={data.sessionId}
+							isActive={ctx.isActive}
 							onSessionIdChange={(id) =>
 								ctx.actions.updateData({ ...data, sessionId: id })
 							}


### PR DESCRIPTION
Fixes #6339

## Problem

Superset becomes unresponsive with more than ~3 projects open, each with several tabs/panes. The triage bot's highest-suspicion path (and "smallest change with largest expected win") is chat snapshot polling.

## Root cause

Every v2 chat pane polls `chat.getSnapshot` on a timer — `fps: 4` → `refetchInterval: 250ms`, with `refetchIntervalInBackground: true` — and the query is gated only on `sessionId` existing, **not** on pane visibility or `isRunning`. An idle/background chat pane therefore refetches the **entire transcript** 4×/sec forever. The cost per tick is O(transcript length) in host-service serialize + renderer parse/compare, so it grows as conversations grow, and all panes share the single renderer thread. Several open panes → additive load that turns the app sluggish.

## Fix

Gate the polling on the pane being the **active tab**, mirroring how `TerminalPane` already gates its queries with `ctx.isActive`:

- `usePaneRegistry.tsx` — pass `ctx.isActive` into `<ChatPane>`.
- `ChatPane.tsx` / `ChatPaneInterface.tsx` / `types.ts` — thread the new `isActive` prop through to `useChatDisplay`.
- `useChatDisplay.ts` — `refetchInterval` is now `isActive ? refetchIntervalMs : false` (and `refetchIntervalInBackground: isActive`). While the pane is not the active tab it stops polling entirely; the cached snapshot stays mounted, so returning to the pane resumes fresh.

`isActive` defaults to `true` when omitted, so any other call site keeps polling as before.

## Tests

No unit test harness exists for the tRPC-coupled `useChatDisplay` hook in this repo (the polling options are built inside a React hook). Verified by:
- `tsc --noEmit` on apps/desktop — 0 errors;
- biome check — clean.

## Note

This is the first and cheapest of the triage bot's fix directions for #6339. The other two (xterm WebGL→DOM latch; GitWatcher per-worktree registration) are larger, separate changes and are intentionally out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops chat panes from polling the transcript while their tab is inactive, reducing renderer load and UI lag with many open tabs. Previously every v2 chat pane polled 4×/sec regardless of visibility; now polling runs only when the pane is active and resumes on focus, with cached data preserved.

- Gates chat snapshot polling in `useWorkspaceChatDisplay` using `isActive` (`refetchInterval: false`, `refetchIntervalInBackground: false` when inactive).
- Propagates `ctx.isActive` from `usePaneRegistry` into `ChatPane` → `ChatPaneInterface` → hook.
- `isActive` defaults to `true` for other call sites; no migration required.

<sup>Written for commit b92deff67e11f543af261b6162886761793c2bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Chat panes now refresh conversation updates only when active.
  * Inactive panes retain cached content without background polling, reducing unnecessary activity.
  * Switching to a chat pane resumes updates automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->