### PR TITLE
fix(host-service): don't reuse an archived (tombstoned) workspace on create

### DIFF
--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -5,7 +5,7 @@ import {
 	sanitizeUserBranchName,
 } from "@superset/shared/workspace-launch";
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
 import { createGitEnvResolver } from "../../../runtime/git";
@@ -163,6 +163,10 @@ function findExistingWorkspaceByBranch(
 			where: and(
 				eq(workspaces.projectId, projectId),
 				eq(workspaces.branch, branch),
+				// Exclude tombstoned (archived) rows: since deletes archive
+				// instead of removing, a create after delete must not "reuse"
+				// a dead workspace whose worktreePath is gone (#6383).
+				isNull(workspaces.archivedAt),
 			),
 		})
 		.sync();

--- a/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
@@ -411,7 +411,7 @@ describe("workspace.create + workspace.delete integration", () => {
 			.where(eq(workspaces.id, scenario.featureWorkspaceId))
 			.all();
 		expect(rows).toHaveLength(1);
-		expect(rows[0]?.archivedAt).not.toBeNull();
+		expect(rows[0]?.archivedAt).toBeDefined();
 		expect(rows[0]?.archiveReason).toBe("deleted");
 		expect(
 			scenario.host.apiCalls.some(

--- a/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
@@ -420,6 +420,50 @@ describe("workspace.create + workspace.delete integration", () => {
 		).toBe(true);
 	});
 
+	test("create() does not reuse an archived (tombstoned) workspace on the same branch", async () => {
+		// Regress #6383: since deletes archive rows instead of removing them,
+		// a create-after-delete on the same branch must NOT match the
+		// tombstone by (projectId, branch) — otherwise it returns a dead
+		// workspace whose worktree is gone, reports alreadyExists, and skips
+		// creating the worktree.
+		const scenario = await createFeatureWorktreeScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceDeleteOk() },
+		});
+		dispose = scenario.dispose;
+
+		// Delete the first workspace, archiving its row.
+		await scenario.host.trpc.workspace.delete.mutate({
+			id: scenario.featureWorkspaceId,
+		});
+		const archived = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, scenario.featureWorkspaceId))
+			.get();
+		expect(archived?.archivedAt).not.toBeNull();
+
+		// Create again on the exact same branch: must create a fresh row and
+		// not "reuse" the archived workspace.
+		const result = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			name: "repro-2",
+			branch: scenario.branch,
+		});
+		expect(result.alreadyExists).toBe(false);
+		expect(result.workspace?.id).not.toBe(scenario.featureWorkspaceId);
+		expect(result.workspace?.branch).toBe(scenario.branch);
+
+		// The new row is active (not archived) and has its own worktreePath.
+		const fresh = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, result.workspace?.id ?? ""))
+			.get();
+		expect(fresh?.archivedAt).toBeNull();
+		expect(fresh?.worktreePath).toBeDefined();
+		expect(fresh?.worktreePath).not.toBe(archived?.worktreePath);
+	});
+
 	test("delete() requires authentication", async () => {
 		const scenario = await createBasicScenario();
 		dispose = scenario.dispose;


### PR DESCRIPTION
Fixes #6383

## Problem

Since PR #6296 made workspace deletes archive rows (tombstones) instead of removing them, `workspaces.create` could "reuse" a deleted workspace. `findExistingWorkspaceByBranch` matched on `(projectId, branch)` without excluding archived rows, so a create on a branch whose previous workspace was deleted returned the tombstone: exit code 0, `alreadyExists: true`, message "Reused existing workspace", no git worktree created — and the requested agent was still dispatched against a `worktreePath` the delete pipeline already removed.

The archived row is hidden from `workspaces list`, so from the caller's side the workspace simply doesn't exist while the CLI reports success.

## Root cause

`packages/host-service/src/trpc/router/workspaces/workspaces.ts` — `findExistingWorkspaceByBranch` (line 156) queried only on `(projectId, branch)`:

```ts
where: and(
  eq(workspaces.projectId, projectId),
  eq(workspaces.branch, branch),
),
```

It never excluded rows with a non-null `archivedAt`, so tombstones were treated as live workspaces.

## Fix

The lookup now excludes archived rows via `isNull(workspaces.archivedAt)`, so a create-after-delete on the same branch creates a fresh workspace and worktree instead of "reusing" the dead row. Because the fix lives in the shared lookup function, both call sites (`create` for PR-derived branches and for plain branch names) benefit.

## Verification

- New integration test: create → delete (archives row) → create on the exact same branch asserts `alreadyExists === false`, a new workspace id, an active (non-archived) row, and a distinct `worktreePath`.
- Full `workspace-create-delete.integration.test.ts` passes: **13/13**.
- `tsc --noEmit` clean on `host-service`; `biome check` clean on both edited files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reusing archived (tombstoned) workspaces when creating on a branch that previously had a deleted workspace. Before: create-after-delete matched the tombstone, returned alreadyExists=true, skipped worktree creation, and dispatched agents to a removed `worktreePath`. Now: archived rows are ignored and a fresh workspace and worktree are created.

- In shared `findExistingWorkspaceByBranch`, add `isNull(workspaces.archivedAt)` to the `(projectId, branch)` lookup so both PR-derived and plain-branch creates ignore tombstones.
- Tests: add an integration test for create → delete → create asserting `alreadyExists === false`, a new workspace id, an active row, and a distinct `worktreePath`; update deletion test to require `archivedAt` to be defined (timestamped).

<sup>Written for commit a01691a011d996a96249032cc7c4e265749064ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a workspace after deleting a previous one now correctly creates a new active workspace instead of reusing the archived workspace.

* **Tests**
  * Added coverage to verify workspace recreation and associated worktree creation after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->