### PR TITLE
chore: drop dead EXPO_PUBLIC_ELECTRIC_URL from env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,6 @@ NEXT_PUBLIC_DOCS_URL=
 # Mobile (Expo) — read at Metro bundle time; EAS builds get these from eas.json
 # -----------------------------------------------------------------------------
 EXPO_PUBLIC_API_URL=
-EXPO_PUBLIC_ELECTRIC_URL=
 EXPO_PUBLIC_POSTHOG_KEY=
 
 # -----------------------------------------------------------------------------

--- a/.env.local.example
+++ b/.env.local.example
@@ -39,10 +39,8 @@ NEXT_PUBLIC_DOCS_URL=http://localhost:3004
 
 # -----------------------------------------------------------------------------
 # Mobile (Expo) — setup.local.sh overrides these with allocated ports.
-# Electric points at the electric-proxy wrangler dev server (plain HTTP).
 # -----------------------------------------------------------------------------
 EXPO_PUBLIC_API_URL=http://localhost:3001
-EXPO_PUBLIC_ELECTRIC_URL=http://localhost:8787
 EXPO_PUBLIC_POSTHOG_KEY=phc_local_dev_disabled
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Unused since #6328 removed Electric sync — no code reads `EXPO_PUBLIC_ELECTRIC_URL` anymore (verified via repo-wide grep). Also removes the stale electric-proxy comment in `.env.local.example`.

The matching variable in the EAS-hosted production environment is deleted alongside this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `EXPO_PUBLIC_ELECTRIC_URL` from `.env.example` and `.env.local.example` and drops a stale electric-proxy comment. Electric sync was removed in #6328; nothing reads this variable now, so there is no behavior change.

**Migration**
- Local: remove `EXPO_PUBLIC_ELECTRIC_URL` from any local `.env.*`; it is ignored.
- Production (EAS): the corresponding variable has been deleted; no further action needed.

<sup>Written for commit cb35ec1a695e06315c5ea2fc01b6ff9ab1efefa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified mobile environment configuration templates by removing the obsolete Electric service URL setting and its explanatory comment.
  - The API URL configuration remains available and unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->