### PR TITLE
feat(desktop,mobile): read host presence live from the relay

### DIFF
--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
@@ -1,6 +1,7 @@
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { env } from "renderer/env.renderer";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { MOCK_ORG_ID } from "shared/constants";
@@ -95,9 +96,18 @@ export function useKnownHosts(): {
 		);
 	}, [liveRows, liveReady, snapshot, organizationId]);
 
+	const presence = useHostsPresence(hosts);
+	const hostsWithPresence = useMemo(() => {
+		if (!presence) return hosts;
+		return hosts.map((host) => ({
+			...host,
+			isOnline: presence.get(host.machineId) ?? host.isOnline,
+		}));
+	}, [hosts, presence]);
+
 	const settled =
 		liveReady ||
 		(snapshot !== null && snapshot.organizationId === organizationId);
 
-	return { hosts, organizationId, settled };
+	return { hosts: hostsWithPresence, organizationId, settled };
 }

--- a/apps/desktop/src/renderer/hooks/useHostsPresence/index.ts
+++ b/apps/desktop/src/renderer/hooks/useHostsPresence/index.ts
@@ -1,0 +1,2 @@
+export type { HostPresenceTarget } from "./useHostsPresence";
+export { useHostsPresence } from "./useHostsPresence";

--- a/apps/desktop/src/renderer/hooks/useHostsPresence/useHostsPresence.ts
+++ b/apps/desktop/src/renderer/hooks/useHostsPresence/useHostsPresence.ts
@@ -1,0 +1,100 @@
+import {
+	buildHostRoutingKey,
+	parseHostRoutingKey,
+} from "@superset/shared/host-routing";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
+import { getJwt } from "renderer/lib/auth-client";
+
+export interface HostPresenceTarget {
+	organizationId: string;
+	machineId: string;
+}
+
+const PRESENCE_BATCH_LIMIT = 50;
+
+interface PresenceResponse {
+	hosts: Record<string, { online: boolean; lastSeenAt: number | null }>;
+}
+
+async function fetchPresenceBatch(
+	relayUrl: string,
+	routingKeys: string[],
+	jwt: string,
+): Promise<PresenceResponse> {
+	const response = await fetch(
+		`${relayUrl}/presence?hostIds=${encodeURIComponent(routingKeys.join(","))}`,
+		{ headers: { authorization: `Bearer ${jwt}` } },
+	);
+	if (!response.ok) throw new Error(`presence fetch: ${response.status}`);
+	return (await response.json()) as PresenceResponse;
+}
+
+export function useHostsPresence(
+	targets: HostPresenceTarget[],
+): Map<string, boolean> | null {
+	const relayUrl = useRelayUrl();
+
+	const routingKeys = useMemo(
+		() =>
+			[
+				...new Set(
+					targets
+						.filter((target) => target.organizationId && target.machineId)
+						.map((target) =>
+							buildHostRoutingKey(target.organizationId, target.machineId),
+						),
+				),
+			].sort(),
+		[targets],
+	);
+
+	const { data: relayIsProto2 } = useQuery({
+		queryKey: ["relay-proto", relayUrl],
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: 1,
+		queryFn: async () => {
+			const response = await fetch(`${relayUrl}/health`);
+			if (!response.ok) throw new Error(`relay health: ${response.status}`);
+			const body = (await response.json()) as { proto?: number };
+			return body.proto === 2;
+		},
+	});
+
+	const enabled = routingKeys.length > 0 && relayIsProto2 === true;
+
+	const { data } = useQuery({
+		queryKey: ["hosts-presence", relayUrl, routingKeys.join(",")],
+		enabled,
+		refetchInterval: 30_000,
+		refetchOnWindowFocus: true,
+		queryFn: async (): Promise<Map<string, boolean>> => {
+			const jwt = getJwt();
+			if (!jwt) throw new Error("no JWT for presence fetch");
+			const chunks: string[][] = [];
+			for (
+				let index = 0;
+				index < routingKeys.length;
+				index += PRESENCE_BATCH_LIMIT
+			) {
+				chunks.push(routingKeys.slice(index, index + PRESENCE_BATCH_LIMIT));
+			}
+			const responses = await Promise.all(
+				chunks.map((chunk) => fetchPresenceBatch(relayUrl, chunk, jwt)),
+			);
+			const online = new Map<string, boolean>();
+			for (const response of responses) {
+				for (const [key, info] of Object.entries(response.hosts)) {
+					const parsed = parseHostRoutingKey(key);
+					if (parsed) online.set(parsed.machineId, info.online);
+				}
+			}
+			return online;
+		},
+	});
+
+	// Null = presence unavailable (v1 relay, probe/fetch failed, empty target
+	// set): callers must keep the Electric-synced isOnline value.
+	return enabled ? (data ?? null) : null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -8,6 +8,7 @@ import { resolveProjectIconUrl } from "renderer/hooks/host-projects/resolveProje
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { deriveTerminalAgentStatus } from "renderer/hooks/host-service/useTerminalAgentStatuses";
 import { useHostWorkspacesSource } from "renderer/hooks/host-workspaces/useHostWorkspaces";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -227,7 +228,7 @@ export function useAccessibleV2Workspaces(
 	const { workspaces: hostWorkspaces, isReady } =
 		deviceFilter === undefined ? fanoutSource : scopedSource;
 
-	const { data: hostRows = [] } = useLiveQuery(
+	const { data: rawHostRows = [] } = useLiveQuery(
 		(q) =>
 			q.from({ hosts: collections.v2Hosts }).select(({ hosts }) => ({
 				organizationId: hosts.organizationId,
@@ -236,6 +237,17 @@ export function useAccessibleV2Workspaces(
 				isOnline: hosts.isOnline,
 			})),
 		[collections],
+	);
+	const presence = useHostsPresence(rawHostRows);
+	const hostRows = useMemo(
+		() =>
+			presence
+				? rawHostRows.map((host) => ({
+						...host,
+						isOnline: presence.get(host.machineId) ?? host.isOnline,
+					}))
+				: rawHostRows,
+		[rawHostRows, presence],
 	);
 
 	const { data: userHostRows = [] } = useLiveQuery(

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
@@ -2,6 +2,7 @@ import { and, eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -58,14 +59,37 @@ export function useWorkspaceHostOptions(): UseWorkspaceHostOptionsResult {
 		[activeOrganizationId, collections, currentUserId],
 	);
 
+	const presenceTargets = useMemo(
+		() =>
+			activeOrganizationId
+				? accessibleHosts.map((host) => ({
+						organizationId: activeOrganizationId,
+						machineId: host.machineId,
+					}))
+				: [],
+		[accessibleHosts, activeOrganizationId],
+	);
+	const presence = useHostsPresence(presenceTargets);
+	const hostsWithPresence = useMemo(
+		() =>
+			presence
+				? accessibleHosts.map((host) => ({
+						...host,
+						isOnline: presence.get(host.machineId) ?? host.isOnline,
+					}))
+				: accessibleHosts,
+		[accessibleHosts, presence],
+	);
+
 	const localHost = useMemo(
-		() => accessibleHosts.find((host) => host.machineId === machineId) ?? null,
-		[accessibleHosts, machineId],
+		() =>
+			hostsWithPresence.find((host) => host.machineId === machineId) ?? null,
+		[hostsWithPresence, machineId],
 	);
 
 	const otherHosts = useMemo(
 		() =>
-			accessibleHosts
+			hostsWithPresence
 				.filter((host) => host.machineId !== machineId)
 				.map((host) => ({
 					id: host.machineId,
@@ -73,7 +97,7 @@ export function useWorkspaceHostOptions(): UseWorkspaceHostOptionsResult {
 					isOnline: host.isOnline ?? false,
 				}))
 				.sort((a, b) => a.name.localeCompare(b.name)),
-		[accessibleHosts, machineId],
+		[hostsWithPresence, machineId],
 	);
 
 	// Always surface the local device, even if its v2Hosts row hasn't synced

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -3,6 +3,7 @@ import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { authClient } from "renderer/lib/auth-client";
 import {
 	type PersistableTransaction,
@@ -52,6 +53,10 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 		[collections, hostId],
 	);
 	const host = hostRows[0];
+	const presence = useHostsPresence(hostRows);
+	const hostIsOnline = host
+		? (presence?.get(host.machineId) ?? host.isOnline)
+		: false;
 
 	const { data: hostUserRows = [] } = useLiveQuery(
 		(q) =>
@@ -167,7 +172,7 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 		<div className="p-6 max-w-4xl w-full mx-auto select-text">
 			<HostHeader
 				name={host.name}
-				isOnline={host.isOnline}
+				isOnline={hostIsOnline}
 				machineId={host.machineId}
 				canRename={isOwner}
 			/>
@@ -177,7 +182,7 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 					hostUrl={hostUrl}
 					hostName={host.name}
 					isRemoteTarget={isRemoteTarget}
-					isOnline={host.isOnline || !isRemoteTarget}
+					isOnline={hostIsOnline || !isRemoteTarget}
 					canEdit={isOwner}
 				/>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/components/HostsSettingsSidebar/HostsSettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/components/HostsSettingsSidebar/HostsSettingsSidebar.tsx
@@ -4,6 +4,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { MOCK_ORG_ID } from "shared/constants";
@@ -50,8 +51,32 @@ export function HostsSettingsSidebar({
 		[collections, activeOrganizationId],
 	);
 
+	const presenceTargets = useMemo(
+		() =>
+			activeOrganizationId
+				? hosts.map((host) => ({
+						organizationId: activeOrganizationId,
+						machineId: host.machineId,
+					}))
+				: [],
+		[hosts, activeOrganizationId],
+	);
+	const presence = useHostsPresence(presenceTargets);
+	const hostsWithPresence = useMemo(
+		() =>
+			presence
+				? hosts.map((host) => ({
+						...host,
+						isOnline: presence.get(host.machineId) ?? host.isOnline,
+					}))
+				: hosts,
+		[hosts, presence],
+	);
+
 	const listGroups = useMemo<Array<SettingsListGroup<HostRow>>>(() => {
-		const sorted = [...hosts].sort((a, b) => a.name.localeCompare(b.name));
+		const sorted = [...hostsWithPresence].sort((a, b) =>
+			a.name.localeCompare(b.name),
+		);
 		return [
 			{
 				id: "online",
@@ -64,7 +89,7 @@ export function HostsSettingsSidebar({
 				rows: sorted.filter((h) => !h.isOnline),
 			},
 		];
-	}, [hosts]);
+	}, [hostsWithPresence]);
 
 	return (
 		<SettingsListSidebar

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/page.tsx
@@ -3,6 +3,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo } from "react";
 import { env } from "renderer/env.renderer";
+import { useHostsPresence } from "renderer/hooks/useHostsPresence";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { MOCK_ORG_ID } from "shared/constants";
@@ -35,11 +36,23 @@ function HostsIndexPage() {
 		[collections, activeOrganizationId],
 	);
 
+	const presenceTargets = useMemo(
+		() =>
+			activeOrganizationId
+				? hosts.map((host) => ({
+						organizationId: activeOrganizationId,
+						machineId: host.id,
+					}))
+				: [],
+		[hosts, activeOrganizationId],
+	);
+	const presence = useHostsPresence(presenceTargets);
+
 	const firstHostId = useMemo(() => {
 		const sorted = [...hosts].sort((a, b) => a.name.localeCompare(b.name));
-		const online = sorted.find((h) => h.isOnline);
+		const online = sorted.find((h) => presence?.get(h.id) ?? h.isOnline);
 		return (online ?? sorted[0])?.id ?? null;
-	}, [hosts]);
+	}, [hosts, presence]);
 
 	useEffect(() => {
 		if (firstHostId) {

--- a/apps/mobile/hooks/useHostsPresence/index.ts
+++ b/apps/mobile/hooks/useHostsPresence/index.ts
@@ -1,0 +1,2 @@
+export type { HostPresenceTarget } from "./useHostsPresence";
+export { useHostsPresence } from "./useHostsPresence";

--- a/apps/mobile/hooks/useHostsPresence/useHostsPresence.ts
+++ b/apps/mobile/hooks/useHostsPresence/useHostsPresence.ts
@@ -1,0 +1,112 @@
+import {
+	buildHostRoutingKey,
+	parseHostRoutingKey,
+} from "@superset/shared/host-routing";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+	getHostAuthToken,
+	getRelayUrl,
+	primeRelayUrl,
+} from "@/lib/host/client";
+
+export interface HostPresenceTarget {
+	organizationId: string;
+	machineId: string;
+}
+
+const PRESENCE_BATCH_LIMIT = 50;
+
+interface PresenceResponse {
+	hosts: Record<string, { online: boolean; lastSeenAt: number | null }>;
+}
+
+async function fetchPresenceBatch(
+	relayUrl: string,
+	routingKeys: string[],
+	token: string,
+): Promise<PresenceResponse> {
+	const response = await fetch(
+		`${relayUrl}/presence?hostIds=${encodeURIComponent(routingKeys.join(","))}`,
+		{ headers: { authorization: `Bearer ${token}` } },
+	);
+	if (!response.ok) throw new Error(`presence fetch: ${response.status}`);
+	return (await response.json()) as PresenceResponse;
+}
+
+export function useHostsPresence(
+	targets: HostPresenceTarget[],
+): Map<string, boolean> | null {
+	const routingKeys = useMemo(
+		() =>
+			[
+				...new Set(
+					targets
+						.filter((target) => target.organizationId && target.machineId)
+						.map((target) =>
+							buildHostRoutingKey(target.organizationId, target.machineId),
+						),
+				),
+			].sort(),
+		[targets],
+	);
+
+	const { data: relayUrl } = useQuery({
+		queryKey: ["relay-url"],
+		staleTime: 5 * 60 * 1000,
+		queryFn: async () => {
+			await primeRelayUrl();
+			return getRelayUrl();
+		},
+	});
+
+	const { data: relayIsProto2 } = useQuery({
+		queryKey: ["relay-proto", relayUrl],
+		enabled: relayUrl !== undefined,
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: 1,
+		queryFn: async () => {
+			const response = await fetch(`${relayUrl}/health`);
+			if (!response.ok) throw new Error(`relay health: ${response.status}`);
+			const body = (await response.json()) as { proto?: number };
+			return body.proto === 2;
+		},
+	});
+
+	const enabled =
+		routingKeys.length > 0 && relayUrl !== undefined && relayIsProto2 === true;
+
+	const { data } = useQuery({
+		queryKey: ["hosts-presence", relayUrl, routingKeys.join(",")],
+		enabled,
+		refetchInterval: 30_000,
+		refetchOnWindowFocus: true,
+		queryFn: async (): Promise<Map<string, boolean>> => {
+			if (relayUrl === undefined) throw new Error("relay URL unresolved");
+			const token = await getHostAuthToken();
+			const chunks: string[][] = [];
+			for (
+				let index = 0;
+				index < routingKeys.length;
+				index += PRESENCE_BATCH_LIMIT
+			) {
+				chunks.push(routingKeys.slice(index, index + PRESENCE_BATCH_LIMIT));
+			}
+			const responses = await Promise.all(
+				chunks.map((chunk) => fetchPresenceBatch(relayUrl, chunk, token)),
+			);
+			const online = new Map<string, boolean>();
+			for (const response of responses) {
+				for (const [key, info] of Object.entries(response.hosts)) {
+					const parsed = parseHostRoutingKey(key);
+					if (parsed) online.set(parsed.machineId, info.online);
+				}
+			}
+			return online;
+		},
+	});
+
+	// Null = presence unavailable (v1 relay, probe/fetch failed, empty target
+	// set): callers must keep the Electric-synced isOnline value.
+	return enabled ? (data ?? null) : null;
+}

--- a/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
+++ b/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
@@ -2,6 +2,7 @@ import type { SelectV2Host } from "@superset/db/schema";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
 import {
 	getHostWorkspacesQueryKey,
 	type HostWorkspaceRow,
@@ -33,16 +34,21 @@ export function useWorkspaceHost(
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
+	const presence = useHostsPresence(hosts ?? []);
 
 	const targets = useMemo(
 		() =>
 			(hosts ?? [])
+				.map((host) => ({
+					...host,
+					isOnline: presence?.get(host.machineId) ?? host.isOnline,
+				}))
 				.filter((host) => host.isOnline)
 				.map((host) => ({
 					host,
 					hostUrl: buildRelayHostUrl(host.organizationId, host.machineId),
 				})),
-		[hosts],
+		[hosts, presence],
 	);
 
 	const queries = useQueries({

--- a/apps/mobile/screens/(authenticated)/(home)/filter/host/HostFilterScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/filter/host/HostFilterScreen.tsx
@@ -2,6 +2,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useRouter } from "expo-router";
 import { useMemo } from "react";
 import { ScrollView } from "react-native";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
 import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/stores/workspacesFilterStore";
 import { useSelectedHost } from "@/screens/(authenticated)/(home)/hooks/useSelectedHost";
 import { HostStatusDot } from "@/screens/(authenticated)/components/HostStatusDot";
@@ -21,10 +22,17 @@ export function HostFilterScreen() {
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
+	const presence = useHostsPresence(hosts ?? []);
 
 	const sortedHosts = useMemo(
-		() => [...(hosts ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
-		[hosts],
+		() =>
+			[...(hosts ?? [])]
+				.map((host) => ({
+					...host,
+					isOnline: presence?.get(host.machineId) ?? host.isOnline,
+				}))
+				.sort((a, b) => a.name.localeCompare(b.name)),
+		[hosts, presence],
 	);
 
 	const selectHost = (machineId: string) => {

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
@@ -3,6 +3,7 @@ import { useQueries } from "@tanstack/react-query";
 import { compareDesc } from "date-fns";
 import { useMemo } from "react";
 import { toHostProjectItem } from "@/hooks/useHostProjects";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
 import {
 	buildRelayHostUrl,
@@ -48,16 +49,17 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
+	const presence = useHostsPresence(hosts ?? []);
 	const onlineHosts = useMemo(
 		() =>
 			(hosts ?? [])
-				.filter((host) => host.isOnline)
+				.filter((host) => presence?.get(host.machineId) ?? host.isOnline)
 				.map((host) => ({
 					machineId: host.machineId,
 					name: host.name,
 					hostUrl: buildRelayHostUrl(host.organizationId, host.machineId),
 				})),
-		[hosts],
+		[hosts, presence],
 	);
 
 	const projectListQueries = useQueries({

--- a/apps/mobile/screens/(authenticated)/(home)/hooks/useSelectedHost/useSelectedHost.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/hooks/useSelectedHost/useSelectedHost.ts
@@ -1,6 +1,7 @@
 import type { SelectV2Host } from "@superset/db/schema";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
 import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/stores/workspacesFilterStore";
 import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
 
@@ -16,16 +17,20 @@ export function useSelectedHost(): SelectV2Host | null {
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
+	const presence = useHostsPresence(hosts ?? []);
 
 	return useMemo(() => {
-		const sorted = [...(hosts ?? [])].sort((a, b) =>
-			a.name.localeCompare(b.name),
-		);
+		const sorted = [...(hosts ?? [])]
+			.map((host) => ({
+				...host,
+				isOnline: presence?.get(host.machineId) ?? host.isOnline,
+			}))
+			.sort((a, b) => a.name.localeCompare(b.name));
 		return (
 			sorted.find((host) => host.machineId === hostFilter) ??
 			sorted.find((host) => host.isOnline) ??
 			sorted[0] ??
 			null
 		);
-	}, [hosts, hostFilter]);
+	}, [hosts, hostFilter, presence]);
 }

--- a/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
@@ -2,6 +2,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { formatDistanceToNow } from "date-fns";
 import { useMemo } from "react";
 import { ScrollView, Text } from "react-native";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
 import { useTheme } from "@/hooks/useTheme";
 import { HostStatusDot } from "@/screens/(authenticated)/components/HostStatusDot";
 import { ListRow } from "@/screens/(authenticated)/components/ListRow";
@@ -15,10 +16,17 @@ export function HostsSettingsScreen() {
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
+	const presence = useHostsPresence(hosts ?? []);
 
 	const hostRows = useMemo(
-		() => [...(hosts ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
-		[hosts],
+		() =>
+			[...(hosts ?? [])]
+				.map((host) => ({
+					...host,
+					isOnline: presence?.get(host.machineId) ?? host.isOnline,
+				}))
+				.sort((a, b) => a.name.localeCompare(b.name)),
+		[hosts, presence],
 	);
 
 	return (


### PR DESCRIPTION
## Summary
Client half of `plans/20260811-relay2-do-presence.md` (server half: #6371). Desktop and mobile stop trusting the Electric-synced `v2_hosts.is_online` for presence when the user's relay is proto-2: a shared `useHostsPresence` hook batch-polls the relay's `GET /presence` (30s + on-focus, chunked at 50, deduped/sorted keys) and overlays `online` at the data funnels — `useKnownHosts` (sidebar cloud icon), `useWorkspaceHostOptions` (device pickers + offline gates + automations notice), `useAccessibleV2Workspaces`, the hosts settings screens, and mobile's `useSelectedHost`/`useWorkspaceHost` + host screens. Leaf components that receive `isOnline` as a prop are untouched.

Fallback semantics: relay not proto-2 (v1/Fly users), probe failure, missing JWT, or a host omitted from the response → the existing Electric value is used unchanged, per host. Proto detection is cached per relay URL (`staleTime: Infinity` on success only — errors retry).

## Test plan
- [x] typecheck clean in apps/desktop and apps/mobile; lint clean
- [x] Server endpoint verified live in prod under #6371 (fresh `lastSeenAt`, omission, 401/400 edges)
- [ ] Next canary: sidebar cloud icons track real reachability within ~30s of a host appearing/vanishing; v1-relay accounts unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Desktop and mobile now read host online presence live from the relay for proto‑2 relays, instead of relying on the synced `v2_hosts.is_online` value. Presence is batch-polled via a shared `useHostsPresence` hook and applied across host lists, pickers, workspace access, and settings; non‑proto‑2 relays and failures fall back to the existing value.

- **New Features**
  - Added `useHostsPresence` (desktop + mobile) to poll `GET /presence` every 30s and on focus; batches 50 IDs, dedupes/sorts keys; proto detection via `/health` is cached.
  - Integrated presence into `useKnownHosts`, `useWorkspaceHostOptions`, `useAccessibleV2Workspaces`, host settings lists/detail, and mobile `useSelectedHost`, `useWorkspaceHost`, Host Filter, New Chat targets, and Hosts Settings.
  - Fallback per host: if relay isn’t proto‑2, auth/request fails, or a host is omitted, keep the synced `is_online` value.

<sup>Written for commit 72052e2a20b26652ab6f0bdeba4c4dd541249e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

