### PR TITLE
fix(admin): stop blocking dashboard tiles on PostHog insight recomputes

### DIFF
--- a/apps/admin/src/app/(dashboard)/components/HogQLLineTile/HogQLLineTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/HogQLLineTile/HogQLLineTile.tsx
@@ -11,14 +11,11 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@superset/ui/chart";
-import { useQuery } from "@tanstack/react-query";
 import { Bar, ComposedChart, Line, XAxis, YAxis } from "recharts";
-import { useTRPC } from "@/trpc/react";
 
+import { useInsightResults } from "../../hooks/useInsightResults";
 import { makeDateAxis } from "../../utils/chartAxis";
 import { InsightTileFrame } from "../InsightTileFrame";
-
-const STALE_TIME_MS = 10 * 60 * 1000;
 
 // Renders a saved HogQL (DataVisualizationNode) insight whose result is an
 // array of rows. Column order is part of the canonical definition in PostHog,
@@ -47,13 +44,7 @@ export function HogQLLineTile({
 	xColumn,
 	series,
 }: HogQLLineTileProps) {
-	const trpc = useTRPC();
-	const query = useQuery(
-		trpc.analytics.getInsightResults.queryOptions(
-			{ insight },
-			{ staleTime: STALE_TIME_MS },
-		),
-	);
+	const query = useInsightResults(insight);
 
 	const rows = Array.isArray(query.data?.result)
 		? (query.data.result as unknown[][]).filter(Array.isArray)
@@ -82,7 +73,7 @@ export function HogQLLineTile({
 			title={query.data?.name ?? insight}
 			description={description}
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading}
+			isLoading={query.isLoading || query.data?.pending}
 			error={query.error}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS[insight]}`}
 			onRefresh={() => query.refetch()}

--- a/apps/admin/src/app/(dashboard)/components/HogQLLineTile/HogQLLineTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/HogQLLineTile/HogQLLineTile.tsx
@@ -73,7 +73,7 @@ export function HogQLLineTile({
 			title={query.data?.name ?? insight}
 			description={description}
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading || query.data?.pending}
+			isLoading={query.isLoading || query.data?.result == null}
 			error={query.error}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS[insight]}`}
 			onRefresh={() => query.refetch()}

