### PR TITLE
fix(mobile): pre-generate worklets output so EAS builds can bundle

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,8 @@
 		"test": "bun test --pass-with-no-tests",
 		"typecheck": "tsc --noEmit",
 		"lint": "biome check .",
-		"lint:fix": "biome check --write ."
+		"lint:fix": "biome check --write .",
+		"eas-build-post-install": "bash ./scripts/warm-worklets.sh"
 	},
 	"dependencies": {
 		"@better-auth/expo": "1.6.22",

--- a/apps/mobile/scripts/warm-worklets.sh
+++ b/apps/mobile/scripts/warm-worklets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-generates react-native-worklets Bundle Mode output so the real bundle
+# step can resolve it.
+#
+# The worklets Babel plugin writes node_modules/react-native-worklets/.worklets/
+# <hash>.js *during* transform and emits imports pointing at them. Metro
+# snapshots its file map at startup, so a file created mid-transform isn't in
+# that map and `getOrComputeSha1` throws:
+#
+#   Failed to get the SHA-1 for: .../react-native-worklets/.worklets/<hash>.js
+#
+# Locally the files survive in node_modules, so only the first run after a wipe
+# is affected. EAS installs fresh every build, so its first bundle always loses
+# the race and the build fails. Each pass writes more of the set and fails on
+# the next missing one, so a few throwaway exports converge (measured: 3).
+#
+# Metro's transform cache suppresses the plugin on warm runs, hence --clear on
+# the first pass; without it the plugin never runs and nothing is written.
+set -u
+
+ATTEMPTS=${WORKLETS_WARMUP_ATTEMPTS:-4}
+OUT_DIR=$(mktemp -d)
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+for i in $(seq 1 "$ATTEMPTS"); do
+	CLEAR=""
+	[ "$i" = "1" ] && CLEAR="--clear"
+	# shellcheck disable=SC2086
+	if npx expo export --platform ios --output-dir "$OUT_DIR/pass-$i" $CLEAR >/dev/null 2>&1; then
+		echo "[warm-worklets] bundle succeeded on pass $i"
+		exit 0
+	fi
+	echo "[warm-worklets] pass $i did not complete; retrying"
+done
+
+# Don't fail the build: the real bundle step reports the actual error, and this
+# is only a warm-up. If it never converged, that step will say so.
+echo "[warm-worklets] did not converge in $ATTEMPTS passes; continuing"
+exit 0


### PR DESCRIPTION
Production iOS builds have **never** succeeded. The Bundle JavaScript phase dies with:

```
Failed to get the SHA-1 for: .../react-native-worklets/.worklets/<hash>.js
```

### Root cause

The worklets Babel plugin (Bundle Mode, used by `react-native-streamdown`) writes `.worklets/<hash>.js` into `node_modules/react-native-worklets/` **during** transform and emits imports pointing at them. Metro snapshots its file map at startup, so a file created mid-transform isn't in the map and `getOrComputeSha1` throws.

Locally the files persist in `node_modules`, so only the first run after a wipe is affected — which is why this looked fine to everyone. EAS installs fresh on every build, so its first bundle always loses the race.

Two details that made this confusing:

- **Metro's transform cache suppresses the plugin on warm runs.** Retrying without `--clear` writes nothing at all, so the obvious "just run it twice" fix silently does nothing. With `--clear`, one pass wrote 507 files.
- **Each pass fails on a different hash.** It converges gradually rather than all at once, which is how long-lived local checkouts accumulate the full set (a sibling worktree here had 524).

### Fix

An `eas-build-post-install` hook runs bounded throwaway exports to populate `.worklets` before the real bundle step. It never fails the build — if it doesn't converge, the real bundle step reports the genuine error rather than this one masking it.

### Verification

Wiped `.worklets` down to the shipped `dummy.md` to simulate a fresh EAS install, then:

- Hook converged on **pass 3 in 48s**, producing 510 files.
- The exact command EAS runs — `expo export:embed --eager --platform ios --dev false` — then produced a **16MB bundle with no error**.

Cost is ~50s of build time.

### Note

This is pre-existing and unrelated to the recent Expo batch alignment (#6455) or the carousel fix (#6449); the last green iOS build was a July simulator build on the `e2e-test` profile, which skips this phase. A cleaner long-term fix would be upstream (Metro learning about transform-time file creation) or dropping Bundle Mode, but this unblocks builds without touching either.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-generates `react-native-worklets` Bundle Mode output during EAS iOS builds so Metro can resolve imports and complete bundling. Previously, production iOS bundles failed because the plugin wrote `.worklets/<hash>.js` during transform after Metro snapshotted its file map; now we warm those files first, trading ~50s build time for reliable bundles.

**Review and rollout**
- Adds `eas-build-post-install` in `apps/mobile/package.json` to run `scripts/warm-worklets.sh`.
- The script runs up to 4 `expo export` passes for iOS (first with `--clear`) to populate `node_modules/react-native-worklets/.worklets`, then exits success even if not converged; the real bundle step surfaces any genuine errors.
- Expected effect: EAS iOS bundling succeeds; Android and local dev unchanged.
- You can tune passes via `WORKLETS_WARMUP_ATTEMPTS`.

<sup>Written for commit ac1eccf4a0a2f859f3063f3788438a267e2472ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved iOS build preparation by pre-generating required animation and worklet artifacts after cloud builds.
  * Added automatic retries and cleanup to make this preparation more reliable without affecting the main build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->