### PR TITLE
fix(host-service): classify worktree-gone terminal failures as NOT_FOUND

### DIFF
--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -22,6 +22,16 @@ function toTerminalIoError(message: string): TRPCError {
 	if (message.includes("belong")) {
 		return new TRPCError({ code: "FORBIDDEN", message });
 	}
+	// A worktree deleted underneath an open terminal is a routine lifecycle
+	// state, not a bug — the runtime reports it as a plain string, so match
+	// the stable prefix here to keep it out of Sentry.
+	if (message.startsWith("Workspace worktree no longer exists")) {
+		return new TRPCError({
+			code: "NOT_FOUND",
+			message,
+			cause: { kind: "WORKTREE_GONE" },
+		});
+	}
 	if (
 		message.includes("not found") ||
 		message.includes("not active") ||


### PR DESCRIPTION
## Problem

HOST-SERVICE-1N (14 events on 1.20.2): when a workspace's worktree directory is deleted while a terminal pane is still open, every `terminal.snapshot` poll throws `INTERNAL_SERVER_ERROR` and the Sentry middleware reports it as a 500 — even though a worktree removed underneath an open terminal is a routine lifecycle condition, not an internal failure.

## Root cause

`createTerminalSessionInternal` (the adoption path under `snapshotSession`/`writeFramedInputToSession`) returns the plain string error `Workspace worktree no longer exists: <path>` when the worktree directory is gone. The router's `toTerminalIoError` helper name-checks a few known messages ("belong" → FORBIDDEN; "not found"/"not active"/"exited" → NOT_FOUND), but this message matches none of them, so it falls through to the `INTERNAL_SERVER_ERROR` branch and the dumb 500=report Sentry middleware files it on every poll.

No typed error class crosses this boundary — the runtime returns `{ error: string }` — so the classification has to match the stable message prefix.

## Fix

Add a branch to `toTerminalIoError` that recognizes the `Workspace worktree no longer exists` prefix and returns `NOT_FOUND` with `cause: { kind: "WORKTREE_GONE" }`. The message and all other behaviour are unchanged; genuine unexpected terminal I/O failures still fall through to `INTERNAL_SERVER_ERROR` and keep reporting.

All terminal procedures that funnel errors through this helper (`send`, `snapshot`) pick up the fix; there are no per-procedure copies.

## Verification

```
$ bunx biome check packages/host-service/src/trpc/router/terminal/terminal.ts
Checked 1 file in 12ms. No fixes applied.

$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false
typecheck exit=0
```

No existing tests cover this helper (`grep -rl "toTerminalIoError" **/*.test.ts` → no matches), so no test run applies.

Refs HOST-SERVICE-1N

https://claude.ai/code/session_0c69890b-c39f-420c-b03a-8038231a89ad

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies "Workspace worktree no longer exists..." terminal errors as NOT_FOUND in `host-service` instead of INTERNAL_SERVER_ERROR, addressing HOST-SERVICE-1N and stopping false 500s/Sentry alerts. Old: `terminal.snapshot` and `send` returned 500; New: they return 404 with cause { kind: "WORKTREE_GONE" }; message unchanged.

**Review notes**
- Change is isolated to `toTerminalIoError`; both procedures inherit it; other errors keep their codes.
- No tests updated; the helper had no coverage.

**Migration**
- Update any client logic that treated deleted worktree terminals as 500 to handle 404 NOT_FOUND instead.
- No action needed if you already treat missing/closed sessions as NOT_FOUND.

<sup>Written for commit a0e24d80ccc4c4b32ba237a268bd81eb3ad8fefe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a workspace worktree no longer exists.
  * Users now receive a clear “not found” error with a specific worktree-related cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->