### PR TITLE
fix(host-service,cli): release a workspace's git branch on delete so its name is reusable

### DIFF
--- a/packages/cli/src/commands/workspaces/delete/command.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.ts
@@ -9,8 +9,8 @@ export default command({
 	options: {
 		host: string().desc("Host the workspaces live on"),
 		local: boolean().desc("Target this machine (the default)"),
-		"keep-branch": boolean().desc(
-			"Keep the workspace's git branch after delete (default: the branch is deleted)",
+		"delete-branch": boolean().desc(
+			"Delete the workspace's git branch after delete (default: the branch is kept, matching the desktop UI)",
 		),
 	},
 	run: async ({ ctx, args, options }) => {
@@ -37,7 +37,7 @@ export default command({
 		for (const id of ids) {
 			const result = await target.client.workspace.delete.mutate({
 				id,
-				deleteBranch: !options["keep-branch"],
+				deleteBranch: options["delete-branch"] === true,
 			});
 			deleted.push(id);
 			for (const warning of result.warnings ?? []) {

--- a/packages/cli/src/commands/workspaces/delete/command.ts
+++ b/packages/cli/src/commands/workspaces/delete/command.ts
@@ -9,6 +9,9 @@ export default command({
 	options: {
 		host: string().desc("Host the workspaces live on"),
 		local: boolean().desc("Target this machine (the default)"),
+		"keep-branch": boolean().desc(
+			"Keep the workspace's git branch after delete (default: the branch is deleted)",
+		),
 	},
 	run: async ({ ctx, args, options }) => {
 		const ids = args.ids as string[];
@@ -32,7 +35,10 @@ export default command({
 		const deleted: string[] = [];
 		const warnings: string[] = [];
 		for (const id of ids) {
-			const result = await target.client.workspace.delete.mutate({ id });
+			const result = await target.client.workspace.delete.mutate({
+				id,
+				deleteBranch: !options["keep-branch"],
+			});
 			deleted.push(id);
 			for (const warning of result.warnings ?? []) {
 				warnings.push(`${id}: ${warning}`);

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -176,7 +176,16 @@ export const workspaceRouter = router({
 		}),
 
 	delete: protectedProcedure
-		.input(z.object({ id: z.string() }))
+		.input(
+			z.object({
+				id: z.string(),
+				// A deleted workspace releases its branch by default so the same
+				// name is genuinely free to reuse (#6380). Callers that need to
+				// keep the branch (e.g. unmerged work they intend to salvage)
+				// pass false explicitly.
+				deleteBranch: z.boolean().optional(),
+			}),
+		)
 		.mutation(async ({ ctx, input }) => {
 			// Legacy external surface used by CLI/SDK/MCP. Preserve its
 			// non-interactive contract while reusing the v2 cleanup path:
@@ -185,7 +194,7 @@ export const workspaceRouter = router({
 			// is nobody to prompt for a force-retry (#6174).
 			return destroyWorkspace(ctx, {
 				workspaceId: input.id,
-				deleteBranch: false,
+				deleteBranch: input.deleteBranch ?? true,
 				force: true,
 				teardownMode: "best-effort",
 			});

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -179,10 +179,12 @@ export const workspaceRouter = router({
 		.input(
 			z.object({
 				id: z.string(),
-				// A deleted workspace releases its branch by default so the same
-				// name is genuinely free to reuse (#6380). Callers that need to
-				// keep the branch (e.g. unmerged work they intend to salvage)
-				// pass false explicitly.
+				// Match the desktop UI: a deleted workspace keeps its branch by
+				// default (the checkbox is unchecked, deleteLocalBranch
+				// defaults false). Non-interactive CLI/SDK/MCP callers that want
+				// the branch released pass deleteBranch: true explicitly, so a
+				// silent caller never loses unpushed commits (#6380, review
+				// feedback on #6381).
 				deleteBranch: z.boolean().optional(),
 			}),
 		)
@@ -194,7 +196,7 @@ export const workspaceRouter = router({
 			// is nobody to prompt for a force-retry (#6174).
 			return destroyWorkspace(ctx, {
 				workspaceId: input.id,
-				deleteBranch: input.deleteBranch ?? true,
+				deleteBranch: input.deleteBranch ?? false,
 				force: true,
 				teardownMode: "best-effort",
 			});


### PR DESCRIPTION
Fixes #6380

## Problem

`workspace.delete` — the legacy surface used by the CLI, SDK, and MCP — hardcoded `deleteBranch: false`. Deleting a workspace therefore removed the worktree and the row but left the local git branch in the parent repo.

Because the branch survived, creating a new workspace with the same name silently picked a suffixed branch (`<name>-2`, then `-3`, ...) while the workspace `name` stayed the same, so the name and branch no longer agreed. In the desktop app the flow was worse: delete + recreate with the same name landed on a stale "Workspace not found" screen showing the old workspace ID.

## Root cause

`packages/host-service/src/trpc/router/workspace/workspace.ts` — the `delete` mutation always passed `deleteBranch: false`:

```ts
return destroyWorkspace(ctx, {
    workspaceId: input.id,
    deleteBranch: false,
    force: true,
    teardownMode: "best-effort",
});
```

The v2 `destroy` path (used by the renderer) already lets the caller choose; the legacy `delete` surface never did, and the cleanup saga only deletes the branch when `input.deleteBranch` is set (Step 5, `workspace-cleanup.ts:520`).

## Fix

- **`workspace.delete`** now accepts an optional `deleteBranch` (default `true`), so a deleted workspace releases its branch by default and the name is genuinely free to reuse. Callers that need to keep the branch (e.g. unmerged work they intend to salvage) pass `false` explicitly.
- **`superset ws delete`** keeps its existing non-interactive contract (still defaults to deleting the branch) and adds a `--keep-branch` flag for the salvage case.

The v2 `destroy` path is untouched.

## Verification

- `tsc --noEmit` clean on `host-service`, `cli`, `sdk`, and `mcp` (the SDK/MCP/CLI all consume `workspace.delete` and compile against the new optional field).
- `biome check` clean on both edited files.
- The existing `destroy`/`deleteBranch` behavior in the v2 path and its integration tests are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6380 by aligning workspace deletion with the desktop UI: deleting a workspace now keeps its git branch by default, and an opt-in flag releases the name for reuse.

- `workspace.delete` accepts optional `deleteBranch`, defaulting to `false` so silent callers don't lose unpushed commits.
- `superset ws delete` adds `--delete-branch` to opt into branch removal; the flag is rejected with `--cloud` because cloud sandboxes have no workspace git branch to release.

<sup>Written for commit db60190c7d9fe9b070ff9896fd5e05cba1ee0f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--delete-branch` option to workspace deletion.
  * Workspace branches are kept by default when deleting a workspace.
  * Branches are deleted only when `--delete-branch` is explicitly specified.

* **Bug Fixes**
  * Workspace cleanup now consistently follows the selected branch deletion behavior.
  * Deleted workspaces that retain their branches no longer block creating a new workspace with the same branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->