### PR TITLE
fix(desktop): stop workspace delete from crash-remounting the renderer via stale v1 routes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -61,7 +61,10 @@ export function useNavigateAwayFromWorkspace() {
 				}).catch(reportRemovalNavigationError);
 				return;
 			}
-			void navigate({ to: "/", replace: true }).catch(
+			// Straight to the v2 empty state — "/" detours through the v1
+			// workspace index, which can restore stale pre-migration state
+			// (SUPER-1814).
+			void navigate({ to: "/new-workspace", replace: true }).catch(
 				reportRemovalNavigationError,
 			);
 		},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -32,6 +32,11 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
 });
 
+// Hoisted for stable props identity — <Navigate> re-navigates whenever its
+// props object changes, so an inline element re-navigates on every re-render
+// until React throws error #185 (see routes/page.tsx, #5729, SUPER-1814).
+const newWorkspaceRedirect = <Navigate to="/new-workspace" replace />;
+
 /** v1 only — v2 deletes go through the globally-mounted DeleteWorkspaceMount
  * (see delete-workspace-intent store). */
 type DeleteTarget = {
@@ -225,7 +230,7 @@ function DashboardLayout() {
 							// dead-end "pick a workspace" screen. v1 users keep the
 							// static state — /new-workspace is a v2-only surface.
 							isV2CloudEnabled ? (
-								<Navigate to="/new-workspace" replace />
+								newWorkspaceRedirect
 							) : (
 								<CrossVersionMismatchState />
 							)

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/page.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/workspace/")({
@@ -17,13 +18,23 @@ function LoadingSpinner() {
 
 function WorkspaceIndexPage() {
 	const navigate = useNavigate();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { data: workspaces, isLoading } =
-		electronTrpc.workspaces.getAllGrouped.useQuery();
+		electronTrpc.workspaces.getAllGrouped.useQuery(undefined, {
+			enabled: !isV2CloudEnabled,
+		});
 
 	const allWorkspaces = workspaces?.flatMap((group) => group.workspaces) ?? [];
 	const hasNoWorkspaces = !isLoading && allWorkspaces.length === 0;
 
 	useEffect(() => {
+		// v2 users must never be routed by the v1 restore logic below — a
+		// stale lastViewedWorkspaceId lands them on a v1 workspace route the
+		// dashboard immediately redirects away from (SUPER-1814).
+		if (isV2CloudEnabled) {
+			navigate({ to: "/new-workspace", replace: true });
+			return;
+		}
 		if (isLoading || !workspaces) return;
 
 		if (allWorkspaces.length === 0) {
@@ -45,7 +56,7 @@ function WorkspaceIndexPage() {
 				replace: true,
 			});
 		}
-	}, [workspaces, isLoading, navigate, allWorkspaces]);
+	}, [workspaces, isLoading, navigate, allWorkspaces, isV2CloudEnabled]);
 
 	if (hasNoWorkspaces) {
 		return <LoadingSpinner />;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/page.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
@@ -24,17 +24,26 @@ function WorkspaceIndexPage() {
 			enabled: !isV2CloudEnabled,
 		});
 
-	const allWorkspaces = workspaces?.flatMap((group) => group.workspaces) ?? [];
+	// Memoized so the v1 restore effect below doesn't re-run on every render
+	// (a fresh array identity would re-fire it during a pending navigation).
+	const allWorkspaces = useMemo(
+		() => workspaces?.flatMap((group) => group.workspaces) ?? [],
+		[workspaces],
+	);
 	const hasNoWorkspaces = !isLoading && allWorkspaces.length === 0;
 
+	// v2 users must never be routed by the v1 restore logic below — a stale
+	// lastViewedWorkspaceId lands them on a v1 workspace route the dashboard
+	// immediately redirects away from (SUPER-1814). Isolated in its own effect
+	// keyed only on isV2CloudEnabled so v1 query churn can't re-trigger it.
 	useEffect(() => {
-		// v2 users must never be routed by the v1 restore logic below — a
-		// stale lastViewedWorkspaceId lands them on a v1 workspace route the
-		// dashboard immediately redirects away from (SUPER-1814).
 		if (isV2CloudEnabled) {
 			navigate({ to: "/new-workspace", replace: true });
-			return;
 		}
+	}, [isV2CloudEnabled, navigate]);
+
+	useEffect(() => {
+		if (isV2CloudEnabled) return;
 		if (isLoading || !workspaces) return;
 
 		if (allWorkspaces.length === 0) {


### PR DESCRIPTION
Fixes SUPER-1814 — reported by Jose Carlos (reacherapp.com) on 1.20.2: every workspace delete "refreshes the whole Superset application" and dumps him on an empty New Workspace screen until a manual reload.

## Root cause

Confirmed against his PostHog timeline (the `desktop_opened` root-mount event re-fires 400ms after each delete, landing on `#/new-workspace`):

1. Deleting the active workspace with no visible sibling falls back to `navigate({ to: "/" })`.
2. `/` redirects to `/workspace` — the **v1** index.
3. For migrated v2 users, the v1 index restores a stale `lastViewedWorkspaceId` (pre-migration v1 row still in the electron localDb) and navigates onto a v1 workspace route.
4. The dashboard's version-mismatch guard rendered an **inline** `<Navigate to="/new-workspace" replace />`. `Navigate` re-navigates whenever its props object identity changes, so every layout re-render during the pending navigation re-navigated until React threw error #185. The throw bubbled to the root `errorComponent`, unmounting the entire tree; the settled navigation reset the boundary and remounted the root — the "app reloaded itself" flash.

Only users with pre-migration v1 leftovers hit this, which is why it never reproduced on clean installs. Step 4 is the same hazard class already fixed in `routes/page.tsx` (#5729).

## Fix

- **Hoist the version-mismatch `<Navigate>`** to module scope for stable props identity — kills the #185 loop no matter how a v2 user reaches a v1 route.
- **Workspace-removal fallback goes straight to `/new-workspace`** instead of detouring through `/` → v1 index.
- **The v1 workspace index redirects v2 users to `/new-workspace`** instead of running v1 restore logic — covers every other path into `/` (sign-in, create-organization, not-found "Go home"), including the sibling "creating a workspace makes the others disappear" symptom in the same report.

## Verification

- Mechanism confirmed in the installed router source: `Navigate` re-navigates on props-identity change (`useNavigate.js`, `previousPropsRef.current !== props`).
- `bun run typecheck` (desktop) clean, `bun run lint` clean, 1454 renderer tests pass.
- No end-to-end CDP repro was run — reproducing requires seeding pre-migration v1 state (stale `lastViewedWorkspaceId` + v1 localDb rows).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SUPER-1814 by stopping the app from remounting after deleting a workspace. V2 users now go straight to `/new-workspace`, avoiding stale v1 routes and a `Navigate` re-navigation loop.

- **Bug Fixes**
  - Hoisted version-mismatch `Navigate` to module scope to keep props stable and prevent re-navigation (React error 185).
  - On delete fallback, route directly to `/new-workspace` instead of `"/"` → v1 index.
  - In the v1 workspace index, detect v2 and redirect to `/new-workspace`; skip `electronTrpc.workspaces.getAllGrouped` for v2; isolate the v2 redirect from v1 query churn and memoize the workspace list to avoid redundant effect triggers during navigation.

<sup>Written for commit a8b0ff2f0f2378032c1cdcbca4f0d250cb108162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic navigation to the new workspace setup when no replacement workspace is available.
  * Added routing from V2 Cloud workspace dashboards to the new workspace experience.

* **Bug Fixes**
  * Improved workspace restoration and navigation behavior for existing V1 workspaces.
  * Prevented unnecessary workspace reloads during dashboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->