### PR TITLE
feat(desktop): show 'being reworked' placeholder in chat panes

### DIFF
--- a/apps/desktop/src/renderer/components/ChatUnderConstruction/ChatUnderConstruction.tsx
+++ b/apps/desktop/src/renderer/components/ChatUnderConstruction/ChatUnderConstruction.tsx
@@ -1,0 +1,15 @@
+import { Construction } from "lucide-react";
+
+export function ChatUnderConstruction() {
+	return (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
+			<Construction className="size-8 text-muted-foreground" />
+			<div className="space-y-1">
+				<p className="font-medium text-sm">Chat is being reworked</p>
+				<p className="text-muted-foreground text-xs">
+					We're rebuilding this feature. Check back soon.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/components/ChatUnderConstruction/index.ts
+++ b/apps/desktop/src/renderer/components/ChatUnderConstruction/index.ts
@@ -1,0 +1,1 @@
+export { ChatUnderConstruction } from "./ChatUnderConstruction";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -1,38 +1,14 @@
+import { ChatUnderConstruction } from "renderer/components/ChatUnderConstruction";
 import type { ChatLaunchConfig } from "shared/tabs-types";
-import { ChatPaneInterface as WorkspaceChatInterface } from "./components/WorkspaceChatInterface";
-import { useWorkspaceChatController } from "./hooks/useWorkspaceChatController";
 
-export function ChatPane({
-	onSessionIdChange,
-	sessionId,
-	workspaceId,
-	initialLaunchConfig,
-	onConsumeLaunchConfig,
-}: {
+// Chat is temporarily disabled while it's being reworked; the pane keeps its
+// props so existing chat panes still mount without churn in the registry.
+export function ChatPane(_props: {
 	onSessionIdChange: (sessionId: string | null) => void;
 	sessionId: string | null;
 	workspaceId: string;
 	initialLaunchConfig?: ChatLaunchConfig | null;
 	onConsumeLaunchConfig?: () => void;
 }) {
-	const { organizationId, workspacePath, handleNewChat, getOrCreateSession } =
-		useWorkspaceChatController({
-			onSessionIdChange,
-			sessionId,
-			workspaceId,
-		});
-
-	return (
-		<WorkspaceChatInterface
-			getOrCreateSession={getOrCreateSession}
-			initialLaunchConfig={initialLaunchConfig ?? null}
-			onConsumeLaunchConfig={onConsumeLaunchConfig}
-			isFocused
-			onResetSession={handleNewChat}
-			sessionId={sessionId}
-			workspaceId={workspaceId}
-			organizationId={organizationId}
-			cwd={workspacePath}
-		/>
-	);
+	return <ChatUnderConstruction />;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
@@ -1,22 +1,9 @@
-import {
-	ChatRuntimeServiceProvider,
-	ChatServiceProvider,
-} from "@superset/chat-legacy/client";
-import { useCallback } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
-import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
-import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
+import { ChatUnderConstruction } from "renderer/components/ChatUnderConstruction";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { SplitPaneOptions, Tab } from "renderer/stores/tabs/types";
 import { TabContentContextMenu } from "../../TabContentContextMenu";
 import { BasePaneWindow, PaneToolbarActions } from "../components";
-import { ChatPaneInterface } from "./ChatPaneInterface";
-import { SessionSelector } from "./components/SessionSelector";
-import { useChatPaneController } from "./hooks/useChatPaneController";
-import { createChatRuntimeServiceIpcClient } from "./utils/chat-runtime-service-client";
-
-const chatRuntimeIpcClient = createChatRuntimeServiceIpcClient();
-const chatIpcClient = createChatServiceIpcClient();
 
 interface ChatPaneProps {
 	paneId: string;
@@ -48,11 +35,12 @@ interface ChatPaneProps {
 	onMoveToNewTab: () => void;
 }
 
+// Chat is temporarily disabled while it's being reworked; the pane keeps its
+// chrome (toolbar, split/close, context menu) but renders a placeholder.
 export function ChatPane({
 	paneId,
 	path,
 	tabId,
-	workspaceId,
 	splitPaneAuto,
 	splitPaneHorizontal,
 	splitPaneVertical,
@@ -62,141 +50,53 @@ export function ChatPane({
 	onMoveToTab,
 	onMoveToNewTab,
 }: ChatPaneProps) {
-	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name ?? "New Chat");
-	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
-	const setPaneAutoTitle = useTabsStore((s) => s.setPaneAutoTitle);
-	const {
-		sessionId,
-		launchConfig,
-		organizationId,
-		workspacePath,
-		isSessionInitializing,
-		hasCurrentSessionRecord,
-		sessionItems,
-		handleSelectSession,
-		handleNewChat,
-		handleStartFreshSession,
-		handleDeleteSession,
-		ensureCurrentSessionRecord,
-		consumeLaunchConfig,
-	} = useChatPaneController({
-		paneId,
-		workspaceId,
-	});
-
-	const applySubmittedMessageFallbackTitle = useCallback(
-		(message: string) => {
-			const normalized = message.trim().replace(/\s+/g, " ");
-			if (!normalized) return;
-			const fallbackTitle =
-				normalized.length > 72
-					? `${normalized.slice(0, 69).trimEnd()}...`
-					: normalized;
-
-			const state = useTabsStore.getState();
-			const pane = state.panes[paneId];
-			const tab = state.tabs.find((candidate) => candidate.id === tabId);
-			const tabPaneCount = Object.values(state.panes).filter(
-				(candidate) => candidate.tabId === tabId,
-			).length;
-			const paneName = pane?.name?.trim() ?? "";
-			const tabName = tab?.name?.trim() ?? "";
-			const hasCustomTabTitle = Boolean(tab?.userTitle?.trim());
-			const shouldSetPaneTitle =
-				paneName.length === 0 || paneName === "New Chat";
-			const shouldSetTabTitle =
-				!hasCustomTabTitle &&
-				(tabName.length === 0 ||
-					tabName === "New Chat" ||
-					(tabPaneCount === 1 && pane?.type === "chat"));
-
-			if (shouldSetPaneTitle) {
-				setPaneAutoTitle(paneId, fallbackTitle);
-			}
-			if (shouldSetTabTitle) {
-				setTabAutoTitle(tabId, fallbackTitle);
-			}
-		},
-		[paneId, setPaneAutoTitle, setTabAutoTitle, tabId],
-	);
 
 	return (
-		<ChatRuntimeServiceProvider
-			client={chatRuntimeIpcClient}
-			queryClient={electronQueryClient}
+		<BasePaneWindow
+			paneId={paneId}
+			path={path}
+			tabId={tabId}
+			splitPaneAuto={splitPaneAuto}
+			removePane={removePane}
+			setFocusedPane={setFocusedPane}
+			renderToolbar={(handlers) => (
+				<div className="flex h-full w-full items-center justify-between px-3">
+					<span className="min-w-0 flex-1 truncate pr-2 text-sm">
+						{paneName}
+					</span>
+					<PaneToolbarActions
+						splitOrientation={handlers.splitOrientation}
+						onSplitPane={handlers.onSplitPane}
+						onClosePane={handlers.onClosePane}
+					/>
+				</div>
+			)}
 		>
-			<ChatServiceProvider
-				client={chatIpcClient}
-				queryClient={electronQueryClient}
+			<TabContentContextMenu
+				onSplitHorizontal={() => splitPaneHorizontal(tabId, paneId, path)}
+				onSplitVertical={() => splitPaneVertical(tabId, paneId, path)}
+				onSplitWithNewChat={() =>
+					splitPaneVertical(tabId, paneId, path, {
+						paneType: "chat",
+					})
+				}
+				onSplitWithNewBrowser={() =>
+					splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
+				}
+				onEqualizePaneSplits={() => equalizePaneSplits(tabId)}
+				onClosePane={() => removePane(paneId)}
+				currentTabId={tabId}
+				availableTabs={availableTabs}
+				onMoveToTab={onMoveToTab}
+				onMoveToNewTab={onMoveToNewTab}
+				closeLabel="Close Chat"
 			>
-				<BasePaneWindow
-					paneId={paneId}
-					path={path}
-					tabId={tabId}
-					splitPaneAuto={splitPaneAuto}
-					removePane={removePane}
-					setFocusedPane={setFocusedPane}
-					renderToolbar={(handlers) => (
-						<div className="flex h-full w-full items-center justify-between px-3">
-							<div className="flex min-w-0 flex-1 items-center gap-2 pr-2">
-								<SessionSelector
-									currentSessionId={sessionId}
-									sessions={sessionItems}
-									fallbackTitle={paneName}
-									isSessionInitializing={isSessionInitializing}
-									onSelectSession={handleSelectSession}
-									onNewChat={handleNewChat}
-									onDeleteSession={handleDeleteSession}
-								/>
-							</div>
-							<PaneToolbarActions
-								splitOrientation={handlers.splitOrientation}
-								onSplitPane={handlers.onSplitPane}
-								onClosePane={handlers.onClosePane}
-							/>
-						</div>
-					)}
-				>
-					<TabContentContextMenu
-						onSplitHorizontal={() => splitPaneHorizontal(tabId, paneId, path)}
-						onSplitVertical={() => splitPaneVertical(tabId, paneId, path)}
-						onSplitWithNewChat={() =>
-							splitPaneVertical(tabId, paneId, path, {
-								paneType: "chat",
-							})
-						}
-						onSplitWithNewBrowser={() =>
-							splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
-						}
-						onEqualizePaneSplits={() => equalizePaneSplits(tabId)}
-						onClosePane={() => removePane(paneId)}
-						currentTabId={tabId}
-						availableTabs={availableTabs}
-						onMoveToTab={onMoveToTab}
-						onMoveToNewTab={onMoveToNewTab}
-						closeLabel="Close Chat"
-					>
-						<div className="h-full w-full">
-							<ChatPaneInterface
-								paneId={paneId}
-								sessionId={sessionId}
-								initialLaunchConfig={launchConfig}
-								workspaceId={workspaceId}
-								organizationId={organizationId}
-								cwd={workspacePath}
-								isFocused={isFocused}
-								isSessionReady={hasCurrentSessionRecord}
-								ensureSessionReady={ensureCurrentSessionRecord}
-								onStartFreshSession={handleStartFreshSession}
-								onConsumeLaunchConfig={consumeLaunchConfig}
-								onUserMessageSubmitted={applySubmittedMessageFallbackTitle}
-							/>
-						</div>
-					</TabContentContextMenu>
-				</BasePaneWindow>
-			</ChatServiceProvider>
-		</ChatRuntimeServiceProvider>
+				<div className="h-full w-full">
+					<ChatUnderConstruction />
+				</div>
+			</TabContentContextMenu>
+		</BasePaneWindow>
 	);
 }


### PR DESCRIPTION
## What

Chat isn't functional right now, so this replaces the chat pane UI with a small "Chat is being reworked" placeholder in both the v1 (`screens/main`) and v2 (`v2-workspace` pane registry) chat panes, via a shared `ChatUnderConstruction` component.

## Details

- Pane chrome is preserved: title bar, split/close actions, and context menu still work, and existing/persisted chat panes mount without churn (v2 `ChatPane` keeps its props signature).
- The v1 pane no longer initializes the chat runtime providers, IPC clients, or session controller, so none of the broken chat machinery runs.
- No chat code is deleted — trivially revertible when chat comes back.
- The flag-gated internal `ChatV3Pane` (`CHAT_V3`) is untouched.

## Verification

Verified live via CDP against this worktree's dev desktop build: opened a v2 workspace → "Open Chat" → pane renders the placeholder with working pane chrome. Typecheck and `bun run lint` clean.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render a “Chat is being reworked” placeholder in desktop chat panes to disable broken chat while keeping pane chrome and registry compatibility. Previously the v1/v2 panes initialized the legacy chat UI and runtime/providers; now they render a placeholder and do not start chat logic.

**Reviewer notes**
- Adds shared `ChatUnderConstruction` component; used by v1 (`screens/main`) and v2 pane registry chat panes.
- Pane chrome retained (title, split/close, context menu); persisted chat panes still mount; `ChatPane` props unchanged.
- v1 pane no longer initializes chat runtime providers, IPC clients, or the session controller.
- Flag-gated `ChatV3Pane` (`CHAT_V3`) is untouched.
- No migration required; callers of `ChatPane` do not change.

<sup>Written for commit c686301571ff9772fa0604cf02e69d7c661b57ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Temporarily replaced the chat interface with a clear “under construction” message.
  * Preserved chat pane controls, including toolbar actions, context menus, split/close behavior, and tab movement.
  * Chat sessions and conversation interactions are currently unavailable while the experience is being reworked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->