### PR TITLE
feat(desktop): add prompt-cards arm to the new-workspace screen

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -48,6 +48,7 @@ import { newWorkspaceAttachmentPaths } from "renderer/stores/new-workspace-attac
 import { useNewWorkspacePromptContext } from "renderer/stores/new-workspace-prompt-context";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../DashboardNewWorkspaceDraftContext";
+import { useNewWorkspacePromptCardsVariant } from "../../hooks/useNewWorkspacePromptCardsVariant";
 import { DevicePicker } from "../DashboardNewWorkspaceForm/components/DevicePicker";
 import { useWorkspaceHostOptions } from "../DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { CompareBaseBranchPicker } from "../DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker";
@@ -73,6 +74,7 @@ import {
 } from "../DashboardNewWorkspaceForm/PromptGroup/types";
 import { useSelectedHostProjectIds } from "../DashboardNewWorkspaceModalContent/hooks/useSelectedHostProjectIds";
 import { AttachmentCard } from "./components/AttachmentCard";
+import { SamplePromptCards } from "./components/SamplePromptCards";
 import { SamplePrompts } from "./components/SamplePrompts";
 
 interface NewWorkspaceScreenProps {
@@ -332,6 +334,9 @@ export function NewWorkspaceScreen({
 			}) ?? null
 		);
 	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
