### PR TITLE
fix(desktop): stop reporting normal renderer exits as errors

### DIFF
--- a/apps/desktop/src/main/lib/renderer-exit.test.ts
+++ b/apps/desktop/src/main/lib/renderer-exit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { isExpectedRendererExit } from "./renderer-exit";
+
+describe("isExpectedRendererExit", () => {
+	test("treats normal lifecycle terminations as expected", () => {
+		expect(isExpectedRendererExit("clean-exit")).toBe(true);
+		expect(isExpectedRendererExit("killed")).toBe(true);
+	});
+
+	// The whole point of the filter is that it must not swallow these.
+	test("keeps reporting every genuine renderer fault", () => {
+		for (const reason of [
+			"crashed",
+			"oom",
+			"launch-failed",
+			"integrity-failure",
+			"abnormal-exit",
+		]) {
+			expect(isExpectedRendererExit(reason)).toBe(false);
+		}
+	});
+
+	test("reports an unrecognised reason rather than assuming it is benign", () => {
+		expect(isExpectedRendererExit("some-future-electron-reason")).toBe(false);
+		expect(isExpectedRendererExit("")).toBe(false);
+	});
+});

--- a/apps/desktop/src/main/lib/renderer-exit.ts
+++ b/apps/desktop/src/main/lib/renderer-exit.ts
@@ -1,0 +1,17 @@
+// Renderer terminations that happen in normal operation: `clean-exit` is the
+// renderer going away on quit, `killed` is a deliberate termination such as a
+// reload or a window teardown. Neither is a crash, and reporting them files an
+// error-level event on ordinary app usage.
+//
+// Everything else — `crashed`, `oom`, `launch-failed`, `integrity-failure`,
+// `abnormal-exit` — is a real fault and must keep reporting.
+const EXPECTED_RENDERER_EXIT_REASONS = new Set(["clean-exit", "killed"]);
+
+/**
+ * Whether a `render-process-gone` reason is ordinary app lifecycle rather than
+ * a crash. Exclude-list on purpose: an unrecognised reason, including one a
+ * future Electron adds, is treated as a fault and still reports.
+ */
+export function isExpectedRendererExit(reason: string): boolean {
+	return EXPECTED_RENDERER_EXIT_REASONS.has(reason);
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -8,6 +8,7 @@ import log from "electron-log/main";
 import { createWindow } from "lib/electron-app/factories/windows/create";
 import { createAppRouter } from "lib/trpc/routers";
 import { localDb } from "main/lib/local-db";
+import { isExpectedRendererExit } from "main/lib/renderer-exit";
 import { NOTIFICATION_EVENTS, PLATFORM } from "shared/constants";
 import {
 	env,
@@ -346,13 +347,19 @@ export async function MainWindow() {
 		// The Sentry SDK's own capture for this event runs off the app-level
 		// listener it registered at init, so it fires before this one and cannot
 		// be tagged retroactively — report the details separately.
-		Sentry.captureMessage(`renderer process gone (${details.reason})`, {
-			level: "error",
-			tags: {
-				renderer_gone_reason: details.reason,
-				renderer_gone_exit_code: String(details.exitCode),
-			},
-		});
+		//
+		// Deliberately an exclude-list, not an allow-list: a reason Electron adds
+		// in a future version reports by default. Silence has to be opted into
+		// one reason at a time, so a new crash mode is never lost to this filter.
+		if (!isExpectedRendererExit(details.reason)) {
+			Sentry.captureMessage(`renderer process gone (${details.reason})`, {
+				level: "error",
+				tags: {
+					renderer_gone_reason: details.reason,
+					renderer_gone_exit_code: String(details.exitCode),
+				},
+			});
+		}
 	});
 
 	window.webContents.on("preload-error", (_event, preloadPath, error) => {


### PR DESCRIPTION
## Problem

#6191 added an error-level `Sentry.captureMessage` on every `render-process-gone`, with no filter on `details.reason`:

```ts
Sentry.captureMessage(`renderer process gone (${details.reason})`, { level: "error", ... });
```

Electron emits that event for `clean-exit` (the renderer going away on quit) and `killed` (reload, window teardown) as well as for real crashes. So once 1.21.0 ships, ordinary app usage files error-level events.

It is unreleased, so there is no production volume yet. That is precisely why it is worth catching now rather than after a release manufactures the noise this automation exists to remove.

Flagged on #6191 by an automated reviewer, verified against the code, and not covered by #6437.

## Root cause

The capture was added without a reason filter. `render-process-gone` is a lifecycle event, not a crash event.

## Fix

`isExpectedRendererExit(reason)` in `main/lib/renderer-exit.ts`, applied at the capture site.

Deliberately an **exclude-list** (`clean-exit`, `killed`) rather than an allow-list of crash reasons: an unrecognised reason — including one a future Electron version introduces — reports by default. Silence has to be opted into one reason at a time, so a new crash mode can never be lost to this filter.

Still reporting: `crashed`, `oom`, `launch-failed`, `integrity-failure`, `abnormal-exit`, and anything unrecognised. The `console.error` and `log.error` lines are untouched, so every termination is still in `main.log` regardless.

## Verification

```
$ bunx biome check apps/desktop/src/main/lib/renderer-exit.ts apps/desktop/src/main/lib/renderer-exit.test.ts apps/desktop/src/main/windows/main.ts
Checked 3 files in 35ms. No fixes applied.

$ bun test apps/desktop/src/main/lib/renderer-exit.test.ts
 3 pass
 0 fail
 9 expect() calls

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit      (clean)
```

No `Refs` line: this fixes an unreleased regression introduced by #6191, so no Sentry issue exists for it — the capture had not shipped to any release yet.

(An earlier revision of this body cited DESKTOP-VW. That was wrong: DESKTOP-VW is a crashpad minidump from a mojo bad-message, raised by the native crash handler, and is unaffected by this JS-side reason filter. It remains archived.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops treating normal Electron renderer exits as errors. Previously we captured an error-level `Sentry.captureMessage` on every `render-process-gone`; now we exclude `clean-exit` and `killed` while still reporting real faults and any unknown reasons. Addresses DESKTOP-VW.

- Adds `isExpectedRendererExit` and guards the capture in `main/windows/main.ts`; new module and tests in `main/lib/renderer-exit.{ts,test.ts}`.
- Exclude-list by design: `crashed`, `oom`, `launch-failed`, `integrity-failure`, `abnormal-exit`, and unrecognized reasons still report.
- Logging unchanged; all terminations continue to appear in `main.log`. No migrations required.
- QA: quit/reload should not create Sentry error events; induce a crash/oom to verify an error event is captured.

<sup>Written for commit 40da8e131cd6f7b778f56ffe56123562e7541c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normal renderer shutdowns and intentional terminations are no longer reported as errors.
  * Unexpected renderer exits continue to be captured with diagnostic details for troubleshooting.

* **Tests**
  * Added coverage for expected, known-fault, unknown, and empty renderer termination reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->