### PR TITLE
chore(mobile,marketing): app store submission metadata and privacy policy

### DIFF
--- a/apps/marketing/content/legal/privacy.mdx
+++ b/apps/marketing/content/legal/privacy.mdx
@@ -1,12 +1,12 @@
 ---
 title: Privacy Policy
 description: Learn how Superset collects, uses, and protects your personal information.
-lastUpdated: 2025-12-11
+lastUpdated: 2026-08-12
 ---
 
 ## 1. Introduction
 
-Superset Inc. ("we", "us", or "our") respects your privacy and is committed to protecting your personal data. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website or use our desktop application.
+Superset Inc. ("we", "us", or "our") respects your privacy and is committed to protecting your personal data. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website or use our desktop or mobile applications.
 
 Please read this policy carefully. If you do not agree with the terms of this Privacy Policy, please do not access our services.
 
@@ -14,19 +14,24 @@ Please read this policy carefully. If you do not agree with the terms of this Pr
 
 ### 2.1 Information You Provide
 
-- **Account Data:** When you sign up for our waitlist or create an account, we may collect your name, email address, and other contact information.
+- **Account Data:** When you sign up for our waitlist or create an account (including via Sign in with Apple, GitHub, or Google), we may collect your name, email address, and other contact information.
+- **User Content:** Messages, tasks, and attachments (such as images) you send to AI agents through our applications are transmitted to and stored by our services so they can be delivered to your workspaces and synced across your devices.
 - **Communications:** When you contact us for support or feedback, we collect the information you provide in those communications.
 - **Payment Data:** If you make a purchase, payment information is processed by our third-party payment processors. We do not store your full payment card details.
 
 ### 2.2 Automatically Collected Information
 
-- **Usage Data:** We collect information about how you interact with our services, including pages visited, features used, and time spent.
-- **Device Data:** We may collect device identifiers, operating system version, browser type, and similar technical information.
+- **Usage Data:** We collect information about how you interact with our services, including pages visited, screens viewed, features used, and time spent. We use analytics providers (such as PostHog) to process this data, associated with your account identifier, name, and email address.
+- **Device Data:** We may collect device identifiers, operating system version, browser type, app version, and similar technical information.
 - **Log Data:** Our servers automatically record information such as IP address, access times, and referring URLs.
 
 ### 2.3 Desktop Application
 
 Our desktop application runs locally on your machine. We do not have access to your source code, terminal commands, or file contents unless you explicitly choose to share diagnostic information with us.
+
+### 2.4 Mobile Application
+
+Our mobile application lets you monitor and chat with AI agents running in your workspaces. With your permission, it can access your photo library, camera, and microphone so you can attach images to messages and dictate text; speech recognition may be processed by Apple. Photos and dictated text are only transmitted when you choose to send them. The mobile application collects the same account, usage, and device data described above.
 
 ## 3. How We Use Your Information
 
@@ -67,7 +72,7 @@ Depending on your location, you may have certain rights regarding your personal 
 - The right to restrict or object to certain processing
 - The right to data portability
 
