### PR TITLE
fix(skills): make Superset skills portable

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/managed-skills.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/managed-skills.test.ts
@@ -12,6 +12,7 @@ import {
 	createManagedSkills,
 	MANAGED_SENTINEL_NAME,
 	MANAGED_SKILL_MARKER,
+	setCommandArgumentHint,
 	setFrontmatterName,
 	withManagedMarker,
 } from "./managed-skills";
@@ -92,6 +93,16 @@ describe("setFrontmatterName", () => {
 	});
 });
 
+describe("setCommandArgumentHint", () => {
+	it("keeps client-specific hints out of the source skill", () => {
+		const source = skillMd("feedback");
+		const command = setCommandArgumentHint(source, "describe the feedback");
+
+		expect(source).not.toContain("argument-hint:");
+		expect(command).toContain('argument-hint: "describe the feedback"');
+	});
+});
+
 describe("createManagedSkills", () => {
 	it("provisions the Claude skills-directory plugin verbatim with a sentinel", async () => {
 		await run();
@@ -155,14 +166,21 @@ describe("createManagedSkills", () => {
 		).toBe(true);
 	});
 
-	it("provisions in-app commands for feedback and 10x only", async () => {
+	it("provisions available in-app commands with command-only hints", async () => {
 		await run();
 
-		for (const file of ["feedback.md", "10x.md"]) {
-			expect(readFileSync(path.join(commandsDir, file), "utf-8")).toContain(
-				MANAGED_SKILL_MARKER,
-			);
-		}
+		const feedback = readFileSync(
+			path.join(commandsDir, "feedback.md"),
+			"utf-8",
+		);
+		expect(feedback).toContain(MANAGED_SKILL_MARKER);
+		expect(feedback).toContain(
+			'argument-hint: "describe the bug, request, or feedback"',
+		);
+
+		const tenX = readFileSync(path.join(commandsDir, "10x.md"), "utf-8");
+		expect(tenX).toContain(MANAGED_SKILL_MARKER);
+		expect(tenX).toContain('argument-hint: "optional topic, e.g. automations"');
 		expect(existsSync(path.join(commandsDir, "orchestrate.md"))).toBe(false);
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/managed-skills.ts
+++ b/apps/desktop/src/main/lib/agent-setup/managed-skills.ts
@@ -28,6 +28,13 @@ const CLAUDE_PLUGIN_DIR_NAME = "superset";
  * the bundled plugin is provisioned automatically.
  */
 const COMMAND_SKILLS = ["feedback", "10x", "setup", "doctor"] as const;
+const COMMAND_ARGUMENT_HINTS: Record<(typeof COMMAND_SKILLS)[number], string> =
+	{
+		feedback: "describe the bug, request, or feedback",
+		"10x": "optional topic, e.g. automations",
+		setup: "optional notes about the project's setup needs",
+		doctor: "describe the symptom",
+	};
 
 export interface ManagedSkillsOptions {
 	homeDir?: string;
@@ -55,6 +62,19 @@ export function setFrontmatterName(content: string, name: string): string {
 	if (frontmatterEnd === -1) return content;
 	const frontmatter = content.slice(0, frontmatterEnd);
 	const rewritten = frontmatter.replace(/^name:[^\n]*$/m, `name: ${name}`);
+	return rewritten + content.slice(frontmatterEnd);
+}
+
+/** Adds command-only UI metadata without putting it in portable Agent Skills. */
+export function setCommandArgumentHint(content: string, hint: string): string {
+	if (!content.startsWith("---\n")) return content;
+	const frontmatterEnd = content.indexOf("\n---\n", 4);
+	if (frontmatterEnd === -1) return content;
+	const frontmatter = content.slice(0, frontmatterEnd);
+	const field = `argument-hint: ${JSON.stringify(hint)}`;
+	const rewritten = /^argument-hint:[^\n]*$/m.test(frontmatter)
+		? frontmatter.replace(/^argument-hint:[^\n]*$/m, field)
+		: `${frontmatter}\n${field}`;
 	return rewritten + content.slice(frontmatterEnd);
 }
 
@@ -306,7 +326,13 @@ export async function createManagedSkills(
 				continue;
 			}
 			fs.mkdirSync(commandNamespaceDir, { recursive: true });
-			writeFileIfChanged(filePath, withManagedMarker(raw), 0o644);
+			writeFileIfChanged(
+				filePath,
+				withManagedMarker(
+					setCommandArgumentHint(raw, COMMAND_ARGUMENT_HINTS[pluginSkill]),
+				),
+				0o644,
+			);
 		} catch (error) {
 			console.warn(
 				`[agent-setup] Failed to provision command ${fileName}:`,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"build": "turbo build --filter=@superset/desktop",
 		"test": "turbo test --concurrency=2",
 		"lint": "./scripts/lint.sh",
+		"check:agent-skills": "bun scripts/check-agent-skills.ts",
 		"check:desktop-git-env": "./scripts/check-desktop-git-env.sh",
 		"lint:fix": "bunx @biomejs/biome@2.4.2 migrate --write && bunx @biomejs/biome@2.4.2 check --write --unsafe .",
 		"format": "bunx @biomejs/biome@2.4.2 format --write .",

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -29,7 +29,13 @@ mock.module("../../../lib/upload-attachments", () => ({
 const { default: createWorkspaceCommand } = await import("./command");
 
 function invoke(
-	overrides: { agent?: string; prompt?: string; effort?: string } = {},
+	overrides: {
+		agent?: string;
+		branch?: string;
+		effort?: string;
+		pr?: number;
+		prompt?: string;
+	} = {},
 ) {
 	return createWorkspaceCommand.run({
 		ctx: {
@@ -74,6 +80,16 @@ describe("workspaces create", () => {
 	test("rejects effort when no agent is selected", async () => {
 		await expect(invoke({ effort: "high" })).rejects.toThrow(
 			/--effort requires --agent/,
+		);
+		expect(createInput).toBeUndefined();
+	});
+
+	test("requires exactly one branch source", async () => {
+		await expect(invoke({ branch: undefined })).rejects.toThrow(
+			/Specify exactly one of --branch or --pr/,
+		);
+		await expect(invoke({ pr: 123 })).rejects.toThrow(
+			/Specify exactly one of --branch or --pr/,
 		);
 		expect(createInput).toBeUndefined();
 	});

--- a/packages/cli/src/lib/host-target/resolveHostFlags.test.ts
+++ b/packages/cli/src/lib/host-target/resolveHostFlags.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { requireHostTarget, resolveHostFilter } from "./resolveHostFlags";
+
+describe("host target flags", () => {
+	test("requires an explicit target for mutating commands", () => {
+		expect(() =>
+			requireHostTarget({ host: undefined, local: undefined }),
+		).toThrow(/Target host required/);
+	});
+
+	test("accepts an explicit remote host", () => {
+		expect(requireHostTarget({ host: "host-1", local: undefined })).toBe(
+			"host-1",
+		);
+	});
+
+	test("rejects conflicting host flags", () => {
+		expect(() => resolveHostFilter({ host: "host-1", local: true })).toThrow(
+			/Pass either --host or --local, not both/,
+		);
+	});
+});

--- a/plugins/superset/skills/10x/SKILL.md
+++ b/plugins/superset/skills/10x/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: 10x
 description: Personalized audit that teaches advanced Superset features the user isn't using yet — automations, parallel agents, tasks, multi-host, terminals, custom commands, MCP. Use when the user wants to get more out of Superset, learn advanced Superset features, or 10x their Superset workflow.
-argument-hint: optional topic, e.g. automations
 ---
 
 # Superset 10x
@@ -34,14 +33,16 @@ For each recommendation in order: a two-sentence pitch, then ask (use the ask_us
 | Feature | Why it 10x's you | Live setup |
 | --- | --- | --- |
 | Automations | Scheduled agents — triage, changelogs, standups run while you sleep | `superset automations create`, then `superset automations logs` to review runs |
-| Parallel workspaces | Every task gets an isolated worktree; run several agents at once instead of queueing | `superset workspaces create --project <id>` then `superset agents create --workspace <id> --agent claude --prompt "..."` |
-| PR review workspaces | Check out any PR into its own workspace in one command | `superset workspaces create --pr <number>` |
+| Parallel workspaces | Every task gets an isolated worktree; run several agents at once instead of queueing | `superset workspaces create --local --project <project-id> --name <workspace-name> --branch <branch-name>`, then `superset agents create --workspace <workspace-id> --agent claude --prompt "..."` |
+| PR review workspaces | Check out any PR into its own workspace in one command | `superset workspaces create --local --project <project-id> --name pr-<number> --pr <number>` |
 | Tasks | A shared queue agents can pick up; track work across sessions | `superset tasks create --title "..."`, `superset tasks update` |
 | Multi-host | Run agents on your desktop from your laptop; wake offline machines | `superset hosts list`, `superset hosts set-wake`, `superset hosts wake <id>` |
 | Terminal remote-control | Read and drive any agent's terminal from anywhere | `superset terminals list / read / send` |
 | Custom slash commands | Your repo's own workflows as commands every agent can run | create `.agents/commands/<name>.md` in their repo |
 | MCP servers | Give every workspace agent the same extra tools | add servers to `.mcp.json` at their repo root |
 | Feedback loop | Report bugs or ideas without leaving the agent | invoke the `feedback` skill from this plugin |
+
+Use `--host <host-id>` instead of `--local` when the target project is on another machine. Capture the workspace ID returned by `workspaces create`; do not guess it from the workspace name.
 
 ## Rules
 

--- a/plugins/superset/skills/10x/agents/openai.yaml
+++ b/plugins/superset/skills/10x/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset 10x"
+  short_description: "Audit and improve your Superset workflow"
+  default_prompt: "Use $superset-10x to audit how I use Superset and recommend the highest-impact feature to adopt next."

--- a/plugins/superset/skills/automate/SKILL.md
+++ b/plugins/superset/skills/automate/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: automate
 description: Turn a recurring chore into a Superset automation — drafts the agent prompt, confirms schedule and target, creates it with the CLI, and reviews the first run together. Use when the user wants a scheduled or recurring agent, a daily/weekly job, or to automate a repeating task with Superset.
-argument-hint: describe the recurring task
 ---
 
 # Superset Automate

--- a/plugins/superset/skills/automate/agents/openai.yaml
+++ b/plugins/superset/skills/automate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Automate"
+  short_description: "Create and verify a scheduled Superset agent"
+  default_prompt: "Use $superset-automate to turn this recurring task into a verified Superset automation."

--- a/plugins/superset/skills/contribute/SKILL.md
+++ b/plugins/superset/skills/contribute/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: contribute
 description: Set up a Superset open-source contribution — fork and clone superset-sh/superset, run local dev setup, and follow the repo's contribution rules through to a merge-ready PR. Use when the user wants to contribute to Superset, fix a Superset bug themselves, or prepare a PR against superset-sh/superset.
-argument-hint: what they want to contribute
 ---
 
 # Contribute to Superset

--- a/plugins/superset/skills/contribute/agents/openai.yaml
+++ b/plugins/superset/skills/contribute/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Contribute to Superset"
+  short_description: "Prepare a merge-ready Superset contribution"
+  default_prompt: "Use $superset-contribute to prepare this Superset contribution and take it through a merge-ready pull request."

--- a/plugins/superset/skills/doctor/SKILL.md
+++ b/plugins/superset/skills/doctor/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: doctor
 description: Diagnose and fix Superset problems — connection failures, offline hosts, terminals not attaching, auth or update issues. Use when the user reports something broken or misbehaving in Superset itself, before filing feedback.
-argument-hint: describe the symptom
 ---
 
 # Superset Doctor

--- a/plugins/superset/skills/doctor/agents/openai.yaml
+++ b/plugins/superset/skills/doctor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Doctor"
+  short_description: "Diagnose and fix Superset problems safely"
+  default_prompt: "Use $superset-doctor to diagnose this Superset problem, apply an approved fix, and verify the result."

--- a/plugins/superset/skills/feedback/SKILL.md
+++ b/plugins/superset/skills/feedback/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: feedback
 description: Collect and submit feedback about Superset — bug reports, feature requests, or general feedback — privately to the Superset team or as a public GitHub issue. Use when the user wants to report a Superset bug, request a feature, or send feedback about Superset.
-argument-hint: describe the bug, request, or feedback
 ---
 
 # Superset Feedback

--- a/plugins/superset/skills/feedback/agents/openai.yaml
+++ b/plugins/superset/skills/feedback/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Feedback"
+  short_description: "Draft and submit feedback about Superset"
+  default_prompt: "Use $superset-feedback to draft this Superset feedback and submit it through my chosen channel after confirmation."

--- a/plugins/superset/skills/setup/SKILL.md
+++ b/plugins/superset/skills/setup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: setup
 description: Make a repository Superset-ready — author .superset/config.json with setup/teardown/run scripts so every new workspace boots configured, then verify with a real workspace. Use when the user wants to set up a project or repo for Superset, configure workspace setup scripts, or fix a failing workspace setup.
-argument-hint: optional notes about the project's setup needs
 ---
 
 # Superset Project Setup
@@ -36,8 +35,8 @@ Each key is an array of shell commands run inside the worktree on workspace crea
 - Copy secrets/env from the main checkout at setup time — never commit them
 - `.superset/config.local.json` (gitignored) lets an individual user extend scripts with `before`/`after` arrays without touching the shared config
 
-Show the user the proposed files and get explicit approval before writing.
+Show the user the proposed files and get explicit approval before writing. Include the exact project, host, workspace name, branch, and planned test-workspace deletion in the approval before verification.
 
 ## 3. Verify for real
 
-Create a throwaway workspace with `superset workspaces create --project <id> --name "setup-test"` and watch the "Workspace Setup" terminal output. Fix and repeat until it completes cleanly, then delete the test workspace. Setup is not done until a real workspace boots green.
+Create a throwaway workspace with `superset workspaces create --local --project <project-id> --name <unique-test-name> --branch <unique-test-branch> --json` and capture its returned workspace ID. Use `--host <host-id>` instead of `--local` for a remote project. Watch the "Workspace Setup" terminal output, fix failures, and repeat until it completes cleanly. Delete only the captured test workspace ID, using the same explicit `--local` or `--host` target, after the approved verification finishes. Setup is not done until a real workspace boots green.

--- a/plugins/superset/skills/setup/agents/openai.yaml
+++ b/plugins/superset/skills/setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Project Setup"
+  short_description: "Configure and verify Superset workspaces"
+  default_prompt: "Use $superset-setup to configure this repository for Superset workspaces and verify the setup with a real workspace."

--- a/plugins/superset/skills/standup/SKILL.md
+++ b/plugins/superset/skills/standup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: standup
 description: Digest of what your Superset agents did — sweeps workspaces, tasks, and agent terminals, then reports what finished, what needs review, and what's blocked. Use when the user asks what their agents did, wants a standup or summary of agent work, or returns after being away.
-argument-hint: optional timeframe or project
 ---
 
 # Superset Standup

--- a/plugins/superset/skills/standup/agents/openai.yaml
+++ b/plugins/superset/skills/standup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Standup"
+  short_description: "Summarize agent work that needs attention"
+  default_prompt: "Use $superset-standup to summarize what my Superset agents did and what needs my attention."

--- a/scripts/check-agent-skills.ts
+++ b/scripts/check-agent-skills.ts
@@ -1,0 +1,228 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const SKILL_ROOTS = [".agents/skills", "plugins/superset/skills"] as const;
+const ALLOWED_FRONTMATTER_FIELDS = new Set([
+	"allowed-tools",
+	"compatibility",
+	"description",
+	"license",
+	"metadata",
+	"name",
+]);
+const WORKSPACE_CREATE_EXAMPLE =
+	/`(superset workspaces create[^`\n]*--[^`\n]*)`/g;
+
+const problems: string[] = [];
+let skillCount = 0;
+
+function report(file: string, message: string): void {
+	problems.push(`${file}: ${message}`);
+}
+
+function validateOptionalFields(
+	file: string,
+	frontmatter: Record<string, unknown>,
+): void {
+	if (
+		frontmatter.compatibility !== undefined &&
+		(typeof frontmatter.compatibility !== "string" ||
+			frontmatter.compatibility.length === 0 ||
+			frontmatter.compatibility.length > 500)
+	) {
+		report(
+			file,
+			"compatibility must be a non-empty string of at most 500 characters",
+		);
+	}
+
+	for (const field of ["allowed-tools", "license"] as const) {
+		if (
+			frontmatter[field] !== undefined &&
+			(typeof frontmatter[field] !== "string" ||
+				frontmatter[field].length === 0)
+		) {
+			report(file, `${field} must be a non-empty string`);
+		}
+	}
+
+	if (frontmatter.metadata !== undefined) {
+		if (
+			typeof frontmatter.metadata !== "object" ||
+			frontmatter.metadata === null ||
+			Array.isArray(frontmatter.metadata)
+		) {
+			report(file, "metadata must be a string-to-string mapping");
+		} else if (
+			Object.values(frontmatter.metadata).some(
+				(value) => typeof value !== "string",
+			)
+		) {
+			report(file, "metadata values must be strings");
+		}
+	}
+}
+
+function validateWorkspaceExamples(file: string, content: string): void {
+	for (const match of content.matchAll(WORKSPACE_CREATE_EXAMPLE)) {
+		const command = match[1];
+		const missing: string[] = [];
+		if (!/--(?:local|host)(?:\s|$)/.test(command))
+			missing.push("--local/--host");
+		if (!/--project(?:\s|$)/.test(command)) missing.push("--project");
+		if (!/--name(?:\s|$)/.test(command)) missing.push("--name");
+		if (!/--(?:branch|pr)(?:\s|$)/.test(command)) missing.push("--branch/--pr");
+		if (missing.length > 0) {
+			report(
+				file,
+				`workspace creation example is missing ${missing.join(", ")}: ${command}`,
+			);
+		}
+	}
+}
+
+function validateOpenAiMetadata(skillDirectory: string): void {
+	const file = path.join(skillDirectory, "agents", "openai.yaml");
+	const isBundledSupersetSkill = skillDirectory.startsWith(
+		path.join("plugins", "superset", "skills"),
+	);
+	if (!existsSync(file)) {
+		if (isBundledSupersetSkill)
+			report(file, "is required for bundled Superset skills");
+		return;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+	} catch (error) {
+		report(
+			file,
+			`has invalid YAML: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return;
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		report(file, "must be a mapping");
+		return;
+	}
+
+	const metadata = parsed as Record<string, unknown>;
+	if (
+		typeof metadata.interface !== "object" ||
+		metadata.interface === null ||
+		Array.isArray(metadata.interface)
+	) {
+		report(file, "must include an interface mapping");
+		return;
+	}
+
+	const interfaceMetadata = metadata.interface as Record<string, unknown>;
+	if (
+		typeof interfaceMetadata.display_name !== "string" ||
+		interfaceMetadata.display_name.length === 0
+	) {
+		report(file, "interface.display_name must be a non-empty string");
+	}
+	if (
+		typeof interfaceMetadata.short_description !== "string" ||
+		interfaceMetadata.short_description.length < 25 ||
+		interfaceMetadata.short_description.length > 64
+	) {
+		report(file, "interface.short_description must be 25-64 characters");
+	}
+
+	const expectedInvocation = isBundledSupersetSkill
+		? `$superset-${path.basename(skillDirectory)}`
+		: `$${path.basename(skillDirectory)}`;
+	if (
+		typeof interfaceMetadata.default_prompt !== "string" ||
+		!interfaceMetadata.default_prompt.includes(expectedInvocation)
+	) {
+		report(file, `interface.default_prompt must mention ${expectedInvocation}`);
+	}
+}
+
+function validateSkill(skillDirectory: string): void {
+	const file = path.join(skillDirectory, "SKILL.md");
+	const content = readFileSync(file, "utf8");
+	if (!content.startsWith("---\n")) {
+		report(file, "must start with YAML frontmatter");
+		return;
+	}
+
+	const frontmatterEnd = content.indexOf("\n---\n", 4);
+	if (frontmatterEnd === -1) {
+		report(file, "has no closing YAML frontmatter delimiter");
+		return;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = Bun.YAML.parse(content.slice(4, frontmatterEnd));
+	} catch (error) {
+		report(
+			file,
+			`has invalid YAML: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return;
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		report(file, "frontmatter must be a mapping");
+		return;
+	}
+
+	const frontmatter = parsed as Record<string, unknown>;
+	for (const field of Object.keys(frontmatter)) {
+		if (!ALLOWED_FRONTMATTER_FIELDS.has(field)) {
+			report(file, `unsupported frontmatter field: ${field}`);
+		}
+	}
+
+	const directoryName = path.basename(skillDirectory);
+	if (frontmatter.name !== directoryName) {
+		report(file, `name must match parent directory: ${directoryName}`);
+	} else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(directoryName)) {
+		report(
+			file,
+			"name must contain only lowercase letters, digits, and single hyphens",
+		);
+	} else if (directoryName.length > 64) {
+		report(file, "name must be at most 64 characters");
+	}
+
+	if (
+		typeof frontmatter.description !== "string" ||
+		frontmatter.description.length === 0 ||
+		frontmatter.description.length > 1024
+	) {
+		report(
+			file,
+			"description must be a non-empty string of at most 1024 characters",
+		);
+	}
+
+	validateOptionalFields(file, frontmatter);
+	if (content.slice(frontmatterEnd + 5).trim().length === 0) {
+		report(file, "must include skill instructions after the frontmatter");
+	}
+	validateWorkspaceExamples(file, content);
+	validateOpenAiMetadata(skillDirectory);
+}
+
+for (const root of SKILL_ROOTS) {
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		validateSkill(path.join(root, entry.name));
+		skillCount += 1;
+	}
+}
+
+if (problems.length > 0) {
+	console.error(`Agent skill validation failed (${problems.length} problems):`);
+	for (const problem of problems) console.error(`- ${problem}`);
+	process.exit(1);
+}
+
+console.log(`Validated ${skillCount} Agent Skills.`);

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -18,5 +18,6 @@ fi
 ./scripts/check-git-ref-strings.sh || exit_code=1
 ./scripts/check-cloud-workspace-usage.sh || exit_code=1
 ./scripts/check-simple-git-usage.sh || exit_code=1
+bun scripts/check-agent-skills.ts || exit_code=1
 
 exit $exit_code


### PR DESCRIPTION
## What changed

- remove the non-standard `argument-hint` field from the bundled Agent Skills
- preserve argument hints only in generated in-app command files
- add `agents/openai.yaml` interface metadata and default prompts for every bundled Superset skill
- correct `workspaces create` examples to include the enforced host, project, name, and branch/PR inputs
- make setup verification capture and clean up the exact approved test workspace
- add a lint-integrated Agent Skills validator for frontmatter, OpenAI metadata, and workspace command examples
- add regression tests for explicit host targeting and branch/PR exclusivity

## Why

Seven bundled skills failed the Agent Skills reference validator because `argument-hint` is client-specific metadata. The `10x` and `setup` skills also showed workspace creation commands that the CLI rejects because required target and branch inputs were missing.

This keeps canonical skills portable while retaining command UI hints in the layer that understands them, and prevents the documented CLI examples from drifting away from runtime enforcement.

## Validation

- `bun run lint`
- `bun run check:agent-skills` — 12 skills valid
- Agent Skills `skills-ref validate` — all 12 source skills valid
- provisioned all eight managed `superset-*` copies and validated each with `skills-ref`
- `bun test packages/cli/src/commands/workspaces/create/command.test.ts packages/cli/src/lib/host-target/resolveHostFlags.test.ts apps/desktop/src/main/lib/agent-setup/managed-skills.test.ts` — 17 passed
- `bun run --cwd packages/cli typecheck`
- `git diff --check`

Full `bun run typecheck` was attempted. It is currently blocked outside this diff by duplicate dependency types: `@types/hast` 3.0.4/3.0.5 in web and Mermaid 11.13/11.16 in desktop.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bundled Superset Agent Skills portable by removing client-only metadata from source skills and moving UI hints to generated in‑app commands. Add OpenAI interface metadata and fix workspace CLI examples, with validation and tests to prevent regressions.

- New Features
  - Added `scripts/check-agent-skills.ts` and wired it into `lint` and `check:agent-skills`; validates SKILL.md frontmatter, `agents/openai.yaml`, and workspace creation examples.
  - Added `agents/openai.yaml` to each bundled Superset skill with display name, short description, and default prompt.
  - Managed skill provisioning now injects command-only `argument-hint` into in‑app command files (not source skills).
  - Setup verification captures the exact approved test workspace and cleans up that ID only.

- Bug Fixes
  - Removed non-standard `argument-hint` from source Superset skills to satisfy the reference validator.
  - Corrected `workspaces create` examples to require explicit host, project, name, and exactly one of branch or PR; added tests for explicit host targeting and branch/PR exclusivity.

<sup>Written for commit d4f19d046695e74a06abb2086791456656e30f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

