### PR TITLE
perf(host-service,workspace-fs): exclude gitignored build dirs from sidebar file tracking

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/useSharedFileDocument.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/useSharedFileDocument.ts
@@ -1,5 +1,7 @@
-import { useWorkspaceClient } from "@superset/workspace-client";
+import { getEventBus, useWorkspaceClient } from "@superset/workspace-client";
 import { useEffect, useState, useSyncExternalStore } from "react";
+import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
+import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
 import { acquireDocument, releaseDocument } from "./fileDocumentStore";
 import type { SharedFileDocument } from "./types";
 
@@ -51,6 +53,21 @@ export function useSharedFileDocument({
 			releaseDocument(workspaceId, absolutePath);
 		};
 	}, [workspaceId, absolutePath]);
+
+	// Declare the open document to the host so files the recursive watcher
+	// can't see (gitignored build dirs, node_modules, nested repos) still get
+	// a targeted watch and live-reload. No-op server-side for covered paths.
+	const hostUrl = useWorkspaceHostUrl(workspaceId);
+	useEffect(() => {
+		if (!hostUrl) return;
+		const bus = getEventBus(hostUrl, () => getHostServiceWsToken(hostUrl));
+		bus.watchFsFile(workspaceId, absolutePath);
+		const release = bus.retain();
+		return () => {
+			bus.unwatchFsFile(workspaceId, absolutePath);
+			release();
+		};
+	}, [hostUrl, workspaceId, absolutePath]);
 
 	useSyncExternalStore(
 		state.handle.subscribe,

--- a/packages/host-service/scripts/gitignored-churn-bench.ts
+++ b/packages/host-service/scripts/gitignored-churn-bench.ts
@@ -114,8 +114,18 @@ async function writeTextFile(path: string, contents: string): Promise<void> {
 	await writeFile(path, contents);
 }
 
+/** Marker so the destructive reset below can never run on a real repo. */
+const BENCH_MARKER = ".superset-bench-repo";
+
 async function ensureRepo(options: Options): Promise<void> {
-	if (existsSync(join(options.repoPath, ".git"))) return;
+	if (existsSync(join(options.repoPath, ".git"))) {
+		if (!existsSync(join(options.repoPath, BENCH_MARKER))) {
+			throw new Error(
+				`${options.repoPath} exists but is not a bench fixture (missing ${BENCH_MARKER}); refusing to reset it`,
+			);
+		}
+		return;
+	}
 	console.log(
 		`Creating bench repo (${options.files} files): ${options.repoPath}`,
 	);
@@ -135,6 +145,7 @@ async function ensureRepo(options: Options): Promise<void> {
 		);
 	}
 	await writeTextFile(join(options.repoPath, ".gitignore"), "buildout/\n");
+	await writeTextFile(join(options.repoPath, BENCH_MARKER), "bench fixture\n");
 	await run("git", ["add", "-A"], options.repoPath);
 	await run("git", ["commit", "-m", "seed"], options.repoPath);
 }

--- a/packages/host-service/scripts/gitignored-churn-bench.ts
+++ b/packages/host-service/scripts/gitignored-churn-bench.ts
@@ -1,0 +1,371 @@
+/**
+ * A/B bench for gitignored-dir watcher pruning.
+ *
+ * Simulates a dev server writing build output into a *gitignored* directory
+ * (`buildout/`, deliberately absent from the static DEFAULT_IGNORE_PATTERNS)
+ * while the real host-service pipeline is running: FsWatcherManager →
+ * GitWatcher → EventBus → (mock renderer) → git-status refresh per
+ * `git:changed`, through the production refresh limiter.
+ *
+ *   --variant after   current branch behavior (native prune + GitWatcher filter)
+ *   --variant before  main-equivalent: no gitignore awareness (provider absent,
+ *                     ignored-dir refresh disabled)
+ *
+ * Run from packages/host-service:
+ *   bun scripts/gitignored-churn-bench.ts --variant before
+ *   bun scripts/gitignored-churn-bench.ts --variant after
+ */
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { monitorEventLoopDelay } from "node:perf_hooks";
+import { FsWatcherManager } from "@superset/workspace-fs/host";
+import type { HostDb } from "../src/db";
+import { EventBus } from "../src/events/event-bus";
+import { GitWatcher } from "../src/events/git-watcher";
+import type { ServerMessage } from "../src/events/types";
+import { WorkspaceFilesystemManager } from "../src/runtime/filesystem";
+import { gitStatusRefreshLimiter } from "../src/trpc/router/git/utils/git-status-refresh-limiter";
+import { getHostWorkerPool } from "../src/workers/host-worker-pool";
+import { gitStatusSnapshotTask } from "../src/workers/tasks/git";
+
+type Variant = "before" | "after";
+
+interface Options {
+	variant: Variant;
+	repoPath: string;
+	outDir: string;
+	files: number;
+	churnEvents: number;
+	churnIntervalMs: number;
+	legitEdits: number;
+}
+
+const WORKSPACE_ID = "gitignored-churn-bench";
+const SETTLE_MS = 3_000;
+
+function parseArgs(argv: string[]): Options {
+	const options: Options = {
+		variant: "after",
+		repoPath: resolve("/tmp/superset-gitignored-churn-repo"),
+		outDir: resolve(".cache/gitignored-churn-bench"),
+		files: 2_000,
+		churnEvents: 300,
+		churnIntervalMs: 20,
+		legitEdits: 3,
+	};
+	for (let i = 0; i < argv.length; i += 2) {
+		const key = argv[i];
+		const value = argv[i + 1];
+		if (key === "--variant" && (value === "before" || value === "after")) {
+			options.variant = value;
+		} else if (key === "--repo" && value) {
+			options.repoPath = resolve(value);
+		} else if (key === "--files" && value) {
+			options.files = Number(value);
+		} else if (key === "--churn" && value) {
+			options.churnEvents = Number(value);
+		} else if (key === "--interval" && value) {
+			options.churnIntervalMs = Number(value);
+		}
+	}
+	return options;
+}
+
+async function run(
+	command: string,
+	args: string[],
+	cwd: string,
+): Promise<void> {
+	await new Promise<void>((resolveRun, rejectRun) => {
+		const child = spawn(command, args, {
+			cwd,
+			env: process.env,
+			stdio: ["ignore", "ignore", "pipe"],
+		});
+		const stderr: Buffer[] = [];
+		child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.on("error", rejectRun);
+		child.on("close", (code) => {
+			if (code === 0) resolveRun();
+			else
+				rejectRun(
+					new Error(
+						`${command} ${args.join(" ")} exited ${code}: ${Buffer.concat(stderr).toString("utf8")}`,
+					),
+				);
+		});
+	});
+}
+
+function trackedFilePath(repoPath: string, id: number): string {
+	const bucket = String(Math.floor(id / 1_000)).padStart(4, "0");
+	return join(
+		repoPath,
+		"src",
+		bucket,
+		`file-${String(id).padStart(6, "0")}.ts`,
+	);
+}
+
+async function writeTextFile(path: string, contents: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, contents);
+}
+
+async function ensureRepo(options: Options): Promise<void> {
+	if (existsSync(join(options.repoPath, ".git"))) return;
+	console.log(
+		`Creating bench repo (${options.files} files): ${options.repoPath}`,
+	);
+	await mkdir(options.repoPath, { recursive: true });
+	await run("git", ["init", "-b", "main"], options.repoPath);
+	await run(
+		"git",
+		["config", "user.email", "bench@example.invalid"],
+		options.repoPath,
+	);
+	await run("git", ["config", "user.name", "Bench"], options.repoPath);
+	await run("git", ["config", "gc.auto", "0"], options.repoPath);
+	for (let id = 0; id < options.files; id++) {
+		await writeTextFile(
+			trackedFilePath(options.repoPath, id),
+			`export const value${id} = ${id};\n`,
+		);
+	}
+	await writeTextFile(join(options.repoPath, ".gitignore"), "buildout/\n");
+	await run("git", ["add", "-A"], options.repoPath);
+	await run("git", ["commit", "-m", "seed"], options.repoPath);
+}
+
+async function installGitShim(
+	wrapperDir: string,
+	logPath: string,
+): Promise<void> {
+	const execPath = await new Promise<string>((res, rej) => {
+		const child = spawn("git", ["--exec-path"], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const out: Buffer[] = [];
+		child.stdout.on("data", (c: Buffer) => out.push(c));
+		child.on("error", rej);
+		child.on("close", () => res(Buffer.concat(out).toString("utf8").trim()));
+	});
+	await mkdir(wrapperDir, { recursive: true });
+	await writeFile(
+		join(wrapperDir, "git"),
+		[
+			"#!/bin/sh",
+			'printf "start\\t%s\\n" "$*" >> "$GIT_PROFILE_LOG"',
+			`"${join(execPath, "git")}" "$@"`,
+			"",
+		].join("\n"),
+	);
+	chmodSync(join(wrapperDir, "git"), 0o755);
+	await writeFile(logPath, "");
+	process.env.GIT_PROFILE_LOG = logPath;
+	process.env.PATH = `${wrapperDir}:${process.env.PATH ?? ""}`;
+}
+
+async function countGitInvocations(logPath: string): Promise<{
+	invocations: number;
+	topCommands: Array<{ command: string; count: number }>;
+}> {
+	const raw = await readFile(logPath, "utf8").catch(() => "");
+	const counts = new Map<string, number>();
+	let invocations = 0;
+	for (const line of raw.split("\n")) {
+		if (!line.startsWith("start\t")) continue;
+		invocations++;
+		const args = line.slice("start\t".length);
+		const command =
+			args
+				.split(" ")
+				.find((word) => !word.startsWith("-") && !word.includes("/")) ?? args;
+		counts.set(command, (counts.get(command) ?? 0) + 1);
+	}
+	const topCommands = [...counts.entries()]
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 6)
+		.map(([command, count]) => ({ command, count }));
+	return { invocations, topCommands };
+}
+
+function createDb(): HostDb {
+	const rows = [{ id: WORKSPACE_ID, worktreePath: "" }];
+	return {
+		select: () => ({
+			from: () => ({ where: () => ({ all: () => rows }), all: () => rows }),
+		}),
+		query: {
+			workspaces: {
+				findFirst: () => ({ sync: () => rows[0] }),
+			},
+		},
+	} as unknown as HostDb;
+}
+
+async function main(): Promise<void> {
+	const options = parseArgs(process.argv.slice(2));
+	await mkdir(options.outDir, { recursive: true });
+	await ensureRepo(options);
+	// Reset any prior churn.
+	await run("git", ["reset", "--hard", "HEAD"], options.repoPath);
+	await run("git", ["clean", "-fdx"], options.repoPath);
+	await mkdir(join(options.repoPath, "buildout"), { recursive: true });
+	await writeTextFile(
+		join(options.repoPath, "buildout", "seed.js"),
+		"// seed\n",
+	);
+
+	const label = `${options.variant}-${Date.now()}`;
+	const gitLogPath = join(options.outDir, `${label}-git.log`);
+	await installGitShim(join(options.outDir, `${label}-bin`), gitLogPath);
+
+	const db = createDb();
+	const rows = (
+		db.select() as unknown as {
+			from: () => { all: () => Array<{ worktreePath: string }> };
+		}
+	)
+		.from()
+		.all();
+	if (rows[0]) rows[0].worktreePath = options.repoPath;
+
+	const filesystem = new WorkspaceFilesystemManager({ db });
+	if (options.variant === "before") {
+		// Main-equivalent: strip gitignore awareness from the native watcher.
+		(
+			filesystem as unknown as { watcherManager: FsWatcherManager }
+		).watcherManager = new FsWatcherManager();
+	}
+	const gitWatcher = new GitWatcher(db, filesystem);
+	if (options.variant === "before") {
+		// Main-equivalent: the ignored-dir set never populates, so the
+		// GitWatcher event filter never drops anything.
+		(
+			gitWatcher as unknown as { refreshIgnoredDirs: () => void }
+		).refreshIgnoredDirs = () => {};
+	}
+	const eventBus = new EventBus({ db, filesystem, gitWatcher });
+
+	const workerPool = getHostWorkerPool();
+	let gitChangedEvents = 0;
+	let fsEventsDelivered = 0;
+	let statusRefreshes = 0;
+	const refreshPromises: Array<Promise<unknown>> = [];
+	const gitEnv = Object.fromEntries(
+		Object.entries(process.env).filter(
+			(entry): entry is [string, string] => typeof entry[1] === "string",
+		),
+	);
+
+	const runRefresh = async () => {
+		statusRefreshes++;
+		await workerPool.run(gitStatusSnapshotTask, {
+			worktreePath: options.repoPath,
+			gitEnv,
+		});
+	};
+
+	const socket = {
+		readyState: 1,
+		send: (data: string) => {
+			const message = JSON.parse(data) as ServerMessage;
+			if (message.type === "fs:events") {
+				fsEventsDelivered += message.events.length;
+			}
+			if (message.type === "git:changed") {
+				gitChangedEvents++;
+				const promise = gitStatusRefreshLimiter.run({
+					workspaceId: WORKSPACE_ID,
+					requestKey: "bench",
+					run: runRefresh,
+				});
+				if (promise) refreshPromises.push(promise);
+			}
+		},
+		close: () => {},
+	};
+
+	gitStatusRefreshLimiter.clear();
+	eventBus.start();
+	await (gitWatcher as unknown as { rescan: () => Promise<void> }).rescan();
+	// Warm the worker and let attach-time git activity settle.
+	await runRefresh();
+	await new Promise((r) => setTimeout(r, 2_000));
+
+	eventBus.handleOpen(socket);
+	eventBus.handleMessage(
+		socket,
+		JSON.stringify({ type: "fs:watch", workspaceId: WORKSPACE_ID }),
+	);
+	await new Promise((r) => setTimeout(r, 500));
+
+	// Measurement window starts here.
+	gitChangedEvents = 0;
+	fsEventsDelivered = 0;
+	statusRefreshes = 0;
+	await writeFile(gitLogPath, "");
+	const histogram = monitorEventLoopDelay({ resolution: 10 });
+	histogram.enable();
+	const startedAt = performance.now();
+
+	// Build churn: a dev server writing into the gitignored dir.
+	for (let event = 0; event < options.churnEvents; event++) {
+		await writeTextFile(
+			join(options.repoPath, "buildout", `chunk-${event % 50}.js`),
+			`// build output ${event}\nmodule.exports = ${event};\n`,
+		);
+		if (options.churnIntervalMs > 0) {
+			await new Promise((r) => setTimeout(r, options.churnIntervalMs));
+		}
+	}
+	// Interleaved legit work: these MUST still produce signal in both variants.
+	for (let edit = 0; edit < options.legitEdits; edit++) {
+		await writeTextFile(
+			trackedFilePath(options.repoPath, edit),
+			`export const value${edit} = ${edit}; // edited\n`,
+		);
+		await new Promise((r) => setTimeout(r, 400));
+	}
+
+	await new Promise((r) => setTimeout(r, SETTLE_MS));
+	await Promise.allSettled(refreshPromises);
+	histogram.disable();
+	const durationMs = Math.round(performance.now() - startedAt);
+	const toMs = (ns: number) => Math.round((ns / 1_000_000) * 10) / 10;
+
+	eventBus.handleClose(socket);
+	eventBus.close();
+	gitWatcher.close();
+	await filesystem.close();
+	gitStatusRefreshLimiter.clear();
+
+	const gitStats = await countGitInvocations(gitLogPath);
+	const result = {
+		variant: options.variant,
+		churnEvents: options.churnEvents,
+		legitEdits: options.legitEdits,
+		durationMs,
+		fsEventsDelivered,
+		gitChangedEvents,
+		statusRefreshes,
+		gitInvocations: gitStats.invocations,
+		topGitCommands: gitStats.topCommands,
+		eventLoopDelayMs: {
+			p50: toMs(histogram.percentile(50)),
+			p99: toMs(histogram.percentile(99)),
+			max: toMs(histogram.max),
+		},
+	};
+	console.log(JSON.stringify(result, null, 2));
+	await writeFile(
+		join(options.outDir, `${label}.json`),
+		`${JSON.stringify(result, null, 2)}\n`,
+	);
+	process.exit(0);
+}
+
+void main();

