### PR TITLE
fix(host-service,shared): stop preset launches stalling 15s and silently losing typed commands across shell setups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,26 @@ jobs:
           RELAY_URL: ${{ secrets.RELAY_URL }}
         run: bun run test
 
+      # The terminal launch-protection suites (src/terminal/*.node-test.ts)
+      # need real PTYs + node:test, which bun can't provide.
+      - name: Setup Node.js (terminal node-tests)
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+
+      # bun install ran with --ignore-scripts, so better-sqlite3 has no native
+      # build; fetch the prebuilt binary for the Node ABI (bun tests use
+      # bun:sqlite and are unaffected).
+      - name: Prepare better-sqlite3 for Node
+        run: |
+          for dir in node_modules/.bun/better-sqlite3@*/node_modules/better-sqlite3; do
+            (cd "$dir" && npx --yes prebuild-install || npx --yes node-gyp rebuild)
+          done
+
+      - name: Terminal node-tests
+        working-directory: packages/host-service
+        run: bun run test:integration:terminal
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,13 @@ jobs:
           node-version: 22
 
       # bun install ran with --ignore-scripts, so better-sqlite3 has no native
-      # build; fetch the prebuilt binary for the Node ABI (bun tests use
+      # build; fetch the prebuilt binary for the Node ABI using the lockfile-
+      # pinned prebuild-install that ships as its dependency (bun tests use
       # bun:sqlite and are unaffected).
       - name: Prepare better-sqlite3 for Node
         run: |
           for dir in node_modules/.bun/better-sqlite3@*/node_modules/better-sqlite3; do
-            (cd "$dir" && npx --yes prebuild-install || npx --yes node-gyp rebuild)
+            (cd "$dir" && ../.bin/prebuild-install)
           done
 
       - name: Terminal node-tests

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -58,6 +58,7 @@
 		"test": "bun test --pass-with-no-tests",
 		"test:integration": "bun test --pass-with-no-tests test/integration",
 		"test:integration:daemon": "node --experimental-strip-types --test src/terminal/DaemonClient/DaemonClient.node-test.ts src/daemon/DaemonSupervisor.node-test.ts",
+		"test:integration:terminal": "node --experimental-strip-types --test src/terminal/terminal.initial-command.node-test.ts src/terminal/terminal.ungated-launch.node-test.ts src/terminal/terminal.shell-ready-learning.node-test.ts src/terminal/terminal.fish-prompt-transport.node-test.ts",
 		"test:integration:workers": "node --experimental-strip-types --test src/workers/worker-termination.node-test.ts",
 		"test:e2e": "bun run scripts/test-e2e.ts",
 		"bench": "bun test test/integration/pull-requests-scaling.bench.ts",

--- a/packages/host-service/src/terminal/shell-ready-evidence.test.ts
+++ b/packages/host-service/src/terminal/shell-ready-evidence.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	__resetShellReadyEvidenceForTesting,
+	getShellReadyMarkerEvidence,
+	recordShellReadyMarkerEvidence,
+} from "./shell-ready-evidence";
+
+const originalHomeDir = process.env.SUPERSET_HOME_DIR;
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "shell-ready-evidence-"));
+	process.env.SUPERSET_HOME_DIR = tmpDir;
+	__resetShellReadyEvidenceForTesting();
+});
+
+afterEach(() => {
+	if (originalHomeDir === undefined) {
+		delete process.env.SUPERSET_HOME_DIR;
+	} else {
+		process.env.SUPERSET_HOME_DIR = originalHomeDir;
+	}
+	__resetShellReadyEvidenceForTesting();
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function waitForFile(filePath: string): Promise<void> {
+	for (let i = 0; i < 100; i++) {
+		try {
+			JSON.parse(fs.readFileSync(filePath, "utf8"));
+			return;
+		} catch {
+			await new Promise((r) => setTimeout(r, 10));
+		}
+	}
+	throw new Error(`file never became readable: ${filePath}`);
+}
+
+describe("shell-ready evidence", () => {
+	test("unknown shells have no evidence", () => {
+		expect(getShellReadyMarkerEvidence("zsh")).toBeNull();
+	});
+
+	test("recorded evidence round-trips in memory and persists to disk", async () => {
+		recordShellReadyMarkerEvidence("zsh", "missing");
+		expect(getShellReadyMarkerEvidence("zsh")).toBe("missing");
+
+		const file = path.join(tmpDir, "shell-ready-evidence.json");
+		await waitForFile(file);
+		expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({
+			zsh: "missing",
+		});
+	});
+
+	test("persisted evidence survives a cache reset (process restart)", async () => {
+		recordShellReadyMarkerEvidence("zsh", "missing");
+		await waitForFile(path.join(tmpDir, "shell-ready-evidence.json"));
+
+		__resetShellReadyEvidenceForTesting();
+		expect(getShellReadyMarkerEvidence("zsh")).toBe("missing");
+	});
+
+	test("evidence flips when the marker is observed again", () => {
+		recordShellReadyMarkerEvidence("zsh", "missing");
+		recordShellReadyMarkerEvidence("zsh", "delivered");
+		expect(getShellReadyMarkerEvidence("zsh")).toBe("delivered");
+	});
+
+	test("a corrupt evidence file reads as no evidence", () => {
+		fs.writeFileSync(
+			path.join(tmpDir, "shell-ready-evidence.json"),
+			"not json",
+		);
+		expect(getShellReadyMarkerEvidence("zsh")).toBeNull();
+	});
+
+	test("unexpected values in the file are ignored", () => {
+		fs.writeFileSync(
+			path.join(tmpDir, "shell-ready-evidence.json"),
+			JSON.stringify({ zsh: "banana", bash: "delivered" }),
+		);
+		expect(getShellReadyMarkerEvidence("zsh")).toBeNull();
+		expect(getShellReadyMarkerEvidence("bash")).toBe("delivered");
+	});
+
+	test("no SUPERSET_HOME_DIR keeps evidence in memory only", () => {
+		delete process.env.SUPERSET_HOME_DIR;
+		__resetShellReadyEvidenceForTesting();
+		recordShellReadyMarkerEvidence("zsh", "missing");
+		expect(getShellReadyMarkerEvidence("zsh")).toBe("missing");
+	});
+});

--- a/packages/host-service/src/terminal/shell-ready-evidence.ts
+++ b/packages/host-service/src/terminal/shell-ready-evidence.ts
@@ -1,0 +1,88 @@
+/**
+ * Learned, per-machine evidence of whether shell launches actually deliver
+ * the OSC 133;A readiness marker to the PTY stream.
+ *
+ * `shellLaunchExpectsReadyMarker` is a static file check: wrapper files on
+ * disk say the marker *should* fire, but a user profile can keep it from ever
+ * reaching the scanner (exec-ing tmux or another shell from .zshrc, a
+ * framework clearing precmd hooks, …). On such machines every marker-gated
+ * launch used to ride the full 15s fallback (SUPER-1103). Recording what the
+ * scanner actually observed lets later launches size their wait to reality:
+ * `missing` machines drop to a short grace, and the first observed marker
+ * flips the record back to `delivered`.
+ *
+ * Persisted as a tiny JSON map keyed by shell basename in
+ * `$SUPERSET_HOME_DIR/shell-ready-evidence.json` so the knowledge survives
+ * host-service restarts. Writes are best-effort; per-org host-service
+ * processes share the file and last-write-wins is fine — they observe the
+ * same machine and shell.
+ */
+import { readFileSync } from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type ShellReadyEvidence = "delivered" | "missing";
+
+const EVIDENCE_FILENAME = "shell-ready-evidence.json";
+
+type EvidenceMap = Record<string, ShellReadyEvidence>;
+
+let cache: { dir: string; evidence: EvidenceMap } | null = null;
+
+function evidenceDir(): string {
+	return process.env.SUPERSET_HOME_DIR || "";
+}
+
+function loadEvidence(dir: string): EvidenceMap {
+	if (cache && cache.dir === dir) return cache.evidence;
+	let evidence: EvidenceMap = {};
+	if (dir) {
+		try {
+			const raw: unknown = JSON.parse(
+				readFileSync(path.join(dir, EVIDENCE_FILENAME), "utf8"),
+			);
+			if (raw && typeof raw === "object") {
+				for (const [shell, value] of Object.entries(raw)) {
+					if (value === "delivered" || value === "missing") {
+						evidence[shell] = value;
+					}
+				}
+			}
+		} catch {
+			evidence = {};
+		}
+	}
+	cache = { dir, evidence };
+	return evidence;
+}
+
+export function getShellReadyMarkerEvidence(
+	shellName: string,
+): ShellReadyEvidence | null {
+	return loadEvidence(evidenceDir())[shellName] ?? null;
+}
+
+export function recordShellReadyMarkerEvidence(
+	shellName: string,
+	evidence: ShellReadyEvidence,
+): void {
+	const dir = evidenceDir();
+	const map = loadEvidence(dir);
+	if (map[shellName] === evidence) return;
+	map[shellName] = evidence;
+	if (!dir) return;
+	// Write-then-rename so concurrent readers (per-org host-service
+	// processes share this file) never see a torn write.
+	const target = path.join(dir, EVIDENCE_FILENAME);
+	const tmp = `${target}.${process.pid}.tmp`;
+	void writeFile(tmp, `${JSON.stringify(map, null, "\t")}\n`)
+		.then(() => rename(tmp, target))
+		.catch(() => {
+			// Best-effort persistence: the in-memory record still governs this
+			// process; a failed write only costs one 15s wait after a restart.
+		});
+}
+
+export function __resetShellReadyEvidenceForTesting(): void {
+	cache = null;
+}

--- a/packages/host-service/src/terminal/shell-ready-evidence.ts
+++ b/packages/host-service/src/terminal/shell-ready-evidence.ts
@@ -28,6 +28,7 @@ const EVIDENCE_FILENAME = "shell-ready-evidence.json";
 type EvidenceMap = Record<string, ShellReadyEvidence>;
 
 let cache: { dir: string; evidence: EvidenceMap } | null = null;
+let warnedReadError = false;
 
 function evidenceDir(): string {
 	return process.env.SUPERSET_HOME_DIR || "";
@@ -48,8 +49,20 @@ function loadEvidence(dir: string): EvidenceMap {
 					}
 				}
 			}
-		} catch {
+		} catch (error) {
 			evidence = {};
+			// No file yet and a corrupt file both legitimately mean "no
+			// evidence"; anything else (EACCES, EISDIR, …) is a real problem
+			// that silently costs a 15s wait per launch — say so once.
+			const code = (error as NodeJS.ErrnoException)?.code;
+			if (code !== "ENOENT" && !(error instanceof SyntaxError)) {
+				if (!warnedReadError) {
+					warnedReadError = true;
+					console.warn("[terminal] failed to read shell-ready evidence", {
+						error,
+					});
+				}
+			}
 		}
 	}
 	cache = { dir, evidence };
@@ -85,4 +98,5 @@ export function recordShellReadyMarkerEvidence(
 
 export function __resetShellReadyEvidenceForTesting(): void {
 	cache = null;
+	warnedReadError = false;
 }

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -25,6 +25,8 @@ export interface ModeTracker {
 	buildPreamble(): Uint8Array | null;
 	isBracketedPasteActive(): boolean;
 	isFocusReportingActive(): boolean;
+	/** Current cursor position on the mirrored screen, 0-based viewport coords. */
+	cursorPosition(): { x: number; y: number };
 	snapshot(maxLines?: number): TerminalSnapshot;
 	dispose(): void;
 }
@@ -157,6 +159,10 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		},
 		isFocusReportingActive() {
 			return term.modes.sendFocusMode;
+		},
+		cursorPosition() {
+			const buffer = term.buffer.active;
+			return { x: buffer.cursorX, y: buffer.cursorY };
 		},
 		snapshot,
 		dispose() {

--- a/packages/host-service/src/terminal/terminal.fish-prompt-transport.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.fish-prompt-transport.node-test.ts
@@ -32,17 +32,37 @@ import {
 } from "./terminal.ts";
 import { __setAccountShellForTesting } from "./user-shell.ts";
 
-const FISH = [
-	"/opt/homebrew/bin/fish",
-	"/usr/local/bin/fish",
-	"/usr/bin/fish",
-].find((candidate) => fs.existsSync(candidate));
+function findOnPath(name: string): string | null {
+	for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+		if (!dir) continue;
+		const candidate = path.join(dir, name);
+		try {
+			fs.accessSync(candidate, fs.constants.X_OK);
+			return candidate;
+		} catch {
+			// keep looking
+		}
+	}
+	return null;
+}
+
+const FISH = findOnPath("fish");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEST_HOME = path.join(os.tmpdir(), `host-svc-fishxport-${process.pid}`);
 const SOCK = path.join(os.tmpdir(), `host-svc-fishxport-${process.pid}.sock`);
 const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
 const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
