### PR TITLE
fix(desktop): open OSC 8 file:// hyperlinks from the terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/links/file-uri.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/file-uri.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { fileUriToPath } from "./file-uri";
+
+describe("fileUriToPath", () => {
+	it("returns the path for a local file URI", () => {
+		expect(
+			fileUriToPath("file:///Users/me/.claude/image-cache/abc/22.png"),
+		).toBe("/Users/me/.claude/image-cache/abc/22.png");
+	});
+
+	it("decodes percent-escaped characters", () => {
+		expect(fileUriToPath("file:///tmp/my%20shot%20(1).png")).toBe(
+			"/tmp/my shot (1).png",
+		);
+	});
+
+	it("accepts an explicit localhost host", () => {
+		expect(fileUriToPath("file://localhost/tmp/a.png")).toBe("/tmp/a.png");
+	});
+
+	it("rejects a UNC path rather than dropping the host", () => {
+		expect(fileUriToPath("file://server/share/a.png")).toBeNull();
+	});
+
+	it("rejects other schemes so they stay on the URL path", () => {
+		expect(fileUriToPath("https://example.com/a.png")).toBeNull();
+		expect(fileUriToPath("javascript:alert(1)")).toBeNull();
+		expect(fileUriToPath("not a uri")).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/links/file-uri.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/file-uri.ts
@@ -1,0 +1,21 @@
+/**
+ * Path from a `file://` URI, or null for anything else.
+ *
+ * Agent CLIs hyperlink attachments they wrote to disk — Claude Code emits
+ * `file:///Users/me/.claude/image-cache/<session>/22.png` on the `[Image #22]`
+ * it prints. Those arrive as OSC 8 links, so the terminal gets a real path and
+ * can open it like any other file.
+ */
+export function fileUriToPath(uri: string): string | null {
+	if (!uri.toLowerCase().startsWith("file://")) return null;
+	try {
+		const url = new URL(uri);
+		// A host component means a UNC path (file://server/share); everything the
+		// agents emit is local, and decodeURIComponent would silently drop it.
+		if (url.hostname && url.hostname !== "localhost") return null;
+		const path = decodeURIComponent(url.pathname);
+		return path.length > 0 ? path : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/links/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/links/index.ts
@@ -4,6 +4,8 @@ export {
 	getXtermLineContent,
 } from "./buffer-helpers";
 
+export { fileUriToPath } from "./file-uri";
+
 export { LinkDetectorAdapter } from "./link-detector-adapter";
 
 export {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
@@ -45,7 +45,7 @@ describe("TerminalLinkManager", () => {
 
 		const linkHandler = terminal.options.linkHandler;
 		expect(linkHandler).toBeTruthy();
-		expect(linkHandler?.allowNonHttpProtocols).toBe(false);
+		expect(linkHandler?.allowNonHttpProtocols).toBe(true);
 
 		const event = {} as MouseEvent;
 		linkHandler?.activate(event, "https://example.com", {
@@ -64,6 +64,65 @@ describe("TerminalLinkManager", () => {
 		expect(onUrlClick).toHaveBeenCalledWith(event, "https://example.com");
 		expect(onLinkHover).toHaveBeenCalledWith(event, { kind: "url" });
 		expect(onLinkLeave).toHaveBeenCalled();
+	});
+
+	it("routes OSC 8 file:// hyperlinks through the file handler", () => {
+		const { terminal } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+		const onFileUrlClick = mock();
+		const onUrlClick = mock();
+		const onLinkHover = mock();
+
+		manager.setHandlers({
+			stat: async () => null,
+			onFileUrlClick,
+			onUrlClick,
+			onLinkHover,
+		});
+
+		const linkHandler = terminal.options.linkHandler;
+		const event = {} as MouseEvent;
+		const range = { start: { x: 1, y: 1 }, end: { x: 20, y: 1 } };
+		const uri = "file:///Users/me/.claude/image-cache/a%20b.png";
+
+		linkHandler?.activate(event, uri, range);
+		linkHandler?.hover?.(event, uri, range);
+
+		expect(onFileUrlClick).toHaveBeenCalledWith(
+			event,
+			"/Users/me/.claude/image-cache/a b.png",
+		);
+		expect(onUrlClick).not.toHaveBeenCalled();
+		expect(onLinkHover).toHaveBeenCalledWith(event, {
+			kind: "file",
+			isDirectory: false,
+		});
+	});
+
+	it("ignores OSC 8 hyperlinks using an unsupported scheme", () => {
+		const { terminal } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+		const onFileUrlClick = mock();
+		const onUrlClick = mock();
+		const onLinkHover = mock();
+
+		manager.setHandlers({
+			stat: async () => null,
+			onFileUrlClick,
+			onUrlClick,
+			onLinkHover,
+		});
+
+		const linkHandler = terminal.options.linkHandler;
+		const event = {} as MouseEvent;
+		const range = { start: { x: 1, y: 1 }, end: { x: 20, y: 1 } };
+
+		linkHandler?.activate(event, "javascript:alert(1)", range);
+		linkHandler?.hover?.(event, "javascript:alert(1)", range);
+
+		expect(onFileUrlClick).not.toHaveBeenCalled();
+		expect(onUrlClick).not.toHaveBeenCalled();
+		expect(onLinkHover).not.toHaveBeenCalled();
 	});
 
 	it("clears only the OSC link handler it installed", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
@@ -11,6 +11,7 @@ import type { ILinkHandler, Terminal as XTerm } from "@xterm/xterm";
 import { UrlLinkProvider } from "../../screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers";
 import type { DetectedLink } from "./links";
 import {
+	fileUriToPath,
 	LinkDetectorAdapter,
 	LocalLinkDetector,
 	type StatCallback,
@@ -22,12 +23,19 @@ export type LinkHoverInfo =
 	| { kind: "file"; isDirectory: boolean }
 	| { kind: "url" };
 
+const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
+
 /**
  * Link handler callbacks for the v2 terminal.
  */
 export interface TerminalLinkHandlers {
 	/** Called when a file path link is activated (Cmd/Ctrl+click). */
 	onFileLinkClick?: (event: MouseEvent, link: DetectedLink) => void;
+	/**
+	 * Called when an OSC 8 hyperlink pointing at a `file://` URI is activated,
+	 * with the decoded absolute path.
+	 */
+	onFileUrlClick?: (event: MouseEvent, path: string) => void;
 	/** Called when a URL link is activated. */
 	onUrlClick?: (event: MouseEvent, url: string) => void;
 	/** Called when the mouse enters a detected link (file path or URL). */
@@ -149,13 +157,27 @@ export class TerminalLinkManager {
 			// xterm always registers its own OSC 8 hyperlink provider first. Without
 			// this, OSC 8 links use xterm's default confirm() + window.open() path,
 			// which is blocked in Electron and also bypasses our link preferences.
+			//
+			// Non-HTTP protocols are allowed through so that `file://` hyperlinks
+			// (agent CLIs emit them for files they wrote) open like any other file
+			// path. `activate` is the allowlist xterm's docs require: every other
+			// scheme is dropped rather than handed to the URL handler.
+			const onFileUrlClick = handlers.onFileUrlClick;
 			this._oscLinkHandler = {
-				allowNonHttpProtocols: false,
+				allowNonHttpProtocols: true,
 				activate: (event, uri) => {
-					onUrlClick(event, uri);
+					const filePath = fileUriToPath(uri);
+					if (filePath) onFileUrlClick?.(event, filePath);
+					else if (HTTP_SCHEME_PATTERN.test(uri)) onUrlClick(event, uri);
 				},
 				hover: onLinkHover
-					? (event) => onLinkHover(event, { kind: "url" })
+					? (event, uri) => {
+							if (fileUriToPath(uri)) {
+								onLinkHover(event, { kind: "file", isDirectory: false });
+							} else if (HTTP_SCHEME_PATTERN.test(uri)) {
+								onLinkHover(event, { kind: "url" });
+							}
+						}
 					: undefined,
 				leave: onLinkLeave ? () => onLinkLeave() : undefined,
 			};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -69,6 +69,28 @@ export function TerminalPane({
 	} = useLinkHoverState();
 	const { hint, showHint } = useLinkClickHint();
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+
+	// Shared by detected file paths and by OSC 8 `file://` hyperlinks.
+	const openFilePath = useCallback(
+		(
+			event: MouseEvent,
+			path: string,
+			position?: { line?: number; column?: number },
+		) => {
+			const action = filePolicy.getAction(event);
+			if (action === null) {
+				showHint(event.clientX, event.clientY);
+				return;
+			}
+			event.preventDefault();
+			if (action === "external") {
+				openInExternalEditor(path, position);
+			} else {
+				onOpenFile(path, action === "newTab");
+			}
+		},
+		[filePolicy, showHint, openInExternalEditor, onOpenFile],
+	);
 	const paneData = ctx.pane.data as TerminalPaneData;
 	const { terminalId } = paneData;
 	const terminalInstanceId = ctx.pane.id;
@@ -276,23 +298,12 @@ export function TerminalPane({
 						return;
 					}
 
-					const action = filePolicy.getAction(event);
-					if (action === null) {
-						showHint(event.clientX, event.clientY);
-						return;
-					}
-					event.preventDefault();
-					if (action === "external") {
-						openInExternalEditor(link.resolvedPath, {
-							line: link.row,
-							column: link.col,
-						});
-					} else if (action === "newTab") {
-						onOpenFile(link.resolvedPath, true);
-					} else {
-						onOpenFile(link.resolvedPath);
-					}
+					openFilePath(event, link.resolvedPath, {
+						line: link.row,
+						column: link.col,
+					});
 				},
+				onFileUrlClick: openFilePath,
 				onUrlClick: (event, url) => {
 					const action = urlPolicy.getAction(event);
 					if (action === null) {
@@ -322,13 +333,12 @@ export function TerminalPane({
 		terminalInstanceId,
 		workspaceId,
 		ctx.store,
-		onOpenFile,
+		openFilePath,
 		onRevealPath,
 		openInExternalEditor,
 		onLinkHover,
 		onLinkLeave,
 		showHint,
-		filePolicy,
 		urlPolicy,
 	]);
 


### PR DESCRIPTION
What & why

Clicking an OSC 8 hyperlink that points at a `file://` URI in a v2 terminal does nothing. Agent CLIs use these to reference files they wrote — Claude Code hyperlinks its `[Image #22]` markers to `file:///Users/me/.claude/image-cache/<session>/22.png`,  so the terminal is handed a real absolute path and drops it.

The OSC 8 handler is installed with `allowNonHttpProtocols: false` (`apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts:158`). xterm's `OscLinkProvider` checks that flag before it yields the link at all, with it off, anything whose protocol isn't `http:`/`https:` is skipped, so the hyperlink is never offered to the terminal: no hover, no cursor change, nothing to click.

This turns the flag on and makes `activate` the allowlist xterm's docs require whenever it is on: a `file://` URI is decoded to a path and routed to the file handler, `http(s)` keeps going to the URL handler, and every other scheme is dropped rather than forwarded. Hover mirrors the same routing, so a `file://` link shows the File-links label instead of the URL one.

In `TerminalPane`, `file://` links reuse the existing **File links** preference tiers — the same dispatch detected file paths already use, extracted into one callback so the two paths can't drift.

No new preference and no new IPC: an image link lands in a file pane, whose view registry already picks `ImageView` for image extensions, and `workspace-fs`'s `readFile` explicitly permits paths outside the workspace root — which is what an agent's cache directory is.

Scoped to the v2 terminal. The legacy `screens/main` terminal shares `TerminalLinkManager` but keeps its own simpler dispatch; `file://` links there are inert before and after this change.

### How I tested it

- `bun test apps/desktop/src/renderer/lib/terminal/links/file-uri.test.ts apps/desktop/src/renderer/lib/terminal/terminal-link manager.test.ts` → 10 pass.
  New cases: a `file://` activate/hover routes to the file handler and not the URL
  handler; an unsupported scheme (`javascript:`) reaches neither handler. Both
  fail without this change.
- `bun test apps/desktop/src/renderer/lib/terminal/` → 312 pass, 10 fail. All 10
  are pre-existing and confined to `appearance/appearance.test.ts` (`document` is
  undefined when that file runs without its DOM preload); untouched here.
- `bun run lint` → exits 0, no output.
- `bun run --cwd apps/desktop typecheck` → 5 errors, all pre-existing mermaid /
  hast plugin type mismatches in markdown code-block components, none in the
  files this PR touches.
- The checks above are unit-level. The same routing was exercised in a local
  build, where Claude Code's `[Image #N]` hyperlinks open through the File links
  preference.

### Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens OSC 8 `file://` hyperlinks in the v2 terminal by allowing non-HTTP protocols and explicitly routing file URIs to the file handler. Previously these links had no hover/click effect; now they open via existing File links preferences, `http(s)` URLs are unchanged, and other schemes are ignored.

**Review notes**
- `TerminalLinkManager`: enables `allowNonHttpProtocols` and allowlists in `activate`/`hover`—`file://` → decoded path via `fileUriToPath` → `onFileUrlClick`; `http(s)` → `onUrlClick`; all other schemes are dropped.
- `TerminalPane`: factors a shared `openFilePath` used by detected file paths and OSC 8 `file://` links; wires `onFileUrlClick` to it; respects current File links policy; no new preferences or IPC.
- Adds `file-uri.ts` (`fileUriToPath`) and tests; rejects UNC/non-local hosts and non-file schemes.
- Scoped to the v2 terminal; the legacy terminal remains unchanged.
- Adds unit tests for file URI decoding and OSC 8 routing.

<sup>Written for commit 2a7a597c8dd14b2a044b3f4aac8fbbaa220e166a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening valid `file://` links from the terminal.
  * File links now decode paths correctly and use the same opening options as detected file paths.
  * HTTP(S) links continue opening as web links, while unsupported schemes are ignored.
  * Added file-specific hover and click handling in terminal links.

* **Bug Fixes**
  * Improved handling of malformed, empty, non-local, and unsupported file links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->