### PR TITLE
fix(desktop): let bash users keep their own prompt via SUPERSET_KEEP_PS1

### DIFF
--- a/packages/agent-setup/src/shell-wrappers.test.ts
+++ b/packages/agent-setup/src/shell-wrappers.test.ts
@@ -874,4 +874,75 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			}
 		});
 	});
+
+	describe("bash PS1 handling (#6311)", () => {
+		function runBash({
+			homeDir,
+			rcArgs = ["-ic"],
+			extraEnv = {},
+		}: {
+			homeDir: string;
+			rcArgs?: string[];
+			extraEnv?: Record<string, string>;
+		}): string {
+			createBashWrapper(TEST_PATHS);
+			return execFileSync(
+				"bash",
+				[
+					"--rcfile",
+					path.join(TEST_BASH_DIR, "rcfile"),
+					...rcArgs,
+					'printf "%s" "$PS1"',
+				],
+				{
+					encoding: "utf-8",
+					env: { HOME: homeDir, PATH: "/usr/bin:/bin", ...extraEnv },
+				},
+			);
+		}
+
+		it("applies the emerald prompt by default in an interactive shell", () => {
+			const homeDir = path.join(TEST_ROOT, "ps1-default", "home");
+			mkdirSync(homeDir, { recursive: true });
+			writeFileSync(path.join(homeDir, ".bashrc"), `PS1='MINE> '\n`);
+
+			const output = runBash({ homeDir });
+			// Escape sequence preserved via $'...': the 38;2;52;211;153 color code.
+			expect(output).toContain("38;2;52;211;153");
+		});
+
+		it("keeps the user's PS1 when SUPERSET_KEEP_PS1 is exported", () => {
+			const homeDir = path.join(TEST_ROOT, "ps1-keep", "home");
+			mkdirSync(homeDir, { recursive: true });
+			writeFileSync(
+				path.join(homeDir, ".bashrc"),
+				`export SUPERSET_KEEP_PS1=1\nPS1='MINE> '\n`,
+			);
+
+			const output = runBash({ homeDir });
+			expect(output).toContain("MINE> ");
+			expect(output).not.toContain("38;2;52;211;153");
+		});
+
+		it("does not set PS1 for non-interactive execution", () => {
+			const homeDir = path.join(TEST_ROOT, "ps1-noninteractive", "home");
+			mkdirSync(homeDir, { recursive: true });
+
+			const output = runBash({ homeDir, rcArgs: ["-c"] });
+			// No prompt in a non-interactive shell (the rcfile is sourced via
+			// getCommandShellArgs for `bash -c` command execution).
+			expect(output).not.toContain("38;2;52;211;153");
+		});
+
+		it("does not leak PS1 into child processes (plain assignment, no export)", () => {
+			const homeDir = path.join(TEST_ROOT, "ps1-noexport", "home");
+			mkdirSync(homeDir, { recursive: true });
+
+			createBashWrapper(TEST_PATHS);
+			const rcfile = readFileSync(path.join(TEST_BASH_DIR, "rcfile"), "utf-8");
+			// The prompt assignment must be a plain `PS1=`, not `export PS1=`.
+			expect(rcfile).toMatch(/\n {2}PS1=\$'/);
+			expect(rcfile).not.toMatch(/export PS1=/);
+		});
+	});
 });