--- a/apps/admin/src/app/(dashboard)/components/PostHogFunnelTile/PostHogFunnelTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/PostHogFunnelTile/PostHogFunnelTile.tsx
@@ -44,7 +44,7 @@ export function PostHogFunnelTile() {
 			title={insight.data?.name ?? "New-user activation"}
 			description="First sign-in view → auth → onboarding → real workspace (last 7d, 2d window)"
 			steps={data}
-			isLoading={insight.isLoading || insight.data?.pending}
+			isLoading={insight.isLoading || insight.data?.result == null}
 			error={insight.error}
 			headerAction={
 				<div className="flex items-center gap-1">

--- a/apps/admin/src/app/(dashboard)/components/PostHogFunnelTile/PostHogFunnelTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/PostHogFunnelTile/PostHogFunnelTile.tsx
@@ -6,14 +6,10 @@ import {
 } from "@superset/trpc/insight-registry";
 import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
-import { useQuery } from "@tanstack/react-query";
 import { LuExternalLink, LuRefreshCw } from "react-icons/lu";
 
-import { useTRPC } from "@/trpc/react";
-
+import { useInsightResults } from "../../hooks/useInsightResults";
 import { FunnelChart } from "../FunnelChart";
-
-const STALE_TIME_MS = 10 * 60 * 1000;
 
 interface PostHogFunnelStep {
 	name: string;
@@ -31,13 +27,7 @@ const STEP_NAME_OVERRIDES: Record<number, string> = {
 };
 
 export function PostHogFunnelTile() {
-	const trpc = useTRPC();
-	const insight = useQuery(
-		trpc.analytics.getInsightResults.queryOptions(
-			{ insight: "activationFunnel" },
-			{ staleTime: STALE_TIME_MS },
-		),
-	);
+	const insight = useInsightResults("activationFunnel");
 
 	const steps = Array.isArray(insight.data?.result)
 		? (insight.data.result as PostHogFunnelStep[])
@@ -54,7 +44,7 @@ export function PostHogFunnelTile() {
 			title={insight.data?.name ?? "New-user activation"}
 			description="First sign-in view → auth → onboarding → real workspace (last 7d, 2d window)"
 			steps={data}
-			isLoading={insight.isLoading}
+			isLoading={insight.isLoading || insight.data?.pending}
 			error={insight.error}
 			headerAction={
 				<div className="flex items-center gap-1">

--- a/apps/admin/src/app/(dashboard)/components/RetentionGridTile/RetentionGridTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/RetentionGridTile/RetentionGridTile.tsx
@@ -4,10 +4,7 @@ import {
 	ADMIN_INSIGHTS,
 	POSTHOG_PROJECT_URL,
 } from "@superset/trpc/insight-registry";
-import { useQuery } from "@tanstack/react-query";
-
-import { useTRPC } from "@/trpc/react";
-
+import { useInsightResults } from "../../hooks/useInsightResults";
 import { formatDay } from "../../utils/chartAxis";
 import {
 	type CohortCellState,
@@ -16,7 +13,6 @@ import {
 } from "../CohortGrid";
 import { InsightTileFrame } from "../InsightTileFrame";
 
-const STALE_TIME_MS = 10 * 60 * 1000;
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface RetentionCohortResult {
@@ -37,13 +33,7 @@ function cellState(
 }
 
 export function RetentionGridTile() {
-	const trpc = useTRPC();
-	const query = useQuery(
-		trpc.analytics.getInsightResults.queryOptions(
-			{ insight: "cohortRetention" },
-			{ staleTime: STALE_TIME_MS },
-		),
-	);
+	const query = useInsightResults("cohortRetention");
 
 	const cohorts = Array.isArray(query.data?.result)
 		? (query.data.result as RetentionCohortResult[]).filter((c) =>
@@ -107,7 +97,7 @@ export function RetentionGridTile() {
 			title={query.data?.name ?? "Cohort retention"}
 			description="Weekly cohorts by first real workspace; % returning with another workspace each week"
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading}
+			isLoading={query.isLoading || query.data?.pending}
 			error={query.error}
 			empty={cohorts.length === 0}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS.cohortRetention}`}

--- a/apps/admin/src/app/(dashboard)/components/RetentionGridTile/RetentionGridTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/RetentionGridTile/RetentionGridTile.tsx
@@ -97,7 +97,7 @@ export function RetentionGridTile() {
 			title={query.data?.name ?? "Cohort retention"}
 			description="Weekly cohorts by first real workspace; % returning with another workspace each week"
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading || query.data?.pending}
+			isLoading={query.isLoading || query.data?.result == null}
 			error={query.error}
 			empty={cohorts.length === 0}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS.cohortRetention}`}

--- a/apps/admin/src/app/(dashboard)/components/TrendSeriesTile/TrendSeriesTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/TrendSeriesTile/TrendSeriesTile.tsx
@@ -85,7 +85,7 @@ export function TrendSeriesTile({
 			title={query.data?.name ?? insight}
 			description={description}
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading || query.data?.pending}
+			isLoading={query.isLoading || query.data?.result == null}
 			error={query.error}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS[insight]}`}
 			onRefresh={() => query.refetch()}

--- a/apps/admin/src/app/(dashboard)/components/TrendSeriesTile/TrendSeriesTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/TrendSeriesTile/TrendSeriesTile.tsx
@@ -11,15 +11,11 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@superset/ui/chart";
-import { useQuery } from "@tanstack/react-query";
 import { Line, LineChart, XAxis, YAxis } from "recharts";
 
-import { useTRPC } from "@/trpc/react";
-
+import { useInsightResults } from "../../hooks/useInsightResults";
 import { makeDateAxis } from "../../utils/chartAxis";
 import { InsightTileFrame } from "../InsightTileFrame";
-
-const STALE_TIME_MS = 10 * 60 * 1000;
 
 // Renders TrendsQuery / funnel-trends insight results: an array of series,
 // each carrying parallel `data` values and `labels`/`days` for the x axis.
@@ -48,13 +44,7 @@ export function TrendSeriesTile({
 	valueSuffix,
 	dashIncompleteLast,
 }: TrendSeriesTileProps) {
-	const trpc = useTRPC();
-	const query = useQuery(
-		trpc.analytics.getInsightResults.queryOptions(
-			{ insight },
-			{ staleTime: STALE_TIME_MS },
-		),
-	);
+	const query = useInsightResults(insight);
 
 	const series = Array.isArray(query.data?.result)
 		? (query.data.result as TrendSeries[]).filter((s) => Array.isArray(s.data))
@@ -95,7 +85,7 @@ export function TrendSeriesTile({
 			title={query.data?.name ?? insight}
 			description={description}
 			lastRefresh={query.data?.lastRefresh}
-			isLoading={query.isLoading}
+			isLoading={query.isLoading || query.data?.pending}
 			error={query.error}
 			href={`${POSTHOG_PROJECT_URL}/insights/${ADMIN_INSIGHTS[insight]}`}
 			onRefresh={() => query.refetch()}

--- a/apps/admin/src/app/(dashboard)/hooks/useInsightResults/index.ts
+++ b/apps/admin/src/app/(dashboard)/hooks/useInsightResults/index.ts
@@ -1,0 +1,1 @@
+export { useInsightResults } from "./useInsightResults";

--- a/apps/admin/src/app/(dashboard)/hooks/useInsightResults/useInsightResults.ts
+++ b/apps/admin/src/app/(dashboard)/hooks/useInsightResults/useInsightResults.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import type { AdminInsightKey } from "@superset/trpc/insight-registry";
+import { useQuery } from "@tanstack/react-query";
+
+import { useTRPC } from "@/trpc/react";
+
+const STALE_TIME_MS = 10 * 60 * 1000;
+const PENDING_POLL_MS = 3 * 1000;
+
+// PostHog returns its cached result right away and recomputes stale insights in
+// the background, so a cold insight comes back `pending` with no result yet.
+// Poll until it lands instead of holding the request open for the recompute.
+export function useInsightResults(insight: AdminInsightKey) {
+	const trpc = useTRPC();
+	return useQuery(
+		trpc.analytics.getInsightResults.queryOptions(
+			{ insight },
+			{
+				staleTime: STALE_TIME_MS,
+				refetchInterval: (q) =>
+					q.state.data?.pending ? PENDING_POLL_MS : false,
+			},
+		),
+	);
+}

--- a/packages/trpc/src/lib/posthog-client.ts
+++ b/packages/trpc/src/lib/posthog-client.ts
@@ -36,6 +36,7 @@ export async function fetchInsightResults(
 			name: string | null;
 			short_id: string;
 			last_refresh: string | null;
+			query_status: { complete?: boolean; error?: boolean } | null;
 			result: unknown;
 		}>;
 	};
@@ -45,11 +46,20 @@ export async function fetchInsightResults(
 		throw new Error(`PostHog insight not found: ${shortId}`);
 	}
 
+	// Past cache_target_age PostHog hands back the stale result *and* a live
+	// query_status for the recompute it just started, so the result being
+	// present is not on its own a sign that there is nothing left to wait for.
+	const recomputing = Boolean(
+		insight.query_status &&
+			!insight.query_status.complete &&
+			!insight.query_status.error,
+	);
+
 	return {
 		name: insight.name ?? "",
 		shortId: insight.short_id,
 		lastRefresh: insight.last_refresh,
-		pending: insight.result == null,
+		pending: insight.result == null || recomputing,
 		result: insight.result,
 	};
 }

--- a/packages/trpc/src/lib/posthog-client.ts
+++ b/packages/trpc/src/lib/posthog-client.ts
@@ -4,16 +4,21 @@ export interface InsightResults {
 	name: string;
 	shortId: string;
 	lastRefresh: string | null;
+	// PostHog is recomputing and had nothing cached to serve; the caller polls
+	// until a result lands.
+	pending: boolean;
 	result: unknown;
 }
 
-// No app-side cache: refresh=blocking serves PostHog's own result cache when
-// fresh and recomputes only past its refresh throttle (~15 min).
+// No app-side cache: refresh=lazy_async serves PostHog's own result cache and
+// recomputes in the background past its refresh throttle (~15 min). It must
+// stay async — the heavy HogQL insights take 15-20s to recompute, and
+// refresh=blocking held the request open for all of it.
 export async function fetchInsightResults(
 	shortId: string,
 ): Promise<InsightResults> {
 	const response = await fetch(
-		`${env.POSTHOG_API_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/insights/?short_id=${shortId}&refresh=blocking`,
+		`${env.POSTHOG_API_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/insights/?short_id=${shortId}&refresh=lazy_async`,
 		{
 			headers: {
 				Authorization: `Bearer ${env.POSTHOG_API_KEY}`,
@@ -44,6 +49,7 @@ export async function fetchInsightResults(
 		name: insight.name ?? "",
 		shortId: insight.short_id,
 		lastRefresh: insight.last_refresh,
+		pending: insight.result == null,
 		result: insight.result,
 	};
 }

--- a/packages/trpc/src/lib/posthog-client.ts
+++ b/packages/trpc/src/lib/posthog-client.ts
@@ -36,7 +36,11 @@ export async function fetchInsightResults(
 			name: string | null;
 			short_id: string;
 			last_refresh: string | null;
-			query_status: { complete?: boolean; error?: boolean } | null;
+			query_status: {
+				complete?: boolean;
+				error?: boolean;
+				error_message?: string | null;
+			} | null;
 			result: unknown;
 		}>;
 	};
@@ -46,20 +50,24 @@ export async function fetchInsightResults(
 		throw new Error(`PostHog insight not found: ${shortId}`);
 	}
 
-	// Past cache_target_age PostHog hands back the stale result *and* a live
-	// query_status for the recompute it just started, so the result being
-	// present is not on its own a sign that there is nothing left to wait for.
-	const recomputing = Boolean(
-		insight.query_status &&
-			!insight.query_status.complete &&
-			!insight.query_status.error,
-	);
+	const status = insight.query_status;
+
+	// A failed query is terminal — retrying means starting a new one, so polling
+	// this one would spin forever behind a skeleton. Surface it instead.
+	if (status?.error) {
+		throw new Error(
+			`PostHog insight ${shortId}: ${status.error_message ?? "query failed"}`,
+		);
+	}
 
 	return {
 		name: insight.name ?? "",
 		shortId: insight.short_id,
 		lastRefresh: insight.last_refresh,
-		pending: insight.result == null || recomputing,
+		// Past cache_target_age PostHog hands back the stale result *and* a live
+		// query_status for the recompute it just started, so a present result is
+		// not on its own a sign that there is nothing left to wait for.
+		pending: insight.result == null || (status != null && !status.complete),
 		result: insight.result,
 	};
 }


### PR DESCRIPTION
## Problem

Every insight tile fetched its saved insight with `refresh=blocking`, which holds the HTTP request open while PostHog recomputes the insight. Timed against the real project on a cold cache:

| insight | cold |
|---|---|
| activeOrgs | **20.3s** |
| activatedRate | **15.2s** |
| newSiteVisitors | **9.4s** |
| the other seven | 0.3–1.0s |

Past PostHog's ~15min refresh throttle, loading the Product tab meant a 20s blocking request.

## Fix

`refresh=blocking` → `refresh=lazy_async`. PostHog serves its cached result immediately and kicks off the recompute in the background. A genuinely cold insight returns no result yet, so `fetchInsightResults` reports `pending` and the tile polls until it lands — the same idiom `getMrr` already uses for Stripe Sigma.

The `staleTime` + pending-poll wiring is now one `useInsightResults` hook rather than the identical query block repeated in all four insight tiles.

## Measurement

Against the local API with all five Product-tab insights forced to recompute, transport unchanged in both runs:

```
before (refresh=blocking) — total 18.0s
  + 4.55s  WAU
  + 4.83s  DAU
  + 4.95s  workspacesPerCreator
  + 9.01s  activatedRate
  +18.05s  activeOrgs

after (refresh=lazy_async) — total 0.85s
  all five tiles landed between +0.80s and +0.85s
```

## Notes

- Tiles now paint last-known numbers first and update when the recompute lands. The tile header already shows `lastRefresh`, so staleness stays visible.
- I also checked whether the tRPC batch link was coupling tiles together. It isn't — `httpBatchStreamLink` streams each result as it resolves (visible in the before-run above, where the fast tiles landed at ~4.5s while activeOrgs was still running). No transport change needed.
- Two adjacent things left alone: `getEnterpriseArr` fetches Stripe subscriptions serially in a loop, and the business tiles have no `staleTime` so they re-run Mercury/Stripe/cohort queries on window refocus.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops blocking admin dashboard tiles on PostHog recomputes. Old behavior held requests with `refresh=blocking`; new behavior uses `refresh=lazy_async` to return cached results immediately and poll during recompute, keeping stale charts visible.

- Adds `useInsightResults(insight)` with `staleTime=10m`; polls every 3s while `pending`.
- `fetchInsightResults` now uses `refresh=lazy_async`; sets `pending` when no `result` or `query_status` is incomplete; throws on `query_status.error` so tiles show an error instead of polling forever.
- Tiles (`HogQLLineTile`, `TrendSeriesTile`, `RetentionGridTile`, `PostHogFunnelTile`) adopt the hook; show a skeleton only when no result exists; stale numbers stay rendered and update when recompute lands; `lastRefresh` remains visible.
- Product tab cold recomputes improve from ~18s to ~0.85s for the last tile to land.

<sup>Written for commit 566daf854ec888ff21657b0f5c41c4db60900df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics insight tiles now share consistent result loading and refresh behavior.
  - Results automatically update while insights are being recalculated, with refreshes continuing until current data is available.
  - Insight results are reused briefly to improve responsiveness and reduce unnecessary reloads.

- **Bug Fixes**
  - Tiles no longer appear complete while results are still pending.
  - Stale results are clearly treated as pending during background recomputation, preventing misleading displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->