### PR TITLE
fix(codex): remove unsupported MCP transport types

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,7 @@
 [mcp_servers.superset]
-type = "sse"
 url = "https://api.superset.sh/api/v2/agent/mcp"
 
 [mcp_servers.expo-mcp]
-type = "sse"
 url = "https://mcp.expo.dev/mcp"
 enabled = false
 
@@ -12,13 +10,10 @@ command = "maestro"
 args = ["mcp"]
 
 [mcp_servers.neon]
-type = "sse"
 url = "https://mcp.neon.tech/mcp"
 
 [mcp_servers.linear]
-type = "sse"
 url = "https://mcp.linear.app/mcp"
 
 [mcp_servers.sentry]
-type = "sse"
 url = "https://mcp.sentry.dev/mcp"


### PR DESCRIPTION
## What & why

Remove the legacy `type = "sse"` fields from the project-scoped Codex MCP configuration.

Current Codex configures Streamable HTTP MCP servers from their `url` and rejects the legacy transport field. Removing it lets contributors load the bundled Superset, Expo, Neon, Linear, and Sentry MCP entries without a configuration schema error while preserving every endpoint and enabled state.

Reference: https://learn.chatgpt.com/docs/extend/mcp?surface=cli

## How I tested it

- `bun run lint:fix` — passed
- `bun run lint` — passed
- Parsed `.codex/config.toml` with Python `tomllib` — passed
- Loaded the URL-only entries with `codex mcp list` — passed; all five remote servers were recognized
- `bun run typecheck` — blocked by a pre-existing `@types/hast` 3.0.4/3.0.5 type conflict in `packages/ui`
- `bun run test` — blocked by a pre-existing timeout in `packages/workspace-fs/src/watch-pathtypes-growth.test.ts`; the isolated rerun failed at the same watcher condition

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (lint passes; typecheck has the unrelated failure documented above)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unsupported MCP transport declarations from the Codex project config so bundled MCP servers load without schema errors. Previously each server declared `type = "sse"`; now Codex infers Streamable HTTP from `url` and rejects `type`, preserving endpoints and enabled flags.

**Reviewer notes**
- Changed only `.codex/config.toml`: removed `type = "sse"` from `superset`, `expo-mcp` (disabled), `neon`, `linear`, and `sentry`.
- Validate with `codex mcp list`; the same five servers should appear with their prior enabled state. No migration required; omit `type` in new MCP entries.

<sup>Written for commit 87f7aa2cb8b519150364e59d56926b38eaaab0ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration entries while retaining existing server URLs and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->