--- a/packages/host-service/src/events/event-bus.test.ts
+++ b/packages/host-service/src/events/event-bus.test.ts
@@ -70,3 +70,123 @@ describe("EventBus port events", () => {
 		expect(sentMessages).toHaveLength(2);
 	});
 });
+
+describe("EventBus fs:watch-file", () => {
+	async function createFileWatchHarness(pruned: boolean) {
+		const fs = await import("node:fs/promises");
+		const os = await import("node:os");
+		const path = await import("node:path");
+		const root = await fs.realpath(
+			await fs.mkdtemp(path.join(os.tmpdir(), "eb-watchfile-")),
+		);
+		const eventBus = new EventBus({
+			db: {} as unknown as HostDb,
+			filesystem: {
+				resolveWorkspaceRoot: () => root,
+				isPathPrunedFromWatch: () => pruned,
+			} as unknown as WorkspaceFilesystemManager,
+			gitWatcher: { onChanged: () => () => {} } as unknown as GitWatcher,
+		});
+		const sent: Array<{ type: string; events?: unknown[] }> = [];
+		const socket = {
+			readyState: 1,
+			send(data: string) {
+				sent.push(JSON.parse(data));
+			},
+			close() {},
+		};
+		eventBus.handleOpen(socket);
+		return { root, eventBus, socket, sent, fs, path };
+	}
+
+	it("delivers exactly one event per change for a pruned path", async () => {
+		const { root, eventBus, socket, sent, fs, path } =
+			await createFileWatchHarness(true);
+		const file = path.join(root, "buildout-file.js");
+		await fs.writeFile(file, "v0");
+		eventBus.handleMessage(
+			socket,
+			JSON.stringify({
+				type: "fs:watch-file",
+				workspaceId: "ws-1",
+				absolutePath: file,
+			}),
+		);
+		// Duplicate watch command must not double-deliver.
+		eventBus.handleMessage(
+			socket,
+			JSON.stringify({
+				type: "fs:watch-file",
+				workspaceId: "ws-1",
+				absolutePath: file,
+			}),
+		);
+		await new Promise((r) => setTimeout(r, 250));
+
+		await fs.writeFile(file, "v1");
+		const deadline = Date.now() + 5_000;
+		while (!sent.some((m) => m.type === "fs:events") && Date.now() < deadline) {
+			await new Promise((r) => setTimeout(r, 25));
+		}
+		// Let any (wrong) duplicate deliveries land before counting.
+		await new Promise((r) => setTimeout(r, 300));
+
+		const fsMessages = sent.filter((m) => m.type === "fs:events");
+		expect(fsMessages).toHaveLength(1);
+
+		eventBus.handleClose(socket);
+		await fs.rm(root, { recursive: true, force: true });
+	}, 15_000);
+
+	it("is a no-op for a covered path (the recursive watcher owns delivery)", async () => {
+		const { root, eventBus, socket, sent, fs, path } =
+			await createFileWatchHarness(false);
+		const file = path.join(root, "src-file.ts");
+		await fs.writeFile(file, "v0");
+		eventBus.handleMessage(
+			socket,
+			JSON.stringify({
+				type: "fs:watch-file",
+				workspaceId: "ws-1",
+				absolutePath: file,
+			}),
+		);
+		await new Promise((r) => setTimeout(r, 250));
+
+		await fs.writeFile(file, "v1");
+		await new Promise((r) => setTimeout(r, 500));
+
+		expect(sent.filter((m) => m.type === "fs:events")).toHaveLength(0);
+
+		// Unwatch of the no-op entry must not throw or leak.
+		eventBus.handleMessage(
+			socket,
+			JSON.stringify({
+				type: "fs:unwatch-file",
+				workspaceId: "ws-1",
+				absolutePath: file,
+			}),
+		);
+		eventBus.handleClose(socket);
+		await fs.rm(root, { recursive: true, force: true });
+	}, 15_000);
+
+	it("rejects paths outside the workspace root", async () => {
+		const { root, eventBus, socket, sent, fs } =
+			await createFileWatchHarness(true);
+		for (const bad of ["/etc/hosts", `${root}/../escape.txt`, "relative.txt"]) {
+			eventBus.handleMessage(
+				socket,
+				JSON.stringify({
+					type: "fs:watch-file",
+					workspaceId: "ws-1",
+					absolutePath: bad,
+				}),
+			);
+		}
+		const errors = sent.filter((m) => m.type === "error");
+		expect(errors).toHaveLength(3);
+		eventBus.handleClose(socket);
+		await fs.rm(root, { recursive: true, force: true });
+	});
+});

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -462,11 +462,17 @@ export class EventBus {
 		}
 
 		const dispose = watchSingleFile(absolutePath, (event: FsWatchEvent) => {
-			sendMessage(socket, {
-				type: "fs:events",
-				workspaceId,
-				events: [event],
-			});
+			// A dead socket must not throw into the watcher's settle loop; the
+			// close handler disposes every file watch for this client.
+			try {
+				sendMessage(socket, {
+					type: "fs:events",
+					workspaceId,
+					events: [event],
+				});
+			} catch (error) {
+				console.error("[event-bus] file-watch send failed", { error });
+			}
 		});
 		state.fileWatches.set(key, dispose);
 	}

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -1,6 +1,10 @@
+import path from "node:path";
 import type { NodeWebSocket } from "@hono/node-ws";
 import type { DetectedPort } from "@superset/port-scanner";
-import type { FsWatchEvent } from "@superset/workspace-fs/host";
+import {
+	type FsWatchEvent,
+	watchSingleFile,
+} from "@superset/workspace-fs/host";
 import type { Hono } from "hono";
 import type { HostDb } from "../db/index.ts";
 import { portManager } from "../ports/port-manager.ts";
