### PR TITLE
feat(desktop): rename Security settings tab to Remote Workspaces + relay toggle on local host page

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/modules/settings/commands.ts
+++ b/apps/desktop/src/renderer/commandPalette/modules/settings/commands.ts
@@ -119,9 +119,10 @@ const TABS: SettingsTab[] = [
 	},
 	{
 		id: "security",
-		title: "Security",
+		title: "Remote Workspaces",
 		path: "/settings/security",
 		icon: KeyRoundIcon,
+		keywords: ["security", "relay"],
 	},
 	{ id: "agents", title: "Agents", path: "/settings/agents", icon: WrenchIcon },
 	{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -69,7 +69,7 @@ export function CreateAutomationDialog({
 	const { localHostId, localHostIsOnline } = useWorkspaceHostOptions();
 	const targetHostId = hostId ?? localHostId;
 	// The local device is only dispatchable once relay access is enabled in
-	// Settings > Security; block creation until then. Offline remote hosts
+	// Settings > Remote Workspaces; block creation until then. Offline remote hosts
 	// only warn — they may reconnect by the time a run is scheduled.
 	const localRelayBlocked =
 		targetHostId === localHostId && localHostIsOnline === false;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx
@@ -25,7 +25,7 @@ interface HostOfflineRunDialogProps {
 /**
  * Shown when "Run now" is skipped because the target host isn't connected to
  * the relay. For the local device it offers enabling relay access in place
- * (same typed confirmation as Settings > Security).
+ * (same typed confirmation as Settings > Remote Workspaces).
  */
 export function HostOfflineRunDialog({
 	hostId,
@@ -70,7 +70,7 @@ export function HostOfflineRunDialog({
 										{remoteHost?.name ?? "the target host"}
 									</span>{" "}
 									isn't connected to the Superset relay. Make sure relay access
-									is on in Settings &gt; Security on that device, then run it
+									is on in Settings &gt; Remote Workspaces on that device, then run it
 									again.
 								</p>
 							)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx
@@ -25,7 +25,7 @@ const ICON = (
 
 /**
  * Automations dispatch from the cloud through the relay, so even the local
- * device is unreachable until relay access is enabled in Settings > Security.
+ * device is unreachable until relay access is enabled in Settings > Remote Workspaces.
  * Renders nothing while connectivity is unknown (row not yet synced).
  */
 export function RelayOfflineNotice({
@@ -89,7 +89,7 @@ export function RelayOfflineNotice({
 					>
 						host settings
 					</Link>
-					, and make sure relay access is on in Settings &gt; Security on that
+					, and make sure relay access is on in Settings &gt; Remote Workspaces on that
 					device.
 				</span>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useEnableRelayAccess/useEnableRelayAccess.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useEnableRelayAccess/useEnableRelayAccess.ts
@@ -1,7 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
-/** Enable relay access with the same mutation + feedback as Settings > Security. */
+/** Enable relay access with the same mutation + feedback as Settings > Remote Workspaces. */
 export function useEnableRelayAccess() {
 	const utils = electronTrpc.useUtils();
 	const setExpose =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/hostOfflineError/hostOfflineError.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/hostOfflineError/hostOfflineError.ts
@@ -4,7 +4,7 @@
 const HOST_OFFLINE_ERRORS = ["target host offline", "no host available"];
 
 export const HOST_OFFLINE_HELP =
-	"The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote workspaces to access this device via relay\" in Settings > Security, then try again.";
+	"The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote workspaces to access this device via relay\" in Settings > Remote Workspaces, then try again.";
 
 export function isHostOfflineError(error: string | null | undefined): boolean {
 	return !!error && HOST_OFFLINE_ERRORS.some((e) => error.includes(e));

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/ExposeViaRelaySection/ExposeViaRelaySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/ExposeViaRelaySection/ExposeViaRelaySection.tsx
@@ -1,0 +1,115 @@
+import { COMPANY } from "@superset/shared/constants";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { useState } from "react";
+import { HiArrowTopRightOnSquare } from "react-icons/hi2";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { ExposeViaRelayConfirmDialog } from "renderer/routes/_authenticated/components/ExposeViaRelayConfirmDialog";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+
+export function ExposeViaRelaySection() {
+	const searchQuery = useSettingsSearchQuery();
+	const utils = electronTrpc.useUtils();
+	const { data: exposeEnabled, isLoading } =
+		electronTrpc.settings.getExposeHostServiceViaRelay.useQuery();
+
+	const setExpose =
+		electronTrpc.settings.setExposeHostServiceViaRelay.useMutation({
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getExposeHostServiceViaRelay.cancel();
+				const previous = utils.settings.getExposeHostServiceViaRelay.getData();
+				utils.settings.getExposeHostServiceViaRelay.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (_err, _vars, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getExposeHostServiceViaRelay.setData(
+						undefined,
+						context.previous,
+					);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getExposeHostServiceViaRelay.invalidate();
+			},
+		});
+
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [confirmTargetEnabled, setConfirmTargetEnabled] = useState(false);
+	const { gateFeature } = usePaywall();
+
+	const runToggle = (enabled: boolean) => {
+		toast.promise(setExpose.mutateAsync({ enabled }), {
+			loading: "Restarting host services…",
+			success: ({ restartedOrgCount }) =>
+				restartedOrgCount > 0
+					? `Restarted ${restartedOrgCount} host service${restartedOrgCount === 1 ? "" : "s"}`
+					: "Setting saved",
+			error: (err: Error) => err.message ?? "Failed to update setting",
+		});
+	};
+
+	const openConfirm = (next: boolean) => {
+		setConfirmTargetEnabled(next);
+		setConfirmOpen(true);
+	};
+
+	const handleChange = (next: boolean) => {
+		if (next) {
+			gateFeature(GATED_FEATURES.REMOTE_WORKSPACES, () => openConfirm(true));
+		} else {
+			openConfirm(false);
+		}
+	};
+
+	return (
+		<>
+			<div className="flex items-start justify-between gap-6">
+				<div className="space-y-1 flex-1">
+					<Label
+						htmlFor="expose-host-service-via-relay"
+						className="text-sm font-medium"
+					>
+						<HighlightText
+							text="Allow remote workspaces to access this device via relay"
+							query={searchQuery}
+						/>
+					</Label>
+					<p className="text-xs text-muted-foreground">
+						When off, remote workspaces can't access the files and tools on this
+						device. You can still connect out to remote sandboxes from here.{" "}
+						<a
+							href={`${COMPANY.DOCS_URL}/remote-workspaces`}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1 text-primary hover:underline"
+						>
+							Learn more
+							<HiArrowTopRightOnSquare className="h-3 w-3" />
+						</a>
+					</p>
+				</div>
+				<Switch
+					id="expose-host-service-via-relay"
+					checked={exposeEnabled ?? false}
+					onCheckedChange={handleChange}
+					disabled={isLoading || setExpose.isPending}
+				/>
+			</div>
+
+			<ExposeViaRelayConfirmDialog
+				open={confirmOpen}
+				targetEnabled={confirmTargetEnabled}
+				onOpenChange={setConfirmOpen}
+				onConfirm={() => {
+					const enabled = confirmTargetEnabled;
+					setConfirmOpen(false);
+					runToggle(enabled);
+				}}
+			/>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/ExposeViaRelaySection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/ExposeViaRelaySection/index.ts
@@ -1,0 +1,1 @@
+export { ExposeViaRelaySection } from "./ExposeViaRelaySection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -189,7 +189,7 @@ const SECTION_GROUPS: SectionGroup[] = [
 			{
 				id: "/settings/security",
 				section: "security",
-				label: "Security",
+				label: "Remote Workspaces",
 				icon: <HiOutlineLockClosed className="h-4 w-4" />,
 			},
 			{

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -9,6 +9,7 @@ import {
 	useOptimisticActions,
 } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { ExposeViaRelaySection } from "renderer/routes/_authenticated/settings/components/ExposeViaRelaySection";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import type { CandidateRow } from "./components/AddMemberDropdown";
@@ -165,6 +166,15 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 					isOnline={hostIsOnline || !isRemoteTarget}
 					canEdit={isOwner}
 				/>
+
+				{hostId === machineId && (
+					<section className="space-y-3">
+						<h3 className="text-sm font-medium">
+							<HighlightText text="Remote workspaces" query={searchQuery} />
+						</h3>
+						<ExposeViaRelaySection />
+					</section>
+				)}
 
 				<section className="space-y-3">
 					<div className="flex items-end justify-between gap-4">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
@@ -1,12 +1,4 @@
-import { Label } from "@superset/ui/label";
-import { toast } from "@superset/ui/sonner";
-import { Switch } from "@superset/ui/switch";
-import { useState } from "react";
-import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
-import { electronTrpc } from "renderer/lib/electron-trpc";
-import { ExposeViaRelayConfirmDialog } from "renderer/routes/_authenticated/components/ExposeViaRelayConfirmDialog";
-import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
-import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { ExposeViaRelaySection } from "renderer/routes/_authenticated/settings/components/ExposeViaRelaySection";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -18,111 +10,21 @@ interface SecuritySettingsProps {
 }
 
 export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
-	const searchQuery = useSettingsSearchQuery();
 	const showRelayToggle = isItemVisible(
 		SETTING_ITEM_ID.SECURITY_EXPOSE_HOST_SERVICE_VIA_RELAY,
 		visibleItems,
 	);
 
-	const utils = electronTrpc.useUtils();
-	const { data: exposeEnabled, isLoading } =
-		electronTrpc.settings.getExposeHostServiceViaRelay.useQuery();
-
-	const setExpose =
-		electronTrpc.settings.setExposeHostServiceViaRelay.useMutation({
-			onMutate: async ({ enabled }) => {
-				await utils.settings.getExposeHostServiceViaRelay.cancel();
-				const previous = utils.settings.getExposeHostServiceViaRelay.getData();
-				utils.settings.getExposeHostServiceViaRelay.setData(undefined, enabled);
-				return { previous };
-			},
-			onError: (_err, _vars, context) => {
-				if (context?.previous !== undefined) {
-					utils.settings.getExposeHostServiceViaRelay.setData(
-						undefined,
-						context.previous,
-					);
-				}
-			},
-			onSettled: () => {
-				utils.settings.getExposeHostServiceViaRelay.invalidate();
-			},
-		});
-
-	const [confirmOpen, setConfirmOpen] = useState(false);
-	const [confirmTargetEnabled, setConfirmTargetEnabled] = useState(false);
-	const { gateFeature } = usePaywall();
-
-	const runToggle = (enabled: boolean) => {
-		toast.promise(setExpose.mutateAsync({ enabled }), {
-			loading: "Restarting host services…",
-			success: ({ restartedOrgCount }) =>
-				restartedOrgCount > 0
-					? `Restarted ${restartedOrgCount} host service${restartedOrgCount === 1 ? "" : "s"}`
-					: "Setting saved",
-			error: (err: Error) => err.message ?? "Failed to update setting",
-		});
-	};
-
-	const openConfirm = (next: boolean) => {
-		setConfirmTargetEnabled(next);
-		setConfirmOpen(true);
-	};
-
-	const handleChange = (next: boolean) => {
-		if (next) {
-			gateFeature(GATED_FEATURES.REMOTE_WORKSPACES, () => openConfirm(true));
-		} else {
-			openConfirm(false);
-		}
-	};
-
 	return (
 		<div className="p-6 max-w-4xl w-full">
 			<div className="mb-8">
-				<h2 className="text-xl font-semibold">Security</h2>
+				<h2 className="text-xl font-semibold">Remote Workspaces</h2>
 				<p className="text-sm text-muted-foreground mt-1">
 					Control how your local machine is reachable from remote workspaces
 				</p>
 			</div>
 
-			{showRelayToggle && (
-				<div className="flex items-start justify-between gap-6">
-					<div className="space-y-1 flex-1">
-						<Label
-							htmlFor="expose-host-service-via-relay"
-							className="text-sm font-medium"
-						>
-							<HighlightText
-								text="Allow remote workspaces to access this device via relay"
-								query={searchQuery}
-							/>
-						</Label>
-						<p className="text-xs text-muted-foreground">
-							When off, your local tools and files cannot be reached from any
-							remote workspace through the Superset relay. This does not affect
-							your ability to connect out to remote sandboxes from this device.
-						</p>
-					</div>
-					<Switch
-						id="expose-host-service-via-relay"
-						checked={exposeEnabled ?? false}
-						onCheckedChange={handleChange}
-						disabled={isLoading || setExpose.isPending}
-					/>
-				</div>
-			)}
-
-			<ExposeViaRelayConfirmDialog
-				open={confirmOpen}
-				targetEnabled={confirmTargetEnabled}
-				onOpenChange={setConfirmOpen}
-				onConfirm={() => {
-					const enabled = confirmTargetEnabled;
-					setConfirmOpen(false);
-					runToggle(enabled);
-				}}
-			/>
+			{showRelayToggle && <ExposeViaRelaySection />}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Renames the **Security** settings tab to **Remote Workspaces** — sidebar label, page header, and command palette entry (route stays `/settings/security`; "security" kept as a search keyword in both settings search and the palette).
- Extracts the expose-via-relay toggle (paywall gate, typed confirmation dialog, optimistic update, restart toast) into a shared `ExposeViaRelaySection` component.
- Adds that toggle to the **local host's** settings page (`Settings > Hosts > <this device>`), rendered only when `hostId === machineId`, so remote workspace access can be switched on from there too.
- Simplifies the toggle description and adds a "Learn more" link to `docs.superset.sh/remote-workspaces`.
- Updates all user-facing "Settings > Security" references in automations (offline-host error, RelayOfflineNotice, HostOfflineRunDialog) to the new tab name.

## Test plan

- `bun run typecheck` (desktop) passes
- Biome clean on touched files
- Desktop unit tests pass
- No tests referenced the old strings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the Settings "Security" tab to "Remote Workspaces" and adds the relay access toggle to the local host settings. This improves discoverability without breaking links (route remains `/settings/security`) and preserves "security" as a search keyword.

- Sidebar label, page header, and command palette entry now show "Remote Workspaces"; command palette adds keywords ["security", "relay"].
- Extracts the relay access toggle into a shared `ExposeViaRelaySection` with paywall gate, typed confirmation, optimistic update, and restart toast; includes a "Learn more" link to the docs.
- Renders the same toggle on the local host page (Settings > Hosts > <this device>) when `hostId === machineId`.
- Updates automation copy to reference "Settings > Remote Workspaces" in notices and dialogs.

<sup>Written for commit f5f738847788c79f99590b7079479b0ac21b6476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

