### PR TITLE
fix(cli,host-service): surface host cloud-registration failures instead of silent "Not found"

### DIFF
--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -1,9 +1,9 @@
-import * as fs from "node:fs";
 import { createServer } from "node:net";
-import path from "node:path";
 
-/** Rotate per-org host-service.log once it exceeds this size. */
-export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
+export {
+	MAX_HOST_LOG_BYTES,
+	openRotatingLogFd,
+} from "@superset/shared/rotating-log";
 
 // Before the server becomes reachable, startup must still clear DB migrate and
 // the daemon bootstrap (the shell-env snapshot now runs in the background, off
@@ -15,40 +15,6 @@ export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 export const HEALTH_POLL_TIMEOUT_MS = 30_000;
 
 const HEALTH_POLL_INTERVAL_MS = 200;
-
-/**
- * Open an append-mode log fd, truncating first if it exceeds maxBytes.
- * Returns -1 on failure so callers can fall back to ignoring child stdio.
- */
-export function openRotatingLogFd(logPath: string, maxBytes: number): number {
-	try {
-		fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o700 });
-		if (fs.existsSync(logPath)) {
-			try {
-				const { size } = fs.statSync(logPath);
-				if (size > maxBytes) {
-					fs.writeFileSync(logPath, "", { mode: 0o600 });
-				}
-			} catch {
-				// Best-effort rotate
-			}
-		}
-		const fd = fs.openSync(logPath, "a", 0o600);
-		// openSync's mode arg only applies on create — normalize an existing
-		// file's perms in case it was rotated out-of-band with laxer bits.
-		try {
-			fs.chmodSync(logPath, 0o600);
-		} catch (error) {
-			console.warn(
-				`[host-service] Failed to chmod log file ${logPath}: ${error}`,
-			);
-		}
-		return fd;
-	} catch (error) {
-		console.warn(`[host-service] Failed to open log file ${logPath}: ${error}`);
-		return -1;
-	}
-}
 
 export async function findFreePort(
 	preferredPorts: Iterable<number> = [],

--- a/packages/cli-framework/src/runner.test.ts
+++ b/packages/cli-framework/src/runner.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { CLIError } from "./errors";
+import { formatError } from "./runner";
+
+function trpcError(code: string, message: string): Error {
+	const error = new Error(message) as Error & { data?: { code?: string } };
+	error.data = { code };
+	return error;
+}
+
+describe("formatError", () => {
+	it("keeps the server message for NOT_FOUND", () => {
+		const result = formatError(
+			trpcError(
+				"NOT_FOUND",
+				"Host abc123 is not registered in this organization",
+			),
+			"superset",
+		);
+		expect(result.message).toBe(
+			"Host abc123 is not registered in this organization",
+		);
+	});
+
+	it("falls back to generic text when NOT_FOUND has no message", () => {
+		const result = formatError(trpcError("NOT_FOUND", ""), "superset");
+		expect(result.message).toBe("Not found");
+	});
+
+	it("maps UNAUTHORIZED to a login hint", () => {
+		const result = formatError(trpcError("UNAUTHORIZED", "nope"), "superset");
+		expect(result.message).toBe("Session expired");
+		expect(result.hint).toBe("Run: superset auth login");
+	});
+
+	it("passes CLIError message and suggestion through", () => {
+		const result = formatError(
+			new CLIError("This machine isn't registered", "Run: superset start"),
+			"superset",
+		);
+		expect(result.message).toBe("This machine isn't registered");
+		expect(result.hint).toBe("Run: superset start");
+	});
+});

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -70,11 +70,13 @@ function formatZodIssues(message: string): string | null {
 	return lines.join("\n");
 }
 
-function handleError(error: unknown, cliName: string): never {
+/** Exported for tests. */
+export function formatError(
+	error: unknown,
+	cliName: string,
+): { message: string; hint?: string } {
 	if (error instanceof CLIError) {
-		process.stderr.write(`Error: ${error.message}\n`);
-		if (error.suggestion) process.stderr.write(`Hint: ${error.suggestion}\n`);
-		process.exit(1);
+		return { message: error.message, hint: error.suggestion };
 	}
 	if (error instanceof Error) {
 		const trpcError = error as Error & {
@@ -83,25 +85,33 @@ function handleError(error: unknown, cliName: string): never {
 		};
 		const code = trpcError.data?.code ?? trpcError.code;
 		if (code === "UNAUTHORIZED") {
-			process.stderr.write(
-				`Error: Session expired\nHint: Run: ${cliName} auth login\n`,
-			);
-		} else if (code === "NOT_FOUND") {
-			process.stderr.write("Error: Not found\n");
-		} else if (
-			code === "FETCH_ERROR" ||
-			error.message.includes("fetch failed")
-		) {
-			process.stderr.write(
-				"Error: Could not connect to API\nHint: Is the API running?\n",
-			);
-		} else {
-			const formatted = formatZodIssues(error.message);
-			process.stderr.write(`Error: ${formatted ?? error.message}\n`);
+			return {
+				message: "Session expired",
+				hint: `Run: ${cliName} auth login`,
+			};
 		}
-		process.exit(1);
+		if (code === "NOT_FOUND") {
+			// The server's message names the missing resource ("Host not
+			// found") — blanking it left users with no way to tell which of
+			// several ids a command resolves was rejected (issue #6415).
+			return { message: error.message || "Not found" };
+		}
+		if (code === "FETCH_ERROR" || error.message.includes("fetch failed")) {
+			return {
+				message: "Could not connect to API",
+				hint: "Is the API running?",
+			};
+		}
+		const formatted = formatZodIssues(error.message);
+		return { message: formatted ?? error.message };
 	}
-	process.stderr.write(`Error: ${String(error)}\n`);
+	return { message: String(error) };
+}
+
+function handleError(error: unknown, cliName: string): never {
+	const { message, hint } = formatError(error, cliName);
+	process.stderr.write(`Error: ${message}\n`);
+	if (hint) process.stderr.write(`Hint: ${hint}\n`);
 	process.exit(1);
 }
 

--- a/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { CLIError } from "@superset/cli-framework";
+import { getHostId } from "@superset/shared/host-info";
+import type { ApiClient } from "../../lib/api-client";
+import { resolveAutomationTarget } from "./resolveAutomationTarget";
+
+function apiWithHosts(hostIds: string[]): ApiClient {
+	return {
+		host: {
+			list: {
+				query: async () => hostIds.map((id) => ({ id, name: id })),
+			},
+		},
+	} as unknown as ApiClient;
+}
+
+const BASE = {
+	organizationId: "org-1",
+	userJwt: "jwt",
+};
+
+describe("resolveAutomationTarget host preflight", () => {
+	it("rejects session mode when this machine is not registered", async () => {
+		await expect(
+			resolveAutomationTarget({ ...BASE, api: apiWithHosts([]) }),
+		).rejects.toThrow(CLIError);
+		await expect(
+			resolveAutomationTarget({ ...BASE, api: apiWithHosts([]) }),
+		).rejects.toThrow(/isn't registered with the cloud/);
+	});
+
+	it("rejects an explicit --host that is not registered", async () => {
+		await expect(
+			resolveAutomationTarget({
+				...BASE,
+				api: apiWithHosts(["some-other-host"]),
+				hostId: "missing-host",
+			}),
+		).rejects.toThrow(/Host missing-host is not registered/);
+	});
+
+	it("allows session mode when this machine is registered", async () => {
+		const target = await resolveAutomationTarget({
+			...BASE,
+			api: apiWithHosts([getHostId()]),
+		});
+		expect(target).toEqual({
+			targetHostId: getHostId(),
+			v2ProjectId: null,
+		});
+	});
+});

--- a/packages/cli/src/commands/automations/resolveAutomationTarget.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.ts
@@ -21,6 +21,25 @@ export async function resolveAutomationTarget(args: {
 }): Promise<{ targetHostId: string; v2ProjectId: string | null }> {
 	const targetHostId = args.hostId ?? getHostId();
 
+	// The cloud rejects automations whose target host has no v2Hosts row
+	// (the host-service registers one at startup, and that registration can
+	// fail silently — issue #6415). Catch it here, where the user can act
+	// on it, instead of surfacing a bare 404 from the API. This guards
+	// every mode, including session mode, which needs no other cloud data.
+	const hosts = await args.api.host.list.query({
+		organizationId: args.organizationId,
+	});
+	if (!hosts.some((host) => host.id === targetHostId)) {
+		throw new CLIError(
+			args.hostId
+				? `Host ${targetHostId} is not registered in this organization`
+				: `This machine (host ${targetHostId}) isn't registered with the cloud`,
+			args.hostId
+				? "Run: superset hosts list"
+				: "Restart the host service (superset stop && superset start), then check: superset hosts list",
+		);
+	}
+
 	if (args.workspaceId) {
 		const { workspace } = await findWorkspaceOnHost(
 			{

--- a/packages/cli/src/commands/status/command.ts
+++ b/packages/cli/src/commands/status/command.ts
@@ -17,14 +17,13 @@ async function checkHealth(
 	endpoint: string,
 	authToken: string,
 ): Promise<HealthResult> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 2_000);
 	try {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 2_000);
 		const res = await fetch(`${endpoint}/trpc/health.check`, {
 			signal: controller.signal,
 			headers: { Authorization: `Bearer ${authToken}` },
 		});
-		clearTimeout(timeout);
 		if (!res.ok) return { healthy: false };
 		const body = (await res.json()) as {
 			result?: { data?: { json?: Record<string, unknown> } };
@@ -43,6 +42,8 @@ async function checkHealth(
 		};
 	} catch {
 		return { healthy: false };
+	} finally {
+		clearTimeout(timeout);
 	}
 }
 

--- a/packages/cli/src/commands/status/command.ts
+++ b/packages/cli/src/commands/status/command.ts
@@ -6,10 +6,17 @@ import { command } from "../../lib/command";
 import { isProcessAlive, readManifest } from "../../lib/host/manifest";
 import { resolveOrganizationFromContext } from "../../lib/resolve-org";
 
+type HealthResult = {
+	healthy: boolean;
+	/** undefined = host-service predates the field (pre-#6415). */
+	cloudRegistered?: boolean;
+	registrationError?: string | null;
+};
+
 async function checkHealth(
 	endpoint: string,
 	authToken: string,
-): Promise<boolean> {
+): Promise<HealthResult> {
 	try {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), 2_000);
@@ -18,9 +25,24 @@ async function checkHealth(
 			headers: { Authorization: `Bearer ${authToken}` },
 		});
 		clearTimeout(timeout);
-		return res.ok;
+		if (!res.ok) return { healthy: false };
+		const body = (await res.json()) as {
+			result?: { data?: { json?: Record<string, unknown> } };
+		};
+		const payload = body.result?.data?.json;
+		return {
+			healthy: true,
+			cloudRegistered:
+				typeof payload?.cloudRegistered === "boolean"
+					? payload.cloudRegistered
+					: undefined,
+			registrationError:
+				typeof payload?.registrationError === "string"
+					? payload.registrationError
+					: undefined,
+		};
 	} catch {
-		return false;
+		return { healthy: false };
 	}
 }
 
@@ -28,12 +50,14 @@ async function fetchHostName(
 	api: ApiClient,
 	organizationId: string,
 	hostId: string,
-): Promise<string | null> {
+): Promise<{ name: string | null; listed: boolean | null }> {
 	try {
 		const hosts = await api.host.list.query({ organizationId });
-		return hosts.find((host) => host.id === hostId)?.name ?? null;
+		const host = hosts.find((row) => row.id === hostId);
+		return { name: host?.name ?? null, listed: !!host };
 	} catch {
-		return null;
+		// API unreachable — unknown, not evidence of a missing registration.
+		return { name: null, listed: null };
 	}
 }
 
@@ -77,27 +101,45 @@ export default command({
 			};
 		}
 
-		const [healthy, hostName] = await Promise.all([
+		const [health, cloudHost] = await Promise.all([
 			checkHealth(manifest.endpoint, manifest.authToken),
 			fetchHostName(ctx.api, organization.id, localHostId),
 		]);
 		const uptime = formatDistanceToNowStrict(new Date(manifest.startedAt));
 
+		// A running host that isn't cloud-registered is invisible to hosts
+		// list/automations while every local check passes (#6415). Trust the
+		// host-service's own registration state when it reports one; fall
+		// back to the cloud host list for older host-services.
+		const cloudRegistered =
+			health.cloudRegistered ??
+			(cloudHost.listed === null ? undefined : cloudHost.listed);
+		const registrationWarning =
+			health.healthy && cloudRegistered === false
+				? `\nWarning: not registered with the cloud for ${organization.name}${
+						health.registrationError ? ` (${health.registrationError})` : ""
+					} — hosts list and automations won't see this machine\nHint: check host-service.log; registration retries automatically, or run: superset stop && superset start`
+				: "";
+
 		return {
 			data: {
 				running: true,
-				healthy,
+				healthy: health.healthy,
 				pid: manifest.pid,
 				port: Number.parseInt(new URL(manifest.endpoint).port || "0", 10),
 				endpoint: manifest.endpoint,
 				organizationId: organization.id,
 				hostId: localHostId,
-				hostName,
+				hostName: cloudHost.name,
+				...(cloudRegistered === undefined ? {} : { cloudRegistered }),
+				...(health.registrationError
+					? { registrationError: health.registrationError }
+					: {}),
 				uptimeSec: Math.floor((Date.now() - manifest.startedAt) / 1000),
 			},
-			message: `${organization.name}: ${hostName ? `${hostName} (${localHostId.slice(0, 8)}…)` : `host ${localHostId.slice(0, 8)}…`} running (pid ${manifest.pid}, up ${uptime})${
-				healthy ? "" : " — not responding to health check"
-			}`,
+			message: `${organization.name}: ${cloudHost.name ? `${cloudHost.name} (${localHostId.slice(0, 8)}…)` : `host ${localHostId.slice(0, 8)}…`} running (pid ${manifest.pid}, up ${uptime})${
+				health.healthy ? "" : " — not responding to health check"
+			}${registrationWarning}`,
 		};
 	},
 });

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -1,11 +1,16 @@
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { existsSync } from "node:fs";
+import { closeSync, existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
+import {
+	MAX_HOST_LOG_BYTES,
+	openRotatingLogFd,
+} from "@superset/shared/rotating-log";
 import type { ApiClient } from "../api-client";
 import { env } from "../env";
 import {
+	ensureManifestDir,
 	type HostServiceManifest,
 	hostDbPath,
 	writeManifest,
@@ -104,8 +109,21 @@ export async function spawnHostService(
 	const migrationsFolder = resolveMigrationsFolder();
 	const relayUrl = await getRelayUrl(options.api);
 
+	// Daemon output goes to the same per-org host-service.log the desktop
+	// writes — with stdio ignored, a failed cloud registration was logged
+	// nowhere on CLI-only installs (issue #6415).
+	const logFd = options.daemon
+		? openRotatingLogFd(
+				join(ensureManifestDir(options.organizationId), "host-service.log"),
+				MAX_HOST_LOG_BYTES,
+			)
+		: -1;
 	const child = spawn(hostBin, [], {
-		stdio: options.daemon ? "ignore" : "inherit",
+		stdio: options.daemon
+			? logFd === -1
+				? "ignore"
+				: ["ignore", logFd, logFd]
+			: "inherit",
 		detached: options.daemon,
 		env: {
 			...process.env,
@@ -123,6 +141,12 @@ export async function spawnHostService(
 			HOST_MIGRATIONS_FOLDER: migrationsFolder,
 		},
 	});
+
+	if (logFd !== -1) {
+		try {
+			closeSync(logFd);
+		} catch {}
+	}
 
 	if (!child.pid) {
 		throw new Error("Failed to spawn host-service");

--- a/packages/host-service/src/trpc/router/health/health.ts
+++ b/packages/host-service/src/trpc/router/health/health.ts
@@ -1,7 +1,16 @@
+import { getRegistrationState } from "../../../tunnel/registration-state";
 import { publicProcedure, router } from "../../index";
 
 export const healthRouter = router({
 	check: publicProcedure.query(() => {
-		return { status: "ok" as const };
+		// A locally-healthy host that failed cloud registration is invisible
+		// to hosts list/automations with no symptom of its own — expose the
+		// registration outcome so `superset status` can report it (#6415).
+		const registration = getRegistrationState();
+		return {
+			status: "ok" as const,
+			cloudRegistered: registration.registered,
+			registrationError: registration.lastError,
+		};
 	}),
 });

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -2,6 +2,10 @@ import { getHostId, getHostName } from "@superset/shared/host-info";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { JwtApiAuthProvider } from "../providers/auth/JwtAuthProvider/JwtAuthProvider";
 import type { ApiClient } from "../types";
+import {
+	recordRegistrationFailure,
+	recordRegistrationSuccess,
+} from "./registration-state";
 import { TunnelClient } from "./tunnel-client";
 import { TunnelClientV2 } from "./tunnel-client-v2";
 
@@ -58,38 +62,57 @@ async function detectRelayProto(relayUrl: string): Promise<1 | 2> {
 	return 1;
 }
 
+const REGISTER_RETRY_BASE_MS = 30_000;
+const REGISTER_RETRY_MAX_MS = 5 * 60_000;
+
 export async function connectRelay(
 	options: ConnectRelayOptions,
 ): Promise<TunnelClient | TunnelClientV2 | null> {
-	try {
-		const host = await options.api.host.ensure.mutate({
-			organizationId: options.organizationId,
-			machineId: getHostId(),
-			name: getHostName(),
-		});
-		console.log(`[host-service] registered as host ${host.machineId}`);
+	// Registration is what makes this host exist server-side (hosts list,
+	// automations, relay routing). A one-shot attempt left a transient API
+	// failure at boot permanently stranding the host as locally-healthy but
+	// cloud-invisible (issue #6415) — so retry with backoff until it lands,
+	// and record the outcome where health.check can report it.
+	for (let attempt = 0; ; attempt++) {
+		try {
+			const host = await options.api.host.ensure.mutate({
+				organizationId: options.organizationId,
+				machineId: getHostId(),
+				name: getHostName(),
+			});
+			recordRegistrationSuccess();
+			console.log(`[host-service] registered as host ${host.machineId}`);
 
-		const relayUrl = await resolveRelayUrl(options.api, options.relayUrl);
-		console.log(`[host-service] relay: ${relayUrl}`);
+			const relayUrl = await resolveRelayUrl(options.api, options.relayUrl);
+			console.log(`[host-service] relay: ${relayUrl}`);
 
-		const clientOptions = {
-			relayUrl,
-			hostId: buildHostRoutingKey(options.organizationId, host.machineId),
-			getAuthToken: () => options.authProvider.getJwt(),
-			localPort: options.localPort,
-			hostServiceSecret: options.hostServiceSecret,
-		};
+			const clientOptions = {
+				relayUrl,
+				hostId: buildHostRoutingKey(options.organizationId, host.machineId),
+				getAuthToken: () => options.authProvider.getJwt(),
+				localPort: options.localPort,
+				hostServiceSecret: options.hostServiceSecret,
+			};
 
-		const proto = await detectRelayProto(relayUrl);
-		console.log(`[host-service] relay protocol: v${proto}`);
-		const tunnel =
-			proto === 2
-				? new TunnelClientV2(clientOptions)
-				: new TunnelClient(clientOptions);
-		void tunnel.connect();
-		return tunnel;
-	} catch (error) {
-		console.error("[host-service] failed to register/connect relay:", error);
-		return null;
+			const proto = await detectRelayProto(relayUrl);
+			console.log(`[host-service] relay protocol: v${proto}`);
+			const tunnel =
+				proto === 2
+					? new TunnelClientV2(clientOptions)
+					: new TunnelClient(clientOptions);
+			void tunnel.connect();
+			return tunnel;
+		} catch (error) {
+			recordRegistrationFailure(error);
+			const delay = Math.min(
+				REGISTER_RETRY_BASE_MS * 2 ** attempt,
+				REGISTER_RETRY_MAX_MS,
+			);
+			console.error(
+				`[host-service] failed to register/connect relay (retrying in ${Math.round(delay / 1000)}s):`,
+				error,
+			);
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
 	}
 }

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -112,7 +112,9 @@ export async function connectRelay(
 				`[host-service] failed to register/connect relay (retrying in ${Math.round(delay / 1000)}s):`,
 				error,
 			);
-			await new Promise((resolve) => setTimeout(resolve, delay));
+			// unref: the HTTP server keeps the process alive between retries;
+			// this timer must not stall shutdown once the server closes.
+			await new Promise((resolve) => setTimeout(resolve, delay).unref());
 		}
 	}
 }

--- a/packages/host-service/src/tunnel/registration-state.ts
+++ b/packages/host-service/src/tunnel/registration-state.ts
@@ -1,0 +1,36 @@
+/**
+ * Cloud-registration state for this host-service instance.
+ *
+ * `host.ensure` is the only thing that makes this host visible server-side
+ * (hosts list, automations, relay routing). When it fails the service keeps
+ * serving locally and looks healthy, so the failure must be queryable —
+ * health.check exposes this state and `superset status` reports it
+ * (issue #6415).
+ */
+export type RegistrationState = {
+	registered: boolean;
+	lastError: string | null;
+	lastAttemptAt: number | null;
+};
+
+const state: RegistrationState = {
+	registered: false,
+	lastError: null,
+	lastAttemptAt: null,
+};
+
+export function getRegistrationState(): RegistrationState {
+	return { ...state };
+}
+
+export function recordRegistrationSuccess(): void {
+	state.registered = true;
+	state.lastError = null;
+	state.lastAttemptAt = Date.now();
+}
+
+export function recordRegistrationFailure(error: unknown): void {
+	state.registered = false;
+	state.lastError = error instanceof Error ? error.message : String(error);
+	state.lastAttemptAt = Date.now();
+}

--- a/packages/host-service/test/integration/smoke.integration.test.ts
+++ b/packages/host-service/test/integration/smoke.integration.test.ts
@@ -15,12 +15,20 @@ describe("host-service smoke", () => {
 
 	test("health.check returns ok without auth", async () => {
 		const result = await host.unauthenticatedTrpc.health.check.query();
-		expect(result).toEqual({ status: "ok" });
+		expect(result).toEqual({
+			status: "ok",
+			cloudRegistered: false,
+			registrationError: null,
+		});
 	});
 
 	test("health.check returns ok with auth", async () => {
 		const result = await host.trpc.health.check.query();
-		expect(result).toEqual({ status: "ok" });
+		expect(result).toEqual({
+			status: "ok",
+			cloudRegistered: false,
+			registrationError: null,
+		});
 	});
 
 	test("protected procedure rejects requests without bearer token", async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -132,6 +132,10 @@
 			"types": "./src/host-info.ts",
 			"default": "./src/host-info.ts"
 		},
+		"./rotating-log": {
+			"types": "./src/rotating-log.ts",
+			"default": "./src/rotating-log.ts"
+		},
 		"./host-routing": {
 			"types": "./src/host-routing.ts",
 			"default": "./src/host-routing.ts"

--- a/packages/shared/src/rotating-log.ts
+++ b/packages/shared/src/rotating-log.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+import path from "node:path";
+
+/** Rotate per-org host-service.log once it exceeds this size. */
+export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Open an append-mode log fd, truncating first if it exceeds maxBytes.
+ * Returns -1 on failure so callers can fall back to ignoring child stdio.
+ */
+export function openRotatingLogFd(logPath: string, maxBytes: number): number {
+	try {
+		fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o700 });
+		if (fs.existsSync(logPath)) {
+			try {
+				const { size } = fs.statSync(logPath);
+				if (size > maxBytes) {
+					fs.writeFileSync(logPath, "", { mode: 0o600 });
+				}
+			} catch {
+				// Best-effort rotate
+			}
+		}
+		const fd = fs.openSync(logPath, "a", 0o600);
+		// openSync's mode arg only applies on create — normalize an existing
+		// file's perms in case it was rotated out-of-band with laxer bits.
+		try {
+			fs.chmodSync(logPath, 0o600);
+		} catch (error) {
+			console.warn(
+				`[host-service] Failed to chmod log file ${logPath}: ${error}`,
+			);
+		}
+		return fd;
+	} catch (error) {
+		console.warn(`[host-service] Failed to open log file ${logPath}: ${error}`);
+		return -1;
+	}
+}

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -56,7 +56,7 @@ async function verifyHostAccess(
 	if (!host) {
 		throw new TRPCError({
 			code: "NOT_FOUND",
-			message: "Host not found",
+			message: `Host ${hostId} is not registered in this organization`,
 		});
 	}
 


### PR DESCRIPTION
Closes #6415.

## Problem

A host only becomes visible server-side via `host.ensure`, called once inside `connectRelay` at host-service boot. If that call failed (expired token, transient API failure, org mismatch), the failure was swallowed: the service kept running and passed local health checks, `superset hosts list` returned `[]`, and every `automations create` variant failed with a bare `Error: Not found` — the CLI blanked the server's `"Host not found"` message, and on CLI-only installs the daemon's stdio was ignored, so the registration error was recorded **nowhere**.

Full diagnosis + verified before/after repro: https://github.com/superset-sh/superset/issues/6415#issuecomment-5276360971

## Changes

**Make the failure self-diagnosing**
- `cli-framework/runner.ts`: NOT_FOUND now prints the server's message (extracted a testable `formatError`)
- `trpc verifyHostAccess`: NOT_FOUND message names the host — `Host <machineId> is not registered in this organization`
- `cli resolveAutomationTarget`: preflights the target host against `host.list` in **all** modes (including the session-mode early return that previously validated nothing) and raises a `CLIError` with a restart hint

**Stop registration failing silently**
- `host-service connectRelay`: retries `host.ensure` with capped backoff (30s → 5min, indefinitely) instead of one-shot; outcome recorded in a registration-state module
- `host-service health.check`: now returns `cloudRegistered` / `registrationError`
- `cli status`: warns when the host is running but not cloud-registered (falls back to the `host.list` lookup for older host-services)
- `cli spawn`: daemon stdio → per-org `host-service.log` (same rotation convention as desktop; `openRotatingLogFd` moved to `@superset/shared/rotating-log` and reused by both)

## Verification (E2E on the dev stack, isolated Neon branch)

Staged the reporter's exact state (deleted the `v2_hosts` row while the host-service kept running) and drove the real CLI + desktop UI over CDP:

- CLI session-mode create: `Error: This machine (host 300d922f…) isn't registered with the cloud` + `Hint: Restart the host service…` (was: `Error: Not found`)
- CLI `--host` create: `Error: Host 300d922f… is not registered in this organization` + `Hint: Run: superset hosts list`
- Desktop UI create (bypasses CLI preflight): server 404 body and inline dialog error both show the new named message
- Real built host-service (`ELECTRON_RUN_AS_NODE`) with an invalid token: logs `failed to register/connect relay (retrying in 30s): … Failed to mint JWT: 401`, `health.check` returns `{"cloudRegistered":false,"registrationError":"Failed to mint JWT: 401"}`
- `superset status` against that instance:
  ```
  Superset: Kiets-Spaceship (300d922f…) running (pid 75054, up 18 seconds)
  Warning: not registered with the cloud for Superset (Failed to mint JWT: 401) — hosts list and automations won't see this machine
  Hint: check host-service.log; registration retries automatically, or run: superset stop && superset start
  ```
- Daemon spawn with a stub binary: child stdout/stderr land in `~/.superset/host/<org>/host-service.log`
- Recovery: restored registration → the same create commands and the same UI dialog succeed

Tests: `formatError` unit tests (mutation-checked), `resolveAutomationTarget` preflight tests. `bun run typecheck` clean, `bun run lint` clean. Pre-existing `bun test packages/cli` failures (execFileSync mock leak) exist on `main` and are unrelated (5 fail on HEAD, 4 with this branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces host cloud-registration failures instead of a silent “Not found” and keeps retrying registration with backoff. Previously `host.ensure` failures were swallowed, the host looked healthy locally while `hosts list` returned `[]`, and `automations create` failed with a blank “Not found”; now the CLI prints the server message, status reports registration state, daemon output is logged, and the retry timer no longer delays shutdown.

- `@superset/cli-framework`: extracted `formatError`; stop blanking `NOT_FOUND` messages; add login hint for `UNAUTHORIZED`.
- `@superset/trpc`: `automation.verifyHostAccess` returns `NOT_FOUND` with `Host <id> is not registered in this organization`.
- `@superset/cli`: `resolveAutomationTarget` preflights host against `host.list` in all modes and raises a `CLIError` with restart guidance; `status` warns when running but not cloud-registered, falls back to `host.list` for older host-services, and clears the health-check timeout on errors.
- `@superset/host-service`: `connectRelay` retries `host.ensure` with capped backoff (30s → 5min) until success and unrefs the retry timer; track registration state; `health.check` returns `cloudRegistered` and `registrationError`.
- `@superset/shared`: new `@superset/shared/rotating-log` used by CLI daemon spawn to write stdout/stderr to per-org `host-service.log`; removes the duplicated desktop helper.
- Tests: unit tests for `formatError` and `resolveAutomationTarget` preflight; health smoke tests updated for new fields.

**Rollout**
- No migrations required. Ensure all apps consume `@superset/shared/rotating-log`.

<sup>Written for commit 061135e4a5eb09a8334727e2b53ff5738fe3a60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host services now retry cloud registration and relay connections automatically.
  * Added rotating daemon logs with size limits and secure file permissions.
  * Status checks now display cloud registration state and related errors.

* **Bug Fixes**
  * Automation commands verify host registration before resolving targets and provide clearer recovery guidance.
  * Host access errors now include the requested host identifier.

* **Improvements**
  * CLI errors provide more accurate messages, login guidance, and helpful hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->