@@ -22,7 +26,12 @@ interface FsSubscription {
 
 interface ClientState {
 	fsSubscriptions: Map<string, FsSubscription>;
+	/** Targeted per-file watches, keyed `${workspaceId}\0${absolutePath}`. */
+	fileWatches: Map<string, () => void>;
 }
+
+/** Open documents per client are bounded by open panes; this is a leak stop. */
+const MAX_FILE_WATCHES_PER_CLIENT = 256;
 
 type WorkspaceChangedListener = (
 	message: Omit<Extract<ServerMessage, { type: "workspace:changed" }>, "type">,
@@ -44,6 +53,13 @@ function parseClientMessage(data: unknown): ClientMessage | null {
 			typeof parsed.workspaceId === "string"
 		) {
 			if (parsed.type === "fs:watch" || parsed.type === "fs:unwatch") {
+				return parsed as ClientMessage;
+			}
+			if (
+				(parsed.type === "fs:watch-file" ||
+					parsed.type === "fs:unwatch-file") &&
+				typeof parsed.absolutePath === "string"
+			) {
 				return parsed as ClientMessage;
 			}
 		}
@@ -118,7 +134,10 @@ export class EventBus {
 	}
 
 	handleOpen(socket: WsSocket): void {
-		this.clients.set(socket, { fsSubscriptions: new Map() });
+		this.clients.set(socket, {
+			fsSubscriptions: new Map(),
+			fileWatches: new Map(),
+		});
 	}
 
 	handleMessage(socket: WsSocket, data: unknown): void {
@@ -132,6 +151,15 @@ export class EventBus {
 			this.startFsWatch(socket, state, message.workspaceId);
 		} else if (message.type === "fs:unwatch") {
 			this.stopFsWatch(state, message.workspaceId);
+		} else if (message.type === "fs:watch-file") {
+			this.startFsFileWatch(
+				socket,
+				state,
+				message.workspaceId,
+				message.absolutePath,
+			);
+		} else if (message.type === "fs:unwatch-file") {
+			this.stopFsFileWatch(state, message.workspaceId, message.absolutePath);
 		}
 	}
 
@@ -379,11 +407,92 @@ export class EventBus {
 		}
 	}
 
+	/**
+	 * Targeted watch for one open document. Installs a real per-file watcher
+	 * only when the recursive workspace watch delivers nothing for the path
+	 * (pruned subtree — gitignored build dir, node_modules, nested repo); a
+	 * covered path records a no-op so unwatch stays symmetric. Port of VS
+	 * Code's per-resource fallback for visible editors.
+	 */
+	private startFsFileWatch(
+		socket: WsSocket,
+		state: ClientState,
+		workspaceId: string,
+		absolutePath: string,
+	): void {
+		const key = `${workspaceId}\0${absolutePath}`;
+		if (state.fileWatches.has(key)) return;
+		if (state.fileWatches.size >= MAX_FILE_WATCHES_PER_CLIENT) {
+			sendMessage(socket, {
+				type: "error",
+				message: "Too many file watches for this client",
+			});
+			return;
+		}
+
+		let rootPath: string;
+		try {
+			rootPath = this.filesystem.resolveWorkspaceRoot(workspaceId);
+		} catch {
+			sendMessage(socket, {
+				type: "error",
+				message: `Workspace not found: ${workspaceId}`,
+			});
+			return;
+		}
+
+		// Only workspace files: a path outside the worktree must not be
+		// watchable through a workspace-scoped command.
+		const resolved = path.resolve(absolutePath);
+		if (
+			resolved !== absolutePath ||
+			!resolved.startsWith(`${rootPath.replace(/\/$/, "")}/`)
+		) {
+			sendMessage(socket, {
+				type: "error",
+				message: "watch-file path must be inside the workspace",
+			});
+			return;
+		}
+
+		if (!this.filesystem.isPathPrunedFromWatch(workspaceId, absolutePath)) {
+			// The recursive watcher already covers this file — nothing to add.
+			state.fileWatches.set(key, () => {});
+			return;
+		}
+
+		const dispose = watchSingleFile(absolutePath, (event: FsWatchEvent) => {
+			sendMessage(socket, {
+				type: "fs:events",
+				workspaceId,
+				events: [event],
+			});
+		});
+		state.fileWatches.set(key, dispose);
+	}
+
+	private stopFsFileWatch(
+		state: ClientState,
+		workspaceId: string,
+		absolutePath: string,
+	): void {
+		const key = `${workspaceId}\0${absolutePath}`;
+		const dispose = state.fileWatches.get(key);
+		if (dispose) {
+			dispose();
+			state.fileWatches.delete(key);
+		}
+	}
+
 	private cleanupClient(_socket: WsSocket, state: ClientState): void {
 		for (const sub of state.fsSubscriptions.values()) {
 			sub.dispose();
 		}
 		state.fsSubscriptions.clear();
+		for (const dispose of state.fileWatches.values()) {
+			dispose();
+		}
+		state.fileWatches.clear();
 	}
 }
 

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -20,6 +20,10 @@ interface GitWatcherInternals {
 	addWorktreePaths(workspaceId: string, paths: Iterable<string>): void;
 	getOrCreateBatch(workspaceId: string): unknown;
 	scheduleFlush(workspaceId: string): void;
+	getOrCreateIgnoredDirsState(workspaceId: string): {
+		dirs: ReadonlySet<string>;
+		rulesChanged: boolean;
+	};
 }
 
 function createWatcher(): GitWatcher {
@@ -173,6 +177,38 @@ describe("filterGitIgnoredEvents", () => {
 		expect(
 			filterGitIgnoredEvents([inside], worktree, new Set()).events,
 		).toEqual([inside]);
+	});
+});
+
+describe("GitWatcher ignore-rule staleness flag", () => {
+	test(".git/info/exclude events flag the ignored set for a native-prune check", () => {
+		const watcher = createWatcher();
+		const state = internals(watcher).getOrCreateIgnoredDirsState("workspace-1");
+		expect(state.rulesChanged).toBe(false);
+
+		internals(watcher).handleGitDirEvent("workspace-1", "info/exclude");
+		expect(state.rulesChanged).toBe(true);
+	});
+
+	test("unrelated .git events do not flag the ignored set", () => {
+		const watcher = createWatcher();
+		const state = internals(watcher).getOrCreateIgnoredDirsState("workspace-1");
+		internals(watcher).handleGitDirEvent("workspace-1", "index");
+		internals(watcher).handleGitDirEvent("workspace-1", "refs/heads/main");
+		expect(state.rulesChanged).toBe(false);
+	});
+
+	test("a .gitignore change in the worktree stream clears the set and flags it", () => {
+		const watcher = createWatcher();
+		const state = internals(watcher).getOrCreateIgnoredDirsState("workspace-1");
+		(state as { dirs: ReadonlySet<string> }).dirs = new Set(["buildout"]);
+
+		const filtered = filterGitIgnoredEvents(
+			[{ kind: "update", absolutePath: "/repo/.gitignore" }],
+			"/repo",
+			state.dirs,
+		);
+		expect(filtered.sawGitignoreChange).toBe(true);
 	});
 });
 

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import {
 	collectWorktreeBatchPaths,
 	DEBOUNCE_MS,
+	filterGitIgnoredEvents,
 	GIT_DIR_DEBOUNCE_MS,
 	type GitChangedEvent,
 	GitWatcher,
@@ -99,6 +100,79 @@ describe("collectWorktreeBatchPaths", () => {
 		);
 
 		expect([...paths]).toEqual(["src/duplicate.ts", "src/later.ts"]);
+	});
+});
+
+describe("filterGitIgnoredEvents", () => {
+	const worktree = "/repo";
+	const ignored = new Set(["dist", "apps/web/.next"]);
+
+	test("drops events inside ignored dirs, keeps everything else", () => {
+		const { events, sawGitignoreChange } = filterGitIgnoredEvents(
+			[
+				{ kind: "create", absolutePath: "/repo/dist/bundle.js" },
+				{ kind: "update", absolutePath: "/repo/apps/web/.next/cache/x" },
+				{ kind: "update", absolutePath: "/repo/apps/web/.next" },
+				{ kind: "update", absolutePath: "/repo/src/app.ts" },
+				{ kind: "create", absolutePath: "/repo/distant/file.ts" },
+			],
+			worktree,
+			ignored,
+		);
+		expect(events.map((e) => e.absolutePath)).toEqual([
+			"/repo/src/app.ts",
+			"/repo/distant/file.ts",
+		]);
+		expect(sawGitignoreChange).toBe(false);
+	});
+
+	test("keeps a rename unless both endpoints are ignored", () => {
+		const { events } = filterGitIgnoredEvents(
+			[
+				{
+					kind: "rename",
+					absolutePath: "/repo/src/kept.ts",
+					oldAbsolutePath: "/repo/dist/old.js",
+				},
+				{
+					kind: "rename",
+					absolutePath: "/repo/dist/a.js",
+					oldAbsolutePath: "/repo/dist/b.js",
+				},
+			],
+			worktree,
+			ignored,
+		);
+		expect(events.map((e) => e.absolutePath)).toEqual(["/repo/src/kept.ts"]);
+	});
+
+	test("flags .gitignore changes at any depth and never drops them", () => {
+		const { events, sawGitignoreChange } = filterGitIgnoredEvents(
+			[
+				{ kind: "update", absolutePath: "/repo/apps/web/.gitignore" },
+				{ kind: "update", absolutePath: "/repo/dist/junk.js" },
+			],
+			worktree,
+			ignored,
+		);
+		expect(events.map((e) => e.absolutePath)).toEqual([
+			"/repo/apps/web/.gitignore",
+		]);
+		expect(sawGitignoreChange).toBe(true);
+	});
+
+	test("fails open on an empty set and on paths outside the worktree", () => {
+		const outside = { kind: "update" as const, absolutePath: "/other/x" };
+		expect(filterGitIgnoredEvents([outside], worktree, ignored).events).toEqual(
+			[outside],
+		);
+		const inside = {
+			kind: "update" as const,
+			absolutePath: "/repo/dist/x.js",
+		};
+		expect(
+			filterGitIgnoredEvents([inside], worktree, new Set()).events,
+		).toEqual([inside]);
 	});
 });
 

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -6,6 +6,7 @@ import { isNull } from "drizzle-orm";
 import type { HostDb } from "../db/index.ts";
 import { workspaces } from "../db/schema.ts";
 import type { WorkspaceFilesystemManager } from "../runtime/filesystem/index.ts";
+import { listGitIgnoredDirs } from "../runtime/git/index.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -26,6 +27,14 @@ export const GIT_DIR_DEBOUNCE_MS = 1_000;
  * than hundreds of per-path invalidations. The null sentinel also lets the
  * watcher skip path normalization for the rest of the debounce window. */
 export const MAX_WORKTREE_PATHS_PER_BATCH = 128;
+
+/**
+ * Min interval between per-workspace gitignored-dir refreshes. Refreshes ride
+ * on emitted `git:changed` events, so churn that is entirely filtered spawns
+ * no git processes at all; this only bounds the cost of a busy-but-legit
+ * workspace.
+ */
+const IGNORED_DIRS_REFRESH_MIN_MS = 5_000;
 
 /**
  * `.git/` top-level dirs whose churn never changes `git status`: `objects/**`
@@ -93,6 +102,71 @@ export function collectWorktreeBatchPaths(
 	return relativePaths;
 }
 
+/** Whether `relative` is (or is inside) one of the ignored directories. */
+function isUnderIgnoredDir(
+	relative: string,
+	ignoredDirs: ReadonlySet<string>,
+): boolean {
+	if (ignoredDirs.size === 0) return false;
+	let slash = relative.indexOf("/");
+	while (slash !== -1) {
+		if (ignoredDirs.has(relative.slice(0, slash))) return true;
+		slash = relative.indexOf("/", slash + 1);
+	}
+	return ignoredDirs.has(relative);
+}
+
+export interface FilterGitIgnoredEventsResult {
+	events: FsWatchEvent[];
+	/**
+	 * A `.gitignore` file changed somewhere in the batch: the ignored set may
+	 * no longer be valid and must be dropped until the next refresh.
+	 */
+	sawGitignoreChange: boolean;
+}
+
+/**
+ * Drop events whose every path sits inside a directory git ignores entirely —
+ * build-output churn (`.next`, `__pycache__`, …) that can't change `git
+ * status`, so it must not trigger the status-refresh cascade or eat into the
+ * MAX_WORKTREE_PATHS_PER_BATCH budget. The set holds worktree-relative dir
+ * paths from `listGitIgnoredDirs`, which only reports fully-untracked
+ * subtrees, so a tracked file's event can never be dropped. Renames are kept
+ * unless both endpoints are ignored. Fails open: paths outside the worktree
+ * or an empty set filter nothing.
+ */
+export function filterGitIgnoredEvents(
+	events: readonly FsWatchEvent[],
+	worktreePath: string,
+	ignoredDirs: ReadonlySet<string>,
+): FilterGitIgnoredEventsResult {
+	const worktreePrefix = worktreePath.endsWith("/")
+		? worktreePath
+		: `${worktreePath}/`;
+	let sawGitignoreChange = false;
+	const kept: FsWatchEvent[] = [];
+
+	const isIgnored = (absolutePath: string | undefined): boolean => {
+		if (!absolutePath || !absolutePath.startsWith(worktreePrefix)) return false;
+		const relative = absolutePath.slice(worktreePrefix.length);
+		if (relative === ".gitignore" || relative.endsWith("/.gitignore")) {
+			sawGitignoreChange = true;
+			return false;
+		}
+		return isUnderIgnoredDir(relative, ignoredDirs);
+	};
+
+	for (const event of events) {
+		const newIgnored = isIgnored(event.absolutePath);
+		const oldIgnored = event.oldAbsolutePath
+			? isIgnored(event.oldAbsolutePath)
+			: true;
+		if (newIgnored && oldIgnored) continue;
+		kept.push(event);
+	}
+	return { events: kept, sawGitignoreChange };
+}
+
 export interface GitChangedEvent {
 	workspaceId: string;
 	/**
@@ -120,6 +194,19 @@ interface WatchedWorkspace {
 	disposeWorktreeWatch: () => void;
 }
 
+interface IgnoredDirsState {
+	/** Worktree-relative fully-gitignored dirs; events under them are dropped. */
+	dirs: ReadonlySet<string>;
+	refreshing: boolean;
+	lastRefreshAt: number;
+	/**
+	 * An ignore-rule source changed (.gitignore, .git/info/exclude) since the
+	 * last refresh: the next refresh must also check whether the native
+	 * watcher's attach-time prune went stale (a dir was UN-ignored).
+	 */
+	rulesChanged: boolean;
+}
+
 /**
  * Watches git state for all workspaces in the host-service DB and emits a
  * coalesced `changed` signal when anything that could affect `git status`
@@ -137,7 +224,12 @@ interface WatchedWorkspace {
  *    working-tree file edits that change `git status` output. The underlying
  *    watcher honors `DEFAULT_IGNORE_PATTERNS`, which excludes `.git/`,
  *    `node_modules/`, `dist/`, etc. — exactly the paths that don't affect
- *    `git status`, so we don't waste refetches on them. Subscription is
+ *    `git status`, so we don't waste refetches on them. Events that survive
+ *    the static list but sit inside a *gitignored* dir (repo-specific build
+ *    output the list can't know about, or a dir created after the native
+ *    watcher attached) are dropped by `filterGitIgnoredEvents` against a
+ *    per-workspace set from `listGitIgnoredDirs`, refreshed after each emit
+ *    and failed open whenever a `.gitignore` changes. Subscription is
  *    multiplexed by `FsWatcherManager` per absolute path, so this shares the
  *    underlying native watcher with any client-owned `fs:watch` subscriptions.
  *
@@ -154,6 +246,7 @@ export class GitWatcher {
 		ReturnType<typeof setTimeout>
 	>();
 	private readonly pendingBatches = new Map<string, PendingBatch>();
+	private readonly ignoredDirs = new Map<string, IgnoredDirsState>();
 	private rescanTimer: ReturnType<typeof setInterval> | null = null;
 	private closed = false;
 
@@ -193,6 +286,71 @@ export class GitWatcher {
 			entry.disposeWorktreeWatch();
 		}
 		this.watched.clear();
+		this.ignoredDirs.clear();
+	}
+
+	private getOrCreateIgnoredDirsState(workspaceId: string): IgnoredDirsState {
+		let state = this.ignoredDirs.get(workspaceId);
+		if (!state) {
+			state = {
+				dirs: new Set(),
+				refreshing: false,
+				lastRefreshAt: 0,
+				rulesChanged: false,
+			};
+			this.ignoredDirs.set(workspaceId, state);
+		}
+		return state;
+	}
+
+	/**
+	 * Re-ask git which dirs are fully ignored. Rides on emitted `git:changed`
+	 * events (plus one call at watch start), so filtered-out churn never spawns
+	 * git; `force` bypasses the min-interval for the initial load.
+	 */
+	private refreshIgnoredDirs(
+		workspaceId: string,
+		worktreePath: string,
+		force = false,
+	): void {
+		const state = this.getOrCreateIgnoredDirsState(workspaceId);
+		if (state.refreshing) return;
+		if (
+			!force &&
+			Date.now() - state.lastRefreshAt < IGNORED_DIRS_REFRESH_MIN_MS
+		)
+			return;
+		state.refreshing = true;
+		const rulesChanged = state.rulesChanged;
+		state.rulesChanged = false;
+		void listGitIgnoredDirs(worktreePath)
+			.then(async (dirs) => {
+				if (this.closed) return;
+				state.dirs = new Set(dirs);
+				state.lastRefreshAt = Date.now();
+				if (rulesChanged) {
+					// Ignore rules changed: a dir may have been UN-ignored, leaving
+					// the native watcher's attach-time prune stale (events for that
+					// dir silently suppressed until restart). refreshIgnores
+					// re-derives the set and swaps the subscription only when it
+					// actually shrank; after a swap, force one broad status refresh
+					// to cover anything written during the swap gap.
+					const swapped = await this.filesystem
+						.refreshWatcherIgnores(workspaceId)
+						.catch((error) => {
+							console.error("[git-watcher] watcher ignore refresh failed", {
+								workspaceId,
+								error,
+							});
+							return false;
+						});
+					if (this.closed) return;
+					if (swapped) this.markGitDirDirty(workspaceId);
+				}
+			})
+			.finally(() => {
+				state.refreshing = false;
+			});
 	}
 
 	private getOrCreateBatch(workspaceId: string): PendingBatch {
@@ -213,6 +371,11 @@ export class GitWatcher {
 		filename: string | null,
 	): void {
 		if (!isStatusRelevantGitDirEvent(filename)) return;
+		// `.git/info/exclude` is an ignore-rule source just like .gitignore;
+		// an edit there can also un-ignore a natively-pruned dir.
+		if (filename?.replace(/\\/g, "/") === "info/exclude") {
+			this.getOrCreateIgnoredDirsState(workspaceId).rulesChanged = true;
+		}
 		this.markGitDirDirty(workspaceId);
 	}
 
@@ -270,6 +433,13 @@ export class GitWatcher {
 						});
 					}
 				}
