### PR TITLE
fix(api): restore chat session REST routes for released desktop builds

### DIFF
--- a/apps/api/src/app/api/chat/[sessionId]/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/route.ts
@@ -1,0 +1,96 @@
+import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { chatSessions } from "@superset/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+
+// Compatibility shim for released desktop builds (<=1.20.x), which create and
+// rename chat sessions over REST. The durable-streams half of this route is
+// gone; only the session row survives. Delete once those builds drain.
+
+async function requireUserId(request: Request): Promise<string | null> {
+	const session = await auth.api.getSession({ headers: request.headers });
+	return session?.user?.id ?? null;
+}
+
+export async function PUT(
+	request: Request,
+	{ params }: { params: Promise<{ sessionId: string }> },
+): Promise<Response> {
+	const userId = await requireUserId(request);
+	if (!userId) return new Response("Unauthorized", { status: 401 });
+
+	const { sessionId } = await params;
+	const body = (await request.json()) as {
+		organizationId?: string;
+		workspaceId?: string;
+	};
+
+	if (!body.organizationId) {
+		return Response.json(
+			{ error: "organizationId is required" },
+			{ status: 400 },
+		);
+	}
+
+	const [existing] = await db
+		.select({ createdBy: chatSessions.createdBy })
+		.from(chatSessions)
+		.where(eq(chatSessions.id, sessionId))
+		.limit(1);
+	if (existing && existing.createdBy !== userId) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	await db
+		.insert(chatSessions)
+		.values({
+			id: sessionId,
+			organizationId: body.organizationId,
+			createdBy: userId,
+			...(body.workspaceId ? { workspaceId: body.workspaceId } : {}),
+		})
+		.onConflictDoNothing();
+
+	if (body.workspaceId) {
+		await db
+			.update(chatSessions)
+			.set({ workspaceId: body.workspaceId })
+			.where(
+				and(
+					eq(chatSessions.id, sessionId),
+					eq(chatSessions.createdBy, userId),
+					isNull(chatSessions.workspaceId),
+				),
+			);
+	}
+
+	return Response.json(
+		{ sessionId, streamUrl: `/api/chat/${sessionId}/stream` },
+		{ status: 200 },
+	);
+}
+
+export async function PATCH(
+	request: Request,
+	{ params }: { params: Promise<{ sessionId: string }> },
+): Promise<Response> {
+	const userId = await requireUserId(request);
+	if (!userId) return new Response("Unauthorized", { status: 401 });
+
+	const { sessionId } = await params;
+	const body = (await request.json()) as { title?: string };
+
+	if (body.title !== undefined) {
+		const [updated] = await db
+			.update(chatSessions)
+			.set({ title: body.title })
+			.where(
+				and(eq(chatSessions.id, sessionId), eq(chatSessions.createdBy, userId)),
+			)
+			.returning({ id: chatSessions.id });
+
+		if (!updated) return new Response("Not found", { status: 404 });
+	}
+
+	return Response.json({ success: true }, { status: 200 });
+}

--- a/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
@@ -1,0 +1,26 @@
+import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { chatSessions } from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
+
+// Compatibility shim for released desktop builds (<=1.20.x): only the session
+// delete survives. The durable-streams transport this path used to proxy is
+// gone, so GET/POST are not restored. Delete once those builds drain.
+
+export async function DELETE(
+	request: Request,
+	{ params }: { params: Promise<{ sessionId: string }> },
+): Promise<Response> {
+	const session = await auth.api.getSession({ headers: request.headers });
+	const userId = session?.user?.id;
+	if (!userId) return new Response("Unauthorized", { status: 401 });
+
+	const { sessionId } = await params;
+	await db
+		.delete(chatSessions)
+		.where(
+			and(eq(chatSessions.id, sessionId), eq(chatSessions.createdBy, userId)),
+		);
+
+	return Response.json({ success: true }, { status: 200 });
+}


### PR DESCRIPTION
## The regression
Deleting the cloud-chat REST path in #6328 broke chat **session creation on every released desktop build**. `PUT /api/chat/:sessionId` now 404s.

**Production evidence (PostHog, since the deploy at ~15:00 UTC Aug 12):**
- `chat_error` went from ~0-20/day to **324 (Aug 12) → 433 (Aug 13)**
- **~100 unique users affected**; 86 unique users on Aug 13 alone vs 0 the days before
- 100% of errors are `operation: session.create`, all HTTP 404, across versions **1.15.0 → 1.20.2**
- Onset is exactly the deploy hour

Chat messaging itself keeps working (`chat_message_sent` flat at ~350/day, 54/day from older builds), so the user-visible symptom is a failed-session toast and retry churn rather than a full outage — but it's real, ours, and hitting everyone on a released build.

## The fix
Restores the session-record routes as thin DB shims: `PUT` (create, idempotent, with the workspace-id backfill the old route had), `PATCH` (rename), and `DELETE` (remove). The durable-streams half is **not** restored — that service is gone and isn't coming back.

Auth is the same session check as before; ownership is still enforced (`createdBy`), so the shim can't touch another user's session.

## Lifetime
Delete once pre-1.21 builds drain — tracked alongside the other compat shims in #6328's PR-2 checklist. The version telemetry from #6331 (`api_procedure_called`) is what will tell us when.

## Not in this PR (investigated, not ours)
A 400-status `electric_sync_stopped` spike hit 422 users in a 90-second window at 02:04 UTC Aug 13 — every client shared one cursor with `expired_handle` rotation, i.e. Electric Cloud invalidating shape handles globally, which our unchanged client treats as terminal. Argues for finishing the stable ramp, not for a code change here.

https://claude.ai/code/session_01Rq18Ske93pkaTqTHByebtq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores chat session REST routes to fix a regression where `PUT /api/chat/:sessionId` returned 404 on desktop builds 1.15–1.20.x after the cloud-chat path removal. Old behavior: 404 and failed-session toasts; new behavior: 200 with idempotent session creation and workspace backfill; messaging remains unaffected and durable-streams are not restored.

**Review and rollout**
- Adds `PUT /api/chat/:sessionId` (create/idempotent), `PATCH /api/chat/:sessionId` (rename), and `DELETE /api/chat/:sessionId/stream` (remove). GET/POST on `/stream` are not restored.
- Auth via `@superset/auth/server` session; enforces ownership by `createdBy`. Uses `@superset/db` and `drizzle-orm`.
- Backfills `workspaceId` only when previously null; `PUT` responds with `{ sessionId, streamUrl }`.
- No client changes required; restores compatibility for ≤1.20.x desktop builds.
- Temporary shim; remove after pre-1.21 builds drain. Use `api_procedure_called` telemetry to decide timing.

<sup>Written for commit 42e4f365f0512a3adea1f23159efbde52d02fa4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

