### PR TITLE
feat(desktop): filter Linear tasks by initiative

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -128,6 +128,7 @@ export function DashboardSidebarHeader({
 		search: lastSearch,
 		typeTab: lastTypeTab,
 		projectFilters: lastProjectFilters,
+		linearInitiativeFilter: lastLinearInitiativeFilter,
 		linearProjectFilter: lastLinearProjectFilter,
 		includeClosedIssues: lastIncludeClosedIssues,
 	} = useTasksFilterStore();
@@ -157,6 +158,7 @@ export function DashboardSidebarHeader({
 					search: lastSearch,
 					typeTab: lastTypeTab,
 					projectFilters: lastProjectFilters,
+					linearInitiativeFilter: lastLinearInitiativeFilter,
 					linearProjectFilter: lastLinearProjectFilter,
 					includeClosedIssues: lastIncludeClosedIssues,
 				}),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
@@ -38,6 +38,7 @@ function TaskDetailPage() {
 		type,
 		project,
 		projects,
+		linearInitiative,
 		linearProject,
 		state,
 	} = TasksLayoutRoute.useSearch();
@@ -51,6 +52,7 @@ function TaskDetailPage() {
 			search: searchQuery ?? "",
 			typeTab: type === "issues" ? "issues" : "tasks",
 			projectFilters: resolveProjectFilterParams(projects, project, []),
+			linearInitiativeFilter: linearInitiative ?? null,
 			linearProjectFilter: linearProject ?? null,
 			includeClosedIssues: state === "all",
 		});
@@ -61,6 +63,7 @@ function TaskDetailPage() {
 		type,
 		project,
 		projects,
+		linearInitiative,
 		linearProject,
 		state,
 	]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -27,6 +27,7 @@ import {
 	type TaskSource,
 	TasksTopBar,
 } from "./components/TasksTopBar";