+				// Anything that emits may also have changed what git ignores (a
+				// build dir appearing, a .gitignore edit) — re-derive the filter
+				// set so the follow-up churn stops emitting.
+				const watchedEntry = this.watched.get(workspaceId);
+				if (watchedEntry) {
+					this.refreshIgnoredDirs(workspaceId, watchedEntry.worktreePath);
+				}
 			}, delay),
 		);
 	}
@@ -299,6 +469,7 @@ export class GitWatcher {
 				entry.watcher.close();
 				entry.disposeWorktreeWatch();
 				this.watched.delete(id);
+				this.ignoredDirs.delete(id);
 			}
 		}
 
@@ -371,6 +542,7 @@ export class GitWatcher {
 			watcher,
 			disposeWorktreeWatch,
 		});
+		this.refreshIgnoredDirs(workspaceId, worktreePath, true);
 	}
 
 	/**
@@ -406,13 +578,31 @@ export class GitWatcher {
 				while (!disposed && iterator) {
 					const next = await iterator.next();
 					if (disposed || next.done) return;
+
+					const ignoredState = this.getOrCreateIgnoredDirsState(workspaceId);
+					const filtered = filterGitIgnoredEvents(
+						next.value.events,
+						worktreePath,
+						ignoredState.dirs,
+					);
+					if (filtered.sawGitignoreChange) {
+						// Rules changed — stop filtering (fail open) until the
+						// post-emit refresh re-derives the set, and have that
+						// refresh check the native prune for staleness.
+						ignoredState.dirs = new Set();
+						ignoredState.rulesChanged = true;
+					}
+					// Entirely gitignored churn (a build writing into .next):
+					// no flush at all — this is the whole point of the filter.
+					if (filtered.events.length === 0) continue;
+
 					if (this.pendingBatches.get(workspaceId)?.paths === null) {
 						this.scheduleFlush(workspaceId);
 						continue;
 					}
 
 					const relativePaths = collectWorktreeBatchPaths(
-						next.value.events,
+						filtered.events,
 						worktreePath,
 					);
 

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -348,8 +348,21 @@ export class GitWatcher {
 					if (swapped) this.markGitDirDirty(workspaceId);
 				}
 			})
+			.catch((error) => {
+				console.error("[git-watcher] ignored-dir refresh failed", {
+					workspaceId,
+					error,
+				});
+			})
 			.finally(() => {
 				state.refreshing = false;
+				// Rules changed again while this refresh ran (e.g. a branch
+				// switch rewriting .gitignore twice): the listing we just stored
+				// is stale and the emit that flagged it was swallowed by the
+				// `refreshing` guard — run once more.
+				if (state.rulesChanged && !this.closed) {
+					this.refreshIgnoredDirs(workspaceId, worktreePath, true);
+				}
 			});
 	}
 

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -169,4 +169,27 @@ export interface FsUnwatchCommand {
 	workspaceId: string;
 }
 
-export type ClientMessage = FsWatchCommand | FsUnwatchCommand;
+/**
+ * Targeted watch on one file the recursive workspace watcher can't see
+ * (inside a pruned subtree — gitignored build dir, node_modules, nested
+ * repo). Sent by the renderer for every open document; the server installs a
+ * per-file watcher only when the recursive watch doesn't already cover the
+ * path. Events come back as regular `fs:events` messages.
+ */
+export interface FsWatchFileCommand {
+	type: "fs:watch-file";
+	workspaceId: string;
+	absolutePath: string;
+}
+
+export interface FsUnwatchFileCommand {
+	type: "fs:unwatch-file";
+	workspaceId: string;
+	absolutePath: string;
+}
+
+export type ClientMessage =
+	| FsWatchCommand
+	| FsUnwatchCommand
+	| FsWatchFileCommand
+	| FsUnwatchFileCommand;

