### PR TITLE
fix(relay2): liveness sweep for hosts that vanish without a close event

### DIFF
--- a/apps/relay2/src/host-tunnel.ts
+++ b/apps/relay2/src/host-tunnel.ts
@@ -326,19 +326,17 @@ export class HostTunnel extends Server<RelayEnv> {
 			return;
 		}
 
-		const lastSeen =
-			(await this.ctx.storage.get<number>("lastHostSeenAt")) ?? 0;
-		if (Date.now() - lastSeen > HOST_STALE_MS) {
+		const [lastSeen, session] = await Promise.all([
+			this.ctx.storage.get<number>("lastHostSeenAt"),
+			this.ctx.storage.get<{ hostId: string; token: string }>("session"),
+		]);
+		if (Date.now() - (lastSeen ?? 0) > HOST_STALE_MS) {
 			const state = host.state as ConnState | undefined;
 			const hostId = state?.kind === "host" ? state.hostId : this.name;
 			console.log(`[relay2] host stale, closing: ${hostId}`);
 			// closeQuietly alone is not enough: a server-initiated close on a
 			// dead peer never completes, so tear presence down here instead of
 			// relying on the close handler.
-			const session = await this.ctx.storage.get<{
-				hostId: string;
-				token: string;
-			}>("session");
 			await this.ctx.storage.put("presenceOnline", false);
 			closeQuietly(host, 1011, "No keepalive from host");
 			if (session) {
@@ -347,6 +345,13 @@ export class HostTunnel extends Server<RelayEnv> {
 			return;
 		}
 
+		// Presence writes race (an offline write can land after the reconnect's
+		// online write and stick), so a live host's row is re-asserted every
+		// sweep rather than trusting the connect-time write to have won.
+		if (session) {
+			await this.ctx.storage.put("presenceOnline", true);
+			this.ctx.waitUntil(this.presence(session.hostId, session.token, true));
+		}
 		await this.ctx.storage.setAlarm(Date.now() + LIVENESS_SWEEP_MS);
 	}
 

--- a/apps/relay2/src/host-tunnel.ts
+++ b/apps/relay2/src/host-tunnel.ts
@@ -18,6 +18,13 @@ const MAX_EARLY_FRAMES = 256;
 // A dial that never pairs with a client (aborted upgrade, late arrival) is
 // closed rather than left open.
 const UNPAIRED_DIAL_TIMEOUT_MS = 15_000;
+// Liveness sweep: deploys and abrupt terminations kill sockets without
+// delivering a close event, so disconnect handlers alone leave presence
+// stale and zombie sockets registered. The alarm is the backstop.
+const LIVENESS_SWEEP_MS = 45_000;
+// Three missed 30s host keepalives. A host that cannot ping for this long
+// cannot serve dials either, so closing it never severs a usable tunnel.
+const HOST_STALE_MS = 90_000;
 
 type ConnState =
 	| { kind: "host"; hostId: string }
@@ -50,7 +57,11 @@ export class HostTunnel extends Server<RelayEnv> {
 
 	// ── RPC (called by the Worker) ────────────────────────────────────
 
-	isConnected(): boolean {
+	async isConnected(): Promise<boolean> {
+		// Arms the sweep for objects whose host predates it (or whose alarm
+		// was lost), so a zombie session is cleaned up as soon as any client
+		// comes looking.
+		await this.ensureLivenessAlarm();
 		return this.hostConn() !== null;
 	}
 
@@ -118,7 +129,12 @@ export class HostTunnel extends Server<RelayEnv> {
 				if (other.id !== conn.id)
 					closeQuietly(other, 1000, "Replaced by new tunnel");
 			}
-			await this.ctx.storage.put("session", { hostId, token });
+			await this.ctx.storage.put({
+				session: { hostId, token },
+				lastHostSeenAt: Date.now(),
+				presenceOnline: true,
+			});
+			await this.ctx.storage.setAlarm(Date.now() + LIVENESS_SWEEP_MS);
 			this.ctx.waitUntil(this.presence(hostId, token, true));
 			console.log(`[relay2] host connected: ${hostId}`);
 			return;
@@ -207,11 +223,15 @@ export class HostTunnel extends Server<RelayEnv> {
 			// Only the live host may rewrite the session: a ping in flight from
 			// a socket that has just been replaced would otherwise revert the
 			// replacement's token to its own stale one.
-			if (ping.token && this.hostConn()?.id === conn.id) {
-				void this.ctx.storage.put("session", {
-					hostId: state.hostId,
-					token: ping.token,
-				});
+			if (this.hostConn()?.id === conn.id) {
+				void this.ctx.storage.put(
+					ping.token
+						? {
+								session: { hostId: state.hostId, token: ping.token },
+								lastHostSeenAt: Date.now(),
+							}
+						: { lastHostSeenAt: Date.now() },
+				);
 			}
 			conn.send('{"type":"pong"}');
 			return;
@@ -267,6 +287,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			// A replaced socket's close lands after the new one registered.
 			if (session && !this.hostConn()) {
 				console.log(`[relay2] host disconnected: ${session.hostId}`);
+				await this.ctx.storage.put("presenceOnline", false);
 				this.ctx.waitUntil(this.presence(session.hostId, session.token, false));
 			}
 			return;
@@ -281,6 +302,57 @@ export class HostTunnel extends Server<RelayEnv> {
 		if (state.peer) {
 			const peer = this.getConnection(state.peer);
 			if (peer) closeQuietly(peer, 1001, "Stream closed");
+		}
+	}
+
+	// ── Liveness sweep ────────────────────────────────────────────────
+
+	async onAlarm(): Promise<void> {
+		const host = this.hostConn();
+
+		if (!host) {
+			// Socket vanished without a close event (deploy, abrupt kill):
+			// the disconnect path never ran, so presence is still online.
+			const [session, online] = await Promise.all([
+				this.ctx.storage.get<{ hostId: string; token: string }>("session"),
+				this.ctx.storage.get<boolean>("presenceOnline"),
+			]);
+			if (session && online !== false) {
+				console.log(`[relay2] host vanished without close: ${session.hostId}`);
+				await this.ctx.storage.put("presenceOnline", false);
+				this.ctx.waitUntil(this.presence(session.hostId, session.token, false));
+			}
+			// Not rescheduled: a reconnecting host re-arms the sweep.
+			return;
+		}
+
+		const lastSeen =
+			(await this.ctx.storage.get<number>("lastHostSeenAt")) ?? 0;
+		if (Date.now() - lastSeen > HOST_STALE_MS) {
+			const state = host.state as ConnState | undefined;
+			const hostId = state?.kind === "host" ? state.hostId : this.name;
+			console.log(`[relay2] host stale, closing: ${hostId}`);
+			// closeQuietly alone is not enough: a server-initiated close on a
+			// dead peer never completes, so tear presence down here instead of
+			// relying on the close handler.
+			const session = await this.ctx.storage.get<{
+				hostId: string;
+				token: string;
+			}>("session");
+			await this.ctx.storage.put("presenceOnline", false);
+			closeQuietly(host, 1011, "No keepalive from host");
+			if (session) {
+				this.ctx.waitUntil(this.presence(session.hostId, session.token, false));
+			}
+			return;
+		}
+
+		await this.ctx.storage.setAlarm(Date.now() + LIVENESS_SWEEP_MS);
+	}
+
+	private async ensureLivenessAlarm(): Promise<void> {
+		if ((await this.ctx.storage.getAlarm()) === null) {
+			await this.ctx.storage.setAlarm(Date.now() + LIVENESS_SWEEP_MS);
 		}
 	}
 


### PR DESCRIPTION
## Summary
Today's deploy storm surfaced a real reliability hole: a Worker deploy terminates every Durable Object **abruptly** — `webSocketClose` never runs — so the disconnect path (`handleGone`) is skipped entirely. Result observed in prod: Town-Hall showed `online: yes` in presence while every client request 503'd, and the host machine held silently-dead sockets it was never told about. A host whose process is executing recovers via its own 75s watchdog, but the relay itself had **zero server-side liveness detection**: it could neither report the truth nor clean up.

This adds a storage-alarm liveness sweep to `HostTunnel` (alarms survive hibernation and deploys):
- Host connect stamps `lastHostSeenAt` + arms a 45s sweep; every host keepalive refreshes the stamp (batched into the existing session-token write).
- Sweep with a live-but-stale host (no keepalive for 90s = 3 missed pings): actively close the socket (an alive-but-confused host sees the close and reconnects) and write presence offline directly — a server-initiated close on a dead peer never completes, so the close handler can't be relied on.
- Sweep with a session but **no** socket (the deploy case): write presence offline.
- `isConnected` arms the sweep lazily, so zombie sessions that predate this deploy are cleaned up as soon as any client comes looking.

A host that can't ping for 90s can't answer dials either, so the stale-close never severs a usable tunnel.

## Test plan
- [x] typecheck + lint clean
- [ ] Deploy, then verify against the live incident: Town-Hall's stale `online: yes` flips to `no` within ~a minute of the first client probe, and `[relay2] host vanished without close` appears in `wrangler tail`
- [ ] Verify a healthy host stays connected across sweeps (no spurious stale-closes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a liveness sweep to `relay2` host tunnels to handle hosts that vanish without a close event. Stale hosts are closed and marked offline, and online presence is reasserted each sweep so presence stays correct and clients stop 503ing.

- **Bug Fixes**
  - Add a 45s storage alarm; track `lastHostSeenAt` on connect/keepalive; after 90s without a ping, close the host socket, write presence offline, and reassert online presence on each sweep to heal reconnect races.
  - If a session exists but the socket is gone (deploy/abrupt kill), write presence offline.
  - Make `isConnected` async to arm the sweep lazily and clean up pre-existing zombie sessions.

<sup>Written for commit 28acb316c2017d82874f5ad9e8f2cc68cf3991eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host connection liveness tracking.
  * Host presence now reflects online and offline status more accurately.
  * Keepalive activity updates connection status and session information.
  * Inactive connections are automatically detected, closed, and cleaned up.
  * Connection monitoring continues automatically while hosts remain active.
  * Disconnected hosts are promptly marked offline, including when an expected close event is missed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->