### PR TITLE
fix(trpc,api): make automation run dedupe compatible with a partial unique index

### DIFF
--- a/apps/api/src/app/api/automations/run-failed/route.ts
+++ b/apps/api/src/app/api/automations/run-failed/route.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import { dbWs } from "@superset/db/client";
 import { automationRuns, automations } from "@superset/db/schema";
 import { Receiver } from "@upstash/qstash";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { env } from "@/env";
@@ -101,6 +101,7 @@ export async function POST(request: Request): Promise<Response> {
 		})
 		.onConflictDoUpdate({
 			target: [automationRuns.automationId, automationRuns.scheduledFor],
+			targetWhere: sql`${automationRuns.scheduledFor} IS NOT NULL`,
 			set: { status: "dispatch_failed", error: errorText },
 		});
 

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -14,7 +14,7 @@ import {
 	sanitizeBranchNameWithMaxLength,
 	slugifyForBranch,
 } from "@superset/shared/workspace-launch";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { fetchRelayPresence } from "../../lib/relay-presence";
 import { RelayDispatchError, relayMutation } from "./relay-client";
 
@@ -77,6 +77,7 @@ export async function dispatchAutomation(
 		})
 		.onConflictDoNothing({
 			target: [automationRuns.automationId, automationRuns.scheduledFor],
+			where: sql`${automationRuns.scheduledFor} IS NOT NULL`,
 		})
 		.returning();
 
@@ -284,6 +285,7 @@ async function recordSkipped(
 		})
 		.onConflictDoNothing({
 			target: [automationRuns.automationId, automationRuns.scheduledFor],
+			where: sql`${automationRuns.scheduledFor} IS NOT NULL`,
 		})
 		.returning({ id: automationRuns.id });
 	return row;


### PR DESCRIPTION
## What

Adds the index predicate to the three `ON CONFLICT` targets on `automation_runs`:

- `dispatch.ts:78` — the run insert
- `dispatch.ts:287` — `recordSkipped`
- `run-failed/route.ts:102` — the QStash failure callback

No behaviour change today.

## Why

Automation triggers need `automation_runs.scheduled_for` to become nullable, because an event-triggered run has no schedule. That means `automation_runs_dedup_idx` has to become **partial**:

```sql
UNIQUE (automation_id, scheduled_for) WHERE scheduled_for IS NOT NULL
```

Postgres does not infer a partial unique index from `ON CONFLICT (cols)` unless the conflict target repeats the predicate. Verified against Postgres 16:

```
CREATE UNIQUE INDEX r_sched ON r (a, s) WHERE s IS NOT NULL;
INSERT ... ON CONFLICT (a, s) DO NOTHING;
-- ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

So all three call sites would start throwing the moment that index changes — scheduled dispatch, skip recording, and the failure callback.

## Why it can merge on its own

The predicate form is compatible in both directions, also verified:

| | Current index | Partial index |
|---|---|---|
| Without predicate | works | **errors** |
| With predicate | works | works |

So this ships first and sits harmlessly until the schema change lands. Shipping them together, or the schema first, would both leave a window where dispatch is broken.

## Testing

- `bun run typecheck` — 37/37 packages
- `bun run lint` — clean
- `bun test packages/trpc apps/api` — 17 pass
- Both `ON CONFLICT` forms exercised against a real Postgres 16 against both index shapes

Part of the automation triggers migration playbook (step A). No migration in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes automation run dedupe compatible with a partial unique index on `(automation_id, scheduled_for)`. Previously `ON CONFLICT` without a predicate worked with the non-partial index but would error once the index becomes partial; now each conflict target includes `WHERE scheduled_for IS NOT NULL`. No behavior change today.

- Adds the predicate to three `ON CONFLICT` sites: run insert and `recordSkipped` in `packages/trpc/src/router/automation/dispatch.ts` (via `.onConflictDoNothing({ where: sql... })`), and the QStash failure callback in `apps/api/src/app/api/automations/run-failed/route.ts` (via `.onConflictDoUpdate({ targetWhere: sql... })`).
- Safe to ship ahead of the schema change that makes `scheduled_for` nullable and the dedupe index partial; no DB migration required.

<sup>Written for commit 05123aa939c139f7747ae9c1dfa97e01a4aa8918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation run deduplication for scheduled runs.
  * Prevented duplicate or skipped automation runs from being created during dispatch and failure handling.
  * Enhanced reliability when processing scheduled automation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->