### PR TITLE
feat(marketing): pricing page and copy improvements

### DIFF
--- a/apps/marketing/src/app/components/FeaturesSection/constants.ts
+++ b/apps/marketing/src/app/components/FeaturesSection/constants.ts
@@ -39,7 +39,7 @@ export const FEATURES: Feature[] = [
 		tag: "Remote Workspaces",
 		title: "Run workspaces anywhere",
 		description:
-			"Add any machine as a host, on every plan. Workspaces keep running when your laptop sleeps, and you can check in from wherever you are.",
+			"Add any machine as a host. Workspaces keep running when your laptop sleeps, and you can check in from wherever you are.",
 	},
 	{
 		tag: "CLI & SDK",

--- a/apps/marketing/src/app/components/FeaturesSection/constants.ts
+++ b/apps/marketing/src/app/components/FeaturesSection/constants.ts
@@ -39,7 +39,7 @@ export const FEATURES: Feature[] = [
 		tag: "Remote Workspaces",
 		title: "Run workspaces anywhere",
 		description:
-			"Add any machine as a host. Workspaces keep running when your laptop sleeps, and you can check in from wherever you are.",
+			"Add any machine as a host, on every plan. Workspaces keep running when your laptop sleeps, and you can check in from wherever you are.",
 	},
 	{
 		tag: "CLI & SDK",

--- a/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
+++ b/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
@@ -68,7 +68,7 @@ function tierPriceLabel(tier: (typeof PRICING_TIERS)[number]): string {
 		return tier.price.display;
 	}
 	if (tier.price.kind === "variable") {
-		return `${tier.price.yearly.display}/user/mo`;
+		return `from ${tier.price.yearly.display}/user/mo`;
 	}
 	return "Custom";
 }

--- a/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
+++ b/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
@@ -30,18 +30,21 @@ export function ComparisonTable() {
 function DesktopTable() {
 	return (
 		<div className="hidden md:block">
-			<table className="w-full table-fixed border-collapse">
+			<table className="w-full table-fixed border-separate border-spacing-0">
 				<thead>
-					<tr className="border-b border-border">
-						<th className="w-2/5 py-4 pr-4 text-left text-sm font-medium text-muted-foreground">
+					<tr>
+						<th className="sticky top-16 z-10 w-2/5 border-b border-border bg-background py-4 pr-4 text-left text-sm font-medium text-muted-foreground">
 							Features
 						</th>
 						{PRICING_TIERS.map((tier) => (
 							<th
 								key={tier.id}
-								className="w-1/5 py-4 px-4 text-left text-sm font-medium text-foreground"
+								className="sticky top-16 z-10 w-1/5 border-b border-border bg-background py-4 px-4 text-left text-sm font-medium text-foreground"
 							>
 								{tier.name}
+								<span className="ml-2 font-normal text-xs text-muted-foreground">
+									{tierPriceLabel(tier)}
+								</span>
 							</th>
 						))}
 					</tr>
@@ -58,6 +61,16 @@ function DesktopTable() {
 			</table>
 		</div>
 	);
+}
+
+function tierPriceLabel(tier: (typeof PRICING_TIERS)[number]): string {
+	if (tier.price.kind === "fixed") {
+		return tier.price.display;
+	}
+	if (tier.price.kind === "variable") {
+		return `${tier.price.yearly.display}/user/mo`;
+	}
+	return "Custom";
 }
 
 function DesktopSectionGroup({
@@ -84,8 +97,8 @@ function DesktopSectionGroup({
 
 function DesktopRow({ row }: { row: ComparisonRow }) {
 	return (
-		<tr className="border-b border-border/60">
-			<td className="py-4 pr-4 text-sm text-foreground">
+		<tr>
+			<td className="border-b border-border/60 py-4 pr-4 text-sm text-foreground">
 				<div className="flex items-center gap-2">
 					<span>{row.label}</span>
 					{row.badge && <RowBadge badge={row.badge} />}
@@ -94,7 +107,7 @@ function DesktopRow({ row }: { row: ComparisonRow }) {
 			{row.values.map((value, index) => (
 				<td
 					key={`${row.label}-${index}`}
-					className="px-4 py-4 text-sm text-foreground"
+					className="border-b border-border/60 px-4 py-4 text-sm text-foreground"
 				>
 					<Cell value={value} />
 				</td>

--- a/apps/marketing/src/app/pricing/components/PricingTiers/components/PricingCard/PricingCard.tsx
+++ b/apps/marketing/src/app/pricing/components/PricingTiers/components/PricingCard/PricingCard.tsx
@@ -55,15 +55,18 @@ export function PricingCard({ tier, isYearly }: PricingCardProps) {
 				{cadence && <p className="text-xs text-muted-foreground">{cadence}</p>}
 			</div>
 
-			<Button asChild variant={tier.cta.variant} size="lg" className="w-full">
-				{tier.cta.external ? (
-					<a href={tier.cta.href} target="_blank" rel="noopener noreferrer">
-						{tier.cta.label}
-					</a>
-				) : (
-					<Link href={tier.cta.href}>{tier.cta.label}</Link>
-				)}
-			</Button>
+			<div className="flex flex-col gap-2">
+				<Button asChild variant={tier.cta.variant} size="lg" className="w-full">
+					{tier.cta.external ? (
+						<a href={tier.cta.href} target="_blank" rel="noopener noreferrer">
+							{tier.cta.label}
+						</a>
+					) : (
+						<Link href={tier.cta.href}>{tier.cta.label}</Link>
+					)}
+				</Button>
+				<CtaNote note={tier.ctaNote} />
+			</div>
 
 			<ul className="flex flex-col gap-3 border-t border-border pt-6">
 				{tier.features.map((feature) => (
@@ -77,6 +80,27 @@ export function PricingCard({ tier, isYearly }: PricingCardProps) {
 				))}
 			</ul>
 		</div>
+	);
+}
+
+function CtaNote({ note }: { note: PricingTier["ctaNote"] }) {
+	if (!note) {
+		return <p className="h-4" aria-hidden="true" />;
+	}
+	if (note.href) {
+		return (
+			<a
+				href={note.href}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-center text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+			>
+				{note.label}
+			</a>
+		);
+	}
+	return (
+		<p className="text-center text-xs text-muted-foreground">{note.label}</p>
 	);
 }
 

--- a/apps/marketing/src/app/pricing/components/TrustStrip/TrustStrip.tsx
+++ b/apps/marketing/src/app/pricing/components/TrustStrip/TrustStrip.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+
+const STRIP_LOGOS = [
+	{
+		name: "microsoft",
+		label: "Microsoft",
+		logo: "/logos/microsoft-wordmark.svg",
+		height: 18,
+	},
+	{
+		name: "openai",
+		label: "OpenAI",
+		logo: "/logos/openai-wordmark.svg",
+		height: 18,
+	},
+	{ name: "google", label: "Google", logo: "/logos/google.svg", height: 22 },
+	{
+		name: "vercel",
+		label: "Vercel",
+		logo: "/logos/vercel-wordmark.svg",
+		height: 34,
+	},
+	{
+		name: "datadog",
+		label: "Datadog",
+		logo: "/logos/datadog-wordmark.svg",
+		height: 38,
+	},
+	{ name: "amazon", label: "Amazon", logo: "/logos/amazon.png", height: 20 },
+];
+
+export function TrustStrip() {
+	return (
+		<div className="flex flex-col items-center gap-6">
+			<p className="text-sm text-muted-foreground">Trusted by builders from</p>
+			<div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-4 opacity-70">
+				{STRIP_LOGOS.map((client) => (
+					<Image
+						key={client.name}
+						src={client.logo}
+						alt={client.label}
+						width={160}
+						height={client.height}
+						className="object-contain grayscale brightness-0 invert"
+						style={{ height: client.height, width: "auto" }}
+						unoptimized
+					/>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/pricing/components/TrustStrip/index.ts
+++ b/apps/marketing/src/app/pricing/components/TrustStrip/index.ts
@@ -1,0 +1,1 @@
+export { TrustStrip } from "./TrustStrip";

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -1,3 +1,4 @@
+import { COMPANY } from "@superset/shared/constants";
 import type { FAQItem } from "@/app/components/FAQSection";
 
 export type TierId = "free" | "pro" | "enterprise";
@@ -22,6 +23,7 @@ export interface PricingTier {
 		variant: "default" | "outline" | "secondary";
 		external?: boolean;
 	};
+	ctaNote?: { label: string; href?: string };
 	highlight?: boolean;
 }
 
@@ -44,6 +46,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			href: "/download",
 			variant: "outline",
 		},
+		ctaNote: { label: "No credit card required. Free forever." },
 	},
 	{
 		id: "pro",
@@ -59,7 +62,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			yearly: {
 				display: "$15",
 				note: "per user/month",
-				cadence: "Billed yearly",
+				cadence: "$180 per user, billed yearly",
 			},
 		},
 		features: [
@@ -87,9 +90,9 @@ export const PRICING_TIERS: PricingTier[] = [
 		},
 		features: [
 			"Everything in Pro",
-			"SSO & advanced security",
+			"SAML SSO & SCIM provisioning",
 			"Audit logs",
-			"SLA & dedicated support",
+			"Uptime SLA & dedicated support",
 			"Custom integrations",
 		],
 		cta: {
@@ -97,6 +100,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			href: "/enterprise",
 			variant: "outline",
 		},
+		ctaNote: { label: "Review our security", href: COMPANY.TRUST_URL },
 	},
 ];
 
@@ -188,5 +192,15 @@ export const PRICING_FAQ_ITEMS: FAQItem[] = [
 		question: "What's included in Enterprise?",
 		answer:
 			"Everything in Pro plus SSO & SAML, SCIM provisioning, IP restrictions, audit logs, a custom SLA, dedicated support, and custom contracts. Pricing is tailored to your organization. Get in touch and we'll scope something that fits.",
+	},
+	{
+		question: "Where does my code run?",
+		answer:
+			"On your machine. Repos, worktrees, terminal output, and agent sessions stay local by default; cloud sync covers account and organization metadata only. Superset doesn't proxy any API calls.",
+	},
+	{
+		question: "Do I need my own coding agent subscriptions?",
+		answer:
+			"Yes. Superset is the workspace your agents run in, not a model provider. Bring Claude Code, Codex, OpenCode, or any CLI agent, and use your existing accounts or API keys on every plan.",
 	},
 ];

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -86,7 +86,7 @@ export const PRICING_TIERS: PricingTier[] = [
 		price: {
 			kind: "custom",
 			display: "Custom pricing",
-			note: "Billed yearly",
+			note: "Annual billing only",
 		},
 		features: [
 			"Everything in Pro",

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -36,7 +36,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			"Local workspaces",
 			"Desktop app",
 			"GitHub integration",
-			"CLI (coming soon)",
+			"CLI",
 		],
 		cta: {
 			label: "Download app",

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -45,7 +45,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			href: "/download",
 			variant: "outline",
 		},
-		ctaNote: { label: "No credit card required. Free forever." },
+		ctaNote: { label: "No credit card required." },
 	},
 	{
 		id: "pro",

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -34,6 +34,7 @@ export const PRICING_TIERS: PricingTier[] = [
 		features: [
 			"1 user",
 			"Local workspaces",
+			"Remote workspaces",
 			"Desktop app",
 			"GitHub integration",
 			"CLI",
@@ -64,8 +65,8 @@ export const PRICING_TIERS: PricingTier[] = [
 		features: [
 			"Everything in Free",
 			"Unlimited users",
-			"Remote workspaces",
 			"Linear integration",
+			"Slack integration",
 			"Mobile (coming soon)",
 		],
 		cta: {
@@ -133,7 +134,7 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 			{ label: "Local workspaces", values: [true, true, true] },
 			{
 				label: "Remote workspaces",
-				values: [null, true, true],
+				values: [true, true, true],
 				badge: { label: "Beta", variant: "default" },
 			},
 			{ label: "Automations", values: [true, true, true] },
@@ -171,7 +172,7 @@ export const PRICING_FAQ_ITEMS: FAQItem[] = [
 	{
 		question: "Is there a free plan?",
 		answer:
-			"Yes. Free covers individuals with 1 user, local workspaces, the desktop app, and GitHub integration. No credit card required.",
+			"Yes. Free covers individuals with 1 user, local and remote workspaces, the desktop app, the CLI, and GitHub integration. No credit card required.",
 	},
 	{
 		question: "How does Pro pricing work?",

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -36,7 +36,6 @@ export const PRICING_TIERS: PricingTier[] = [
 		features: [
 			"1 user",
 			"Local workspaces",
-			"Remote workspaces",
 			"Desktop app",
 			"GitHub integration",
 			"CLI",
@@ -68,6 +67,7 @@ export const PRICING_TIERS: PricingTier[] = [
 		features: [
 			"Everything in Free",
 			"Unlimited users",
+			"Remote workspaces",
 			"Linear integration",
 			"Slack integration",
 			"Mobile (coming soon)",
@@ -138,7 +138,7 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 			{ label: "Local workspaces", values: [true, true, true] },
 			{
 				label: "Remote workspaces",
-				values: [true, true, true],
+				values: [null, true, true],
 				badge: { label: "Beta", variant: "default" },
 			},
 			{ label: "Automations", values: [true, true, true] },
@@ -176,7 +176,7 @@ export const PRICING_FAQ_ITEMS: FAQItem[] = [
 	{
 		question: "Is there a free plan?",
 		answer:
-			"Yes. Free covers individuals with 1 user, local and remote workspaces, the desktop app, the CLI, and GitHub integration. No credit card required.",
+			"Yes. Free covers individuals with 1 user, local workspaces, the desktop app, the CLI, and GitHub integration. No credit card required.",
 	},
 	{
 		question: "How does Pro pricing work?",

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -4,6 +4,7 @@ import { ComparisonTable } from "./components/ComparisonTable";
 import { PricingFAQ } from "./components/PricingFAQ";
 import { PricingHero } from "./components/PricingHero";
 import { PricingTiers } from "./components/PricingTiers";
+import { TrustStrip } from "./components/TrustStrip";
 
 export const metadata: Metadata = {
 	title: "Pricing",
@@ -21,6 +22,12 @@ export default function PricingPage() {
 			<section className="relative border-b border-border">
 				<div className="max-w-6xl mx-auto px-6 py-12 md:py-16">
 					<PricingTiers />
+				</div>
+			</section>
+
+			<section className="relative border-b border-border">
+				<div className="max-w-6xl mx-auto px-6 py-10 md:py-12">
+					<TrustStrip />
 				</div>
 			</section>
 

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -1,10 +1,12 @@
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
+import { FAQPageJsonLd } from "@/components/JsonLd";
 import { ComparisonTable } from "./components/ComparisonTable";
 import { PricingFAQ } from "./components/PricingFAQ";
 import { PricingHero } from "./components/PricingHero";
 import { PricingTiers } from "./components/PricingTiers";
 import { TrustStrip } from "./components/TrustStrip";
+import { PRICING_FAQ_ITEMS } from "./constants";
 
 export const metadata: Metadata = {
 	title: "Pricing",
@@ -17,6 +19,7 @@ export const metadata: Metadata = {
 export default function PricingPage() {
 	return (
 		<main className="relative min-h-screen">
+			<FAQPageJsonLd items={PRICING_FAQ_ITEMS} />
 			<PricingHero />
 
 			<section className="relative border-b border-border">

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -69,7 +69,7 @@ export function SoftwareApplicationJsonLd() {
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
 		name: COMPANY.NAME,
-		operatingSystem: "macOS, Windows, Linux",
+		operatingSystem: "macOS",
 		applicationCategory: "DeveloperApplication",
 		applicationSubCategory: "Developer Tools",
 		offers: {


### PR DESCRIPTION
## Summary
- Copy accuracy fixes across the marketing site (platform metadata, CLI availability, plan placement)
- Pricing page polish: enterprise card copy, trust logo strip, sticky comparison-table header, clearer yearly price framing, two new FAQs, FAQ structured data

## Testing
- `bun run typecheck` + `bun run lint` clean
- Verified with screenshots from the dev server (desktop, mobile emulation, scrolled table)