### PR TITLE
docs(readme): add shipping tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 Orchestrate swarms of Claude Code, Codex, and more in parallel.<br />
 Works with any CLI agent. Built for local worktree-based development.
 
+Spend less time juggling terminals and more time shipping code.
+
 <br />
 
 [**Download for macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)


### PR DESCRIPTION
Adds a short tagline beneath the README introduction for this requested test edit.

Validation: `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a short tagline beneath the README introduction to reinforce the value proposition: "Spend less time juggling terminals and more time shipping code."

<sup>Written for commit bc9adb63b15b9c4716df4c76ce579ab23edc28c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a tagline highlighting reduced terminal switching and faster code delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->