### PR TITLE
fix(api,auth): surface cancellation reason and customer email in billing Slack alerts

### DIFF
--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
@@ -94,13 +94,13 @@ async function enrichFromSubscription(
 ): Promise<EnrichedSubscription | null> {
 	const stripeSub = await stripeClient.subscriptions.retrieve(
 		stripeSubscriptionId,
-		{ expand: ["discounts.source.coupon"] },
+		{ expand: ["discounts.source.coupon", "customer"] },
 	);
 
+	const customer =
+		typeof stripeSub.customer === "string" ? null : stripeSub.customer;
 	const customerId =
-		typeof stripeSub.customer === "string"
-			? stripeSub.customer
-			: stripeSub.customer?.id;
+		typeof stripeSub.customer === "string" ? stripeSub.customer : customer?.id;
 
 	if (!customerId) return null;
 
@@ -129,6 +129,7 @@ async function enrichFromSubscription(
 		discount: getDiscountInfo(stripeSub),
 		accessEndsAt: dbSub?.periodEnd ?? null,
 		cancellationDetails: stripeSub.cancellation_details,
+		customerEmail: customer && !customer.deleted ? customer.email : null,
 	};
 }
 
@@ -182,13 +183,23 @@ export async function POST(request: Request) {
 		case "subscription_started":
 			blocks = formatSubscriptionStarted(enriched);
 			break;
-		case "subscription_cancelled":
+		case "subscription_cancelled": {
+			// Prefer fresh fields: the portal attaches feedback after the queued webhook snapshot
+			const queued = payload.cancellationDetails ?? null;
+			const fresh = enriched.cancellationDetails;
 			blocks = formatSubscriptionCancelled({
 				...enriched,
 				cancellationDetails:
-					payload.cancellationDetails ?? enriched.cancellationDetails,
+					fresh || queued
+						? {
+								comment: fresh?.comment ?? queued?.comment,
+								feedback: fresh?.feedback ?? queued?.feedback,
+								reason: fresh?.reason ?? queued?.reason,
+							}
+						: null,
 			});
 			break;
+		}
 		case "seat_added":
 			blocks = formatSeatAdded(
 				enriched,

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
@@ -19,6 +19,7 @@ function createEnrichedSubscription(
 		discount: null,
 		accessEndsAt: new Date("2026-05-31T00:00:00.000Z"),
 		cancellationDetails: null,
+		customerEmail: "founder@acme.com",
 		...overrides,
 	};
 }
@@ -46,6 +47,15 @@ describe("formatSubscriptionCancelled", () => {
 		expect(serializedBlocks).toContain(
 			"*Comment:*\\nMissing an admin approval workflow.",
 		);
+		expect(serializedBlocks).toContain("*Email:*\\nfounder@acme.com");
+	});
+
+	test("renders N/A when the customer email is missing", () => {
+		const blocks = formatSubscriptionCancelled(
+			createEnrichedSubscription({ customerEmail: null }),
+		);
+
+		expect(JSON.stringify(blocks)).toContain("*Email:*\\nN/A");
 	});
 
 	test("renders unknown Stripe cancellation values without throwing", () => {

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
@@ -109,6 +109,7 @@ export interface EnrichedSubscription {
 	discount: DiscountInfo | null;
 	accessEndsAt: Date | null;
 	cancellationDetails: CancellationDetails | null;
+	customerEmail: string | null;
 }
 
 // --- Shared field builders ---
@@ -230,16 +231,17 @@ function safeCancellationDetailsBlock(
 
 /**
  * Consistent 2-column field grid used by every event formatter.
- * Row 1: Organization | Plan
- * Row 2: Billing      | Seats
- * Row 3: Price        | Discount
- * Row 4: Total
+ * Row 1: Organization | Email
+ * Row 2: Plan         | Billing
+ * Row 3: Seats        | Price
+ * Row 4: Discount     | Total
  */
 function standardFields(enriched: EnrichedSubscription): unknown {
 	return {
 		type: "section",
 		fields: [
 			{ type: "mrkdwn", text: `*Organization:*\n${enriched.organizationName}` },
+			{ type: "mrkdwn", text: `*Email:*\n${enriched.customerEmail ?? "N/A"}` },
 			{ type: "mrkdwn", text: `*Plan:*\n${enriched.planName}` },
 			{ type: "mrkdwn", text: `*Billing:*\n${enriched.interval}` },
 			{ type: "mrkdwn", text: `*Seats:*\n${enriched.seatCount}` },

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1055,6 +1055,8 @@ export const auth = betterAuth({
 								),
 							},
 							retries: 3,
+							// portal collects the cancellation survey after cancel confirms; give it time
+							delay: 120,
 						});
 					} catch (error) {
 						console.error(


### PR DESCRIPTION
## Problem

The #billing Slack "Subscription Cancelled" message always showed **Cancellation reason: N/A** and **Comment: N/A**, even though "Collect a cancellation reason" is enabled in the Stripe customer portal (verified in the live dashboard).

Root cause is a timing race, not configuration: the portal shows the "why are you cancelling?" survey **after** the cancel is confirmed. The `customer.subscription.updated` webhook fires at confirmation time with `feedback`/`comment` still null, and we snapshot those nulls into the QStash payload. Stripe attaches the survey answer in a second update we never re-read — and the notify-slack job preferred the stale snapshot over its own fresh Stripe fetch (`payload.cancellationDetails ?? enriched.cancellationDetails`).

## Fix

- **notify-slack route**: merge cancellation details field-wise, preferring the fresh Stripe fetch over the queued snapshot.
- **auth server**: publish the `subscription_cancelled` job with `delay: 120` so the customer has time to submit the survey before the job's fresh fetch runs (the Slack message just arrives 2 minutes later).
- **Email in notifications**: expand `customer` on the subscription fetch and add an `Email:` field to the shared field grid, so all billing notifications (started, cancelled, seat changes, payments) show the customer email. "N/A" fallback for deleted/emailless customers.

Note: if a customer dismisses the survey without answering, N/A is still correct — Stripe never receives a reason.

## Testing

- `bun test` on notify-slack: 5/5 pass (new assertions for the email field and N/A fallback)
- `tsc` clean in `apps/api` and `packages/auth`, Biome clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing Slack alerts so “Subscription Cancelled” shows the real cancellation reason/comment, and adds the customer email to all billing alerts. Also delays the cancel notification to capture portal survey responses.

- **Bug Fixes**
  - Merge cancellation details field‑wise, preferring fresh Stripe data over the queued snapshot to avoid “N/A”.
  - Delay the `subscription_cancelled` job by 120s in `packages/auth` so the Stripe portal survey can complete.

- **New Features**
  - Show customer email in all billing alerts by expanding `customer` on the Stripe subscription fetch in `apps/api` (falls back to “N/A”).

<sup>Written for commit cc153506adc5db6fe67333ab3d29897d0fa0b3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Subscription cancellation notifications now include the customer’s email when available.
  * Slack notification details are presented in a clearer, more consistent layout.
  * Cancellation messages combine the latest billing information with previously queued details, preserving available information when some fields are missing.
  * Notifications display “N/A” when customer email information is unavailable.
* **Reliability**
  * Subscription cancellation notifications are delivered with a brief delay to help ensure billing details are up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->