--- a/packages/agent-setup/src/shell-wrappers.test.ts
+++ b/packages/agent-setup/src/shell-wrappers.test.ts
@@ -878,27 +878,30 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 	describe("bash PS1 handling (#6311)", () => {
 		function runBash({
 			homeDir,
-			rcArgs = ["-ic"],
+			interactive = true,
+			command,
 			extraEnv = {},
 		}: {
 			homeDir: string;
-			rcArgs?: string[];
+			interactive?: boolean;
+			command?: string;
 			extraEnv?: Record<string, string>;
 		}): string {
 			createBashWrapper(TEST_PATHS);
-			return execFileSync(
-				"bash",
-				[
-					"--rcfile",
-					path.join(TEST_BASH_DIR, "rcfile"),
-					...rcArgs,
-					'printf "%s" "$PS1"',
-				],
-				{
-					encoding: "utf-8",
-					env: { HOME: homeDir, PATH: "/usr/bin:/bin", ...extraEnv },
-				},
-			);
+			const rcfile = path.join(TEST_BASH_DIR, "rcfile");
+			// bash only honours `--rcfile` for interactive shells, so for the
+			// non-interactive case we source the wrapper rcfile explicitly to
+			// actually exercise the `$- == *i*` guard.
+			const args = interactive
+				? ["--rcfile", rcfile, "-ic", command ?? 'printf "%s" "$PS1"']
+				: [
+						"-c",
+						`source ${quoteShellLiteral(rcfile)} && ${command ?? 'printf "%s" "$PS1"'}`,
+					];
+			return execFileSync("bash", args, {
+				encoding: "utf-8",
+				env: { HOME: homeDir, PATH: "/usr/bin:/bin", ...extraEnv },
+			});
 		}
 
 		it("applies the emerald prompt by default in an interactive shell", () => {
@@ -928,21 +931,38 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			const homeDir = path.join(TEST_ROOT, "ps1-noninteractive", "home");
 			mkdirSync(homeDir, { recursive: true });
 
-			const output = runBash({ homeDir, rcArgs: ["-c"] });
-			// No prompt in a non-interactive shell (the rcfile is sourced via
-			// getCommandShellArgs for `bash -c` command execution).
+			// Source the rcfile in a non-interactive `-c` shell; the `$- == *i*`
+			// guard must skip the prompt assignment.
+			const output = runBash({ homeDir, interactive: false });
 			expect(output).not.toContain("38;2;52;211;153");
 		});
 
-		it("does not leak PS1 into child processes (plain assignment, no export)", () => {
+		it("does not export PS1 to child processes even if user config did", () => {
 			const homeDir = path.join(TEST_ROOT, "ps1-noexport", "home");
 			mkdirSync(homeDir, { recursive: true });
+			// User config exports PS1 before Superset's wrapper sets its own.
+			// The wrapper's `export -n PS1` must keep it unexported to children.
+			writeFileSync(path.join(homeDir, ".bashrc"), `export PS1='user'\n`);
 
-			createBashWrapper(TEST_PATHS);
-			const rcfile = readFileSync(path.join(TEST_BASH_DIR, "rcfile"), "utf-8");
-			// The prompt assignment must be a plain `PS1=`, not `export PS1=`.
-			expect(rcfile).toMatch(/\n {2}PS1=\$'/);
-			expect(rcfile).not.toMatch(/export PS1=/);
+			const output = runBash({
+				homeDir,
+				command: 'printf "%s" "${' + "PS1-}" + '"',
+			});
+			// Superset's emerald prompt wins in the shell...
+			expect(output).toContain("38;2;52;211;153");
+		});
+
+		it("does not leak PS1 into child processes (plain assignment, no export)", () => {
+			const homeDir = path.join(TEST_ROOT, "ps1-noexport-child", "home");
+			mkdirSync(homeDir, { recursive: true });
+			writeFileSync(path.join(homeDir, ".bashrc"), `export PS1='user'\n`);
+
+			// A grandchild shell must NOT inherit PS1 as an exported variable.
+			const output = runBash({
+				homeDir,
+				command: 'env | grep -c "^PS1=" || true',
+			});
+			expect(output.trim()).toBe("0");
 		});
 	});
 });

--- a/packages/agent-setup/src/shell-wrappers.test.ts
+++ b/packages/agent-setup/src/shell-wrappers.test.ts
@@ -937,11 +937,12 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			expect(output).not.toContain("38;2;52;211;153");
 		});
 
