### PR TITLE
docs(readme): align README positioning with parallel-agents tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <br />
 
-Orchestrate swarms of Claude Code, Codex, and more in parallel.<br />
-Works with any CLI agent. Built for local worktree-based development.
+Claude Code, Codex, or any CLI agent, each in its own isolated worktree.<br />
+Spend your time shipping, not waiting.
 
 <br />
 
@@ -26,7 +26,7 @@ Works with any CLI agent. Built for local worktree-based development.
 
 ## Code 10x Faster With No Switching Cost
 
-Superset orchestrates CLI-based coding agents across isolated git worktrees, with built-in terminal, review, and open-in-editor workflows.
+Superset runs CLI-based coding agents in parallel across isolated git worktrees, with built-in terminal, review, and open-in-editor workflows.
 
 - **Run multiple agents simultaneously** without context switching overhead
 - **Isolate each task** in its own git worktree so agents don't interfere with each other
@@ -45,7 +45,7 @@ Wait less, ship more.
 
 ### Parallel Workspaces
 
-Run 10+ coding agents at once, each in its own git worktree with its own branch, terminal, and environment. Compare the results and merge the winner.
+Run 100+ coding agents at once, each in its own git worktree with its own branch, terminal, and environment. Compare the results and merge the winner.
 
 [Docs →](https://docs.superset.sh/workspaces)
 


### PR DESCRIPTION
GitHub-surface catch-up after #6420-#6422:

- Subtitle: "Orchestrate swarms of Claude Code, Codex, and more in parallel" → mirrors the site hero ("Claude Code, Codex, or any CLI agent, each in its own isolated worktree. Spend your time shipping, not waiting.") — research verdict: run > orchestrate, and "swarms" is the maximalist register we don't want
- Intro line: "orchestrates" → "runs … in parallel"
- Parallel Workspaces feature: "Run 10+" → "Run 100+" (was contradicting the header one screen above)

Left alone: the superset:orchestrate skill reference (line 173) since that's the skill's actual name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns README messaging with the site hero to emphasize running agents in parallel and removes a contradictory capacity claim.

- Replace “Orchestrate swarms of Claude Code, Codex, and more in parallel.” with “Claude Code, Codex, or any CLI agent, each in its own isolated worktree. Spend your time shipping, not waiting.”
- Change “Superset orchestrates…” to “Superset runs … in parallel…”.
- Update “Run 10+” to “Run 100+” in Parallel Workspaces to match the header.
- Leave `superset:orchestrate` reference unchanged (it is the skill name). Only `README.md` changed; no code or migration required.

<sup>Written for commit e7746c6f35c9458016e6f077bb4b7b62f34dac5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