--- a/packages/host-service/src/runtime/filesystem/filesystem.ts
+++ b/packages/host-service/src/runtime/filesystem/filesystem.ts
@@ -7,6 +7,7 @@ import {
 import { eq } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { projects, workspaces } from "../../db/schema.ts";
+import { listGitIgnoredDirs } from "../git/index.ts";
 
 export interface WorkspaceFilesystemManagerOptions {
 	db: HostDb;
@@ -28,7 +29,9 @@ export class ProjectNotFoundError extends Error {
 
 export class WorkspaceFilesystemManager {
 	private readonly db: HostDb;
-	private readonly watcherManager = new FsWatcherManager();
+	private readonly watcherManager = new FsWatcherManager({
+		listGitIgnoredDirs,
+	});
 	private readonly serviceCache = new Map<string, FsHostService>();
 
 	constructor(options: WorkspaceFilesystemManagerOptions) {
@@ -65,6 +68,30 @@ export class WorkspaceFilesystemManager {
 
 	getServiceForProject(projectId: string): FsHostService {
 		return this.getServiceForRootPath(this.resolveProjectRoot(projectId));
+	}
+
+	/**
+	 * Whether the workspace's recursive watcher delivers no events for this
+	 * path (pruned subtree, outside the root, or no watcher attached). Callers
+	 * use it to decide whether an open file needs its own targeted watch.
+	 */
+	isPathPrunedFromWatch(workspaceId: string, absolutePath: string): boolean {
+		return this.watcherManager.isPathPruned(
+			this.resolveWorkspaceRoot(workspaceId),
+			absolutePath,
+		);
+	}
+
+	/**
+	 * Swap the workspace's native subscription onto a freshly derived ignore
+	 * set. Required after a directory is UN-ignored — the attach-time prune
+	 * would otherwise suppress its events until restart. Returns whether the
+	 * subscription was actually swapped.
+	 */
+	async refreshWatcherIgnores(workspaceId: string): Promise<boolean> {
+		return await this.watcherManager.refreshIgnores(
+			this.resolveWorkspaceRoot(workspaceId),
+		);
 	}
 
 	private getServiceForRootPath(rootPath: string): FsHostService {

--- a/packages/host-service/src/runtime/git/ignored-dirs.test.ts
+++ b/packages/host-service/src/runtime/git/ignored-dirs.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { simpleGit } from "simple-git";
+import { listGitIgnoredDirs } from "./ignored-dirs";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((root) => rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function createRepo(): Promise<string> {
+	const dir = await mkdtemp(path.join(tmpdir(), "ignored-dirs-"));
+	tempRoots.push(dir);
+	await simpleGit(dir).init();
+	return dir;
+}
+
+describe("listGitIgnoredDirs", () => {
+	test("returns fully-ignored directories, not ignored files or tracked-content dirs", async () => {
+		const dir = await createRepo();
+		await writeFile(path.join(dir, ".gitignore"), "dist/\n*.log\nmixed/\n");
+		await mkdir(path.join(dir, "dist"), { recursive: true });
+		await writeFile(path.join(dir, "dist", "bundle.js"), "x");
+		await writeFile(path.join(dir, "root.log"), "x");
+		// A dir matching an ignore rule but holding a tracked file must never be
+		// collapsed — pruning it would hide that file's changes.
+		await mkdir(path.join(dir, "mixed"), { recursive: true });
+		await writeFile(path.join(dir, "mixed", "kept.ts"), "x");
+		const git = simpleGit(dir);
+		await git.raw(["add", "-f", "mixed/kept.ts"]);
+
+		const ignored = await listGitIgnoredDirs(dir);
+
+		expect(ignored).toContain("dist");
+		expect(ignored).not.toContain("root.log");
+		expect(ignored.some((entry) => entry.startsWith("mixed"))).toBe(false);
+	});
+
+	test("returns [] for a non-git directory", async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "ignored-dirs-plain-"));
+		tempRoots.push(dir);
+		expect(await listGitIgnoredDirs(dir)).toEqual([]);
+	});
+
+	test("returns [] for a missing path", async () => {
+		expect(
+			await listGitIgnoredDirs("/nonexistent/definitely-not-here"),
+		).toEqual([]);
+	});
+});

--- a/packages/host-service/src/runtime/git/ignored-dirs.test.ts
+++ b/packages/host-service/src/runtime/git/ignored-dirs.test.ts
@@ -55,6 +55,34 @@ describe("listGitIgnoredDirs", () => {
 		).toEqual([]);
 	});
 
+	test("reports the on-disk casing when the .gitignore rule differs in case", async () => {
+		// macOS: core.ignorecase makes `buildout/` match an on-disk `Buildout`.
+		// What matters for the watcher is that the returned name is the ON-DISK
+		// casing — that's what kernel event paths carry, so glob and filter
+		// comparisons stay consistent. (On a case-sensitive FS the rule simply
+		// doesn't match and nothing is returned — also consistent.)
+		const dir = await createRepo();
+		await writeFile(path.join(dir, ".gitignore"), "buildout/\n");
+		await mkdir(path.join(dir, "Buildout"), { recursive: true });
+		await writeFile(path.join(dir, "Buildout", "junk.js"), "x");
+
+		const ignored = await listGitIgnoredDirs(dir);
+
+		if (ignored.length > 0) {
+			expect(ignored).toEqual(["Buildout"]);
+		}
+	});
+
+	test("honors .git/info/exclude rules, not just .gitignore", async () => {
+		const dir = await createRepo();
+		await mkdir(path.join(dir, ".git", "info"), { recursive: true });
+		await writeFile(path.join(dir, ".git", "info", "exclude"), "hidden/\n");
+		await mkdir(path.join(dir, "hidden"), { recursive: true });
+		await writeFile(path.join(dir, "hidden", "junk.js"), "x");
+
+		expect(await listGitIgnoredDirs(dir)).toContain("hidden");
+	});
+
 	test("never returns a dir containing a negated (re-included) child", async () => {
 		const dir = await createRepo();
 		// `dist/*` + `!dist/keep.txt`: git will not collapse `dist/` because it

--- a/packages/host-service/src/runtime/git/ignored-dirs.test.ts
+++ b/packages/host-service/src/runtime/git/ignored-dirs.test.ts
@@ -54,4 +54,24 @@ describe("listGitIgnoredDirs", () => {
 			await listGitIgnoredDirs("/nonexistent/definitely-not-here"),
 		).toEqual([]);
 	});
+
+	test("never returns a dir containing a negated (re-included) child", async () => {
+		const dir = await createRepo();
+		// `dist/*` + `!dist/keep.txt`: git will not collapse `dist/` because it
+		// holds a non-ignored entry — pruning it would hide keep.txt forever.
+		await writeFile(
+			path.join(dir, ".gitignore"),
+			"dist/*\n!dist/keep.txt\nfully/\n",
+		);
+		await mkdir(path.join(dir, "dist"), { recursive: true });
+		await writeFile(path.join(dir, "dist", "bundle.js"), "x");
+		await writeFile(path.join(dir, "dist", "keep.txt"), "x");
+		await mkdir(path.join(dir, "fully"), { recursive: true });
+		await writeFile(path.join(dir, "fully", "junk.js"), "x");
+
+		const ignored = await listGitIgnoredDirs(dir);
+
+		expect(ignored.some((entry) => entry.startsWith("dist"))).toBe(false);
+		expect(ignored).toContain("fully");
+	});
 });

--- a/packages/host-service/src/runtime/git/ignored-dirs.ts
+++ b/packages/host-service/src/runtime/git/ignored-dirs.ts
@@ -1,0 +1,54 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// Bounds for a pathological repo (thousands of ignored entries): the caller
+// turns each dir into a per-event glob/prefix check, so an unbounded list
+// would trade watcher churn for matcher churn.
+const MAX_IGNORED_DIRS = 200;
+const TIMEOUT_MS = 3_000;
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Worktree-relative directories that git ignores entirely, straight from
+ * `git ls-files --others --ignored --exclude-standard --directory`. Asking
+ * git (instead of parsing .gitignore) keeps the answer authoritative across
+ * nested .gitignore files, `.git/info/exclude`, and the global excludesfile.
+ *
+ * Only collapsed `dir/` entries are returned: `--directory` collapses a
+ * directory to one entry only when nothing inside it is tracked, so pruning
+ * these subtrees can never hide a tracked file's changes. Individual ignored
+ * files (e.g. `.env`) are deliberately excluded — files stay watched so an
+ * open gitignored file still live-reloads.
+ *
+ * Returns [] for non-git roots, timeouts, and every other failure — callers
+ * degrade to the static ignore list, never block on this.
+ */
+export async function listGitIgnoredDirs(rootPath: string): Promise<string[]> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			[
+				"-C",
+				rootPath,
+				"ls-files",
+				"--others",
+				"--ignored",
+				"--exclude-standard",
+				"--directory",
+				"-z",
+			],
+			{ timeout: TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
+		);
+		const dirs: string[] = [];
+		for (const entry of stdout.split("\0")) {
+			if (!entry.endsWith("/")) continue;
+			dirs.push(entry.slice(0, -1));
+			if (dirs.length >= MAX_IGNORED_DIRS) break;
+		}
+		return dirs;
+	} catch {
+		return [];
+	}
+}

--- a/packages/host-service/src/runtime/git/index.ts
+++ b/packages/host-service/src/runtime/git/index.ts
@@ -1,4 +1,5 @@
 export { createGitEnvResolver, createGitFactory } from "./git";
+export { listGitIgnoredDirs } from "./ignored-dirs";
 export type { ResolvedRef, ResolveRefOptions } from "./refs";
 export {
 	asLocalRef,

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -137,6 +137,12 @@ interface ConnectionState {
 	refCount: number;
 	listeners: Set<ListenerEntry>;
 	fsWatchedWorkspaces: Map<string, number>;
+	/** Refcounted per-file watches, keyed `${workspaceId}\0${absolutePath}`. */
+	fsWatchedFiles: Map<string, number>;
+}
+
+function fileWatchKey(workspaceId: string, absolutePath: string): string {
+	return `${workspaceId}\0${absolutePath}`;
 }
 
 const connections = new Map<string, ConnectionState>();
@@ -275,12 +281,23 @@ function getOrCreateConnection(
 		refCount: 0,
 		listeners: new Set(),
 		fsWatchedWorkspaces: new Map(),
+		fsWatchedFiles: new Map(),
 	};
 
 	socket.addEventListener("open", () => {
 		// Re-send all active fs:watch commands
 		for (const workspaceId of state.fsWatchedWorkspaces.keys()) {
 			sendCommand(state, { type: "fs:watch", workspaceId });
+		}
+		for (const key of state.fsWatchedFiles.keys()) {
+			const [workspaceId, absolutePath] = key.split("\0");
+			if (workspaceId && absolutePath) {
+				sendCommand(state, {
+					type: "fs:watch-file",
+					workspaceId,
+					absolutePath,
+				});
+			}
 		}
 	});
 	socket.addEventListener("message", (event) => {
@@ -312,6 +329,13 @@ export interface EventBusHandle {
 	): () => void;
 	watchFs(workspaceId: string): void;
 	unwatchFs(workspaceId: string): void;
+	/**
+	 * Declare one open file so the host can install a targeted watch when the
+	 * recursive workspace watcher doesn't cover it (gitignored build dirs,
+	 * node_modules, nested repos). Events arrive as regular `fs:events`.
+	 */
+	watchFsFile(workspaceId: string, absolutePath: string): void;
+	unwatchFsFile(workspaceId: string, absolutePath: string): void;
 	retain(): () => void;
 }
 
@@ -359,6 +383,34 @@ export function getEventBus(
 				sendCommand(state, { type: "fs:unwatch", workspaceId });
 			} else {
 				state.fsWatchedWorkspaces.set(workspaceId, count - 1);
+			}
+		},
+
+		watchFsFile(workspaceId: string, absolutePath: string): void {
+			const key = fileWatchKey(workspaceId, absolutePath);
+			const count = state.fsWatchedFiles.get(key) ?? 0;
+			state.fsWatchedFiles.set(key, count + 1);
+			if (count === 0) {
+				sendCommand(state, {
+					type: "fs:watch-file",
+					workspaceId,
+					absolutePath,
+				});
+			}
+		},
+
+		unwatchFsFile(workspaceId: string, absolutePath: string): void {
+			const key = fileWatchKey(workspaceId, absolutePath);
+			const count = state.fsWatchedFiles.get(key) ?? 0;
+			if (count <= 1) {
+				state.fsWatchedFiles.delete(key);
+				sendCommand(state, {
+					type: "fs:unwatch-file",
+					workspaceId,
+					absolutePath,
+				});
+			} else {
+				state.fsWatchedFiles.set(key, count - 1);
 			}
 		},
 

--- a/packages/workspace-fs/src/host/index.ts
+++ b/packages/workspace-fs/src/host/index.ts
@@ -4,4 +4,5 @@ export * from "../paths";
 export * from "../search";
 export * from "../types";
 export * from "../watch";
+export * from "../watch-file";
 export * from "./service";

--- a/packages/workspace-fs/src/watch-file.test.ts
+++ b/packages/workspace-fs/src/watch-file.test.ts
@@ -107,6 +107,31 @@ describe("watchSingleFile", () => {
 		await waitFor(events, (e) => e.kind === "create");
 	}, 20_000);
 
+	it("survives the path becoming a directory and a file again", async () => {
+		const file = await createTempFile();
+		const events: FsWatchEvent[] = [];
+		disposers.push(
+			watchSingleFile(file, (e) => events.push(e), {
+				debounceMs: 25,
+				pollMs: 100,
+			}),
+		);
+		await new Promise((r) => setTimeout(r, 150));
+
+		// File → directory at the same path.
+		await fs.rm(file);
+		await waitFor(events, (e) => e.kind === "delete");
+		await fs.mkdir(file);
+		await waitFor(events, (e) => e.kind === "create" && e.isDirectory === true);
+
+		// Directory → file again: the watch must keep following the path.
+		events.length = 0;
+		await fs.rmdir(file);
+		await waitFor(events, (e) => e.kind === "delete");
+		await fs.writeFile(file, "file again");
+		await waitFor(events, (e) => e.kind === "create" && !e.isDirectory);
+	}, 20_000);
+
 	it("starts against a missing file and emits create when it lands", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "watch-file-"));
 		tempRoots.push(dir);

--- a/packages/workspace-fs/src/watch-file.test.ts
+++ b/packages/workspace-fs/src/watch-file.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { FsWatchEvent } from "./types";
+import { watchSingleFile } from "./watch-file";
+
+const tempRoots: string[] = [];
+const disposers: Array<() => void> = [];
+
+afterEach(async () => {
+	for (const dispose of disposers.splice(0)) dispose();
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((root) => fs.rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function createTempFile(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "watch-file-"));
+	tempRoots.push(dir);
+	const file = path.join(dir, "target.env");
+	await fs.writeFile(file, "initial");
+	return file;
+}
+
+async function waitFor(
+	events: FsWatchEvent[],
+	predicate: (e: FsWatchEvent) => boolean,
+	timeoutMs = 8_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!events.some(predicate)) {
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Timed out. seen: ${events.map((e) => e.kind).join(", ")}`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+describe("watchSingleFile", () => {
+	it("emits update on in-place writes", async () => {
+		const file = await createTempFile();
+		const events: FsWatchEvent[] = [];
+		disposers.push(
+			watchSingleFile(file, (e) => events.push(e), { debounceMs: 25 }),
+		);
+		await new Promise((r) => setTimeout(r, 150));
+
+		await fs.writeFile(file, "changed");
+		await waitFor(events, (e) => e.kind === "update");
+	}, 15_000);
+
+	it("survives an atomic save (write-temp + rename over the path)", async () => {
+		const file = await createTempFile();
+		const events: FsWatchEvent[] = [];
+		disposers.push(
+			watchSingleFile(file, (e) => events.push(e), { debounceMs: 25 }),
+		);
+		await new Promise((r) => setTimeout(r, 150));
+
+		// First atomic replace — swaps the inode out from under the watch.
+		const temp1 = `${file}.tmp1`;
+		await fs.writeFile(temp1, "v2");
+		await fs.rename(temp1, file);
+		await waitFor(events, (e) => e.kind === "update");
+
+		// Second replace must still be observed (the watch re-installed).
+		events.length = 0;
+		const temp2 = `${file}.tmp2`;
+		await fs.writeFile(temp2, "v3");
+		await fs.rename(temp2, file);
+		await waitFor(events, (e) => e.kind === "update");
+	}, 15_000);
+
+	it("emits delete, then create when the file reappears", async () => {
+		const file = await createTempFile();
+		const events: FsWatchEvent[] = [];
+		disposers.push(
+			watchSingleFile(file, (e) => events.push(e), {
+				debounceMs: 25,
+				pollMs: 100,
+			}),
+		);
+		await new Promise((r) => setTimeout(r, 150));
+
+		await fs.rm(file);
+		await waitFor(events, (e) => e.kind === "delete");
+
+		await fs.writeFile(file, "resurrected");
+		await waitFor(events, (e) => e.kind === "create");
+
+		// And the re-installed watch keeps working after resurrection.
+		events.length = 0;
+		await fs.writeFile(file, "again");
+		await waitFor(events, (e) => e.kind === "update");
+	}, 15_000);
+
+	it("starts against a missing file and emits create when it lands", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "watch-file-"));
+		tempRoots.push(dir);
+		const file = path.join(dir, "not-yet.env");
+		const events: FsWatchEvent[] = [];
+		disposers.push(
+			watchSingleFile(file, (e) => events.push(e), {
+				debounceMs: 25,
+				pollMs: 100,
+			}),
+		);
+		await new Promise((r) => setTimeout(r, 150));
+		expect(events).toEqual([]);
+
+		await fs.writeFile(file, "born");
+		await waitFor(events, (e) => e.kind === "create");
+	}, 15_000);
+});

--- a/packages/workspace-fs/src/watch-file.test.ts
+++ b/packages/workspace-fs/src/watch-file.test.ts
@@ -97,7 +97,15 @@ describe("watchSingleFile", () => {
 		events.length = 0;
 		await fs.writeFile(file, "again");
 		await waitFor(events, (e) => e.kind === "update");
-	}, 15_000);
+
+		// Second full cycle (VS Code's nodejsWatcher suspend/resume tests run
+		// the delete→recreate loop twice — resumption must not be one-shot).
+		events.length = 0;
+		await fs.rm(file);
+		await waitFor(events, (e) => e.kind === "delete");
+		await fs.writeFile(file, "twice-resurrected");
+		await waitFor(events, (e) => e.kind === "create");
+	}, 20_000);
 
 	it("starts against a missing file and emits create when it lands", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "watch-file-"));

--- a/packages/workspace-fs/src/watch-file.ts
+++ b/packages/workspace-fs/src/watch-file.ts
@@ -1,0 +1,147 @@
+import { type FSWatcher, watch } from "node:fs";
+import { stat } from "node:fs/promises";
+import type { FsWatchEvent } from "./types";
+
+const DEBOUNCE_MS = 75;
+const RECREATION_POLL_MS = 2_000;
+
+export interface WatchSingleFileOptions {
+	debounceMs?: number;
+	/** How often to poll for the file to (re)appear while it's absent. */
+	pollMs?: number;
+}
+
+/**
+ * Targeted watch on one file, for paths the recursive workspace watcher
+ * can't see (inside pruned subtrees like node_modules or gitignored build
+ * dirs). Port of VS Code's per-resource fallback for visible editors
+ * (editorService.ts `activeOutOfWorkspaceWatchers`).
+ *
+ * `node:fs.watch` on a file follows the inode, so after an atomic save
+ * (write-temp + rename — most editors) the old watch is deaf. Every settled
+ * event therefore re-installs the watch at the path. While the file is
+ * absent the watch can't exist at all; a slow poll waits for recreation and
+ * emits `create` when it lands.
+ */
+export function watchSingleFile(
+	absolutePath: string,
+	onEvent: (event: FsWatchEvent) => void,
+	options: WatchSingleFileOptions = {},
+): () => void {
+	const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
+	const pollMs = options.pollMs ?? RECREATION_POLL_MS;
+
+	let disposed = false;
+	let watcher: FSWatcher | null = null;
+	let exists = false;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	let settling = false;
+	let settleQueued = false;
+
+	const emit = (kind: "create" | "update" | "delete", isDirectory: boolean) => {
+		onEvent({ kind, absolutePath, isDirectory });
+	};
+
+	const closeWatcher = () => {
+		watcher?.close();
+		watcher = null;
+	};
+
+	const startPolling = () => {
+		if (pollTimer || disposed) return;
+		const timer = setInterval(() => void settle(), pollMs);
+		timer.unref?.();
+		pollTimer = timer;
+	};
+
+	const stopPolling = () => {
+		if (pollTimer) {
+			clearInterval(pollTimer);
+			pollTimer = null;
+		}
+	};
+
+	const installWatcher = (): boolean => {
+		closeWatcher();
+		try {
+			watcher = watch(absolutePath, () => scheduleSettle());
+			watcher.on("error", () => scheduleSettle());
+			return true;
+		} catch {
+			watcher = null;
+			return false;
+		}
+	};
+
+	const scheduleSettle = () => {
+		if (disposed || debounceTimer) return;
+		const timer = setTimeout(() => {
+			debounceTimer = null;
+			void settle();
+		}, debounceMs);
+		timer.unref?.();
+		debounceTimer = timer;
+	};
+
+	/** Re-derive state from disk and emit the transition, if any. */
+	const settle = async (): Promise<void> => {
+		if (disposed) return;
+		if (settling) {
+			// An event landed mid-settle — its transition must not be lost.
+			settleQueued = true;
+			return;
+		}
+		settling = true;
+		try {
+			const stats = await stat(absolutePath).catch(() => null);
+			if (disposed) return;
+			if (stats) {
+				const existed = exists;
+				exists = true;
+				stopPolling();
+				// Re-install unconditionally: the previous watch may be following
+				// a replaced inode (atomic save) and would never fire again.
+				if (!installWatcher()) {
+					startPolling();
+				}
+				emit(existed ? "update" : "create", stats.isDirectory());
+			} else {
+				const existed = exists;
+				exists = false;
+				closeWatcher();
+				startPolling();
+				if (existed) {
+					emit("delete", false);
+				}
+			}
+		} finally {
+			settling = false;
+		}
+		if (settleQueued) {
+			settleQueued = false;
+			scheduleSettle();
+		}
+	};
+
+	// Initial attach: no emit — the caller already has the file's current
+	// state (or its absence). Just start watching/polling from it.
+	void (async () => {
+		const stats = await stat(absolutePath).catch(() => null);
+		if (disposed) return;
+		exists = stats !== null;
+		if (!exists || !installWatcher()) {
+			startPolling();
+		}
+	})();
+
+	return () => {
+		disposed = true;
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+			debounceTimer = null;
+		}
+		stopPolling();
+		closeWatcher();
+	};
+}

--- a/packages/workspace-fs/src/watch-file.ts
+++ b/packages/workspace-fs/src/watch-file.ts
@@ -34,6 +34,8 @@ export function watchSingleFile(
 	let disposed = false;
 	let watcher: FSWatcher | null = null;
 	let exists = false;
+	/** Inode behind the current watch; a change means the watch is deaf. */
+	let watchedIno: bigint | number | null = null;
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 	let settling = false;
@@ -46,6 +48,7 @@ export function watchSingleFile(
 	const closeWatcher = () => {
 		watcher?.close();
 		watcher = null;
+		watchedIno = null;
 	};
 
 	const startPolling = () => {
@@ -62,14 +65,21 @@ export function watchSingleFile(
 		}
 	};
 
-	const installWatcher = (): boolean => {
+	const installWatcher = (ino: bigint | number): boolean => {
 		closeWatcher();
 		try {
-			watcher = watch(absolutePath, () => scheduleSettle());
-			watcher.on("error", () => scheduleSettle());
+			const installed = watch(absolutePath, () => scheduleSettle());
+			installed.on("error", () => {
+				// A dead watch must not be mistaken for a live same-inode one.
+				if (watcher === installed) closeWatcher();
+				scheduleSettle();
+			});
+			watcher = installed;
+			watchedIno = ino;
 			return true;
 		} catch {
 			watcher = null;
+			watchedIno = null;
 			return false;
 		}
 	};
@@ -100,10 +110,15 @@ export function watchSingleFile(
 				const existed = exists;
 				exists = true;
 				stopPolling();
-				// Re-install unconditionally: the previous watch may be following
-				// a replaced inode (atomic save) and would never fire again.
-				if (!installWatcher()) {
-					startPolling();
+				// Re-install only when the inode behind the path changed (atomic
+				// save replaced it — the old watch follows the dead inode). A
+				// same-inode close+reopen is not just wasted work: Bun's kqueue
+				// teardown of the old watch races the new registration and can
+				// leave the fresh watch deaf.
+				if (!watcher || watchedIno !== stats.ino) {
+					if (!installWatcher(stats.ino)) {
+						startPolling();
+					}
 				}
 				emit(existed ? "update" : "create", stats.isDirectory());
 			} else {
@@ -130,7 +145,7 @@ export function watchSingleFile(
 		const stats = await stat(absolutePath).catch(() => null);
 		if (disposed) return;
 		exists = stats !== null;
-		if (!exists || !installWatcher()) {
+		if (!stats || !installWatcher(stats.ino)) {
 			startPolling();
 		}
 	})();

--- a/packages/workspace-fs/src/watch-file.ts
+++ b/packages/workspace-fs/src/watch-file.ts
@@ -109,6 +109,16 @@ export function watchSingleFile(
 			if (stats) {
 				const existed = exists;
 				exists = true;
+				if (stats.isDirectory()) {
+					// macOS fs.watch on a directory never reports the directory's
+					// own deletion (VS Code skips their folder-delete test on
+					// darwin for this reason) — a watch here would go silently
+					// deaf. Poll instead until the path is a plain file again.
+					closeWatcher();
+					startPolling();
+					emit(existed ? "update" : "create", true);
+					return;
+				}
 				stopPolling();
 				// Re-install only when the inode behind the path changed (atomic
 				// save replaced it — the old watch follows the dead inode). A
@@ -120,7 +130,7 @@ export function watchSingleFile(
 						startPolling();
 					}
 				}
-				emit(existed ? "update" : "create", stats.isDirectory());
+				emit(existed ? "update" : "create", false);
 			} else {
 				const existed = exists;
 				exists = false;

--- a/packages/workspace-fs/src/watch-file.ts
+++ b/packages/workspace-fs/src/watch-file.ts
@@ -36,6 +36,8 @@ export function watchSingleFile(
 	let exists = false;
 	/** Inode behind the current watch; a change means the watch is deaf. */
 	let watchedIno: bigint | number | null = null;
+	/** mtime last observed while the path is a directory (poll dedupe). */
+	let dirMtimeMs: number | null = null;
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 	let settling = false;
@@ -114,11 +116,20 @@ export function watchSingleFile(
 					// own deletion (VS Code skips their folder-delete test on
 					// darwin for this reason) — a watch here would go silently
 					// deaf. Poll instead until the path is a plain file again.
+					// Emit only on transition or mtime change; a poll tick with
+					// nothing new must stay silent or consumers reload forever.
 					closeWatcher();
 					startPolling();
-					emit(existed ? "update" : "create", true);
+					if (!existed) {
+						emit("create", true);
+					} else if (dirMtimeMs === null || stats.mtimeMs !== dirMtimeMs) {
+						// First observation as a dir (file→dir swap) or real change.
+						emit("update", true);
+					}
+					dirMtimeMs = stats.mtimeMs;
 					return;
 				}
+				dirMtimeMs = null;
 				stopPolling();
 				// Re-install only when the inode behind the path changed (atomic
 				// save replaced it — the old watch follows the dead inode). A

--- a/packages/workspace-fs/src/watch-gitignored-prune.test.ts
+++ b/packages/workspace-fs/src/watch-gitignored-prune.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { FsWatcherManager, isRelPathUnderPrunedDirs } from "./watch";
+
+const tempRoots: string[] = [];
+const managers: FsWatcherManager[] = [];
+
+afterEach(async () => {
+	await Promise.all(managers.splice(0).map((m) => m.close()));
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((root) => fs.rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function createTempRoot(): Promise<string> {
+	const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "watch-ignored-"));
+	const real = await fs.realpath(tempPath);
+	tempRoots.push(real);
+	return real;
+}
+
+async function waitFor(
+	seen: string[],
+	needle: string,
+	timeoutMs = 8_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!seen.includes(needle)) {
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Timed out waiting for ${needle}\nseen: ${seen.join(", ")}`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+describe("FsWatcherManager gitignored-dir pruning", () => {
+	it("does not emit events inside a provider-reported ignored dir", async () => {
+		const rootPath = await createTempRoot();
+		// A repo-specific build dir the static ignore list can't know about.
+		const ignoredDir = path.join(rootPath, "generated", "__pycache__");
+		await fs.mkdir(ignoredDir, { recursive: true });
+
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async () => ["generated/__pycache__"],
+		});
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		await fs.writeFile(path.join(ignoredDir, "module.pyc"), "x");
+		// A sibling write must still surface, proving the stream is live and the
+		// prune (not a dead watcher) suppressed the ignored event.
+		const siblingFile = path.join(rootPath, "generated", "kept.py");
+		await fs.writeFile(siblingFile, "x");
+
+		await waitFor(seen, `create:${siblingFile}`);
+		expect(seen).not.toContain(`create:${path.join(ignoredDir, "module.pyc")}`);
+	}, 20_000);
+
+	it("still watches when the provider throws", async () => {
+		const rootPath = await createTempRoot();
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async () => {
+				throw new Error("git exploded");
+			},
+		});
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		const rootFile = path.join(rootPath, "tracked.ts");
+		await fs.writeFile(rootFile, "x");
+		await waitFor(seen, `create:${rootFile}`);
+	}, 20_000);
+});
+
+describe("isRelPathUnderPrunedDirs", () => {
+	it("matches static default dirs at any depth, dynamic prefixes only at root", () => {
+		expect(isRelPathUnderPrunedDirs("node_modules/pkg/index.js", [])).toBe(
+			true,
+		);
+		expect(isRelPathUnderPrunedDirs("apps/web/dist/main.js", [])).toBe(true);
+		expect(isRelPathUnderPrunedDirs(".claude/worktrees/x/file.ts", [])).toBe(
+			true,
+		);
+		expect(isRelPathUnderPrunedDirs("src/app.ts", [])).toBe(false);
+		// A file merely named like an ignored dir is not inside one.
+		expect(isRelPathUnderPrunedDirs("dist", [])).toBe(false);
+		expect(isRelPathUnderPrunedDirs("distance/file.ts", [])).toBe(false);
+
+		expect(
+			isRelPathUnderPrunedDirs("generated/__pycache__/m.pyc", [
+				"generated/__pycache__",
+			]),
+		).toBe(true);
+		expect(
+			isRelPathUnderPrunedDirs("generated/other.py", ["generated/__pycache__"]),
+		).toBe(false);
+	});
+});
+
+describe("FsWatcherManager.isPathPruned", () => {
+	it("reports pruned subtrees, covered files, and unknown roots correctly", async () => {
+		const rootPath = await createTempRoot();
+		await fs.mkdir(path.join(rootPath, "buildout"), { recursive: true });
+
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async () => ["buildout"],
+		});
+		managers.push(manager);
+
+		// Unknown root (no subscription yet): err toward "pruned".
+		expect(manager.isPathPruned(rootPath, path.join(rootPath, "a.ts"))).toBe(
+			true,
+		);
+
+		await manager.subscribe({ absolutePath: rootPath }, () => {});
+
+		expect(manager.isPathPruned(rootPath, path.join(rootPath, "a.ts"))).toBe(
+			false,
+		);
+		expect(
+			manager.isPathPruned(rootPath, path.join(rootPath, "buildout", "x.js")),
+		).toBe(true);
+		expect(
+			manager.isPathPruned(
+				rootPath,
+				path.join(rootPath, "node_modules", "pkg", "i.js"),
+			),
+		).toBe(true);
+		// Outside the root: no coverage from this watcher.
+		expect(manager.isPathPruned(rootPath, "/elsewhere/file.ts")).toBe(true);
+	}, 20_000);
+});
+
+describe("FsWatcherManager.refreshIgnores", () => {
+	it("re-attaches after a dir is un-ignored so its events flow again", async () => {
+		const rootPath = await createTempRoot();
+		const ignoredDir = path.join(rootPath, "buildout");
+		await fs.mkdir(ignoredDir, { recursive: true });
+
+		let ignored = ["buildout"];
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async () => ignored,
+		});
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		// While ignored: no events from the dir (prove liveness via sibling).
+		await fs.writeFile(path.join(ignoredDir, "suppressed.js"), "x");
+		const probeFile = path.join(rootPath, "probe.ts");
+		await fs.writeFile(probeFile, "x");
+		await waitFor(seen, `create:${probeFile}`);
+		expect(seen).not.toContain(
+			`create:${path.join(ignoredDir, "suppressed.js")}`,
+		);
+
+		// Rule removed but no refresh yet → still returns false only when
+		// nothing shrank; here it must swap.
+		ignored = [];
+		expect(await manager.refreshIgnores(rootPath)).toBe(true);
+
+		const nowVisible = path.join(ignoredDir, "now-visible.js");
+		await fs.writeFile(nowVisible, "x");
+		await waitFor(seen, `create:${nowVisible}`);
+
+		// No shrink → no swap.
+		expect(await manager.refreshIgnores(rootPath)).toBe(false);
+	}, 30_000);
+});

