### PR TITLE
fix(desktop): repair dropped paths whose Unicode whitespace arrives folded

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
 	getAppCommand,
 	RelativePathWithoutCwdError,
+	resolveDroppedPath,
 	resolvePath,
 	stripPathWrappers,
 } from "./helpers";
@@ -745,5 +747,53 @@ describe("resolvePath guards against process.cwd() fallback", () => {
 		expect(resolvePath("src/index.ts", "/workspace")).toBe(
 			"/workspace/src/index.ts",
 		);
+	});
+});
+
+describe("resolveDroppedPath", () => {
+	const NNBSP = "\u202f";
+	let dir: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), "dropped-path-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("repairs a path whose narrow no-break space arrived as a plain space", async () => {
+		const onDisk = path.join(dir, `Screenshot at 9.42.51${NNBSP}am.png`);
+		fs.writeFileSync(onDisk, "x");
+		const dropped = path.join(dir, "Screenshot at 9.42.51 am.png");
+
+		expect(fs.existsSync(dropped)).toBe(false);
+		expect(await resolveDroppedPath(dropped)).toBe(onDisk);
+		expect(fs.existsSync(await resolveDroppedPath(dropped))).toBe(true);
+	});
+
+	test("leaves a path that already exists untouched", async () => {
+		const onDisk = path.join(dir, `real${NNBSP}name.png`);
+		fs.writeFileSync(onDisk, "x");
+		expect(await resolveDroppedPath(onDisk)).toBe(onDisk);
+	});
+
+	test("gives up when two siblings fold to the same name", async () => {
+		fs.writeFileSync(path.join(dir, `a${NNBSP}b.png`), "x");
+		fs.writeFileSync(path.join(dir, "a\u00a0b.png"), "x");
+		const dropped = path.join(dir, "a b.png");
+		expect(fs.existsSync(dropped)).toBe(false);
+		expect(await resolveDroppedPath(dropped)).toBe(dropped);
+	});
+
+	test("returns the input when nothing in the directory matches", async () => {
+		fs.writeFileSync(path.join(dir, "other.png"), "x");
+		const dropped = path.join(dir, "missing.png");
+		expect(await resolveDroppedPath(dropped)).toBe(dropped);
+	});
+
+	test("returns the input when the directory does not exist", async () => {
+		const dropped = path.join(dir, "nope", "missing.png");
+		expect(await resolveDroppedPath(dropped)).toBe(dropped);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -796,4 +796,16 @@ describe("resolveDroppedPath", () => {
 		const dropped = path.join(dir, "nope", "missing.png");
 		expect(await resolveDroppedPath(dropped)).toBe(dropped);
 	});
+
+	test("leaves a relative path alone rather than scanning the cwd", async () => {
+		expect(await resolveDroppedPath("relative/name.png")).toBe(
+			"relative/name.png",
+		);
+	});
+
+	test("handles a path directly under the root without bailing out", async () => {
+		// dirname("/x.png") is "/", which an empty-string check would reject.
+		const dropped = "/superset-dropped-path-probe.png";
+		expect(await resolveDroppedPath(dropped)).toBe(dropped);
+	});
 });

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -1,7 +1,9 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import nodePath from "node:path";
 import type { ExternalApp } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
+import { matchByFoldedName, splitPath } from "shared/dropped-path-repair";
 
 /** Map of app IDs to their macOS application names */
 const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
@@ -413,6 +415,30 @@ export function spawnAsync(command: string, args: string[]): Promise<void> {
 			}
 		});
 	});
+}
+
+/** A drop lands in one directory; a huge one is not a screenshot folder. */
+const MAX_REPAIR_DIRECTORY_ENTRIES = 5_000;
+
+/**
+ * The on-disk path behind a dropped one whose Unicode whitespace came back
+ * folded to ASCII (#6369). Returns the input unchanged whenever it already
+ * resolves, the directory cannot be read, or more than one sibling matches —
+ * so this only ever swaps a path that does not exist for one that does.
+ */
+export async function resolveDroppedPath(dropped: string): Promise<string> {
+	if (fs.existsSync(dropped)) return dropped;
+	const { dir, base } = splitPath(dropped);
+	if (!dir || !base) return dropped;
+	let entries: string[];
+	try {
+		entries = await fs.promises.readdir(dir);
+	} catch {
+		return dropped;
+	}
+	if (entries.length > MAX_REPAIR_DIRECTORY_ENTRIES) return dropped;
+	const match = matchByFoldedName(base, entries);
+	return match ? nodePath.join(dir, match) : dropped;
 }
 
 export type { ExternalApp };

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import nodePath from "node:path";
 import type { ExternalApp } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
