### PR TITLE
feat(desktop): surface a host unreachable screen for v2 workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
@@ -1,1 +1,0 @@
-export { WorkspaceHostOfflineState } from "./WorkspaceHostOfflineState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/WorkspaceHostUnreachableState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/WorkspaceHostUnreachableState.tsx
@@ -1,16 +1,29 @@
 import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Monitor, Settings, WifiOff } from "lucide-react";
+import { Monitor, RefreshCw, Settings, WifiOff } from "lucide-react";
 
-interface WorkspaceHostOfflineStateProps {
+interface WorkspaceHostUnreachableStateProps {
 	hostId: string;
 	hostName: string;
+	/** Why this connection in particular is down. */
+	detail: string;
+	/** The socket is still dialling on its own backoff. */
+	isReconnecting: boolean;
+	onRetry: () => void;
+	retryLabel?: string;
+	retryBusyLabel?: string;
 }
 
-export function WorkspaceHostOfflineState({
+export function WorkspaceHostUnreachableState({
 	hostId,
 	hostName,
-}: WorkspaceHostOfflineStateProps) {
+	detail,
+	isReconnecting,
+	onRetry,
+	retryLabel = "Retry",
+	retryBusyLabel = "Retrying…",
+}: WorkspaceHostUnreachableStateProps) {
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
 			<div className="flex w-full max-w-sm flex-col items-start gap-6">
@@ -32,12 +45,15 @@ export function WorkspaceHostOfflineState({
 
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
-						Host offline
+						Host unreachable
 					</h1>
 					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
-						This workspace lives on a paired device that is not reachable right
-						now. Terminals and file actions are unavailable until that device
-						reconnects.
+						This workspace lives on a device Superset can't reach right now.
+						Terminals, files, and agents stay put — they come back as soon as
+						the connection does.
+					</p>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground/80">
+						{detail}
 					</p>
 				</div>
 
@@ -45,13 +61,21 @@ export function WorkspaceHostOfflineState({
 					<div className="flex items-center gap-2.5 px-3 py-2">
 						<span
 							aria-hidden="true"
-							className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+							className={cn(
+								"size-1.5 shrink-0 rounded-full",
+								isReconnecting
+									? "animate-pulse bg-yellow-500"
+									: "bg-muted-foreground/40",
+							)}
 						/>
 						<span
 							className="select-text cursor-text min-w-0 truncate text-[13px] font-medium text-foreground"
 							title={hostName}
 						>
 							{hostName}
+						</span>
+						<span className="ml-auto shrink-0 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+							{isReconnecting ? "Reconnecting" : "Disconnected"}
 						</span>
 					</div>
 					<div className="border-t border-border/60 px-3 py-2">
@@ -73,10 +97,23 @@ export function WorkspaceHostOfflineState({
 
 				<div className="flex flex-wrap items-center gap-2">
 					<Button
+						size="sm"
+						variant="secondary"
+						className="h-7 gap-1.5 px-2.5 text-[13px] font-medium"
+						onClick={onRetry}
+					>
+						<RefreshCw
+							className={cn("size-3.5", isReconnecting && "animate-spin")}
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						{isReconnecting ? retryBusyLabel : retryLabel}
+					</Button>
+					<Button
 						asChild
 						size="sm"
 						variant="ghost"
-						className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
 					>
 						<Link to="/settings/hosts/$hostId" params={{ hostId }}>
 							<Settings
@@ -85,21 +122,6 @@ export function WorkspaceHostOfflineState({
 								aria-hidden="true"
 							/>
 							Host settings
-						</Link>
-					</Button>
-					<Button
-						asChild
-						size="sm"
-						variant="ghost"
-						className="h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
-					>
-						<Link to="/v2-workspaces">
-							Browse workspaces
-							<ArrowRight
-								className="size-3.5"
-								strokeWidth={2}
-								aria-hidden="true"
-							/>
 						</Link>
 					</Button>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceHostUnreachableState } from "./WorkspaceHostUnreachableState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/index.ts
@@ -1,0 +1,4 @@
+export {
+	type HostReachability,
+	useHostReachability,
+} from "./useHostReachability";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
@@ -1,0 +1,103 @@
+import {
+	getEventBus,
+	type HostConnectionStatus,
+} from "@superset/workspace-client";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
+import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
+
+/**
+ * How long the host has to stay unreachable before the workspace hands over to
+ * the unreachable screen. The socket reconnects on its own backoff, so a relay
+ * redeploy, a laptop lid, or a half-open TCP flap resolves well inside this
+ * window — taking the screen over for those would be the false-positive that
+ * got the earlier cloud-presence gate reverted twice (#4430, #4727).
+ */
+const UNREACHABLE_GRACE_MS = 10_000;
+
+/**
+ * While the screen is up, dial on this cadence instead of riding the socket's
+ * own backoff. That backoff grows to 30s, so a host that came back could sit
+ * behind "Reconnecting…" for half a minute — measured at 20.7s — which reads
+ * as broken next to copy promising the workspace returns with the connection.
+ * Only runs while the takeover is visible, so it can't hammer a healthy host.
+ */
+const REDIAL_INTERVAL_MS = 5_000;
+
+export interface HostReachability {
+	/** Sustained loss of the host connection — safe to take the screen over. */
+	isUnreachable: boolean;
+	/** A dial is in flight right now (auto-backoff or a manual retry). */
+	isReconnecting: boolean;
+	/** What the relay preflight says is wrong. Only read while unreachable. */
+	detail: string;
+	/** Dial now instead of waiting out the backoff. */
+	retry: () => void;
+}
+
+function describeFailure(
+	status: HostConnectionStatus,
+	isRelayHost: boolean,
+): string {
+	if (!isRelayHost) {
+		return "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart.";
+	}
+	const probe = status.probe;
+	// No probe result at all: the relay itself never answered.
+	if (!probe) {
+		return "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine.";
+	}
+	if (probe.status === 503) {
+		return "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is.";
+	}
+	if (probe.status === 401 || probe.status === 403) {
+		return "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security.";
+	}
+	if (probe.status === 502 || probe.status === 504) {
+		return "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works.";
+	}
+	if (probe.status === 200) {
+		const where = probe.region ? ` (region ${probe.region})` : "";
+		return `That device is online${where} but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device.`;
+	}
+	return `The connection failed (relay status ${probe.status}). Retry, and if it persists restart Superset on that device.`;
+}
+
+/**
+ * Live reachability of the host serving this workspace, read off the shared
+ * event-bus socket — the same connection the workspace's own data flows over,
+ * so it reflects what the UI can actually do rather than the cloud's `isOnline`
+ * flag (which drifts through relay redeploys and API blips).
+ */
+export function useHostReachability(hostUrl: string): HostReachability {
+	const bus = useMemo(
+		() => getEventBus(hostUrl, () => getHostServiceWsToken(hostUrl)),
+		[hostUrl],
+	);
+	// Hold the connection open for as long as this screen is mounted: the
+	// panes that normally keep the bus alive are gone once we take over, and a
+	// closed socket would never observe the host coming back.
+	useEffect(() => bus.retain(), [bus]);
+
+	const status = useSyncExternalStore(
+		useCallback((onChange) => bus.subscribeConnectionStatus(onChange), [bus]),
+		() => bus.getConnectionStatus(),
+	);
+
+	const isDown = status.state !== "open";
+	const isUnreachable = useDelayElapsed(isDown, UNREACHABLE_GRACE_MS);
+	const isRelayHost = /\/hosts\/[^/]+/.test(hostUrl);
+
+	useEffect(() => {
+		if (!isUnreachable) return;
+		const timer = window.setInterval(() => bus.reconnect(), REDIAL_INTERVAL_MS);
+		return () => window.clearInterval(timer);
+	}, [isUnreachable, bus]);
+
+	return {
+		isUnreachable,
+		isReconnecting: isDown && status.state !== "closed",
+		detail: describeFailure(status, isRelayHost),
+		retry: () => bus.reconnect(),
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
@@ -61,9 +61,13 @@ export function WorkspaceProvider({
 
 	return (
 		<WorkspaceContext.Provider value={{ workspace, hostUrl }}>
+			{/* Keyed on the workspace alone: the host service can come back on a
+			    different port, and keying on the URL too would remount every pane
+			    for what is only a transport swap. WorkspaceClientProvider already
+			    rebuilds its clients when hostUrl changes. */}
 			<WorkspaceTrpcProvider
 				cacheKey={workspace.id}
-				key={`${workspace.id}:${hostUrl}`}
+				key={workspace.id}
 				hostUrl={hostUrl}
 				headers={() => getHostServiceHeaders(hostUrl)}
 				wsToken={() => getHostServiceWsToken(hostUrl)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
@@ -1,5 +1,11 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { createContext, type ReactNode, useContext } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useRef,
+} from "react";
 import type { HostShapedWorkspace } from "renderer/hooks/host-workspaces/useHostWorkspaces";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import {
@@ -8,6 +14,8 @@ import {
 } from "renderer/lib/host-service-auth";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { WorkspaceTrpcProvider } from "../WorkspaceTrpcProvider";
+import { WorkspaceHostGate } from "./components/WorkspaceHostGate";
+import { WorkspaceLocalHostPendingState } from "./components/WorkspaceLocalHostPendingState";
 
 interface WorkspaceContextValue {
 	workspace: HostShapedWorkspace;
@@ -25,16 +33,30 @@ export function WorkspaceProvider({
 }) {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const relayUrl = useRelayUrl();
+
+	// A host-service restart takes the coordinator's port away for ~5s and
+	// usually brings it back on the same one. Dropping to null there would
+	// unmount the whole workspace — panes, scrollback, unsaved files — and
+	// leave a blank frame until it returned. Keep serving the last URL we had
+	// and let WorkspaceHostGate handle the dead socket in place.
+	const lastLocalHostUrlRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (activeHostUrl) lastLocalHostUrlRef.current = activeHostUrl;
+	}, [activeHostUrl]);
+	const localHostUrl = activeHostUrl ?? lastLocalHostUrlRef.current;
+
 	const hostUrl =
 		workspace.hostId === machineId
-			? activeHostUrl
+			? localHostUrl
 			: `${relayUrl}/hosts/${buildHostRoutingKey(
 					workspace.organizationId,
 					workspace.hostId,
 				)}`;
 
+	// Only before the local host service has ever reported a port — there is
+	// nothing to point a client at, so this can't go through WorkspaceHostGate.
 	if (!hostUrl) {
-		return <div className="flex h-full w-full" />;
+		return <WorkspaceLocalHostPendingState hostId={workspace.hostId} />;
 	}
 
 	return (
@@ -46,7 +68,7 @@ export function WorkspaceProvider({
 				headers={() => getHostServiceHeaders(hostUrl)}
 				wsToken={() => getHostServiceWsToken(hostUrl)}
 			>
-				{children}
+				<WorkspaceHostGate workspace={workspace}>{children}</WorkspaceHostGate>
 			</WorkspaceTrpcProvider>
 		</WorkspaceContext.Provider>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -1,0 +1,64 @@
+import { useWorkspaceHostUrl } from "@superset/workspace-client";
+import type { ReactNode } from "react";
+import type { HostShapedWorkspace } from "renderer/hooks/host-workspaces/useHostWorkspaces";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { StateScreenShell } from "../../../../components/StateScreenShell";
+import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
+import { useHostReachability } from "../../../../hooks/useHostReachability";
+
+const HOST_LIST_STALE_MS = 30_000;
+
+/**
+ * Covers the workspace with the unreachable screen while its host is down.
+ * Overlays rather than replaces: panes keep their live state (terminal
+ * scrollback, unsaved editor documents, in-flight agent sessions) so a dropped
+ * connection costs nothing once the host is back.
+ */
+export function WorkspaceHostGate({
+	workspace,
+	children,
+}: {
+	workspace: HostShapedWorkspace;
+	children: ReactNode;
+}) {
+	const hostUrl = useWorkspaceHostUrl();
+	const { isUnreachable, isReconnecting, detail, retry } =
+		useHostReachability(hostUrl);
+	const { machineId } = useLocalHostService();
+	const { data: hostRows = [] } = cloudTrpc.v2Host.list.useQuery(undefined, {
+		staleTime: HOST_LIST_STALE_MS,
+	});
+
+	const hostRow =
+		hostRows.find(
+			(host) =>
+				host.organizationId === workspace.organizationId &&
+				host.machineId === workspace.hostId,
+		) ?? null;
+	const hostName =
+		hostRow?.name ??
+		(workspace.hostId === machineId ? "This device" : "Unknown host");
+
+	// The wrapper renders unconditionally — dropping it when the host is
+	// reachable would move `children` in the tree and remount the whole
+	// workspace on every reconnect.
+	return (
+		<div className="relative flex min-h-0 min-w-0 flex-1">
+			{children}
+			{isUnreachable ? (
+				<div className="absolute inset-0 z-50 bg-background">
+					<StateScreenShell>
+						<WorkspaceHostUnreachableState
+							hostId={workspace.hostId}
+							hostName={hostName}
+							detail={detail}
+							isReconnecting={isReconnecting}
+							onRetry={retry}
+						/>
+					</StateScreenShell>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -45,7 +45,11 @@ export function WorkspaceHostGate({
 	// workspace on every reconnect.
 	return (
 		<div className="relative flex min-h-0 min-w-0 flex-1">
-			{children}
+			{/* Covered panes stay mounted, so without `inert` they keep taking Tab
+			    stops and screen-reader focus behind the takeover. */}
+			<div className="flex min-h-0 min-w-0 flex-1" inert={isUnreachable}>
+				{children}
+			</div>
 			{isUnreachable ? (
 				<div className="absolute inset-0 z-50 bg-background">
 					<StateScreenShell>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceHostGate } from "./WorkspaceHostGate";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
@@ -1,0 +1,76 @@
+import { toast } from "@superset/ui/sonner";
+import { useEffect } from "react";
+import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { StateScreenShell } from "../../../../components/StateScreenShell";
+import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
+
+/**
+ * The workspace lives on this device but the local host service has no port
+ * yet — it is starting, wedged, or stopped. The provider polls for it every 5s,
+ * so hold a blank frame briefly (normal at boot) before saying anything.
+ */
+const LOCAL_HOST_GRACE_MS = 10_000;
+
+const DETAIL_BY_STATUS = {
+	starting:
+		"The local host service is still starting up. It should be ready in a few seconds.",
+	stopped:
+		"The local host service isn't running, so nothing on this device can serve the workspace. Restarting it reattaches your terminals and files — nothing on disk is lost.",
+	// The process is up but its port hasn't reached us yet: getProcessStatus
+	// polls every second, the connection every five. Never advise a restart
+	// here — the service is healthy and this clears itself.
+	running: "The local host service just came up. Reconnecting to it now.",
+	unknown:
+		"The local host service isn't responding. Restarting it usually clears this; if it keeps happening, restart Superset.",
+} as const;
+
+export function WorkspaceLocalHostPendingState({ hostId }: { hostId: string }) {
+	const { hostServiceStatus, activeOrganizationId } = useLocalHostService();
+	const showState = useDelayElapsed(true, LOCAL_HOST_GRACE_MS);
+	const utils = electronTrpc.useUtils();
+
+	// The process reports running before the 5s connection poll hands us its
+	// port. Ask for the port now rather than leaving this screen up over a
+	// host service that is already serving.
+	useEffect(() => {
+		if (hostServiceStatus !== "running") return;
+		void utils.hostServiceCoordinator.getConnection.invalidate();
+	}, [hostServiceStatus, utils]);
+
+	const restart = electronTrpc.hostServiceCoordinator.restart.useMutation({
+		onError: (error) => {
+			toast.error("Couldn't restart the host service", {
+				description: `${error.message} — try the Superset tray menu > Host Service > Restart.`,
+			});
+		},
+	});
+
+	if (!showState) return <div className="flex h-full w-full" />;
+
+	// Restarting mid-start races the pending spawn, exactly as the tray menu
+	// avoids — and "running" here means a healthy service whose port is still
+	// in flight. Both show progress instead of inviting a restart.
+	const isStarting =
+		hostServiceStatus === "starting" ||
+		hostServiceStatus === "running" ||
+		restart.isPending;
+
+	return (
+		<StateScreenShell>
+			<WorkspaceHostUnreachableState
+				hostId={hostId}
+				hostName="This device"
+				detail={DETAIL_BY_STATUS[hostServiceStatus]}
+				isReconnecting={isStarting}
+				retryLabel="Restart host service"
+				retryBusyLabel="Starting…"
+				onRetry={() => {
+					if (isStarting || !activeOrganizationId) return;
+					restart.mutate({ organizationId: activeOrganizationId });
+				}}
+			/>
+		</StateScreenShell>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
@@ -67,7 +67,16 @@ export function WorkspaceLocalHostPendingState({ hostId }: { hostId: string }) {
 				retryLabel="Restart host service"
 				retryBusyLabel="Starting…"
 				onRetry={() => {
-					if (isStarting || !activeOrganizationId) return;
+					if (isStarting) return;
+					// The button reads as enabled without an org, so swallowing the
+					// click here would look like the restart silently failed.
+					if (!activeOrganizationId) {
+						toast.error("No active organization", {
+							description:
+								"Switch organization or sign in again to restart the host service.",
+						});
+						return;
+					}
 					restart.mutate({ organizationId: activeOrganizationId });
 				}}
 			/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceLocalHostPendingState } from "./WorkspaceLocalHostPendingState";

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -6,6 +6,8 @@ export {
 	type EventBusHandle,
 	type GitChangedPayload,
 	getEventBus,
+	type HostConnectionState,
+	type HostConnectionStatus,
 	type PortChangedPayload,
 	type ProjectChangedPayload,
 	type ProjectSnapshotPayload,

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -5,6 +5,7 @@ import type {
 } from "@superset/host-service/events";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
+import type { RelayAffinityProbe } from "./primeRelayAffinity";
 import { createRelaySocket, type RelaySocket } from "./relaySocket";
 
 export type { AgentIdentity };
@@ -132,6 +133,26 @@ const RECONNECT_MAX_MS = 30_000;
 // outright so access granted later (host sharing) is picked up eventually.
 const ACCESS_DENIED_RETRY_MS = 5 * 60_000;
 
+export type HostConnectionState =
+	| "connecting"
+	| "open"
+	| "reconnecting"
+	| "closed";
+
+export interface HostConnectionStatus {
+	state: HostConnectionState;
+	/** Timestamp of the last transition into `state`. */
+	since: number;
+	/**
+	 * Last `_whoowns` preflight result: 503 host not connected to the relay,
+	 * 401/403 unauthorized, null for a direct (non-relay) host URL or when the
+	 * relay itself couldn't be reached. Names *why* the socket is down.
+	 */
+	probe: RelayAffinityProbe | null;
+}
+
+type ConnectionStatusListener = (status: HostConnectionStatus) => void;
+
 interface ConnectionState {
 	socket: RelaySocket;
 	refCount: number;
@@ -139,10 +160,30 @@ interface ConnectionState {
 	fsWatchedWorkspaces: Map<string, number>;
 	/** Refcounted per-file watches, keyed `${workspaceId}\0${absolutePath}`. */
 	fsWatchedFiles: Map<string, number>;
+	/** Replaced, never mutated, so `useSyncExternalStore` snapshots stay stable. */
+	status: HostConnectionStatus;
+	statusListeners: Set<ConnectionStatusListener>;
 }
 
 function fileWatchKey(workspaceId: string, absolutePath: string): string {
 	return `${workspaceId}\0${absolutePath}`;
+}
+
+function setConnectionStatus(
+	state: ConnectionState,
+	next: { state?: HostConnectionState; probe?: RelayAffinityProbe | null },
+): void {
+	const current = state.status;
+	const nextState = next.state ?? current.state;
+	const nextProbe = "probe" in next ? (next.probe ?? null) : current.probe;
+	if (nextState === current.state && nextProbe === current.probe) return;
+
+	state.status = {
+		state: nextState,
+		since: nextState === current.state ? current.since : Date.now(),
+		probe: nextProbe,
+	};
+	for (const listener of state.statusListeners) listener(state.status);
 }
 
 const connections = new Map<string, ConnectionState>();
@@ -274,6 +315,9 @@ function getOrCreateConnection(
 		minReconnectionDelay: RECONNECT_BASE_MS,
 		maxReconnectionDelay: RECONNECT_MAX_MS,
 		maxEnqueuedMessages: 0,
+		onProbe: (probe) => {
+			setConnectionStatus(state, { probe });
+		},
 	});
 
 	const state: ConnectionState = {
@@ -282,9 +326,21 @@ function getOrCreateConnection(
 		listeners: new Set(),
 		fsWatchedWorkspaces: new Map(),
 		fsWatchedFiles: new Map(),
+		status: { state: "connecting", since: Date.now(), probe: null },
+		statusListeners: new Set(),
 	};
 
+	socket.addEventListener("close", () => {
+		// partysocket keeps dialling on its own backoff unless the close was
+		// terminal (explicit close, retries exhausted), so "reconnecting" is the
+		// normal outcome here — the socket is still working toward a connection.
+		setConnectionStatus(state, {
+			state: socket.shouldReconnect ? "reconnecting" : "closed",
+		});
+	});
 	socket.addEventListener("open", () => {
+		setConnectionStatus(state, { state: "open" });
+
 		// Re-send all active fs:watch commands
 		for (const workspaceId of state.fsWatchedWorkspaces.keys()) {
 			sendCommand(state, { type: "fs:watch", workspaceId });
@@ -313,7 +369,13 @@ function maybeCleanupConnection(hostUrl: string): void {
 	const state = connections.get(key);
 	if (!state) return;
 
-	if (state.refCount > 0 || state.listeners.size > 0) return;
+	if (
+		state.refCount > 0 ||
+		state.listeners.size > 0 ||
+		state.statusListeners.size > 0
+	) {
+		return;
+	}
 
 	state.socket.close(1000, "No more subscribers");
 	connections.delete(key);
@@ -337,6 +399,11 @@ export interface EventBusHandle {
 	watchFsFile(workspaceId: string, absolutePath: string): void;
 	unwatchFsFile(workspaceId: string, absolutePath: string): void;
 	retain(): () => void;
+	/** Live reachability of this host, as observed on the real data path. */
+	getConnectionStatus(): HostConnectionStatus;
+	subscribeConnectionStatus(listener: ConnectionStatusListener): () => void;
+	/** Dial now instead of waiting out the backoff (retry buttons). */
+	reconnect(): void;
 }
 
 /**
@@ -424,6 +491,25 @@ export function getEventBus(
 				state.refCount = Math.max(0, state.refCount - 1);
 				maybeCleanupConnection(hostUrl);
 			};
+		},
+
+		getConnectionStatus(): HostConnectionStatus {
+			return state.status;
+		},
+
+		subscribeConnectionStatus(listener: ConnectionStatusListener): () => void {
+			state.statusListeners.add(listener);
+			return () => {
+				state.statusListeners.delete(listener);
+				maybeCleanupConnection(hostUrl);
+			};
+		},
+
+		reconnect(): void {
+			// The synthetic close partysocket dispatches lands first, so publish
+			// "connecting" after it — otherwise the retry reads as a fresh failure.
+			state.socket.reconnect(1000, "manual reconnect");
+			setConnectionStatus(state, { state: "connecting" });
 		},
 	};
 }


### PR DESCRIPTION
## Summary

A v2 workspace whose host stops answering used to degrade into failing panes or a blank frame — the durable-object/relay connection dropping was never surfaced. This adds a takeover screen wired to the real connection.

- **`packages/workspace-client`** — the shared per-host event-bus socket now tracks `connecting | open | reconnecting | closed` plus the last `_whoowns` probe, exposed as `getConnectionStatus` / `subscribeConnectionStatus` / `reconnect()`.
- **`useHostReachability`** — reads that status, retains the bus so it keeps dialling, and reports unreachable only after **10s of sustained loss**. Keyed off the real data path rather than the cloud `isOnline` flag, whose drift got this gate reverted twice before (#4430, #4727).
- **`WorkspaceHostUnreachableState`** — revives the orphaned `WorkspaceHostOfflineState` left on disk by #4727, with a live Reconnecting/Disconnected chip, a reason line derived from the relay probe (503 host not connected, 401/403 unauthorized, 502/504, routing, relay unreachable), and a Retry button.
- **`WorkspaceHostGate`** — overlays the screen instead of replacing the workspace, so panes stay mounted and terminal scrollback, unsaved editor documents and in-flight agent sessions survive a drop.
- **`WorkspaceLocalHostPendingState`** — replaces the blank `<div>` the provider rendered when the local host service has no port, with copy per `hostServiceStatus` and a button that restarts the service through the same coordinator call the tray menu uses.

Two fixes came out of driving the running app over CDP:

- **Blank frame on a host-service restart.** Losing the port set `activeHostUrl` to null, which unmounted the whole workspace and left ~5s of empty pane before the service returned. The provider now holds the last known local host URL through a port gap. Measured: 45s across a kill and respawn, zero blank frames.
- **Recovery lagged 20.7s** behind the host coming back, riding partysocket's backoff toward its 30s ceiling. The hook now re-dials every 5s while the screen is visible → 5.7s.

## Test plan

- [x] `bun run typecheck` (desktop) and `biome check` clean; `packages/workspace-client` tests pass (13/13)
- [x] Normal opens and route changes never flash the screen — 189/181/286/308 samples at 100ms, zero visible frames, no console errors
- [x] Sustained local outage: screen appears 14.1s in (≈10s after the socket closed), correct copy, one visibility transition, no flicker
- [x] Recovery: clears 5.7s after the host is listenable again
- [x] Host-service crash: workspace stays mounted, no blank frame
- [ ] **Remote/relay path unverified** — the dev stack runs no relay and every other device has zero workspaces, so the six probe-status variants are only verified as rendered components, not end to end


## Screens

Captured from the running app over CDP — real host name, real host ID, not mocked.

**The takeover.** Amber Reconnecting chip while the socket keeps dialling, Retry and Host settings. Note the right sidebar stays reachable outside the overlay, which is why there is no "browse workspaces" escape link.

<img width="2560" alt="Host unreachable screen in the app" src="https://github.com/user-attachments/assets/8df2db94-7b9c-4c3a-a67d-074c52f59601" />

**Before — the blank frame this PR also fixes.** A host-service restart nulled the host URL, which unmounted the whole workspace and left ~5s of empty pane with no explanation. Measured 7.5s–12.7s on a plain crash.

<img width="2560" alt="Blank content area during a host-service restart" src="https://github.com/user-attachments/assets/75ba4a22-dfb2-48ff-a228-67428f50b224" />

**After the host returns.** The screen lifts on its own — no reload, no navigation — 5.7s after the host is listenable again. (This workspace had no panes open, so it lands on the empty state.)

<img width="2560" alt="Workspace restored after the host reconnects" src="https://github.com/user-attachments/assets/316b9e67-3a4f-4e47-aae3-a2fba8af440e" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces a Host unreachable overlay for v2 workspaces to prevent blank frames and failing panes. Previously we unmounted or left panes failing; now after 10s of sustained loss we cover the workspace, keep panes mounted, and redial every 5s to cut recovery lag.

- `packages/workspace-client`: per-host event bus now tracks `connecting | open | reconnecting | closed` plus last relay `_whoowns` probe; adds `getConnectionStatus`, `subscribeConnectionStatus`, and `reconnect()`; exports `HostConnectionState` and `HostConnectionStatus`. No migration required.
- `useHostReachability`: retains the bus, declares unreachable after 10s, runs a 5s redial loop only while the overlay is visible, and maps probe status to user-facing detail.
- `WorkspaceHostGate`: overlays instead of unmounting so terminals, unsaved files, and agent sessions survive; marks covered panes `inert` to stop focus behind the overlay; resolves host names via the cloud list; wrapper stays mounted to avoid remount on reconnect.
- `WorkspaceHostUnreachableState`: shows a Reconnecting/Disconnected chip, probe-derived reason, a Retry button wired to `reconnect()`, and a link to host settings.
- `WorkspaceLocalHostPendingState`: status-specific copy before the local host service exposes a port; can restart the service via the coordinator; never prompts restart while starting/running; shows a toast if restart is clicked without an active org.
- `WorkspaceProvider`: caches the last local host URL across host-service restarts to avoid blank frames; shows the pending state only before any port has ever been seen; keys `WorkspaceTrpcProvider` on the workspace (not the host URL) so a port change swaps transport without remounting panes.

**Review focus**
- Event-bus status transitions, probe wiring, listener lifecycles, and `retain`/`subscribeConnectionStatus` cleanup.
- Redial loop: runs only while the overlay is visible and doesn’t fight partysocket backoff; manual `reconnect()` sets state correctly.
- Overlay behavior: no flicker, children never remount, and covered panes are truly inert.
- Local-host pending path: restart behavior, no restart prompt while starting/running, and toast on missing org.

<sup>Written for commit 7107deed6b3e9c87fb650786c080721a3e7d99bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer workspace host connection states, including connecting, reconnecting, unreachable, and disconnected.
  * Added automatic reconnection attempts and a manual retry option.
  * Added connection-specific messaging for relay and local host failures.
  * Preserved workspace content while displaying host connectivity status.
  * Added pending-state feedback when a local host is starting or restarting.
  * Improved handling of temporary local host service restarts.
  * Kept workspace content mounted and protected it from interaction during host outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
