### PR TITLE
perf(marketing): cut critical-path payload to raise Lighthouse performance score

### DIFF
--- a/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
+++ b/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import Link from "next/link";
 import { useState } from "react";
 import { HiPlus } from "react-icons/hi2";
@@ -34,7 +34,7 @@ function FAQAccordionItem({
 			</button>
 			<AnimatePresence initial={false}>
 				{isOpen && (
-					<motion.div
+					<m.div
 						initial={{ height: 0, opacity: 0 }}
 						animate={{ height: "auto", opacity: 1 }}
 						exit={{ height: 0, opacity: 0 }}
@@ -54,7 +54,7 @@ function FAQAccordionItem({
 								</Link>
 							)}
 						</div>
-					</motion.div>
+					</m.div>
 				)}
 			</AnimatePresence>
 		</div>

--- a/apps/marketing/src/app/components/FeaturesSection/components/AutomationsDemo/AutomationsDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/AutomationsDemo/AutomationsDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import { useRef } from "react";
 
 const AUTOMATIONS = [
@@ -26,7 +26,7 @@ export function AutomationsDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full max-w-md overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -58,7 +58,7 @@ export function AutomationsDemo() {
 						Last run
 					</div>
 					{AUTOMATIONS.map((automation, index) => (
-						<motion.div
+						<m.div
 							key={automation.name}
 							className="contents"
 							initial={{ opacity: 0 }}
@@ -77,7 +77,7 @@ export function AutomationsDemo() {
 									{automation.lastRun}
 								</div>
 							)}
-						</motion.div>
+						</m.div>
 					))}
 				</div>
 
@@ -86,7 +86,7 @@ export function AutomationsDemo() {
 						daily-triage
 					</div>
 					{LOG_LINES.map((line, index) => (
-						<motion.div
+						<m.div
 							key={line}
 							className="text-muted-foreground/70"
 							initial={{ opacity: 0 }}
@@ -94,10 +94,10 @@ export function AutomationsDemo() {
 							transition={{ duration: 0.3, delay: 0.5 + index * 0.15 }}
 						>
 							<span className="text-muted-foreground/45">→</span> {line}
-						</motion.div>
+						</m.div>
 					))}
 				</div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/CliDemo/CliDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/CliDemo/CliDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import { useRef } from "react";
 
 const WORKSPACE_ROWS = [
@@ -19,7 +19,7 @@ export function CliDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full max-w-md overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -47,7 +47,7 @@ export function CliDemo() {
 						&quot;fix onboarding crash&quot; --agent claude
 					</span>
 				</div>
-				<motion.div
+				<m.div
 					className="text-muted-foreground"
 					initial={{ opacity: 0 }}
 					animate={isInView ? { opacity: 1 } : { opacity: 0 }}
@@ -55,9 +55,9 @@ export function CliDemo() {
 				>
 					<span className="text-emerald-400/85">✓</span> workspace ready ·{" "}
 					<span className="text-muted-foreground/55">fix-onboarding-crash</span>
-				</motion.div>
+				</m.div>
 
-				<motion.div
+				<m.div
 					className="pt-2 text-foreground"
 					initial={{ opacity: 0 }}
 					animate={isInView ? { opacity: 1 } : { opacity: 0 }}
@@ -65,9 +65,9 @@ export function CliDemo() {
 				>
 					<span className="text-muted-foreground/55">❯</span>{" "}
 					<span className="text-brand-light">superset ls</span>
-				</motion.div>
+				</m.div>
 				{WORKSPACE_ROWS.map((row, index) => (
-					<motion.div
+					<m.div
 						key={row.name}
 						className="flex items-center gap-2 text-muted-foreground"
 						initial={{ opacity: 0 }}
@@ -84,9 +84,9 @@ export function CliDemo() {
 						<span className="w-14 text-right text-muted-foreground/45">
 							{row.state}
 						</span>
-					</motion.div>
+					</m.div>
 				))}
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/IsolationDemo/IsolationDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/IsolationDemo/IsolationDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import { useRef } from "react";
 import {
 	HiOutlineChatBubbleLeftRight,
@@ -48,7 +48,7 @@ const DIFF_LINES = [
 	{
 		id: "line-8",
 		type: "added",
-		content: "\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0<motion.h1",
+		content: "\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0<m.h1",
 	},
 	{
 		id: "line-9",
@@ -76,7 +76,7 @@ const DIFF_LINES = [
 	{
 		id: "line-13",
 		type: "added",
-		content: "\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0</motion.h1>",
+		content: "\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0</m.h1>",
 	},
 	{
 		id: "line-14",
@@ -98,7 +98,7 @@ export function IsolationDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full min-w-[500px] max-w-2xl overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -164,7 +164,7 @@ export function IsolationDemo() {
 							Unstaged
 						</div>
 						{SIDEBAR_FILES.map((file, index) => (
-							<motion.div
+							<m.div
 								key={file.name}
 								className="flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-foreground/[0.04] rounded-sm cursor-pointer"
 								initial={{ opacity: 0, x: -5 }}
@@ -188,7 +188,7 @@ export function IsolationDemo() {
 										-{file.removed}
 									</span>
 								)}
-							</motion.div>
+							</m.div>
 						))}
 					</div>
 				</div>
@@ -197,7 +197,7 @@ export function IsolationDemo() {
 				<div className="flex-1 overflow-hidden">
 					<div className="font-mono text-[11px]">
 						{DIFF_LINES.map((line, index) => (
-							<motion.div
+							<m.div
 								key={line.id}
 								className={`flex ${
 									line.type === "added"
@@ -250,11 +250,11 @@ export function IsolationDemo() {
 								>
 									{line.content}
 								</span>
-							</motion.div>
+							</m.div>
 						))}
 					</div>
 				</div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/OpenInDemo/OpenInDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/OpenInDemo/OpenInDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import Image from "next/image";
 import { useRef } from "react";
 import {
@@ -40,7 +40,7 @@ export function OpenInDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full max-w-sm"
 			initial={{ opacity: 0, y: 20 }}
@@ -78,7 +78,7 @@ export function OpenInDemo() {
 					</div>
 
 					{/* Open in button */}
-					<motion.div
+					<m.div
 						className="inline-flex items-stretch"
 						initial={{ opacity: 0, scale: 0.95 }}
 						animate={
@@ -106,13 +106,13 @@ export function OpenInDemo() {
 						>
 							<HiChevronDown className="w-3.5 h-3.5" />
 						</button>
-					</motion.div>
+					</m.div>
 				</div>
 
 				{/* File tree */}
 				<div className="py-2">
 					{FILE_TREE.map((item, index) => (
-						<motion.div
+						<m.div
 							key={item.name}
 							className={`flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer transition-colors ${
 								item.selected
@@ -138,20 +138,20 @@ export function OpenInDemo() {
 								</>
 							)}
 							<span>{item.name}</span>
-						</motion.div>
+						</m.div>
 					))}
 				</div>
 			</div>
 
 			{/* Dropdown Menu - positioned outside window for overflow effect */}
-			<motion.div
+			<m.div
 				className="absolute -right-10 top-[104px] z-10 w-44 overflow-hidden rounded-lg border border-border bg-card py-1.5 shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 				initial={{ opacity: 0, y: -8 }}
 				animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: -8 }}
 				transition={{ duration: 0.3, delay: 0.4 }}
 			>
 				{IDE_OPTIONS.map((ide, index) => (
-					<motion.div
+					<m.div
 						key={ide.id}
 						className="flex cursor-pointer items-center justify-between px-3 py-1.5 text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground/90"
 						initial={{ opacity: 0, x: -10 }}
@@ -175,9 +175,9 @@ export function OpenInDemo() {
 								{ide.shortcut}
 							</span>
 						)}
-					</motion.div>
+					</m.div>
 				))}
-			</motion.div>
-		</motion.div>
+			</m.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/ParallelExecutionDemo/ParallelExecutionDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/ParallelExecutionDemo/ParallelExecutionDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { HiCheck } from "react-icons/hi2";
 
@@ -75,7 +75,7 @@ function SpinnerIcon({
 	rotation?: number;
 }) {
 	return (
-		<motion.svg
+		<m.svg
 			className={className}
 			viewBox="0 0 24 24"
 			fill="none"
@@ -100,7 +100,7 @@ function SpinnerIcon({
 				fill="currentColor"
 				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
 			/>
-		</motion.svg>
+		</m.svg>
 	);
 }
 
@@ -127,7 +127,7 @@ export function ParallelExecutionDemo() {
 	}, [isInView]);
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full min-w-[500px] max-w-2xl overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -160,7 +160,7 @@ export function ParallelExecutionDemo() {
 							</span>
 						</div>
 						{IN_PROGRESS_TASKS.map((task, index) => (
-							<motion.div
+							<m.div
 								key={task.id}
 								className="flex cursor-pointer items-start gap-2 rounded-sm px-1 py-1.5 hover:bg-foreground/[0.04]"
 								initial={{ opacity: 0, x: -10 }}
@@ -181,7 +181,7 @@ export function ParallelExecutionDemo() {
 										{task.status}
 									</div>
 								</div>
-							</motion.div>
+							</m.div>
 						))}
 					</div>
 
@@ -194,7 +194,7 @@ export function ParallelExecutionDemo() {
 							</span>
 						</div>
 						{READY_FOR_REVIEW.map((task, index) => (
-							<motion.div
+							<m.div
 								key={task.id}
 								className="flex cursor-pointer items-start gap-2 rounded-sm px-1 py-1.5 hover:bg-foreground/[0.04]"
 								initial={{ opacity: 0, x: -10 }}
@@ -220,7 +220,7 @@ export function ParallelExecutionDemo() {
 										)}
 									</div>
 								</div>
-							</motion.div>
+							</m.div>
 						))}
 					</div>
 				</div>
@@ -251,6 +251,6 @@ export function ParallelExecutionDemo() {
 					</div>
 				</div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/RemoteWorkspacesDemo/RemoteWorkspacesDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/RemoteWorkspacesDemo/RemoteWorkspacesDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import { useRef } from "react";
 
 const WORKSPACES = [
@@ -14,7 +14,7 @@ export function RemoteWorkspacesDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full max-w-md overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -39,15 +39,15 @@ export function RemoteWorkspacesDemo() {
 					<span className="text-muted-foreground/55">❯</span>{" "}
 					<span className="text-brand-light">ssh gpu-box</span>
 				</div>
-				<motion.div
+				<m.div
 					className="text-muted-foreground/65"
 					initial={{ opacity: 0 }}
 					animate={isInView ? { opacity: 1 } : { opacity: 0 }}
 					transition={{ duration: 0.3, delay: 0.2 }}
 				>
 					Welcome to gpu-box · us-east · 64 cores · 128 GB
-				</motion.div>
-				<motion.div
+				</m.div>
+				<m.div
 					className="pt-2 text-foreground"
 					initial={{ opacity: 0 }}
 					animate={isInView ? { opacity: 1 } : { opacity: 0 }}
@@ -55,17 +55,17 @@ export function RemoteWorkspacesDemo() {
 				>
 					<span className="text-muted-foreground/55">❯</span>{" "}
 					<span className="text-brand-light">superset status</span>
-				</motion.div>
-				<motion.div
+				</m.div>
+				<m.div
 					className="text-muted-foreground"
 					initial={{ opacity: 0 }}
 					animate={isInView ? { opacity: 1 } : { opacity: 0 }}
 					transition={{ duration: 0.3, delay: 0.55 }}
 				>
 					3 workspaces running
-				</motion.div>
+				</m.div>
 				{WORKSPACES.map((workspace, index) => (
-					<motion.div
+					<m.div
 						key={workspace.name}
 						className="text-muted-foreground"
 						initial={{ opacity: 0 }}
@@ -79,9 +79,9 @@ export function RemoteWorkspacesDemo() {
 						)}{" "}
 						{workspace.name} ·{" "}
 						<span className="text-muted-foreground/55">{workspace.detail}</span>
-					</motion.div>
+					</m.div>
 				))}
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/FeaturesSection/components/UniversalCompatibilityDemo/UniversalCompatibilityDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/UniversalCompatibilityDemo/UniversalCompatibilityDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { m, useInView } from "framer-motion";
 import Image from "next/image";
 import { useRef } from "react";
 import { HiOutlineTerminal } from "react-icons/hi";
@@ -22,7 +22,7 @@ export function UniversalCompatibilityDemo() {
 	const isInView = useInView(ref, { once: true, margin: "-100px" });
 
 	return (
-		<motion.div
+		<m.div
 			ref={ref}
 			className="relative w-full max-w-xs overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			initial={{ opacity: 0, y: 20 }}
@@ -52,7 +52,7 @@ export function UniversalCompatibilityDemo() {
 
 			<div className="py-1.5">
 				{AGENTS.map((agent, index) => (
-					<motion.div
+					<m.div
 						key={agent.name}
 						className="flex cursor-pointer items-center gap-3 px-4 py-1.5 text-[12px] text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground/90"
 						initial={{ opacity: 0, x: -10 }}
@@ -69,7 +69,7 @@ export function UniversalCompatibilityDemo() {
 							/>
 						</div>
 						<span>{agent.name}</span>
-					</motion.div>
+					</m.div>
 				))}
 			</div>
 
@@ -79,6 +79,6 @@ export function UniversalCompatibilityDemo() {
 					<span className="text-[11px]">Terminals (3)</span>
 				</div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { COMPANY } from "@superset/shared/constants";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -70,7 +70,7 @@ export function Footer() {
 
 	return (
 		<footer className="border-t border-border bg-background">
-			<motion.div
+			<m.div
 				initial={{ opacity: 0 }}
 				whileInView={{ opacity: 1 }}
 				viewport={{ once: true }}
@@ -96,7 +96,7 @@ export function Footer() {
 					<FooterColumn title="Resources" links={RESOURCE_LINKS} />
 					<FooterColumn title="Legal" links={LEGAL_LINKS} />
 				</div>
-			</motion.div>
+			</m.div>
 		</footer>
 	);
 }

--- a/apps/marketing/src/app/components/Header/Header.tsx
+++ b/apps/marketing/src/app/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -32,7 +32,7 @@ export function Header({ ctaButtons, starCounter }: HeaderProps) {
 		>
 			<div className="px-4 sm:px-6">
 				<div className="flex items-center justify-between h-16">
-					<motion.div
+					<m.div
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1 }}
 						transition={{ duration: 0.3 }}
@@ -44,9 +44,9 @@ export function Header({ ctaButtons, starCounter }: HeaderProps) {
 						>
 							<SupersetLogo />
 						</Link>
-					</motion.div>
+					</m.div>
 
-					<motion.div
+					<m.div
 						className="hidden lg:flex items-center gap-8"
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1 }}
@@ -55,7 +55,7 @@ export function Header({ ctaButtons, starCounter }: HeaderProps) {
 						<DesktopNav />
 						{starCounter}
 						<div className="flex items-center gap-3 shrink-0">{ctaButtons}</div>
-					</motion.div>
+					</m.div>
 
 					<MobileNav ctaButtons={ctaButtons} starCounter={starCounter} />
 				</div>

--- a/apps/marketing/src/app/components/Header/components/MobileNav/MobileNav.tsx
+++ b/apps/marketing/src/app/components/Header/components/MobileNav/MobileNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -37,7 +37,7 @@ export function MobileNav({ ctaButtons, starCounter }: MobileNavProps) {
 
 			<AnimatePresence>
 				{isOpen && (
-					<motion.div
+					<m.div
 						className="absolute inset-x-0 top-14 border-t border-border bg-background/95 backdrop-blur-sm"
 						initial={{ opacity: 0, height: 0 }}
 						animate={{ opacity: 1, height: "auto" }}
@@ -61,7 +61,7 @@ export function MobileNav({ ctaButtons, starCounter }: MobileNavProps) {
 								{ctaButtons}
 							</div>
 						</div>
-					</motion.div>
+					</m.div>
 				)}
 			</AnimatePresence>
 		</div>

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/LeftSidebar/LeftSidebar.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/LeftSidebar/LeftSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import {
 	LuChevronDown,
 	LuChevronRight,
@@ -38,7 +38,7 @@ export function LeftSidebar({ activeDemo }: LeftSidebarProps) {
 			<div className="mt-6 flex-1 overflow-hidden">
 				<GroupHeader label="desktop" count={5} expanded />
 
-				<motion.div
+				<m.div
 					className="overflow-hidden"
 					initial={{ height: 0, opacity: 0 }}
 					animate={{
@@ -58,7 +58,7 @@ export function LeftSidebar({ activeDemo }: LeftSidebarProps) {
 							creating
 						</span>
 					</div>
-				</motion.div>
+				</m.div>
 
 				<div className="mt-1 space-y-0.5">
 					{WORKSPACES.map((workspace) => (
@@ -79,7 +79,7 @@ export function LeftSidebar({ activeDemo }: LeftSidebarProps) {
 				<div className="mt-3">
 					<GroupHeader label="cloud" count={3} expanded={isRemote} />
 				</div>
-				<motion.div
+				<m.div
 					className="overflow-hidden"
 					initial={{ height: 0, opacity: 0 }}
 					animate={{
@@ -102,7 +102,7 @@ export function LeftSidebar({ activeDemo }: LeftSidebarProps) {
 							/>
 						))}
 					</div>
-				</motion.div>
+				</m.div>
 				<div className="mt-1">
 					<GroupHeader label="mobile" count={1} />
 				</div>

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/MainPanel/MainPanel.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/MainPanel/MainPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { LuGitPullRequest } from "react-icons/lu";
 import { AUTOMATIONS } from "../../constants";
@@ -27,7 +27,7 @@ export function MainPanel({ activeDemo }: MainPanelProps) {
 	return (
 		<div className="flex min-w-0 flex-1 flex-col bg-background">
 			<div className="relative flex-1 overflow-hidden p-5 font-mono text-[11px] leading-relaxed">
-				<motion.div
+				<m.div
 					className="flex h-full flex-col"
 					initial={{ opacity: 1 }}
 					animate={{ opacity: isDefault ? 1 : 0 }}
@@ -131,10 +131,10 @@ export function MainPanel({ activeDemo }: MainPanelProps) {
 							</span>
 						</div>
 					</div>
-				</motion.div>
+				</m.div>
 
 				{/* Automate Tasks: scheduled agents running on their own */}
-				<motion.div
+				<m.div
 					className="absolute inset-0 p-5 font-mono text-[11px] leading-relaxed"
 					initial={{ opacity: 0 }}
 					animate={{ opacity: isAutomate ? 1 : 0 }}
@@ -179,10 +179,10 @@ export function MainPanel({ activeDemo }: MainPanelProps) {
 							</div>
 						))}
 					</div>
-				</motion.div>
+				</m.div>
 
 				{/* Remote Workspaces: same workspace model, on a box that isn't yours */}
-				<motion.div
+				<m.div
 					className="absolute inset-0 p-5 font-mono text-[11px] leading-relaxed"
 					initial={{ opacity: 0 }}
 					animate={{ opacity: isRemote ? 1 : 0 }}
@@ -201,7 +201,7 @@ export function MainPanel({ activeDemo }: MainPanelProps) {
 							· 64 cores · 128 GB
 						</div>
 					</div>
-				</motion.div>
+				</m.div>
 			</div>
 		</div>
 	);

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RemoteSessionPopup/RemoteSessionPopup.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RemoteSessionPopup/RemoteSessionPopup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import type { ActiveDemo } from "../../types";
 import { AsciiSpinner } from "../AsciiSpinner";
 
@@ -12,7 +12,7 @@ export function RemoteSessionPopup({ activeDemo }: RemoteSessionPopupProps) {
 	const isRemote = activeDemo === "Remote Workspaces";
 
 	return (
-		<motion.div
+		<m.div
 			className="absolute bottom-20 right-6 w-[52%] overflow-hidden rounded-lg border border-border bg-background shadow-[0_1px_1px_rgba(0,0,0,0.4),0_24px_70px_-16px_rgba(0,0,0,0.75)]"
 			style={{
 				pointerEvents: isRemote ? "auto" : "none",
@@ -70,6 +70,6 @@ export function RemoteSessionPopup({ activeDemo }: RemoteSessionPopupProps) {
 					<span className="text-muted-foreground/55">PR opened</span>
 				</div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RightSidebar/RightSidebar.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RightSidebar/RightSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { LuArrowRight, LuGitPullRequest, LuPlay } from "react-icons/lu";
 import { FILE_CHANGES } from "../../constants";
 import type { ActiveDemo } from "../../types";
@@ -16,7 +16,7 @@ export function RightSidebar({ activeDemo }: RightSidebarProps) {
 	const isDiff = activeDemo === "See Changes";
 
 	return (
-		<motion.div
+		<m.div
 			className="relative flex shrink-0 flex-col overflow-hidden border-l border-border/60 bg-card text-[11px]"
 			initial={{ width: 236 }}
 			animate={{ width: isDiff ? 380 : 236 }}
@@ -77,7 +77,7 @@ export function RightSidebar({ activeDemo }: RightSidebarProps) {
 			</div>
 
 			<div className="relative flex-1 bg-background">
-				<motion.div
+				<m.div
 					className="absolute inset-0 flex flex-col"
 					initial={{ opacity: 1 }}
 					animate={{ opacity: isDiff ? 0 : 1 }}
@@ -96,9 +96,9 @@ export function RightSidebar({ activeDemo }: RightSidebarProps) {
 							/>
 						))}
 					</div>
-				</motion.div>
+				</m.div>
 
-				<motion.div
+				<m.div
 					className="absolute inset-0 flex flex-col bg-background"
 					initial={{ opacity: 0 }}
 					animate={{ opacity: isDiff ? 1 : 0 }}
@@ -156,9 +156,9 @@ export function RightSidebar({ activeDemo }: RightSidebarProps) {
 							Comment
 						</button>
 					</div>
-				</motion.div>
+				</m.div>
 			</div>
-		</motion.div>
+		</m.div>
 	);
 }
 

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/TabBar/TabBar.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/TabBar/TabBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { LuChevronDown, LuPlus } from "react-icons/lu";
 import { AGENT_TABS } from "../../constants";
@@ -33,7 +33,7 @@ export function TabBar({ activeDemo }: TabBarProps) {
 				</div>
 
 				{AGENT_TABS.map((tab) => (
-					<motion.div
+					<m.div
 						key={tab.label}
 						className="flex h-full shrink-0 items-center gap-1.5 overflow-hidden text-[11px] text-muted-foreground/65 hover:text-foreground/90"
 						initial={{
@@ -56,7 +56,7 @@ export function TabBar({ activeDemo }: TabBarProps) {
 					>
 						<Image src={tab.src} alt={tab.alt} width={12} height={12} />
 						<span className="min-w-0 flex-1 truncate">{tab.label}</span>
-					</motion.div>
+					</m.div>
 				))}
 			</div>
 

--- a/apps/marketing/src/app/components/HeroSection/components/BoidsBackground/BoidsBackground.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/BoidsBackground/BoidsBackground.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useEffect, useRef } from "react";
 
 // character grid — glyphs stay upright and snapped, like real terminal text
@@ -349,7 +349,7 @@ export function BoidsBackground() {
 	}, []);
 
 	return (
-		<motion.div
+		<m.div
 			className="absolute inset-0 pointer-events-none z-0"
 			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
@@ -365,6 +365,6 @@ export function BoidsBackground() {
 			}}
 		>
 			<canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/HeroSection/components/GridBackground/GridBackground.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/GridBackground/GridBackground.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 
 export function GridBackground() {
 	return (
-		<motion.div
+		<m.div
 			className="absolute inset-0 pointer-events-none z-0"
 			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
@@ -49,6 +49,6 @@ export function GridBackground() {
 					mask="url(#grid-mask)"
 				/>
 			</svg>
-		</motion.div>
+		</m.div>
 	);
 }

--- a/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useScroll, useTransform } from "framer-motion";
+import { m, useScroll, useTransform } from "framer-motion";
 import { useEffect, useState } from "react";
 import { type ActiveDemo, AppMockup } from "../AppMockup";
 import { SelectorPill } from "./components/SelectorPill";
@@ -55,16 +55,16 @@ export function ProductDemo() {
 			</div>
 
 			{/* Desktop: vertical radio column, opened by scroll */}
-			<motion.div
+			<m.div
 				className="hidden lg:flex flex-col justify-center shrink-0 overflow-hidden"
 				style={{ width: selectorWidth, opacity: selectorOpacity }}
 			>
 				<div className="w-60 pr-6 flex flex-col gap-1">{options}</div>
-			</motion.div>
+			</m.div>
 
 			{/* Mockup: oversized, lower hero state that docks as you scroll */}
 			<div className="relative flex-1 min-w-0">
-				<motion.div
+				<m.div
 					className="relative"
 					style={
 						isDesktop
@@ -88,7 +88,7 @@ export function ProductDemo() {
 					<div className="relative overflow-x-auto scrollbar-hide max-md:[mask-image:linear-gradient(to_right,black_88%,transparent)]">
 						<AppMockup activeDemo={activeOption} />
 					</div>
-				</motion.div>
+				</m.div>
 			</div>
 		</div>
 	);

--- a/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useEffect, useState } from "react";
 
 interface TextSegment {
@@ -67,7 +67,7 @@ export function TypewriterText({
 
 	const renderCursor = (override?: string) =>
 		showCursor ? (
-			<motion.span
+			<m.span
 				className={
 					override ??
 					cursorClassName ??

--- a/apps/marketing/src/app/components/HowItWorksSection/HowItWorksSection.tsx
+++ b/apps/marketing/src/app/components/HowItWorksSection/HowItWorksSection.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { HOW_IT_WORKS_STEPS } from "./constants";
 
 export function HowItWorksSection() {
 	return (
 		<section id="how-it-works" className="relative py-24 sm:py-32">
 			<div className="max-w-7xl mx-auto px-6 sm:px-8">
-				<motion.div
+				<m.div
 					className="mb-16 sm:mb-20 space-y-4"
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
@@ -22,11 +22,11 @@ export function HowItWorksSection() {
 						<br />
 						not one prompt at a time.
 					</h2>
-				</motion.div>
+				</m.div>
 
 				<div className="grid grid-cols-1 md:grid-cols-3 gap-10 md:gap-8 lg:gap-12">
 					{HOW_IT_WORKS_STEPS.map((step, index) => (
-						<motion.div
+						<m.div
 							key={step.number}
 							className="space-y-4 border-t border-border pt-6"
 							initial={{ opacity: 0, y: 20 }}
@@ -43,7 +43,7 @@ export function HowItWorksSection() {
 							<p className="text-base text-muted-foreground leading-relaxed">
 								{step.description}
 							</p>
-						</motion.div>
+						</m.div>
 					))}
 				</div>
 			</div>

--- a/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
+++ b/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import type { ReactNode } from "react";
 import {
 	HiOutlineCodeBracket,
@@ -38,7 +38,7 @@ export function SecuritySection() {
 		<section id="security" className="relative py-24 sm:py-32">
 			<div className="max-w-7xl mx-auto px-6 sm:px-8">
 				{/* Heading */}
-				<motion.div
+				<m.div
 					className="mb-16 space-y-4"
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
@@ -57,10 +57,10 @@ export function SecuritySection() {
 						Your code stays local by default, with explicit control over
 						connected services.
 					</p>
-				</motion.div>
+				</m.div>
 
 				{/* Features Grid */}
-				<motion.div
+				<m.div
 					className="grid grid-cols-1 md:grid-cols-3 gap-6"
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
@@ -68,7 +68,7 @@ export function SecuritySection() {
 					transition={{ duration: 0.5, delay: 0.2 }}
 				>
 					{SECURITY_FEATURES.map((feature, index) => (
-						<motion.div
+						<m.div
 							key={feature.title}
 							className="relative p-6 rounded-[2px] border border-foreground/[0.1] bg-foreground/[0.03]"
 							initial={{ opacity: 0, y: 20 }}
@@ -85,9 +85,9 @@ export function SecuritySection() {
 							<p className="text-sm leading-relaxed text-muted-foreground">
 								{feature.description}
 							</p>
-						</motion.div>
+						</m.div>
 					))}
-				</motion.div>
+				</m.div>
 			</div>
 		</section>
 	);

--- a/apps/marketing/src/app/components/WaitlistForm/WaitlistForm.tsx
+++ b/apps/marketing/src/app/components/WaitlistForm/WaitlistForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import posthog from "posthog-js";
 import { useState } from "react";
 import { track } from "@/lib/analytics";
+import { withPosthog } from "@/lib/analytics/lazy";
 
 interface WaitlistFormProps {
 	heading?: string;
@@ -17,16 +17,18 @@ export function WaitlistForm({ heading, description }: WaitlistFormProps) {
 		e.preventDefault();
 		if (!email) return;
 
-		const wasOptedOut = posthog.has_opted_out_capturing();
-		if (wasOptedOut) {
-			posthog.opt_in_capturing();
-		}
+		withPosthog((posthog) => {
+			const wasOptedOut = posthog.has_opted_out_capturing();
+			if (wasOptedOut) {
+				posthog.opt_in_capturing();
+			}
 
-		track("waitlist_signup", { email, platform: "windows_linux" });
+			track("waitlist_signup", { email, platform: "windows_linux" });
 
-		if (wasOptedOut) {
-			posthog.opt_out_capturing();
-		}
+			if (wasOptedOut) {
+				posthog.opt_out_capturing();
+			}
+		});
 
 		setSubmitted(true);
 	}

--- a/apps/marketing/src/app/enterprise/components/EnterpriseFAQ/EnterpriseFAQ.tsx
+++ b/apps/marketing/src/app/enterprise/components/EnterpriseFAQ/EnterpriseFAQ.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { useMemo, useState } from "react";
 import { HiPlus } from "react-icons/hi2";
 import type { FAQItem } from "@/app/components/FAQSection";
@@ -51,7 +51,7 @@ function FAQAccordionItem({
 			</button>
 			<AnimatePresence initial={false}>
 				{isOpen && (
-					<motion.div
+					<m.div
 						id={contentId}
 						role="region"
 						aria-labelledby={contentId}
@@ -64,7 +64,7 @@ function FAQAccordionItem({
 						<p className="pb-5 text-sm text-muted-foreground leading-relaxed pr-8">
 							{item.answer}
 						</p>
-					</motion.div>
+					</m.div>
 				)}
 			</AnimatePresence>
 		</div>

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { COMPANY } from "@superset/shared/constants";
-import { GeistPixelGrid, GeistPixelSquare } from "geist/font/pixel";
 import type { Metadata } from "next";
-import { IBM_Plex_Mono, Inter, Micro_5, Pixelify_Sans } from "next/font/google";
+import { IBM_Plex_Mono, Inter } from "next/font/google";
 import Script from "next/script";
 
 import { CookieConsent } from "@/components/CookieConsent";
@@ -24,6 +23,8 @@ const ibmPlexMono = IBM_Plex_Mono({
 	subsets: ["latin"],
 	variable: "--font-ibm-plex-mono",
 	display: "swap",
+	// Not used by the LCP hero text; keep it off the critical preload path
+	preload: false,
 });
 
 // Variable font with the opsz axis: large sizes render as Inter Display
@@ -32,20 +33,6 @@ const inter = Inter({
 	variable: "--font-inter",
 	display: "swap",
 	axes: ["opsz"],
-});
-
-const micro5 = Micro_5({
-	weight: "400",
-	subsets: ["latin"],
-	variable: "--font-micro5",
-	display: "swap",
-});
-
-const pixelifySans = Pixelify_Sans({
-	weight: ["400", "500", "600", "700"],
-	subsets: ["latin"],
-	variable: "--font-pixel",
-	display: "swap",
 });
 
 const siteDescription =
@@ -125,7 +112,7 @@ export default function RootLayout({
 	return (
 		<html
 			lang="en"
-			className={`dark overscroll-none ${ibmPlexMono.variable} ${inter.variable} ${micro5.variable} ${pixelifySans.variable} ${GeistPixelSquare.variable} ${GeistPixelGrid.variable}`}
+			className={`dark overscroll-none ${ibmPlexMono.variable} ${inter.variable}`}
 			suppressHydrationWarning
 		>
 			<head>
@@ -135,9 +122,9 @@ export default function RootLayout({
 				{/* Google tag (gtag.js) — Google Ads */}
 				<Script
 					src="https://www.googletagmanager.com/gtag/js?id=AW-18209336001"
-					strategy="afterInteractive"
+					strategy="lazyOnload"
 				/>
-				<Script id="google-ads-gtag" strategy="afterInteractive">
+				<Script id="google-ads-gtag" strategy="lazyOnload">
 					{`
 						window.dataLayer = window.dataLayer || [];
 						function gtag(){dataLayer.push(arguments);}
@@ -146,7 +133,7 @@ export default function RootLayout({
 					`}
 				</Script>
 				{/* Reddit Pixel */}
-				<Script id="reddit-pixel" strategy="afterInteractive">
+				<Script id="reddit-pixel" strategy="lazyOnload">
 					{`
 						!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js?pixel_id=${REDDIT_PIXEL_ID}",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);
 						rdt('init','${REDDIT_PIXEL_ID}');

--- a/apps/marketing/src/app/motion-features.ts
+++ b/apps/marketing/src/app/motion-features.ts
@@ -1,0 +1,5 @@
+import { domAnimation } from "framer-motion";
+
+// Loaded async by LazyMotion (see providers.tsx) so the animation runtime
+// stays out of the critical-path bundle
+export default domAnimation;

--- a/apps/marketing/src/app/pricing/components/PricingFAQ/PricingFAQ.tsx
+++ b/apps/marketing/src/app/pricing/components/PricingFAQ/PricingFAQ.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { useMemo, useState } from "react";
 import { HiPlus } from "react-icons/hi2";
 import type { FAQItem } from "@/app/components/FAQSection";
@@ -50,7 +50,7 @@ function FAQAccordionItem({
 			</button>
 			<AnimatePresence initial={false}>
 				{isOpen && (
-					<motion.div
+					<m.div
 						id={contentId}
 						role="region"
 						aria-labelledby={contentId}
@@ -63,7 +63,7 @@ function FAQAccordionItem({
 						<p className="pb-5 text-sm text-muted-foreground leading-relaxed pr-8">
 							{item.answer}
 						</p>
-					</motion.div>
+					</m.div>
 				)}
 			</AnimatePresence>
 		</div>

--- a/apps/marketing/src/app/providers.tsx
+++ b/apps/marketing/src/app/providers.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { THEME_STORAGE_KEY } from "@superset/shared/constants";
+import { LazyMotion } from "framer-motion";
 import { ThemeProvider } from "next-themes";
-import posthog from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
+
+// Components use `m.*` (not `motion.*`) so the framer-motion feature bundle
+// loads in this async chunk instead of the critical-path JS
+const loadMotionFeatures = () =>
+	import("./motion-features").then((mod) => mod.default);
 
 export function Providers({ children }: { children: React.ReactNode }) {
 	return (
-		<PostHogProvider client={posthog}>
+		<LazyMotion features={loadMotionFeatures}>
 			<ThemeProvider
 				attribute="class"
 				defaultTheme="dark"
@@ -17,6 +21,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
 			>
 				{children}
 			</ThemeProvider>
-		</PostHogProvider>
+		</LazyMotion>
 	);
 }

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
+import { Micro_5 } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -9,6 +10,14 @@ import {
 } from "react-icons/ri";
 import { getAllPeople } from "@/lib/people";
 import { TeamBio } from "./components/TeamBio";
+
+// Loaded here instead of the root layout so other pages don't preload it
+const micro5 = Micro_5({
+	weight: "400",
+	subsets: ["latin"],
+	variable: "--font-micro5",
+	display: "swap",
+});
 
 export const metadata: Metadata = {
 	title: "About",
@@ -37,7 +46,7 @@ export default function TeamPage() {
 	const people = getAllPeople();
 
 	return (
-		<main className="relative min-h-screen bg-background">
+		<main className={`relative min-h-screen bg-background ${micro5.variable}`}>
 			<div className="max-w-5xl mx-auto px-6 py-24 md:py-32">
 				{/* Header Section */}
 				<section className="mb-20 md:mb-28">

--- a/apps/marketing/src/components/CookieConsent/CookieConsent.tsx
+++ b/apps/marketing/src/components/CookieConsent/CookieConsent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Button } from "@superset/ui/button";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import Link from "next/link";
-import posthog from "posthog-js";
 import { useEffect, useState } from "react";
 
+import { withPosthog } from "@/lib/analytics/lazy";
 import { ANALYTICS_CONSENT_KEY } from "@/lib/constants";
 
 export function CookieConsent() {
@@ -21,19 +21,19 @@ export function CookieConsent() {
 	const handleAccept = () => {
 		localStorage.setItem(ANALYTICS_CONSENT_KEY, "accepted");
 		setShowBanner(false);
-		posthog.opt_in_capturing();
+		withPosthog((posthog) => posthog.opt_in_capturing());
 	};
 
 	const handleOptOut = () => {
 		localStorage.setItem(ANALYTICS_CONSENT_KEY, "declined");
-		posthog.opt_out_capturing();
+		withPosthog((posthog) => posthog.opt_out_capturing());
 		setShowBanner(false);
 	};
 
 	return (
 		<AnimatePresence>
 			{showBanner && (
-				<motion.div
+				<m.div
 					initial={{ y: 20, opacity: 0 }}
 					animate={{ y: 0, opacity: 1 }}
 					exit={{ y: 20, opacity: 0 }}
@@ -56,7 +56,7 @@ export function CookieConsent() {
 							</Button>
 						</div>
 					</div>
-				</motion.div>
+				</m.div>
 			)}
 		</AnimatePresence>
 	);

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -1,57 +1,108 @@
-import * as Sentry from "@sentry/nextjs";
 import { POSTHOG_COOKIE_NAME } from "@superset/shared/constants";
-import {
-	SENTRY_DENY_URLS,
-	SENTRY_IGNORE_ERRORS,
-} from "@superset/shared/sentry";
-import posthog from "posthog-js";
 
 import { env } from "@/env";
+import { setPosthogInstance } from "@/lib/analytics/lazy";
 import { ANALYTICS_CONSENT_KEY } from "@/lib/constants";
 
-posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
-	api_host: "/ingest",
-	ui_host: "https://us.posthog.com",
-	defaults: "2025-11-30",
-	capture_pageview: "history_change",
-	capture_pageleave: true,
-	capture_exceptions: true,
-	debug: false,
-	cross_subdomain_cookie: true,
-	person_profiles: "always",
-	persistence: "cookie",
-	persistence_name: POSTHOG_COOKIE_NAME,
-	disable_session_recording: true,
-	loaded: (posthog) => {
-		const consent = localStorage.getItem(ANALYTICS_CONSENT_KEY);
-		if (consent === "declined") {
-			posthog.opt_out_capturing();
-		}
-	},
-});
+// posthog-js and @sentry/nextjs together add ~200KiB to the initial bundle,
+// which tanks the Lighthouse LCP on throttled mobile. Both are dynamically
+// imported once the page has loaded (or on first interaction, whichever comes
+// first) so they stay off the critical rendering path. Analytics calls made
+// before then are queued via withPosthog().
 
-posthog.register({
-	app_name: "marketing",
-	domain: window.location.hostname,
-});
+type SentryClient = typeof import("@sentry/nextjs");
 
-Sentry.init({
-	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
-	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
-	replaysSessionSampleRate: 0,
-	replaysOnErrorSampleRate: 0,
-	sendDefaultPii: true,
-	integrations: [
-		Sentry.thirdPartyErrorFilterIntegration({
-			filterKeys: ["superset-marketing"],
-			behaviour: "drop-error-if-exclusively-contains-third-party-frames",
-		}),
-	],
-	ignoreErrors: SENTRY_IGNORE_ERRORS,
-	denyUrls: SENTRY_DENY_URLS,
-	debug: false,
-});
+let sentryClient: SentryClient | null = null;
+let started = false;
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+async function initPosthog() {
+	const { default: posthog } = await import("posthog-js");
+
+	posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
+		api_host: "/ingest",
+		ui_host: "https://us.posthog.com",
+		defaults: "2025-11-30",
+		capture_pageview: "history_change",
+		capture_pageleave: true,
+		capture_exceptions: true,
+		debug: false,
+		cross_subdomain_cookie: true,
+		person_profiles: "always",
+		persistence: "cookie",
+		persistence_name: POSTHOG_COOKIE_NAME,
+		disable_session_recording: true,
+		loaded: (posthog) => {
+			const consent = localStorage.getItem(ANALYTICS_CONSENT_KEY);
+			if (consent === "declined") {
+				posthog.opt_out_capturing();
+			}
+		},
+	});
+
+	posthog.register({
+		app_name: "marketing",
+		domain: window.location.hostname,
+	});
+
+	setPosthogInstance(posthog);
+}
+
+async function initSentry() {
+	const [Sentry, { SENTRY_DENY_URLS, SENTRY_IGNORE_ERRORS }] =
+		await Promise.all([
+			import("@sentry/nextjs"),
+			import("@superset/shared/sentry"),
+		]);
+
+	Sentry.init({
+		dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
+		environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+		enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
+		tracesSampleRate: 0.01,
+		replaysSessionSampleRate: 0,
+		replaysOnErrorSampleRate: 0,
+		sendDefaultPii: true,
+		integrations: [
+			Sentry.thirdPartyErrorFilterIntegration({
+				filterKeys: ["superset-marketing"],
+				behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+			}),
+		],
+		ignoreErrors: SENTRY_IGNORE_ERRORS,
+		denyUrls: SENTRY_DENY_URLS,
+		debug: false,
+	});
+
+	sentryClient = Sentry;
+}
+
+function start() {
+	if (started) return;
+	started = true;
+	void initPosthog();
+	void initSentry();
+}
+
+function scheduleIdle() {
+	if ("requestIdleCallback" in window) {
+		requestIdleCallback(start, { timeout: 3000 });
+	} else {
+		setTimeout(start, 1500);
+	}
+}
+
+if (document.readyState === "complete") {
+	scheduleIdle();
+} else {
+	window.addEventListener("load", scheduleIdle, { once: true });
+}
+// Don't lose events from visitors who interact before the idle load fires
+window.addEventListener("pointerdown", start, { once: true, capture: true });
+window.addEventListener("keydown", start, { once: true, capture: true });
+
+export function onRouterTransitionStart(
+	href: string,
+	navigationType: string,
+): void {
+	sentryClient?.captureRouterTransitionStart(href, navigationType);
+}

--- a/apps/marketing/src/lib/analytics/index.ts
+++ b/apps/marketing/src/lib/analytics/index.ts
@@ -1,5 +1,4 @@
-import posthog from "posthog-js";
-
+import { withPosthog } from "./lazy";
 import { trackReddit } from "./reddit";
 
 /**
@@ -16,7 +15,7 @@ export function track(
 	event: string,
 	properties?: Record<string, unknown>,
 ): void {
-	posthog.capture(event, properties);
+	withPosthog((posthog) => posthog.capture(event, properties));
 
 	const redditEvent = REDDIT_EVENT_MAP[event];
 	if (redditEvent) {

--- a/apps/marketing/src/lib/analytics/lazy.ts
+++ b/apps/marketing/src/lib/analytics/lazy.ts
@@ -1,0 +1,27 @@
+import type { PostHog } from "posthog-js";
+
+type PosthogCallback = (posthog: PostHog) => void;
+
+let instance: PostHog | null = null;
+const queue: PosthogCallback[] = [];
+
+/**
+ * Runs the callback with the PostHog instance once it has loaded. posthog-js
+ * is dynamically imported after page load (see instrumentation-client.ts) so
+ * it stays off the critical rendering path; calls made before then are queued
+ * and flushed in order when it arrives.
+ */
+export function withPosthog(callback: PosthogCallback): void {
+	if (instance) {
+		callback(instance);
+	} else {
+		queue.push(callback);
+	}
+}
+
+export function setPosthogInstance(posthog: PostHog): void {
+	instance = posthog;
+	for (const callback of queue.splice(0)) {
+		callback(posthog);
+	}
+}


### PR DESCRIPTION
## Summary

Homepage was the one Lighthouse category not at 100 (Performance 79 in the report, 75 reproducible locally). The failing metric was LCP alone — everything else was already ~1.0. This PR removes ~500KiB from the critical rendering path with no visual or functional change:

- **Fonts (~150KiB)**: `geist/font/pixel` instantiates all five GeistPixel faces at module scope, so importing two preloaded five files — and none were used anywhere. Pixelify Sans was also unused. Both removed; Micro5 moved into `/team` (its only consumer). IBM Plex Mono keeps `display: swap` but drops preload since it's not the LCP font.
- **Analytics (~204KiB)**: posthog-js + Sentry were the largest initial chunk via `instrumentation-client.ts`. Both now dynamic-import after window load (or first interaction, whichever comes first); call sites queue through `lib/analytics/lazy` `withPosthog()` so no events are lost. Unused `PostHogProvider` removed.
- **Ad pixels (~175KiB)**: gtag + Reddit pixel moved `afterInteractive` → `lazyOnload`.
- **framer-motion**: switched to `LazyMotion` + `m.*` app-wide; the animation feature bundle loads as an async chunk.

## Results (CDP-attached Lighthouse, prod build, medians of repeated runs)

| | before | after |
|---|---|---|
| Mobile simulated | 75 | **82** (stable ×3) |
| Desktop | 98 | **100** |
| Mobile devtools-throttled (real UX) | — | **94–97**, LCP 1.9s |

Note: simulated-mobile on prod swings 78–93 run-to-run on identical code (Lantern extrapolates from the observed trace), so judge post-deploy PSI by median of several runs. Remaining gap to a guaranteed 90 is structural (React hydration payload counted against LCP by the simulator); closing it needs design trade-offs (Inter `opsz`, de-hydrating the hero).

## Verification
- Analytics confirmed firing in Lighthouse traces: posthog `/ingest/e/`, Reddit PageVisit, gtag conversion
- All 12 top-level routes 200 on the prod build; homepage + /team screenshots visually unchanged (typewriter, boids, mockup, Micro5 on /team)
- Best Practices 77 on this Lighthouse version is identical on unchanged prod (ad-pixel third-party cookies etc.) — pre-existing, not from this PR
- lint + typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers analytics (`posthog-js` and `@sentry/nextjs`), ad pixels, and `framer-motion` features and removes unused fonts to cut critical‑path payload and improve LCP. Previously these assets loaded before first paint; now they load after window load or first interaction, with early analytics calls queued, raising Lighthouse Performance without visual changes.

**Migration and review notes**
- Do not import `posthog-js` directly. Use `track()` and `withPosthog(callback)` from `lib/analytics`; analytics initialize lazily in `instrumentation-client.ts`. Remove/avoid `PostHogProvider`.
- Use `m.*` instead of `motion.*` and keep the app wrapped in `<LazyMotion>` (configured in `providers.tsx`) so the `framer-motion` feature bundle loads async.
- Fonts: `Micro_5` is now loaded only on `/team`. Import any non‑LCP fonts per page as needed; `IBM Plex Mono` remains but is not preloaded. Do not reintroduce font preloads for non‑LCP text.
- Ad/marketing tags use `lazyOnload`. Apply the same strategy for new tags.
- Use `onRouterTransitionStart()` from `instrumentation-client` if needed; it no‑ops until Sentry initializes.

<sup>Written for commit a1f72875ebe1da1b64e8e452167cfdd5df138503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved marketing-page loading by deferring animation features, analytics, advertising, and error monitoring until needed.
  * Reduced unnecessary font preloading and optimized page resource usage.

* **Analytics**
  * Improved reliability of signup and cookie-consent tracking, including support for visitors who previously opted out.

* **Visual Experience**
  * Preserved existing animations, FAQ interactions, demonstrations, navigation, and page content without changing their appearance or behavior.

* **Typography**
  * Updated the team page to load and apply its intended display font.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->