-import { matchByFoldedName, splitPath } from "shared/dropped-path-repair";
+import { matchByFoldedName } from "shared/dropped-path-repair";
 
 /** Map of app IDs to their macOS application names */
 const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
@@ -427,16 +427,41 @@ const MAX_REPAIR_DIRECTORY_ENTRIES = 5_000;
  * so this only ever swaps a path that does not exist for one that does.
  */
 export async function resolveDroppedPath(dropped: string): Promise<string> {
+	if (!nodePath.isAbsolute(dropped)) return dropped;
 	if (fs.existsSync(dropped)) return dropped;
-	const { dir, base } = splitPath(dropped);
-	if (!dir || !base) return dropped;
-	let entries: string[];
+
+	// nodePath rather than a hand-rolled split: it keeps the root directory for
+	// a file dropped straight into `/`, and it understands the backslash
+	// separator that Electron hands back on Windows.
+	const dir = nodePath.dirname(dropped);
+	const base = nodePath.basename(dropped);
+	if (!base) return dropped;
+
+	// Streamed with opendir so the cap bounds the scan itself; readdir would
+	// have materialized the whole listing before we could check it. Breaking
+	// out of `for await` closes the directory handle.
+	const entries: string[] = [];
+	let overflowed = false;
 	try {
-		entries = await fs.promises.readdir(dir);
-	} catch {
+		const directory = await fs.promises.opendir(dir);
+		for await (const entry of directory) {
+			entries.push(entry.name);
+			if (entries.length > MAX_REPAIR_DIRECTORY_ENTRIES) {
+				overflowed = true;
+				break;
+			}
+		}
+	} catch (error) {
+		// A permission or I/O failure is not a non-match — say so, then fall
+		// back to the path we were given.
+		console.warn(
+			"[external/resolveDroppedPath] Could not read the dropped file's directory",
+			{ dropped, dir, error },
+		);
 		return dropped;
 	}
-	if (entries.length > MAX_REPAIR_DIRECTORY_ENTRIES) return dropped;
+	if (overflowed) return dropped;
+
 	const match = matchByFoldedName(base, entries);
 	return match ? nodePath.join(dir, match) : dropped;
 }

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -19,6 +19,7 @@ import {
 	type ExternalApp,
 	getAppCommand,
 	RelativePathWithoutCwdError,
+	resolveDroppedPath,
 	resolvePath,
 	spawnAsync,
 } from "./helpers";