+
+	const promptCardsVariant = useNewWorkspacePromptCardsVariant(isOpen);
+
 	const { agents: v2Agents, isFetched: v2AgentsFetched } =
 		useV2AgentChoices(launchHostUrl);
 	const selectableAgentIds = useMemo(
@@ -575,7 +580,7 @@ export function NewWorkspaceScreen({
 			</div>
 			<div className="relative flex w-full max-w-[640px] flex-col px-6 pb-8">
 				<AnimatePresence initial={false}>
-					{isPromptEmpty && (
+					{isPromptEmpty && promptCardsVariant !== null && (
 						<motion.div
 							key="sample-prompts"
 							initial={{ opacity: 0, y: 12 }}
@@ -584,7 +589,15 @@ export function NewWorkspaceScreen({
 							transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
 							className="absolute inset-x-6 bottom-full mb-1"
 						>
-							<SamplePrompts onSelect={applyPrompt} />
+							{promptCardsVariant === "test" ? (
+								<SamplePromptCards
+									hostUrl={launchHostUrl}
+									projectId={projectId}
+									onSelect={applyPrompt}
+								/>
+							) : (
+								<SamplePrompts onSelect={applyPrompt} />
+							)}
 						</motion.div>
 					)}
 				</AnimatePresence>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { BookOpenIcon, BugIcon, WrenchIcon } from "lucide-react";
+import { track } from "renderer/lib/analytics";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { SAMPLE_PROMPTS } from "../SamplePrompts/constants";
+
+const CARD_ICONS: Record<string, typeof WrenchIcon> = {
+	"set-up-project": WrenchIcon,
+	"explain-repo": BookOpenIcon,
+	"fix-small-bug": BugIcon,
+};
+
+const CARD_COUNT = 2;
+
+interface SamplePromptCardsProps {
+	hostUrl: string | null;
+	projectId: string | null;
+	onSelect: (prompt: string) => void;
+}
+
+export function SamplePromptCards({
+	hostUrl,
+	projectId,
+	onSelect,
+}: SamplePromptCardsProps) {
+	// Setup takes 75% of all prompt clicks, so it leads — but pitching setup for
+	// a project that already has setup/teardown/run commands reads as noise.
+	// Same query the v2 sidebar setup card uses.
+	const canCheckSetup = Boolean(hostUrl && projectId);
+	const { data: needsSetupScripts, isPending } = useQuery({
+		queryKey: ["host-config", "shouldShowSetupCard", hostUrl, projectId],
+		queryFn: () =>
+			hostUrl && projectId
+				? getHostServiceClientByUrl(hostUrl).config.shouldShowSetupCard.query({
+						projectId,
+					})
+				: false,
+		enabled: canCheckSetup,
+	});
+
+	// Deciding mid-flight would swap a card out from under the pointer.
+	if (canCheckSetup && isPending) return null;
+
+	const cards = SAMPLE_PROMPTS.filter(
+		(sample) => sample.id !== "set-up-project" || needsSetupScripts === true,
+	).slice(0, CARD_COUNT);
+
+	return (
+		<div className="grid grid-cols-2 gap-2 px-1 pb-2">
+			{cards.map((sample) => {
+				const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
+				return (
+					<button
+						key={sample.id}
+						type="button"
+						className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl border-[0.5px] border-border bg-foreground/[0.02] p-3 text-left transition-colors hover:border-foreground/20 hover:bg-foreground/[0.05]"
+						onClick={() => {
+							track("new_workspace_sample_prompt_clicked", {
+								prompt_id: sample.id,
+								layout: "cards",
+							});
+							onSelect(sample.prompt);
+						}}
+					>
+						<Icon className="size-3.5 shrink-0 text-muted-foreground" />
+						<span className="text-sm font-medium text-foreground/90">
+							{sample.label}
+						</span>
+						<span className="text-xs text-muted-foreground">
+							{sample.description}
+						</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/index.ts
@@ -1,0 +1,1 @@
+export { SamplePromptCards } from "./SamplePromptCards";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -17,6 +17,7 @@ export function SamplePrompts({ onSelect }: SamplePromptsProps) {
 					onClick={() => {
 						track("new_workspace_sample_prompt_clicked", {
 							prompt_id: sample.id,
+							layout: "rows",
 						});
 						onSelect(sample.prompt);
 					}}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -1,7 +1,9 @@
 export interface SamplePrompt {
 	id: string;
-	/** Short row label shown in the UI. */
+	/** Short row label shown in the UI, and the card title. */
 	label: string;
+	/** Card-only supporting line; the row layout shows the label alone. */
+	description: string;
 	/** Full instruction inserted into the composer on click. */
 	prompt: string;
 }
@@ -10,17 +12,23 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 	{
 		id: "set-up-project",
 		label: "Set up this project for Superset",
+		description:
+			"Write setup and teardown scripts so every new workspace starts ready to run.",
 		prompt: `Set up this repository to work well with Superset workspaces. Read https://docs.superset.sh/setup-teardown-scripts and create a .superset/config.json with: setup commands that install dependencies and copy untracked files (like .env) from "$SUPERSET_ROOT_PATH" into new workspaces, teardown commands that stop anything setup starts, and a run command that launches the dev server. If parallel workspaces would collide on dev-server ports, make the scripts pick a free port per workspace (see https://docs.superset.sh/ports). When you're done, summarize what you configured and how to use it.`,
 	},
 	{
 		id: "explain-repo",
 		label: "Explain to me how this repository works",
+		description:
+			"Get an architecture tour: entry points, how to run it, what to read first.",
 		prompt:
 			"Explain how this repository works: the overall architecture, the main entry points, how to run it locally, and what I should read first to get productive. Keep it practical and concrete.",
 	},
 	{
 		id: "fix-small-bug",
-		label: "Find a small bug in this codebase and fix it",
+		label: "Find and fix a small bug",
+		description:
+			"Pick a low-risk papercut, fix it, and explain how it was verified.",
 		prompt:
 			"Find a small, low-risk bug or papercut in this codebase and fix it. Keep the change minimal, explain what the bug was, and describe how you verified the fix.",
 	},

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/index.ts
@@ -1,0 +1,1 @@
+export { useNewWorkspacePromptCardsVariant } from "./useNewWorkspacePromptCardsVariant";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
@@ -1,16 +1,20 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import { useLayoutEffect, useState } from "react";
 
 /**
  * Assigns the prompt-cards arm for the new-workspace screen. Same imperative
  * `getFeatureFlag` shape as `useNewWorkspaceScreenVariant`: exposure fires only
  * once the screen is actually open, and only after flags have loaded — reading
- * the flag earlier returns undefined and would show control to a test user.
+ * the flag earlier returns undefined, which would show control to a test user.
  *
- * The override flag short-circuits everything: it forces the cards without ever
- * evaluating the experiment flag, so overridden users (team, dev accounts) emit
- * no exposure and cannot contaminate results.
+ * Both flags are read inside the loaded callback rather than through
+ * `useFeatureFlagEnabled`: that hook returns undefined until its own passive
+ * effect sees the flags, which lands after this layout effect has already run
+ * `getFeatureFlag` and burned an exposure on an overridden user.
+ *
+ * The override short-circuits everything, so team and dev accounts can see the
+ * cards without entering the analysis.
  *
  * Returns null until resolved so the caller can render neither arm for that
  * first frame instead of flashing the rows and swapping to cards.
@@ -19,18 +23,19 @@ export function useNewWorkspacePromptCardsVariant(
 	isOpen: boolean,
 ): "control" | "test" | null {
 	const posthog = usePostHog();
-	const overrideEnabled = useFeatureFlagEnabled(
-		FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE,
-	);
 	const [variant, setVariant] = useState<"control" | "test" | null>(null);
 
 	useLayoutEffect(() => {
 		if (!isOpen) return;
-		if (overrideEnabled) {
-			setVariant("test");
-			return;
-		}
 		const evaluate = () => {
+			if (
+				posthog.isFeatureEnabled(
+					FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE,
+				)
+			) {
+				setVariant("test");
+				return;
+			}
 			const value = posthog.getFeatureFlag(
 				FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS,
 			);
@@ -45,7 +50,7 @@ export function useNewWorkspacePromptCardsVariant(
 			unsubscribe?.();
 			window.clearTimeout(fallback);
 		};
-	}, [isOpen, overrideEnabled, posthog]);
+	}, [isOpen, posthog]);
 
 	return variant;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
@@ -1,0 +1,51 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { useLayoutEffect, useState } from "react";
+
+/**
+ * Assigns the prompt-cards arm for the new-workspace screen. Same imperative
+ * `getFeatureFlag` shape as `useNewWorkspaceScreenVariant`: exposure fires only
+ * once the screen is actually open, and only after flags have loaded — reading
+ * the flag earlier returns undefined and would show control to a test user.
+ *
+ * The override flag short-circuits everything: it forces the cards without ever
+ * evaluating the experiment flag, so overridden users (team, dev accounts) emit
+ * no exposure and cannot contaminate results.
+ *
+ * Returns null until resolved so the caller can render neither arm for that
+ * first frame instead of flashing the rows and swapping to cards.
+ */
+export function useNewWorkspacePromptCardsVariant(
+	isOpen: boolean,
+): "control" | "test" | null {
+	const posthog = usePostHog();
+	const overrideEnabled = useFeatureFlagEnabled(
+		FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE,
+	);
+	const [variant, setVariant] = useState<"control" | "test" | null>(null);
+
+	useLayoutEffect(() => {
+		if (!isOpen) return;
+		if (overrideEnabled) {
+			setVariant("test");
+			return;
+		}
+		const evaluate = () => {
+			const value = posthog.getFeatureFlag(
+				FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS,
+			);
+			setVariant(value === "test" ? "test" : "control");
+		};
+		const unsubscribe = posthog.onFeatureFlags(evaluate);
+		const fallback = window.setTimeout(
+			() => setVariant((current) => current ?? "control"),
+			2000,
+		);
+		return () => {
+			unsubscribe?.();
+			window.clearTimeout(fallback);
+		};
+	}, [isOpen, overrideEnabled, posthog]);
+
+	return variant;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -151,6 +151,26 @@ export const FEATURE_FLAGS = {
 	 */
 	NEW_WORKSPACE_SCREEN_OVERRIDE: "new-workspace-screen-override",
 	/**
+	 * Experiment flag (control/test) nested inside the shipped new-workspace
+	 * screen: control keeps the inline sample-prompt rows, test replaces them
+	 * with two cards above the composer. Prompt text is identical in both arms
+	 * so the comparison isolates presentation. Evaluated when the screen opens,
+	 * like NEW_WORKSPACE_SCREEN, so exposure matches the population that sees it.
+	 *
+	 * Eligibility (new accounts only) is a release condition on the flag, not
+	 * code: a `created_at` person property cutoff, which the renderer sends with
+	 * flag requests at identify time. Existing accounts get `false` back and
+	 * render the rows exactly as they do today, with no exposure recorded.
+	 */
+	NEW_WORKSPACE_PROMPT_CARDS: "new-workspace-prompt-cards",
+	/**
+	 * Boolean override that forces the prompt cards without evaluating the
+	 * experiment flag — no exposure event, so team and dev accounts can look at
+	 * the cards without entering the analysis. Checked before the experiment
+	 * flag, same as NEW_WORKSPACE_SCREEN_OVERRIDE.
+	 */
+	NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE: "new-workspace-prompt-cards-override",
+	/**
 	 * Shows the rebuilt chat pane (ChatV3Pane). UI-only: host-service always
 	 * serves its `/chat-v3/*` routes, so this flag decides who sees the pane,
 	 * not what the host can do — flips take effect live, with no host restart.


### PR DESCRIPTION
Test arm for experiment [419092](https://us.posthog.com/project/264803/experiments/419092): replaces the three low-contrast sample-prompt rows on the new-workspace screen with two bordered cards above the composer.

## Why

Of 837 new accounts that reached this screen between 5 and 13 August, **430 (51.4%) created a real workspace** and **272 added a repo and never started work**. Only 11% ever click a suggested prompt, and 75% of the clicks that do happen land on "Set up this project for Superset" — so that card leads, gated on the project having no setup/teardown/run commands (the same `config.shouldShowSetupCard` query the v2 sidebar card uses).

## Scope

- **Control renders exactly as it does today.** No behavior change for anyone not in the experiment.
- Eligibility is a `created_at` release condition on the flag, not code, so existing accounts get `false`, keep the rows, and record no exposure.
- The variant hook reads the flag imperatively on screen open, so `$feature_flag_called` matches the population that sees the surface rather than everyone who launches the app.
- `new-workspace-prompt-cards-override` forces the cards for team accounts without evaluating the experiment flag, so previewing emits no exposure.
- Prompt text is byte-identical across arms; presentation and one line of card body copy are the only differences.

## Measurement

Primary is activation (`workspace_created` where `type != main`). Secondaries are the prompt click rate as the mediator (tagged `layout: cards | rows`), real workspaces per user, and two guardrails — "came back and worked again" and day-2 app reopen — so a creation lift that comes from nagging doesn't read as a win.

## Do not launch before this ships

Old builds never evaluate the flag, so starting the experiment before a desktop release carrying this code would enroll a pure-control population. At launch, bump the flag's `created_at` cutoff to the actual publish time.

## Checks

`lint:fix`, `typecheck` (37/37) and `sherif` pass. `bun test` reports 154 pre-existing failures locally (real-git integration tests and a missing `electronTRPC` global) — identical counts on a clean tree, so zero delta from this change.

Registry entry: [Experiment Log](https://app.notion.com/p/3bbb9d5bf6168107bb58f222d8cbbf54)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the prompt-cards experiment arm to the new-workspace screen to test whether more prominent suggestions lift activation. Old behavior: three inline sample-prompt rows; new behavior: two bordered cards above the composer when `new-workspace-prompt-cards` is "test"; control unchanged.

- `useNewWorkspacePromptCardsVariant` evaluates on screen open, returns null until flags load to avoid flashing, and reads `new-workspace-prompt-cards-override` before the experiment flag so overridden accounts do not record exposure; falls back to control after 2s if flags don’t load.
- `SamplePromptCards` shows two cards; the “Set up this project for Superset” card appears only when `config.shouldShowSetupCard` is true for the project. Prompt text is identical across arms; cards add icons and a short description.
- Analytics: prompt clicks include `layout: cards | rows`. Exposure matches users who open the screen.
- Eligibility/rollout: use a flag-side `created_at` cutoff (not code). Existing accounts stay on rows with no exposure. Do not start the experiment until a desktop release with this code; at launch, set the flag’s `created_at` to the publish time.
- Adds `NEW_WORKSPACE_PROMPT_CARDS` and `NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE` in packages/shared constants.

<sup>Written for commit da000b0333ca35611ff93fe9718cc113333c7c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable prompt cards when creating a new workspace.
  * Prompt cards can display setup suggestions based on the current workspace context.
  * Added descriptions and improved labels for sample prompts.
  * The prompt-card experience is introduced selectively and falls back to the standard prompt list when unavailable.
* **Analytics**
  * Sample-prompt selections now record the card layout used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->