### PR TITLE
fix(api): sync-presence may only flip hosts online, never offline

### DIFF
--- a/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
+++ b/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
@@ -78,31 +78,24 @@ export async function POST(request: Request): Promise<Response> {
 	// `${uuid}:${32-char-hex}` so the unquoted `{a,b,c}` literal is safe.
 	const connectedArrayLiteral = `{${connected.join(",")}}`;
 
+	// Flip-on only. The directory covers just the v1 relay, so absence proves
+	// nothing: relay2 hosts are never in it, and reconciling them to offline
+	// mass-flips every live relay2 host. The offline direction is owned by the
+	// relays' own disconnect writes and the relay2 liveness sweep.
 	let rows: Array<{
 		organization_id: string;
 		machine_id: string;
-		is_online: boolean;
 	}>;
 	try {
 		const result = await db.execute<{
 			organization_id: string;
 			machine_id: string;
-			is_online: boolean;
 		}>(sql`
-			WITH desired AS (
-				SELECT
-					organization_id,
-					machine_id,
-					(organization_id::text || ':' || machine_id) = ANY(${connectedArrayLiteral}::text[]) AS expected
-				FROM v2_hosts
-			)
-			UPDATE v2_hosts h
-			SET is_online = d.expected
-			FROM desired d
-			WHERE h.organization_id = d.organization_id
-				AND h.machine_id = d.machine_id
-				AND h.is_online IS DISTINCT FROM d.expected
-			RETURNING h.organization_id, h.machine_id, h.is_online
+			UPDATE v2_hosts
+			SET is_online = true
+			WHERE (organization_id::text || ':' || machine_id) = ANY(${connectedArrayLiteral}::text[])
+				AND is_online = false
+			RETURNING organization_id, machine_id
 		`);
 		rows = result.rows;
 	} catch (error) {
@@ -110,12 +103,9 @@ export async function POST(request: Request): Promise<Response> {
 		return Response.json({ error: "Reconcile write failed" }, { status: 502 });
 	}
 
-	const flippedOn = rows.filter((r) => r.is_online === true).length;
-	const flippedOff = rows.filter((r) => r.is_online === false).length;
-
 	return Response.json({
 		connected: connected.length,
-		flippedOn,
-		flippedOff,
+		flippedOn: rows.length,
+		flippedOff: 0,
 	});
 }


### PR DESCRIPTION
## Summary
The `sync-presence` cron reconciles `v2_hosts.is_online` against the v1 relay's Redis TTL directory — but computes `expected` for **every** host row from membership in that set. Relay2-connected hosts are never in the v1 directory, so as long as one v1 host keeps the set non-empty, every cron run flips every live relay2 host offline. This has been actively corrupting team host presence since the relay2 port (the relay2 liveness sweep's 45s re-assert was masking it by winning the write race).

Fix: the cron may only flip hosts **on** (a directory entry is positive proof of a live v1 tunnel). The offline direction is owned by the relays' own disconnect writes and the relay2 liveness sweep, which actually observe the sockets. The whole job is deleted at Fly cutover per `plans/20260811-relay2-do-presence.md`.

## Test plan
- [x] typecheck + lint clean
- [ ] After deploy: cron response shows `flippedOff: 0` always; relay2-connected team hosts stop oscillating offline between sweep re-asserts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `sync-presence` cron only flip hosts online when they appear in the v1 relay Redis directory, never offline. This stops relay2-connected hosts from being incorrectly marked offline and stabilizes presence.

- **Bug Fixes**
  - Update SQL to set `is_online = true` only for hosts found in the directory; remove global expected/offline reconciliation.
  - API response now always returns `flippedOff: 0`; offline is handled by relay disconnect writes and the relay2 liveness sweep.

<sup>Written for commit 23f217f3c9fd569341e8b4473568d9b270e735ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host presence synchronization to reliably mark connected hosts as online.
  * Prevented active hosts from being incorrectly marked offline during synchronization.
  * Offline status continues to update through disconnect and liveness monitoring processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->