@@ -229,6 +230,13 @@ export const createExternalRouter = () => {
 			.query(({ input }) =>
 				withResolveGuard(() => resolvePath(input.path, input.worktreePath)),
 			),
+
+		// Repairs a dropped file path whose Unicode whitespace came back folded
+		// to ASCII. Only ever returns a path that exists; anything ambiguous or
+		// unreadable comes back unchanged, so the caller needs no branch.
+		resolveDroppedPath: publicProcedure
+			.input(z.object({ path: z.string() }))
+			.query(({ input }) => resolveDroppedPath(input.path)),
 
 		statPath: publicProcedure
 			.input(

--- a/apps/desktop/src/renderer/lib/terminal/repair-dropped-paths.ts
+++ b/apps/desktop/src/renderer/lib/terminal/repair-dropped-paths.ts
@@ -1,0 +1,23 @@
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+/**
+ * Ask the main process to check each dropped path against the filesystem and
+ * repair it if the drop folded a Unicode space in the name (#6369). A path
+ * that already resolves comes back untouched, and so does one the main process
+ * cannot improve, so callers can use the result unconditionally.
+ */
+export async function repairDroppedPaths(
+	paths: readonly string[],
+): Promise<string[]> {
+	return Promise.all(
+		paths.map(async (path) => {
+			try {
+				return await electronTrpcClient.external.resolveDroppedPath.query({
+					path,
+				});
+			} catch {
+				return path;
+			}
+		}),
+	);
+}

--- a/apps/desktop/src/renderer/lib/terminal/repair-dropped-paths.ts
+++ b/apps/desktop/src/renderer/lib/terminal/repair-dropped-paths.ts
@@ -15,7 +15,14 @@ export async function repairDroppedPaths(
 				return await electronTrpcClient.external.resolveDroppedPath.query({
 					path,
 				});
-			} catch {
+			} catch (error) {
+				// The drop still has to land, so fall back to the path we were
+				// given — but say that the check never ran, otherwise a dead
+				// main process looks exactly like a path that needed no repair.
+				console.warn(
+					"[terminal/drop] Could not resolve a dropped path against disk",
+					{ path, error },
+				);
 				return path;
 			}
 		}),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -390,6 +390,9 @@ export function TerminalPane({
 
 	const [isDropActive, setIsDropActive] = useState(false);
 	const dragCounterRef = useRef(0);
+	/** Which terminal this pane currently shows, for re-checking after an await. */
+	const terminalIdRef = useRef(terminalId);
+	terminalIdRef.current = terminalId;
 
 	const resolveDroppedText = async (
 		dataTransfer: DataTransfer,
@@ -433,6 +436,18 @@ export function TerminalPane({
 		if (connectionState === "closed") return;
 		const text = await resolveDroppedText(event.dataTransfer);
 		if (!text) return;
+		// Resolving a dropped path is async, and the pane can be re-pointed at
+		// another terminal while it runs (session dropdown, tab switch). Drop
+		// the paste rather than send it to whichever terminal we captured.
+		if (terminalIdRef.current !== terminalId) return;
+		if (
+			terminalRuntimeRegistry.getConnectionState(
+				terminalId,
+				terminalInstanceId,
+			) === "closed"
+		) {
+			return;
+		}
 		terminalRuntimeRegistry
 			.getTerminal(terminalId, terminalInstanceId)
 			?.focus();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -19,6 +19,7 @@ import {
 	useTerminalFilePolicy,
 	useTerminalUrlPolicy,
 } from "renderer/lib/clickPolicy";
+import { repairDroppedPaths } from "renderer/lib/terminal/repair-dropped-paths";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
@@ -390,13 +391,16 @@ export function TerminalPane({
 	const [isDropActive, setIsDropActive] = useState(false);
 	const dragCounterRef = useRef(0);
 
-	const resolveDroppedText = (dataTransfer: DataTransfer): string | null => {
+	const resolveDroppedText = async (
+		dataTransfer: DataTransfer,
+	): Promise<string | null> => {
 		const files = Array.from(dataTransfer.files);
 		if (files.length > 0) {
 			const paths = files
 				.map((file) => window.webUtils.getPathForFile(file))
 				.filter(Boolean);
-			return paths.length > 0 ? shellEscapePaths(paths) : null;
+			if (paths.length === 0) return null;
+			return shellEscapePaths(await repairDroppedPaths(paths));
 		}
 		const plainText = dataTransfer.getData("text/plain");
 		return plainText ? shellEscapePaths([plainText]) : null;
@@ -422,12 +426,12 @@ export function TerminalPane({
 		}
 	};
 
-	const handleDrop = (event: React.DragEvent) => {
+	const handleDrop = async (event: React.DragEvent) => {
 		event.preventDefault();
 		dragCounterRef.current = 0;
 		setIsDropActive(false);
 		if (connectionState === "closed") return;
-		const text = resolveDroppedText(event.dataTransfer);
+		const text = await resolveDroppedText(event.dataTransfer);
 		if (!text) return;
 		terminalRuntimeRegistry
 			.getTerminal(terminalId, terminalInstanceId)

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { sanitizeTerminalFontFamily } from "renderer/lib/terminal/appearance";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
+import { repairDroppedPaths } from "renderer/lib/terminal/repair-dropped-paths";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTerminalTheme } from "renderer/stores/theme";
 import { SessionKilledOverlay } from "./components";
@@ -424,14 +425,14 @@ export const Terminal = memo(function Terminal({
 		event.dataTransfer.dropEffect = "copy";
 	};
 
-	const handleDrop = (event: React.DragEvent) => {
+	const handleDrop = async (event: React.DragEvent) => {
 		event.preventDefault();
 		const files = Array.from(event.dataTransfer.files);
 		let text: string;
 		if (files.length > 0) {
 			// Native file drop (from Finder, etc.)
 			const paths = files.map((file) => window.webUtils.getPathForFile(file));
-			text = shellEscapePaths(paths);
+			text = shellEscapePaths(await repairDroppedPaths(paths));
 		} else {
 			// Internal drag (from file tree) - path is in text/plain
 			const plainText = event.dataTransfer.getData("text/plain");

--- a/apps/desktop/src/shared/dropped-path-repair.test.ts
+++ b/apps/desktop/src/shared/dropped-path-repair.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import {
+	foldSpaces,
+	matchByFoldedName,
+	splitPath,
+} from "./dropped-path-repair";
+
+describe("foldSpaces", () => {
+	it("folds the narrow no-break space macOS puts before am/pm", () => {
+		expect(foldSpaces("9.42.51\u202fam.png")).toBe("9.42.51 am.png");
+	});
+
+	it("folds the other space separators", () => {
+		expect(foldSpaces("a\u00a0b\u2007c\u205fd\u3000e")).toBe("a b c d e");
+	});
+
+	it("leaves a plain name alone", () => {
+		expect(foldSpaces("Screenshot 1.png")).toBe("Screenshot 1.png");
+	});
+
+	it("does not touch tabs or newlines, which are not space separators", () => {
+		expect(foldSpaces("a\tb\nc")).toBe("a\tb\nc");
+	});
+});
+
+describe("splitPath", () => {
+	it("splits a directory from a basename", () => {
+		expect(splitPath("/var/folders/x/Screenshot.png")).toEqual({
+			dir: "/var/folders/x",
+			base: "Screenshot.png",
+		});
+	});
+
+	it("treats a bare name as having no directory", () => {
+		expect(splitPath("Screenshot.png")).toEqual({
+			dir: "",
+			base: "Screenshot.png",
+		});
+	});
+
+	it("keeps the root slash", () => {
+		expect(splitPath("/tmp")).toEqual({ dir: "", base: "tmp" });
+	});
+});
+
+describe("matchByFoldedName", () => {
+	const onDisk = "Screenshot 2026-08-12 at 9.42.51\u202fam.png";
+
+	it("finds the on-disk name behind a plain-space basename", () => {
+		expect(
+			matchByFoldedName("Screenshot 2026-08-12 at 9.42.51 am.png", [
+				"other.png",
+				onDisk,
+			]),
+		).toBe(onDisk);
+	});
+
+	it("returns null when nothing matches", () => {
+		expect(matchByFoldedName("missing.png", [onDisk])).toBeNull();
+	});
+
+	it("returns null when two entries fold to the same name", () => {
+		expect(
+			matchByFoldedName("a b.png", ["a b.png", "a\u202fb.png"]),
+		).toBeNull();
+	});
+
+	it("returns null for an empty directory", () => {
+		expect(matchByFoldedName("a.png", [])).toBeNull();
+	});
+
+	it("does not match across a different name", () => {
+		expect(matchByFoldedName("a b.png", ["a-b.png"])).toBeNull();
+	});
+});

--- a/apps/desktop/src/shared/dropped-path-repair.test.ts
+++ b/apps/desktop/src/shared/dropped-path-repair.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	foldSpaces,
-	matchByFoldedName,
-	splitPath,
-} from "./dropped-path-repair";
+import { foldSpaces, matchByFoldedName } from "./dropped-path-repair";
 
 describe("foldSpaces", () => {
 	it("folds the narrow no-break space macOS puts before am/pm", () => {
@@ -20,26 +16,6 @@ describe("foldSpaces", () => {
 
 	it("does not touch tabs or newlines, which are not space separators", () => {
 		expect(foldSpaces("a\tb\nc")).toBe("a\tb\nc");
-	});
-});
-
-describe("splitPath", () => {
-	it("splits a directory from a basename", () => {
-		expect(splitPath("/var/folders/x/Screenshot.png")).toEqual({
-			dir: "/var/folders/x",
-			base: "Screenshot.png",
-		});
-	});
-
-	it("treats a bare name as having no directory", () => {
-		expect(splitPath("Screenshot.png")).toEqual({
-			dir: "",
-			base: "Screenshot.png",
-		});
-	});
-
-	it("keeps the root slash", () => {
-		expect(splitPath("/tmp")).toEqual({ dir: "", base: "tmp" });
 	});
 });
 

--- a/apps/desktop/src/shared/dropped-path-repair.ts
+++ b/apps/desktop/src/shared/dropped-path-repair.ts
@@ -1,0 +1,36 @@
+// A path handed to us by a file drop does not always match the file on disk.
+// macOS names screenshots with U+202F NARROW NO-BREAK SPACE before am/pm under
+// a 12-hour locale, and the path that comes back from the drop can carry a
+// plain U+0020 there instead, so nothing can open it (#6369).
+//
+// The repair below only ever turns a path that does not resolve into one that
+// does: it runs when the dropped path is missing, and gives up unless exactly
+// one sibling matches once every Unicode space separator is folded to an ASCII
+// space. A drop that already points at a real file never reaches it.
+
+/** Unicode space separators (category Zs) plus the ASCII space itself. */
+const SPACE_SEPARATOR = /\p{Zs}/gu;
+
+export function foldSpaces(value: string): string {
+	return value.replace(SPACE_SEPARATOR, " ");
+}
+
+export function splitPath(path: string): { dir: string; base: string } {
+	const cut = path.lastIndexOf("/");
+	if (cut < 0) return { dir: "", base: path };
+	return { dir: path.slice(0, cut), base: path.slice(cut + 1) };
+}
+
+/**
+ * The on-disk name the dropped basename was meant to point at, or null when
+ * the answer is not unique — two candidates mean we cannot tell which file the
+ * user dragged, and guessing is worse than leaving the path alone.
+ */
+export function matchByFoldedName(
+	base: string,
+	entries: readonly string[],
+): string | null {
+	const wanted = foldSpaces(base);
+	const matches = entries.filter((entry) => foldSpaces(entry) === wanted);
+	return matches.length === 1 ? (matches[0] ?? null) : null;
+}

--- a/apps/desktop/src/shared/dropped-path-repair.ts
+++ b/apps/desktop/src/shared/dropped-path-repair.ts
@@ -15,12 +15,6 @@ export function foldSpaces(value: string): string {
 	return value.replace(SPACE_SEPARATOR, " ");
 }
 
-export function splitPath(path: string): { dir: string; base: string } {
-	const cut = path.lastIndexOf("/");
-	if (cut < 0) return { dir: "", base: path };
-	return { dir: path.slice(0, cut), base: path.slice(cut + 1) };
-}
-
 /**
  * The on-disk name the dropped basename was meant to point at, or null when
  * the answer is not unique — two candidates mean we cannot tell which file the


### PR DESCRIPTION
## What & why

Fixes #6369. Dragging a file whose name contains U+202F NARROW NO-BREAK SPACE
inserts a path with a plain U+0020 in that position, so the path does not exist
and the agent cannot read the file. Under a 12-hour-clock locale macOS puts
U+202F before am/pm, so every screenshot filename hits this:

```
on disk:  … 39 2e 34 32 2e 35 31  e2 80 af  61 6d 2e 70 6e 67
dropped:  … 39 2e 34 32 2e 35 31  20        61 6d 2e 70 6e 67
```

The drop handlers (v1 `Terminal`, v2 `TerminalPane`) now resolve each dropped
path through the main process before inserting it. `resolveDroppedPath`:

- returns the path untouched if it already exists — the normal case never
  reaches any of the logic below;
- otherwise reads the containing directory and looks for a sibling whose name
  matches once every Unicode space separator (`\p{Zs}`) is folded to an ASCII
  space;
- returns the input unchanged if nothing matches, if two siblings fold to the
  same name, if the directory cannot be read, or if it holds more than 5000
  entries.

So a drop can only go from broken to working. Anything ambiguous is left
exactly as it is today.

## On the root cause — this is a repair, not a source fix

I could not pin the mangling on a specific layer, and I would rather say so than
imply otherwise. Ruled out, each checked directly rather than reasoned about:

| layer | result |
| --- | --- |
| `shell-quote@1.9.0` `quote()` | preserves U+202F (single-quotes the path) |
| `@xterm/xterm@6.1.0-beta.289` `paste()` | only `\r\n`→`\r` and ESC→`␛`; no normalization |
| websocket hop (`JSON.stringify({type:"input"})`) | lossless |
| `Buffer.from(data,"utf8")` → `pty.write` | lossless |
| zsh in a PTY, `LANG=en_AU.UTF-8` and `LANG=C` | `[ -e '…U+202F…' ]` → YES in both |
| Electron 41.10.3 / Chromium 146 `webUtils.getPathForFile` + `File.name` | both preserve U+202F for a file-input-sourced `File` |

That last row is the interesting one: I drove a real Electron window and used
CDP `DOM.setFileInputFiles` to hand it a file literally named
`U202F probe 9.42.51<U+202F>am.png`, and both `File.name` and
`webUtils.getPathForFile` came back with `202f` intact. So Blink's File→path
conversion is clean, and the remaining suspect is the macOS drag pasteboard
path (`web_drag_dest_mac.mm`), which needs a real OS drag to inspect. Happy to
drop this PR and chase that instead if a maintainer would rather fix it there.

## How I tested it

**End-to-end, against a real Claude Code 2.1.215 in a PTY** (tmux 120x45,
`tmux paste-buffer -p`), with a real PNG on disk named
`Screenshot 2026-08-12 at 9.42.51<U+202F>am.png`:

- before — the dropped form of the path (ASCII space):
  `❯ '/tmp/…/Screenshot 2026-08-12 at 9.42.51 am.png'`, no attachment
- after — `resolveDroppedPath`'s output:
  `❯ [Image #1]`

**Unit tests**

- `apps/desktop/src/shared/dropped-path-repair.test.ts` — folding and matching,
  including the ambiguous case and the "not a space separator" case (tabs,
  newlines).
- `apps/desktop/src/lib/trpc/routers/external/helpers.test.ts` — five cases
  against a real temp directory: repairs the U+202F name, leaves an existing
  path alone, gives up on two folded-equal siblings, gives up when nothing
  matches, gives up when the directory is missing.

**Gates**

- `bun run lint` → clean.
- `bun run typecheck --filter=@superset/desktop` → clean.
- `bun test src/shared src/lib/trpc/routers/external` → 254 pass, 0 fail.

No screenshot: I could not get the desktop dev app running in this clone
(`bun install` fails building `better-sqlite3` here), so the end-to-end evidence
is the PTY before/after rather than the app UI.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

---

## Update: Chromium's macOS drag path read in source

A follow-up pass read the current Chromium `main` sources rather than reasoning
about them, and cleared the drag ingestion too. Chain of custody for a real file
dragged from Finder — and, per an explicit comment in Chromium, for the macOS
screenshot thumbnail as well:

- `content/browser/web_contents/web_drag_dest_mac.mm`
  (`PopulateDropDataFromPasteboard`) assigns
  `drop_data.filenames = ui::clipboard_util::FilesFromPasteboard(pboard)` with
  no sanitizer on that line. A comment right below states that a pasteboard item
  can advertise both a real file URL and file-promise content as two
  representations of the same file, "e.g. an unsaved macOS screenshot", and that
  the promise branch is skipped when `filenames` is non-empty. So the screenshot
  thumbnail takes the real-file path, not the promise path.
- `ui/base/clipboard/clipboard_util_mac.mm` `FilesFromPasteboard` reads
  `NSPasteboardTypeFileURL` and converts with `base::apple::NSURLToFilePath` /
  `NSStringToFilePath` — plain CFString/CFURL conversions, no substitution.
- `base/i18n/file_util_icu.cc` keeps Unicode whitespace (`[:WSpace:]`, which
  includes U+202F) in `illegal_at_ends_`, **not** `illegal_anywhere_`, so even
  when it runs it only replaces whitespace at the first or last character. It is
  not on this call chain anyway; it is reachable only through
  `net::GenerateFileName`, which `web_drag_dest_mac.mm` calls solely in the
  `file_contents_content_disposition` branch that real files skip.
- Blink `DataObject::AddFilename` → `File::CreateForUserProvidedFile` via
  `FilePathToString`, a pure UTF-8/UTF-16 conversion.
- Electron `GetPathForFile` returns `blink::WebBlob::Path()` — a thin wrapper.

So no layer I have been able to read collapses Unicode whitespace, which leaves
either the macOS pasteboard/Foundation boundary itself or something about the
`NSIRD_screencaptureui_*` temp entry. Worth flagging the alternative reading
honestly: if the temp-directory entry never contained U+202F in the first place,
then the missing file is not a folding bug at all, and this repair would simply
never fire for that case — it fails closed, returning the input untouched.

The unit tests pin the behaviour either way, and the repair still fixes the
reproducible case: a real file on disk named with U+202F, addressed by a path
carrying U+0020.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal file drag-and-drop handling by repairing missing paths with Unicode space differences.
  * Supports repaired paths across both terminal drop experiences.
  * Preserves valid paths and safely leaves ambiguous or unresolved paths unchanged.

* **Bug Fixes**
  * Prevents dropped files from becoming unusable when their names contain inconsistent space characters.
  * Maintains reliable terminal input when path repair cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->