### PR TITLE
perf(desktop): cut sidebar hover and polling render fan-out

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/index.ts
@@ -1,1 +1,5 @@
-export { type DiffStats, useDiffStats } from "./useDiffStats";
+export {
+	type DiffStats,
+	getDiffStatsQueryKey,
+	useDiffStats,
+} from "./useDiffStats";

--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -9,6 +9,13 @@ export interface DiffStats {
 	deletions: number;
 }
 
+export function getDiffStatsQueryKey(
+	hostUrl: string | null,
+	workspaceId: string,
+) {
+	return ["diff-stats", hostUrl, workspaceId] as const;
+}
+
 export function useDiffStats(
 	workspaceId: string,
 	options?: { enabled?: boolean },
@@ -17,7 +24,7 @@ export function useDiffStats(
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
 	const queryKey = useMemo(
-		() => ["diff-stats", hostUrl, workspaceId] as const,
+		() => getDiffStatsQueryKey(hostUrl, workspaceId),
 		[hostUrl, workspaceId],
 	);
 

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
@@ -1,8 +1,5 @@
 export {
-	useMarkWorkspaceTerminalsSeen,
 	useV2AttentionWorkspaceCount,
 	useV2PaneNotificationStatus,
 	useV2SourcesNotificationStatus,
-	useV2WorkspaceIsUnread,
-	useV2WorkspaceNotificationStatus,
 } from "./useV2NotificationStatus";

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	getV2NotificationSourceKey,
 	getV2NotificationSourcesForPane,
@@ -11,10 +11,7 @@ import {
 	type ActivePaneStatus,
 	getHighestPriorityStatus,
 } from "shared/tabs-types";
-import {
-	type TerminalAgentBinding,
-	useTerminalAgentBindings,
-} from "../useTerminalAgentBindings";
+import type { TerminalAgentBinding } from "../useTerminalAgentBindings";
 import {
 	deriveTerminalAgentStatus,
 	useTerminalAgentStatuses,
@@ -61,55 +58,12 @@ export function useV2PaneNotificationStatus(
 	);
 }
 
-export function useV2WorkspaceNotificationStatus(
-	workspaceId: string,
-): ActivePaneStatus | null {
-	const statuses = useTerminalAgentStatuses(workspaceId);
-	const manualUnread = useV2NotificationStore((state) =>
-		Boolean(state.manualUnread[workspaceId]),
-	);
-	return getHighestPriorityStatus([
-		manualUnread ? "review" : undefined,
-		...statuses.values(),
-	]);
-}
-
-export function useV2WorkspaceIsUnread(workspaceId: string): boolean {
-	const statuses = useTerminalAgentStatuses(workspaceId);
-	const manualUnread = useV2NotificationStore((state) =>
-		Boolean(state.manualUnread[workspaceId]),
-	);
-	if (manualUnread) return true;
-	for (const status of statuses.values()) {
-		if (status === "review" || status === "failed") return true;
-	}
-	return false;
-}
-
-/**
- * Returns a callback that marks every terminal with a live agent binding in
- * the workspace as seen, clearing derived `review` statuses. Used by the
- * sidebar "mark read" / "clear status" actions.
- */
-export function useMarkWorkspaceTerminalsSeen(workspaceId: string): () => void {
-	const bindings = useTerminalAgentBindings(workspaceId);
-	const markTerminalSeen = useV2NotificationStore(
-		(state) => state.markTerminalSeen,
-	);
-	return useCallback(() => {
-		// Host-clock only: "seen through the binding's last event".
-		for (const binding of bindings.values()) {
-			markTerminalSeen(binding.terminalId, binding.lastEventAt);
-		}
-	}, [bindings, markTerminalSeen]);
-}
-
 /**
  * Number of distinct workspaces needing attention (any derived terminal
  * status other than `working`, or a manual unread mark). Drives the OS dock
- * badge. Aggregates over the bindings queries already mounted by sidebar
- * rows via the react-query cache; workspaces with no observed bindings
- * query contribute only their manual unread mark.
+ * badge. Aggregates over the bindings queries already mounted by the
+ * sidebar's workspace status provider via the react-query cache; workspaces
+ * with no observed bindings query contribute only their manual unread mark.
  */
 export function useV2AttentionWorkspaceCount(): number {
 	const queryClient = useQueryClient();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -35,6 +35,10 @@ import { DashboardSidebarDndProvider } from "./providers/DashboardSidebarDndProv
 import { DashboardSidebarHoverProvider } from "./providers/DashboardSidebarHoverProvider";
 import { DashboardSidebarPortsProvider } from "./providers/DashboardSidebarPortsProvider";
 import { DashboardSidebarSelectionProvider } from "./providers/DashboardSidebarSelectionProvider";
+import {
+	DashboardSidebarWorkspaceStatusProvider,
+	type SidebarStatusWorkspaceRef,
+} from "./providers/DashboardSidebarWorkspaceStatusProvider";
 import type { DashboardSidebarProject } from "./types";
 import { getProjectChildrenWorkspaces } from "./utils/projectChildren";
 
@@ -168,6 +172,25 @@ export function DashboardSidebar({
 		[orderedGroups],
 	);
 
+	// Every workspace the sidebar can render (pinned, sessions, project rows) —
+	// the status provider fans out bindings queries and event subscriptions for
+	// these once, instead of per row.
+	const statusWorkspaces = useMemo<SidebarStatusWorkspaceRef[]>(() => {
+		const byId = new Map<string, SidebarStatusWorkspaceRef>();
+		for (const workspace of pinnedWorkspaces) {
+			byId.set(workspace.id, { id: workspace.id, hostId: workspace.hostId });
+		}
+		for (const workspace of sessionWorkspaces) {
+			byId.set(workspace.id, { id: workspace.id, hostId: workspace.hostId });
+		}
+		for (const project of orderedGroups) {
+			for (const workspace of getProjectChildrenWorkspaces(project.children)) {
+				byId.set(workspace.id, { id: workspace.id, hostId: workspace.hostId });
+			}
+		}
+		return [...byId.values()];
+	}, [pinnedWorkspaces, sessionWorkspaces, orderedGroups]);
+
 	const activeV2Project = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;
 		// A pinned active workspace renders outside its project group, so
@@ -210,114 +233,121 @@ export function DashboardSidebar({
 		>
 			<DashboardSidebarSectionRenameProvider>
 				<DashboardSidebarHoverProvider>
-					<DashboardSidebarPortsProvider enabled={!isCollapsed}>
-						<DashboardSidebarHoverCardOverlay>
-							<DashboardSidebarDndProvider
-								projects={orderedGroups}
-								pinnedWorkspaces={pinnedWorkspaces}
-								sessionWorkspaces={sessionWorkspaces}
-								isSidebarCollapsed={isCollapsed}
-								workspaceShortcutLabels={workspaceShortcutLabels}
-								onReorderProjects={handleReorderProjects}
-							>
-								<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
-									<DashboardSidebarHeader isCollapsed={isCollapsed} />
+					<DashboardSidebarWorkspaceStatusProvider
+						workspaces={statusWorkspaces}
+						activeWorkspaceId={activeV2WorkspaceId}
+					>
+						<DashboardSidebarPortsProvider enabled={!isCollapsed}>
+							<DashboardSidebarHoverCardOverlay>
+								<DashboardSidebarDndProvider
+									projects={orderedGroups}
+									pinnedWorkspaces={pinnedWorkspaces}
+									sessionWorkspaces={sessionWorkspaces}
+									isSidebarCollapsed={isCollapsed}
+									workspaceShortcutLabels={workspaceShortcutLabels}
+									onReorderProjects={handleReorderProjects}
+								>
+									<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
+										<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
-									<OverflowFadeContainer
-										fadeEdges={["top", "bottom"]}
-										className="flex-1 overflow-y-auto hide-scrollbar"
-									>
-										{(isCollapsed || !workspacesListCollapsed) && (
-											<DashboardSidebarPinnedSection
-												pinnedWorkspaces={pinnedWorkspaces}
+										<OverflowFadeContainer
+											fadeEdges={["top", "bottom"]}
+											className="flex-1 overflow-y-auto hide-scrollbar"
+										>
+											{(isCollapsed || !workspacesListCollapsed) && (
+												<DashboardSidebarPinnedSection
+													pinnedWorkspaces={pinnedWorkspaces}
+													isCollapsed={isCollapsed}
+													onWorkspaceHover={refreshWorkspacePullRequest}
+												/>
+											)}
+											<DashboardSidebarSessionsSection
+												sessionWorkspaces={sessionWorkspaces}
 												isCollapsed={isCollapsed}
+												rowsHidden={!isCollapsed && workspacesListCollapsed}
+												workspaceShortcutLabels={workspaceShortcutLabels}
 												onWorkspaceHover={refreshWorkspacePullRequest}
 											/>
-										)}
-										<DashboardSidebarSessionsSection
-											sessionWorkspaces={sessionWorkspaces}
-											isCollapsed={isCollapsed}
-											rowsHidden={!isCollapsed && workspacesListCollapsed}
-											workspaceShortcutLabels={workspaceShortcutLabels}
-											onWorkspaceHover={refreshWorkspacePullRequest}
-										/>
-										{!isCollapsed && (
-											<DashboardSidebarBulkActions projects={orderedGroups}>
-												<DashboardSidebarWorkspacesHeader />
-											</DashboardSidebarBulkActions>
-										)}
-										{(isCollapsed || !workspacesListCollapsed) && (
-											<SortableContext
-												items={projectOrder}
-												strategy={verticalListSortingStrategy}
-											>
-												{orderedGroups.map((project) => (
-													<SortableProjectWrapper
-														key={project.id}
-														project={project}
-														isCollapsed={isCollapsed}
-														workspaceShortcutLabels={workspaceShortcutLabels}
-														onWorkspaceHover={refreshWorkspacePullRequest}
-														onToggleCollapse={toggleProjectCollapsed}
-													/>
-												))}
-											</SortableContext>
-										)}
-									</OverflowFadeContainer>
-									{!isCollapsed && !inlineWorkspacePortsEnabled && (
-										<DashboardSidebarPortsList />
-									)}
-									{!isCollapsed && activeV2Project && activeHostUrl && (
-										<V2SetupScriptCard
-											hostUrl={activeHostUrl}
-											projectId={activeV2Project.id}
-											projectName={activeV2Project.name}
-										/>
-									)}
-									<HiringBanner surface="v2" isCollapsed={isCollapsed} />
-									<div
-										className={cn(
-											isCollapsed
-												? "flex flex-col items-center gap-2 py-2"
-												: "flex items-center gap-1 p-2",
-										)}
-									>
-										{isCollapsed ? (
-											<OrganizationDropdown variant="collapsed" />
-										) : (
-											<div className="min-w-0 flex-1">
-												<OrganizationDropdown variant="expanded" />
-											</div>
-										)}
-
-										<UpdatesPill isCollapsed={isCollapsed} />
-										<Tooltip delayDuration={300}>
-											<TooltipTrigger asChild>
-												<button
-													type="button"
-													aria-label="Settings"
-													onClick={() => navigate({ to: "/settings/account" })}
-													className={cn(
-														"flex size-8 shrink-0 items-center justify-center rounded-md transition-colors",
-														isSettingsOpen
-															? "bg-fill-selected text-muted-foreground"
-															: "text-muted-foreground hover:bg-fill-hover",
-													)}
+											{!isCollapsed && (
+												<DashboardSidebarBulkActions projects={orderedGroups}>
+													<DashboardSidebarWorkspacesHeader />
+												</DashboardSidebarBulkActions>
+											)}
+											{(isCollapsed || !workspacesListCollapsed) && (
+												<SortableContext
+													items={projectOrder}
+													strategy={verticalListSortingStrategy}
 												>
-													<HiOutlineCog6Tooth className="size-3.5" />
-												</button>
-											</TooltipTrigger>
-											<TooltipContent side={isCollapsed ? "right" : "top"}>
-												{settingsHotkey !== "Unassigned"
-													? `Settings (${settingsHotkey})`
-													: "Settings"}
-											</TooltipContent>
-										</Tooltip>
+													{orderedGroups.map((project) => (
+														<SortableProjectWrapper
+															key={project.id}
+															project={project}
+															isCollapsed={isCollapsed}
+															workspaceShortcutLabels={workspaceShortcutLabels}
+															onWorkspaceHover={refreshWorkspacePullRequest}
+															onToggleCollapse={toggleProjectCollapsed}
+														/>
+													))}
+												</SortableContext>
+											)}
+										</OverflowFadeContainer>
+										{!isCollapsed && !inlineWorkspacePortsEnabled && (
+											<DashboardSidebarPortsList />
+										)}
+										{!isCollapsed && activeV2Project && activeHostUrl && (
+											<V2SetupScriptCard
+												hostUrl={activeHostUrl}
+												projectId={activeV2Project.id}
+												projectName={activeV2Project.name}
+											/>
+										)}
+										<HiringBanner surface="v2" isCollapsed={isCollapsed} />
+										<div
+											className={cn(
+												isCollapsed
+													? "flex flex-col items-center gap-2 py-2"
+													: "flex items-center gap-1 p-2",
+											)}
+										>
+											{isCollapsed ? (
+												<OrganizationDropdown variant="collapsed" />
+											) : (
+												<div className="min-w-0 flex-1">
+													<OrganizationDropdown variant="expanded" />
+												</div>
+											)}
+
+											<UpdatesPill isCollapsed={isCollapsed} />
+											<Tooltip delayDuration={300}>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														aria-label="Settings"
+														onClick={() =>
+															navigate({ to: "/settings/account" })
+														}
+														className={cn(
+															"flex size-8 shrink-0 items-center justify-center rounded-md transition-colors",
+															isSettingsOpen
+																? "bg-fill-selected text-muted-foreground"
+																: "text-muted-foreground hover:bg-fill-hover",
+														)}
+													>
+														<HiOutlineCog6Tooth className="size-3.5" />
+													</button>
+												</TooltipTrigger>
+												<TooltipContent side={isCollapsed ? "right" : "top"}>
+													{settingsHotkey !== "Unassigned"
+														? `Settings (${settingsHotkey})`
+														: "Settings"}
+												</TooltipContent>
+											</Tooltip>
+										</div>
 									</div>
-								</div>
-							</DashboardSidebarDndProvider>
-						</DashboardSidebarHoverCardOverlay>
-					</DashboardSidebarPortsProvider>
+								</DashboardSidebarDndProvider>
+							</DashboardSidebarHoverCardOverlay>
+						</DashboardSidebarPortsProvider>
+					</DashboardSidebarWorkspaceStatusProvider>
 				</DashboardSidebarHoverProvider>
 			</DashboardSidebarSectionRenameProvider>
 		</DashboardSidebarSelectionProvider>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/DashboardSidebarPinnedSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/DashboardSidebarPinnedSection.tsx
@@ -46,7 +46,7 @@ export function DashboardSidebarPinnedSection({
 						key={workspace.id}
 						workspace={workspace}
 						isCollapsed
-						onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+						onHoverCardOpen={onWorkspaceHover}
 					/>
 				))}
 				<div className="mx-3 mt-1 border-b border-border" />
@@ -85,7 +85,7 @@ export function DashboardSidebarPinnedSection({
 								projectName: project?.name ?? null,
 								projectIconUrl: project?.iconUrl ?? null,
 							}}
-							onHoverCardOpen={() => onWorkspaceHover(parsed.realId)}
+							onHoverCardOpen={onWorkspaceHover}
 						/>
 					);
 				})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/DashboardSidebarCollapsedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/DashboardSidebarCollapsedProjectContent.tsx
@@ -113,7 +113,7 @@ export const DashboardSidebarCollapsedProjectContent = forwardRef<
 												key={String(id)}
 												sortableId={String(id)}
 												workspace={workspace}
-												onHoverCardOpen={() => onWorkspaceHover(parsed.realId)}
+												onHoverCardOpen={onWorkspaceHover}
 												shortcutLabel={workspaceShortcutLabels.get(
 													parsed.realId,
 												)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/components/SortableCollapsedWorkspaceItem/SortableCollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/components/SortableCollapsedWorkspaceItem/SortableCollapsedWorkspaceItem.tsx
@@ -7,7 +7,7 @@ import { DashboardSidebarWorkspaceItem } from "../../../../../DashboardSidebarWo
 interface SortableCollapsedWorkspaceItemProps {
 	sortableId: string;
 	workspace: DashboardSidebarWorkspace;
-	onHoverCardOpen?: () => void;
+	onHoverCardOpen?: (workspaceId: string) => void | Promise<void>;
 	shortcutLabel?: string;
 	disabled?: boolean;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -2,6 +2,7 @@ import {
 	SortableContext,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import {
@@ -132,49 +133,54 @@ export function DashboardSidebarExpandedProjectContent({
 										workspace.type === "worktree" &&
 										workspace.pendingTransaction?.type !== "insert";
 
+									// Rows collapse via a CSS grid-row transition instead of a
+									// per-row AnimatePresence/motion.div (~80 motion components
+									// cost real render time). Hidden rows stay mounted: `inert`
+									// removes them from focus/hit-testing and the disabled
+									// sortable unregisters their droppable, matching the old
+									// unmount behavior for DnD.
 									return (
-										<AnimatePresence key={String(id)} initial={false}>
-											{!hidden && (
-												<motion.div
-													initial={{ height: 0, opacity: 0 }}
-													animate={{ height: "auto", opacity: 1 }}
-													exit={{ height: 0, opacity: 0 }}
-													transition={{ duration: 0.15, ease: "easeOut" }}
-												>
-													<SortableWorkspaceItem
-														sortableId={String(id)}
-														workspace={workspace}
-														accentColor={group?.color}
-														isInSection={groupInfo.has(parsed.realId)}
-														onHoverCardOpen={() =>
-															onWorkspaceHover(parsed.realId)
-														}
-														shortcutLabel={workspaceShortcutLabels.get(
-															parsed.realId,
-														)}
-														isSelected={
-															canBulkSelect &&
-															isWorkspaceSelected(parsed.realId)
-														}
-														onSelectionClick={
-															canBulkSelect
-																? (event) =>
-																		selectWorkspaceFromEvent(event, {
-																			workspaceId: parsed.realId,
-																			projectId,
-																			orderedWorkspaceIds:
-																				selectableWorkspaceIds,
-																		})
-																: undefined
-														}
-														disabled={
-															workspace.type === "main" &&
-															workspace.hostType === "local-device"
-														}
-													/>
-												</motion.div>
+										<div
+											key={String(id)}
+											className={cn(
+												"grid transition-[grid-template-rows,opacity] duration-150 ease-out",
+												hidden
+													? "grid-rows-[0fr] opacity-0"
+													: "grid-rows-[1fr] opacity-100",
 											)}
-										</AnimatePresence>
+											inert={hidden}
+										>
+											<div className="min-h-0 overflow-hidden">
+												<SortableWorkspaceItem
+													sortableId={String(id)}
+													workspace={workspace}
+													accentColor={group?.color}
+													isInSection={isInSection}
+													onHoverCardOpen={onWorkspaceHover}
+													shortcutLabel={workspaceShortcutLabels.get(
+														parsed.realId,
+													)}
+													isSelected={
+														canBulkSelect && isWorkspaceSelected(parsed.realId)
+													}
+													onSelectionClick={
+														canBulkSelect
+															? (event) =>
+																	selectWorkspaceFromEvent(event, {
+																		workspaceId: parsed.realId,
+																		projectId,
+																		orderedWorkspaceIds: selectableWorkspaceIds,
+																	})
+															: undefined
+													}
+													disabled={
+														hidden ||
+														(workspace.type === "main" &&
+															workspace.hostType === "local-device")
+													}
+												/>
+											</div>
+										</div>
 									);
 								})}
 							</SortableContext>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
@@ -62,7 +62,7 @@ export function DashboardSidebarSessionsSection({
 						workspace={workspace}
 						isCollapsed
 						isInSection={false}
-						onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+						onHoverCardOpen={onWorkspaceHover}
 					/>
 				))}
 				<div className="mx-3 mt-1 border-b border-border" />
@@ -106,7 +106,7 @@ export function DashboardSidebarSessionsSection({
 								sortableId={String(id)}
 								workspace={workspace}
 								shortcutLabel={workspaceShortcutLabels?.get(parsed.realId)}
-								onHoverCardOpen={() => onWorkspaceHover(parsed.realId)}
+								onHoverCardOpen={onWorkspaceHover}
 							/>
 						);
 					})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -7,12 +7,14 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
-import { useV2WorkspaceNotificationStatus } from "renderer/hooks/host-service/useV2NotificationStatus";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
-import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
+import {
+	useDashboardSidebarHoverActions,
+	useDashboardSidebarIsHovered,
+} from "../../providers/DashboardSidebarHoverProvider";
 import type { WorkspaceSelectionEvent } from "../../providers/DashboardSidebarSelectionProvider";
+import { useSidebarWorkspaceStatus } from "../../providers/DashboardSidebarWorkspaceStatusProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
 import { DashboardSidebarExpandedWorkspaceRow } from "./components/DashboardSidebarExpandedWorkspaceRow";
@@ -25,7 +27,7 @@ import { useDashboardSidebarWorkspaceItemActions } from "./hooks/useDashboardSid
 
 interface DashboardSidebarWorkspaceItemProps {
 	workspace: DashboardSidebarWorkspace;
-	onHoverCardOpen?: () => void;
+	onHoverCardOpen?: (workspaceId: string) => void | Promise<void>;
 	shortcutLabel?: string;
 	isCollapsed?: boolean;
 	isInSection?: boolean;
@@ -61,7 +63,7 @@ export function DashboardSidebarWorkspaceItem({
 		pullRequest,
 	} = workspace;
 	const isMainWorkspace = workspace.type === "main";
-	const workspaceStatus = useV2WorkspaceNotificationStatus(id);
+	const { status: workspaceStatus, diffStats } = useSidebarWorkspaceStatus(id);
 	const {
 		cancelRename,
 		handleClearStatus,
@@ -92,10 +94,6 @@ export function DashboardSidebarWorkspaceItem({
 		isPinned: workspace.isPinned,
 	});
 
-	// Only the active workspace row shows line counts, so skip the per-item
-	// git status query everywhere else.
-	const diffStats = useDiffStats(id, { enabled: isActive });
-
 	const { v2Workspaces: v2WorkspaceActions } = useOptimisticCollectionActions();
 	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
 		null,
@@ -106,11 +104,10 @@ export function DashboardSidebarWorkspaceItem({
 	const isPending = pendingTransaction?.type === "insert";
 
 	const {
-		hoveredId: hoverHoveredId,
 		requestOpen: hoverRequestOpen,
 		requestClose: hoverRequestClose,
 		syncIfHovered: hoverSyncIfHovered,
-	} = useDashboardSidebarHover();
+	} = useDashboardSidebarHoverActions();
 	const rowRef = useRef<HTMLDivElement>(null);
 	const hoverEligible = !isPending;
 	const hoverPayload = useMemo(
@@ -136,10 +133,12 @@ export function DashboardSidebarWorkspaceItem({
 		[hoverEligible, hoverRequestClose, id],
 	);
 
-	const isHovered = hoverHoveredId === id;
+	const isHovered = useDashboardSidebarIsHovered(id);
 	useEffect(() => {
-		if (isHovered && hostType === "local-device") onHoverCardOpen?.();
-	}, [isHovered, hostType, onHoverCardOpen]);
+		// Fires on the committed hover only (hoveredId set after OPEN_DELAY or an
+		// open-card switch), never on transient row mouseenter.
+		if (isHovered && hostType === "local-device") void onHoverCardOpen?.(id);
+	}, [isHovered, hostType, onHoverCardOpen, id]);
 	useEffect(() => {
 		if (!isHovered) return;
 		hoverSyncIfHovered(id, hoverPayload);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/DashboardSidebarWorkspaceChips.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/DashboardSidebarWorkspaceChips.tsx
@@ -30,10 +30,7 @@ export function DashboardSidebarWorkspaceChips({
 
 	const portGroup = useDashboardSidebarWorkspacePorts(workspaceId);
 	const ports = inlineWorkspacePortsEnabled ? (portGroup?.ports ?? []) : [];
-	const runningAgents = useDashboardSidebarWorkspaceRunningAgents(
-		workspaceId,
-		workspaceAgentsRowEnabled,
-	);
+	const runningAgents = useDashboardSidebarWorkspaceRunningAgents(workspaceId);
 	const agents =
 		workspaceAgentsRowEnabled && runningAgents.length > 1 ? runningAgents : [];
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarChipHoverSuppression/useDashboardSidebarChipHoverSuppression.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarChipHoverSuppression/useDashboardSidebarChipHoverSuppression.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useDashboardSidebarHover } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider";
+import { useDashboardSidebarHoverActions } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider";
 
 interface UseDashboardSidebarChipHoverSuppressionResult {
 	isOpen: boolean;
@@ -17,7 +17,7 @@ interface UseDashboardSidebarChipHoverSuppressionResult {
  */
 export function useDashboardSidebarChipHoverSuppression(): UseDashboardSidebarChipHoverSuppressionResult {
 	const { beginHoverCardSuppression, endHoverCardSuppression } =
-		useDashboardSidebarHover();
+		useDashboardSidebarHoverActions();
 	const holdsRef = useRef(0);
 	const isOpenRef = useRef(false);
 	const dismissedByClickRef = useRef(false);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -3,8 +3,7 @@ import {
 	type AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 import { useMemo } from "react";
-import { useTerminalAgentBindings } from "renderer/hooks/host-service/useTerminalAgentBindings";
-import { useTerminalAgentStatuses } from "renderer/hooks/host-service/useTerminalAgentStatuses";
+import { useSidebarWorkspaceStatus } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider";
 import type { V2NotificationSource } from "renderer/stores/v2-notifications";
 import type { PaneStatus } from "shared/tabs-types";
 
@@ -40,10 +39,8 @@ export interface DashboardSidebarRunningAgent {
  */
 export function useDashboardSidebarWorkspaceRunningAgents(
 	workspaceId: string,
-	enabled = true,
 ): DashboardSidebarRunningAgent[] {
-	const bindings = useTerminalAgentBindings(workspaceId, { enabled });
-	const statuses = useTerminalAgentStatuses(workspaceId, { enabled });
+	const { bindings, statuses } = useSidebarWorkspaceStatus(workspaceId);
 
 	return useMemo(() => {
 		const agents: DashboardSidebarRunningAgent[] = [];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceBulkContextMenu/DashboardSidebarWorkspaceBulkContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceBulkContextMenu/DashboardSidebarWorkspaceBulkContextMenu.tsx
@@ -18,7 +18,7 @@ import {
 } from "react-icons/lu";
 import { useBulkWorkspaceDeleteDialog } from "../../../../hooks/useBulkWorkspaceDeleteDialog";
 import { useBulkWorkspaceMoveActions } from "../../../../hooks/useBulkWorkspaceMoveActions";
-import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
+import { useDashboardSidebarHoverActions } from "../../../../providers/DashboardSidebarHoverProvider";
 import { useDashboardSidebarSelection } from "../../../../providers/DashboardSidebarSelectionProvider";
 import { DashboardSidebarBulkDeleteDialog } from "../../../DashboardSidebarBulkDeleteDialog";
 import { useWorkspaceBulkMenuScope } from "../WorkspaceBulkMenuScope";
@@ -31,7 +31,7 @@ export function DashboardSidebarWorkspaceBulkContextMenu({
 	children,
 }: DashboardSidebarWorkspaceBulkContextMenuProps) {
 	const scope = useWorkspaceBulkMenuScope();
-	const { setContextMenuOpen } = useDashboardSidebarHover();
+	const { setContextMenuOpen } = useDashboardSidebarHoverActions();
 	const { clearSelection, removeSelectedWorkspaces } =
 		useDashboardSidebarSelection();
 	const {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -31,7 +31,7 @@ import {
 } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
+import { useDashboardSidebarHoverActions } from "../../../../providers/DashboardSidebarHoverProvider";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { useDashboardSidebarPortKill } from "../../../DashboardSidebarPortsList/hooks/useDashboardSidebarPortKill";
 
@@ -88,7 +88,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 	children,
 }: DashboardSidebarWorkspaceContextMenuProps) {
 	const collections = useCollections();
-	const { setContextMenuOpen } = useDashboardSidebarHover();
+	const { setContextMenuOpen } = useDashboardSidebarHoverActions();
 	const portGroup = useDashboardSidebarWorkspacePorts(workspaceId);
 	const { isPending: isKillingPorts, killPorts } =
 		useDashboardSidebarPortKill();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -3,10 +3,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { getTerminalAgentBindingsQueryKey } from "renderer/hooks/host-service/useTerminalAgentBindings";
-import {
-	useMarkWorkspaceTerminalsSeen,
-	useV2WorkspaceIsUnread,
-} from "renderer/hooks/host-service/useV2NotificationStatus";
 import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -14,6 +10,10 @@ import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unava
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useDashboardSidebarSectionRename } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSectionRenameContext";
 import { DASHBOARD_SIDEBAR_PULL_REQUEST_QUERY_KEY_PREFIX } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets";
+import {
+	useMarkSidebarWorkspaceTerminalsSeen,
+	useSidebarWorkspaceStatus,
+} from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -48,8 +48,9 @@ export function useDashboardSidebarWorkspaceItemActions({
 	const { requestSectionRename } = useDashboardSidebarSectionRename();
 	const setManualUnread = useV2NotificationStore((s) => s.setManualUnread);
 	const clearManualUnread = useV2NotificationStore((s) => s.clearManualUnread);
-	const markWorkspaceTerminalsSeen = useMarkWorkspaceTerminalsSeen(workspaceId);
-	const isUnread = useV2WorkspaceIsUnread(workspaceId);
+	const markWorkspaceTerminalsSeen =
+		useMarkSidebarWorkspaceTerminalsSeen(workspaceId);
+	const { isUnread } = useSidebarWorkspaceStatus(workspaceId);
 	const workspaceHostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -10,7 +10,7 @@ interface SortableWorkspaceItemProps {
 	workspace: DashboardSidebarWorkspace;
 	accentColor?: string | null;
 	isInSection?: boolean;
-	onHoverCardOpen?: () => void;
+	onHoverCardOpen?: (workspaceId: string) => void | Promise<void>;
 	shortcutLabel?: string;
 	disabled?: boolean;
 	isSelected?: boolean;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/pullRequestRefreshCooldown.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/pullRequestRefreshCooldown.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createPullRequestRefreshGate,
+	PULL_REQUEST_REFRESH_COOLDOWN_MS,
+} from "./pullRequestRefreshCooldown";
+
+describe("createPullRequestRefreshGate", () => {
+	test("allows the first refresh for a workspace", () => {
+		const gate = createPullRequestRefreshGate();
+		expect(gate.shouldRefresh("ws-1", 1_000)).toBe(true);
+	});
+
+	test("rejects a second refresh inside the cool-down window", () => {
+		const gate = createPullRequestRefreshGate();
+		expect(gate.shouldRefresh("ws-1", 1_000)).toBe(true);
+		expect(
+			gate.shouldRefresh("ws-1", 1_000 + PULL_REQUEST_REFRESH_COOLDOWN_MS - 1),
+		).toBe(false);
+	});
+
+	test("allows a refresh once the cool-down has elapsed", () => {
+		const gate = createPullRequestRefreshGate();
+		expect(gate.shouldRefresh("ws-1", 1_000)).toBe(true);
+		expect(
+			gate.shouldRefresh("ws-1", 1_000 + PULL_REQUEST_REFRESH_COOLDOWN_MS),
+		).toBe(true);
+	});
+
+	test("tracks workspaces independently", () => {
+		const gate = createPullRequestRefreshGate();
+		expect(gate.shouldRefresh("ws-1", 1_000)).toBe(true);
+		expect(gate.shouldRefresh("ws-2", 1_001)).toBe(true);
+		expect(gate.shouldRefresh("ws-1", 1_002)).toBe(false);
+	});
+
+	test("a rejected attempt does not extend the window", () => {
+		const gate = createPullRequestRefreshGate(1_000);
+		expect(gate.shouldRefresh("ws-1", 0)).toBe(true);
+		expect(gate.shouldRefresh("ws-1", 999)).toBe(false);
+		expect(gate.shouldRefresh("ws-1", 1_000)).toBe(true);
+	});
+
+	test("an allowed attempt restarts the window", () => {
+		const gate = createPullRequestRefreshGate(1_000);
+		expect(gate.shouldRefresh("ws-1", 0)).toBe(true);
+		expect(gate.shouldRefresh("ws-1", 1_500)).toBe(true);
+		expect(gate.shouldRefresh("ws-1", 2_400)).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/pullRequestRefreshCooldown.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/pullRequestRefreshCooldown.ts
@@ -1,0 +1,31 @@
+/**
+ * Hover-triggered PR refreshes fire a host-service mutation per card open;
+ * sweeping the pointer across rows would otherwise re-refresh the same
+ * workspace many times per minute for no new data.
+ */
+export const PULL_REQUEST_REFRESH_COOLDOWN_MS = 45_000;
+
+export interface PullRequestRefreshGate {
+	/**
+	 * True when `workspaceId` has not been refreshed within the cool-down.
+	 * A `true` result records `now` as the workspace's last refresh, so
+	 * concurrent callers inside the window are rejected too.
+	 */
+	shouldRefresh: (workspaceId: string, now: number) => boolean;
+}
+
+export function createPullRequestRefreshGate(
+	cooldownMs: number = PULL_REQUEST_REFRESH_COOLDOWN_MS,
+): PullRequestRefreshGate {
+	const lastRefreshAtByWorkspaceId = new Map<string, number>();
+	return {
+		shouldRefresh(workspaceId, now) {
+			const lastRefreshAt = lastRefreshAtByWorkspaceId.get(workspaceId);
+			if (lastRefreshAt !== undefined && now - lastRefreshAt < cooldownMs) {
+				return false;
+			}
+			lastRefreshAtByWorkspaceId.set(workspaceId, now);
+			return true;
+		},
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -31,8 +31,12 @@ import {
 	getDashboardSidebarPullRequestQueryKey,
 	type PullRequestQueryTarget,
 } from "./derivePullRequestQueryTargets";
+import { createPullRequestRefreshGate } from "./pullRequestRefreshCooldown";
 
 const MAIN_WORKSPACE_TAB_ORDER = Number.MIN_SAFE_INTEGER;
+
+// Module-level so remounting the sidebar doesn't reset the cool-down.
+const pullRequestRefreshGate = createPullRequestRefreshGate();
 
 type SidebarPullRequest = DashboardSidebarWorkspace["pullRequest"];
 type PullRequestWorkspaceRow = {
@@ -444,6 +448,9 @@ export function useDashboardSidebarData() {
 				(candidate) => candidate.machineId === workspace.hostId,
 			);
 			if (!target?.hostUrl) return;
+			if (!pullRequestRefreshGate.shouldRefresh(workspaceId, Date.now())) {
+				return;
+			}
 
 			const client = getHostServiceClientByUrl(target.hostUrl);
 			await client.pullRequests.refreshByWorkspaces.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarDndProvider/DashboardSidebarDndProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarDndProvider/DashboardSidebarDndProvider.tsx
@@ -17,7 +17,7 @@ import type {
 	DashboardSidebarProject,
 	DashboardSidebarWorkspace,
 } from "../../types";
-import { useDashboardSidebarHover } from "../DashboardSidebarHoverProvider";
+import { useDashboardSidebarHoverActions } from "../DashboardSidebarHoverProvider";
 
 interface DashboardSidebarDndProviderProps {
 	/** Projects in their current display order. */
@@ -65,7 +65,7 @@ export function DashboardSidebarDndProvider({
 	// popping open under the drop point). Hold a hover suppression for the
 	// drag's duration; dnd-kit pairs every start with exactly one end/cancel.
 	const { beginHoverCardSuppression, endHoverCardSuppression, forceClose } =
-		useDashboardSidebarHover();
+		useDashboardSidebarHoverActions();
 	// try/finally throughout: a throwing drag handler (e.g. a persistence
 	// write) must not leak the counted suppression, or hover cards stay dead
 	// until the sidebar remounts.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
 import type { DashboardSidebarWorkspace } from "../../types";
 
@@ -129,6 +130,31 @@ interface HoverContextValue {
 
 const HoverContext = createContext<HoverContextValue | null>(null);
 
+/**
+ * The subset of the hover machine whose identities never change. Row-count
+ * components (workspace rows, their context menus, chips) consume this
+ * instead of the full context so a hovered-id commit doesn't re-render every
+ * row in the sidebar; only the overlay needs the stateful context above.
+ */
+interface HoverActionsContextValue {
+	requestOpen: HoverContextValue["requestOpen"];
+	requestClose: HoverContextValue["requestClose"];
+	cancelClose: () => void;
+	forceClose: () => void;
+	setContextMenuOpen: (open: boolean) => void;
+	beginHoverCardSuppression: () => void;
+	endHoverCardSuppression: () => void;
+	syncIfHovered: HoverContextValue["syncIfHovered"];
+	setCardElement: (element: HTMLElement | null) => void;
+	/** Per-row hovered-state subscription backing useDashboardSidebarIsHovered. */
+	subscribeHoveredId: (listener: () => void) => () => void;
+	getHoveredId: () => string | null;
+}
+
+const HoverActionsContext = createContext<HoverActionsContextValue | null>(
+	null,
+);
+
 export function DashboardSidebarHoverProvider({
 	children,
 }: {
@@ -157,9 +183,23 @@ export function DashboardSidebarHoverProvider({
 	}, []);
 
 	const stateRef = useRef(state);
+	const hoveredIdListenersRef = useRef(new Set<() => void>());
 	useEffect(() => {
+		const hoveredIdChanged = stateRef.current.hoveredId !== state.hoveredId;
 		stateRef.current = state;
+		if (hoveredIdChanged) {
+			for (const listener of [...hoveredIdListenersRef.current]) {
+				listener();
+			}
+		}
 	}, [state]);
+	const subscribeHoveredId = useCallback((listener: () => void) => {
+		hoveredIdListenersRef.current.add(listener);
+		return () => {
+			hoveredIdListenersRef.current.delete(listener);
+		};
+	}, []);
+	const getHoveredId = useCallback(() => stateRef.current.hoveredId, []);
 
 	const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -434,8 +474,40 @@ export function DashboardSidebarHoverProvider({
 		],
 	);
 
+	// Every entry is identity-stable, so this memo never invalidates and
+	// consumers of the actions context never re-render from hover churn.
+	const actionsValue = useMemo<HoverActionsContextValue>(
+		() => ({
+			requestOpen,
+			requestClose,
+			cancelClose,
+			forceClose,
+			setContextMenuOpen,
+			beginHoverCardSuppression,
+			endHoverCardSuppression,
+			syncIfHovered,
+			setCardElement,
+			subscribeHoveredId,
+			getHoveredId,
+		}),
+		[
+			requestOpen,
+			requestClose,
+			cancelClose,
+			forceClose,
+			beginHoverCardSuppression,
+			endHoverCardSuppression,
+			syncIfHovered,
+			setCardElement,
+			subscribeHoveredId,
+			getHoveredId,
+		],
+	);
+
 	return (
-		<HoverContext.Provider value={value}>{children}</HoverContext.Provider>
+		<HoverActionsContext.Provider value={actionsValue}>
+			<HoverContext.Provider value={value}>{children}</HoverContext.Provider>
+		</HoverActionsContext.Provider>
 	);
 }
 
@@ -447,4 +519,27 @@ export function useDashboardSidebarHover() {
 		);
 	}
 	return ctx;
+}
+
+export function useDashboardSidebarHoverActions() {
+	const ctx = useContext(HoverActionsContext);
+	if (!ctx) {
+		throw new Error(
+			"useDashboardSidebarHoverActions must be used inside DashboardSidebarHoverProvider",
+		);
+	}
+	return ctx;
+}
+
+/**
+ * Whether `id` is the committed hovered row. Subscription-based so a hover
+ * commit re-renders only the two affected rows, not every context consumer.
+ */
+export function useDashboardSidebarIsHovered(id: string): boolean {
+	const { subscribeHoveredId, getHoveredId } =
+		useDashboardSidebarHoverActions();
+	return useSyncExternalStore(
+		subscribeHoveredId,
+		useCallback(() => getHoveredId() === id, [getHoveredId, id]),
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/index.ts
@@ -2,4 +2,6 @@ export {
 	type DashboardSidebarHoverPayload,
 	DashboardSidebarHoverProvider,
 	useDashboardSidebarHover,
+	useDashboardSidebarHoverActions,
+	useDashboardSidebarIsHovered,
 } from "./DashboardSidebarHoverProvider";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
@@ -1,0 +1,382 @@
+import { getEventBus } from "@superset/workspace-client";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
+import {
+	type DiffStats,
+	getDiffStatsQueryKey,
+	useDiffStats,
+} from "renderer/hooks/host-service/useDiffStats";
+import {
+	getTerminalAgentBindingsQueryKey,
+	type TerminalAgentBinding,
+} from "renderer/hooks/host-service/useTerminalAgentBindings";
+import { deriveTerminalAgentStatus } from "renderer/hooks/host-service/useTerminalAgentStatuses";
+import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useV2NotificationStore } from "renderer/stores/v2-notifications";
+import {
+	type ActivePaneStatus,
+	getHighestPriorityStatus,
+	type PaneStatus,
+} from "shared/tabs-types";
+
+export interface SidebarWorkspaceStatusEntry {
+	/** Highest-priority attention status across the workspace's terminals. */
+	status: ActivePaneStatus | null;
+	/** Manual unread mark, or any terminal in review/failed. */
+	isUnread: boolean;
+	/** `terminalId → host agent binding` (source rows for mark-seen). */
+	bindings: ReadonlyMap<string, TerminalAgentBinding>;
+	/** `terminalId → derived agent status` (drives the agents chip). */
+	statuses: ReadonlyMap<string, PaneStatus>;
+	/** Populated only for the active workspace — the only row that shows it. */
+	diffStats: DiffStats | null;
+}
+
+const EMPTY_ENTRY: SidebarWorkspaceStatusEntry = {
+	status: null,
+	isUnread: false,
+	bindings: new Map(),
+	statuses: new Map(),
+	diffStats: null,
+};
+
+/**
+ * Per-workspace external store: rows subscribe to their own entry via
+ * useSyncExternalStore, so a bindings/status change re-renders only the rows
+ * whose entry actually changed — not every row on every cache update.
+ */
+class SidebarWorkspaceStatusStore {
+	private entries = new Map<string, SidebarWorkspaceStatusEntry>();
+	private listeners = new Map<string, Set<() => void>>();
+	private pendingChanged: string[] = [];
+
+	get(workspaceId: string): SidebarWorkspaceStatusEntry {
+		return this.entries.get(workspaceId) ?? EMPTY_ENTRY;
+	}
+
+	subscribe(workspaceId: string, listener: () => void): () => void {
+		let set = this.listeners.get(workspaceId);
+		if (!set) {
+			set = new Set();
+			this.listeners.set(workspaceId, set);
+		}
+		set.add(listener);
+		return () => {
+			set.delete(listener);
+			if (set.size === 0) this.listeners.delete(workspaceId);
+		};
+	}
+
+	/**
+	 * Swaps the entry map during the provider's render (so children mounting
+	 * afterwards read fresh snapshots) and queues change notifications, which
+	 * must only fire after commit — see flushNotifications.
+	 */
+	replaceEntries(next: Map<string, SidebarWorkspaceStatusEntry>): void {
+		if (next === this.entries) return;
+		for (const [workspaceId, entry] of next) {
+			if (this.entries.get(workspaceId) !== entry) {
+				this.pendingChanged.push(workspaceId);
+			}
+		}
+		for (const workspaceId of this.entries.keys()) {
+			if (!next.has(workspaceId)) this.pendingChanged.push(workspaceId);
+		}
+		this.entries = next;
+	}
+
+	flushNotifications(): void {
+		if (this.pendingChanged.length === 0) return;
+		const changed = new Set(this.pendingChanged);
+		this.pendingChanged = [];
+		for (const workspaceId of changed) {
+			const set = this.listeners.get(workspaceId);
+			if (!set) continue;
+			for (const listener of [...set]) listener();
+		}
+	}
+}
+
+const StatusStoreContext = createContext<SidebarWorkspaceStatusStore | null>(
+	null,
+);
+
+export interface SidebarStatusWorkspaceRef {
+	id: string;
+	hostId: string;
+}
+
+interface WorkspaceStatusTarget {
+	workspaceId: string;
+	hostUrl: string | null;
+}
+
+function mapsShallowEqual<Value>(
+	left: ReadonlyMap<string, Value>,
+	right: ReadonlyMap<string, Value>,
+): boolean {
+	if (left.size !== right.size) return false;
+	for (const [key, value] of left) {
+		if (right.get(key) !== value) return false;
+	}
+	return true;
+}
+
+function entriesEqual(
+	left: SidebarWorkspaceStatusEntry,
+	right: SidebarWorkspaceStatusEntry,
+): boolean {
+	return (
+		left.status === right.status &&
+		left.isUnread === right.isUnread &&
+		(left.diffStats === right.diffStats ||
+			(left.diffStats !== null &&
+				right.diffStats !== null &&
+				left.diffStats.additions === right.diffStats.additions &&
+				left.diffStats.deletions === right.diffStats.deletions)) &&
+		mapsShallowEqual(left.bindings, right.bindings) &&
+		mapsShallowEqual(left.statuses, right.statuses)
+	);
+}
+
+/**
+ * Owns the sidebar's terminal-agent-bindings queries and lifecycle-event
+ * subscriptions for every visible workspace, replacing the per-row copies
+ * (~4 query observers + 2 bus listeners per row). Query keys, fetch shape,
+ * and staleTime match useTerminalAgentBindings exactly, so the react-query
+ * cache semantics (and consumers like useV2AttentionWorkspaceCount, which
+ * aggregates over these keys) are unchanged — this reduces subscription
+ * fan-out, not fetches.
+ */
+export function DashboardSidebarWorkspaceStatusProvider({
+	workspaces,
+	activeWorkspaceId,
+	children,
+}: {
+	workspaces: SidebarStatusWorkspaceRef[];
+	activeWorkspaceId: string | null;
+	children: ReactNode;
+}) {
+	const [store] = useState(() => new SidebarWorkspaceStatusStore());
+	const queryClient = useQueryClient();
+	const { cache: hostWorkspacesCache } = useHostWorkspaces();
+
+	const computedTargets = useMemo<WorkspaceStatusTarget[]>(
+		() =>
+			workspaces.map((workspace) => ({
+				workspaceId: workspace.id,
+				hostUrl: hostWorkspacesCache.resolveHostUrl(workspace.hostId),
+			})),
+		[workspaces, hostWorkspacesCache],
+	);
+	// Fingerprint-stabilized: the host-workspaces cache object churns identity
+	// on unrelated updates, and the subscription effect below must only re-run
+	// when a workspace or its host URL actually changes.
+	const previousTargetsRef = useRef<{
+		fingerprint: string;
+		targets: WorkspaceStatusTarget[];
+	} | null>(null);
+	const targets = useMemo(() => {
+		const fingerprint = JSON.stringify(computedTargets);
+		const previous = previousTargetsRef.current;
+		if (previous?.fingerprint === fingerprint) return previous.targets;
+		previousTargetsRef.current = { fingerprint, targets: computedTargets };
+		return computedTargets;
+	}, [computedTargets]);
+
+	const bindingRowsByIndex = useQueries({
+		queries: targets.map((target) => ({
+			queryKey: getTerminalAgentBindingsQueryKey(target.workspaceId),
+			enabled: target.hostUrl !== null,
+			queryFn: () => {
+				if (!target.hostUrl) return [] as TerminalAgentBinding[];
+				return getHostServiceClientByUrl(
+					target.hostUrl,
+				).terminalAgents.listByWorkspace.query({
+					workspaceId: target.workspaceId,
+				});
+			},
+			// Lifecycle events invalidate for instant updates; the finite
+			// staleTime lets focus/remount refetches self-heal any staleness
+			// from events missed while the WS was down (host restart, sleep).
+			staleTime: 30_000,
+		})),
+		combine: (results) => results.map((result) => result.data),
+	});
+
+	// One lifecycle/git subscription pass for the whole sidebar (the per-row
+	// hooks used to register these per workspace, several times over). The
+	// git:changed invalidation keeps diff-stats caches fresh for rows that
+	// aren't currently displaying them (staleTime is Infinity there, so a
+	// missed invalidation would freeze counts on the next activation).
+	useEffect(() => {
+		const cleanups: Array<() => void> = [];
+		const retainedHostUrls = new Set<string>();
+		for (const { workspaceId, hostUrl } of targets) {
+			if (!hostUrl) continue;
+			const bus = getEventBus(hostUrl, () => getHostServiceWsToken(hostUrl));
+			if (!retainedHostUrls.has(hostUrl)) {
+				retainedHostUrls.add(hostUrl);
+				cleanups.push(bus.retain());
+			}
+			const invalidateBindings = () => {
+				void queryClient.invalidateQueries({
+					queryKey: getTerminalAgentBindingsQueryKey(workspaceId),
+				});
+			};
+			cleanups.push(bus.on("agent:lifecycle", workspaceId, invalidateBindings));
+			cleanups.push(
+				bus.on("terminal:lifecycle", workspaceId, invalidateBindings),
+			);
+			cleanups.push(
+				bus.on("git:changed", workspaceId, () => {
+					void queryClient.invalidateQueries({
+						queryKey: getDiffStatsQueryKey(hostUrl, workspaceId),
+					});
+				}),
+			);
+		}
+		return () => {
+			for (const cleanup of cleanups) cleanup();
+		};
+	}, [targets, queryClient]);
+
+	// Only the active row renders diff stats, so one query serves the sidebar.
+	const activeDiffStats = useDiffStats(activeWorkspaceId ?? "", {
+		enabled: activeWorkspaceId !== null,
+	});
+
+	const manualUnread = useV2NotificationStore((state) => state.manualUnread);
+	const terminalSeenAt = useV2NotificationStore(
+		(state) => state.terminalSeenAt,
+	);
+
+	const previousEntriesRef = useRef(
+		new Map<string, SidebarWorkspaceStatusEntry>(),
+	);
+	const entries = useMemo(() => {
+		const previous = previousEntriesRef.current;
+		const next = new Map<string, SidebarWorkspaceStatusEntry>();
+		targets.forEach((target, index) => {
+			const bindingRows = bindingRowsByIndex[index] ?? [];
+			const bindings = new Map<string, TerminalAgentBinding>();
+			const statuses = new Map<string, PaneStatus>();
+			for (const binding of bindingRows) {
+				bindings.set(binding.terminalId, binding);
+				statuses.set(
+					binding.terminalId,
+					deriveTerminalAgentStatus({
+						lastEventType: binding.lastEventType,
+						lastEventAt: binding.lastEventAt,
+						lastSeenAt: terminalSeenAt[binding.terminalId],
+					}),
+				);
+			}
+			const hasManualUnread = Boolean(manualUnread[target.workspaceId]);
+			let hasAttentionTerminal = false;
+			for (const status of statuses.values()) {
+				if (status === "review" || status === "failed") {
+					hasAttentionTerminal = true;
+					break;
+				}
+			}
+			const candidate: SidebarWorkspaceStatusEntry = {
+				status: getHighestPriorityStatus([
+					hasManualUnread ? "review" : undefined,
+					...statuses.values(),
+				]),
+				isUnread: hasManualUnread || hasAttentionTerminal,
+				bindings,
+				statuses,
+				diffStats:
+					target.workspaceId === activeWorkspaceId ? activeDiffStats : null,
+			};
+			const previousEntry = previous.get(target.workspaceId);
+			next.set(
+				target.workspaceId,
+				previousEntry && entriesEqual(previousEntry, candidate)
+					? previousEntry
+					: candidate,
+			);
+		});
+		previousEntriesRef.current = next;
+		return next;
+	}, [
+		targets,
+		bindingRowsByIndex,
+		manualUnread,
+		terminalSeenAt,
+		activeWorkspaceId,
+		activeDiffStats,
+	]);
+
+	store.replaceEntries(entries);
+	useEffect(() => {
+		store.flushNotifications();
+	});
+
+	return (
+		<StatusStoreContext.Provider value={store}>
+			{children}
+		</StatusStoreContext.Provider>
+	);
+}
+
+function useSidebarWorkspaceStatusStore(): SidebarWorkspaceStatusStore {
+	const store = useContext(StatusStoreContext);
+	if (!store) {
+		throw new Error(
+			"useSidebarWorkspaceStatus must be used inside DashboardSidebarWorkspaceStatusProvider",
+		);
+	}
+	return store;
+}
+
+/**
+ * A row's status entry. Re-renders the caller only when this workspace's
+ * entry changes; the entry object is referentially stable otherwise.
+ */
+export function useSidebarWorkspaceStatus(
+	workspaceId: string,
+): SidebarWorkspaceStatusEntry {
+	const store = useSidebarWorkspaceStatusStore();
+	return useSyncExternalStore(
+		useCallback(
+			(listener) => store.subscribe(workspaceId, listener),
+			[store, workspaceId],
+		),
+		useCallback(() => store.get(workspaceId), [store, workspaceId]),
+	);
+}
+
+/**
+ * Marks every terminal with a live agent binding in the workspace as seen,
+ * clearing derived `review` statuses. Reads bindings from the store at call
+ * time, so callers don't subscribe to binding updates just to hold this.
+ */
+export function useMarkSidebarWorkspaceTerminalsSeen(
+	workspaceId: string,
+): () => void {
+	const store = useSidebarWorkspaceStatusStore();
+	const markTerminalSeen = useV2NotificationStore(
+		(state) => state.markTerminalSeen,
+	);
+	return useCallback(() => {
+		// Host-clock only: "seen through the binding's last event".
+		for (const binding of store.get(workspaceId).bindings.values()) {
+			markTerminalSeen(binding.terminalId, binding.lastEventAt);
+		}
+	}, [store, workspaceId, markTerminalSeen]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/index.ts
@@ -1,0 +1,7 @@
+export {
+	DashboardSidebarWorkspaceStatusProvider,
+	type SidebarStatusWorkspaceRef,
+	type SidebarWorkspaceStatusEntry,
+	useMarkSidebarWorkspaceTerminalsSeen,
+	useSidebarWorkspaceStatus,
+} from "./DashboardSidebarWorkspaceStatusProvider";


### PR DESCRIPTION
Stacked follow-up to #6364 (sidebar pin drag-and-drop). Addresses the three pre-existing sidebar rendering costs identified while profiling that work.

## Summary
- **Hover-open PR refresh gets a cool-down** (`pullRequestRefreshCooldown`, unit-tested): opening a row's hover card no longer fires an unthrottled host `pullRequests.refreshByWorkspaces` mutation + query invalidation per hover.
- **~80 per-row query subscriptions collapse into one**: new `DashboardSidebarWorkspaceStatusProvider` holds a single sidebar-level subscription with per-row selectors (a row re-renders only when *its* entry changes); the hover provider is split so rows consume a stable actions context instead of churning state.
- **Per-row framer-motion wrappers replaced with CSS row-collapse**: only the whole-project expand/collapse motion wrapper remains. Section collapse still animates; rows still hide while their section header is dragged.

## Why / Context
CPU profiles during the #6364 work showed a plain mouse sweep across sidebar rows costing ~358ms of long tasks (worst 129ms) with `shallowEqualObjects`/`useBaseQuery` hot — hover-open side effects, per-row react-query subscriptions notified on every 10s PR poll, and ~80 motion components.

## How It Works
- The cool-down is a module-level per-workspace timestamp map checked before firing the refresh; semantics of *what* refreshes are unchanged, only the rate.
- `DashboardSidebarWorkspaceStatusProvider` subscribes once and exposes selector hooks; poll ticks no longer run ~80 per-row subscription compare passes.
- The hover provider now exports a state context and a separate stable actions context; the DnD provider and rows consume actions without re-rendering on hover-state changes.

## Verification
Authored by an orchestrated worker agent; independently re-verified by the coordinator, then rebased onto post-#6364 main with one conflict reconciled (`DashboardSidebarDndProvider`: kept the actions-context split *and* the try/finally suppression release + fire-time open-timer re-check from 1aab78f3f — both suppression guards confirmed present after the merge).

- `bun run typecheck`, `bun run lint` (exit 0, no post-lint diff), 92/92 tests across the sidebar + state + host-service-hook suites — run on the rebased branch.
- CDP on the rebased branch (worker worktree stack, correct-instance verified): pin-by-drag works, and the drag-in-then-drag-out single gesture (the #6364 review finding) completes both transfers; zero React errors.
- Hover-sweep long tasks, same methodology as the baseline: **358ms / 4 tasks / 129ms worst → 178ms / 2 tasks / 90ms worst** in my measurement window (the worker measured 0ms in a quieter window; the residual in mine coincides with the 10s PR-poll tick, which this PR reduces in fan-out but deliberately does not re-schedule).

## Manual QA for reviewer (dev dataset couldn't exercise these)
- [ ] Agent status dots on sidebar rows render/update correctly with live running agents (status data now flows through the new provider)
- [ ] Section group collapse/expand animation looks right with real section groups (CSS transition replaced per-row framer-motion)

## Risks / Rollback
- Risk: status/notification display regressions (every row's status now flows through one provider). Mitigated by preserved query semantics + suites; the two QA boxes above are the uncovered surface.
- Rollback: revert this single commit; no schema or persisted-state changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce sidebar render fan-out on hover and polling to cut long-task time during a hover sweep by ~50% and limit re-renders to only affected rows.

- **Performance**
  - Add a 45s cool-down for hover-open PR refreshes to avoid repeated `pullRequests.refreshByWorkspaces` calls per hover (unit-tested).
  - Introduce `DashboardSidebarWorkspaceStatusProvider` to replace ~80 per-row query subscriptions with one sidebar-level subscription + per-row selectors; also centralizes lifecycle event listeners and diff-stats invalidation.
  - Split hover provider into a stable actions context plus a per-row `isHovered` subscription so a hover commit re-renders only the two involved rows.
  - Replace per-row framer-motion wrappers with a CSS grid-row/opacity transition; rows stay mounted but inert; section animations preserved.

<sup>Written for commit 99e71a6b3908c1fb28c074a46bae7313254a2e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consolidated workspace status indicators to the dashboard sidebar, including attention states, terminal activity, and diff statistics.
  * Improved sidebar hover behavior and transitions for smoother interactions.
  * Added workspace-specific unread and attention counts.
* **Performance**
  * Limited pull-request refreshes to once every 45 seconds per workspace.
* **Bug Fixes**
  * Improved sidebar status updates and terminal-seen handling across workspace rows.
* **Tests**
  * Added coverage for pull-request refresh cooldown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->