### PR TITLE
fix(mobile): stop the attachments carousel painting at corrupted frames

### DIFF
--- a/apps/mobile/TODO.md
+++ b/apps/mobile/TODO.md
@@ -30,10 +30,3 @@ The chat-row context menu (`screens/(authenticated)/(home)/home/components/Sessi
 - Decide fork scope: copy full message history vs. fork-from-a-message; whether the fork stays in the same workspace.
 - After forking, push the new thread route (`/(authenticated)/workspace/<workspaceId>/chat/<newSessionId>`).
 
-## Fix the attachments-sheet photo carousel (SUPER-1199)
-
-https://linear.app/superset-sh/issue/SUPER-1199 — expo-image tiles that mount while the `attachments` formSheet is presenting (or that live through a detent resize) paint at corrupted native frames and never recover. The sheet ships clean/idiomatic with this as a known bug.
-
-- Yoga/onLayout report correct 96×96 frames the whole time; every JS-level fix was disproven (flexShrink, wrappers, inset overrides, `allowDownscaling`, explicit numeric dimensions + overflow crop).
-- First lead: upgrade react-native-screens (bug found on 4.25.2; 4.26.0+ has been landing formSheet/Fabric fixes), then reproduce cold (kill app → relaunch → `superset:///attachments` deep link — fast refresh masks the bug).
-- Verified stop-gaps if needed: defer mounting image tiles until the sheet's `transitionEnd` (fixes presentation, not detent drags), or single detent `[1.0]` so the sheet never resizes.

--- a/apps/mobile/screens/(authenticated)/(home)/attachments/AttachmentsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/attachments/AttachmentsScreen.tsx
@@ -80,7 +80,12 @@ export function AttachmentsScreen() {
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button icon="xmark" onPress={() => router.back()} />
 			</Stack.Toolbar>
-			<View className="pt-3">
+			{/* collapsable={false} keeps RN's view flattening from hoisting these
+			    wrappers' children into the sheet container. react-native-screens
+			    lays a formSheet out expecting at most 2 subviews next to a
+			    ScrollView; flattened to 6 it mis-sizes the carousel's native
+			    frames (SUPER-1199) while Yoga still reports correct boxes. */}
+			<View className="pt-3" collapsable={false}>
 				<PhotoCarousel selected={selected} onToggle={toggleAsset} />
 				<View className="px-5 pt-4">
 					{mainRows.map((row) => (


### PR DESCRIPTION
Fixes SUPER-1199, the known bug recorded in `apps/mobile/TODO.md`.

### Root cause
react-native-screens lays a formSheet out expecting **at most two subviews** alongside a ScrollView. React Native's view flattening was hoisting the attachments screen's wrapper children straight into the sheet container, so it saw six and mis-sized the carousel's native frames. Tiles painted at roughly 60% height with square bottom corners, while Yoga and `onLayout` reported correct 96x96 boxes the entire time, which is why every previous JS-level attempt (flexShrink, wrappers, inset overrides, `allowDownscaling`, explicit dimensions) came back clean.

The library was already warning about it on every present:

```
WARN [RNScreens] FormSheet with ScrollView expects at most 2 subviews.
Got 6 for container: RNSSafeAreaViewComponentView. This might result in
incorrect layout. ... apply `collapsable: false` on your header component view.
```

### Fix
Mark the content wrapper `collapsable={false}` so flattening can't hoist its children. One line plus a comment.

### Verification
Reproduced first, on an iOS 26 simulator against a local stack:

- Tiles mounting **after** presentation (permission card occupies the sheet during the animation, then swaps): correct, full-height squares.
- Tiles mounting **during** presentation (reopen with permission already granted): corrupted, ~60% height, clipped bottom corners.
- After the fix, same journey: correct. Confirmed **cold** as well (kill app, relaunch, open the sheet), since fast refresh masks this, and the subview warning stopped being emitted.

### Notes
The TODO's first lead was upgrading react-native-screens from 4.25.2. That turns out to be unnecessary, which is worth keeping: a native navigation bump across the whole app right before App Store submission is real regression risk for no gain. The single-detent pin in `(home)/_layout.tsx` still covers the other trigger (detent resizes), so I left it alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the attachments carousel from painting at corrupted frames on iOS form sheets. Previously tiles rendered ~60% height with clipped corners during presentation or after detent resizes; now they render at the correct 96×96 by preventing React Native view flattening (fixes Linear SUPER-1199).

**Review notes**
- Set `collapsable={false}` on the content wrapper to keep children from being hoisted; `react-native-screens` form sheets expect at most two subviews next to a ScrollView.
- No dependency upgrades; removed the TODO entry referencing SUPER-1199.
- Verify on cold start and during presentation; the “FormSheet with ScrollView expects at most 2 subviews” warning should disappear and tiles remain square.

<sup>Written for commit ccb1141e51877aa73ec12cde83fafa390c8b6c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the photo carousel layout in the attachments sheet.
  * Prevented layout issues that could cause carousel content to display incorrectly in form sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->