### PR TITLE
feat(desktop): reveal sidebar jump shortcuts while holding ⌘

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -30,6 +30,7 @@ import { DashboardSidebarWorkspacesHeader } from "./components/DashboardSidebarW
 import { V2SetupScriptCard } from "./components/V2SetupScriptCard";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
+import { useHoldJumpShortcutReveal } from "./hooks/useHoldJumpShortcutReveal";
 import { useDashboardSidebarDnd } from "./hooks/useSidebarDnd";
 import { DashboardSidebarDndProvider } from "./providers/DashboardSidebarDndProvider";
 import { DashboardSidebarHoverProvider } from "./providers/DashboardSidebarHoverProvider";
@@ -156,6 +157,7 @@ export function DashboardSidebar({
 		orderedGroups,
 		sessionWorkspaces,
 	);
+	const revealJumpShortcuts = useHoldJumpShortcutReveal();
 	const selectableWorkspaceIds = useMemo(
 		() =>
 			new Set(
@@ -247,7 +249,12 @@ export function DashboardSidebar({
 									workspaceShortcutLabels={workspaceShortcutLabels}
 									onReorderProjects={handleReorderProjects}
 								>
-									<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
+									<div
+										className="group/sidebar flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35"
+										data-jump-shortcuts={
+											revealJumpShortcuts ? "true" : undefined
+										}
+									>
 										<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
 										<OverflowFadeContainer

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
@@ -69,6 +69,7 @@ export function DashboardSidebarSessionsSection({
 						workspace={workspace}
 						isCollapsed
 						isInSection={false}
+						shortcutLabel={workspaceShortcutLabels?.get(workspace.id)}
 						onHoverCardOpen={onWorkspaceHover}
 					/>
 				))}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -215,6 +215,7 @@ export function DashboardSidebarWorkspaceItem({
 					onClick={handleClick}
 					isCreatePending={isPending}
 					pullRequestState={pullRequest?.state ?? null}
+					shortcutLabel={shortcutLabel}
 					aria-label={isPending ? `Creating workspace: ${name}` : undefined}
 				/>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -17,6 +17,7 @@ interface DashboardSidebarCollapsedWorkspaceButtonProps
 	workspaceStatus?: ActivePaneStatus | null;
 	isCreatePending: boolean;
 	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
+	shortcutLabel?: string;
 }
 
 export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
@@ -32,11 +33,13 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 			workspaceStatus = null,
 			isCreatePending,
 			pullRequestState = null,
+			shortcutLabel,
 			className,
 			...props
 		},
 		ref,
 	) => {
+		const overlayDigit = shortcutLabel?.match(/[1-9]$/)?.[0];
 		return (
 			<button
 				type="button"
@@ -61,6 +64,14 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 					isCreatePending={isCreatePending}
 					pullRequestState={pullRequestState}
 				/>
+				{overlayDigit && (
+					<span
+						aria-hidden
+						className="pointer-events-none absolute -right-0.5 -bottom-0.5 hidden min-w-3.5 rounded-sm bg-background px-0.5 text-center font-mono text-[9px] leading-4 text-muted-foreground tabular-nums shadow-sm group-data-[jump-shortcuts]/sidebar:flex"
+					>
+						{overlayDigit}
+					</span>
+				)}
 			</button>
 		);
 	},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -39,7 +39,6 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 		},
 		ref,
 	) => {
-		const overlayDigit = shortcutLabel?.match(/[1-9]$/)?.[0];
 		return (
 			<button
 				type="button"
@@ -64,12 +63,12 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 					isCreatePending={isCreatePending}
 					pullRequestState={pullRequestState}
 				/>
-				{overlayDigit && (
+				{shortcutLabel && (
 					<span
 						aria-hidden
-						className="pointer-events-none absolute -right-0.5 -bottom-0.5 hidden min-w-3.5 rounded-sm bg-background px-0.5 text-center font-mono text-[9px] leading-4 text-muted-foreground tabular-nums shadow-sm group-data-[jump-shortcuts]/sidebar:flex"
+						className="pointer-events-none absolute inset-0 hidden items-center justify-center rounded-md bg-background/90 font-mono text-[10px] tabular-nums text-muted-foreground group-data-[jump-shortcuts]/sidebar:flex"
 					>
-						{overlayDigit}
+						{shortcutLabel}
 					</span>
 				)}
 			</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -316,72 +316,79 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								)
 							)}
 							{!isPending && !isSelected && (
-								<div className="hidden items-center justify-end gap-1.5 group-hover:flex group-focus-within:flex">
+								<div
+									className={cn(
+										"hidden items-center justify-end gap-1.5 group-hover:flex group-focus-within:flex",
+										shortcutLabel && "group-data-[jump-shortcuts]/sidebar:flex",
+									)}
+								>
 									{shortcutLabel && (
 										<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
 											{shortcutLabel}
 										</span>
 									)}
-									{isLocalMainWorkspace ? null : isMainWorkspace ? (
-										<Tooltip delayDuration={300}>
-											<TooltipTrigger asChild>
-												<button
-													type="button"
-													onClick={(event) => {
-														event.stopPropagation();
-														onRemoveFromSidebarClick();
-													}}
-													onKeyDown={(event) => {
-														if (
-															event.key === "Enter" ||
-															event.key === " " ||
-															event.key === "Spacebar"
-														) {
+									<div className="contents group-data-[jump-shortcuts]/sidebar:hidden">
+										{isLocalMainWorkspace ? null : isMainWorkspace ? (
+											<Tooltip delayDuration={300}>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														onClick={(event) => {
 															event.stopPropagation();
-														}
-													}}
-													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-													aria-label="Remove from sidebar"
-												>
-													<HiMiniMinus className="size-3.5" />
-												</button>
-											</TooltipTrigger>
-											<TooltipContent side="top">
-												<HotkeyLabel label="Remove from sidebar" />
-											</TooltipContent>
-										</Tooltip>
-									) : (
-										<Tooltip delayDuration={300}>
-											<TooltipTrigger asChild>
-												<button
-													type="button"
-													onClick={(event) => {
-														event.stopPropagation();
-														onCloseWorkspaceClick();
-													}}
-													onKeyDown={(event) => {
-														if (
-															event.key === "Enter" ||
-															event.key === " " ||
-															event.key === "Spacebar"
-														) {
+															onRemoveFromSidebarClick();
+														}}
+														onKeyDown={(event) => {
+															if (
+																event.key === "Enter" ||
+																event.key === " " ||
+																event.key === "Spacebar"
+															) {
+																event.stopPropagation();
+															}
+														}}
+														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+														aria-label="Remove from sidebar"
+													>
+														<HiMiniMinus className="size-3.5" />
+													</button>
+												</TooltipTrigger>
+												<TooltipContent side="top">
+													<HotkeyLabel label="Remove from sidebar" />
+												</TooltipContent>
+											</Tooltip>
+										) : (
+											<Tooltip delayDuration={300}>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														onClick={(event) => {
 															event.stopPropagation();
-														}
-													}}
-													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-													aria-label="Close workspace"
-												>
-													<HiMiniXMark className="size-3.5" />
-												</button>
-											</TooltipTrigger>
-											<TooltipContent side="top">
-												<HotkeyLabel
-													label="Close workspace"
-													id={isActive ? "CLOSE_WORKSPACE" : undefined}
-												/>
-											</TooltipContent>
-										</Tooltip>
-									)}
+															onCloseWorkspaceClick();
+														}}
+														onKeyDown={(event) => {
+															if (
+																event.key === "Enter" ||
+																event.key === " " ||
+																event.key === "Spacebar"
+															) {
+																event.stopPropagation();
+															}
+														}}
+														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+														aria-label="Close workspace"
+													>
+														<HiMiniXMark className="size-3.5" />
+													</button>
+												</TooltipTrigger>
+												<TooltipContent side="top">
+													<HotkeyLabel
+														label="Close workspace"
+														id={isActive ? "CLOSE_WORKSPACE" : undefined}
+													/>
+												</TooltipContent>
+											</Tooltip>
+										)}
+									</div>
 								</div>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/holdJumpShortcutReveal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/holdJumpShortcutReveal.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type HoldJumpShortcutRevealMods,
+	type HoldJumpShortcutRevealPhase,
+	reduceHoldJumpShortcutReveal,
+} from "./holdJumpShortcutReveal";
+
+function mods(
+	partial: Partial<HoldJumpShortcutRevealMods> &
+		Pick<HoldJumpShortcutRevealMods, "key" | "code">,
+): HoldJumpShortcutRevealMods {
+	return {
+		metaKey: false,
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		repeat: false,
+		...partial,
+	};
+}
+
+function reduce(
+	phase: HoldJumpShortcutRevealPhase,
+	input: Parameters<typeof reduceHoldJumpShortcutReveal>[1],
+	platform: "mac" | "windows" = "mac",
+) {
+	return reduceHoldJumpShortcutReveal(phase, input, platform);
+}
+
+const metaDown = mods({
+	key: "Meta",
+	code: "MetaLeft",
+	metaKey: true,
+});
+const ctrlDown = mods({
+	key: "Control",
+	code: "ControlLeft",
+	ctrlKey: true,
+});
+
+describe("reduceHoldJumpShortcutReveal (mac)", () => {
+	test("⌘ down starts the pending timer", () => {
+		expect(reduce("idle", { type: "keydown", mods: metaDown })).toEqual({
+			phase: "pending",
+			startTimer: true,
+			clearTimer: false,
+		});
+	});
+
+	test("key-repeat on ⌘ does not restart the timer", () => {
+		expect(
+			reduce("pending", {
+				type: "keydown",
+				mods: { ...metaDown, repeat: true },
+			}),
+		).toEqual({
+			phase: "pending",
+			startTimer: false,
+			clearTimer: false,
+		});
+	});
+
+	test("⌘C before the timer fires cancels", () => {
+		expect(
+			reduce("pending", {
+				type: "keydown",
+				mods: mods({
+					key: "c",
+					code: "KeyC",
+					metaKey: true,
+				}),
+			}),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+
+	test("⌘ up while pending cancels", () => {
+		expect(
+			reduce("pending", {
+				type: "keyup",
+				mods: mods({ key: "Meta", code: "MetaLeft" }),
+			}),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+
+	test("⌘ up while visible hides the overlay", () => {
+		expect(
+			reduce("visible", {
+				type: "keyup",
+				mods: mods({ key: "Meta", code: "MetaLeft" }),
+			}),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+
+	test("pressing 1 while visible hides so the jump chord can fire", () => {
+		expect(
+			reduce("visible", {
+				type: "keydown",
+				mods: mods({
+					key: "1",
+					code: "Digit1",
+					metaKey: true,
+				}),
+			}),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+
+	test("⌘⇧ cancels because Shift is not part of the Mac jump chord", () => {
+		expect(
+			reduce("pending", {
+				type: "keydown",
+				mods: mods({
+					key: "Shift",
+					code: "ShiftLeft",
+					metaKey: true,
+					shiftKey: true,
+				}),
+			}),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+
+	test("blur resets from either non-idle phase", () => {
+		expect(reduce("pending", { type: "reset" }).phase).toBe("idle");
+		expect(reduce("visible", { type: "reset" }).phase).toBe("idle");
+	});
+});
+
+describe("reduceHoldJumpShortcutReveal (windows)", () => {
+	test("Ctrl down starts the pending timer", () => {
+		expect(
+			reduce("idle", { type: "keydown", mods: ctrlDown }, "windows"),
+		).toEqual({
+			phase: "pending",
+			startTimer: true,
+			clearTimer: false,
+		});
+	});
+
+	test("Ctrl+Shift stays pending — Shift is part of the jump chord", () => {
+		expect(
+			reduce(
+				"pending",
+				{
+					type: "keydown",
+					mods: mods({
+						key: "Shift",
+						code: "ShiftLeft",
+						ctrlKey: true,
+						shiftKey: true,
+					}),
+				},
+				"windows",
+			),
+		).toEqual({
+			phase: "pending",
+			startTimer: false,
+			clearTimer: false,
+		});
+	});
+
+	test("releasing Shift while Ctrl is still held keeps the overlay", () => {
+		expect(
+			reduce(
+				"visible",
+				{
+					type: "keyup",
+					mods: mods({
+						key: "Shift",
+						code: "ShiftLeft",
+						ctrlKey: true,
+					}),
+				},
+				"windows",
+			),
+		).toEqual({
+			phase: "visible",
+			startTimer: false,
+			clearTimer: false,
+		});
+	});
+
+	test("Ctrl+C cancels", () => {
+		expect(
+			reduce(
+				"pending",
+				{
+					type: "keydown",
+					mods: mods({
+						key: "c",
+						code: "KeyC",
+						ctrlKey: true,
+					}),
+				},
+				"windows",
+			),
+		).toEqual({
+			phase: "idle",
+			startTimer: false,
+			clearTimer: true,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/holdJumpShortcutReveal.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/holdJumpShortcutReveal.ts
@@ -1,0 +1,117 @@
+import type { Platform } from "renderer/hotkeys";
+
+/**
+ * Delay before ⌘1–⌘9 hints appear while the jump modifier is held. Long
+ * enough that ⌘C / ⌘V never flash the overlay; short enough that a
+ * deliberate peek still feels instant. Codex uses ~1s; 400ms matches the
+ * sidebar hover-card open delay.
+ */
+export const HOLD_JUMP_SHORTCUT_REVEAL_MS = 400;
+
+export type HoldJumpShortcutRevealPhase = "idle" | "pending" | "visible";
+
+export interface HoldJumpShortcutRevealMods {
+	key: string;
+	code: string;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+	repeat: boolean;
+}
+
+export type HoldJumpShortcutRevealInput =
+	| { type: "keydown"; mods: HoldJumpShortcutRevealMods }
+	| { type: "keyup"; mods: HoldJumpShortcutRevealMods }
+	| { type: "reset" };
+
+export interface HoldJumpShortcutRevealResult {
+	phase: HoldJumpShortcutRevealPhase;
+	startTimer: boolean;
+	clearTimer: boolean;
+}
+
+function isMetaKey(key: string, code: string): boolean {
+	return key === "Meta" || code === "MetaLeft" || code === "MetaRight";
+}
+
+function isControlKey(key: string, code: string): boolean {
+	return key === "Control" || code === "ControlLeft" || code === "ControlRight";
+}
+
+function isShiftKey(key: string, code: string): boolean {
+	return key === "Shift" || code === "ShiftLeft" || code === "ShiftRight";
+}
+
+function isRevealModifierKey(
+	platform: Platform,
+	mods: HoldJumpShortcutRevealMods,
+): boolean {
+	return platform === "mac"
+		? isMetaKey(mods.key, mods.code)
+		: isControlKey(mods.key, mods.code);
+}
+
+/**
+ * Mac jump chords are ⌘1–⌘9 (no other modifiers). Win/Linux chords are
+ * Ctrl+Shift+1–9, so Shift may stay held while the overlay is up.
+ */
+function isRevealChordHeld(
+	platform: Platform,
+	mods: Pick<
+		HoldJumpShortcutRevealMods,
+		"metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+	>,
+): boolean {
+	if (platform === "mac") {
+		return mods.metaKey && !mods.ctrlKey && !mods.altKey && !mods.shiftKey;
+	}
+	return mods.ctrlKey && !mods.metaKey && !mods.altKey;
+}
+
+function isAllowedExtraKeydown(
+	platform: Platform,
+	mods: HoldJumpShortcutRevealMods,
+): boolean {
+	return platform !== "mac" && isShiftKey(mods.key, mods.code);
+}
+
+function idle(): HoldJumpShortcutRevealResult {
+	return { phase: "idle", startTimer: false, clearTimer: true };
+}
+
+function unchanged(
+	phase: HoldJumpShortcutRevealPhase,
+): HoldJumpShortcutRevealResult {
+	return { phase, startTimer: false, clearTimer: false };
+}
+
+export function reduceHoldJumpShortcutReveal(
+	phase: HoldJumpShortcutRevealPhase,
+	input: HoldJumpShortcutRevealInput,
+	platform: Platform,
+): HoldJumpShortcutRevealResult {
+	if (input.type === "reset") return idle();
+
+	if (input.type === "keyup") {
+		return isRevealChordHeld(platform, input.mods) ? unchanged(phase) : idle();
+	}
+
+	const { mods } = input;
+	if (
+		isRevealModifierKey(platform, mods) &&
+		isRevealChordHeld(platform, mods)
+	) {
+		if (mods.repeat || phase !== "idle") return unchanged(phase);
+		return { phase: "pending", startTimer: true, clearTimer: false };
+	}
+
+	if (phase === "idle") return unchanged(phase);
+	if (
+		isAllowedExtraKeydown(platform, mods) &&
+		isRevealChordHeld(platform, mods)
+	) {
+		return unchanged(phase);
+	}
+	return idle();
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/index.ts
@@ -1,0 +1,2 @@
+export { HOLD_JUMP_SHORTCUT_REVEAL_MS } from "./holdJumpShortcutReveal";
+export { useHoldJumpShortcutReveal } from "./useHoldJumpShortcutReveal";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/useHoldJumpShortcutReveal.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/useHoldJumpShortcutReveal.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import { PLATFORM } from "renderer/hotkeys";
+import {
+	HOLD_JUMP_SHORTCUT_REVEAL_MS,
+	type HoldJumpShortcutRevealMods,
+	type HoldJumpShortcutRevealPhase,
+	reduceHoldJumpShortcutReveal,
+} from "./holdJumpShortcutReveal";
+
+function modsFromEvent(event: KeyboardEvent): HoldJumpShortcutRevealMods {
+	return {
+		key: event.key,
+		code: event.code,
+		metaKey: event.metaKey,
+		ctrlKey: event.ctrlKey,
+		altKey: event.altKey,
+		shiftKey: event.shiftKey,
+		repeat: event.repeat,
+	};
+}
+
+/**
+ * True after the jump-to-workspace modifier (⌘ on Mac, Ctrl on Windows/Linux)
+ * has been held alone for {@link HOLD_JUMP_SHORTCUT_REVEAL_MS}. Sidebar rows
+ * use this to reveal their ⌘1–⌘9 hints.
+ */
+export function useHoldJumpShortcutReveal(
+	delayMs = HOLD_JUMP_SHORTCUT_REVEAL_MS,
+): boolean {
+	const [visible, setVisible] = useState(false);
+	const phaseRef = useRef<HoldJumpShortcutRevealPhase>("idle");
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		const clearTimer = () => {
+			if (timerRef.current == null) return;
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		};
+
+		const apply = (
+			input: Parameters<typeof reduceHoldJumpShortcutReveal>[1],
+		) => {
+			const result = reduceHoldJumpShortcutReveal(
+				phaseRef.current,
+				input,
+				PLATFORM,
+			);
+			phaseRef.current = result.phase;
+			if (result.clearTimer) clearTimer();
+			if (result.startTimer) {
+				clearTimer();
+				timerRef.current = setTimeout(() => {
+					phaseRef.current = "visible";
+					timerRef.current = null;
+					setVisible(true);
+				}, delayMs);
+			}
+			setVisible(result.phase === "visible");
+		};
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.isComposing) return;
+			apply({ type: "keydown", mods: modsFromEvent(event) });
+		};
+		const onKeyUp = (event: KeyboardEvent) => {
+			apply({ type: "keyup", mods: modsFromEvent(event) });
+		};
+		const onReset = () => apply({ type: "reset" });
+		const onVisibilityChange = () => {
+			if (document.visibilityState !== "visible") onReset();
+		};
+
+		window.addEventListener("keydown", onKeyDown, true);
+		window.addEventListener("keyup", onKeyUp, true);
+		window.addEventListener("blur", onReset);
+		document.addEventListener("visibilitychange", onVisibilityChange);
+		return () => {
+			clearTimer();
+			window.removeEventListener("keydown", onKeyDown, true);
+			window.removeEventListener("keyup", onKeyUp, true);
+			window.removeEventListener("blur", onReset);
+			document.removeEventListener("visibilitychange", onVisibilityChange);
+		};
+	}, [delayMs]);
+
+	return visible;
+}


### PR DESCRIPTION
## What & why

Holding ⌘ (Ctrl on Windows/Linux) for 400ms reveals ⌘1–⌘9 on every mapped session and workspace row in the v2 dashboard sidebar, including the collapsed rail. Hovering a single row was the only way to see a shortcut, so the jump map was not scannable.

Chords such as ⌘C cancel before the overlay appears. Release, blur, or any other key hides it. Pinned rows are unchanged; they are still excluded from the shortcut map.

## How I tested it

- `bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useHoldJumpShortcutReveal/holdJumpShortcutReveal.test.ts` (12 pass)
- `npx @biomejs/biome@2.4.2 check` on the touched files (clean)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Holding the jump modifier reveals sidebar jump shortcuts so the map is scannable. Previously hints only appeared on hover; now holding ⌘ (Ctrl on Windows/Linux) for 400ms shows ⌘1–⌘9 on all session and workspace rows, including the collapsed rail; the collapsed overlay now displays the full label (⌘N), not just the digit.

- Introduces `useHoldJumpShortcutReveal` with a platform-aware reducer. Listens to keydown/keyup, blur, and `visibilitychange`; ignores key repeat; starts a 400ms timer (`HOLD_JUMP_SHORTCUT_REVEAL_MS`) when the modifier is held alone.
- Mac: ⌘1–⌘9 (no Shift). Windows/Linux: Ctrl+Shift+1–9; Shift may remain held without hiding the overlay. Pressing the jump digit hides the overlay so the chord fires; releasing the modifier or any unrelated key hides it.
- Propagates `data-jump-shortcuts="true"` to the sidebar container to toggle visibility. Shows `shortcutLabel` on expanded rows and the collapsed rail; hides action icons while the overlay is active.
- Adds unit tests for reducer behavior across platforms and cancellation paths in `apps/desktop/.../useHoldJumpShortcutReveal/holdJumpShortcutReveal.test.ts`.

<sup>Written for commit cd33ca145086ba455c52fcedbb1fc190e751408a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold the platform-specific modifier key to reveal jump-to-workspace keyboard shortcuts in the dashboard sidebar.
  * Collapsed workspaces now display their configured shortcut number when shortcut hints are visible.
  * Workspace action controls are temporarily hidden while shortcut hints are displayed.

* **Bug Fixes**
  * Improved shortcut hint behavior across macOS, Windows, and Linux, including key repeats, cancellation, and focus changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->