### PR TITLE
fix(desktop): create new folders and files reliably in the Files tab

### DIFF
--- a/apps/desktop/src/renderer/lib/pierreTree/index.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/index.ts
@@ -8,4 +8,4 @@ export {
 	type PierreGitStatus,
 	type PierreGitStatusEntry,
 } from "./pierreGitStatus";
-export { stripTrailingSlash } from "./treePaths";
+export { canonicalizeTreePath, stripTrailingSlash } from "./treePaths";

--- a/apps/desktop/src/renderer/lib/pierreTree/treePaths.test.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/treePaths.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { canonicalizeTreePath, stripTrailingSlash } from "./treePaths";
+
+describe("canonicalizeTreePath", () => {
+	it("leaves file paths untouched", () => {
+		expect(canonicalizeTreePath("notes.txt", false)).toEqual("notes.txt");
+		expect(canonicalizeTreePath("src/notes.txt", false)).toEqual(
+			"src/notes.txt",
+		);
+	});
+
+	it("adds the trailing slash Pierre omits for directories", () => {
+		expect(canonicalizeTreePath("Untitled", true)).toEqual("Untitled/");
+		expect(canonicalizeTreePath(".claude", true)).toEqual(".claude/");
+	});
+
+	it("canonicalizes nested directory paths", () => {
+		expect(canonicalizeTreePath("src/components/Button", true)).toEqual(
+			"src/components/Button/",
+		);
+	});
+
+	it("is idempotent on an already-canonical path", () => {
+		expect(canonicalizeTreePath("Untitled/", true)).toEqual("Untitled/");
+		expect(
+			canonicalizeTreePath(canonicalizeTreePath("a/b", true), true),
+		).toEqual("a/b/");
+	});
+
+	it("round-trips with stripTrailingSlash", () => {
+		for (const path of ["Untitled", "src/components/Button", ".claude"]) {
+			expect(stripTrailingSlash(canonicalizeTreePath(path, true))).toEqual(
+				path,
+			);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/lib/pierreTree/treePaths.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/treePaths.ts
@@ -6,3 +6,23 @@
 export function stripTrailingSlash(path: string): string {
 	return path.endsWith("/") ? path.slice(0, -1) : path;
 }
+
+/**
+ * Put a path back into `@pierre/trees`' canonical form, where directories carry
+ * a trailing `/`.
+ *
+ * Needed because Pierre is inconsistent about which form it hands out:
+ * `FileTreeRenameEvent` reports slash-less paths even when its own `isFolder`
+ * flag is `true`, while its model — and any bookkeeping keyed alongside it —
+ * uses the trailing-slash form. Canonicalize event paths before looking them up
+ * anywhere, or directory lookups silently miss.
+ *
+ * Idempotent, so it is safe to apply to a path that is already canonical.
+ */
+export function canonicalizeTreePath(
+	path: string,
+	isDirectory: boolean,
+): string {
+	if (!isDirectory) return path;
+	return path.endsWith("/") ? path : `${path}/`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -10,7 +10,6 @@ import {
 	useFileTree as usePierreFileTree,
 } from "@pierre/trees/react";
 import type { AppRouter } from "@superset/host-service";
-import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import type { inferRouterOutputs } from "@trpc/server";
 import {
@@ -114,6 +113,7 @@ export function FilesTab({
 	const handlersRef = useRef({
 		onSelect(_path: string) {},
 		onRename(_event: FileTreeRenameEvent) {},
+		onRenameError(_message: string) {},
 		renderRowDecoration(
 			_ctx: FileTreeRowDecorationContext,
 		): FileTreeRowDecoration | null {
@@ -128,7 +128,7 @@ export function FilesTab({
 		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
 		renaming: {
 			onRename: (event) => handlersRef.current.onRename(event),
-			onError: (message) => toast.error(message),
+			onError: (message) => handlersRef.current.onRenameError(message),
 		},
 		gitStatus: initialGitStatusEntriesRef.current,
 		icons: { set: "complete", colored: true },
@@ -147,15 +147,53 @@ export function FilesTab({
 	});
 
 	const bridge = useFilesTabBridge({ model, workspaceId, rootPath });
-	const { reveal, startCreating, handleRename, handleDelete, collapseAll } =
-		useFilesTabActions({
-			model,
-			bridge,
-			rootPath,
-			workspaceId,
-			selectedFilePath,
-			onSelectFile,
-		});
+	const {
+		reveal,
+		startCreating,
+		handleRename,
+		handleRenameError,
+		notifyManualRename,
+		handleDelete,
+		collapseAll,
+	} = useFilesTabActions({
+		model,
+		bridge,
+		rootPath,
+		workspaceId,
+		onSelectFile,
+	});
+
+	// Clicking blank space below the rows clears the selection, so "New Folder"
+	// can target the workspace root. Pierre renders rows in a shadow root and
+	// stamps them with `data-item-path`, so walk composedPath() to tell a row
+	// click from a background click.
+	const handleTreeBackgroundClick = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			for (const node of event.nativeEvent.composedPath()) {
+				if (
+					node instanceof HTMLElement &&
+					node.getAttribute("data-item-path")
+				) {
+					return;
+				}
+			}
+			for (const selectedPath of model.getSelectedPaths()) {
+				model.getItem(selectedPath)?.deselect();
+			}
+		},
+		[model],
+	);
+
+	// A rename the user started themselves, rather than one that follows a
+	// creation. Tells the actions to drop any stale provisional entry so this
+	// session can't be mistaken for naming a freshly created item.
+	const startManualRename = useCallback(
+		(treePath: string) => {
+			notifyManualRename();
+			model.startRenaming(treePath);
+		},
+		[model, notifyManualRename],
+	);
 	const drop = useFilesTabDrop({ model, bridge, rootPath, workspaceId });
 
 	// Push live git status updates into Pierre.
@@ -187,6 +225,7 @@ export function FilesTab({
 	// Wire the ref-based handlers so Pierre's stable callbacks always reach
 	// the latest closures. Updated on every render — no diffing needed.
 	handlersRef.current.onRename = (event) => void handleRename(event);
+	handlersRef.current.onRenameError = (message) => handleRenameError(message);
 	handlersRef.current.onSelect = (treePath) => {
 		const abs = toAbs(rootPath, treePath);
 		// Skip the reveal-induced echo. The reveal flow programmatically
@@ -239,7 +278,7 @@ export function FilesTab({
 							relativePath={rel}
 							onNewFile={() => void startCreating("file", abs)}
 							onNewFolder={() => void startCreating("folder", abs)}
-							onRename={() => model.startRenaming(treePath)}
+							onRename={() => startManualRename(treePath)}
 							onDelete={() => handleDelete(abs, item.name, true)}
 						/>
 					) : (
@@ -249,7 +288,7 @@ export function FilesTab({
 							onOpen={() => onSelectFile(abs)}
 							onOpenInNewTab={() => onSelectFile(abs, true)}
 							onOpenInEditor={() => openInExternalEditor(abs)}
-							onRename={() => model.startRenaming(treePath)}
+							onRename={() => startManualRename(treePath)}
 							onDelete={() => handleDelete(abs, item.name, false)}
 						/>
 					)}
@@ -257,12 +296,12 @@ export function FilesTab({
 			);
 		},
 		[
-			model,
 			rootPath,
 			startCreating,
 			handleDelete,
 			onSelectFile,
 			openInExternalEditor,
+			startManualRename,
 		],
 	);
 
@@ -287,10 +326,12 @@ export function FilesTab({
 
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: Drop zone for external file upload
+		// biome-ignore lint/a11y/useKeyWithClickEvents: click target is the empty background below the rows, used only to clear the selection; keyboard users move between rows directly and never land on it
 		<div
 			ref={fadeContainerRef}
 			className="relative flex h-full min-h-0 flex-col overflow-hidden"
 			onClickCapture={handleClickCapture}
+			onClick={handleTreeBackgroundClick}
 			onDragOver={drop.onDragOver}
 			onDragLeave={drop.onDragLeave}
 			onDrop={drop.onDrop}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -152,7 +152,6 @@ export function FilesTab({
 		startCreating,
 		handleRename,
 		handleRenameError,
-		notifyManualRename,
 		handleDelete,
 		collapseAll,
 	} = useFilesTabActions({
@@ -160,19 +159,26 @@ export function FilesTab({
 		bridge,
 		rootPath,
 		workspaceId,
-		onSelectFile,
 	});
 
 	// Clicking blank space below the rows clears the selection, so "New Folder"
-	// can target the workspace root. Pierre renders rows in a shadow root and
-	// stamps them with `data-item-path`, so walk composedPath() to tell a row
-	// click from a background click.
+	// can target the workspace root.
+	//
+	// This sits on the tab's outermost element, so it sees every click in the
+	// tab — including the header's own buttons, which bubble up here. Only a
+	// click that reaches the empty tree viewport should deselect: Refresh or
+	// Collapse All silently retargeting the next New Folder at the root would be
+	// far worse than a sticky selection. Pierre renders rows in a shadow root
+	// and stamps them with `data-item-path`, so walk composedPath() and bail on
+	// a row, the header, or any interactive control.
 	const handleTreeBackgroundClick = useCallback(
 		(event: React.MouseEvent<HTMLDivElement>) => {
 			for (const node of event.nativeEvent.composedPath()) {
+				if (!(node instanceof HTMLElement)) continue;
 				if (
-					node instanceof HTMLElement &&
-					node.getAttribute("data-item-path")
+					node.dataset.itemPath !== undefined ||
+					node.dataset.fileTreeHeader !== undefined ||
+					node.closest("button, a, input, [role='button'], [role='menuitem']")
 				) {
 					return;
 				}
@@ -184,16 +190,6 @@ export function FilesTab({
 		[model],
 	);
 
-	// A rename the user started themselves, rather than one that follows a
-	// creation. Tells the actions to drop any stale provisional entry so this
-	// session can't be mistaken for naming a freshly created item.
-	const startManualRename = useCallback(
-		(treePath: string) => {
-			notifyManualRename();
-			model.startRenaming(treePath);
-		},
-		[model, notifyManualRename],
-	);
 	const drop = useFilesTabDrop({ model, bridge, rootPath, workspaceId });
 
 	// Push live git status updates into Pierre.
@@ -278,7 +274,7 @@ export function FilesTab({
 							relativePath={rel}
 							onNewFile={() => void startCreating("file", abs)}
 							onNewFolder={() => void startCreating("folder", abs)}
-							onRename={() => startManualRename(treePath)}
+							onRename={() => model.startRenaming(treePath)}
 							onDelete={() => handleDelete(abs, item.name, true)}
 						/>
 					) : (
@@ -288,7 +284,7 @@ export function FilesTab({
 							onOpen={() => onSelectFile(abs)}
 							onOpenInNewTab={() => onSelectFile(abs, true)}
 							onOpenInEditor={() => openInExternalEditor(abs)}
-							onRename={() => startManualRename(treePath)}
+							onRename={() => model.startRenaming(treePath)}
 							onDelete={() => handleDelete(abs, item.name, false)}
 						/>
 					)}
@@ -301,7 +297,7 @@ export function FilesTab({
 			handleDelete,
 			onSelectFile,
 			openInExternalEditor,
-			startManualRename,
+			model.startRenaming,
 		],
 	);
 
@@ -342,7 +338,10 @@ export function FilesTab({
 					className="flex-1 min-h-0"
 					style={TREE_STYLE}
 					header={
-						<div className="group flex h-10 items-center gap-1 bg-background px-2">
+						<div
+							data-file-tree-header="true"
+							className="group flex h-10 items-center gap-1 bg-background px-2"
+						>
 							{onSearch && (
 								<button
 									type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
@@ -300,7 +300,7 @@ export function useFilesTabActions({
 			// openFilePaneFromTreeClick's "clicked the active row" branch and pin
 			// the pane — so cancelling would delete the file and strand a pinned
 			// pane pointing at it.
-			provisionalRef.current = entry;
+			dispatchProvisional({ type: "created", entry });
 		},
 		[
 			model,
@@ -309,6 +309,7 @@ export function useFilesTabActions({
 			bridge,
 			createUniqueEntry,
 			discardProvisional,
+			dispatchProvisional,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
@@ -31,7 +31,6 @@ interface UseFilesTabActionsOptions {
 	/** Workspace worktree root (absolute). */
 	rootPath: string;
 	workspaceId: string;
-	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
 }
 
 export interface FilesTabActions {
@@ -41,10 +40,8 @@ export interface FilesTabActions {
 	startCreating(mode: "file" | "folder", parentAbs?: string): Promise<void>;
 	/** Commit a Pierre rename event by moving the entry on disk. */
 	handleRename(event: FileTreeRenameEvent): Promise<void>;
-	/** Surface a name Pierre rejected, and reopen the rename so it can be fixed. */
+	/** Surface a name Pierre rejected and stand the creation flow down. */
 	handleRenameError(message: string): void;
-	/** Tell the actions a user-initiated rename (F2 / context menu) is starting. */
-	notifyManualRename(): void;
 	/** Confirm + delete a file/folder. */
 	handleDelete(absolutePath: string, name: string, isDirectory: boolean): void;
 	/** Collapse every expanded directory in the tree. */
@@ -69,7 +66,6 @@ export function useFilesTabActions({
 	bridge,
 	rootPath,
 	workspaceId,
-	onSelectFile,
 }: UseFilesTabActionsOptions): FilesTabActions {
 	const createUniqueEntry =
 		workspaceTrpc.filesystem.createUniqueEntry.useMutation();
@@ -184,13 +180,6 @@ export function useFilesTabActions({
 			);
 			provisionalRef.current = state;
 
-			if (action.type === "reopen-rename") {
-				// Without removeIfCanceled: by now the entry is no longer provisional,
-				// so cancelling this session must not delete it.
-				model.startRenaming(action.key);
-				return;
-			}
-
 			if (action.type !== "cleanup") return;
 
 			const { entry } = action;
@@ -213,7 +202,7 @@ export function useFilesTabActions({
 					});
 				});
 		},
-		[model, bridge, discardProvisional],
+		[bridge, discardProvisional],
 	);
 
 	const startCreating = useCallback(
@@ -305,8 +294,13 @@ export function useFilesTabActions({
 				return;
 			}
 
+			// A new file opens in the editor, but we deliberately don't call
+			// onSelectFile here: startRenaming selects the row, which emits
+			// onSelectionChange, which already opens it. Opening twice would hit
+			// openFilePaneFromTreeClick's "clicked the active row" branch and pin
+			// the pane — so cancelling would delete the file and strand a pinned
+			// pane pointing at it.
 			provisionalRef.current = entry;
-			if (mode === "file") onSelectFile(entry.absolutePath);
 		},
 		[
 			model,
@@ -315,7 +309,6 @@ export function useFilesTabActions({
 			bridge,
 			createUniqueEntry,
 			discardProvisional,
-			onSelectFile,
 		],
 	);
 
@@ -418,17 +411,13 @@ export function useFilesTabActions({
 	const handleRenameError = useCallback(
 		(message: string): void => {
 			toast.error(message);
-			// Clears provisional state, then reopens the rename so the user can fix
-			// the name. Reopening is deliberately not armed with removeIfCanceled —
-			// see reduceProvisional's `rename-error` case.
+			// Pierre has already ended the rename session. The entry keeps its
+			// current name on disk, so it stays usable — see reduceProvisional's
+			// `rename-error` case for why we don't reopen the inline rename.
 			dispatchProvisional({ type: "rename-error" });
 		},
 		[dispatchProvisional],
 	);
-
-	const notifyManualRename = useCallback((): void => {
-		dispatchProvisional({ type: "manual-rename-started" });
-	}, [dispatchProvisional]);
 
 	const handleDelete = useCallback(
 		(absolutePath: string, name: string, isDirectory: boolean): void => {
@@ -473,7 +462,6 @@ export function useFilesTabActions({
 		startCreating,
 		handleRename,
 		handleRenameError,
-		notifyManualRename,
 		handleDelete,
 		collapseAll,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabActions/useFilesTabActions.ts
@@ -2,16 +2,22 @@ import type { FileTree, FileTreeRenameEvent } from "@pierre/trees";
 import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { canonicalizeTreePath } from "renderer/lib/pierreTree";
 import { FILE_EXPLORER_ROW_HEIGHT } from "../../constants";
 import {
+	buildCreationKey,
+	CREATION_BASE_NAME,
 	deriveCreationParent,
-	pickPlaceholderName,
 } from "../../utils/creationPaths";
+import type {
+	ProvisionalEntry,
+	ProvisionalEvent,
+} from "../../utils/provisionalEntry";
+import { reduceProvisional } from "../../utils/provisionalEntry";
 import { scrollTreeToRow } from "../../utils/scrollTreeToRow";
 import {
 	asDirectoryHandle,
-	basename,
 	parentRel,
 	stripTrailingSlash,
 	toAbs,
@@ -25,18 +31,20 @@ interface UseFilesTabActionsOptions {
 	/** Workspace worktree root (absolute). */
 	rootPath: string;
 	workspaceId: string;
-	/** Absolute path of the file currently open in the diff/editor pane, if any. */
-	selectedFilePath: string | undefined;
 	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
 }
 
 export interface FilesTabActions {
 	/** Expand every ancestor directory of `absolutePath` then scroll the row into view. */
 	reveal(absolutePath: string, isDirectory: boolean): Promise<void>;
-	/** Start the inline "New file/folder" flow under `parentAbs` (or near the selection). */
+	/** Create a file/folder on disk, then open the inline rename on it. */
 	startCreating(mode: "file" | "folder", parentAbs?: string): Promise<void>;
-	/** Commit a Pierre rename event — either finalizing a pending create or moving an existing path. */
+	/** Commit a Pierre rename event by moving the entry on disk. */
 	handleRename(event: FileTreeRenameEvent): Promise<void>;
+	/** Surface a name Pierre rejected, and reopen the rename so it can be fixed. */
+	handleRenameError(message: string): void;
+	/** Tell the actions a user-initiated rename (F2 / context menu) is starting. */
+	notifyManualRename(): void;
 	/** Confirm + delete a file/folder. */
 	handleDelete(absolutePath: string, name: string, isDirectory: boolean): void;
 	/** Collapse every expanded directory in the tree. */
@@ -48,20 +56,36 @@ export interface FilesTabActions {
  * reveal / collapse-all. Owns the tRPC mutations and the bridge bookkeeping
  * dance (optimistic Pierre updates + workspace-switch race guards) so
  * `FilesTab` itself stays focused on wiring the tree.
+ *
+ * Creation writes to disk *before* opening the inline rename, so what the user
+ * names is a real entry and every commit is an ordinary rename. The alternative
+ * — a purely in-memory placeholder finalized on commit — cannot work here:
+ * Pierre emits no callback at all when a rename commits unchanged, so accepting
+ * the default name would silently create nothing and strand a row for a file
+ * that does not exist.
  */
 export function useFilesTabActions({
 	model,
 	bridge,
 	rootPath,
 	workspaceId,
-	selectedFilePath,
 	onSelectFile,
 }: UseFilesTabActionsOptions): FilesTabActions {
-	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
-	const createDirectory =
-		workspaceTrpc.filesystem.createDirectory.useMutation();
+	const createUniqueEntry =
+		workspaceTrpc.filesystem.createUniqueEntry.useMutation();
+	const removeEmptyDirectory =
+		workspaceTrpc.filesystem.removeEmptyDirectory.useMutation();
+	const removeFileIfUnchanged =
+		workspaceTrpc.filesystem.removeFileIfUnchanged.useMutation();
 	const movePath = workspaceTrpc.filesystem.movePath.useMutation();
 	const deletePath = workspaceTrpc.filesystem.deletePath.useMutation();
+
+	// The entry the user is naming right now, if any. A ref (not state) because
+	// Pierre's callbacks fire outside React's render cycle and every consumer
+	// reads it imperatively.
+	const provisionalRef = useRef<ProvisionalEntry | null>(null);
+	/** `workspaceId:rootPath` the provisional entry above belongs to. */
+	const provisionalWorkspaceRef = useRef<string>("");
 
 	const reveal = useCallback(
 		async (absolutePath: string, isDirectory: boolean): Promise<void> => {
@@ -126,101 +150,233 @@ export function useFilesTabActions({
 		[model, rootPath, bridge.fetchDir, bridge.knownPaths],
 	);
 
+	/**
+	 * Undo a provisional entry on disk. Returns false when the entry was left
+	 * alone because it is no longer the empty thing we created — the caller then
+	 * has to put its row back rather than pretend it is gone.
+	 */
+	const discardProvisional = useCallback(
+		async (entry: ProvisionalEntry): Promise<boolean> => {
+			if (entry.mode === "folder") {
+				const result = await removeEmptyDirectory.mutateAsync({
+					workspaceId,
+					absolutePath: entry.absolutePath,
+				});
+				return result.ok;
+			}
+			// Nothing to compare against; leave it rather than risk the wrong file.
+			if (entry.revision === undefined) return false;
+			const result = await removeFileIfUnchanged.mutateAsync({
+				workspaceId,
+				absolutePath: entry.absolutePath,
+				revision: entry.revision,
+			});
+			return result.ok;
+		},
+		[workspaceId, removeEmptyDirectory, removeFileIfUnchanged],
+	);
+
+	const dispatchProvisional = useCallback(
+		(event: ProvisionalEvent): void => {
+			const { state, action } = reduceProvisional(
+				provisionalRef.current,
+				event,
+			);
+			provisionalRef.current = state;
+
+			if (action.type === "reopen-rename") {
+				// Without removeIfCanceled: by now the entry is no longer provisional,
+				// so cancelling this session must not delete it.
+				model.startRenaming(action.key);
+				return;
+			}
+
+			if (action.type !== "cleanup") return;
+
+			const { entry } = action;
+			void discardProvisional(entry)
+				.then((removed) => {
+					if (removed || !bridge.isCurrent(entry.versionToken)) return;
+					// Still on disk — restore the row so the tree matches reality.
+					bridge.addPath(entry.key);
+					toast.info(
+						entry.mode === "folder"
+							? "Kept the new folder — it is no longer empty"
+							: "Kept the new file — it changed after it was created",
+					);
+				})
+				.catch((error) => {
+					if (!bridge.isCurrent(entry.versionToken)) return;
+					bridge.addPath(entry.key);
+					toast.error("Failed to discard the new item", {
+						description: error instanceof Error ? error.message : undefined,
+					});
+				});
+		},
+		[model, bridge, discardProvisional],
+	);
+
 	const startCreating = useCallback(
 		async (mode: "file" | "folder", parentAbs?: string): Promise<void> => {
 			if (!rootPath) return;
+			// Read the selection at click time, not render time — the user may have
+			// changed it since the last render.
 			const parentAbsPath =
 				parentAbs ??
-				deriveCreationParent(selectedFilePath, bridge.knownPaths, rootPath);
+				deriveCreationParent(
+					model.getSelectedPaths(),
+					bridge.knownPaths,
+					rootPath,
+				);
 			const parentRelPath = toRel(rootPath, parentAbsPath);
 			const parentDirKey = parentRelPath ? `${parentRelPath}/` : "";
+			const versionToken = bridge.getVersion();
 
 			// Make sure Pierre has the parent's children loaded + expanded so
-			// the placeholder row appears in the right place.
+			// the new row appears in the right place.
 			if (parentRelPath) {
 				await bridge.fetchDir(parentRelPath);
+				if (!bridge.isCurrent(versionToken)) return;
 				const handle = asDirectoryHandle(model.getItem(parentDirKey));
 				if (handle && !handle.isExpanded()) {
 					handle.expand();
 				}
 			}
 
-			const placeholderName = pickPlaceholderName(
-				parentRelPath,
-				mode,
-				bridge.knownPaths,
-			);
-			const placeholderPath =
-				(parentRelPath ? `${parentRelPath}/` : "") +
-				placeholderName +
-				(mode === "folder" ? "/" : "");
+			// The host picks the actual name: it retries Untitled-2, Untitled-3, ...
+			// against the filesystem, so a listing we haven't refreshed can't make us
+			// collide with — or worse, adopt — an entry that already exists.
+			let created: Awaited<ReturnType<typeof createUniqueEntry.mutateAsync>>;
+			try {
+				created = await createUniqueEntry.mutateAsync({
+					workspaceId,
+					parentAbsolutePath: parentAbsPath,
+					baseName: CREATION_BASE_NAME[mode],
+					kind: mode === "folder" ? "directory" : "file",
+				});
+			} catch (error) {
+				if (!bridge.isCurrent(versionToken)) return;
+				toast.error("Failed to create item", {
+					description: error instanceof Error ? error.message : undefined,
+				});
+				return;
+			}
 
-			bridge.pendingCreates.set(placeholderPath, mode);
-			bridge.knownPaths.add(placeholderPath);
-			model.add(placeholderPath);
-			// removeIfCanceled cleans up the placeholder if user hits Esc.
-			model.startRenaming(placeholderPath, { removeIfCanceled: true });
+			if (!created.ok) {
+				if (!bridge.isCurrent(versionToken)) return;
+				toast.error("Failed to create item", {
+					description:
+						created.reason === "exhausted"
+							? "Too many untitled items here already."
+							: "That name isn't allowed.",
+				});
+				return;
+			}
+
+			const entry: ProvisionalEntry = {
+				key: buildCreationKey(parentRelPath, created.name, mode),
+				absolutePath: created.absolutePath,
+				mode,
+				revision: created.revision,
+				rootPath,
+				versionToken,
+			};
+
+			// The user moved on mid-flight; take the entry back out rather than
+			// leaving it behind in a workspace they're no longer looking at.
+			if (!bridge.isCurrent(versionToken)) {
+				void discardProvisional(entry).catch(() => {
+					// Nothing useful to surface — the workspace is gone from view.
+				});
+				return;
+			}
+
+			// Show it now instead of waiting on the fs watcher's debounce.
+			if (!bridge.addPath(entry.key)) {
+				void discardProvisional(entry).catch(() => {});
+				toast.error("Failed to create item");
+				return;
+			}
+
+			if (!model.startRenaming(entry.key, { removeIfCanceled: true })) {
+				void discardProvisional(entry).catch(() => {});
+				bridge.removePath(entry.key);
+				toast.error("Failed to create item");
+				return;
+			}
+
+			provisionalRef.current = entry;
+			if (mode === "file") onSelectFile(entry.absolutePath);
 		},
-		[model, rootPath, selectedFilePath, bridge],
+		[
+			model,
+			rootPath,
+			workspaceId,
+			bridge,
+			createUniqueEntry,
+			discardProvisional,
+			onSelectFile,
+		],
 	);
+
+	// Pierre fires `remove` when an inline rename is cancelled with
+	// removeIfCanceled. Because we created the entry up front, cancelling has to
+	// take it back off disk — but only if it is still our own provisional entry
+	// (see reduceProvisional).
+	useEffect(() => {
+		return model.onMutation("remove", (event) => {
+			dispatchProvisional({
+				type: "removed",
+				path: event.path,
+				rootPath,
+				versionToken: bridge.getVersion(),
+			});
+		});
+	}, [model, rootPath, bridge, dispatchProvisional]);
+
+	// A provisional entry belongs to the workspace it was created in. Drop the
+	// bookkeeping on a switch without deleting anything — it exists on disk and
+	// the user may come back to it.
+	//
+	// Guarded on the identity rather than firing whenever the effect re-runs:
+	// `dispatchProvisional` changes identity as its own dependencies change, and
+	// an unguarded reset would clear the entry out from under a user who is
+	// still typing its name.
+	useEffect(() => {
+		const identity = `${workspaceId}:${rootPath}`;
+		if (provisionalWorkspaceRef.current === identity) return;
+		provisionalWorkspaceRef.current = identity;
+		dispatchProvisional({ type: "workspace-changed" });
+	}, [workspaceId, rootPath, dispatchProvisional]);
 
 	const handleRename = useCallback(
 		async (event: FileTreeRenameEvent): Promise<void> => {
 			if (!rootPath) return;
-			const { sourcePath, destinationPath, isFolder } = event;
-			const pendingMode = bridge.pendingCreates.get(sourcePath);
+			const { isFolder } = event;
+			// Pierre reports slash-less paths on this event even when isFolder is
+			// true, while its model and our knownPaths key directories WITH a
+			// trailing slash. Canonicalize once, here, so nothing downstream can
+			// look a directory up under the wrong key.
+			const sourcePath = canonicalizeTreePath(event.sourcePath, isFolder);
+			const destinationPath = canonicalizeTreePath(
+				event.destinationPath,
+				isFolder,
+			);
+
+			// Committed under a real name — it isn't provisional any more.
+			dispatchProvisional({ type: "renamed", sourceKey: sourcePath });
+
 			// Snapshot before any await so post-mutation cleanup against a
 			// stale workspace (user switched mid-flight) bails out instead of
 			// leaking source/destination paths into the new workspace's
 			// knownPaths / model.
 			const versionToken = bridge.getVersion();
 
-			if (pendingMode) {
-				bridge.pendingCreates.delete(sourcePath);
-				// Pierre has already moved placeholder → destinationPath in
-				// its tree; sync our knownPaths so we don't double-account.
-				bridge.knownPaths.delete(sourcePath);
-				bridge.knownPaths.add(destinationPath);
-				const absPath = toAbs(rootPath, destinationPath);
-				try {
-					if (pendingMode === "folder") {
-						await createDirectory.mutateAsync({
-							workspaceId,
-							absolutePath: absPath,
-							recursive: true,
-						});
-					} else {
-						const segments = stripTrailingSlash(
-							basename(destinationPath),
-						).split("/");
-						if (segments.length === 0) return;
-						await writeFile.mutateAsync({
-							workspaceId,
-							absolutePath: absPath,
-							content: "",
-							options: { create: true, overwrite: false },
-						});
-						if (bridge.isCurrent(versionToken)) onSelectFile(absPath);
-					}
-				} catch (error) {
-					if (!bridge.isCurrent(versionToken)) return;
-					bridge.knownPaths.delete(destinationPath);
-					try {
-						model.remove(destinationPath, { recursive: true });
-					} catch {
-						// ignore
-					}
-					toast.error("Failed to create item", {
-						description: error instanceof Error ? error.message : undefined,
-					});
-				}
-				return;
-			}
-
-			// Genuine rename. Pierre has already moved the entry on its side.
-			// For folders, also rekey every cached descendant (knownPaths +
-			// loadedDirs) under the new prefix so later fs reconciliation /
-			// reveals don't target stale paths.
+			// Every commit is an ordinary rename: the entry already exists on disk,
+			// created before the inline rename opened. Pierre has already moved it
+			// on its side. For folders, also rekey every cached descendant
+			// (knownPaths + loadedDirs) under the new prefix so later fs
+			// reconciliation / reveals don't target stale paths.
 			bridge.knownPaths.delete(sourcePath);
 			bridge.knownPaths.add(destinationPath);
 			if (isFolder) {
@@ -256,17 +412,23 @@ export function useFilesTabActions({
 				});
 			}
 		},
-		[
-			model,
-			rootPath,
-			workspaceId,
-			createDirectory,
-			writeFile,
-			movePath,
-			onSelectFile,
-			bridge,
-		],
+		[model, rootPath, workspaceId, movePath, bridge, dispatchProvisional],
 	);
+
+	const handleRenameError = useCallback(
+		(message: string): void => {
+			toast.error(message);
+			// Clears provisional state, then reopens the rename so the user can fix
+			// the name. Reopening is deliberately not armed with removeIfCanceled —
+			// see reduceProvisional's `rename-error` case.
+			dispatchProvisional({ type: "rename-error" });
+		},
+		[dispatchProvisional],
+	);
+
+	const notifyManualRename = useCallback((): void => {
+		dispatchProvisional({ type: "manual-rename-started" });
+	}, [dispatchProvisional]);
 
 	const handleDelete = useCallback(
 		(absolutePath: string, name: string, isDirectory: boolean): void => {
@@ -306,5 +468,13 @@ export function useFilesTabActions({
 		}
 	}, [model, bridge.knownPaths]);
 
-	return { reveal, startCreating, handleRename, handleDelete, collapseAll };
+	return {
+		reveal,
+		startCreating,
+		handleRename,
+		handleRenameError,
+		notifyManualRename,
+		handleDelete,
+		collapseAll,
+	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -3,6 +3,8 @@ import { workspaceTrpc } from "@superset/workspace-client";
 import type { FsWatchEvent } from "@superset/workspace-fs/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import type { TreeBookkeeping } from "../../utils/treeBookkeeping";
+import { purgeDirectory, rekeyDirectory } from "../../utils/treeBookkeeping";
 import {
 	asDirectoryHandle,
 	stripTrailingSlash,
@@ -53,10 +55,15 @@ export interface FilesTabBridge {
 /**
  * Bridges Pierre's path-flat tree model to our lazy-loading useFileTree backend.
  *
- * Owns two pieces of mutable bookkeeping (mutated in place — never reassigned —
+ * Owns three pieces of mutable bookkeeping (mutated in place — never reassigned —
  * so consumers can hold references safely):
  *   - `knownPaths`: union of every path Pierre has been told about
  *   - `loadedDirs`: directories whose children we've already fetched
+ *   - `unloadedDirCandidates`: known directories still awaiting a fetch
+ *
+ * All three are path-keyed, so a folder rename or removal invalidates every
+ * entry beneath it at once. `purgeDirectory` / `rekeyDirectory` move them
+ * together — see `utils/treeBookkeeping`.
  *
  * Drives four side-effects:
  *   - Initial load: fetch root on mount / workspace switch
@@ -99,6 +106,18 @@ export function useFilesTabBridge({
 	// Pierre fires model.subscribe (on expansion, selection, etc.) we only
 	// check these candidates instead of iterating the entire knownPaths set.
 	const unloadedDirCandidatesRef = useRef(new Set<string>());
+
+	// The three path-keyed sets always move together on a rename or removal, so
+	// hand them to the helpers as one value rather than passing them separately
+	// and risking one being forgotten.
+	const bookkeeping = useCallback(
+		(): TreeBookkeeping => ({
+			knownPaths: knownPathsRef.current,
+			loadedDirs: loadedDirsRef.current,
+			unloadedDirCandidates: unloadedDirCandidatesRef.current,
+		}),
+		[],
+	);
 
 	const fetchDir = useCallback(
 		async (relDir: string): Promise<void> => {
@@ -249,10 +268,10 @@ export function useFilesTabBridge({
 			if (event.path.endsWith("/")) {
 				const dir = stripTrailingSlash(event.path);
 				loadedDirsRef.current.delete(dir);
-				purgeDescendants(knownPathsRef.current, loadedDirsRef.current, dir);
+				purgeDirectory(bookkeeping(), dir);
 			}
 		});
-	}, [model]);
+	}, [model, bookkeeping]);
 
 	useWorkspaceEvent(
 		"fs:events",
@@ -303,22 +322,13 @@ export function useFilesTabBridge({
 						if (isFolder) {
 							const oldDir = stripTrailingSlash(oldKey);
 							const newDir = stripTrailingSlash(newKey);
-							rekeyDescendants(
-								knownPathsRef.current,
-								loadedDirsRef.current,
-								oldDir,
-								newDir,
-							);
+							rekeyDirectory(bookkeeping(), oldDir, newDir);
 						}
 					} catch {
 						// Pierre rejected the move — fall back to remove + add.
 						removeKnownPath(model, knownPathsRef.current, oldKey);
 						if (isFolder) {
-							purgeDescendants(
-								knownPathsRef.current,
-								loadedDirsRef.current,
-								stripTrailingSlash(oldKey),
-							);
+							purgeDirectory(bookkeeping(), stripTrailingSlash(oldKey));
 						}
 						addKnownPath(model, knownPathsRef.current, newKey);
 					}
@@ -343,11 +353,7 @@ export function useFilesTabBridge({
 				const matched = matchKnown(knownPathsRef.current, rel) ?? key;
 				removeKnownPath(model, knownPathsRef.current, matched);
 				if (isFolder) {
-					purgeDescendants(
-						knownPathsRef.current,
-						loadedDirsRef.current,
-						stripTrailingSlash(matched),
-					);
+					purgeDirectory(bookkeeping(), stripTrailingSlash(matched));
 				}
 				return;
 			}
@@ -369,14 +375,9 @@ export function useFilesTabBridge({
 
 	const rekeyDescendantsBound = useCallback(
 		(oldDir: string, newDir: string) => {
-			rekeyDescendants(
-				knownPathsRef.current,
-				loadedDirsRef.current,
-				oldDir,
-				newDir,
-			);
+			rekeyDirectory(bookkeeping(), oldDir, newDir);
 		},
-		[],
+		[bookkeeping],
 	);
 
 	const getVersion = useCallback(() => versionRef.current, []);
@@ -417,10 +418,10 @@ export function useFilesTabBridge({
 				const dirRel = stripTrailingSlash(treePath);
 				loadedDirsRef.current.delete(dirRel);
 				unloadedDirCandidatesRef.current.delete(dirRel);
-				purgeDescendants(knownPathsRef.current, loadedDirsRef.current, dirRel);
+				purgeDirectory(bookkeeping(), dirRel);
 			}
 		},
-		[model],
+		[model, bookkeeping],
 	);
 
 	return {
@@ -469,51 +470,5 @@ function removeKnownPath(
 		model.remove(path, { recursive: true });
 	} catch {
 		// ignore
-	}
-}
-
-// Walk knownPaths/loadedDirs and remove anything under `dirRel`. Used after a
-// folder is removed (or renamed, paired with rekey) so stale descendants don't
-// pin paths that no longer exist on disk.
-function purgeDescendants(
-	known: Set<string>,
-	loaded: Set<string>,
-	dirRel: string,
-): void {
-	const prefix = `${dirRel}/`;
-	for (const path of known) {
-		if (path.startsWith(prefix)) known.delete(path);
-	}
-	for (const dir of loaded) {
-		if (dir === dirRel || dir.startsWith(prefix)) loaded.delete(dir);
-	}
-}
-
-// Walk knownPaths/loadedDirs and re-key any descendants of `oldDir` to live
-// under `newDir`. Pierre's `model.move(oldKey, newKey)` already moves the
-// renamed subtree on its side, but our bookkeeping is path-keyed — without
-// this, fs reconciliation looks up old paths and skips real changes.
-function rekeyDescendants(
-	known: Set<string>,
-	loaded: Set<string>,
-	oldDir: string,
-	newDir: string,
-): void {
-	const oldPrefix = `${oldDir}/`;
-	const movedKnown: string[] = [];
-	for (const path of known) {
-		if (path.startsWith(oldPrefix)) movedKnown.push(path);
-	}
-	for (const path of movedKnown) {
-		known.delete(path);
-		known.add(newDir + path.slice(oldDir.length));
-	}
-	const movedLoaded: string[] = [];
-	for (const dir of loaded) {
-		if (dir === oldDir || dir.startsWith(oldPrefix)) movedLoaded.push(dir);
-	}
-	for (const dir of movedLoaded) {
-		loaded.delete(dir);
-		loaded.add(newDir + dir.slice(oldDir.length));
 	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -21,8 +21,14 @@ export interface FilesTabBridge {
 	knownPaths: Set<string>;
 	/** Relative directory paths whose children we've fetched. "" = root. */
 	loadedDirs: Set<string>;
-	/** Placeholder paths created via "New File/Folder", awaiting rename commit. */
-	pendingCreates: Map<string, "file" | "folder">;
+	/**
+	 * Surface a path in the tree without waiting for the fs watcher. Idempotent.
+	 * Returns false if Pierre rejected it, in which case our bookkeeping is
+	 * rolled back too — callers must not assume the row exists.
+	 */
+	addPath(treePath: string): boolean;
+	/** Drop a path (and, for directories, its cached descendants) from the tree. */
+	removePath(treePath: string): void;
 	/** Lazy-load a directory's children into Pierre. Idempotent + dedup'd. */
 	fetchDir(relDir: string): Promise<void>;
 	/** Re-fetch every loaded directory and resetPaths so drift can't accumulate. */
@@ -47,11 +53,10 @@ export interface FilesTabBridge {
 /**
  * Bridges Pierre's path-flat tree model to our lazy-loading useFileTree backend.
  *
- * Owns three pieces of mutable bookkeeping (mutated in place — never reassigned —
+ * Owns two pieces of mutable bookkeeping (mutated in place — never reassigned —
  * so consumers can hold references safely):
  *   - `knownPaths`: union of every path Pierre has been told about
  *   - `loadedDirs`: directories whose children we've already fetched
- *   - `pendingCreates`: placeholder paths from the inline "New" flow
  *
  * Drives four side-effects:
  *   - Initial load: fetch root on mount / workspace switch
@@ -59,9 +64,8 @@ export interface FilesTabBridge {
  *     that becomes expanded but isn't loaded yet
  *   - Live sync: apply fs:events (create / delete / rename / overflow) to the
  *     model + bookkeeping, falling back to a full refresh on overflow
- *   - Pending-create cleanup: when Pierre's renaming flow is canceled with
- *     `removeIfCanceled`, it fires a `remove` mutation; we use that to drop
- *     the placeholder from our bookkeeping
+ *   - Row removal: mirror Pierre's `remove` mutations into our bookkeeping
+ *     (the Files tab's own cancel handling lives in useFilesTabActions)
  *
  * Workspace-switch races: every async listing captures a `versionRef` snapshot
  * and aborts its mutations if `versionRef` advanced (i.e. workspace/root
@@ -86,7 +90,6 @@ export function useFilesTabBridge({
 	// fetchDir before reveal's own `await fetchDir` runs — without shared
 	// promises, reveal would resolve before children land in knownPaths.
 	const inflightDirsRef = useRef(new Map<string, Promise<void>>());
-	const pendingCreatesRef = useRef(new Map<string, "file" | "folder">());
 
 	// Bumped on workspace/root change so async listings started against an
 	// old workspace can detect they're stale and bail out before mutating.
@@ -211,7 +214,6 @@ export function useFilesTabBridge({
 		knownPathsRef.current.clear();
 		loadedDirsRef.current.clear();
 		inflightDirsRef.current.clear();
-		pendingCreatesRef.current.clear();
 		unloadedDirCandidatesRef.current.clear();
 		model.resetPaths([]);
 		void fetchDir("");
@@ -236,12 +238,13 @@ export function useFilesTabBridge({
 	}, [model, fetchDir]);
 
 	// Pierre fires a `remove` mutation when an inline rename is canceled with
-	// `removeIfCanceled: true`. Mirror that into our bookkeeping so the
-	// placeholder doesn't ghost in pendingCreates / knownPaths. (Renames that
-	// commit fire `move`, not `remove` — those are handled in handleRename.)
+	// `removeIfCanceled: true`. Mirror that into our bookkeeping so the row
+	// doesn't ghost in knownPaths. (Renames that commit fire `move`, not
+	// `remove` — those are handled in handleRename. Deleting the cancelled
+	// entry from disk is useFilesTabActions' job, via its own `remove`
+	// listener; Pierre supports several per mutation type.)
 	useEffect(() => {
 		return model.onMutation("remove", (event) => {
-			pendingCreatesRef.current.delete(event.path);
 			knownPathsRef.current.delete(event.path);
 			if (event.path.endsWith("/")) {
 				const dir = stripTrailingSlash(event.path);
@@ -382,10 +385,49 @@ export function useFilesTabBridge({
 		[],
 	);
 
+	const addPath = useCallback(
+		(treePath: string): boolean => {
+			if (!knownPathsRef.current.has(treePath)) {
+				knownPathsRef.current.add(treePath);
+				try {
+					model.add(treePath);
+				} catch {
+					// Pierre refused the path. Roll our bookkeeping back rather than
+					// claiming to know a row the tree doesn't have.
+					knownPathsRef.current.delete(treePath);
+					return false;
+				}
+			}
+			// A new directory still needs to lazy-load when the user expands it.
+			if (treePath.endsWith("/")) {
+				const dirRel = stripTrailingSlash(treePath);
+				if (!loadedDirsRef.current.has(dirRel)) {
+					unloadedDirCandidatesRef.current.add(dirRel);
+				}
+			}
+			return true;
+		},
+		[model],
+	);
+
+	const removePath = useCallback(
+		(treePath: string): void => {
+			removeKnownPath(model, knownPathsRef.current, treePath);
+			if (treePath.endsWith("/")) {
+				const dirRel = stripTrailingSlash(treePath);
+				loadedDirsRef.current.delete(dirRel);
+				unloadedDirCandidatesRef.current.delete(dirRel);
+				purgeDescendants(knownPathsRef.current, loadedDirsRef.current, dirRel);
+			}
+		},
+		[model],
+	);
+
 	return {
 		knownPaths: knownPathsRef.current,
 		loadedDirs: loadedDirsRef.current,
-		pendingCreates: pendingCreatesRef.current,
+		addPath,
+		removePath,
 		fetchDir,
 		doRefresh,
 		rekeyDescendants: rekeyDescendantsBound,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -7,6 +7,7 @@ import type { TreeBookkeeping } from "../../utils/treeBookkeeping";
 import { purgeDirectory, rekeyDirectory } from "../../utils/treeBookkeeping";
 import {
 	asDirectoryHandle,
+	resolveDeleteTreePath,
 	stripTrailingSlash,
 	toAbs,
 	toRel,
@@ -74,9 +75,9 @@ export interface FilesTabBridge {
  *   - Row removal: mirror Pierre's `remove` mutations into our bookkeeping
  *     (the Files tab's own cancel handling lives in useFilesTabActions)
  *
- * Workspace-switch races: every async listing captures a `versionRef` snapshot
- * and aborts its mutations if `versionRef` advanced (i.e. workspace/root
- * changed) before the await resolved.
+ * Async-listing races: every listing captures both the workspace version and a
+ * tree revision. It aborts if the workspace changes or if a destructive tree
+ * mutation (rename or removal) happens before the await resolves.
  */
 export function useFilesTabBridge({
 	model,
@@ -101,6 +102,9 @@ export function useFilesTabBridge({
 	// Bumped on workspace/root change so async listings started against an
 	// old workspace can detect they're stale and bail out before mutating.
 	const versionRef = useRef(0);
+	// Bumped on structural changes within the current workspace so a delayed
+	// listing cannot restore paths that were renamed or removed after it began.
+	const treeRevisionRef = useRef(0);
 
 	// Track directories that are known but haven't been loaded yet. When
 	// Pierre fires model.subscribe (on expansion, selection, etc.) we only
@@ -119,21 +123,33 @@ export function useFilesTabBridge({
 		[],
 	);
 
+	const invalidateTreeListings = useCallback(() => {
+		treeRevisionRef.current += 1;
+	}, []);
+
 	const fetchDir = useCallback(
-		async (relDir: string): Promise<void> => {
+		async function fetchDirectory(relDir: string): Promise<void> {
 			if (!rootPath || !workspaceId) return;
 			if (loadedDirsRef.current.has(relDir)) return;
 			const existing = inflightDirsRef.current.get(relDir);
 			if (existing) return existing;
 
 			const startVersion = versionRef.current;
+			const startTreeRevision = treeRevisionRef.current;
+			let shouldRetry = false;
 			const promise = (async () => {
 				try {
 					const result = await utils.filesystem.listDirectory.fetch({
 						workspaceId,
 						absolutePath: toAbs(rootPath, relDir),
 					});
-					if (versionRef.current !== startVersion) return;
+					if (
+						versionRef.current !== startVersion ||
+						treeRevisionRef.current !== startTreeRevision
+					) {
+						shouldRetry = versionRef.current === startVersion;
+						return;
+					}
 					const ops: { type: "add"; path: string }[] = [];
 					for (const entry of result.entries) {
 						const rel = toRel(rootPath, entry.absolutePath);
@@ -153,7 +169,13 @@ export function useFilesTabBridge({
 					loadedDirsRef.current.add(relDir);
 					unloadedDirCandidatesRef.current.delete(relDir);
 				} catch (error) {
-					if (versionRef.current !== startVersion) return;
+					if (
+						versionRef.current !== startVersion ||
+						treeRevisionRef.current !== startTreeRevision
+					) {
+						shouldRetry = versionRef.current === startVersion;
+						return;
+					}
 					console.error("[v2 FilesTab] listDirectory failed", {
 						relDir,
 						error,
@@ -169,6 +191,18 @@ export function useFilesTabBridge({
 				if (inflightDirsRef.current.get(relDir) === promise) {
 					inflightDirsRef.current.delete(relDir);
 				}
+				if (!shouldRetry || versionRef.current !== startVersion) return;
+				// Root is always relevant. Nested directories are retried only when
+				// they still exist at the same path and remain expanded; a renamed or
+				// removed directory must not produce a request against its old path.
+				if (relDir === "") {
+					void fetchDirectory(relDir);
+					return;
+				}
+				const dirKey = `${relDir}/`;
+				if (!knownPathsRef.current.has(dirKey)) return;
+				const handle = asDirectoryHandle(model.getItem(dirKey));
+				if (handle?.isExpanded()) void fetchDirectory(relDir);
 			});
 			return promise;
 		},
@@ -179,37 +213,59 @@ export function useFilesTabBridge({
 		if (!rootPath || !workspaceId) return;
 		setIsRefreshing(true);
 		const startVersion = versionRef.current;
+		const startTreeRevision = treeRevisionRef.current;
 		try {
 			const dirsToReload = Array.from(loadedDirsRef.current).sort(
 				(a, b) => a.split("/").length - b.split("/").length,
 			);
-			loadedDirsRef.current.clear();
-
 			// Collect fresh listings into a flat set then resetPaths so what
-			// Pierre shows can't drift from what we think we know.
+			// Pierre shows can't drift from what we think we know. Keep the live
+			// loaded-dir set untouched until commit so a stale refresh can abort
+			// without partially clearing current bookkeeping.
 			const freshPaths = new Set<string>();
+			const freshLoadedDirs = new Set<string>();
 			for (const dir of dirsToReload) {
 				try {
 					const result = await utils.filesystem.listDirectory.fetch(
 						{ workspaceId, absolutePath: toAbs(rootPath, dir) },
 						{ staleTime: 0 },
 					);
-					if (versionRef.current !== startVersion) return;
+					if (
+						versionRef.current !== startVersion ||
+						treeRevisionRef.current !== startTreeRevision
+					) {
+						return;
+					}
 					for (const entry of result.entries) {
 						const rel = toRel(rootPath, entry.absolutePath);
 						freshPaths.add(entry.kind === "directory" ? `${rel}/` : rel);
 					}
-					loadedDirsRef.current.add(dir);
+					freshLoadedDirs.add(dir);
 				} catch (error) {
+					if (
+						versionRef.current !== startVersion ||
+						treeRevisionRef.current !== startTreeRevision
+					) {
+						return;
+					}
 					console.error("[v2 FilesTab] refresh listDirectory failed", {
 						dir,
 						error,
 					});
 				}
 			}
-			if (versionRef.current !== startVersion) return;
+			if (
+				versionRef.current !== startVersion ||
+				treeRevisionRef.current !== startTreeRevision
+			) {
+				return;
+			}
 			knownPathsRef.current.clear();
+			loadedDirsRef.current.clear();
 			unloadedDirCandidatesRef.current.clear();
+			for (const dir of freshLoadedDirs) {
+				loadedDirsRef.current.add(dir);
+			}
 			for (const path of freshPaths) {
 				knownPathsRef.current.add(path);
 				if (path.endsWith("/")) {
@@ -230,13 +286,14 @@ export function useFilesTabBridge({
 	useEffect(() => {
 		if (!rootPath || !workspaceId) return;
 		versionRef.current += 1;
+		invalidateTreeListings();
 		knownPathsRef.current.clear();
 		loadedDirsRef.current.clear();
 		inflightDirsRef.current.clear();
 		unloadedDirCandidatesRef.current.clear();
 		model.resetPaths([]);
 		void fetchDir("");
-	}, [model, rootPath, workspaceId, fetchDir]);
+	}, [model, rootPath, workspaceId, fetchDir, invalidateTreeListings]);
 
 	// On every model change, check only unloaded directory candidates for
 	// expansion. Pierre doesn't surface an explicit "expand" event, so we
@@ -264,6 +321,7 @@ export function useFilesTabBridge({
 	// listener; Pierre supports several per mutation type.)
 	useEffect(() => {
 		return model.onMutation("remove", (event) => {
+			invalidateTreeListings();
 			knownPathsRef.current.delete(event.path);
 			if (event.path.endsWith("/")) {
 				const dir = stripTrailingSlash(event.path);
@@ -271,7 +329,7 @@ export function useFilesTabBridge({
 				purgeDirectory(bookkeeping(), dir);
 			}
 		});
-	}, [model, bookkeeping]);
+	}, [model, bookkeeping, invalidateTreeListings]);
 
 	useWorkspaceEvent(
 		"fs:events",
@@ -310,6 +368,7 @@ export function useFilesTabBridge({
 			}
 
 			if (event.kind === "rename" && event.oldAbsolutePath) {
+				invalidateTreeListings();
 				const oldRel = toRel(rootPath, event.oldAbsolutePath);
 				const oldKey = matchKnown(knownPathsRef.current, oldRel);
 				const isFolder = event.isDirectory ?? oldKey?.endsWith("/") ?? false;
@@ -344,15 +403,26 @@ export function useFilesTabBridge({
 					}
 					addKnownPath(model, knownPathsRef.current, newKey);
 				}
+				if (isFolder) {
+					const newDir = stripTrailingSlash(newKey);
+					if (!loadedDirsRef.current.has(newDir)) {
+						unloadedDirCandidatesRef.current.add(newDir);
+					}
+					const handle = asDirectoryHandle(model.getItem(newKey));
+					if (handle?.isExpanded()) void fetchDir(newDir);
+				}
 				return;
 			}
 
 			if (event.kind === "delete") {
-				const isFolder = event.isDirectory ?? false;
-				const key = isFolder ? `${rel}/` : rel;
-				const matched = matchKnown(knownPathsRef.current, rel) ?? key;
+				invalidateTreeListings();
+				const { treePath: matched, isDirectory } = resolveDeleteTreePath(
+					knownPathsRef.current,
+					rel,
+					event.isDirectory,
+				);
 				removeKnownPath(model, knownPathsRef.current, matched);
-				if (isFolder) {
+				if (isDirectory) {
 					purgeDirectory(bookkeeping(), stripTrailingSlash(matched));
 				}
 				return;
@@ -375,9 +445,13 @@ export function useFilesTabBridge({
 
 	const rekeyDescendantsBound = useCallback(
 		(oldDir: string, newDir: string) => {
+			invalidateTreeListings();
 			rekeyDirectory(bookkeeping(), oldDir, newDir);
+			const newKey = `${newDir}/`;
+			const handle = asDirectoryHandle(model.getItem(newKey));
+			if (handle?.isExpanded()) void fetchDir(newDir);
 		},
-		[bookkeeping],
+		[bookkeeping, fetchDir, invalidateTreeListings, model],
 	);
 
 	const getVersion = useCallback(() => versionRef.current, []);
@@ -413,6 +487,9 @@ export function useFilesTabBridge({
 
 	const removePath = useCallback(
 		(treePath: string): void => {
+			if (knownPathsRef.current.has(treePath)) {
+				invalidateTreeListings();
+			}
 			removeKnownPath(model, knownPathsRef.current, treePath);
 			if (treePath.endsWith("/")) {
 				const dirRel = stripTrailingSlash(treePath);
@@ -421,7 +498,7 @@ export function useFilesTabBridge({
 				purgeDirectory(bookkeeping(), dirRel);
 			}
 		},
-		[model, bookkeeping],
+		[model, bookkeeping, invalidateTreeListings],
 	);
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/creationPaths.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/creationPaths.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { canonicalizeTreePath } from "renderer/lib/pierreTree";
+import { buildCreationKey, deriveCreationParent } from "./creationPaths";
+
+const ROOT = "/workspace";
+
+describe("buildCreationKey", () => {
+	it("marks folders with a trailing slash and leaves files bare", () => {
+		expect(buildCreationKey("", "Untitled", "folder")).toEqual("Untitled/");
+		expect(buildCreationKey("", "untitled", "file")).toEqual("untitled");
+	});
+
+	it("prefixes the parent directory", () => {
+		expect(buildCreationKey("src", "Untitled", "folder")).toEqual(
+			"src/Untitled/",
+		);
+		expect(buildCreationKey("src/components", "untitled", "file")).toEqual(
+			"src/components/untitled",
+		);
+	});
+});
+
+describe("creation key ↔ Pierre rename event", () => {
+	// The reported bug: `startCreating` registered "Untitled/" but Pierre's
+	// onRename reported "Untitled", so the lookup missed, the commit fell through
+	// to the rename branch, and we renamed a directory that never existed —
+	// ENOENT. The two forms must agree once the event path is canonicalized.
+	it("canonicalizes a folder rename event back to the created key", () => {
+		const createdKey = buildCreationKey("", "Untitled", "folder");
+		const pierreReportedSourcePath = "Untitled"; // isFolder: true, no slash
+
+		expect(canonicalizeTreePath(pierreReportedSourcePath, true)).toEqual(
+			createdKey,
+		);
+	});
+
+	it("canonicalizes a nested folder rename event back to the created key", () => {
+		const createdKey = buildCreationKey("src", "Untitled", "folder");
+
+		expect(canonicalizeTreePath("src/Untitled", true)).toEqual(createdKey);
+	});
+
+	it("leaves file rename events alone", () => {
+		const createdKey = buildCreationKey("src", "untitled", "file");
+
+		expect(canonicalizeTreePath("src/untitled", false)).toEqual(createdKey);
+	});
+});
+
+describe("deriveCreationParent", () => {
+	it("falls back to the workspace root with nothing selected", () => {
+		expect(deriveCreationParent([], new Set(), ROOT)).toEqual(ROOT);
+	});
+
+	it("creates inside a selected folder", () => {
+		const knownPaths = new Set(["src/"]);
+
+		expect(deriveCreationParent(["src/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/src`,
+		);
+	});
+
+	it("creates inside a selected nested folder", () => {
+		const knownPaths = new Set(["src/", "src/deep/"]);
+
+		expect(deriveCreationParent(["src/deep/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/src/deep`,
+		);
+	});
+
+	it("creates beside a selected file", () => {
+		const knownPaths = new Set(["src/", "src/index.ts"]);
+
+		expect(deriveCreationParent(["src/index.ts"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/src`,
+		);
+	});
+
+	it("uses the root for a file selected at the root", () => {
+		const knownPaths = new Set(["index.ts"]);
+
+		expect(deriveCreationParent(["index.ts"], knownPaths, ROOT)).toEqual(ROOT);
+	});
+
+	// Every folder the user picked resolved to the same directory, because the
+	// target came from the editor's open file rather than the tree selection.
+	it("follows whichever folder is selected", () => {
+		const knownPaths = new Set(["src/", "docs/", "docs/api/"]);
+
+		expect(deriveCreationParent(["src/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/src`,
+		);
+		expect(deriveCreationParent(["docs/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/docs`,
+		);
+		expect(deriveCreationParent(["docs/api/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/docs/api`,
+		);
+	});
+
+	it("honours the last entry of a multi-selection", () => {
+		const knownPaths = new Set(["src/", "docs/"]);
+
+		expect(deriveCreationParent(["src/", "docs/"], knownPaths, ROOT)).toEqual(
+			`${ROOT}/docs`,
+		);
+	});
+
+	// REGRESSION: a row can outlive the directory it names — rename a folder and
+	// any stale selection still points at the old path. Creating into it asked
+	// the host to mkdir inside a directory that no longer existed (ENOENT).
+	it("falls back to the root when the selected folder no longer exists", () => {
+		const knownPaths = new Set(["test2/", "test2/untitled"]);
+
+		expect(deriveCreationParent(["Untitled/"], knownPaths, ROOT)).toEqual(ROOT);
+	});
+
+	it("falls back to the root when a selected file's parent is gone", () => {
+		const knownPaths = new Set(["test2/", "test2/untitled"]);
+
+		expect(
+			deriveCreationParent(["Untitled/untitled"], knownPaths, ROOT),
+		).toEqual(ROOT);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/creationPaths.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/creationPaths.ts
@@ -1,40 +1,64 @@
-import { toRel } from "../treePath";
+import { toAbs } from "../treePath";
 
 /**
- * Pick the directory a new file/folder should be created in, based on the
- * current selection: the selected path if it's itself a known directory,
- * otherwise the selected file's parent, otherwise the workspace root.
+ * Pick the directory a new file/folder should be created in, from the tree's
+ * own selection: a selected folder, a selected file's parent, or — with
+ * nothing selected — the workspace root.
+ *
+ * Driven by the visible selection rather than the editor's open file. The two
+ * disagree constantly: the editor keeps a path across folder renames, and it
+ * can point somewhere the tree isn't even showing, which made the button
+ * create in one fixed place no matter which folder was highlighted.
+ *
+ * Every candidate is still checked against `knownPaths`, so a row for a
+ * directory that has since been renamed or deleted falls back to the root
+ * instead of targeting a path that no longer exists.
  */
 export function deriveCreationParent(
-	selectedFilePath: string | undefined,
+	selectedTreePaths: readonly string[],
 	knownPaths: Set<string>,
 	rootPath: string,
 ): string {
-	if (!selectedFilePath) return rootPath;
-	const selectedRel = toRel(rootPath, selectedFilePath);
-	if (knownPaths.has(`${selectedRel}/`)) return selectedFilePath;
-	const lastSlash = selectedFilePath.lastIndexOf("/");
-	return lastSlash > rootPath.length
-		? selectedFilePath.slice(0, lastSlash)
+	const selected = selectedTreePaths[selectedTreePaths.length - 1];
+	if (!selected) return rootPath;
+
+	// Pierre marks directory rows with a trailing slash.
+	if (selected.endsWith("/")) {
+		return knownPaths.has(selected) ? toAbs(rootPath, selected) : rootPath;
+	}
+
+	const lastSlash = selected.lastIndexOf("/");
+	if (lastSlash < 0) return rootPath;
+
+	const parentRelPath = selected.slice(0, lastSlash);
+	return knownPaths.has(`${parentRelPath}/`)
+		? toAbs(rootPath, parentRelPath)
 		: rootPath;
 }
 
+/** Base name a new entry starts from, before the host de-duplicates it. */
+export const CREATION_BASE_NAME = {
+	folder: "Untitled",
+	file: "untitled",
+} as const;
+
 /**
- * First non-colliding placeholder name for an inline "New file/folder" row
- * under `parentRel` — `untitled` / `Untitled`, then `-2`, `-3`, …
+ * Pierre's canonical tree key for a newly created entry: `parentRel` + `name`,
+ * with the trailing slash that marks a directory row.
+ *
+ * The single place this key is spelled out, so the key we register in the tree
+ * cannot drift from the key we later look up.
  */
-export function pickPlaceholderName(
+export function buildCreationKey(
 	parentRel: string,
+	name: string,
 	mode: "file" | "folder",
-	knownPaths: Set<string>,
 ): string {
-	const base = mode === "folder" ? "Untitled" : "untitled";
-	const suffix = mode === "folder" ? "/" : "";
 	const prefix = parentRel ? `${parentRel}/` : "";
-	if (!knownPaths.has(`${prefix}${base}${suffix}`)) return base;
-	for (let i = 2; i < 100; i++) {
-		const name = `${base}-${i}`;
-		if (!knownPaths.has(`${prefix}${name}${suffix}`)) return name;
-	}
-	return `${base}-${Date.now()}`;
+	return `${prefix}${name}${mode === "folder" ? "/" : ""}`;
 }
+
+// De-duplicating the name (`Untitled`, `Untitled-2`, …) used to happen here,
+// against the client's `knownPaths` cache. It now happens host-side in
+// `createUniqueEntry`, where each attempt is an exclusive create: a cache that
+// hasn't caught up can no longer pick a name that already exists on disk.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/creationPaths/index.ts
@@ -1,1 +1,5 @@
-export { deriveCreationParent, pickPlaceholderName } from "./creationPaths";
+export {
+	buildCreationKey,
+	CREATION_BASE_NAME,
+	deriveCreationParent,
+} from "./creationPaths";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/index.ts
@@ -1,0 +1,6 @@
+export {
+	type ProvisionalAction,
+	type ProvisionalEntry,
+	type ProvisionalEvent,
+	reduceProvisional,
+} from "./provisionalEntry";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import type { ProvisionalEntry } from "./provisionalEntry";
+import { reduceProvisional } from "./provisionalEntry";
+
+const ROOT = "/workspace";
+const VERSION = 1;
+
+function folderEntry(
+	overrides: Partial<ProvisionalEntry> = {},
+): ProvisionalEntry {
+	return {
+		key: "Untitled/",
+		absolutePath: `${ROOT}/Untitled`,
+		mode: "folder",
+		rootPath: ROOT,
+		versionToken: VERSION,
+		...overrides,
+	};
+}
+
+/** The `removed` event as the Files tab dispatches it for the current workspace. */
+function removedHere(path: string) {
+	return {
+		type: "removed" as const,
+		path,
+		rootPath: ROOT,
+		versionToken: VERSION,
+	};
+}
+
+describe("reduceProvisional", () => {
+	it("arms on creation", () => {
+		const entry = folderEntry();
+
+		const result = reduceProvisional(null, { type: "created", entry });
+
+		expect(result.state).toEqual(entry);
+		expect(result.action).toEqual({ type: "none" });
+	});
+
+	it("cleans up when its own entry is removed in the same workspace", () => {
+		const entry = folderEntry();
+
+		const result = reduceProvisional(entry, removedHere("Untitled/"));
+
+		expect(result.state).toBeNull();
+		expect(result.action).toEqual({ type: "cleanup", entry });
+	});
+
+	it("disarms once the entry is committed under a new name", () => {
+		const entry = folderEntry();
+
+		const committed = reduceProvisional(entry, {
+			type: "renamed",
+			sourceKey: "Untitled/",
+		});
+
+		expect(committed.state).toBeNull();
+		expect(
+			reduceProvisional(committed.state, removedHere("Untitled/")).action,
+		).toEqual({ type: "none" });
+	});
+
+	it("ignores removal of an unrelated path", () => {
+		const entry = folderEntry();
+
+		expect(reduceProvisional(entry, removedHere("src/other/")).action).toEqual({
+			type: "none",
+		});
+	});
+
+	it("ignores removal after a workspace switch", () => {
+		const entry = folderEntry();
+
+		// Same path, different workspace root.
+		expect(
+			reduceProvisional(entry, {
+				type: "removed",
+				path: "Untitled/",
+				rootPath: "/other-workspace",
+				versionToken: VERSION,
+			}).action,
+		).toEqual({ type: "none" });
+
+		// Same root, but the bridge version moved on.
+		expect(
+			reduceProvisional(entry, {
+				type: "removed",
+				path: "Untitled/",
+				rootPath: ROOT,
+				versionToken: VERSION + 1,
+			}).action,
+		).toEqual({ type: "none" });
+	});
+
+	it("drops state on workspace change without deleting anything", () => {
+		const result = reduceProvisional(folderEntry(), {
+			type: "workspace-changed",
+		});
+
+		expect(result.state).toBeNull();
+		expect(result.action).toEqual({ type: "none" });
+	});
+
+	describe("stale provisional state cannot delete a committed folder", () => {
+		// Accepting the default name commits the folder, but Pierre emits no
+		// rename/error/remove event for an unchanged commit, so the entry stays
+		// armed. Both guards below must independently prevent a later collision +
+		// Esc on that same folder from deleting it.
+		const staleAfterUnchangedCommit = folderEntry();
+
+		it("disarms when the user starts their own rename (F2 / context menu)", () => {
+			const result = reduceProvisional(staleAfterUnchangedCommit, {
+				type: "manual-rename-started",
+			});
+
+			expect(result.state).toBeNull();
+			expect(result.action).toEqual({ type: "none" });
+			expect(
+				reduceProvisional(result.state, removedHere("Untitled/")).action,
+			).toEqual({ type: "none" });
+		});
+
+		it("disarms on a rename error before reopening the rename", () => {
+			const errored = reduceProvisional(staleAfterUnchangedCommit, {
+				type: "rename-error",
+			});
+
+			// Reopens so the user can fix the name, but is no longer armed — the
+			// caller must start that session without `removeIfCanceled`.
+			expect(errored.action).toEqual({
+				type: "reopen-rename",
+				key: "Untitled/",
+			});
+			expect(errored.state).toBeNull();
+
+			// The Esc that follows must not delete the committed folder.
+			expect(
+				reduceProvisional(errored.state, removedHere("Untitled/")).action,
+			).toEqual({ type: "none" });
+		});
+	});
+
+	it("does nothing on a rename error with no provisional entry", () => {
+		const result = reduceProvisional(null, { type: "rename-error" });
+
+		expect(result.state).toBeNull();
+		expect(result.action).toEqual({ type: "none" });
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.test.ts
@@ -102,42 +102,35 @@ describe("reduceProvisional", () => {
 		expect(result.action).toEqual({ type: "none" });
 	});
 
+	// Accepting the default name commits the folder, but Pierre emits no
+	// rename/error/remove event for an unchanged commit, so the entry stays
+	// armed. A later rename error on any row must not turn that into a delete.
 	describe("stale provisional state cannot delete a committed folder", () => {
-		// Accepting the default name commits the folder, but Pierre emits no
-		// rename/error/remove event for an unchanged commit, so the entry stays
-		// armed. Both guards below must independently prevent a later collision +
-		// Esc on that same folder from deleting it.
 		const staleAfterUnchangedCommit = folderEntry();
 
-		it("disarms when the user starts their own rename (F2 / context menu)", () => {
-			const result = reduceProvisional(staleAfterUnchangedCommit, {
-				type: "manual-rename-started",
-			});
-
-			expect(result.state).toBeNull();
-			expect(result.action).toEqual({ type: "none" });
-			expect(
-				reduceProvisional(result.state, removedHere("Untitled/")).action,
-			).toEqual({ type: "none" });
-		});
-
-		it("disarms on a rename error before reopening the rename", () => {
+		it("disarms on a rename error and asks for nothing", () => {
 			const errored = reduceProvisional(staleAfterUnchangedCommit, {
 				type: "rename-error",
 			});
 
-			// Reopens so the user can fix the name, but is no longer armed — the
-			// caller must start that session without `removeIfCanceled`.
-			expect(errored.action).toEqual({
-				type: "reopen-rename",
-				key: "Untitled/",
-			});
+			// Never reopens a rename: Pierre's onError carries no path, so any
+			// reopen would guess a row — and re-arm cleanup on a committed folder.
+			expect(errored.action).toEqual({ type: "none" });
 			expect(errored.state).toBeNull();
 
 			// The Esc that follows must not delete the committed folder.
 			expect(
 				reduceProvisional(errored.state, removedHere("Untitled/")).action,
 			).toEqual({ type: "none" });
+		});
+
+		it("self-heals when that row is eventually renamed", () => {
+			const renamed = reduceProvisional(staleAfterUnchangedCommit, {
+				type: "renamed",
+				sourceKey: "Untitled/",
+			});
+
+			expect(renamed.state).toBeNull();
 		});
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.ts
@@ -1,0 +1,108 @@
+/**
+ * A newly created entry that is still being named inline.
+ *
+ * The Files tab creates files/folders on disk *before* opening the rename
+ * input, so the inline name is a rename of something real. That makes
+ * accept-the-default, cancel, and name collisions all end in a state that
+ * matches disk — but it also means cancelling has to delete what we made, so we
+ * have to be certain we are deleting our own provisional entry and nothing
+ * else.
+ *
+ * Identity is therefore the tree key *plus* the workspace it belongs to. A bare
+ * relative path is not enough: the same path exists in every workspace.
+ */
+export interface ProvisionalEntry {
+	/** Canonical Pierre tree key — directories carry a trailing slash. */
+	key: string;
+	absolutePath: string;
+	mode: "file" | "folder";
+	/** Files only: guards cleanup against a file that changed after creation. */
+	revision?: string;
+	rootPath: string;
+	/** `bridge.getVersion()` at creation — bumped on every workspace switch. */
+	versionToken: number;
+}
+
+export type ProvisionalEvent =
+	| { type: "created"; entry: ProvisionalEntry }
+	| { type: "renamed"; sourceKey: string }
+	| { type: "rename-error" }
+	| { type: "manual-rename-started" }
+	| { type: "removed"; path: string; rootPath: string; versionToken: number }
+	| { type: "workspace-changed" };
+
+export type ProvisionalAction =
+	| { type: "none" }
+	/** Remove the entry from disk — only ever our own, still-provisional entry. */
+	| { type: "cleanup"; entry: ProvisionalEntry }
+	/**
+	 * Reopen the inline rename so the user can fix a rejected name. The caller
+	 * MUST start it without `removeIfCanceled`: by the time this is returned the
+	 * entry is no longer provisional, so cancelling must not delete anything.
+	 */
+	| { type: "reopen-rename"; key: string };
+
+const NONE: { state: ProvisionalEntry | null; action: ProvisionalAction } = {
+	state: null,
+	action: { type: "none" },
+};
+
+/**
+ * Decides what happens to the provisional entry as the rename session plays out.
+ *
+ * Pure and exhaustively tested because getting it wrong deletes user data — see
+ * the `rename-error` case below.
+ */
+export function reduceProvisional(
+	state: ProvisionalEntry | null,
+	event: ProvisionalEvent,
+): { state: ProvisionalEntry | null; action: ProvisionalAction } {
+	switch (event.type) {
+		case "created":
+			return { state: event.entry, action: { type: "none" } };
+
+		// Committed under a new name: it is a real, named entry now.
+		case "renamed":
+			return state?.key === event.sourceKey
+				? NONE
+				: { state, action: { type: "none" } };
+
+		// Pierre rejected the typed name (collision, or a `/` in it) and ended the
+		// rename session.
+		//
+		// Clearing state here is load-bearing, not tidiness. Pierre emits NO event
+		// when a rename commits unchanged, so after "New Folder → Enter" the entry
+		// stays armed even though it is now committed. If a later F2 rename on that
+		// same folder hit a collision and we re-armed the rename with
+		// `removeIfCanceled`, Esc would delete a folder the user had kept. So:
+		// disarm first, and reopen without `removeIfCanceled`.
+		case "rename-error":
+			return state === null
+				? NONE
+				: { state: null, action: { type: "reopen-rename", key: state.key } };
+
+		// The user started their own rename (F2 / context menu). Anything still
+		// armed from an earlier creation is stale by definition — drop it so a
+		// user-initiated session can never consume it.
+		case "manual-rename-started":
+			return NONE;
+
+		// Pierre removed the row. Only our own provisional entry, in this
+		// workspace, may be cleaned up from disk.
+		case "removed":
+			if (
+				state === null ||
+				state.key !== event.path ||
+				state.rootPath !== event.rootPath ||
+				state.versionToken !== event.versionToken
+			) {
+				return { state, action: { type: "none" } };
+			}
+			return { state: null, action: { type: "cleanup", entry: state } };
+
+		// The entry exists on disk and the user may come back to it, so drop the
+		// bookkeeping without deleting anything.
+		case "workspace-changed":
+			return NONE;
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/provisionalEntry/provisionalEntry.ts
@@ -27,20 +27,13 @@ export type ProvisionalEvent =
 	| { type: "created"; entry: ProvisionalEntry }
 	| { type: "renamed"; sourceKey: string }
 	| { type: "rename-error" }
-	| { type: "manual-rename-started" }
 	| { type: "removed"; path: string; rootPath: string; versionToken: number }
 	| { type: "workspace-changed" };
 
 export type ProvisionalAction =
 	| { type: "none" }
 	/** Remove the entry from disk — only ever our own, still-provisional entry. */
-	| { type: "cleanup"; entry: ProvisionalEntry }
-	/**
-	 * Reopen the inline rename so the user can fix a rejected name. The caller
-	 * MUST start it without `removeIfCanceled`: by the time this is returned the
-	 * entry is no longer provisional, so cancelling must not delete anything.
-	 */
-	| { type: "reopen-rename"; key: string };
+	| { type: "cleanup"; entry: ProvisionalEntry };
 
 const NONE: { state: ProvisionalEntry | null; action: ProvisionalAction } = {
 	state: null,
@@ -50,8 +43,16 @@ const NONE: { state: ProvisionalEntry | null; action: ProvisionalAction } = {
 /**
  * Decides what happens to the provisional entry as the rename session plays out.
  *
- * Pure and exhaustively tested because getting it wrong deletes user data — see
- * the `rename-error` case below.
+ * Pure and exhaustively tested because getting it wrong deletes user data.
+ *
+ * One state is unavoidable: committing a rename unchanged (New Folder →
+ * Enter) emits no Pierre event at all, so the entry stays armed even though it
+ * is now a committed folder. That is safe here because the only action this
+ * can produce is `cleanup`, which requires a `remove` for that exact path in
+ * the same workspace — and `remove` with cleanup semantics is only ever armed
+ * by our own creation flow. Should one slip through, cleanup is an `rmdir`
+ * that refuses a non-empty directory, so the worst case is an empty folder we
+ * created ourselves disappearing, never user data.
  */
 export function reduceProvisional(
 	state: ProvisionalEntry | null,
@@ -70,21 +71,14 @@ export function reduceProvisional(
 		// Pierre rejected the typed name (collision, or a `/` in it) and ended the
 		// rename session.
 		//
-		// Clearing state here is load-bearing, not tidiness. Pierre emits NO event
-		// when a rename commits unchanged, so after "New Folder → Enter" the entry
-		// stays armed even though it is now committed. If a later F2 rename on that
-		// same folder hit a collision and we re-armed the rename with
-		// `removeIfCanceled`, Esc would delete a folder the user had kept. So:
-		// disarm first, and reopen without `removeIfCanceled`.
+		// The entry keeps its current name on disk, so it stays usable and the
+		// user can rename it again whenever. We deliberately do NOT reopen the
+		// inline rename: Pierre's `onError` reports only a message, never a path,
+		// so we cannot tell which row failed — F2 is handled inside Pierre and
+		// never reaches our wrappers. Reopening would guess, and after an
+		// unchanged commit (which emits no event, leaving this state armed) the
+		// guess would land on a committed folder and re-arm cleanup on it.
 		case "rename-error":
-			return state === null
-				? NONE
-				: { state: null, action: { type: "reopen-rename", key: state.key } };
-
-		// The user started their own rename (F2 / context menu). Anything still
-		// armed from an earlier creation is stale by definition — drop it so a
-		// user-initiated session can never consume it.
-		case "manual-rename-started":
 			return NONE;
 
 		// Pierre removed the row. Only our own provisional entry, in this

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/index.ts
@@ -1,0 +1,5 @@
+export {
+	purgeDirectory,
+	rekeyDirectory,
+	type TreeBookkeeping,
+} from "./treeBookkeeping";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/treeBookkeeping.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/treeBookkeeping.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import type { TreeBookkeeping } from "./treeBookkeeping";
+import { purgeDirectory, rekeyDirectory } from "./treeBookkeeping";
+
+function bookkeeping(
+	overrides: Partial<Record<keyof TreeBookkeeping, string[]>> = {},
+): TreeBookkeeping {
+	return {
+		knownPaths: new Set(overrides.knownPaths ?? []),
+		loadedDirs: new Set(overrides.loadedDirs ?? []),
+		unloadedDirCandidates: new Set(overrides.unloadedDirCandidates ?? []),
+	};
+}
+
+describe("rekeyDirectory", () => {
+	it("moves descendants of the renamed directory", () => {
+		const state = bookkeeping({
+			knownPaths: ["src/", "src/index.ts", "src/deep/", "other.ts"],
+			loadedDirs: ["src", "src/deep"],
+		});
+
+		rekeyDirectory(state, "src", "lib");
+
+		// The directory's own key moves too: "src/" starts with the "src/" prefix.
+		expect([...state.knownPaths].sort()).toEqual([
+			"lib/",
+			"lib/deep/",
+			"lib/index.ts",
+			"other.ts",
+		]);
+		expect([...state.loadedDirs].sort()).toEqual(["lib", "lib/deep"]);
+	});
+
+	// REGRESSION: a folder renamed before it was ever expanded kept its old key
+	// in unloadedDirCandidates, so the expand subscriber never matched the new
+	// key, fetchDir was never called, and the folder rendered empty. Every newly
+	// created folder hits this, since creation registers a candidate and the
+	// inline rename immediately renames it.
+	it("moves the directory's own lazy-load candidate", () => {
+		const state = bookkeeping({
+			knownPaths: ["Untitled/"],
+			unloadedDirCandidates: ["Untitled"],
+		});
+
+		rekeyDirectory(state, "Untitled", "docs");
+
+		expect([...state.unloadedDirCandidates]).toEqual(["docs"]);
+	});
+
+	it("moves nested lazy-load candidates", () => {
+		const state = bookkeeping({
+			unloadedDirCandidates: ["src", "src/deep", "unrelated"],
+		});
+
+		rekeyDirectory(state, "src", "lib");
+
+		expect([...state.unloadedDirCandidates].sort()).toEqual([
+			"lib",
+			"lib/deep",
+			"unrelated",
+		]);
+	});
+
+	it("leaves unrelated entries alone", () => {
+		const state = bookkeeping({
+			knownPaths: ["srcfile.ts", "source/"],
+			loadedDirs: ["source"],
+			unloadedDirCandidates: ["source"],
+		});
+
+		rekeyDirectory(state, "src", "lib");
+
+		expect([...state.knownPaths].sort()).toEqual(["source/", "srcfile.ts"]);
+		expect([...state.loadedDirs]).toEqual(["source"]);
+		expect([...state.unloadedDirCandidates]).toEqual(["source"]);
+	});
+});
+
+describe("purgeDirectory", () => {
+	it("drops the directory and its descendants", () => {
+		const state = bookkeeping({
+			knownPaths: ["src/", "src/index.ts", "src/deep/", "other.ts"],
+			loadedDirs: ["src", "src/deep", "other"],
+			unloadedDirCandidates: ["src", "src/deep", "other"],
+		});
+
+		purgeDirectory(state, "src");
+
+		// "src/" itself starts with the "src/" prefix, so it goes with the rest.
+		expect([...state.knownPaths]).toEqual(["other.ts"]);
+		expect([...state.loadedDirs]).toEqual(["other"]);
+		expect([...state.unloadedDirCandidates]).toEqual(["other"]);
+	});
+
+	// A removed folder that kept its candidate would make a later folder of the
+	// same name skip its fetch and render empty.
+	it("drops the directory's own lazy-load candidate", () => {
+		const state = bookkeeping({ unloadedDirCandidates: ["docs"] });
+
+		purgeDirectory(state, "docs");
+
+		expect([...state.unloadedDirCandidates]).toEqual([]);
+	});
+
+	it("leaves unrelated entries alone", () => {
+		const state = bookkeeping({
+			knownPaths: ["srcfile.ts"],
+			loadedDirs: ["source"],
+			unloadedDirCandidates: ["source"],
+		});
+
+		purgeDirectory(state, "src");
+
+		expect([...state.knownPaths]).toEqual(["srcfile.ts"]);
+		expect([...state.loadedDirs]).toEqual(["source"]);
+		expect([...state.unloadedDirCandidates]).toEqual(["source"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/treeBookkeeping.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treeBookkeeping/treeBookkeeping.ts
@@ -1,0 +1,86 @@
+/**
+ * The Files tab's path-keyed view of the tree, kept alongside Pierre's own
+ * model. All three sets have to move together: they are keyed by path, so a
+ * folder rename invalidates every entry underneath it at once.
+ */
+export interface TreeBookkeeping {
+	/** Every path Pierre knows about. Files bare, directories trailing-slash. */
+	knownPaths: Set<string>;
+	/** Relative directories whose children have been fetched. "" = root. */
+	loadedDirs: Set<string>;
+	/**
+	 * Known-but-unfetched directories, checked on expand to decide what to
+	 * lazy-load. A directory missing from here after a rename can never load its
+	 * children, so it must be rekeyed with the rest.
+	 */
+	unloadedDirCandidates: Set<string>;
+}
+
+/**
+ * Drop `dirRel` and everything under it. Used after a folder is removed (or
+ * renamed, paired with `rekeyDirectory`) so stale descendants don't pin paths
+ * that no longer exist on disk.
+ */
+export function purgeDirectory(
+	bookkeeping: TreeBookkeeping,
+	dirRel: string,
+): void {
+	const { knownPaths, loadedDirs, unloadedDirCandidates } = bookkeeping;
+	const prefix = `${dirRel}/`;
+
+	for (const path of knownPaths) {
+		if (path.startsWith(prefix)) knownPaths.delete(path);
+	}
+	for (const dir of loadedDirs) {
+		if (dir === dirRel || dir.startsWith(prefix)) loadedDirs.delete(dir);
+	}
+	for (const dir of unloadedDirCandidates) {
+		if (dir === dirRel || dir.startsWith(prefix)) {
+			unloadedDirCandidates.delete(dir);
+		}
+	}
+}
+
+/**
+ * Re-key `oldDir` and its descendants to live under `newDir`.
+ *
+ * Pierre's `model.move` already moves the renamed subtree on its side, but our
+ * bookkeeping is path-keyed, so without this the fs reconciler looks up paths
+ * that no longer exist and skips real changes — and a renamed directory that
+ * was never expanded loses its place in `unloadedDirCandidates`, which means
+ * expanding it later never triggers a fetch and it renders empty.
+ */
+export function rekeyDirectory(
+	bookkeeping: TreeBookkeeping,
+	oldDir: string,
+	newDir: string,
+): void {
+	const { knownPaths, loadedDirs, unloadedDirCandidates } = bookkeeping;
+	const oldPrefix = `${oldDir}/`;
+
+	// Collect before mutating: rewriting a Set while iterating it can revisit
+	// entries that were just re-added under the new prefix.
+	const movedKnown = [...knownPaths].filter((path) =>
+		path.startsWith(oldPrefix),
+	);
+	for (const path of movedKnown) {
+		knownPaths.delete(path);
+		knownPaths.add(newDir + path.slice(oldDir.length));
+	}
+
+	const movedLoaded = [...loadedDirs].filter(
+		(dir) => dir === oldDir || dir.startsWith(oldPrefix),
+	);
+	for (const dir of movedLoaded) {
+		loadedDirs.delete(dir);
+		loadedDirs.add(newDir + dir.slice(oldDir.length));
+	}
+
+	const movedCandidates = [...unloadedDirCandidates].filter(
+		(dir) => dir === oldDir || dir.startsWith(oldPrefix),
+	);
+	for (const dir of movedCandidates) {
+		unloadedDirCandidates.delete(dir);
+		unloadedDirCandidates.add(newDir + dir.slice(oldDir.length));
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/index.ts
@@ -2,6 +2,7 @@ export {
 	asDirectoryHandle,
 	basename,
 	parentRel,
+	resolveDeleteTreePath,
 	stripTrailingSlash,
 	toAbs,
 	toPosix,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.test.ts
@@ -19,6 +19,13 @@ describe("resolveDeleteTreePath", () => {
 		).toEqual({ treePath: "src/index.ts", isDirectory: false });
 	});
 
+	it("trusts a tracked canonical directory over conflicting metadata", () => {
+		expect(resolveDeleteTreePath(new Set(["src/"]), "src", false)).toEqual({
+			treePath: "src/",
+			isDirectory: true,
+		});
+	});
+
 	it("uses explicit directory metadata for an unknown path", () => {
 		expect(resolveDeleteTreePath(new Set(), "docs", true)).toEqual({
 			treePath: "docs/",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { resolveDeleteTreePath } from "./treePath";
+
+describe("resolveDeleteTreePath", () => {
+	it("infers a tracked directory when watcher metadata is absent", () => {
+		expect(resolveDeleteTreePath(new Set(["src/"]), "src", undefined)).toEqual({
+			treePath: "src/",
+			isDirectory: true,
+		});
+	});
+
+	it("infers a tracked file when watcher metadata is absent", () => {
+		expect(
+			resolveDeleteTreePath(
+				new Set(["src/index.ts"]),
+				"src/index.ts",
+				undefined,
+			),
+		).toEqual({ treePath: "src/index.ts", isDirectory: false });
+	});
+
+	it("uses explicit directory metadata for an unknown path", () => {
+		expect(resolveDeleteTreePath(new Set(), "docs", true)).toEqual({
+			treePath: "docs/",
+			isDirectory: true,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.ts
@@ -35,6 +35,26 @@ export function basename(rel: string): string {
 	return i < 0 ? trimmed : trimmed.slice(i + 1);
 }
 
+/** Resolve a watcher deletion to Pierre's canonical path and entry type. */
+export function resolveDeleteTreePath(
+	known: Set<string>,
+	rel: string,
+	isDirectory: boolean | undefined,
+): { treePath: string; isDirectory: boolean } {
+	const directoryPath = `${rel}/`;
+	const treePath = known.has(rel)
+		? rel
+		: known.has(directoryPath)
+			? directoryPath
+			: isDirectory
+				? directoryPath
+				: rel;
+	return {
+		treePath,
+		isDirectory: isDirectory ?? treePath.endsWith("/"),
+	};
+}
+
 // Pierre's `isDirectory()` is typed as `() => true | false` (literal returns
 // per branch) but isn't a TS predicate, so the union doesn't narrow. This
 // helper turns it into one.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/utils/treePath/treePath.ts
@@ -42,16 +42,15 @@ export function resolveDeleteTreePath(
 	isDirectory: boolean | undefined,
 ): { treePath: string; isDirectory: boolean } {
 	const directoryPath = `${rel}/`;
-	const treePath = known.has(rel)
-		? rel
-		: known.has(directoryPath)
-			? directoryPath
-			: isDirectory
-				? directoryPath
-				: rel;
+	const resolvedIsDirectory = known.has(directoryPath)
+		? true
+		: known.has(rel)
+			? false
+			: isDirectory === true;
+	const treePath = resolvedIsDirectory ? directoryPath : rel;
 	return {
 		treePath,
-		isDirectory: isDirectory ?? treePath.endsWith("/"),
+		isDirectory: resolvedIsDirectory,
 	};
 }
 

--- a/packages/host-service/src/trpc/router/filesystem/filesystem.ts
+++ b/packages/host-service/src/trpc/router/filesystem/filesystem.ts
@@ -384,6 +384,66 @@ export const filesystemRouter = router({
 			);
 		}),
 
+	/**
+	 * Create a new entry whose name the user has not chosen yet, so the Files tab
+	 * can open its inline rename on something that actually exists.
+	 *
+	 * The de-duplication (`Untitled`, `Untitled-2`, …) happens host-side on
+	 * purpose: the client's tree listing can be stale, and each attempt here is
+	 * exclusive, so an entry that already exists is never adopted. The attempt
+	 * cap is a module constant rather than an input — it bounds how many syscalls
+	 * one request can make.
+	 */
+	createUniqueEntry: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				parentAbsolutePath: z.string(),
+				baseName: z.string(),
+				kind: z.enum(["directory", "file"]),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { workspaceId, ...serviceInput } = input;
+			const service = getFilesystemService(ctx, workspaceId);
+			return await withFsErrorTranslation(() =>
+				service.createUniqueEntry(serviceInput),
+			);
+		}),
+
+	/** Cancel path for a provisional folder — never recursive. */
+	removeEmptyDirectory: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				absolutePath: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { workspaceId, ...serviceInput } = input;
+			const service = getFilesystemService(ctx, workspaceId);
+			return await withFsErrorTranslation(() =>
+				service.removeEmptyDirectory(serviceInput),
+			);
+		}),
+
+	/** Cancel path for a provisional file — no-ops if it changed after creation. */
+	removeFileIfUnchanged: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				absolutePath: z.string(),
+				revision: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const { workspaceId, ...serviceInput } = input;
+			const service = getFilesystemService(ctx, workspaceId);
+			return await withFsErrorTranslation(() =>
+				service.removeFileIfUnchanged(serviceInput),
+			);
+		}),
+
 	deletePath: protectedProcedure
 		.input(
 			z.object({

--- a/packages/host-service/test/integration/filesystem.integration.test.ts
+++ b/packages/host-service/test/integration/filesystem.integration.test.ts
@@ -103,4 +103,148 @@ describe("filesystem router integration", () => {
 		});
 		expect(result.matches).toEqual([]);
 	});
+
+	// The Files tab creates an entry on disk, then opens an inline rename on it,
+	// then either moves it (commit) or removes it (cancel). Exercised end to end
+	// here because a break anywhere along it either loses the user's folder or
+	// leaves the tree describing something that doesn't exist.
+	describe("provisional entry lifecycle", () => {
+		test("create → rename commits the entry under its new name", async () => {
+			const created =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "Untitled",
+					kind: "directory",
+				});
+			expect(created.ok).toBe(true);
+			if (!created.ok) return;
+			expect(created.name).toBe("Untitled");
+
+			await scenario.host.trpc.filesystem.movePath.mutate({
+				workspaceId: scenario.workspaceId,
+				sourceAbsolutePath: created.absolutePath,
+				destinationAbsolutePath: join(scenario.repo.repoPath, ".claude"),
+			});
+
+			const entries = await scenario.host.trpc.filesystem.listDirectory.query({
+				workspaceId: scenario.workspaceId,
+				absolutePath: scenario.repo.repoPath,
+			});
+			const names = entries.entries.map((e) => e.name);
+			expect(names).toContain(".claude");
+			expect(names).not.toContain("Untitled");
+		});
+
+		test("create → cancel removes the entry", async () => {
+			const created =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "Untitled",
+					kind: "directory",
+				});
+			expect(created.ok).toBe(true);
+			if (!created.ok) return;
+
+			const removed =
+				await scenario.host.trpc.filesystem.removeEmptyDirectory.mutate({
+					workspaceId: scenario.workspaceId,
+					absolutePath: created.absolutePath,
+				});
+			expect(removed).toEqual({ ok: true });
+
+			const entries = await scenario.host.trpc.filesystem.listDirectory.query({
+				workspaceId: scenario.workspaceId,
+				absolutePath: scenario.repo.repoPath,
+			});
+			expect(entries.entries.map((e) => e.name)).not.toContain("Untitled");
+		});
+
+		test("cancel keeps the folder once something is inside it", async () => {
+			const created =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "Untitled",
+					kind: "directory",
+				});
+			expect(created.ok).toBe(true);
+			if (!created.ok) return;
+
+			writeFileSync(join(created.absolutePath, "precious.txt"), "keep me");
+
+			const removed =
+				await scenario.host.trpc.filesystem.removeEmptyDirectory.mutate({
+					workspaceId: scenario.workspaceId,
+					absolutePath: created.absolutePath,
+				});
+			expect(removed).toEqual({ ok: false, reason: "not-empty" });
+			expect(
+				readFileSync(join(created.absolutePath, "precious.txt"), "utf8"),
+			).toBe("keep me");
+		});
+
+		test("never adopts a directory that already exists on disk", async () => {
+			const existing = join(scenario.repo.repoPath, "Untitled");
+			mkdirSync(existing);
+			writeFileSync(join(existing, "precious.txt"), "keep me");
+
+			const created =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "Untitled",
+					kind: "directory",
+				});
+			expect(created.ok).toBe(true);
+			if (!created.ok) return;
+			expect(created.name).toBe("Untitled-2");
+
+			// Cancelling the new one must not touch the pre-existing one.
+			await scenario.host.trpc.filesystem.removeEmptyDirectory.mutate({
+				workspaceId: scenario.workspaceId,
+				absolutePath: created.absolutePath,
+			});
+			expect(readFileSync(join(existing, "precious.txt"), "utf8")).toBe(
+				"keep me",
+			);
+		});
+
+		test("file create → cancel is guarded by the creation revision", async () => {
+			const created =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "untitled",
+					kind: "file",
+				});
+			expect(created.ok).toBe(true);
+			if (!created.ok || created.revision === undefined) return;
+
+			// Someone wrote to it after we created it — cancelling must not delete it.
+			writeFileSync(created.absolutePath, "typed by the user");
+			expect(
+				await scenario.host.trpc.filesystem.removeFileIfUnchanged.mutate({
+					workspaceId: scenario.workspaceId,
+					absolutePath: created.absolutePath,
+					revision: created.revision,
+				}),
+			).toEqual({ ok: false, reason: "modified" });
+			expect(readFileSync(created.absolutePath, "utf8")).toBe(
+				"typed by the user",
+			);
+		});
+
+		test("rejects a baseName that is not a single path leaf", async () => {
+			const result =
+				await scenario.host.trpc.filesystem.createUniqueEntry.mutate({
+					workspaceId: scenario.workspaceId,
+					parentAbsolutePath: scenario.repo.repoPath,
+					baseName: "../escaped",
+					kind: "directory",
+				});
+			expect(result).toEqual({ ok: false, reason: "invalid-name" });
+		});
+	});
 });

--- a/packages/host-service/test/integration/filesystem.integration.test.ts
+++ b/packages/host-service/test/integration/filesystem.integration.test.ts
@@ -220,6 +220,7 @@ describe("filesystem router integration", () => {
 					kind: "file",
 				});
 			expect(created.ok).toBe(true);
+			expect(created.ok && created.revision).toBeTruthy();
 			if (!created.ok || created.revision === undefined) return;
 
 			// Someone wrote to it after we created it — cancelling must not delete it.

--- a/packages/workspace-fs/src/fs.test.ts
+++ b/packages/workspace-fs/src/fs.test.ts
@@ -2,7 +2,15 @@ import { afterEach, describe, expect, it } from "bun:test";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createDirectory, readFile, writeFile } from "./fs";
+import {
+	createDirectory,
+	createUniqueEntry,
+	movePath,
+	readFile,
+	removeEmptyDirectory,
+	removeFileIfUnchanged,
+	writeFile,
+} from "./fs";
 
 const tempRoots: string[] = [];
 
@@ -328,5 +336,325 @@ describe("createDirectory", () => {
 		}
 
 		expect(didThrow).toEqual(true);
+	});
+});
+
+describe("createUniqueEntry", () => {
+	it("uses the base name when nothing collides", async () => {
+		const rootPath = await createTempRoot();
+
+		const result = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "Untitled",
+			kind: "directory",
+		});
+
+		expect(result.ok).toEqual(true);
+		if (!result.ok) return;
+		expect(result.name).toEqual("Untitled");
+		expect(result.absolutePath).toEqual(path.join(rootPath, "Untitled"));
+		expect((await fs.stat(result.absolutePath)).isDirectory()).toEqual(true);
+	});
+
+	// The Files tab used to pick names from a client-side cache. A directory that
+	// exists on disk but is absent from that cache must still not be adopted —
+	// the caller deletes what it creates when the user cancels.
+	it("never adopts an existing directory", async () => {
+		const rootPath = await createTempRoot();
+		const existing = path.join(rootPath, "Untitled");
+		await fs.mkdir(existing);
+		await fs.writeFile(path.join(existing, "keep.txt"), "precious");
+
+		const result = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "Untitled",
+			kind: "directory",
+		});
+
+		expect(result.ok).toEqual(true);
+		if (!result.ok) return;
+		expect(result.name).toEqual("Untitled-2");
+		expect(
+			(await fs.readFile(path.join(existing, "keep.txt"))).toString(),
+		).toEqual("precious");
+	});
+
+	it("never adopts an existing file", async () => {
+		const rootPath = await createTempRoot();
+		await fs.writeFile(path.join(rootPath, "untitled"), "precious");
+
+		const result = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "untitled",
+			kind: "file",
+		});
+
+		expect(result.ok).toEqual(true);
+		if (!result.ok) return;
+		expect(result.name).toEqual("untitled-2");
+		expect(
+			(await fs.readFile(path.join(rootPath, "untitled"))).toString(),
+		).toEqual("precious");
+		expect(result.revision).toBeTruthy();
+	});
+
+	it("keeps counting past the first collision", async () => {
+		const rootPath = await createTempRoot();
+		await fs.mkdir(path.join(rootPath, "Untitled"));
+		await fs.mkdir(path.join(rootPath, "Untitled-2"));
+
+		const result = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "Untitled",
+			kind: "directory",
+		});
+
+		expect(result.ok).toEqual(true);
+		if (!result.ok) return;
+		expect(result.name).toEqual("Untitled-3");
+	});
+
+	it("rejects names that are not a single path leaf", async () => {
+		const rootPath = await createTempRoot();
+		const rejected = ["", "   ", ".", "..", "a/b", "a\\b", "a\0b"];
+
+		for (const baseName of rejected) {
+			const result = await createUniqueEntry({
+				rootPath,
+				parentAbsolutePath: rootPath,
+				baseName,
+				kind: "directory",
+			});
+			expect(result).toEqual({ ok: false, reason: "invalid-name" });
+		}
+
+		// Nothing was created for any of them.
+		expect(await fs.readdir(rootPath)).toEqual([]);
+	});
+
+	it("reports exhausted once every candidate is taken", async () => {
+		const rootPath = await createTempRoot();
+		await fs.mkdir(path.join(rootPath, "Untitled"));
+		for (let index = 2; index <= 100; index++) {
+			await fs.mkdir(path.join(rootPath, `Untitled-${index}`));
+		}
+
+		const result = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "Untitled",
+			kind: "directory",
+		});
+
+		expect(result).toEqual({ ok: false, reason: "exhausted" });
+	});
+
+	it("rejects a parent outside the workspace root", async () => {
+		const rootPath = await createTempRoot();
+		const outsideRoot = await createTempRoot();
+		let didThrow = false;
+
+		try {
+			await createUniqueEntry({
+				rootPath,
+				parentAbsolutePath: outsideRoot,
+				baseName: "Untitled",
+				kind: "directory",
+			});
+		} catch {
+			didThrow = true;
+		}
+
+		expect(didThrow).toEqual(true);
+	});
+});
+
+describe("removeEmptyDirectory", () => {
+	it("removes an empty directory", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "Untitled");
+		await fs.mkdir(absolutePath);
+
+		expect(await removeEmptyDirectory({ rootPath, absolutePath })).toEqual({
+			ok: true,
+		});
+		expect(await fs.readdir(rootPath)).toEqual([]);
+	});
+
+	// The cancel path must be incapable of destroying data.
+	it("keeps a populated directory and leaves its contents intact", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "Untitled");
+		await fs.mkdir(absolutePath);
+		await fs.writeFile(path.join(absolutePath, "keep.txt"), "precious");
+
+		expect(await removeEmptyDirectory({ rootPath, absolutePath })).toEqual({
+			ok: false,
+			reason: "not-empty",
+		});
+		expect(
+			(await fs.readFile(path.join(absolutePath, "keep.txt"))).toString(),
+		).toEqual("precious");
+	});
+
+	it("treats an already-missing directory as removed", async () => {
+		const rootPath = await createTempRoot();
+
+		expect(
+			await removeEmptyDirectory({
+				rootPath,
+				absolutePath: path.join(rootPath, "gone"),
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("reports wrong-type for a file", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "notes.txt");
+		await fs.writeFile(absolutePath, "hello");
+
+		expect(await removeEmptyDirectory({ rootPath, absolutePath })).toEqual({
+			ok: false,
+			reason: "wrong-type",
+		});
+		expect((await fs.readFile(absolutePath)).toString()).toEqual("hello");
+	});
+
+	it("refuses the workspace root", async () => {
+		const rootPath = await createTempRoot();
+		let didThrow = false;
+
+		try {
+			await removeEmptyDirectory({ rootPath, absolutePath: rootPath });
+		} catch {
+			didThrow = true;
+		}
+
+		expect(didThrow).toEqual(true);
+		expect((await fs.stat(rootPath)).isDirectory()).toEqual(true);
+	});
+});
+
+describe("removeFileIfUnchanged", () => {
+	it("removes a file whose revision still matches", async () => {
+		const rootPath = await createTempRoot();
+		const created = await createUniqueEntry({
+			rootPath,
+			parentAbsolutePath: rootPath,
+			baseName: "untitled",
+			kind: "file",
+		});
+		expect(created.ok).toEqual(true);
+		if (!created.ok || created.revision === undefined) return;
+
+		expect(
+			await removeFileIfUnchanged({
+				rootPath,
+				absolutePath: created.absolutePath,
+				revision: created.revision,
+			}),
+		).toEqual({ ok: true });
+		expect(await fs.readdir(rootPath)).toEqual([]);
+	});
+
+	it("keeps a file that changed after creation", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "untitled");
+		await fs.writeFile(absolutePath, "written by someone else");
+
+		expect(
+			await removeFileIfUnchanged({
+				rootPath,
+				absolutePath,
+				revision: "0:0",
+			}),
+		).toEqual({ ok: false, reason: "modified" });
+		expect((await fs.readFile(absolutePath)).toString()).toEqual(
+			"written by someone else",
+		);
+	});
+
+	it("treats an already-missing file as removed", async () => {
+		const rootPath = await createTempRoot();
+
+		expect(
+			await removeFileIfUnchanged({
+				rootPath,
+				absolutePath: path.join(rootPath, "gone"),
+				revision: "0:0",
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("reports wrong-type for a directory", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "folder");
+		await fs.mkdir(absolutePath);
+
+		expect(
+			await removeFileIfUnchanged({
+				rootPath,
+				absolutePath,
+				revision: "0:0",
+			}),
+		).toEqual({ ok: false, reason: "wrong-type" });
+		expect((await fs.stat(absolutePath)).isDirectory()).toEqual(true);
+	});
+});
+
+describe("movePath", () => {
+	it("renames a directory onto a free name", async () => {
+		const rootPath = await createTempRoot();
+		const sourceAbsolutePath = path.join(rootPath, "Untitled");
+		const destinationAbsolutePath = path.join(rootPath, ".claude");
+		await fs.mkdir(sourceAbsolutePath);
+
+		await movePath({ rootPath, sourceAbsolutePath, destinationAbsolutePath });
+
+		expect((await fs.stat(destinationAbsolutePath)).isDirectory()).toEqual(
+			true,
+		);
+		expect(await fs.readdir(rootPath)).toEqual([".claude"]);
+	});
+
+	// The exact backend behaviour behind the reported bug: the Files tab asked to
+	// rename a placeholder directory that had never been created.
+	it("throws ENOENT when the source does not exist", async () => {
+		const rootPath = await createTempRoot();
+		let code: string | undefined;
+
+		try {
+			await movePath({
+				rootPath,
+				sourceAbsolutePath: path.join(rootPath, "Untitled"),
+				destinationAbsolutePath: path.join(rootPath, ".claude"),
+			});
+		} catch (error) {
+			code = (error as NodeJS.ErrnoException).code;
+		}
+
+		expect(code).toEqual("ENOENT");
+	});
+
+	it("rejects a destination that already exists", async () => {
+		const rootPath = await createTempRoot();
+		const sourceAbsolutePath = path.join(rootPath, "Untitled");
+		const destinationAbsolutePath = path.join(rootPath, ".claude");
+		await fs.mkdir(sourceAbsolutePath);
+		await fs.mkdir(destinationAbsolutePath);
+		let didThrow = false;
+
+		try {
+			await movePath({ rootPath, sourceAbsolutePath, destinationAbsolutePath });
+		} catch {
+			didThrow = true;
+		}
+
+		expect(didThrow).toEqual(true);
+		expect((await fs.stat(sourceAbsolutePath)).isDirectory()).toEqual(true);
 	});
 });

--- a/packages/workspace-fs/src/fs.test.ts
+++ b/packages/workspace-fs/src/fs.test.ts
@@ -549,6 +549,7 @@ describe("removeFileIfUnchanged", () => {
 			kind: "file",
 		});
 		expect(created.ok).toEqual(true);
+		expect(created.ok && created.revision).toBeTruthy();
 		if (!created.ok || created.revision === undefined) return;
 
 		expect(

--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -664,6 +664,210 @@ export async function createDirectory({
 	return { absolutePath: targetPath, kind: "directory" };
 }
 
+/**
+ * How many `baseName`, `baseName-2`, `baseName-3`, ... candidates
+ * `createUniqueEntry` will try before giving up. Deliberately a module
+ * constant rather than a parameter: it bounds the syscalls one request can
+ * make, so it must not be caller-controlled.
+ */
+const CREATE_UNIQUE_MAX_ATTEMPTS = 100;
+
+export type FsCreateUniqueResult =
+	| { ok: true; absolutePath: string; name: string; revision?: string }
+	| { ok: false; reason: "exhausted" | "invalid-name" };
+
+/**
+ * A single path leaf — no separators, no traversal, no NUL. `ensureWithinRoot`
+ * and `assertRealpathWithinRoot` are a backstop, not the primary guard here: a
+ * `baseName` of `a/b` stays inside the root, so it would silently create a
+ * nested path instead of being rejected.
+ */
+function isValidLeafName(name: string): boolean {
+	if (name.trim().length === 0) return false;
+	if (name === "." || name === "..") return false;
+	return !(name.includes("/") || name.includes("\\") || name.includes("\0"));
+}
+
+function isEnotempty(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) return false;
+	// POSIX reports ENOTEMPTY; some platforms report EEXIST for the same case.
+	return error.code === "ENOTEMPTY" || error.code === "EEXIST";
+}
+
+/**
+ * Atomically create a new, empty entry under `parentAbsolutePath`, starting at
+ * `baseName` and falling back to `baseName-2`, `baseName-3`, ... until one
+ * wins.
+ *
+ * Every attempt is exclusive — `mkdir` without `recursive`, `writeFile` with
+ * the `wx` flag — so a stale client-side listing or a concurrent creator can
+ * never cause an existing entry to be adopted. Callers depend on that:
+ * the Files tab removes the entry it created when the user cancels, which
+ * would be destructive if creation could silently adopt someone else's.
+ *
+ * This is why `createDirectory` is not reused — it treats an existing
+ * directory as success.
+ */
+export async function createUniqueEntry({
+	rootPath,
+	parentAbsolutePath,
+	baseName,
+	kind,
+}: {
+	rootPath: string;
+	parentAbsolutePath: string;
+	baseName: string;
+	kind: "directory" | "file";
+}): Promise<FsCreateUniqueResult> {
+	if (!isValidLeafName(baseName)) {
+		return { ok: false, reason: "invalid-name" };
+	}
+
+	const parentPath = ensureWithinRoot({
+		rootPath,
+		absolutePath: parentAbsolutePath,
+	});
+	await assertRealpathWithinRoot(rootPath, parentPath);
+
+	for (let attempt = 0; attempt < CREATE_UNIQUE_MAX_ATTEMPTS; attempt++) {
+		const name = attempt === 0 ? baseName : `${baseName}-${attempt + 1}`;
+		const targetPath = ensureWithinRoot({
+			rootPath,
+			absolutePath: path.join(parentPath, name),
+		});
+
+		try {
+			if (kind === "directory") {
+				await fs.mkdir(targetPath);
+				return { ok: true, absolutePath: targetPath, name };
+			}
+
+			await fs.writeFile(targetPath, Buffer.alloc(0), { flag: "wx" });
+			const stats = await fs.stat(targetPath);
+			return {
+				ok: true,
+				absolutePath: targetPath,
+				name,
+				revision: toRevision(stats),
+			};
+		} catch (error) {
+			if (isEexist(error)) continue;
+			throw error;
+		}
+	}
+
+	return { ok: false, reason: "exhausted" };
+}
+
+export type FsRemoveEmptyDirectoryResult =
+	| { ok: true }
+	| { ok: false; reason: "not-empty" | "wrong-type" };
+
+/**
+ * Remove a directory only if it is empty, via `rmdir` — never `rm -r`.
+ *
+ * This is the cancel path for a provisionally-created folder, so it must be
+ * incapable of destroying data: if anything landed in the directory between
+ * creation and cancellation, the removal fails and the caller keeps the
+ * directory. `lstat` (not `stat`) also means a symlink is reported as
+ * `wrong-type` rather than followed.
+ */
+export async function removeEmptyDirectory({
+	rootPath,
+	absolutePath,
+}: {
+	rootPath: string;
+	absolutePath: string;
+}): Promise<FsRemoveEmptyDirectoryResult> {
+	if (normalizeAbsolutePath(absolutePath) === normalizeAbsolutePath(rootPath)) {
+		throw new WorkspaceFsPathError(
+			"Cannot target workspace root",
+			"INVALID_TARGET",
+		);
+	}
+
+	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
+
+	let stats: Stats;
+	try {
+		stats = await fs.lstat(targetPath);
+	} catch (error) {
+		if (isEnoent(error)) return { ok: true };
+		throw error;
+	}
+
+	if (!stats.isDirectory()) return { ok: false, reason: "wrong-type" };
+
+	await assertRealpathWithinRoot(rootPath, targetPath);
+
+	try {
+		await fs.rmdir(targetPath);
+		return { ok: true };
+	} catch (error) {
+		if (isEnoent(error)) return { ok: true };
+		if (isEnotempty(error)) return { ok: false, reason: "not-empty" };
+		throw error;
+	}
+}
+
+export type FsRemoveFileIfUnchangedResult =
+	| { ok: true }
+	| { ok: false; reason: "modified" | "wrong-type" };
+
+/**
+ * Remove a file only if it still matches `revision` (as returned by
+ * `writeFile` / `createUniqueEntry`).
+ *
+ * Best-effort, and deliberately so: the stat-then-unlink pair is serialized
+ * against other `withPathLock` holders, but nothing stops an unrelated process
+ * writing between the two syscalls. It is the cancel path for a provisional
+ * empty file we created moments earlier, so the residual window is tiny and
+ * the worst case is removing a file that an external writer touched in that
+ * instant. Folder cancellation has no equivalent gap — `rmdir` is atomic.
+ */
+export async function removeFileIfUnchanged({
+	rootPath,
+	absolutePath,
+	revision,
+}: {
+	rootPath: string;
+	absolutePath: string;
+	revision: string;
+}): Promise<FsRemoveFileIfUnchangedResult> {
+	if (normalizeAbsolutePath(absolutePath) === normalizeAbsolutePath(rootPath)) {
+		throw new WorkspaceFsPathError(
+			"Cannot target workspace root",
+			"INVALID_TARGET",
+		);
+	}
+
+	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
+
+	return await withPathLock(targetPath, async () => {
+		let stats: Stats;
+		try {
+			stats = await fs.lstat(targetPath);
+		} catch (error) {
+			if (isEnoent(error)) return { ok: true };
+			throw error;
+		}
+
+		if (!stats.isFile()) return { ok: false, reason: "wrong-type" };
+		if (toRevision(stats) !== revision)
+			return { ok: false, reason: "modified" };
+
+		await assertRealpathWithinRoot(rootPath, targetPath);
+
+		try {
+			await fs.rm(targetPath);
+			return { ok: true };
+		} catch (error) {
+			if (isEnoent(error)) return { ok: true };
+			throw error;
+		}
+	});
+}
+
 export async function deletePath({
 	rootPath,
 	absolutePath,

--- a/packages/workspace-fs/src/host/service.ts
+++ b/packages/workspace-fs/src/host/service.ts
@@ -1,12 +1,20 @@
 import type { FsService } from "../core/service";
+import type {
+	FsCreateUniqueResult,
+	FsRemoveEmptyDirectoryResult,
+	FsRemoveFileIfUnchangedResult,
+} from "../fs";
 import {
 	copyPath,
 	createDirectory,
+	createUniqueEntry,
 	deletePath,
 	getMetadata,
 	listDirectory,
 	movePath,
 	readFile,
+	removeEmptyDirectory,
+	removeFileIfUnchanged,
 	writeFile,
 } from "../fs";
 import { normalizeAbsolutePath } from "../paths";
@@ -17,6 +25,29 @@ import type { FsWatcherManager, WatchPathOptions } from "../watch";
 
 export interface FsHostService extends FsService {
 	close(): Promise<void>;
+
+	/**
+	 * Host-only provisional-entry lifecycle, used by editors that create an entry
+	 * on disk before letting the user name it inline.
+	 *
+	 * Deliberately not on `FsService`: that interface is mirrored by
+	 * `createFsClient` through `FsRequestMap`, and nothing consumes these over
+	 * that transport. Widening it would add remote surface for no caller.
+	 */
+	createUniqueEntry(input: {
+		parentAbsolutePath: string;
+		baseName: string;
+		kind: "directory" | "file";
+	}): Promise<FsCreateUniqueResult>;
+
+	removeEmptyDirectory(input: {
+		absolutePath: string;
+	}): Promise<FsRemoveEmptyDirectoryResult>;
+
+	removeFileIfUnchanged(input: {
+		absolutePath: string;
+		revision: string;
+	}): Promise<FsRemoveFileIfUnchangedResult>;
 }
 
 export interface FsHostServiceOptions {
@@ -177,6 +208,30 @@ export function createFsHostService(
 				rootPath,
 				absolutePath: input.absolutePath,
 				recursive: input.recursive,
+			});
+		},
+
+		async createUniqueEntry(input) {
+			return await createUniqueEntry({
+				rootPath,
+				parentAbsolutePath: input.parentAbsolutePath,
+				baseName: input.baseName,
+				kind: input.kind,
+			});
+		},
+
+		async removeEmptyDirectory(input) {
+			return await removeEmptyDirectory({
+				rootPath,
+				absolutePath: input.absolutePath,
+			});
+		},
+
+		async removeFileIfUnchanged(input) {
+			return await removeFileIfUnchanged({
+				rootPath,
+				absolutePath: input.absolutePath,
+				revision: input.revision,
 			});
 		},
 


### PR DESCRIPTION
## What & why

I could not create a folder from the Files tab. Upon checking into it turned up five related problems. Here they are in the order I hit them, with steps to reproduce.

### 1. New folder always failed

1. Open a project, Files tab
2. Click New Folder
3. Type any name, press Enter

Result: `Failed to rename / ENOENT: no such file or directory, rename '<root>/Untitled' -> '<root>/<name>'`. The row snaps back to `Untitled` and looks like a real folder, but nothing is created on disk. Renaming that row throws the same error.

<img width="828" height="462" alt="image" src="https://github.com/user-attachments/assets/a9f82093-888c-4a07-b933-7071343085a4" />

### 2. Accepting the default name created nothing

New Folder, then press Enter without typing. Result: an `Untitled` row sits in the tree with nothing behind it.

### 3. A name that already existed left a dead row

New Folder, type the name of a folder that already exists there, Enter. Result: error toast, and the `Untitled` row stays in the tree pointing at nothing. The next New Folder then offers `Untitled-2`.

### 4. New folders ignored which folder I selected

Select folder A, New Folder. Select folder B, New Folder. Result: both land in the same directory. Selecting a folder made no difference, and there was no way to target the workspace root.

### 5. Creating after a rename failed

Open a file inside folder `X`, rename `X` to `Y`, click New Folder. Result: `ENOENT: no such file or directory, mkdir '<root>/X/Untitled'`.

### What I found

Two causes behind all five.

New Folder built an in-memory placeholder row keyed `Untitled/` (Pierre marks directories with a trailing slash) and only wrote to disk once you committed the name. But Pierre's `onRename` reports paths without the trailing slash even when its own `isFolder` flag is true, so the lookup missed, the commit fell through to the rename branch, and we asked the host to rename a directory that had never been created. Files were unaffected because their keys have no trailing slash. Pierre also emits no callback at all when a name is committed unchanged, and none that says which row an error belongs to, so 2 and 3 were not detectable from that flow.

For 4 and 5, the target directory came from the editor's open file rather than the tree selection. That is why it was fixed no matter what I highlighted, and why it went stale as soon as I renamed an ancestor folder.

## What I changed

Creation now writes to disk first, then opens the inline rename on a real entry. Every commit is an ordinary rename, so accepting the default name, cancelling, and name collisions all end up matching disk.

That means cancelling has to remove what we created, which needs primitives we did not have. `createDirectory` treats an existing directory as success, and `deletePath` is `rm -rf`, so cancel could have deleted a folder we did not create or one that had gained contents in the meantime. I added three to `workspace-fs`:

- `createUniqueEntry`: allocates `Untitled`, `Untitled-2`, and so on, where each attempt is an exclusive create. Naming moved to the host, so a stale client listing can no longer pick a name that already exists on disk.
- `removeEmptyDirectory`: `rmdir`, never recursive. Refuses a folder that is not empty.
- `removeFileIfUnchanged`: only unlinks if the file still matches the revision from when we created it.

New entries now go where I point them: selected folder, selected file's parent, or the workspace root. Clicking empty space below the rows clears the selection so root is one click away. Every candidate is checked against the tree, so a row pointing at a renamed or deleted directory falls back to root instead of erroring.

I put the provisional entry lifecycle in a pure reducer (`provisionalEntry.ts`) so it can be tested without React.

Two things to flag for review:

- This includes the selection targeting change, which is technically a second fix. It shares the same function and the same root cause as 5, and without it I could not test root level creation at all. Happy to split it if you would rather.
- On a name collision the inline editor now closes instead of reopening. Pierre's error callback gives a message and no path, so reopening had to guess which row it belonged to, and after an unchanged commit that guess could land on a folder I had kept and delete it on Esc. The folder keeps its name on disk, so F2 renames it.

## How I tested it

I reproduced every case above in the dev app before the fix, then reran the same steps after. Checked on disk in Finder each time, not just in the tree.

Creation

- New Folder, type a name, Enter: folder appears and exists in Finder
- New Folder, Enter on the default: `Untitled` actually exists
- New Folder, Esc: gone from disk
- Same three for New File, and it opens in the editor

Targeting

- Select folder A, New Folder: lands in A. Select folder B: lands in B
- Click empty space, New Folder: lands at root
- Select a folder, click Refresh, New Folder: still lands in that folder
- Open a file inside a folder, rename the folder, New Folder: no ENOENT

Safety

- Drop a file into a new folder before pressing Esc: folder and file survive, toast says it was kept
- New Folder, Enter on default, F2 that folder, type an existing name, Esc: folder still exists
- New File, Esc: file gone, no leftover pinned tab
- Create an `Untitled` folder in Finder without refreshing the tree, then New Folder: get `Untitled-2`, existing folder untouched

Automated

- 21 new tests in `packages/workspace-fs/src/fs.test.ts` for the three primitives, including "never adopts an existing directory" and "keeps a populated directory". Also added `movePath` coverage, which had none, pinning the ENOENT from 1
- 6 new integration tests through the host tRPC router for create then commit, and create then cancel
- 23 renderer tests for path canonicalisation, creation targeting, and the provisional reducer, including the case where cancel must not delete a committed folder
- Full suite: 2690 desktop, 1095 host-service, 77 workspace-fs, 0 failures. `bun run lint` and `bun run typecheck` clean

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create files and folders on disk before inline rename in the Files tab, fixing ENOENT on commit, dead placeholders, wrong-target creation, and empty-after-rename folders. Previously we renamed in-memory placeholders; now the host creates a unique entry, we move it on commit, and cancel removes only what we created.

- Adds `workspace-fs` and `host-service` primitives: `createUniqueEntry` (exclusive `Untitled`/`-2` allocation), `removeEmptyDirectory` (non‑recursive), `removeFileIfUnchanged` (revision‑guarded).
- Canonicalizes `@pierre/trees` event paths: `canonicalizeTreePath` for renames and `resolveDeleteTreePath` so delete events map to the correct file/folder key.
- Targets creation from the tree selection (selected folder, selected file’s parent, or root). Clicking the empty tree background clears selection; header and controls don’t.
- Introduces bridge `addPath`/`removePath` and rekeys/purges directory bookkeeping so known paths, loaded dirs, and lazy‑load candidates move together; prevents newly renamed folders rendering empty.
- Invalidates stale tree listings and guards `listDirectory` with a workspace version and tree revision; retries only when the directory still exists and remains expanded.
- UX: does not reopen inline rename on errors; shows a toast and keeps the current name. New files open once (no accidental pinning).
- Tests cover fs primitives and guarded cancel paths, host endpoints, path canonicalization (including delete events), creation targeting, provisional cleanup, tree bookkeeping, and stale‑listing guards.

<sup>Written for commit 92ea68f09e81676a7bcaae5db8c09f3b1284b501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creating files and folders now immediately creates uniquely named entries on disk before inline renaming.
  * Renaming supports directory paths more reliably, with safe rollback after errors.
  * Rename validation errors are shown without reopening rename mode.
  * File-tree selection clears only when clicking empty background areas.

* **Bug Fixes**
  * Improved handling of name collisions, stale selections, workspace changes, and filesystem updates.
  * Added safeguards against deleting modified files or protected directories.
  * Improved tree consistency after moves and deletions.
  * Cancelled creations safely preserve existing files and non-empty folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->