### PR TITLE
fix(marketing,docs): align stale tagline copy with parallel-agents positioning

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 		default: `${COMPANY.NAME} Documentation`,
 		template: `%s | ${COMPANY.NAME} Docs`,
 	},
-	description: `Official documentation for ${COMPANY.NAME} - the terminal for coding agents. Learn how to run parallel coding agents on your machine.`,
+	description: `Official documentation for ${COMPANY.NAME}. Learn how to run 100+ coding agents in parallel on your machine.`,
 	keywords: [
 		`${COMPANY.NAME} documentation`,
 		"coding agents docs",
@@ -31,12 +31,12 @@ export const metadata: Metadata = {
 		url: COMPANY.DOCS_URL,
 		siteName: `${COMPANY.NAME} Docs`,
 		title: `${COMPANY.NAME} Documentation`,
-		description: `Official documentation for ${COMPANY.NAME} - the terminal for coding agents.`,
+		description: `Official documentation for ${COMPANY.NAME}, the app for running 100+ coding agents in parallel.`,
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: `${COMPANY.NAME} Documentation`,
-		description: `Official documentation for ${COMPANY.NAME} - the terminal for coding agents.`,
+		description: `Official documentation for ${COMPANY.NAME}, the app for running 100+ coding agents in parallel.`,
 		creator: "@superset_sh",
 	},
 	robots: {

--- a/apps/marketing/content/compare/best-terminal-for-ai-coding.mdx
+++ b/apps/marketing/content/compare/best-terminal-for-ai-coding.mdx
@@ -24,7 +24,7 @@ The best terminal for AI coding depends on what problem you are actually trying 
 
 If you want built-in AI and one polished interface, Warp is the obvious candidate. If you want a classic daily-driver terminal, iTerm2, Ghostty, kitty, Alacritty, and WezTerm are all credible choices. If you want to run multiple coding agents safely on the same repository, the answer changes: you need orchestration and Git isolation more than you need another tab bar.
 
-That is where Superset stands apart. It is not trying to be the best general-purpose terminal emulator. It is increasingly closer to a local-first agent workspace or code editor for AI agents than a classic terminal, and that is exactly why it stands out for parallel coding workflows.
+That is where Superset stands apart. It is not trying to be the best general-purpose terminal emulator. It is a local-first workspace for running 100+ coding agents in parallel, not a classic terminal, and that is exactly why it stands out for parallel coding workflows.
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-warp.mdx
+++ b/apps/marketing/content/compare/superset-vs-warp.mdx
@@ -55,7 +55,7 @@ Both tools support multiple agents, but the isolation model differs. Superset gi
 
 ### Terminal Quality vs Orchestration Focus
 
-Warp is a polished terminal: GPU-accelerated, with block-based output and a command palette. Superset includes terminals because agents need them, but the product is increasingly closer to a code editor for AI agents than a classic daily-driver terminal. You would still use Warp, iTerm2, or Kitty for SSH and ad-hoc commands.
+Warp is a polished terminal: GPU-accelerated, with block-based output and a command palette. Superset includes terminals because agents need them, but the product is a workspace for running 100+ coding agents in parallel, not a classic daily-driver terminal. You would still use Warp, iTerm2, or Kitty for SSH and ad-hoc commands.
 
 ### Team Collaboration
 

--- a/apps/marketing/src/app/components/Header/constants.ts
+++ b/apps/marketing/src/app/components/Header/constants.ts
@@ -11,7 +11,7 @@ export const PRODUCT_LINKS: NavLink[] = [
 	{
 		href: "/",
 		label: "Overview",
-		description: "The terminal for coding agents.",
+		description: "Run 100+ coding agents in parallel.",
 	},
 	{
 		href: "/changelog",


### PR DESCRIPTION
Catch-up sweep after #6420/#6421 (grep for every label the change replaced):

- Docs site metadata (3x): "the terminal for coding agents" → parallel-agents phrasing
- Marketing header nav Overview description: same
- Two compare pages whose prose still self-described Superset as "a code editor for AI agents"

Intentionally left: competitor-page SEO keywords ("agentic ide" etc. target search terms), a desktop test fixture string, and competitor descriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns docs metadata and marketing copy with the parallel-agents positioning. Replaces “the terminal for coding agents” with “run 100+ coding agents in parallel” to ensure consistent SEO and social previews.

- Update docs meta description and Open Graph/Twitter descriptions to the new phrasing.
- Update Marketing Header Overview description to “Run 100+ coding agents in parallel.”
- Replace outdated wording on two compare pages to reflect a workspace for running 100+ coding agents in parallel.
- Intentional exclusions: competitor-page SEO keywords, a desktop test fixture string, and competitor descriptions.

<sup>Written for commit 3627a5b3c2b53782c756a64e1830bfdcdd85973c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

