### PR TITLE
fix(desktop): classify out-of-space update failures by free disk, not message text

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { statfsSync } from "node:fs";
 import * as Sentry from "@sentry/electron/main";
 import { app, dialog } from "electron";
 import log from "electron-log/main";
@@ -6,6 +7,7 @@ import { autoUpdater, type UpdateCheckResult } from "electron-updater";
 import { env } from "main/env.main";
 import { setSkipQuitConfirmation } from "main/index";
 import { appState } from "main/lib/app-state";
+import { isEnvironmentUpdateError } from "main/lib/update-error-classification";
 import { gte, prerelease } from "semver";
 import {
 	AUTO_UPDATE_STATUS,
@@ -83,31 +85,16 @@ function isNetworkError(error: Error | string): boolean {
 	return SILENT_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
 }
 
-const ENVIRONMENT_ERRNO_CODES = [
-	"ENOENT",
-	"EACCES",
-	"EPERM",
-	"EBUSY",
-	"ENOSPC",
-];
-const UPDATER_PATH_MARKERS = ["-updater", "shipit"];
-
-// Update failures owned by the user's machine, not by us: a corrupt or
-// half-removed updater cache, an app bundle that can't be written, and stalled
-// requests. Squirrel and electron-updater surface these as plain messages
-// without errno properties, so match on the text.
-function isEnvironmentUpdateError(message: string): boolean {
-	const lowerMessage = message.toLowerCase();
-	if (
-		lowerMessage.includes("read-only volume") ||
-		lowerMessage.includes("the request timed out")
-	) {
-		return true;
+// Free bytes on the volume backing the updater caches, which sit beside our app
+// data. Returns null when the volume can't be queried, so an unknown answer
+// never reads as "out of space".
+function freeStagingBytes(): number | null {
+	try {
+		const { bavail, bsize } = statfsSync(app.getPath("userData"));
+		return bavail * bsize;
+	} catch {
+		return null;
 	}
-	return (
-		ENVIRONMENT_ERRNO_CODES.some((code) => message.includes(`${code}:`)) &&
-		UPDATER_PATH_MARKERS.some((marker) => lowerMessage.includes(marker))
-	);
 }
 
 // electron-updater starts the auto-download inside checkForUpdates and hands
@@ -376,7 +363,12 @@ export function setupAutoUpdater(): void {
 		);
 		void clearCachedUpdate(`error: ${error?.message ?? "unknown"}`);
 		emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
-		if (!isEnvironmentUpdateError(error?.message ?? String(error))) {
+		if (
+			!isEnvironmentUpdateError(
+				error?.message ?? String(error),
+				freeStagingBytes(),
+			)
+		) {
 			Sentry.captureException(error);
 		}
 	});

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -48,8 +48,23 @@ describe("isEnvironmentUpdateError", () => {
 		}
 	});
 
-	test("suppresses every updater failure while the volume is full", () => {
-		expect(isEnvironmentUpdateError(CHECKSUM_MISMATCH, FULL_VOLUME)).toBe(true);
+	test("still reports our own defects even while the volume is full", () => {
+		// A full disk does not corrupt a download or break a signature. If these
+		// were suppressed, a bad release would go unreported for exactly the
+		// users least able to recover from it.
+		for (const message of [
+			CHECKSUM_MISMATCH,
+			SIGNATURE_FAILURE,
+			FEED_FAILURE,
+		]) {
+			expect(isEnvironmentUpdateError(message, FULL_VOLUME)).toBe(false);
+		}
+	});
+
+	test("still treats an unrecognised failure on a full volume as environmental", () => {
+		expect(
+			isEnvironmentUpdateError("something we have never seen", FULL_VOLUME),
+		).toBe(true);
 	});
 
 	test("keeps the existing errno and read-only classifications", () => {

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -19,6 +19,12 @@ const SIGNATURE_FAILURE =
 	'Could not get code signature for running application: Error: Command failed: codesign --verify -vvvv "/Applications/Superset.app"';
 const FEED_FAILURE =
 	"HttpError: 404 Not Found\nCannot parse update info from latest-mac.yml";
+// Further electron-updater release-artifact defects. Each must survive a full
+// volume; a gap here silences a bad release for the users least able to cope.
+const MISSING_CHANNEL = "Cannot find channel “latest-mac.yml” update info";
+const NO_FILES = "No files provided in update info";
+const NO_CHECKSUM =
+	"Update info doesn't contain nor sha256 neither sha512 checksum";
 
 describe("isEnvironmentUpdateError", () => {
 	test("classifies a full staging volume without reading the message", () => {
@@ -56,8 +62,12 @@ describe("isEnvironmentUpdateError", () => {
 			CHECKSUM_MISMATCH,
 			SIGNATURE_FAILURE,
 			FEED_FAILURE,
+			MISSING_CHANNEL,
+			NO_FILES,
+			NO_CHECKSUM,
 		]) {
 			expect(isEnvironmentUpdateError(message, FULL_VOLUME)).toBe(false);
+			expect(isEnvironmentUpdateError(message, ROOMY_VOLUME)).toBe(false);
 		}
 	});
 

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { isEnvironmentUpdateError } from "./update-error-classification";
+
+const GIGABYTE = 1024 * 1024 * 1024;
+const FULL_VOLUME = 40 * 1024 * 1024;
+const ROOMY_VOLUME = 60 * GIGABYTE;
+
+// Captured from production, with the account name and archive digest replaced.
+const DITTO_NO_SPACE_EN = [
+	"ditto: /Users/<user>/Library/Caches/com.superset.desktop.ShipIt/update.aBcDeF1/Superset.app/Contents/Resources/app.asar: No space left on device",
+	"ditto: Couldn't read pkzip signature.",
+].join("\n");
+const SQUIRREL_NO_SPACE_ES =
+	"El archivo “<digest>.zip” no puede guardarse porque no queda suficiente espacio.: No hay suficiente espacio. Elimina algunos archivos del volumen e inténtalo de nuevo.";
+
+const CHECKSUM_MISMATCH =
+	"sha512 checksum mismatch, expected 1PbOs3lC, got fT2wPk9d";
+const SIGNATURE_FAILURE =
+	'Could not get code signature for running application: Error: Command failed: codesign --verify -vvvv "/Applications/Superset.app"';
+const FEED_FAILURE =
+	"HttpError: 404 Not Found\nCannot parse update info from latest-mac.yml";
+
+describe("isEnvironmentUpdateError", () => {
+	test("classifies a full staging volume without reading the message", () => {
+		expect(isEnvironmentUpdateError(DITTO_NO_SPACE_EN, FULL_VOLUME)).toBe(true);
+		expect(isEnvironmentUpdateError(SQUIRREL_NO_SPACE_ES, FULL_VOLUME)).toBe(
+			true,
+		);
+	});
+
+	test("reports those same failures when the volume has room", () => {
+		expect(isEnvironmentUpdateError(DITTO_NO_SPACE_EN, ROOMY_VOLUME)).toBe(
+			false,
+		);
+		expect(isEnvironmentUpdateError(SQUIRREL_NO_SPACE_ES, ROOMY_VOLUME)).toBe(
+			false,
+		);
+	});
+
+	test("reports genuine updater bugs", () => {
+		for (const message of [
+			CHECKSUM_MISMATCH,
+			SIGNATURE_FAILURE,
+			FEED_FAILURE,
+		]) {
+			expect(isEnvironmentUpdateError(message, ROOMY_VOLUME)).toBe(false);
+			expect(isEnvironmentUpdateError(message, null)).toBe(false);
+		}
+	});
+
+	test("suppresses every updater failure while the volume is full", () => {
+		expect(isEnvironmentUpdateError(CHECKSUM_MISMATCH, FULL_VOLUME)).toBe(true);
+	});
+
+	test("keeps the existing errno and read-only classifications", () => {
+		expect(
+			isEnvironmentUpdateError(
+				"ENOENT: no such file or directory, rename '/Users/<user>/Library/Caches/superset-updater/pending/x.zip'",
+				ROOMY_VOLUME,
+			),
+		).toBe(true);
+		expect(
+			isEnvironmentUpdateError(
+				"Error: Cannot update while running on a read-only volume",
+				ROOMY_VOLUME,
+			),
+		).toBe(true);
+		expect(
+			isEnvironmentUpdateError(
+				"ENOENT: no such file or directory",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -12,6 +12,18 @@ const UPDATER_PATH_MARKERS = ["-updater", "shipit"];
 // hold one however we behave.
 export const UPDATE_STAGING_MIN_FREE_BYTES = 1024 * 1024 * 1024;
 
+// Failures that are ours no matter what the disk looks like: we served a bad
+// artifact, signed it wrong, or published an unreadable feed. A full volume
+// does not cause any of these, so they must be checked before the free-space
+// heuristic — otherwise a genuine release defect goes unreported for every
+// user who happens to be low on space.
+const UPDATER_DEFECT_PATTERNS = [
+	"checksum mismatch",
+	"code signature",
+	"codesign",
+	"cannot parse update info",
+];
+
 // Update failures owned by the user's machine, not by us. A full volume is the
 // common one, and neither staging tool gives us a code to match: `ditto` prints
 // an errno-free line and Squirrel forwards NSError text localised to the user's
@@ -23,13 +35,18 @@ export function isEnvironmentUpdateError(
 	message: string,
 	freeStagingBytes: number | null,
 ): boolean {
+	const lowerMessage = message.toLowerCase();
+	if (
+		UPDATER_DEFECT_PATTERNS.some((pattern) => lowerMessage.includes(pattern))
+	) {
+		return false;
+	}
 	if (
 		freeStagingBytes !== null &&
 		freeStagingBytes < UPDATE_STAGING_MIN_FREE_BYTES
 	) {
 		return true;
 	}
-	const lowerMessage = message.toLowerCase();
 	if (
 		lowerMessage.includes("read-only volume") ||
 		lowerMessage.includes("the request timed out")

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -1,0 +1,43 @@
+const ENVIRONMENT_ERRNO_CODES = [
+	"ENOENT",
+	"EACCES",
+	"EPERM",
+	"EBUSY",
+	"ENOSPC",
+];
+const UPDATER_PATH_MARKERS = ["-updater", "shipit"];
+
+// Staging an update downloads a ~600MB archive into the user's cache directory
+// and unpacks it alongside itself, so a volume with less than this free cannot
+// hold one however we behave.
+export const UPDATE_STAGING_MIN_FREE_BYTES = 1024 * 1024 * 1024;
+
+// Update failures owned by the user's machine, not by us. A full volume is the
+// common one, and neither staging tool gives us a code to match: `ditto` prints
+// an errno-free line and Squirrel forwards NSError text localised to the user's
+// language, so ask the filesystem how much room is left rather than reading the
+// words. The rest — a corrupt or half-removed updater cache, an app bundle that
+// can't be written, stalled requests — arrive as plain messages without errno
+// properties, so those still match on the text.
+export function isEnvironmentUpdateError(
+	message: string,
+	freeStagingBytes: number | null,
+): boolean {
+	if (
+		freeStagingBytes !== null &&
+		freeStagingBytes < UPDATE_STAGING_MIN_FREE_BYTES
+	) {
+		return true;
+	}
+	const lowerMessage = message.toLowerCase();
+	if (
+		lowerMessage.includes("read-only volume") ||
+		lowerMessage.includes("the request timed out")
+	) {
+		return true;
+	}
+	return (
+		ENVIRONMENT_ERRNO_CODES.some((code) => message.includes(`${code}:`)) &&
+		UPDATER_PATH_MARKERS.some((marker) => lowerMessage.includes(marker))
+	);
+}

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -17,11 +17,16 @@ export const UPDATE_STAGING_MIN_FREE_BYTES = 1024 * 1024 * 1024;
 // does not cause any of these, so they must be checked before the free-space
 // heuristic — otherwise a genuine release defect goes unreported for every
 // user who happens to be low on space.
+// Keep this list ahead of the release-artifact failure modes electron-updater
+// can surface. A missing entry means that defect is silently suppressed for
+// every user low on disk, which is the failure this ordering exists to prevent.
 const UPDATER_DEFECT_PATTERNS = [
-	"checksum mismatch",
+	"checksum", // mismatch, and "doesn't contain nor sha256 neither sha512 checksum"
 	"code signature",
 	"codesign",
 	"cannot parse update info",
+	"cannot find channel",
+	"no files provided",
 ];
 
 // Update failures owned by the user's machine, not by us. A full volume is the


### PR DESCRIPTION
## Problem

macOS auto-update failures caused by a full user disk are captured as Sentry exceptions. They arrive several times a day and can never be archived: the failure message embeds the full per-user staging path, so every occurrence fingerprints as a brand-new issue.

Two further consequences:

- The staging path contains the user's macOS account name, so **the account name lands in the title of a public-facing Sentry issue list**. That alone is reason to stop capturing these, independent of the noise.
- Real update bugs are buried under a daily stream of issues that are not bugs.

## Root cause

`isEnvironmentUpdateError` already existed to keep user-environment update failures out of Sentry, but it only recognised two shapes: a Node errno prefix (`ENOSPC:`, `EACCES:`, …) combined with an updater path marker, or one of two hardcoded English phrases.

Out-of-space failures match neither:

- The extraction step is a macOS command-line tool, not Node, so its message carries **no errno prefix** — just the tool name, the file it was writing, and a description.
- The download step surfaces a Cocoa `NSError`, whose text is **localised to the user's system language**. Evidence so far includes English and Spanish; there is no reason to think that set is closed. The localised variant carries **no path at all**, only an archive filename.

So the guard never fired and the handler captured every one.

## Fix

Classify on a structural signal instead of the message text: on an updater error, `statfs` the volume holding the updater staging caches and treat the failure as environmental when that volume cannot hold a staged update.

- Language-independent — it never reads the message for this case, so it covers every localisation, including ones we have not seen yet.
- Path-independent — it uses the staging directory we already own rather than parsing a path out of user-supplied text. This matters because the localised variant has no path to parse.
- Fails toward visibility — if the volume cannot be queried the reader returns `null` and the error reports as before.

Threshold is 1 GiB. A macOS update downloads a ~600MB archive into the user's cache directory and unpacks it alongside itself, so a volume under 1 GiB free cannot stage one regardless of what our updater does.

I looked for a stronger signal first and there is none. `MacUpdater` forwards Electron's native `autoUpdater` error verbatim (`this.nativeUpdater.on("error", it => this.emit("error", it))`); that error is built from an `NSError` localised description with no `code`, no `errno`, no exit status, and no electron-updater error class. Free space on the staging volume is the most structural signal reachable at this site. **No message-regex matching was added.**

The pure predicate moved to a sibling module so it can be tested without booting the main-process entry point; its existing text branches are unchanged.

### What still reports as a Sentry exception

Everything that is not the named condition, whenever the staging volume has ≥1 GiB free:

- corrupt downloads (sha512 checksum mismatch)
- code-signature verification failures
- feed and manifest errors (404s, unparseable `latest-mac.yml`)
- extraction and staging failures for any reason **other** than space — including the same tool failing with a full disk's message on a volume that is not full

Unchanged from before this PR: read-only-volume failures, `the request timed out`, and errno-plus-updater-path failures remain classified as environmental.

**The tradeoff, stated plainly:** while the volume is under 1 GiB free, *every* updater error is treated as environmental, including a genuine bug that happens to coincide with a full disk. That is deliberate — no update can be staged on such a volume, so no failure on it is actionable for us — but it is broader than "out of space" alone and is pinned by a test so it cannot change silently.

### What is unchanged

This is a classification change only. `log.error` and the `AUTO_UPDATE_STATUS.ERROR` status emitted to the renderer are untouched, so the app still tells the user the update failed with the same message. No `beforeSend` filter, no Sentry-side suppression — the decision stays at the capture site. Nothing about update staging, disk cleanup, or the user's disk-full condition is touched.

## Verification

`bunx biome check` on the changed files:

```
Checked 3 files in 12ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

`bun test apps/desktop/src/main/lib`:

```
 546 pass
 0 fail
 1332 expect() calls
Ran 546 tests across 30 files. [9.70s]
```

The new test pins both captured message shapes (account name and archive digest replaced with placeholders in the fixtures), that both report when the volume has room, that checksum/signature/feed failures still report, and the full-volume tradeoff above.

Refs DESKTOP-W8
Refs DESKTOP-W6
Refs DESKTOP-W5
Refs DESKTOP-W3
Refs DESKTOP-W2
Refs DESKTOP-W0

https://claude.ai/code/session_893897ca-3db6-4631-ba08-967e4ea0b7d5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies macOS auto-update “disk full” failures by free space on the staging volume to stop Sentry issue churn and PII leakage. Previously localized, path-specific errors always captured as new issues; now volumes with <1 GiB free classify as environment, while known `electron-updater` release defects still report regardless of disk state.

- Centralizes classification in `update-error-classification.ts`; `auto-updater.ts` adds `freeStagingBytes()` via `statfsSync(app.getPath("userData"))` and passes it to the predicate. If the volume query fails, we fall back to capture.
- Checks defect patterns first so they always report: checksum mismatch and no-checksum wording, code-signature failures, unreadable feed, “Cannot find channel”, and “No files provided”.
- Keeps prior environment matches (“read-only volume”, “the request timed out”, errno+updater-path markers). No Sentry-side filters; logs and renderer `AUTO_UPDATE_STATUS.ERROR` are unchanged.
- Tests cover English and Spanish disk-full messages and the expanded defect set; confirm defects report even when <1 GiB free, and unknown failures on a full volume still classify as environment.

<sup>Written for commit a81fa98bb91eae923eba6451cdcc92085b657185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved software update reliability when the device has insufficient storage or a read-only drive.
  - Better distinguishes local device conditions from genuine update service failures.
  - Improved handling of update timeouts and common filesystem errors.
  - Recognizes storage-related update failures across English and Spanish error messages.
  - Reduced unnecessary error reporting for failures caused by local storage conditions, helping diagnostics focus on actionable service issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->