+
+// The harness overwrites process-wide env; restore whatever was there so this
+// suite composes with others in the same node --test invocation.
+const OVERRIDDEN_ENV_KEYS = [
+	"SUPERSET_PTY_DAEMON_SOCKET",
+	"SUPERSET_HOME_DIR",
+	"HOST_SERVICE_VERSION",
+	"NODE_ENV",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
 
 let server: Server;
 let db: HostDb;
@@ -78,6 +98,7 @@ before(async () => {
 	});
 	await server.listen();
 
+	for (const key of OVERRIDDEN_ENV_KEYS) savedEnv.set(key, process.env[key]);
 	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
 	process.env.SUPERSET_HOME_DIR = TEST_HOME;
 	process.env.HOST_SERVICE_VERSION = "0.0.0-fishxport-e2e";
@@ -111,6 +132,10 @@ after(async () => {
 	__setAccountShellForTesting(undefined);
 	await disposeDaemonClient();
 	await server.close();
+	for (const [key, value] of savedEnv) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
 	try {
 		fs.rmSync(TEST_HOME, { recursive: true, force: true });
 	} catch {
@@ -135,17 +160,19 @@ describe("fish prompt transport rewrite", () => {
 			});
 
 			const terminalId = await launchAndRead(initialCommand);
-			await waitFor(() => fs.existsSync(outFile), 25_000);
-			await new Promise((r) => setTimeout(r, 300));
-			assert.equal(fs.readFileSync(outFile, "utf8"), PROMPT);
+			try {
+				await waitFor(() => fs.existsSync(outFile), 25_000);
+				await new Promise((r) => setTimeout(r, 300));
+				assert.equal(fs.readFileSync(outFile, "utf8"), PROMPT);
 
-			// The staged prompt file deleted itself when the command consumed it.
-			const leftovers = fs
-				.readdirSync(os.tmpdir())
-				.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
-			assert.deepEqual(leftovers, []);
-
-			await disposeSessionAndWait(terminalId, db);
+				// The staged prompt file deleted itself when the command consumed it.
+				const leftovers = fs
+					.readdirSync(os.tmpdir())
+					.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
+				assert.deepEqual(leftovers, []);
+			} finally {
+				await disposeSessionAndWait(terminalId, db);
+			}
 		},
 	);
 
@@ -163,17 +190,19 @@ describe("fish prompt transport rewrite", () => {
 			});
 
 			const terminalId = await launchAndRead(initialCommand);
-			await waitFor(() => fs.existsSync(outFile), 25_000);
-			await new Promise((r) => setTimeout(r, 300));
-			// The heredoc body carries a trailing newline; so does the staged file.
-			assert.equal(fs.readFileSync(outFile, "utf8"), `${PROMPT}\n`);
+			try {
+				await waitFor(() => fs.existsSync(outFile), 25_000);
+				await new Promise((r) => setTimeout(r, 300));
+				// The heredoc body carries a trailing newline; so does the staged file.
+				assert.equal(fs.readFileSync(outFile, "utf8"), `${PROMPT}\n`);
 
-			const leftovers = fs
-				.readdirSync(os.tmpdir())
-				.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
-			assert.deepEqual(leftovers, []);
-
-			await disposeSessionAndWait(terminalId, db);
+				const leftovers = fs
+					.readdirSync(os.tmpdir())
+					.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
+				assert.deepEqual(leftovers, []);
+			} finally {
+				await disposeSessionAndWait(terminalId, db);
+			}
 		},
 	);
 });

--- a/packages/host-service/src/terminal/terminal.fish-prompt-transport.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.fish-prompt-transport.node-test.ts
@@ -1,0 +1,187 @@
+// End-to-end tests for the fish prompt-transport rewrite (#4705): the shared
+// agent prompt transport is a bash-only command-substitution heredoc
+// ("$(cat <<'SUPERSET_PROMPT_…')"), which fish cannot parse — the launch died
+// with "Expected a string, but found a redirection" and the agent never
+// started. The host now rewrites the heredoc for fish launch shells into a
+// staged prompt file consumed with fish-native syntax, preserving the prompt
+// byte-for-byte and deleting the file as soon as it's consumed.
+//
+// Same harness as terminal.initial-command.node-test.ts (real pty-daemon
+// Server, real SQLite host DB) with a real fish. Skipped when fish isn't
+// installed.
+//
+//   node --experimental-strip-types --test <file>
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { Server } from "@superset/pty-daemon";
+import { buildPromptCommandString } from "@superset/shared/agent-prompt-launch";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const FISH = [
+	"/opt/homebrew/bin/fish",
+	"/usr/local/bin/fish",
+	"/usr/bin/fish",
+].find((candidate) => fs.existsSync(candidate));
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-fishxport-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-fishxport-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+
+// Exercises quotes, dollars, backticks, blank lines, and multi-line content —
+// all of it must reach the agent argv/stdin byte-for-byte.
+const PROMPT = "fix the 'bug'\n$HOME `pwd` \"quoted\"\n\ndone";
+
+async function launchAndRead(initialCommand: string): Promise<string> {
+	const terminalId = `e2e-fishxport-${randomUUID().slice(0, 8)}`;
+	const session = await createTerminalSessionInternal({
+		terminalId,
+		workspaceId,
+		db,
+		listed: true,
+		initialCommand,
+	});
+	assert.ok(!("error" in session), "error" in session ? session.error : "");
+	return terminalId;
+}
+
+before(async () => {
+	if (!FISH) return;
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	fs.mkdirSync(FAKE_USER_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-fishxport-e2e",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-fishxport-e2e";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting(FISH);
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: FAKE_USER_HOME,
+		SHELL: FISH,
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({
+			id: workspaceId,
+			projectId,
+			worktreePath,
+			branch: "main",
+		})
+		.run();
+});
+
+after(async () => {
+	if (!FISH) return;
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe("fish prompt transport rewrite", () => {
+	test(
+		"argv heredoc transport delivers the exact prompt to a real fish",
+		{ skip: !FISH, timeout: 30_000 },
+		async () => {
+			const outFile = path.join(TEST_HOME, "argv-out");
+			// `printf '%s'` prints its argv-1 verbatim — whatever fish passes as
+			// the substituted argument is exactly what lands in the file.
+			const initialCommand = buildPromptCommandString({
+				command: "printf '%s'",
+				suffix: `> "${outFile}"`,
+				transport: "argv",
+				prompt: PROMPT,
+				randomId: randomUUID(),
+			});
+
+			const terminalId = await launchAndRead(initialCommand);
+			await waitFor(() => fs.existsSync(outFile), 25_000);
+			await new Promise((r) => setTimeout(r, 300));
+			assert.equal(fs.readFileSync(outFile, "utf8"), PROMPT);
+
+			// The staged prompt file deleted itself when the command consumed it.
+			const leftovers = fs
+				.readdirSync(os.tmpdir())
+				.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
+			assert.deepEqual(leftovers, []);
+
+			await disposeSessionAndWait(terminalId, db);
+		},
+	);
+
+	test(
+		"stdin heredoc transport delivers the exact prompt to a real fish",
+		{ skip: !FISH, timeout: 30_000 },
+		async () => {
+			const outFile = path.join(TEST_HOME, "stdin-out");
+			const initialCommand = buildPromptCommandString({
+				command: "cat",
+				suffix: `> "${outFile}"`,
+				transport: "stdin",
+				prompt: PROMPT,
+				randomId: randomUUID(),
+			});
+
+			const terminalId = await launchAndRead(initialCommand);
+			await waitFor(() => fs.existsSync(outFile), 25_000);
+			await new Promise((r) => setTimeout(r, 300));
+			// The heredoc body carries a trailing newline; so does the staged file.
+			assert.equal(fs.readFileSync(outFile, "utf8"), `${PROMPT}\n`);
+
+			const leftovers = fs
+				.readdirSync(os.tmpdir())
+				.filter((f) => f.startsWith(`superset-launch-prompt-${terminalId}`));
+			assert.deepEqual(leftovers, []);
+
+			await disposeSessionAndWait(terminalId, db);
+		},
+	);
+});
+
+async function waitFor(predicate: () => boolean, ms: number): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > ms) throw new Error("waitFor timed out");
+		await new Promise((r) => setTimeout(r, 25));
+	}
+}

--- a/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.initial-command.node-test.ts
@@ -107,7 +107,7 @@ describe("initialCommand delivery", () => {
 			listed: true,
 			initialCommand: command,
 		});
-		assert.ok(!("error" in session), JSON.stringify(session));
+		assert.ok(!("error" in session), "error" in session ? session.error : "");
 		if ("error" in session) return;
 
 		// The command round-trips byte-for-byte, so nothing was truncated and
@@ -148,7 +148,7 @@ describe("initialCommand delivery", () => {
 				listed: true,
 				initialCommand: command,
 			});
-			assert.ok(!("error" in session), JSON.stringify(session));
+			assert.ok(!("error" in session), "error" in session ? session.error : "");
 			if ("error" in session) return;
 
 			await waitFor(
@@ -181,7 +181,7 @@ describe("initialCommand delivery", () => {
 			listed: true,
 			initialCommand: command,
 		});
-		assert.ok(!("error" in session), JSON.stringify(session));
+		assert.ok(!("error" in session), "error" in session ? session.error : "");
 		if ("error" in session) return;
 
 		const staged = () =>

--- a/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
@@ -91,7 +91,9 @@ export ZDOTDIR="$_superset_home"
 	);
 }
 
