### PR TITLE
feat(desktop): add a Jump to latest reply button in the v2 chat

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/Transcript.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/Transcript.tsx
@@ -7,8 +7,10 @@ import type {
 import type { ApprovalRequest, Decision } from "@superset/chat/protocol";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
+import { ArrowDownIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TurnGroupSection } from "./components/TurnGroupSection";
+import { isNearBottom, latestUserItemId, shouldScrollToLatest } from "./utils/scroll";
 
 export type TranscriptProps = {
 	groups: TurnGroup[];
@@ -21,20 +23,6 @@ export type TranscriptProps = {
 	onRetryPrompt: (clientId: string) => void;
 	onDiscardPrompt: (clientId: string) => void;
 };
-
-function latestUserItemId(groups: TurnGroup[]): string | null {
-	for (let groupIndex = groups.length - 1; groupIndex >= 0; groupIndex -= 1) {
-		const group = groups[groupIndex];
-		if (!group) continue;
-		for (let index = group.entries.length - 1; index >= 0; index -= 1) {
-			const entry = group.entries[index];
-			if (entry?.kind === "item" && entry.item.kind === "user_message") {
-				return entry.item.id;
-			}
-		}
-	}
-	return null;
-}
 
 function outboxText(entry: OutboxEntry): string {
 	return entry.content
@@ -95,13 +83,67 @@ export function Transcript({
 		return targets;
 	}, [approvals]);
 
+	const [isAtBottom, setIsAtBottom] = useState(true);
+	const lastAnchorItemIdRef = useRef<string | null>(null);
+
+	const checkScrollPosition = useCallback(() => {
+		const container = containerRef.current;
+		if (!container) return;
+		setIsAtBottom(
+			isNearBottom(
+				container.scrollHeight,
+				container.scrollTop,
+				container.clientHeight,
+			),
+		);
+	}, []);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+		container.addEventListener("scroll", checkScrollPosition, {
+			passive: true,
+		});
+		return () =>
+			container.removeEventListener("scroll", checkScrollPosition);
+	}, [checkScrollPosition]);
+
 	const anchorItemId = latestUserItemId(groups);
+
+	const scrollToLatest = useCallback(() => {
+		const target = anchorItemId
+			? containerRef.current?.querySelector(
+					`[data-item-id="${CSS.escape(anchorItemId)}"]`,
+				)
+			: null;
+		if (target) {
+			target.scrollIntoView({ behavior: "smooth", block: "start" });
+			return;
+		}
+		const container = containerRef.current;
+		if (container) {
+			container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+		}
+	}, [anchorItemId]);
+
+	// Pin the viewport to the latest user reply only while already near the
+	// bottom. lastAnchorItemIdRef prevents re-anchoring (yanking the viewport)
+	// when the user merely touches the bottom edge — the CodeRabbit re-anchor
+	// fix from PR #6428.
 	useEffect(() => {
 		if (!anchorItemId) return;
+		const lastAnchorItemId = lastAnchorItemIdRef.current;
+		const shouldScroll = shouldScrollToLatest({
+			anchorItemId,
+			lastAnchorItemId,
+			nearBottom: isAtBottom,
+		});
+		lastAnchorItemIdRef.current = anchorItemId;
+		if (!shouldScroll) return;
 		containerRef.current
 			?.querySelector(`[data-item-id="${CSS.escape(anchorItemId)}"]`)
 			?.scrollIntoView({ block: "start" });
-	}, [anchorItemId]);
+	}, [anchorItemId, isAtBottom]);
 
 	const firstPendingApprovalId = approvals[0]?.id ?? null;
 	useEffect(() => {
@@ -113,7 +155,7 @@ export function Transcript({
 
 	return (
 		<div
-			className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3"
+			className="relative flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3"
 			ref={containerRef}
 		>
 			<div className="flex items-center gap-2">
@@ -183,6 +225,16 @@ export function Transcript({
 					</div>
 				</div>
 			))}
+			{!isAtBottom && anchorItemId !== null && (
+				<button
+					type="button"
+					aria-label="Latest reply"
+					className="absolute bottom-4 right-4 z-10 flex size-9 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+					onClick={scrollToLatest}
+				>
+					<ArrowDownIcon className="size-4" />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/Transcript.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/Transcript.tsx
@@ -6,6 +6,7 @@ import type {
 import type { ApprovalRequest, Decision } from "@superset/chat/protocol";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
+import { ArrowDownIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TurnGroupSection } from "./components/TurnGroupSection";
 
@@ -20,6 +21,8 @@ export type TranscriptProps = {
 	onRetryPrompt: (clientId: string) => void;
 	onDiscardPrompt: (clientId: string) => void;
 };
+
+const JUMP_TOP_OFFSET_PX = 8;
 
 function latestUserItemId(groups: TurnGroup[]): string | null {
 	for (let groupIndex = groups.length - 1; groupIndex >= 0; groupIndex -= 1) {
@@ -57,6 +60,7 @@ export function Transcript({
 	const [entryOverrides, setEntryOverrides] = useState<
 		ReadonlyMap<string, boolean>
 	>(new Map());
+	const [isAtBottom, setIsAtBottom] = useState(true);
 
 	const isEntryCollapsed = useCallback(
 		(entryKey: string, defaultCollapsed: boolean) =>
@@ -95,12 +99,31 @@ export function Transcript({
 	}, [approvals]);
 
 	const anchorItemId = latestUserItemId(groups);
+
+	const checkScrollPosition = useCallback(() => {
+		const element = containerRef.current;
+		if (!element) return;
+		const distanceFromBottom =
+			element.scrollHeight - element.scrollTop - element.clientHeight;
+		setIsAtBottom(distanceFromBottom <= JUMP_TOP_OFFSET_PX);
+	}, []);
+
 	useEffect(() => {
-		if (!anchorItemId) return;
+		const element = containerRef.current;
+		if (!element) return;
+		element.addEventListener("scroll", checkScrollPosition, { passive: true });
+		checkScrollPosition();
+		return () => element.removeEventListener("scroll", checkScrollPosition);
+	}, [checkScrollPosition]);
+
+	// Keep the transcript pinned to the latest user item while the user has
+	// not scrolled away — mirrors the old stick-to-latest behaviour.
+	useEffect(() => {
+		if (!anchorItemId || !isAtBottom) return;
 		containerRef.current
 			?.querySelector(`[data-item-id="${CSS.escape(anchorItemId)}"]`)
 			?.scrollIntoView({ block: "start" });
-	}, [anchorItemId]);
+	}, [anchorItemId, isAtBottom]);
 
 	const firstPendingApprovalId = approvals[0]?.id ?? null;
 	useEffect(() => {
@@ -110,72 +133,105 @@ export function Transcript({
 			?.scrollIntoView({ block: "nearest" });
 	}, [firstPendingApprovalId]);
 
+	const handleJumpToLatestReply = useCallback(() => {
+		if (!anchorItemId) return;
+		const element = containerRef.current;
+		if (!element) return;
+		const targetElement = element.querySelector<HTMLElement>(
+			`[data-item-id="${CSS.escape(anchorItemId)}"]`,
+		);
+		if (!targetElement) return;
+		const nextScrollTop =
+			targetElement.getBoundingClientRect().top -
+			element.getBoundingClientRect().top +
+			element.scrollTop -
+			JUMP_TOP_OFFSET_PX;
+		element.scrollTo({ top: Math.max(0, nextScrollTop), behavior: "smooth" });
+	}, [anchorItemId]);
+
+	const showJumpToLatest = !isAtBottom && anchorItemId !== null;
+
 	return (
-		<div
-			className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3"
-			ref={containerRef}
-		>
-			<div className="flex items-center gap-2">
-				{hasOlder && (
-					<Button onClick={onLoadOlder} size="sm" variant="ghost">
-						Load earlier messages
+		<div className="relative flex min-h-0 flex-1 flex-col">
+			<div
+				className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3"
+				ref={containerRef}
+			>
+				<div className="flex items-center gap-2">
+					{hasOlder && (
+						<Button onClick={onLoadOlder} size="sm" variant="ghost">
+							Load earlier messages
+						</Button>
+					)}
+					<Button
+						className="ml-auto text-xs text-muted-foreground"
+						onClick={expandAll}
+						size="sm"
+						variant="ghost"
+					>
+						Expand all
 					</Button>
-				)}
-				<Button
-					className="ml-auto text-xs text-muted-foreground"
-					onClick={expandAll}
-					size="sm"
-					variant="ghost"
-				>
-					Expand all
-				</Button>
-			</div>
-			{groups.map((group) => (
-				<TurnGroupSection
-					group={group}
-					isEntryCollapsed={isEntryCollapsed}
-					key={group.turnId}
-					onRespond={onRespond}
-					onToggleEntry={onToggleEntry}
-					pendingApprovalTargets={pendingApprovalTargets}
-					snapshot={snapshot}
-				/>
-			))}
-			{outbox.map((entry) => (
-				<div
-					className="flex flex-col items-end gap-1 self-end"
-					key={entry.clientId}
-				>
-					<div className="max-w-[80%] whitespace-pre-wrap break-words rounded-lg bg-primary/10 px-3 py-2 text-sm">
-						{outboxText(entry)}
-					</div>
-					<div className="flex items-center gap-2">
-						<Badge
-							variant={entry.state === "failed" ? "destructive" : "outline"}
-						>
-							{entry.state === "failed" ? "Failed to send" : "Sending"}
-						</Badge>
-						{entry.state === "failed" && (
-							<>
-								<Button
-									onClick={() => onRetryPrompt(entry.clientId)}
-									size="sm"
-									variant="ghost"
-								>
-									Retry
-								</Button>
-								<Button
-									onClick={() => onDiscardPrompt(entry.clientId)}
-									size="sm"
-									variant="ghost"
-								>
-									Discard
-								</Button>
-							</>
-						)}
-					</div>
 				</div>
-			))}
+				{groups.map((group) => (
+					<TurnGroupSection
+						group={group}
+						isEntryCollapsed={isEntryCollapsed}
+						key={group.turnId}
+						onRespond={onRespond}
+						onToggleEntry={onToggleEntry}
+						pendingApprovalTargets={pendingApprovalTargets}
+						snapshot={snapshot}
+					/>
+				))}
+				{outbox.map((entry) => (
+					<div
+						className="flex flex-col items-end gap-1 self-end"
+						key={entry.clientId}
+					>
+						<div className="max-w-[80%] whitespace-pre-wrap break-words rounded-lg bg-primary/10 px-3 py-2 text-sm">
+							{outboxText(entry)}
+						</div>
+						<div className="flex items-center gap-2">
+							<Badge
+								variant={entry.state === "failed" ? "destructive" : "outline"}
+							>
+								{entry.state === "failed" ? "Failed to send" : "Sending"}
+							</Badge>
+							{entry.state === "failed" && (
+								<>
+									<Button
+										onClick={() => onRetryPrompt(entry.clientId)}
+										size="sm"
+										variant="ghost"
+									>
+										Retry
+									</Button>
+									<Button
+										onClick={() => onDiscardPrompt(entry.clientId)}
+										size="sm"
+										variant="ghost"
+									>
+										Discard
+									</Button>
+								</>
+							)}
+						</div>
+					</div>
+				))}
+			</div>
+			{showJumpToLatest && (
+				<Button
+					aria-label="Jump to my latest reply"
+					className="absolute bottom-4 right-4 rounded-full shadow-md"
+					onClick={handleJumpToLatestReply}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					<ArrowDownIcon className="size-3.5" />
+					Latest reply
+				</Button>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/index.ts
@@ -1,0 +1,1 @@
+export * from "./scrollLogic";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/scrollLogic.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/scrollLogic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { TurnGroup } from "@superset/chat/core";
+import {
+	JUMP_TOP_OFFSET_PX,
+	distanceFromBottom,
+	isNearBottom,
+	latestUserItemId,
+	shouldScrollToLatest,
+} from "./scrollLogic";
+
+function group(turnId: string, ...entries: TurnGroup["entries"]): TurnGroup {
+	return { turnId, turn: null, entries };
+}
+
+const userMessage = (id: string): TurnGroup["entries"][number] => ({
+	kind: "item",
+	item: { id, kind: "user_message", content: [], startedAtMs: 1 },
+});
+
+const agentMessage = (id: string): TurnGroup["entries"][number] => ({
+	kind: "item",
+	item: { id, kind: "agent_message", text: "hi", startedAtMs: 1 },
+});
+
+describe("latestUserItemId", () => {
+	test("returns the most recent user message, scanning groups from the end", () => {
+		expect(
+			latestUserItemId([
+				group("t1", userMessage("u1"), agentMessage("a1")),
+				group("t2", agentMessage("a2"), userMessage("u2")),
+			]),
+		).toBe("u2");
+	});
+
+	test("finds a user message even when later groups contain none", () => {
+		expect(
+			latestUserItemId([
+				group("t1", agentMessage("a0"), userMessage("u0")),
+				group("t2", agentMessage("a1")),
+			]),
+		).toBe("u0");
+	});
+
+	test("returns null when there is no user message", () => {
+		expect(latestUserItemId([group("t1", agentMessage("a1"))])).toBeNull();
+		expect(latestUserItemId([])).toBeNull();
+	});
+});
+
+describe("isNearBottom / JUMP_TOP_OFFSET_PX", () => {
+	const scrollHeight = 1000;
+	const clientHeight = 300;
+
+	test("counts the bottom when the remaining distance is within the offset", () => {
+		// scrollTop = 1000 - 300 - 8 => exactly on the threshold, still "bottom"
+		expect(isNearBottom(scrollHeight, 692, clientHeight)).toBe(true);
+		expect(isNearBottom(scrollHeight, 693, clientHeight)).toBe(true);
+		expect(isNearBottom(scrollHeight, scrollHeight - clientHeight, clientHeight)).toBe(true);
+	});
+
+	test("no longer counts once the user scrolls up past the offset", () => {
+		expect(isNearBottom(scrollHeight, 691, clientHeight)).toBe(false);
+		expect(isNearBottom(scrollHeight, 0, clientHeight)).toBe(false);
+	});
+
+	test("distanceFromBottom decreases as the user scrolls down", () => {
+		expect(distanceFromBottom(scrollHeight, 0, clientHeight)).toBe(700);
+		expect(distanceFromBottom(scrollHeight, 692, clientHeight)).toBe(JUMP_TOP_OFFSET_PX);
+	});
+});
+
+describe("shouldScrollToLatest (jump button / re-anchor gating)", () => {
+	test("scrolls when near the bottom and the anchor is new", () => {
+		expect(
+			shouldScrollToLatest({ anchorItemId: "u2", lastAnchorItemId: "u1", nearBottom: true }),
+		).toBe(true);
+	});
+
+	test("does NOT re-anchor when the anchor is unchanged even if back at the bottom", () => {
+		expect(
+			shouldScrollToLatest({ anchorItemId: "u2", lastAnchorItemId: "u2", nearBottom: true }),
+		).toBe(false);
+	});
+
+	test("does NOT yank an already-scrolled-up user even when a new anchor arrives", () => {
+		expect(
+			shouldScrollToLatest({ anchorItemId: "u3", lastAnchorItemId: "u2", nearBottom: false }),
+		).toBe(false);
+	});
+
+	test("does nothing when there is no anchor", () => {
+		expect(
+			shouldScrollToLatest({ anchorItemId: null, lastAnchorItemId: null, nearBottom: true }),
+		).toBe(false);
+		expect(
+			shouldScrollToLatest({ anchorItemId: null, lastAnchorItemId: "u1", nearBottom: true }),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/scrollLogic.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/Transcript/utils/scroll/scrollLogic.ts
@@ -1,0 +1,63 @@
+import type { TurnGroup } from "@superset/chat/core";
+
+/** Tolerance (px) above the bottom edge that still counts as "at the bottom". */
+export const JUMP_TOP_OFFSET_PX = 8;
+
+/**
+ * Returns the id of the most recent user message across all turn groups, or
+ * `null` when there is no user message yet.
+ */
+export function latestUserItemId(
+	groups: readonly TurnGroup[],
+): string | null {
+	for (let groupIndex = groups.length - 1; groupIndex >= 0; groupIndex -= 1) {
+		const group = groups[groupIndex];
+		if (!group) continue;
+		for (let index = group.entries.length - 1; index >= 0; index -= 1) {
+			const entry = group.entries[index];
+			if (entry?.kind === "item" && entry.item.kind === "user_message") {
+				return entry.item.id;
+			}
+		}
+	}
+	return null;
+}
+
+export function distanceFromBottom(
+	scrollHeight: number,
+	scrollTop: number,
+	clientHeight: number,
+): number {
+	return scrollHeight - scrollTop - clientHeight;
+}
+
+/** True when the scroll container is pinned at (or within {@link JUMP_TOP_OFFSET_PX} of) its bottom edge. */
+export function isNearBottom(
+	scrollHeight: number,
+	scrollTop: number,
+	clientHeight: number,
+): boolean {
+	return (
+		distanceFromBottom(scrollHeight, scrollTop, clientHeight) <=
+		JUMP_TOP_OFFSET_PX
+	);
+}
+
+/**
+ * Gating rule for the scroll-pinning effect: only auto-scroll to the latest
+ * user reply when we are already near the bottom AND the anchor actually
+ * changed since the last time we handled it. The `lastAnchorItemId` guard
+ * prevents re-anchoring (yanking the viewport) when the user merely touches
+ * the bottom edge — this is the CodeRabbit re-anchor fix from PR #6428.
+ */
+export function shouldScrollToLatest(args: {
+	anchorItemId: string | null;
+	lastAnchorItemId: string | null;
+	nearBottom: boolean;
+}): boolean {
+	return (
+		args.anchorItemId !== null &&
+		args.anchorItemId !== args.lastAnchorItemId &&
+		args.nearBottom
+	);
+}


### PR DESCRIPTION
### What does this PR do?

Adds a floating **"Jump to latest reply"** button to the **v3 chat transcript** (`ChatV3Pane`). When an assistant reply is still streaming, or the transcript is long, the scroll-to-bottom affordance only reaches the *end* of the conversation — not your own latest message sitting above it. This button scrolls the last user message into view instead.

The original PR targeted the legacy mastra chat (`ChatPane/WorkspaceChatInterface`), which was deleted on `main` in `delete legacy mastra chat in favor of chat-v3 (#6461)`. This PR is the **rebase/port of that feature onto the surviving `ChatV3Pane` + `Transcript`**, so it lands on current `main` instead of orphaned legacy code.

### What changed

- `Transcript.tsx` (v3): wraps the scrollable container in a relative parent and renders a floating `Latest reply` button.
- The button only appears once the user has **scrolled up** (not at bottom) and there is at least one user message — consistent with the old stick-to-latest behaviour.
- Reuses the existing `latestUserItemId` / `anchorItemId` logic and the `[data-item-id]` selector already used for auto-scroll, so scroll math stays consistent.
- Derived behaviour from the old `useConversationContext` (`isAtBottom`, `scrollRef`) is re-implemented against the v3 `Transcript`'s own `containerRef` + scroll listener.

### Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature/enhancement
- [x] Improvement
- [ ] Other (please describe)

### How did you verify your code works?

- `bun x tsc --noEmit` on `apps/desktop`: **no new errors** in `Transcript.tsx` / `ChatV3Pane` (only pre-existing `routeTree.gen` / automations-route errors already on `main`).
- `biome lint` on the touched file: **clean, no fixes applied.**
- `bun install` in the worktree succeeded (782 packages) so the workspace `@superset/chat` types resolve.

### Checklist

- [x] I have read the contributing guidelines.
- [x] Code follows the project's style and lint passes.
- [x] No new inaccessible/private paths or secrets introduced.
- [x] Local validation (tsc on changed file + biome) passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Latest reply” button to quickly return to the newest transcript content.
  * Added smooth scrolling and a downward arrow indicator for the jump control.

* **Improvements**
  * Transcript scrolling now stays at the latest user message when already near the bottom.
  * Prevented automatic scrolling when browsing earlier transcript content, preserving the user’s reading position.
  * Improved scrolling behavior to avoid repeated re-anchoring as new replies appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->