### PR TITLE
fix(auth): control arm gets no emails; fail-closed activation variant

### DIFF
--- a/packages/auth/src/lib/lifecycle.ts
+++ b/packages/auth/src/lib/lifecycle.ts
@@ -19,9 +19,9 @@ export async function getActivationVariant(
 			userId,
 		);
 		await posthog.flush();
-		return variant === "control" ? "control" : "test";
+		return variant === "test" ? "test" : "control";
 	} catch (error) {
 		console.error("[lifecycle] Failed to evaluate activation flag:", error);
-		return "test";
+		return "control";
 	}
 }

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -247,39 +247,39 @@ export const auth = betterAuth({
 							.where(eq(authSchema.sessions.userId, user.id));
 					}
 
-					try {
-						await resend.emails.send({
-							from: "Superset <noreply@superset.sh>",
-							replyTo: "founders@superset.sh",
-							to: user.email,
-							subject: "Welcome to Superset",
-							react: WelcomeEmail({
-								userName: user.name,
-								userEmail: user.email,
-							}),
-						});
-					} catch (error) {
-						console.error(
-							`[lifecycle] Failed to send welcome email to ${user.id}:`,
-							error,
-						);
-					}
+					const variant = await getActivationVariant(user.id);
+					if (variant === "test") {
+						try {
+							await resend.emails.send({
+								from: "Superset <noreply@superset.sh>",
+								replyTo: "founders@superset.sh",
+								to: user.email,
+								subject: "Welcome to Superset",
+								react: WelcomeEmail({
+									userName: user.name,
+									userEmail: user.email,
+								}),
+							});
+						} catch (error) {
+							console.error(
+								`[lifecycle] Failed to send welcome email to ${user.id}:`,
+								error,
+							);
+						}
 
-					try {
-						const variant = await getActivationVariant(user.id);
-						if (variant === "test") {
+						try {
 							const { error } = await resend.events.send({
 								event: "user.signed_up",
 								email: user.email,
 								payload: { userId: user.id, name: user.name },
 							});
 							if (error) throw new Error(error.message);
+						} catch (error) {
+							console.error(
+								`[lifecycle] Failed to emit signup event for ${user.id}:`,
+								error,
+							);
 						}
-					} catch (error) {
-						console.error(
-							`[lifecycle] Failed to emit signup event for ${user.id}:`,
-							error,
-						);
 					}
 				},
 			},


### PR DESCRIPTION
The welcome email was shipped unconditionally in #5938, so the control arm of the activation-email-campaign experiment (PostHog 387868) was being treated: everyone got the welcome email regardless of variant, and only the Resend drip enrollment was gated. On top of that, `getActivationVariant` failed open to `"test"`, so any flag-evaluation failure silently enrolled users in the drip without a recorded exposure.

This PR:

- Gates all campaign email to the test variant: `getActivationVariant(user.id)` is evaluated first in the user-create lifecycle hook, and both the welcome email send and the `user.signed_up` Resend event (drip enrollment) run only when the variant is `"test"`. Control gets no emails at all.
- Makes flag evaluation fail closed: unknown variants and evaluation errors now resolve to `"control"`, so failures can no longer silently enroll users in the drip without a recorded exposure.

Per-step error handling is unchanged: a failed welcome send still does not prevent the `user.signed_up` event, and errors log with the same `[lifecycle]` prefixes.

The experiment will be reset after deploy.

https://claude.ai/code/session_01PnUMCXtTTZRYrKSKjQnGjp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the activation-email experiment so the control arm receives no emails and flag evaluation fails closed. Previously, all users got the welcome email and evaluation failures defaulted to "test", which silently enrolled users in the drip without a recorded exposure.

- Gate both the welcome email and Resend drip enrollment to the "test" variant by evaluating the activation variant first in the user-create hook; control receives no emails.
- Make `getActivationVariant` fail closed: unknown variants and errors resolve to "control".
- Error handling and logging are unchanged; a failed welcome send does not block drip enrollment when variant is "test".
- Rollout: reset the experiment after deploy to clear prior exposures.

<sup>Written for commit a6fe343d693505dce5732b4bab75567208b92ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected activation variant handling so only the exact “test” value is treated as a test.
  * Welcome emails are now sent only to users assigned to the test variant.
  * Signup events continue to be recorded for all activation variants, even if email delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->