--- a/packages/workspace-fs/src/watch-gitignored-prune.test.ts
+++ b/packages/workspace-fs/src/watch-gitignored-prune.test.ts
@@ -69,6 +69,36 @@ describe("FsWatcherManager gitignored-dir pruning", () => {
 		expect(seen).not.toContain(`create:${path.join(ignoredDir, "module.pyc")}`);
 	}, 20_000);
 
+	it("prunes an ignored dir with a unicode (NFC) name on darwin's NFD filesystem", async () => {
+		const rootPath = await createTempRoot();
+		// "café" in NFC — APFS lookups are normalization-insensitive, and git
+		// (core.precomposeunicode) reports NFC; the glob must still prune.
+		const dirName = "café-out";
+		await fs.mkdir(path.join(rootPath, dirName), { recursive: true });
+
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async () => [dirName],
+		});
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		await fs.writeFile(path.join(rootPath, dirName, "junk.js"), "x");
+		const probeFile = path.join(rootPath, "probe.ts");
+		await fs.writeFile(probeFile, "x");
+
+		await waitFor(seen, `create:${probeFile}`);
+		expect(seen.some((entry) => entry.includes(`${dirName}/junk.js`))).toBe(
+			false,
+		);
+	}, 20_000);
+
 	it("still watches when the provider throws", async () => {
 		const rootPath = await createTempRoot();
 		const manager = new FsWatcherManager({

--- a/packages/workspace-fs/src/watch-gitignored-prune.test.ts
+++ b/packages/workspace-fs/src/watch-gitignored-prune.test.ts
@@ -99,6 +99,53 @@ describe("FsWatcherManager gitignored-dir pruning", () => {
 		);
 	}, 20_000);
 
+	it("prunes through a symlinked watch root and maps events back to the symlink form", async () => {
+		const realRoot = await createTempRoot();
+		const ignoredDir = path.join(realRoot, "buildout");
+		await fs.mkdir(ignoredDir, { recursive: true });
+		// Watch via a symlink to the root — the ignore provider must be asked
+		// with the RESOLVED path (globs are relative to what parcel watches),
+		// and emitted events must come back in symlink form.
+		const linkParent = await createTempRoot();
+		const linkRoot = path.join(linkParent, "linked-root");
+		await fs.symlink(realRoot, linkRoot);
+
+		const providerCalls: string[] = [];
+		const manager = new FsWatcherManager({
+			debounceMs: 50,
+			listGitIgnoredDirs: async (rootPath) => {
+				providerCalls.push(rootPath);
+				return ["buildout"];
+			},
+		});
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: linkRoot }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+		expect(providerCalls).toEqual([realRoot]);
+
+		await fs.writeFile(path.join(ignoredDir, "junk.js"), "x");
+		const probeLinkForm = path.join(linkRoot, "probe.ts");
+		await fs.writeFile(path.join(realRoot, "probe.ts"), "x");
+
+		await waitFor(seen, `create:${probeLinkForm}`);
+		expect(seen.some((entry) => entry.includes("buildout/junk.js"))).toBe(
+			false,
+		);
+
+		// isPathPruned must answer in the caller's (symlink) path space too.
+		expect(
+			manager.isPathPruned(linkRoot, path.join(linkRoot, "buildout", "x.js")),
+		).toBe(true);
+		expect(manager.isPathPruned(linkRoot, path.join(linkRoot, "src.ts"))).toBe(
+			false,
+		);
+	}, 20_000);
+
 	it("still watches when the provider throws", async () => {
 		const rootPath = await createTempRoot();
 		const manager = new FsWatcherManager({

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -60,6 +60,38 @@ function escapeGlobMagic(input: string): string {
 // if the scan truncates here.
 const NESTED_REPO_SCAN_DEADLINE_MS = 3_000;
 
+/**
+ * Whether a root-relative path falls under any pruned directory: a static
+ * default (any path segment in DEFAULT_IGNORE_DIR_NAMES, plus the multi-
+ * segment `.claude/worktrees` convention), or one of the per-root dynamic
+ * prefixes (nested repos, gitignored dirs). Mirrors the semantics of the
+ * ignore globs handed to parcel, minus file patterns (`*.tsbuildinfo`) —
+ * over-reporting a file there as watched only costs a missed targeted watch
+ * on a file type nobody opens.
+ */
+export function isRelPathUnderPrunedDirs(
+	relative: string,
+	prunedRelPrefixes: readonly string[],
+): boolean {
+	const segments = relative.split("/");
+	for (let i = 0; i < segments.length - 1; i += 1) {
+		const segment = segments[i] as string;
+		if (DEFAULT_IGNORE_DIR_NAMES.has(segment)) {
+			return true;
+		}
+		// `**/.claude/worktrees/**` is the one multi-segment static glob.
+		if (segment === ".claude" && segments[i + 1] === "worktrees") {
+			return true;
+		}
+	}
+	for (const prefix of prunedRelPrefixes) {
+		if (relative.startsWith(`${prefix}/`)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // Watches are always recursive — @parcel/watcher offers no shallow mode.
 export interface WatchPathOptions {
 	absolutePath: string;
@@ -99,6 +131,13 @@ interface WatcherState {
 	overflowRootCheckTimer: ReturnType<typeof setInterval> | null;
 	overflowRootChecksLeft: number;
 	listeners: Set<WatchListener>;
+	/**
+	 * Root-relative directories pruned from the native subscription beyond the
+	 * static defaults (nested repos + gitignored dirs), kept queryable so
+	 * `isPathPruned` can tell callers "this path gets no events — install a
+	 * targeted watch if you need it".
+	 */
+	prunedRelPrefixes: string[];
 	filePaths: Map<string, true>;
 	directoryPaths: Set<string>;
 	pendingEvents: ParcelWatcherEvent[];
@@ -156,6 +195,14 @@ function internalToSearchPatchEvent(
 export interface FsWatcherManagerOptions {
 	debounceMs?: number;
 	ignore?: string[];
+	/**
+	 * Returns watch-root-relative directories that git ignores entirely
+	 * (fully-untracked subtrees like `.next` or `__pycache__`), so they can be
+	 * pruned from the native subscription alongside the static defaults.
+	 * Injected (rather than spawning git here) to mirror how search injects
+	 * `runRipgrep`. Best-effort: failures degrade to the static list.
+	 */
+	listGitIgnoredDirs?: (rootPath: string) => Promise<string[]>;
 	/** Per-watcher LRU cap on tracked file paths. Test-only override. */
 	filePathsMax?: number;
 	/** How often a suspended watcher polls for its deleted root to reappear. */
@@ -165,6 +212,7 @@ export interface FsWatcherManagerOptions {
 export class FsWatcherManager {
 	private readonly debounceMs: number;
 	private readonly ignore: string[];
+	private readonly listGitIgnoredDirs?: (rootPath: string) => Promise<string[]>;
 	private readonly filePathsMax: number;
 	private readonly recoveryPollMs: number;
 	private readonly watchers = new Map<string, WatcherState>();
@@ -183,6 +231,7 @@ export class FsWatcherManager {
 		this.ignore = options.ignore
 			? [...new Set([...DEFAULT_IGNORE_PATTERNS, ...options.ignore])]
 			: DEFAULT_IGNORE_PATTERNS;
+		this.listGitIgnoredDirs = options.listGitIgnoredDirs;
 		this.filePathsMax = options.filePathsMax ?? FILE_PATHS_MAX;
 		this.recoveryPollMs = options.recoveryPollMs ?? 2_000;
 	}
@@ -400,6 +449,7 @@ export class FsWatcherManager {
 			overflowRootCheckTimer: null,
 			overflowRootChecksLeft: 0,
 			listeners: new Set<WatchListener>(),
+			prunedRelPrefixes: [],
 			filePaths: new Map<string, true>(),
 			directoryPaths: new Set<string>(),
 			pendingEvents: [],
@@ -441,7 +491,22 @@ export class FsWatcherManager {
 		// hand parcel a root-relative `<relative>/**` glob per repo, which prunes
 		// the subtree from traversal (same mechanism as the `**/node_modules/**`
 		// default — stops inotify watch creation on Linux, the ENOSPC trigger).
-		const nestedRepoIgnores = await this.computeNestedRepoIgnores(realPath);
+		// Gitignored dirs get the same treatment: repo-specific build output
+		// (`__pycache__`, `packages/*/lib`, …) that the static list can't know
+		// about is pruned via whatever git itself considers fully ignored.
+		const [nestedRepoRelDirs, gitIgnoredRelDirs] = await Promise.all([
+			this.computeNestedRepoRelDirs(realPath),
+			this.computeGitIgnoredRelDirs(realPath),
+		]);
+		state.prunedRelPrefixes = [...nestedRepoRelDirs, ...gitIgnoredRelDirs];
+		// Root-relative escaped globs: parcel matches ignores relative to the
+		// watch root (its defaults are all `**/…`), so an absolute path never
+		// matches. Bare paths aren't safe either — parcel's `is-glob` check
+		// misclassifies paths containing glob magic (a Next.js `app/[id]` route
+		// segment) as patterns. Escaping + relativizing handles both.
+		const prunedDirIgnores = state.prunedRelPrefixes.map(
+			(relDir) => `${escapeGlobMagic(relDir)}/**`,
+		);
 
 		// parcel dedupes native backends by (dir, ignore-set); a wedged backend
 		// from the dead stream (its unsubscribe can hang) would be silently
@@ -452,7 +517,7 @@ export class FsWatcherManager {
 			...(generation === 1
 				? []
 				: [`**/.superset-watch-generation-${generation}/**`]),
-			...nestedRepoIgnores,
+			...prunedDirIgnores,
 		];
 
 		// Subscribe to the resolved real path so kernel paths come back in a
@@ -518,11 +583,12 @@ export class FsWatcherManager {
 	}
 
 	/**
-	 * Best-effort discovery of nested repo/worktree roots to prune. Never blocks
-	 * watching: on failure or a truncated scan we watch with whatever we found
-	 * (an unpruned subtree degrades to the pre-existing behavior, not a crash).
+	 * Best-effort discovery of nested repo/worktree roots to prune, as
+	 * root-relative dir paths. Never blocks watching: on failure or a truncated
+	 * scan we watch with whatever we found (an unpruned subtree degrades to the
+	 * pre-existing behavior, not a crash).
 	 */
-	private async computeNestedRepoIgnores(realPath: string): Promise<string[]> {
+	private async computeNestedRepoRelDirs(realPath: string): Promise<string[]> {
 		try {
 			const { roots, truncated } = await findNestedRepoRoots(realPath, {
 				pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
@@ -534,16 +600,7 @@ export class FsWatcherManager {
 					{ absolutePath: realPath, found: roots.length },
 				);
 			}
-			// Emit each root as a root-relative, escaped `<relative>/**` glob.
-			// parcel matches ignore globs relative to the watch root (its defaults
-			// are all `**/…`), so an absolute path never matches. Bare absolute
-			// paths aren't a safe alternative either: parcel's `is-glob` check
-			// misclassifies any path containing glob magic (e.g. a Next.js
-			// `app/[id]/` route segment) as a pattern, so it lands in the glob set
-			// too and mis-prunes. Escaping + relativizing handles both.
-			return roots.map(
-				(root) => `${escapeGlobMagic(path.relative(realPath, root))}/**`,
-			);
+			return roots.map((root) => path.relative(realPath, root));
 		} catch (error) {
 			console.error("[workspace-fs/watch] nested-repo scan failed", {
 				absolutePath: realPath,
@@ -551,6 +608,121 @@ export class FsWatcherManager {
 			});
 			return [];
 		}
+	}
+
+	/**
+	 * Fully-gitignored directories as root-relative dir paths, via the injected
+	 * provider (git decides — nested .gitignore, info/exclude, and the global
+	 * excludesfile all honored). Snapshot at attach time: a dir created later
+	 * (first `bun dev` making `.next`) stays watched until the next attach, but
+	 * the git-watcher's own ignored-path filter caps its downstream cost.
+	 */
+	private async computeGitIgnoredRelDirs(realPath: string): Promise<string[]> {
+		if (!this.listGitIgnoredDirs) {
+			return [];
+		}
+		try {
+			const dirs = await this.listGitIgnoredDirs(realPath);
+			return dirs.filter(
+				(dir) =>
+					dir.length > 0 &&
+					!dir.startsWith("/") &&
+					!dir.split("/").includes(".."),
+			);
+		} catch (error) {
+			console.error("[workspace-fs/watch] gitignored-dir scan failed", {
+				absolutePath: realPath,
+				error: toErrorMessage(error),
+			});
+			return [];
+		}
+	}
+
+	/**
+	 * Re-derive the dynamic ignore set (nested repos + gitignored dirs) and
+	 * swap the native subscription to it. Needed when a directory is
+	 * UN-ignored: the attach-time prune otherwise keeps suppressing its events
+	 * until process restart (VS Code re-subscribes on watcherExclude changes
+	 * for the same reason). Growth of the set never requires this — new
+	 * ignored dirs are filtered downstream.
+	 *
+	 * The old stream stays attached until the new one is live, but its events
+	 * are dropped by the generation guard once attach begins, so a short gap
+	 * is possible. Callers should follow up with a broad refresh of whatever
+	 * they derive from events; the search index is invalidated here.
+	 *
+	 * Returns true when the subscription was actually swapped. No-swap cases:
+	 * the fresh ignore set still contains every currently-pruned dir (growth
+	 * is handled downstream without re-attach), or the root is absent,
+	 * suspended, or recovering (the next attach re-runs the providers anyway).
+	 */
+	async refreshIgnores(rootAbsolutePath: string): Promise<boolean> {
+		const state = this.watchers.get(normalizeAbsolutePath(rootAbsolutePath));
+		if (!state || !state.subscription || state.recoveryTimer) {
+			return false;
+		}
+		const [nestedRepoRelDirs, gitIgnoredRelDirs] = await Promise.all([
+			this.computeNestedRepoRelDirs(state.realPath),
+			this.computeGitIgnoredRelDirs(state.realPath),
+		]);
+		const fresh = new Set([...nestedRepoRelDirs, ...gitIgnoredRelDirs]);
+		const shrunk = state.prunedRelPrefixes.some((dir) => !fresh.has(dir));
+		if (!shrunk) {
+			return false;
+		}
+		if (!state.subscription || state.recoveryTimer) {
+			// State changed while the providers ran.
+			return false;
+		}
+		const oldSubscription = state.subscription;
+		try {
+			await this.attachNativeSubscription(state);
+		} catch (error) {
+			// Old subscription is still installed and valid — keep it.
+			console.error("[workspace-fs/watch] ignore refresh re-attach failed", {
+				absolutePath: state.absolutePath,
+				error: toErrorMessage(error),
+			});
+			return false;
+		}
+		await unsubscribeQuietly(oldSubscription);
+		// Disposal or root-deletion recovery may have raced the swap; the fresh
+		// subscription is then an orphan neither path knows to release.
+		if (
+			this.watchers.get(state.absolutePath) !== state ||
+			state.recoveryTimer
+		) {
+			const orphaned = state.subscription;
+			state.subscription = null;
+			await unsubscribeQuietly(orphaned);
+			return false;
+		}
+		// Events during the swap gap may have been missed.
+		invalidateSearchIndexesForRoot(state.absolutePath);
+		return true;
+	}
+
+	/**
+	 * Whether `absolutePath` gets no events from the recursive watch on
+	 * `rootAbsolutePath` — because it sits inside a pruned subtree (static
+	 * defaults, nested repo, gitignored dir), lies outside the root, or no
+	 * watcher exists for that root at all. Callers use this to decide whether a
+	 * file needs its own targeted watch (see watch-file.ts). Errs toward `true`:
+	 * a spurious targeted watch costs one fd; a missed one costs live reload.
+	 */
+	isPathPruned(rootAbsolutePath: string, absolutePath: string): boolean {
+		const state = this.watchers.get(normalizeAbsolutePath(rootAbsolutePath));
+		if (!state || !state.subscription) {
+			return true;
+		}
+		const relative = path.relative(
+			state.absolutePath,
+			normalizeAbsolutePath(absolutePath),
+		);
+		if (relative === "" || relative.startsWith("..")) {
+			return true;
+		}
+		return isRelPathUnderPrunedDirs(relative, state.prunedRelPrefixes);
 	}
 
 	/**

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -674,27 +674,42 @@ export class FsWatcherManager {
 			// State changed while the providers ran.
 			return false;
 		}
+		// Detach the old stream BEFORE attaching the new one. Keeping both
+		// alive briefly buys nothing (the generation bump discards old events
+		// anyway) and inotify tears down watch descriptors shared across
+		// coexisting parcel backends on the same dir, leaving the fresh
+		// subscription deaf. The swap gap is covered by the caller's follow-up
+		// broad refresh and the search-index invalidation below.
 		const oldSubscription = state.subscription;
-		try {
-			await this.attachNativeSubscription(state);
-		} catch (error) {
-			// Old subscription is still installed and valid — keep it.
-			console.error("[workspace-fs/watch] ignore refresh re-attach failed", {
-				absolutePath: state.absolutePath,
-				error: toErrorMessage(error),
-			});
-			return false;
-		}
+		state.subscription = null;
+		state.generation += 1;
 		await unsubscribeQuietly(oldSubscription);
-		// Disposal or root-deletion recovery may have raced the swap; the fresh
-		// subscription is then an orphan neither path knows to release.
+		// Disposal or root-deletion recovery may have raced the detach.
 		if (
 			this.watchers.get(state.absolutePath) !== state ||
 			state.recoveryTimer
 		) {
-			const orphaned = state.subscription;
-			state.subscription = null;
-			await unsubscribeQuietly(orphaned);
+			return false;
+		}
+		try {
+			await this.attachNativeSubscription(state);
+		} catch (error) {
+			// The root is now unwatched; a transient failure must not leave it
+			// that way silently. Reuse the root-recovery poll, which re-attaches,
+			// verifies liveness, and emits a root create so consumers refetch.
+			console.error(
+				"[workspace-fs/watch] ignore refresh re-attach failed — entering recovery",
+				{
+					absolutePath: state.absolutePath,
+					error: toErrorMessage(error),
+				},
+			);
+			const timer = setInterval(
+				() => void this.tryRecover(state),
+				this.recoveryPollMs,
+			);
+			timer.unref?.();
+			state.recoveryTimer = timer;
 			return false;
 		}
 		// Events during the swap gap may have been missed.


### PR DESCRIPTION
## Problem

The sidebar's file tracking watches everything the static ignore list doesn't cover. Repo-specific gitignored build output (`__pycache__`, `packages/*/lib`, custom out-dirs, `.next` created mid-session) flows through the full pipeline: per-event serial `stat()`s, search-index invalidation, IPC to the renderer, and — worst — `git:changed` → multi-subprocess `git status` cascades every 300ms window.

## Approach

Ask **git** which directories are fully ignored (`git ls-files --others --ignored --exclude-standard --directory`, collapsed entries only — a dir only collapses when nothing inside is tracked, so pruning can never hide a tracked file). No `.gitignore` parsing, no per-event `check-ignore` (index-blind, unsafe for suppression). Three layers:

1. **Native prune** (`packages/workspace-fs/src/watch.ts`): gitignored dirs join the nested-repo ignores as escaped root-relative globs in the parcel subscription, via an injected `listGitIgnoredDirs` provider (same injection style as search's `runRipgrep`).
2. **GitWatcher filter** (`packages/host-service/src/events/git-watcher.ts`): `filterGitIgnoredEvents` drops events under a cached per-workspace set before they can schedule a flush — a fully-ignored batch produces zero `git:changed`, zero git subprocesses, and can't trip the 128-path broad invalidation. The set refreshes after each emitted event (5s floor) and at watch start.
3. **Open-document safety net** (VS Code `activeOutOfWorkspaceWatchers` port): the renderer declares each open document (`fs:watch-file` over the event-bus WS); the host installs a targeted `watchSingleFile` **only when the recursive watcher can't see the path** (`isPathPruned`). Files in gitignored dirs — and `node_modules`/`dist`, where live-reload has been broken since the static list existed — now reload in open editors. Survives atomic-save inode swaps (re-installs `fs.watch` per event) and delete → recreate (poll).

**Un-ignore staleness** (found by stress testing): removing a dir from `.gitignore` left the attach-time native prune stale — its events silently suppressed until restart. `.gitignore`/`.git/info/exclude` changes now fail open on the filter and trigger `FsWatcherManager.refreshIgnores()`, which re-derives the set and swaps the native subscription only when it shrank, followed by one broad catch-up refresh. (VS Code re-subscribes on `files.watcherExclude` changes for the same reason.)

## Numbers

A/B bench (`packages/host-service/scripts/gitignored-churn-bench.ts`, real GitWatcher→EventBus→status-limiter pipeline, 300 gitignored writes + 3 tracked edits over ~10.5s):

| metric | before | after |
|---|---|---|
| fs events to renderer | 303 | **3** (exactly the tracked edits) |
| `git:changed` emissions | 17 | 5 |
| git subprocesses | 255 | **76** |

## Verification

- Unit/integration: git-derived dir listing against real scratch repos (incl. tracked-file-inside-ignored-rule dir never collapsed); watcher prune with injected provider; glob-magic paths; un-ignore re-attach; single-file watch atomic-replace/delete/recreate; GitWatcher filter semantics (renames kept unless both endpoints ignored, `.gitignore` events always pass and flag staleness).
- CDP end-to-end in the dev desktop (live WS measurements + trusted input + screenshots): 200 gitignored writes → 0 events/0 refreshes while 2 tracked edits came through path-scoped; Changes panel shows only real files; ignored dirs still browsable/dimmed in Files tree.
- Stress matrix, all against the live app: 5000-file burst → 0 events, 13ms frame time mid-burst, zero renderer errors; runtime-created ignored dir suppressed after one rule-change refresh; live un-ignore restores signal (file appears in Changes) then re-ignore suppresses again; tracked file inside a gitignore-matched dir always signals; boundary renames signal both directions; open-doc: 100 rapid writes settle, dirty buffer survives external edit, delete shows orphan banner and recreate reloads.

## Known limitation (deliberate)

A dir that becomes ignored *after* attach still sends raw fs events to the renderer until the next attach — only the expensive layers (git cascades) are suppressed immediately. Tightening the native set requires a subscription swap, which we reserve for the correctness-critical shrink direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude fully gitignored build-output dirs from sidebar file tracking to cut renderer noise and Git status churn; previously all writes under repo-specific out-dirs flowed end‑to‑end. Open files in pruned dirs (and in `node_modules`) now live‑reload via targeted per‑file watches.

- `workspace-fs`
  - Injects `listGitIgnoredDirs` and prunes returned dirs alongside nested repos; stores root‑relative, escaped globs and prefixes for `isPathPruned`.
  - Adds `refreshIgnores()` to re‑derive ignores and swap the native subscription only when rules shrank; detaches before re‑attach and enters recovery on attach failure; invalidates search once.
  - New `watchSingleFile` installs an inode‑aware watch that survives atomic saves and delete→recreate; when the path is a directory, polls and emits only on transition or mtime change to avoid reload loops.
  - Handles symlinked roots and Unicode/case‑divergent dir names.
- `host-service`
  - `GitWatcher` drops events under a cached per‑workspace ignored‑dir set, refreshes it after emits (5s floor), fails open on `.gitignore` changes, and triggers `refreshWatcherIgnores()` when the set shrinks. A rules change during a refresh now schedules a follow‑up refresh.
  - `event-bus`: adds `fs:watch-file`/`fs:unwatch-file` with containment checks and a per‑client cap (256); installs `watchSingleFile` only when `isPathPruned`; guards against socket send errors.
  - `workspace-client`: wires `watchFsFile`/`unwatchFsFile` and replays on reconnect; renderer (`useSharedFileDocument`) declares open documents to the host.
- Tests cover ignore negations, `.git/info/exclude`, symlinked roots, Unicode/casing, exactly‑once delivery for pruned paths, containment rejections, repeated delete→recreate cycles, and bench safety.
- Performance (300 ignored writes + 3 tracked edits): fs events to renderer 303 → 3; `git:changed` emits 17 → 5; git subprocesses 255 → 76.

<sup>Written for commit 890a68e633efa1ac0edc71c8c3cdd47d5d9bd2d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added targeted monitoring for individual workspace files, including updates, replacements, deletions, recreation, and directory transitions.
  - File monitoring reconnects after service interruptions and cleans up when no longer needed.
  - Monitoring safely handles missing files and paths outside the workspace.

- **Bug Fixes**
  - Reduced unnecessary refreshes caused by changes in Git-ignored directories.
  - Preserved reliable updates for tracked files and refreshed monitoring when ignore rules change.

- **Tests**
  - Added coverage for file lifecycle events, ignored-directory filtering, watcher pruning, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->