### PR TITLE
test(host-service): make the fs:watch-file dedupe test deterministic

### DIFF
--- a/packages/host-service/src/events/event-bus.test.ts
+++ b/packages/host-service/src/events/event-bus.test.ts
@@ -99,40 +99,40 @@ describe("EventBus fs:watch-file", () => {
 		return { root, eventBus, socket, sent, fs, path };
 	}
 
-	it("delivers exactly one event per change for a pruned path", async () => {
+	it("dedupes duplicate watch commands (one unwatch stops delivery)", async () => {
 		const { root, eventBus, socket, sent, fs, path } =
 			await createFileWatchHarness(true);
 		const file = path.join(root, "buildout-file.js");
 		await fs.writeFile(file, "v0");
-		eventBus.handleMessage(
-			socket,
-			JSON.stringify({
-				type: "fs:watch-file",
-				workspaceId: "ws-1",
-				absolutePath: file,
-			}),
-		);
-		// Duplicate watch command must not double-deliver.
-		eventBus.handleMessage(
-			socket,
-			JSON.stringify({
-				type: "fs:watch-file",
-				workspaceId: "ws-1",
-				absolutePath: file,
-			}),
-		);
+		const watch = JSON.stringify({
+			type: "fs:watch-file",
+			workspaceId: "ws-1",
+			absolutePath: file,
+		});
+		eventBus.handleMessage(socket, watch);
+		// Duplicate watch must not install a second watcher.
+		eventBus.handleMessage(socket, watch);
 		await new Promise((r) => setTimeout(r, 250));
 
-		await fs.writeFile(file, "v1");
-		const deadline = Date.now() + 5_000;
-		while (!sent.some((m) => m.type === "fs:events") && Date.now() < deadline) {
-			await new Promise((r) => setTimeout(r, 25));
-		}
-		// Let any (wrong) duplicate deliveries land before counting.
-		await new Promise((r) => setTimeout(r, 300));
+		// A single unwatch disposes the only watcher there should be. If the
+		// duplicate had installed a second one, it would survive this and keep
+		// delivering. Asserting silence is deterministic; asserting an exact
+		// event count is not, because OS file watchers coalesce or double-fire
+		// a single write differently per platform.
+		eventBus.handleMessage(
+			socket,
+			JSON.stringify({
+				type: "fs:unwatch-file",
+				workspaceId: "ws-1",
+				absolutePath: file,
+			}),
+		);
+		sent.length = 0;
 
-		const fsMessages = sent.filter((m) => m.type === "fs:events");
-		expect(fsMessages).toHaveLength(1);
+		await fs.writeFile(file, "v1");
+		await new Promise((r) => setTimeout(r, 600));
+
+		expect(sent.filter((m) => m.type === "fs:events")).toHaveLength(0);
 
 		eventBus.handleClose(socket);
 		await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## The problem

`EventBus fs:watch-file > delivers exactly one event per change for a pruned path` asserted an exact count of one `fs:events` message per write. **No code can guarantee that** — OS file watchers coalesce or double-fire a single write differently per platform.

Result: it failed **100% of runs on macOS** (expected 1, received 2 — reproduced 3/3) while passing in CI on Linux. So every local test run showed a red suite, and the standing advice became "ignore the known failure" — which is exactly how a real regression slips through unnoticed.

## The fix

Rewritten to assert the invariant it was actually meant to protect: **a duplicate `fs:watch-file` installs only one watcher**, so a single `fs:unwatch-file` stops delivery entirely. If dedupe broke, the second watcher would survive the unwatch and keep sending events. Asserting silence-after-unwatch is deterministic on any platform; asserting an absolute event count is not.

**Verified by mutation**: removing the `if (state.fileWatches.has(key)) return;` guard in `event-bus.ts` makes the new test fail; restoring it makes it pass. The test genuinely protects the logic.

No production code changed — `event-bus.ts` is untouched in this PR.

## Verification
- new test: 3/3 runs green on macOS (the platform where the old one always failed)
- `src/events/`: 32 pass / 0 fail
- lint exit 0

## Not included
Two genuinely load-flaky tests remain (`terminal disposal cleans up background process groups`, `resolveBaseComparison > local-tracking branch`). Both pass in isolation and fail only under full-suite parallelism when spawning real processes/git — a harness concurrency issue, not test-logic rot. They cover real behavior, so serializing the integration suite is likely the right fix rather than deletion. Left for a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `fs:watch-file` dedupe test deterministic by asserting silence after a single unwatch instead of “exactly one event per write.” The old test failed on macOS due to platform-specific watcher coalescing; the new test protects the actual dedupe invariant across platforms.

- Rewrites the test to: issue duplicate `fs:watch-file`, issue one `fs:unwatch-file`, then write and expect zero `fs:events`.
- Verified by mutation: removing the dedupe guard makes the test fail.
- No production code changed.

<sup>Written for commit 1314fbb5f626c3f504cf7a68907941b11886a284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate file watchers from being installed when the same watch command is issued multiple times.
  * Ensured stopping a watch consistently prevents further filesystem event notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->