### PR TITLE
fix(mobile): apply saved home filters before the first render

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -58,6 +58,7 @@ export function HomeScreen() {
 		(store) => store.projectFilter,
 	);
 	const sort = useWorkspacesFilterStore((store) => store.sort);
+	const hasHydrated = useWorkspacesFilterStore((store) => store.hasHydrated);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [visibleIds, setVisibleIds] = useState<string[]>([]);
 	const [refreshing, setRefreshing] = useState(false);
@@ -99,7 +100,11 @@ export function HomeScreen() {
 		return newest?.projectId ?? sortedProjects[0]?.id ?? null;
 	}, [workspaces, sortedProjects]);
 
-	const selectedProjectId = projectFilter ?? defaultProjectId;
+	// The saved project arrives a beat after mount; picking a default before
+	// then flashes the wrong project's list on every cold start.
+	const selectedProjectId = hasHydrated
+		? (projectFilter ?? defaultProjectId)
+		: null;
 
 	const projectNamesById = useMemo(
 		() => new Map(projects.map((project) => [project.id, project.name])),
@@ -393,7 +398,7 @@ export function HomeScreen() {
 						<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 					}
 					ListEmptyComponent={
-						isReady ? (
+						isReady && hasHydrated ? (
 							<View className="items-center justify-center py-20">
 								<Text className="text-center text-muted-foreground">
 									{searchQuery.trim()

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
@@ -43,6 +43,12 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 	const projectFilter = useWorkspacesFilterStore(
 		(state) => state.projectFilter,
 	);
+	const preferencesHydrated = useNewSessionPreferencesStore(
+		(state) => state.hasHydrated,
+	);
+	const filtersHydrated = useWorkspacesFilterStore(
+		(state) => state.hasHydrated,
+	);
 
 	const presence = useHostsPresence(hosts);
 	const onlineHosts = useMemo(
@@ -89,6 +95,10 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 
 	const defaultTarget = useMemo<NewChatTarget | null>(() => {
 		if (targets.length === 0) return null;
+		// Both the last used target and the project filter are read back from
+		// storage asynchronously — defaulting first would land on the wrong
+		// project, and a send in that window would create the workspace there.
+		if (!preferencesHydrated || !filtersHydrated) return null;
 
 		const persisted = targets.find(
 			(target) => target.key === persistedTargetKey,
@@ -114,7 +124,14 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 			if (match) return match;
 		}
 		return targets[0] ?? null;
-	}, [targets, persistedTargetKey, projectFilter, workspaces]);
+	}, [
+		targets,
+		persistedTargetKey,
+		projectFilter,
+		workspaces,
+		preferencesHydrated,
+		filtersHydrated,
+	]);
 
 	return { targets, defaultTarget };
 }

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore/newSessionPreferencesStore.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore/newSessionPreferencesStore.ts
@@ -11,6 +11,8 @@ interface NewSessionPreferencesStore {
 	targetKey: string | null;
 	/** Draft base branch for the next session; null = default branch. */
 	baseBranch: string | null;
+	/** False until AsyncStorage has answered — the saved picks aren't here yet. */
+	hasHydrated: boolean;
 	setAgentId: (agentId: string) => void;
 	setTargetKey: (targetKey: string) => void;
 	setBaseBranch: (baseBranch: string | null) => void;
@@ -23,6 +25,7 @@ export const useNewSessionPreferencesStore =
 				agentId: DEFAULT_AGENT_ID,
 				targetKey: null,
 				baseBranch: null,
+				hasHydrated: false,
 				setAgentId: (agentId) => set({ agentId }),
 				setTargetKey: (targetKey) => set({ targetKey, baseBranch: null }),
 				setBaseBranch: (baseBranch) => set({ baseBranch }),
@@ -34,6 +37,11 @@ export const useNewSessionPreferencesStore =
 					agentId: state.agentId,
 					targetKey: state.targetKey,
 				}),
+				// Same async-rehydration window as the filter store: until this
+				// flips, the composer would fall back to a default target instead
+				// of the last used one.
+				onRehydrateStorage: () => () =>
+					useNewSessionPreferencesStore.setState({ hasHydrated: true }),
 			},
 		),
 	);