+import { useLinearInitiatives } from "./hooks/useLinearInitiatives";
 import type { TaskWithStatus } from "./hooks/useTasksData";
 
 interface TasksViewProps {
@@ -35,6 +36,7 @@ interface TasksViewProps {
 	initialSearch?: string;
 	initialType?: "tasks" | "issues";
 	initialProjects?: string[];
+	initialLinearInitiative?: string;
 	initialLinearProject?: string;
 	initialState?: "open" | "all";
 }
@@ -45,6 +47,7 @@ export function TasksView({
 	initialSearch,
 	initialType,
 	initialProjects,
+	initialLinearInitiative,
 	initialLinearProject,
 	initialState,
 }: TasksViewProps) {
@@ -57,12 +60,14 @@ export function TasksView({
 		search: storedSearch,
 		typeTab: storedTypeTab,
 		projectFilters: storedProjectFilters,
+		linearInitiativeFilter: storedLinearInitiativeFilter,
 		linearProjectFilter: storedLinearProjectFilter,
 		setTab: storeSetTab,
 		setAssignee: storeSetAssignee,
 		setSearch: storeSetSearch,
 		setTypeTab: storeSetTypeTab,
 		setProjectFilters: storeSetProjectFilters,
+		setLinearInitiativeFilter: storeSetLinearInitiativeFilter,
 		setLinearProjectFilter: storeSetLinearProjectFilter,
 		includeClosedIssues: storedIncludeClosedIssues,
 		setIncludeClosedIssues: storeSetIncludeClosedIssues,
@@ -75,6 +80,8 @@ export function TasksView({
 	const assigneeFilter = initialAssignee ?? storedAssignee;
 	const typeTab = initialType ?? storedTypeTab;
 	const projectFilters = initialProjects ?? storedProjectFilters;
+	const linearInitiativeFilter =
+		initialLinearInitiative ?? storedLinearInitiativeFilter;
 	const linearProjectFilter = initialLinearProject ?? storedLinearProjectFilter;
 	const includeClosedIssues =
 		initialState === undefined
@@ -95,6 +102,7 @@ export function TasksView({
 			search?: string;
 			type?: "tasks" | "issues";
 			projects?: string[];
+			linearInitiative?: string | null;
 			linearProject?: string | null;
 			includeClosedIssues?: boolean;
 		}) =>
@@ -110,6 +118,10 @@ export function TasksView({
 					overrides.projects !== undefined
 						? overrides.projects
 						: projectFilters,
+				linearInitiativeFilter:
+					overrides.linearInitiative !== undefined
+						? overrides.linearInitiative
+						: linearInitiativeFilter,
 				linearProjectFilter:
 					overrides.linearProject !== undefined
 						? overrides.linearProject
@@ -123,6 +135,7 @@ export function TasksView({
 			searchQuery,
 			typeTab,
 			projectFilters,
+			linearInitiativeFilter,
 			linearProjectFilter,
 			includeClosedIssues,
 		],
@@ -170,6 +183,10 @@ export function TasksView({
 	useEffect(() => {
 		storeSetProjectFilters(projectFilters);
 	}, [projectFilters, storeSetProjectFilters]);
+
+	useEffect(() => {
+		storeSetLinearInitiativeFilter(linearInitiativeFilter);
+	}, [linearInitiativeFilter, storeSetLinearInitiativeFilter]);
 
 	useEffect(() => {
 		storeSetLinearProjectFilter(linearProjectFilter);
@@ -223,6 +240,67 @@ export function TasksView({
 
 	const isLinearConnected =
 		integrations?.some((i) => i.provider === "linear") ?? false;
+	const linearInitiativesQuery = useLinearInitiatives({
+		organizationId: activeOrganizationId ?? null,
+		enabled: isLinearConnected && typeTab === "tasks",
+	});
+	const linearInitiatives = useMemo(
+		() => linearInitiativesQuery.data ?? [],
+		[linearInitiativesQuery.data],
+	);
+	const selectedLinearInitiative = useMemo(
+		() =>
+			linearInitiativeFilter
+				? (linearInitiatives.find(
+						(initiative) => initiative.id === linearInitiativeFilter,
+					) ?? null)
+				: null,
+		[linearInitiativeFilter, linearInitiatives],
+	);
+	const linearInitiativeProjectIds =
+		linearInitiativeFilter && selectedLinearInitiative
+			? selectedLinearInitiative.projectIds
+			: null;
+
+	useEffect(() => {
+		if (!linearInitiativeFilter || !linearInitiativesQuery.isSuccess) return;
+
+		if (!selectedLinearInitiative) {
+			storeSetLinearInitiativeFilter(null);
+			cancelPendingSearchNavigation();
+			navigate({
+				to: "/tasks",
+				search: buildSearch({ linearInitiative: null }),
+				replace: true,
+			});
+			return;
+		}
+
+		if (
+			!linearProjectFilter ||
+			selectedLinearInitiative.projectIds.includes(linearProjectFilter)
+		) {
+			return;
+		}
+
+		storeSetLinearProjectFilter(null);
+		cancelPendingSearchNavigation();
+		navigate({
+			to: "/tasks",
+			search: buildSearch({ linearProject: null }),
+			replace: true,
+		});
+	}, [
+		linearInitiativeFilter,
+		linearProjectFilter,
+		linearInitiativesQuery.isSuccess,
+		selectedLinearInitiative,
+		storeSetLinearInitiativeFilter,
+		storeSetLinearProjectFilter,
+		cancelPendingSearchNavigation,
+		navigate,
+		buildSearch,
+	]);
 
 	// Defaults ("all"/null) are omitted from the URL, so write the store too —
 	// otherwise the render falls back to the stale stored value (no-op select).
@@ -267,6 +345,19 @@ export function TasksView({
 		navigate({
 			to: "/tasks",
 			search: buildSearch({ projects }),
+			replace: true,
+		});
+	};
+
+	const handleLinearInitiativeFilterChange = (
+		linearInitiative: string | null,
+	) => {
+		cancelPendingSearchNavigation();
+		storeSetLinearInitiativeFilter(linearInitiative);
+		storeSetLinearProjectFilter(null);
+		navigate({
+			to: "/tasks",
+			search: buildSearch({ linearInitiative, linearProject: null }),
 			replace: true,
 		});
 	};
@@ -355,6 +446,14 @@ export function TasksView({
 				onTaskSourceChange={handleTaskSourceChange}
 				projectFilters={projectFilters}
 				onProjectFiltersChange={handleProjectFiltersChange}
+				linearInitiatives={linearInitiatives}
+				linearInitiativeFilter={linearInitiativeFilter}
+				onLinearInitiativeFilterChange={handleLinearInitiativeFilterChange}
+				isLoadingLinearInitiatives={linearInitiativesQuery.isLoading}
+				isLinearInitiativesError={linearInitiativesQuery.isError}
+				onRetryLinearInitiatives={() => {
+					void linearInitiativesQuery.refetch();
+				}}
 				linearProjectFilter={linearProjectFilter}
 				onLinearProjectFilterChange={handleLinearProjectFilterChange}
 				includeClosedIssues={includeClosedIssues}
@@ -371,6 +470,7 @@ export function TasksView({
 								filterTab={currentTab}
 								searchQuery={deferredSearchQuery}
 								assigneeFilter={assigneeFilter}
+								linearInitiativeProjectIds={linearInitiativeProjectIds}
 								linearProjectFilter={linearProjectFilter}
 								onTaskClick={handleTaskClick}
 							/>
@@ -379,6 +479,7 @@ export function TasksView({
 								filterTab={currentTab}
 								searchQuery={deferredSearchQuery}
 								assigneeFilter={assigneeFilter}
+								linearInitiativeProjectIds={linearInitiativeProjectIds}
 								linearProjectFilter={linearProjectFilter}
 								onTaskClick={handleTaskClick}
 								onSelectionChange={handleSelectionChange}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
@@ -3,6 +3,7 @@ import { LuRefreshCw } from "react-icons/lu";
 import { useAutoLoadEmptyPages } from "../../hooks/useAutoLoadEmptyPages";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
 import { useTasksData } from "../../hooks/useTasksData";
+import { linearInitiativeProjectIdsKey } from "../../utils/filterTasksByLinearScope";
 import { TasksBoardView } from "../TasksBoardView";
 import type { TabValue } from "../TasksTopBar";
 
@@ -41,7 +42,7 @@ export function BoardContent({
 	useAutoLoadEmptyPages({
 		isEmpty: data.length === 0,
 		isLoading: isLoadingTasks,
-		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIds?.join(",") ?? ""}\0${linearProjectFilter ?? ""}`,
+		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIdsKey(linearInitiativeProjectIds)}\0${linearProjectFilter ?? ""}`,
 		hasNextPage: hasNextTasksPage,
 		isFetchingNextPage: isFetchingNextTasksPage,
 		onLoadMore: fetchNextTasksPage,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
@@ -10,6 +10,7 @@ interface BoardContentProps {
 	filterTab: TabValue;
 	searchQuery: string;
 	assigneeFilter: string | null;
+	linearInitiativeProjectIds: readonly string[] | null;
 	linearProjectFilter: string | null;
 	onTaskClick: (task: TaskWithStatus) => void;
 }
@@ -18,6 +19,7 @@ export function BoardContent({
 	filterTab,
 	searchQuery,
 	assigneeFilter,
+	linearInitiativeProjectIds,
 	linearProjectFilter,
 	onTaskClick,
 }: BoardContentProps) {
@@ -32,13 +34,14 @@ export function BoardContent({
 		filterTab,
 		searchQuery,
 		assigneeFilter,
+		linearInitiativeProjectIds,
 		linearProjectFilter,
 	});
 
 	useAutoLoadEmptyPages({
 		isEmpty: data.length === 0,
 		isLoading: isLoadingTasks,
-		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearProjectFilter ?? ""}`,
+		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIds?.join(",") ?? ""}\0${linearProjectFilter ?? ""}`,
 		hasNextPage: hasNextTasksPage,
 		isFetchingNextPage: isFetchingNextTasksPage,
 		onLoadMore: fetchNextTasksPage,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
@@ -11,6 +11,7 @@ interface TableContentProps {
 	filterTab: TabValue;
 	searchQuery: string;
 	assigneeFilter: string | null;
+	linearInitiativeProjectIds: readonly string[] | null;
 	linearProjectFilter: string | null;
 	onTaskClick: (task: TaskWithStatus) => void;
 	onSelectionChange?: (
@@ -23,6 +24,7 @@ export function TableContent({
 	filterTab,
 	searchQuery,
 	assigneeFilter,
+	linearInitiativeProjectIds,
 	linearProjectFilter,
 	onTaskClick,
 	onSelectionChange,
@@ -40,6 +42,7 @@ export function TableContent({
 		filterTab,
 		searchQuery,
 		assigneeFilter,
+		linearInitiativeProjectIds,
 		linearProjectFilter,
 	});
 
@@ -48,7 +51,7 @@ export function TableContent({
 	useAutoLoadEmptyPages({
 		isEmpty: rows.length === 0,
 		isLoading: isLoadingTasks,
-		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearProjectFilter ?? ""}`,
+		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIds?.join(",") ?? ""}\0${linearProjectFilter ?? ""}`,
 		hasNextPage: hasNextTasksPage,
 		isFetchingNextPage: isFetchingNextTasksPage,
 		onLoadMore: fetchNextTasksPage,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
@@ -3,6 +3,7 @@ import { HiCheckCircle } from "react-icons/hi2";
 import { useAutoLoadEmptyPages } from "../../hooks/useAutoLoadEmptyPages";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
 import { useTasksTable } from "../../hooks/useTasksTable";
+import { linearInitiativeProjectIdsKey } from "../../utils/filterTasksByLinearScope";
 import { TasksTableView } from "../TasksTableView";
 import type { TabValue } from "../TasksTopBar";
 import { getSelectedTasks } from "./utils/getSelectedTasks";
@@ -51,7 +52,7 @@ export function TableContent({
 	useAutoLoadEmptyPages({
 		isEmpty: rows.length === 0,
 		isLoading: isLoadingTasks,
-		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIds?.join(",") ?? ""}\0${linearProjectFilter ?? ""}`,
+		filterKey: `${filterTab}\0${searchQuery}\0${assigneeFilter ?? ""}\0${linearInitiativeProjectIdsKey(linearInitiativeProjectIds)}\0${linearProjectFilter ?? ""}`,
 		hasNextPage: hasNextTasksPage,
 		isFetchingNextPage: isFetchingNextTasksPage,
 		onLoadMore: fetchNextTasksPage,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { cn } from "@superset/ui/utils";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { GoIssueOpened } from "react-icons/go";
 import {
 	HiOutlinePencilSquare,
@@ -15,10 +15,12 @@ import { OpenClosedFilter } from "renderer/routes/_authenticated/_dashboard/comp
 import { ProjectFilter } from "renderer/routes/_authenticated/_dashboard/components/ProjectFilter";
 import { WorkItemsSearch } from "renderer/routes/_authenticated/_dashboard/components/WorkItemsSearch";
 import type { ViewMode } from "../../../../stores/tasks-filter-state";
+import type { LinearInitiative } from "../../hooks/useLinearInitiatives";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
 import type { SelectedIssue } from "../GitHubIssuesContent";
 import { AssigneeFilter } from "./components/AssigneeFilter";
 import { CreateTaskDialog } from "./components/CreateTaskDialog";
+import { LinearInitiativeFilter } from "./components/LinearInitiativeFilter";
 import { LinearProjectFilter } from "./components/LinearProjectFilter";
 import { RunInWorkspacePopover } from "./components/RunInWorkspacePopover";
 import { RunInWorkspacePopoverV2 } from "./components/RunInWorkspacePopoverV2";
@@ -52,6 +54,12 @@ interface TasksTopBarProps {
 	onTaskSourceChange: (taskSource: TaskSource) => void;
 	projectFilters: string[];
 	onProjectFiltersChange: (projectIds: string[]) => void;
+	linearInitiatives: LinearInitiative[];
+	linearInitiativeFilter: string | null;
+	onLinearInitiativeFilterChange: (initiativeId: string | null) => void;
+	isLoadingLinearInitiatives: boolean;
+	isLinearInitiativesError: boolean;
+	onRetryLinearInitiatives: () => void;
 	linearProjectFilter: string | null;
 	onLinearProjectFilterChange: (projectId: string | null) => void;
 	includeClosedIssues: boolean;
@@ -80,6 +88,12 @@ export function TasksTopBar({
 	onTaskSourceChange,
 	projectFilters,
 	onProjectFiltersChange,
+	linearInitiatives,
+	linearInitiativeFilter,
+	onLinearInitiativeFilterChange,
+	isLoadingLinearInitiatives,
+	isLinearInitiativesError,
+	onRetryLinearInitiatives,
 	linearProjectFilter,
 	onLinearProjectFilterChange,
 	includeClosedIssues,
@@ -99,6 +113,22 @@ export function TasksTopBar({
 			: null;
 	const [isCreateTaskOpen, setIsCreateTaskOpen] = useState(false);
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const selectedLinearInitiative = useMemo(
+		() =>
+			linearInitiativeFilter
+				? linearInitiatives.find(
+						(initiative) => initiative.id === linearInitiativeFilter,
+					)
+				: undefined,
+		[linearInitiativeFilter, linearInitiatives],
+	);
+	const allowedLinearProjectIds = useMemo(
+		() =>
+			selectedLinearInitiative
+				? new Set(selectedLinearInitiative.projectIds)
+				: undefined,
+		[selectedLinearInitiative],
+	);
 
 	const hasSelection = selectedCount > 0;
 
@@ -174,10 +204,22 @@ export function TasksTopBar({
 
 								{showTaskOnlyControls ? (
 									<>
-										<LinearProjectFilter
-											value={linearProjectFilter}
-											onChange={onLinearProjectFilterChange}
-										/>
+										<div className="flex items-center gap-0.5">
+											<LinearInitiativeFilter
+												initiatives={linearInitiatives}
+												value={linearInitiativeFilter}
+												onChange={onLinearInitiativeFilterChange}
+												isLoading={isLoadingLinearInitiatives}
+												isError={isLinearInitiativesError}
+												onRetry={onRetryLinearInitiatives}
+											/>
+											<LinearProjectFilter
+												value={linearProjectFilter}
+												onChange={onLinearProjectFilterChange}
+												allowedProjectIds={allowedLinearProjectIds}
+												initiativeName={selectedLinearInitiative?.name}
+											/>
+										</div>
 										<div className="h-4 w-px shrink-0 bg-border" />
 										<StatusFilter value={currentTab} onChange={onTabChange} />
 										<div className="h-4 w-px shrink-0 bg-border" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearInitiativeFilter/LinearInitiativeFilter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearInitiativeFilter/LinearInitiativeFilter.tsx
@@ -1,0 +1,143 @@
+import { Button } from "@superset/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { useMemo, useState } from "react";
+import {
+	HiArrowPath,
+	HiCheck,
+	HiChevronDown,
+	HiOutlineFlag,
+} from "react-icons/hi2";
+import type { LinearInitiative } from "../../../../hooks/useLinearInitiatives";
+
+interface LinearInitiativeFilterProps {
+	initiatives: LinearInitiative[];
+	value: string | null;
+	onChange: (value: string | null) => void;
+	isLoading: boolean;
+	isError: boolean;
+	onRetry: () => void;
+}
+
+export function LinearInitiativeFilter({
+	initiatives,
+	value,
+	onChange,
+	isLoading,
+	isError,
+	onRetry,
+}: LinearInitiativeFilterProps) {
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+	const selected = useMemo(
+		() =>
+			value
+				? (initiatives.find((initiative) => initiative.id === value) ?? null)
+				: null,
+		[value, initiatives],
+	);
+	const filtered = useMemo(() => {
+		const query = search.trim().toLowerCase();
+		if (!query) return initiatives;
+		return initiatives.filter((initiative) =>
+			initiative.name.toLowerCase().includes(query),
+		);
+	}, [initiatives, search]);
+
+	const handleSelect = (id: string | null) => {
+		onChange(id);
+		setOpen(false);
+		setSearch("");
+	};
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next);
+				if (!next) setSearch("");
+			}}
+		>
+			<PopoverTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					title={selected?.name ?? "Initiative"}
+					aria-label={selected?.name ?? "Initiative"}
+					className="h-8 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+				>
+					{isLoading ? (
+						<HiArrowPath className="size-4 animate-spin motion-reduce:animate-none" />
+					) : (
+						<HiOutlineFlag className="size-4" />
+					)}
+					<span className="hidden text-sm @4xl:inline">
+						{selected?.name ?? "Initiative"}
+					</span>
+					<HiChevronDown className="size-3" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-64 p-0">
+				<Command shouldFilter={false}>
+					<CommandInput
+						placeholder="Search initiatives..."
+						value={search}
+						onValueChange={setSearch}
+					/>
+					<CommandList className="max-h-80">
+						{isError ? (
+							<div className="flex items-center justify-between gap-3 px-3 py-2 text-sm text-muted-foreground">
+								<span>Couldn’t load initiatives.</span>
+								<Button variant="ghost" size="xs" onClick={onRetry}>
+									Retry
+								</Button>
+							</div>
+						) : (
+							<>
+								{filtered.length === 0 && !isLoading && (
+									<CommandEmpty>
+										{search
+											? "No initiatives found."
+											: "No initiatives in this workspace."}
+									</CommandEmpty>
+								)}
+								<CommandGroup>
+									{!search && (
+										<CommandItem onSelect={() => handleSelect(null)}>
+											<HiOutlineFlag className="size-4 shrink-0" />
+											<span className="truncate text-sm">All initiatives</span>
+											{value === null && (
+												<HiCheck className="ml-auto size-3.5 shrink-0" />
+											)}
+										</CommandItem>
+									)}
+									{filtered.map((initiative) => (
+										<CommandItem
+											key={initiative.id}
+											onSelect={() => handleSelect(initiative.id)}
+										>
+											<HiOutlineFlag className="size-4 shrink-0" />
+											<span className="truncate text-sm">
+												{initiative.name}
+											</span>
+											{initiative.id === value && (
+												<HiCheck className="ml-auto size-3.5 shrink-0" />
+											)}
+										</CommandItem>
+									))}
+								</CommandGroup>
+							</>
+						)}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearInitiativeFilter/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearInitiativeFilter/index.ts
@@ -1,0 +1,1 @@
+export { LinearInitiativeFilter } from "./LinearInitiativeFilter";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearProjectFilter/LinearProjectFilter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearProjectFilter/LinearProjectFilter.tsx
@@ -102,15 +102,16 @@ export function LinearProjectFilter({
 						onValueChange={setSearch}
 					/>
 					<CommandList className="max-h-80">
-						{filtered.length === 0 && (
-							<CommandEmpty>
-								{search
-									? "No projects found."
-									: initiativeName
+						{filtered.length === 0 &&
+							(search ? (
+								<CommandEmpty>No projects found.</CommandEmpty>
+							) : (
+								<div className="px-3 py-2 text-sm text-muted-foreground">
+									{initiativeName
 										? `No synced projects in ${initiativeName}.`
 										: "No synced projects."}
-							</CommandEmpty>
-						)}
+								</div>
+							))}
 						<CommandGroup>
 							{!search && (
 								<CommandItem onSelect={() => handleSelect(null)}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearProjectFilter/LinearProjectFilter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/LinearProjectFilter/LinearProjectFilter.tsx
@@ -16,6 +16,8 @@ import { TASK_PICKER_INPUT } from "../../../../hooks/useTasksData";
 interface LinearProjectFilterProps {
 	value: string | null;
 	onChange: (value: string | null) => void;
+	allowedProjectIds?: ReadonlySet<string>;
+	initiativeName?: string;
 }
 
 interface LinearProjectOption {
@@ -26,6 +28,8 @@ interface LinearProjectOption {
 export function LinearProjectFilter({
 	value,
 	onChange,
+	allowedProjectIds,
+	initiativeName,
 }: LinearProjectFilterProps) {
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
@@ -42,8 +46,13 @@ export function LinearProjectFilter({
 				name: task.externalProjectName ?? task.externalProjectId,
 			});
 		}
-		return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
-	}, [taskPage]);
+		return [...byId.values()]
+			.filter(
+				(project) =>
+					allowedProjectIds === undefined || allowedProjectIds.has(project.id),
+			)
+			.sort((a, b) => a.name.localeCompare(b.name));
+	}, [allowedProjectIds, taskPage]);
 
 	const selected = useMemo(
 		() => (value ? (projects.find((p) => p.id === value) ?? null) : null),
@@ -93,8 +102,14 @@ export function LinearProjectFilter({
 						onValueChange={setSearch}
 					/>
 					<CommandList className="max-h-80">
-						{filtered.length === 0 && search && (
-							<CommandEmpty>No projects found.</CommandEmpty>
+						{filtered.length === 0 && (
+							<CommandEmpty>
+								{search
+									? "No projects found."
+									: initiativeName
+										? `No synced projects in ${initiativeName}.`
+										: "No synced projects."}
+							</CommandEmpty>
 						)}
 						<CommandGroup>
 							{!search && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useLinearInitiatives/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useLinearInitiatives/index.ts
@@ -1,0 +1,4 @@
+export {
+	type LinearInitiative,
+	useLinearInitiatives,
+} from "./useLinearInitiatives";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useLinearInitiatives/useLinearInitiatives.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useLinearInitiatives/useLinearInitiatives.ts
@@ -1,0 +1,25 @@
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+
+export interface LinearInitiative {
+	id: string;
+	name: string;
+	projectIds: string[];
+}
+
+interface UseLinearInitiativesParams {
+	organizationId: string | null;
+	enabled: boolean;
+}
+
+export function useLinearInitiatives({
+	organizationId,
+	enabled,
+}: UseLinearInitiativesParams) {
+	return cloudTrpc.integration.linear.getInitiatives.useQuery(
+		{ organizationId: organizationId ?? "" },
+		{
+			enabled: enabled && organizationId !== null,
+			staleTime: 5 * 60 * 1000,
+		},
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksData/useTasksData.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksData/useTasksData.tsx
@@ -3,6 +3,7 @@ import type { RouterOutputs } from "@superset/trpc";
 import { useCallback, useMemo } from "react";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import type { TabValue } from "../../components/TasksTopBar";
+import { filterTasksByLinearScope } from "../../utils/filterTasksByLinearScope";
 import { matchesTaskStatusFilter } from "../../utils/matchesTaskStatusFilter";
 import { compareTasks } from "../../utils/sorting";
 import { useHybridSearch } from "../useHybridSearch";
@@ -36,6 +37,7 @@ interface UseTasksDataParams {
 	filterTab: TabValue;
 	searchQuery: string;
 	assigneeFilter: string | null;
+	linearInitiativeProjectIds: readonly string[] | null;
 	linearProjectFilter: string | null;
 }
 
@@ -93,6 +95,7 @@ export function useTasksData({
 	filterTab,
 	searchQuery,
 	assigneeFilter,
+	linearInitiativeProjectIds,
 	linearProjectFilter,
 }: UseTasksDataParams): TasksPagination & {
 	data: TaskWithStatus[];
@@ -118,13 +121,11 @@ export function useTasksData({
 	}, [sortedData, searchQuery, search]);
 
 	const filteredData = useMemo(() => {
-		let result = searchedData;
-
-		if (linearProjectFilter) {
-			result = result.filter(
-				(task) => task.externalProjectId === linearProjectFilter,
-			);
-		}
+		let result = filterTasksByLinearScope(
+			searchedData,
+			linearInitiativeProjectIds,
+			linearProjectFilter,
+		);
 
 		if (filterTab !== "all") {
 			result = result.filter((task) =>
@@ -145,7 +146,13 @@ export function useTasksData({
 		}
 
 		return result;
-	}, [searchedData, filterTab, assigneeFilter, linearProjectFilter]);
+	}, [
+		searchedData,
+		filterTab,
+		assigneeFilter,
+		linearInitiativeProjectIds,
+		linearProjectFilter,
+	]);
 
 	return {
 		data: filteredData,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/useTasksTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/useTasksTable.tsx
@@ -22,6 +22,7 @@ import {
 	type StatusType,
 } from "../../components/shared/StatusIcon";
 import type { TabValue } from "../../components/TasksTopBar";
+import { filterTasksByLinearScope } from "../../utils/filterTasksByLinearScope";
 import { matchesTaskStatusFilter } from "../../utils/matchesTaskStatusFilter";
 import { useHybridSearch } from "../useHybridSearch";
 import {
@@ -57,6 +58,7 @@ interface UseTasksTableParams {
 	filterTab: TabValue;
 	searchQuery: string;
 	assigneeFilter: string | null;
+	linearInitiativeProjectIds: readonly string[] | null;
 	linearProjectFilter: string | null;
 }
 
@@ -64,6 +66,7 @@ export function useTasksTable({
 	filterTab,
 	searchQuery,
 	assigneeFilter,
+	linearInitiativeProjectIds,
 	linearProjectFilter,
 }: UseTasksTableParams): TasksPagination & {
 	table: Table<TaskWithStatus>;
@@ -90,11 +93,12 @@ export function useTasksTable({
 	} = useTasksJoinedWithStatuses();
 
 	const projectScopedData = useMemo(() => {
-		if (!linearProjectFilter) return sortedData;
-		return sortedData.filter(
-			(task) => task.externalProjectId === linearProjectFilter,
+		return filterTasksByLinearScope(
+			sortedData,
+			linearInitiativeProjectIds,
+			linearProjectFilter,
 		);
-	}, [sortedData, linearProjectFilter]);
+	}, [sortedData, linearInitiativeProjectIds, linearProjectFilter]);
 
 	const { search } = useHybridSearch(projectScopedData);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { filterTasksByLinearScope } from "./filterTasksByLinearScope";
+import {
+	filterTasksByLinearScope,
+	linearInitiativeProjectIdsKey,
+} from "./filterTasksByLinearScope";
 
 const tasks = [
 	{ id: "task-1", externalProjectId: "project-1" },
@@ -27,5 +30,18 @@ describe("filterTasksByLinearScope", () => {
 
 	test("shows no tasks when the selected initiative has no projects", () => {
 		expect(filterTasksByLinearScope(tasks, [], null)).toEqual([]);
+	});
+});
+
+describe("linearInitiativeProjectIdsKey", () => {
+	test("distinguishes no initiative from an initiative with no projects", () => {
+		expect(linearInitiativeProjectIdsKey(null)).toBe("*");
+		expect(linearInitiativeProjectIdsKey([])).toBe("");
+	});
+
+	test("serializes selected initiative project ids", () => {
+		expect(linearInitiativeProjectIdsKey(["project-a", "project-b"])).toBe(
+			"project-a,project-b",
+		);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { filterTasksByLinearScope } from "./filterTasksByLinearScope";
+
+const tasks = [
+	{ id: "task-1", externalProjectId: "project-1" },
+	{ id: "task-2", externalProjectId: "project-2" },
+	{ id: "task-3", externalProjectId: "project-3" },
+	{ id: "task-4", externalProjectId: null },
+];
+
+describe("filterTasksByLinearScope", () => {
+	test("shows tasks from every project when no Linear scope is selected", () => {
+		expect(filterTasksByLinearScope(tasks, null, null)).toEqual(tasks);
+	});
+
+	test("filters tasks to all projects in the selected initiative", () => {
+		expect(
+			filterTasksByLinearScope(tasks, ["project-1", "project-3"], null),
+		).toEqual([tasks[0], tasks[2]]);
+	});
+
+	test("narrows a selected initiative to one project", () => {
+		expect(
+			filterTasksByLinearScope(tasks, ["project-1", "project-3"], "project-3"),
+		).toEqual([tasks[2]]);
+	});
+
+	test("shows no tasks when the selected initiative has no projects", () => {
+		expect(filterTasksByLinearScope(tasks, [], null)).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.ts
@@ -24,3 +24,9 @@ export function filterTasksByLinearScope<T extends TaskWithLinearProject>(
 
 	return result;
 }
+
+export function linearInitiativeProjectIdsKey(
+	projectIds: readonly string[] | null,
+): string {
+	return projectIds === null ? "*" : projectIds.join(",");
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.ts
@@ -1,0 +1,26 @@
+interface TaskWithLinearProject {
+	externalProjectId: string | null;
+}
+
+export function filterTasksByLinearScope<T extends TaskWithLinearProject>(
+	tasks: T[],
+	initiativeProjectIds: readonly string[] | null,
+	projectId: string | null,
+): T[] {
+	let result = tasks;
+
+	if (initiativeProjectIds !== null) {
+		const allowedProjectIds = new Set(initiativeProjectIds);
+		result = result.filter(
+			(task) =>
+				task.externalProjectId !== null &&
+				allowedProjectIds.has(task.externalProjectId),
+		);
+	}
+
+	if (projectId) {
+		result = result.filter((task) => task.externalProjectId === projectId);
+	}
+
+	return result;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/index.ts
@@ -1,1 +1,4 @@
-export { filterTasksByLinearScope } from "./filterTasksByLinearScope";
+export {
+	filterTasksByLinearScope,
+	linearInitiativeProjectIdsKey,
+} from "./filterTasksByLinearScope";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/index.ts
@@ -1,0 +1,1 @@
+export { filterTasksByLinearScope } from "./filterTasksByLinearScope";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
@@ -54,11 +54,13 @@ function IssueDetailPage() {
 				search: search.search ?? "",
 				typeTab: "issues",
 				projectFilters: resolveProjectFilterParams(search.projects, null, []),
+				linearInitiativeFilter: search.linearInitiative ?? null,
 				linearProjectFilter: search.linearProject ?? null,
 				includeClosedIssues: search.state === "all",
 			}),
 		[
 			search.assignee,
+			search.linearInitiative,
 			search.linearProject,
 			search.search,
 			search.projects,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
@@ -14,6 +14,7 @@ export type TasksSearch = {
 	type?: "tasks" | "prs" | "issues";
 	project?: string;
 	projects?: string;
+	linearInitiative?: string;
 	linearProject?: string;
 	state?: "open" | "all";
 };
@@ -39,6 +40,10 @@ export const Route = createFileRoute("/_authenticated/_dashboard/tasks")({
 			: undefined,
 		project: typeof search.project === "string" ? search.project : undefined,
 		projects: typeof search.projects === "string" ? search.projects : undefined,
+		linearInitiative:
+			typeof search.linearInitiative === "string"
+				? search.linearInitiative
+				: undefined,
 		linearProject:
 			typeof search.linearProject === "string"
 				? search.linearProject

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
@@ -31,6 +31,7 @@ function TasksPage() {
 		type,
 		project,
 		projects,
+		linearInitiative,
 		linearProject,
 		state,
 	} = TasksLayoutRoute.useSearch();
@@ -46,6 +47,7 @@ function TasksPage() {
 			initialSearch={search}
 			initialType={type === "prs" ? undefined : type}
 			initialProjects={initialProjects}
+			initialLinearInitiative={linearInitiative}
 			initialLinearProject={linearProject}
 			initialState={state}
 		/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.test.ts
@@ -33,6 +33,7 @@ describe("tasksSearchFromFilters", () => {
 				search: "",
 				typeTab: "tasks",
 				projectFilters: [],
+				linearInitiativeFilter: null,
 				linearProjectFilter: null,
 				includeClosedIssues: false,
 			}),
@@ -47,6 +48,7 @@ describe("tasksSearchFromFilters", () => {
 				search: "remote host",
 				typeTab: "issues",
 				projectFilters: ["project-1", "project-2"],
+				linearInitiativeFilter: null,
 				linearProjectFilter: null,
 				includeClosedIssues: true,
 			}),
@@ -68,11 +70,13 @@ describe("tasksSearchFromFilters", () => {
 				search: "",
 				typeTab: "tasks",
 				projectFilters: ["project-1"],
+				linearInitiativeFilter: "initiative-1",
 				linearProjectFilter: "linear-project-1",
 				includeClosedIssues: true,
 			}),
 		).toEqual({
 			projects: "project-1",
+			linearInitiative: "initiative-1",
 			linearProject: "linear-project-1",
 		});
 	});
@@ -97,6 +101,7 @@ describe("migrateTasksFilterState", () => {
 			migrateTasksFilterState({
 				tab: "waiting",
 				viewMode: "grid",
+				linearInitiativeFilter: 42,
 				linearProjectFilter: 42,
 				projectFilters: ["project-1", false, "project-1"],
 			}),
@@ -105,6 +110,7 @@ describe("migrateTasksFilterState", () => {
 			typeTab: "tasks",
 			viewMode: "table",
 			includeClosedIssues: false,
+			linearInitiativeFilter: null,
 			linearProjectFilter: null,
 			projectFilters: ["project-1"],
 		});
@@ -113,6 +119,7 @@ describe("migrateTasksFilterState", () => {
 			typeTab: "tasks",
 			viewMode: "table",
 			includeClosedIssues: false,
+			linearInitiativeFilter: null,
 			linearProjectFilter: null,
 			projectFilters: [],
 		});
@@ -125,6 +132,16 @@ describe("migrateTasksFilterState", () => {
 			}),
 		).toMatchObject({
 			linearProjectFilter: "linear-project-1",
+		});
+	});
+
+	test("normalizes a persisted Linear initiative filter", () => {
+		expect(
+			migrateTasksFilterState({
+				linearInitiativeFilter: "  initiative-1  ",
+			}),
+		).toMatchObject({
+			linearInitiativeFilter: "initiative-1",
 		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
@@ -38,6 +38,7 @@ interface TasksFilterState {
 	viewMode: ViewMode;
 	typeTab: TypeTab;
 	projectFilters: string[];
+	linearInitiativeFilter: string | null;
 	linearProjectFilter: string | null;
 	includeClosedIssues: boolean;
 	setTab: (tab: FilterTab) => void;
@@ -46,6 +47,7 @@ interface TasksFilterState {
 	setViewMode: (viewMode: ViewMode) => void;
 	setTypeTab: (typeTab: TypeTab) => void;
 	setProjectFilters: (projectFilters: string[]) => void;
+	setLinearInitiativeFilter: (linearInitiativeFilter: string | null) => void;
 	setLinearProjectFilter: (linearProjectFilter: string | null) => void;
 	setIncludeClosedIssues: (includeClosedIssues: boolean) => void;
 }
@@ -56,6 +58,7 @@ type PersistedTasksFilterState = Pick<
 	| "viewMode"
 	| "typeTab"
 	| "projectFilters"
+	| "linearInitiativeFilter"
 	| "linearProjectFilter"
 	| "includeClosedIssues"
 >;
@@ -76,6 +79,11 @@ export function migrateTasksFilterState(
 			state.projectFilters ??
 				(typeof state.projectFilter === "string" ? [state.projectFilter] : []),
 		),
+		linearInitiativeFilter:
+			typeof state.linearInitiativeFilter === "string" &&
+			state.linearInitiativeFilter.trim().length > 0
+				? state.linearInitiativeFilter.trim()
+				: null,
 		linearProjectFilter:
 			typeof state.linearProjectFilter === "string" &&
 			state.linearProjectFilter.trim().length > 0
@@ -93,6 +101,7 @@ export const useTasksFilterStore = create<TasksFilterState>()(
 			viewMode: "table",
 			typeTab: "tasks",
 			projectFilters: [],
+			linearInitiativeFilter: null,
 			linearProjectFilter: null,
 			includeClosedIssues: false,
 			setTab: (tab) => set({ tab }),
@@ -109,6 +118,8 @@ export const useTasksFilterStore = create<TasksFilterState>()(
 						? state
 						: { projectFilters: next };
 				}),
+			setLinearInitiativeFilter: (linearInitiativeFilter) =>
+				set({ linearInitiativeFilter }),
 			setLinearProjectFilter: (linearProjectFilter) =>
 				set({ linearProjectFilter }),
 			setIncludeClosedIssues: (includeClosedIssues) =>
@@ -116,10 +127,11 @@ export const useTasksFilterStore = create<TasksFilterState>()(
 		}),
 		{
 			name: "tasks-filter-state",
-			version: 4,
+			version: 5,
 			migrate: migrateTasksFilterState,
 			partialize: (state) => ({
 				projectFilters: state.projectFilters,
+				linearInitiativeFilter: state.linearInitiativeFilter,
 				linearProjectFilter: state.linearProjectFilter,
 				tab: state.tab,
 				typeTab: state.typeTab,
@@ -136,6 +148,7 @@ export interface TasksFilters {
 	search: string;
 	typeTab: TypeTab;
 	projectFilters: string[];
+	linearInitiativeFilter: string | null;
 	linearProjectFilter: string | null;
 	includeClosedIssues: boolean;
 }
@@ -150,6 +163,8 @@ export function tasksSearchFromFilters(
 	if (filters.typeTab !== "tasks") out.type = filters.typeTab;
 	const projects = serializeProjectFilters(filters.projectFilters);
 	if (projects) out.projects = projects;
+	if (filters.linearInitiativeFilter)
+		out.linearInitiative = filters.linearInitiativeFilter;
 	if (filters.linearProjectFilter)
 		out.linearProject = filters.linearProjectFilter;
 	if (filters.typeTab === "issues" && filters.includeClosedIssues)

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -49,6 +49,7 @@ export function WorkspaceSidebarHeader({
 		search: lastSearch,
 		typeTab: lastTypeTab,
 		projectFilters: lastProjectFilters,
+		linearInitiativeFilter: lastLinearInitiativeFilter,
 		linearProjectFilter: lastLinearProjectFilter,
 		includeClosedIssues: lastIncludeClosedIssues,
 	} = useTasksFilterStore();
@@ -70,6 +71,7 @@ export function WorkspaceSidebarHeader({
 					search: lastSearch,
 					typeTab: lastTypeTab,
 					projectFilters: lastProjectFilters,
+					linearInitiativeFilter: lastLinearInitiativeFilter,
 					linearProjectFilter: lastLinearProjectFilter,
 					includeClosedIssues: lastIncludeClosedIssues,
 				}),

--- a/packages/trpc/src/router/integration/linear/initiative-projects.test.ts
+++ b/packages/trpc/src/router/integration/linear/initiative-projects.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { buildLinearInitiativeProjects } from "./initiative-projects";
+
+describe("buildLinearInitiativeProjects", () => {
+	test("groups project ids under sorted active initiatives", () => {
+		expect(
+			buildLinearInitiativeProjects(
+				[
+					{ id: "initiative-2", name: "Reliability" },
+					{ id: "initiative-1", name: "Developer experience" },
+					{ id: "initiative-3", name: "Archived", trashed: true },
+				],
+				[
+					{ initiativeId: "initiative-2", projectId: "project-3" },
+					{ initiativeId: "initiative-1", projectId: "project-1" },
+					{ initiativeId: "initiative-1", projectId: "project-2" },
+					{ initiativeId: "initiative-1", projectId: "project-2" },
+					{ initiativeId: undefined, projectId: "project-4" },
+				],
+			),
+		).toEqual([
+			{
+				id: "initiative-1",
+				name: "Developer experience",
+				projectIds: ["project-1", "project-2"],
+			},
+			{
+				id: "initiative-2",
+				name: "Reliability",
+				projectIds: ["project-3"],
+			},
+		]);
+	});
+
+	test("keeps initiatives that do not have projects", () => {
+		expect(
+			buildLinearInitiativeProjects(
+				[{ id: "initiative-1", name: "Future work" }],
+				[],
+			),
+		).toEqual([{ id: "initiative-1", name: "Future work", projectIds: [] }]);
+	});
+});

--- a/packages/trpc/src/router/integration/linear/initiative-projects.ts
+++ b/packages/trpc/src/router/integration/linear/initiative-projects.ts
@@ -1,0 +1,75 @@
+import type { LinearClient } from "@linear/sdk";
+
+interface LinearConnection<T> {
+	nodes: T[];
+	pageInfo: { hasNextPage: boolean };
+	fetchNext: () => Promise<LinearConnection<T>>;
+}
+
+interface LinearInitiative {
+	id: string;
+	name: string;
+	trashed?: boolean | null;
+}
+
+interface LinearInitiativeToProject {
+	initiativeId?: string;
+	projectId?: string;
+}
+
+export interface LinearInitiativeProjects {
+	id: string;
+	name: string;
+	projectIds: string[];
+}
+
+async function fetchAllNodes<T>(
+	connectionPromise: Promise<LinearConnection<T>>,
+): Promise<T[]> {
+	const connection = await connectionPromise;
+	while (connection.pageInfo.hasNextPage) {
+		await connection.fetchNext();
+	}
+	return connection.nodes;
+}
+
+export function buildLinearInitiativeProjects(
+	initiatives: LinearInitiative[],
+	relations: LinearInitiativeToProject[],
+): LinearInitiativeProjects[] {
+	const projectIdsByInitiative = new Map<string, Set<string>>();
+	for (const relation of relations) {
+		if (!relation.initiativeId || !relation.projectId) continue;
+		const projectIds = projectIdsByInitiative.get(relation.initiativeId);
+		if (projectIds) {
+			projectIds.add(relation.projectId);
+		} else {
+			projectIdsByInitiative.set(
+				relation.initiativeId,
+				new Set([relation.projectId]),
+			);
+		}
+	}
+
+	return initiatives
+		.filter((initiative) => !initiative.trashed)
+		.map((initiative) => ({
+			id: initiative.id,
+			name: initiative.name,
+			projectIds: [...(projectIdsByInitiative.get(initiative.id) ?? [])],
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getLinearInitiativeProjects(
+	client: LinearClient,
+): Promise<LinearInitiativeProjects[]> {
+	const [initiatives, relations] = await Promise.all([
+		fetchAllNodes(client.initiatives({ first: 250, includeArchived: false })),
+		fetchAllNodes(
+			client.initiativeToProjects({ first: 250, includeArchived: false }),
+		),
+	]);
+
+	return buildLinearInitiativeProjects(initiatives, relations);
+}

--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -11,6 +11,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { getLinearInitiativeProjects } from "./initiative-projects";
 import { callLinear } from "./refresh";
 
 export const linearRouter = {
@@ -133,6 +134,16 @@ export const linearRouter = {
 			);
 			if (!teams) return [];
 			return teams.nodes.map((t) => ({ id: t.id, name: t.name, key: t.key }));
+		}),
+
+	getInitiatives: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			return (
+				(await callLinear(input.organizationId, getLinearInitiativeProjects)) ??
+				[]
+			);
 		}),
 
 	updateConfig: protectedProcedure


### PR DESCRIPTION
## What & why

Superset's desktop Tasks view could filter Linear work by project, but not by the initiatives that organize those projects. This adds an Initiative filter ahead of Project so selecting an initiative:

- limits Linear tasks to every project in that initiative
- narrows the Project picker to that initiative's projects
- clears an incompatible project selection atomically
- persists through URL navigation, detail pages, and sidebar return navigation

Initiatives and initiative-to-project relationships are read live from Linear with pagination. No database schema or sync migration is required.

## How I tested it

- `bun test packages/trpc/src/router/integration/linear/initiative-projects.test.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/filterTasksByLinearScope/filterTasksByLinearScope.test.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.test.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.test.ts` — 22 pass, 0 fail
- `bun run lint` — passes with no warnings
- `bun run --cwd packages/trpc typecheck` — passes
- `bun run --cwd apps/desktop compile:app` — passes, including the bundled CLI and PTY bundle check
- Exact desktop renderer: `/Users/roshvan/europa/superset`, renderer `http://localhost:3005`, CDP `9335`, Tasks route. Verified the visible Initiative menu, selected initiative URL persistence, and the Project menu narrowing to the selected initiative.

The screenshots use the actual desktop renderer with local preview query data. This workspace's pre-existing local database is missing `auth.users.deletion_requested_at`, so repository policy prevented migrating it for an authenticated live Linear readback. The focused data-path tests and production desktop compile are green.

### Screenshots

Initiative picker:

![Initiative picker](https://raw.githubusercontent.com/Roshvan/superset/2fecb3fcc0d7a219b519231def59cc501ca3b3fd/.github/pr-assets/linear-initiative-filter/initiative-filter-menu.png)

Selecting **Quality & Reliability** narrows the Project picker to **Reliability**:

![Project picker narrowed by initiative](https://raw.githubusercontent.com/Roshvan/superset/2fecb3fcc0d7a219b519231def59cc501ca3b3fd/.github/pr-assets/linear-initiative-filter/initiative-project-scope.png)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too) — lint passes; root typecheck is blocked by the existing duplicate `@types/hast` 3.0.4/3.0.5 mismatch at `packages/ui/src/components/ai-elements/code-block.tsx:123`
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Linear Initiative filter to the desktop Tasks view so users can scope tasks by initiative, not only by project. Previously tasks were filterable by project only; now choosing an initiative shows tasks from all projects in that initiative, narrows the Project picker to those projects, clears incompatible project selections, and persists in the URL across navigation.

- Frontend: adds Linear initiative picker with search, empty-state, and retry-on-error; introduces `linearInitiative` search param; updates the tasks filter store to v5 with migration; extracts filtering into `filterTasksByLinearScope`; narrows the Project filter via `allowedProjectIds` and shows initiative-aware messaging; loads initiatives only when Linear is connected and the Tasks tab is active; clears invalid initiative or incompatible project selections and replaces the URL.
- Backend (`packages/trpc`): adds `integration.linear.getInitiatives` that returns initiatives with `projectIds`, built by fetching Linear initiatives and initiative-to-project relations with pagination and excluding trashed items. No database or sync changes. Tests cover initiative-to-project mapping, Linear scope filtering, and store migration.

**Rollout**
- No database or sync migration.
- Persisted tasks filter state auto-migrates to v5; no action required.

<sup>Written for commit 14684543af695c19cae727e98950aef7c33f1e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linear initiative filtering to the Tasks view.
  * Searchable initiatives can be selected, cleared, or retried if loading fails.
  * Tasks can be narrowed by an initiative’s associated projects.
  * Initiative filters persist in URLs and remain selected when navigating between task views.

* **Bug Fixes**
  * Project filters now reset when incompatible with the selected initiative.
  * Improved empty-state messaging for initiatives without synced projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->