### PR TITLE
docs(cli,agents): no em dashes in user-facing copy; fix stale theme-set restart note

### DIFF
--- a/.agents/skills/superset-settings/SKILL.md
+++ b/.agents/skills/superset-settings/SKILL.md
@@ -6,7 +6,7 @@ description: Read and update the Superset desktop app's user settings (theme, fo
 # Superset settings via CLI
 
 Change the desktop app's user settings from the command line with
-`superset settings`. Works offline, no login required — everything is local
+`superset settings`. Works offline, no login required; everything is local
 to this machine.
 
 ## Commands
@@ -27,17 +27,17 @@ superset settings theme import <file>               # add/replace custom themes 
 superset settings theme remove <id>                 # delete a custom theme
 ```
 
-Prefer `--json` (auto-on in agent environments — parse it rather than
+Prefer `--json` (auto-on in agent environments; parse it rather than
 matching the human sentences) and `superset settings list` to discover keys
 and allowed values instead of guessing. In Superset terminals `superset` is
 already on PATH. `SUPERSET_HOME_DIR` overrides the target profile
-(`~/.superset` by default) — useful for testing against a sandbox copy.
+(`~/.superset` by default); useful for testing against a sandbox copy.
 
 ## Creating custom themes
 
 Two paths; both end with import → set (a running app restyles live).
 
-**From scratch** — a minimal file is enough. Every color you omit is filled
+**From scratch**: a minimal file is enough. Every color you omit is filled
 in from the built-in base theme for your declared `type`, so start small and
 override only what you care about:
 
@@ -59,7 +59,7 @@ superset settings theme import ocean.json   # -> Imported 1 theme: midnight-ocea
 superset settings theme set midnight-ocean  # a running app applies it live
 ```
 
-**From a starter** — export any theme's complete definition (all ~38 ui +
+**From a starter**: export any theme's complete definition (all ~38 ui +
 21 terminal colors) and edit it. Best when restyling everything:
 
 ```bash
@@ -73,7 +73,7 @@ superset settings theme import my-theme.json && superset settings theme set my-t
 | Field | Notes |
 | --- | --- |
 | `name` / `id` | either works; the id is slugified (`"Midnight Ocean"` → `midnight-ocean`). Reserved: `dark`, `light`, `monokai`, `system` |
-| `type` | `"dark"` or `"light"` (defaults to dark) — picks the base theme that fills omitted colors |
+| `type` | `"dark"` or `"light"` (defaults to dark); picks the base theme that fills omitted colors |
 | `ui` | app chrome. Highest-impact keys: `background`, `foreground`, `sidebar`, `card`, `popover`, `primary`, `accent`, `muted`, `border`, `input`, `ring`, plus `sidebar*` variants |
 | `terminal` | xterm colors: `background`, `foreground`, `cursor`, `selectionBackground`, and the 16 ANSI names (`red`, `brightRed`, ...) |
 | `editor` | optional `{ "colors": {...}, "syntax": {...} }` for the file editor; generated from `ui`/`type` when omitted |
@@ -82,7 +82,7 @@ superset settings theme import my-theme.json && superset settings theme set my-t
 Rules (same parser as the app's Appearance → Import): all colors are CSS color
 strings; missing colors inherit from the base; a file can hold one theme, an
 array, or a pack `{ "themes": [...] }`; max 256 KB; re-importing an id
-replaces that theme; import never activates — `theme set` does.
+replaces that theme; import never activates; `theme set` does.
 
 ### Verify and iterate
 
@@ -94,21 +94,21 @@ superset settings theme remove midnight-ocean   # active falls back to dark
 ```
 
 Iterating on colors: each `import` replaces the theme, and a running app
