### PR TITLE
fix(desktop): allow empty new-workspace submits and route branch rename to the owning host

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -477,7 +477,6 @@ export function NewWorkspaceScreen({
 			handleGoToSetup();
 			return;
 		}
-		if (isPromptEmpty) return;
 		if (submitBlocker) {
 			if ((draft.hostId ?? machineId) === machineId && !activeHostUrl) {
 				showHostServiceUnavailableToast(hostService, {
@@ -495,7 +494,6 @@ export function NewWorkspaceScreen({
 		draft.hostId,
 		handleGoToSetup,
 		hostService,
-		isPromptEmpty,
 		machineId,
 		needsSetup,
 		submitBlocker,
@@ -759,7 +757,7 @@ export function NewWorkspaceScreen({
 							</Tooltip>
 							<PromptInputSubmit
 								className="size-[22px] rounded-full border border-transparent bg-foreground/10 shadow-none p-[5px] hover:bg-foreground/20"
-								disabled={needsSetup || isPromptEmpty}
+								disabled={needsSetup}
 								onClick={(e) => {
 									e.preventDefault();
 									handleSubmit();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/RenameBranchDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/RenameBranchDialog.tsx
@@ -11,6 +11,7 @@ import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
 import { useEffect, useState } from "react";
+import { useWorkspaceHostTarget } from "renderer/hooks/host-service/useWorkspaceHostUrl";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
@@ -36,6 +37,12 @@ export function RenameBranchDialog({
 	const electronUtils = electronTrpc.useUtils();
 	const hostService = useLocalHostService();
 	const { activeHostUrl } = hostService;
+	// Workspace records are host-owned: a v2 workspace resolves to its owning
+	// host (which may be remote, via relay). v1 workspaces aren't in the host
+	// collection and fall back to the local host-service.
+	const hostTarget = useWorkspaceHostTarget(workspaceId);
+	const workspaceHostUrl =
+		hostTarget.status === "ready" ? hostTarget.url : activeHostUrl;
 
 	useEffect(() => {
 		if (open) setValue(currentBranchName);
@@ -47,14 +54,14 @@ export function RenameBranchDialog({
 
 	const handleSubmit = async () => {
 		if (isInvalid || isSubmitting) return;
-		if (!activeHostUrl) {
+		if (!workspaceHostUrl) {
 			showHostServiceUnavailableToast(hostService, {
 				action: "rename the branch",
 			});
 			return;
 		}
 
-		const client = getHostServiceClientByUrl(activeHostUrl);
+		const client = getHostServiceClientByUrl(workspaceHostUrl);
 		const renamePromise = client.git.renameBranch.mutate({
 			workspaceId,
 			oldName: currentBranchName,


### PR DESCRIPTION
## Summary

Two fixes from the workspace-naming discussion in #6398:

**Allow empty-body submissions on the new-workspace screen.** The `new-workspace-screen` test arm gated submit on a non-empty prompt (`isPromptEmpty` in the button `disabled` and an early return in `handleSubmit`); the control modal has no such gate (`disabled={needsSetup}` only). This was accidental drift in the test arm, not a designed difference. Removing it restores the prompt-less create path: `useSubmitWorkspace` already handles it — no agent launch, no `namingPrompt`, so the server creates instantly with a friendly-random name and no LLM call. `isPromptEmpty` stays for the sample-prompts overlay.

**Route branch rename to the workspace's owning host.** `RenameBranchDialog` (shared by the v1 sidebar hover card and the v2 dashboard sidebar) always sent `git.renameBranch` to the local host-service via `useLocalHostService().activeHostUrl`. The procedure resolves the worktree path from the host's own DB, so for a workspace on a remote host the rename always failed — while the UI still offered the rename pencil on every row. The dialog now resolves the owning host with `useWorkspaceHostTarget(workspaceId)` (the same host-owned-write pattern as `trackedWorkspaceWrite`): v2 workspaces route to their owning host (remote via relay), v1 workspaces aren't in the host collection and fall back to the local host URL, preserving current behavior. The post-rename record update (`onAfterRename` → host-owned `workspace.update`) was already routed correctly.

Related: #6398

## Test plan

- [ ] Test arm (`new-workspace-screen`): submit with an empty prompt → workspace created with a friendly-random name, no agent session, no AI rename
- [ ] Test arm: submit with a prompt → unchanged (agent launch + AI naming as before)
- [ ] Local workspace: sidebar hover card → rename branch → still works (falls back to local host URL for v1; resolves local host for v2)
- [ ] Remote workspace: sidebar hover card → rename branch → now succeeds via relay (previously failed against the local host-service)
- [ ] `bun run lint` and `bun run typecheck` pass

https://claude.ai/code/session_016CmJ4ikm3QVPStDpb5GbFh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows empty submissions on the new-workspace screen and routes branch renames to the workspace’s owning host to fix remote rename failures. Previously the test arm required a non-empty prompt and the rename dialog always hit the local host; now empty submits create immediately with a friendly-random name and no agent/LLM call, and renames resolve the owning host (remote via relay for v2, fallback to local for v1). The sample-prompts overlay still uses the empty-prompt check.

**Verification**
- New-workspace screen (test arm): empty prompt → creates instantly with a friendly-random name; non-empty prompt → unchanged (agent launch + AI naming).
- Local workspace: rename branch still works (v1 fallback/local v2 routing).
- Remote workspace: rename branch succeeds via relay; shows “host unavailable” toast if the owning host cannot be reached.

<sup>Written for commit 1f046612c68aa179c3e3d50cbaaeb07016b8da30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty prompts can now be submitted when project setup isn’t required.
  * Improved branch renaming for remote workspaces by using the correct workspace host.
  * Added a fallback to the active local host when the workspace host is unavailable.
  * Preserved existing handling when the host service cannot be reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->