### PR TITLE
fix(host-service): disable commit signing for scaffolding commits

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -404,6 +404,92 @@ describe("scaffolding commits bypass user git hooks", () => {
 	});
 });
 
+// ── scaffolding commits vs user commit signing ────────────────────
+
+describe("scaffolding commits bypass user commit signing", () => {
+	// Simulates a global config that requires SSH-signed commits with a
+	// signing key git cannot load, which makes every commit die with
+	// "fatal: failed to write commit object" (HOST-SERVICE-22). Nothing
+	// here disables signing for the repos under test — that is the point.
+	let savedGlobalConfig: string | undefined;
+	let signingConfig: string;
+	let identityConfig: string;
+
+	beforeEach(() => {
+		const identity = "[user]\n\tname = test\n\temail = test@example.com\n";
+		const missingKey = join(workRoot, "absent-signing-key.pub");
+		signingConfig = join(workRoot, "gitconfig-signing");
+		writeFileSync(
+			signingConfig,
+			`${identity}\tsigningkey = ${missingKey}\n[gpg]\n\tformat = ssh\n[commit]\n\tgpgsign = true\n`,
+		);
+		identityConfig = join(workRoot, "gitconfig-identity");
+		writeFileSync(identityConfig, `${identity}[commit]\n\tgpgsign = false\n`);
+		savedGlobalConfig = process.env.GIT_CONFIG_GLOBAL;
+		process.env.GIT_CONFIG_GLOBAL = signingConfig;
+	});
+
+	afterEach(() => {
+		if (savedGlobalConfig === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+		else process.env.GIT_CONFIG_GLOBAL = savedGlobalConfig;
+	});
+
+	test("fixture sanity: the unusable signing key aborts a plain commit", async () => {
+		const repo = join(workRoot, "signed");
+		mkdirSync(repo);
+		const git = simpleGit(repo);
+		await git.init();
+
+		// simple-git's chain object is a thenable, not a Promise —
+		// `expect().rejects` won't unwrap it, so catch manually.
+		let rejected = false;
+		try {
+			await git.raw(["commit", "--allow-empty", "-m", "should be rejected"]);
+		} catch {
+			rejected = true;
+		}
+		expect(rejected).toBe(true);
+	});
+
+	test("initEmptyRepo commits despite required signing with an unusable key", async () => {
+		const resolved = await initEmptyRepo(workRoot, "fresh-signed");
+
+		expect(eqRealpath(resolved.repoPath, join(workRoot, "fresh-signed"))).toBe(
+			true,
+		);
+	});
+
+	test("initLocalRepoInPlace commits despite required signing with an unusable key", async () => {
+		const dir = join(workRoot, "in-place-signed");
+		mkdirSync(dir);
+
+		const resolved = await initLocalRepoInPlace(dir);
+
+		expect(eqRealpath(resolved.repoPath, dir)).toBe(true);
+	});
+
+	test("cloneTemplateInto snapshot commit despite required signing with an unusable key", async () => {
+		const template = join(workRoot, "template-signed");
+		mkdirSync(template);
+		writeFileSync(join(template, "README.md"), "template");
+		// Seed the template fixture without required signing in effect —
+		// only the code under test may exercise the bypass path.
+		process.env.GIT_CONFIG_GLOBAL = identityConfig;
+		const templateGit = simpleGit(template);
+		await templateGit.init();
+		await templateGit.add(".");
+		await templateGit.raw(["commit", "-m", "seed"]);
+		process.env.GIT_CONFIG_GLOBAL = signingConfig;
+
+		const resolved = await cloneTemplateInto(template, workRoot, "from-tpl");
+
+		expect(eqRealpath(resolved.repoPath, join(workRoot, "from-tpl"))).toBe(
+			true,
+		);
+		expect(existsSync(join(workRoot, "from-tpl", "README.md"))).toBe(true);
+	});
+});
+
 // ── cloneRepoInto ─────────────────────────────────────────────────
 
 describe("cloneRepoInto", () => {

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -144,12 +144,25 @@ function asInitialCommitTrpcError(err: unknown): TRPCError {
 
 /**
  * Scaffolding commits are authored by us in repos we just created — the
- * user's global git hooks (e.g. a `core.hooksPath` commit-msg policy) must
- * not be able to reject them. `--no-verify` skips pre-commit/commit-msg;
- * the empty `core.hooksPath` override covers the rest (a failing
- * prepare-commit-msg still aborts a `--no-verify` commit).
+ * user's local git policy must not be able to reject them. Two bypasses,
+ * both per-invocation `-c` overrides that never touch stored config:
+ *
+ * - Hooks: `--no-verify` skips pre-commit/commit-msg; the empty
+ *   `core.hooksPath` override covers the rest (a failing
+ *   prepare-commit-msg still aborts a `--no-verify` commit).
+ * - Signing: `commit.gpgsign=false` — this is our scaffolding, not the
+ *   user's work, so it must not carry their signing identity, and a
+ *   signing key that git cannot load (absent, unreadable, or not in the
+ *   agent) must not fail the commit outright (HOST-SERVICE-22).
  */
-const scaffoldCommitArgs = ["-c", "core.hooksPath=", "commit", "--no-verify"];
+const scaffoldCommitArgs = [
+	"-c",
+	"core.hooksPath=",
+	"-c",
+	"commit.gpgsign=false",
+	"commit",
+	"--no-verify",
+];
 
 /** `git init --initial-branch=main` with a fallback for older git versions. */
 async function gitInitMainBranch(targetPath: string): Promise<void> {


### PR DESCRIPTION
## Problem

Creating a new empty project fails outright for any user whose global git config enables commit signing with a signing key git cannot load (absent, unreadable, or not loaded into the agent). `project.create` dies with:

```
TRPCError: Failed to create initial commit: error: No private key found for public key "<redacted>.pub"?

fatal: failed to write commit object
```

This is deterministic, not intermittent: the user cannot create a project at all short of changing their global git config. It reports as a 500 (`trpc_code: INTERNAL_SERVER_ERROR`, `trpc_path: project.create`).

## Root cause

We initialise a fresh git repo and author a scaffolding initial commit on the user's behalf. That commit was already deliberately shielded from the user's local git policy — `scaffoldCommitArgs` passes `--no-verify` plus a per-invocation `-c core.hooksPath=` so a global hooks policy can't reject our own scaffolding — but it never applied the same treatment to signing. So git tries to sign our scaffolding commit with the user's signing identity and refuses to write the commit object when that key can't be loaded. Same class of problem the hooks bypass already solved, one config knob short.

## Fix

Extend `scaffoldCommitArgs` with a second per-invocation override, `-c commit.gpgsign=false`, in the same style as the hooks bypass. Nothing is written to the user's stored config; the override applies only to the scaffold commit invocation. A commit we author in a repo we just created is our scaffolding, not the user's work, so it must not carry their signing identity and must not be able to fail on their signing setup.

All three scaffold commit sites share the constant and are fixed together: `initEmptyRepo`, `initLocalRepoInPlace`, and the `cloneTemplateInto` snapshot commit. These are the only commits host-service authors — `git init` is a separate invocation that does not commit, and workspace creation authors no commits (it only resolves start points via `rev-parse`).

Adjacent site, named and left alone: `apps/desktop/src/lib/trpc/routers/projects/projects.ts:121` (v1 desktop `initGitRepo`) runs a bare `git commit --allow-empty` with the same failure mode, but it is a separate v1 path in a different package with its own error handling and no hooks bypass to extend — out of scope for this issue.

## Classification

`asInitialCommitTrpcError` is left unchanged, and this is deliberate. It special-cases unconfigured git identity (`empty ident` / `user.email` / `user.name`) as `PRECONDITION_FAILED` and falls through to `INTERNAL_SERVER_ERROR` otherwise. With hooks and signing both bypassed and identity already classified, there is no remaining *known* user-environment condition on this path to type — broadening the mapper past the conditions it names would make it match failures it can't actually diagnose.

What still reports as a 500 on this path: everything that is not an unconfigured-identity error. Concretely, filesystem and repo-state failures during the initial commit — no space left on device, a read-only or permission-denied target directory, a stale `index.lock`, a broken/missing `git` binary — plus anything unanticipated. Those are genuine internal failures and should keep paging us.

No typed `cause` was added: nothing reads one on this path — no renderer branch, no retry decision, no test — so the throw sites stay plain `new TRPCError({ code, message })`.

## Verification

`bunx biome check` on both changed files (after one `--write` formatting pass):

```
Checked 2 files in 10ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
```

(clean, no diagnostics)

`bun test packages/host-service/src/trpc/router/project`:

```
bun test v1.3.14 (0d9b296a)

 41 pass
 0 fail
 86 expect() calls
Ran 41 tests across 2 files. [10.05s]
```

New tests: a `scaffolding commits bypass user commit signing` block alongside the existing hooks-bypass tests. It points `GIT_CONFIG_GLOBAL` at a config with `commit.gpgsign = true`, `gpg.format = ssh`, and a `user.signingkey` pointing at a file that does not exist, and — unlike the other fixtures in this file — does **not** disable signing for the repos under test. A sanity test first proves a plain commit is rejected under that config, then `initEmptyRepo`, `initLocalRepoInPlace`, and `cloneTemplateInto` are each asserted to succeed.

Confirmed the tests fail without the fix: reverting just the `-c commit.gpgsign=false` argument and re-running gives `35 pass / 3 fail`, with all three failures being the new bypass assertions dying on `fatal: failed to write commit object`.

Repo-wide `bun run lint` was not run (it hangs on cross-worktree bun locks).

Refs HOST-SERVICE-22

https://claude.ai/code/session_14da01cf-ad34-4e6b-b244-8cb19bb6121b


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables commit signing for scaffolding commits in `packages/host-service` to unblock new-project creation when a user's global git config requires signing with an unusable key. Previously, scaffolding honored the user's signing policy and could fail with “fatal: failed to write commit object”; now signing is disabled per invocation, so scaffolding commits succeed regardless of the user's signing setup. Addresses HOST-SERVICE-22.

**Review notes**
- Adds `-c commit.gpgsign=false` to `scaffoldCommitArgs` (alongside the existing hooks bypass) and uses it in `initEmptyRepo`, `initLocalRepoInPlace`, and `cloneTemplateInto`; no stored config is modified.
- Keeps `asInitialCommitTrpcError` unchanged; only missing identity maps to `PRECONDITION_FAILED`, all other initial-commit failures remain `INTERNAL_SERVER_ERROR`.
- Adds tests that require signed commits with a missing SSH key; plain commits fail, scaffolding commits succeed.
- Out of scope: v1 desktop path in `apps/desktop` continues to run `git commit` without the bypass.

<sup>Written for commit 28b4f4389cb8336443b304704d06b93c55687c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project repository setup now completes successfully when global SSH commit signing is enabled but the configured signing key is unavailable.
  * Empty repository initialization, local repository setup, and template imports reliably create their required scaffolding commits without being blocked by signing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->