### PR TITLE
fix(mobile): patch metro so release bundles can hash Bundle Mode worklets

### DIFF
--- a/apps/mobile/metro-worklets-patch.test.ts
+++ b/apps/mobile/metro-worklets-patch.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Guards the bun patch on metro (patches/README.md). Without it, every cold
+// release bundle — `expo export`, and so every EAS build — dies with "Failed to
+// get the SHA-1" for a Bundle Mode worklet file. patchedDependencies is keyed to
+// an exact version, so bumping metro (an Expo SDK bump will) silently drops the
+// patch and the store build breaks again. If this fails after a bump, pull the
+// matching patch per patches/README.md; do NOT delete the test.
+describe("metro Bundle Mode SHA-1 patch", () => {
+	const source = readFileSync(
+		join(
+			dirname(require.resolve("metro/package.json")),
+			"src/node-haste/DependencyGraph.js",
+		),
+		"utf8",
+	);
+
+	test("short-circuits SHA-1 for generated .worklets modules", () => {
+		expect(source).toContain('"react-native-worklets"');
+		expect(source).toContain('".worklets"');
+		expect(source).toMatch(
+			/getOrComputeSha1\(mixedPath\)\s*{\s*if \(mixedPath\.includes\(workletsDirPath\)\)/,
+		);
+	});
+});

--- a/apps/mobile/metro-worklets-patch.test.ts
+++ b/apps/mobile/metro-worklets-patch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 // Guards the bun patch on metro (patches/README.md). Without it, every cold
 // release bundle — `expo export`, and so every EAS build — dies with "Failed to
@@ -8,20 +8,39 @@ import { dirname, join } from "node:path";
 // an exact version, so bumping metro (an Expo SDK bump will) silently drops the
 // patch and the store build breaks again. If this fails after a bump, pull the
 // matching patch per patches/README.md; do NOT delete the test.
-describe("metro Bundle Mode SHA-1 patch", () => {
-	const source = readFileSync(
-		join(
-			dirname(require.resolve("metro/package.json")),
-			"src/node-haste/DependencyGraph.js",
-		),
-		"utf8",
-	);
+//
+// Everything here reads repo files rather than the installed package: metro is
+// nobody's declared dependency, so under bun's isolated linker it isn't
+// resolvable from this workspace.
+const repoRoot = join(import.meta.dir, "../..");
+const patched: Record<string, string> =
+	JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"))
+		.patchedDependencies ?? {};
+const lockfile = readFileSync(join(repoRoot, "bun.lock"), "utf8");
 
-	test("short-circuits SHA-1 for generated .worklets modules", () => {
-		expect(source).toContain('"react-native-worklets"');
-		expect(source).toContain('".worklets"');
-		expect(source).toMatch(
-			/getOrComputeSha1\(mixedPath\)\s*{\s*if \(mixedPath\.includes\(workletsDirPath\)\)/,
-		);
+describe("metro Bundle Mode SHA-1 patch", () => {
+	test("every resolved metro version is patched", () => {
+		const resolved = [
+			...lockfile.matchAll(/"metro": \["metro@([^"]+)"/g),
+		].map((match) => `metro@${match[1]}`);
+
+		expect(resolved.length).toBeGreaterThan(0);
+		for (const version of resolved) {
+			expect(patched[version]).toBeString();
+		}
+	});
+
+	test("the patch short-circuits SHA-1 for generated .worklets modules", () => {
+		for (const path of Object.entries(patched)
+			.filter(([name]) => name.startsWith("metro@"))
+			.map(([, file]) => file)) {
+			const patch = readFileSync(join(repoRoot, path), "utf8");
+			expect(patch).toContain("node-haste/DependencyGraph.js");
+			expect(patch).toContain('"react-native-worklets"');
+			expect(patch).toContain('".worklets"');
+			expect(patch).toMatch(
+				/\+\s*if \(mixedPath\.includes\(workletsDirPath\)\)/,
+			);
+		}
 	});
 });

--- a/apps/mobile/metro-worklets-patch.test.ts
+++ b/apps/mobile/metro-worklets-patch.test.ts
@@ -20,9 +20,9 @@ const lockfile = readFileSync(join(repoRoot, "bun.lock"), "utf8");
 
 describe("metro Bundle Mode SHA-1 patch", () => {
 	test("every resolved metro version is patched", () => {
-		const resolved = [
-			...lockfile.matchAll(/"metro": \["metro@([^"]+)"/g),
-		].map((match) => `metro@${match[1]}`);
+		const resolved = [...lockfile.matchAll(/"metro": \["metro@([^"]+)"/g)].map(
+			(match) => `metro@${match[1]}`,
+		);
 
 		expect(resolved.length).toBeGreaterThan(0);
 		for (const version of resolved) {

--- a/bun.lock
+++ b/bun.lock
@@ -1275,6 +1275,7 @@
   ],
   "patchedDependencies": {
     "@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
+    "metro@0.84.4": "patches/metro@0.84.4.patch",
   },
   "overrides": {
     "@types/hast": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"workerd"
 	],
 	"patchedDependencies": {
-		"@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch"
+		"@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
+		"metro@0.84.4": "patches/metro@0.84.4.patch"
 	}
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,6 +6,46 @@ package makes its patch stop matching, and the fix silently disappears while
 everything still builds. Every patch listed here must have a CI guard test
 that fails when its markers vanish from the installed package.
 
+## metro (`metro@<version>.patch`)
+
+**Why:** `apps/mobile` runs worklets Bundle Mode (`react-native-streamdown`, see
+`apps/mobile/babel.config.js`). Its Babel plugin writes each worklet to
+`node_modules/react-native-worklets/.worklets/<hash>.js` *during* the transform
+pass — after Metro has crawled the filesystem — so a one-shot bundle can't hash
+files that didn't exist at crawl time and dies with `Failed to get the SHA-1`.
+The dev server survives on re-crawls; `expo export` and every EAS build fail
+100% of the time from a clean install, which is what errored the first two
+production builds (2026-08-13). Upgrading worklets does not fix it — 0.11.4
+fails identically.
+
+**What it changes** (`src/node-haste/DependencyGraph.js`): `getOrComputeSha1`
+returns a synthetic hash for any path under `react-native-worklets/.worklets`
+instead of consulting the file map. Taken verbatim from upstream —
+[`bundleMode/patches/patch-package/metro`](https://github.com/software-mansion/react-native-reanimated/tree/main/packages/react-native-worklets/bundleMode/patches)
+— and documented as the recommended fix in the [Bundle Mode setup
+guide](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup/).
+Temporary until the change lands in Metro.
+
+**Guard test:** `apps/mobile/metro-worklets-patch.test.ts`.
+
+**Regenerating after a version bump** (~5 min): upstream keeps one patch per
+Metro version. Find yours with `bun why metro --top`, then:
+
+```bash
+bun patch metro
+curl -L "https://github.com/software-mansion/react-native-reanimated/raw/main/packages/react-native-worklets/bundleMode/patches/patch-package/metro/metro%2B<version>.patch" | git apply
+bun patch --commit 'node_modules/metro'
+bun test apps/mobile/metro-worklets-patch.test.ts
+```
+
+If upstream has no patch for the new Metro yet, the previous version's patch
+usually still applies — the touched function is stable. Verify with a cold
+bundle: delete `node_modules/react-native-worklets/.worklets/*.js`, then
+`npx expo export --platform ios --clear` from `apps/mobile`.
+
+Worklets also publishes a `metro-runtime` patch that extends Fast Refresh to
+worklet runtimes. Not applied here — it's dev-only ergonomics, not a build fix.
+
 ## @xterm/addon-webgl (`@xterm%2Faddon-webgl@<version>.patch`)
 
 **Why:** SUPER-1793 / PR #6352. Truecolor-heavy TUI output (e.g. Claude Code's

--- a/patches/metro@0.84.4.patch
+++ b/patches/metro@0.84.4.patch
@@ -1,0 +1,31 @@
+diff --git a/src/node-haste/DependencyGraph.js b/src/node-haste/DependencyGraph.js
+index 8222d8c69059bfb3fe444acba9f96ab2cc7bec0b..e36770d2932e08c467c28f1796092a88e10fbc9f 100644
+--- a/src/node-haste/DependencyGraph.js
++++ b/src/node-haste/DependencyGraph.js
+@@ -32,6 +32,11 @@ function getOrCreateMap(map, field) {
+   }
+   return subMap;
+ }
++
++const workletsDirPath = _path.default.join(
++  "react-native-worklets",
++  ".worklets",
++);
+ class DependencyGraph extends _events.default {
+   #packageCache;
+   #dependencyPlugin;
+@@ -197,6 +202,14 @@ class DependencyGraph extends _events.default {
+     return (0, _nullthrows.default)(this._fileSystem).getAllFiles();
+   }
+   async getOrComputeSha1(mixedPath) {
++    if (mixedPath.includes(workletsDirPath)) {
++      const createHash = require("crypto").createHash;
++      return {
++        sha1: createHash("sha1")
++          .update(performance.now().toString())
++          .digest("hex"),
++      };
++    }
+     const result = await this._fileSystem.getOrComputeSha1(mixedPath);
+     if (!result || !result.sha1) {
+       throw new Error(`Failed to get the SHA-1 for: ${mixedPath}.


### PR DESCRIPTION
## Summary

- Apply upstream's `metro` patch via `bun patch` so cold release bundles stop failing with `Failed to get the SHA-1`. This is what errored the first two iOS production builds (7 and 8, 2026-08-13), both in the Bundle JavaScript phase.
- No dependency versions change: worklets 0.8.3 / reanimated 4.3.1 (Expo SDK 56's pinned pairing) stay as-is.

## Why / Context

`apps/mobile` runs worklets Bundle Mode, required by `react-native-streamdown` (`babel.config.js`). Its Babel plugin writes each worklet to `node_modules/react-native-worklets/.worklets/<hash>.js` **during** the transform pass — after Metro has already crawled the filesystem. Metro then can't hash a file that was never in its file map and throws.

The dev server survives because it re-crawls on file events, and a local machine usually has `.worklets` already populated from a previous run. A one-shot bundle from a clean install — `expo export`, and therefore every EAS build — fails 100% of the time. That asymmetry is why this only surfaced at store-build time.

Upgrading worklets does **not** fix it: 0.11.4 with reanimated 4.5.3 (the newest peer-compatible pairing; 0.12.0 has no stable reanimated partner yet) fails identically, and it moves off the versions Expo SDK 56 pins and tests. Reverted.

## How It Works

`patches/metro@0.84.4.patch` is upstream's patch, taken verbatim from [`bundleMode/patches/patch-package/metro`](https://github.com/software-mansion/react-native-reanimated/tree/main/packages/react-native-worklets/bundleMode/patches). It makes `DependencyGraph.getOrComputeSha1` return a synthetic hash for any path under `react-native-worklets/.worklets` instead of consulting the file map. Software Mansion documents this as the recommended fix in the [Bundle Mode setup guide](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup/), temporary until the change lands in Metro.

`patches/README.md` requires a guard test for every patch, and this one earns it: `patchedDependencies` is keyed to an exact version, so the next Expo SDK bump moves Metro, silently drops the patch, and breaks the store build again with no other signal.

## Manual QA Checklist

Reproduced from the EAS cold state — `node_modules/react-native-worklets/.worklets` emptied down to the `dummy.md` the package ships:

- [x] `npx expo export --platform ios --clear` fails with `Failed to get the SHA-1` before the patch (3/3 attempts, including on worklets 0.11.4)
- [x] Same command succeeds after the patch, emitting an 11MB `.hbc`
- [x] Succeeds on a second cold run with `.worklets` re-emptied
- [x] `bun install` applies the patch on a clean tree (`patchedDependencies` + `bun.lock`)
- [ ] EAS production build succeeds end-to-end — **in flight**, [build a8b4bc71](https://expo.dev/accounts/supserset-sh/projects/superset/builds/a8b4bc71-b18d-4358-b1e0-4f5cf413bc72). Native compilation is past what a JS bundle test covers, so this is the real acceptance gate; will confirm on this PR before merge.

## Testing

- `bun run lint`
- `bun run typecheck` (mobile, clean)
- `bun test apps/mobile/metro-worklets-patch.test.ts`

## Design Decisions

- **Patch Metro instead of a warm-up bundle in `eas-build-post-install`**: a throwaway `expo export` before the real one would also work, but it doubles bundle time on every build and hides the reason. The patch is upstream's own, ~10 lines, and self-documents in `patches/README.md`.
- **Stay on Expo SDK 56's pinned versions**: the upgrade path was tested first and doesn't fix the bug, so taking it would only add unverified native changes days before an App Store submission.
- **`metro-runtime` patch not applied**: upstream also publishes one that extends Fast Refresh to worklet runtimes. Dev-only ergonomics, not a build fix — left out to keep this scoped.

## Risks / Rollout

- Risk: low, build-tooling only. The patch narrows to paths containing `react-native-worklets/.worklets`; every other module still gets a real content hash. Worst case is worklet modules missing transform-cache reuse.
- Rollback: delete the `patchedDependencies` entry, the patch file, and the guard test. Reverts to today's behavior — where iOS release builds don't build at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches `metro@0.84.4` so release bundles can hash Bundle Mode worklets. Before: cold `expo export`/EAS builds failed with “Failed to get the SHA-1” for generated files under `react-native-worklets/.worklets`. Now: Metro returns a synthetic hash for those paths, allowing bundling to complete.

- Applies upstream `metro` patch via `patchedDependencies`/`bun patch`; scope limited to `.worklets` paths.
- Strengthens the guard test to read repo files (`bun.lock` and the patch) instead of module resolution; asserts every resolved `metro` version is patched and the patch contains the `.worklets` short-circuit.
- Formats the guard test with Biome (no behavior change).
- Keeps `react-native-worklets` 0.8.3 and `react-native-reanimated` 4.3.1 (Expo SDK 56) unchanged.
- On future `metro` bumps: regenerate and commit the patch (see `patches/README.md`), then run `bun test apps/mobile/metro-worklets-patch.test.ts`.

<sup>Written for commit daa125a08e20e4c76da25efbae7c427fa47faa5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for React Native Worklets Bundle Mode with Metro 0.84.4.
  * Worklets-generated files now receive dynamic hashes, helping ensure bundle updates are recognized correctly.

* **Bug Fixes**
  * Prevented stale bundle results when Metro processes generated Worklets files.

* **Documentation**
  * Added guidance for the Metro patch, verification steps, version updates, and maintenance workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->