--- a/apps/mobile/screens/(authenticated)/(home)/home/stores/workspacesFilterStore/workspacesFilterStore.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/stores/workspacesFilterStore/workspacesFilterStore.ts
@@ -13,6 +13,8 @@ interface WorkspacesFilterStore {
 	projectFilter: string | null;
 	hostFilter: string | null;
 	sort: WorkspaceSort;
+	/** False until AsyncStorage has answered — the saved filter isn't here yet. */
+	hasHydrated: boolean;
 	setProjectFilter: (projectId: string | null) => void;
 	setHostFilter: (machineId: string | null) => void;
 	setSort: (sort: WorkspaceSort) => void;
@@ -24,6 +26,7 @@ export const useWorkspacesFilterStore = create<WorkspacesFilterStore>()(
 			projectFilter: null,
 			hostFilter: null,
 			sort: "updatedAt",
+			hasHydrated: false,
 			setProjectFilter: (projectId) => set({ projectFilter: projectId }),
 			setHostFilter: (machineId) => set({ hostFilter: machineId }),
 			setSort: (sort) => set({ sort }),
@@ -31,6 +34,18 @@ export const useWorkspacesFilterStore = create<WorkspacesFilterStore>()(
 		{
 			name: "workspaces-filter",
 			storage: createJSONStorage(() => AsyncStorage),
+			partialize: ({ projectFilter, hostFilter, sort }) => ({
+				projectFilter,
+				hostFilter,
+				sort,
+			}),
+			// Rehydration is async — measured at ~165ms on a cold start — so
+			// readers see the defaults first and the home screen would spend that
+			// window showing (and fetching) the wrong host's default project.
+			// Consumers wait on this flag instead. It flips on storage errors too,
+			// so a failed read falls back to the defaults rather than hanging.
+			onRehydrateStorage: () => () =>
+				useWorkspacesFilterStore.setState({ hasHydrated: true }),
 		},
 	),
 );

--- a/apps/mobile/screens/(authenticated)/(home)/hooks/useSelectedHost/useSelectedHost.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/hooks/useSelectedHost/useSelectedHost.ts
@@ -6,14 +6,18 @@ import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/
 /**
  * The list view is always scoped to one host: the explicit filter pick if
  * that host still exists, else the first online host, else the first host.
+ * Null until the saved pick has been read back from storage — falling back
+ * before then scopes the whole screen to the wrong host for a few frames.
  */
 export function useSelectedHost(): OrgHost | null {
 	const hosts = useOrgHosts();
 	const hostFilter = useWorkspacesFilterStore((store) => store.hostFilter);
+	const hasHydrated = useWorkspacesFilterStore((store) => store.hasHydrated);
 
 	const presence = useHostsPresence(hosts);
 
 	return useMemo(() => {
+		if (!hasHydrated) return null;
 		const sorted = hosts
 			.map((host) => ({
 				...host,
@@ -26,5 +30,5 @@ export function useSelectedHost(): OrgHost | null {
 			sorted[0] ??
 			null
 		);
-	}, [hosts, hostFilter, presence]);
+	}, [hosts, hostFilter, presence, hasHydrated]);
 }


### PR DESCRIPTION
## What was wrong

Not a missing-persistence bug — `workspacesFilterStore` and `newSessionPreferencesStore` were already wrapped in zustand `persist` over AsyncStorage, nothing resets them programmatically, and the values **are** written and **do** come back.

**It's lead #1: the async rehydration window.** Instrumented on the simulator, a cold start looks like this:

```
[dbg] workspacesFilterStore module eval  +0ms
[dbg] rehydrate start                    +3ms
[dbg] HomeScreen render  {"projectFilter":null,  "selectedProjectId":null}   <- default
[dbg] HomeScreen render  {"projectFilter":null,  "selectedProjectId":null}   <- default
[dbg] raw workspaces-filter on disk:   +163ms  {"projectFilter":"…","hostFilter":"…","sort":"createdAt"}
[dbg] rehydrate done                   +164ms
[dbg] HomeScreen render  {"projectFilter":"…", "selectedProjectId":"…"}      <- correct
```

For those ~165 ms every consumer reads the defaults, so the home screen resolves the **first online host** instead of the saved one, lists that host's most recently updated project instead of the filtered one, and fires the workspace / terminal / project queries against it before swapping. That is what reads as "the filters reset on restart". Whether the window is even visible depends on whether the auth session or AsyncStorage resolves first, which varies run to run.

Lead #2 (a stale projects/hosts list invalidating the saved id) was ruled out: nothing validates or clears the persisted id, and the only callers of the setters are the three filter screens.

`newSessionPreferencesStore` has the identical bug — the composer picks a default target over the last used one in the same window, and a send landing there would create the workspace on the wrong project. Fixed too.

## The fix

Both stores expose `hasHydrated`, flipped from `onRehydrateStorage` — including on read errors, so a failed read falls back to the defaults instead of hanging. It's excluded from `partialize` so it never reaches disk. Consumers wait on it:

- `useSelectedHost` returns `null` (all four call sites already handle null)
- `HomeScreen` holds its project pick and suppresses the empty state
- `useNewChatTargets` holds its default target until both stores have answered

## Verification

On the iOS simulator, against `RCTAsyncLocalStorage_V1/manifest.json` and the Metro console:

- Set sort to "Date created" → written to disk
- `xcrun simctl terminate booted sh.superset.mobile`, relaunch
- Sort screen still shows "Date created" checked; `hasHydrated` flips with the saved values intact and never appears on disk

**Caveat:** this simulator has no hosts/projects/workspaces (the worktree's local stack isn't running), so the project/host filter rows couldn't be visually confirmed against real data — those were verified at the store level (persisted values rehydrate and reach `HomeScreen`'s derived `selectedProjectId`) plus the disk manifest.

`bun run lint:fix` and `bun run typecheck` clean in `apps/mobile` (after `build:types` in `packages/host-service`). Root `scripts/lint.sh` reports 2 errors, both in untouched `apps/desktop` files inherited from `main`; all four guard scripts pass.

No tests added, per repo preference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply saved home filters and composer preferences before the first render to remove the cold-start reset flash and prevent queries against the wrong host. Previously consumers read defaults until storage rehydrated (~165 ms) and resolved the first online host/project; now consumers wait for hydration.

- Add hasHydrated to the workspaces filter store and the new-session preferences store; flip it in onRehydrateStorage (also on read errors) and exclude it from persistence.
- HomeScreen defers selectedProjectId and suppresses the empty state until filters hydrate.
- useSelectedHost returns null until the filter store hydrates.
- useNewChatTargets defers defaultTarget until both stores hydrate to avoid creating a workspace on the wrong project.

<sup>Written for commit bb4617488508a29c224c70171f3905ac1f8e06c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home screen loading to prevent incorrect projects, workspaces, or hosts from appearing before saved preferences are restored.
  * Delayed empty-workspace messaging until workspace data and filters are fully ready.
  * Ensured new chats use the correct default target after preferences finish loading.
  * Improved handling of persisted filter settings when storage restoration encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->