-async function launchAndMeasure(command: string): Promise<number> {
+async function launchAndMeasure(
+	command: string,
+): Promise<{ elapsed: number; body: string }> {
 	const terminalId = `e2e-ready-${randomUUID().slice(0, 8)}`;
 	const outFile = path.join(TEST_HOME, `out-${terminalId}`);
 	const start = Date.now();
@@ -105,8 +107,11 @@ async function launchAndMeasure(command: string): Promise<number> {
 	assert.ok(!("error" in session), "error" in session ? session.error : "");
 	await waitFor(() => fs.existsSync(outFile), 25_000);
 	const elapsed = Date.now() - start;
+	// Small settle so the redirect finishes writing before we read it back.
+	await new Promise((r) => setTimeout(r, 150));
+	const body = fs.readFileSync(outFile, "utf8").trim();
 	await disposeSessionAndWait(terminalId, db);
-	return elapsed;
+	return { elapsed, body };
 }
 
 function readEvidenceFile(): Record<string, string> {
@@ -187,7 +192,7 @@ describe("shell-ready evidence learning", () => {
 			"wrapper files should make the launch marker-backed",
 		);
 
-		const elapsed = await launchAndMeasure("date +%s");
+		const { elapsed } = await launchAndMeasure("date +%s");
 		assert.ok(
 			elapsed < 10_000,
 			`healthy profile took ${elapsed}ms — gate fell back to the timeout`,
@@ -208,19 +213,19 @@ describe("shell-ready evidence learning", () => {
 
 			const first = await launchAndMeasure("date +%s");
 			assert.ok(
-				first >= 15_000,
-				`first marker-less launch took ${first}ms — expected the full 15s fallback`,
+				first.elapsed >= 15_000,
+				`first marker-less launch took ${first.elapsed}ms — expected the full 15s fallback`,
 			);
 			await waitFor(() => readEvidenceFile().zsh === "missing", 5_000);
 
 			const second = await launchAndMeasure("date +%s");
 			assert.ok(
-				second < 10_000,
-				`branded-missing launch took ${second}ms — evidence should shrink the wait`,
+				second.elapsed < 10_000,
+				`branded-missing launch took ${second.elapsed}ms — evidence should shrink the wait`,
 			);
 			assert.ok(
-				second >= 2_000,
-				`branded-missing launch took ${second}ms — grace period should still apply`,
+				second.elapsed >= 2_000,
+				`branded-missing launch took ${second.elapsed}ms — grace period should still apply`,
 			);
 		},
 	);
@@ -230,13 +235,59 @@ describe("shell-ready evidence learning", () => {
 		// so the very next launch re-learns `delivered`.
 		fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
 
-		const elapsed = await launchAndMeasure("date +%s");
+		const { elapsed } = await launchAndMeasure("date +%s");
 		assert.ok(
 			elapsed < 10_000,
 			`recovered profile took ${elapsed}ms — expected a prompt launch`,
 		);
 		await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
 	});
+
+	test(
+		"stdin-eating marker-less profile: grace launch survives a startup `read`",
+		{ timeout: 60_000 },
+		async () => {
+			// Adversarial combo (the omz-updater class of #3941, on a machine
+			// whose marker also never arrives): a startup `read` is consuming the
+			// TTY when the learned grace window fires, so a blindly typed command
+			// loses its first byte(s) — `date …` runs as `ate …`, performing the
+			// redirect (empty out file) and then failing. The grace path must
+			// verify the command echoed back intact and retype it if not.
+			fs.writeFileSync(
+				path.join(FAKE_USER_HOME, ".zshrc"),
+				"read -t 3 -k 1 _j || true\nexec /bin/zsh -f\n",
+			);
+
+			// Previous test re-learned `delivered`, so this first launch rides
+			// the full fallback (typing at 15s, long after the eater is gone)
+			// and re-brands the shell `missing`.
+			const first = await launchAndMeasure("date +%s");
+			assert.ok(
+				first.elapsed >= 15_000,
+				`first eater launch took ${first.elapsed}ms — expected the full 15s fallback`,
+			);
+			assert.match(
+				first.body,
+				/^\d{10}$/,
+				`first eater launch produced ${JSON.stringify(first.body)} — command mangled`,
+			);
+			await waitFor(() => readEvidenceFile().zsh === "missing", 5_000);
+
+			// Grace-window launch fires while `read -t 3` is still eating stdin.
+			const second = await launchAndMeasure("date +%s");
+			assert.match(
+				second.body,
+				/^\d{10}$/,
+				`grace launch produced ${JSON.stringify(second.body)} — the startup read ate the command`,
+			);
+			assert.ok(
+				second.elapsed < 10_000,
+				`grace launch took ${second.elapsed}ms — echo verification gave back the latency win`,
+			);
+
+			fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
+		},
+	);
 });
 
 async function waitFor(predicate: () => boolean, ms: number): Promise<void> {

--- a/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
@@ -1,0 +1,248 @@
+// End-to-end tests for shell-ready evidence learning (SUPER-1103): a user
+// profile can keep the OSC 133;A marker from ever reaching the PTY stream
+// (exec-ing another shell or tmux from .zshrc, cleared precmd hooks). Before
+// learning, every marker-gated launch on such a machine rode the full 15s
+// fallback — clicking an agent preset stalled exactly 15s, every time. The
+// host now records what the scanner actually observed: the first timed-out
+// launch brands the shell `missing`, later launches use a short grace, and an
+// observed marker flips the brand back to `delivered`.
+//
+// Same harness as terminal.initial-command.node-test.ts (real pty-daemon
+// Server, real SQLite host DB) but with real /bin/zsh plus the desktop's zsh
+// wrapper files, so shellLaunchExpectsReadyMarker() returns true and the
+// shell-ready gate is exercised for real.
+//
+//   node --experimental-strip-types --test <file>
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { Server } from "@superset/pty-daemon";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import { shellLaunchExpectsReadyMarker } from "./shell-launch.ts";
+import { __resetShellReadyEvidenceForTesting } from "./shell-ready-evidence.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-shellready-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-shellready-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+
+// Isolated fake user home so the test never sources the real user's rc files.
+const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+
+/**
+ * Faithful copy of the zsh wrapper chain that
+ * apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts writes (minus the
+ * PATH-prepend helpers, which don't affect readiness): ZDOTDIR redirection
+ * through .zshenv/.zprofile/.zshrc, marker hook registered last in .zlogin.
+ */
+function writeZshWrappers(zshDir: string): void {
+	const SAVE = `_superset_saved_env="$(export -p 2>/dev/null | grep ' SUPERSET_')"`;
+	const RESTORE = `eval "$_superset_saved_env" 2>/dev/null || true`;
+	const quoted = `'${zshDir}'`;
+	fs.mkdirSync(zshDir, { recursive: true });
+	const sourceUser = (file: string, guard?: string) =>
+		[
+			SAVE,
+			`_superset_home="\${SUPERSET_ORIG_ZDOTDIR:-$HOME}"`,
+			`export ZDOTDIR="$_superset_home"`,
+			guard
+				? `if [[ -o interactive ]]; then\n  [[ -f "$_superset_home/${file}" ]] && source "$_superset_home/${file}"\nfi`
+				: `[[ -f "$_superset_home/${file}" ]] && source "$_superset_home/${file}"`,
+			RESTORE,
+		].join("\n");
+	fs.writeFileSync(
+		path.join(zshDir, ".zshenv"),
+		`${sourceUser(".zshenv")}\nexport ZDOTDIR=${quoted}\n`,
+	);
+	fs.writeFileSync(
+		path.join(zshDir, ".zprofile"),
+		`${sourceUser(".zprofile")}\nexport ZDOTDIR=${quoted}\n`,
+	);
+	fs.writeFileSync(
+		path.join(zshDir, ".zshrc"),
+		`${sourceUser(".zshrc")}\nexport ZDOTDIR=${quoted}\n`,
+	);
+	fs.writeFileSync(
+		path.join(zshDir, ".zlogin"),
+		`${sourceUser(".zlogin", "interactive")}
+__superset_prompt_mark() {
+  printf "\\033]777;superset-shell-ready\\007\\033]133;A\\007"
+}
+precmd_functions=(\${precmd_functions[@]} __superset_prompt_mark)
+export ZDOTDIR="$_superset_home"
+`,
+	);
+}
+
+async function launchAndMeasure(command: string): Promise<number> {
+	const terminalId = `e2e-ready-${randomUUID().slice(0, 8)}`;
+	const outFile = path.join(TEST_HOME, `out-${terminalId}`);
+	const start = Date.now();
+	const session = await createTerminalSessionInternal({
+		terminalId,
+		workspaceId,
+		db,
+		listed: true,
+		initialCommand: `${command} > "${outFile}"`,
+	});
+	assert.ok(!("error" in session), "error" in session ? session.error : "");
+	await waitFor(() => fs.existsSync(outFile), 25_000);
+	const elapsed = Date.now() - start;
+	await disposeSessionAndWait(terminalId, db);
+	return elapsed;
+}
+
+function readEvidenceFile(): Record<string, string> {
+	try {
+		return JSON.parse(
+			fs.readFileSync(
+				path.join(TEST_HOME, "shell-ready-evidence.json"),
+				"utf8",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	fs.mkdirSync(FAKE_USER_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+	writeZshWrappers(path.join(TEST_HOME, "zsh"));
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-shellready-e2e",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-shellready-e2e";
+	process.env.NODE_ENV = "development";
+
+	__resetShellReadyEvidenceForTesting();
+	__setAccountShellForTesting("/bin/zsh");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: FAKE_USER_HOME,
+		SHELL: "/bin/zsh",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({
+			id: workspaceId,
+			projectId,
+			worktreePath,
+			branch: "main",
+		})
+		.run();
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	__resetShellReadyEvidenceForTesting();
+	await disposeDaemonClient();
+	await server.close();
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe("shell-ready evidence learning", () => {
+	test("marker-delivering profile: prompt launch, evidence records delivered", async () => {
+		assert.equal(
+			shellLaunchExpectsReadyMarker({
+				shell: "/bin/zsh",
+				supersetHomeDir: TEST_HOME,
+			}),
+			true,
+			"wrapper files should make the launch marker-backed",
+		);
+
+		const elapsed = await launchAndMeasure("date +%s");
+		assert.ok(
+			elapsed < 10_000,
+			`healthy profile took ${elapsed}ms — gate fell back to the timeout`,
+		);
+		await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
+	});
+
+	test(
+		"marker-diverting profile: one full timeout, then launches use the short grace",
+		{ timeout: 60_000 },
+		async () => {
+			// A .zshrc that execs another shell keeps the wrapper .zlogin (and
+			// so the marker) from ever running — the class behind SUPER-1103.
+			fs.writeFileSync(
+				path.join(FAKE_USER_HOME, ".zshrc"),
+				"exec /bin/zsh -f\n",
+			);
+
+			const first = await launchAndMeasure("date +%s");
+			assert.ok(
+				first >= 15_000,
+				`first marker-less launch took ${first}ms — expected the full 15s fallback`,
+			);
+			await waitFor(() => readEvidenceFile().zsh === "missing", 5_000);
+
+			const second = await launchAndMeasure("date +%s");
+			assert.ok(
+				second < 10_000,
+				`branded-missing launch took ${second}ms — evidence should shrink the wait`,
+			);
+			assert.ok(
+				second >= 2_000,
+				`branded-missing launch took ${second}ms — grace period should still apply`,
+			);
+		},
+	);
+
+	test("recovered profile: an observed marker flips evidence back to delivered", async () => {
+		// Profile fixed: markers flow again and arrive within the grace window,
+		// so the very next launch re-learns `delivered`.
+		fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
+
+		const elapsed = await launchAndMeasure("date +%s");
+		assert.ok(
+			elapsed < 10_000,
+			`recovered profile took ${elapsed}ms — expected a prompt launch`,
+		);
+		await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
+	});
+});
+
+async function waitFor(predicate: () => boolean, ms: number): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > ms) throw new Error("waitFor timed out");
+		await new Promise((r) => setTimeout(r, 25));
+	}
+}

--- a/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.shell-ready-learning.node-test.ts
@@ -42,6 +42,32 @@ const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
 // Isolated fake user home so the test never sources the real user's rc files.
 const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
 
+function findOnPath(name: string): string | null {
+	for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+		if (!dir) continue;
+		const candidate = path.join(dir, name);
+		try {
+			fs.accessSync(candidate, fs.constants.X_OK);
+			return candidate;
+		} catch {
+			// keep looking
+		}
+	}
+	return null;
+}
+
+const ZSH = findOnPath("zsh");
+
+// The harness overwrites process-wide env; restore whatever was there so this
+// suite composes with others in the same node --test invocation.
+const OVERRIDDEN_ENV_KEYS = [
+	"SUPERSET_PTY_DAEMON_SOCKET",
+	"SUPERSET_HOME_DIR",
+	"HOST_SERVICE_VERSION",
+	"NODE_ENV",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
 let server: Server;
 let db: HostDb;
 let workspaceId: string;
@@ -105,13 +131,15 @@ async function launchAndMeasure(
 		initialCommand: `${command} > "${outFile}"`,
 	});
 	assert.ok(!("error" in session), "error" in session ? session.error : "");
-	await waitFor(() => fs.existsSync(outFile), 25_000);
-	const elapsed = Date.now() - start;
-	// Small settle so the redirect finishes writing before we read it back.
-	await new Promise((r) => setTimeout(r, 150));
-	const body = fs.readFileSync(outFile, "utf8").trim();
-	await disposeSessionAndWait(terminalId, db);
-	return { elapsed, body };
+	try {
+		await waitFor(() => fs.existsSync(outFile), 25_000);
+		const elapsed = Date.now() - start;
+		// Small settle so the redirect finishes writing before we read it back.
+		await new Promise((r) => setTimeout(r, 150));
+		return { elapsed, body: fs.readFileSync(outFile, "utf8").trim() };
+	} finally {
+		await disposeSessionAndWait(terminalId, db);
+	}
 }
 
 function readEvidenceFile(): Record<string, string> {
@@ -128,6 +156,7 @@ function readEvidenceFile(): Record<string, string> {
 }
 
 before(async () => {
+	if (!ZSH) return;
 	fs.mkdirSync(TEST_HOME, { recursive: true });
 	fs.mkdirSync(FAKE_USER_HOME, { recursive: true });
 	const worktreePath = path.join(TEST_HOME, "worktree");
@@ -140,17 +169,18 @@ before(async () => {
 	});
 	await server.listen();
 
+	for (const key of OVERRIDDEN_ENV_KEYS) savedEnv.set(key, process.env[key]);
 	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
 	process.env.SUPERSET_HOME_DIR = TEST_HOME;
 	process.env.HOST_SERVICE_VERSION = "0.0.0-shellready-e2e";
 	process.env.NODE_ENV = "development";
 
 	__resetShellReadyEvidenceForTesting();
-	__setAccountShellForTesting("/bin/zsh");
+	__setAccountShellForTesting(ZSH);
 	initTerminalBaseEnv({
 		PATH: process.env.PATH ?? "/usr/bin:/bin",
 		HOME: FAKE_USER_HOME,
-		SHELL: "/bin/zsh",
+		SHELL: ZSH,
 	});
 
 	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
@@ -169,11 +199,16 @@ before(async () => {
 });
 
 after(async () => {
+	if (!ZSH) return;
 	__resetSessionsForTesting();
 	__setAccountShellForTesting(undefined);
 	__resetShellReadyEvidenceForTesting();
 	await disposeDaemonClient();
 	await server.close();
+	for (const [key, value] of savedEnv) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
 	try {
 		fs.rmSync(TEST_HOME, { recursive: true, force: true });
 	} catch {
@@ -182,27 +217,32 @@ after(async () => {
 });
 
 describe("shell-ready evidence learning", () => {
-	test("marker-delivering profile: prompt launch, evidence records delivered", async () => {
-		assert.equal(
-			shellLaunchExpectsReadyMarker({
-				shell: "/bin/zsh",
-				supersetHomeDir: TEST_HOME,
-			}),
-			true,
-			"wrapper files should make the launch marker-backed",
-		);
+	test(
+		"marker-delivering profile: prompt launch, evidence records delivered",
+		{ skip: !ZSH },
+		async () => {
+			assert.ok(ZSH);
+			assert.equal(
+				shellLaunchExpectsReadyMarker({
+					shell: ZSH,
+					supersetHomeDir: TEST_HOME,
+				}),
+				true,
+				"wrapper files should make the launch marker-backed",
+			);
 
-		const { elapsed } = await launchAndMeasure("date +%s");
-		assert.ok(
-			elapsed < 10_000,
-			`healthy profile took ${elapsed}ms — gate fell back to the timeout`,
-		);
-		await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
-	});
+			const { elapsed } = await launchAndMeasure("date +%s");
+			assert.ok(
+				elapsed < 10_000,
+				`healthy profile took ${elapsed}ms — gate fell back to the timeout`,
+			);
+			await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
+		},
+	);
 
 	test(
 		"marker-diverting profile: one full timeout, then launches use the short grace",
-		{ timeout: 60_000 },
+		{ skip: !ZSH, timeout: 60_000 },
 		async () => {
 			// A .zshrc that execs another shell keeps the wrapper .zlogin (and
 			// so the marker) from ever running — the class behind SUPER-1103.
@@ -230,22 +270,26 @@ describe("shell-ready evidence learning", () => {
 		},
 	);
 
-	test("recovered profile: an observed marker flips evidence back to delivered", async () => {
-		// Profile fixed: markers flow again and arrive within the grace window,
-		// so the very next launch re-learns `delivered`.
-		fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
+	test(
+		"recovered profile: an observed marker flips evidence back to delivered",
+		{ skip: !ZSH },
+		async () => {
+			// Profile fixed: markers flow again and arrive within the grace window,
+			// so the very next launch re-learns `delivered`.
+			fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
 
-		const { elapsed } = await launchAndMeasure("date +%s");
-		assert.ok(
-			elapsed < 10_000,
-			`recovered profile took ${elapsed}ms — expected a prompt launch`,
-		);
-		await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
-	});
+			const { elapsed } = await launchAndMeasure("date +%s");
+			assert.ok(
+				elapsed < 10_000,
+				`recovered profile took ${elapsed}ms — expected a prompt launch`,
+			);
+			await waitFor(() => readEvidenceFile().zsh === "delivered", 5_000);
+		},
+	);
 
 	test(
 		"stdin-eating marker-less profile: grace launch survives a startup `read`",
-		{ timeout: 60_000 },
+		{ skip: !ZSH, timeout: 60_000 },
 		async () => {
 			// Adversarial combo (the omz-updater class of #3941, on a machine
 			// whose marker also never arrives): a startup `read` is consuming the
@@ -286,6 +330,34 @@ describe("shell-ready evidence learning", () => {
 			);
 
 			fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
+		},
+	);
+
+	test(
+		"late marker after the grace window flips evidence back to delivered",
+		{ skip: !ZSH, timeout: 60_000 },
+		async () => {
+			// A slow-init profile delivers the marker AFTER the 2s grace fires
+			// (typed on learned `missing` evidence). The late marker is still
+			// proof this profile delivers — evidence must self-heal instead of
+			// `missing` being a one-way brand.
+			assert.equal(
+				readEvidenceFile().zsh,
+				"missing",
+				"precondition: previous test left zsh branded missing",
+			);
+			fs.writeFileSync(path.join(FAKE_USER_HOME, ".zshrc"), "sleep 4\n");
+			try {
+				const { body } = await launchAndMeasure("date +%s");
+				assert.match(
+					body,
+					/^\d{10}$/,
+					`late-marker launch produced ${JSON.stringify(body)}`,
+				);
+				await waitFor(() => readEvidenceFile().zsh === "delivered", 10_000);
+			} finally {
+				fs.rmSync(path.join(FAKE_USER_HOME, ".zshrc"), { force: true });
+			}
 		},
 	);
 });

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -312,6 +312,35 @@ const SHELL_READY_TIMEOUT_MS = 15_000;
 const SHELL_READY_MISSING_MARKER_GRACE_MS = 2_000;
 
 /**
+ * How long a grace-window launch watches the PTY stream for its own command
+ * echoing back before concluding a startup stdin reader ate it. The grace
+ * fires on learned evidence, not an observed prompt, so an oh-my-zsh-style
+ * `read` can still be consuming the TTY when we type (the #3941 eater class
+ * combined with a marker-less profile). Echo is the same kind of evidence the
+ * marker was: proof of what the shell actually received.
+ */
+const GRACE_ECHO_WINDOW_MS = 1_200;
+
+/**
+ * Output silence required after an intact-looking echo before trusting it.
+ * The kernel echoes typed bytes at input time, before any reader consumes
+ * them, so an intact echo alone can't prove the line editor holds the text —
+ * a raw-mode `read -k` steals the first byte(s) anyway and the surviving
+ * suffix re-echoes moments later when the editor drains the queue. The quiet
+ * window gives that mangle signature time to arrive.
+ */
+const GRACE_ECHO_QUIET_MS = 250;
+
+/**
+ * Retype attempts (Ctrl-U + text) after a missed or mangled echo before
+ * falling back to typing blind, exactly like the marker-timeout path always
+ * has. Each cycle costs at most one echo window, so this also bounds added
+ * latency when echo detection false-negatives (a TUI repainting instead of
+ * echoing).
+ */
+const GRACE_ECHO_MAX_RETYPES = 2;
+
+/**
  * Gap between writing the initialCommand text and the Enter (`\r`) that runs
  * it. The shell-ready marker fires from precmd, before the line editor reads
  * input — plugin init in that window can flush the PTY input queue, eating a
@@ -404,6 +433,17 @@ interface TerminalSession {
 	shellReadyPromise: Promise<void>;
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
 	scanState: ShellReadyScanState;
+	/**
+	 * True when this launch's readiness timeout was the short learned grace
+	 * rather than the full fallback. A grace timeout types while startup may
+	 * still be consuming stdin, so that path must echo-verify what it typed.
+	 */
+	usedMissingMarkerGrace: boolean;
+	/**
+	 * Active echo watcher for a grace-window initialCommand: fed every output
+	 * chunk so typeInitialCommandVerifyingEcho can see its text echo back.
+	 */
+	echoProbe: ((bytes: Uint8Array) => void) | null;
 	initialCommandQueued: boolean;
 	/**
 	 * Basename of the launch shell. Picks the source keyword when a long
@@ -1373,6 +1413,149 @@ function stageInitialCommandScript(
 	return { typedLine: `${sourceKeyword} ${quotedPath}`, scriptPath };
 }
 
+/**
+ * Longest leading run of printable ASCII from the typed line, capped so the
+ * probe fits on one terminal row even after a prompt. The prefix is what a
+ * stdin eater mangles (it consumes from the front), so it's both the match
+ * target and the mangle detector (see judgeCommandEcho). Returns null when
+ * the command starts with bytes a terminal won't echo verbatim — those
+ * launches type blind, exactly as before.
+ */
+function commandEchoProbe(typedText: string): string | null {
+	let end = 0;
+	while (end < typedText.length && end < 32) {
+		const code = typedText.charCodeAt(end);
+		if (code < 0x20 || code > 0x7e) break;
+		end++;
+	}
+	const probe = typedText.slice(0, end);
+	return probe.length >= 6 ? probe : null;
+}
+
+/**
+ * Strip escape sequences and control bytes so echoed text can be matched
+ * regardless of prompt colors, syntax-highlight repaints, or line wraps
+ * (which only insert controls/CSI between the printable characters).
+ */
+function stripEchoDecorations(raw: string): string {
+	return (
+		raw
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping OSC sequences intentionally
+			.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, "")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping DCS/SOS/PM/APC sequences intentionally
+			.replace(/\x1b[PX^_][\s\S]*?(?:\x1b\\|\x07|$)/g, "")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping CSI sequences intentionally
+			.replace(/\x1b\[[0-9;:?<=>]*[ -/]*[@-~]/g, "")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping two-byte escapes intentionally
+			.replace(/\x1b./g, "")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control chars intentionally
+			.replace(/[\x00-\x1f\x7f]/g, "")
+	);
+}
+
+/**
+ * Judge the echoed stream against the typed probe. `intact` needs the full
+ * probe present with no orphan suffix after its last occurrence: a startup
+ * reader that stole leading byte(s) leaves the intact kernel echo in place
+ * and then re-echoes the surviving tail when the line editor drains the
+ * queue (`date +%s …` followed by `ate +%s …`), so a reappearing proper
+ * suffix means the editor holds a mangled copy. `mangled` is definitive —
+ * the caller retypes immediately instead of waiting out the window.
+ */
+function judgeCommandEcho(
+	cleaned: string,
+	probe: string,
+): "absent" | "intact" | "mangled" {
+	const lastFull = cleaned.lastIndexOf(probe);
+	if (lastFull === -1) return "absent";
+	const tail = cleaned.slice(lastFull + probe.length);
+	// Suffixes shorter than 3 chars collide with prompts/status text too easily.
+	for (let cut = 1; cut <= probe.length - 3; cut++) {
+		if (tail.includes(probe.slice(cut))) return "mangled";
+	}
+	return "intact";
+}
+
+/**
+ * Resolve true once `probe` echoes back intact and the stream then stays
+ * quiet long enough for a mangle signature to have shown up; false on a
+ * detected mangle or when the window closes without an intact echo.
+ */
+function waitForCommandEcho(
+	session: TerminalSession,
+	probe: string,
+	windowMs: number,
+): Promise<boolean> {
+	return new Promise((resolve) => {
+		let raw = "";
+		let quietTimer: ReturnType<typeof setTimeout> | null = null;
+		const finish = (ok: boolean) => {
+			session.echoProbe = null;
+			clearTimeout(windowTimer);
+			if (quietTimer) clearTimeout(quietTimer);
+			resolve(ok);
+		};
+		const windowTimer = setTimeout(() => finish(false), windowMs);
+		session.echoProbe = (bytes) => {
+			raw += Buffer.from(
+				bytes.buffer,
+				bytes.byteOffset,
+				bytes.byteLength,
+			).toString("latin1");
+			// Keep the tail bounded; far more than enough overlap for the probe.
+			if (raw.length > 65_536) raw = raw.slice(-32_768);
+			// Every chunk re-opens the quiet window — whatever painted may have
+			// been the start of a mangle signature.
+			if (quietTimer) {
+				clearTimeout(quietTimer);
+				quietTimer = null;
+			}
+			const verdict = judgeCommandEcho(stripEchoDecorations(raw), probe);
+			if (verdict === "mangled") {
+				finish(false);
+			} else if (verdict === "intact") {
+				quietTimer = setTimeout(() => finish(true), GRACE_ECHO_QUIET_MS);
+			}
+		};
+	});
+}
+
+/**
+ * Grace-window typing (learned `missing` evidence, no observed prompt): a
+ * startup stdin reader can still be consuming the TTY when the grace fires —
+ * the oh-my-zsh-updater `read` of #3941 on a profile that also never delivers
+ * the marker — and a blindly typed command loses its leading byte(s) to it
+ * (`claude` runs as `laude`). So watch the stream for the command echoing
+ * back intact; when the echo doesn't appear, clear the line and retype.
+ * Ctrl-U is safe in every mode the TTY can be in here — kill-line for a live
+ * line editor, the canonical kill character for kernel-queued input, and a
+ * literal 0x15 the editor will treat as kill when it drains a raw queue — so
+ * a false-negative echo costs a retype, never a corrupted command. After the
+ * retry budget the command is typed blind, matching the old fallback path:
+ * it must eventually run.
+ */
+async function typeInitialCommandVerifyingEcho(
+	session: TerminalSession,
+	typedText: string,
+	probe: string,
+	scriptPath: string | null,
+	isDefunct: () => boolean,
+): Promise<void> {
+	const dropStagedScript = () => {
+		// Enter never sent — the staged script won't run, so it can't self-delete.
+		if (scriptPath) void rm(scriptPath, { force: true }).catch(() => {});
+	};
+	for (let attempt = 0; attempt <= GRACE_ECHO_MAX_RETYPES; attempt++) {
+		if (isDefunct()) return dropStagedScript();
+		if (attempt > 0) session.pty.write("\x15");
+		session.pty.write(typedText);
+		if (await waitForCommandEcho(session, probe, GRACE_ECHO_WINDOW_MS)) break;
+	}
+	await new Promise((r) => setTimeout(r, INITIAL_COMMAND_ENTER_DELAY_MS));
+	if (isDefunct()) return dropStagedScript();
+	session.pty.write("\r");
+}
+
 function queueInitialCommand(
 	session: TerminalSession,
 	initialCommand: string,
@@ -1408,6 +1591,25 @@ function queueInitialCommand(
 			if (staged) {
 				typedText = staged.typedLine;
 				scriptPath = staged.scriptPath;
+			}
+		}
+		// A grace-window timeout typed on learned evidence alone — no marker, no
+		// observed prompt — so startup may still be reading stdin. That path
+		// must verify its own echo instead of trusting the write.
+		if (
+			session.shellReadyState === "timed_out" &&
+			session.usedMissingMarkerGrace
+		) {
+			const probe = commandEchoProbe(typedText);
+			if (probe) {
+				void typeInitialCommandVerifyingEcho(
+					session,
+					typedText,
+					probe,
+					scriptPath,
+					isDefunct,
+				);
+				return;
 			}
 		}
 		// The OSC 133;A marker fires from precmd, which runs BEFORE the line
@@ -1986,6 +2188,8 @@ export async function createTerminalSessionInternal({
 		shellReadyPromise,
 		shellReadyTimeoutId: null,
 		scanState: createScanState(),
+		usedMissingMarkerGrace: false,
+		echoProbe: null,
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
 		initialCommandQueued: isAdopted,
@@ -2007,13 +2211,17 @@ export async function createTerminalSessionInternal({
 	if (session.shellReadyState === "pending") {
 		// Size the wait to observed reality: on machines whose profile never
 		// delivers the marker, the full wait *is* the launch latency.
-		const readyWaitMs =
-			getShellReadyMarkerEvidence(session.launchShellName) === "missing"
+		const missingEvidence =
+			getShellReadyMarkerEvidence(session.launchShellName) === "missing";
+		session.usedMissingMarkerGrace = missingEvidence;
+		session.shellReadyTimeoutId = setTimeout(
+			() => {
+				resolveShellReady(session, "timed_out");
+			},
+			missingEvidence
 				? SHELL_READY_MISSING_MARKER_GRACE_MS
-				: SHELL_READY_TIMEOUT_MS;
-		session.shellReadyTimeoutId = setTimeout(() => {
-			resolveShellReady(session, "timed_out");
-		}, readyWaitMs);
+				: SHELL_READY_TIMEOUT_MS,
+		);
 	}
 
 	session.unsubscribeDaemon = daemon.subscribe(
@@ -2041,6 +2249,8 @@ export async function createTerminalSessionInternal({
 					}
 				}
 				if (bytes.byteLength === 0) return;
+
+				session.echoProbe?.(bytes);
 
 				// portManager.checkOutputForHint runs URL/port regexes on
 				// strings; the per-session StringDecoder buffers partial

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -7,6 +7,10 @@ import { StringDecoder } from "node:string_decoder";
 import type { NodeWebSocket } from "@hono/node-ws";
 import { hasRunningForegroundProcess } from "@superset/pty-daemon/process-tree";
 import {
+	buildFishPromptCommandString,
+	parsePromptHeredocCommand,
+} from "@superset/shared/agent-prompt-launch";
+import {
 	createScanState,
 	type ShellReadyScanState,
 	scanForShellReady,
@@ -341,6 +345,32 @@ const GRACE_ECHO_QUIET_MS = 250;
 const GRACE_ECHO_MAX_RETYPES = 2;
 
 /**
+ * Output silence required before an ungated launch (no marker expected at
+ * all: unwrapped bash, sh/ksh, nushell) types its initialCommand. Typing
+ * while startup output is still streaming is how reedline-class editors
+ * (nushell) lose the command outright: they enable raw mode after init and
+ * flush pending typeahead — the kernel-echoed command looks delivered but the
+ * editor never held it (#6024). Quiescence alone is not enough (a silent
+ * startup `read -t` window looks quiescent, #3941/#5712) — that's what the
+ * echo verification below catches.
+ */
+const UNGATED_QUIESCENT_MS = 500;
+
+/**
+ * Cap on each quiescence wait so a busy startup (spinners, streaming MOTD)
+ * can only delay an ungated launch, never park it. After the cap the launch
+ * proceeds to the echo-verified type, whose retype loop is the real guard.
+ */
+const UNGATED_QUIESCENCE_CAP_MS = 8_000;
+
+/**
+ * Echo window for ungated launches. Must cover the post-echo quiet
+ * requirement (INITIAL_COMMAND_ENTER_DELAY_MS, doing double duty as the
+ * text→Enter separation) plus echo latency.
+ */
+const UNGATED_ECHO_WINDOW_MS = 1_800;
+
+/**
  * Gap between writing the initialCommand text and the Enter (`\r`) that runs
  * it. The shell-ready marker fires from precmd, before the line editor reads
  * input — plugin init in that window can flush the PTY input queue, eating a
@@ -444,6 +474,11 @@ interface TerminalSession {
 	 * chunk so typeInitialCommandVerifyingEcho can see its text echo back.
 	 */
 	echoProbe: ((bytes: Uint8Array) => void) | null;
+	/**
+	 * Trailing bytes of the previous output chunk (up to 3), so a DSR cursor
+	 * query (`ESC[6n`) straddling a chunk boundary is still recognized.
+	 */
+	dsrCarry: Uint8Array;
 	initialCommandQueued: boolean;
 	/**
 	 * Basename of the launch shell. Picks the source keyword when a long
@@ -1060,6 +1095,64 @@ function readRetainedFrom(session: TerminalSession, from: number): Uint8Array {
  * counts toward `outputSeq` MUST flow through here and nowhere else, or
  * seq-aware clients drift out of sync.
  */
+/** ESC [ 6 n — DSR cursor position report request. */
+const DSR_CURSOR_QUERY = new Uint8Array([0x1b, 0x5b, 0x36, 0x6e]);
+
+/**
+ * Count DSR cursor queries in this chunk (joined with the previous chunk's
+ * tail so boundary-straddling sequences still match) and update the carry.
+ */
+function scanForDsrCursorQueries(
+	session: TerminalSession,
+	chunk: Uint8Array,
+): number {
+	const joined = new Uint8Array(session.dsrCarry.length + chunk.length);
+	joined.set(session.dsrCarry, 0);
+	joined.set(chunk, session.dsrCarry.length);
+	let count = 0;
+	// Start where a match could involve carried bytes; matches wholly inside
+	// the carry were already counted last chunk.
+	for (
+		let i = Math.max(
+			0,
+			session.dsrCarry.length - (DSR_CURSOR_QUERY.length - 1),
+		);
+		i + DSR_CURSOR_QUERY.length <= joined.length;
+		i++
+	) {
+		let matched = true;
+		for (let j = 0; j < DSR_CURSOR_QUERY.length; j++) {
+			if (joined[i + j] !== DSR_CURSOR_QUERY[j]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) count++;
+	}
+	session.dsrCarry = joined.slice(
+		Math.max(0, joined.length - (DSR_CURSOR_QUERY.length - 1)),
+	);
+	return count;
+}
+
+/**
+ * Answer a program's DSR cursor query when no renderer is attached to do it.
+ * reedline (nushell) asks `ESC[6n` after init and will not paint its prompt —
+ * or accept input — until the terminal answers; a preset launch into an
+ * unattached session therefore wedged forever (#6024). An attached renderer's
+ * xterm answers by itself (so we stay silent then, like tmux does for
+ * attached clients); for unattached sessions the mirrored headless screen is
+ * the truth and answers with the real cursor position.
+ */
+function answerDsrCursorQueries(session: TerminalSession, count: number) {
+	if (count === 0 || session.exited) return;
+	if (pruneAndCountOpenSockets(session) > 0) return;
+	const { x, y } = session.modeTracker.cursorPosition();
+	for (let i = 0; i < count; i++) {
+		session.pty.write(`\x1b[${y + 1};${x + 1}R`);
+	}
+}
+
 function deliverOutput(session: TerminalSession, bytes: Uint8Array) {
 	session.modeTracker.feed(bytes);
 	retainOutput(session, bytes);
@@ -1477,15 +1570,39 @@ function judgeCommandEcho(
 }
 
 /**
+ * The part of the echoed stream after the last full probe occurrence that the
+ * typed command itself cannot explain. The echo of a command longer than its
+ * probe legitimately continues past it, so the tail is only unexpected once
+ * it diverges from (or extends beyond) that remainder. Whitespace is ignored
+ * on both sides — editor repaints and line wraps shuffle it freely. A
+ * non-empty result after an intact echo is the reedline-flush signature: the
+ * kernel echoed the bytes at input time, the editor then finished starting
+ * up (painting a banner or prompt AFTER the echo) and flushed the typeahead,
+ * so the intact-looking command was never held by the line editor.
+ */
+function unexpectedEchoTail(tail: string, expectedRemainder: string): string {
+	const seen = tail.replace(/\s+/g, "");
+	const expected = expectedRemainder.replace(/\s+/g, "");
+	if (expected.startsWith(seen)) return "";
+	if (seen.startsWith(expected)) return seen.slice(expected.length);
+	return seen;
+}
+
+/**
  * Resolve true once `probe` echoes back intact and the stream then stays
  * quiet long enough for a mangle signature to have shown up; false on a
  * detected mangle or when the window closes without an intact echo.
+ * `expectedRemainder` (ungated launches) additionally fails the wait when
+ * output after an intact echo isn't the typed command's own continuation —
+ * the flush signature described at unexpectedEchoTail.
  */
 function waitForCommandEcho(
 	session: TerminalSession,
 	probe: string,
 	windowMs: number,
+	opts?: { quietMs?: number; expectedRemainder?: string },
 ): Promise<boolean> {
+	const quietMs = opts?.quietMs ?? GRACE_ECHO_QUIET_MS;
 	return new Promise((resolve) => {
 		let raw = "";
 		let quietTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1510,12 +1627,47 @@ function waitForCommandEcho(
 				clearTimeout(quietTimer);
 				quietTimer = null;
 			}
-			const verdict = judgeCommandEcho(stripEchoDecorations(raw), probe);
+			const cleaned = stripEchoDecorations(raw);
+			const verdict = judgeCommandEcho(cleaned, probe);
 			if (verdict === "mangled") {
 				finish(false);
 			} else if (verdict === "intact") {
-				quietTimer = setTimeout(() => finish(true), GRACE_ECHO_QUIET_MS);
+				if (opts?.expectedRemainder !== undefined) {
+					const tail = cleaned.slice(cleaned.lastIndexOf(probe) + probe.length);
+					if (unexpectedEchoTail(tail, opts.expectedRemainder) !== "") {
+						finish(false);
+						return;
+					}
+				}
+				quietTimer = setTimeout(() => finish(true), quietMs);
 			}
+		};
+	});
+}
+
+/**
+ * Resolve once the PTY stream has been silent for `quietMs` (capped at
+ * `capMs` so streaming startups can't park the launch). Uses the same
+ * single-slot echoProbe channel as waitForCommandEcho — the two never run
+ * concurrently for a session.
+ */
+function waitForOutputQuiescence(
+	session: TerminalSession,
+	quietMs: number,
+	capMs: number,
+): Promise<void> {
+	return new Promise((resolve) => {
+		const finish = () => {
+			session.echoProbe = null;
+			clearTimeout(quietTimer);
+			clearTimeout(capTimer);
+			resolve();
+		};
+		let quietTimer = setTimeout(finish, quietMs);
+		const capTimer = setTimeout(finish, capMs);
+		session.echoProbe = () => {
+			clearTimeout(quietTimer);
+			quietTimer = setTimeout(finish, quietMs);
 		};
 	});
 }
@@ -1538,22 +1690,124 @@ async function typeInitialCommandVerifyingEcho(
 	session: TerminalSession,
 	typedText: string,
 	probe: string,
-	scriptPath: string | null,
+	dropStagedFiles: () => void,
 	isDefunct: () => boolean,
 ): Promise<void> {
-	const dropStagedScript = () => {
-		// Enter never sent — the staged script won't run, so it can't self-delete.
-		if (scriptPath) void rm(scriptPath, { force: true }).catch(() => {});
-	};
 	for (let attempt = 0; attempt <= GRACE_ECHO_MAX_RETYPES; attempt++) {
-		if (isDefunct()) return dropStagedScript();
+		if (isDefunct()) return dropStagedFiles();
 		if (attempt > 0) session.pty.write("\x15");
 		session.pty.write(typedText);
 		if (await waitForCommandEcho(session, probe, GRACE_ECHO_WINDOW_MS)) break;
 	}
 	await new Promise((r) => setTimeout(r, INITIAL_COMMAND_ENTER_DELAY_MS));
-	if (isDefunct()) return dropStagedScript();
+	if (isDefunct()) return dropStagedFiles();
 	session.pty.write("\r");
+}
+
+/**
+ * Ungated typing (shellLaunchExpectsReadyMarker() false — unwrapped bash,
+ * sh/ksh, nushell): there is no marker and never will be, so before this the
+ * command was typed the instant the PTY opened. Two startup classes ate it:
+ * a profile `read` steals the leading byte(s) (#3941/#5712), and reedline
+ * (nushell) flushes ALL pending typeahead when it enables raw mode after
+ * init — the command vanishes with an intact-looking kernel echo (#6024).
+ *
+ * So: wait for the startup output to go quiet (a shell at prompt is quiet; a
+ * banner-printing one isn't), type, then verify the echo. Quiescence can't
+ * see a silent `read -t` window — the echo mangle signature catches that —
+ * and the echo can't distinguish kernel echo from editor echo — the
+ * unexpected-tail rule (output after the echo that isn't the command's own
+ * continuation) catches the flush class. Failures re-quiesce before the
+ * Ctrl-U retype so the retry lands on the now-live editor instead of inside
+ * the same init storm. The accept path requires a full Enter-delay of
+ * post-echo quiet, which already provides the text→Enter separation, so
+ * Enter goes out immediately on acceptance. After the retry budget the
+ * command falls back to a blind Enter, exactly like the gated paths.
+ */
+async function typeInitialCommandUngated(
+	session: TerminalSession,
+	typedText: string,
+	probe: string,
+	dropStagedFiles: () => void,
+	isDefunct: () => boolean,
+): Promise<void> {
+	const expectedRemainder = Buffer.from(typedText, "utf8")
+		.toString("latin1")
+		.slice(probe.length);
+	for (let attempt = 0; attempt <= GRACE_ECHO_MAX_RETYPES; attempt++) {
+		if (attempt > 0) session.pty.write("\x15");
+		await waitForOutputQuiescence(
+			session,
+			UNGATED_QUIESCENT_MS,
+			UNGATED_QUIESCENCE_CAP_MS,
+		);
+		if (isDefunct()) return dropStagedFiles();
+		session.pty.write(typedText);
+		const verified = await waitForCommandEcho(
+			session,
+			probe,
+			UNGATED_ECHO_WINDOW_MS,
+			{
+				quietMs: INITIAL_COMMAND_ENTER_DELAY_MS,
+				expectedRemainder,
+			},
+		);
+		if (verified) {
+			if (isDefunct()) return dropStagedFiles();
+			session.pty.write("\r");
+			return;
+		}
+	}
+	await new Promise((r) => setTimeout(r, INITIAL_COMMAND_ENTER_DELAY_MS));
+	if (isDefunct()) return dropStagedFiles();
+	session.pty.write("\r");
+}
+
+/**
+ * Rewrite a bash-only heredoc prompt transport for a fish launch shell. fish
+ * has no heredocs, so the shared "$(cat <<'SUPERSET_PROMPT_…')" transport
+ * dies at parse and the agent never starts (#4705). The prompt bytes go to a
+ * staged temp file (the `superset-launch-` prefix keeps it under the boot
+ * sweep's crash cleanup) and the typed command becomes the fish equivalent,
+ * which deletes the file as soon as it's consumed. POSIX shells keep today's
+ * heredoc byte-for-byte — this runs only when the launch shell is fish.
+ * Returns null (type the original text) for non-transport commands or when
+ * staging fails.
+ */
+function stageFishPromptTransport(
+	session: TerminalSession,
+	commandText: string,
+): { commandText: string; promptPath: string } | null {
+	const parsed = parsePromptHeredocCommand(commandText);
+	if (!parsed) return null;
+	const safeId = session.terminalId.replace(/[^\w-]/g, "_").slice(0, 60);
+	const promptPath = join(
+		tmpdir(),
+		`superset-launch-prompt-${safeId}-${randomBytes(4).toString("hex")}.txt`,
+	);
+	try {
+		// Trailing newline matches the heredoc body (`…\n` before the tag);
+		// both bash "$()" and fish `string collect` trim it back off.
+		writeFileSync(promptPath, `${parsed.prompt}\n`, {
+			mode: 0o600,
+			flag: "wx",
+		});
+	} catch (error) {
+		console.warn(
+			"[terminal] failed to stage fish prompt file; typing heredoc as-is",
+			{ terminalId: session.terminalId, error },
+		);
+		return null;
+	}
+	return {
+		commandText: buildFishPromptCommandString({
+			command: parsed.command,
+			suffix: parsed.suffix,
+			transport: parsed.transport,
+			promptFilePath: promptPath,
+		}),
+		promptPath,
+	};
 }
 
 function queueInitialCommand(
@@ -1578,19 +1832,37 @@ function queueInitialCommand(
 		sessions.get(session.terminalId) !== session;
 	void session.shellReadyPromise.then(() => {
 		if (isDefunct()) return;
+		const stagedPaths: string[] = [];
+		// Enter never sent — a staged script/prompt file won't run or be
+		// consumed, so it can't self-delete.
+		const dropStagedFiles = () => {
+			for (const staged of stagedPaths) {
+				void rm(staged, { force: true }).catch(() => {});
+			}
+		};
+		// fish can't parse the heredoc prompt transport — swap it for the
+		// staged-file equivalent before any typing decisions are made.
+		let effectiveCommand = commandText;
+		if (session.launchShellName === "fish") {
+			const fishStaged = stageFishPromptTransport(session, commandText);
+			if (fishStaged) {
+				effectiveCommand = fishStaged.commandText;
+				stagedPaths.push(fishStaged.promptPath);
+			}
+		}
 		// Even after the marker, the TTY is still in canonical mode (the marker
 		// fires from precmd, before the line editor takes over), so whatever we
 		// type here rides the kernel's MAX_CANON line limit. Long commands go
 		// to disk; only a short source line is typed.
-		let typedText = commandText;
-		let scriptPath: string | null = null;
+		let typedText = effectiveCommand;
 		if (
-			Buffer.byteLength(commandText, "utf8") > MAX_TYPED_INITIAL_COMMAND_BYTES
+			Buffer.byteLength(effectiveCommand, "utf8") >
+			MAX_TYPED_INITIAL_COMMAND_BYTES
 		) {
-			const staged = stageInitialCommandScript(session, commandText);
+			const staged = stageInitialCommandScript(session, effectiveCommand);
 			if (staged) {
 				typedText = staged.typedLine;
-				scriptPath = staged.scriptPath;
+				stagedPaths.push(staged.scriptPath);
 			}
 		}
 		// A grace-window timeout typed on learned evidence alone — no marker, no
@@ -1606,7 +1878,23 @@ function queueInitialCommand(
 					session,
 					typedText,
 					probe,
-					scriptPath,
+					dropStagedFiles,
+					isDefunct,
+				);
+				return;
+			}
+		}
+		// No marker was ever expected for this launch (unwrapped bash, sh/ksh,
+		// nushell): quiesce, type, and echo-verify instead of typing blind into
+		// whatever the startup is doing to stdin.
+		if (session.shellReadyState === "unsupported") {
+			const probe = commandEchoProbe(typedText);
+			if (probe) {
+				void typeInitialCommandUngated(
+					session,
+					typedText,
+					probe,
+					dropStagedFiles,
 					isDefunct,
 				);
 				return;
@@ -1623,9 +1911,7 @@ function queueInitialCommand(
 		session.pty.write(typedText);
 		setTimeout(() => {
 			if (isDefunct()) {
-				// Enter never sent — the staged script won't run, so it can't
-				// self-delete.
-				if (scriptPath) void rm(scriptPath, { force: true }).catch(() => {});
+				dropStagedFiles();
 				return;
 			}
 			session.pty.write("\r");
@@ -2190,6 +2476,7 @@ export async function createTerminalSessionInternal({
 		scanState: createScanState(),
 		usedMissingMarkerGrace: false,
 		echoProbe: null,
+		dsrCarry: new Uint8Array(0),
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
 		initialCommandQueued: isAdopted,
@@ -2265,7 +2552,11 @@ export async function createTerminalSessionInternal({
 				// — the chunk is still output and must refresh the idle clock.
 				portManager.checkOutputForHint(terminalId, hintText);
 
+				const dsrQueries = scanForDsrCursorQueries(session, bytes);
 				deliverOutput(session, bytes);
+				// After deliverOutput so the mirror has consumed this chunk and
+				// the reported cursor position is current.
+				answerDsrCursorQueries(session, dsrQueries);
 			},
 			onExit({ code, signal }) {
 				session.exited = true;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -44,6 +44,10 @@ import {
 } from "./env.ts";
 import { listTerminalResourceSessions } from "./resource-sessions.ts";
 import {
+	getShellReadyMarkerEvidence,
+	recordShellReadyMarkerEvidence,
+} from "./shell-ready-evidence.ts";
+import {
 	createModeTracker,
 	type ModeTracker,
 	type TerminalSnapshot,
@@ -295,6 +299,17 @@ type TerminalSocket = {
  * via direnv; same budget as the v1 stack.
  */
 const SHELL_READY_TIMEOUT_MS = 15_000;
+
+/**
+ * Wait budget when learned evidence says this machine's profile never
+ * delivers the marker (see shell-ready-evidence.ts): the full 15s wait would
+ * be the *normal* path there — every preset launch stalled exactly 15s
+ * (SUPER-1103). A short grace still covers the init window where startup
+ * hooks can read or flush PTY input, without pretending a marker is coming.
+ * A marker observed within this grace flips the evidence back to
+ * `delivered`, restoring the full wait for later launches.
+ */
+const SHELL_READY_MISSING_MARKER_GRACE_MS = 2_000;
 
 /**
  * Gap between writing the initialCommand text and the Enter (`\r`) that runs
@@ -1264,6 +1279,15 @@ function resolveShellReady(
 		session.scanState.matchPos = 0;
 		deliverOutput(session, heldBytes);
 	}
+	if (state === "ready") {
+		recordShellReadyMarkerEvidence(session.launchShellName, "delivered");
+	} else if (session.outputSeq > 0) {
+		// The shell painted output but the marker never came — this machine's
+		// profile diverts it (exec tmux/another shell, cleared precmd hooks).
+		// Zero output means the shell may not have started at all (wedged
+		// daemon); that says nothing about the profile, so record nothing.
+		recordShellReadyMarkerEvidence(session.launchShellName, "missing");
+	}
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
 		session.shellReadyResolve = null;
@@ -1981,9 +2005,15 @@ export async function createTerminalSessionInternal({
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
 
 	if (session.shellReadyState === "pending") {
+		// Size the wait to observed reality: on machines whose profile never
+		// delivers the marker, the full wait *is* the launch latency.
+		const readyWaitMs =
+			getShellReadyMarkerEvidence(session.launchShellName) === "missing"
+				? SHELL_READY_MISSING_MARKER_GRACE_MS
+				: SHELL_READY_TIMEOUT_MS;
 		session.shellReadyTimeoutId = setTimeout(() => {
 			resolveShellReady(session, "timed_out");
-		}, SHELL_READY_TIMEOUT_MS);
+		}, readyWaitMs);
 	}
 
 	session.unsubscribeDaemon = daemon.subscribe(

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -8,6 +8,7 @@ import type { NodeWebSocket } from "@hono/node-ws";
 import { hasRunningForegroundProcess } from "@superset/pty-daemon/process-tree";
 import {
 	buildFishPromptCommandString,
+	type ParsedPromptHeredocCommand,
 	parsePromptHeredocCommand,
 } from "@superset/shared/agent-prompt-launch";
 import {
@@ -316,6 +317,17 @@ const SHELL_READY_TIMEOUT_MS = 15_000;
 const SHELL_READY_MISSING_MARKER_GRACE_MS = 2_000;
 
 /**
+ * How long after creation a session whose marker wait timed out keeps
+ * watching the stream for a late OSC 133;A. A marker that lands after the
+ * grace window (a slow-init profile branded `missing`) is still proof this
+ * profile delivers — record it so the evidence self-heals in both directions
+ * instead of `missing` being a one-way brand. Evidence-only: nothing is
+ * withheld from the output stream. Bounded to the full marker budget so the
+ * scan can't run for the session's whole life.
+ */
+const LATE_MARKER_OBSERVATION_MS = SHELL_READY_TIMEOUT_MS;
+
+/**
  * How long a grace-window launch watches the PTY stream for its own command
  * echoing back before concluding a startup stdin reader ate it. The grace
  * fires on learned evidence, not an observed prompt, so an oh-my-zsh-style
@@ -469,6 +481,11 @@ interface TerminalSession {
 	 * still be consuming stdin, so that path must echo-verify what it typed.
 	 */
 	usedMissingMarkerGrace: boolean;
+	/**
+	 * True once a post-timeout OSC 133;A was seen and recorded as `delivered`
+	 * evidence, ending the late-marker scan for this session.
+	 */
+	lateMarkerRecorded: boolean;
 	/**
 	 * Active echo watcher for a grace-window initialCommand: fed every output
 	 * chunk so typeInitialCommandVerifyingEcho can see its text echo back.
@@ -1673,6 +1690,22 @@ function waitForOutputQuiescence(
 }
 
 /**
+ * Deferred launch typing races session teardown: the daemon socket can drop
+ * before `isDefunct()` (registry/exited checks) observes the disposal, so a
+ * write can throw "socket not connected" from inside a floating promise or
+ * timer. A failed write means the session is gone — treat it as defunct and
+ * abort the launch quietly.
+ */
+function tryTypeToPty(session: TerminalSession, data: string): boolean {
+	try {
+		session.pty.write(data);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Grace-window typing (learned `missing` evidence, no observed prompt): a
  * startup stdin reader can still be consuming the TTY when the grace fires —
  * the oh-my-zsh-updater `read` of #3941 on a profile that also never delivers
@@ -1695,13 +1728,15 @@ async function typeInitialCommandVerifyingEcho(
 ): Promise<void> {
 	for (let attempt = 0; attempt <= GRACE_ECHO_MAX_RETYPES; attempt++) {
 		if (isDefunct()) return dropStagedFiles();
-		if (attempt > 0) session.pty.write("\x15");
-		session.pty.write(typedText);
+		if (attempt > 0 && !tryTypeToPty(session, "\x15")) {
+			return dropStagedFiles();
+		}
+		if (!tryTypeToPty(session, typedText)) return dropStagedFiles();
 		if (await waitForCommandEcho(session, probe, GRACE_ECHO_WINDOW_MS)) break;
 	}
 	await new Promise((r) => setTimeout(r, INITIAL_COMMAND_ENTER_DELAY_MS));
 	if (isDefunct()) return dropStagedFiles();
-	session.pty.write("\r");
+	if (!tryTypeToPty(session, "\r")) dropStagedFiles();
 }
 
 /**
@@ -1723,26 +1758,38 @@ async function typeInitialCommandVerifyingEcho(
  * post-echo quiet, which already provides the text→Enter separation, so
  * Enter goes out immediately on acceptance. After the retry budget the
  * command falls back to a blind Enter, exactly like the gated paths.
+ *
+ * A null `probe` (command too short or non-ASCII start — commandEchoProbe)
+ * only disables the echo verification: the quiescence wait still applies, so
+ * short commands like `ls` don't regress into the blind-write reedline-flush
+ * loss (#6024). Those launches type once and send the delayed Enter.
  */
 async function typeInitialCommandUngated(
 	session: TerminalSession,
 	typedText: string,
-	probe: string,
+	probe: string | null,
 	dropStagedFiles: () => void,
 	isDefunct: () => boolean,
 ): Promise<void> {
-	const expectedRemainder = Buffer.from(typedText, "utf8")
-		.toString("latin1")
-		.slice(probe.length);
-	for (let attempt = 0; attempt <= GRACE_ECHO_MAX_RETYPES; attempt++) {
-		if (attempt > 0) session.pty.write("\x15");
+	const expectedRemainder = probe
+		? Buffer.from(typedText, "utf8").toString("latin1").slice(probe.length)
+		: "";
+	const maxRetypes = probe ? GRACE_ECHO_MAX_RETYPES : 0;
+	for (let attempt = 0; attempt <= maxRetypes; attempt++) {
 		await waitForOutputQuiescence(
 			session,
 			UNGATED_QUIESCENT_MS,
 			UNGATED_QUIESCENCE_CAP_MS,
 		);
 		if (isDefunct()) return dropStagedFiles();
-		session.pty.write(typedText);
+		// Ctrl-U after the re-quiesce, not before it — sent earlier, the same
+		// startup reader that ate the command swallows the kill char too and
+		// the retype appends to the leftover line.
+		if (attempt > 0 && !tryTypeToPty(session, "\x15")) {
+			return dropStagedFiles();
+		}
+		if (!tryTypeToPty(session, typedText)) return dropStagedFiles();
+		if (!probe) break;
 		const verified = await waitForCommandEcho(
 			session,
 			probe,
@@ -1754,13 +1801,13 @@ async function typeInitialCommandUngated(
 		);
 		if (verified) {
 			if (isDefunct()) return dropStagedFiles();
-			session.pty.write("\r");
+			if (!tryTypeToPty(session, "\r")) dropStagedFiles();
 			return;
 		}
 	}
 	await new Promise((r) => setTimeout(r, INITIAL_COMMAND_ENTER_DELAY_MS));
 	if (isDefunct()) return dropStagedFiles();
-	session.pty.write("\r");
+	if (!tryTypeToPty(session, "\r")) dropStagedFiles();
 }
 
 /**
@@ -1771,15 +1818,14 @@ async function typeInitialCommandUngated(
  * sweep's crash cleanup) and the typed command becomes the fish equivalent,
  * which deletes the file as soon as it's consumed. POSIX shells keep today's
  * heredoc byte-for-byte — this runs only when the launch shell is fish.
- * Returns null (type the original text) for non-transport commands or when
- * staging fails.
+ * Returns null when staging fails; the caller must NOT fall back to typing
+ * the heredoc (fish dies parsing it — the very failure this rewrite exists
+ * to prevent) and surfaces a launch error instead.
  */
 function stageFishPromptTransport(
 	session: TerminalSession,
-	commandText: string,
+	parsed: ParsedPromptHeredocCommand,
 ): { commandText: string; promptPath: string } | null {
-	const parsed = parsePromptHeredocCommand(commandText);
-	if (!parsed) return null;
 	const safeId = session.terminalId.replace(/[^\w-]/g, "_").slice(0, 60);
 	const promptPath = join(
 		tmpdir(),
@@ -1793,8 +1839,8 @@ function stageFishPromptTransport(
 			flag: "wx",
 		});
 	} catch (error) {
-		console.warn(
-			"[terminal] failed to stage fish prompt file; typing heredoc as-is",
+		console.error(
+			"[terminal] failed to stage fish prompt file; aborting agent launch",
 			{ terminalId: session.terminalId, error },
 		);
 		return null;
@@ -1809,6 +1855,12 @@ function stageFishPromptTransport(
 		promptPath,
 	};
 }
+
+// Shown in the terminal when a fish prompt launch can't be staged — the
+// alternative (typing the bash heredoc into fish) is guaranteed garbage.
+const FISH_PROMPT_STAGE_FAILED_NOTICE = new TextEncoder().encode(
+	"\r\n\x1b[31m[superset] Failed to stage the agent prompt for fish — the agent was not started. Retry the launch; see host-service logs for the cause.\x1b[0m\r\n",
+);
 
 function queueInitialCommand(
 	session: TerminalSession,
@@ -1841,11 +1893,18 @@ function queueInitialCommand(
 			}
 		};
 		// fish can't parse the heredoc prompt transport — swap it for the
-		// staged-file equivalent before any typing decisions are made.
+		// staged-file equivalent before any typing decisions are made. When
+		// staging fails there is no fish-parseable fallback; typing the bash
+		// heredoc guarantees a parse error, so surface the failure and stop.
 		let effectiveCommand = commandText;
 		if (session.launchShellName === "fish") {
-			const fishStaged = stageFishPromptTransport(session, commandText);
-			if (fishStaged) {
+			const parsedTransport = parsePromptHeredocCommand(commandText);
+			if (parsedTransport) {
+				const fishStaged = stageFishPromptTransport(session, parsedTransport);
+				if (!fishStaged) {
+					deliverOutput(session, FISH_PROMPT_STAGE_FAILED_NOTICE);
+					return;
+				}
 				effectiveCommand = fishStaged.commandText;
 				stagedPaths.push(fishStaged.promptPath);
 			}
@@ -1886,19 +1945,17 @@ function queueInitialCommand(
 		}
 		// No marker was ever expected for this launch (unwrapped bash, sh/ksh,
 		// nushell): quiesce, type, and echo-verify instead of typing blind into
-		// whatever the startup is doing to stdin.
+		// whatever the startup is doing to stdin. A null probe only skips the
+		// echo verification — the quiescence wait still applies.
 		if (session.shellReadyState === "unsupported") {
-			const probe = commandEchoProbe(typedText);
-			if (probe) {
-				void typeInitialCommandUngated(
-					session,
-					typedText,
-					probe,
-					dropStagedFiles,
-					isDefunct,
-				);
-				return;
-			}
+			void typeInitialCommandUngated(
+				session,
+				typedText,
+				commandEchoProbe(typedText),
+				dropStagedFiles,
+				isDefunct,
+			);
+			return;
 		}
 		// The OSC 133;A marker fires from precmd, which runs BEFORE the line
 		// editor starts reading input. Plugin init in that gap (vi-mode,
@@ -1908,13 +1965,14 @@ function queueInitialCommand(
 		// write — and as `\r`, what a real Enter key sends, bound to accept-line
 		// in every keymap — so it lands after the init storm. One Enter total,
 		// so a double-run is impossible.
-		session.pty.write(typedText);
+		if (!tryTypeToPty(session, typedText)) {
+			dropStagedFiles();
+			return;
+		}
 		setTimeout(() => {
-			if (isDefunct()) {
+			if (isDefunct() || !tryTypeToPty(session, "\r")) {
 				dropStagedFiles();
-				return;
 			}
-			session.pty.write("\r");
 		}, INITIAL_COMMAND_ENTER_DELAY_MS);
 	});
 }
@@ -2475,6 +2533,7 @@ export async function createTerminalSessionInternal({
 		shellReadyTimeoutId: null,
 		scanState: createScanState(),
 		usedMissingMarkerGrace: false,
+		lateMarkerRecorded: false,
 		echoProbe: null,
 		dsrCarry: new Uint8Array(0),
 		// Adopted sessions have already run their initialCommand in the prior
@@ -2533,6 +2592,22 @@ export async function createTerminalSessionInternal({
 					bytes = result.output;
 					if (result.matched) {
 						resolveShellReady(session, "ready");
+					}
+				} else if (
+					session.shellReadyState === "timed_out" &&
+					!session.lateMarkerRecorded &&
+					Date.now() - session.createdAt < LATE_MARKER_OBSERVATION_MS
+				) {
+					// Evidence-only scan for a marker arriving after the (grace)
+					// timeout — output passes through untouched; a match flips a
+					// `missing` brand back to `delivered` (self-healing evidence).
+					const result = scanForShellReady(session.scanState, chunk);
+					if (result.matched) {
+						session.lateMarkerRecorded = true;
+						recordShellReadyMarkerEvidence(
+							session.launchShellName,
+							"delivered",
+						);
 					}
 				}
 				if (bytes.byteLength === 0) return;

--- a/packages/host-service/src/terminal/terminal.ungated-launch.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.ungated-launch.node-test.ts
@@ -1,0 +1,222 @@
+// End-to-end tests for ungated initialCommand protection: launches whose
+// shell configuration never installs the OSC 133;A marker (unwrapped bash
+// falling back to `-l`, sh/ksh, nushell) used to type the command the instant
+// the PTY opened. Two startup classes ate it: a profile `read` steals the
+// leading byte(s) so `date` runs as `ate` (#3941/#5712 for bash users), and
+// reedline-style editors flush ALL pending typeahead when they enable raw
+// mode after init, so the command vanishes behind an intact-looking kernel
+// echo (#6024). reedline also blocks on a DSR cursor query (`ESC[6n`) that
+// nothing answers when no renderer is attached.
+//
+// Same harness as terminal.initial-command.node-test.ts (real pty-daemon
+// Server, real SQLite host DB) with real /bin/bash and NO wrapper rcfile, so
+// shellLaunchExpectsReadyMarker() returns false and the ungated path is
+// exercised for real.
+//
+//   node --experimental-strip-types --test <file>
+
+import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { Server } from "@superset/pty-daemon";
+import { createDb, type HostDb } from "../db/index.ts";
+import { projects, workspaces } from "../db/schema.ts";
+import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import { initTerminalBaseEnv } from "./env.ts";
+import { shellLaunchExpectsReadyMarker } from "./shell-launch.ts";
+import {
+	__resetSessionsForTesting,
+	createTerminalSessionInternal,
+	disposeSessionAndWait,
+} from "./terminal.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HOME = path.join(os.tmpdir(), `host-svc-ungated-${process.pid}`);
+const SOCK = path.join(os.tmpdir(), `host-svc-ungated-${process.pid}.sock`);
+const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
+const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
+
+let server: Server;
+let db: HostDb;
+let workspaceId: string;
+
+async function launchAndMeasure(
+	command: string,
+): Promise<{ elapsed: number; body: string }> {
+	const terminalId = `e2e-ungated-${randomUUID().slice(0, 8)}`;
+	const outFile = path.join(TEST_HOME, `out-${terminalId}`);
+	const start = Date.now();
+	const session = await createTerminalSessionInternal({
+		terminalId,
+		workspaceId,
+		db,
+		listed: true,
+		initialCommand: `${command} > "${outFile}"`,
+	});
+	assert.ok(!("error" in session), "error" in session ? session.error : "");
+	await waitFor(() => fs.existsSync(outFile), 25_000);
+	const elapsed = Date.now() - start;
+	// Small settle so the redirect finishes writing before we read it back.
+	await new Promise((r) => setTimeout(r, 150));
+	const body = fs.readFileSync(outFile, "utf8").trim();
+	await disposeSessionAndWait(terminalId, db);
+	return { elapsed, body };
+}
+
+before(async () => {
+	fs.mkdirSync(TEST_HOME, { recursive: true });
+	fs.mkdirSync(FAKE_USER_HOME, { recursive: true });
+	const worktreePath = path.join(TEST_HOME, "worktree");
+	fs.mkdirSync(worktreePath, { recursive: true });
+
+	server = new Server({
+		socketPath: SOCK,
+		daemonVersion: "0.0.0-ungated-e2e",
+	});
+	await server.listen();
+
+	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
+	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	process.env.HOST_SERVICE_VERSION = "0.0.0-ungated-e2e";
+	process.env.NODE_ENV = "development";
+
+	__setAccountShellForTesting("/bin/bash");
+	initTerminalBaseEnv({
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: FAKE_USER_HOME,
+		SHELL: "/bin/bash",
+	});
+
+	db = createDb(path.join(TEST_HOME, "host.db"), MIGRATIONS);
+
+	const projectId = randomUUID();
+	workspaceId = randomUUID();
+	db.insert(projects).values({ id: projectId, repoPath: worktreePath }).run();
+	db.insert(workspaces)
+		.values({
+			id: workspaceId,
+			projectId,
+			worktreePath,
+			branch: "main",
+		})
+		.run();
+});
+
+after(async () => {
+	__resetSessionsForTesting();
+	__setAccountShellForTesting(undefined);
+	await disposeDaemonClient();
+	await server.close();
+	try {
+		fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+describe("ungated launch protection", () => {
+	test(
+		"startup stdin eater: the command survives via echo-verified retype",
+		{ timeout: 60_000 },
+		async () => {
+			// No wrapper rcfile on disk — the launch falls back to `bash -l` and
+			// no marker will ever arrive.
+			assert.equal(
+				shellLaunchExpectsReadyMarker({
+					shell: "/bin/bash",
+					supersetHomeDir: TEST_HOME,
+				}),
+				false,
+				"bash without a wrapper rcfile must be ungated",
+			);
+
+			// The #3941/#5712 class: a login-profile `read` is consuming the TTY
+			// during startup. Typed-blind launches lose their first byte to it.
+			fs.writeFileSync(
+				path.join(FAKE_USER_HOME, ".bash_profile"),
+				"read -t 2 -n 1 _j || true\n",
+			);
+			try {
+				for (let i = 1; i <= 2; i++) {
+					const { elapsed, body } = await launchAndMeasure("date +%s");
+					assert.match(
+						body,
+						/^\d{10}$/,
+						`launch ${i} produced ${JSON.stringify(body)} — the startup read ate the command`,
+					);
+					assert.ok(
+						elapsed < 10_000,
+						`launch ${i} took ${elapsed}ms — expected well under 10s`,
+					);
+				}
+			} finally {
+				fs.rmSync(path.join(FAKE_USER_HOME, ".bash_profile"), {
+					force: true,
+				});
+			}
+		},
+	);
+
+	test(
+		"clean ungated launch waits for quiescence and lands intact",
+		{ timeout: 30_000 },
+		async () => {
+			const { elapsed, body } = await launchAndMeasure("date +%s");
+			assert.match(body, /^\d{10}$/);
+			assert.ok(elapsed < 10_000, `clean launch took ${elapsed}ms`);
+		},
+	);
+
+	test(
+		"unattached session answers a DSR cursor query (reedline init gate)",
+		{ timeout: 30_000 },
+		async () => {
+			// Stand-in for nushell's reedline: emit ESC[6n and refuse to start
+			// the line editor until the terminal answers. With no renderer
+			// attached, only the host can answer — without that, this shell
+			// never reaches a prompt and the launch is lost.
+			const replyFile = path.join(TEST_HOME, `dsr-reply-${process.pid}`);
+			const fakeShell = path.join(TEST_HOME, "reedline-like");
+			fs.writeFileSync(
+				fakeShell,
+				[
+					"#!/bin/bash",
+					"printf 'starting up\\n'",
+					"printf '\\033[6n'",
+					"IFS='' read -r -d 'R' -t 5 _reply || true",
+					`printf '%s' "$_reply" > "${replyFile}"`,
+					"exec /bin/bash --noprofile --norc -i",
+					"",
+				].join("\n"),
+				{ mode: 0o755 },
+			);
+			__setAccountShellForTesting(fakeShell);
+			try {
+				const { body } = await launchAndMeasure("date +%s");
+				assert.match(body, /^\d{10}$/);
+				const reply = fs.readFileSync(replyFile, "utf8");
+				assert.match(
+					reply,
+					// biome-ignore lint/suspicious/noControlCharactersInRegex: asserting the raw DSR reply bytes
+					/^\x1b\[\d+;\d+$/,
+					`expected a cursor position report, got ${JSON.stringify(reply)}`,
+				);
+			} finally {
+				__setAccountShellForTesting("/bin/bash");
+			}
+		},
+	);
+});
+
+async function waitFor(predicate: () => boolean, ms: number): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > ms) throw new Error("waitFor timed out");
+		await new Promise((r) => setTimeout(r, 25));
+	}
+}

--- a/packages/host-service/src/terminal/terminal.ungated-launch.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.ungated-launch.node-test.ts
@@ -41,6 +41,16 @@ const SOCK = path.join(os.tmpdir(), `host-svc-ungated-${process.pid}.sock`);
 const MIGRATIONS = path.resolve(__dirname, "../../drizzle");
 const FAKE_USER_HOME = path.join(TEST_HOME, "user-home");
 
+// The harness overwrites process-wide env; restore whatever was there so this
+// suite composes with others in the same node --test invocation.
+const OVERRIDDEN_ENV_KEYS = [
+	"SUPERSET_PTY_DAEMON_SOCKET",
+	"SUPERSET_HOME_DIR",
+	"HOST_SERVICE_VERSION",
+	"NODE_ENV",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
 let server: Server;
 let db: HostDb;
 let workspaceId: string;
@@ -59,13 +69,15 @@ async function launchAndMeasure(
 		initialCommand: `${command} > "${outFile}"`,
 	});
 	assert.ok(!("error" in session), "error" in session ? session.error : "");
-	await waitFor(() => fs.existsSync(outFile), 25_000);
-	const elapsed = Date.now() - start;
-	// Small settle so the redirect finishes writing before we read it back.
-	await new Promise((r) => setTimeout(r, 150));
-	const body = fs.readFileSync(outFile, "utf8").trim();
-	await disposeSessionAndWait(terminalId, db);
-	return { elapsed, body };
+	try {
+		await waitFor(() => fs.existsSync(outFile), 25_000);
+		const elapsed = Date.now() - start;
+		// Small settle so the redirect finishes writing before we read it back.
+		await new Promise((r) => setTimeout(r, 150));
+		return { elapsed, body: fs.readFileSync(outFile, "utf8").trim() };
+	} finally {
+		await disposeSessionAndWait(terminalId, db);
+	}
 }
 
 before(async () => {
@@ -80,6 +92,7 @@ before(async () => {
 	});
 	await server.listen();
 
+	for (const key of OVERRIDDEN_ENV_KEYS) savedEnv.set(key, process.env[key]);
 	process.env.SUPERSET_PTY_DAEMON_SOCKET = SOCK;
 	process.env.SUPERSET_HOME_DIR = TEST_HOME;
 	process.env.HOST_SERVICE_VERSION = "0.0.0-ungated-e2e";
@@ -112,6 +125,10 @@ after(async () => {
 	__setAccountShellForTesting(undefined);
 	await disposeDaemonClient();
 	await server.close();
+	for (const [key, value] of savedEnv) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
 	try {
 		fs.rmSync(TEST_HOME, { recursive: true, force: true });
 	} catch {

--- a/packages/host-service/test/integration/setup-scripts.integration.test.ts
+++ b/packages/host-service/test/integration/setup-scripts.integration.test.ts
@@ -33,6 +33,9 @@ describe("setup scripts integration", () => {
 		}
 	});
 
+	// The ungated typing path adds deliberate delay (quiescence wait + echo
+	// verification) before the command and its Enter land — give the test
+	// headroom beyond bun's 5s default.
 	test("v2 settings config is the same config used by workspace setup terminals", async () => {
 		const scenario = await createProjectScenario({
 			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
@@ -151,10 +154,11 @@ describe("setup scripts integration", () => {
 		expect(setupTerminal.meta.env?.SUPERSET_ROOT_PATH).toBe(
 			scenario.repo.repoPath,
 		);
-	});
+	}, 20_000);
 });
 
 function createFakePty(pid: number, writes: string[]) {
+	const dataCallbacks: Array<(data: Buffer) => void> = [];
 	const exitCallbacks: Array<
 		(info: { code: number | null; signal: number | null }) => void
 	> = [];
@@ -162,9 +166,16 @@ function createFakePty(pid: number, writes: string[]) {
 	return {
 		pid,
 		write(data: string | Uint8Array) {
-			writes.push(
-				typeof data === "string" ? data : Buffer.from(data).toString("utf-8"),
-			);
+			const text =
+				typeof data === "string" ? data : Buffer.from(data).toString("utf-8");
+			writes.push(text);
+			// Simulate the kernel's canonical-mode echo: an ungated (`/bin/sh`)
+			// launch verifies its typed command by watching for this echo and
+			// would otherwise burn its whole retype budget against silence.
+			const echoed = Buffer.from(text, "utf-8");
+			queueMicrotask(() => {
+				for (const callback of dataCallbacks) callback(echoed);
+			});
 		},
 		resize() {},
 		kill() {
@@ -172,7 +183,9 @@ function createFakePty(pid: number, writes: string[]) {
 				callback({ code: null, signal: null });
 			}
 		},
-		onData() {},
+		onData(callback: (data: Buffer) => void) {
+			dataCallbacks.push(callback);
+		},
 		onExit(
 			callback: (info: { code: number | null; signal: number | null }) => void,
 		) {

--- a/packages/shared/src/agent-prompt-launch.test.ts
+++ b/packages/shared/src/agent-prompt-launch.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
+	buildFishPromptCommandString,
 	buildPromptCommandString,
+	parsePromptHeredocCommand,
 	sanitizePromptForPty,
 } from "./agent-prompt-launch";
 
@@ -67,6 +69,99 @@ describe("buildPromptCommandString", () => {
 
 		expect(command).toBe(
 			"amp <<'SUPERSET_PROMPT_1234_X'\nSUPERSET_PROMPT_1234\nrm -rf /\nSUPERSET_PROMPT_1234_X",
+		);
+	});
+});
+
+describe("parsePromptHeredocCommand", () => {
+	const trickyPrompt = "line 'one'\n$HOME `pwd` \"two\"\n\nlast";
+
+	it("round-trips the argv transport, prompt bytes exact", () => {
+		const built = buildPromptCommandString({
+			command: "claude --model opus",
+			suffix: "--verbose",
+			transport: "argv",
+			prompt: trickyPrompt,
+			randomId: "abc123",
+		});
+		expect(parsePromptHeredocCommand(built)).toEqual({
+			transport: "argv",
+			command: "claude --model opus",
+			prompt: trickyPrompt,
+			suffix: "--verbose",
+		});
+	});
+
+	it("round-trips the argv transport without a suffix", () => {
+		const built = buildPromptCommandString({
+			command: "claude",
+			transport: "argv",
+			prompt: trickyPrompt,
+			randomId: "abc123",
+		});
+		expect(parsePromptHeredocCommand(built)).toEqual({
+			transport: "argv",
+			command: "claude",
+			prompt: trickyPrompt,
+			suffix: undefined,
+		});
+	});
+
+	it("round-trips the stdin transport", () => {
+		const built = buildPromptCommandString({
+			command: "amp",
+			suffix: "--dangerous",
+			transport: "stdin",
+			prompt: trickyPrompt,
+			randomId: "abc123",
+		});
+		expect(parsePromptHeredocCommand(built)).toEqual({
+			transport: "stdin",
+			command: "amp --dangerous",
+			prompt: trickyPrompt,
+		});
+	});
+
+	it("round-trips a collision-extended delimiter (_X runs)", () => {
+		const prompt = "SUPERSET_PROMPT_1234\nbody";
+		const built = buildPromptCommandString({
+			command: "amp",
+			transport: "stdin",
+			prompt,
+			randomId: "1234",
+		});
+		expect(parsePromptHeredocCommand(built)?.prompt).toBe(prompt);
+	});
+
+	it("returns null for plain commands and foreign heredocs", () => {
+		expect(parsePromptHeredocCommand("claude --resume abc")).toBeNull();
+		expect(parsePromptHeredocCommand("cat <<'EOF'\nhello\nEOF")).toBeNull();
+	});
+});
+
+describe("buildFishPromptCommandString", () => {
+	it("argv transport reads the staged file via string collect and self-deletes", () => {
+		expect(
+			buildFishPromptCommandString({
+				command: "claude",
+				suffix: "--verbose",
+				transport: "argv",
+				promptFilePath: "/tmp/superset-launch-prompt-x.txt",
+			}),
+		).toBe(
+			"claude (begin; cat '/tmp/superset-launch-prompt-x.txt'; command rm -f -- '/tmp/superset-launch-prompt-x.txt'; end | string collect --allow-empty) --verbose",
+		);
+	});
+
+	it("stdin transport redirects the staged file and unlinks it after open", () => {
+		expect(
+			buildFishPromptCommandString({
+				command: "amp --dangerous",
+				transport: "stdin",
+				promptFilePath: "/tmp/p.txt",
+			}),
+		).toBe(
+			"begin; command rm -f -- '/tmp/p.txt'; amp --dangerous; end < '/tmp/p.txt'",
 		);
 	});
 });

--- a/packages/shared/src/agent-prompt-launch.ts
+++ b/packages/shared/src/agent-prompt-launch.ts
@@ -83,6 +83,86 @@ export function buildPromptCommandString({
 	return `${command} "$(cat <<'${delimiter}'\n${prompt}\n${delimiter}\n)"${suffix ? ` ${suffix}` : ""}`;
 }
 
+/**
+ * Parsed shape of a heredoc prompt command produced by
+ * buildPromptCommandString. Both heredoc forms are bash/zsh-only — fish has
+ * no heredocs, so typing one into a fish session dies at parse ("Expected a
+ * string, but found a redirection", #4705). The host rewrites such commands
+ * at launch time when the shell is fish; the parser lives next to the builder
+ * so the two can't drift apart.
+ */
+export interface ParsedPromptHeredocCommand {
+	transport: PromptTransport;
+	/** For argv: the program + args before the payload. For stdin: the full command. */
+	command: string;
+	/** Exact prompt bytes carried by the heredoc body. */
+	prompt: string;
+	/** argv-transport trailing suffix (without its leading space), or undefined. */
+	suffix?: string;
+}
+
+// The delimiter is SUPERSET_PROMPT_<hex uuid> plus optional _X de-collision
+// runs — never present in the prompt body (resolveDelimiter guarantees it),
+// so the backreference match is unambiguous.
+const ARGV_HEREDOC_PATTERN =
+	/^([\s\S]+?) "\$\(cat <<'(SUPERSET_PROMPT_[A-Za-z0-9_]+)'\n([\s\S]*)\n\2\n\)"([^\n]*)$/;
+const STDIN_HEREDOC_PATTERN =
+	/^([\s\S]+?) <<'(SUPERSET_PROMPT_[A-Za-z0-9_]+)'\n([\s\S]*)\n\2$/;
+
+export function parsePromptHeredocCommand(
+	commandText: string,
+): ParsedPromptHeredocCommand | null {
+	const argv = ARGV_HEREDOC_PATTERN.exec(commandText);
+	if (argv) {
+		const [, command, , prompt, rawSuffix] = argv;
+		if (command === undefined || prompt === undefined) return null;
+		const suffix = rawSuffix?.replace(/^ /, "");
+		return {
+			transport: "argv",
+			command,
+			prompt,
+			suffix: suffix || undefined,
+		};
+	}
+	const stdin = STDIN_HEREDOC_PATTERN.exec(commandText);
+	if (stdin) {
+		const [, command, , prompt] = stdin;
+		if (command === undefined || prompt === undefined) return null;
+		return { transport: "stdin", command, prompt };
+	}
+	return null;
+}
+
+/**
+ * fish equivalent of buildPromptCommandString for a prompt already staged to
+ * disk. `(cat file | string collect)` is fish's documented way to read a file
+ * into a single argument with internal newlines preserved; like bash's
+ * `"$()"`, trailing newlines are trimmed, and --allow-empty keeps the arity
+ * identical (one argument even when the file is empty). Each form deletes the
+ * staged file the moment it has been read (argv) or opened (stdin — the
+ * begin-block redirection opens the fd before the rm runs, plain unix
+ * unlink semantics), so the prompt bytes never outlive the launch.
+ * promptFilePath must not contain backslashes (fish single-quote escaping
+ * differs from POSIX there); staged tmp-dir paths satisfy this.
+ */
+export function buildFishPromptCommandString({
+	command,
+	suffix,
+	transport,
+	promptFilePath,
+}: {
+	command: string;
+	suffix?: string;
+	transport: PromptTransport;
+	promptFilePath: string;
+}): string {
+	const quotedPath = quoteSingleShell(promptFilePath);
+	if (transport === "stdin") {
+		return `begin; command rm -f -- ${quotedPath}; ${joinCommand(command, suffix)}; end < ${quotedPath}`;
+	}
+	return `${command} (begin; cat ${quotedPath}; command rm -f -- ${quotedPath}; end | string collect --allow-empty)${suffix ? ` ${suffix}` : ""}`;
+}
+
 export function buildPromptFileCommandString({
 	command,
 	suffix,


### PR DESCRIPTION
## Problem

Clicking an agent preset (or running a workspace setup command) types the command into a fresh shell session. Three distinct failure mechanisms existed depending on the user's shell setup:

1. **15s stall on every launch** (SUPER-1103): the launch gate waits for the OSC 133;A prompt marker, but profiles that `exec` tmux or another shell from `.zshrc` prevent the marker from ever reaching the PTY stream — so the 15s fallback timeout was the *normal* path, every single click. Diagnosed live on a customer call (Nourish, Aug 11).
2. **First character eaten** (#3941, #5712): startup stdin readers (oh-my-zsh update prompt) consume early typed bytes — `claude` becomes `laude`.
3. **Command silently discarded**: ungated shells (bash without wrapper rcfile, nushell #6024) type immediately; nushell's reedline flushes queued typeahead on raw-mode init, dropping the command entirely — even on clean configs. fish never got that far: the prompt transport's bash heredoc is a parse error in fish (#4705).

## Fix (three commits)

- **`e74599c` — learned shell-ready evidence**: host-service records what the marker scanner actually observed per shell. First timed-out launch brands the shell `missing`; later launches use a ~2s grace instead of 15s; an observed marker flips it back to `delivered`. Self-healing both directions.
- **`67a51a7` — echo-verified grace launches**: grace-window typing is verified against the PTY stream using the mangle signature (a stolen-prefix re-echo after the intact kernel echo — plain echo matching is fooled by kernel echo during raw-mode reads). On corruption: Ctrl-U, retype, up to 2 retries, then fall back to the old blind path.
- **`77b14cf` — universal ungated protection + fish transport**: ungated launches now wait for output quiescence, type, then echo-verify (including reedline-flush detection and headless DSR answering for nushell). The agent prompt transport is shell-aware: fish gets a staged-file transport instead of heredocs, byte-identical behavior preserved for bash/zsh/sh.

## Verification

Every scenario run end-to-end through a real pty-daemon + real shells (`/bin/zsh`, `/bin/bash`, fish 4.x, nu 0.114, real tmux) with the desktop's actual wrapper files, measuring latency **and** command integrity, before and after:

| Profile class | Before | After |
|---|---|---|
| healthy zsh | 0.6s | 0.6s |
| .zshrc execs shell / tmux (SUPER-1103) | **15.5s every launch** | 15.5s once, then ~2.8s |
| oh-my-zsh update prompt (#3941/#5712) | first char eaten | ~2.6s intact |
| stdin eater + no marker | 15.5s intact / corrupted under naive grace | 15.5s once, then 2.8s intact |
| bash wrapped + eater | — | 2.5s intact |
| bash unwrapped + eater | **corrupted every launch (~0.5s)** | 1.5s intact |
| fish heredoc transport (#4705) | **never executes** | 2.6s intact |
| nushell (#6024) | **command discarded, even clean** | ~2.1s intact |

New node-tests cover all three mechanisms (each proven to fail without its fix). `bun test src/terminal` 122/122, typecheck clean, lint 0. Pre-existing failures unrelated and reproduced on main: send-snapshot tRPC strip-types import (#5580), create-on-attach exit hang.

Closes #3941, closes #4705, closes #6024. Also fixes the class behind #5712 (closed). Refs SUPER-1103.

## Follow-ups (not this PR)
- Foreground-pgrp readiness probe to eliminate the one-time 15s learning hit.
- Telemetry on evidence transitions (`delivered` → `missing`) to count affected machines in the wild.
- #6308 control-chars-on-relaunch is the session-restore query-replay family, untouched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 15s stalls and silently dropped preset commands across zsh/bash/fish/nushell by learning when the OSC 133;A prompt marker won’t arrive, verifying echo before Enter, protecting ungated shells, rewriting fish prompt transport, and answering headless DSR. Old: marker‑gated launches often waited 15s and ungated shells typed immediately; fish failed to parse heredocs; headless nushell wedged on DSR. New: learned ~2s grace with self‑healing evidence, echo‑verified typing and safe retype, quiescence + echo checks for ungated shells, fish staged‑file transport, and DSR answers; side effect: small added latency on first learning and when echo checks retype.

- Evidence learning (`host-service`): persist per‑shell state in `$SUPERSET_HOME_DIR/shell-ready-evidence.json`. A timeout with output brands `missing`; later launches use ~2s grace. Any observed marker (including after the grace, within the 15s budget) flips back to `delivered`. Zero‑output timeouts do not write; unexpected read errors warn once.
- Grace‑window launches: watch for our echo, detect mangle (orphaned suffix), then Ctrl‑U and retype up to 2 times; fall back to blind Enter. All deferred PTY writes are guarded so disposed sessions don’t throw.
- Ungated shells (bash/sh/ksh/nushell): wait for output quiescence (≤8s cap), type, then echo‑verify; detect stdin‑reader mangling and reedline flush via “unexpected tail,” re‑quiesce, Ctrl‑U, and retype. Short/non‑ASCII commands still quiesce even without a probe.
- Fish support (`shared`, `host-service`): parse heredoc prompt commands and replace with a staged‑file fish command that self‑deletes; on staging failure, show an in‑terminal error and do not type the heredoc.
- Headless readiness: answer `ESC[6n` cursor queries from the mirrored screen so nushell reaches a prompt.
- Tests/CI: add Node‑based terminal suites (shell‑ready learning, grace echo, ungated protection, fish transport) and run them in CI; use a lockfile‑pinned `prebuild-install` to fetch `better-sqlite3` for Node 22; setup‑scripts fake PTY now echoes writes.

Addresses SUPER-1103; fixes #3941, #4705, #6024.

<sup>Written for commit d42f0a218a3270ff981088457fb8618e8ffbd140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved terminal startup reliability by detecting shell readiness and adapting launch timing.
  - Added adaptive handling for shells with delayed or missing readiness markers, including learned behavior across sessions.
  - Added reliable prompt delivery for fish, including automatic temporary-file cleanup.
  - Improved cursor-position handling for unattached terminal sessions.
  - Added command-echo verification, output settling, and retry safeguards when startup output consumes input.

- **Bug Fixes**
  - Improved prompt delivery consistency across argument and standard-input transport methods.
  - Improved handling of delayed shell responses and late readiness signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->