### PR TITLE
fix(desktop): ignore Claude subagent hook events in notify hook

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -32,7 +32,7 @@ mock.module("shared/env.shared", () => ({
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v7",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v8",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -37,7 +37,29 @@ function runNotifyHook(
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v7");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v8");
+	});
+
+	it("ignores hooks fired inside a subagent (agent_id present)", () => {
+		const result = runNotifyHook({
+			hook_event_name: "PostToolUse",
+			session_id: "main-session",
+			agent_id: "a251e067cfdbabec7",
+			agent_type: "general-purpose",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toBe("");
+	});
+
+	it("still dispatches main-loop hooks without agent_id", () => {
+		const result = runNotifyHook({
+			hook_event_name: "Stop",
+			session_id: "main-session",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toContain("[notify-hook] event=Stop");
 	});
 
 	it("exits silently outside Superset terminals even with a payload session id", () => {

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -4,7 +4,7 @@ import { env } from "shared/env.shared";
 import { HOOKS_DIR } from "./paths";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v7";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v8";
 
 const NOTIFY_SCRIPT_TEMPLATE_PATH = path.join(
 	__dirname,

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -17,6 +17,12 @@ fi
 # payload alone must never dispatch.
 [ -n "$SUPERSET_TERMINAL_ID" ] || [ -n "$SUPERSET_TAB_ID" ] || exit 0
 
+# Claude Code (and forks sharing its hook schema) set agent_id only when the
+# hook fires inside a subagent (Task tool). Subagent activity must not drive
+# terminal-level agent status or notifications — only the main loop counts.
+SUBAGENT_ID=$(echo "$INPUT" | grep -oE '"agent_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+[ -n "$SUBAGENT_ID" ] && exit 0
+
 HOOK_SESSION_ID=$(echo "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 if [ -z "$HOOK_SESSION_ID" ]; then
   # Grok's envelope is camelCase.


### PR DESCRIPTION
## Problem

Claude Code (2.1.x) now identifies subagent context in hook payloads: hooks fired inside a Task-tool subagent carry an `agent_id` field (absent in main-loop hooks; `session_id` is identical for both, so it could never distinguish them).

Superset registers `PostToolUse`/`PostToolUseFailure`/`PermissionRequest` with `matcher: *`, so every tool call made *by a subagent* also dispatched to host-service. `mapEventType("PostToolUse") → "Start"` means a background subagent flips the terminal agent binding back to **working** after the main loop already stopped — status flap and spurious "agent active" signal while the session is actually idle waiting on a task notification.

## Fix

`notify-hook.template.sh` bails out immediately when the payload carries a non-empty `agent_id` — only main-loop lifecycle events drive agent status and notifications. Marker bumped v7 → v8. Scoped to snake_case `agent_id` (Claude schema and forks that mirror it); Grok's camelCase envelope and Codex's payload shape are unaffected.

## Tests

- `notify-hook.test.ts`: subagent payload (`agent_id` present) produces no dispatch; main-loop payload still dispatches. Mutation-checked: with the guard stripped, the subagent payload dispatches (test fails).

## E2E verification (dev desktop from this branch, CDP-driven)

Real journey: dev app booted from this worktree (regenerated the v8 script at startup), opened this workspace, created a terminal (`SUPERSET_TERMINAL_ID=2c4e7fbe…`, `SUPERSET_HOME_DIR=<worktree>/superset-dev-data` confirmed in-pane), ran interactive Claude Code 2.1.229 spawning a background subagent (3 × `sleep 4 && echo`), polling the `terminal_agent_bindings` row in host.db each second plus the notify-hook debug log.

**Before (guard stripped from the generated script, same journey):**
```
23:38:52 Start → 23:38:54 PostToolUse (Task spawn) → 23:38:55 Stop (main turn ends)
23:39:01 / 23:39:06 / 23:39:11 PostToolUse  ← subagent bash steps, AFTER Stop, all HTTP 200
binding last_event_type: Stop → Start@23:39:01 (flapped back to working while idle)
```

**After (v8 guarded script, same journey, same terminal, same session):**
```
23:40:13 Start → 23:40:15 PostToolUse (Task spawn) → 23:40:16 Stop
— 17s of silence while the subagent runs —
23:40:33 Start / 23:40:35 Stop (genuine task-notification turn)
binding last_event_type: held Stop through the entire subagent window
```

Binding-state polls and dispatch logs are end-to-end; screenshots captured of the session transcript showing the backgrounded agent. Unit tests are synthetic.

## Caveat

Subagent-fired `PermissionRequest` events are also skipped: if a subagent blocks on a permission prompt, the terminal won't be flagged as needing input. Intentional per "only main agent", and rare (subagents inherit main-loop permission mode), but flag if you want that event exempted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Claude subagent hook events in the desktop `notify.sh` so subagent activity no longer flips terminal status. Previously, subagent hooks were dispatched and `PostToolUse` mapped to `Start` after a main-loop `Stop`; now the script exits early when `agent_id` is present, so only main-loop events drive status and notifications.

- Marker bump v7→v8 to force regeneration on startup; tests updated to cover ignore and main-loop behavior.
- Scope: checks snake_case `agent_id` (Claude schema); Grok/camelCase and Codex payloads are unaffected.
- Side effect: subagent `PermissionRequest` events are skipped by design; only the main agent can flag input-needed.
- Migration: no action required; the desktop app regenerates the v8 notify script on launch.

<sup>Written for commit bd953b55249ced6819a10d82f6c11f30f0d6e97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented subagent activity from generating terminal-level notifications.
  * Main-agent notifications continue to be dispatched normally.
  * Updated notification hook versioning and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->