### PR TITLE
chore(mobile): point App Review notes at the flattened settings page

### DIFF
--- a/apps/marketing/content/legal/privacy.mdx
+++ b/apps/marketing/content/legal/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy
 description: Learn how Superset collects, uses, and protects your personal information.
-lastUpdated: 2026-08-12
+lastUpdated: 2026-08-13
 ---
 
 ## 1. Introduction
@@ -72,7 +72,7 @@ Depending on your location, you may have certain rights regarding your personal 
 - The right to restrict or object to certain processing
 - The right to data portability
 
-You can delete your account at any time from Settings → Account → Delete account in our mobile or desktop applications, or from your account settings on our website. Your account is deactivated immediately and permanently deleted after a 30-day recovery period, during which you can restore it by signing back in. After deletion, content you created in shared organizations is retained in de-identified form as part of those organizations' records. To exercise your other rights, please contact us using the information provided below.
+You can delete your account at any time from Settings in our mobile application, from Settings → Account → Delete account in our desktop application, or from your account settings on our website. Your account is deactivated immediately and permanently deleted after a 30-day recovery period, during which you can restore it by signing back in. After deletion, content you created in shared organizations is retained in de-identified form as part of those organizations' records. To exercise your other rights, please contact us using the information provided below.
 
 ## 8. Cookies and Tracking Technologies
 

--- a/apps/mobile/store.config.js
+++ b/apps/mobile/store.config.js
@@ -40,7 +40,7 @@ module.exports = {
 			demoUsername: process.env.APP_REVIEW_EMAIL ?? "",
 			demoPassword: process.env.APP_REVIEW_PASSWORD ?? "",
 			notes:
-				"Superset Mobile is a companion app for the Superset desktop product (https://superset.sh): developers monitor and chat with AI coding agents running in their own workspaces. Access requires a Superset Pro subscription purchased outside the app (multiplatform service; there are no in-app purchases). Please use the provided demo account (sign in via the 'Sign in with email' link) to access a Pro workspace with sample data. Sign in with Apple, GitHub, or Google also works and creates a free account instantly, which shows the subscription-required screen. Account deletion is available from Settings > Account and from the subscription screen.",
+				"Superset Mobile is a companion app for the Superset desktop product (https://superset.sh): developers monitor and chat with AI coding agents running in their own workspaces. Access requires a Superset Pro subscription purchased outside the app (multiplatform service; there are no in-app purchases). Please use the provided demo account (sign in via the 'Sign in with email' link) to access a Pro workspace with sample data. Sign in with Apple, GitHub, or Google also works and creates a free account instantly, which shows the subscription-required screen. Account deletion is available from Settings, under Danger Zone. Settings is reachable even on the subscription-required screen, via the organization name in the top-left.",
 		},
 	},
 };


### PR DESCRIPTION
The App Review notes in `store.config.js` told the reviewer that account deletion lives at `Settings > Account`. #6414 removed that sub-screen and moved deletion inline under Danger Zone on the settings page itself, so the instruction now points at a screen that no longer exists.

Updated to describe the current flow, including how to reach Settings from behind the paywall (org name in the top-left opens the switcher sheet, which carries Settings and Log out). Getting this right matters because 5.1.1(v) rejections usually come from a reviewer being unable to find deletion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates App Review notes to point reviewers to account deletion on the flattened Settings page and aligns the privacy policy. Previously mobile copy said Settings → Account; now it directs to Settings (Danger Zone) and explains how to reach Settings from the paywall.

- `apps/mobile/store.config.js`: Notes now say “Account deletion is available from Settings, under Danger Zone” and that Settings is reachable from the subscription screen via the organization name in the top-left.
- `apps/marketing/content/legal/privacy.mdx`: Mobile path updated to “Settings” and `lastUpdated` bumped.

<sup>Written for commit a6f610423a97285de9f150f175607e08611ca4bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email-and-password sign-in with loading and error feedback.
  * Added a Free-plan paywall with organization switching and refresh actions.
  * Added account deletion, plan management, support, help, and community options in Settings.
  * Enabled credential sign-in across all environments.
* **Bug Fixes**
  * Improved home search layout on newer iOS versions.
  * Restricted unpaid access to applicable app areas.
* **Style**
  * Refined social sign-in button spacing, alignment, and Apple iconography.
* **Documentation**
  * Expanded app review instructions and demo access details.
  * Updated privacy policy account-deletion guidance and date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->