### PR TITLE
revert(chat-ui): restore the package deleted in #6435

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -806,6 +806,32 @@
         "typescript": "6.0.3",
       },
     },
+    "packages/chat-ui": {
+      "name": "@superset/chat-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lexical/react": "0.41.0",
+        "@shadcn/react": "0.2.1",
+        "@superset/chat": "workspace:*",
+        "@superset/ui": "workspace:*",
+        "lexical": "0.41.0",
+        "lucide-react": "0.563.0",
+      },
+      "devDependencies": {
+        "@storybook/react-vite": "10.4.2",
+        "@superset/typescript": "workspace:*",
+        "@types/node": "24.12.0",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
+        "storybook": "10.4.2",
+        "typescript": "6.0.3",
+      },
+      "peerDependencies": {
+        "react": "19.2.3",
+      },
+    },
     "packages/cli": {
       "name": "@superset/cli",
       "version": "1.21.0",
@@ -1751,11 +1777,11 @@
 
     "@electron/windows-sign": ["@electron/windows-sign@1.2.2", "", { "dependencies": { "cross-dirname": "^0.1.0", "debug": "^4.3.4", "fs-extra": "^11.1.1", "minimist": "^1.2.8", "postject": "^1.0.0-alpha.6" }, "bin": { "electron-windows-sign": "bin/electron-windows-sign.js" } }, "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ=="],
 
-    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
 
@@ -1893,6 +1919,8 @@
 
     "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
 
+    "@floating-ui/react": ["@floating-ui/react@0.27.20", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "tabbable": "^6.0.0" }, "peerDependencies": { "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw=="],
+
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
@@ -2020,6 +2048,50 @@
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
 
     "@legendapp/list": ["@legendapp/list@3.0.3", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-native": "*" }, "optionalPeers": ["react-dom", "react-native"] }, "sha512-iPDCQza1sRZTQY/W6DNb/rLTiLd5m5HxZr+KCAvpVh8lBbyGtv9j9PeysqQeyQgaOaao37Yrh76VRVVqMhB+uw=="],
+
+    "@lexical/clipboard": ["@lexical/clipboard@0.41.0", "", { "dependencies": { "@lexical/html": "0.41.0", "@lexical/list": "0.41.0", "@lexical/selection": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-Ex5lPkb4NBBX1DCPzOAIeHBJFH1bJcmATjREaqpnTfxCbuOeQkt44wchezUA0oDl+iAxNZ3+pLLWiUju9icoSA=="],
+
+    "@lexical/code": ["@lexical/code@0.41.0", "", { "dependencies": { "@lexical/utils": "0.41.0", "lexical": "0.41.0", "prismjs": "^1.30.0" } }, "sha512-0hoNi1KC9/N3SBOGcOcFqnT0OpwmcRRAhfxTKMGqfCtCvAMzULVwZ8RWc9/NV9bKYESgBTW5D9xkDANP2mspHg=="],
+
+    "@lexical/devtools-core": ["@lexical/devtools-core@0.41.0", "", { "dependencies": { "@lexical/html": "0.41.0", "@lexical/link": "0.41.0", "@lexical/mark": "0.41.0", "@lexical/table": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" }, "peerDependencies": { "react": ">=17.x", "react-dom": ">=17.x" } }, "sha512-FzJtluBhBc8bKS11TUZe72KoZN/hnzIyiiM0SPJAsPwGpoXuM01jqpXQGybWf/1bWB+bmmhOae7O4Nywi/Csuw=="],
+
+    "@lexical/dragon": ["@lexical/dragon@0.41.0", "", { "dependencies": { "@lexical/extension": "0.41.0", "lexical": "0.41.0" } }, "sha512-gBEqkk8Q6ZPruvDaRcOdF1EK9suCVBODzOCcR+EnoJTaTjfDkCM7pkPAm4w90Wa1wCZEtFHvCfas+jU9MDSumg=="],
+
+    "@lexical/extension": ["@lexical/extension@0.41.0", "", { "dependencies": { "@lexical/utils": "0.41.0", "@preact/signals-core": "^1.11.0", "lexical": "0.41.0" } }, "sha512-sF4SPiP72yXvIGchmmIZ7Yg2XZTxNLOpFEIIzdqG7X/1fa1Ham9P/T7VbrblWpF6Ei5LJtK9JgNVB0hb4l3o1g=="],
+
+    "@lexical/hashtag": ["@lexical/hashtag@0.41.0", "", { "dependencies": { "@lexical/text": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-tFWM74RW4KU0E/sj2aowfWl26vmLUTp331CgVESnhQKcZBfT40KJYd57HEqBDTfQKn4MUhylQCCA0hbpw6EeFQ=="],
+
+    "@lexical/history": ["@lexical/history@0.41.0", "", { "dependencies": { "@lexical/extension": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-kGoVWsiOn62+RMjRolRa+NXZl8jFwxav6GNDiHH8yzivtoaH8n1SwUfLJELXCzeqzs81HySqD4q30VLJVTGoDg=="],
+
+    "@lexical/html": ["@lexical/html@0.41.0", "", { "dependencies": { "@lexical/selection": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-3RyZy+H/IDKz2D66rNN/NqYx87xVFrngfEbyu1OWtbY963RUFnopiVHCQvsge/8kT04QSZ7U/DzjVFqeNS6clg=="],
+
+    "@lexical/link": ["@lexical/link@0.41.0", "", { "dependencies": { "@lexical/extension": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-Rjtx5cGWAkKcnacncbVsZ1TqRnUB2Wm4eEVKpaAEG41+kHgqghzM2P+UGT15yROroxJu8KvAC9ISiYFiU4XE1w=="],
+
+    "@lexical/list": ["@lexical/list@0.41.0", "", { "dependencies": { "@lexical/extension": "0.41.0", "@lexical/selection": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-RXvB+xcbzVoQLGRDOBRCacztG7V+bI95tdoTwl8pz5xvgPtAaRnkZWMDP+yMNzMJZsqEChdtpxbf0NgtMkun6g=="],
+
+    "@lexical/mark": ["@lexical/mark@0.41.0", "", { "dependencies": { "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-UO5WVs9uJAYIKHSlYh4Z1gHrBBchTOi21UCYBIZ7eAs4suK84hPzD+3/LAX5CB7ZltL6ke5Sly3FOwNXv/wfpA=="],
+
+    "@lexical/markdown": ["@lexical/markdown@0.41.0", "", { "dependencies": { "@lexical/code": "0.41.0", "@lexical/link": "0.41.0", "@lexical/list": "0.41.0", "@lexical/rich-text": "0.41.0", "@lexical/text": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-bzI73JMXpjGFhqUWNV6KqfjWcgAWzwFT+J3RHtbCF5rysC8HLldBYojOgAAtPfXqfxyv2mDzsY7SoJ75s9uHZA=="],
+
+    "@lexical/offset": ["@lexical/offset@0.41.0", "", { "dependencies": { "lexical": "0.41.0" } }, "sha512-2RHBXZqC8gm3X9C0AyRb0M8w7zJu5dKiasrif+jSKzsxPjAUeF1m95OtIOsWs1XLNUgASOSUqGovDZxKJslZfA=="],
+
+    "@lexical/overflow": ["@lexical/overflow@0.41.0", "", { "dependencies": { "lexical": "0.41.0" } }, "sha512-Iy6ZiJip8X14EBYt1zKPOrXyQ4eG9JLBEoPoSVBTiSbVd+lYicdUvaOThT0k0/qeVTN9nqTaEltBjm56IrVKCQ=="],
+
+    "@lexical/plain-text": ["@lexical/plain-text@0.41.0", "", { "dependencies": { "@lexical/clipboard": "0.41.0", "@lexical/dragon": "0.41.0", "@lexical/selection": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-HIsGgmFUYRUNNyvckun33UQfU7LRzDlxymHUq67+Bxd5bXqdZOrStEKJXuDX+LuLh/GXZbaWNbDLqwLBObfbQg=="],
+
+    "@lexical/react": ["@lexical/react@0.41.0", "", { "dependencies": { "@floating-ui/react": "^0.27.16", "@lexical/devtools-core": "0.41.0", "@lexical/dragon": "0.41.0", "@lexical/extension": "0.41.0", "@lexical/hashtag": "0.41.0", "@lexical/history": "0.41.0", "@lexical/link": "0.41.0", "@lexical/list": "0.41.0", "@lexical/mark": "0.41.0", "@lexical/markdown": "0.41.0", "@lexical/overflow": "0.41.0", "@lexical/plain-text": "0.41.0", "@lexical/rich-text": "0.41.0", "@lexical/table": "0.41.0", "@lexical/text": "0.41.0", "@lexical/utils": "0.41.0", "@lexical/yjs": "0.41.0", "lexical": "0.41.0", "react-error-boundary": "^6.0.0" }, "peerDependencies": { "react": ">=17.x", "react-dom": ">=17.x" } }, "sha512-7+GUdZUm6sofWm+zdsWAs6cFBwKNsvsHezZTrf6k8jrZxL461ZQmbz/16b4DvjCGL9r5P1fR7md9/LCmk8TiCg=="],
+
+    "@lexical/rich-text": ["@lexical/rich-text@0.41.0", "", { "dependencies": { "@lexical/clipboard": "0.41.0", "@lexical/dragon": "0.41.0", "@lexical/selection": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-yUcr7ZaaVTZNi8bow4CK1M8jy2qyyls1Vr+5dVjwBclVShOL/F/nFyzBOSb6RtXXRbd3Ahuk9fEleppX/RNIdw=="],
+
+    "@lexical/selection": ["@lexical/selection@0.41.0", "", { "dependencies": { "lexical": "0.41.0" } }, "sha512-1s7/kNyRzcv5uaTwsUL28NpiisqTf5xZ1zNukLsCN1xY+TWbv9RE9OxIv+748wMm4pxNczQe/UbIBODkbeknLw=="],
+
+    "@lexical/table": ["@lexical/table@0.41.0", "", { "dependencies": { "@lexical/clipboard": "0.41.0", "@lexical/extension": "0.41.0", "@lexical/utils": "0.41.0", "lexical": "0.41.0" } }, "sha512-d3SPThBAr+oZ8O74TXU0iXM3rLbrAVC7/HcOnSAq7/AhWQW8yMutT51JQGN+0fMLP9kqoWSAojNtkdvzXfU/+A=="],
+
+    "@lexical/text": ["@lexical/text@0.41.0", "", { "dependencies": { "lexical": "0.41.0" } }, "sha512-gGA+Anc7ck110EXo4KVKtq6Ui3M7Vz3OpGJ4QE6zJHWW8nV5h273koUGSutAMeoZgRVb6t01Izh3ORoFt/j1CA=="],
+
+    "@lexical/utils": ["@lexical/utils@0.41.0", "", { "dependencies": { "@lexical/selection": "0.41.0", "lexical": "0.41.0" } }, "sha512-Wlsokr5NQCq83D+7kxZ9qs5yQ3dU3Qaf2M+uXxLRoPoDaXqW8xTWZq1+ZFoEzsHzx06QoPa4Vu/40BZR91uQPg=="],
+
+    "@lexical/yjs": ["@lexical/yjs@0.41.0", "", { "dependencies": { "@lexical/offset": "0.41.0", "@lexical/selection": "0.41.0", "lexical": "0.41.0" }, "peerDependencies": { "yjs": ">=13.5.22" } }, "sha512-PaKTxSbVC4fpqUjQ7vUL9RkNF1PjL8TFl5jRe03PqoPYpE33buf3VXX6+cOUEfv9+uknSqLCPHoBS/4jN3a97w=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
@@ -2279,7 +2351,7 @@
 
     "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA=="],
 
@@ -2372,6 +2444,8 @@
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@posthog/core": ["@posthog/core@1.9.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-j7KSWxJTUtNyKynLt/p0hfip/3I46dWU2dk+pt7dKRoz2l5CYueHuHK4EO7Wlgno5yo1HO4sc4s30MXMTICHJw=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.14.4", "", {}, "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="],
 
     "@promptbook/utils": ["@promptbook/utils@0.69.5", "", { "dependencies": { "spacetrim": "0.11.59" } }, "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ=="],
 
@@ -2897,9 +2971,9 @@
 
     "@storybook/mcp": ["@storybook/mcp@0.6.2", "", { "dependencies": { "@tmcp/adapter-valibot": "^0.1.5", "@tmcp/transport-http": "^0.8.5", "tmcp": "^1.19.3", "valibot": "1.2.0" } }, "sha512-zND9XHI2G4+sjpcxx79AZOg3ShWAA8Kj1W+GS+URT40l8Bml1t9K/72/Juco1uxAkh7+uxybR5OR0lPmg1kGUg=="],
 
-    "@storybook/react": ["@storybook/react@10.5.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.5.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-T2Xj0ey7a9RHU6coYLC0L5lhjcdyhLCs9wNv15FvHvgmrRobkynEV72kq5vGW8tFkahNWI1X9+GZPQ6r8Nm38w=="],
+    "@storybook/react": ["@storybook/react@10.4.2", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.4.2", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.4.2", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg=="],
 
-    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.5.5", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg=="],
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.4.2", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.4.2" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w=="],
 
     "@storybook/react-native": ["@storybook/react-native@10.4.2", "", { "dependencies": { "@storybook/mcp": "^0.6.1", "@storybook/react": "^10.3.2", "@storybook/react-native-theming": "^10.4.2", "@storybook/react-native-ui": "^10.4.2", "@storybook/react-native-ui-common": "^10.4.2", "@tmcp/adapter-valibot": "^0.1.4", "@tmcp/transport-http": "^0.8.5", "commander": "^14.0.2", "dedent": "^1.7.2", "deepmerge": "^4.3.1", "esbuild-register": "^3.6.0", "glob": "^13.0.0", "react-native-url-polyfill": "^3.0.0", "setimmediate": "^1.0.5", "tmcp": "^1.19.3", "valibot": "^1.3.1", "ws": "^8.20.0" }, "peerDependencies": { "@gorhom/bottom-sheet": ">=4", "react": "*", "react-native": ">=0.72.0", "react-native-gesture-handler": ">=2", "react-native-reanimated": ">=2", "react-native-safe-area-context": "*", "storybook": ">=10 || ^10" }, "optionalPeers": ["@gorhom/bottom-sheet", "react-native-gesture-handler", "react-native-reanimated"], "bin": { "sb-rn-get-stories": "./bin/get-stories.js" } }, "sha512-sgmP7aH5gRD2uKBm68bfJzWStRms5yPPQmXEHxyNrhoT3FHImVytLyARQ0wvMoxNWG4lyQFgZq02sgXdWki95A=="],
 
@@ -2924,6 +2998,8 @@
     "@superset/chat-legacy": ["@superset/chat-legacy@workspace:packages/chat-legacy"],
 
     "@superset/chat-runtime": ["@superset/chat-runtime@workspace:packages/chat-runtime"],
+
+    "@superset/chat-ui": ["@superset/chat-ui@workspace:packages/chat-ui"],
 
     "@superset/cli": ["@superset/cli@workspace:packages/cli"],
 
@@ -4911,6 +4987,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic.js": ["isomorphic.js@0.2.5", "", {}, "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="],
+
     "its-fine": ["its-fine@2.0.0", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng=="],
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
@@ -5008,6 +5086,10 @@
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "lexical": ["lexical@0.41.0", "", {}, "sha512-pNIm5+n+hVnJHB9gYPDYsIO5Y59dNaDU9rJmPPsfqQhP2ojKFnUoPbcRnrI9FJLXB14sSumcY8LUw7Sq70TZqA=="],
+
+    "lib0": ["lib0@0.2.117", "", { "dependencies": { "isomorphic.js": "^0.2.4" }, "bin": { "0serve": "bin/0serve.js", "0gentesthtml": "bin/gentesthtml.js", "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js" } }, "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw=="],
 
     "libsql": ["libsql@0.5.22", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.22", "@libsql/darwin-x64": "0.5.22", "@libsql/linux-arm-gnueabihf": "0.5.22", "@libsql/linux-arm-musleabihf": "0.5.22", "@libsql/linux-arm64-gnu": "0.5.22", "@libsql/linux-arm64-musl": "0.5.22", "@libsql/linux-x64-gnu": "0.5.22", "@libsql/linux-x64-musl": "0.5.22", "@libsql/win32-x64-msvc": "0.5.22" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA=="],
 
@@ -5785,6 +5867,8 @@
 
     "react-email": ["react-email@5.0.7", "", { "dependencies": { "@babel/parser": "^7.27.0", "@babel/traverse": "^7.27.0", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "debounce": "^2.0.0", "esbuild": "^0.25.0", "glob": "^11.0.0", "jiti": "2.4.2", "log-symbols": "^7.0.0", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.0", "ora": "^8.0.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tsconfig-paths": "4.2.0" }, "bin": { "email": "dist/index.js" } }, "sha512-JsWzxl3O82Gw9HRRNJm8VjQLB8c7R5TGbP89Ffj+/Qdb2H2N4J0XRXkhqiucMvmucuqNqe9mNndZkh3jh638xA=="],
 
+    "react-error-boundary": ["react-error-boundary@6.1.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng=="],
+
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 
     "react-fast-marquee": ["react-fast-marquee@1.6.5", "", { "peerDependencies": { "react": ">= 16.8.0 || ^18.0.0", "react-dom": ">= 16.8.0 || ^18.0.0" } }, "sha512-swDnPqrT2XISAih0o74zQVE2wQJFMvkx+9VZXYYNSLb/CUcAzU9pNj637Ar2+hyRw6b4tP6xh4GQZip2ZCpQpg=="],
@@ -6153,7 +6237,7 @@
 
     "sorted-btree": ["sorted-btree@1.8.1", "", {}, "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="],
 
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -6274,6 +6358,8 @@
     "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
 
     "systeminformation": ["systeminformation@5.33.1", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w=="],
+
+    "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -6643,6 +6729,8 @@
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
+    "yjs": ["yjs@13.6.32", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yocto-spinner": ["yocto-spinner@1.2.2", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng=="],
@@ -6758,8 +6846,6 @@
     "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
     "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.31", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6", "undici": "^5.29.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hlxLxqbdV+f7gBpL2SbLL+UhjV+DfUpJ28J4vSHekVV9fiTRrhqcd/ewJwaVbR/ahtLCGJPAVYzj+yJzaddc6g=="],
-
-    "@apm-js-collab/code-transformer/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "@appium/logger/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
@@ -6937,13 +7023,13 @@
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "@neondatabase/serverless/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@3.3.2", "", { "dependencies": { "cjs-module-lexer": "^2.2.0", "es-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA=="],
-
-    "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -7033,6 +7119,8 @@
 
     "@rn-primitives/tabs/@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.21", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-use-controllable-state": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
+
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
 
     "@sentry/browser/@sentry/browser-utils": ["@sentry/browser-utils@10.67.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.67.0" } }, "sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw=="],
@@ -7087,9 +7175,13 @@
 
     "@storybook/mcp/valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
+    "@storybook/react-native/@storybook/react": ["@storybook/react@10.5.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.5.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-T2Xj0ey7a9RHU6coYLC0L5lhjcdyhLCs9wNv15FvHvgmrRobkynEV72kq5vGW8tFkahNWI1X9+GZPQ6r8Nm38w=="],
+
     "@storybook/react-native/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
-    "@storybook/react-vite/@storybook/react": ["@storybook/react@10.4.2", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.4.2", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.4.2", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg=="],
+    "@storybook/react-native-ui/@storybook/react": ["@storybook/react@10.5.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.5.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-T2Xj0ey7a9RHU6coYLC0L5lhjcdyhLCs9wNv15FvHvgmrRobkynEV72kq5vGW8tFkahNWI1X9+GZPQ6r8Nm38w=="],
+
+    "@storybook/react-native-ui-common/@storybook/react": ["@storybook/react@10.5.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.5.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["@types/react", "@types/react-dom", "typescript"] }, "sha512-T2Xj0ey7a9RHU6coYLC0L5lhjcdyhLCs9wNv15FvHvgmrRobkynEV72kq5vGW8tFkahNWI1X9+GZPQ6r8Nm38w=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -7243,8 +7335,6 @@
 
     "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
-    "css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
     "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -7291,13 +7381,13 @@
 
     "escodegen/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "esquery/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -7529,8 +7619,6 @@
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
-
     "p-event/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
 
     "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -7631,8 +7719,6 @@
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
-    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
@@ -7642,6 +7728,8 @@
     "resq/fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -7678,8 +7766,6 @@
     "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "socks-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -8011,8 +8097,6 @@
 
     "@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
-    "@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
-
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@puppeteer/browsers/tar-fs/tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
@@ -8155,6 +8239,8 @@
 
     "@rn-primitives/tabs/@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
+
     "@sentry/electron/@sentry/node/@sentry/node-core": ["@sentry/node-core@10.67.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.67.0", "@sentry/opentelemetry": "10.67.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base"] }, "sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA=="],
 
     "@sentry/electron/@sentry/node/@sentry/opentelemetry": ["@sentry/opentelemetry@10.67.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.67.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" } }, "sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ=="],
@@ -8175,7 +8261,11 @@
 
     "@shikijs/transformers/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
 
-    "@storybook/react-vite/@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.4.2", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.4.2" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w=="],
+    "@storybook/react-native-ui-common/@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.5.5", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg=="],
+
+    "@storybook/react-native-ui/@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.5.5", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg=="],
+
+    "@storybook/react-native/@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.5.5", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.5" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg=="],
 
     "@tailwindcss/node/lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@superset/chat-ui",
+	"private": true,
+	"version": "0.1.0",
+	"type": "module",
+	"exports": {
+		"./*": "./src/components/*/index.ts"
+	},
+	"scripts": {
+		"clean": "git clean -xdf .cache .turbo dist node_modules",
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+	},
+	"dependencies": {
+		"@lexical/react": "0.41.0",
+		"@shadcn/react": "0.2.1",
+		"@superset/chat": "workspace:*",
+		"@superset/ui": "workspace:*",
+		"lexical": "0.41.0",
+		"lucide-react": "0.563.0"
+	},
+	"devDependencies": {
+		"@storybook/react-vite": "10.4.2",
+		"@superset/typescript": "workspace:*",
+		"@types/node": "24.12.0",
+		"@types/react": "19.2.14",
+		"@types/react-dom": "19.2.3",
+		"react": "19.2.3",
+		"react-dom": "19.2.3",
+		"storybook": "10.4.2",
+		"typescript": "6.0.3"
+	},
+	"peerDependencies": {
+		"react": "19.2.3"
+	}
+}

--- a/packages/chat-ui/src/components/ComposerDropZone/ComposerDropZone.tsx
+++ b/packages/chat-ui/src/components/ComposerDropZone/ComposerDropZone.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { cn } from "@superset/ui/utils";
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+
+type DropZoneContextValue = {
+	register(sink: (files: FileList) => void): () => void;
+};
+
+const ComposerDropZoneContext = createContext<DropZoneContextValue | null>(
+	null,
+);
+
+export function useComposerDropZone(): DropZoneContextValue | null {
+	return useContext(ComposerDropZoneContext);
+}
+
+export type ComposerDropZoneProps = {
+	children: ReactNode;
+	label?: string;
+	className?: string;
+};
+
+/**
+ * Layout-level file drop target: mount around the whole content area (like the
+ * new-workspace screen) and any composer rendered inside registers itself as
+ * the drop sink automatically.
+ */
+export function ComposerDropZone({
+	children,
+	label = "Drop files to attach",
+	className,
+}: ComposerDropZoneProps) {
+	const sinkRef = useRef<((files: FileList) => void) | null>(null);
+	// dragover + timeout reset instead of an enter/leave counter, so
+	// Esc-cancelled drags and drops outside the window can't wedge the overlay.
+	const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+
+	useEffect(() => {
+		let timer: number | null = null;
+		const onDragOver = (event: DragEvent) => {
+			if (!Array.from(event.dataTransfer?.types ?? []).includes("Files"))
+				return;
+			setIsDraggingFiles(true);
+			if (timer !== null) window.clearTimeout(timer);
+			timer = window.setTimeout(() => setIsDraggingFiles(false), 200);
+		};
+		const onDrop = () => {
+			if (timer !== null) window.clearTimeout(timer);
+			timer = null;
+			setIsDraggingFiles(false);
+		};
+		document.addEventListener("dragover", onDragOver);
+		document.addEventListener("drop", onDrop);
+		return () => {
+			document.removeEventListener("dragover", onDragOver);
+			document.removeEventListener("drop", onDrop);
+			if (timer !== null) window.clearTimeout(timer);
+		};
+	}, []);
+
+	const contextValue = useMemo<DropZoneContextValue>(
+		() => ({
+			register(sink) {
+				sinkRef.current = sink;
+				return () => {
+					if (sinkRef.current === sink) sinkRef.current = null;
+				};
+			},
+		}),
+		[],
+	);
+
+	return (
+		<ComposerDropZoneContext.Provider value={contextValue}>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop target; keyboard users attach via the composer's file picker */}
+			<div
+				className={cn("relative", className)}
+				onDragOver={(event) => {
+					if (event.dataTransfer.types.includes("Files"))
+						event.preventDefault();
+				}}
+				onDrop={(event) => {
+					// The composer's editor may have consumed this already;
+					// preventDefault marks it and the event still bubbles here.
+					if (event.defaultPrevented) return;
+					if (event.dataTransfer.files.length === 0) return;
+					event.preventDefault();
+					sinkRef.current?.(event.dataTransfer.files);
+				}}
+			>
+				{children}
+				<div
+					aria-hidden={!isDraggingFiles}
+					className={cn(
+						"pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-primary/10 transition-opacity duration-150 motion-reduce:transition-none",
+						isDraggingFiles ? "opacity-100" : "opacity-0",
+					)}
+				>
+					<span
+						className={cn(
+							"inline-flex items-center rounded-md border border-border/50 bg-secondary px-3 py-1 text-sm text-foreground shadow transition-transform duration-150 motion-reduce:transition-none",
+							isDraggingFiles ? "scale-100" : "scale-95",
+						)}
+					>
+						{label}
+					</span>
+				</div>
+			</div>
+		</ComposerDropZoneContext.Provider>
+	);
+}

--- a/packages/chat-ui/src/components/ComposerDropZone/index.ts
+++ b/packages/chat-ui/src/components/ComposerDropZone/index.ts
@@ -1,0 +1,5 @@
+export {
+	ComposerDropZone,
+	type ComposerDropZoneProps,
+	useComposerDropZone,
+} from "./ComposerDropZone";

--- a/packages/chat-ui/src/components/PromptInput/PromptInput.stories.tsx
+++ b/packages/chat-ui/src/components/PromptInput/PromptInput.stories.tsx
@@ -1,0 +1,806 @@
+import { MessageScroller } from "@shadcn/react/message-scroller";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+	type ChatHistorySidebarMessage,
+	ChatHistorySidebarScroller,
+} from "@superset/ui/chat-history-sidebar";
+import { getPresetIcon } from "@superset/ui/icons/preset-icons";
+import {
+	BoxIcon,
+	ChartNoAxesColumnIcon,
+	CircleDashedIcon,
+	DatabaseIcon,
+	FileCode2Icon,
+	FilePlus2Icon,
+	FolderIcon,
+	GitCompareArrowsIcon,
+	GitPullRequestArrowIcon,
+	LightbulbIcon,
+	MessageSquarePlusIcon,
+	MessagesSquareIcon,
+	PaperclipIcon,
+	ServerIcon,
+	ShieldCheckIcon,
+	SparklesIcon,
+	SplitIcon,
+	ZapIcon,
+} from "lucide-react";
+import { useRef, useState } from "react";
+import { ComposerDropZone } from "../ComposerDropZone";
+import { ScrollToBottomButton } from "../ScrollToBottomButton";
+import { PromptInput } from "./PromptInput";
+import type {
+	ComposerMentionEntry,
+	ComposerMentionProvider,
+	PromptInputAttachment,
+	PromptInputCommand,
+	PromptInputSubmitPayload,
+} from "./types";
+
+const REPO_DIRS = [
+	"packages/",
+	"packages/chat-ui/",
+	"packages/chat-ui/src/",
+	"packages/chat/",
+	"packages/ui/",
+	"apps/",
+	"apps/desktop/",
+	"apps/web/",
+];
+
+const REPO_FILES = [
+	"packages/chat-ui/src/components/PromptInput/PromptInput.tsx",
+	"packages/chat-ui/src/components/PromptInput/types.ts",
+	"packages/chat/src/protocol/items.ts",
+	"packages/ui/src/components/ChatHistorySidebar/ChatHistorySidebar.tsx",
+	"apps/desktop/src/main/index.ts",
+	"apps/web/src/app/page.tsx",
+	"README.md",
+	"package.json",
+];
+
+const SKILLS = [
+	{
+		id: "create-pr",
+		label: "create-pr",
+		description: "Open a pull request",
+		color: "#16A34A",
+		icon: <GitPullRequestArrowIcon className="size-5" strokeWidth={1.75} />,
+	},
+	{
+		id: "db-migrations",
+		label: "db-migrations",
+		description: "Drizzle migration workflow",
+		color: "#2563EB",
+		icon: <DatabaseIcon className="size-5" strokeWidth={1.75} />,
+	},
+	{
+		id: "ci-check",
+		label: "ci-check",
+		description: "Lint, typecheck, test",
+		color: "#9333EA",
+		icon: <ShieldCheckIcon className="size-5" strokeWidth={1.75} />,
+	},
+];
+
+const WORKSPACES = ["woolly-smoke", "quiet-fjord", "amber-basin"];
+
+const CONVERSATIONS = [
+	{
+		id: "conv-1",
+		title: "Fix rail follow-scroll at transcript bottom",
+		agent: "claude",
+		agentLabel: "Claude Code",
+		workspace: "woolly-smoke",
+	},
+	{
+		id: "conv-2",
+		title: "Composer bake-off: Lexical vs Tiptap",
+		agent: "claude",
+		agentLabel: "Claude Code",
+		workspace: "woolly-smoke",
+	},
+	{
+		id: "conv-3",
+		title: "Investigate relay reconnect loop",
+		agent: "codex",
+		agentLabel: "Codex",
+		workspace: "quiet-fjord",
+	},
+	{
+		id: "conv-4",
+		title: "Ship provider-based mention registry",
+		agent: "copilot",
+		agentLabel: "Copilot",
+		workspace: "amber-basin",
+	},
+];
+
+const PLUGINS = [
+	{
+		id: "docs",
+		label: "Google Docs",
+		description: "Draft and edit documents",
+		domain: "docs.google.com",
+	},
+	{
+		id: "figma",
+		label: "Figma",
+		description: "Inspect designs and export assets",
+		domain: "figma.com",
+	},
+	{
+		id: "github",
+		label: "GitHub",
+		description: "Triage PRs, issues, and CI",
+		domain: "github.com",
+	},
+	{
+		id: "linear",
+		label: "Linear",
+		description: "Create and update issues",
+		domain: "linear.app",
+	},
+	{
+		id: "gmail",
+		label: "Gmail",
+		description: "Read and manage email",
+		domain: "gmail.com",
+	},
+];
+
+function Favicon({ domain }: { domain: string }) {
+	return (
+		<img
+			src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
+			alt=""
+			className="size-5 rounded-[5px]"
+		/>
+	);
+}
+
+function PresetIcon({ name }: { name: string }) {
+	return (
+		<img
+			src={getPresetIcon(name, true)}
+			alt=""
+			className="size-4.5 rounded-[4px]"
+		/>
+	);
+}
+
+function pluginsProvider(priority: number): ComposerMentionProvider {
+	return {
+		id: "plugins",
+		title: "Plugins",
+		priority,
+		source: {
+			kind: "static",
+			load: () =>
+				PLUGINS.map((plugin) => ({
+					id: plugin.id,
+					label: plugin.label,
+					description: plugin.description,
+					icon: <Favicon domain={plugin.domain} />,
+					select: (ctx) =>
+						ctx.insertChip({
+							label: plugin.label,
+							serialized: `plugin://${plugin.id}`,
+							iconUrl: `https://www.google.com/s2/favicons?domain=${plugin.domain}&sz=64`,
+							data: { plugin: plugin.id },
+						}),
+				})),
+		},
+	};
+}
+
+function fileSearchProvider(priority: number): ComposerMentionProvider {
+	return {
+		id: "files",
+		title: "Files",
+		priority,
+		source: {
+			kind: "search",
+			emptyState: "Type to search files",
+			loadingState: "Searching files\u2026",
+			search: async (query) => {
+				await new Promise((resolve) => setTimeout(resolve, 90));
+				const lowered = query.toLowerCase();
+				const dirs = REPO_DIRS.filter(
+					(dir) => dir.toLowerCase().startsWith(lowered) && dir !== query,
+				).map(
+					(dir): ComposerMentionEntry => ({
+						id: `dir:${dir}`,
+						label: dir,
+						description: "Directory",
+						icon: <FolderIcon className="size-4.5" />,
+						select: (ctx) =>
+							ctx.insertChip({
+								label: dir,
+								serialized: `@${dir}`,
+								data: { directory: true },
+							}),
+					}),
+				);
+				const files = REPO_FILES.filter((path) =>
+					path.toLowerCase().includes(lowered),
+				).map(
+					(path): ComposerMentionEntry => ({
+						id: path,
+						label: path,
+						icon: <FileCode2Icon className="size-4.5" />,
+						select: (ctx) =>
+							ctx.insertChip({ label: path, serialized: `@${path}` }),
+					}),
+				);
+				return [...dirs, ...files].slice(0, 8);
+			},
+		},
+	};
+}
+
+function skillsProvider(priority: number): ComposerMentionProvider {
+	return {
+		id: "skills",
+		title: "Skills",
+		priority,
+		source: {
+			kind: "static",
+			load: () =>
+				SKILLS.map((skill) => ({
+					id: skill.id,
+					label: skill.label,
+					description: skill.description,
+					icon: skill.icon,
+					select: (ctx) =>
+						ctx.insertChip({
+							label: skill.label,
+							serialized: `$${skill.label}`,
+							brandColor: skill.color,
+						}),
+				})),
+		},
+	};
+}
+
+function workspacesProvider(priority: number): ComposerMentionProvider {
+	return {
+		id: "workspaces",
+		title: "Workspaces",
+		priority,
+		source: {
+			kind: "static",
+			load: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 120));
+				return WORKSPACES.map((name) => ({
+					id: name,
+					label: name,
+					description: "Workspace",
+					icon: <PresetIcon name="superset" />,
+					select: (ctx) =>
+						ctx.insertChip({
+							label: name,
+							serialized: `workspace://${name}`,
+							iconUrl: getPresetIcon("superset", true),
+							data: { workspace: name },
+						}),
+				}));
+			},
+		},
+	};
+}
+
+function conversationsProvider(priority: number): ComposerMentionProvider {
+	return {
+		id: "conversations",
+		title: "Conversations",
+		priority,
+		source: {
+			kind: "static",
+			load: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return CONVERSATIONS.map((conversation) => ({
+					id: conversation.id,
+					label: conversation.title,
+					description: `${conversation.agentLabel} · ${conversation.workspace}`,
+					icon: <PresetIcon name={conversation.agent} />,
+					keywords: [conversation.agentLabel, conversation.workspace],
+					select: (ctx) =>
+						ctx.insertChip({
+							label: conversation.title,
+							serialized: `conversation://${conversation.id}`,
+							iconUrl: getPresetIcon(conversation.agent, true),
+							data: {
+								conversationId: conversation.id,
+								agent: conversation.agent,
+							},
+						}),
+				}));
+			},
+		},
+	};
+}
+
+function addProvider(
+	priority: number,
+	setPlanMode: (on: boolean) => void,
+): ComposerMentionProvider {
+	return {
+		id: "add",
+		title: "Add",
+		priority,
+		source: {
+			kind: "static",
+			load: () => [
+				{
+					id: "files-and-folders",
+					label: "Files and folders",
+					icon: <PaperclipIcon className="size-4.5" />,
+					select: (ctx) => ctx.attachFiles(),
+				},
+				{
+					id: "plan-mode",
+					label: "Plan mode",
+					description: "Turn plan mode on",
+					icon: <LightbulbIcon className="size-4.5" />,
+					select: () => setPlanMode(true),
+				},
+			],
+		},
+	};
+}
+
+const SKILL_COMMANDS = SKILLS.map(
+	(skill): PromptInputCommand => ({
+		id: `skill:${skill.id}`,
+		title: skill.label,
+		description: skill.description,
+		icon: skill.icon,
+		group: "Skills",
+		onSelect: (ctx) =>
+			ctx.insertChip({
+				label: skill.label,
+				serialized: `$${skill.label}`,
+				brandColor: skill.color,
+			}),
+	}),
+);
+
+const COMMANDS: PromptInputCommand[] = [
+	{
+		id: "compact",
+		title: "Compact",
+		description: "Compact this conversation's context",
+		icon: <CircleDashedIcon className="size-4.5" />,
+		searchAliases: ["summarize"],
+		onSelect: () => {},
+	},
+	{
+		id: "new-chat",
+		title: "New chat",
+		description: "Start a blank chat in this workspace",
+		icon: <MessageSquarePlusIcon className="size-4.5" />,
+		searchAliases: ["blank"],
+		onSelect: () => {},
+	},
+	...SKILL_COMMANDS,
+];
+
+function DemoToolbar({
+	planMode,
+	model,
+}: {
+	planMode: boolean;
+	model: string;
+}) {
+	return (
+		<>
+			<button
+				type="button"
+				className="flex h-8 cursor-pointer items-center gap-1.5 rounded-lg px-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+			>
+				<SparklesIcon className="size-4" />
+				{model}
+			</button>
+			<button
+				type="button"
+				className="flex h-8 cursor-pointer items-center gap-1.5 rounded-lg px-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+			>
+				<ChartNoAxesColumnIcon className="size-4" />
+				High
+			</button>
+			{planMode && (
+				<span className="flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm text-amber-500">
+					<LightbulbIcon className="size-4" />
+					Plan mode
+				</span>
+			)}
+		</>
+	);
+}
+
+const meta = {
+	component: PromptInput,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PromptInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+let messageId = 0;
+const nextId = () => `m${messageId++}`;
+
+const SEED_EXCHANGES: Array<[string, string]> = [
+	[
+		"Can you port the chat history rail from the reference app?",
+		"Done — the rail is a pure CSS scaleX falloff over sibling rows, with a hover card anchored per row. It's in packages/ui with Storybook coverage.",
+	],
+	[
+		"Now the composer — file mentions, slash commands, drag and drop",
+		"Built on Lexical with a provider-based mention registry: static sources load at mount, search sources query per keystroke with abort. Chips serialize as typed labels.",
+	],
+	[
+		"How does it compare to the reference implementation?",
+		"Item and section shapes converged almost exactly. We kept a provider registry at the component boundary since chat-ui feeds three apps; they hard-code sections because they're a single app.",
+	],
+];
+
+const SEED_MESSAGES: ChatHistorySidebarMessage[] = SEED_EXCHANGES.flatMap(
+	([user, assistant]) => [
+		{ id: nextId(), role: "user" as const, preview: user },
+		{ id: nextId(), role: "assistant" as const, preview: assistant },
+	],
+);
+
+function ChatScreen() {
+	const [messages, setMessages] =
+		useState<ChatHistorySidebarMessage[]>(SEED_MESSAGES);
+	const [streaming, setStreaming] = useState(false);
+	const [planMode, setPlanMode] = useState(false);
+	const [model, setModel] = useState("Sonnet 5");
+	// App-owned attachment click handling: images get a lightbox here; a real
+	// surface might open files in the editor instead.
+	const [preview, setPreview] = useState<PromptInputAttachment | null>(null);
+	const [fileNotice, setFileNotice] = useState<string | null>(null);
+	const [providers] = useState<ComposerMentionProvider[]>(() => [
+		addProvider(0, setPlanMode),
+		pluginsProvider(1),
+		skillsProvider(2),
+		workspacesProvider(3),
+		conversationsProvider(4),
+		fileSearchProvider(5),
+	]);
+
+	const noticeTimerRef = useRef<number | null>(null);
+	const showNotice = (text: string) => {
+		setFileNotice(text);
+		if (noticeTimerRef.current != null)
+			window.clearTimeout(noticeTimerRef.current);
+		noticeTimerRef.current = window.setTimeout(() => setFileNotice(null), 2500);
+	};
+
+	const commands: PromptInputCommand[] = [
+		{
+			id: "plan",
+			title: "Plan",
+			description: planMode
+				? "Turn off plan mode"
+				: "Plan before making changes",
+			icon: <LightbulbIcon className="size-4.5" />,
+			onSelect: () => setPlanMode((previous) => !previous),
+		},
+		{
+			id: "model",
+			title: "Model",
+			description: model,
+			icon: <BoxIcon className="size-4.5" />,
+			onSelect: () =>
+				setModel((previous) =>
+					previous === "Sonnet 5" ? "Opus 5" : "Sonnet 5",
+				),
+		},
+		{
+			id: "compact",
+			title: "Compact",
+			description: "Compact this conversation's context",
+			icon: <CircleDashedIcon className="size-4.5" />,
+			searchAliases: ["summarize"],
+			onSelect: () => showNotice("Compacted the conversation context"),
+		},
+		{
+			id: "new-chat",
+			title: "New chat",
+			description: "Start a blank chat in this workspace",
+			icon: <MessageSquarePlusIcon className="size-4.5" />,
+			searchAliases: ["blank"],
+			onSelect: () => showNotice("Would start a new chat"),
+		},
+		{
+			id: "review",
+			title: "Review",
+			description: "Review the current diff",
+			icon: <GitCompareArrowsIcon className="size-4.5" />,
+			onSelect: () => showNotice("Would start a code review"),
+		},
+		{
+			id: "continue",
+			title: "Continue in new chat",
+			description: "Carry this context into a fresh chat",
+			icon: <SplitIcon className="size-4.5" />,
+			onSelect: () => showNotice("Would continue in a new chat"),
+		},
+		{
+			id: "fast",
+			title: "Fast",
+			description: "Toggle faster responses",
+			icon: <ZapIcon className="size-4.5" />,
+			onSelect: () => showNotice("Would toggle fast mode"),
+		},
+		{
+			id: "feedback",
+			title: "Feedback",
+			description: "Send feedback about this chat",
+			icon: <MessagesSquareIcon className="size-4.5" />,
+			onSelect: () => showNotice("Would open the feedback form"),
+		},
+		{
+			id: "init",
+			title: "Init",
+			description: "Create an AGENTS.md for this repo",
+			icon: <FilePlus2Icon className="size-4.5" />,
+			onSelect: () => showNotice("Would draft AGENTS.md"),
+		},
+		{
+			id: "mcp",
+			title: "MCP",
+			description: "Show MCP server status",
+			icon: <ServerIcon className="size-4.5" />,
+			onSelect: () => showNotice("Would show MCP status"),
+		},
+		...SKILL_COMMANDS,
+	];
+
+	const handleSubmit = ({ text, mentions }: PromptInputSubmitPayload) => {
+		setMessages((previous) => [
+			...previous,
+			{ id: nextId(), role: "user", preview: text },
+		]);
+		setStreaming(true);
+		window.setTimeout(() => {
+			setMessages((previous) => [
+				...previous,
+				{
+					id: nextId(),
+					role: "assistant",
+					preview:
+						mentions.length > 0
+							? `On it — I'll start from ${mentions.map((m) => m.label).join(", ")}.`
+							: "On it.",
+				},
+			]);
+			setStreaming(false);
+		}, 1400);
+	};
+
+	return (
+		<ComposerDropZone className="flex h-screen bg-background text-foreground">
+			<MessageScroller.Provider autoScroll defaultScrollPosition="end">
+				<div className="flex w-16 shrink-0 items-center pl-3">
+					<ChatHistorySidebarScroller messages={messages} />
+				</div>
+				<MessageScroller.Root className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+					<MessageScroller.Viewport className="flex flex-1 flex-col overflow-y-auto">
+						<MessageScroller.Content className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-10">
+							{messages.map((message) => (
+								<MessageScroller.Item
+									key={message.id}
+									messageId={message.id}
+									scrollAnchor={message.role === "user"}
+									className={
+										message.role === "user"
+											? "ml-auto max-w-[80%] rounded-2xl bg-secondary px-4 py-2.5 text-sm text-secondary-foreground"
+											: "text-sm leading-relaxed text-foreground/90"
+									}
+								>
+									{message.preview}
+								</MessageScroller.Item>
+							))}
+							{streaming && (
+								<p className="text-sm text-muted-foreground">Thinking…</p>
+							)}
+						</MessageScroller.Content>
+					</MessageScroller.Viewport>
+					<div className="relative mx-auto w-full max-w-3xl px-6 pb-[18px]">
+						<div className="pointer-events-none absolute inset-x-0 -top-12 flex justify-center">
+							<ScrollToBottomButton />
+						</div>
+						{fileNotice && (
+							<p className="pb-2 text-xs text-muted-foreground">{fileNotice}</p>
+						)}
+						<PromptInput
+							placeholder="Ask to make changes, @mention files, run /commands"
+							mentionProviders={providers}
+							commands={commands}
+							dictation={{
+								transcribe: async () => {
+									const shouldFail = (window as { __failTranscribe?: boolean })
+										.__failTranscribe;
+									await new Promise((resolve) => setTimeout(resolve, 900));
+									if (shouldFail) throw new Error("fetch failed");
+									return "Tighten the composer spacing and ship it.";
+								},
+								onError: (error) => showNotice(error.message),
+							}}
+							status={streaming ? "streaming" : "ready"}
+							toolbar={<DemoToolbar planMode={planMode} model={model} />}
+							onStop={() => setStreaming(false)}
+							onSubmit={handleSubmit}
+							onAttachmentClick={(attachment) => {
+								if (attachment.previewUrl) {
+									setPreview(attachment);
+								} else {
+									showNotice(
+										`Would open ${attachment.file.name} in your editor`,
+									);
+								}
+							}}
+							onChipClick={(chip) => showNotice(`Would open ${chip.label}`)}
+						/>
+					</div>
+				</MessageScroller.Root>
+			</MessageScroller.Provider>
+			{preview?.previewUrl && (
+				// biome-ignore lint/a11y/useKeyWithClickEvents: demo lightbox, backdrop dismissal
+				// biome-ignore lint/a11y/noStaticElementInteractions: demo lightbox, backdrop dismissal
+				<div
+					className="fixed inset-0 z-[100] flex cursor-pointer items-center justify-center bg-background/80 p-10 backdrop-blur-sm"
+					onClick={() => setPreview(null)}
+				>
+					<img
+						src={preview.previewUrl}
+						alt={preview.file.name}
+						className="max-h-full max-w-full rounded-xl shadow-2xl"
+					/>
+				</div>
+			)}
+		</ComposerDropZone>
+	);
+}
+
+function ComposerOnly() {
+	const [providers] = useState<ComposerMentionProvider[]>(() => [
+		pluginsProvider(0),
+		skillsProvider(1),
+		workspacesProvider(2),
+		conversationsProvider(3),
+		fileSearchProvider(4),
+	]);
+	return (
+		<div className="flex min-h-screen items-end justify-center bg-background px-6 pb-10 text-foreground">
+			<div className="w-full max-w-3xl">
+				<PromptInput
+					placeholder="Ask to make changes, @mention files, run /commands"
+					mentionProviders={providers}
+					commands={COMMANDS}
+					dictation={{
+						transcribe: async () => {
+							const shouldFail = (window as { __failTranscribe?: boolean })
+								.__failTranscribe;
+							await new Promise((resolve) => setTimeout(resolve, 900));
+							if (shouldFail) throw new Error("fetch failed");
+							return "Tighten the composer spacing and ship it.";
+						},
+					}}
+					onSubmit={() => {}}
+					onAttachmentClick={() => {}}
+					onChipClick={() => {}}
+				/>
+			</div>
+		</div>
+	);
+}
+
+// Speech-like synthetic mic input so the story needs no permission prompt.
+function stubMicrophone() {
+	const context = new AudioContext();
+	const oscillator = context.createOscillator();
+	const gain = context.createGain();
+	const burst = context.createOscillator();
+	const burstDepth = context.createGain();
+	const destination = context.createMediaStreamDestination();
+	oscillator.frequency.value = 220;
+	gain.gain.value = 0.4;
+	burst.frequency.value = 1.6;
+	burstDepth.gain.value = 0.4;
+	burst.connect(burstDepth);
+	burstDepth.connect(gain.gain);
+	oscillator.connect(gain);
+	gain.connect(destination);
+	oscillator.start();
+	burst.start();
+	navigator.mediaDevices.getUserMedia = async () => destination.stream;
+}
+
+export const Default: Story = {
+	args: { mentionProviders: [], commands: COMMANDS },
+	render: () => <ChatScreen />,
+};
+
+export const Recording: Story = {
+	args: { mentionProviders: [], commands: COMMANDS },
+	render: () => <ComposerOnly />,
+	play: async ({ canvasElement }) => {
+		stubMicrophone();
+		canvasElement
+			.querySelector<HTMLButtonElement>('[aria-label="Dictate"]')
+			?.click();
+	},
+};
+
+export const DictationError: Story = {
+	args: { mentionProviders: [], commands: COMMANDS },
+	render: () => <ComposerOnly />,
+	play: async ({ canvasElement }) => {
+		stubMicrophone();
+		const flags = window as { __failTranscribe?: boolean };
+		flags.__failTranscribe = true;
+		canvasElement
+			.querySelector<HTMLButtonElement>('[aria-label="Dictate"]')
+			?.click();
+		await new Promise((resolve) => setTimeout(resolve, 1200));
+		canvasElement
+			.querySelector<HTMLButtonElement>('[aria-label="Stop dictation"]')
+			?.click();
+		// Let the failing transcription land, then "restore the connection"
+		// so the retry button succeeds.
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+		flags.__failTranscribe = false;
+	},
+};
+
+export const BrowseMenu: Story = {
+	args: { mentionProviders: [], commands: COMMANDS },
+	render: () => <ComposerOnly />,
+	play: async ({ canvasElement }) => {
+		canvasElement
+			.querySelector<HTMLButtonElement>(
+				'[aria-label="Add files, apps, and more"]',
+			)
+			?.click();
+	},
+};
+
+export const WithAttachments: Story = {
+	args: { mentionProviders: [], commands: COMMANDS },
+	render: () => <ComposerOnly />,
+	play: async ({ canvasElement }) => {
+		const canvas = document.createElement("canvas");
+		canvas.width = 64;
+		canvas.height = 64;
+		const context = canvas.getContext("2d");
+		if (context) {
+			context.fillStyle = "#0ea5e9";
+			context.fillRect(0, 0, 64, 64);
+			context.fillStyle = "#f59e0b";
+			context.beginPath();
+			context.arc(32, 32, 18, 0, Math.PI * 2);
+			context.fill();
+		}
+		const blob = await new Promise<Blob | null>((resolve) =>
+			canvas.toBlob(resolve, "image/png"),
+		);
+		const transfer = new DataTransfer();
+		if (blob)
+			transfer.items.add(
+				new File([blob], "screenshot.png", { type: "image/png" }),
+			);
+		transfer.items.add(new File(["{}"], "bun.lock", { type: "" }));
+		canvasElement.querySelector(".prompt-input-editor")?.dispatchEvent(
+			new DragEvent("drop", {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer: transfer,
+			}),
+		);
+	},
+};

--- a/packages/chat-ui/src/components/PromptInput/PromptInput.tsx
+++ b/packages/chat-ui/src/components/PromptInput/PromptInput.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+	type InitialConfigType,
+	LexicalComposer as LexicalRoot,
+} from "@lexical/react/LexicalComposer";
+import { useState } from "react";
+import { ComposerBody } from "./components/ComposerBody";
+import { MentionChipNode } from "./nodes/mentionChipNode";
+import type { PromptInputProps } from "./types";
+import "./prompt-input.css";
+
+export type {
+	ComposerActionContext,
+	ComposerChip,
+	ComposerMentionEntry,
+	ComposerMentionProvider,
+	ComposerMentionSource,
+	ComposerPanelContent,
+	PromptInputAttachment,
+	PromptInputCommand,
+	PromptInputDictation,
+	PromptInputProps,
+	PromptInputSubmitPayload,
+} from "./types";
+
+export function PromptInput({
+	placeholder = "Do anything",
+	mentionProviders,
+	commands,
+	dictation,
+	status = "ready",
+	placement = "top",
+	toolbar,
+	onSubmit,
+	onStop,
+	onMentionHighlight,
+	onAttachmentClick,
+	onChipClick,
+	className,
+}: PromptInputProps) {
+	const [initialConfig] = useState<InitialConfigType>(() => ({
+		namespace: "prompt-input",
+		nodes: [MentionChipNode],
+		onError: (error: Error) => {
+			throw error;
+		},
+	}));
+
+	return (
+		<div className={className}>
+			<LexicalRoot initialConfig={initialConfig}>
+				<ComposerBody
+					placeholder={placeholder}
+					mentionProviders={mentionProviders}
+					commands={commands}
+					dictation={dictation}
+					status={status}
+					placement={placement}
+					toolbar={toolbar}
+					onSubmit={onSubmit}
+					onStop={onStop}
+					onMentionHighlight={onMentionHighlight}
+					onAttachmentClick={onAttachmentClick}
+					onChipClick={onChipClick}
+				/>
+			</LexicalRoot>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/AttachmentPills.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/AttachmentPills.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+	FileArchiveIcon,
+	FileCode2Icon,
+	FileJson2Icon,
+	FileTextIcon,
+	ImageIcon,
+	Music2Icon,
+} from "lucide-react";
+import type { JSX } from "react";
+import type { PromptInputAttachment } from "../../types";
+import { RemoveButton } from "./components/RemoveButton";
+
+export type AttachmentPillsProps = {
+	attachments: PromptInputAttachment[];
+	onRemove: (id: string) => void;
+	onPreviewError?: (id: string) => void;
+	onAttachmentClick?: (attachment: PromptInputAttachment) => void;
+};
+
+const CODE_EXTENSIONS = new Set([
+	"ts",
+	"tsx",
+	"js",
+	"jsx",
+	"py",
+	"rs",
+	"go",
+	"rb",
+	"swift",
+	"css",
+	"html",
+	"sh",
+]);
+const DATA_EXTENSIONS = new Set(["json", "yaml", "yml", "toml", "lock"]);
+const ARCHIVE_EXTENSIONS = new Set(["zip", "tar", "gz", "tgz", "7z", "rar"]);
+
+// Mime type first (audio, images demoted after a failed preview), then
+// extension for the text-ish formats mime can't distinguish.
+function fileTypeIcon(mediaType: string, extension: string): JSX.Element {
+	if (mediaType.startsWith("audio/"))
+		return <Music2Icon className="size-5 text-muted-foreground" />;
+	if (mediaType.startsWith("image/"))
+		return <ImageIcon className="size-5 text-muted-foreground" />;
+	const lowered = extension.toLowerCase();
+	if (CODE_EXTENSIONS.has(lowered))
+		return <FileCode2Icon className="size-5 text-muted-foreground" />;
+	if (DATA_EXTENSIONS.has(lowered))
+		return <FileJson2Icon className="size-5 text-muted-foreground" />;
+	if (ARCHIVE_EXTENSIONS.has(lowered))
+		return <FileArchiveIcon className="size-5 text-muted-foreground" />;
+	return <FileTextIcon className="size-5 text-muted-foreground" />;
+}
+
+export function AttachmentPills({
+	attachments,
+	onRemove,
+	onPreviewError,
+	onAttachmentClick,
+}: AttachmentPillsProps) {
+	if (attachments.length === 0) return null;
+	return (
+		<div className="flex flex-wrap gap-2 px-3 pt-3">
+			{attachments.map((attachment) => {
+				const filename = attachment.file.name || "attachment";
+				const dotIndex = filename.lastIndexOf(".");
+				const extension =
+					dotIndex > 0 ? filename.slice(dotIndex + 1).toUpperCase() : "";
+				if (attachment.previewUrl) {
+					return (
+						<div key={attachment.id} className="relative shrink-0">
+							<button
+								type="button"
+								aria-label={filename}
+								className="group/attachment relative block size-16 cursor-pointer overflow-hidden rounded-xl border-[0.5px] border-border bg-foreground/[0.04]"
+								onClick={() => onAttachmentClick?.(attachment)}
+							>
+								{attachment.file.type.startsWith("video/") ? (
+									<video
+										src={attachment.previewUrl}
+										muted
+										className="size-full object-cover"
+										onError={() => onPreviewError?.(attachment.id)}
+									/>
+								) : (
+									<img
+										src={attachment.previewUrl}
+										alt={filename}
+										className="size-full object-cover"
+										onError={() => onPreviewError?.(attachment.id)}
+									/>
+								)}
+								<span className="pointer-events-none absolute inset-0 bg-foreground/[0.02] opacity-0 transition-opacity duration-150 group-hover/attachment:opacity-100" />
+							</button>
+							<RemoveButton onClick={() => onRemove(attachment.id)} />
+						</div>
+					);
+				}
+				return (
+					<div key={attachment.id} className="relative shrink-0">
+						<button
+							type="button"
+							onClick={() => onAttachmentClick?.(attachment)}
+							className="group/attachment relative flex h-16 w-[200px] cursor-pointer items-center gap-2.5 overflow-hidden rounded-xl border-[0.5px] border-border bg-foreground/[0.03] px-2.5 text-left"
+						>
+							<span className="pointer-events-none absolute inset-0 bg-foreground/[0.02] opacity-0 transition-opacity duration-150 group-hover/attachment:opacity-100" />
+							<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.06]">
+								{fileTypeIcon(attachment.file.type, extension)}
+							</div>
+							<div className="min-w-0 flex-1 pr-3">
+								<div className="truncate text-xs text-foreground">
+									{filename}
+								</div>
+								{extension && (
+									<div className="text-[10px] text-muted-foreground">
+										{extension}
+									</div>
+								)}
+							</div>
+						</button>
+						<RemoveButton onClick={() => onRemove(attachment.id)} />
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/components/RemoveButton/RemoveButton.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/components/RemoveButton/RemoveButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+
+export type RemoveButtonProps = {
+	onClick: () => void;
+};
+
+export function RemoveButton({ onClick }: RemoveButtonProps) {
+	return (
+		<button
+			type="button"
+			aria-label="Remove attachment"
+			className="absolute top-1 right-1 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm transition-opacity hover:opacity-90"
+			onClick={onClick}
+		>
+			<XIcon className="size-3" />
+		</button>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/components/RemoveButton/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/components/RemoveButton/index.ts
@@ -1,0 +1,1 @@
+export { RemoveButton, type RemoveButtonProps } from "./RemoveButton";

--- a/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/AttachmentPills/index.ts
@@ -1,0 +1,1 @@
+export { AttachmentPills, type AttachmentPillsProps } from "./AttachmentPills";

--- a/packages/chat-ui/src/components/PromptInput/components/CommandMenu/CommandMenu.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/CommandMenu/CommandMenu.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { cn } from "@superset/ui/utils";
+import { SlashSquareIcon } from "lucide-react";
+import { Fragment } from "react";
+import type { PromptInputCommand } from "../../types";
+
+export type CommandMenuProps = {
+	commands: PromptInputCommand[];
+	selectedIndex: number | null;
+	onHighlight: (index: number) => void;
+	onSelect: (command: PromptInputCommand) => void;
+};
+
+export function CommandMenu({
+	commands,
+	selectedIndex,
+	onHighlight,
+	onSelect,
+}: CommandMenuProps) {
+	if (commands.length === 0) return null;
+	let previousGroup: string | null = null;
+	return (
+		<div
+			role="listbox"
+			className="relative z-50 w-full rounded-2xl bg-popover/95 p-1.5 shadow-xl ring-1 ring-border backdrop-blur-sm"
+		>
+			<div className="scroll-fade max-h-96 overflow-y-auto">
+				{commands.map((command, index) => {
+					const group = command.group ?? null;
+					const heading = group !== previousGroup ? group : null;
+					previousGroup = group;
+					return (
+						<Fragment key={command.id}>
+							{heading && (
+								<p className="px-3 pt-2.5 pb-1 text-[13px] text-muted-foreground">
+									{heading}
+								</p>
+							)}
+							{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by the editor */}
+							{/* biome-ignore lint/a11y/useFocusableInteractive: focus stays in the editor; listbox is virtual */}
+							<div
+								role="option"
+								aria-selected={index === selectedIndex}
+								className={cn(
+									"flex cursor-pointer items-center gap-2.5 rounded-[10px] px-3 py-[5px] text-[15px] leading-[21px]",
+									index === selectedIndex
+										? "bg-accent text-accent-foreground"
+										: "text-foreground",
+								)}
+								onMouseEnter={() => onHighlight(index)}
+								onMouseDown={(event) => event.preventDefault()}
+								onClick={() => onSelect(command)}
+							>
+								<span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+									{command.icon ?? <SlashSquareIcon className="size-4.5" />}
+								</span>
+								<span className="shrink-0 font-medium">{command.title}</span>
+								{command.description && (
+									<span className="ml-auto min-w-0 truncate pl-6 text-muted-foreground">
+										{command.description}
+									</span>
+								)}
+								{command.rightIcon && (
+									<span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+										{command.rightIcon}
+									</span>
+								)}
+							</div>
+						</Fragment>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/CommandMenu/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/CommandMenu/index.ts
@@ -1,0 +1,1 @@
+export { CommandMenu, type CommandMenuProps } from "./CommandMenu";

--- a/packages/chat-ui/src/components/PromptInput/components/ComposerBody/ComposerBody.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/ComposerBody/ComposerBody.tsx
@@ -1,0 +1,790 @@
+"use client";
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { cn } from "@superset/ui/utils";
+import {
+	$createNodeSelection,
+	$createTextNode,
+	$getNearestNodeFromDOMNode,
+	$getRoot,
+	$getSelection,
+	$isNodeSelection,
+	$isRangeSelection,
+	$isTextNode,
+	$setSelection,
+	CLICK_COMMAND,
+	COMMAND_PRIORITY_HIGH,
+	COMMAND_PRIORITY_LOW,
+	DROP_COMMAND,
+	KEY_BACKSPACE_COMMAND,
+	KEY_DELETE_COMMAND,
+	KEY_ENTER_COMMAND,
+	type LexicalNode,
+	PASTE_COMMAND,
+} from "lexical";
+import {
+	ArrowUpIcon,
+	MicIcon,
+	RefreshCcwIcon,
+	SquareIcon,
+	XIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useComposerDropZone } from "../../../ComposerDropZone";
+import { useDictation } from "../../hooks/useDictation";
+import { useMentionSources } from "../../hooks/useMentionSources";
+import { MentionChipNode } from "../../nodes/mentionChipNode";
+import type {
+	ComposerActionContext,
+	ComposerChip,
+	ComposerMentionEntry,
+	ComposerPanelContent,
+	PromptInputAttachment,
+	PromptInputProps,
+} from "../../types";
+import { matchToken } from "../../utils/matchToken";
+import { rankCommands } from "../../utils/rankCommands";
+import {
+	CommandTypeaheadOption,
+	MentionTypeaheadOption,
+} from "../../utils/typeaheadOptions";
+import { AttachmentPills } from "../AttachmentPills";
+import { CommandMenu } from "../CommandMenu";
+import { ComposerPanel } from "../ComposerPanel";
+import { ContextButton } from "../ContextButton";
+import { DictationBar } from "../DictationBar";
+import { MentionMenu } from "../MentionMenu";
+
+// Slash commands only trigger while the "/token" is the entire message.
+function matchCommandToken(text: string) {
+	const match = /^\/([^/\r\n]*)$/.exec(text);
+	if (!match) return null;
+	return {
+		leadOffset: 0,
+		matchingString: match[1] ?? "",
+		replaceableString: match[0],
+	};
+}
+
+export type ComposerBodyProps = Required<
+	Pick<PromptInputProps, "placeholder" | "status" | "placement">
+> &
+	Pick<
+		PromptInputProps,
+		| "mentionProviders"
+		| "commands"
+		| "dictation"
+		| "toolbar"
+		| "onSubmit"
+		| "onStop"
+		| "onMentionHighlight"
+		| "onAttachmentClick"
+		| "onChipClick"
+	>;
+
+function $insertChipAtSelection(chip: ComposerChip) {
+	let selection = $getSelection();
+	if (!$isRangeSelection(selection)) {
+		$getRoot().selectEnd();
+		selection = $getSelection();
+	}
+	if (!$isRangeSelection(selection)) return;
+	const chipNode = MentionChipNode.fromChip(chip);
+	selection.insertNodes([chipNode, $createTextNode(" ")]);
+}
+
+function $collectChips(): ComposerChip[] {
+	const chips: ComposerChip[] = [];
+	const visit = (node: LexicalNode) => {
+		if (node instanceof MentionChipNode) {
+			chips.push(node.toChip());
+		}
+		if ("getChildren" in node) {
+			for (const child of (
+				node as unknown as { getChildren(): LexicalNode[] }
+			).getChildren()) {
+				visit(child);
+			}
+		}
+	};
+	visit($getRoot());
+	return chips;
+}
+
+export function ComposerBody({
+	placeholder,
+	mentionProviders,
+	commands,
+	dictation,
+	status,
+	placement,
+	toolbar,
+	onSubmit,
+	onStop,
+	onMentionHighlight,
+	onAttachmentClick,
+	onChipClick,
+}: ComposerBodyProps) {
+	const [editor] = useLexicalComposerContext();
+	const [attachments, setAttachments] = useState<PromptInputAttachment[]>([]);
+	const [isEmpty, setIsEmpty] = useState(true);
+	const [dragging, setDragging] = useState(false);
+	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+	const [commandQuery, setCommandQuery] = useState<string | null>(null);
+	const [commandDismissed, setCommandDismissed] = useState(false);
+	const [panel, setPanel] = useState<ComposerPanelContent | null>(null);
+	const [menuSlot, setMenuSlot] = useState<HTMLDivElement | null>(null);
+	const [browseOpen, setBrowseOpen] = useState(false);
+	const [browseIndex, setBrowseIndex] = useState(0);
+	const [typeaheadDismissed, setTypeaheadDismissed] = useState(false);
+	const rootRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	// Lexical command listeners register once; this ref bridges them to live React state.
+	const stateRef = useRef({ attachments, onChipClick, onSubmit, status });
+	stateRef.current = { attachments, onChipClick, onSubmit, status };
+
+	const addFiles = (files: FileList | File[]) => {
+		const incoming = Array.from(files);
+		if (incoming.length === 0) return;
+		setAttachments((previous) => [
+			...previous,
+			...incoming.map((file) => ({
+				id: crypto.randomUUID(),
+				file,
+				previewUrl:
+					file.type.startsWith("image/") || file.type.startsWith("video/")
+						? URL.createObjectURL(file)
+						: undefined,
+			})),
+		]);
+	};
+	const addFilesRef = useRef(addFiles);
+	addFilesRef.current = addFiles;
+
+	const dropZone = useComposerDropZone();
+	useEffect(() => {
+		return dropZone?.register((files) => addFilesRef.current(files));
+	}, [dropZone]);
+
+	const actionContext: ComposerActionContext = {
+		insertChip: (chip) => {
+			editor.update(() => $insertChipAtSelection(chip));
+		},
+		attachFiles: () => fileInputRef.current?.click(),
+		openPanel: setPanel,
+		query: mentionQuery ?? "",
+	};
+	const actionContextRef = useRef(actionContext);
+	actionContextRef.current = actionContext;
+
+	const sections = useMentionSources(
+		mentionProviders ?? [],
+		mentionQuery != null || browseOpen,
+		mentionQuery ?? "",
+	);
+	const browseEntries = useMemo(
+		() => sections.flatMap((section) => section.entries),
+		[sections],
+	);
+
+	useEffect(() => {
+		setTypeaheadDismissed(false);
+		// The two menu modes are mutually exclusive: typing "@" replaces browse.
+		if (mentionQuery != null) setBrowseOpen(false);
+	}, [mentionQuery]);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset dismissal whenever the token changes
+	useEffect(() => {
+		setCommandDismissed(false);
+	}, [commandQuery]);
+	const mentionOptions = useMemo(
+		() =>
+			sections.flatMap((section) =>
+				section.entries.map((entry) => new MentionTypeaheadOption(entry)),
+			),
+		[sections],
+	);
+
+	const rankedCommands = useMemo(
+		() => rankCommands(commands ?? [], commandQuery ?? ""),
+		[commands, commandQuery],
+	);
+	const commandOptions = useMemo(
+		() => rankedCommands.map((command) => new CommandTypeaheadOption(command)),
+		[rankedCommands],
+	);
+
+	const selectMentionEntry = (
+		entry: ComposerMentionEntry,
+		nodeToReplace: LexicalNode | null,
+		closeMenu: () => void,
+	) => {
+		if (entry.completionQuery != null) {
+			const completion = entry.completionQuery;
+			editor.update(() => {
+				if (nodeToReplace && "setTextContent" in nodeToReplace) {
+					const textNode = nodeToReplace as unknown as {
+						setTextContent(text: string): void;
+						select(anchor: number, focus: number): void;
+					};
+					const text = `@${completion}`;
+					textNode.setTextContent(text);
+					textNode.select(text.length, text.length);
+				}
+			});
+			return;
+		}
+		editor.update(() => {
+			nodeToReplace?.remove();
+			closeMenu();
+		});
+		void entry.select(actionContextRef.current);
+	};
+
+	useEffect(() => {
+		if (mentionQuery == null) onMentionHighlight?.(null);
+	}, [mentionQuery, onMentionHighlight]);
+
+	const releaseAttachment = (attachment: PromptInputAttachment) => {
+		if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+	};
+
+	const submit = () => {
+		if (stateRef.current.status === "streaming") return;
+		const { text, mentions } = editor.getEditorState().read(() => ({
+			text: $getRoot().getTextContent().trim(),
+			mentions: $collectChips(),
+		}));
+		const files = stateRef.current.attachments.map(
+			(attachment) => attachment.file,
+		);
+		if (!text && files.length === 0) return;
+		stateRef.current.onSubmit?.({ text, files, mentions });
+		editor.update(() => $getRoot().clear());
+		setAttachments((previous) => {
+			for (const attachment of previous) releaseAttachment(attachment);
+			return [];
+		});
+		setPanel(null);
+	};
+	const submitRef = useRef(submit);
+	submitRef.current = submit;
+
+	const dictationSession = useDictation({
+		transcribe: (audio) => dictation?.transcribe(audio) ?? "",
+		onError: (dictationError) => dictation?.onError?.(dictationError),
+		onTranscript: (text) => {
+			editor.update(() => {
+				$getRoot().selectEnd();
+				const selection = $getSelection();
+				if (!$isRangeSelection(selection)) return;
+				const anchorNode = selection.anchor.getNode();
+				const offset = selection.anchor.offset;
+				const previousChar = $isTextNode(anchorNode)
+					? anchorNode.getTextContent()[offset - 1]
+					: undefined;
+				const needsSpace = previousChar != null && !/\s/.test(previousChar);
+				selection.insertText(needsSpace ? ` ${text}` : text);
+			});
+		},
+	});
+
+	useEffect(() => {
+		const unregisterText = editor.registerTextContentListener((text) =>
+			setIsEmpty(text.trim().length === 0),
+		);
+		const unregisterEnter = editor.registerCommand<KeyboardEvent | null>(
+			KEY_ENTER_COMMAND,
+			(event) => {
+				if (event?.shiftKey) return false;
+				event?.preventDefault();
+				submitRef.current();
+				return true;
+			},
+			COMMAND_PRIORITY_LOW,
+		);
+		const unregisterDrop = editor.registerCommand<DragEvent>(
+			DROP_COMMAND,
+			(event) => {
+				const files = event.dataTransfer?.files;
+				if (files && files.length > 0) {
+					event.preventDefault();
+					addFilesRef.current(files);
+					setDragging(false);
+					return true;
+				}
+				return false;
+			},
+			COMMAND_PRIORITY_HIGH,
+		);
+		const unregisterPaste = editor.registerCommand<ClipboardEvent>(
+			PASTE_COMMAND,
+			(event) => {
+				const files =
+					event instanceof ClipboardEvent ? event.clipboardData?.files : null;
+				if (files && files.length > 0) {
+					event.preventDefault();
+					addFilesRef.current(files);
+					return true;
+				}
+				return false;
+			},
+			COMMAND_PRIORITY_HIGH,
+		);
+		// Chips are decorator nodes: clicks select them as a node selection (and
+		// notify the app), and Backspace/Delete remove the selected chips.
+		const unregisterClick = editor.registerCommand<MouseEvent>(
+			CLICK_COMMAND,
+			(event) => {
+				const target = event.target;
+				if (!(target instanceof Element)) return false;
+				const chipElement = target.closest("[data-mention-chip]");
+				if (!chipElement) return false;
+				const node = $getNearestNodeFromDOMNode(chipElement);
+				if (!(node instanceof MentionChipNode)) return false;
+				const selection = $createNodeSelection();
+				selection.add(node.getKey());
+				$setSelection(selection);
+				stateRef.current.onChipClick?.(node.toChip());
+				return true;
+			},
+			COMMAND_PRIORITY_LOW,
+		);
+		const removeSelectedChips = (event: KeyboardEvent | null) => {
+			const selection = $getSelection();
+			if (!$isNodeSelection(selection)) return false;
+			const nodes = selection.getNodes();
+			if (
+				nodes.length === 0 ||
+				!nodes.every((node) => node instanceof MentionChipNode)
+			)
+				return false;
+			event?.preventDefault();
+			for (const node of nodes) node.remove();
+			return true;
+		};
+		const unregisterBackspace = editor.registerCommand<KeyboardEvent | null>(
+			KEY_BACKSPACE_COMMAND,
+			removeSelectedChips,
+			COMMAND_PRIORITY_LOW,
+		);
+		const unregisterDelete = editor.registerCommand<KeyboardEvent | null>(
+			KEY_DELETE_COMMAND,
+			removeSelectedChips,
+			COMMAND_PRIORITY_LOW,
+		);
+		return () => {
+			unregisterText();
+			unregisterEnter();
+			unregisterDrop();
+			unregisterPaste();
+			unregisterClick();
+			unregisterBackspace();
+			unregisterDelete();
+		};
+	}, [editor]);
+
+	const toggleBrowseMenu = () => {
+		setTypeaheadDismissed(true);
+		setBrowseIndex(0);
+		setBrowseOpen((previous) => !previous);
+	};
+
+	const selectBrowseEntry = (entry: ComposerMentionEntry) => {
+		setBrowseOpen(false);
+		if (entry.completionQuery != null) {
+			const completion = entry.completionQuery;
+			editor.focus();
+			editor.update(() => {
+				let selection = $getSelection();
+				if (!$isRangeSelection(selection)) {
+					$getRoot().selectEnd();
+					selection = $getSelection();
+				}
+				if (!$isRangeSelection(selection)) return;
+				const anchorNode = selection.anchor.getNode();
+				const offset = selection.anchor.offset;
+				const previousChar = $isTextNode(anchorNode)
+					? anchorNode.getTextContent()[offset - 1]
+					: undefined;
+				const needsSpace =
+					(previousChar != null && !/\s/.test(previousChar)) ||
+					(!$isTextNode(anchorNode) && offset > 0);
+				selection.insertText(needsSpace ? ` @${completion}` : `@${completion}`);
+			});
+			return;
+		}
+		void entry.select(actionContextRef.current);
+	};
+
+	// Escape aborts dictation without transcribing; it outranks every other
+	// Escape behavior while a recording or failed transcription is active.
+	useEffect(() => {
+		if (
+			dictationSession.status !== "recording" &&
+			dictationSession.status !== "error"
+		)
+			return;
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== "Escape") return;
+			event.preventDefault();
+			event.stopPropagation();
+			dictationSession.cancel();
+		};
+		window.addEventListener("keydown", onKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener("keydown", onKeyDown, { capture: true });
+	});
+
+	// Browse-mode keyboard: the editor may not be focused, so listen globally.
+	useEffect(() => {
+		if (!browseOpen) return;
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+				event.preventDefault();
+				const delta = event.key === "ArrowDown" ? 1 : -1;
+				setBrowseIndex((previous) => {
+					const count = browseEntries.length;
+					return count === 0 ? 0 : (previous + delta + count) % count;
+				});
+				return;
+			}
+			if (event.key === "Enter") {
+				event.preventDefault();
+				const entry = browseEntries[browseIndex];
+				if (entry) selectBrowseEntry(entry);
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				setBrowseOpen(false);
+			}
+		};
+		window.addEventListener("keydown", onKeyDown, { capture: true });
+		return () =>
+			window.removeEventListener("keydown", onKeyDown, { capture: true });
+	});
+
+	// Any pointer press outside the composer and its menus dismisses both
+	// modes; a press on the editor itself closes browse (typing intent).
+	useEffect(() => {
+		const onPointerDown = (event: PointerEvent) => {
+			const target = event.target as Node | null;
+			if (target && rootRef.current?.contains(target)) {
+				if (
+					target instanceof Element &&
+					target.closest(".prompt-input-editor")
+				) {
+					setBrowseOpen(false);
+				}
+				return;
+			}
+			setBrowseOpen(false);
+			setTypeaheadDismissed(true);
+			setCommandDismissed(true);
+		};
+		document.addEventListener("pointerdown", onPointerDown);
+		return () => document.removeEventListener("pointerdown", onPointerDown);
+	}, []);
+
+	const canSend = !isEmpty || attachments.length > 0;
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop target; keyboard users attach via the file picker button
+		<div
+			ref={rootRef}
+			className={cn(
+				"relative flex flex-col rounded-2xl bg-card ring-1 ring-border transition-shadow focus-within:ring-ring/40",
+			)}
+			onDragOver={(event) => {
+				if (dropZone == null && event.dataTransfer.types.includes("Files")) {
+					event.preventDefault();
+					setDragging(true);
+				}
+			}}
+			onDragLeave={(event) => {
+				if (!event.currentTarget.contains(event.relatedTarget as Node | null))
+					setDragging(false);
+			}}
+			onDrop={(event) => {
+				// The editor's DROP_COMMAND handler may have consumed this already;
+				// preventDefault marks it and the event still bubbles here. Inside a
+				// layout ComposerDropZone the zone owns non-editor drops instead.
+				if (
+					dropZone == null &&
+					!event.defaultPrevented &&
+					event.dataTransfer.files.length > 0
+				) {
+					event.preventDefault();
+					addFiles(event.dataTransfer.files);
+				}
+				setDragging(false);
+			}}
+		>
+			<div
+				ref={setMenuSlot}
+				className={cn(
+					"pointer-events-none absolute inset-x-0 [&>*]:pointer-events-auto",
+					placement === "bottom" ? "top-full pt-2" : "bottom-full pb-2",
+				)}
+			>
+				{browseOpen && (
+					<MentionMenu
+						sections={sections}
+						selectedIndex={browseIndex}
+						onHighlight={setBrowseIndex}
+						onSelectionChange={onMentionHighlight}
+						onSelect={selectBrowseEntry}
+					/>
+				)}
+			</div>
+			{panel && (
+				<ComposerPanel
+					title={panel.title}
+					placement={placement}
+					onClose={() => setPanel(null)}
+				>
+					{panel.render()}
+				</ComposerPanel>
+			)}
+			<div
+				aria-hidden={!dragging}
+				className={cn(
+					"pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-primary/10 transition-opacity duration-150 motion-reduce:transition-none",
+					dragging ? "opacity-100" : "opacity-0",
+				)}
+			>
+				<span
+					className={cn(
+						"inline-flex items-center rounded-md border border-border/50 bg-secondary px-3 py-1 text-sm text-foreground shadow transition-transform duration-150 motion-reduce:transition-none",
+						dragging ? "scale-100" : "scale-95",
+					)}
+				>
+					Drop to attach
+				</span>
+			</div>
+			<AttachmentPills
+				attachments={attachments}
+				onAttachmentClick={onAttachmentClick}
+				onPreviewError={(id) =>
+					setAttachments((previous) =>
+						previous.map((entry) => {
+							if (entry.id !== id || !entry.previewUrl) return entry;
+							URL.revokeObjectURL(entry.previewUrl);
+							return { ...entry, previewUrl: undefined };
+						}),
+					)
+				}
+				onRemove={(id) =>
+					setAttachments((previous) =>
+						previous.filter((entry) => {
+							if (entry.id !== id) return true;
+							releaseAttachment(entry);
+							return false;
+						}),
+					)
+				}
+			/>
+			<div className="relative px-4 pt-3.5 pb-1">
+				<PlainTextPlugin
+					contentEditable={<ContentEditable className="prompt-input-editor" />}
+					placeholder={
+						<span className="pointer-events-none absolute top-3.5 left-4 text-sm text-muted-foreground/70">
+							{placeholder}
+						</span>
+					}
+					ErrorBoundary={LexicalErrorBoundary}
+				/>
+				<HistoryPlugin />
+				<LexicalTypeaheadMenuPlugin<MentionTypeaheadOption>
+					onQueryChange={setMentionQuery}
+					onSelectOption={(option, nodeToReplace, closeMenu) =>
+						selectMentionEntry(option.entry, nodeToReplace, closeMenu)
+					}
+					options={mentionOptions}
+					triggerFn={(text) => matchToken(text, "@")}
+					commandPriority={COMMAND_PRIORITY_HIGH}
+					onClose={() => setMentionQuery(null)}
+					menuRenderFn={(
+						anchorElementRef,
+						{ selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+					) =>
+						anchorElementRef.current && menuSlot && !typeaheadDismissed
+							? createPortal(
+									<MentionMenu
+										sections={sections}
+										selectedIndex={selectedIndex}
+										onHighlight={setHighlightedIndex}
+										onSelectionChange={onMentionHighlight}
+										onSelect={(entry) => {
+											const option = mentionOptions.find(
+												(candidate) => candidate.entry.id === entry.id,
+											);
+											if (option) selectOptionAndCleanUp(option);
+										}}
+									/>,
+									menuSlot,
+								)
+							: null
+					}
+				/>
+				<LexicalTypeaheadMenuPlugin<CommandTypeaheadOption>
+					onQueryChange={setCommandQuery}
+					onSelectOption={(option, nodeToReplace, closeMenu) => {
+						editor.update(() => {
+							nodeToReplace?.remove();
+							closeMenu();
+						});
+						void option.command.onSelect(actionContextRef.current);
+					}}
+					options={commandOptions}
+					triggerFn={(text) => matchCommandToken(text)}
+					commandPriority={COMMAND_PRIORITY_HIGH}
+					menuRenderFn={(
+						anchorElementRef,
+						{ selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+					) =>
+						anchorElementRef.current &&
+						menuSlot &&
+						!commandDismissed &&
+						rankedCommands.length > 0
+							? createPortal(
+									<CommandMenu
+										commands={rankedCommands}
+										selectedIndex={selectedIndex}
+										onHighlight={setHighlightedIndex}
+										onSelect={(command) => {
+											const option = commandOptions.find(
+												(candidate) => candidate.command.id === command.id,
+											);
+											if (option) selectOptionAndCleanUp(option);
+										}}
+									/>,
+									menuSlot,
+								)
+							: null
+					}
+				/>
+			</div>
+			<div className="flex min-h-12 items-center gap-2 px-3 pb-2.5">
+				<ContextButton
+					onClick={toggleBrowseMenu}
+					disabled={dictationSession.status !== "idle"}
+				/>
+				<input
+					ref={fileInputRef}
+					type="file"
+					multiple
+					className="hidden"
+					onChange={(event) => {
+						if (event.target.files) addFiles(event.target.files);
+						event.target.value = "";
+					}}
+				/>
+				{dictationSession.status === "error" ? (
+					<>
+						<span className="min-w-0 flex-1 truncate pl-1 text-sm text-muted-foreground">
+							{dictationSession.error?.message}
+						</span>
+						<button
+							type="button"
+							aria-label="Retry dictation"
+							onClick={() => void dictationSession.retry()}
+							className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80"
+						>
+							<RefreshCcwIcon className="size-4" />
+						</button>
+						<button
+							type="button"
+							aria-label="Discard recording"
+							onClick={dictationSession.cancel}
+							className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						>
+							<XIcon className="size-4" />
+						</button>
+						<button
+							type="button"
+							aria-label="Send message"
+							disabled
+							className="flex size-8 shrink-0 cursor-not-allowed items-center justify-center rounded-lg bg-secondary text-muted-foreground"
+						>
+							<ArrowUpIcon className="size-4.5" />
+						</button>
+					</>
+				) : dictationSession.status !== "idle" ? (
+					<>
+						<DictationBar
+							canvasRef={dictationSession.canvasRef}
+							seconds={dictationSession.seconds}
+						/>
+						<button
+							type="button"
+							aria-label="Stop dictation"
+							disabled={dictationSession.status === "transcribing"}
+							onClick={() => void dictationSession.finish()}
+							className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:cursor-default disabled:opacity-50"
+						>
+							<SquareIcon className="size-3.5 fill-current" />
+						</button>
+						<button
+							type="button"
+							aria-label="Send message"
+							disabled
+							className="flex size-8 shrink-0 cursor-not-allowed items-center justify-center rounded-lg bg-secondary text-muted-foreground"
+						>
+							<ArrowUpIcon className="size-4.5" />
+						</button>
+					</>
+				) : (
+					<>
+						{toolbar}
+						<div className="flex-1" />
+						{dictation && status !== "streaming" && (
+							<button
+								type="button"
+								aria-label="Dictate"
+								onClick={() => {
+									setBrowseOpen(false);
+									void dictationSession.start();
+								}}
+								className="flex size-8 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+							>
+								<MicIcon className="size-4.5" />
+							</button>
+						)}
+						{status === "streaming" ? (
+							<button
+								type="button"
+								aria-label="Stop response"
+								onClick={onStop}
+								className="flex size-8 cursor-pointer items-center justify-center rounded-lg bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80"
+							>
+								<SquareIcon className="size-3.5 fill-current" />
+							</button>
+						) : (
+							<button
+								type="button"
+								aria-label="Send message"
+								disabled={!canSend}
+								onClick={submit}
+								className={cn(
+									"flex size-8 items-center justify-center rounded-lg transition-colors",
+									canSend
+										? "cursor-pointer bg-primary text-primary-foreground hover:bg-primary/90"
+										: "cursor-not-allowed bg-secondary text-muted-foreground",
+								)}
+							>
+								<ArrowUpIcon className="size-4.5" />
+							</button>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/ComposerBody/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/ComposerBody/index.ts
@@ -1,0 +1,1 @@
+export { ComposerBody, type ComposerBodyProps } from "./ComposerBody";

--- a/packages/chat-ui/src/components/PromptInput/components/ComposerPanel/ComposerPanel.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/ComposerPanel/ComposerPanel.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type ComposerPanelProps = {
+	title: string;
+	placement?: "top" | "bottom";
+	onClose: () => void;
+	children: ReactNode;
+};
+
+export function ComposerPanel({
+	title,
+	placement = "top",
+	onClose,
+	children,
+}: ComposerPanelProps) {
+	return (
+		<div
+			className={`absolute left-0 z-30 w-full rounded-2xl bg-popover/95 p-4 shadow-xl ring-1 ring-border backdrop-blur-sm ${placement === "bottom" ? "top-full mt-2" : "bottom-full mb-2"}`}
+		>
+			<div className="mb-3 flex items-center justify-between">
+				<p className="text-sm text-muted-foreground">{title}</p>
+				<button
+					type="button"
+					aria-label={`Close ${title}`}
+					onClick={onClose}
+					className="flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				>
+					<XIcon className="size-4" />
+				</button>
+			</div>
+			<div className="overflow-x-auto">{children}</div>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/ComposerPanel/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/ComposerPanel/index.ts
@@ -1,0 +1,1 @@
+export { ComposerPanel, type ComposerPanelProps } from "./ComposerPanel";

--- a/packages/chat-ui/src/components/PromptInput/components/ContextButton/ContextButton.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/ContextButton/ContextButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+
+export type ContextButtonProps = {
+	onClick: () => void;
+	disabled?: boolean;
+};
+
+// Click-equivalent of typing "@": opens the mention menu in browse mode.
+export function ContextButton({ onClick, disabled }: ContextButtonProps) {
+	return (
+		<button
+			type="button"
+			aria-label="Add files, apps, and more"
+			title="Add files, apps, and more (@)"
+			disabled={disabled}
+			onClick={onClick}
+			className="flex size-8 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+		>
+			<PlusIcon className="size-4.5" />
+		</button>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/ContextButton/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/ContextButton/index.ts
@@ -1,0 +1,1 @@
+export { ContextButton, type ContextButtonProps } from "./ContextButton";

--- a/packages/chat-ui/src/components/PromptInput/components/DictationBar/DictationBar.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/DictationBar/DictationBar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { RefObject } from "react";
+
+export type DictationBarProps = {
+	canvasRef: RefObject<HTMLCanvasElement | null>;
+	seconds: number;
+};
+
+function formatElapsed(seconds: number): string {
+	const minutes = Math.floor(seconds / 60);
+	return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function DictationBar({ canvasRef, seconds }: DictationBarProps) {
+	return (
+		<div className="flex min-w-0 flex-1 items-center gap-3">
+			<canvas
+				ref={canvasRef}
+				className="h-7 min-w-0 flex-1 text-muted-foreground"
+			/>
+			<span className="shrink-0 text-sm text-muted-foreground tabular-nums">
+				{formatElapsed(seconds)}
+			</span>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/DictationBar/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/DictationBar/index.ts
@@ -1,0 +1,1 @@
+export { DictationBar, type DictationBarProps } from "./DictationBar";

--- a/packages/chat-ui/src/components/PromptInput/components/MentionMenu/MentionMenu.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/MentionMenu/MentionMenu.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { cn } from "@superset/ui/utils";
+import { useEffect } from "react";
+import type { MentionSection } from "../../hooks/useMentionSources";
+import type { ComposerMentionEntry } from "../../types";
+
+export type MentionMenuProps = {
+	sections: MentionSection[];
+	selectedIndex: number | null;
+	onHighlight: (index: number) => void;
+	onSelect: (entry: ComposerMentionEntry) => void;
+	onSelectionChange?: (entry: ComposerMentionEntry | null) => void;
+};
+
+export function MentionMenu({
+	sections,
+	selectedIndex,
+	onHighlight,
+	onSelect,
+	onSelectionChange,
+}: MentionMenuProps) {
+	const flatEntries = sections.flatMap((section) => section.entries);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: flatEntries identity churns per render; selection identity is (index, length)
+	useEffect(() => {
+		onSelectionChange?.(
+			selectedIndex == null ? null : (flatEntries[selectedIndex] ?? null),
+		);
+	}, [selectedIndex, flatEntries.length]);
+
+	if (sections.length === 0) return null;
+	let flatIndex = -1;
+	return (
+		<div
+			role="listbox"
+			className="relative z-50 w-full rounded-2xl bg-popover/95 p-1.5 shadow-xl ring-1 ring-border backdrop-blur-sm"
+		>
+			<div className="scroll-fade max-h-96 overflow-y-auto">
+				{sections.map((section) => (
+					<div key={section.providerId}>
+						<p className="px-3 pt-2.5 pb-1 text-[13px] text-muted-foreground">
+							{section.title}
+						</p>
+						{section.isLoading && section.entries.length === 0 && (
+							<p className="px-3 pb-2 text-[15px] text-muted-foreground/60">
+								{section.loadingState ?? "Loading…"}
+							</p>
+						)}
+						{!section.isLoading &&
+							section.emptyState != null &&
+							section.entries.length === 0 && (
+								<p className="px-3 pb-2 text-[15px] text-muted-foreground/60">
+									{section.emptyState}
+								</p>
+							)}
+						{section.entries.map((entry) => {
+							flatIndex += 1;
+							const index = flatIndex;
+							return (
+								// biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by the editor
+								// biome-ignore lint/a11y/useFocusableInteractive: focus stays in the editor; listbox is virtual
+								<div
+									key={entry.id}
+									role="option"
+									aria-selected={index === selectedIndex}
+									className={cn(
+										"flex cursor-pointer items-center gap-2.5 rounded-[10px] px-3 py-[5px] text-[15px] leading-[21px]",
+										index === selectedIndex
+											? "bg-accent text-accent-foreground"
+											: "text-foreground",
+									)}
+									onMouseEnter={() => onHighlight(index)}
+									onMouseDown={(event) => event.preventDefault()}
+									onClick={() => onSelect(entry)}
+								>
+									{entry.icon && (
+										<span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+											{entry.icon}
+										</span>
+									)}
+									<span className="shrink-0 font-medium">{entry.label}</span>
+									{entry.description && (
+										<span className="min-w-0 truncate text-muted-foreground">
+											{entry.description}
+										</span>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/PromptInput/components/MentionMenu/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/components/MentionMenu/index.ts
@@ -1,0 +1,1 @@
+export { MentionMenu, type MentionMenuProps } from "./MentionMenu";

--- a/packages/chat-ui/src/components/PromptInput/hooks/useDictation/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/hooks/useDictation/index.ts
@@ -1,0 +1,6 @@
+export {
+	type Dictation,
+	type DictationStatus,
+	type UseDictationOptions,
+	useDictation,
+} from "./useDictation";

--- a/packages/chat-ui/src/components/PromptInput/hooks/useDictation/useDictation.ts
+++ b/packages/chat-ui/src/components/PromptInput/hooks/useDictation/useDictation.ts
@@ -1,0 +1,267 @@
+"use client";
+
+import { type RefObject, useEffect, useRef, useState } from "react";
+import type { PromptInputDictationError } from "../../types";
+
+const BAR_SPACING = 4;
+const BAR_WIDTH = 2;
+const BAR_INTERVAL_MS = 60;
+const AMPLITUDE_SCALE = 10;
+const SILENCE_FLOOR = 0.0025;
+const SILENCE_ALPHA = 0.35;
+
+export type DictationStatus = "idle" | "recording" | "transcribing" | "error";
+
+export type UseDictationOptions = {
+	transcribe: (audio: Blob) => Promise<string> | string;
+	onTranscript: (text: string) => void;
+	onError?: (error: PromptInputDictationError) => void;
+};
+
+export type Dictation = {
+	status: DictationStatus;
+	seconds: number;
+	error: PromptInputDictationError | null;
+	canvasRef: RefObject<HTMLCanvasElement | null>;
+	start: () => Promise<void>;
+	finish: () => Promise<void>;
+	retry: () => Promise<void>;
+	cancel: () => void;
+};
+
+function describeStartError(error: unknown): PromptInputDictationError {
+	const name = error instanceof Error ? error.name : null;
+	if (name === "NotAllowedError" || name === "SecurityError")
+		return {
+			message: "Allow microphone access to use dictation",
+			canRetry: false,
+		};
+	if (
+		name === "NotFoundError" ||
+		name === "DevicesNotFoundError" ||
+		name === "OverconstrainedError"
+	)
+		return {
+			message: "Connect a microphone to use dictation",
+			canRetry: false,
+		};
+	if (name === "NotReadableError" || name === "TrackStartError")
+		return {
+			message: "Close other apps using the microphone",
+			canRetry: false,
+		};
+	if (name === "NotSupportedError" || name === "TypeError")
+		return {
+			message: "Dictation is not available on this device",
+			canRetry: false,
+		};
+	return { message: "Unable to start dictation", canRetry: false };
+}
+
+function describeTranscribeError(error: unknown): PromptInputDictationError {
+	const text = error instanceof Error ? error.message.toLowerCase() : "";
+	if (
+		text.includes("fetch failed") ||
+		text.includes("failed to fetch") ||
+		text.includes("network")
+	)
+		return { message: "Check your connection and try again", canRetry: true };
+	return { message: "Unable to transcribe audio", canRetry: true };
+}
+
+export function useDictation({
+	transcribe,
+	onTranscript,
+	onError,
+}: UseDictationOptions): Dictation {
+	const [status, setStatus] = useState<DictationStatus>("idle");
+	const [seconds, setSeconds] = useState(0);
+	const [error, setError] = useState<PromptInputDictationError | null>(null);
+	const retryAudioRef = useRef<Blob | null>(null);
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const sessionRef = useRef<{
+		stream: MediaStream;
+		recorder: MediaRecorder;
+		audioContext: AudioContext;
+		chunks: Blob[];
+		frame: number;
+	} | null>(null);
+	const historyRef = useRef<number[]>([]);
+	const bucketPeakRef = useRef(0);
+	const nextBarAtRef = useRef(0);
+	const startedAtRef = useRef(0);
+
+	useEffect(() => {
+		return () => {
+			const session = sessionRef.current;
+			if (!session) return;
+			cancelAnimationFrame(session.frame);
+			for (const track of session.stream.getTracks()) track.stop();
+			session.audioContext.close().catch(() => {});
+			sessionRef.current = null;
+		};
+	}, []);
+
+	const draw = () => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+		const devicePixels = window.devicePixelRatio || 1;
+		const width = canvas.clientWidth;
+		const height = canvas.clientHeight;
+		if (canvas.width !== width * devicePixels) {
+			canvas.width = width * devicePixels;
+			canvas.height = height * devicePixels;
+		}
+		const context = canvas.getContext("2d");
+		if (!context) return;
+		context.setTransform(devicePixels, 0, 0, devicePixels, 0, 0);
+		context.clearRect(0, 0, width, height);
+		context.fillStyle = getComputedStyle(canvas).color;
+		const barCount = Math.max(1, Math.floor(width / BAR_SPACING));
+		const recorded = historyRef.current.slice(-barCount);
+		// Left-pad with silence so the full track shows from the first frame;
+		// new bars enter at the right edge and scroll left.
+		const padCount = barCount - recorded.length;
+		const firstVoiced = recorded.findIndex((value) => value > SILENCE_FLOOR);
+		const midline = height / 2;
+		for (let index = 0; index < barCount; index += 1) {
+			const value =
+				index < padCount ? SILENCE_FLOOR : recorded[index - padCount];
+			const radius = Math.max(
+				0.75,
+				Math.min(
+					midline - 1,
+					(value ?? SILENCE_FLOOR) * AMPLITUDE_SCALE * midline,
+				),
+			);
+			const voiced = firstVoiced !== -1 && index - padCount >= firstVoiced;
+			context.globalAlpha = voiced ? 1 : SILENCE_ALPHA;
+			context.fillRect(
+				index * BAR_SPACING,
+				midline - radius,
+				BAR_WIDTH,
+				radius * 2,
+			);
+		}
+		context.globalAlpha = 1;
+	};
+
+	const start = async () => {
+		if (sessionRef.current) return;
+		setError(null);
+		retryAudioRef.current = null;
+		let stream: MediaStream;
+		let recorder: MediaRecorder;
+		try {
+			stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+			recorder = new MediaRecorder(stream);
+		} catch (cause) {
+			onError?.(describeStartError(cause));
+			return;
+		}
+		const chunks: Blob[] = [];
+		recorder.ondataavailable = (event) => {
+			if (event.data.size > 0) chunks.push(event.data);
+		};
+		recorder.start();
+		const audioContext = new AudioContext();
+		const source = audioContext.createMediaStreamSource(stream);
+		const analyser = audioContext.createAnalyser();
+		analyser.fftSize = 2048;
+		source.connect(analyser);
+		const samples = new Float32Array(analyser.fftSize);
+		historyRef.current = [];
+		bucketPeakRef.current = 0;
+		startedAtRef.current = performance.now();
+		nextBarAtRef.current = startedAtRef.current + BAR_INTERVAL_MS;
+		setSeconds(0);
+		setStatus("recording");
+		const tick = () => {
+			analyser.getFloatTimeDomainData(samples);
+			let sum = 0;
+			for (const sample of samples) sum += sample * sample;
+			const rms = Math.sqrt(sum / samples.length);
+			bucketPeakRef.current = Math.max(bucketPeakRef.current, rms);
+			const now = performance.now();
+			// A stalled frame can span several bar intervals; every missed bar
+			// gets the measured peak so gaps never read as sudden silence.
+			const peak = Math.max(SILENCE_FLOOR, bucketPeakRef.current);
+			let pushed = false;
+			while (now >= nextBarAtRef.current) {
+				historyRef.current.push(peak);
+				if (historyRef.current.length > 4096) historyRef.current.shift();
+				nextBarAtRef.current += BAR_INTERVAL_MS;
+				pushed = true;
+			}
+			if (pushed) bucketPeakRef.current = 0;
+			setSeconds(Math.floor((now - startedAtRef.current) / 1000));
+			draw();
+			const session = sessionRef.current;
+			if (session) session.frame = requestAnimationFrame(tick);
+		};
+		sessionRef.current = {
+			stream,
+			recorder,
+			audioContext,
+			chunks,
+			frame: requestAnimationFrame(tick),
+		};
+	};
+
+	const runTranscription = async (audio: Blob) => {
+		setStatus("transcribing");
+		try {
+			const text = await Promise.resolve(transcribe(audio));
+			if (text) onTranscript(text);
+			retryAudioRef.current = null;
+			setError(null);
+			setStatus("idle");
+		} catch (cause) {
+			// Keep the recording so a retry never loses the user's speech.
+			const described = describeTranscribeError(cause);
+			retryAudioRef.current = audio;
+			setError(described);
+			setStatus("error");
+			onError?.(described);
+		}
+	};
+
+	const finish = async () => {
+		const session = sessionRef.current;
+		if (!session) return;
+		sessionRef.current = null;
+		cancelAnimationFrame(session.frame);
+		const audio = await new Promise<Blob>((resolve) => {
+			session.recorder.onstop = () =>
+				resolve(new Blob(session.chunks, { type: session.recorder.mimeType }));
+			session.recorder.stop();
+		});
+		for (const track of session.stream.getTracks()) track.stop();
+		session.audioContext.close().catch(() => {});
+		await runTranscription(audio);
+	};
+
+	const retry = async () => {
+		const audio = retryAudioRef.current;
+		if (!audio) return;
+		await runTranscription(audio);
+	};
+
+	// Abort without transcribing: tears down a live recording or clears the
+	// error state.
+	const cancel = () => {
+		const session = sessionRef.current;
+		if (session) {
+			sessionRef.current = null;
+			cancelAnimationFrame(session.frame);
+			session.recorder.stop();
+			for (const track of session.stream.getTracks()) track.stop();
+			session.audioContext.close().catch(() => {});
+		}
+		retryAudioRef.current = null;
+		setError(null);
+		setStatus("idle");
+	};
+
+	return { status, seconds, error, canvasRef, start, finish, retry, cancel };
+}

--- a/packages/chat-ui/src/components/PromptInput/hooks/useMentionSources/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/hooks/useMentionSources/index.ts
@@ -1,0 +1,1 @@
+export { type MentionSection, useMentionSources } from "./useMentionSources";

--- a/packages/chat-ui/src/components/PromptInput/hooks/useMentionSources/useMentionSources.ts
+++ b/packages/chat-ui/src/components/PromptInput/hooks/useMentionSources/useMentionSources.ts
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+	ComposerMentionEntry,
+	ComposerMentionProvider,
+} from "../../types";
+
+export type MentionSection = {
+	providerId: string;
+	title: string;
+	entries: ComposerMentionEntry[];
+	emptyState?: string;
+	loadingState?: string;
+	isLoading: boolean;
+};
+
+function matchesQuery(entry: ComposerMentionEntry, query: string): boolean {
+	if (!query) return true;
+	const lowered = query.toLowerCase();
+	if (entry.label.toLowerCase().includes(lowered)) return true;
+	return (entry.keywords ?? []).some((keyword) =>
+		keyword.toLowerCase().includes(lowered),
+	);
+}
+
+export function useMentionSources(
+	providers: ComposerMentionProvider[],
+	menuOpen: boolean,
+	query: string,
+): MentionSection[] {
+	const [staticEntries, setStaticEntries] = useState<
+		Record<string, ComposerMentionEntry[]>
+	>({});
+	const [searchEntries, setSearchEntries] = useState<
+		Record<string, ComposerMentionEntry[]>
+	>({});
+	const [searchPending, setSearchPending] = useState<Record<string, boolean>>(
+		{},
+	);
+	const providersRef = useRef(providers);
+	providersRef.current = providers;
+
+	// Load static sources at mount and refresh them each time the menu opens;
+	// cached entries stay visible while fresh ones load.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: staticEntries gates the initial mount load only
+	useEffect(() => {
+		if (!menuOpen && Object.keys(staticEntries).length > 0) return;
+		const controller = new AbortController();
+		for (const provider of providersRef.current) {
+			if (provider.source.kind !== "static") continue;
+			Promise.resolve(provider.source.load(controller.signal))
+				.then((entries) => {
+					if (controller.signal.aborted) return;
+					setStaticEntries((previous) => ({
+						...previous,
+						[provider.id]: entries,
+					}));
+				})
+				.catch(() => {});
+		}
+		return () => controller.abort();
+	}, [menuOpen]);
+
+	// Search sources fire per keystroke; aborting the previous request replaces
+	// debouncing.
+	useEffect(() => {
+		if (!menuOpen) return;
+		const controller = new AbortController();
+		for (const provider of providersRef.current) {
+			if (provider.source.kind !== "search") continue;
+			if (query === "") {
+				setSearchEntries((previous) => ({ ...previous, [provider.id]: [] }));
+				setSearchPending((previous) => ({
+					...previous,
+					[provider.id]: false,
+				}));
+				continue;
+			}
+			setSearchPending((previous) => ({ ...previous, [provider.id]: true }));
+			provider.source
+				.search(query, controller.signal)
+				.then((entries) => {
+					if (controller.signal.aborted) return;
+					setSearchEntries((previous) => ({
+						...previous,
+						[provider.id]: entries,
+					}));
+					setSearchPending((previous) => ({
+						...previous,
+						[provider.id]: false,
+					}));
+				})
+				.catch(() => {});
+		}
+		return () => controller.abort();
+	}, [menuOpen, query]);
+
+	return useMemo(() => {
+		const sections: MentionSection[] = [];
+		const sorted = [...providers].sort((a, b) => a.priority - b.priority);
+		for (const provider of sorted) {
+			if (provider.source.kind === "static") {
+				const entries = (staticEntries[provider.id] ?? []).filter((entry) =>
+					matchesQuery(entry, query),
+				);
+				if (entries.length > 0) {
+					sections.push({
+						providerId: provider.id,
+						title: provider.title,
+						entries,
+						isLoading: false,
+					});
+				}
+			} else {
+				const entries = query === "" ? [] : (searchEntries[provider.id] ?? []);
+				const isLoading = searchPending[provider.id] === true;
+				if (entries.length > 0 || query === "" || isLoading) {
+					sections.push({
+						providerId: provider.id,
+						title: provider.title,
+						entries,
+						emptyState: query === "" ? provider.source.emptyState : undefined,
+						loadingState: provider.source.loadingState,
+						isLoading,
+					});
+				}
+			}
+		}
+		return sections;
+	}, [providers, staticEntries, searchEntries, searchPending, query]);
+}

--- a/packages/chat-ui/src/components/PromptInput/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/index.ts
@@ -1,0 +1,13 @@
+export {
+	type ComposerActionContext,
+	type ComposerChip,
+	type ComposerMentionEntry,
+	type ComposerMentionProvider,
+	type ComposerMentionSource,
+	type ComposerPanelContent,
+	PromptInput,
+	type PromptInputAttachment,
+	type PromptInputCommand,
+	type PromptInputProps,
+	type PromptInputSubmitPayload,
+} from "./PromptInput";

--- a/packages/chat-ui/src/components/PromptInput/nodes/mentionChipNode/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/nodes/mentionChipNode/index.ts
@@ -1,0 +1,4 @@
+export {
+	MentionChipNode,
+	type SerializedMentionChipNode,
+} from "./mentionChipNode";

--- a/packages/chat-ui/src/components/PromptInput/nodes/mentionChipNode/mentionChipNode.tsx
+++ b/packages/chat-ui/src/components/PromptInput/nodes/mentionChipNode/mentionChipNode.tsx
@@ -1,0 +1,161 @@
+import { useLexicalNodeSelection } from "@lexical/react/useLexicalNodeSelection";
+import {
+	DecoratorNode,
+	type NodeKey,
+	type SerializedLexicalNode,
+	type Spread,
+} from "lexical";
+import type { JSX } from "react";
+import type { ComposerChip } from "../../types";
+
+function MentionChipComponent({
+	nodeKey,
+	label,
+	brandColor,
+	iconUrl,
+}: {
+	nodeKey: NodeKey;
+	label: string;
+	brandColor: string | null;
+	iconUrl: string | null;
+}) {
+	const [isSelected] = useLexicalNodeSelection(nodeKey);
+	return (
+		<span
+			className="prompt-input-chip"
+			data-mention-chip="true"
+			data-selected={isSelected || undefined}
+			style={
+				brandColor
+					? ({ "--chip-color": brandColor } as React.CSSProperties)
+					: undefined
+			}
+		>
+			{iconUrl && (
+				<span className="prompt-input-chip-icon">
+					<img src={iconUrl} alt="" draggable={false} />
+				</span>
+			)}
+			<span className="prompt-input-chip-label">{label}</span>
+		</span>
+	);
+}
+
+export type SerializedMentionChipNode = Spread<
+	{
+		label: string;
+		serialized: string;
+		brandColor: string | null;
+		iconUrl: string | null;
+		dataJson: string | null;
+	},
+	SerializedLexicalNode
+>;
+
+export class MentionChipNode extends DecoratorNode<JSX.Element> {
+	__label: string;
+	__serialized: string;
+	__brandColor: string | null;
+	__iconUrl: string | null;
+	__dataJson: string | null;
+
+	static getType(): string {
+		return "mention-chip";
+	}
+
+	static clone(node: MentionChipNode): MentionChipNode {
+		return new MentionChipNode(
+			node.__label,
+			node.__serialized,
+			node.__brandColor,
+			node.__iconUrl,
+			node.__dataJson,
+			node.__key,
+		);
+	}
+
+	constructor(
+		label: string,
+		serialized: string,
+		brandColor: string | null,
+		iconUrl: string | null,
+		dataJson: string | null,
+		key?: NodeKey,
+	) {
+		super(key);
+		this.__label = label;
+		this.__serialized = serialized;
+		this.__brandColor = brandColor;
+		this.__iconUrl = iconUrl;
+		this.__dataJson = dataJson;
+	}
+
+	static fromChip(chip: ComposerChip): MentionChipNode {
+		return new MentionChipNode(
+			chip.label,
+			chip.serialized,
+			chip.brandColor ?? null,
+			chip.iconUrl ?? null,
+			chip.data === undefined ? null : JSON.stringify(chip.data),
+		);
+	}
+
+	toChip(): ComposerChip {
+		return {
+			label: this.__label,
+			serialized: this.__serialized,
+			brandColor: this.__brandColor ?? undefined,
+			iconUrl: this.__iconUrl ?? undefined,
+			data: this.__dataJson == null ? undefined : JSON.parse(this.__dataJson),
+		};
+	}
+
+	static importJSON(serialized: SerializedMentionChipNode): MentionChipNode {
+		return new MentionChipNode(
+			serialized.label,
+			serialized.serialized,
+			serialized.brandColor,
+			serialized.iconUrl,
+			serialized.dataJson,
+		);
+	}
+
+	exportJSON(): SerializedMentionChipNode {
+		return {
+			...super.exportJSON(),
+			type: "mention-chip",
+			label: this.__label,
+			serialized: this.__serialized,
+			brandColor: this.__brandColor,
+			iconUrl: this.__iconUrl,
+			dataJson: this.__dataJson,
+		};
+	}
+
+	createDOM(): HTMLElement {
+		return document.createElement("span");
+	}
+
+	updateDOM(): boolean {
+		return false;
+	}
+
+	isInline(): boolean {
+		return true;
+	}
+
+	getTextContent(): string {
+		return this.__serialized;
+	}
+
+	decorate(): JSX.Element {
+		return (
+			<MentionChipComponent
+				nodeKey={this.__key}
+				label={this.__label}
+				brandColor={this.__brandColor}
+				iconUrl={this.__iconUrl}
+			/>
+		);
+	}
+}

--- a/packages/chat-ui/src/components/PromptInput/prompt-input.css
+++ b/packages/chat-ui/src/components/PromptInput/prompt-input.css
@@ -1,0 +1,66 @@
+.prompt-input-chip {
+	display: inline-flex;
+	max-width: 100%;
+	gap: 3px;
+	padding: 0 2px;
+	border-radius: 4px;
+	font-weight: 500;
+	color: color-mix(
+		in srgb,
+		var(--chip-color, var(--primary)) 80%,
+		var(--foreground) 20%
+	);
+	vertical-align: bottom;
+	user-select: none;
+	cursor: pointer;
+}
+
+/* Brand colors blend toward the foreground in dark mode for legibility. */
+.dark .prompt-input-chip {
+	color: color-mix(
+		in oklch,
+		var(--chip-color, var(--primary)) 50%,
+		var(--foreground) 50%
+	);
+}
+
+.prompt-input-chip[data-selected="true"] {
+	background: var(--accent);
+}
+
+.prompt-input-chip:hover .prompt-input-chip-label {
+	text-decoration: underline;
+	text-decoration-style: dashed;
+	text-decoration-thickness: 0.5px;
+	text-underline-offset: 2px;
+}
+
+/* Icon rides the first text line even when the label wraps. */
+.prompt-input-chip-icon {
+	position: relative;
+	height: 1lh;
+	width: 14px;
+	flex-shrink: 0;
+}
+
+.prompt-input-chip-icon img {
+	position: absolute;
+	top: 50%;
+	translate: 0 -50%;
+	width: 14px;
+	height: 14px;
+	border-radius: 3px;
+	object-fit: contain;
+}
+
+.prompt-input-chip-label {
+	min-width: 0;
+	overflow-wrap: break-word;
+}
+
+.prompt-input-editor {
+	font-size: 14px;
+	line-height: 20px;
+	min-height: 40px;
+	outline: none;
+}

--- a/packages/chat-ui/src/components/PromptInput/types.ts
+++ b/packages/chat-ui/src/components/PromptInput/types.ts
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+
+export type ComposerChip = {
+	label: string;
+	serialized: string;
+	brandColor?: string;
+	// Icon as a URL string so chips stay serializable data.
+	iconUrl?: string;
+	data?: unknown;
+};
+
+export type ComposerActionContext = {
+	insertChip(chip: ComposerChip): void;
+	attachFiles(): void;
+	openPanel(panel: ComposerPanelContent): void;
+	query: string;
+};
+
+export type ComposerPanelContent = {
+	title: string;
+	render: () => ReactNode;
+};
+
+export type ComposerMentionEntry = {
+	id: string;
+	label: string;
+	description?: string;
+	icon?: ReactNode;
+	keywords?: string[];
+	// When set, selecting rewrites the query to this value and keeps the menu
+	// open (directory drilling); select() is not called.
+	completionQuery?: string;
+	select(ctx: ComposerActionContext): void | Promise<void>;
+};
+
+export type ComposerMentionSource =
+	| {
+			kind: "static";
+			load(
+				signal: AbortSignal,
+			): ComposerMentionEntry[] | Promise<ComposerMentionEntry[]>;
+	  }
+	| {
+			kind: "search";
+			search(
+				query: string,
+				signal: AbortSignal,
+			): Promise<ComposerMentionEntry[]>;
+			emptyState: string;
+			loadingState?: string;
+	  };
+
+export type ComposerMentionProvider = {
+	id: string;
+	title: string;
+	priority: number;
+	source: ComposerMentionSource;
+};
+
+export type PromptInputCommand = {
+	id: string;
+	title: string;
+	description?: string;
+	icon?: ReactNode;
+	rightIcon?: ReactNode;
+	group?: string;
+	searchAliases?: string[];
+	onSelect(ctx: ComposerActionContext): void | Promise<void>;
+};
+
+export type PromptInputAttachment = {
+	id: string;
+	file: File;
+	// Object URL for image attachments; owned and revoked by the composer.
+	previewUrl?: string;
+};
+
+export type PromptInputSubmitPayload = {
+	text: string;
+	files: File[];
+	mentions: ComposerChip[];
+};
+
+export type PromptInputDictationError = {
+	message: string;
+	canRetry: boolean;
+};
+
+export type PromptInputDictation = {
+	transcribe(audio: Blob): Promise<string> | string;
+	// Surfaced for app-owned toasts; retryable failures also keep the
+	// recording and show retry controls in the composer row.
+	onError?(error: PromptInputDictationError): void;
+};
+
+export type PromptInputProps = {
+	placeholder?: string;
+	mentionProviders: ComposerMentionProvider[];
+	commands: PromptInputCommand[];
+	status?: "ready" | "streaming";
+	placement?: "top" | "bottom";
+	// Enables the mic button; the app owns speech-to-text.
+	dictation?: PromptInputDictation;
+	toolbar?: ReactNode;
+	onSubmit?: (payload: PromptInputSubmitPayload) => void;
+	onStop?: () => void;
+	onMentionHighlight?: (entry: ComposerMentionEntry | null) => void;
+	onAttachmentClick?: (attachment: PromptInputAttachment) => void;
+	onChipClick?: (chip: ComposerChip) => void;
+	className?: string;
+};

--- a/packages/chat-ui/src/components/PromptInput/utils/matchToken/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/matchToken/index.ts
@@ -1,0 +1,1 @@
+export { matchToken } from "./matchToken";

--- a/packages/chat-ui/src/components/PromptInput/utils/matchToken/matchToken.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/matchToken/matchToken.ts
@@ -1,0 +1,16 @@
+import type { MenuTextMatch } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+
+export function matchToken(
+	text: string,
+	trigger: string,
+): MenuTextMatch | null {
+	const pattern = new RegExp(`(^|\\s)(\\${trigger}([\\w./:-]*))$`);
+	const match = pattern.exec(text);
+	if (!match) return null;
+	const leadOffset = match.index + (match[1]?.length ?? 0);
+	return {
+		leadOffset,
+		matchingString: match[3] ?? "",
+		replaceableString: match[2] ?? "",
+	};
+}

--- a/packages/chat-ui/src/components/PromptInput/utils/rankCommands/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/rankCommands/index.ts
@@ -1,0 +1,1 @@
+export { rankCommands } from "./rankCommands";

--- a/packages/chat-ui/src/components/PromptInput/utils/rankCommands/rankCommands.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/rankCommands/rankCommands.ts
@@ -1,0 +1,40 @@
+import type { PromptInputCommand } from "../../types";
+
+function termScore(candidate: string, query: string): number {
+	const lowered = candidate.toLowerCase();
+	if (lowered.startsWith(query)) return 2;
+	if (lowered.includes(query)) return 1;
+	return 0;
+}
+
+function commandScore(command: PromptInputCommand, query: string): number {
+	return Math.max(
+		termScore(command.title, query),
+		termScore(command.id, query),
+		...(command.searchAliases ?? []).map((alias) => termScore(alias, query)),
+	);
+}
+
+export function rankCommands(
+	commands: PromptInputCommand[],
+	query: string,
+): PromptInputCommand[] {
+	const trimmed = query.trim().toLowerCase();
+	if (trimmed.length === 0) return commands;
+	const groupOrder = new Map<string | null, number>();
+	for (const command of commands) {
+		const group = command.group ?? null;
+		if (!groupOrder.has(group)) groupOrder.set(group, groupOrder.size);
+	}
+	return commands
+		.map((command) => ({ command, score: commandScore(command, trimmed) }))
+		.filter((scored) => scored.score > 0)
+		.sort(
+			(a, b) =>
+				(groupOrder.get(a.command.group ?? null) ?? 0) -
+					(groupOrder.get(b.command.group ?? null) ?? 0) ||
+				b.score - a.score ||
+				a.command.title.localeCompare(b.command.title),
+		)
+		.map((scored) => scored.command);
+}

--- a/packages/chat-ui/src/components/PromptInput/utils/typeaheadOptions/index.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/typeaheadOptions/index.ts
@@ -1,0 +1,4 @@
+export {
+	CommandTypeaheadOption,
+	MentionTypeaheadOption,
+} from "./typeaheadOptions";

--- a/packages/chat-ui/src/components/PromptInput/utils/typeaheadOptions/typeaheadOptions.ts
+++ b/packages/chat-ui/src/components/PromptInput/utils/typeaheadOptions/typeaheadOptions.ts
@@ -1,0 +1,18 @@
+import { MenuOption } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import type { ComposerMentionEntry, PromptInputCommand } from "../../types";
+
+export class MentionTypeaheadOption extends MenuOption {
+	entry: ComposerMentionEntry;
+	constructor(entry: ComposerMentionEntry) {
+		super(entry.id);
+		this.entry = entry;
+	}
+}
+
+export class CommandTypeaheadOption extends MenuOption {
+	command: PromptInputCommand;
+	constructor(command: PromptInputCommand) {
+		super(command.id);
+		this.command = command;
+	}
+}

--- a/packages/chat-ui/src/components/ScrollToBottomButton/ScrollToBottomButton.tsx
+++ b/packages/chat-ui/src/components/ScrollToBottomButton/ScrollToBottomButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { MessageScroller } from "@shadcn/react/message-scroller";
+import { cn } from "@superset/ui/utils";
+import { ArrowDownIcon } from "lucide-react";
+
+export type ScrollToBottomButtonProps = {
+	className?: string;
+};
+
+// Floating circular button that appears when the transcript is scrolled up.
+// Must render inside a MessageScroller.Provider.
+export function ScrollToBottomButton({ className }: ScrollToBottomButtonProps) {
+	return (
+		<MessageScroller.Button
+			direction="end"
+			behavior="smooth"
+			aria-label="Scroll to bottom"
+			className={cn(
+				"pointer-events-auto flex size-9 cursor-pointer items-center justify-center rounded-full bg-background/80 text-muted-foreground shadow-sm ring-1 ring-border backdrop-blur transition-[opacity,scale,color] duration-150 hover:text-foreground",
+				"data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0",
+				className,
+			)}
+		>
+			<ArrowDownIcon className="size-4.5" />
+		</MessageScroller.Button>
+	);
+}

--- a/packages/chat-ui/src/components/ScrollToBottomButton/index.ts
+++ b/packages/chat-ui/src/components/ScrollToBottomButton/index.ts
@@ -1,0 +1,4 @@
+export {
+	ScrollToBottomButton,
+	type ScrollToBottomButtonProps,
+} from "./ScrollToBottomButton";

--- a/packages/chat-ui/src/types/svg.d.ts
+++ b/packages/chat-ui/src/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+	const content: string;
+	export default content;
+}

--- a/packages/chat-ui/tsconfig.json
+++ b/packages/chat-ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@superset/typescript/base.json",
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"jsx": "react-jsx",
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts", "src/**/*.tsx"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -4,6 +4,10 @@ import tailwindcss from "@tailwindcss/vite";
 const config: StorybookConfig = {
 	stories: [
 		{ directory: "../src/components", files: "**/*.stories.@(ts|tsx)" },
+		{
+			directory: "../../chat-ui/src/components",
+			files: "**/*.stories.@(ts|tsx)",
+		},
 	],
 	framework: "@storybook/react-vite",
 	viteFinal: (viteConfig) => {

--- a/packages/ui/.storybook/storybook.css
+++ b/packages/ui/.storybook/storybook.css
@@ -1,2 +1,3 @@
 @import "../src/globals.css";
 @import "shadcn/tailwind.css";
+@source "../../chat-ui/src";


### PR DESCRIPTION
Restores `packages/chat-ui` (40 files), deleted in #6435 as an "orphan package."

**It was not an orphan.** It depends on `@superset/chat` — the chat-v3 protocol package — which makes it the in-progress UI layer for chat-v3, not debris. The deletion was justified on the evidence that nothing imported it, and that was the wrong test: **zero importers is exactly what unfinished-but-intended work looks like.** The check that would have caught it is "what does this package depend on?", which points at chat-v3 and reveals intent.

Restores `PromptInput` (with its Lexical editor), `ComposerDropZone`, `ScrollToBottomButton`, their shared components, and the two storybook wiring lines in `packages/ui`. Verified byte-identical to the pre-deletion tree.

Everything else in #6435 stands — the chat-legacy hono server, the device-presence system, and the `device_presence` table were all genuinely dead.

**Verification**: lint exit 0 · typecheck exit 0 (38/38) · sherif exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `packages/chat-ui` as the in‑progress UI for chat‑v3, reversing its removal in #6435. It depends on `@superset/chat`, so the package was not an orphan; restoring it unblocks chat‑v3 work without changing app behavior.

- Adds back `@superset/chat-ui` (PromptInput, ComposerDropZone, ScrollToBottomButton, stories, `tsconfig.json`, `svg.d.ts`).
- Updates `packages/ui` Storybook to include `chat-ui` stories and sources.
- Updates `bun.lock` to add `@lexical/react`, `lexical`, `lucide-react`, `@shadcn/react`, and workspace links.
- Package is `private` and not imported by the app; runtime behavior is unchanged. Other removals from #6435 remain removed.

<sup>Written for commit 1ccbdcf10c1c5a0177dd890236864a248fba9800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable chat composer with rich prompt editing, mentions, slash commands, attachments, drag-and-drop uploads, dictation, and submission controls.
  * Added attachment previews, removal controls, command and mention menus, context panels, and selectable mention chips.
  * Added a scroll-to-bottom control for chat transcripts.
* **Documentation**
  * Added Storybook examples covering chat, recording, dictation errors, browsing, and attachment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->