### PR TITLE
fix(host-service): classify expected GitHub auth and 404 outcomes as non-500s

### DIFF
--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -2,6 +2,7 @@ import { createNodeWebSocket } from "@hono/node-ws";
 import { trpcServer } from "@hono/trpc-server";
 import { Octokit } from "@octokit/rest";
 import { ChatService } from "@superset/chat-legacy/server/desktop";
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 import { Hono } from "hono";
@@ -94,9 +95,15 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		(async () => {
 			const token = await providers.credentials.getToken("github.com");
 			if (!token) {
-				throw new Error(
-					"No GitHub token available. Set GITHUB_TOKEN/GH_TOKEN or authenticate via git credential manager.",
-				);
+				// Expected precondition failure (user has no GitHub auth), not an
+				// internal error — every procedure calling ctx.github() inherits
+				// this classification.
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message:
+						"No GitHub token available. Set GITHUB_TOKEN/GH_TOKEN or authenticate via git credential manager.",
+					cause: { kind: "NO_GITHUB_TOKEN" },
+				});
 			}
 			return new Octokit({ auth: token });
 		});

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -402,7 +402,8 @@ async function octokitDirectLookupMatchesReviewFilter(
 
 /**
  * Octokit twin of {@link ghDirectLookupRow}: direct-lookup one repo, apply
- * author/review filters, enrich checks best-effort. Null = filtered out.
+ * author/review filters, enrich checks best-effort. Null = filtered out or
+ * PR not found/inaccessible.
  */
 async function octokitDirectLookupRow(
 	octokit: Octokit,
@@ -412,11 +413,20 @@ async function octokitDirectLookupRow(
 	reviewFilter: PullRequestReviewFilter | undefined,
 ): Promise<PullRequestResult | null> {
 	const { repo } = target;
-	const { data: pr } = await octokit.pulls.get({
-		owner: repo.owner,
-		repo: repo.name,
-		pull_number: prNumber,
-	});
+	const response = await octokit.pulls
+		.get({
+			owner: repo.owner,
+			repo: repo.name,
+			pull_number: prNumber,
+		})
+		.catch((error: unknown) => {
+			// A 404 means the PR doesn't exist or isn't accessible to the user —
+			// an expected empty result, not an internal error.
+			if (isGithubNotFoundError(error)) return null;
+			throw error;
+		});
+	if (!response) return null;
+	const pr = response.data;
 	if (!matchesAuthor(pr.user?.login ?? null, author)) return null;
 	if (
 		reviewFilter &&


### PR DESCRIPTION
## Problem

Two expected GitHub outcomes escape host-service tRPC procedures as `INTERNAL_SERVER_ERROR` 500s and file Sentry issues:

- **HOST-SERVICE-1M** (6 events, 1.20.2): when a user has no GitHub credentials configured, the shared `github()` context factory throws a plain `Error("No GitHub token available...")` the moment any procedure requests an Octokit client (seen on `git.getPullRequestThreads`). Every PR view without GitHub auth files a 500.
- **HOST-SERVICE-1Q** (2 events, 1.20.2): in `workspaceCreation.searchPullRequests`, an explicit-PR-number lookup for a PR that doesn't exist or isn't accessible rejects with an Octokit HttpError 404 that propagates unclassified.

## Root cause

Both are expected domain states (missing precondition / empty result) thrown as untyped errors, so the tRPC Sentry middleware — which reports anything still `INTERNAL_SERVER_ERROR` at the boundary — correctly treats them as bugs. Per the repo's error contract, the missing translation belongs at the throw sites, never as a Sentry-side filter.

## Fix

- `packages/host-service/src/app.ts`: the `github()` context factory now throws `TRPCError({ code: "PRECONDITION_FAILED", cause: { kind: "NO_GITHUB_TOKEN" } })` with the existing message unchanged. Every procedure that calls `ctx.github()` inherits the classification from this one shared site; no call sites touched.
- `packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts`: `octokitDirectLookupRow` treats a 404 from `octokit.pulls.get` as "no matching PR" and returns `null`, which the single-target caller already handles gracefully (`emptyPullRequestsPage`) and which matches how the multi-target `Promise.allSettled` path already filters 404 rejections via `isGithubNotFoundError` (status/name check, no `instanceof`).

Genuine unexpected GitHub failures (5xx, network, rate limits) still propagate and report exactly as before. `github.mergePR` classification (HOST-SERVICE-1P) is intentionally untouched — open PR #6228 owns `github.ts`.

## Verification

`bunx biome check` on the two changed files:

```
Checked 2 files in 12ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
typecheck exit=0
```

No existing tests cover the changed code paths (no co-located test files for `app.ts` or `search-pull-requests.ts`), so no test run applies.

Refs HOST-SERVICE-1M
Refs HOST-SERVICE-1Q

https://claude.ai/code/session_72e9200a-ff85-4667-ac6d-add2c90fb109


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies two expected GitHub outcomes so they no longer surface as 500s or file Sentry issues. Previously, missing GitHub credentials or a direct PR lookup 404 resulted in INTERNAL_SERVER_ERROR; now missing credentials throw PRECONDITION_FAILED and 404 direct lookups return null (empty result). Unexpected GitHub failures still propagate unchanged.

**What changed**
- `packages/host-service/src/app.ts`: `github()` now throws `TRPCError` (`PRECONDITION_FAILED`, cause `{ kind: "NO_GITHUB_TOKEN" }`) from `@trpc/server` instead of a generic error.
- `packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts`: treat `@octokit/rest` `pulls.get` 404 as “no matching PR” and return `null` via existing `isGithubNotFoundError`; caller already handles empty results. No call sites changed.
- Client-visible behavior: missing GitHub auth is now a `PRECONDITION_FAILED` tRPC error; single-PR direct lookup may return `null` instead of throwing. Sentry noise is reduced; `github.mergePR` handling is unchanged.

<sup>Written for commit c928b752d2c4cf259481aea7694a7e57bead7292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

