### PR TITLE
fix(desktop): stop dock-badge cache subscriber from setState during other components' renders

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -75,6 +75,12 @@ export function useV2AttentionWorkspaceCount(): number {
 
 	useEffect(() => {
 		return queryClient.getQueryCache().subscribe((event) => {
+			// `added` fires synchronously inside the render that first builds a
+			// query — setState there is a render-phase update. Data-bearing
+			// events (`updated`/`removed`) are the only ones that move the count.
+			if (event.type !== "updated" && event.type !== "removed") {
+				return;
+			}
 			if (event.query.queryKey[0] === "terminal-agent-bindings") {
 				setCacheVersion((version) => version + 1);
 			}


### PR DESCRIPTION
## Problem

Rapidly switching workspaces (or the first switch after boot) logs a React error:

```
Cannot update a component (DockBadgeController) while rendering a different
component (DashboardSidebarWorkspaceStatusProvider).
```

`useV2AttentionWorkspaceCount` (drives the OS dock badge) subscribes raw to the React Query cache and bumps local state on every `terminal-agent-bindings` cache event. Query `added` events fire **synchronously inside whichever component's render first builds the query** — here the sidebar status provider's `useQueries` (`getOptimisticResult → new QueryObserver → cache.build → notify`), making the bump a render-phase update of another component. Stack trace confirming the path is in the verification notes below.

## Fix

Filter the subscription to data-bearing events (`updated`/`removed`). `added` carries no data — the fetch that follows emits `updated` — and observer add/remove events never move the aggregated count, so this also drops pointless dock-badge recomputes on every sidebar row mount/unmount.

## Verification (CDP, dev desktop from this branch)

- **Before** (3 independent reproductions): error fires on the first workspace switch after boot — twice on this worktree's pre-fix instance, once on another worktree's instance running current main.
- **After**: page reload with Runtime console capture armed before first render + 10 rapid workspace switches → **0 console errors, 0 render-phase setState errors**. Dock badge path unchanged for data events.
- Verified against the correct instance (CDP target URL matched this worktree's `DESKTOP_VITE_PORT`, Electron cwd checked).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents render-phase updates in the dock badge by filtering React Query cache events. Previously, `useV2AttentionWorkspaceCount` updated state on all `terminal-agent-bindings` events (including `added`), triggering “Cannot update a component while rendering a different component” on first/rapid workspace switches; now it only reacts to `updated` and `removed`, keeping badge behavior correct and avoiding unnecessary recomputes.

**Review notes**
- Change is isolated to `apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts`: early return unless `event.type` is `updated` or `removed`.
- No state updates on `added` or observer add/remove; badge updates still occur on data changes.
- Assumes `added` carries no data; if upstream event semantics change, revisit.
- Verify by rapidly switching workspaces after boot; expect no React console errors.

<sup>Written for commit 9447fc162bafffbd8d945b805e0cdc25ab288c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification status updates to prevent unnecessary rendering activity.
  * Ensured attention workspace counts continue updating correctly when data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->