### PR TITLE
fix(desktop): reformat automations relay-offline copy

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx
@@ -70,8 +70,8 @@ export function HostOfflineRunDialog({
 										{remoteHost?.name ?? "the target host"}
 									</span>{" "}
 									isn't connected to the Superset relay. Make sure relay access
-									is on in Settings &gt; Remote Workspaces on that device, then run it
-									again.
+									is on in Settings &gt; Remote Workspaces on that device, then
+									run it again.
 								</p>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx
@@ -89,8 +89,8 @@ export function RelayOfflineNotice({
 					>
 						host settings
 					</Link>
-					, and make sure relay access is on in Settings &gt; Remote Workspaces on that
-					device.
+					, and make sure relay access is on in Settings &gt; Remote Workspaces
+					on that device.
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
`main` is currently failing the **Lint** job, so every open PR inherits a red check — the merge ref includes main's breakage.

Two files are unformatted under the pinned `@biomejs/biome@2.4.2` that `scripts/lint.sh` uses:

- `automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx`
- `automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx`

The Settings rename in #6481 ("Security" → "Remote Workspaces") lengthened these strings, which changes where the JSX text wraps; the reflow was never applied.

Verified the failure reproduces against `origin/main` alone, independent of any PR. Formatter output only — no behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformats two automations components to satisfy the pinned `@biomejs/biome@2.4.2` formatter, fixing the failing Lint job on main. No behavior change; only JSX text reflow after the Settings rename to “Remote Workspaces.”

- Formatter-only changes; verify locally with `scripts/lint.sh`.
- Updated files: apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/HostOfflineRunDialog/HostOfflineRunDialog.tsx, apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/RelayOfflineNotice/RelayOfflineNotice.tsx.
- Merging will clear the inherited red Lint check for other open PRs.

<sup>Written for commit 4ec0b580abfb428b66f29ce28a27fe9dcab3edb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved line wrapping in remote-host offline messages.
  * Separated settings links and follow-up instructions onto distinct lines for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->