### PR TITLE
fix(marketing): align join-us hero width and theme the WaaS embed

### DIFF
--- a/apps/marketing/src/app/join-us/page.tsx
+++ b/apps/marketing/src/app/join-us/page.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 export default function JoinUsPage() {
 	return (
 		<main className="relative min-h-screen bg-background">
-			<div className="max-w-7xl mx-auto px-6 pt-24 md:pt-32">
+			<div className="max-w-[90rem] mx-auto px-6 pt-24 md:pt-32">
 				<section className="grid gap-10 md:grid-cols-[2fr_3fr] md:gap-24 lg:gap-32">
 					<h1 className="text-4xl md:text-5xl font-normal leading-tight text-foreground m-0">
 						Building the last piece of software
@@ -87,8 +87,12 @@ export default function JoinUsPage() {
 							--waas-primary: var(--brand);
 							--waas-radius: 0px;
 							--waas-border: var(--color-border);
+							--waas-border-focus: var(--brand);
 							--waas-bg: #101012;
 							--waas-bg-subtle: rgba(255, 255, 255, 0.06);
+							--waas-font: var(--font-inter), ui-sans-serif, sans-serif;
+							--waas-text: var(--foreground);
+							--waas-text-secondary: var(--muted-foreground);
 							--waas-font-size-base: 15px;
 							--waas-font-size-md: 18px;
 							--waas-font-size-xl: 22px;
@@ -100,7 +104,23 @@ export default function JoinUsPage() {
 					/>
 					{/* show-filters="false" attribute is ignored (Lit boolean), so set the property; detail-view spacing has no CSS-var hooks, so patch its shadow root directly */}
 					<Script id="waas-board-config" strategy="afterInteractive">
-						{`customElements.whenDefined("waas-job-board").then(() => {
+						{`// the embed renders hCaptcha without a theme option, so force dark by patching render() as the hcaptcha script assigns its global
+						{
+							const darken = (h) => {
+								if (!h?.render || h.__supersetDark) return h;
+								const orig = h.render.bind(h);
+								h.render = (el, cfg) => orig(el, { theme: "dark", ...cfg });
+								h.__supersetDark = true;
+								return h;
+							};
+							let hc = darken(window.hcaptcha);
+							Object.defineProperty(window, "hcaptcha", {
+								configurable: true,
+								get: () => hc,
+								set: (v) => { hc = darken(v); },
+							});
+						}
+						customElements.whenDefined("waas-job-board").then(() => {
 							// !important: Lit's adoptedStyleSheets are ordered after tree styles, so plain rules lose
 							const inject = (root, css) => {
 								if (!root || root.getElementById("superset-overrides")) return;
@@ -109,14 +129,35 @@ export default function JoinUsPage() {
 								style.textContent = css;
 								root.append(style);
 							};
+							// site CTA recipe (see DownloadButton): mono uppercase, foreground/background flip, brand on hover
+							const mono = "font-family:var(--font-ibm-plex-mono),ui-monospace,monospace !important;text-transform:uppercase !important;letter-spacing:0.05em !important";
+							const detailCss = [
+								".two-col{gap:192px !important}",
+								".tabs{margin-bottom:48px !important;gap:40px !important}",
+								".main-content{max-width:760px !important}",
+								".tab{" + mono + ";font-size:13px !important}",
+								".back-link{" + mono + ";font-size:12px !important}",
+								".sidebar-label{" + mono + ";font-size:11px !important}",
+								".sidebar-item{border-bottom:1px solid var(--_border) !important}", // default rgba(0,0,0,.06) vanishes on dark bg
+							].join("");
+							const formCss = [
+								".primary-button{" + mono + ";font-size:13px !important;font-weight:400 !important;background:var(--foreground) !important;color:var(--background) !important;transition:background-color .15s ease,color .15s ease !important}",
+								".primary-button:hover:not(:disabled){background:var(--brand) !important;color:#fff !important;filter:none !important}",
+							].join("");
+							const cardCss = [
+								".job-card{border-bottom:none !important}",
+								".job-card:hover{background:rgba(255,255,255,0.04) !important}", // default rgba(0,0,0,.03) vanishes on dark bg
+								".job-salary{font-family:var(--font-ibm-plex-mono),ui-monospace,monospace !important;letter-spacing:0.02em !important}",
+							].join("");
 							for (const board of document.querySelectorAll("waas-job-board")) {
 								board.showFilters = false;
 								const patch = () => {
 									const detail = board.shadowRoot?.querySelector("waas-job-detail");
-									inject(detail?.shadowRoot, ".two-col{gap:192px !important}.tabs{margin-bottom:48px !important;gap:40px !important}.main-content{max-width:760px !important}");
+									inject(detail?.shadowRoot, detailCss);
+									inject(detail?.shadowRoot?.querySelector("waas-apply-form")?.shadowRoot, formCss);
 									const list = board.shadowRoot?.querySelector("waas-job-list");
 									for (const card of list?.shadowRoot?.querySelectorAll("waas-job-card") ?? []) {
-										inject(card.shadowRoot, ".job-card{border-bottom:none !important}");
+										inject(card.shadowRoot, cardCss);
 									}
 								};
 								patch();


### PR DESCRIPTION
## Summary
- Widen the join-us hero container (`max-w-7xl` → `max-w-[90rem]`) so it lines up with the Open roles section below.
- Style the embedded WaaS job board to match the site:
  - Theme tokens via the embed's CSS vars: Inter (`--waas-font`), `--foreground`/`--muted-foreground` text colors, brand focus ring.
  - Mono-uppercase (IBM Plex Mono) tabs, back-link, sidebar labels, and salary lines.
  - Submit button uses the site CTA recipe (foreground bg / background text, brand orange hover) — injected into the nested `waas-apply-form` shadow root, since parent-level injection can't reach it.
  - Fix hardcoded light-theme colors that vanish on our dark bg (sidebar dividers, job-card hover).
- Force hCaptcha's dark theme by patching `hcaptcha.render` via a `window.hcaptcha` setter (the embed renders it themeless → always light).

## Verification
Verified on the dev server via CDP with real mouse clicks through list → job detail → Application tab → submit button: screenshots of all views plus computed-style check on the submit button (IBM Plex Mono, uppercase, foreground/background colors resolved inside the nested shadow root). hCaptcha renders dark. `bun run lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Join Us hero width with the Open roles section and themes the WaaS job board to match the site, including a dark `hCaptcha`.

- New Features
  - Widen hero container to `max-w-[90rem]` for alignment.
  - Theme `waas-job-board` via CSS vars (Inter font, foreground/muted text, brand focus), mono-uppercase tabs/back-link/sidebar/salary, and CTA button styled via nested `waas-apply-form` shadow-root injection.

- Bug Fixes
  - Force dark theme for `hCaptcha` by patching `hcaptcha.render` via `window.hcaptcha`.
  - Fix light-only colors that vanished on dark backgrounds (sidebar dividers, job-card hover).

<sup>Written for commit 3f8f260971ff8e0c62b415f82750bb9f59d45fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Join Us page layout with a wider primary content area.
  * Updated typography, text colors, spacing, borders, and button states across job details, application forms, and job cards.
  * Enhanced dark-theme styling, including hover states and embedded hCaptcha appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->