-applies it live — the loop is edit → import → `theme set <id>` (re-set to
+applies it live; the loop is edit → import → `theme set <id>` (re-set to
 re-apply the active theme after edits).
 
 ## How changes take effect
 
 After every write the CLI nudges the running desktop app
 (`POST /settings-changed` on its local server) and the app refreshes
-immediately — themes included, no restart. The command output tells you
+immediately, themes included, no restart. The command output tells you
 which happened: "refreshed immediately" / "Applied to the running desktop
 app" means the nudge landed. The notes below are the fallback behavior when
 no app acknowledged (app not running, or an older app version):
 
 - **Regular settings** (most of `settings set`): written to
   `~/.superset/local.db`. A running older app picks them up the next time
-  its window regains focus — no restart needed.
+  its window regains focus; no restart needed.
 - **Git settings** (`branchPrefixMode`, `branchPrefixCustom`,
   `worktreeBaseDir`): host-wide values written through the local host
   service (auth via its manifest, no login needed). Requires the desktop app
@@ -118,9 +118,9 @@ no app acknowledged (app not running, or an older app version):
   after an app restart.
 - **Theme** (`settings theme set`): applies live when the nudge lands. If
   the output shows the restart fallback instead: quit the app cleanly first,
-  then set, then relaunch — a running older app overwrites the file on its
+  then set, then relaunch; a running older app overwrites the file on its
   own writes. If you are an agent running inside a Superset terminal, never
-  kill the app yourself (that kills your own session) — ask the user to
+  kill the app yourself (that kills your own session); ask the user to
   restart instead.
 - Both stores are created by the desktop app. On a machine that never ran
   the app, `set` commands fail with a hint to launch it once.
@@ -132,7 +132,7 @@ Booleans accept `true/false/on/off/1/0/yes/no`.
 | Section | Keys |
 | --- | --- |
 | behavior | `confirmOnQuit`, `fileOpenMode` (`split-pane\|new-tab`), `showResourceMonitor`, `openLinksInApp`, `defaultEditor` (vscode, cursor, zed, ...) |
-| git | `branchPrefixMode` (`none\|github\|author\|custom`), `branchPrefixCustom`, `worktreeBaseDir` — host-wide, written through the local host service, so the app (or `superset start`) must be running |
+| git | `branchPrefixMode` (`none\|github\|author\|custom`), `branchPrefixCustom`, `worktreeBaseDir`; host-wide, written through the local host service, so the app (or `superset start`) must be running |
 | notifications | `selectedRingtoneId` (shamisen, arcade, ping, quick, doowap, woman, african, afrobeat, edm, comeback, shabala), `notificationSoundsMuted`, `notificationVolume` (0-100) |
 | terminal | `terminalLinkBehavior` (`external-editor\|file-viewer`), `terminalParkedRuntimeCap` (2-64), `showPresetsBar`, `useCompactTerminalAddButton`, `autoApplyDefaultPreset`, `waitForSetupBeforeAgent` |
 | terminal appearance | `terminalFontFamily`, `terminalFontSize` (10-24, 0.5 steps), `terminalLineHeight` (1-2.5), `terminalLetterSpacing` (-2-4), `terminalFontWeight` (100-900), `terminalLigatures`, `terminalMinimumContrast` (1\|3\|4.5\|7), `terminalCursorStyle` (`block\|bar\|underline`), `terminalCursorBlink` |
@@ -140,11 +140,11 @@ Booleans accept `true/false/on/off/1/0/yes/no`.
 
 ## Not settable here (by design)
 
-- `exposeHostServiceViaRelay` — security-sensitive; the app gates it behind
+- `exposeHostServiceViaRelay`: security-sensitive; the app gates it behind
   a plan check and an explicit confirmation dialog. Point the user to
   Settings → Security.
 - Structured settings (terminal presets, agent preset overrides/custom
-  agents, disabled agent hooks) — use `superset agents ...` or the app UI.
+  agents, disabled agent hooks); use `superset agents ...` or the app UI.
 - `deleteLocalBranch` and other renderer-only prefs stored in the app's
   localStorage (diff view, chat model, hotkey rebinds) are not reachable
   from outside the renderer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ When a user asks for UI verification through the Chrome DevTools Protocol (CDP):
 9. **TanStack DB / Electric live queries are cache-first** - `useLiveQuery` can return persisted rows in `data` while the collection is still not `isReady`. Always render existing rows first. Use `isReady` only to decide what to show when no row/data exists yet: no data + not ready = loading/skeleton/null; no data + ready = empty/not-found. Never hide, blank, or replace existing `data` just because `isReady` is false or `isLoading` is true. This cache-first rendering rule does not apply to write/seeding side effects: wait for strict readiness before deriving missing rows or writing defaults, unless the write is provably idempotent.
 10. **PR titles are conventional commits** - PRs are squash-merged using the PR title as the commit subject, so every title needs a conventional-commit type and scope, e.g. `feat(desktop): add copy-logs button to failed CI checks` or `fix(host-service): guard against missing PR`.
 11. **Mobile is iOS-only for the time being** - `apps/mobile` targets iOS only. Don't add Android fallbacks or platform guards for iOS-only APIs (e.g. `@expo/ui/swift-ui`), and don't treat Android incompatibility as a blocker until Android is explicitly put in scope.
