### PR TITLE
feat(desktop): let users type a workspace name on the new-workspace screen

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
@@ -43,16 +43,25 @@ describe("resolveNames", () => {
 	test("sanitizes a typed workspace name as the branch candidate", () => {
 		const names = resolveNames(
 			draft({
-				workspaceName: "feature/cache-fix",
+				workspaceName: "feature:cache-fix",
 				workspaceNameEdited: true,
 			}),
 		);
-		expect(names.branchName).toBe("feature/cache-fix");
+		expect(names.branchName).toBe("featurecache-fix");
+	});
+
+	test("rejects a workspace name that sanitizes to an empty branch", () => {
+		const names = resolveNames(
+			draft({ workspaceName: ":", workspaceNameEdited: true }),
+		);
+		expect(names.workspaceName).toBe(":");
+		expect(names.branchName).toBeNull();
 	});
 
 	test("ignores a workspace name that was not edited (e.g. AI-suggested)", () => {
 		const names = resolveNames(draft({ workspaceName: "suggested" }));
 		expect(names.workspaceName).toBeNull();
+		expect(names.branchName).toBeNull();
 	});
 
 	test("returns a sanitized typed branch name (preserves spaces)", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import type { DashboardNewWorkspaceDraft } from "../../../../../DashboardNewWorkspaceDraftContext";
+import { resolveNames } from "./resolveNames";
+
+function draft(
+	overrides: Partial<DashboardNewWorkspaceDraft> = {},
+): DashboardNewWorkspaceDraft {
+	return {
+		selectedProjectId: null,
+		isSession: false,
+		hostId: null,
+		prompt: "",
+		baseBranch: null,
+		baseBranchSource: null,
+		workspaceName: "",
+		workspaceNameEdited: false,
+		branchName: "",
+		branchNameEdited: false,
+		branchNameFromProvider: false,
+		linkedIssues: [],
+		linkedPR: null,
+		selectedAgentId: null,
+		attachments: [],
+		...overrides,
+	};
+}
+
+describe("resolveNames", () => {
+	test("returns null name when nothing was typed", () => {
+		const names = resolveNames(draft());
+		expect(names.workspaceName).toBeNull();
+		expect(names.branchName).toBeNull();
+	});
+
+	test("returns a user-typed workspace name (not an AI hint)", () => {
+		const names = resolveNames(
+			draft({ workspaceName: "my-remix", workspaceNameEdited: true }),
+		);
+		expect(names.workspaceName).toBe("my-remix");
+	});
+
+	test("ignores a workspace name that was not edited (e.g. AI-suggested)", () => {
+		const names = resolveNames(draft({ workspaceName: "suggested" }));
+		expect(names.workspaceName).toBeNull();
+	});
+
+	test("returns a sanitized typed branch name (preserves spaces)", () => {
+		const names = resolveNames(
+			draft({
+				branchName: "Fix UI bug",
+				branchNameEdited: true,
+			}),
+		);
+		// sanitizeUserBranchName only strips git-forbidden chars; it preserves
+		// case and spaces (the UI slugifies spaces on the way in).
+		expect(names.branchName).toBe("Fix UI bug");
+		// A typed name seeds a branch slug; the workspace name comes straight through.
+		expect(names.workspaceName).toBeNull();
+	});
+
+	test("typed name and typed branch both resolve", () => {
+		const names = resolveNames(
+			draft({
+				workspaceName: "My Workspace",
+				workspaceNameEdited: true,
+				branchName: "feature/new-pane",
+				branchNameEdited: true,
+			}),
+		);
+		expect(names.workspaceName).toBe("My Workspace");
+		expect(names.branchName).toBe("feature/new-pane");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts
@@ -37,6 +37,17 @@ describe("resolveNames", () => {
 			draft({ workspaceName: "my-remix", workspaceNameEdited: true }),
 		);
 		expect(names.workspaceName).toBe("my-remix");
+		expect(names.branchName).toBe("my-remix");
+	});
+
+	test("sanitizes a typed workspace name as the branch candidate", () => {
+		const names = resolveNames(
+			draft({
+				workspaceName: "feature/cache-fix",
+				workspaceNameEdited: true,
+			}),
+		);
+		expect(names.branchName).toBe("feature/cache-fix");
 	});
 
 	test("ignores a workspace name that was not edited (e.g. AI-suggested)", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
@@ -9,12 +9,13 @@ interface ResolvedNames {
 }
 
 /**
- * Returns whatever the user typed; null otherwise. The host-service
- * seeds the branch from a typed name, otherwise creates with a friendly
- * random and applies AI names as a deferred rename.
+ * Returns the user-typed names; null otherwise. An explicitly seeded or
+ * edited branch wins; otherwise a manually entered workspace name is also
+ * sent as the branch candidate so the host does not truncate or reinterpret
+ * it through its generated-name path.
  */
 export function resolveNames(draft: DashboardNewWorkspaceDraft): ResolvedNames {
-	const branchName =
+	const explicitBranchName =
 		draft.branchNameEdited && draft.branchName.trim()
 			? sanitizeUserBranchName(draft.branchName.trim())
 			: null;
@@ -23,6 +24,9 @@ export function resolveNames(draft: DashboardNewWorkspaceDraft): ResolvedNames {
 		draft.workspaceNameEdited && draft.workspaceName.trim()
 			? draft.workspaceName.trim()
 			: null;
+	const branchName =
+		explicitBranchName ??
+		(workspaceName ? sanitizeUserBranchName(workspaceName) : null);
 
 	return { branchName, workspaceName };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.ts
@@ -26,7 +26,7 @@ export function resolveNames(draft: DashboardNewWorkspaceDraft): ResolvedNames {
 			: null;
 	const branchName =
 		explicitBranchName ??
-		(workspaceName ? sanitizeUserBranchName(workspaceName) : null);
+		(workspaceName ? sanitizeUserBranchName(workspaceName) || null : null);
 
 	return { branchName, workspaceName };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -11,6 +11,7 @@ import {
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
 import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
 import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -574,6 +575,22 @@ export function NewWorkspaceScreen({
 				</h1>
 			</div>
 			<div className="relative flex w-full max-w-[640px] flex-col px-6 pb-8">
+				<Input
+					className="mb-2 h-10 w-full border-border bg-foreground/[0.02] text-sm font-medium placeholder:text-muted-foreground/50 focus-visible:ring-0"
+					placeholder="Workspace name (optional)"
+					value={draft.workspaceName}
+					onChange={(e) =>
+						updateDraft({
+							workspaceName: e.target.value,
+							workspaceNameEdited: true,
+						})
+					}
+					onBlur={() => {
+						if (!draft.workspaceName.trim())
+							updateDraft({ workspaceName: "", workspaceNameEdited: false });
+					}}
+					aria-label="Workspace name"
+				/>
 				<AnimatePresence initial={false}>
 					{isPromptEmpty && (
 						<motion.div


### PR DESCRIPTION
Fixes #6398

## What & why

The new-workspace screen (experiment test arm) had no way to type a name:
whatever was entered went through as an AI naming hint, and picking "No
agent" did not change that. Under the hood a typed name is the cheaper,
exact path — `resolveNames` returns it and `workspaces.create` sets
`wantAi = false` (skipping the LLM call and the deferred rename) — but the
UI never offered it.

This adds a "Workspace name (optional)" field above the composer. It writes
`workspaceName`/`workspaceNameEdited` into the existing draft store, which
the submit path already reads via `resolveNames`. So a name alone (no
prompt) creates an exact-named workspace and the branch seeds from the
name. This matters especially for remote hosts, where the branch-picker
workaround required pushing a throwaway branch first.

### Files changed

- `apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx`
  — add the name input (mirrors the control modal's field: `updateDraft` +
  `workspaceNameEdited`, clears on blur if empty).
- `apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/resolveNames.test.ts`
  — new unit tests for the naming path.

## How I tested it

- `bun install` clean.
- `bun test resolveNames.test.ts` -> **5 pass / 0 fail** (typed name
  resolves to a real workspace name, an unedited/AI-suggested name is
  ignored, typed branch/name pairs both resolve).
- `biome check` clean on both files.
- `bun x tsc --noEmit -p apps/desktop/tsconfig.json` introduces no new
  errors vs `main` (85 pre-existing, identical before/after).

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (no new errors vs main)
- [ ] "Allow edits from maintainers" is checked on fork PRs
- [x] I have added tests that prove the feature works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets users type a workspace name on the new-workspace screen and treats it as the exact name. Previously any text acted as a naming hint and always used automatic naming; now a typed name creates an exact-named workspace and skips the deferred rename.

- Adds a name input above the composer; writes workspaceName/workspaceNameEdited to the draft and clears both on blur when empty.
- Updates resolveNames to prefer an explicitly edited branch; otherwise sanitizes the typed workspaceName and uses it as the branch candidate; ignores unedited/suggested names; returns a null branch if sanitization empties it.
- Adds unit tests covering typed names, ignoring unedited suggestions, branch sanitization (including empty results and preserving spaces), and typed name plus typed branch together.

<sup>Written for commit db4ac32261a6053f145c9b5c3c0d2ef620a9719e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional workspace-name field when creating a new workspace.
  * Workspace names are retained when entered and cleared when left blank.
  * When no branch name is provided, the workspace name is used as a sanitized fallback for the branch name.
  * Explicitly provided branch names continue to take precedence over workspace names.

* **Tests**
  * Added coverage for workspace and branch-name resolution, including edited names, suggested names, empty drafts, and branch-name formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->