### PR TITLE
fix(desktop): deliver v1 terminal file drops as a paste, not raw input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -438,9 +438,13 @@ export const Terminal = memo(function Terminal({
 			if (!plainText) return;
 			text = shellEscapePaths([plainText]);
 		}
-		if (!isExitedRef.current) {
-			writeRef.current({ paneId, data: text });
-		}
+		if (isExitedRef.current) return;
+		// Paste instead of writing raw. xterm wraps the text in bracketed-paste
+		// markers when the foreground app has asked for them, and that envelope
+		// is how an agent TUI tells a dropped path apart from typing — Claude
+		// Code attaches a pasted image path and leaves a typed one as text.
+		// v2 terminal panes already go through paste(); so does Cmd+V here.
+		xtermRef.current?.paste(text);
 	};
 
 	return (


### PR DESCRIPTION
## What & why

A file dropped on a **v1** terminal pane was written straight to the PTY:

```ts
writeRef.current({ paneId, data: text });
```

so the foreground app saw the path as typing. Agent TUIs use the
bracketed-paste envelope to tell a dropped path apart from a typed one, so the
path stayed literal text and a dropped image was never attached. Related to
#6370.

I measured this against a real Claude Code TUI (2.1.215) in a PTY — tmux,
120x45, `tmux paste-buffer -p` for the paste rows and `tmux send-keys -l` for
the typed rows, dropping `/tmp/drop-probe/scratch/My Screenshot.png` which
exists on disk:

| inserted text | delivery | result |
| --- | --- | --- |
| `'/tmp/…/My Screenshot.png'` (shell-quote) | bracketed paste | `❯ [Image #1]` |
| `/tmp/…/My\ Screenshot.png` (backslash) | bracketed paste | `❯ [Image #1]` |
| `'/tmp/…/My Screenshot.png'` | typed | `❯ '/tmp/…/My Screenshot.png'` |
| `/tmp/…/My\ Screenshot.png` | typed | `❯ /tmp/…/My\ Screenshot.png` |

Delivery decides it. The escaping style makes no difference — worth recording,
because #6370 guessed the single quotes were the problem and they are not. I
also checked that a bracketed paste of a path to a **missing** file stays
literal text, which is the same symptom.

v2 panes already call xterm's `paste()`, and so does Cmd+V in a v1 pane. This
routes the v1 drop through the same call.

## Scope

This covers v1 panes only, and I want to be straight about what it does not
prove. v2 (`TerminalPane`) already pastes, so the v2 half of #6370 has a
different cause — most likely that the dropped path does not exist, since both
#6370 and #6369 drag from the macOS screenshot floating thumbnail and land on
a `/var/folders/…/NSIRD_screencaptureui_*` temp path. I have not been able to
reproduce that half yet and did not want to guess at a fix for it in the same
PR.

There is prior art for that temp path being trouble: crbug 1148078 recorded
`/var/folders/.../TemporaryItems/NSIRD_screencaptureui_.../Screen Shot ....png`
drags failing with `ERR_ACCESS_DENIED`, and Chrome 93 fixed it by copying the
file into a Chrome-owned temp directory
(`DroppedScreenShotCopierMac`, `content/app_shim_remote_cocoa/web_contents_view_cocoa.mm`)
— which is app-shim-specific and should not be assumed to run in an ordinary
Electron window. Reading `File.arrayBuffer()` on drop and writing our own temp
copy would sidestep the whole class, but that is a bigger change than this one
and belongs in its own PR.

## How I tested it

- The PTY matrix above — real `claude` process, real bracketed-paste bytes, not
  a mock. Script: a ~40-line tmux driver, happy to paste it in if useful.
- `bun run lint` → clean.
- `bun run typecheck --filter=@superset/desktop` → clean.
- `bun run test` → `2677 pass, 1 fail`; the failure is
  `Shell Environment > getProcessEnvWithShellPath applies shell PATH and
  preserves string vars`, which asserts against this machine's real shell PATH
  and fails the same way on an unmodified checkout.

No screenshot: I could not get the desktop dev app running in this clone
(`bun install` fails building `better-sqlite3` here), so the end-to-end
evidence is the PTY matrix rather than the app UI. Happy to redo it in the app
if a maintainer would rather see that.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file drop handling in active terminals by using paste behavior, preserving expected input formatting.
  * Prevented dropped content from being processed after a terminal has exited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->