### PR TITLE
fix(desktop): click branch name to rename without layout shift

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesHeader/ChangesHeader.tsx
@@ -1,5 +1,6 @@
 import { GitBranch, Pencil } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
+import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { Branch } from "../../types";
 import { BaseBranchSelector } from "../BaseBranchSelector";
 
@@ -24,14 +25,10 @@ export function ChangesHeader({
 }: ChangesHeaderProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState(currentBranch.name);
-	const inputRef = useRef<HTMLInputElement>(null);
-	const skipBlurRef = useRef(false);
 
 	const startEditing = () => {
 		setEditValue(currentBranch.name);
 		setIsEditing(true);
-		skipBlurRef.current = false;
-		requestAnimationFrame(() => inputRef.current?.select());
 	};
 
 	const handleSubmit = () => {
@@ -46,42 +43,34 @@ export function ChangesHeader({
 		<div className="group flex items-center gap-1.5 px-3 py-2 text-xs">
 			<GitBranch className="size-3 shrink-0 text-muted-foreground" />
 			{isEditing ? (
-				<input
-					ref={inputRef}
+				<RenameInput
 					value={editValue}
-					onChange={(e) => setEditValue(e.target.value)}
-					onKeyDown={(e) => {
-						if (e.key === "Enter") {
-							skipBlurRef.current = true;
-							handleSubmit();
-						}
-						if (e.key === "Escape") {
-							skipBlurRef.current = true;
-							setIsEditing(false);
-						}
-					}}
-					onBlur={() => {
-						if (skipBlurRef.current) return;
-						handleSubmit();
-					}}
-					className="min-w-0 flex-1 truncate rounded-sm bg-transparent px-1 font-medium outline-none ring-1 ring-ring"
+					onChange={setEditValue}
+					onSubmit={handleSubmit}
+					onCancel={() => setIsEditing(false)}
+					className="-ml-1 min-w-0 flex-1 border-none bg-transparent px-1 py-0 font-medium outline-none"
 				/>
 			) : (
 				<>
-					<span
-						className="min-w-0 truncate font-medium"
-						title={currentBranch.name}
-					>
-						{currentBranch.name}
-					</span>
-					{canRename && (
+					{canRename ? (
 						<button
 							type="button"
 							onClick={startEditing}
-							className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+							title={currentBranch.name}
+							className="flex min-w-0 items-center gap-1.5 text-left"
 						>
-							<Pencil className="size-3" />
+							<span className="min-w-0 truncate font-medium">
+								{currentBranch.name}
+							</span>
+							<Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
 						</button>
+					) : (
+						<span
+							className="min-w-0 truncate font-medium"
+							title={currentBranch.name}
+						>
+							{currentBranch.name}
+						</span>
 					)}
 					<span className="shrink-0 text-muted-foreground/60">from</span>
 					<BaseBranchSelector


### PR DESCRIPTION
## Summary
- Make the branch name in the v2 workspace Changes tab clickable to enter rename mode (name + pencil are one button, mirroring `HostHeader`), instead of only the small pencil icon
- Fix the layout/font shift when entering edit mode by swapping the hand-rolled input (`px-1` + `ring-1`, no offset) for the shared `RenameInput` with the dashboard sidebar's zero-shift recipe (`-ml-1 px-1 py-0 bg-transparent border-none outline-none`, same `font-medium`)
- Drops the local `skipBlurRef`/`requestAnimationFrame` focus plumbing in favor of `RenameInput`'s built-in focus/select, Enter/Escape, and blur-to-commit handling

https://claude.ai/code/session_01CzDnULzTVGRCTD86K4BK9k

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the branch name in the v2 workspace Changes tab now enters rename mode, and renaming no longer causes a layout/font shift. Previously only the pencil icon triggered rename and the input shifted the layout.

- Replaces the custom input with the shared `RenameInput` (handles focus/select, Enter/Escape, and blur-to-commit).
- Makes the branch name and pencil a single button when `canRename`; falls back to a static label otherwise.
- Removes local focus/blur plumbing and `requestAnimationFrame` logic.
- Applies zero-shift styling to match the dashboard sidebar.
- Scope: `ChangesHeader.tsx` only; no API changes.

**Review notes**
- Click the name and pencil to enter rename; verify no font or layout shift.
- Check Enter commits, Escape cancels, and blur commits.
- Confirm truncation and title tooltip still work.
- Verify behavior is gated by `canRename`.

<sup>Written for commit b924114482340559155f2135af2e33f2c0b420c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved branch renaming in the Changes header.
  * Added a clearer rename button with an integrated pencil icon when renaming is available.
  * Branch names are displayed as non-interactive text when renaming is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->