### PR TITLE
ci(relay2): only deploy relay2 when relay2-relevant paths change

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -476,6 +476,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy
 
+  # Every relay2 deploy restarts its Durable Objects, severing every live host
+  # tunnel — so unlike the stateless workers above, only deploy when something
+  # relay2 actually ships has changed. workflow_dispatch always deploys.
   deploy-relay2:
     name: Deploy Relay2 to Cloudflare
     runs-on: ubuntu-latest
@@ -485,22 +488,39 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Detect relay2-relevant changes
+        if: github.event_name == 'push'
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            relay2:
+              - "apps/relay2/**"
+              - "packages/shared/**"
+              - "packages/trpc/**"
+              - "bun.lock"
+              - ".github/workflows/deploy-production.yml"
+
       - name: Setup Bun
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relay2 == 'true'
         id: setup-bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
       - name: Cache dependencies
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relay2 == 'true'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relay2 == 'true'
         run: bun install --frozen --ignore-scripts
 
       - name: Deploy Worker
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.relay2 == 'true'
         working-directory: apps/relay2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
Every relay2 deploy restarts its Durable Objects, which severs every live host tunnel (hosts reconnect in ~2s, but in-flight streams drop). `deploy-production.yml` runs on every push to `main` with no path gating, so today's six unrelated merges bounced the entire relay2 fleet six times in one hour.

This gates the `deploy-relay2` job with `dorny/paths-filter` (pinned v3.0.2): it now deploys only when `apps/relay2/**`, its workspace deps (`packages/shared/**`, `packages/trpc/**`), `bun.lock`, or the workflow itself changed. `workflow_dispatch` always deploys, preserving the manual escape hatch.

The stateless Cloudflare workers (electric-proxy) are left as-is — redeploying them on every push is harmless.

## Test plan
- [x] `bun run lint` clean
- [ ] After merge: verify an unrelated main push skips the Deploy Worker step, and a relay2-touching push (or manual dispatch) still deploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment handling by detecting relevant changes before running deployment steps.
  * Manual deployments continue to run on demand without change filtering.
  * Added clearer deployment guidance, including information about restart behavior during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate relay2 deployments so the job only runs when relay2-related files change, preventing unnecessary Durable Object restarts and dropped host tunnels. Uses `dorny/paths-filter@v3.0.2` to watch `apps/relay2/**`, `packages/shared/**`, `packages/trpc/**`, `bun.lock`, and the workflow; `workflow_dispatch` still triggers a deploy.

<sup>Written for commit 951001292cf58d257b93bdf0d9b2dfe9ea04f3a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

