### PR TITLE
fix(desktop): classify declined commits by git exit status and bound captured failures

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import type { SimpleGitOptions } from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getCurrentBranch } from "../workspaces/utils/git";
@@ -10,6 +11,7 @@ import {
 	isUpstreamMissingError,
 } from "./git-utils";
 import { assertRegisteredWorktree } from "./security/path-validation";
+import { rethrowCommitFailure } from "./utils/commit-failure";
 import {
 	fetchCurrentBranch,
 	getTrackingBranchStatus,
@@ -28,8 +30,11 @@ import { clearWorktreeStatusCaches } from "./utils/worktree-status-caches";
 
 export { isUpstreamMissingError };
 
-async function getGitWithShellPath(worktreePath: string) {
-	return getSimpleGitWithShellPath(worktreePath);
+async function getGitWithShellPath(
+	worktreePath: string,
+	overrides?: Partial<SimpleGitOptions>,
+) {
+	return getSimpleGitWithShellPath(worktreePath, overrides);
 }
 
 /** Runs a git-backed operation, rethrowing environmental git failures
@@ -120,8 +125,23 @@ export const createGitOperationsRouter = () => {
 					assertRegisteredWorktree(input.worktreePath);
 
 					return runGitOperation(async () => {
-						const git = await getGitWithShellPath(input.worktreePath);
-						const result = await git.commit(input.message);
+						// Commits run the user's own hooks, whose output becomes the
+						// failure message. Keep git's exit status for the classifier so
+						// it never has to read that output.
+						let exitCode: number | undefined;
+						const git = await getGitWithShellPath(input.worktreePath, {
+							errors(error, result) {
+								exitCode = result.exitCode;
+								return error;
+							},
+						});
+
+						let result: Awaited<ReturnType<typeof git.commit>>;
+						try {
+							result = await git.commit(input.message);
+						} catch (error) {
+							rethrowCommitFailure(error, exitCode);
+						}
 						clearStatusCacheForWorktree(input.worktreePath);
 						return { success: true, hash: result.commit };
 					});

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import { rethrowCommitFailure, toBoundedCommitFailure } from "./commit-failure";
+
+// Synthesized in the shape simple-git surfaces: a rejected commit's message is
+// the hook program's own stdout/stderr, with nothing of git's in it.
+const HOOK_REJECTION = [
+	"[STARTED] Running tasks for staged files...",
+	"[COMPLETED] lint",
+	"FAIL  src/example/thing.test.ts",
+	"  ● renders the row",
+	"    Expected: 1",
+	"    Received: 0",
+	"error Command failed with exit code 1.",
+].join("\n");
+
+// git's own die() text, which keeps reporting.
+const INDEX_LOCK_FATAL =
+	"fatal: Unable to create '/repo/.git/index.lock': File exists.\n";
+
+function capture(error: unknown, exitCode: number | undefined) {
+	try {
+		rethrowCommitFailure(error, exitCode);
+		return null;
+	} catch (thrown) {
+		return thrown as Error;
+	}
+}
+
+function causeKind(thrown: unknown): string | undefined {
+	return ((thrown as TRPCError | null)?.cause as { kind?: string } | undefined)
+		?.kind;
+}
+
+describe("rethrowCommitFailure", () => {
+	test("classifies a hook-rejected commit as a typed non-500", () => {
+		const thrown = capture(new Error(HOOK_REJECTION), 1);
+		expect(thrown).toBeInstanceOf(TRPCError);
+		expect((thrown as TRPCError).code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("COMMIT_DECLINED");
+	});
+
+	test("keeps the whole hook output for the user on the declined path", () => {
+		const thrown = capture(new Error(HOOK_REJECTION), 1);
+		expect(thrown?.message).toBe(HOOK_REJECTION);
+	});
+
+	test("still reports a genuine git failure", () => {
+		const thrown = capture(new Error(INDEX_LOCK_FATAL), 128);
+		expect(thrown).not.toBeInstanceOf(TRPCError);
+		expect(thrown?.message).toContain("Unable to create");
+	});
+
+	test("classifies environmental failures before wrapping", () => {
+		const thrown = capture(
+			new Error(
+				"fatal: not a git repository (or any of the parent directories)",
+			),
+			128,
+		);
+		expect((thrown as TRPCError).code).toBe("BAD_REQUEST");
+		expect(causeKind(thrown)).toBe("NOT_GIT_REPO");
+	});
+
+	test("passes existing TRPCErrors through untouched", () => {
+		const original = new TRPCError({ code: "BAD_REQUEST", message: "nope" });
+		expect(capture(original, 1)).toBe(original);
+	});
+
+	test("bounds a large reported failure", () => {
+		const huge = new Error(`${INDEX_LOCK_FATAL}${"x".repeat(60_000)}`);
+		const thrown = capture(huge, 128);
+		expect(thrown?.message.length).toBeLessThan(300);
+		expect(thrown?.message).toContain("truncated");
+	});
+});
+
+describe("toBoundedCommitFailure", () => {
+	test("truncates unbounded subprocess output", () => {
+		const bounded = toBoundedCommitFailure(
+			new Error(`${HOOK_REJECTION}\n${"noise ".repeat(20_000)}`),
+		);
+		expect(bounded.message.length).toBeLessThan(300);
+		expect(bounded.message.startsWith("git commit failed: ")).toBe(true);
+	});
+
+	test("drops line breaks so no stack frames survive in the capture", () => {
+		const bounded = toBoundedCommitFailure(
+			new Error("boom\n    at Object.<anonymous> (/repo/src/thing.js:1:1)"),
+		);
+		expect(bounded.message).not.toContain("\n");
+	});
+
+	test("frames short failures without a truncation note", () => {
+		const bounded = toBoundedCommitFailure(new Error(INDEX_LOCK_FATAL));
+		expect(bounded.message).toBe(
+			"git commit failed: fatal: Unable to create '/repo/.git/index.lock': File exists.",
+		);
+	});
+
+	test("handles non-Error throws", () => {
+		expect(toBoundedCommitFailure("plain string").message).toBe(
+			"git commit failed: plain string",
+		);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.ts
@@ -1,0 +1,58 @@
+import { TRPCError } from "@trpc/server";
+import { rethrowEnvironmentalGitError } from "../../workspaces/utils/git-errors";
+
+// git exits 1 when it declines to create the commit — a pre-commit or
+// commit-msg hook rejected it, the message was empty. That lives in the user's
+// repo, not in our code. Git's own hard failures die() with 128, and usage
+// errors exit 129, so the exit status separates the two without reading the
+// text a hook wrote: that text is arbitrary user program output and matching
+// it would classify on the hook author's prose.
+const GIT_COMMIT_DECLINED_EXIT_CODE = 1;
+
+// A commit failure message is whatever the user's hooks printed: task-runner
+// logs, linter and test output, absolute paths, fixture rows. Reported errors
+// must therefore carry our own framing plus a short leading excerpt only, and
+// never the whole stream.
+const CAPTURED_EXCERPT_LIMIT = 200;
+
+/**
+ * Replaces a git failure with one safe to capture: bounded length, no line
+ * breaks (so no stack frames can be parsed back out of the child's output).
+ */
+export function toBoundedCommitFailure(error: unknown): Error {
+	const raw = error instanceof Error ? error.message : String(error);
+	const collapsed = raw.replace(/\s+/g, " ").trim();
+	const excerpt = collapsed.slice(0, CAPTURED_EXCERPT_LIMIT);
+	const truncated = collapsed.length > CAPTURED_EXCERPT_LIMIT;
+	return new Error(
+		truncated
+			? `git commit failed: ${excerpt} (truncated, ${collapsed.length} chars)`
+			: `git commit failed: ${excerpt}`,
+	);
+}
+
+/**
+ * Boundary catch for the commit procedure. `exitCode` is git's own status for
+ * the failed command; a declined commit becomes a typed non-500 keeping git's
+ * full output for the user, and anything still worth reporting is bounded
+ * first so a capture can never carry the child process's stream content.
+ */
+export function rethrowCommitFailure(
+	error: unknown,
+	exitCode: number | undefined,
+): never {
+	if (error instanceof TRPCError) {
+		throw error;
+	}
+	// Before wrapping: a deleted worktree or a non-repo has its own kinds that
+	// consumers branch on, and the outer boundary skips TRPCErrors.
+	rethrowEnvironmentalGitError(error);
+	if (exitCode === GIT_COMMIT_DECLINED_EXIT_CODE) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: error instanceof Error ? error.message : String(error),
+			cause: { kind: "COMMIT_DECLINED" },
+		});
+	}
+	throw toBoundedCommitFailure(error);
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -16,11 +16,18 @@ const execFileAsync = promisify(execFile);
 const SIMPLE_GIT_OPTIONS =
 	USER_GIT_ENV_SIMPLE_GIT_OPTIONS satisfies Partial<SimpleGitOptions>;
 
