### PR TITLE
fix(host-service): guard upgrade sockets in the desktop entrypoint against peer resets

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -11,6 +11,7 @@ import {
 	createApp,
 	initSentry,
 	installProcessSafetyNet,
+	installUpgradeSocketGuard,
 	JwtApiAuthProvider,
 	LocalGitCredentialProvider,
 	LocalModelProvider,
@@ -149,6 +150,7 @@ async function main(): Promise<void> {
 		},
 	);
 	serverRef.current = server;
+	installUpgradeSocketGuard(server);
 	injectWebSocket(server);
 }
 

--- a/packages/host-service/src/index.ts
+++ b/packages/host-service/src/index.ts
@@ -19,7 +19,7 @@ export {
 	LocalModelProvider,
 } from "./providers/model-providers";
 export type { GitCredentialProvider, GitFactory } from "./runtime/git";
-export { installProcessSafetyNet } from "./safety";
+export { installProcessSafetyNet, installUpgradeSocketGuard } from "./safety";
 export { captureFatalStartupError, initSentry } from "./sentry";
 export { startTerminalReaper } from "./terminal/reaper";
 export type {

--- a/packages/host-service/src/safety.ts
+++ b/packages/host-service/src/safety.ts
@@ -13,9 +13,39 @@
  * remaining iterations, so those sites use inline `try/catch` directly.
  */
 
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
 import * as Sentry from "@sentry/node";
 
 let safetyNetInstalled = false;
+
+/**
+ * Node detaches its own socket error handling before emitting 'upgrade',
+ * and @hono/node-ws awaits app.request() before ws adopts the socket — a
+ * peer reset in that window is an uncaught ECONNRESET at TCP.onStreamRead
+ * (and a peer gone before the reject-path socket.end() is an uncaught
+ * EPIPE). Keep a listener attached for the socket's lifetime so resets are
+ * logged instead. Must be installed by every entrypoint that calls
+ * injectWebSocket — shipped in serve.ts by #6196, but the desktop
+ * entrypoint has its own bootstrap and kept crashing (HOST-SERVICE-5).
+ */
+export function installUpgradeSocketGuard(server: {
+	on(
+		event: "upgrade",
+		listener: (request: IncomingMessage, socket: Duplex) => void,
+	): unknown;
+}): void {
+	server.on("upgrade", (request: IncomingMessage, socket: Duplex) => {
+		// Path only: the upgrade URL's query string carries HOST_SERVICE_SECRET
+		// as `token` for relayed connections.
+		const requestPath = request.url?.split("?")[0] ?? "<unknown>";
+		socket.on("error", (error: NodeJS.ErrnoException) => {
+			console.warn(
+				`[host-service] upgrade socket error (${error.code ?? error.message}) on ${requestPath} from ${request.socket.remoteAddress ?? "<unknown>"}`,
+			);
+		});
+	});
+}
 
 export function installProcessSafetyNet(): void {
 	if (safetyNetInstalled) return;

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -1,5 +1,3 @@
-import type { IncomingMessage } from "node:http";
-import type { Duplex } from "node:stream";
 import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { getSupervisor, startDaemonBootstrap } from "./daemon";
@@ -11,7 +9,7 @@ import {
 import { LocalGitCredentialProvider } from "./providers/git";
 import { PskHostAuthProvider } from "./providers/host-auth";
 import { LocalModelProvider } from "./providers/model-providers";
-import { installProcessSafetyNet } from "./safety";
+import { installProcessSafetyNet, installUpgradeSocketGuard } from "./safety";
 import { captureFatalStartupError, initSentry } from "./sentry";
 import { startTerminalBaseEnvResolution } from "./terminal/env";
 import { startTerminalReaper } from "./terminal/reaper";
@@ -116,21 +114,7 @@ async function main(): Promise<void> {
 			});
 		}
 	});
-	// Node detaches its own socket error handling before emitting 'upgrade',
-	// and @hono/node-ws awaits app.request() before ws adopts the socket — a
-	// peer reset in that window is an uncaught ECONNRESET at TCP.onStreamRead
-	// that takes down the whole process. Keep a listener attached for the
-	// socket's lifetime so resets are logged instead.
-	server.on("upgrade", (request: IncomingMessage, socket: Duplex) => {
-		// Path only: the upgrade URL's query string carries HOST_SERVICE_SECRET
-		// as `token` for relayed connections.
-		const requestPath = request.url?.split("?")[0] ?? "<unknown>";
-		socket.on("error", (error: NodeJS.ErrnoException) => {
-			console.warn(
-				`[host-service] upgrade socket error (${error.code ?? error.message}) on ${requestPath} from ${request.socket.remoteAddress ?? "<unknown>"}`,
-			);
-		});
-	});
+	installUpgradeSocketGuard(server);
 	injectWebSocket(server);
 }
 


### PR DESCRIPTION
## Problem

