### PR TITLE
chore(trpc,mcp,cli,sdk,desktop): remove dead mcpScope plumbing

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -172,7 +172,6 @@ export function CreateAutomationDialog({
 				v2WorkspaceId,
 				rrule: rrule.trim(),
 				timezone: DEFAULT_TIMEZONE,
-				mcpScope: [],
 			});
 		},
 		onSuccess: (result) => {

--- a/packages/cli/src/commands/automations/create/command.ts
+++ b/packages/cli/src/commands/automations/create/command.ts
@@ -66,7 +66,6 @@ export default command({
 			rrule: options.rrule,
 			dtstart: options.dtstart ? new Date(options.dtstart) : undefined,
 			timezone: options.timezone ?? DEFAULT_TIMEZONE,
-			mcpScope: [],
 		});
 
 		return {

--- a/packages/cli/src/commands/automations/update/command.ts
+++ b/packages/cli/src/commands/automations/update/command.ts
@@ -19,7 +19,6 @@ export default command({
 		session: boolean().desc(
 			"Switch to session mode: no project, each run creates a project-less session workspace",
 		),
-		mcpScope: string().desc("Comma-separated MCP scope strings"),
 		enabled: boolean().desc("Enable or pause the automation"),
 	},
 	run: async ({ ctx, args, options }) => {
@@ -39,14 +38,6 @@ export default command({
 				enabled: options.enabled,
 			});
 		}
-
-		const mcpScope =
-			options.mcpScope !== undefined
-				? options.mcpScope
-						.split(",")
-						.map((s) => s.trim())
-						.filter(Boolean)
-				: undefined;
 
 		// Retargeting (--workspace or --project) re-derives targetHostId +
 		// v2ProjectId; the resource must exist on the target host.
@@ -88,7 +79,6 @@ export default command({
 			// Session mode clears both the project and any workspace pin.
 			...(options.session ? { v2ProjectId: null, v2WorkspaceId: null } : {}),
 			...target,
-			...(mcpScope !== undefined ? { mcpScope } : {}),
 		});
 
 		return {

--- a/packages/mcp/src/tools/automations/create.ts
+++ b/packages/mcp/src/tools/automations/create.ts
@@ -64,10 +64,6 @@ export function register(server: McpServer): void {
 				.string()
 				.min(1)
 				.describe("IANA timezone (e.g. America/New_York)."),
-			mcpScope: z
-				.array(z.string())
-				.default([])
-				.describe("Optional MCP scope strings the run should request."),
 		},
 		handler: async (input, ctx) => {
 			const caller = createMcpCaller(ctx);

--- a/packages/mcp/src/tools/automations/update.ts
+++ b/packages/mcp/src/tools/automations/update.ts
@@ -34,7 +34,6 @@ export function register(server: McpServer): void {
 				.optional()
 				.describe("First scheduled fire (ISO 8601)."),
 			timezone: z.string().min(1).optional(),
-			mcpScope: z.array(z.string()).optional(),
 		},
 		handler: async (input, ctx) => {
 			const caller = createMcpCaller(ctx);

--- a/packages/sdk/src/resources/automations.ts
+++ b/packages/sdk/src/resources/automations.ts
@@ -191,7 +191,6 @@ export interface AutomationSummary {
 	dtstart: string;
 	timezone: string;
 	enabled: boolean;
-	mcpScope: string[];
 	nextRunAt: string;
 	/** Human-readable schedule description, derived from rrule. */
 	scheduleText?: string;
@@ -242,8 +241,6 @@ export interface AutomationCreateParams {
 	targetHostId?: string | null;
 	/** ISO timestamp; defaults to now if omitted. */
 	dtstart?: string;
-	/** MCP server names this automation is allowed to use. */
-	mcpScope?: string[];
 }
 
 export interface AutomationUpdateParams {
@@ -273,7 +270,6 @@ export interface AutomationUpdateParams {
 	rrule?: string;
 	dtstart?: string;
 	timezone?: string;
-	mcpScope?: string[];
 }
 
 export interface AutomationRun {

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -290,7 +290,6 @@ export const automationRouter = {
 						rrule: input.rrule,
 						dtstart,
 						timezone: input.timezone,
-						mcpScope: input.mcpScope,
 						nextRunAt,
 					})
 					.returning();
@@ -448,7 +447,6 @@ export const automationRouter = {
 					rrule: nextRrule,
 					dtstart: nextDtstart,
 					timezone: nextTimezone,
-					mcpScope: input.mcpScope ?? existing.mcpScope,
 					nextRunAt: recomputedNextRunAt,
 				})
 				.where(eq(automations.id, input.id))

--- a/packages/trpc/src/router/automation/schema.ts
+++ b/packages/trpc/src/router/automation/schema.ts
@@ -36,7 +36,6 @@ export const createAutomationSchema = z.object({
 	rrule: rruleBody,
 	dtstart: z.coerce.date().optional(),
 	timezone: iana,
-	mcpScope: z.array(z.string()).default([]),
 });
 
 export const updateAutomationSchema = z.object({
@@ -51,7 +50,6 @@ export const updateAutomationSchema = z.object({
 	rrule: rruleBody.optional(),
 	dtstart: z.coerce.date().optional(),
 	timezone: iana.optional(),
-	mcpScope: z.array(z.string()).optional(),
 });
 
 export const setAutomationPromptSchema = z.object({


### PR DESCRIPTION
## What

Removes `mcpScope` from every surface that carries it:

- tRPC `createAutomationSchema` / `updateAutomationSchema` and the router
- MCP `automations.create` / `automations.update` tool inputs
- CLI `automations create` and the `--mcp-scope` flag on `automations update`
- SDK `Automation`, `AutomationCreateParams`, `AutomationUpdateParams`
- Desktop `CreateAutomationDialog`

The `automations.mcp_scope` column stays.

## Why

It has never had a consumer. `dispatch.ts` builds the `agents.run` payload from `agent` and `prompt` and never passes it, and MCP was hardcoded `disableMcp: true` when automations shipped.

Every caller writes `[]` unconditionally:

- `CreateAutomationDialog.tsx` hardcodes `mcpScope: []`
- `cli/automations/create` hardcodes `mcpScope: []`
- the tRPC schema defaults it to `[]`

So it is a field users can set through three public surfaces that has no effect anywhere.

## Why the column stays

Dropping it now would break currently deployed code, since Drizzle selects columns explicitly and running instances still name `mcp_scope` in their `SELECT`. It drops alongside `rrule`, `dtstart`, `timezone`, and `next_run_at` once the automation trigger cutover is complete and nothing reads the legacy columns.

## Note on public surfaces

This removes a field from the CLI and SDK. It is technically a breaking change for anyone passing `mcpScope`, but passing it has never done anything, so nothing can regress behaviourally.

## Testing

- `bun run typecheck` — 37/37 packages
- `bun run lint` — clean
- `bun test packages/trpc packages/cli apps/api` — 131 pass
- `grep` confirms the only remaining reference is the column definition

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused mcpScope field from automation create/update across tRPC, MCP tools, CLI, SDK types, and the desktop dialog. The field never affected execution; the database column remains to avoid breaking running instances.

- Migration/rollout:
  - Remove `--mcp-scope` from any `automations update` CLI usage.
  - Stop sending `mcpScope` in SDK payloads and tRPC/MCP inputs; delete references to `Automation.mcpScope`, `AutomationCreateParams.mcpScope`, and `AutomationUpdateParams.mcpScope`.
  - The `automations.mcp_scope` column stays for now and will be dropped with other legacy trigger columns after the cutover.

<sup>Written for commit bab40b5cc3157e8dcb764403fd5bec8a9fa25a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

