### PR TITLE
feat(relay2): typed close codes and Sentry exception capture

### DIFF
--- a/apps/relay2/package.json
+++ b/apps/relay2/package.json
@@ -9,6 +9,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
+		"@sentry/cloudflare": "10.68.0",
 		"@superset/shared": "workspace:*",
 		"@superset/trpc": "workspace:*",
 		"@trpc/client": "11.16.0",

--- a/apps/relay2/src/host-tunnel.ts
+++ b/apps/relay2/src/host-tunnel.ts
@@ -1,6 +1,7 @@
 import {
 	type ControlPing,
 	DIAL_TIMEOUT_MS,
+	RELAY_CLOSE,
 	type StreamDial,
 } from "@superset/shared/tunnel-v2-protocol";
 import { type Connection, type ConnectionContext, Server } from "partyserver";
@@ -134,7 +135,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			// Last-write-wins: the new socket evicts any old one.
 			for (const other of this.getConnections(HOST_TAG)) {
 				if (other.id !== conn.id)
-					closeQuietly(other, 1000, "Replaced by new tunnel");
+					closeQuietly(other, RELAY_CLOSE.replaced, "Replaced by new tunnel");
 			}
 			await this.ctx.storage.put("lastHostSeenAt", Date.now());
 			await this.ctx.storage.setAlarm(Date.now() + LIVENESS_SWEEP_MS);
@@ -153,7 +154,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			// ticket is this route's only credential, so anything else is
 			// refused rather than left open.
 			if (!waiting) {
-				conn.close(1008, "Unknown or expired ticket");
+				conn.close(RELAY_CLOSE.unknownTicket, "Unknown or expired ticket");
 				return;
 			}
 			conn.setState({ kind: "dial", ticket } satisfies ConnState);
@@ -163,7 +164,11 @@ export class HostTunnel extends Server<RelayEnv> {
 				setTimeout(() => {
 					this.unpairedDialTimers.delete(ticket);
 					this.earlyFrames.delete(conn.id);
-					closeQuietly(conn, 1011, "Client never attached");
+					closeQuietly(
+						conn,
+						RELAY_CLOSE.unknownTicket,
+						"Client never attached",
+					);
 				}, UNPAIRED_DIAL_TIMEOUT_MS),
 			);
 			waiting(true);
@@ -173,7 +178,7 @@ export class HostTunnel extends Server<RelayEnv> {
 		if (conn.tags.includes("client")) {
 			const dial = this.findByTicket(ticket, "dial");
 			if (!dial) {
-				conn.close(1011, "Stream expired");
+				conn.close(RELAY_CLOSE.unknownTicket, "Stream expired");
 				return;
 			}
 			const dialTimer = this.unpairedDialTimers.get(ticket);
@@ -199,7 +204,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			return;
 		}
 
-		conn.close(1008, "Unknown endpoint");
+		conn.close(RELAY_CLOSE.badRequest, "Unknown endpoint");
 	}
 
 	onMessage(
@@ -269,7 +274,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			// replacement host socket still mid-onConnect is never torn down.
 			for (const other of this.getConnections()) {
 				if (other.id === conn.id || other.tags.includes(HOST_TAG)) continue;
-				closeQuietly(other, 1001, "Tunnel disconnected");
+				closeQuietly(other, RELAY_CLOSE.tunnelGone, "Tunnel disconnected");
 			}
 			for (const [, timer] of this.unpairedDialTimers) clearTimeout(timer);
 			this.unpairedDialTimers.clear();
@@ -310,7 +315,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			console.log(
 				`[relay2] host stale, closing: ${state?.kind === "host" ? state.hostId : this.name}`,
 			);
-			closeQuietly(host, 1011, "No keepalive from host");
+			closeQuietly(host, RELAY_CLOSE.staleHost, "No keepalive from host");
 			return;
 		}
 

