### PR TITLE
fix(desktop,host-service): address unreviewed findings from the sentry fix wave

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -31,6 +31,7 @@ import {
 	getPrInfo,
 	getPrLocalBranchName,
 	getWorktreeCreatedAt,
+	isDetachedHead,
 	listBranches,
 	listExternalWorktrees,
 	type PullRequestInfo,
@@ -745,6 +746,14 @@ export const createCreateProcedures = () => {
 				const branch =
 					input.branch || (await getCurrentBranch(project.mainRepoPath));
 				if (!branch) {
+					// Only blame HEAD once we know it is actually detached: a null
+					// here also covers an unreadable repo, and reporting that as
+					// detached HEAD both misleads the user and hides the real fault.
+					if (!(await isDetachedHead(project.mainRepoPath))) {
+						throw new Error(
+							`Could not determine current branch for ${project.mainRepoPath}`,
+						);
+					}
 					throw new TRPCError({
 						code: "BAD_REQUEST",
 						message:

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -27,15 +27,14 @@ import {
 	type ExternalWorktree,
 	generateBranchName,
 	getBranchWorktreePath,
-	getCurrentBranch,
 	getPrInfo,
 	getPrLocalBranchName,
 	getWorktreeCreatedAt,
-	isDetachedHead,
 	listBranches,
 	listExternalWorktrees,
 	type PullRequestInfo,
 	parsePrUrl,
+	readCurrentBranch,
 	safeCheckoutBranch,
 	sanitizeBranchNameWithMaxLength,
 	worktreeExists,
@@ -743,23 +742,22 @@ export const createCreateProcedures = () => {
 					});
 				}
 
-				const branch =
-					input.branch || (await getCurrentBranch(project.mainRepoPath));
+				let branch = input.branch;
 				if (!branch) {
-					// Only blame HEAD once we know it is actually detached: a null
-					// here also covers an unreadable repo, and reporting that as
-					// detached HEAD both misleads the user and hides the real fault.
-					if (!(await isDetachedHead(project.mainRepoPath))) {
-						throw new Error(
-							`Could not determine current branch for ${project.mainRepoPath}`,
-						);
+					// readCurrentBranch throws for a repository we cannot read, so
+					// only a genuinely detached HEAD reaches the typed error below;
+					// anything else stays a reportable failure instead of being
+					// mislabelled as a HEAD problem.
+					const head = await readCurrentBranch(project.mainRepoPath);
+					if (head.kind === "detached") {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message:
+								"Cannot open this repository from detached HEAD. Please checkout a branch and try again.",
+							cause: { kind: "DETACHED_HEAD" },
+						});
 					}
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message:
-							"Cannot open this repository from detached HEAD. Please checkout a branch and try again.",
-						cause: { kind: "DETACHED_HEAD" },
-					});
+					branch = head.branch;
 				}
 
 				if (input.branch) {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1519,6 +1519,24 @@ export async function getCurrentBranch(
 }
 
 /**
+ * Whether HEAD is genuinely detached, as opposed to unreadable.
+ *
+ * `getCurrentBranch` collapses "detached HEAD" and "this git call failed"
+ * into the same `null`, so callers that want to blame the user's HEAD state
+ * must confirm it first — otherwise a missing repo, a permission wall or a
+ * missing git binary all get reported to the user as a detached HEAD, and
+ * the underlying failure stops being visible.
+ *
+ * Throws the underlying git error when the repository cannot be read at all,
+ * so genuine breakage keeps surfacing instead of being reclassified.
+ */
+export async function isDetachedHead(repoPath: string): Promise<boolean> {
+	const git = await getSimpleGitWithShellPath(repoPath);
+	const head = await git.revparse(["--abbrev-ref", "HEAD"]);
+	return head.trim() === "HEAD";
+}
+
+/**
  * Result of pre-checkout safety checks
  */
 export interface CheckoutSafetyResult {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1495,45 +1495,56 @@ export async function listBranches(
  * @param repoPath - Path to the repository
  * @returns The current branch name, or null if in detached HEAD state
  */
+export type CurrentBranch =
+	| { kind: "branch"; branch: string }
+	| { kind: "detached" };
+
+/**
+ * Reads HEAD, distinguishing a genuinely detached HEAD from a repository we
+ * cannot read at all. Real git failures (not a repository, permission wall,
+ * git missing) propagate rather than collapsing into "detached", so they
+ * stay visible instead of being reported to the user as a HEAD problem.
+ */
+export async function readCurrentBranch(
+	repoPath: string,
+): Promise<CurrentBranch> {
+	const git = await getSimpleGitWithShellPath(repoPath);
+
+	let revparseError: unknown;
+	try {
+		const trimmed = (await git.revparse(["--abbrev-ref", "HEAD"])).trim();
+		if (trimmed && trimmed !== "HEAD") {
+			return { kind: "branch", branch: trimmed };
+		}
+	} catch (error) {
+		// An unborn HEAD (fresh repo, no commits) fails here but still
+		// resolves through symbolic-ref below, so hold the error rather than
+		// giving up on it.
+		revparseError = error;
+	}
+
+	try {
+		const trimmed = (await git.raw(["symbolic-ref", "--short", "HEAD"])).trim();
+		if (trimmed) return { kind: "branch", branch: trimmed };
+	} catch {
+		// symbolic-ref fails on a detached HEAD, which is only meaningful if
+		// revparse got far enough to tell us HEAD is readable. If it did not,
+		// the repository itself is the problem and that error is the real one.
+		if (revparseError) throw revparseError;
+	}
+
+	return { kind: "detached" };
+}
+
 export async function getCurrentBranch(
 	repoPath: string,
 ): Promise<string | null> {
-	const git = await getSimpleGitWithShellPath(repoPath);
 	try {
-		const branch = await git.revparse(["--abbrev-ref", "HEAD"]);
-		const trimmed = branch.trim();
-		if (trimmed && trimmed !== "HEAD") {
-			return trimmed;
-		}
-	} catch {
-		// Fall back to symbolic-ref below for unborn HEAD repos.
-	}
-
-	try {
-		const branch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
-		const trimmed = branch.trim();
-		return trimmed || null;
+		const head = await readCurrentBranch(repoPath);
+		return head.kind === "branch" ? head.branch : null;
 	} catch {
 		return null;
 	}
-}
-
-/**
- * Whether HEAD is genuinely detached, as opposed to unreadable.
- *
- * `getCurrentBranch` collapses "detached HEAD" and "this git call failed"
- * into the same `null`, so callers that want to blame the user's HEAD state
- * must confirm it first — otherwise a missing repo, a permission wall or a
- * missing git binary all get reported to the user as a detached HEAD, and
- * the underlying failure stops being visible.
- *
- * Throws the underlying git error when the repository cannot be read at all,
- * so genuine breakage keeps surfacing instead of being reclassified.
- */
-export async function isDetachedHead(repoPath: string): Promise<boolean> {
-	const git = await getSimpleGitWithShellPath(repoPath);
-	const head = await git.revparse(["--abbrev-ref", "HEAD"]);
-	return head.trim() === "HEAD";
 }
 
 /**

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -620,6 +620,7 @@ describe("HostServiceCoordinator respawn after a crash", () => {
 			status: "running",
 			spawnedAt: Date.now(),
 			outputTail: "",
+			redactions: ["secret"],
 			owned: true,
 		});
 	}

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -74,6 +74,12 @@ interface HostServiceProcess {
 	/** Rolling tail of the child's stdout/stderr, attached to crash reports. */
 	outputTail: string;
 	/**
+	 * Every secret handed to this child. `outputTail` is raw child output, so
+	 * anything the child logs (a request header, an env dump in a stack trace)
+	 * can land in a crash report — strip these before it reaches telemetry.
+	 */
+	redactions: string[];
+	/**
 	 * True when this instance spawned the child and owns its lifecycle (may
 	 * SIGTERM it and remove its manifest). False when the entry was *adopted*
 	 * from another live app instance's host-service — we connect to it but must
@@ -649,6 +655,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			status: "running",
 			spawnedAt: manifest.startedAt,
 			outputTail: "",
+			// Adopted children are owned by another app instance: we never see
+			// their stdio, so outputTail stays empty and this is belt-and-braces.
+			redactions: [manifest.authToken],
 			owned: false,
 		});
 		this.rememberPort(organizationId, port);
@@ -681,6 +690,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			status: "starting",
 			spawnedAt: Date.now(),
 			outputTail: "",
+			redactions: [secret, config.authToken].filter((value): value is string =>
+				Boolean(value),
+			),
 			owned: true,
 		};
 		this.instances.set(organizationId, instance);
@@ -934,11 +946,10 @@ export class HostServiceCoordinator extends EventEmitter {
 							pid: childPid,
 							version: app.getVersion(),
 							uptimeMs: Date.now() - current.spawnedAt,
-							// The child's own auth secret can reach its logs (request
-							// headers); never ship it to Sentry.
-							outputTail: current.outputTail
-								.split(current.secret)
-								.join("[redacted]"),
+							outputTail: current.redactions.reduce(
+								(tail, secret) => tail.split(secret).join("[redacted]"),
+								current.outputTail,
+							),
 						},
 					}),
 				)

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/local-project.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/local-project.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { projects } from "../../../../db/schema";
@@ -31,10 +31,12 @@ export function requireLocalProject(
 // lifecycle state, not a bug — classify it here so simple-git's construct
 // error can't escape a workspace-creation procedure as a reportable 500.
 export function requireProjectRepoPath(localProject: LocalProject): string {
-	if (!existsSync(localProject.repoPath)) {
+	if (
+		!statSync(localProject.repoPath, { throwIfNoEntry: false })?.isDirectory()
+	) {
 		throw new TRPCError({
 			code: "NOT_FOUND",
-			message: "Project directory no longer exists on disk",
+			message: "Project directory is no longer a directory on disk",
 			cause: { kind: "PROJECT_DIR_MISSING", repoPath: localProject.repoPath },
 		});
 	}

--- a/packages/ui/src/components/mesh-gradient.tsx
+++ b/packages/ui/src/components/mesh-gradient.tsx
@@ -26,13 +26,26 @@ interface GradientInstance {
 	};
 }
 
+/**
+ * Browsers cap how many WebGL contexts may be live at once, and a probe
+ * context counts against that cap until it is explicitly lost. Probing on
+ * every mount without releasing would eventually starve the real gradient of
+ * a context, so release immediately and cache the answer: WebGL support does
+ * not change over a page's lifetime.
+ */
+let webglSupport: boolean | undefined;
+
 function supportsWebgl(): boolean {
+	if (webglSupport !== undefined) return webglSupport;
 	try {
 		const probe = document.createElement("canvas");
-		return Boolean(probe.getContext("webgl2") || probe.getContext("webgl"));
+		const context = probe.getContext("webgl2") || probe.getContext("webgl");
+		context?.getExtension("WEBGL_lose_context")?.loseContext();
+		webglSupport = Boolean(context);
 	} catch {
-		return false;
+		webglSupport = false;
 	}
+	return webglSupport;
 }
 
 export function MeshGradient({


### PR DESCRIPTION
## Problem

The sentry-fix wave (#6191, #6218, #6258, #6259, #6260, #6316–#6320) was merged on 2026-08-13 after sitting open for 3–8 days. Reviewing the merge afterwards turned up something worth recording: **not one of those PRs had a human review**, and none had `CHANGES_REQUESTED`. They were not declined, they were never looked at. But the automated reviewers did leave findings, and nobody acted on them.

This PR fixes the four that verify as real against the code. Two others were checked and dismissed: the Windows-separator concern on #6218 (git emits `/` on every platform, so changeset paths never contain `\`) and the "preserve the original message" concern on #6259 (that substitution was the pre-existing behaviour and is deliberate).

## Root cause and fix, per finding

**1. Cloud credential could reach Sentry (#6191, flagged Major).** The coordinator attaches a tail of the child's stdout/stderr to crash reports and redacted `instance.secret` from it — but it also injects `config.authToken`, the cloud credential, into the same child's env. Anything the child logged that embedded that token (a request header, an env dump inside a stack trace) would have been captured verbatim.

Replaced the single `.split(secret).join(...)` with a `redactions: string[]` on the instance, populated at spawn from both secrets and at adopt from the manifest token. A list also means the next secret added to the child env is one array entry away from being covered, rather than another chained replacement someone has to remember.

The test helper that stands up a running instance for the exit handler was constructing it through a loosely-typed internals map, so it silently omitted the new field; it now sets it. Production code stays strict rather than defaulting the field, so the type system keeps telling the truth.

**2. Any git failure reported as a detached HEAD (#6258, flagged P2).** `getCurrentBranch()` returns `null` for a detached HEAD *and* for every other git failure — not a repository, permission denied, git not on PATH — because both of its lookups swallow their errors. #6258 turned that `null` into `BAD_REQUEST` / `{ kind: "DETACHED_HEAD" }`, so those users are now told to "checkout a branch", and, because the code is no longer a 500, the underlying breakage stopped reaching Sentry entirely. That is a net loss of signal on top of a misleading message.

Added `readCurrentBranch()`, which returns a discriminated `{ kind: "branch" } | { kind: "detached" }` and lets a genuine git failure propagate. `getCurrentBranch` now delegates to it and keeps its existing `string | null` contract for its other callers, so nothing else changes.

A first attempt added a separate `isDetachedHead()` helper, which CI correctly rejected: it constructed a second simple-git client on the Electron main process, and `no-main-process-blocking.test.ts` ratchets that count downward. Bumping the allowlist would have defeated the point of the ratchet. Reading HEAD once through one client keeps the count unchanged at 21 and is the better shape anyway.

**3. WebGL probe leaked a context per mount (#6318, flagged P2).** `supportsWebgl()` created a canvas and acquired a context on every mount and never released it. Browsers cap concurrent WebGL contexts, so enough remounts starve the real gradient and leave otherwise-capable browsers on the static fallback permanently — the fix quietly causing the failure it was written to prevent. Now releases the probe via `WEBGL_lose_context` and caches the answer, which cannot change over a page's lifetime.

**4. Directory guard accepted a regular file (#6316, flagged P2).** `existsSync` is true for a file. Switched to `statSync(..., { throwIfNoEntry: false })?.isDirectory()` and corrected the message, which claimed the directory was missing.

## Verification

`bunx biome check` on the six changed files:

```
Checked 6 files in 47ms. No fixes applied.
```

Typecheck:

```
desktop typecheck=0
host-service typecheck=0
```

Tests:

```
apps/desktop        752 pass, 0 fail (48 files)
packages/host-service 161 pass, 0 fail (12 files)
```

## Not fixed here

`spawn git ENOENT` is still unclassified in the host-service git classifier (flagged P1 on #6260). Deliberately skipped: Node reports the same ENOENT whether the working directory vanished or git is not installed, and collapsing those would repeat exactly the over-classification this PR fixes in finding 2. It needs a cwd existence check at the classification site to be done correctly.

Refs DESKTOP-JM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four unreviewed findings from the Sentry fix wave to prevent credential leakage, restore accurate git failure signal, release WebGL probe contexts, and correctly require a directory for project repos. Aligns with `DESKTOP-JM` by tightening telemetry redaction and error classification.

- `apps/desktop` workspaces/create: Use a new `readCurrentBranch` that returns `{ kind: "branch" | "detached" }`. Only genuine detachment is `BAD_REQUEST`; other git failures throw and reach Sentry. Reads HEAD once via a single git client.
- `apps/desktop` host-service coordinator: Replace single-secret replacement with per-instance `redactions` applied to crash-report `outputTail`, covering both the child secret and the cloud `authToken`. Tests set `redactions`.
- `packages/ui`: Release the WebGL probe via `WEBGL_lose_context` and cache support for the page lifetime. Old: leaked one context per mount.
- `packages/host-service`: Guard project repos with `statSync(...).isDirectory()` and fix the error message. Old: regular files passed the check.

- No API or config changes; no migration required.
- Expect accurate Sentry signal for git failures and no credentials in crash reports; the WebGL decision is cached for the page lifetime.

<sup>Written for commit a8575f01ac177993a9f1426237d8df76a784df68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