+12. **No em dashes in user-facing copy** - docs, CLI output, skill/command docs, marketing copy, social posts, and video captions never use em dashes (—). Use a comma, semicolon, colon, period, or parentheses instead. Code comments are exempt.
 
 
 ---

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -1301,12 +1301,12 @@ superset automations logs aut_…
 
 ### settings
 
-Read and update the Superset desktop app's settings on this machine —
-behavior, git, notifications, terminal, and terminal/editor appearance —
-plus the app theme. These commands work offline and don't require login.
+Read and update the Superset desktop app's settings on this machine:
+behavior, git, notifications, terminal, terminal/editor appearance, and the
+app theme. These commands work offline and don't require login.
 
 After every write the CLI nudges the running desktop app, which refreshes
-immediately — themes included, no restart (the command output confirms
+immediately, themes included, no restart (the command output confirms
 with "refreshed immediately" / "applied to the running desktop app").
 Without a running app (or on older app versions) settings apply on next
 window focus and theme changes on next launch. Git settings
@@ -1433,7 +1433,7 @@ superset settings theme get
 	]}
 	output="Theme (full definition JSON)"
 >
-Export a theme's full JSON definition — the starting point for creating a
+Export a theme's full JSON definition, the starting point for creating a
 custom theme: export a built-in, edit the colors, then import it.
 
 ```bash
@@ -1488,9 +1488,10 @@ superset settings theme remove my-theme
 		{ flag: "--system-dark <id>", description: "Theme used for OS dark mode when the active theme is `system`." },
 	]}
 >
-Set the active theme and/or the system light/dark mappings. Restart the
-desktop app to apply — quit it first if it's running, or the app may
-overwrite the change.
+Set the active theme and/or the system light/dark mappings. A running
+desktop app restyles live; without one the theme applies on next launch.
+(On app versions without live reload, quit the app first, then set, then
+relaunch, or the app may overwrite the change.)
 
 ```bash
 superset settings theme set monokai

--- a/packages/cli/src/commands/settings/notes.ts
+++ b/packages/cli/src/commands/settings/notes.ts
@@ -6,7 +6,7 @@ export const HOST_EFFECT =
 	"Applied host-wide via the host service; the desktop app reflects it the next time its window regains focus.";
 
 export const THEME_EFFECT =
-	"Restart the Superset desktop app to apply. Quit it first if it's running — otherwise the app may overwrite this change.";
+	"Restart the Superset desktop app to apply. Quit it first if it's running; otherwise the app may overwrite this change.";
 
 export const RINGTONE_EFFECT =
 	"The new sound plays immediately; the selection shown in Settings → Notifications updates after the next app restart.";


### PR DESCRIPTION
## Summary
- Remove every em dash from the `superset settings` user-facing copy: the CLI reference settings section, the `superset-settings` skill, and the CLI's theme fallback message.
- Add Agent Rule 12 to `AGENTS.md`: no em dashes in user-facing copy (docs, CLI output, marketing, social, captions); code comments exempt.
- Fix a stale claim on the same lines: the `theme set` docs still said "restart the desktop app to apply", which #6418's live reload made wrong. It now describes live apply with the old-app fallback in parentheses.

## Testing
- `bun run lint`
- `bun test` (packages/cli settings suites, 49 tests)
- Docs-only otherwise; reviewed rendered text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes em dashes from user-facing copy and documents a “no em dash” rule. Updates `superset settings theme set` docs to describe live theme application with a clear restart fallback; runtime behavior is unchanged.

- `apps/docs` and `.agents/skills/superset-settings/SKILL.md`: copy edits only; phrasing now uses commas/semicolons/colons and explains that a running app restyles live, with older versions requiring a quit → set → relaunch fallback.
- `AGENTS.md`: adds Rule 12 (no em dashes in user-facing copy); code comments are exempt.
- `packages/cli/src/commands/settings/notes.ts`: punctuation-only tweak to the theme restart fallback string; message intent and logic are unchanged.

<sup>Written for commit d653686e072a34bc24408e9deadb0dcac3aa7f5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified settings documentation, including theme behavior, live restyling, next-launch effects, and restart requirements.
  * Improved wording, punctuation, formatting, and readability across settings guidance.
* **Chores**
  * Added a writing guideline for user-facing copy to avoid em dashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->