-To exercise these rights, please contact us using the information provided below.
+You can delete your account at any time from Settings → Account → Delete account in our mobile or desktop applications, or from your account settings on our website. Your account is deactivated immediately and permanently deleted after a 30-day recovery period, during which you can restore it by signing back in. After deletion, content you created in shared organizations is retained in de-identified form as part of those organizations' records. To exercise your other rights, please contact us using the information provided below.
 
 ## 8. Cookies and Tracking Technologies
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -24,7 +24,7 @@ export default ({ config }: ConfigContext) => ({
 		backgroundColor: "#09090b",
 	},
 	ios: {
-		supportsTablet: true,
+		supportsTablet: false,
 		bundleIdentifier: "sh.superset.mobile",
 		usesAppleSignIn: true,
 		infoPlist: {

--- a/apps/mobile/store.config.json
+++ b/apps/mobile/store.config.json
@@ -5,7 +5,7 @@
 		"categories": ["DEVELOPER_TOOLS", "PRODUCTIVITY"],
 		"info": {
 			"en-US": {
-				"title": "Superset Mobile",
+				"title": "Superset: AI Agent Manager",
 				"subtitle": "Run AI agents from anywhere",
 				"description": "Superset lets you run and manage AI coding agents from anywhere. Kick off tasks, review progress, and chat with agents working across your projects — all from your phone.\n\n- Start and monitor agent sessions in isolated workspaces\n- Chat with agents and attach images to your messages\n- Track tasks and pull requests across your organization\n- Stay in sync with your team in real time",
 				"keywords": [

--- a/apps/mobile/store.config.json
+++ b/apps/mobile/store.config.json
@@ -31,9 +31,9 @@
 			"firstName": "Satya",
 			"lastName": "Patel",
 			"email": "support@superset.sh",
-			"phone": "+1 000 000 0000",
+			"phone": "+1 510 519 1602",
 			"demoRequired": false,
-			"notes": "Sign in requires a GitHub or Google account. TODO: provide a demo account before App Store review."
+			"notes": "Sign in with Apple, GitHub, or Google. Signing in with Apple creates a free account instantly, so no demo credentials are needed. Superset is a companion app for the Superset desktop product (https://superset.sh): it lets developers monitor and chat with AI coding agents running in their own workspaces. A fresh account with no connected desktop host will show an empty state after onboarding. Account deletion is available in Settings > Account."
 		}
 	}
 }

--- a/apps/mobile/store.config.json
+++ b/apps/mobile/store.config.json
@@ -32,8 +32,8 @@
 			"lastName": "Patel",
 			"email": "support@superset.sh",
 			"phone": "+1 510 519 1602",
-			"demoRequired": false,
-			"notes": "Sign in with Apple, GitHub, or Google. Signing in with Apple creates a free account instantly, so no demo credentials are needed. Superset is a companion app for the Superset desktop product (https://superset.sh): it lets developers monitor and chat with AI coding agents running in their own workspaces. A fresh account with no connected desktop host will show an empty state after onboarding. Account deletion is available in Settings > Account."
+			"demoRequired": true,
+			"notes": "Superset Mobile is a companion app for the Superset desktop product (https://superset.sh): developers monitor and chat with AI coding agents running in their own workspaces. Access requires a Superset Pro subscription purchased outside the app (multiplatform service; there are no in-app purchases). Please use the provided demo account (sign in via the 'Sign in with email' link) to access a Pro workspace with sample data. Sign in with Apple, GitHub, or Google also works and creates a free account instantly, which shows the subscription-required screen. Account deletion is available from Settings > Account and from the subscription screen."
 		}
 	}
 }


### PR DESCRIPTION
The final code/content changes before TestFlight (launch-gate D3, D4, D7, D8):

- **iPhone-only** (`supportsTablet: false`): no iPad screenshot set, no iPad review pass, and no stretched phone UI judged on a 13" display. One-way-door aware: device families can be added in any later update but never removed, so claiming iPad now would be irreversible.
- **Review contact** (`store.config.json`): real phone — the org Google Voice number, which is intentionally public-safe (it also serves as the published EU trader phone if we later enable EU storefronts). Review notes rewritten: Sign in with Apple creates a free account instantly (no demo credentials), companion-app empty state explained, account deletion location cited.
- **Privacy policy**: covers the mobile app (photo/camera/mic/speech permissions), names analytics (PostHog, identified), user content storage, and the grace-period deletion flow on mobile/desktop/web — including the 30-day recovery window and de-identified retention of shared-org content. Apple reviewers check that the policy matches the app.

Not included by design: app name stays "Superset Mobile" (D5), EU storefronts deferred (D6 — trader declaration is an ASC manual step regardless).

After this: manual ASC steps (age rating questionnaire, privacy nutrition labels, screenshots, trader declaration) → `eas metadata:push` → first production build → TestFlight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the iOS app iPhone‑only, updates App Store metadata (title, review contact, pro‑gated companion‑app notes and demo access), and expands the privacy policy for mobile permissions, analytics, and the 30‑day account deletion window. This narrows v1 review scope and aligns storefront and policy with real behavior.

**What to review**
- Device family: supports iPhone only (`supportsTablet: false`, was `true`).
- Store title: renamed from “Superset Mobile” to “Superset: AI Agent Manager”.
- Review metadata: phone updated to +1 510 519 1602; `demoRequired` set to `true` (was `false`); notes clarify no in‑app purchases, external Pro subscription, companion‑app scope, demo access via “Sign in with email,” and that SSO creates a free account that lands on the subscription‑required screen; deletion path called out.
- Privacy policy: adds mobile permissions (photos, camera, mic, speech recognition), identifies analytics (`PostHog`) tied to account identifiers, and documents immediate deactivation, a 30‑day recovery window, and de‑identified retention for shared org content.

**Rollout**
- Complete App Store Connect items (age rating, privacy labels, screenshots, trader declaration), ensure demo account is live and referenced in review notes, run `eas metadata:push`, build, and submit to TestFlight.

<sup>Written for commit 801a82a02916a3bb23ba19ef4a14515413b9c845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the privacy policy with details about third-party sign-ins, AI-agent messages and attachments, analytics, device data, mobile capabilities, and account deletion timelines.
  - Clarified data retention for shared organizational content after account deletion.

- **Configuration**
  - Updated iOS settings to disable tablet support.
  - Renamed the app to “Superset: AI Agent Manager.”
  - Expanded App Store review guidance for sign-in, onboarding, subscriptions, support, and account deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->