### PR TITLE
feat(desktop): name the host in the sidebar workspace tooltip

### DIFF
--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
@@ -64,6 +64,7 @@ export function useKnownHosts(): {
 				.map((host) => ({
 					organizationId: host.organizationId,
 					machineId: host.machineId,
+					name: host.name,
 					isOnline: host.isOnline,
 				})),
 		[hostRows, organizationId],

--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.utils.test.ts
@@ -7,6 +7,7 @@ function makeHost(overrides: Partial<KnownHostRow> = {}): KnownHostRow {
 	return {
 		organizationId: ORG,
 		machineId: "machine-a",
+		name: "Machine A",
 		isOnline: true,
 		...overrides,
 	};

--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.utils.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.utils.ts
@@ -4,6 +4,12 @@ import { get as idbGet, set as idbSet } from "idb-keyval";
 export interface KnownHostRow {
 	organizationId: string;
 	machineId: string;
+	/**
+	 * Display name from `v2Host.list`. Empty string when a pre-name snapshot
+	 * is served, so UI that labels a host falls back to generic copy rather
+	 * than rendering a blank name.
+	 */
+	name: string;
 	isOnline: boolean;
 }
 
@@ -40,11 +46,21 @@ export async function loadKnownHostsSnapshot(
 		// Guard against a snapshot written under a different key scheme or a
 		// corrupted value — bad persistence must degrade to "no snapshot".
 		if (!Array.isArray(rows)) return undefined;
-		return rows.filter(
-			(row) =>
-				row &&
-				typeof row.machineId === "string" &&
-				row.organizationId === organizationId,
+		return (
+			rows
+				.filter(
+					(row) =>
+						row &&
+						typeof row.machineId === "string" &&
+						row.organizationId === organizationId,
+				)
+				// Snapshots written before `name` existed carry no name. Keeping the
+				// key (rather than bumping it) means an offline boot still renders
+				// its hosts; the next live response fills the name in.
+				.map((row) => ({
+					...row,
+					name: typeof row.name === "string" ? row.name : "",
+				}))
 		);
 	} catch (error) {
 		console.warn("[known-hosts] snapshot read failed", {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -22,6 +22,7 @@ import type {
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
 import { DashboardSidebarWorkspaceChips } from "./components/DashboardSidebarWorkspaceChips";
+import { getWorkspaceHostTooltip } from "./utils/getWorkspaceHostTooltip";
 
 const PR_STATE_LABEL: Record<
 	DashboardSidebarWorkspacePullRequest["state"],
@@ -94,6 +95,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		const {
 			hostType,
 			hostIsOnline,
+			hostName,
 			name,
 			branch,
 			pullRequest,
@@ -118,12 +120,12 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		// minus would remove the project's anchor row. Removal stays available via
 		// the context menu.
 		const isLocalMainWorkspace = isMainWorkspace && hostType === "local-device";
-		const workspaceKindTitle = isMainWorkspace
-			? "Main workspace"
-			: "Worktree workspace";
-		const workspaceKindDescription = isMainWorkspace
-			? "Uses the repository checkout on this host"
-			: "Isolated copy for parallel development";
+		const hostTooltip = getWorkspaceHostTooltip({
+			hostType,
+			workspaceType: workspace.type,
+			hostIsOnline,
+			hostName,
+		});
 
 		return (
 			<div
@@ -229,27 +231,9 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 									</>
 								) : (
 									<>
-										<p className="text-xs font-medium">
-											{isMainWorkspace
-												? workspaceKindTitle
-												: hostType === "local-device"
-													? "Local workspace"
-													: hostType === "remote-device"
-														? hostIsOnline === false
-															? "Remote workspace — device offline"
-															: "Remote workspace"
-														: "Cloud workspace"}
-										</p>
+										<p className="text-xs font-medium">{hostTooltip.title}</p>
 										<p className="text-xs text-muted-foreground">
-											{isMainWorkspace
-												? workspaceKindDescription
-												: hostType === "local-device"
-													? "Running on this device"
-													: hostType === "remote-device"
-														? hostIsOnline === false
-															? "The associated device isn't reachable right now"
-															: "Running on a paired device"
-														: "Hosted in the cloud"}
+											{hostTooltip.description}
 										</p>
 									</>
 								)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/getWorkspaceHostTooltip.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/getWorkspaceHostTooltip.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import {
+	getWorkspaceHostTooltip,
+	type WorkspaceHostTooltipInput,
+} from "./getWorkspaceHostTooltip";
+
+const remote: WorkspaceHostTooltipInput = {
+	hostType: "remote-device",
+	workspaceType: "worktree",
+	hostIsOnline: true,
+	hostName: "OCI Ralu",
+};
+
+describe("getWorkspaceHostTooltip", () => {
+	it("names the host a remote workspace runs on", () => {
+		expect(getWorkspaceHostTooltip(remote)).toEqual({
+			title: "Remote workspace",
+			description: "Running on OCI Ralu",
+		});
+	});
+
+	it("tells two remote hosts apart", () => {
+		const first = getWorkspaceHostTooltip(remote);
+		const second = getWorkspaceHostTooltip({ ...remote, hostName: "Jaz PC-1" });
+
+		expect(first.description).not.toBe(second.description);
+	});
+
+	it("names the host in the offline description", () => {
+		expect(getWorkspaceHostTooltip({ ...remote, hostIsOnline: false })).toEqual(
+			{
+				title: "Remote workspace — device offline",
+				description: "OCI Ralu isn't reachable right now",
+			},
+		);
+	});
+
+	it("names the host a remote main workspace is checked out on", () => {
+		expect(
+			getWorkspaceHostTooltip({ ...remote, workspaceType: "main" }),
+		).toEqual({
+			title: "Main workspace",
+			description: "Uses the repository checkout on OCI Ralu",
+		});
+	});
+
+	it("falls back to generic copy when the host name is unknown", () => {
+		expect(getWorkspaceHostTooltip({ ...remote, hostName: null })).toEqual({
+			title: "Remote workspace",
+			description: "Running on a paired device",
+		});
+		expect(
+			getWorkspaceHostTooltip({
+				...remote,
+				hostName: null,
+				hostIsOnline: false,
+			}).description,
+		).toBe("The associated device isn't reachable right now");
+		expect(
+			getWorkspaceHostTooltip({
+				...remote,
+				hostName: null,
+				workspaceType: "main",
+			}).description,
+		).toBe("Uses the repository checkout on this host");
+	});
+
+	it("keeps local copy device-relative", () => {
+		expect(
+			getWorkspaceHostTooltip({
+				...remote,
+				hostType: "local-device",
+				hostIsOnline: null,
+			}),
+		).toEqual({
+			title: "Local workspace",
+			description: "Running on this device",
+		});
+	});
+
+	it("keeps cloud copy unchanged", () => {
+		expect(
+			getWorkspaceHostTooltip({
+				...remote,
+				hostType: "cloud",
+				hostIsOnline: null,
+			}),
+		).toEqual({
+			title: "Cloud workspace",
+			description: "Hosted in the cloud",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/getWorkspaceHostTooltip.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/getWorkspaceHostTooltip.ts
@@ -1,0 +1,82 @@
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspaceType,
+} from "../../../../../../types";
+
+export interface WorkspaceHostTooltipInput {
+	hostType: DashboardSidebarWorkspaceHostType;
+	workspaceType: DashboardSidebarWorkspaceType;
+	hostIsOnline: boolean | null;
+	/** Owning host's display name, or null when it isn't known yet. */
+	hostName: string | null;
+}
+
+export interface WorkspaceHostTooltip {
+	title: string;
+	description: string;
+}
+
+function getTitle(
+	hostType: DashboardSidebarWorkspaceHostType,
+	isMainWorkspace: boolean,
+	hostIsOnline: boolean | null,
+): string {
+	if (isMainWorkspace) return "Main workspace";
+	if (hostType === "local-device") return "Local workspace";
+	if (hostType !== "remote-device") return "Cloud workspace";
+	return hostIsOnline === false
+		? "Remote workspace — device offline"
+		: "Remote workspace";
+}
+
+/**
+ * Tooltip copy for a sidebar row's host icon.
+ *
+ * Every remote host draws the same cloud glyph, so the icon alone cannot say
+ * which machine a workspace runs on once a user pairs a second host. The
+ * description names the host whenever `hostName` is known, and falls back to
+ * the previous generic wording when it isn't — a cached host snapshot written
+ * before names were stored has no name to show.
+ */
+export function getWorkspaceHostTooltip({
+	hostType,
+	workspaceType,
+	hostIsOnline,
+	hostName,
+}: WorkspaceHostTooltipInput): WorkspaceHostTooltip {
+	const isMainWorkspace = workspaceType === "main";
+	const title = getTitle(hostType, isMainWorkspace, hostIsOnline);
+
+	if (isMainWorkspace) {
+		return {
+			title,
+			description: hostName
+				? `Uses the repository checkout on ${hostName}`
+				: "Uses the repository checkout on this host",
+		};
+	}
+
+	if (hostType === "local-device") {
+		return { title, description: "Running on this device" };
+	}
+
+	if (hostType !== "remote-device") {
+		return { title, description: "Hosted in the cloud" };
+	}
+
+	if (hostIsOnline === false) {
+		return {
+			title,
+			description: hostName
+				? `${hostName} isn't reachable right now`
+				: "The associated device isn't reachable right now",
+		};
+	}
+
+	return {
+		title,
+		description: hostName
+			? `Running on ${hostName}`
+			: "Running on a paired device",
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/utils/getWorkspaceHostTooltip/index.ts
@@ -1,0 +1,5 @@
+export {
+	getWorkspaceHostTooltip,
+	type WorkspaceHostTooltip,
+	type WorkspaceHostTooltipInput,
+} from "./getWorkspaceHostTooltip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -53,6 +53,7 @@ function makeWorkspace(
 		hostId: MACHINE_ID,
 		type: "worktree",
 		hostIsOnline: true,
+		hostName: "Local Device",
 		name: "Workspace",
 		branch: "main",
 		taskId: null,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -41,6 +41,7 @@ export interface SidebarWorkspaceInput {
 	hostId: string;
 	type: DashboardSidebarWorkspaceType;
 	hostIsOnline: boolean;
+	hostName: string | null;
 	name: string;
 	branch: string;
 	taskId: string | null;
@@ -87,6 +88,7 @@ function decorateSidebarWorkspace(
 		hostType,
 		type: workspace.type,
 		hostIsOnline: hostType === "remote-device" ? workspace.hostIsOnline : null,
+		hostName: workspace.hostName,
 		accentColor: null,
 		name: getV2WorkspaceDisplayName(workspace),
 		branch: workspace.branch,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -309,6 +309,7 @@ export function useDashboardSidebarData() {
 			rawSidebarWorkspaces.map((workspace) => ({
 				...workspace,
 				hostIsOnline: hostsByMachineId.get(workspace.hostId)?.isOnline ?? false,
+				hostName: hostsByMachineId.get(workspace.hostId)?.name || null,
 				pendingTransaction: workspaceTransactionsById[workspace.id] ?? null,
 			})),
 		[hostsByMachineId, rawSidebarWorkspaces, workspaceTransactionsById],
@@ -357,6 +358,7 @@ export function useDashboardSidebarData() {
 			rawLocalMainWorkspaces.map((workspace) => ({
 				...workspace,
 				hostIsOnline: hostsByMachineId.get(workspace.hostId)?.isOnline ?? false,
+				hostName: hostsByMachineId.get(workspace.hostId)?.name || null,
 				pendingTransaction: workspaceTransactionsById[workspace.id] ?? null,
 			})),
 		[hostsByMachineId, rawLocalMainWorkspaces, workspaceTransactionsById],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -32,6 +32,12 @@ export interface DashboardSidebarWorkspace {
 	hostType: DashboardSidebarWorkspaceHostType;
 	type: DashboardSidebarWorkspaceType;
 	hostIsOnline: boolean | null;
+	/**
+	 * Display name of the owning host, or null when it isn't known yet (host
+	 * list still loading, or a cached snapshot written before names were
+	 * stored). Null means fall back to generic copy, never an empty name.
+	 */
+	hostName: string | null;
 	accentColor: string | null;
 	name: string;
 	branch: string;


### PR DESCRIPTION
## What & why

With more than one remote host paired, the sidebar cannot say which machine a workspace runs on.

`DashboardSidebarWorkspaceIcon` maps `hostType` to a glyph, so every `remote-device` row draws the same `TbCloud`. Two remote hosts are pixel-identical. The tooltip did not close the gap either — it read "Running on a paired device" for every remote host, and "Uses the repository checkout on this host" for every main workspace. The host's name was reachable from Settings → Hosts and nowhere else.

This carries the host's display name through to the row and names it in the tooltip:

| Case | Before | After |
| --- | --- | --- |
| Remote worktree | Running on a paired device | Running on OCI Ralu |
| Remote worktree, host offline | The associated device isn't reachable right now | OCI Ralu isn't reachable right now |
| Main workspace | Uses the repository checkout on this host | Uses the repository checkout on OCI Ralu |

Titles are unchanged. Local and cloud copy are unchanged.

Notes on the approach:

- `useKnownHosts` already fetched `name` from `v2Host.list` and dropped it during the row map, so this is plumbing rather than a new read.
- Every string falls back to the previous generic wording when the name is unknown. That covers the window before the host list resolves, and cached snapshots written before names were stored.
- The IndexedDB snapshot key is deliberately **not** bumped. Bumping it would empty the host list on an offline boot, which clears every host-derived sidebar row (the failure `useKnownHosts` documents from 2026-08-01). `loadKnownHostsSnapshot` fills a missing name with `""` instead, and the next live response supplies the real one.
- The tooltip's nested ternaries moved into `getWorkspaceHostTooltip`. Two of their branches — `"Worktree workspace"` and `"Isolated copy for parallel development"` — were unreachable, because the ternary only consulted them when `isMainWorkspace` was true. They are gone rather than preserved.

This is the smaller half of the problem. The icon itself still cannot distinguish two remote hosts at a glance, which needs a design decision rather than a plumbing change. That half is #6468; this PR is the part that has one obvious answer.

## How I tested it

- `bun run lint` — passes
- `bun run typecheck` — passes
- `bun run test` — passes (16/16 tasks)
- New unit tests in `getWorkspaceHostTooltip.test.ts` (7 cases): names the host, tells two remote hosts apart, offline wording, main-workspace wording, all three generic fallbacks, and local/cloud copy held unchanged.

**No screenshot, and I want to be straight about why.** `.superset/setup.local.sh` needs Docker for its Postgres/Electric/Redis bundle, and Docker is not installed on this machine, so I could not bring up the dev app to capture the tooltip via CDP. The change is tooltip copy driven by a pure function, and the table above is asserted directly by the unit tests — but I have not seen it rendered in a running build, and I would rather say so than imply I did. Happy to add a capture if a maintainer would like one before merging.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1xktnNtqNzBjPYVkNkLpn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard workspace tooltips now provide clearer host and workspace details.
  * Named remote hosts are displayed in workspace descriptions when available.
  * Tooltips include helpful status information for online and offline hosts.

* **Bug Fixes**
  * Improved handling of saved host data when names are unavailable, with generic fallback text provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->