Host-service keeps reporting fatal uncaught `read ECONNRESET` at `TCP.onStreamRead` (12 events, level fatal, mechanism `onuncaughtexception`) — and still on 1.20.2, even though #6196 shipped a websocket upgrade-socket guard in that release. On builds before the process safety net this killed the whole host-service process; on current builds it survives via the safety net but still fires a fatal Sentry event on every peer reset.

## Root cause

#6196 added the guard to `packages/host-service/src/serve.ts` — but that is only the standalone/CLI entrypoint. The desktop app bundles its **own** bootstrap, `apps/desktop/src/main/host-service/index.ts`, which duplicates the serve wiring and calls `injectWebSocket(server)` with no guard. Confirmed against the shipped bundle: the packaged `host-service.js` contains exactly one `server.on("upgrade")` listener (@hono/node-ws's internal one) and no guard. Every event in this issue comes from desktop-spawned hosts, so the guard was never in the code path that crashes.

The crash window is the one #6196 described: Node detaches its own socket error handling before emitting `'upgrade'`, and @hono/node-ws `await`s `app.request()` (async auth middleware) before `ws` adopts the socket. A renderer/relay peer resetting in that window emits `'error'` on a listener-less `net.Socket` → uncaught exception. The same unguarded socket also produces the adjacent uncaught `write EPIPE` from node-ws's reject path (`socket.end()` after the peer is gone), visible in local host-service logs with a stack pointing into the bundled `injectWebSocket` handler.

Reproduced exactly on Node 24 with the repo's `@hono/node-server` 2.0.10 + `@hono/node-ws` 1.3.0: an RST landing inside the awaited `app.request()` window yields the identical one-frame signature:

```
UNCAUGHT: ECONNRESET
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
```

With the guard installed, the same run logs `[host-service] upgrade socket error (ECONNRESET) on /ws ...` and survives.

## Fix

Extract #6196's guard into `installUpgradeSocketGuard(server)` in `packages/host-service/src/safety.ts` (the crash-isolation module), export it from the package root, and install it in **both** entrypoints:

- `packages/host-service/src/serve.ts` — replaces the inline block from #6196, behavior unchanged.
- `apps/desktop/src/main/host-service/index.ts` — the previously unguarded entrypoint that ships in the app.

No process-wide swallowing and no Sentry-side filtering: the handler is attached per upgrade socket and only logs the reset; uncaught exceptions elsewhere keep reporting exactly as before.

## Verification

Repro harness (Node v24.1.0, repo's exact @hono deps), before — no guard, RST inside the `app.request()` window:

```
caseA: RST inside app.request window
UNCAUGHT: ECONNRESET
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
exit=42
```

After — same harness importing the real `installUpgradeSocketGuard` from `src/safety.ts`, wired exactly as the desktop entrypoint now is:

```
caseA: RST inside app.request window
[host-service] upgrade socket error (ECONNRESET) on /ws from <unknown>
caseB: RST before reject-path socket.end
[host-service] upgrade socket error (ECONNRESET) on /not-a-ws-route from <unknown>
SURVIVED
exit=0
```

A control matrix over the other socket classes in this process (established/adopted ws sockets, idle keep-alive HTTP, in-flight and streaming SSE responses, undici `fetch` pool, undici client `WebSocket`) all survive RSTs on Node 24 — the upgrade window is the only crash path, matching the single-frame plaintext-TCP stack.

- `bunx biome check` on the 4 changed files → `Checked 4 files in 11ms. No fixes applied.`
- `cd packages/host-service && bun run typecheck` → exit 0
- `cd apps/desktop && bun run typecheck` → exit 0 (desktop file touched)
- No existing tests cover `safety.ts`/these entrypoints; none added.

Refs HOST-SERVICE-5

https://claude.ai/code/session_535393a9-0307-4689-92d2-b25e59453993


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards WebSocket upgrade sockets in the desktop host-service entrypoint to prevent uncaught peer resets. Previously, peer resets during the `@hono/node-ws` async upgrade window caused uncaught `read ECONNRESET`/`write EPIPE`; now they are logged per socket and the process continues without emitting fatal Sentry events.

- Extracts `installUpgradeSocketGuard(server)` into `packages/host-service/src/safety.ts` and exports it from the package root.
- Installs the guard in both entrypoints: desktop (`apps/desktop/src/main/host-service/index.ts`) and CLI (`packages/host-service/src/serve.ts` now uses the shared helper; behavior unchanged).
- No process-wide swallowing: only upgrade-socket errors are handled; other uncaught exceptions still report to Sentry.
- No configuration or migration required; adds a new exported helper only.
- Addresses HOST-SERVICE-5 by applying the guard in the desktop bundle.

<sup>Written for commit 205a9b0cc7d5b66bcf944198109eb37d1b4114cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WebSocket connection errors during upgrades.
  * Prevented upgrade-time socket failures from causing unexpected application crashes.
  * Added diagnostic logging with connection path and address details for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->