### PR TITLE
fix(desktop): keep the PR badge (merge chevron) from clipping in the right sidebar's mid-width dead zone

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
@@ -96,8 +96,11 @@ export function V2OpenInMenuButton({
 						className={cn(
 							// Icon-only when the nearest @container is narrow; the branch
 							// label comes back once there's room (right sidebar is resizable,
-							// so viewport breakpoints don't apply here).
-							"group flex h-6 items-center justify-center gap-1.5 rounded-l border border-r-0 border-border/60 bg-secondary/50 px-1.5 text-xs font-medium @[240px]:pr-2",
+							// so viewport breakpoints don't apply here). The threshold is
+							// higher than the PR badge's so the badge (with its merge
+							// chevron) keeps space priority and never clips in the 240-320px
+							// dead zone (#6385).
+							"group flex h-6 items-center justify-center gap-1.5 rounded-l border border-r-0 border-border/60 bg-secondary/50 px-1.5 text-xs font-medium @[320px]:pr-2",
 							"transition-all duration-150 ease-out",
 							"hover:bg-secondary hover:border-border",
 							"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -114,7 +117,7 @@ export function V2OpenInMenuButton({
 						)}
 						{branch && (
 							<OverflowFadeText
-								className="hidden max-w-[140px] text-muted-foreground tabular-nums @[240px]:inline-block"
+								className="hidden max-w-[140px] text-muted-foreground tabular-nums @[320px]:inline-block"
 								title={branch}
 							>
 								/{branch}


### PR DESCRIPTION
Fixes #6385

## Problem

In the v2 workspace right sidebar, the PR badge clips at the panel edge when the sidebar sits in a middle width range (~260-290px). The parts that vanish are the checks dot and the merge chevron — and the chevron is the only way to merge a PR from the UI.

## Root cause

`PRActionHeader` is a `@container`. Both the workspace open-in button and the PR badge exposed their full content from `@[240px]`:
- open-in shows up to 140px of branch path (`max-w-[140px]`)
- badge shows the PR number, checks indicators, and merge chevron

Together the full row needs roughly 300px. Between ~240px and ~300px the row overflows the panel, and the badge's right edge (checks dot + merge chevron) is what gets cut. Below ~240px everything collapses to icon-only and fits again — hence the "dead zone".

## Fix

`apps/desktop/.../V2OpenInMenuButton.tsx`: the open-in button now stays icon-only until `@[320px]` (raised from `@[240px]`) on both the button padding and the branch label. Between ~240px and ~320px the open-in yields space to the PR badge, so the badge keeps its number, checks indicators, and merge chevron — which is the only way to merge from the UI.

The PR badge's own breakpoints are unchanged. `V2WorkspaceOpenInButton` is used only inside `PRActionHeader`, so this doesn't affect any other surface.

## Verification

- `biome check` clean on the edited file.
- Change is Tailwind class literals only (no logic/type surface).
- Visual: with a long branch name, the sidebar at ~260-320px now keeps the full badge; the open-in collapses to icon-only until there's room for both.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the PR badge from clipping in the v2 workspace right sidebar by keeping the open‑in button icon‑only until `@[320px]`. Previously both expanded at `@[240px]`, causing overflow around 240–300px and hiding the merge chevron.

**Details**
- In `V2OpenInMenuButton.tsx`, raise the breakpoint for right‑side padding and the branch label from `@[240px]` to `@[320px]`, so the open‑in stays icon‑only between ~240–320px.
- `PRActionHeader` remains a `@container`; PR badge breakpoints are unchanged and now keep the number, checks indicator, and merge chevron across this range.
- Scope is limited to `V2OpenInMenuButton` within `PRActionHeader`; change is Tailwind class literals only.

<sup>Written for commit aefc2511d7c378f7a185039c3af0e66bed0f5c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior in the dashboard top bar.
  * The open-in button and branch label now appear at narrower container widths, starting at 320px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->