-		it("does not export PS1 to child processes even if user config did", () => {
+		it("applies the emerald prompt in the shell even when user config exported PS1", () => {
 			const homeDir = path.join(TEST_ROOT, "ps1-noexport", "home");
 			mkdirSync(homeDir, { recursive: true });
 			// User config exports PS1 before Superset's wrapper sets its own.
-			// The wrapper's `export -n PS1` must keep it unexported to children.
+			// The wrapper's `export -n PS1` must keep it unexported to children
+			// (the grandchild-env case is covered by the next test).
 			writeFileSync(path.join(homeDir, ".bashrc"), `export PS1='user'\n`);
 
 			const output = runBash({

--- a/packages/agent-setup/src/shell-wrappers.ts
+++ b/packages/agent-setup/src/shell-wrappers.ts
@@ -256,7 +256,10 @@ hash -r 2>/dev/null || true
 # when the user has not opted out with SUPERSET_KEEP_PS1=1. Plain assignment
 # (no export) so PS1 does not leak into child processes, where rc files and
 # scripts that test for a set PS1 to detect interactivity would be misled.
+# export -n clears the export attribute if the user's own config exported
+# PS1 before this point, so the "not exported" guarantee holds either way.
 if [[ -z "\${SUPERSET_KEEP_PS1:-}" && $- == *i* ]]; then
+  export -n PS1 2>/dev/null || true
   PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
 fi
 # Shell readiness markers — see zsh wrapper for rationale on emitting both.

--- a/packages/agent-setup/src/shell-wrappers.ts
+++ b/packages/agent-setup/src/shell-wrappers.ts
@@ -250,8 +250,15 @@ ${SUPERSET_ENV_RESTORE}
 # Keep superset bin first without duplicating entries
 ${buildPathPrependFunction(paths.BIN_DIR)}
 hash -r 2>/dev/null || true
-# Minimal prompt (path/env shown in toolbar) - emerald to match app theme
-export PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
+# Minimal prompt (path/env shown in toolbar) - emerald to match app theme.
+# Only set it for an interactive shell (this rcfile is also sourced for
+# non-interactive command execution, where a prompt is meaningless), and only
+# when the user has not opted out with SUPERSET_KEEP_PS1=1. Plain assignment
+# (no export) so PS1 does not leak into child processes, where rc files and
+# scripts that test for a set PS1 to detect interactivity would be misled.
+if [[ -z "\${SUPERSET_KEEP_PS1:-}" && $- == *i* ]]; then
+  PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
+fi
 # Shell readiness markers — see zsh wrapper for rationale on emitting both.
 # Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
 __superset_prompt_mark() {


### PR DESCRIPTION
Fixes #6311

## Problem

For **bash — and only bash** — Superset unconditionally replaces the user's prompt. `createBashWrapper` sources the user's profile/`.bashrc` first and then clobbers `PS1` with the emerald `❯`, so there is no way for a user config to win, and no env var, setting, or file opts out. zsh and fish never touch `PROMPT`/`PS1`, so this is an asymmetry rather than a requirement of shell integration.

Three concrete problems in the one `export PS1=…` line:

1. **No opt-out** — any `PS1` a user sets in `.bashrc` is always overwritten.
2. **`export` leaks** `PS1` into child processes, where rc files and scripts that test `[ -n "$PS1" ]` for interactivity are misled.
3. **Non-interactive execution** — the same rcfile is sourced for `bash -c` command execution (`getCommandShellArgs`), where a prompt is meaningless.

## Fix

In `createBashWrapper` (shell-wrappers.ts), the prompt is now assigned only when all three hold:

```bash
if [[ -z "${SUPERSET_KEEP_PS1:-}" && $- == *i* ]]; then
  PS1=$'\[\e[1;38;2;52;211;153m\]❯\[\e[0m\] '
fi
```

- **Opt-out:** set `export SUPERSET_KEEP_PS1=1` in your bash config to keep your own prompt. The guard runs *after* user config is sourced, and the `SUPERSET_ENV_SAVE`/`RESTORE` pair never unsets newly-added vars, so an exported `SUPERSET_KEEP_PS1` from `.bashrc`/`.bash_profile` survives to the guard.
- **Interactive only:** `$- == *i*` skips the assignment for non-interactive `bash -c` execution.
- **No leak:** plain `PS1=` instead of `export PS1=`.

The shell-readiness markers ride `PROMPT_COMMAND` (independent of `PS1`), so terminal automation is unaffected.

## Tests

`shell-wrappers.test.ts` (4 new cases, running real bash with `--rcfile`, matching the existing integration-test pattern):
- Emerald prompt still applied by default in an interactive shell.
- `SUPERSET_KEEP_PS1=1` exported from user `.bashrc` keeps the user's `MINE> ` prompt.
- No `PS1` set for non-interactive `-c` execution.
- The generated rcfile uses a plain `PS1=` (no `export`).

All 29 tests in the file pass; `tsc --noEmit` and biome are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let bash users keep their own prompt. The wrapper now sets the emerald ❯ only in interactive bash when `SUPERSET_KEEP_PS1` is not set, and keeps `PS1` unexported so it does not leak to child processes.

- Opt-out: set `SUPERSET_KEEP_PS1=1` to keep your prompt.
- Interactive only: guard on `$-` containing `i`; skip for `bash -c`.
- No leak: clear any export with `export -n PS1`, then assign `PS1=…`.
- zsh and fish remain unchanged.

<sup>Written for commit 9d2767c72b9c1f9223d5c6fc8e7d3c08e43ea722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bash wrappers now configure the default prompt only in interactive shells.
  * Added `SUPERSET_KEEP_PS1` support to preserve existing prompts.
  * Prevented prompt variables from leaking into child processes.
  * Ensured user-defined prompts are handled appropriately without unwanted exporting.
* **Tests**
  * Added coverage for interactive and non-interactive shells, prompt overrides, prompt preservation, and child-process environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->