### PR TITLE
chore(desktop): bump version to 1.22.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.21.0",
+	"version": "1.22.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -834,7 +834,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -930,7 +930,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.21.0",
+	"version": "1.22.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.21.0",
+	"version": "1.22.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns versions for the 1.22.0 desktop draft release: bumps `@superset/desktop`, `@superset/cli`, and `@superset/host-service` from 1.21.0 to 1.22.0 and updates `bun.lock`. No runtime or API changes.

**Review notes**
- Verify each package’s `package.json` and `bun.lock` entries reflect 1.22.0.
- No migrations or configuration changes required.

<sup>Written for commit ddbafc196f429200e3ca21d6a5e352c6a9e4d08c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application, command-line interface, and host service to version 1.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->