--- a/apps/relay2/src/index.ts
+++ b/apps/relay2/src/index.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/cloudflare";
+import { RELAY_CLOSE } from "@superset/shared/tunnel-v2-protocol";
 import type { Context, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -38,12 +40,13 @@ function isWsUpgrade(c: Context<AppContext>): boolean {
 }
 
 // A failed auth on a WebSocket upgrade completes the handshake and closes
-// 1008 with a reason ≤123 bytes — the only way the peer can see *why*
-// (browsers and plain WS clients cannot read a non-101 response).
-function acceptAndClose(reason: string): Response {
+// with a typed RELAY_CLOSE code + reason ≤123 bytes — the only way the peer
+// can see *why* (browsers and plain WS clients cannot read a non-101
+// response).
+function acceptAndClose(code: number, reason: string): Response {
 	const pair = new WebSocketPair();
 	pair[1].accept();
-	pair[1].close(1008, reason);
+	pair[1].close(code, reason);
 	return new Response(null, { status: 101, webSocket: pair[0] });
 }
 
@@ -85,9 +88,14 @@ app.get("/v2/control", async (c) => {
 		return c.json({ error: "WebSocket upgrade required" }, 426);
 	}
 	const hostId = c.req.query("hostId");
-	if (!hostId) return acceptAndClose("Missing hostId");
+	if (!hostId) return acceptAndClose(RELAY_CLOSE.badRequest, "Missing hostId");
 	const result = await authenticate(c, hostId);
-	if (isDenial(result)) return acceptAndClose(result.message);
+	if (isDenial(result)) {
+		return acceptAndClose(
+			result.status === 401 ? RELAY_CLOSE.authExpired : RELAY_CLOSE.forbidden,
+			result.message,
+		);
+	}
 
 	const stub = await tunnelStub(c, hostId);
 	return stub.fetch(
@@ -107,7 +115,8 @@ app.get("/v2/dial", async (c) => {
 	}
 	const hostId = c.req.query("hostId");
 	const ticket = c.req.query("ticket");
-	if (!hostId || !ticket) return acceptAndClose("Missing hostId or ticket");
+	if (!hostId || !ticket)
+		return acceptAndClose(RELAY_CLOSE.badRequest, "Missing hostId or ticket");
 	const stub = await tunnelStub(c, hostId);
 	return stub.fetch(
 		`https://relay2/dial?ticket=${encodeURIComponent(ticket)}`,
@@ -254,8 +263,22 @@ app.get("/hosts/:hostId/*", async (c) => {
 	);
 });
 
-export { HostTunnel };
+// Exceptions only — console/breadcrumb capture stays off (the v1 relay's
+// memory leak was Sentry's console firehose). No-op until SENTRY_DSN is set.
+const sentryOptions = (env: RelayEnv): Sentry.CloudflareOptions => ({
+	dsn: env.SENTRY_DSN,
+	tracesSampleRate: 0,
+	sendDefaultPii: false,
+	integrations: (defaults) =>
+		defaults.filter((integration) => integration.name !== "Console"),
+});
 
-export default {
+const InstrumentedHostTunnel = Sentry.instrumentDurableObjectWithSentry(
+	sentryOptions,
+	HostTunnel,
+);
+export { InstrumentedHostTunnel as HostTunnel };
+
+export default Sentry.withSentry(sentryOptions, {
 	fetch: app.fetch,
-} satisfies ExportedHandler<RelayEnv>;
+} satisfies ExportedHandler<RelayEnv>);

--- a/apps/relay2/src/types.ts
+++ b/apps/relay2/src/types.ts
@@ -2,5 +2,7 @@ import type { HostTunnel } from "./host-tunnel";
 
 export interface RelayEnv {
 	NEXT_PUBLIC_API_URL: string;
+	/** Optional; Sentry capture is a no-op until the secret is set. */
+	SENTRY_DSN?: string;
 	HostTunnel: DurableObjectNamespace<HostTunnel>;
 }

--- a/apps/relay2/wrangler.jsonc
+++ b/apps/relay2/wrangler.jsonc
@@ -3,6 +3,7 @@
 	"name": "superset-relay2",
 	"main": "src/index.ts",
 	"compatibility_date": "2026-07-01",
+	"compatibility_flags": ["nodejs_als"],
 	"vars": {
 		// Must match the API's JWT issuer/audience exactly — a mismatch 401s
 		// every connection. Same value as the Fly relay's NEXT_PUBLIC_API_URL.

--- a/bun.lock
+++ b/bun.lock
@@ -627,6 +627,7 @@
       "name": "@superset/relay2",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/cloudflare": "10.68.0",
         "@superset/shared": "workspace:*",
         "@superset/trpc": "workspace:*",
         "@trpc/client": "11.16.0",
@@ -2854,6 +2855,8 @@
     "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
 
     "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+
+    "@sentry/cloudflare": ["@sentry/cloudflare@10.68.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.68.0", "@sentry/server-utils": "10.68.0", "magic-string": "~0.30.21" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x || ^5.x", "wrangler": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types", "wrangler"] }, "sha512-IcSjfncUSkisoZy66SbLMb4gtH+Jr9mS02DIqjuz3JsrKnkxFaQIBiosoDTgHlCMWFIEU5M4MpErYZ1dzJpo6Q=="],
 
     "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
 

--- a/packages/host-service/src/tunnel/tunnel-client-v2.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-v2.ts
@@ -1,6 +1,7 @@
-import type {
-	HttpDialFrame,
-	StreamDial,
+import {
+	describeRelayClose,
+	type HttpDialFrame,
+	type StreamDial,
 } from "@superset/shared/tunnel-v2-protocol";
 import ReconnectingWebSocket from "partysocket/ws";
 
@@ -87,9 +88,10 @@ export class TunnelClientV2 {
 		});
 
 		control.addEventListener("close", (event) => {
-			if (event.code === 1008) {
+			const described = describeRelayClose(event.code) ?? "";
+			if (event.code === 1008 || described) {
 				console.warn(
-					`[host-service:tunnel-v2] relay rejected connection (${event.reason ?? ""}); partysocket will retry`,
+					`[host-service:tunnel-v2] relay closed control (${event.code} ${described}): ${event.reason ?? ""}; partysocket will retry`,
 				);
 			}
 		});

--- a/packages/shared/src/tunnel-v2-protocol.ts
+++ b/packages/shared/src/tunnel-v2-protocol.ts
@@ -19,6 +19,42 @@ export interface ControlPing {
 	type: "ping";
 }
 
+// ── Close codes ─────────────────────────────────────────────────────
+// Application close codes (4400-4499) with fixed recovery semantics, so
+// every leg logs the same name and no client infers behavior from reason
+// strings. Anything else is a transport-level close.
+export const RELAY_CLOSE = {
+	/** Malformed upgrade (missing hostId/ticket, unknown endpoint): fix the caller. */
+	badRequest: 4400,
+	/** JWT missing, invalid, or expired: mint a fresh token, then reconnect. */
+	authExpired: 4401,
+	/** Access check denied this identity: retry slowly, likely a config problem. */
+	forbidden: 4403,
+	/** Dial ticket unknown, expired, or already consumed: abandon this stream. */
+	unknownTicket: 4404,
+	/** Host sent no keepalive inside the stale window: reconnect immediately. */
+	staleHost: 4408,
+	/** A newer socket for the same host registered: yield, do not reconnect over it. */
+	replaced: 4409,
+	/** The host's control channel went away: this stream is dead, re-dial later. */
+	tunnelGone: 4410,
+} as const;
+
+const RELAY_CLOSE_DESCRIPTIONS: Record<number, string> = {
+	[RELAY_CLOSE.badRequest]: "bad-request: malformed upgrade, fix the caller",
+	[RELAY_CLOSE.authExpired]: "auth-expired: mint a fresh token and reconnect",
+	[RELAY_CLOSE.forbidden]: "forbidden: access denied, retry slowly",
+	[RELAY_CLOSE.unknownTicket]:
+		"unknown-ticket: stream credential gone, abandon",
+	[RELAY_CLOSE.staleHost]: "stale-host: no keepalive, reconnect now",
+	[RELAY_CLOSE.replaced]: "replaced: a newer host socket took over",
+	[RELAY_CLOSE.tunnelGone]: "tunnel-gone: host control channel disconnected",
+};
+
+export function describeRelayClose(code: number): string | null {
+	return RELAY_CLOSE_DESCRIPTIONS[code] ?? null;
+}
+
 export interface ControlPong {
 	type: "pong";
 }


### PR DESCRIPTION
## Summary
The observability items from the Orca comparison — the two that are just better, no behavioral hardening:

**Typed close codes** (`RELAY_CLOSE`, 4400–4410, in the shared tunnel-v2 protocol): every WS close now carries a fixed recovery meaning — `4401 auth-expired` (mint a fresh token, reconnect), `4403 forbidden` (config problem, retry slowly), `4404 unknown-ticket` (abandon the stream), `4408 stale-host`, `4409 replaced`, `4410 tunnel-gone`, `4400 bad-request` — and the host client logs them by name via `describeRelayClose`. The Town-Hall incident's anonymous `1008 Forbidden` retry loop would have read `4401 auth-expired: mint a fresh token and reconnect` in the log.

**Sentry** (`@sentry/cloudflare` 10.68.0, matching the repo's Sentry train): `withSentry` on the Worker plus `instrumentDurableObjectWithSentry` on `HostTunnel`, so thrown exceptions from both surface with stacks. Console/breadcrumb capture is explicitly filtered out — the v1 relay's memory leak was Sentry's console firehose — and the integration is a no-op until the `SENTRY_DSN` secret is set (`wrangler secret put SENTRY_DSN`, needs a Sentry project). Adds the `nodejs_als` compat flag Sentry requires.

Workers Logs was already enabled in wrangler.jsonc — persistent, queryable logs exist in the CF dashboard today; nothing to add there.

## Test plan
- [x] typecheck clean (relay2, shared, host-service); lint clean
- [x] Deployed and probed live: bad token → `4401 "Unauthorized"`, missing hostId → `4400`, bogus dial ticket → `4404` (this also exercises the Sentry-instrumented DO end-to-end)
- [x] Post-deploy health: both team hosts back online with fresh `lastSeenAt` via `/presence`
- [ ] After a Sentry project + DSN secret exist: throw path visible in Sentry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed WebSocket close codes to the tunnel-v2 protocol and instruments relay2 with Sentry for exception capture, improving recovery guidance and error visibility. Previously the relay closed with generic 1008/1011; now it uses named `RELAY_CLOSE` codes (4400–4410) and the host logs them by name.

**Review notes**
- Protocol: adds `RELAY_CLOSE` constants and `describeRelayClose` in `packages/shared`; callers no longer infer behavior from reason strings.
- Relay: replaces all closes with typed codes (`badRequest`, `authExpired`, `forbidden`, `unknownTicket`, `staleHost`, `replaced`, `tunnelGone`) and updates the handshake helper to send a code + reason.
- Host client: `packages/host-service` logs close codes with `describeRelayClose`; no reconnect logic changes.
- Sentry: adds `@sentry/cloudflare` and wraps the Worker and `HostTunnel` with Sentry; disables console/breadcrumb capture; no-op until `SENTRY_DSN` is set; adds `nodejs_als` compat flag and `SENTRY_DSN` to `RelayEnv`.

**Rollout**
- Set the `SENTRY_DSN` secret in Cloudflare to enable capture: `wrangler secret put SENTRY_DSN`.
- Deploy the `wrangler.jsonc` change (includes `compatibility_flags: ["nodejs_als"]`).
- No client action required; hosts will log the new codes automatically.

<sup>Written for commit ac179e9ce4f9cf42c3cafd48e172b7d11c4d4568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

