### PR TITLE
fix(marketing): clip feature demos on mobile, in-flow hiring pill, align hero caret

### DIFF
--- a/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/FeatureDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/FeatureDemo.tsx
@@ -7,7 +7,9 @@ interface FeatureDemoProps {
 
 export function FeatureDemo({ children, className = "" }: FeatureDemoProps) {
 	return (
-		<div className={`relative w-full min-h-[300px] lg:aspect-4/3 ${className}`}>
+		<div
+			className={`relative w-full min-h-[300px] lg:aspect-4/3 overflow-hidden ${className}`}
+		>
 			{/* Soft ember glow behind the demo window, same stage lighting as the hero */}
 			<div
 				className="pointer-events-none absolute inset-0"

--- a/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/FeatureDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/FeatureDemo/FeatureDemo.tsx
@@ -8,7 +8,7 @@ interface FeatureDemoProps {
 export function FeatureDemo({ children, className = "" }: FeatureDemoProps) {
 	return (
 		<div
-			className={`relative w-full min-h-[300px] lg:aspect-4/3 overflow-hidden ${className}`}
+			className={`relative w-full min-h-[300px] lg:aspect-4/3 overflow-hidden max-sm:[mask-image:linear-gradient(to_right,black_82%,transparent)] ${className}`}
 		>
 			{/* Soft ember glow behind the demo window, same stage lighting as the hero */}
 			<div

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -30,22 +30,22 @@ export function HeroSection() {
 		<div>
 			<div className="relative flex flex-col items-center pt-24 sm:pt-32 lg:pt-40 pb-16 sm:pb-24 overflow-hidden">
 				<BoidsBackground />
-				{/* Hiring pill: pinned just below the sticky header, out of the hero flow */}
-				<Link
-					href="/join-us"
-					className="group absolute top-5 sm:top-6 left-1/2 -translate-x-1/2 z-10 inline-flex items-center gap-2 rounded-[2px] border border-border bg-background/80 px-3 py-1.5 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/[0.2]"
-				>
-					<span className="text-brand shrink-0">●</span>
-					<span>
-						We&apos;re hiring engineers
-						<span className="hidden sm:inline"> in San Francisco</span>
-					</span>
-					<span className="shrink-0 transition-transform group-hover:translate-x-0.5">
-						→
-					</span>
-				</Link>
 				<div className="relative w-full max-w-7xl mx-auto px-6 sm:px-8">
 					<div className="flex flex-col items-center text-center">
+						{/* Hiring pill: in-flow badge above the headline */}
+						<Link
+							href="/join-us"
+							className="group mb-6 sm:mb-8 inline-flex w-max items-center gap-2 whitespace-nowrap rounded-[2px] border border-border bg-background/80 px-3 py-1.5 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/[0.2]"
+						>
+							<span className="text-brand shrink-0">●</span>
+							<span>
+								We&apos;re hiring engineers
+								<span className="hidden sm:inline"> in San Francisco</span>
+							</span>
+							<span className="shrink-0 transition-transform group-hover:translate-x-0.5">
+								→
+							</span>
+						</Link>
 						<div className="space-y-4 sm:space-y-6">
 							<h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] [word-spacing:0.15em] text-foreground relative max-w-6xl mx-auto">
 								{/* Sizer must mirror the visible segments' styling so wrapping matches */}

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -15,8 +15,10 @@ const HERO_COPY = {
 		{ text: "The Code Editor for " },
 		{
 			text: "AI Agents.",
-			className:
-				"corner-brackets inline-block px-[0.2em] py-[0.06em] whitespace-nowrap",
+			// Plain inline (not inline-block): vertical padding on inline boxes
+			// paints the brackets without affecting line height, so the line
+			// can't jump when this segment mounts mid-animation
+			className: "corner-brackets px-[0.2em] py-[0.06em] whitespace-nowrap",
 		},
 	],
 	subheadline:
@@ -61,10 +63,10 @@ export function HeroSection() {
 										segments={HERO_COPY.segments}
 										speed={40}
 										delay={600}
-										// Caret matches the corner-bracket box height (1.22em) for the
+										// Caret matches the corner-bracket box height (1.30em) for the
 										// whole animation; drawn via scale-y so its layout height stays
 										// 0.72em and can't inflate the line box
-										cursorClassName="inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] origin-bottom scale-y-[1.694] translate-y-[0.229em] bg-brand"
+										cursorClassName="inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] origin-bottom scale-y-[1.806] translate-y-[0.268em] bg-brand"
 									/>
 								</span>
 							</h1>

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -61,6 +61,10 @@ export function HeroSection() {
 										segments={HERO_COPY.segments}
 										speed={40}
 										delay={600}
+										// Caret matches the corner-bracket box height (1.22em) for the
+										// whole animation; drawn via scale-y so its layout height stays
+										// 0.72em and can't inflate the line box
+										cursorClassName="inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] origin-bottom scale-y-[1.694] translate-y-[0.229em] bg-brand"
 									/>
 								</span>
 							</h1>

--- a/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
@@ -85,7 +85,7 @@ export function ProductDemo() {
 								"radial-gradient(ellipse 42% 38% at 50% 22%, rgba(232,128,74,0.06), rgba(232,128,74,0.02) 55%, transparent 78%)",
 						}}
 					/>
-					<div className="relative overflow-x-auto scrollbar-hide">
+					<div className="relative overflow-x-auto scrollbar-hide max-md:[mask-image:linear-gradient(to_right,black_88%,transparent)]">
 						<AppMockup activeDemo={activeOption} />
 					</div>
 				</motion.div>

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -76,7 +76,9 @@ export function TypewriterText({
 				style={{ originY: 1 }}
 				initial={isFirstAppearance ? { scaleY: 0.13 } : false}
 				animate={
-					isTypingComplete ? { opacity: 0, scaleY: 1 } : { opacity: 1, scaleY: 1 }
+					isTypingComplete
+						? { opacity: 0, scaleY: 1 }
+						: { opacity: 1, scaleY: 1 }
 				}
 				transition={
 					isTypingComplete

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -8,6 +8,8 @@ interface TextSegment {
 	className?: string;
 	style?: React.CSSProperties;
 	render?: (visibleText: string) => React.ReactNode;
+	/** Overrides the caret style while this segment is being typed */
+	cursorClassName?: string;
 }
 
 interface TypewriterTextProps {
@@ -18,6 +20,7 @@ interface TypewriterTextProps {
 	speed?: number;
 	delay?: number;
 	showCursor?: boolean;
+	cursorClassName?: string;
 }
 
 export function TypewriterText({
@@ -28,6 +31,7 @@ export function TypewriterText({
 	speed = 50,
 	delay = 500,
 	showCursor = true,
+	cursorClassName,
 }: TypewriterTextProps) {
 	const fullText = segments
 		? segments.map((s) => s.text).join("")
@@ -57,13 +61,18 @@ export function TypewriterText({
 
 	const isTypingComplete = isTyping && displayedText.length === fullText.length;
 
-	const cursor = showCursor ? (
-		<motion.span
-			className="inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] bg-brand"
-			animate={isTypingComplete ? { opacity: 0 } : { opacity: 1 }}
-			transition={isTypingComplete ? { duration: 0.25, delay: 0.5 } : {}}
-		/>
-	) : null;
+	const renderCursor = (override?: string) =>
+		showCursor ? (
+			<motion.span
+				className={
+					override ??
+					cursorClassName ??
+					"inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] bg-brand"
+				}
+				animate={isTypingComplete ? { opacity: 0 } : { opacity: 1 }}
+				transition={isTypingComplete ? { duration: 0.25, delay: 0.5 } : {}}
+			/>
+		) : null;
 
 	const renderText = () => {
 		if (!segments) return displayedText;
@@ -90,7 +99,7 @@ export function TypewriterText({
 					style={segment.style}
 				>
 					{segment.render ? segment.render(visibleText) : visibleText}
-					{holdsCursor && cursor}
+					{holdsCursor && renderCursor(segment.cursorClassName)}
 				</span>
 			);
 		});
@@ -99,7 +108,7 @@ export function TypewriterText({
 	return (
 		<span className={className} style={style}>
 			{renderText()}
-			{(!segments || displayedText.length === 0) && cursor}
+			{(!segments || displayedText.length === 0) && renderCursor()}
 		</span>
 	);
 }

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -59,21 +59,9 @@ export function TypewriterText({
 
 	const cursor = showCursor ? (
 		<motion.span
-			className="inline-block ml-0.5 w-3 -mr-3.5 h-[1em] bg-brand translate-y-0.5"
-			animate={
-				isTypingComplete
-					? { opacity: [1, 1, 0, 0, 1, 1, 0, 0] }
-					: { opacity: 1 }
-			}
-			transition={
-				isTypingComplete
-					? {
-							duration: 1.6,
-							times: [0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1],
-							ease: "linear",
-						}
-					: {}
-			}
+			className="inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] bg-brand"
+			animate={isTypingComplete ? { opacity: 0 } : { opacity: 1 }}
+			transition={isTypingComplete ? { duration: 0.25, delay: 0.5 } : {}}
 		/>
 	) : null;
 

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -61,6 +61,10 @@ export function TypewriterText({
 
 	const isTypingComplete = isTyping && displayedText.length === fullText.length;
 
+	// The caret remounts as it moves between segments; only its very first
+	// appearance (before any text) grows in from a square dot
+	const isFirstAppearance = displayedText.length === 0;
+
 	const renderCursor = (override?: string) =>
 		showCursor ? (
 			<motion.span
@@ -69,8 +73,16 @@ export function TypewriterText({
 					cursorClassName ??
 					"inline-block ml-0.5 w-3 -mr-3.5 h-[0.72em] bg-brand"
 				}
-				animate={isTypingComplete ? { opacity: 0 } : { opacity: 1 }}
-				transition={isTypingComplete ? { duration: 0.25, delay: 0.5 } : {}}
+				style={{ originY: 1 }}
+				initial={isFirstAppearance ? { scaleY: 0.13 } : false}
+				animate={
+					isTypingComplete ? { opacity: 0, scaleY: 1 } : { opacity: 1, scaleY: 1 }
+				}
+				transition={
+					isTypingComplete
+						? { duration: 0.25, delay: 0.5 }
+						: { scaleY: { duration: 0.35, delay: 0.15, ease: "easeOut" } }
+				}
 			/>
 		) : null;
 

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -57,6 +57,26 @@ export function TypewriterText({
 
 	const isTypingComplete = isTyping && displayedText.length === fullText.length;
 
+	const cursor = showCursor ? (
+		<motion.span
+			className="inline-block ml-0.5 w-3 -mr-3.5 h-[1em] bg-brand translate-y-0.5"
+			animate={
+				isTypingComplete
+					? { opacity: [1, 1, 0, 0, 1, 1, 0, 0] }
+					: { opacity: 1 }
+			}
+			transition={
+				isTypingComplete
+					? {
+							duration: 1.6,
+							times: [0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1],
+							ease: "linear",
+						}
+					: {}
+			}
+		/>
+	) : null;
+
 	const renderText = () => {
 		if (!segments) return displayedText;
 
@@ -71,18 +91,9 @@ export function TypewriterText({
 				0,
 				Math.min(segment.text.length, displayedText.length - segStart),
 			);
-
-			if (segment.render) {
-				return (
-					<span
-						key={segment.text}
-						className={segment.className}
-						style={segment.style}
-					>
-						{segment.render(visibleText)}
-					</span>
-				);
-			}
+			// The caret lives inside the segment being typed so decorated
+			// segments (e.g. corner-brackets) keep it within their box
+			const holdsCursor = displayedText.length <= charIndex;
 
 			return (
 				<span
@@ -90,7 +101,8 @@ export function TypewriterText({
 					className={segment.className}
 					style={segment.style}
 				>
-					{visibleText}
+					{segment.render ? segment.render(visibleText) : visibleText}
+					{holdsCursor && cursor}
 				</span>
 			);
 		});
@@ -99,25 +111,7 @@ export function TypewriterText({
 	return (
 		<span className={className} style={style}>
 			{renderText()}
-			{showCursor && (
-				<motion.span
-					className="inline-block ml-0.5 w-3 -mr-3.5 h-[1em] bg-brand translate-y-0.5"
-					animate={
-						isTypingComplete
-							? { opacity: [1, 1, 0, 0, 1, 1, 0, 0] }
-							: { opacity: 1 }
-					}
-					transition={
-						isTypingComplete
-							? {
-									duration: 1.6,
-									times: [0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1],
-									ease: "linear",
-								}
-							: {}
-					}
-				/>
-			)}
+			{(!segments || displayedText.length === 0) && cursor}
 		</span>
 	);
 }


### PR DESCRIPTION
## Problem

The homepage overflowed horizontally on mobile (page grew to 540px at a 390px viewport), the hero hiring pill wrapped onto two lines on narrow screens, and the typewriter caret overshot the corner-bracket box around "AI Agents."

## Root causes & fixes

1. **Mobile overflow** — #6336 removed `overflow-hidden` from the `FeatureDemo` wrapper while two demos inside it (`ParallelExecutionDemo`, `IsolationDemo`) have `min-w-[500px]`; they were previously clipped on mobile. Restored `overflow-hidden`.
2. **Wrapping hiring pill** — the pill was absolutely positioned with `left-1/2`, which caps shrink-to-fit width at 50% of the container, wrapping the text on mobile. Moved it into the hero flow above the headline (Linear-style badge pill) with `w-max whitespace-nowrap`.
3. **Caret misalignment** — `TypewriterText` appended the caret after all segments, so it landed outside the decorated corner-brackets segment. The caret now renders inside the segment currently being typed, keeping it within the bracket box.

## Verification

Measured with headless Chrome (CDP) at a 390px viewport: document scrollWidth was 540px before, exactly 390px after on both `/` and `/pricing`, with zero unclipped overflowing elements. Screenshot-verified the one-line pill at 390px and 1440px, and zoomed captures of the headline mid-typing and post-typing confirm the caret sits inside the brackets. Typecheck and root lint pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mobile horizontal overflow by clipping and subtly fading the right edge of demos. Keep the hiring pill on one line and align the hero caret inside the bracketed segment; it matches the bracket height, grows from a dot, and fades out after typing without line-height jumps.

- **Bug Fixes**
  - Add a mobile right-edge mask fade in `FeatureDemo` and the hero mockup strip; restore `overflow-hidden` to stop horizontal growth.
  - Move the hiring pill into the hero flow with `w-max` and `whitespace-nowrap` to prevent wrapping.
  - Render the caret inside the active segment; make the bracketed segment a plain inline to stop line-height jumps, and size the caret with scale-y so it doesn’t inflate the line box or pop mid-typing.

<sup>Written for commit 06bdf0aecea8c8f91c9fb60e26a22a401f25f49e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented content from overflowing in feature demonstrations and product previews.
  - Improved cursor placement, sizing, animation, and consistency while typing segmented or decorated hero text.

- **Style**
  - Moved the hiring badge above the hero headline with improved responsive spacing and non-wrapping behavior.
  - Refined hero text alignment and whitespace handling.
  - Added subtle right-edge fades on smaller screens for horizontally scrolling content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->