-function createUserSimpleGit(repoPath?: string): SimpleGit {
+function createUserSimpleGit(
+	repoPath?: string,
+	overrides?: Partial<SimpleGitOptions>,
+): SimpleGit {
+	const options = overrides
+		? { ...SIMPLE_GIT_OPTIONS, ...overrides }
+		: SIMPLE_GIT_OPTIONS;
 	try {
-		return repoPath
-			? simpleGit(repoPath, SIMPLE_GIT_OPTIONS)
-			: simpleGit(SIMPLE_GIT_OPTIONS);
+		if (repoPath) {
+			return simpleGit(repoPath, options);
+		}
+		return simpleGit(options);
 	} catch (error) {
 		throw new GitEnvironmentError(
 			error instanceof Error ? error.message : String(error),
@@ -30,8 +37,9 @@ function createUserSimpleGit(repoPath?: string): SimpleGit {
 
 export async function getSimpleGitWithShellPath(
 	repoPath?: string,
+	overrides?: Partial<SimpleGitOptions>,
 ): Promise<SimpleGit> {
-	const git = createUserSimpleGit(repoPath);
+	const git = createUserSimpleGit(repoPath, overrides);
 	git.env(await getProcessEnvWithShellPath());
 	return git;
 }


### PR DESCRIPTION
Stacked on #6260 (`sentry/git-env-classify`). Merge this **after** #6260.

## Problem

Committing from the Changes tab runs the user's own pre-commit tooling. When that tooling rejects the commit, the git command's entire combined output became the thrown error's message and escaped as an internal-server-error, so it was reported verbatim.

**Privacy dimension (the reason this is escalated over a 1-event issue).** That output is arbitrary text written by user-authored hook programs. In the captured event it ran to hundreds of kilobytes and included task-runner narration, linter and test-runner output, absolute paths inside the user's home directory, a third party's source tree with file and function names, and tabular fixture rows that read like real end-customer records. All of it became the title and body of an issue in our Sentry project, and Sentry parsed a stack trace out of it, so the "culprit" frames were the user's own repository. The tRPC message field was caught by Sentry's scrubber and stored filtered; the exception message itself was not, so the data landed anyway.

## Root cause

Two independent defects on the same path:

1. **Classification.** A failing user hook is a user-environment condition, not a bug in our code, but the commit procedure let the raw failure escape untyped. The middleware reports on status code alone, so an untyped failure is a 500 and a 500 reports.
2. **Unbounded capture.** Even for failures that legitimately keep reporting, nothing bounded what went into the message. Any other git failure on this path would have carried the same kind of payload.

Fixing only (1) would leave (2) live, so both are fixed here.

## Fix

**Classify on git's exit status, not on the hook's prose.** We do not own the producer: the text comes from the git CLI and from arbitrary user hook programs, surfaced through simple-git. Verified against git 2.50.1: when a pre-commit hook rejects a commit, git contributes *no wording of its own*, so there is nothing of git's in the message to match, and matching the hook's output would mean classifying on user-authored text. What git does give us is its exit status, and it is decisive:

| commit outcome | exit |
| --- | --- |
| hook rejected the commit | 1 |
| git `die()` (index.lock held, unreadable cwd, not a repo) | 128 |
| usage error | 129 |

simple-git's `GitError` does not carry the exit code, but its `errors` plugin hook receives it, so the commit procedure now passes an `errors` override that records the status. Exit 1 is classified as `PRECONDITION_FAILED` with `cause: { kind: "COMMIT_DECLINED" }` (read by the new tests, matching the sibling classifiers in this area). Environmental classification from #6260 still runs first so `NOT_GIT_REPO` / `GIT_ENVIRONMENT` keep their kinds.

**Bound the captured message, independently of classification.** Anything on the commit path that still reports is replaced with a fresh `Error` carrying our own framing plus a leading excerpt capped at 200 characters, with whitespace collapsed so no stack frames can be parsed back out of the child's output. The replacement carries no cause chain, so the raw text cannot reach the capture by another route.

**Where the line is drawn, and what the user still sees.** The declined path, which is the one that actually carries hook output, keeps git's message *in full* and unmodified: it is exactly what tells the user why their commit was rejected, and it is a non-500, so it is never captured. Only the reporting path is truncated, and that path carries git's own short `fatal:` diagnostic rather than hook output. Concretely, on a hook rejection producing ~203 KB of output the user still gets all 203 KB in the UI; on an `index.lock` fatal the reported message is 242 characters.

**Which failures on the commit path still report as 500s after this change:** any commit failure that is neither an existing `TRPCError`, nor environmental (`NOT_GIT_REPO` / `GIT_ENVIRONMENT`), nor exit 1. In practice that is git exiting 128 or 129 (index.lock held, corrupt object, bad usage), a failure to spawn git at all, and any bug in the procedure itself. All of them now report with a bounded message.

No Sentry-side suppression, `beforeSend` filter or scrubbing rule is involved; both halves are done at the throw site.

## Verification

`bunx biome check` on the changed files (after `--write` on the test file):

```
$ bunx biome check apps/desktop/src/lib/trpc/routers/changes/git-operations.ts apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.ts apps/desktop/src/lib/trpc/routers/changes/utils/commit-failure.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
Checked 4 files in 7ms. No fixes applied.
```

```
$ cd apps/desktop && bun run typecheck
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

```
$ bun test apps/desktop/src/lib/trpc/routers/changes
bun test v1.3.14 (0d9b296a)
 88 pass
 0 fail
 189 expect() calls
Ran 88 tests across 8 files. [3.02s]
```

Ratchet on on-main-thread git client construction (unchanged in both directions; no allowlisted count was raised):

```
$ bun test apps/desktop/src/no-main-process-blocking.test.ts
bun test v1.3.14 (0d9b296a)
 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [140.00ms]
```

End-to-end against a throwaway repo with a real failing pre-commit hook emitting ~203 KB of synthetic output (scratch script, not committed):

```
=== HOOK REJECTION (exit 1) ===
thrown TRPCError? true code: PRECONDITION_FAILED cause.kind: COMMIT_DECLINED
message length: 202909
=== FATAL (exit 128) ===
thrown TRPCError? false code: undefined cause.kind: undefined
message length: 242
first 120: "git commit failed: fatal: Unable to create '/private/tmp/..."
=== SUCCESS ===
RESULT: { success: true, hash: "8b8da8f25afa867e31329f76371a4cd070cf3510" }
```

Repo-wide `bun run lint` was not run: it hangs on cross-worktree bun locks.

## Tests

New `changes/utils/commit-failure.test.ts` covers a hook rejection classifying as a typed non-500 with the full output preserved, an unrelated genuine git failure still reporting, environmental failures keeping their kinds, and a very large subprocess output being truncated in the thrown message. Fixtures are synthesized; none of the captured content is reproduced.

## Not fixed here

Two other sites interpolate raw subprocess output into errors that can still be captured. Left for a follow-up that batches them rather than widening this diff:

- `apps/desktop/src/lib/trpc/routers/changes/git-operations.ts` `mergePR`, `Failed to merge PR: ${message}` (raw `gh` output into an `INTERNAL_SERVER_ERROR`).
- `apps/desktop/src/lib/trpc/routers/projects/projects.ts` `initGitRepo`, `Failed to create initial commit: ${errorMessage}` (raw git/hook output into a thrown `Error`; this one runs `git commit`, so it can carry hook output too).

The push path already routes hook and remote rejections through `PRECONDITION_FAILED`, so pre-push hook output is not captured.

Refs DESKTOP-TZ

https://claude.ai/code/session_19d115ec-f8f0-4162-a158-db598f0c8ad2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies declined commits by git exit status and bounds reported commit failures to prevent leaking user hook output to Sentry. Previously a hook rejection surfaced as a 500 with the hook’s entire stdout/stderr; now exit 1 returns PRECONDITION_FAILED with cause COMMIT_DECLINED, and other failures report with a short, framed excerpt. Aligns with DESKTOP-TZ privacy requirements.

- Review notes
  - Capture git’s exit code via the `simple-git` `errors` hook and rethrow with `rethrowCommitFailure`; environmental classifiers still run first via `rethrowEnvironmentalGitError`.
  - Replace reportable messages with `toBoundedCommitFailure` (200-char excerpt, whitespace-collapsed).
  - Still reports: git exit 128/129, spawn failures, and internal bugs; all use bounded messages.
  - Touchpoints: `getSimpleGitWithShellPath` and the git client accept `SimpleGitOptions` overrides; tests cover classification and truncation.
  - No Sentry filters or migrations required.

<sup>Written for commit f488a23edcc99739e34bfd60790744ae4c1c83be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

