### PR TITLE
chore(desktop): bump version to 1.21.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.20.2",
+	"version": "1.21.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.20.2",
+      "version": "1.21.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@ai-sdk/anthropic": "3.0.64",
@@ -837,7 +837,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.20.2",
+      "version": "1.21.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -934,7 +934,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.20.2",
+      "version": "1.21.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.20.2",
+	"version": "1.21.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.20.2",
+	"version": "1.21.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `@superset/desktop`, `@superset/cli`, and `@superset/host-service` to version 1.21.0 for the desktop v1.21.0 release. Updates `bun.lock` accordingly; no runtime or API changes.

- Verify only `version` fields changed from 1.20.2 to 1.21.0 in affected `package.json` files and `bun.lock`.
- No migration required; build and publish pipelines will pick up 1.21.0.

<sup>Written for commit 067182bced0ea141ed949555859fb94121fa7d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application, command-line interface, and host service to version 1.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->