### PR TITLE
feat(marketing): reposition hero around parallel-agents value prop and remove em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img width="full" alt="Claude and OpenCode working in parallel Superset workspaces with live diffs" src="apps/marketing/public/images/readme-hero.gif" />
 
-### The Code Editor for AI Agents
+### Run 100+ Coding Agents in Parallel
 
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
@@ -170,7 +170,7 @@ Jump to any workspace, action, or setting from one search box.
 
 **Also in the box:**
 
-- **[Built-in skills](https://docs.superset.sh/skills)**: agents come pre-loaded with `superset:*` skills — orchestrate parallel agents, schedule automations, file feedback, diagnose issues — provisioned automatically at launch
+- **[Built-in skills](https://docs.superset.sh/skills)**: agents come pre-loaded with `superset:*` skills (orchestrate parallel agents, schedule automations, file feedback, diagnose issues), provisioned automatically at launch
 - **[Model picker & custom agents](https://docs.superset.sh/agent-integration)**: choose a model and reasoning effort at launch, and add any terminal agent with its own icon
 - **[Workspace setup scripts](https://docs.superset.sh/setup-teardown-scripts)**: automate env setup, dependency installs, and dev servers per workspace
 - **[Terminal presets](https://docs.superset.sh/terminal-presets)**: save agent and shell layouts and open them with one keystroke

--- a/apps/marketing/content/blog/2026-08-orchestration-skill-outline.md
+++ b/apps/marketing/content/blog/2026-08-orchestration-skill-outline.md
@@ -13,7 +13,7 @@ Suggested frontmatter:
 
 ## 1. You became the orchestrator. That's the new bottleneck.
 
-- Callback to the February post ("You Don't Need Another AI Coding Agent — You
+- Callback to the February post ("You Don't Need Another AI Coding Agent: You
   Need an Orchestrator"): agents got good, the workflow around them didn't.
 - Superset solved the running-in-parallel half. The remaining half: a human
   still assigns tasks, checks panes, relays context between agents.

--- a/apps/marketing/content/blog/_archive/history-of-git-worktrees.mdx
+++ b/apps/marketing/content/blog/_archive/history-of-git-worktrees.mdx
@@ -59,4 +59,4 @@ When using worktrees for parallel development:
 
 ## Conclusion
 
-What started as a niche feature for advanced Git users has become essential infrastructure for the age of AI-assisted development. As coding agents become more capable, the ability to run them in parallel—powered by git worktrees—will only become more important.
+What started as a niche feature for advanced Git users has become essential infrastructure for the age of AI-assisted development. As coding agents become more capable, the ability to run them in parallel, powered by git worktrees, will only become more important.

--- a/apps/marketing/content/blog/agent-orchestration-not-another-agent.mdx
+++ b/apps/marketing/content/blog/agent-orchestration-not-another-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "You Don't Need Another AI Coding Agent — You Need an Orchestrator"
-description: "The AI coding tools landscape is flooded with agents. The real bottleneck isn't agent quality — it's managing multiple agents at scale. Here's why orchestration is the missing layer."
+title: "You Don't Need Another AI Coding Agent: You Need an Orchestrator"
+description: "The AI coding tools landscape is flooded with agents. The real bottleneck isn't agent quality. It's managing multiple agents at scale. Here's why orchestration is the missing layer."
 author: satya
 date: 2026-02-18
 category: Product
@@ -41,7 +41,7 @@ Running them one at a time means 50 tasks at 15 minutes each: over 12 hours. Run
 
 ### Isolation
 
-Two agents in the same directory destroy each other's work. You need filesystem-level isolation — each agent in its own working directory with its own branch. Git worktrees solve this elegantly, but setting them up manually for every task is tedious.
+Two agents in the same directory destroy each other's work. You need filesystem-level isolation: each agent in its own working directory with its own branch. Git worktrees solve this elegantly, but setting them up manually for every task is tedious.
 
 ### Session Management
 
@@ -75,11 +75,11 @@ Creating a task should automatically create a Git worktree and branch. No manual
 
 ### Session Persistence
 
-Agent sessions should survive crashes, app restarts, and laptop sleep cycles. A background daemon that owns the sessions independently of the UI solves this — the same pattern that tmux uses for terminal multiplexing, applied to agent orchestration.
+Agent sessions should survive crashes, app restarts, and laptop sleep cycles. A background daemon that owns the sessions independently of the UI solves this: the same pattern that tmux uses for terminal multiplexing, applied to agent orchestration.
 
 ### Agent Agnosticism
 
-Lock-in to a single agent is a strategic mistake. The AI landscape moves fast. Today's best agent might be tomorrow's second-best. An orchestrator should run any CLI-based agent — Claude Code, Codex, Aider, OpenCode, or whatever ships next week.
+Lock-in to a single agent is a strategic mistake. The AI landscape moves fast. Today's best agent might be tomorrow's second-best. An orchestrator should run any CLI-based agent: Claude Code, Codex, Aider, OpenCode, or whatever ships next week.
 
 ### Unified Review
 
@@ -87,13 +87,13 @@ All active tasks, their status, and their diffs should be visible in one place. 
 
 ### Editor Integration
 
-Developers have strong editor preferences. The orchestrator shouldn't force an editor choice. It should integrate with whatever you use — VS Code, Cursor, JetBrains, Xcode, Neovim — and let you open any worktree in your preferred environment.
+Developers have strong editor preferences. The orchestrator shouldn't force an editor choice. It should integrate with whatever you use (VS Code, Cursor, JetBrains, Xcode, Neovim) and let you open any worktree in your preferred environment.
 
 ---
 
 ## Building This at Superset
 
-We built [Superset](https://superset.sh) because we hit this ceiling ourselves. We were running Claude Code for everything — and it was great for individual tasks. But scaling to 5-7 agents manually was operational overhead that distracted from the actual work.
+We built [Superset](https://superset.sh) because we hit this ceiling ourselves. We were running Claude Code for everything, and it was great for individual tasks. But scaling to 5-7 agents manually was operational overhead that distracted from the actual work.
 
 The architecture is intentionally simple:
 
@@ -103,7 +103,7 @@ The architecture is intentionally simple:
 - **Built-in diff viewer** for fast review
 - **Editor integration** for deep inspection (VS Code, Cursor, JetBrains, Xcode)
 
-The orchestrator doesn't make agents smarter. It makes using agents at scale practical. That's the missing layer in most developers' AI workflows — not a better agent, but a better way to run the agents they already have.
+The orchestrator doesn't make agents smarter. It makes using agents at scale practical. That's the missing layer in most developers' AI workflows: not a better agent, but a better way to run the agents they already have.
 
 ---
 
@@ -111,10 +111,10 @@ The orchestrator doesn't make agents smarter. It makes using agents at scale pra
 
 Running parallel agents has a compound effect on productivity:
 
-1. **More tasks completed per day** — 5x agents means 5x throughput (minus review overhead)
-2. **Faster iteration** — while one agent iterates on feedback, others are working on new tasks
-3. **Better agent matching** — use the right agent for each task instead of one-size-fits-all
-4. **Reduced context switching** — tasks run to completion in isolation instead of being stashed and resumed
+1. **More tasks completed per day**: 5x agents means 5x throughput (minus review overhead)
+2. **Faster iteration**: while one agent iterates on feedback, others are working on new tasks
+3. **Better agent matching**: use the right agent for each task instead of one-size-fits-all
+4. **Reduced context switching**: tasks run to completion in isolation instead of being stashed and resumed
 
 The developers we work with who've adopted parallel agent workflows don't go back to single-agent work. The throughput difference is too large. The question shifts from "which agent should I use?" to "how many agents can I effectively manage?"
 

--- a/apps/marketing/content/blog/git-worktrees-history-deep-dive.mdx
+++ b/apps/marketing/content/blog/git-worktrees-history-deep-dive.mdx
@@ -9,7 +9,7 @@ relatedSlugs:
   - how-to-get-hit
 ---
 
-Git worktrees have been around since 2015. For most of that time, they were a curiosity — something kernel developers used, something that showed up in obscure Stack Overflow answers, something most developers had never heard of.
+Git worktrees have been around since 2015. For most of that time, they were a curiosity: something kernel developers used, something that showed up in obscure Stack Overflow answers, something most developers had never heard of.
 
 Now they're having a moment. AI coding agents need isolated environments. Developers are working on multiple features simultaneously. Code review culture demands quick context switches. The workflows that make worktrees valuable finally caught up to the feature.
 
@@ -35,7 +35,7 @@ git stash pop
 # wait, where was I?
 ```
 
-The friction isn't just the commands — it's the mental overhead. Your editor reloads files. Your language server re-indexes. Your node_modules might need reinstalling. Your brain has to context-switch twice.
+The friction isn't just the commands. It's the mental overhead. Your editor reloads files. Your language server re-indexes. Your node_modules might need reinstalling. Your brain has to context-switch twice.
 
 For years, developers worked around this with various hacks:
 
@@ -82,8 +82,8 @@ The initial commit message laid out the vision:
 > "A git repository can support multiple working trees, allowing you to check out more than one branch at a time."
 
 The key insight was that a git repository is really two things:
-1. **The object store** — All your commits, trees, and blobs (the `.git/objects` directory)
-2. **The working state** — What's currently checked out, staged, etc.
+1. **The object store**: All your commits, trees, and blobs (the `.git/objects` directory)
+2. **The working state**: What's currently checked out, staged, etc.
 
 These don't have to live in the same place. Worktrees formalized this separation.
 
@@ -118,9 +118,9 @@ And in the main repo, `.git/worktrees/feature-branch/` contains:
 ```
 
 This architecture means:
-- **Shared objects** — Commits, trees, blobs exist once
-- **Shared refs** — Branches and tags are visible from all worktrees
-- **Separate working state** — Each worktree has its own HEAD, index, and working directory
+- **Shared objects**: Commits, trees, blobs exist once
+- **Shared refs**: Branches and tags are visible from all worktrees
+- **Separate working state**: Each worktree has its own HEAD, index, and working directory
 
 ### The One Branch Rule
 
@@ -212,7 +212,7 @@ This is linear. You finish one thing before starting another. Worktrees solve pa
 
 ### 2. Git GUIs Didn't Support Them
 
-Popular git interfaces — GitKraken, SourceTree, GitHub Desktop, VS Code's git panel — either didn't support worktrees or treated them as second-class. If your tool doesn't expose a feature, you don't use it.
+Popular git interfaces (GitKraken, SourceTree, GitHub Desktop, VS Code's git panel) either didn't support worktrees or treated them as second-class. If your tool doesn't expose a feature, you don't use it.
 
 ### 3. The Commands Were Obscure
 
@@ -249,7 +249,7 @@ Complex projects often need you to test against different branches. Does this PR
 
 ### 3. Monorepo Workflows
 
-Large monorepos make cloning expensive. If your repo is 10GB, cloning it twice for parallel work wastes 10GB. Worktrees share the object store — each additional worktree only costs the size of the working files.
+Large monorepos make cloning expensive. If your repo is 10GB, cloning it twice for parallel work wastes 10GB. Worktrees share the object store, so each additional worktree only costs the size of the working files.
 
 ### 4. AI Coding Agents
 
@@ -275,7 +275,7 @@ The agent can:
 
 When it's done, you review the diff and merge. It's the same workflow as reviewing a coworker's PR, but the coworker is an AI and works in a worktree instead of a fork.
 
-This pattern — parallel human + AI work on the same codebase — is driving a resurgence in worktree usage that the git developers probably never anticipated.
+This pattern (parallel human + AI work on the same codebase) is driving a resurgence in worktree usage that the git developers probably never anticipated.
 
 ---
 
@@ -306,9 +306,9 @@ The code that handles this is in `setup.c` and `path.c` in the git source. The f
 
 Multiple worktrees can run git commands simultaneously. Git uses lock files to prevent corruption:
 
-- `.git/index.lock` — Prevents concurrent index modifications
-- `.git/refs/heads/<branch>.lock` — Prevents concurrent ref updates
-- `.git/worktrees/<name>/locked` — Marks a worktree as locked (won't be pruned)
+- `.git/index.lock`: Prevents concurrent index modifications
+- `.git/refs/heads/<branch>.lock`: Prevents concurrent ref updates
+- `.git/worktrees/<name>/locked`: Marks a worktree as locked (won't be pruned)
 
 The worktree-specific lock is useful when a worktree is on removable media or a network drive that might be temporarily unavailable.
 
@@ -409,9 +409,9 @@ Don't let old worktrees accumulate.
 
 ## Conclusion
 
-Git worktrees are a decade-old feature whose time has finally come. They solve parallel work — something that didn't matter much when developers worked linearly, but matters immensely now that AI agents are writing code alongside us.
+Git worktrees are a decade-old feature whose time has finally come. They solve parallel work, something that didn't matter much when developers worked linearly, but matters immensely now that AI agents are writing code alongside us.
 
-The implementation is elegant: share the expensive stuff (object store), separate the cheap stuff (working directory). It's the same insight that makes containers efficient — share the base, isolate the differences.
+The implementation is elegant: share the expensive stuff (object store), separate the cheap stuff (working directory). It's the same insight that makes containers efficient: share the base, isolate the differences.
 
 Whether you're reviewing PRs, testing branches, or letting an AI agent work in parallel, worktrees provide isolation without duplication. They're not new technology. They're old technology that suddenly fits the moment.
 

--- a/apps/marketing/content/blog/parallel-coding-agents-guide.mdx
+++ b/apps/marketing/content/blog/parallel-coding-agents-guide.mdx
@@ -24,7 +24,7 @@ But most codebases have dozens of parallelizable tasks at any given time:
 - Updating API docs doesn't conflict with fixing a database query
 - Adding input validation doesn't conflict with migrating a config format
 
-These tasks are independent. They can — and should — run simultaneously. The bottleneck isn't the agent or the model. It's the human orchestrating one task at a time.
+These tasks are independent. They can, and should, run simultaneously. The bottleneck isn't the agent or the model. It's the human orchestrating one task at a time.
 
 ---
 
@@ -37,7 +37,7 @@ Agent 1: Opens src/auth/login.ts, starts refactoring
 Agent 2: Opens src/auth/login.ts, starts adding validation
 Agent 1: Writes its version of login.ts
 Agent 2: Writes its version of login.ts (overwrites Agent 1)
-Agent 1: Commits — but the file is Agent 2's version
+Agent 1: Commits, but the file is Agent 2's version
 ```
 
 This isn't a theoretical risk. It happens every time two agents touch overlapping files. Even if they're editing different files, a shared `git index` means their commits can include each other's uncommitted changes. The clean fix is [a Git worktree per agent](/compare/git-worktrees-for-ai-agents).
@@ -66,7 +66,7 @@ They share the git object store, so creating a worktree takes seconds and costs 
 
 ### Pattern 1: Manual Worktrees
 
-The simplest approach — create worktrees yourself and run agents manually:
+The simplest approach is to create worktrees yourself and run agents manually:
 
 ```bash
 git worktree add ../project-tests -b agent/tests
@@ -98,11 +98,11 @@ Better, but still no unified view of all tasks, no session persistence, and no d
 
 Tools like [Superset](https://superset.sh) handle orchestration end-to-end:
 
-1. **Task creation** — describe the task, pick an agent
-2. **Automatic isolation** — worktree and branch created automatically
-3. **Session management** — persistent daemon keeps sessions alive across crashes
-4. **Diff review** — built-in diff viewer for reviewing agent output
-5. **Editor integration** — open any worktree in VS Code, Cursor, JetBrains, or Xcode
+1. **Task creation**: describe the task, pick an agent
+2. **Automatic isolation**: worktree and branch created automatically
+3. **Session management**: persistent daemon keeps sessions alive across crashes
+4. **Diff review**: built-in diff viewer for reviewing agent output
+5. **Editor integration**: open any worktree in VS Code, Cursor, JetBrains, or Xcode
 
 This is the approach that scales to 5-10+ concurrent agents without operational overhead.
 
@@ -187,7 +187,7 @@ Start with 2-3 until you're comfortable with the review workflow. Scaling to 10 
 
 ### Vague Task Descriptions
 
-"Fix the bugs" will produce unpredictable results. "Fix the null pointer in UserService.getProfile when user.avatar is null — add a null check and return a default avatar URL" gives the agent exactly what it needs.
+"Fix the bugs" will produce unpredictable results. "Fix the null pointer in UserService.getProfile when user.avatar is null: add a null check and return a default avatar URL" gives the agent exactly what it needs.
 
 ### Ignoring Branch Conflicts
 
@@ -201,13 +201,13 @@ If the agent doesn't run tests, you're reviewing blind. Either include "run test
 
 ## Getting Started
 
-1. **Pick an orchestrator** — [Superset](https://superset.sh) handles worktrees, sessions, and review
-2. **Pick your agents** — Start with Claude Code or Codex, expand later
-3. **Start with 2-3 tasks** — Parallelizable, non-overlapping tasks
-4. **Review quickly** — Focus on diffs, not full file reads
-5. **Scale gradually** — Add more agents as your review speed improves
+1. **Pick an orchestrator**: [Superset](https://superset.sh) handles worktrees, sessions, and review
+2. **Pick your agents**: Start with Claude Code or Codex, expand later
+3. **Start with 2-3 tasks**: Parallelizable, non-overlapping tasks
+4. **Review quickly**: Focus on diffs, not full file reads
+5. **Scale gradually**: Add more agents as your review speed improves
 
-The goal isn't to run the most agents possible. It's to maximize useful throughput — tasks completed per hour that meet your quality bar. Parallel agents get you there faster than sequential work, but only if the orchestration and review workflow supports it.
+The goal isn't to run the most agents possible. It's to maximize useful throughput: tasks completed per hour that meet your quality bar. Parallel agents get you there faster than sequential work, but only if the orchestration and review workflow supports it.
 
 ---
 

--- a/apps/marketing/content/blog/roadmap-to-100-agents.mdx
+++ b/apps/marketing/content/blog/roadmap-to-100-agents.mdx
@@ -6,7 +6,7 @@ date: 2026-02-02
 category: Product
 ---
 
-![Superset — managing coding agents in parallel](/blog/roadmap-to-100-agents/cover.png)
+![Superset: managing coding agents in parallel](/blog/roadmap-to-100-agents/cover.png)
 
 Right now at Superset, we're able to reliably manage 5-7 coding agents in parallel - whether that's Claude Code, Codex,
 etc. - at a time. Our goal is to be able to manage 100 coding agents in parallel each by the end of 2026.
@@ -22,7 +22,7 @@ Scale the agents all you want - it's the humans that don't scale.
 
 You can imagine the agent loop as a pipeline, and the goal is to improve throughput:
 
-![The agent pipeline — most steps require a human](/blog/roadmap-to-100-agents/pipeline-diagram.svg)
+![The agent pipeline: most steps require a human](/blog/roadmap-to-100-agents/pipeline-diagram.svg)
 
 There's a clear bottleneck that emerges when you look at this. A human is involved in almost every step, and each of
 these steps has a steep context-switching cost - you have to open that agent's code, spin up dev servers, click through
@@ -40,7 +40,7 @@ The fix is straightforward: pull the human out of steps where they're not needed
 
 If you've worked with a coding agent, you've had the experience: the agent comes back with something half-baked, you
 spend 15 minutes catching up to what it did, spin up a dev server, click around, then feed it the same feedback you've
-given a dozen agents before. Most of the time you spend reviewing isn't making decisions — it's catching problems that
+given a dozen agents before. Most of the time you spend reviewing isn't making decisions. It's catching problems that
 should have been caught before the work reached you.
 
 The fix is adding layers between the agent and you. The agent's work should be vetted thoroughly before it ever is
@@ -67,12 +67,12 @@ feedback. Each layer increases the odds that problems are found and resolved bef
 
 The same logic applies to testing. Giving agents access to the browser through tools like
 [BrowserUse](https://browser-use.com/) or [Maestro](https://maestro.mobile.dev/) tests lets them verify their own work
-visually — catching UI regressions, layout issues, and interaction bugs that are invisible in code review alone.
+visually, catching UI regressions, layout issues, and interaction bugs that are invisible in code review alone.
 
 ### Long-running agents
 
 Most agent workflows today are one-shot: you give a task, the agent works, it comes back. But agents should be able to
-run longer loops — trying an approach, hitting an issue, adjusting, and iterating until they're confident or genuinely
+run longer loops: trying an approach, hitting an issue, adjusting, and iterating until they're confident or genuinely
 stuck. [Ralph loops](https://ghuntley.com/loop/) are a popular pattern for this: treat the agent's work as clay on a
 wheel, refining iteratively, rather than laying bricks in a line.
 
@@ -81,7 +81,7 @@ for an hour and is confident in its solution is far easier to review than one th
 
 ## Make it fast to review agents' work
 
-Most developer tools today are human-driven — you open a diff, you spin up a dev server, you navigate to the right page.
+Most developer tools today are human-driven: you open a diff, you spin up a dev server, you navigate to the right page.
 Agents plug into these tools, but the human is still doing the legwork. We want to shift the paradigm towards
 agent-driven UIs - interfaces that agents orchestrate for the human's benefit, where each review takes seconds, not
 minutes.
@@ -98,21 +98,21 @@ that matter. When you open a completed task, you should be looking at a prepared
 
 ### Make existing tools better
 
-PR reviews, CI dashboards, IDEs — these are all built for a world where humans drive the interactions. In an agent-first
+PR reviews, CI dashboards, IDEs: these are all built for a world where humans drive the interactions. In an agent-first
 world, the tools need to meet you differently. Agents should be annotating their own PRs before you open them, the way
 [Devin's review](https://app.devin.ai/review) adds context to diffs ahead of time. CI results should be summarized and
 triaged by an agent, not presented as a raw log for you to parse. The tools we use every day were designed for human
-authors — adapting them for human reviewers of agent work is a different design problem.
+authors. Adapting them for human reviewers of agent work is a different design problem.
 
 ### Reducing friction to zero
 
 Every interaction between you and an agent should be as lightweight as possible. You should be able to click yes or no
-for straightforward changes. Agents should prep multiple-choice questions — "I found three approaches to this, which do
-you prefer?" — so you're choosing instead of typing. When an agent does need written feedback, supporting agents can
+for straightforward changes. Agents should prep multiple-choice questions ("I found three approaches to this, which do
+you prefer?") so you're choosing instead of typing. When an agent does need written feedback, supporting agents can
 prefill a draft response based on the context, so you're editing instead of writing from scratch. Quick actions like
 "create PR" or "deploy to staging" should also be easy to reach.
 
-The goal isn't just faster review — it's making the interaction so lightweight that you can do it from your phone
+The goal isn't just faster review. It's making the interaction so lightweight that you can do it from your phone
 between meetings.
 
 ## Have agents be more proactive
@@ -120,13 +120,13 @@ between meetings.
 ![Events trigger agents automatically](/blog/roadmap-to-100-agents/proactive-agents.svg)
 
 Everything above assumes you're the one deciding what agents work on. But at 100 agents, planning is itself a
-bottleneck. You can't spec out 100 tasks a day — that requires understanding the codebase, the product priorities, and
+bottleneck. You can't spec out 100 tasks a day. That requires understanding the codebase, the product priorities, and
 the nuances of each task.
 
 ### Reusable workflows
 
 The building blocks for this are already emerging. [OpenAI's Codex skills](https://developers.openai.com/codex/skills/)
-let you package repeatable workflows — deploy procedures, migration steps, test patterns — as reusable bundles that
+let you package repeatable workflows (deploy procedures, migration steps, test patterns) as reusable bundles that
 agents can invoke on their own when the situation matches. Instead of writing the same instructions every time, you
 encode them once and the agent recognizes when to apply them.
 
@@ -134,13 +134,13 @@ encode them once and the agent recognizes when to apply them.
 
 [Devin's workflows](https://devin.ai/) take this further with event-driven triggers. A build fails, and a Devin instance
 spins up to investigate. A Linear ticket is created, and an agent starts working on it automatically. Teams create
-playbooks for recurring tasks — setting up changelogs, running code migrations, adding test coverage — that agents
+playbooks for recurring tasks (setting up changelogs, running code migrations, adding test coverage) that agents
 execute on a schedule or in response to events without anyone initiating them.
 
 ### Beyond code
 
 Even outside of code, this pattern is taking hold. [Circleback](https://circleback.ai/) listens to your meetings and
-doesn't just take notes — it extracts action items, creates Linear tickets for feature requests mentioned in product
+doesn't just take notes: it extracts action items, creates Linear tickets for feature requests mentioned in product
 demos, and updates your CRM after sales calls. The meeting ends and the downstream work is already in motion.
 
 We don't have all of this figured out yet. Some of it is live, some is on our roadmap, and some is still taking shape.

--- a/apps/marketing/content/blog/terminal-daemon-deep-dive.mdx
+++ b/apps/marketing/content/blog/terminal-daemon-deep-dive.mdx
@@ -252,13 +252,13 @@ This avoids the O(n²) string concatenation problem while maintaining ~30fps vis
 
 ## The Headless Emulator: State Without a Screen
 
-Each daemon session runs a headless xterm.js emulator. This might seem redundant—why emulate if there's no screen?
+Each daemon session runs a headless xterm.js emulator. This might seem redundant: why emulate if there's no screen?
 
 The emulator gives us:
 
 1. **Accurate snapshots**: When a new client attaches, we serialize the *current screen state*, not just raw scrollback. The user sees exactly what was on screen, cursor position included.
 
-2. **Terminal mode tracking**: Application mode, bracketed paste, mouse tracking—all parsed and tracked so reconnecting clients get correct state.
+2. **Terminal mode tracking**: Application mode, bracketed paste, mouse tracking. All parsed and tracked so reconnecting clients get correct state.
 
 3. **CWD detection**: By parsing OSC escape sequences, we know the shell's current directory even when the session was created hours ago.
 
@@ -368,7 +368,7 @@ interface TerminalRuntime {
 }
 ```
 
-Today, `LocalTerminalRuntime` wraps our daemon. Tomorrow, `CloudTerminalRuntime` could wrap SSH connections or remote tmux sessions—same interface, different backend. The renderer doesn't need to know where the terminal lives.
+Today, `LocalTerminalRuntime` wraps our daemon. Tomorrow, `CloudTerminalRuntime` could wrap SSH connections or remote tmux sessions: same interface, different backend. The renderer doesn't need to know where the terminal lives.
 
 ---
 

--- a/apps/marketing/content/blog/working-with-worktrees-in-superset.mdx
+++ b/apps/marketing/content/blog/working-with-worktrees-in-superset.mdx
@@ -9,7 +9,7 @@ relatedSlugs:
   - roadmap-to-100-agents
 ---
 
-Running one AI coding agent is useful. Running ten at once is a different game entirely. But running ten agents in the same working directory is a disaster — they step on each other's files, create merge conflicts mid-edit, and leave your codebase in an unpredictable state.
+Running one AI coding agent is useful. Running ten at once is a different game entirely. But running ten agents in the same working directory is a disaster: they step on each other's files, create merge conflicts mid-edit, and leave your codebase in an unpredictable state.
 
 Superset solves this with Git worktrees. Every agent gets its own branch and its own copy of the working directory, all backed by the same Git object store. No duplication, no conflicts, no chaos. This post walks through how it works in practice.
 
@@ -21,17 +21,17 @@ When you run a coding agent like Claude Code or Codex, the agent reads files, wr
 
 Git worktrees eliminate this problem at the filesystem level. Each worktree is a separate checkout with its own:
 
-- **Working directory** — files on disk that the agent can read and modify
-- **Branch** — an isolated ref that tracks the agent's changes
-- **Index** — a separate staging area for commits
+- **Working directory**: files on disk that the agent can read and modify
+- **Branch**: an isolated ref that tracks the agent's changes
+- **Index**: a separate staging area for commits
 
 What's shared across all worktrees:
 
-- **Object store** — commits, trees, and blobs exist exactly once
-- **Refs** — branches created in one worktree are visible in all others
-- **Config** — repository settings, remotes, hooks
+- **Object store**: commits, trees, and blobs exist exactly once
+- **Refs**: branches created in one worktree are visible in all others
+- **Config**: repository settings, remotes, hooks
 
-This means creating a new worktree is fast (seconds, not minutes) and cheap (megabytes, not gigabytes). You're not cloning the repo — you're checking out another copy of the files while sharing the entire history.
+This means creating a new worktree is fast (seconds, not minutes) and cheap (megabytes, not gigabytes). You're not cloning the repo. You're checking out another copy of the files while sharing the entire history.
 
 ---
 
@@ -41,7 +41,7 @@ Here's what happens when you create a new task in Superset:
 
 ### 1. Create a Task
 
-You describe what you want done — "add input validation to the signup form" or "refactor the payment service to use the new API." Superset creates a new Git worktree and checks out a fresh branch.
+You describe what you want done: "add input validation to the signup form" or "refactor the payment service to use the new API." Superset creates a new Git worktree and checks out a fresh branch.
 
 ```
 ~/my-project/                          # Your main working tree
@@ -60,7 +60,7 @@ The agent runs inside its worktree. It can:
 - Run builds and tests
 - Make commits to its branch
 
-Meanwhile, your main working directory is untouched. You can keep coding, run your dev server, or create more tasks — each in its own worktree.
+Meanwhile, your main working directory is untouched. You can keep coding, run your dev server, or create more tasks, each in its own worktree.
 
 ### 3. Review the Diff
 
@@ -68,7 +68,7 @@ When the agent finishes, Superset shows you a diff of everything it changed. The
 
 ### 4. Merge or Iterate
 
-If the changes look good, merge the branch. If not, give the agent feedback and let it iterate — still in its own worktree, still isolated from everything else.
+If the changes look good, merge the branch. If not, give the agent feedback and let it iterate, still in its own worktree, still isolated from everything else.
 
 ---
 
@@ -87,7 +87,7 @@ Task 2: "Refactor database queries to use prepared statements"
 
 Task 3: "Update API documentation for v2 endpoints"
   → Branch: agent/api-docs
-  → Status: Complete — ready for review
+  → Status: Complete, ready for review
 
 Task 4: "Fix the race condition in the websocket handler"
   → Branch: agent/ws-fix
@@ -100,9 +100,9 @@ Each task has its own worktree and branch. Agent 1 can't accidentally break Agen
 
 Superset's persistent daemon manages all agent sessions via Unix domain sockets. This architecture means:
 
-- **Sessions survive crashes** — close and reopen Superset, your agents are still running
-- **Priority-based scheduling** — the focused pane gets full resources, background tabs hydrate gradually
-- **No interference** — each agent's terminal session is completely independent
+- **Sessions survive crashes**: close and reopen Superset, your agents are still running
+- **Priority-based scheduling**: the focused pane gets full resources, background tabs hydrate gradually
+- **No interference**: each agent's terminal session is completely independent
 
 ---
 
@@ -114,12 +114,12 @@ Begin with 2-3 parallel agents to get comfortable with the review workflow. As y
 
 ### Choose the Right Agent for Each Task
 
-Different agents have different strengths. Superset is agent-agnostic — use whatever works best for the job:
+Different agents have different strengths. Superset is agent-agnostic. Use whatever works best for the job:
 
-- **Claude Code** — strong at complex refactors, architectural changes, and multi-file edits
-- **Codex** — fast for well-scoped tasks with clear specifications
-- **Aider** — good for iterative changes with tight feedback loops
-- **OpenCode** — flexible with 75+ model providers, great for cost optimization
+- **Claude Code**: strong at complex refactors, architectural changes, and multi-file edits
+- **Codex**: fast for well-scoped tasks with clear specifications
+- **Aider**: good for iterative changes with tight feedback loops
+- **OpenCode**: flexible with 75+ model providers, great for cost optimization
 
 ### Organize Your Tasks
 
@@ -146,15 +146,15 @@ Why worktrees instead of containers, VMs, or separate clones?
 | **Docker containers** | Minutes | Medium (image layers) | Depends on mount | Volume-based, complex |
 | **VMs** | Minutes | High (full OS) | No | Network-based, slow |
 
-Worktrees win on every axis that matters for coding agents: they're fast to create, cheap on disk, share git history natively, and use standard git merging. The agent doesn't know or care that it's in a worktree — it just sees a normal git repository.
+Worktrees win on every axis that matters for coding agents: they're fast to create, cheap on disk, share git history natively, and use standard git merging. The agent doesn't know or care that it's in a worktree: it just sees a normal git repository.
 
 ---
 
 ## When Worktrees Aren't Enough
 
-Worktrees isolate files and branches, but they share the runtime environment. If two agents both need to run `npm install` with conflicting dependencies, they'll still conflict at the system level. For full environment isolation, you'd layer containers on top of worktrees — but for the vast majority of coding tasks, worktree-level isolation is sufficient and dramatically simpler.
+Worktrees isolate files and branches, but they share the runtime environment. If two agents both need to run `npm install` with conflicting dependencies, they'll still conflict at the system level. For full environment isolation, you'd layer containers on top of worktrees, but for the vast majority of coding tasks, worktree-level isolation is sufficient and dramatically simpler.
 
-The other limitation is the one-branch rule: Git doesn't allow the same branch to be checked out in multiple worktrees simultaneously. This is actually a feature — it prevents the exact class of bugs that parallel work creates. Superset enforces unique branches per task by default.
+The other limitation is the one-branch rule: Git doesn't allow the same branch to be checked out in multiple worktrees simultaneously. This is actually a feature: it prevents the exact class of bugs that parallel work creates. Superset enforces unique branches per task by default.
 
 ---
 
@@ -163,11 +163,11 @@ The other limitation is the one-branch rule: Git doesn't allow the same branch t
 If you're already using a CLI coding agent, adding Superset takes about two minutes:
 
 1. **Download Superset** from [superset.sh](https://superset.sh)
-2. **Open your project** — Superset detects your git repository automatically
-3. **Create a task** — describe what you want done, pick your agent
-4. **Watch it work** — the agent runs in its own worktree while you keep coding
+2. **Open your project**: Superset detects your git repository automatically
+3. **Create a task**: describe what you want done, pick your agent
+4. **Watch it work**: the agent runs in its own worktree while you keep coding
 
-The first time you see three agents working in parallel — each on its own branch, none interfering with each other — the workflow clicks. It's not three times faster (review is still human-speed), but it's dramatically more throughput than running agents one at a time.
+The first time you see three agents working in parallel (each on its own branch, none interfering with each other), the workflow clicks. It's not three times faster (review is still human-speed), but it's dramatically more throughput than running agents one at a time.
 
 Git worktrees have been in Git since 2015. They were designed for a world where humans needed to work on multiple branches. Turns out, they're even more useful in a world where AI agents do.
 

--- a/apps/marketing/content/changelog/2026-01-20-changes-org-settings.mdx
+++ b/apps/marketing/content/changelog/2026-01-20-changes-org-settings.mdx
@@ -25,4 +25,4 @@ image: /changelog/changes.png
 
 ## Middle-Click to Close Tabs <PRBadge url="https://github.com/superset-sh/superset/pull/853" />
 
-Added middle-click support for tabs—users can now close a tab by middle-clicking on it for quicker navigation. Matches standard browser tab behavior.
+Added middle-click support for tabs: users can now close a tab by middle-clicking on it for quicker navigation. Matches standard browser tab behavior.

--- a/apps/marketing/content/changelog/2026-02-09-sidebar-ux-chat-improvements.mdx
+++ b/apps/marketing/content/changelog/2026-02-09-sidebar-ux-chat-improvements.mdx
@@ -6,45 +6,45 @@ image: /changelog/new-diff.png
 
 ## New Diff View, Powered by diffs.com <PRBadge url="https://github.com/superset-sh/superset/pull/1308" />
 
-The Changes view has been completely rebuilt with [Pierre Computer's diffs.com](https://diffs.com) engine — delivering a drastically improved diff experience in both UI and performance. Large changesets that previously lagged now render instantly, and the new interface makes reviewing diffs feel native and fluid.
+The Changes view has been completely rebuilt with [Pierre Computer's diffs.com](https://diffs.com) engine, delivering a drastically improved diff experience in both UI and performance. Large changesets that previously lagged now render instantly, and the new interface makes reviewing diffs feel native and fluid.
 
-The new viewer includes an edit mode toggle — switch between read-only review and live editing, and hit Ctrl+S to save changes directly from the diff.
+The new viewer includes an edit mode toggle: switch between read-only review and live editing, and hit Ctrl+S to save changes directly from the diff.
 
-- **Workspace-scoped base branch** — base branch selection is now per-workspace instead of global, so diffs always compare against the right branch <PRBadge url="https://github.com/superset-sh/superset/pull/1329" />
-- **Preserved file explorer state** — expanded folders, scroll position, and selection persist when switching between Changes and Files tabs <PRBadge url="https://github.com/superset-sh/superset/pull/1297" />
-- **Compact tab buttons** — Changes and Files tabs collapse to icon-only mode with tooltips when the sidebar is narrow <PRBadge url="https://github.com/superset-sh/superset/pull/1334" />
+- **Workspace-scoped base branch**: base branch selection is now per-workspace instead of global, so diffs always compare against the right branch <PRBadge url="https://github.com/superset-sh/superset/pull/1329" />
+- **Preserved file explorer state**: expanded folders, scroll position, and selection persist when switching between Changes and Files tabs <PRBadge url="https://github.com/superset-sh/superset/pull/1297" />
+- **Compact tab buttons**: Changes and Files tabs collapse to icon-only mode with tooltips when the sidebar is narrow <PRBadge url="https://github.com/superset-sh/superset/pull/1334" />
 
 ## Early Preview of Chat GUI <PRBadge url="https://github.com/superset-sh/superset/pull/1309" />
 
-A native AI chat interface built right into Superset — and it works with your existing Claude Code sessions. Pick up where you left off without switching windows.
+A native AI chat interface built right into Superset, and it works with your existing Claude Code sessions. Pick up where you left off without switching windows.
 
-- **Existing session support** — scan and restore previous Claude Code sessions so you never lose context
-- **Slash commands** — type `/` to browse available commands with fuzzy search and keyboard navigation
-- **File mentions** — tag files with `@` and fuzzy search to pull in exactly the context you need <PRBadge url="https://github.com/superset-sh/superset/pull/1307" />
-- **Rich tool rendering** — tool calls display with specialized UI for bash output, web searches, file diffs, and user questions
-- **Session persistence** — chat sessions survive app restarts with local storage and automatic restore <PRBadge url="https://github.com/superset-sh/superset/pull/1287" />
+- **Existing session support**: scan and restore previous Claude Code sessions so you never lose context
+- **Slash commands**: type `/` to browse available commands with fuzzy search and keyboard navigation
+- **File mentions**: tag files with `@` and fuzzy search to pull in exactly the context you need <PRBadge url="https://github.com/superset-sh/superset/pull/1307" />
+- **Rich tool rendering**: tool calls display with specialized UI for bash output, web searches, file diffs, and user questions
+- **Session persistence**: chat sessions survive app restarts with local storage and automatic restore <PRBadge url="https://github.com/superset-sh/superset/pull/1287" />
 
-This is an early preview — general availability is coming next week. We'd love your feedback in the meantime.
+This is an early preview. General availability is coming next week. We'd love your feedback in the meantime.
 
 ![Chat GUI with slash commands and tool rendering](/changelog/chat-gui.png)
 
 ## Powerful Preset Settings <PRBadge url="https://github.com/superset-sh/superset/pull/1320" />
 
-Terminal presets now have granular auto-apply controls. Configure when presets run independently for workspace creation and new tabs — so you can auto-run setup commands on new workspaces without them firing every time you open a tab.
+Terminal presets now have granular auto-apply controls. Configure when presets run independently for workspace creation and new tabs, so you can auto-run setup commands on new workspaces without them firing every time you open a tab.
 
-- **Apply preset on workspace creation** — controls initialization commands when spinning up workspaces
-- **Apply preset on new tab** — controls whether presets run when opening new tabs, panes, or splits
+- **Apply preset on workspace creation**: controls initialization commands when spinning up workspaces
+- **Apply preset on new tab**: controls whether presets run when opening new tabs, panes, or splits
 - Explicit preset launches via hotkey or menu always work regardless of these settings
 
 {/* TODO: Screenshot of terminal settings with both toggles */}
 
 ## Improvements
 
-- **Improved new tab buttons** — grouped outline button bar for New Terminal and New Chat with keyboard shortcuts (Cmd+T, Cmd+Shift+T) <PRBadge url="https://github.com/superset-sh/superset/pull/1321" />
-- **Setup script card** — persistent sidebar card replaces toast for missing setup scripts with direct link to configuration <PRBadge url="https://github.com/superset-sh/superset/pull/1270" />
-- **Push auto-setup** — first `git push` from worktrees automatically creates remote branch and sets upstream tracking <PRBadge url="https://github.com/superset-sh/superset/pull/1267" />
-- **Project image toggle** — hide/show project GitHub avatars in sidebar with colored initial letters as fallback <PRBadge url="https://github.com/superset-sh/superset/pull/1276" />
-- **Teardown logs modal** — failed teardown scripts show logs in a modal instead of dumping output in error toast <PRBadge url="https://github.com/superset-sh/superset/pull/1277" />
+- **Improved new tab buttons**: grouped outline button bar for New Terminal and New Chat with keyboard shortcuts (Cmd+T, Cmd+Shift+T) <PRBadge url="https://github.com/superset-sh/superset/pull/1321" />
+- **Setup script card**: persistent sidebar card replaces toast for missing setup scripts with direct link to configuration <PRBadge url="https://github.com/superset-sh/superset/pull/1270" />
+- **Push auto-setup**: first `git push` from worktrees automatically creates remote branch and sets upstream tracking <PRBadge url="https://github.com/superset-sh/superset/pull/1267" />
+- **Project image toggle**: hide/show project GitHub avatars in sidebar with colored initial letters as fallback <PRBadge url="https://github.com/superset-sh/superset/pull/1276" />
+- **Teardown logs modal**: failed teardown scripts show logs in a modal instead of dumping output in error toast <PRBadge url="https://github.com/superset-sh/superset/pull/1277" />
 
 ---
 

--- a/apps/marketing/content/changelog/2026-02-16-browser-linux-improvements.mdx
+++ b/apps/marketing/content/changelog/2026-02-16-browser-linux-improvements.mdx
@@ -8,7 +8,7 @@ image: /changelog/chat.png
 
 Chat got a major upgrade this week. Streaming responses now support interactive tool-approval flows, so you can review and approve each tool call as it happens. A new multi-provider model picker lets you choose between providers and models. Agent and tool calls render as expandable UI blocks with tool-specific displays, and a new web search tool lets Claude fetch and reference live content.
 
-We also shipped a series of fixes to MCP connectivity — replacing the stagnant `mcp-handler` library with a direct SDK transport <PRBadge url="https://github.com/superset-sh/superset/pull/1518" />, fixing OAuth connections through the reverse proxy <PRBadge url="https://github.com/superset-sh/superset/pull/1512" />, and resolving SDK version conflicts that caused session failures <PRBadge url="https://github.com/superset-sh/superset/pull/1515" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1516" />.
+We also shipped a series of fixes to MCP connectivity: replacing the stagnant `mcp-handler` library with a direct SDK transport <PRBadge url="https://github.com/superset-sh/superset/pull/1518" />, fixing OAuth connections through the reverse proxy <PRBadge url="https://github.com/superset-sh/superset/pull/1512" />, and resolving SDK version conflicts that caused session failures <PRBadge url="https://github.com/superset-sh/superset/pull/1515" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1516" />.
 
 ![Chat with tool approval](/changelog/chat.png)
 
@@ -16,7 +16,7 @@ We also shipped a series of fixes to MCP connectivity — replacing the stagnant
 
 Browse documentation, preview dev servers, and test web apps without leaving Superset. The new embedded browser includes Chrome-like URL autocomplete with browsing history, favicon capture, and DevTools support.
 
-- Navigate directly from detected ports — click the external link icon to open in a browser pane instead of your system browser
+- Navigate directly from detected ports: click the external link icon to open in a browser pane instead of your system browser
 - URL bar with persistent history and keyboard navigation
 - Clear browsing data from the overflow menu
 - Open browser tabs with Cmd+Shift+B hotkey
@@ -25,7 +25,7 @@ Browse documentation, preview dev servers, and test web apps without leaving Sup
 
 ## Desktop Automation Tools <PRBadge url="https://github.com/superset-sh/superset/pull/1481" />
 
-Added MCP-based automation tools that let Claude Code interact with the Superset UI programmatically. Claude can now take screenshots, click UI elements, type into fields, and inspect the DOM — enabling fully automated testing and debugging workflows through natural language.
+Added MCP-based automation tools that let Claude Code interact with the Superset UI programmatically. Claude can now take screenshots, click UI elements, type into fields, and inspect the DOM, enabling fully automated testing and debugging workflows through natural language.
 
 ## Improvements
 

--- a/apps/marketing/content/changelog/2026-03-02-desktop-v1-mastra-prompts-onboarding.mdx
+++ b/apps/marketing/content/changelog/2026-03-02-desktop-v1-mastra-prompts-onboarding.mdx
@@ -4,9 +4,9 @@ date: 2026-03-02
 image: /changelog/ph-chat.png
 ---
 
-## Improved Chat View — Now Generally Available <PRBadge url="https://github.com/superset-sh/superset/pull/1876" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1973" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1983" />
+## Improved Chat View: Now Generally Available <PRBadge url="https://github.com/superset-sh/superset/pull/1876" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1973" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1983" />
 
-The redesigned chat interface is now generally available to all users. Previously behind early access, the new chat view features refreshed tool call visuals with collapsible panels, improved diff rendering, and cleaner file views. Superset's own MCP tools—tasks, workspaces, and agent sessions—now render as rich, interactive cards directly in the chat. Superset Chat is also available as a first-class agent option with its own launch config and icon.
+The redesigned chat interface is now generally available to all users. Previously behind early access, the new chat view features refreshed tool call visuals with collapsible panels, improved diff rendering, and cleaner file views. Superset's own MCP tools (tasks, workspaces, and agent sessions) now render as rich, interactive cards directly in the chat. Superset Chat is also available as a first-class agent option with its own launch config and icon.
 
 - Refreshed tool call visuals with collapsible output panels and inline status icons
 - Rich UI cards for Superset MCP tool calls (tasks, workspaces, agent sessions)
@@ -15,7 +15,7 @@ The redesigned chat interface is now generally available to all users. Previousl
 
 ## Open Worktree with Prompt <PRBadge url="https://github.com/superset-sh/superset/pull/1882" /> <PRBadge url="https://github.com/superset-sh/superset/pull/1912" />
 
-The new workspace modal has been redesigned with a send-to-agent flow. When creating a worktree you can now write a prompt that gets sent directly to an agent in the new workspace—describe what you want built and the agent starts working as soon as the workspace is ready. The modal also includes a project selector, an import flow for cloning repos, and auto-generated branch names derived from your prompt.
+The new workspace modal has been redesigned with a send-to-agent flow. When creating a worktree you can now write a prompt that gets sent directly to an agent in the new workspace: describe what you want built and the agent starts working as soon as the workspace is ready. The modal also includes a project selector, an import flow for cloning repos, and auto-generated branch names derived from your prompt.
 
 ![Open worktree with prompt](/changelog/ws-prompt.png)
 

--- a/apps/marketing/content/changelog/2026-03-23-review-tab-presets-run.mdx
+++ b/apps/marketing/content/changelog/2026-03-23-review-tab-presets-run.mdx
@@ -9,7 +9,7 @@ image: /changelog/review-tab.png
 The changes sidebar now has a dedicated Review tab. You can read, filter, and respond to PR review comments without leaving the desktop app.
 
 - Resolved comments are separated from open ones so you can focus on what still needs attention
-- Stays in sync with GitHub — refreshes automatically after PR mutations
+- Stays in sync with GitHub, refreshing automatically after PR mutations
 
 ## Task Create & Detail Actions <PRBadge url="https://github.com/superset-sh/superset/pull/2656" /> <PRBadge url="https://github.com/superset-sh/superset/pull/2660" />
 

--- a/apps/marketing/content/changelog/2026-04-20-v2-workspace-brand-cli.mdx
+++ b/apps/marketing/content/changelog/2026-04-20-v2-workspace-brand-cli.mdx
@@ -12,25 +12,25 @@ A big update covering the last three weeks. The chat interface got a top-to-bott
 
 The prompt is now a ProseMirror-based rich text editor with inline chips for commands and file references.
 
-- **Slash command chips** — type `/` to open a command menu; the command becomes an inline chip anywhere in the message instead of submitting immediately. Chips with an `argumentHint` expose an inline editable input with auto-sizing and keyboard nav; `/model` shows a dropdown of available models.
-- **File mention chips** — type `@` to open a file-search popover anchored to the cursor. Picking a file inserts a chip that serializes to `@path` on send.
-- **Skill preload** — `/command` chips are extracted before the LLM turn so the harness loads the right skill first. A `SkillToolCall` row shows in the message while the skill loads.
-- **Preview on hover** — hovering a chip shows a popover with its description (hidden while an arg input is focused).
+- **Slash command chips**: type `/` to open a command menu; the command becomes an inline chip anywhere in the message instead of submitting immediately. Chips with an `argumentHint` expose an inline editable input with auto-sizing and keyboard nav; `/model` shows a dropdown of available models.
+- **File mention chips**: type `@` to open a file-search popover anchored to the cursor. Picking a file inserts a chip that serializes to `@path` on send.
+- **Skill preload**: `/command` chips are extracted before the LLM turn so the harness loads the right skill first. A `SkillToolCall` row shows in the message while the skill loads.
+- **Preview on hover**: hovering a chip shows a popover with its description (hidden while an arg input is focused).
 - IME composition guard prevents submit while CJK input is pending; Tab no longer auto-selects commands (Enter or click only).
 
 ### Redesigned tool calls
 
 - Compact, monospaced `ToolInput` / `ToolOutput` / `ToolHeader` layout with a braille spinner and left-side icons
 - Subagent activity rendered inline as a collapsible tool wrapper, with full markdown for task prompt and response
-- Clickable file names on every file-related tool call row (read, write, LSP inspect) — clicking opens the file in the editor pane
+- Clickable file names on every file-related tool call row (read, write, LSP inspect): clicking opens the file in the editor pane
 - Syntax-highlighted read-file output with filename header and line-range label; expand/collapse and copy on every code block
 
 ### ask_user flow
 
-- Footer overlay with pinned header/footer and scrollable option buttons — no more inline question UI
+- Footer overlay with pinned header/footer and scrollable option buttons: no more inline question UI
 - Status chips (Awaiting Response / Answered / Cancelled) with a collapsible answer bubble; cancelled shows immediately when aborted
 - Optimistic dismiss on submit; prompt textarea auto-focuses after answering
-- `ask_user` is now required for all Superset questions — no plain-text fallbacks
+- `ask_user` is now required for all Superset questions: no plain-text fallbacks
 
 ### Workspace status and notifications
 
@@ -42,7 +42,7 @@ The prompt is now a ProseMirror-based rich text editor with inline chips for com
 
 ![v2 workspace early access](/changelog/v2-early-access.png)
 
-v2 is a ground-up rebuild of the workspace aimed at cloud. We tore out v1's accumulated cruft, rewrote the terminal from scratch to fix the rendering glitches, and re-architected the app like a real IDE — Tab → Split → Pane, a proper file tree with git decorations, a full editor, and a diff viewer that handles large changesets. Opt-in for now; here's what's in the box:
+v2 is a ground-up rebuild of the workspace aimed at cloud. We tore out v1's accumulated cruft, rewrote the terminal from scratch to fix the rendering glitches, and re-architected the app like a real IDE: Tab → Split → Pane, a proper file tree with git decorations, a full editor, and a diff viewer that handles large changesets. Opt-in for now; here's what's in the box:
 
 ### Pane layout system <PRBadge url="https://github.com/superset-sh/superset/pull/3088" />
 
@@ -65,7 +65,7 @@ A GitHub-style multi-file diff pane with lazy loading, a persistent "Viewed" sta
 
 ![v2 file tree and editor](/changelog/v2-file-tree.png)
 
-A full editor pane — foundation, views, and a large stability pass. The file tree shows git decorations inline <PRBadge url="https://github.com/superset-sh/superset/pull/3320" />.
+A full editor pane: foundation, views, and a large stability pass. The file tree shows git decorations inline <PRBadge url="https://github.com/superset-sh/superset/pull/3320" />.
 
 ### Review tab <PRBadge url="https://github.com/superset-sh/superset/pull/3463" />
 
@@ -77,7 +77,7 @@ Check out a PR directly from v2 via a widened checkout procedure, and compose a 
 
 ### Browser pane <PRBadge url="https://github.com/superset-sh/superset/pull/3346" />
 
-Pages stay loaded across tab switches and workspace navigations — no reloads, no lost scroll or form state. URL bar, back/forward/reload, history autocomplete, DevTools, screenshots, and hard reload from the overflow menu.
+Pages stay loaded across tab switches and workspace navigations: no reloads, no lost scroll or form state. URL bar, back/forward/reload, history autocomplete, DevTools, screenshots, and hard reload from the overflow menu.
 
 ### Git Changes sidebar <PRBadge url="https://github.com/superset-sh/superset/pull/3177" />
 
@@ -103,40 +103,40 @@ Binaries for macOS (arm64, x64) and Linux x64. `--json` output mode for scriptin
 
 ## Brand refresh <PRBadge url="https://github.com/superset-sh/superset/pull/3367" />
 
-![Brand refresh — new logo and icon treatment](/changelog/brand-refresh.png)
+![Brand refresh: new logo and icon treatment](/changelog/brand-refresh.png)
 
 New logo and icon treatment across the desktop app, DMG installer background, tray icon, and wordmark. In dev builds, each workspace gets a color-coded corner fold on the dock icon so open workspaces are distinguishable at a glance.
 
 ## GitHub integration is free <PRBadge url="https://github.com/superset-sh/superset/pull/3152" />
 
-PR review, issue linking, and push-from-desktop are available on every plan — no Pro subscription required.
+PR review, issue linking, and push-from-desktop are available on every plan, no Pro subscription required.
 
 ## Improvements
 
-- **V2 file editor foundation** — editor views plus a large stability pass <PRBadge url="https://github.com/superset-sh/superset/pull/3526" />
-- **V2 review tab** — PR info, checks, and comments inline <PRBadge url="https://github.com/superset-sh/superset/pull/3463" />
-- **V2 PR checkout** — checkout a PR directly in a v2 workspace <PRBadge url="https://github.com/superset-sh/superset/pull/3525" />
-- **V2 launch context composition** — prep files, instructions, and branch state before launching <PRBadge url="https://github.com/superset-sh/superset/pull/3467" />
-- **Recently Viewed in Quick Open** — surfaces files you were just looking at <PRBadge url="https://github.com/superset-sh/superset/pull/3488" />
-- **Paginated branch picker** — scales to thousands of branches with inline checkout + open actions <PRBadge url="https://github.com/superset-sh/superset/pull/3397" />
-- **Modifier-keyed terminal file links** — ⌘/Ctrl+click opens in external editor or new tab <PRBadge url="https://github.com/superset-sh/superset/pull/3512" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3398" />
-- **Drag-and-drop into v2 terminal panes** — drop files to insert their paths <PRBadge url="https://github.com/superset-sh/superset/pull/3542" />
+- **V2 file editor foundation**: editor views plus a large stability pass <PRBadge url="https://github.com/superset-sh/superset/pull/3526" />
+- **V2 review tab**: PR info, checks, and comments inline <PRBadge url="https://github.com/superset-sh/superset/pull/3463" />
+- **V2 PR checkout**: checkout a PR directly in a v2 workspace <PRBadge url="https://github.com/superset-sh/superset/pull/3525" />
+- **V2 launch context composition**: prep files, instructions, and branch state before launching <PRBadge url="https://github.com/superset-sh/superset/pull/3467" />
+- **Recently Viewed in Quick Open**: surfaces files you were just looking at <PRBadge url="https://github.com/superset-sh/superset/pull/3488" />
+- **Paginated branch picker**: scales to thousands of branches with inline checkout + open actions <PRBadge url="https://github.com/superset-sh/superset/pull/3397" />
+- **Modifier-keyed terminal file links**: ⌘/Ctrl+click opens in external editor or new tab <PRBadge url="https://github.com/superset-sh/superset/pull/3512" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3398" />
+- **Drag-and-drop into v2 terminal panes**: drop files to insert their paths <PRBadge url="https://github.com/superset-sh/superset/pull/3542" />
 - **Tasks link restored in v2 dashboard sidebar** <PRBadge url="https://github.com/superset-sh/superset/pull/3553" />
 - **Escape closes settings** <PRBadge url="https://github.com/superset-sh/superset/pull/3466" />
-- **Hotkey defaults** — unbound defaults plus restored prev/next tab and workspace shortcuts <PRBadge url="https://github.com/superset-sh/superset/pull/3422" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3472" />
+- **Hotkey defaults**: unbound defaults plus restored prev/next tab and workspace shortcuts <PRBadge url="https://github.com/superset-sh/superset/pull/3422" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3472" />
 - **Allow hotkeys in editable content** <PRBadge url="https://github.com/superset-sh/superset/pull/3418" />
-- **Terminal search** — ⌘F / Ctrl+Shift+F in the v2 terminal <PRBadge url="https://github.com/superset-sh/superset/pull/3289" />
-- **Kitty keyboard protocol** — better modifier support in neovim, fish 4+, and others <PRBadge url="https://github.com/superset-sh/superset/pull/3289" />
+- **Terminal search**: ⌘F / Ctrl+Shift+F in the v2 terminal <PRBadge url="https://github.com/superset-sh/superset/pull/3289" />
+- **Kitty keyboard protocol**: better modifier support in neovim, fish 4+, and others <PRBadge url="https://github.com/superset-sh/superset/pull/3289" />
 - **Terminal theme and font settings** in v2 (parity with v1) <PRBadge url="https://github.com/superset-sh/superset/pull/3155" />
-- **Fast file search** — VS Code's path-aware fuzzy scorer with pre-warmed index <PRBadge url="https://github.com/superset-sh/superset/pull/3136" />
-- **V2 top bar** — right sidebar toggle, org dropdown, unified "Open In" button <PRBadge url="https://github.com/superset-sh/superset/pull/3197" />
+- **Fast file search**: VS Code's path-aware fuzzy scorer with pre-warmed index <PRBadge url="https://github.com/superset-sh/superset/pull/3136" />
+- **V2 top bar**: right sidebar toggle, org dropdown, unified "Open In" button <PRBadge url="https://github.com/superset-sh/superset/pull/3197" />
 - **Git decorations in v2 file tree** <PRBadge url="https://github.com/superset-sh/superset/pull/3320" />
 - **V2 preset parity + setup scripts** <PRBadge url="https://github.com/superset-sh/superset/pull/3354" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3359" />
 - **V1/v2 toggle from the top bar**, preference persists <PRBadge url="https://github.com/superset-sh/superset/pull/3347" />
-- **Host service durability** — survives app quits, re-adopted on next launch <PRBadge url="https://github.com/superset-sh/superset/pull/3157" />
-- **Relay security setting** — Settings → Security controls whether this machine is exposed; defaults to off <PRBadge url="https://github.com/superset-sh/superset/pull/3304" />
-- **Unified workspace delete** — v2 delete goes through the host-service <PRBadge url="https://github.com/superset-sh/superset/pull/3443" />
-- **Focus neighbor on workspace delete** — drops you on an adjacent workspace, not `/` <PRBadge url="https://github.com/superset-sh/superset/pull/3401" />
+- **Host service durability**: survives app quits, re-adopted on next launch <PRBadge url="https://github.com/superset-sh/superset/pull/3157" />
+- **Relay security setting**: Settings → Security controls whether this machine is exposed; defaults to off <PRBadge url="https://github.com/superset-sh/superset/pull/3304" />
+- **Unified workspace delete**: v2 delete goes through the host-service <PRBadge url="https://github.com/superset-sh/superset/pull/3443" />
+- **Focus neighbor on workspace delete**: drops you on an adjacent workspace, not `/` <PRBadge url="https://github.com/superset-sh/superset/pull/3401" />
 - **Create Section Below** promoted to top-level on the workspace menu <PRBadge url="https://github.com/superset-sh/superset/pull/3537" />
 - **Event-driven tray menu** showing the real org name <PRBadge url="https://github.com/superset-sh/superset/pull/3458" />
 - **Notification sound volume** dropdown in settings <PRBadge url="https://github.com/superset-sh/superset/pull/3073" />
@@ -147,31 +147,31 @@ PR review, issue linking, and push-from-desktop are available on every plan — 
 
 **Bug fixes**
 
-- Security — bumped drizzle-orm and better-auth to patch CVEs <PRBadge url="https://github.com/superset-sh/superset/pull/3560" />; pinned axios against a known supply-chain vector <PRBadge url="https://github.com/superset-sh/superset/pull/3043" />
-- Chat — cut display polling to 4fps and restored query cache defaults <PRBadge url="https://github.com/superset-sh/superset/pull/3562" />
-- Chat — prevent keyboard shortcuts from leaking characters into the chat input <PRBadge url="https://github.com/superset-sh/superset/pull/3520" />
-- Terminal — recover from non-monospace font crash <PRBadge url="https://github.com/superset-sh/superset/pull/3554" />
-- Terminal — unblock v1 input during shell init <PRBadge url="https://github.com/superset-sh/superset/pull/3550" />
-- Terminal — sync v1 dimensions to backend on connect <PRBadge url="https://github.com/superset-sh/superset/pull/3545" />
-- Terminal — match VS Code clipboard handling <PRBadge url="https://github.com/superset-sh/superset/pull/3415" />
-- Terminal — restore ⌘+click for v1 file links; refresh v2 link tooltip editor <PRBadge url="https://github.com/superset-sh/superset/pull/3457" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3552" />
-- Terminal — correct dimensions sent after attach (fixes TUI apps) <PRBadge url="https://github.com/superset-sh/superset/pull/3154" />
-- Terminal — garbling fix via tRPC-first sessions <PRBadge url="https://github.com/superset-sh/superset/pull/3252" />
-- Auto-updater — restored on macOS; recover from corrupt update cache; spinner while pending; guard repeat clicks <PRBadge url="https://github.com/superset-sh/superset/pull/3291" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3278" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3495" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3561" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3549" />
-- macOS quit — ⌘Q and Dock Quit now fully exit instead of backgrounding to tray <PRBadge url="https://github.com/superset-sh/superset/pull/3205" />
-- macOS — trigger Local Network permission on startup <PRBadge url="https://github.com/superset-sh/superset/pull/3551" />
-- Port scanner — stop excessive `lsof` spawning <PRBadge url="https://github.com/superset-sh/superset/pull/3547" />
-- V2 workspace — prevent "workspace not found" flash after create; gate children on collection readiness; derive base branch from git config <PRBadge url="https://github.com/superset-sh/superset/pull/3494" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3464" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3492" />
-- V2 file tree — no longer blocks on `git.getStatus` in shared tRPC batch; file icons resolve on nested routes <PRBadge url="https://github.com/superset-sh/superset/pull/3400" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3199" />
-- V2 sidebar — LOC badge hidden when no changes; section count matches visual grouping; native clipboard for copy path <PRBadge url="https://github.com/superset-sh/superset/pull/3399" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3544" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3462" />
-- V2 diff sidebar — removed viewed checkboxes; right sidebar toggle is reactive <PRBadge url="https://github.com/superset-sh/superset/pull/3480" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3421" />
-- V2 — Open In editor is project-scoped, not workspace-scoped; duplicate panes on new-tab file opens; modal focus trap on workspace dialogs <PRBadge url="https://github.com/superset-sh/superset/pull/3393" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3093" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3392" />
-- V1 — fix Cmd+O firing open-in twice; fix split pane startup sizing; `--no-track` in createWorktree <PRBadge url="https://github.com/superset-sh/superset/pull/3511" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3416" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3548" />
-- Keyboard — Ctrl bindings, `event.code` unification, terminal override respect <PRBadge url="https://github.com/superset-sh/superset/pull/3391" />
+- Security: bumped drizzle-orm and better-auth to patch CVEs <PRBadge url="https://github.com/superset-sh/superset/pull/3560" />; pinned axios against a known supply-chain vector <PRBadge url="https://github.com/superset-sh/superset/pull/3043" />
+- Chat: cut display polling to 4fps and restored query cache defaults <PRBadge url="https://github.com/superset-sh/superset/pull/3562" />
+- Chat: prevent keyboard shortcuts from leaking characters into the chat input <PRBadge url="https://github.com/superset-sh/superset/pull/3520" />
+- Terminal: recover from non-monospace font crash <PRBadge url="https://github.com/superset-sh/superset/pull/3554" />
+- Terminal: unblock v1 input during shell init <PRBadge url="https://github.com/superset-sh/superset/pull/3550" />
+- Terminal: sync v1 dimensions to backend on connect <PRBadge url="https://github.com/superset-sh/superset/pull/3545" />
+- Terminal: match VS Code clipboard handling <PRBadge url="https://github.com/superset-sh/superset/pull/3415" />
+- Terminal: restore ⌘+click for v1 file links; refresh v2 link tooltip editor <PRBadge url="https://github.com/superset-sh/superset/pull/3457" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3552" />
+- Terminal: correct dimensions sent after attach (fixes TUI apps) <PRBadge url="https://github.com/superset-sh/superset/pull/3154" />
+- Terminal: garbling fix via tRPC-first sessions <PRBadge url="https://github.com/superset-sh/superset/pull/3252" />
+- Auto-updater: restored on macOS; recover from corrupt update cache; spinner while pending; guard repeat clicks <PRBadge url="https://github.com/superset-sh/superset/pull/3291" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3278" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3495" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3561" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3549" />
+- macOS quit: ⌘Q and Dock Quit now fully exit instead of backgrounding to tray <PRBadge url="https://github.com/superset-sh/superset/pull/3205" />
+- macOS: trigger Local Network permission on startup <PRBadge url="https://github.com/superset-sh/superset/pull/3551" />
+- Port scanner: stop excessive `lsof` spawning <PRBadge url="https://github.com/superset-sh/superset/pull/3547" />
+- V2 workspace: prevent "workspace not found" flash after create; gate children on collection readiness; derive base branch from git config <PRBadge url="https://github.com/superset-sh/superset/pull/3494" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3464" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3492" />
+- V2 file tree: no longer blocks on `git.getStatus` in shared tRPC batch; file icons resolve on nested routes <PRBadge url="https://github.com/superset-sh/superset/pull/3400" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3199" />
+- V2 sidebar: LOC badge hidden when no changes; section count matches visual grouping; native clipboard for copy path <PRBadge url="https://github.com/superset-sh/superset/pull/3399" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3544" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3462" />
+- V2 diff sidebar: removed viewed checkboxes; right sidebar toggle is reactive <PRBadge url="https://github.com/superset-sh/superset/pull/3480" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3421" />
+- V2: Open In editor is project-scoped, not workspace-scoped; duplicate panes on new-tab file opens; modal focus trap on workspace dialogs <PRBadge url="https://github.com/superset-sh/superset/pull/3393" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3093" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3392" />
+- V1: fix Cmd+O firing open-in twice; fix split pane startup sizing; `--no-track` in createWorktree <PRBadge url="https://github.com/superset-sh/superset/pull/3511" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3416" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3548" />
+- Keyboard: Ctrl bindings, `event.code` unification, terminal override respect <PRBadge url="https://github.com/superset-sh/superset/pull/3391" />
 - IME composition in new-workspace Enter handlers <PRBadge url="https://github.com/superset-sh/superset/pull/3486" />
 - File attachments pass through the prompt input <PRBadge url="https://github.com/superset-sh/superset/pull/3334" />
-- Close-workspace shortcut no longer conflicts with tab close — now ⌘⇧⌫ <PRBadge url="https://github.com/superset-sh/superset/pull/3037" />
+- Close-workspace shortcut no longer conflicts with tab close (now ⌘⇧⌫) <PRBadge url="https://github.com/superset-sh/superset/pull/3037" />
 - Pending failure error messages are selectable <PRBadge url="https://github.com/superset-sh/superset/pull/3432" />
 - Font-settings query no longer silently routed through host-service <PRBadge url="https://github.com/superset-sh/superset/pull/3394" />
-- MCP — accept resource URL as valid OAuth audience; fix devices incorrectly classified as offline <PRBadge url="https://github.com/superset-sh/superset/pull/3459" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3299" />
+- MCP: accept resource URL as valid OAuth audience; fix devices incorrectly classified as offline <PRBadge url="https://github.com/superset-sh/superset/pull/3459" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3299" />
 - CLI auth switched to OAuth PKCE + loopback <PRBadge url="https://github.com/superset-sh/superset/pull/3318" />

--- a/apps/marketing/content/changelog/2026-04-27-hosts-settings-terminal-sessions.mdx
+++ b/apps/marketing/content/changelog/2026-04-27-hosts-settings-terminal-sessions.mdx
@@ -4,21 +4,21 @@ date: 2026-04-27
 image: /changelog/v2-public-beta.png
 ---
 
-**Superset 2.0 is in open beta.** Enable it under **Settings → Experimental** <PRBadge url="https://github.com/superset-sh/superset/pull/3748" /> — it's a 2-way door, and your v1 workspaces and sessions stay put when you flip back.
+**Superset 2.0 is in open beta.** Enable it under **Settings → Experimental** <PRBadge url="https://github.com/superset-sh/superset/pull/3748" />. It's a 2-way door, and your v1 workspaces and sessions stay put when you flip back.
 
-![Settings → Experimental — Try Superset v2 toggle and v1 → v2 migration](/changelog/v2-enable-flag.png)
+![Settings → Experimental: Try Superset v2 toggle and v1 → v2 migration](/changelog/v2-enable-flag.png)
 
 ## Remote workspaces
 
-Every workspace in 2.0 is a cloud workspace. Point your local app at any Superset device on the same network — a beefier box across the room, a cloud VM, a teammate's host — and run workspaces on it as if they were local. Terminal, file editor, and chat all behave the same way <PRBadge url="https://github.com/superset-sh/superset/pull/3566" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3606" />, and ports listening on the remote host show up in your sidebar <PRBadge url="https://github.com/superset-sh/superset/pull/3676" />.
+Every workspace in 2.0 is a cloud workspace. Point your local app at any Superset device on the same network (a beefier box across the room, a cloud VM, a teammate's host) and run workspaces on it as if they were local. Terminal, file editor, and chat all behave the same way <PRBadge url="https://github.com/superset-sh/superset/pull/3566" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3606" />, and ports listening on the remote host show up in your sidebar <PRBadge url="https://github.com/superset-sh/superset/pull/3676" />.
 
 ![Sidebar with a Cloud workspace group and a remote workspace hover card](/changelog/v2-remote-workspaces.png)
 
 ## Reimagined diff view
 
-The diff viewer is rebuilt to feel like reviewing a PR on your machine — one infinite-scroll diff with a compact sidebar of changed files, per-file viewed state <PRBadge url="https://github.com/superset-sh/superset/pull/3715" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3776" />, and shift/cmd-click selection across the file list <PRBadge url="https://github.com/superset-sh/superset/pull/3683" />.
+The diff viewer is rebuilt to feel like reviewing a PR on your machine: one infinite-scroll diff with a compact sidebar of changed files, per-file viewed state <PRBadge url="https://github.com/superset-sh/superset/pull/3715" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3776" />, and shift/cmd-click selection across the file list <PRBadge url="https://github.com/superset-sh/superset/pull/3683" />.
 
-![v2 Changes pane — infinite-scroll diff with compact file sidebar and review tab](/changelog/v2-changes-pane.png)
+![v2 Changes pane: infinite-scroll diff with compact file sidebar and review tab](/changelog/v2-changes-pane.png)
 
 ## Superset CLI
 
@@ -33,7 +33,7 @@ superset auth login
 
 ## A real IDE shell
 
-**Tab → Split → Pane** with drag-and-drop everywhere — drop panes onto the tab strip to spawn tabs <PRBadge url="https://github.com/superset-sh/superset/pull/3809" />. File tree with git decorations, file editor, a browser pane that keeps state across switches, a fresh terminal (XTerm.js + WebGL, kitty keyboard, OSC links, search), and Electric collections with optimistic updates <PRBadge url="https://github.com/superset-sh/superset/pull/3722" /> — all in one window.
+**Tab → Split → Pane** with drag-and-drop everywhere: drop panes onto the tab strip to spawn tabs <PRBadge url="https://github.com/superset-sh/superset/pull/3809" />. File tree with git decorations, file editor, a browser pane that keeps state across switches, a fresh terminal (XTerm.js + WebGL, kitty keyboard, OSC links, search), and Electric collections with optimistic updates <PRBadge url="https://github.com/superset-sh/superset/pull/3722" />, all in one window.
 
 ## Migration in place
 
@@ -53,7 +53,7 @@ superset auth login
 
 ### Scheduled agent runs <PRBadge url="https://github.com/superset-sh/superset/pull/3576" />
 
-Automations now run on a cadence — same execution path as a manual run.
+Automations now run on a cadence: same execution path as a manual run.
 
 ### Sidebar
 
@@ -62,7 +62,7 @@ Automations now run on a cadence — same execution path as a manual run.
 - AI generates title + branch together on workspace create <PRBadge url="https://github.com/superset-sh/superset/pull/3692" />
 - Sortable v2 workspaces table <PRBadge url="https://github.com/superset-sh/superset/pull/3660" />
 - Refreshed icons <PRBadge url="https://github.com/superset-sh/superset/pull/3755" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3800" />, branch row dropped (lives in hover card) <PRBadge url="https://github.com/superset-sh/superset/pull/3733" />, open state persists across workspaces <PRBadge url="https://github.com/superset-sh/superset/pull/3656" />
-- Group management — inline rename on create, cleaner ungroup/delete, hover-only actions <PRBadge url="https://github.com/superset-sh/superset/pull/3745" />
+- Group management: inline rename on create, cleaner ungroup/delete, hover-only actions <PRBadge url="https://github.com/superset-sh/superset/pull/3745" />
 - Mark-as-unread <PRBadge url="https://github.com/superset-sh/superset/pull/3773" /> clears on click <PRBadge url="https://github.com/superset-sh/superset/pull/3765" />, notification hooks play client-side <PRBadge url="https://github.com/superset-sh/superset/pull/3675" />
 
 ### Cross-workspace terminals
@@ -96,12 +96,12 @@ Automations now run on a cadence — same execution path as a manual run.
 
 **Bug fixes**
 
-- Terminal — sleep lifecycle <PRBadge url="https://github.com/superset-sh/superset/pull/3711" />, OSC links <PRBadge url="https://github.com/superset-sh/superset/pull/3736" />, resize <PRBadge url="https://github.com/superset-sh/superset/pull/3739" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3756" />, paste auto-submit <PRBadge url="https://github.com/superset-sh/superset/pull/3582" />, Unicode 11 buffer <PRBadge url="https://github.com/superset-sh/superset/pull/3581" />, Shift+Enter in TUIs <PRBadge url="https://github.com/superset-sh/superset/pull/3667" />, connection diagnostics <PRBadge url="https://github.com/superset-sh/superset/pull/3801" />
+- Terminal: sleep lifecycle <PRBadge url="https://github.com/superset-sh/superset/pull/3711" />, OSC links <PRBadge url="https://github.com/superset-sh/superset/pull/3736" />, resize <PRBadge url="https://github.com/superset-sh/superset/pull/3739" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3756" />, paste auto-submit <PRBadge url="https://github.com/superset-sh/superset/pull/3582" />, Unicode 11 buffer <PRBadge url="https://github.com/superset-sh/superset/pull/3581" />, Shift+Enter in TUIs <PRBadge url="https://github.com/superset-sh/superset/pull/3667" />, connection diagnostics <PRBadge url="https://github.com/superset-sh/superset/pull/3801" />
 - v2 stability across workspace switches <PRBadge url="https://github.com/superset-sh/superset/pull/3687" />, browser passthrough on resize <PRBadge url="https://github.com/superset-sh/superset/pull/3744" />
-- Git correctness — upstream/3-dot/numstat <PRBadge url="https://github.com/superset-sh/superset/pull/3543" />, cross-fork PR attribution <PRBadge url="https://github.com/superset-sh/superset/pull/3625" />, branch-only workspace status <PRBadge url="https://github.com/superset-sh/superset/pull/3295" />
-- Sidebar — new workspaces at top of project <PRBadge url="https://github.com/superset-sh/superset/pull/3619" />, hide rows during destroy <PRBadge url="https://github.com/superset-sh/superset/pull/3621" />, sync <PRBadge url="https://github.com/superset-sh/superset/pull/3746" />, no nav-away on delete <PRBadge url="https://github.com/superset-sh/superset/pull/3771" />, active selection after removal <PRBadge url="https://github.com/superset-sh/superset/pull/3767" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3741" />, delete toast + switch <PRBadge url="https://github.com/superset-sh/superset/pull/3661" />, project settings route <PRBadge url="https://github.com/superset-sh/superset/pull/3592" />, scrollable project dropdown <PRBadge url="https://github.com/superset-sh/superset/pull/3628" />
+- Git correctness: upstream/3-dot/numstat <PRBadge url="https://github.com/superset-sh/superset/pull/3543" />, cross-fork PR attribution <PRBadge url="https://github.com/superset-sh/superset/pull/3625" />, branch-only workspace status <PRBadge url="https://github.com/superset-sh/superset/pull/3295" />
+- Sidebar: new workspaces at top of project <PRBadge url="https://github.com/superset-sh/superset/pull/3619" />, hide rows during destroy <PRBadge url="https://github.com/superset-sh/superset/pull/3621" />, sync <PRBadge url="https://github.com/superset-sh/superset/pull/3746" />, no nav-away on delete <PRBadge url="https://github.com/superset-sh/superset/pull/3771" />, active selection after removal <PRBadge url="https://github.com/superset-sh/superset/pull/3767" /> <PRBadge url="https://github.com/superset-sh/superset/pull/3741" />, delete toast + switch <PRBadge url="https://github.com/superset-sh/superset/pull/3661" />, project settings route <PRBadge url="https://github.com/superset-sh/superset/pull/3592" />, scrollable project dropdown <PRBadge url="https://github.com/superset-sh/superset/pull/3628" />
 - Long workspace names wrap in v1 hover <PRBadge url="https://github.com/superset-sh/superset/pull/3603" />, no overflow on create-error page <PRBadge url="https://github.com/superset-sh/superset/pull/3718" />, DevicePicker dedupe <PRBadge url="https://github.com/superset-sh/superset/pull/3593" />
 - AI naming for OAuth-only users <PRBadge url="https://github.com/superset-sh/superset/pull/3580" />, `ask_user` vs sandbox prompt <PRBadge url="https://github.com/superset-sh/superset/pull/3662" />, no spurious folder picker on settings nav <PRBadge url="https://github.com/superset-sh/superset/pull/3602" />
 - Host services survive app update <PRBadge url="https://github.com/superset-sh/superset/pull/3620" />, restart adoption <PRBadge url="https://github.com/superset-sh/superset/pull/3732" />, tray org name <PRBadge url="https://github.com/superset-sh/superset/pull/3629" />, ports dropdown failed-host indicator <PRBadge url="https://github.com/superset-sh/superset/pull/3787" />, duplicate clone URLs allowed <PRBadge url="https://github.com/superset-sh/superset/pull/3723" />
-- Automations — list flicker <PRBadge url="https://github.com/superset-sh/superset/pull/3772" />, timezone scheduling <PRBadge url="https://github.com/superset-sh/superset/pull/3738" />
-- Security — `shell.openExternal` URL allowlist <PRBadge url="https://github.com/superset-sh/superset/pull/3650" />, uuid GHSA-w5hq-g745-h8pq <PRBadge url="https://github.com/superset-sh/superset/pull/3680" />
+- Automations: list flicker <PRBadge url="https://github.com/superset-sh/superset/pull/3772" />, timezone scheduling <PRBadge url="https://github.com/superset-sh/superset/pull/3738" />
+- Security: `shell.openExternal` URL allowlist <PRBadge url="https://github.com/superset-sh/superset/pull/3650" />, uuid GHSA-w5hq-g745-h8pq <PRBadge url="https://github.com/superset-sh/superset/pull/3680" />

--- a/apps/marketing/content/changelog/2026-05-18-teams-slack-sdk-workspaces.mdx
+++ b/apps/marketing/content/changelog/2026-05-18-teams-slack-sdk-workspaces.mdx
@@ -8,20 +8,20 @@ Superset is now usable from a lot more places than the desktop app: a fleshed-ou
 
 ## Automations
 
-**Automations are cron jobs for agent sessions.** Pick a project, write a prompt, set a schedule — and Superset dispatches an agent run against a fresh workspace every time it fires. The output is a live workspace you can open, review, and continue interactively.
+**Automations are cron jobs for agent sessions.** Pick a project, write a prompt, set a schedule, and Superset dispatches an agent run against a fresh workspace every time it fires. The output is a live workspace you can open, review, and continue interactively.
 
 Typical uses:
 
-- **Nightly standups** — summarize PRs, issues, and activity from the last 24 hours
-- **Release notes** — draft from merged commits each week
-- **Security & dependency sweeps** — scan for vulnerable packages or deprecated APIs every morning
-- **Long-running refactors** — "bump TypeScript to 5.7 in the next un-migrated package" on a daily cadence
+- **Nightly standups**: summarize PRs, issues, and activity from the last 24 hours
+- **Release notes**: draft from merged commits each week
+- **Security & dependency sweeps**: scan for vulnerable packages or deprecated APIs every morning
+- **Long-running refactors**: "bump TypeScript to 5.7 in the next un-migrated package" on a daily cadence
 
 This batch brings automations into their own as a first-class workflow:
 
-- **Prompt version history** <PRBadge url="https://github.com/superset-sh/superset/pull/3996" /> — every edit to an automation's prompt is snapshotted. Browse previous versions and restore any of them, so an accidental change is no longer a one-way door.
-- **Redesigned automations tab** <PRBadge url="https://github.com/superset-sh/superset/pull/4225" /> — new layout that makes a queue of runs easier to scan at a glance.
-- **Mine vs. Team filter** <PRBadge url="https://github.com/superset-sh/superset/pull/4403" /> — automations now belong to a team. Filter the runs view between **Mine** and **Team** to see only what you ran vs. everything your team kicked off.
+- **Prompt version history** <PRBadge url="https://github.com/superset-sh/superset/pull/3996" />: every edit to an automation's prompt is snapshotted. Browse previous versions and restore any of them, so an accidental change is no longer a one-way door.
+- **Redesigned automations tab** <PRBadge url="https://github.com/superset-sh/superset/pull/4225" />: new layout that makes a queue of runs easier to scan at a glance.
+- **Mine vs. Team filter** <PRBadge url="https://github.com/superset-sh/superset/pull/4403" />: automations now belong to a team. Filter the runs view between **Mine** and **Team** to see only what you ran vs. everything your team kicked off.
 
 ### Drive them from the CLI
 
@@ -58,10 +58,10 @@ The `superset` CLI grew real project and workspace commands and a cross-device l
 
 **New commands:**
 
-- `superset projects create` <PRBadge url="https://github.com/superset-sh/superset/pull/4355" /> — scaffold a new Superset project from your shell.
-- `superset projects setup` <PRBadge url="https://github.com/superset-sh/superset/pull/4356" /> — link an existing local repo to a Superset project.
-- `superset workspaces open` <PRBadge url="https://github.com/superset-sh/superset/pull/4258" /> — open a workspace directly from the terminal.
-- `superset auth login` <PRBadge url="https://github.com/superset-sh/superset/pull/3965" /> — now uses OAuth device code + PKCE, so it works on headless servers and across devices.
+- `superset projects create` <PRBadge url="https://github.com/superset-sh/superset/pull/4355" />: scaffold a new Superset project from your shell.
+- `superset projects setup` <PRBadge url="https://github.com/superset-sh/superset/pull/4356" />: link an existing local repo to a Superset project.
+- `superset workspaces open` <PRBadge url="https://github.com/superset-sh/superset/pull/4258" />: open a workspace directly from the terminal.
+- `superset auth login` <PRBadge url="https://github.com/superset-sh/superset/pull/3965" />: now uses OAuth device code + PKCE, so it works on headless servers and across devices.
 
 **Setting it up:**
 
@@ -79,7 +79,7 @@ superset projects create
 superset workspaces open
 ```
 
-The accompanying **TypeScript SDK** <PRBadge url="https://github.com/superset-sh/superset/pull/3937" /> (`@superset_sh/sdk`) mirrors the CLI 1:1 — same procedures, same shapes — so anything you can do from your shell, you can do from a script, a CI job, or an internal tool.
+The accompanying **TypeScript SDK** <PRBadge url="https://github.com/superset-sh/superset/pull/3937" /> (`@superset_sh/sdk`) mirrors the CLI 1:1 (same procedures, same shapes), so anything you can do from your shell, you can do from a script, a CI job, or an internal tool.
 
 ```bash
 npm install @superset_sh/sdk
@@ -99,9 +99,9 @@ Linux `superset start` and `superset update` are now fixed <PRBadge url="https:/
 
 `@superset` in Slack is now an actual agent, not a task-filer. Mention it in a channel or DM it from anywhere, and it can:
 
-- **Create, update, search, and triage tasks** from the conversation it's standing in — pulling assignees, statuses, and priorities from your team's Linear/Superset setup.
+- **Create, update, search, and triage tasks** from the conversation it's standing in, pulling assignees, statuses, and priorities from your team's Linear/Superset setup.
 - **Spin up a cloud workspace and launch a coding agent** to actually do the work. For code-change requests (e.g. "@superset bump our Sentry SDK to v9 across all apps"), it now defaults to spawning a workspace and agent rather than just filing a ticket <PRBadge url="https://github.com/superset-sh/superset/pull/4660" />.
-- **Read the thread or channel history** on its own to gather context — no need to copy-paste the prior messages.
+- **Read the thread or channel history** on its own to gather context: no need to copy-paste the prior messages.
 - **Search the web with citations** when a request needs up-to-date info.
 - **Unfurl Superset task and workspace links** with rich previews when they're shared in a channel.
 
@@ -111,17 +111,17 @@ Linux `superset start` and `superset update` are now fixed <PRBadge url="https:/
 2. Click **Connect** to install the Superset Slack app into your workspace (OAuth).
 3. Mention `@superset` in any channel, or open a DM with the bot, and describe what you want done.
 
-If Slack was already connected before this release, no action needed — proactive workspace creation is on by default.
+If Slack was already connected before this release, no action needed: proactive workspace creation is on by default.
 
 ## Mobile: internal review
 
-The mobile app is in **internal review**. Core flows — workspaces list, task triage, agent chat, and the live terminal viewer — are wired up against the same APIs as web and desktop. We're dogfooding on-device now ahead of a wider beta.
+The mobile app is in **internal review**. Core flows (workspaces list, task triage, agent chat, and the live terminal viewer) are wired up against the same APIs as web and desktop. We're dogfooding on-device now ahead of a wider beta.
 
 ## Also in this batch
 
-- **Teams as a first-class primitive** <PRBadge url="https://github.com/superset-sh/superset/pull/4403" /> — assign members, workspaces, and automations to a team. Powers the Mine/Team automations split above.
-- **Terminal sessions survive app updates** <PRBadge url="https://github.com/superset-sh/superset/pull/3971" /> — the PTY daemon hands off file descriptors on upgrade, so running shells stay alive when Superset auto-updates.
-- **Web terminal presets** <PRBadge url="https://github.com/superset-sh/superset/pull/4653" /> — run your common commands with a single click in the web terminal, same as desktop.
+- **Teams as a first-class primitive** <PRBadge url="https://github.com/superset-sh/superset/pull/4403" />: assign members, workspaces, and automations to a team. Powers the Mine/Team automations split above.
+- **Terminal sessions survive app updates** <PRBadge url="https://github.com/superset-sh/superset/pull/3971" />: the PTY daemon hands off file descriptors on upgrade, so running shells stay alive when Superset auto-updates.
+- **Web terminal presets** <PRBadge url="https://github.com/superset-sh/superset/pull/4653" />: run your common commands with a single click in the web terminal, same as desktop.
 
 ## Minor updates
 

--- a/apps/marketing/content/changelog/2026-07-06-custom-agents-workspace-activity-fable.mdx
+++ b/apps/marketing/content/changelog/2026-07-06-custom-agents-workspace-activity-fable.mdx
@@ -28,7 +28,7 @@ The v2 sidebar now surfaces what each workspace is actually doing in a single co
 
 Launch agents with the Fable model family and pick a reasoning-effort level right from the workspace.
 
-![New workspace dialog — pick the model (Fable, Opus, Sonnet, Haiku) and reasoning effort inline](/changelog/2026-07-06-model-picker.png)
+![New workspace dialog: pick the model (Fable, Opus, Sonnet, Haiku) and reasoning effort inline](/changelog/2026-07-06-model-picker.png)
 
 - Fable 5 available in the copilot, cursor-agent, and opencode model pickers <PRBadge url="https://github.com/superset-sh/superset/pull/5435" />
 - Model picker added to the workspace create dialog <PRBadge url="https://github.com/superset-sh/superset/pull/5248" />
@@ -41,7 +41,7 @@ The macOS dock icon now shows a badge for workspaces with unread activity or tha
 
 ## Improvements
 
-**Real tables for Automations & Workspaces** — sortable columns, grouped project headers, row context menus, and an overflow fix. <PRBadge url="https://github.com/superset-sh/superset/pull/5454" />
+**Real tables for Automations & Workspaces**: sortable columns, grouped project headers, row context menus, and an overflow fix. <PRBadge url="https://github.com/superset-sh/superset/pull/5454" />
 
 ![Automations table with sortable columns, Mine/Team tabs, and run status](/changelog/2026-07-06-automations-table.png)
 

--- a/apps/marketing/content/changelog/2026-07-06-tweet.md
+++ b/apps/marketing/content/changelog/2026-07-06-tweet.md
@@ -1,5 +1,5 @@
 ---
-title: Launch thread — Custom agents, activity strip, Fable 5
+title: "Launch thread: Custom agents, activity strip, Fable 5"
 date: 2026-07-06
 type: tweet
 ---
@@ -11,13 +11,13 @@ What we shipped this week @ Superset 🛳️
 
 1. Bring your own agents 🧩
 
-The best coding agent for a job changes week to week — and you shouldn't have to wait for us to ship support for it. Superset now lets you register any terminal agent as a first-class citizen: give it a name, an icon, and a launch command, and it runs everywhere the built-ins do.
+The best coding agent for a job changes week to week, and you shouldn't have to wait for us to ship support for it. Superset now lets you register any terminal agent as a first-class citizen: give it a name, an icon, and a launch command, and it runs everywhere the built-ins do.
 
-We're betting the future is many specialized agents, not one — so we added Polygraph as a new built-in too, with more on the way.
+We're betting the future is many specialized agents, not one, so we added Polygraph as a new built-in too, with more on the way.
 
 2. Workspace activity strip 👀
 
-When you're running a fleet of agents you need to see the whole board at a glance. The v2 sidebar now shows what each workspace is actually doing — running agents and open ports inline on every row, persisted across restarts, with in-progress work pushed to the top.
+When you're running a fleet of agents you need to see the whole board at a glance. The v2 sidebar now shows what each workspace is actually doing: running agents and open ports inline on every row, persisted across restarts, with in-progress work pushed to the top.
 
 3. Fable 5 + reasoning effort 🧠
 

--- a/apps/marketing/content/compare/best-ai-coding-agents-2026.mdx
+++ b/apps/marketing/content/compare/best-ai-coding-agents-2026.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Best AI Coding Tools and Agents (2026): Complete Comparison"
-description: "Compare the top AI coding tools of 2026 — Superset, Cursor, Claude Code, Codex, Windsurf, Devin, Capy, Conductor, and more. Find the right stack for your workflow."
+description: "Compare the top AI coding tools of 2026: Superset, Cursor, Claude Code, Codex, Windsurf, Devin, Capy, Conductor, and more. Find the right stack for your workflow."
 date: 2026-02-18
 lastUpdated: 2026-03-21
 type: "roundup"
@@ -45,26 +45,26 @@ One important correction to older comparison copy: Superset is no longer well-de
 
 These tools do the coding work itself:
 
-- **Claude Code** — Anthropic's coding agent, available through the CLI and a desktop app
-- **Codex** — OpenAI's coding stack spanning CLI, IDE extension, desktop app, and cloud delegation
-- **GitHub Copilot** — Inline completions, chat, agent mode, and GitHub-centered workflows
-- **Devin** — Fully autonomous cloud AI software engineer
-- **OpenCode** — Open-source terminal agent with broad model/provider support
-- **Aider** — Open-source terminal pair-programming assistant
+- **Claude Code**: Anthropic's coding agent, available through the CLI and a desktop app
+- **Codex**: OpenAI's coding stack spanning CLI, IDE extension, desktop app, and cloud delegation
+- **GitHub Copilot**: Inline completions, chat, agent mode, and GitHub-centered workflows
+- **Devin**: Fully autonomous cloud AI software engineer
+- **OpenCode**: Open-source terminal agent with broad model/provider support
+- **Aider**: Open-source terminal pair-programming assistant
 
 ### 2. AI Editors
 
 These center the editing environment itself:
 
-- **Cursor** — AI-native editor plus cloud agents, web/mobile agents, and automations
-- **Windsurf** — AI-native IDE with Cascade workflows
+- **Cursor**: AI-native editor plus cloud agents, web/mobile agents, and automations
+- **Windsurf**: AI-native IDE with Cascade workflows
 ### 3. Agent Orchestrators and Workspaces
 
 These tools run and manage multiple agents:
 
-- **Superset** — Local-first workspace that runs 100+ agents in parallel via Git worktrees
-- **Capy** — Hosted parallel-agent platform with isolated environments
-- **Conductor** — macOS app for running Claude Code and Codex in parallel
+- **Superset**: Local-first workspace that runs 100+ agents in parallel via Git worktrees
+- **Capy**: Hosted parallel-agent platform with isolated environments
+- **Conductor**: macOS app for running Claude Code and Codex in parallel
 
 Most serious workflows now use one tool from more than one layer. The agent does the coding. The IDE improves the editing loop. The orchestrator scales work across many tasks.
 

--- a/apps/marketing/content/compare/buzz-alternative.mdx
+++ b/apps/marketing/content/compare/buzz-alternative.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Best Buzz Alternatives in 2026"
-description: "The best alternatives to Buzz by Block for working with AI coding agents, including Superset, Orca, Emdash, and OpenHands — from agent workspaces to self-hosted platforms."
+description: "The best alternatives to Buzz by Block for working with AI coding agents, including Superset, Orca, Emdash, and OpenHands, from agent workspaces to self-hosted platforms."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "roundup"

--- a/apps/marketing/content/compare/cindy-alternative.mdx
+++ b/apps/marketing/content/compare/cindy-alternative.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Best Cindy Alternatives in 2026"
-description: "The best alternatives to Cindy for running AI coding agents in parallel, including Superset, Orca, Emdash, and Conductor — purpose-built developer workspaces."
+description: "The best alternatives to Cindy for running AI coding agents in parallel, including Superset, Orca, Emdash, and Conductor, purpose-built developer workspaces."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "roundup"

--- a/apps/marketing/content/compare/herdr-alternative.mdx
+++ b/apps/marketing/content/compare/herdr-alternative.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Best Herdr Alternatives in 2026"
-description: "The best alternatives to Herdr for running AI coding agents, including Superset, Orca, Emdash, cmux, and Claude Squad — from full workspaces to terminal-native tools."
+description: "The best alternatives to Herdr for running AI coding agents, including Superset, Orca, Emdash, cmux, and Claude Squad, from full workspaces to terminal-native tools."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "roundup"

--- a/apps/marketing/content/compare/superset-vs-agent-orchestrator.mdx
+++ b/apps/marketing/content/compare/superset-vs-agent-orchestrator.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Agent Orchestrator (2026): Two Agent IDEs for Parallel Fleets"
-description: "Compare Superset and Agent Orchestrator (AO) for running fleets of AI coding agents — worktree workspaces, CI-failure loops, review routing, and automation surfaces."
+description: "Compare Superset and Agent Orchestrator (AO) for running fleets of AI coding agents: worktree workspaces, CI-failure loops, review routing, and automation surfaces."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-aider.mdx
+++ b/apps/marketing/content/compare/superset-vs-aider.mdx
@@ -14,7 +14,7 @@ keywords:
   - parallel coding agents
 ---
 
-Aider is one of the most popular open-source AI pair programmers — a single, focused CLI that edits your code and commits to Git from the terminal. Superset solves a broader problem: it is a local-first workspace that runs Aider (and other agents) across many isolated worktrees at once. In fact, Aider is one of the agents Superset can launch, so the real question is single-session pair programming versus multi-agent orchestration.
+Aider is one of the most popular open-source AI pair programmers: a single, focused CLI that edits your code and commits to Git from the terminal. Superset solves a broader problem: it is a local-first workspace that runs Aider (and other agents) across many isolated worktrees at once. In fact, Aider is one of the agents Superset can launch, so the real question is single-session pair programming versus multi-agent orchestration.
 
 ---
 
@@ -23,8 +23,8 @@ Aider is one of the most popular open-source AI pair programmers — a single, f
 | | **Superset** | **Aider** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | Terminal AI pair programmer |
-| **AI approach** | Agent-agnostic — runs Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Model-agnostic — Claude, GPT, Gemini, DeepSeek, or local models |
-| **Parallelism** | Core feature — 100+ agents across isolated Git worktrees | One interactive session per terminal |
+| **AI approach** | Agent-agnostic: runs Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Model-agnostic: Claude, GPT, Gemini, DeepSeek, or local models |
+| **Parallelism** | Core feature: 100+ agents across isolated Git worktrees | One interactive session per terminal |
 | **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Command-line REPL in your terminal |
 | **Git model** | Isolated worktree per task | Auto-commits to your current branch |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source (Apache-2.0); bring your own API keys |
@@ -39,7 +39,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Aider?
 
-Aider is an open-source AI pair programming tool that runs in your terminal. You point it at a repository, chat with it about changes, and it edits files and commits them to Git for you. It builds a map of your repo to work effectively in larger codebases, supports a wide range of models (Anthropic, OpenAI, Google, DeepSeek, and local models via OpenAI-compatible endpoints), and stays deliberately lightweight — no GUI, no vendor runtime, just a fast command-line loop. It is free and open source under Apache-2.0.
+Aider is an open-source AI pair programming tool that runs in your terminal. You point it at a repository, chat with it about changes, and it edits files and commits them to Git for you. It builds a map of your repo to work effectively in larger codebases, supports a wide range of models (Anthropic, OpenAI, Google, DeepSeek, and local models via OpenAI-compatible endpoints), and stays deliberately lightweight: no GUI, no vendor runtime, just a fast command-line loop. It is free and open source under Apache-2.0.
 
 ---
 
@@ -47,11 +47,11 @@ Aider is an open-source AI pair programming tool that runs in your terminal. You
 
 ### Single Session vs Parallel Agents
 
-Aider is designed around one focused conversation: you and the model, iterating on a change in one terminal. Superset is built for parallelism — it runs many agents at once, each in its own Git worktree, so a refactor, a test-generation pass, and a bug fix can all progress simultaneously without stepping on each other.
+Aider is designed around one focused conversation: you and the model, iterating on a change in one terminal. Superset is built for parallelism: it runs many agents at once, each in its own Git worktree, so a refactor, a test-generation pass, and a bug fix can all progress simultaneously without stepping on each other.
 
 ### Terminal Loop vs Full Workspace
 
-Aider is intentionally minimal: a terminal REPL that edits and commits. Superset wraps agents in a desktop workspace with a diff/file editor, chat, an in-app browser for previewing dev servers and docs, port management, and MCP tooling — so reviewing and steering agents does not require leaving the app.
+Aider is intentionally minimal: a terminal REPL that edits and commits. Superset wraps agents in a desktop workspace with a diff/file editor, chat, an in-app browser for previewing dev servers and docs, port management, and MCP tooling, so reviewing and steering agents does not require leaving the app.
 
 ### Complementary, Not Mutually Exclusive
 
@@ -65,7 +65,7 @@ Both keep the code on your machine and let you choose your own model provider. S
 
 ## Pricing
 
-Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex): transparent provider costs, no platform credit system.
 
 Aider is free and open source (Apache-2.0). You only pay for the model API you point it at, or nothing at all if you run a local model. That makes Aider the cheapest possible way to start, at the cost of a single-session, terminal-only workflow.
 
@@ -101,4 +101,4 @@ Yes. Aider is open source under Apache-2.0 and free to use. You only pay for the
 
 ### Does Aider support parallel agents?
 
-Not on its own — Aider runs one interactive session per terminal. To run Aider (or a mix of agents) across many tasks at once, you can launch multiple instances inside Superset, each in its own worktree.
+Not on its own: Aider runs one interactive session per terminal. To run Aider (or a mix of agents) across many tasks at once, you can launch multiple instances inside Superset, each in its own worktree.

--- a/apps/marketing/content/compare/superset-vs-claude-code.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-code.mdx
@@ -15,7 +15,7 @@ keywords:
   - ai coding agent comparison
 ---
 
-Claude Code is Anthropic's AI coding agent, with both terminal and desktop app surfaces. Superset is a local-first desktop workspace that can run multiple Claude Code sessions, other agents, and Superset Chat in parallel across isolated Git worktrees. They're complementary — Claude Code is the agent, while Superset is the orchestration and review layer around many agents.
+Claude Code is Anthropic's AI coding agent, with both terminal and desktop app surfaces. Superset is a local-first desktop workspace that can run multiple Claude Code sessions, other agents, and Superset Chat in parallel across isolated Git worktrees. They're complementary: Claude Code is the agent, while Superset is the orchestration and review layer around many agents.
 
 ---
 
@@ -25,9 +25,9 @@ Claude Code is Anthropic's AI coding agent, with both terminal and desktop app s
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding agent (CLI + desktop app) |
 | **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and debugs code in your terminal or desktop app |
-| **AI approach** | Agent-agnostic — orchestrates Claude Code, Codex, Aider, OpenCode, Superset Chat, and more | Claude models only (Sonnet, Opus, Haiku) via Anthropic API |
-| **Parallelism** | Core feature — many agents on separate branches simultaneously | Single session; requires separate terminal tabs for parallelism |
-| **Isolation** | Automatic Git worktree per task — agents cannot conflict | Shares your working directory — manual worktree setup needed |
+| **AI approach** | Agent-agnostic: orchestrates Claude Code, Codex, Aider, OpenCode, Superset Chat, and more | Claude models only (Sonnet, Opus, Haiku) via Anthropic API |
+| **Parallelism** | Core feature: many agents on separate branches simultaneously | Single session; requires separate terminal tabs for parallelism |
+| **Isolation** | Automatic Git worktree per task: agents cannot conflict | Shares your working directory. Manual worktree setup needed |
 | **Pricing** | Free tier + Pro $20/seat/mo | Claude Pro / Max / Teams / Enterprise / Console account, or provider usage |
 | **License** | Source-available (ELv2) | Source-available (not open source) |
 
@@ -49,7 +49,7 @@ Claude Code is Anthropic's official coding agent. The CLI is still the core expe
 
 ### Orchestrator vs Agent
 
-Claude Code is the agent — it talks to Claude models, reads your code, and makes changes. Superset is the orchestration workspace — it runs many Claude Code instances in parallel, each in its own isolated environment, then gives you chat, browser preview, diff/file review, and MCP-connected workflow around them. Claude Code does the work; Superset scales and organizes it.
+Claude Code is the agent: it talks to Claude models, reads your code, and makes changes. Superset is the orchestration workspace: it runs many Claude Code instances in parallel, each in its own isolated environment, then gives you chat, browser preview, diff/file review, and MCP-connected workflow around them. Claude Code does the work; Superset scales and organizes it.
 
 ### Single Product Surface vs Many Isolated Sessions
 
@@ -61,7 +61,7 @@ Running Claude Code directly, it modifies files in your current directory. If yo
 
 ### Agent Flexibility
 
-Claude Code only works with Anthropic's models. Superset doesn't care which agent you use — run Claude Code for complex refactors, Codex for well-defined tasks, Aider for iterative changes, or mix and match per task. If a better agent ships tomorrow, you can use it in Superset immediately without changing your workflow.
+Claude Code only works with Anthropic's models. Superset doesn't care which agent you use: run Claude Code for complex refactors, Codex for well-defined tasks, Aider for iterative changes, or mix and match per task. If a better agent ships tomorrow, you can use it in Superset immediately without changing your workflow.
 
 ### Session Persistence
 
@@ -90,7 +90,7 @@ Superset offers a free tier and Pro at $20/seat/month. Claude Code currently req
 - Plan to use other agents alongside Claude Code (Codex, Aider, OpenCode)
 - Work on large codebases where parallel execution saves hours
 
-Most Superset users run Claude Code as their primary agent. Superset doesn't compete with Claude Code — it makes Claude Code more powerful by adding parallelism, isolation, and persistence.
+Most Superset users run Claude Code as their primary agent. Superset doesn't compete with Claude Code: it makes Claude Code more powerful by adding parallelism, isolation, and persistence.
 
 ---
 
@@ -102,7 +102,7 @@ Not really. Superset now has built-in chat, MCP tooling, browser previews, and f
 
 ### Can I use Claude Code without Superset?
 
-Yes. Claude Code works on its own from the CLI or Anthropic's Desktop app. Superset adds value when you want to run multiple Claude Code sessions in parallel with automatic isolation — which becomes important as you scale from one agent to many.
+Yes. Claude Code works on its own from the CLI or Anthropic's Desktop app. Superset adds value when you want to run multiple Claude Code sessions in parallel with automatic isolation, which becomes important as you scale from one agent to many.
 
 ### How many Claude Code instances can I run in Superset?
 
@@ -110,7 +110,7 @@ As many as your machine and API rate limits allow. Most developers run 5-10 conc
 
 ### Does Superset modify how Claude Code works?
 
-No. Claude Code runs exactly as it would in any terminal. Superset just provides the worktree, branch, and terminal session. All Claude Code features — tool use, MCP servers, hooks, slash commands — work normally.
+No. Claude Code runs exactly as it would in any terminal. Superset just provides the worktree, branch, and terminal session. All Claude Code features (tool use, MCP servers, hooks, slash commands) work normally.
 
 ### Is Superset open source?
 

--- a/apps/marketing/content/compare/superset-vs-cline.mdx
+++ b/apps/marketing/content/compare/superset-vs-cline.mdx
@@ -14,7 +14,7 @@ keywords:
   - parallel coding agents
 ---
 
-Cline is a popular open-source autonomous coding agent that lives inside VS Code. It plans, edits files, runs terminal commands, and uses your own API keys — all within the editor. Superset takes a different shape: it is an editor-independent, local-first workspace that runs many CLI agents in parallel across isolated Git worktrees, and treats your editor as a choice rather than the container.
+Cline is a popular open-source autonomous coding agent that lives inside VS Code. It plans, edits files, runs terminal commands, and uses your own API keys, all within the editor. Superset takes a different shape: it is an editor-independent, local-first workspace that runs many CLI agents in parallel across isolated Git worktrees, and treats your editor as a choice rather than the container.
 
 ---
 
@@ -24,8 +24,8 @@ Cline is a popular open-source autonomous coding agent that lives inside VS Code
 |---|---|---|
 | **Category** | Agent orchestration workspace | In-editor autonomous agent |
 | **Home** | Standalone desktop app | VS Code (and forks) extension |
-| **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic — Anthropic, OpenRouter, Bedrock, and more via your keys |
-| **Parallelism** | Core feature — 100+ agents across isolated Git worktrees | One agent per editor window/session |
+| **AI approach** | Agent-agnostic: Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic: Anthropic, OpenRouter, Bedrock, and more via your keys |
+| **Parallelism** | Core feature: 100+ agents across isolated Git worktrees | One agent per editor window/session |
 | **Isolation** | Git worktree per task | Works in your open workspace folder |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source; bring your own API keys |
 
@@ -39,7 +39,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Cline?
 
-Cline is an open-source AI coding agent that runs as a VS Code extension. It works in Plan and Act modes: it can read and write files, run terminal commands, use a browser, and connect to MCP servers, all from inside the editor. You bring your own model access (Anthropic, OpenRouter, AWS Bedrock, and others), so there is no hosted runtime or credit system — the extension is free and you pay your provider directly. Its strength is tight, in-editor autonomy: the agent operates right where you already write code.
+Cline is an open-source AI coding agent that runs as a VS Code extension. It works in Plan and Act modes: it can read and write files, run terminal commands, use a browser, and connect to MCP servers, all from inside the editor. You bring your own model access (Anthropic, OpenRouter, AWS Bedrock, and others), so there is no hosted runtime or credit system: the extension is free and you pay your provider directly. Its strength is tight, in-editor autonomy: the agent operates right where you already write code.
 
 ---
 
@@ -47,7 +47,7 @@ Cline is an open-source AI coding agent that runs as a VS Code extension. It wor
 
 ### In-Editor Agent vs Editor-Independent Workspace
 
-Cline is embedded in VS Code — its context is your open editor window. Superset sits outside any single editor: it orchestrates agents around the repository and lets you review in its own UI or in VS Code, Cursor, JetBrains, or Xcode. If you are not a VS Code user, Cline does not fit; Superset does not care which editor you use.
+Cline is embedded in VS Code: its context is your open editor window. Superset sits outside any single editor: it orchestrates agents around the repository and lets you review in its own UI or in VS Code, Cursor, JetBrains, or Xcode. If you are not a VS Code user, Cline does not fit; Superset does not care which editor you use.
 
 ### One Agent vs Many in Parallel
 
@@ -59,15 +59,15 @@ Cline operates in your currently open workspace folder. Superset gives every tas
 
 ### Privacy
 
-Both keep code local and use your own model keys — no required hosted runtime. Cline is fully open source; Superset is source-available (ELv2) and runs agents locally in worktrees.
+Both keep code local and use your own model keys: no required hosted runtime. Cline is fully open source; Superset is source-available (ELv2) and runs agents locally in worktrees.
 
 ---
 
 ## Pricing
 
-Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex): transparent provider costs, no platform credit system.
 
-Cline is free and open source. You pay only for the model API you connect it to. That makes both tools "bring your own keys" with no markup — the difference is form factor, not billing model.
+Cline is free and open source. You pay only for the model API you connect it to. That makes both tools "bring your own keys" with no markup. The difference is form factor, not billing model.
 
 ---
 
@@ -81,7 +81,7 @@ Cline is free and open source. You pay only for the model API you connect it to.
 
 **Choose Superset if you:**
 - Want to run many agents in parallel across isolated Git worktrees
-- Use JetBrains, Xcode, Neovim, or multiple editors — or want to stay editor-independent
+- Use JetBrains, Xcode, Neovim, or multiple editors, or want to stay editor-independent
 - Need a workspace with diff review, chat, browser preview, and port management around your agents
 - Want to mix agents (Claude Code, Codex, Aider, and more) rather than one in-editor agent
 

--- a/apps/marketing/content/compare/superset-vs-codex.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex.mdx
@@ -25,8 +25,8 @@ Codex CLI is OpenAI's terminal-based coding agent, but it now sits inside a broa
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding agent (terminal-native) |
 | **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | AI assistant that reads, writes, and executes code via OpenAI models |
-| **AI approach** | Agent-agnostic — works with Codex, Claude Code, Aider, OpenCode, Superset Chat, and more | OpenAI's Codex model family and related OpenAI coding workflows |
-| **Parallelism** | Core feature — many agents on separate branches simultaneously | Single session; cloud Codex runs tasks remotely |
+| **AI approach** | Agent-agnostic: works with Codex, Claude Code, Aider, OpenCode, Superset Chat, and more | OpenAI's Codex model family and related OpenAI coding workflows |
+| **Parallelism** | Core feature: many agents on separate branches simultaneously | Single session; cloud Codex runs tasks remotely |
 | **Isolation** | Automatic Git worktree per task | Sandbox modes (network-disabled, full-auto) per session |
 | **Pricing** | Free tier + Pro $20/seat/mo | ChatGPT-plan access and API usage vary by Codex surface |
 | **License** | Source-available (ELv2) | Open source (Apache 2.0) |
@@ -49,7 +49,7 @@ Codex CLI is OpenAI's open-source local terminal client for Codex. It runs on yo
 
 ### Orchestrator vs Agent Suite
 
-Codex is the agent suite — it reads code, talks to OpenAI models, and writes changes through local and cloud surfaces. Superset is the orchestration workspace around agents — it runs many Codex sessions in parallel, each in its own isolated environment, then gives you chat, review, browser preview, and MCP-connected workflow around them. Run Codex inside Superset to get automatic worktree isolation and parallel execution with zero manual setup.
+Codex is the agent suite: it reads code, talks to OpenAI models, and writes changes through local and cloud surfaces. Superset is the orchestration workspace around agents: it runs many Codex sessions in parallel, each in its own isolated environment, then gives you chat, review, browser preview, and MCP-connected workflow around them. Run Codex inside Superset to get automatic worktree isolation and parallel execution with zero manual setup.
 
 ### Local, App, and Cloud vs Local Orchestration
 
@@ -57,11 +57,11 @@ Codex now spans multiple surfaces: CLI, IDE extension, desktop app, and cloud de
 
 ### Single Product Stack vs Mixed-Agent Stack
 
-With Codex alone, whether from the CLI or app, you stay inside OpenAI's Codex product model. With Superset, you can assign tasks to multiple Codex instances simultaneously — or mix Codex with Claude Code, Aider, OpenCode, or Superset Chat — each on its own branch with its own worktree.
+With Codex alone, whether from the CLI or app, you stay inside OpenAI's Codex product model. With Superset, you can assign tasks to multiple Codex instances simultaneously (or mix Codex with Claude Code, Aider, OpenCode, or Superset Chat), each on its own branch with its own worktree.
 
 ### Agent Flexibility
 
-Codex CLI only works with OpenAI's models. Superset doesn't care which agent you use — run Codex for tasks where OpenAI models excel, Claude Code for complex architectural work, and Aider for iterative changes. Mix and match per task based on what works best.
+Codex CLI only works with OpenAI's models. Superset doesn't care which agent you use: run Codex for tasks where OpenAI models excel, Claude Code for complex architectural work, and Aider for iterative changes. Mix and match per task based on what works best.
 
 ### Session Persistence
 
@@ -90,7 +90,7 @@ Superset offers a free tier and Pro at $20/seat/month. Codex pricing now depends
 - Plan to mix Codex with other agents (Claude Code, Aider, OpenCode) per task
 - Work on large codebases where parallel execution saves hours
 
-Superset and Codex CLI work together naturally. Each Superset task launches Codex in its own worktree — you get Codex's coding ability with Superset's parallelism and isolation.
+Superset and Codex CLI work together naturally. Each Superset task launches Codex in its own worktree: you get Codex's coding ability with Superset's parallelism and isolation.
 
 ---
 
@@ -102,7 +102,7 @@ Not really. Superset now has built-in chat, MCP tooling, browser previews, and f
 
 ### Can I run Codex in Full Auto mode inside Superset?
 
-Yes. Each Superset task runs Codex in its own isolated worktree. You can use any Codex mode — Suggest, Auto Edit, or Full Auto — safely, because worktree isolation means an autonomous agent can't affect your main working directory.
+Yes. Each Superset task runs Codex in its own isolated worktree. You can use any Codex mode (Suggest, Auto Edit, or Full Auto) safely, because worktree isolation means an autonomous agent can't affect your main working directory.
 
 ### How does the Codex app compare to Superset?
 

--- a/apps/marketing/content/compare/superset-vs-cursor.mdx
+++ b/apps/marketing/content/compare/superset-vs-cursor.mdx
@@ -22,8 +22,8 @@ Cursor started as an AI-native editor, but it now spans its own IDE, cloud agent
 | | **Superset** | **Cursor** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding suite (editor + cloud agents) |
-| **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Managed platform with Cursor-hosted agents and access to frontier models |
-| **Parallelism** | Core feature — 100+ agents across isolated worktrees | Up to 8 agents in local Git worktrees (Cursor 2.0), plus cloud agents |
+| **AI approach** | Agent-agnostic: works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Managed platform with Cursor-hosted agents and access to frontier models |
+| **Parallelism** | Core feature: 100+ agents across isolated worktrees | Up to 8 agents in local Git worktrees (Cursor 2.0), plus cloud agents |
 | **Editor surface** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | Cursor IDE first, plus JetBrains via ACP and web/mobile agent surfaces |
 | **Pricing** | Free tier + Pro $20/seat/mo | Hobby free, Pro $20/mo, Pro+ $60/mo, Ultra $200/mo, Teams $40/user/mo |
 | **Privacy** | Local Git worktrees; you control agent and provider choices | Requests route through Cursor's services for managed models and cloud agents |
@@ -64,7 +64,7 @@ Superset runs agents locally in Git worktrees and has a source-available codebas
 
 ## Pricing
 
-Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex): transparent provider costs, no platform credit system.
 
 Cursor's current public pricing is Hobby (free), Pro ($20/month), Pro+ ($60/month), Ultra ($200/month), Teams ($40/user/month), and Enterprise (custom). That structure makes Cursor easier to adopt out of the box, but it also means your agent usage, hosted runtime, and model access stay bundled inside Cursor's platform economics.
 
@@ -74,7 +74,7 @@ Cursor's current public pricing is Hobby (free), Pro ($20/month), Pro+ ($60/mont
 
 **Choose Cursor if you:**
 - Want one managed product for editor AI, cloud agents, and web/mobile agent access
-- Prefer convenience over control — no separate CLI agent setup or API key juggling
+- Prefer convenience over control: no separate CLI agent setup or API key juggling
 - Like Cursor's hosted model access and plan-based workflow
 - Want AI tightly integrated into either Cursor IDE or its remote agent surfaces
 

--- a/apps/marketing/content/compare/superset-vs-devin.mdx
+++ b/apps/marketing/content/compare/superset-vs-devin.mdx
@@ -23,8 +23,8 @@ Devin is a cloud-based AI software engineer that works autonomously in a remote 
 | | **Superset** | **Devin** |
 |---|---|---|
 | **Category** | Agent orchestration workspace | Autonomous AI software engineer |
-| **Architecture** | Local-first today — worktrees, review, browser, and chat run on your machine | Fully remote — runs in cloud VMs |
-| **AI approach** | Agent-agnostic — orchestrates external agents plus Superset Chat and MCP tools | Proprietary AI with browser, editor, and terminal in cloud |
+| **Architecture** | Local-first today: worktrees, review, browser, and chat run on your machine | Fully remote: runs in cloud VMs |
+| **AI approach** | Agent-agnostic: orchestrates external agents plus Superset Chat and MCP tools | Proprietary AI with browser, editor, and terminal in cloud |
 | **Parallelism** | 100+ agents across isolated local worktrees | Parallel cloud sessions (10 concurrent on Pro, unlimited on Max) |
 | **Code privacy** | Local-first; outbound model traffic depends on your chosen agents/providers | Code runs on Cognition's cloud infrastructure |
 | **Pricing** | Free tier + Pro $20/seat/mo | Free; Pro $20/mo, Max $200/mo, Teams $80 + $40/seat |
@@ -40,7 +40,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Devin?
 
-Devin is Cognition's AI software engineer — a cloud-based autonomous agent that runs in its own virtual machine with a browser, code editor, terminal, and planner. You assign tasks via chat or Slack, and Devin works independently: reading docs, writing code, debugging, running tests, and creating pull requests. It has event-driven workflows (triggers from Linear, Slack, etc.) and a review system that annotates PRs before human review. Since Devin 2.0, Cognition retired the old $500/month usage model for flat tiers starting at $20/month, with parallel cloud sessions (up to 10 concurrent on Pro, unlimited on Max). Devin and the former Windsurf editor are now sold as one product family, so every paid tier also bundles Devin Desktop; see [Superset vs Windsurf](/compare/superset-vs-windsurf) for the editor comparison.
+Devin is Cognition's AI software engineer: a cloud-based autonomous agent that runs in its own virtual machine with a browser, code editor, terminal, and planner. You assign tasks via chat or Slack, and Devin works independently: reading docs, writing code, debugging, running tests, and creating pull requests. It has event-driven workflows (triggers from Linear, Slack, etc.) and a review system that annotates PRs before human review. Since Devin 2.0, Cognition retired the old $500/month usage model for flat tiers starting at $20/month, with parallel cloud sessions (up to 10 concurrent on Pro, unlimited on Max). Devin and the former Windsurf editor are now sold as one product family, so every paid tier also bundles Devin Desktop; see [Superset vs Windsurf](/compare/superset-vs-windsurf) for the editor comparison.
 
 ---
 
@@ -48,19 +48,19 @@ Devin is Cognition's AI software engineer — a cloud-based autonomous agent tha
 
 ### Local vs Cloud
 
-Superset's shipped workflow is local-first today. Your repo, worktrees, review flow, chat, and browser preview stay on your machine, and outbound traffic depends on the specific agents or providers you choose. Devin runs entirely in Cognition's cloud — your code is cloned into remote VMs where Devin operates. This is the fundamental architectural difference and drives most of the trade-offs below.
+Superset's shipped workflow is local-first today. Your repo, worktrees, review flow, chat, and browser preview stay on your machine, and outbound traffic depends on the specific agents or providers you choose. Devin runs entirely in Cognition's cloud: your code is cloned into remote VMs where Devin operates. This is the fundamental architectural difference and drives most of the trade-offs below.
 
 ### Control vs Autonomy
 
-Superset gives you direct access to each agent session. You can watch the terminal, inspect diffs, open a browser preview, chat in the same workspace, interrupt, or redirect mid-task. Devin aims for full autonomy — you assign a task and check back later for a PR. This makes Devin more hands-off but less controllable when it goes in the wrong direction.
+Superset gives you direct access to each agent session. You can watch the terminal, inspect diffs, open a browser preview, chat in the same workspace, interrupt, or redirect mid-task. Devin aims for full autonomy: you assign a task and check back later for a PR. This makes Devin more hands-off but less controllable when it goes in the wrong direction.
 
 ### Agent Flexibility
 
-Devin is a single proprietary agent — you use Cognition's AI or nothing. Superset is agent-agnostic: run Claude Code for complex refactors, Codex for well-scoped tasks, Aider for iterative work. When a better agent ships, use it in Superset immediately. With Devin, you wait for Cognition to improve their model.
+Devin is a single proprietary agent: you use Cognition's AI or nothing. Superset is agent-agnostic: run Claude Code for complex refactors, Codex for well-scoped tasks, Aider for iterative work. When a better agent ships, use it in Superset immediately. With Devin, you wait for Cognition to improve their model.
 
 ### Isolation Mechanism
 
-Superset isolates agents using Git worktrees — lightweight, fast, and built into git itself. Devin isolates each session in a full cloud VM with its own OS, browser, and toolchain. VMs provide stronger isolation and fuller environment parity, but at much higher cost and latency.
+Superset isolates agents using Git worktrees: lightweight, fast, and built into git itself. Devin isolates each session in a full cloud VM with its own OS, browser, and toolchain. VMs provide stronger isolation and fuller environment parity, but at much higher cost and latency.
 
 ### Pricing
 
@@ -77,9 +77,9 @@ Superset offers a free tier and Pro at $20/seat/month plus your agents' API cost
 - Want autonomous parallel cloud sessions and the ROI justifies the cloud usage
 
 **Choose Superset if you:**
-- Want direct control over each agent — see what they're doing, redirect in real time
+- Want direct control over each agent: see what they're doing, redirect in real time
 - Need local execution and direct control over each agent
-- Want agent flexibility (Claude Code, Codex, Aider, OpenCode — your choice per task)
+- Want agent flexibility (your choice per task: Claude Code, Codex, Aider, OpenCode)
 - Prefer the cost efficiency of local execution with direct API pricing
 - Need a source-available tool you can inspect and modify
 

--- a/apps/marketing/content/compare/superset-vs-gastown.mdx
+++ b/apps/marketing/content/compare/superset-vs-gastown.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Gas Town (2026): Agent Workspace vs Autonomous Agent Fleet"
-description: "Compare Superset and Gas Town (Steve Yegge's multi-agent orchestrator) for running AI coding agents — a desktop workspace vs an autonomous 20-30 agent fleet."
+description: "Compare Superset and Gas Town (Steve Yegge's multi-agent orchestrator) for running AI coding agents: a desktop workspace vs an autonomous 20-30 agent fleet."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-github-copilot.mdx
+++ b/apps/marketing/content/compare/superset-vs-github-copilot.mdx
@@ -25,8 +25,8 @@ GitHub Copilot is an AI pair programmer that lives inside your editor, offering 
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI pair programmer (editor extension) |
 | **What it does** | Runs 100+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Inline code completions, chat, and Copilot Agent mode in your editor |
-| **AI approach** | Agent-agnostic — orchestrates any CLI agent | Multiple frontier models (Claude, GPT, Gemini) via GitHub |
-| **Parallelism** | Core feature — many agents on separate branches simultaneously | In-editor agent mode; cloud coding agent runs on a branch and opens a PR |
+| **AI approach** | Agent-agnostic: orchestrates any CLI agent | Multiple frontier models (Claude, GPT, Gemini) via GitHub |
+| **Parallelism** | Core feature: many agents on separate branches simultaneously | In-editor agent mode; cloud coding agent runs on a branch and opens a PR |
 | **Editor** | Works alongside any editor | VS Code, JetBrains, Visual Studio, Neovim (extension) |
 | **Pricing** | Free tier + Pro $20/seat/mo | Free; Pro $10/mo, Pro+ $39/mo, Max $100/mo; Business $19/user, Enterprise $39/user |
 | **License** | Source-available (ELv2) | Closed source |
@@ -49,11 +49,11 @@ GitHub Copilot is an AI coding assistant from GitHub (Microsoft). It integrates 
 
 ### Inline Assistant vs Parallel Orchestrator
 
-Copilot is built for the editing experience — it completes your code as you type, answers questions in a chat panel, and can make changes across files via Agent mode. Superset runs many autonomous agents simultaneously, each on a separate task in a separate worktree, then adds chat, file review, and browser preview around those tasks. Copilot makes you faster at writing code; Superset makes many agents work in parallel while you do something else.
+Copilot is built for the editing experience: it completes your code as you type, answers questions in a chat panel, and can make changes across files via Agent mode. Superset runs many autonomous agents simultaneously, each on a separate task in a separate worktree, then adds chat, file review, and browser preview around those tasks. Copilot makes you faster at writing code; Superset makes many agents work in parallel while you do something else.
 
 ### Completions vs Autonomous Tasks
 
-Copilot's primary interaction is inline completion: you type, it suggests. Its Agent mode and Coding Agent can handle larger tasks, but the core experience is real-time assistance while you code. Superset dispatches fully autonomous tasks — "refactor the payment service," "add tests for the auth module" — and agents work independently until done, with the resulting diffs and local app previews collected inside the same workspace.
+Copilot's primary interaction is inline completion: you type, it suggests. Its Agent mode and Coding Agent can handle larger tasks, but the core experience is real-time assistance while you code. Superset dispatches fully autonomous tasks ("refactor the payment service," "add tests for the auth module") and agents work independently until done, with the resulting diffs and local app previews collected inside the same workspace.
 
 ### Editor Integration vs Editor Independence
 
@@ -61,7 +61,7 @@ Copilot lives inside your editor (VS Code, JetBrains, Neovim). Superset is a sep
 
 ### Model and Agent Flexibility
 
-Copilot supports multiple frontier models (Claude, GPT, Gemini) through GitHub's infrastructure. Superset supports any CLI-based agent — and by extension, whatever models those agents support. The difference is direct vs proxied: with Superset, you bring your own API keys and pay providers directly. With Copilot, you use GitHub's model access through their pricing tiers.
+Copilot supports multiple frontier models (Claude, GPT, Gemini) through GitHub's infrastructure. Superset supports any CLI-based agent, and by extension, whatever models those agents support. The difference is direct vs proxied: with Superset, you bring your own API keys and pay providers directly. With Copilot, you use GitHub's model access through their pricing tiers.
 
 ### Privacy
 
@@ -90,7 +90,7 @@ Superset offers a free tier and Pro at $20/seat/month, plus your agents' API cos
 - Need local execution and direct control over providers
 - Work on large codebases where parallel execution saves hours
 
-**Use both** for the best of each: Copilot for inline completions while you code, Superset to dispatch parallel agents for larger tasks. They don't overlap — Copilot helps you write code faster, Superset helps you scale agent work wider.
+**Use both** for the best of each: Copilot for inline completions while you code, Superset to dispatch parallel agents for larger tasks. They don't overlap: Copilot helps you write code faster, Superset helps you scale agent work wider.
 
 ---
 
@@ -102,11 +102,11 @@ No. Superset is not an inline-completion assistant. It does provide in-app chat,
 
 ### How does Copilot's Coding Agent compare to Superset?
 
-Copilot's Coding Agent runs in a cloud VM and creates PRs from GitHub Issues — one task at a time per repository. Superset runs many agents locally in parallel across Git worktrees. Copilot's agent is cloud-hosted and GitHub-integrated; Superset's approach is local, agent-agnostic, and parallel.
+Copilot's Coding Agent runs in a cloud VM and creates PRs from GitHub Issues, one task at a time per repository. Superset runs many agents locally in parallel across Git worktrees. Copilot's agent is cloud-hosted and GitHub-integrated; Superset's approach is local, agent-agnostic, and parallel.
 
 ### Can I use Copilot inside a Superset worktree?
 
-Yes. When you open a Superset worktree in VS Code, Copilot works normally — it sees the worktree as a regular git repository. You get Copilot's completions while reviewing or editing agent output.
+Yes. When you open a Superset worktree in VS Code, Copilot works normally: it sees the worktree as a regular git repository. You get Copilot's completions while reviewing or editing agent output.
 
 ### Is Superset open source?
 

--- a/apps/marketing/content/compare/superset-vs-mux.mdx
+++ b/apps/marketing/content/compare/superset-vs-mux.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Mux (2026): Agent-Agnostic Workspace vs Coder's Agent Multiplexer"
-description: "Compare Superset and Mux by Coder for parallel agentic development — running any CLI agent in worktrees vs Mux's built-in agent loop with container and Coder runtimes."
+description: "Compare Superset and Mux by Coder for parallel agentic development: running any CLI agent in worktrees vs Mux's built-in agent loop with container and Coder runtimes."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-openhands.mdx
+++ b/apps/marketing/content/compare/superset-vs-openhands.mdx
@@ -24,8 +24,8 @@ OpenHands (formerly OpenDevin) is an open-source platform for autonomous AI soft
 |---|---|---|
 | **Category** | Agent orchestration workspace | Autonomous agent platform |
 | **Execution** | Local Git worktrees on your machine | Sandboxed runtime (Docker) or OpenHands Cloud |
-| **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic agent framework (via LiteLLM) |
-| **Parallelism** | Core feature — 100+ agents across isolated worktrees | Multiple sessions, typically one sandbox per task |
+| **AI approach** | Agent-agnostic: Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic agent framework (via LiteLLM) |
+| **Parallelism** | Core feature: 100+ agents across isolated worktrees | Multiple sessions, typically one sandbox per task |
 | **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Web UI / CLI over a sandboxed agent |
 | **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Open source (MIT) to self-host; Cloud is usage-based |
 
@@ -47,11 +47,11 @@ OpenHands, from All Hands AI, is an open-source platform for autonomous AI agent
 
 ### Sandboxed Runtime vs Local Worktrees
 
-OpenHands executes agents inside a sandbox (Docker or cloud), which is great for isolation and reproducibility but adds a runtime layer between the agent and your working copy. Superset runs agents directly on your machine, each in its own Git worktree — no container to manage, and the code stays in your local repo the whole time.
+OpenHands executes agents inside a sandbox (Docker or cloud), which is great for isolation and reproducibility but adds a runtime layer between the agent and your working copy. Superset runs agents directly on your machine, each in its own Git worktree: no container to manage, and the code stays in your local repo the whole time.
 
 ### Autonomous Agent vs Agent Orchestrator
 
-OpenHands is itself the agent: one framework that plans and executes. Superset does not ship its own single autonomous engine — it orchestrates the agents you already use (Claude Code, Codex, Aider, and more), letting you pick the right one per task and run several side by side.
+OpenHands is itself the agent: one framework that plans and executes. Superset does not ship its own single autonomous engine: it orchestrates the agents you already use (Claude Code, Codex, Aider, and more), letting you pick the right one per task and run several side by side.
 
 ### Review and Workspace Surface
 
@@ -65,7 +65,7 @@ Superset keeps everything local in Git worktrees and is source-available. OpenHa
 
 ## Pricing
 
-Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex): transparent provider costs, no platform credit system.
 
 OpenHands is open source under MIT, so self-hosting is free apart from the model API and the compute you run the sandbox on. OpenHands Cloud is a managed, usage-based option if you would rather not run the runtime yourself.
 
@@ -101,4 +101,4 @@ No. Superset runs agents directly on your machine in isolated Git worktrees rath
 
 ### Can I self-host either tool?
 
-OpenHands is open source (MIT) and designed to be self-hosted, with a managed cloud option. Superset is a source-available (ELv2) local-first desktop app — it already runs entirely on your machine, with a free tier and a $20/seat/month Pro plan.
+OpenHands is open source (MIT) and designed to be self-hosted, with a managed cloud option. Superset is a source-available (ELv2) local-first desktop app: it already runs entirely on your machine, with a free tier and a $20/seat/month Pro plan.

--- a/apps/marketing/content/compare/superset-vs-paperclip.mdx
+++ b/apps/marketing/content/compare/superset-vs-paperclip.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Paperclip (2026): Agent Workspace vs the Agent Company"
-description: "Compare Superset and Paperclip for managing AI agents — a developer workspace for parallel coding agents vs an open-source platform that runs agents like a company."
+description: "Compare Superset and Paperclip for managing AI agents: a developer workspace for parallel coding agents vs an open-source platform that runs agents like a company."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-solo.mdx
+++ b/apps/marketing/content/compare/superset-vs-solo.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Solo (2026): Agent Workspace vs Process Dashboard"
-description: "Compare Superset and Solo (soloterm.com) — parallel coding agents in Git worktrees vs Aaron Francis's native dashboard for agents and your dev stack."
+description: "Compare Superset and Solo (soloterm.com): parallel coding agents in Git worktrees vs Aaron Francis's native dashboard for agents and your dev stack."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-symphony.mdx
+++ b/apps/marketing/content/compare/superset-vs-symphony.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Superset vs Symphony (2026): Agent Workspace vs OpenAI's Tracker-Driven Orchestration"
-description: "Compare Superset and OpenAI's Symphony — an interactive workspace for parallel coding agents vs an open-source spec that turns tickets into autonomous Codex runs."
+description: "Compare Superset and OpenAI's Symphony: an interactive workspace for parallel coding agents vs an open-source spec that turns tickets into autonomous Codex runs."
 date: 2026-08-07
 lastUpdated: 2026-08-07
 type: "1v1"

--- a/apps/marketing/content/compare/superset-vs-t3-chat.mdx
+++ b/apps/marketing/content/compare/superset-vs-t3-chat.mdx
@@ -26,7 +26,7 @@ T3 Chat and Superset both help developers work with AI, but they sit at differen
 | **What it does** | Runs 100+ coding agents in parallel with Git worktrees, built-in chat, diff/file review, and browser preview | Lets you chat with multiple frontier models from one hosted interface |
 | **AI approach** | Agent-agnostic orchestration plus Superset Chat and MCP tools | Hosted chat surface with model switching, search, attachments, and profiles |
 | **Execution model** | Local agents can read, edit, and run code in your repo | Chat-first workflow; useful for questions, planning, and pasted context |
-| **Parallelism** | Core feature — many agents across isolated worktrees | Conversation-based, not agent orchestration |
+| **Parallelism** | Core feature: many agents across isolated worktrees | Conversation-based, not agent orchestration |
 | **Isolation** | Automatic Git worktree per task | No Git worktree or branch isolation |
 | **Pricing model** | Free tier + Pro $20/seat/mo | Free up to usage limits, with paid usage beyond those limits |
 

--- a/apps/marketing/content/compare/superset-vs-warp.mdx
+++ b/apps/marketing/content/compare/superset-vs-warp.mdx
@@ -24,8 +24,8 @@ Superset and Warp both help developers work with AI around the command line, but
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI-powered terminal emulator |
 | **What it does** | Runs 10+ AI coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Modern terminal with built-in AI agents, code editing, and collaboration |
-| **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Built-in agents (OpenAI, Anthropic, Google); supports BYOK and third-party CLI agents |
-| **Parallelism** | Core feature — every task gets its own worktree and branch | Agents run in terminal panes; Oz cloud orchestrator for background agents |
+| **AI approach** | Agent-agnostic: works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Built-in agents (OpenAI, Anthropic, Google); supports BYOK and third-party CLI agents |
+| **Parallelism** | Core feature: every task gets its own worktree and branch | Agents run in terminal panes; Oz cloud orchestrator for background agents |
 | **Pricing** | Free tier + Pro $20/seat/mo | Free; Build $20/mo, Max $200/mo, Business $50/seat |
 | **License** | Source-available (ELv2) | Open source |
 
@@ -33,7 +33,7 @@ Superset and Warp both help developers work with AI around the command line, but
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. You spin up 100+ agents on separate tasks simultaneously, each in its own Git worktree with a dedicated branch and working directory. Around that core, Superset adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. Superset ships no required model layer — you can bring Claude Code, Codex, Aider, OpenCode, or other agents, and you can review inside Superset or jump into your editor of choice. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. You spin up 100+ agents on separate tasks simultaneously, each in its own Git worktree with a dedicated branch and working directory. Around that core, Superset adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. Superset ships no required model layer: you can bring Claude Code, Codex, Aider, OpenCode, or other agents, and you can review inside Superset or jump into your editor of choice. Source-available under Elastic License 2.0 (ELv2).
 
 ---
 
@@ -47,15 +47,15 @@ Warp is a Rust-based, GPU-accelerated terminal that evolved into an agentic deve
 
 ### Built-In Agents vs Bring-Your-Own
 
-Warp ships its own agents — type a prompt, get results, no external tools to install. Superset is more bring-your-own by default: you install Claude Code, Codex, Aider, or another agent, and Superset runs them in parallel. Warp is more convenient out of the box; Superset gives you complete freedom over which agent, model, and provider you use, while still adding its own chat and workspace tooling around them.
+Warp ships its own agents: type a prompt, get results, no external tools to install. Superset is more bring-your-own by default: you install Claude Code, Codex, Aider, or another agent, and Superset runs them in parallel. Warp is more convenient out of the box; Superset gives you complete freedom over which agent, model, and provider you use, while still adding its own chat and workspace tooling around them.
 
 ### Parallelism and Isolation
 
-Both tools support multiple agents, but the isolation model differs. Superset gives each agent a dedicated Git worktree — separate branch, separate working directory — so agents cannot modify each other's files. Warp runs agents in terminal panes on your file system directly. For a few agents on unrelated tasks, that works. For ten agents on the same codebase, worktree isolation prevents conflicts.
+Both tools support multiple agents, but the isolation model differs. Superset gives each agent a dedicated Git worktree (separate branch, separate working directory) so agents cannot modify each other's files. Warp runs agents in terminal panes on your file system directly. For a few agents on unrelated tasks, that works. For ten agents on the same codebase, worktree isolation prevents conflicts.
 
 ### Terminal Quality vs Orchestration Focus
 
-Warp is a polished terminal — GPU-accelerated, with block-based output and a command palette. Superset includes terminals because agents need them, but the product is increasingly closer to a code editor for AI agents than a classic daily-driver terminal. You would still use Warp, iTerm2, or Kitty for SSH and ad-hoc commands.
+Warp is a polished terminal: GPU-accelerated, with block-based output and a command palette. Superset includes terminals because agents need them, but the product is increasingly closer to a code editor for AI agents than a classic daily-driver terminal. You would still use Warp, iTerm2, or Kitty for SSH and ad-hoc commands.
 
 ### Team Collaboration
 
@@ -75,7 +75,7 @@ Warp's terminal features are free, and the app is now open source. AI features c
 
 **Choose Warp if you:**
 - Want an all-in-one terminal with built-in AI agents, code editing, and team tools
-- Value terminal polish — GPU rendering, block output, command palette
+- Value terminal polish: GPU rendering, block output, command palette
 - Need cross-platform support (macOS, Windows, Linux)
 - Prefer built-in agents that work without configuring external tools
 

--- a/apps/marketing/docs/copywriting-references.md
+++ b/apps/marketing/docs/copywriting-references.md
@@ -1,0 +1,67 @@
+# Copywriting references: taglines & hero copy
+
+Research compiled 2026-08-12 for the tagline repositioning (`update-tagline-value-prop`).
+Use this when writing or reviewing any homepage/hero/landing copy.
+
+## The four framework resources
+
+| Resource | URL | Core rule |
+|---|---|---|
+| Julian Shapiro, Landing Page Handbook | julian.com/guide/growth/landing-pages | Header must be fully descriptive: "If the visitor reads only this text, will they know exactly what you sell?" Subheader = 1-2 sentences explaining how the bold claim is possible. |
+| Harry Dry, Landing Page Guide | marketingexamples.com/conversion/landing-page-guide | Title = value, subtitle = how, image = visualize, social proof = believe, CTA = easy. Edit test: "Would this help me sell if I met the customer in person?" |
+| April Dunford, positioning | aprildunford.com/post/a-quickstart-guide-to-positioning | Positioning is NOT a tagline; it is the input. Start from what customers would do without you, not phantom competitors. |
+| Markepear (dev-tool teardowns) | markepear.dev/examples/landing-page | Category + differentiator in plain infrastructure nouns; quantified claims demonstrated, not asserted; CTAs in developer verbs ("Install", "Get API keys"). |
+
+### Worked examples from those resources
+
+- Julian, good: "Visually design and develop sites from scratch. No coding." / "Groceries delivered in 1 hour. Say goodbye to traffic, parking, and long lines."
+- Julian, bad: "Improve your workflow!" / "Supercharge your collaboration!"
+- Harry Dry: Privy "How small brands sell more online" (conviction) made believable by "18,000+ reviews", not by the words.
+- Markepear's showcase heroes: Supabase "open-source Firebase alternative"; ClickHouse "Query billions of rows in milliseconds"; Fly.io "Launch Apps Near Users"; Snyk "Find and fix vulnerabilities in open-source software" (unchanged ~7 years); Neon "Fully managed serverless Postgres"; Alpaca "Stock trading API"; Bun (benchmarks in the header).
+- Dunford's repositioning cases: database → "an AWESOME BI tool for machine-generated data" (escaped the "how are you better than Oracle" trap); Janna Systems generic CRM → "CRM for investment banks" ($2M → $70M in 18 months).
+
+## The hacker-trusted canon (sources engineers actually respect)
+
+### Doctrine
+
+- **YC / Michael Seibel**, "How to Pitch Your Company" (ycombinator.com/blog/how-to-pitch-your-company): "You don't need to sound cool. You need to be clear." Eliminate jargon, acronyms, and "any ambiguous terms such as 'platform'." Airbnb test: "we allow you to rent out the extra room in your house" beats "we're a marketplace for space." Email test: two sentences to a smart friend; any clarifying question = revise.
+- **37signals, Getting Real**, "Copywriting is Interface Design" (basecamp.com/gettingreal/09.7): "Great interfaces are written... every letter matters." No internal lingo; short and sweet.
+- **Kathy Sierra, Badass: Making Users Awesome**: "People don't want to be badass at using your tool. They want to be badass at what your tool helps them do." Sell the user's new power in their domain, not the tool's capability.
+- **patio11** (kalzumeus.com): sell the quantified business outcome; single blazingly-obvious goal per page; ad copy must anticipate landing copy. The counterweight to understatement: bold claims are fine when quantified and cashed.
+- **swyx** (dx.tips): "benefits, not features" advice fails for developers — "we deal in building blocks... cut the marketing BS and try to explain how things work." Developers need ~14 exposures before adopting; the hero is one touch, so be exact, not maximal.
+
+### Taglines HN reveres (verified exact text)
+
+| Product | Tagline | Why respected |
+|---|---|---|
+| SQLite | "Small. Fast. Reliable. Choose any three." | Joke at marketing's expense; falsifiable; product cashes it |
+| jQuery | "The Write Less, Do More, JavaScript Library" | Exact developer benefit in four words |
+| Tailscale (early) | "Private networks made easy." | Praised on HN because the product delivered the "easy" |
+| WireGuard | "fast, modern, secure VPN tunnel" | Reads like a man-page NAME line; zero business language |
+| PostgreSQL | "The World's Most Advanced Open Source Relational Database" | Superlative engineers agree is true (vs MySQL's "most popular") |
+| Tarsnap | "Online backups for the truly paranoid" | Names its niche with self-aware humor |
+| Pinboard | "Social Bookmarking for Introverts" | Same: honest niche + personality |
+| Ghostty | "...speed, features, or native UIs. Ghostty provides all three." | Conscious SQLite homage |
+| Redis (today) | "Developers love Redis. Unlock the full potential..." | NEGATIVE control: the enterprise-speak HN mourns |
+
+Common thread: falsifiable specificity over aspiration; category nouns developers already know; understatement or self-aware humor; no "empower/unlock/supercharge"; claims the product visibly cashes. HN has no "best taglines" mega-thread — taglines get praised in situ, next to a working product.
+
+## How this graded our hero (2026-08-12)
+
+H1 "Run 100+ Coding Agents in Parallel." + subtitle "Give Claude Code, Codex, or any CLI agent its own isolated workspace, automate recurring tasks, and stay on top of it all from anywhere."
+
+Grade **B/B-** against the canon. Passes: fully descriptive (Julian), mechanism-register subtitle with concrete third-party nouns (swyx, Markepear), jargon-free for the audience (Seibel). Two flagged misalignments:
+
+1. **Kathy Sierra test**: the H1 sells tool capacity (running agents) rather than the user's new power (shipping more). Nobody's aspiration is agent-herding.
+2. **SQLite honesty test**: "100+" is a max-spec superlative, not a typical-use truth; HN's instinct is to poke at exactly this number ("who runs 100?"). Defensible in the patio11 quantified-boldness school, but the page must visibly cash the claim (demo showing real scale).
+
+Minor: "stay on top of it all from anywhere" is the subtitle's one abstract clause; the subtitle appends two extra planks (automations, anywhere) where Dry would deepen the single title promise.
+
+## Elite subtitle patterns (Linear/Stripe/Vercel/etc., fetched 2026-08-12)
+
+Median 16 words (range 6-29); 1-2 sentences, never 3; zero colons; long subtitles earn length via parallel verb triplets (Stripe: "Accept payments, offer financial services, and implement custom revenue models"); concrete nouns; sentence 2 never opens a new feature list; H1 = claim, subtitle = mechanism.
+
+## House style
+
+- No em dashes anywhere in marketing copy or README (repo-wide sweep, Aug 2026). Rewrite with colon, comma, period, or parentheses.
+- Voice-of-customer vocabulary that converts (from HN/X research, Aug 2026): "parallel coding agents" (the converged category phrase), "without losing track", "terminal tabs don't scale", "babysitting" (pain), "native TUIs, no bloat", "worktrees". Avoid: "mission control" (GitHub owns it), "herding" (herdr owns it), "editor/IDE" (category the leaders exited), "agentic" (saturated).

--- a/apps/marketing/src/app/.well-known/agent-card.json/route.ts
+++ b/apps/marketing/src/app/.well-known/agent-card.json/route.ts
@@ -8,7 +8,7 @@ export function GET() {
 		protocolVersion: "0.3.0",
 		name: "Superset",
 		description:
-			"Superset runs parallel AI coding agents in isolated Git worktrees. This service speaks the Model Context Protocol (JSON-RPC over Streamable HTTP) rather than the A2A message protocol — connect an MCP client to the URL below to create workspaces, launch coding agents, schedule automations, and manage tasks on behalf of a Superset user.",
+			"Superset runs parallel AI coding agents in isolated Git worktrees. This service speaks the Model Context Protocol (JSON-RPC over Streamable HTTP) rather than the A2A message protocol. Connect an MCP client to the URL below to create workspaces, launch coding agents, schedule automations, and manage tasks on behalf of a Superset user.",
 		url: MCP_SERVER_URL,
 		preferredTransport: "JSONRPC",
 		provider: {

--- a/apps/marketing/src/app/.well-known/mcp/route.ts
+++ b/apps/marketing/src/app/.well-known/mcp/route.ts
@@ -8,7 +8,7 @@ export function GET() {
 				{
 					name: "superset",
 					description:
-						"Superset MCP server — orchestrate parallel coding agents, workspaces, automations, and tasks.",
+						"Superset MCP server: orchestrate parallel coding agents, workspaces, automations, and tasks.",
 					url: MCP_SERVER_URL,
 					transport: "streamable-http",
 					serverCard: `${COMPANY.MARKETING_URL}/.well-known/mcp/server-card.json`,
@@ -21,7 +21,7 @@ export function GET() {
 				{
 					name: "superset-docs",
 					description:
-						"Superset documentation over MCP — search and read docs pages.",
+						"Superset documentation over MCP: search and read docs pages.",
 					url: `${COMPANY.DOCS_URL}/mcp`,
 					transport: "streamable-http",
 					authentication: { type: "none" },

--- a/apps/marketing/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/marketing/src/app/.well-known/mcp/server-card.json/route.ts
@@ -27,7 +27,7 @@ export async function GET() {
 			card = await response.json();
 		}
 	} catch {
-		// api unreachable — serve the static fallback
+		// api unreachable; serve the static fallback
 	}
 
 	return Response.json(card, {

--- a/apps/marketing/src/app/agents.md/route.ts
+++ b/apps/marketing/src/app/agents.md/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
 		`Full walkthrough: [auth.md](${baseUrl}/auth.md).`,
 		"",
 		`- Unauthenticated requests to the MCP endpoint return \`401\` with \`WWW-Authenticate: Bearer resource_metadata="${API_URL}/.well-known/oauth-protected-resource"\`.`,
-		"- OAuth 2.1 authorization code + PKCE, with RFC 7591 dynamic client registration — no manual app setup needed.",
+		"- OAuth 2.1 authorization code + PKCE, with RFC 7591 dynamic client registration, so no manual app setup is needed.",
 		"- Alternatively, a user-issued Superset API key can be sent as a Bearer token.",
 		"",
 		"## Setup one-liners",

--- a/apps/marketing/src/app/api/llms.txt/route.ts
+++ b/apps/marketing/src/app/api/llms.txt/route.ts
@@ -11,7 +11,7 @@ export function GET() {
 		"",
 		`> Programmatic access to ${COMPANY.NAME} for AI agents: an MCP server (Streamable HTTP) plus OAuth 2.1 with dynamic client registration.`,
 		"",
-		`The primary API surface is the MCP server at ${MCP_SERVER_URL} (alias: ${API_URL}/mcp). Authenticate via OAuth 2.1 + PKCE or a Superset API key — walkthrough at ${COMPANY.MARKETING_URL}/auth.md.`,
+		`The primary API surface is the MCP server at ${MCP_SERVER_URL} (alias: ${API_URL}/mcp). Authenticate via OAuth 2.1 + PKCE or a Superset API key; walkthrough at ${COMPANY.MARKETING_URL}/auth.md.`,
 		"",
 		...buildDeveloperResourcesSection(),
 	];

--- a/apps/marketing/src/app/auth.md/route.ts
+++ b/apps/marketing/src/app/auth.md/route.ts
@@ -48,7 +48,7 @@ The response contains your \`client_id\`. Public clients (no secret) with PKCE a
 
 ## 4. Claim
 
-Send the user to the authorization endpoint to claim the registration — this is the human-approval step:
+Send the user to the authorization endpoint to claim the registration. This is the human-approval step:
 
 \`\`\`
 GET ${API_URL}/api/auth/oauth2/authorize?client_id=...&response_type=code&redirect_uri=...&scope=openid+profile+email+offline_access&code_challenge=...&code_challenge_method=S256
@@ -80,9 +80,9 @@ Access tokens expire after one hour; refresh with \`grant_type=refresh_token\` a
 
 All errors are JSON. The ones you will see:
 
-- \`401\` \`{"error": {"code": "UNAUTHORIZED", "message": "..."}}\` — missing, expired, or revoked token. Re-read \`WWW-Authenticate\` and re-authenticate.
-- \`invalid_grant\` from the token endpoint — the refresh token was revoked or the code expired; restart at "Claim".
-- \`invalid_client\` — the registration is unknown; restart at "Register".
+- \`401\` \`{"error": {"code": "UNAUTHORIZED", "message": "..."}}\`: missing, expired, or revoked token. Re-read \`WWW-Authenticate\` and re-authenticate.
+- \`invalid_grant\` from the token endpoint: the refresh token was revoked or the code expired; restart at "Claim".
+- \`invalid_client\`: the registration is unknown; restart at "Register".
 
 ## 7. Revocation
 

--- a/apps/marketing/src/app/components/CTASection/CTASection.tsx
+++ b/apps/marketing/src/app/components/CTASection/CTASection.tsx
@@ -30,7 +30,7 @@ export function CTASection() {
 						</button>
 					</div>
 					<p className="mt-10 mb-4 text-sm text-muted-foreground">
-						Or install the CLI — paste the agent tab into Claude Code and it
+						Or install the CLI: paste the agent tab into Claude Code and it
 						installs itself.
 					</p>
 					<InstallCommand />

--- a/apps/marketing/src/app/components/CTASection/components/InstallCommand/InstallCommand.tsx
+++ b/apps/marketing/src/app/components/CTASection/components/InstallCommand/InstallCommand.tsx
@@ -17,7 +17,7 @@ export function InstallCommand() {
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		} catch {
-			// Clipboard unavailable (e.g. insecure context) — ignore
+			// Clipboard unavailable (e.g. insecure context); ignore
 		}
 	};
 

--- a/apps/marketing/src/app/components/FAQSection/constants.ts
+++ b/apps/marketing/src/app/components/FAQSection/constants.ts
@@ -12,7 +12,7 @@ export const FAQ_ITEMS: FAQItem[] = [
 		question:
 			"How is Superset different from just running Claude Code in a terminal?",
 		answer:
-			"Claude Code, Codex, and OpenCode are the agents — Superset is where you run many of them at once. Each task gets its own isolated Git worktree, so ten agents can work on ten branches simultaneously while you monitor, review, and merge from one place.",
+			"Claude Code, Codex, and OpenCode are the agents; Superset is where you run many of them at once. Each task gets its own isolated Git worktree, so ten agents can work on ten branches simultaneously while you monitor, review, and merge from one place.",
 		link: {
 			href: "/compare",
 			label: "See how Superset compares to other tools",

--- a/apps/marketing/src/app/components/FeaturesSection/components/CliDemo/CliDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/CliDemo/CliDemo.tsx
@@ -35,7 +35,7 @@ export function CliDemo() {
 					<div className="size-2 rounded-full bg-[#28c840]/85" />
 				</div>
 				<span className="pointer-events-none absolute inset-x-0 text-center font-mono text-[10px] tracking-tight text-muted-foreground/60">
-					superset — cli
+					superset (cli)
 				</span>
 			</div>
 

--- a/apps/marketing/src/app/components/FeaturesSection/components/RemoteWorkspacesDemo/RemoteWorkspacesDemo.tsx
+++ b/apps/marketing/src/app/components/FeaturesSection/components/RemoteWorkspacesDemo/RemoteWorkspacesDemo.tsx
@@ -30,7 +30,7 @@ export function RemoteWorkspacesDemo() {
 					<div className="size-2 rounded-full bg-[#28c840]/85" />
 				</div>
 				<span className="pointer-events-none absolute inset-x-0 text-center font-mono text-[10px] tracking-tight text-muted-foreground/60">
-					gpu-box — ssh
+					gpu-box (ssh)
 				</span>
 			</div>
 

--- a/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
+++ b/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
@@ -27,7 +27,7 @@ const triggerClass = cn(
 export function DesktopNav() {
 	// Radix's NavigationMenu is uncontrolled by default, so a hover-opened
 	// trigger and a click on that same trigger both race to set its shared
-	// internal `value` — a click toggles, so clicking a menu that hover just
+	// internal `value`. A click toggles, so clicking a menu that hover just
 	// opened immediately closes it again. Controlling `value` ourselves lets
 	// us make click idempotent (open-only) instead of toggling, so it can
 	// never fight with the hover-intent timers.

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -12,9 +12,9 @@ import { TypewriterText } from "./components/TypewriterText";
 
 const HERO_COPY = {
 	segments: [
-		{ text: "The Code Editor for " },
+		{ text: "Run 100+ Coding Agents " },
 		{
-			text: "AI Agents.",
+			text: "in Parallel.",
 			// Plain inline (not inline-block): vertical padding on inline boxes
 			// paints the brackets without affecting line height, so the line
 			// can't jump when this segment mounts mid-animation
@@ -22,7 +22,7 @@ const HERO_COPY = {
 		},
 	],
 	subheadline:
-		"Orchestrate 100+ parallel coding agents, automate recurring tasks, and run workspaces anywhere.",
+		"Claude Code, Codex, or any CLI agent, each in its own isolated workspace. Spend your time shipping, not waiting.",
 };
 
 export function HeroSection() {

--- a/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RemoteSessionPopup/RemoteSessionPopup.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/AppMockup/components/RemoteSessionPopup/RemoteSessionPopup.tsx
@@ -34,7 +34,7 @@ export function RemoteSessionPopup({ activeDemo }: RemoteSessionPopupProps) {
 					<div className="size-2 rounded-full bg-[#28c840]/85" />
 				</div>
 				<span className="pointer-events-none absolute inset-x-0 text-center font-mono text-[10px] tracking-tight text-muted-foreground/60">
-					gpu-box — ssh
+					gpu-box (ssh)
 				</span>
 			</div>
 

--- a/apps/marketing/src/app/components/HeroSection/components/BoidsBackground/BoidsBackground.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/BoidsBackground/BoidsBackground.tsx
@@ -3,11 +3,11 @@
 import { m } from "framer-motion";
 import { useEffect, useRef } from "react";
 
-// character grid — glyphs stay upright and snapped, like real terminal text
+// character grid: glyphs stay upright and snapped, like real terminal text
 const CELL = 13;
 const FONT_SIZE = 11;
 
-// the source text each boid writes as it flies — trails spell real code
+// the source text each boid writes as it flies, so trails spell real code
 const CODE =
 	'awaitagent.spawn({preset:"claude",workspace:"boid"})superset.orchestrate({agents:100,' +
 	'parallel:true})agent.review({channel:"all",sla:"24h"})awaitworktree.create({branch:"main",' +
@@ -208,7 +208,7 @@ export function BoidsBackground() {
 					wrapped = true;
 				}
 
-				// write the next character only after real net displacement — a boid
+				// write the next character only after real net displacement: a boid
 				// hovering on a cell boundary shouldn't flicker through its code string
 				if (wrapped) {
 					this.sx = this.x;

--- a/apps/marketing/src/app/download/components/DownloadInterstitial/DownloadInterstitial.tsx
+++ b/apps/marketing/src/app/download/components/DownloadInterstitial/DownloadInterstitial.tsx
@@ -26,7 +26,7 @@ export function DownloadInterstitial() {
 
 	const isMac = isMacPlatform(platform);
 	// Only auto-download on Mac (the only built binary). Windows/Linux/Mobile see
-	// the waitlist instead — never the .dmg. Unknown waits for detection.
+	// the waitlist instead, never the .dmg. Unknown waits for detection.
 	const showWaitlist = !isMac && platform !== Platform.Unknown;
 
 	useEffect(() => {

--- a/apps/marketing/src/app/hooks/useOS/useOS.ts
+++ b/apps/marketing/src/app/hooks/useOS/useOS.ts
@@ -20,7 +20,7 @@ function detectMacArch():
 	| typeof Platform.MacIntel {
 	// Browser-side arch detection is unreliable: navigator.userAgent always
 	// reports "Intel Mac OS X" on Apple Silicon for compat. The most reliable
-	// signal that works in Safari is the WebGL renderer string — Apple GPUs
+	// signal that works in Safari is the WebGL renderer string: Apple GPUs
 	// expose "Apple GPU" / "Apple M*", Intel Macs expose Intel/AMD/Nvidia.
 	try {
 		const canvas = document.createElement("canvas");

--- a/apps/marketing/src/app/index.md/route.ts
+++ b/apps/marketing/src/app/index.md/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
 	const docsUrl = COMPANY.DOCS_URL;
 
 	const lines: string[] = [
-		`# ${COMPANY.NAME} — Run 100+ parallel coding agents on your machine`,
+		`# ${COMPANY.NAME}: Run 100+ parallel coding agents on your machine`,
 		"",
 		PRODUCT_SUMMARY,
 		"",

--- a/apps/marketing/src/app/join-us/page.tsx
+++ b/apps/marketing/src/app/join-us/page.tsx
@@ -81,7 +81,7 @@ export default function JoinUsPage() {
 						Open roles
 					</h2>
 
-					{/* Managed via YC Work at a Startup — layout/colors configured at bookface.ycombinator.com/workatastartup/job_board_settings */}
+					{/* Managed via YC Work at a Startup; layout/colors configured at bookface.ycombinator.com/workatastartup/job_board_settings */}
 					<style>{`
 						waas-job-board {
 							--waas-primary: var(--brand);

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -71,7 +71,7 @@ export const metadata: Metadata = {
 				url: "/og-image.png",
 				width: 1200,
 				height: 630,
-				alt: `${COMPANY.NAME} - The Terminal for Coding Agents`,
+				alt: `${COMPANY.NAME} - Run 100+ coding agents in parallel`,
 			},
 		],
 	},
@@ -119,7 +119,7 @@ export default function RootLayout({
 				<OrganizationJsonLd />
 				<SoftwareApplicationJsonLd />
 				<WebsiteJsonLd />
-				{/* Google tag (gtag.js) — Google Ads */}
+				{/* Google tag (gtag.js) for Google Ads */}
 				<Script
 					src="https://www.googletagmanager.com/gtag/js?id=AW-18209336001"
 					strategy="lazyOnload"

--- a/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata({
 	}
 
 	const kind = theme.type === "dark" ? "Dark" : "Light";
-	const title = `${theme.name} — ${kind} Theme for Superset`;
+	const title = `${theme.name}: ${kind} Theme for Superset`;
 	const description = `${theme.description} Download the ${theme.name} ${kind.toLowerCase()} theme for Superset, the local-first AI coding workspace.`;
 	const url = `${COMPANY.MARKETING_URL}/marketplace/themes/${theme.slug}`;
 

--- a/apps/marketing/src/app/roadmap/data.ts
+++ b/apps/marketing/src/app/roadmap/data.ts
@@ -50,7 +50,7 @@ export const STATUS_LABELS: Record<RoadmapStatus, string> = {
 
 export const STATUS_DESCRIPTIONS: Record<RoadmapStatus, string> = {
 	now: "Being built right now.",
-	next: "Committed — starting soon.",
+	next: "Committed, starting soon.",
 	later: "On our radar. Order and scope may change.",
 	shipped: "Live in the app.",
 };
@@ -95,7 +95,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "chat-v3",
 		title: "Next-generation chat",
 		description:
-			"A rebuilt chat surface for driving agents — richer tool output, smoother steering, faster everything.",
+			"A rebuilt chat surface for driving agents: richer tool output, smoother steering, faster everything.",
 		category: "Agents",
 		status: "next",
 	},
@@ -103,7 +103,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "native-pr-reviews",
 		title: "Native PR reviews",
 		description:
-			"Review pull requests inside Superset — diff pane, agent-assisted review, act on comments directly.",
+			"Review pull requests inside Superset: diff pane, agent-assisted review, act on comments directly.",
 		category: "Desktop",
 		status: "next",
 	},
@@ -144,7 +144,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "work-from-tickets",
 		title: "Work from tickets",
 		description:
-			"Start a workspace straight from a Linear ticket — the agent picks it up and reports back with a PR.",
+			"Start a workspace straight from a Linear ticket. The agent picks it up and reports back with a PR.",
 		category: "Integrations",
 		status: "later",
 	},
@@ -152,7 +152,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "autonomous-ticket-to-pr",
 		title: "Autonomous ticket-to-PR pipeline",
 		description:
-			"File a ticket, get back a verified, merge-ready PR — with screenshots or a screencast as proof the change works.",
+			"File a ticket, get back a verified, merge-ready PR, with screenshots or a screencast as proof the change works.",
 		category: "Agents",
 		status: "later",
 	},
@@ -160,7 +160,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "automations",
 		title: "Automations & event triggers",
 		description:
-			"Scheduled and event-triggered agents — cron, GitHub events, webhooks — with ready-made templates.",
+			"Scheduled and event-triggered agents (cron, GitHub events, webhooks) with ready-made templates.",
 		category: "Agents",
 		status: "later",
 	},
@@ -184,7 +184,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "session-snapshots",
 		title: "Session snapshots & revert",
 		description:
-			"Roll back an agent session to any checkpoint — conversation and file changes together.",
+			"Roll back an agent session to any checkpoint, conversation and file changes together.",
 		category: "Desktop",
 		status: "later",
 	},
@@ -225,7 +225,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "offline-local-first",
 		title: "Offline / local-first mode",
 		description:
-			"The full core loop — import a repo, run an agent, review the diff — now works signed out and offline.",
+			"The full core loop (import a repo, run an agent, review the diff) now works signed out and offline.",
 		category: "Desktop",
 		status: "shipped",
 		shippedDate: "Aug 2026",
@@ -246,7 +246,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "sidebar-redesign",
 		title: "Cleaner, denser sidebar",
 		description:
-			"A full restyle — denser rows, port and agent chips under each workspace, one-click stop for everything.",
+			"A full restyle: denser rows, port and agent chips under each workspace, one-click stop for everything.",
 		category: "Desktop",
 		status: "shipped",
 		shippedDate: "Aug 2026",
@@ -288,7 +288,7 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
 		id: "terminal-rich-input",
 		title: "Rich input for the terminal",
 		description:
-			"Press ⌘I over any terminal and compose in a real editor — multiline prompts and @file mentions.",
+			"Press ⌘I over any terminal and compose in a real editor, with multiline prompts and @file mentions.",
 		category: "Desktop",
 		status: "shipped",
 		shippedDate: "Jul 2026",

--- a/apps/marketing/src/app/roadmap/page.tsx
+++ b/apps/marketing/src/app/roadmap/page.tsx
@@ -65,8 +65,8 @@ export default function RoadmapPage() {
 							className="text-foreground underline underline-offset-4 hover:no-underline"
 						>
 							Tell us in Discord
-						</a>{" "}
-						— much of what's here started as a user request.
+						</a>
+						. Much of what's here started as a user request.
 					</p>
 
 					<GridCross className="bottom-0 left-0" />

--- a/apps/marketing/src/app/robots.txt/route.ts
+++ b/apps/marketing/src/app/robots.txt/route.ts
@@ -10,7 +10,7 @@ Allow: /api/llms.txt
 Disallow: /api/
 Disallow: /_next/
 
-# AI assistants and AI search crawlers — explicitly welcome
+# AI assistants and AI search crawlers: explicitly welcome
 User-Agent: ChatGPT-User
 Allow: /
 
@@ -29,7 +29,7 @@ Allow: /
 User-Agent: GoogleOther
 Allow: /
 
-# Bulk-scraping crawlers — not welcome
+# Bulk-scraping crawlers: not welcome
 User-Agent: CCBot
 Disallow: /
 

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -214,7 +214,7 @@ export function HomeWebPageJsonLd() {
 		"@type": "WebPage",
 		"@id": COMPANY.MARKETING_URL,
 		url: COMPANY.MARKETING_URL,
-		name: `${COMPANY.NAME} — Run 100+ parallel coding agents on your machine`,
+		name: `${COMPANY.NAME}: Run 100+ parallel coding agents on your machine`,
 		isPartOf: {
 			"@type": "WebSite",
 			name: COMPANY.NAME,

--- a/apps/marketing/src/lib/llms.ts
+++ b/apps/marketing/src/lib/llms.ts
@@ -40,12 +40,12 @@ export function buildWhenToUseSection(): string[] {
 		"",
 		"Reach for Superset when you need to:",
 		"",
-		"- Run several coding agents (Claude Code, Codex, OpenCode, or any CLI agent) at the same time on one repository without them stepping on each other — each agent gets an isolated Git worktree and its own branch.",
+		"- Run several coding agents (Claude Code, Codex, OpenCode, or any CLI agent) at the same time on one repository without them stepping on each other. Each agent gets an isolated Git worktree and its own branch.",
 		"- Orchestrate agent work programmatically: create workspaces, launch agents with a prompt, open terminals, and track tasks from another agent or script via the Superset MCP server.",
 		"- Schedule recurring agent runs (automations) that execute a prompt on a cron-like schedule in a fresh or existing workspace.",
 		"- Review diffs, manage ports, and monitor many concurrent agent sessions from one dashboard.",
 		"",
-		"Superset is not a coding agent itself — it is the workspace and orchestration layer the agents run in. If you are an AI agent, the fastest way to act on a user's Superset account is the MCP server below (OAuth or API key auth); the fastest way to learn the product is the docs index at https://docs.superset.sh.",
+		"Superset is not a coding agent itself; it is the workspace and orchestration layer the agents run in. If you are an AI agent, the fastest way to act on a user's Superset account is the MCP server below (OAuth or API key auth); the fastest way to learn the product is the docs index at https://docs.superset.sh.",
 	];
 }
 
@@ -57,7 +57,7 @@ export function buildDeveloperResourcesSection(): string[] {
 		"",
 		`- [API docs](${docsUrl}/mcp-server): Superset MCP server documentation`,
 		`- [OpenAPI spec](${API_URL}/openapi.json): OpenAPI 3.1 description of the Superset API surface`,
-		`- [MCP server](${MCP_SERVER_URL}): Model Context Protocol server (Streamable HTTP transport) — tools for tasks, workspaces, agents, automations, terminals, hosts, and projects; full catalog in the server card. Legacy alias: ${API_URL}/api/v2/agent/mcp`,
+		`- [MCP server](${MCP_SERVER_URL}): Model Context Protocol server (Streamable HTTP transport) with tools for tasks, workspaces, agents, automations, terminals, hosts, and projects; full catalog in the server card. Legacy alias: ${API_URL}/api/v2/agent/mcp`,
 		`- [Docs MCP server](${docsUrl}/mcp): search and read the Superset documentation over MCP (Streamable HTTP, no auth)`,
 		`- [MCP server card](${baseUrl}/.well-known/mcp/server-card.json): machine-readable MCP server description`,
 		`- [A2A agent card](${baseUrl}/.well-known/agent-card.json): Agent-to-Agent capability card`,
@@ -66,7 +66,7 @@ export function buildDeveloperResourcesSection(): string[] {
 		`- [Agent instructions](${baseUrl}/agents.md): when and how AI agents should use Superset`,
 		`- [OAuth protected resource metadata](${API_URL}/.well-known/oauth-protected-resource): RFC 9728`,
 		`- [OAuth authorization server metadata](${API_URL}/.well-known/oauth-authorization-server): RFC 8414`,
-		`- [Agent skills](https://github.com/superset-sh/skills): official skills for the CLI and MCP server — \`npx skills add superset-sh/skills\``,
+		`- [Agent skills](https://github.com/superset-sh/skills): official skills for the CLI and MCP server; install with \`npx skills add superset-sh/skills\``,
 		`- [CLI](${docsUrl}/cli/getting-started): \`brew install superset-sh/tap/superset\` or \`curl -fsSL https://superset.sh/cli/install.sh | sh\``,
 		`- [TypeScript SDK](${docsUrl}/sdk/getting-started): \`npm install @superset_sh/sdk\``,
 		`- [Docs llms.txt](${docsUrl}/llms.txt): scoped context for the documentation`,

--- a/apps/marketing/src/proxy.ts
+++ b/apps/marketing/src/proxy.ts
@@ -38,7 +38,7 @@ export default function proxy(request: NextRequest) {
 	}
 
 	// Accept negotiation on content pages that have a markdown twin. Segments
-	// with an extension (llms.txt, feed.xml) are files, not pages — skip them.
+	// with an extension (llms.txt, feed.xml) are files, not pages, so skip them.
 	if (
 		/^\/(blog|compare|changelog)\/[^/.]+$/.test(pathname) &&
 		acceptsMarkdown(request)


### PR DESCRIPTION
## What

- Hero H1: "The Code Editor for AI Agents" → **"Run 100+ Coding Agents in Parallel."**
- Subheadline: "Claude Code, Codex, or any CLI agent, each in its own isolated workspace. Spend your time shipping, not waiting."
- README header + og-image alt aligned to the same positioning.
- Removed all 370 em dashes from marketing copy (src, blog, compare, changelogs) and README, each rewritten with a colon, comma, period, or parentheses.
- Added `apps/marketing/docs/copywriting-references.md`: the research canon (Shapiro/Dry/Dunford/Markepear, YC one-liner doctrine, HN-revered taglines, elite subtitle patterns) and house style for future copy work.

## Why

Research across HN/X/GitHub sentiment, 30+ competitor homepages, and category voice-of-customer showed "code editor" is a category the leaders exited and users called an undersell. "Parallel coding agents" is the converged category phrase; "100+" is defensible vs platform concurrency caps; the subheadline pairs mechanism with the user outcome.

## Notes

- Blog title changed: "…Agent — You Need an Orchestrator" → "…Agent: You Need an Orchestrator" (cross-reference updated).
- Follow-ups (separate PR): restore automations + remote-workspaces weight as feature-section headers; make the hero demo visibly show double-digit sessions to cash the "100+" claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repositions the marketing hero to “Run 100+ Coding Agents in Parallel” and removes em dashes across site copy for clearer, consistent style. Previously “The Code Editor for AI Agents”; README and metadata now match the new value prop, which affects on-page messaging and link preview text.

- Verify the hero text and animation in `HeroSection` render without layout jumps; confirm the updated subheadline.
- Confirm README, `JsonLd`, `index.md`, and `layout` OG image alt reflect the new phrasing.
- Spot-check MDX/markdown pages where em dashes were replaced with colons/commas/periods/parentheses for grammar and headings; ensure titles didn’t alter slugs.
- Ensure `.well-known` routes (`agent-card.json`, `mcp`) build with the revised descriptions.
- New doc `apps/marketing/docs/copywriting-references.md` sets the house style for future copy; no migration required.

<sup>Written for commit 793068a03ab5caa0d2cc032fbaed0749d813f6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the homepage messaging to highlight running 100+ coding agents in parallel across isolated workspaces.
  - Clarified support for Claude Code, Codex, and other CLI-based agents.

- **Documentation**
  - Added comprehensive copywriting guidance covering messaging, style, terminology, and marketing claims.
  - Refined blog posts, comparisons, changelogs, API guidance, and agent documentation for clearer presentation.

- **Style**
  - Standardized punctuation, separators, list formatting, terminal labels, metadata, and image descriptions throughout the marketing site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->