### PR TITLE
fix(desktop): make "All tasks" and "All projects" reset tasks-page filter dropdowns

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -224,13 +224,17 @@ export function TasksView({
 	const isLinearConnected =
 		integrations?.some((i) => i.provider === "linear") ?? false;
 
+	// Defaults ("all"/null) are omitted from the URL, so write the store too —
+	// otherwise the render falls back to the stale stored value (no-op select).
 	const handleTabChange = (tab: TabValue) => {
 		cancelPendingSearchNavigation();
+		storeSetTab(tab);
 		navigate({ to: "/tasks", search: buildSearch({ tab }), replace: true });
 	};
 
 	const handleAssigneeFilterChange = (assignee: string | null) => {
 		cancelPendingSearchNavigation();
+		storeSetAssignee(assignee);
 		navigate({
 			to: "/tasks",
 			search: buildSearch({ assignee }),
@@ -269,6 +273,7 @@ export function TasksView({
 
 	const handleLinearProjectFilterChange = (linearProject: string | null) => {
 		cancelPendingSearchNavigation();
+		storeSetLinearProjectFilter(linearProject);
 		navigate({
 			to: "/tasks",
 			search: buildSearch({ linearProject }),


### PR DESCRIPTION
## Summary
- Selecting **"All tasks"** in the status dropdown or **"All projects"** in the Linear project dropdown on the tasks page did nothing — the filter stayed on the previous value. Same latent bug when clearing the assignee filter. Fixed by writing the filter store in the change handlers before navigating.

## Why / Context
`tasksSearchFromFilters` deliberately omits default values from the URL (no `tab` param when the tab is `"all"`, no `linearProject` when it's `null`). The view resolves the effective filter as `initialTab ?? storedTab` / `initialLinearProject ?? storedLinearProjectFilter`, so when a default was selected the URL param disappeared and the render fell back to the **stale zustand-persisted value** — a no-op. Every non-default option worked because the URL carried it.

## How It Works
`handleTabChange`, `handleLinearProjectFilterChange`, and `handleAssigneeFilterChange` now write the store before navigating — the exact pattern the neighboring handlers for other omitted-when-default filters (`handleProjectFiltersChange`, `handleIncludeClosedIssuesChange`, `navigateToType`) already use.

## Manual QA (CDP, end-to-end)
Verified against the real dev app over CDP with real mouse input, screencast-recorded, with the fix reverted (before) and applied (after) under identical steps:

| Step | Before fix | After fix |
|---|---|---|
| Select "Active" | ✅ works (URL `?tab=active`, label updates) | ✅ works |
| Select "All tasks" | ❌ label stays "Active", store stays `tab:"active"` | ✅ label "All tasks", URL clean, store `tab:"all"` |
| Select project "Usage-based billing" | ✅ works (URL `?linearProject=…`) | ✅ works |
| Select "All projects" | ❌ label stays "Usage-based billing", store keeps project id | ✅ label "Project", URL clean, store `null` |

- Journey: fresh persisted state → sidebar "Tasks" → dropdown clicks via `Input.dispatchMouseEvent`; state asserted from trigger labels + `location.hash` + persisted store after each step.
- `console.error` hooked during both runs: only a pre-existing, unrelated boot warning (`DockBadgeController`/`DashboardSidebarWorkspaceStatusProvider` setState-in-render), present before and after.
- Video evidence (screencast recordings) attached below.

## Testing
- `bun run typecheck` (desktop)
- `bun run lint` (Biome clean on changed file)
- No automated test added: the bug lives in URL↔store round-trip wiring inside `TasksView`; covered by the recorded E2E QA above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tasks-page filters so selecting “All tasks,” “All projects,” or clearing the assignee actually resets the filters. Previously these defaults did nothing because they were omitted from the URL and the view fell back to a stale stored value; the store now updates before navigation.

**Review notes**
- Write to the filter store in `TasksView.tsx` before navigating: `handleTabChange`, `handleAssigneeFilterChange`, `handleLinearProjectFilterChange`.
- Behavior: default selections now update labels, omit default params from the URL, and set store to `tab: "all"`, `linearProject: null`, `assignee: null`.
- Matches the existing pattern in `handleProjectFiltersChange`, `handleIncludeClosedIssuesChange`, and `navigateToType`.
- Scope: single file, +5/−0. No migrations or API changes.

<sup>Written for commit 72bbca3dcbd81e10a04626b1b3f3c739e402a227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task filtering behavior by keeping selected tabs, assignees, and projects synchronized when navigating.
  * Default filter selections now remain consistent between the page URL and the app’s stored state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->