### PR TITLE
fix(desktop): unmute the star nag on a real unstar, stop polling on focus

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/github-star/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/github-star/index.ts
@@ -8,6 +8,9 @@ export type GithubStarState = "starred" | "not_starred" | "unknown";
 const STARRED_REPO_PATH = "user/starred/superset-sh/superset";
 // A hung `gh` process must not leave the query/mutation pending forever —
 // both callers already treat any failure as a safe "unknown"/false outcome.
+// This only bounds the `gh` call itself: execWithShellEnv resolves the shell
+// environment first, which has its own ~8s timeout (shell-env.ts) on a cache
+// miss — worst case end-to-end is closer to 18s, not 10s.
 const GH_CALL_TIMEOUT_MS = 10_000;
 
 /**

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -17,6 +17,7 @@ import {
 	TriangleAlertIcon,
 	XIcon,
 } from "lucide-react";
+import { previewStarNagOnboardingToast } from "renderer/components/StarNagToast";
 import { env } from "renderer/env.renderer";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
@@ -276,15 +277,11 @@ export const actionsProvider: CommandProvider = {
 					section: "dev",
 					icon: StarIcon,
 					keywords: ["star", "github", "nag", "dev", "preview", "test"],
-					// Dynamically imported so StarNagToast (and its AnimatedStarButton /
-					// framer-motion tree) isn't pulled into the always-loaded module
-					// graph just for a dev-only preview command.
-					run: async () => {
-						const { previewStarNagOnboardingToast } = await import(
-							"renderer/components/StarNagToast"
-						);
-						previewStarNagOnboardingToast();
-					},
+					// A dynamic import here would only defer this file's own module —
+					// AnimatedStarButton (and framer-motion) is already statically
+					// imported by StarNagCard, which DashboardSidebar/WorkspaceSidebar
+					// import unconditionally, so it's already in the eager bundle.
+					run: () => previewStarNagOnboardingToast(),
 				},
 				{
 					id: "dev.resetStarNagState",

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -17,7 +17,6 @@ import {
 	TriangleAlertIcon,
 	XIcon,
 } from "lucide-react";
-import { previewStarNagOnboardingToast } from "renderer/components/StarNagToast";
 import { env } from "renderer/env.renderer";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
@@ -277,7 +276,15 @@ export const actionsProvider: CommandProvider = {
 					section: "dev",
 					icon: StarIcon,
 					keywords: ["star", "github", "nag", "dev", "preview", "test"],
-					run: () => previewStarNagOnboardingToast(),
+					// Dynamically imported so StarNagToast (and its AnimatedStarButton /
+					// framer-motion tree) isn't pulled into the always-loaded module
+					// graph just for a dev-only preview command.
+					run: async () => {
+						const { previewStarNagOnboardingToast } = await import(
+							"renderer/components/StarNagToast"
+						);
+						previewStarNagOnboardingToast();
+					},
 				},
 				{
 					id: "dev.resetStarNagState",
@@ -291,6 +298,7 @@ export const actionsProvider: CommandProvider = {
 							STAR_NAG_INITIAL_THRESHOLD;
 						useStarNagStore.setState({
 							completed: false,
+							completedAt: null,
 							workspacesCreatedSinceBaseline: threshold,
 							nextThreshold: threshold,
 							deferredUntil: null,

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.css
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.css
@@ -1,0 +1,116 @@
+/* Ported directly from the reference: same padding/font/line-height/border,
+ * same color-mix background formula (canvas/canvasText -> this app's own
+ * --background/--foreground so it tracks the in-app theme toggle, not just
+ * the OS scheme), same corner offset-path geometry and 0.26s/0.12s timing.
+ *
+ * One deliberate departure from the reference's own CSS: `transition` lives
+ * on the resting selector, not inside `:hover`. The reference scopes it only
+ * inside `:hover`, which is what caused corner marks to get stuck mid-flight
+ * on mouse-leave in this app's Chromium (verified via a full
+ * hover-then-leave cycle, not just hover-in). Same visual values, same
+ * timing — just placed so the reverse direction has a transition to run
+ * under too. */
+
+.star-button {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.625rem;
+	padding: 0.75rem 1rem;
+	font-family: ui-monospace, "SF Mono", Menlo, monospace;
+	font-size: 0.75rem;
+	text-transform: uppercase;
+	line-height: 1;
+	border: 0;
+	cursor: pointer;
+	background: color-mix(in oklch, var(--background), var(--foreground) 4%);
+	color: color-mix(in oklch, var(--foreground), transparent 25%);
+	transition-property: background, color;
+	transition-duration: 0.26s;
+	transition-timing-function: ease-out;
+}
+
+.star-button.star-button--compact {
+	gap: 0.4375rem;
+	padding: 0.4375rem 0.625rem;
+	font-size: 0.625rem;
+}
+
+.star-button:focus-visible {
+	outline: color-mix(in oklch, var(--foreground), transparent) dashed 1px;
+	outline-offset: 0.5rem;
+}
+
+.star-button:is(:hover, :focus-visible) {
+	color: var(--foreground);
+	background: color-mix(in oklch, var(--background), var(--foreground) 10%);
+}
+
+.star-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.star-button__corners {
+	container-type: size;
+	pointer-events: none;
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+}
+
+.star-button__corners span {
+	position: absolute;
+	width: 10px;
+	height: 10px;
+	display: grid;
+	place-items: center;
+	offset-path: border-box;
+	color: currentColor;
+}
+
+.star-button__corners span svg {
+	width: 100%;
+}
+
+.star-button__corners span:nth-of-type(1) {
+	offset-distance: 0;
+}
+.star-button__corners span:nth-of-type(2) {
+	offset-distance: 100cqi;
+}
+.star-button__corners span:nth-of-type(3) {
+	offset-rotate: 180deg;
+	offset-distance: calc(100cqi + 100cqh);
+}
+.star-button__corners span:nth-of-type(4) {
+	offset-rotate: 180deg;
+	offset-distance: -100cqh;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.star-button__corners span {
+		transition: transform 0.26s ease-out;
+	}
+	.star-button__corners span svg {
+		transition: rotate 0.26s ease-out;
+	}
+
+	.star-button:is(:hover, :focus-visible) .star-button__corners span {
+		transition-delay: 0.12s;
+	}
+	.star-button:is(:hover, :focus-visible)
+		.star-button__corners
+		span:nth-of-type(even) {
+		transform: translateY(100cqh);
+	}
+	.star-button:is(:hover, :focus-visible)
+		.star-button__corners
+		span:nth-of-type(odd) {
+		transform: translateX(100cqi);
+	}
+	.star-button:is(:hover, :focus-visible) .star-button__corners span svg {
+		rotate: 360deg;
+		transition-delay: 0.12s;
+	}
+}

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -4,32 +4,12 @@ import { Star } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
 import "./AnimatedStarButton.css";
+import { PlusMark } from "./components/PlusMark";
 
 // Four corner marks, positioned via offset-path purely by DOM order (see
 // AnimatedStarButton.css) — never reordered, so a stable static key per
 // corner is correct here.
 const CORNERS = ["top-left", "top-right", "bottom-right", "bottom-left"];
-
-// Same path data as the reference's corner icon — not a library icon, so
-// there's no risk of a different icon set's paths rendering subtly
-// differently at 10px.
-function PlusMark() {
-	return (
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M5 12h14" />
-			<path d="M12 5v14" />
-		</svg>
-	);
-}
 
 // Star = gold, matching GitHub's own convention and every other star icon
 // anywhere. Emerald is this app's existing "success" token (see e.g.

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -1,16 +1,45 @@
 import { cn } from "@superset/ui/utils";
-import {
-	AnimatePresence,
-	motion,
-	useReducedMotion,
-	useSpring,
-} from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Star } from "lucide-react";
-import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
+import "./AnimatedStarButton.css";
 
-const CONFETTI_COLORS = ["#892ab8", "#ea4c89", "#ffff04", "#4af2fd"];
-const PARTICLE_COUNT = 12;
+// Four corner marks, positioned via offset-path purely by DOM order (see
+// AnimatedStarButton.css) — never reordered, so a stable static key per
+// corner is correct here.
+const CORNERS = ["top-left", "top-right", "bottom-right", "bottom-left"];
+
+// Same path data as the reference's corner icon — not a library icon, so
+// there's no risk of a different icon set's paths rendering subtly
+// differently at 10px.
+function PlusMark() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M5 12h14" />
+			<path d="M12 5v14" />
+		</svg>
+	);
+}
+
+// Star = gold, matching GitHub's own convention and every other star icon
+// anywhere. Emerald is this app's existing "success" token (see e.g.
+// WorkspaceAheadBehind, ChecksList) — reused here instead of inventing a new
+// accent. Deliberately not amber-adjacent beyond the star itself: amber
+// already means "pending/warning" elsewhere in this app (PRIcon, git
+// ahead/behind, unstaged changes), so doubling it up as a "success" color
+// here would collide with that meaning.
+const CONFETTI_COLORS = ["#fbbf24", "#34d399", "#fbbf24"];
+const PARTICLE_COUNT = 8;
 
 // How long the post-star celebration (icon pop + confetti) stays visible.
 // Shared with GitHubStarPill and StarNagCard so they keep rendering the
@@ -29,9 +58,9 @@ interface Particle {
 function createBurst(): Particle[] {
 	return Array.from({ length: PARTICLE_COUNT }, (_, id) => ({
 		id,
-		angle: (Math.PI * 2 * id) / PARTICLE_COUNT + Math.random() * 0.6,
-		distance: 22 + Math.random() * 20,
-		rotate: Math.random() * 540 - 270,
+		angle: (Math.PI * 2 * id) / PARTICLE_COUNT + Math.random() * 0.5,
+		distance: 16 + Math.random() * 14,
+		rotate: Math.random() * 360 - 180,
 		color: CONFETTI_COLORS[id % CONFETTI_COLORS.length] as string,
 		size: 3 + Math.random() * 2,
 	}));
@@ -42,72 +71,44 @@ interface AnimatedStarButtonProps {
 	busy: boolean;
 	onActivate: () => void;
 	className?: string;
+	/** Smaller padding/font — for tighter contexts like the onboarding toast. */
+	compact?: boolean;
 }
 
 /**
  * Shared "Star on GitHub" button for the empty-state pill, sidebar card, and
- * onboarding toast: a tilt-on-hover solid button (auto-inverts light/dark
- * via bg-foreground/text-background) with a label crossfade and a confetti
- * burst on success. Framer Motion only (already a dependency) — no new
- * libraries, no external assets.
+ * onboarding toast. Chrome (padding, monospace uppercase label, color-mix
+ * background, sharp corners, four plus marks relaying around the border on
+ * hover) is a direct port of a reference design — see AnimatedStarButton.css
+ * for the full port and the one deliberate deviation (transition placement,
+ * a correctness fix, not a style change). The star icon, its pop-on-success,
+ * the label crossfade, and the confetti burst are this component's own,
+ * layered on top via Framer Motion.
  */
 export function AnimatedStarButton({
 	state,
 	busy,
 	onActivate,
 	className,
+	compact,
 }: AnimatedStarButtonProps) {
 	const [particles, setParticles] = useState<Particle[]>([]);
 	const [justStarred, setJustStarred] = useState(false);
-	const [recoiling, setRecoiling] = useState(false);
 	const prevStateRef = useRef(state);
 	const prefersReducedMotion = useReducedMotion();
 
-	const rotateX = useSpring(0, { stiffness: 300, damping: 20 });
-	const rotateY = useSpring(0, { stiffness: 300, damping: 20 });
-
-	function handleMouseMove(e: MouseEvent<HTMLButtonElement>) {
-		if (prefersReducedMotion) return;
-		const bounds = e.currentTarget.getBoundingClientRect();
-		const px =
-			(e.clientX - bounds.left - bounds.width / 2) / (bounds.width / 2);
-		const py =
-			(e.clientY - bounds.top - bounds.height / 2) / (bounds.height / 2);
-		rotateY.set(px * 8);
-		rotateX.set(py * -8);
-	}
-
-	function handleMouseLeave() {
-		rotateX.set(0);
-		rotateY.set(0);
-	}
-
 	useEffect(() => {
-		if (prevStateRef.current !== "starred" && state === "starred") {
-			if (prefersReducedMotion) {
-				setJustStarred(true);
-				const clearTimer = setTimeout(
-					() => setJustStarred(false),
-					STAR_SUCCESS_ANIMATION_MS,
-				);
-				return () => clearTimeout(clearTimer);
-			}
-			setRecoiling(true);
-			const recoilTimer = setTimeout(() => {
-				setRecoiling(false);
-				setJustStarred(true);
-				setParticles(createBurst());
-			}, 140);
+		const prevState = prevStateRef.current;
+		prevStateRef.current = state;
+		if (prevState !== "starred" && state === "starred") {
+			setJustStarred(true);
+			if (!prefersReducedMotion) setParticles(createBurst());
 			const clearTimer = setTimeout(() => {
 				setJustStarred(false);
 				setParticles([]);
 			}, STAR_SUCCESS_ANIMATION_MS);
-			return () => {
-				clearTimeout(recoilTimer);
-				clearTimeout(clearTimer);
-			};
+			return () => clearTimeout(clearTimer);
 		}
-		prevStateRef.current = state;
 	}, [state, prefersReducedMotion]);
 
 	const isStarred = state === "starred";
@@ -120,47 +121,39 @@ export function AnimatedStarButton({
 				: "Star on GitHub";
 
 	return (
-		<motion.button
+		<button
 			type="button"
 			onClick={onActivate}
-			onMouseMove={handleMouseMove}
-			onMouseLeave={handleMouseLeave}
 			disabled={busy || state === "loading"}
-			style={{ rotateX, rotateY, transformPerspective: 500 }}
-			whileHover={prefersReducedMotion ? undefined : { scale: 1.03 }}
-			whileTap={prefersReducedMotion ? undefined : { scale: 0.97 }}
-			transition={{ type: "spring", stiffness: 220, damping: 26 }}
 			className={cn(
-				"group relative inline-flex items-center gap-2.5 rounded-xl bg-foreground py-1.5 pl-1.5 pr-3.5 text-[13px] font-semibold text-background shadow-md shadow-black/10 transition-[filter,box-shadow] duration-300 ease-out will-change-transform hover:brightness-105 hover:shadow-[0_10px_28px_-8px_rgba(245,197,24,0.55)] disabled:pointer-events-none disabled:opacity-60 dark:shadow-black/30 dark:hover:shadow-[0_10px_28px_-8px_rgba(251,191,36,0.35)]",
+				"star-button group",
+				compact && "star-button--compact",
 				className,
 			)}
 		>
-			<motion.span
-				animate={
-					recoiling ? { x: -2, y: 2, scale: 0.92 } : { x: 0, y: 0, scale: 1 }
-				}
-				transition={
-					recoiling
-						? { duration: 0.12 }
-						: { type: "spring", stiffness: 300, damping: 12 }
-				}
-				className="relative flex size-6 shrink-0 items-center justify-center"
-			>
+			<span className="star-button__corners" aria-hidden="true">
+				{CORNERS.map((corner) => (
+					<span key={corner}>
+						<PlusMark />
+					</span>
+				))}
+			</span>
+			<span className="relative z-10 flex size-3.5 shrink-0 items-center justify-center">
 				<motion.span
 					animate={
 						justStarred && !prefersReducedMotion
-							? { scale: [1, 1.5, 0.85, 1.1, 1], rotate: [0, -20, 15, -8, 0] }
-							: { scale: 1, rotate: 0 }
+							? { scale: [1, 1.22, 1] }
+							: { scale: 1 }
 					}
-					transition={{ duration: 0.7, ease: "easeOut" }}
+					transition={{ duration: 0.4, ease: "easeOut", times: [0, 0.45, 1] }}
 					className="block"
 				>
 					<Star
 						className={cn(
-							"size-3.5 text-background transition-colors",
+							"size-3.5 transition-colors",
 							isStarred
 								? "fill-amber-400 text-amber-400"
-								: "group-hover:fill-amber-400/80 group-hover:text-amber-400/80",
+								: "group-hover:fill-amber-400/70 group-hover:text-amber-400/70 group-active:fill-amber-400 group-active:text-amber-400",
 						)}
 					/>
 				</motion.span>
@@ -171,25 +164,13 @@ export function AnimatedStarButton({
 							initial={{ opacity: 1, x: 0, y: 0, scale: 1 }}
 							animate={{
 								opacity: 0,
-								x: [
-									0,
-									Math.cos(p.angle) * p.distance * 0.6,
-									Math.cos(p.angle) * p.distance,
-								],
-								y: [
-									0,
-									Math.sin(p.angle) * p.distance * 0.5 - 10,
-									Math.sin(p.angle) * p.distance + 8,
-								],
+								x: Math.cos(p.angle) * p.distance,
+								y: Math.sin(p.angle) * p.distance,
 								rotate: p.rotate,
-								scale: 0.5,
+								scale: 0.4,
 							}}
 							exit={{ opacity: 0 }}
-							transition={{
-								duration: 1.3,
-								ease: "easeOut",
-								times: [0, 0.4, 1],
-							}}
+							transition={{ duration: 0.9, ease: "easeOut" }}
 							className="pointer-events-none absolute left-1/2 top-1/2 rounded-sm"
 							style={{
 								width: p.size,
@@ -199,21 +180,21 @@ export function AnimatedStarButton({
 						/>
 					))}
 				</AnimatePresence>
-			</motion.span>
-			<span className="relative inline-block overflow-hidden">
+			</span>
+			<span className="relative z-10 inline-block overflow-hidden">
 				<AnimatePresence mode="wait" initial={false}>
 					<motion.span
 						key={label}
-						initial={{ opacity: 0, y: 6 }}
+						initial={{ opacity: 0, y: 4 }}
 						animate={{ opacity: 1, y: 0 }}
-						exit={{ opacity: 0, y: -6 }}
-						transition={{ duration: 0.15 }}
+						exit={{ opacity: 0, y: -4 }}
+						transition={{ duration: 0.2, ease: "easeOut" }}
 						className="block"
 					>
 						{label}
 					</motion.span>
 				</AnimatePresence>
 			</span>
-		</motion.button>
+		</button>
 	);
 }

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/components/PlusMark/PlusMark.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/components/PlusMark/PlusMark.tsx
@@ -1,0 +1,20 @@
+// Same path data as the reference's corner icon — not a library icon, so
+// there's no risk of a different icon set's paths rendering subtly
+// differently at 10px.
+export function PlusMark() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M5 12h14" />
+			<path d="M12 5v14" />
+		</svg>
+	);
+}

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/components/PlusMark/index.ts
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/components/PlusMark/index.ts
@@ -1,0 +1,1 @@
+export { PlusMark } from "./PlusMark";

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -15,45 +15,52 @@ interface GitHubStarPillProps {
 /**
  * Small, always-optional "Star Superset on GitHub" pill for the empty
  * "no pane open" screens (v1 EmptyTabView and v2 WorkspaceEmptyState).
- * Hides once starred — either immediately if it was already starred before
- * this mounted, or after a short grace period if the user just starred it
- * here, so the confetti/label animation has time to play.
+ * Renders from live `state`, not the nag-suppression `isMuted` flag — unlike
+ * the sidebar card/toast, this is a low-key status indicator, not an
+ * interruptive campaign, so it's allowed to be fully truthful: it hides the
+ * instant `state` is "starred" and reappears the instant a later unstar is
+ * confirmed, without waiting on the mute grace window. It briefly stays
+ * mounted past that point so the confetti/label animation on a fresh star
+ * has time to play.
  */
 export function GitHubStarPill({ className }: GitHubStarPillProps) {
 	const { state, activate, isBusy } = useGithubStarAction();
-	const [visible, setVisible] = useState(true);
 	const prevStateRef = useRef<GithubStarActionState | null>(null);
 
+	const [staysVisibleForAnimation, setStaysVisibleForAnimation] =
+		useState(false);
 	useEffect(() => {
 		const prev = prevStateRef.current;
 		prevStateRef.current = state;
 		const justStarred =
 			(prev === "not_starred" || prev === "unknown") && state === "starred";
-		if (state === "starred" && !justStarred) {
-			setVisible(false);
-			return;
-		}
 		if (justStarred) {
+			setStaysVisibleForAnimation(true);
 			const timer = setTimeout(
-				() => setVisible(false),
+				() => setStaysVisibleForAnimation(false),
 				STAR_SUCCESS_ANIMATION_MS,
 			);
 			return () => clearTimeout(timer);
 		}
 	}, [state]);
 
-	// Fire at most once per mount — without this guard, a failed star attempt
-	// (not_starred -> unknown) reports a second "shown" for the same session,
-	// inflating impressions relative to star_nag_starred.
+	// Fire at most once per showing — reset once starred so a later unstar
+	// that re-shows the pill tracks a fresh "shown" impression instead of
+	// staying silent forever after the first one.
 	const trackedShownRef = useRef(false);
 	useEffect(() => {
+		if (state === "starred") {
+			trackedShownRef.current = false;
+			return;
+		}
 		if (trackedShownRef.current) return;
 		if (state !== "not_starred" && state !== "unknown") return;
 		trackedShownRef.current = true;
 		track("star_nag_shown", { surface: "empty_state" });
 	}, [state]);
 
-	if (state === "loading" || !visible) return null;
+	if (state === "loading") return null;
+	if (state === "starred" && !staysVisibleForAnimation) return null;
 
 	const handleClick = () => {
 		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@superset/ui/utils";
+import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import {
 	AnimatedStarButton,
@@ -15,26 +16,50 @@ interface GitHubStarPillProps {
 /**
  * Small, always-optional "Star Superset on GitHub" pill for the empty
  * "no pane open" screens (v1 EmptyTabView and v2 WorkspaceEmptyState).
- * Renders from live `state`, not the nag-suppression `isMuted` flag — unlike
+ * Renders straight from live `state`, with no nag-suppression layer — unlike
  * the sidebar card/toast, this is a low-key status indicator, not an
  * interruptive campaign, so it's allowed to be fully truthful: it hides the
  * instant `state` is "starred" and reappears the instant a later unstar is
- * confirmed, without waiting on the mute grace window. It briefly stays
+ * confirmed, without waiting on any mute grace window. It briefly stays
  * mounted past that point so the confetti/label animation on a fresh star
- * has time to play.
+ * has time to play, then dissolves out (fade + soft blur) instead of
+ * vanishing instantly.
  */
 export function GitHubStarPill({ className }: GitHubStarPillProps) {
 	const { state, activate, isBusy } = useGithubStarAction();
 	const prevStateRef = useRef<GithubStarActionState | null>(null);
 
+	// Computed synchronously during render (not inside the effect below) so
+	// the hide check further down can't lag a render behind the state flip.
+	// That lag used to unmount this component's child AnimatedStarButton for
+	// exactly one render right as `state` became "starred" — before
+	// staysVisibleForAnimation had a chance to flip true — which reset
+	// AnimatedStarButton's own "was I just starred" ref on remount and
+	// silently dropped its confetti/pop celebration.
+	const prevState = prevStateRef.current;
+	prevStateRef.current = state;
+	const justStarred =
+		(prevState === "not_starred" || prevState === "unknown") &&
+		state === "starred";
+
+	// Separate ref + effect from the render-time justStarred above, and keyed
+	// on `state` rather than `justStarred`: `justStarred` itself flips back to
+	// false on the very next render (setStaysVisibleForAnimation(true) causes
+	// a re-render, and prevStateRef has already advanced to "starred" by
+	// then) — if this effect depended on `justStarred` directly, that flip
+	// would re-run it, firing the cleanup that cancels the just-started timer
+	// before it ever fires, and no replacement timer gets scheduled since
+	// justStarred is false by then. Keying on `state` (which only changes
+	// once) keeps the timer alive for its full duration instead.
 	const [staysVisibleForAnimation, setStaysVisibleForAnimation] =
 		useState(false);
+	const prevStateForTimerRef = useRef<GithubStarActionState | null>(null);
 	useEffect(() => {
-		const prev = prevStateRef.current;
-		prevStateRef.current = state;
-		const justStarred =
+		const prev = prevStateForTimerRef.current;
+		prevStateForTimerRef.current = state;
+		const justStarredForTimer =
 			(prev === "not_starred" || prev === "unknown") && state === "starred";
-		if (justStarred) {
+		if (justStarredForTimer) {
 			setStaysVisibleForAnimation(true);
 			const timer = setTimeout(
 				() => setStaysVisibleForAnimation(false),
@@ -60,7 +85,12 @@ export function GitHubStarPill({ className }: GitHubStarPillProps) {
 	}, [state]);
 
 	if (state === "loading") return null;
-	if (state === "starred" && !staysVisibleForAnimation) return null;
+
+	const isVisible = !(
+		state === "starred" &&
+		!justStarred &&
+		!staysVisibleForAnimation
+	);
 
 	const handleClick = () => {
 		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
@@ -70,12 +100,23 @@ export function GitHubStarPill({ className }: GitHubStarPillProps) {
 	};
 
 	return (
-		<div className={cn("flex items-center justify-center", className)}>
-			<AnimatedStarButton
-				state={state}
-				busy={isBusy}
-				onActivate={handleClick}
-			/>
-		</div>
+		<AnimatePresence>
+			{isVisible && (
+				<motion.div
+					key="star-pill"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0, scale: 0.92, filter: "blur(3px)" }}
+					transition={{ duration: 0.32, ease: "easeOut" }}
+					className={cn("flex items-center justify-center", className)}
+				>
+					<AnimatedStarButton
+						state={state}
+						busy={isBusy}
+						onActivate={handleClick}
+					/>
+				</motion.div>
+			)}
+		</AnimatePresence>
 	);
 }

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -27,7 +27,14 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	const shouldShow = useStarNagStore((s) => s.shouldShowThresholdCard());
 	const deferredUntil = useStarNagStore((s) => s.deferredUntil);
 	const dismiss = useStarNagStore((s) => s.dismiss);
-	const { state, activate, isBusy } = useGithubStarAction();
+	// The card is mounted unconditionally in both sidebars regardless of the
+	// flag or collapsed state — without this, checkStarred (which shells out
+	// to `gh`) would fire in the background for every user on every window
+	// focus, even with the flag off. isMuted still reflects the shared store
+	// even while this instance's own query is disabled.
+	const { state, activate, isBusy } = useGithubStarAction({
+		enabled: !isCollapsed && isEnabled === true,
+	});
 
 	// shouldShowThresholdCard() is only re-evaluated when the store itself
 	// changes — a cooldown expiring is a pure passage of time, not a store
@@ -68,8 +75,17 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	const renderVisible = shouldShow || staysVisibleForAnimation;
 	const isVisible = !isCollapsed && isEnabled && shouldShow;
 
+	// Fire at most once per visible showing — without the reset, every
+	// sidebar collapse/expand cycle re-triggers this effect and inflates
+	// impressions relative to the other surfaces' once-per-showing trackers.
+	const trackedShownRef = useRef(false);
 	useEffect(() => {
-		if (!isVisible) return;
+		if (!isVisible) {
+			trackedShownRef.current = false;
+			return;
+		}
+		if (trackedShownRef.current) return;
+		trackedShownRef.current = true;
 		track("star_nag_shown", { surface: "card" });
 	}, [isVisible]);
 

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -28,10 +28,12 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	const deferredUntil = useStarNagStore((s) => s.deferredUntil);
 	const dismiss = useStarNagStore((s) => s.dismiss);
 	// The card is mounted unconditionally in both sidebars regardless of the
-	// flag or collapsed state — without this, checkStarred (which shells out
-	// to `gh`) would fire in the background for every user on every window
-	// focus, even with the flag off. isMuted still reflects the shared store
-	// even while this instance's own query is disabled.
+	// flag or collapsed state. StarNagObserver's own always-on query already
+	// covers the pill/toast/settings row's need for a live read regardless of
+	// this flag, so gating this instance can't stop `gh` from ever being
+	// called for a disabled user — it only avoids a second, redundant active
+	// query observer (and its own extra mount-time refetch) tied to this
+	// card's collapse/expand and flag-load cycles specifically.
 	const { state, activate, isBusy } = useGithubStarAction({
 		enabled: !isCollapsed && isEnabled === true,
 	});

--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -53,6 +53,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 				busy={isBusy}
 				onActivate={handleAction}
 				className="mt-3 w-full justify-center"
+				compact
 			/>
 		</div>
 	);
@@ -81,10 +82,14 @@ export function showStarNagOnboardingToast() {
 		duration: TOAST_DURATION_MS,
 		// Only fires when the toast's own duration elapses naturally — a
 		// manual toast.dismiss() from starring or clicking the X does not
-		// trigger this, so it can't double-count a dismissal.
+		// trigger this, so it can't double-count a dismissal. Ignoring the
+		// toast isn't an explicit "no thanks", so it starts the same cooldown
+		// as a real dismiss() without also doubling the sidebar card's
+		// threshold — the default new-user path (see the toast, keep working)
+		// would otherwise make the card nearly impossible to trigger.
 		onAutoClose: () => {
 			track("star_nag_dismissed", { surface: "toast" });
-			useStarNagStore.getState().dismiss();
+			useStarNagStore.getState().snoozeThresholdCard();
 		},
 	});
 }

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
@@ -1,2 +1,8 @@
 export type { GithubStarActionState } from "./useGithubStarAction";
-export { useGithubStarAction } from "./useGithubStarAction";
+export {
+	CHECK_STARRED_STALE_TIME_MS,
+	msUntilUnstarGraceWindowCloses,
+	shouldUnmuteOnUnstarredRead,
+	UNSTAR_CONFIRM_DELAY_MS,
+	useGithubStarAction,
+} from "./useGithubStarAction";

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.test.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import {
+	msUntilUnstarGraceWindowCloses,
+	shouldUnmuteOnUnstarredRead,
+	UNSTAR_CONFIRM_DELAY_MS,
+} from "./useGithubStarAction";
+
+describe("shouldUnmuteOnUnstarredRead", () => {
+	test("ignores reads other than not_starred", () => {
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: true,
+				completedAt: 0,
+				checkResult: "starred",
+				now: 1_000_000,
+			}),
+		).toBe(false);
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: true,
+				completedAt: 0,
+				checkResult: "unknown",
+				now: 1_000_000,
+			}),
+		).toBe(false);
+	});
+
+	test("ignores a not_starred read while not currently completed", () => {
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: false,
+				completedAt: null,
+				checkResult: "not_starred",
+				now: 1_000_000,
+			}),
+		).toBe(false);
+	});
+
+	test("suppresses a not_starred read within the flaky-read grace window", () => {
+		const completedAt = 1_000_000;
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: true,
+				completedAt,
+				checkResult: "not_starred",
+				now: completedAt + UNSTAR_CONFIRM_DELAY_MS - 1,
+			}),
+		).toBe(false);
+	});
+
+	test("trusts a not_starred read once the grace window has elapsed", () => {
+		const completedAt = 1_000_000;
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: true,
+				completedAt,
+				checkResult: "not_starred",
+				now: completedAt + UNSTAR_CONFIRM_DELAY_MS + 1,
+			}),
+		).toBe(true);
+	});
+
+	test("trusts a not_starred read immediately for a null completedAt (pre-timestamp schema)", () => {
+		expect(
+			shouldUnmuteOnUnstarredRead({
+				completed: true,
+				completedAt: null,
+				checkResult: "not_starred",
+				now: 1_000_000,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("msUntilUnstarGraceWindowCloses", () => {
+	test("returns null when not completed", () => {
+		expect(
+			msUntilUnstarGraceWindowCloses({
+				completed: false,
+				completedAt: null,
+				now: 1_000_000,
+			}),
+		).toBeNull();
+	});
+
+	test("returns null for a pre-timestamp completedAt — nothing to schedule, shouldUnmuteOnUnstarredRead already trusts it immediately", () => {
+		expect(
+			msUntilUnstarGraceWindowCloses({
+				completed: true,
+				completedAt: null,
+				now: 1_000_000,
+			}),
+		).toBeNull();
+	});
+
+	test("returns the remaining time while inside the grace window", () => {
+		const completedAt = 1_000_000;
+		const now = completedAt + 10_000;
+		expect(
+			msUntilUnstarGraceWindowCloses({ completed: true, completedAt, now }),
+		).toBe(UNSTAR_CONFIRM_DELAY_MS - 10_000);
+	});
+
+	test("returns null once the grace window has already elapsed — nothing to schedule", () => {
+		const completedAt = 1_000_000;
+		const now = completedAt + UNSTAR_CONFIRM_DELAY_MS + 1;
+		expect(
+			msUntilUnstarGraceWindowCloses({ completed: true, completedAt, now }),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -1,6 +1,5 @@
 import { COMPANY } from "@superset/shared/constants";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { useStarNagStore } from "renderer/stores/star-nag";
 
 export type GithubStarActionState =
 	| "loading"
@@ -68,26 +67,31 @@ interface UseGithubStarActionOptions {
 	 * Skip the checkStarred query entirely. Every check shells out to the
 	 * user's local `gh` CLI, so a surface that isn't currently eligible to be
 	 * shown (e.g. a feature-flagged sidebar card that's collapsed or
-	 * disabled) has no reason to keep checking in the background — `isMuted`
-	 * still reflects the shared store regardless of any one hook instance's
-	 * query being disabled. Defaults to true.
+	 * disabled) has no reason to keep checking in the background. Defaults to
+	 * true.
 	 */
 	enabled?: boolean;
+	/**
+	 * Always fetch a fresh read on mount, ignoring staleTime (still never on
+	 * window focus). For a surface the user navigates to specifically to
+	 * check status — the Settings row — rather than one that's ambiently
+	 * displayed most of a session, staying honest on every visit matters more
+	 * than avoiding a `gh` call. Defaults to false.
+	 */
+	alwaysFreshOnMount?: boolean;
 }
 
 /**
  * Shared check-star-repo/star-repo/open-web-fallback flow, reused by every
  * "Star Superset on GitHub" surface (settings row, empty-state pill,
- * threshold card, onboarding toast).
+ * threshold card, onboarding toast). `state` is the live, truthful star
+ * status — backed by the shared query cache, so a confirmed star from any
+ * one surface is reflected on every other mounted surface immediately.
  *
- * Returns two independent things: `state` is the live, truthful star status
- * (backed by the shared query cache, so a confirmed star from any one
- * surface is reflected on every other mounted surface immediately) — this is
- * what should be displayed. `isMuted` is whether nag surfaces should
- * suppress themselves; it lags `state` deliberately (see
- * shouldUnmuteOnUnstarredRead) to absorb flaky checkStarred reads that would
- * otherwise flicker the ask back on. A status surface like the Settings row
- * or the empty-state pill should only ever read `state`, never `isMuted`.
+ * Suppression (whether a nag surface should show itself at all) is NOT this
+ * hook's concern — StarNagCard and StarNagToast derive that straight from
+ * useStarNagStore (shouldShowThresholdCard()/isEligible()), and the pill and
+ * Settings row are deliberately always-truthful with no suppression at all.
  *
  * checkResult -> store side effects (markCompleted/markUnstarred) are NOT
  * handled here — StarNagObserver owns that, once, so the four independently
@@ -101,10 +105,10 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 			enabled,
 			staleTime: CHECK_STARRED_STALE_TIME_MS,
 			refetchOnWindowFocus: false,
+			refetchOnMount: options?.alwaysFreshOnMount ? "always" : true,
 		});
 	const starMutation = electronTrpc.githubStar.star.useMutation();
 	const openUrlMutation = electronTrpc.external.openUrl.useMutation();
-	const completed = useStarNagStore((s) => s.completed);
 
 	const state: GithubStarActionState = isSuccess ? checkResult : "loading";
 
@@ -131,17 +135,34 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 					undefined,
 					starred ? "starred" : "unknown",
 				);
+				if (!starred) markStaleWithoutRefetch(utils);
 			},
 			onError: () => {
 				utils.githubStar.checkStarred.setData(undefined, "unknown");
+				markStaleWithoutRefetch(utils);
 			},
 		});
 	};
 
 	return {
 		state,
-		isMuted: completed,
 		activate,
 		isBusy: starMutation.isPending || openUrlMutation.isPending,
 	};
+}
+
+/**
+ * A failed/declined star attempt still writes "unknown" into the cache for
+ * immediate UI feedback (the web-fallback state), but unlike a real
+ * "starred"/"not_starred" confirmation it shouldn't count as a fresh,
+ * settled-for-10-minutes read — mark it stale (with no eager refetch of its
+ * own) so the next mount naturally rechecks instead of every surface being
+ * stuck on the failure fallback for up to staleTime.
+ */
+function markStaleWithoutRefetch(
+	utils: ReturnType<typeof electronTrpc.useUtils>,
+) {
+	void utils.githubStar.checkStarred.invalidate(undefined, {
+		refetchType: "none",
+	});
 }

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -1,5 +1,4 @@
 import { COMPANY } from "@superset/shared/constants";
-import { useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useStarNagStore } from "renderer/stores/star-nag";
 
@@ -9,40 +8,105 @@ export type GithubStarActionState =
 	| "unknown"
 	| "starred";
 
+// GitHub's starred-check API has been observed to flap between 204 and 404 on
+// rapid successive calls (see the "flaky checkStarred" fix) — so a
+// "not_starred" read moments after we mark the repo starred is more likely
+// that flake than a real unstar. Require this much time to have passed since
+// we last marked it starred before trusting a "not_starred" read enough to
+// unmute again. See StarNagObserver, which schedules a follow-up check right
+// as this window closes.
+export const UNSTAR_CONFIRM_DELAY_MS = 60_000;
+
+// checkStarred shells out to the user's local `gh` CLI on every fetch, and
+// this data changes rarely — there's no reason to treat "the window regained
+// focus" as a trigger (every call site disables refetchOnWindowFocus).
+// Mount-time fetches gated by this staleTime, plus StarNagObserver's
+// deliberate invalidate() calls, are the only triggers.
+export const CHECK_STARRED_STALE_TIME_MS = 10 * 60_000;
+
+/**
+ * Whether a live "not_starred" read is trustworthy enough to unmute the nag
+ * again, given we currently believe the repo is starred. Exported standalone
+ * so the grace-window edge cases (never-set completedAt, boundary) are
+ * unit-testable without rendering anything.
+ */
+export function shouldUnmuteOnUnstarredRead(params: {
+	completed: boolean;
+	completedAt: number | null;
+	checkResult: GithubStarActionState | undefined;
+	now: number;
+}): boolean {
+	const { completed, completedAt, checkResult, now } = params;
+	if (checkResult !== "not_starred" || !completed) return false;
+	// A null completedAt means this account completed under the
+	// pre-timestamp schema, which we can't date — treat it as long enough
+	// ago to trust immediately.
+	return completedAt === null || now - completedAt > UNSTAR_CONFIRM_DELAY_MS;
+}
+
+/**
+ * How long until the flaky-read grace window closes, or `null` if there's
+ * nothing to wait for (not completed, or a pre-timestamp `completedAt` that
+ * shouldUnmuteOnUnstarredRead already trusts immediately). Exported
+ * standalone for the same reason as shouldUnmuteOnUnstarredRead — the
+ * scheduling decision is unit-testable without a real timer or a mounted
+ * component.
+ */
+export function msUntilUnstarGraceWindowCloses(params: {
+	completed: boolean;
+	completedAt: number | null;
+	now: number;
+}): number | null {
+	const { completed, completedAt, now } = params;
+	if (!completed || completedAt === null) return null;
+	const msRemaining = completedAt + UNSTAR_CONFIRM_DELAY_MS - now;
+	return msRemaining > 0 ? msRemaining : null;
+}
+
+interface UseGithubStarActionOptions {
+	/**
+	 * Skip the checkStarred query entirely. Every check shells out to the
+	 * user's local `gh` CLI, so a surface that isn't currently eligible to be
+	 * shown (e.g. a feature-flagged sidebar card that's collapsed or
+	 * disabled) has no reason to keep checking in the background — `isMuted`
+	 * still reflects the shared store regardless of any one hook instance's
+	 * query being disabled. Defaults to true.
+	 */
+	enabled?: boolean;
+}
+
 /**
  * Shared check-star-repo/star-repo/open-web-fallback flow, reused by every
  * "Star Superset on GitHub" surface (settings row, empty-state pill,
- * threshold card). Starring successfully from any surface permanently mutes
- * the threshold nag everywhere else via useStarNagStore.markCompleted().
+ * threshold card, onboarding toast).
+ *
+ * Returns two independent things: `state` is the live, truthful star status
+ * (backed by the shared query cache, so a confirmed star from any one
+ * surface is reflected on every other mounted surface immediately) — this is
+ * what should be displayed. `isMuted` is whether nag surfaces should
+ * suppress themselves; it lags `state` deliberately (see
+ * shouldUnmuteOnUnstarredRead) to absorb flaky checkStarred reads that would
+ * otherwise flicker the ask back on. A status surface like the Settings row
+ * or the empty-state pill should only ever read `state`, never `isMuted`.
+ *
+ * checkResult -> store side effects (markCompleted/markUnstarred) are NOT
+ * handled here — StarNagObserver owns that, once, so the four independently
+ * mounted surfaces don't each run their own copy of the same effect.
  */
-export function useGithubStarAction() {
+export function useGithubStarAction(options?: UseGithubStarActionOptions) {
+	const enabled = options?.enabled ?? true;
+	const utils = electronTrpc.useUtils();
 	const { data: checkResult, isSuccess } =
-		electronTrpc.githubStar.checkStarred.useQuery();
+		electronTrpc.githubStar.checkStarred.useQuery(undefined, {
+			enabled,
+			staleTime: CHECK_STARRED_STALE_TIME_MS,
+			refetchOnWindowFocus: false,
+		});
 	const starMutation = electronTrpc.githubStar.star.useMutation();
 	const openUrlMutation = electronTrpc.external.openUrl.useMutation();
 	const completed = useStarNagStore((s) => s.completed);
-	const markCompleted = useStarNagStore((s) => s.markCompleted);
-	// Overrides the query result once the user has acted, so the UI reflects
-	// the outcome immediately instead of waiting on a refetch.
-	const [override, setOverride] = useState<GithubStarActionState | null>(null);
 
-	// `completed` wins over everything else, including a fresh mount's own
-	// query result: GitHub's starred-check API has been observed to flap
-	// between 204 and 404 on rapid successive calls, so a component that
-	// remounts (e.g. a new empty-state pill on a different workspace) must
-	// not re-show the ask just because it happened to poll during a flaky
-	// "not_starred" read. Once any surface has ever confirmed starred, every
-	// surface stays permanently suppressed regardless of later query noise.
-	const state: GithubStarActionState = completed
-		? "starred"
-		: (override ?? (isSuccess ? checkResult : "loading"));
-
-	// The repo can already be starred from outside the app (e.g. the user
-	// starred it on github.com, or via `gh` directly) — treat that exactly
-	// like a fresh star action so every other surface stops nagging too.
-	useEffect(() => {
-		if (checkResult === "starred") markCompleted();
-	}, [checkResult, markCompleted]);
+	const state: GithubStarActionState = isSuccess ? checkResult : "loading";
 
 	const activate = () => {
 		if (state === "unknown") {
@@ -50,21 +114,33 @@ export function useGithubStarAction() {
 			return;
 		}
 		if (state !== "not_starred") return;
-		setOverride("starred");
+		// Deliberately NOT optimistic: writing "starred" into the cache before
+		// the mutation resolves would make StarNagObserver's checkResult effect
+		// treat the optimistic value as confirmation and mark completed — even
+		// if the `gh` call then fails, with no path back since a failure lands
+		// on "unknown", which shouldUnmuteOnUnstarredRead never acts on.
+		// `isBusy` already gives immediate feedback ("Starring…"), so waiting
+		// for a real result costs nothing but correctness.
 		starMutation.mutate(undefined, {
 			onSuccess: (starred) => {
-				if (starred) {
-					markCompleted();
-				} else {
-					setOverride("unknown");
-				}
+				// Written into the shared query cache (not per-hook-instance
+				// state) so every mounted surface reflects the confirmed result
+				// immediately; StarNagObserver reacts to the change and marks
+				// completed.
+				utils.githubStar.checkStarred.setData(
+					undefined,
+					starred ? "starred" : "unknown",
+				);
 			},
-			onError: () => setOverride("unknown"),
+			onError: () => {
+				utils.githubStar.checkStarred.setData(undefined, "unknown");
+			},
 		});
 	};
 
 	return {
 		state,
+		isMuted: completed,
 		activate,
 		isBusy: starMutation.isPending || openUrlMutation.isPending,
 	};

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -126,7 +126,16 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 		// `isBusy` already gives immediate feedback ("Starring…"), so waiting
 		// for a real result costs nothing but correctness.
 		starMutation.mutate(undefined, {
-			onSuccess: (starred) => {
+			onSuccess: async (starred) => {
+				// Cancel any in-flight checkStarred fetch first: it may have
+				// started before this mutation resolved (e.g. Settings'
+				// alwaysFreshOnMount, or a fresh mount elsewhere) and, if left
+				// running, could resolve *after* the setData below and silently
+				// overwrite this confirmed result with a stale pre-mutation
+				// read — react-query's own out-of-order protection only covers
+				// its own fetches racing each other, not a fetch racing a
+				// direct cache write like setData.
+				await utils.githubStar.checkStarred.cancel();
 				// Written into the shared query cache (not per-hook-instance
 				// state) so every mounted surface reflects the confirmed result
 				// immediately; StarNagObserver reacts to the change and marks
@@ -137,7 +146,8 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 				);
 				if (!starred) markStaleWithoutRefetch(utils);
 			},
-			onError: () => {
+			onError: async () => {
+				await utils.githubStar.checkStarred.cancel();
 				utils.githubStar.checkStarred.setData(undefined, "unknown");
 				markStaleWithoutRefetch(utils);
 			},

--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateFromPr.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateFromPr.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { recordV1WorkspaceCreatedIfNew } from "renderer/stores/star-nag";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
 
@@ -24,6 +25,8 @@ export function useCreateFromPr(options?: MutationOptions) {
 		onSuccess: async (data, ...rest) => {
 			const agentLaunchRequest = pendingLaunchRequestRef.current;
 			pendingLaunchRequestRef.current = null;
+
+			recordV1WorkspaceCreatedIfNew(data.wasExisting);
 
 			if (!data.wasExisting && (data.initialCommands || agentLaunchRequest)) {
 				const optimisticProgress: WorkspaceInitProgress = {

--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showWorkspaceAutoNameWarningToast";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
-import { useStarNagStore } from "renderer/stores/star-nag";
+import { recordV1WorkspaceCreatedIfNew } from "renderer/stores/star-nag";
 import type { PendingTerminalSetup } from "renderer/stores/workspace-init";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
@@ -77,8 +77,9 @@ export function useCreateWorkspace(options?: UseCreateWorkspaceOptions) {
 				});
 			}
 
+			recordV1WorkspaceCreatedIfNew(data.wasExisting);
+
 			if (!data.wasExisting) {
-				useStarNagStore.getState().recordWorkspaceCreated();
 				const normalizedLaunchRequest =
 					pendingSetupOverrides?.agentLaunchRequest
 						? {

--- a/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { recordV1WorkspaceCreatedIfNew } from "renderer/stores/star-nag";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
 
@@ -20,6 +21,8 @@ export function useOpenMainRepoWorkspace(
 		...options,
 		onSuccess: async (data, ...rest) => {
 			await utils.workspaces.invalidate();
+
+			recordV1WorkspaceCreatedIfNew(data.wasExisting);
 
 			if (!data.wasExisting) {
 				let setupData = null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/StarNagObserver.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/StarNagObserver.tsx
@@ -41,15 +41,25 @@ export function StarNagObserver() {
 	const markCompleted = useStarNagStore((s) => s.markCompleted);
 	const markUnstarred = useStarNagStore((s) => s.markUnstarred);
 
-	const { data: checkResult } = electronTrpc.githubStar.checkStarred.useQuery(
-		undefined,
-		{
+	const { data: checkResult, dataUpdatedAt } =
+		electronTrpc.githubStar.checkStarred.useQuery(undefined, {
 			staleTime: CHECK_STARRED_STALE_TIME_MS,
 			refetchOnWindowFocus: false,
+			// Without this, the backstop interval simply doesn't fire while the
+			// window is unfocused/backgrounded (TanStack Query's default) — which
+			// is exactly the "one empty pane left open for a while" scenario it
+			// exists for.
+			refetchIntervalInBackground: true,
 			refetchInterval: completed ? UNSTAR_BACKSTOP_INTERVAL_MS : false,
-		},
-	);
+		});
 
+	// dataUpdatedAt is deliberately in the deps below though unreferenced
+	// here: the scheduled re-verify can resolve to the *same* checkResult
+	// string as the read that started the grace window (e.g. "not_starred"
+	// both times) — without a value that changes on every completed fetch,
+	// React sees no dependency change and skips re-running this effect
+	// entirely, so a confirmed unstar can silently never call markUnstarred().
+	// biome-ignore lint/correctness/useExhaustiveDependencies: see above
 	useEffect(() => {
 		if (checkResult === "starred" && !completed) {
 			markCompleted();
@@ -65,7 +75,14 @@ export function StarNagObserver() {
 		) {
 			markUnstarred();
 		}
-	}, [checkResult, completed, completedAt, markCompleted, markUnstarred]);
+	}, [
+		checkResult,
+		dataUpdatedAt,
+		completed,
+		completedAt,
+		markCompleted,
+		markUnstarred,
+	]);
 
 	// A "not_starred" read inside the grace window is ignored above (that's
 	// the flaky-checkStarred protection) — schedule exactly one re-verify

--- a/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/StarNagObserver.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/StarNagObserver.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from "react";
+import {
+	CHECK_STARRED_STALE_TIME_MS,
+	msUntilUnstarGraceWindowCloses,
+	shouldUnmuteOnUnstarredRead,
+} from "renderer/hooks/useGithubStarAction";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useStarNagStore } from "renderer/stores/star-nag";
+
+// Backstop for the case where no star-nag surface (pill, settings, card,
+// toast) happens to mount for a long time after the repo is unstarred — e.g.
+// one empty pane left open for hours with no navigation. The grace-window
+// follow-up below already covers the common case (unstarred shortly after
+// starring); this only matters for a long-tail idle session. Deliberately
+// infrequent and gated to only-while-muted — an un-completed user already
+// gets frequent live checks from whichever surface is currently showing the
+// ask.
+const UNSTAR_BACKSTOP_INTERVAL_MS = 30 * 60_000;
+
+/**
+ * App-shell singleton — mounted once in the authenticated layout, renders
+ * nothing — that owns every checkStarred -> useStarNagStore side effect, so
+ * the four independently-mounted star-nag surfaces (settings row,
+ * empty-state pill, sidebar card, onboarding toast) don't each run their own
+ * copy of this logic.
+ *
+ * Also the only place that ever schedules a deliberate re-check of star
+ * status. Never on window focus — the three triggers are:
+ *   1. once per app session, from this component's own always-enabled query
+ *      (the query cache is empty on a fresh launch, so this fires for free);
+ *   2. right as the flaky-checkStarred grace window closes after marking
+ *      completed, so a genuine unstar shortly after starring isn't stuck
+ *      behind a 60s window with no follow-up; and
+ *   3. a slow backstop interval while muted, in case nothing else remounts
+ *      for a long time.
+ */
+export function StarNagObserver() {
+	const utils = electronTrpc.useUtils();
+	const completed = useStarNagStore((s) => s.completed);
+	const completedAt = useStarNagStore((s) => s.completedAt);
+	const markCompleted = useStarNagStore((s) => s.markCompleted);
+	const markUnstarred = useStarNagStore((s) => s.markUnstarred);
+
+	const { data: checkResult } = electronTrpc.githubStar.checkStarred.useQuery(
+		undefined,
+		{
+			staleTime: CHECK_STARRED_STALE_TIME_MS,
+			refetchOnWindowFocus: false,
+			refetchInterval: completed ? UNSTAR_BACKSTOP_INTERVAL_MS : false,
+		},
+	);
+
+	useEffect(() => {
+		if (checkResult === "starred" && !completed) {
+			markCompleted();
+			return;
+		}
+		if (
+			shouldUnmuteOnUnstarredRead({
+				completed,
+				completedAt,
+				checkResult,
+				now: Date.now(),
+			})
+		) {
+			markUnstarred();
+		}
+	}, [checkResult, completed, completedAt, markCompleted, markUnstarred]);
+
+	// A "not_starred" read inside the grace window is ignored above (that's
+	// the flaky-checkStarred protection) — schedule exactly one re-verify
+	// right when the window closes, via a plain invalidate() rather than a
+	// direct markUnstarred(), so the result still passes through the same
+	// effect above and only unmutes if the fresh read still says not_starred.
+	useEffect(() => {
+		const msRemaining = msUntilUnstarGraceWindowCloses({
+			completed,
+			completedAt,
+			now: Date.now(),
+		});
+		if (msRemaining === null) return;
+		const timer = setTimeout(() => {
+			void utils.githubStar.checkStarred.invalidate();
+		}, msRemaining);
+		return () => clearTimeout(timer);
+	}, [completed, completedAt, utils]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/StarNagObserver/index.ts
@@ -1,0 +1,1 @@
+export { StarNagObserver } from "./StarNagObserver";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -29,6 +29,7 @@ import { DaemonAutoUpdateFailureDialog } from "renderer/routes/_authenticated/co
 import { DashboardNewWorkspaceModal } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal";
 import { DiffThemeSync } from "renderer/routes/_authenticated/components/DiffThemeSync";
 import { PendingDeletionScreen } from "renderer/routes/_authenticated/components/PendingDeletionScreen";
+import { StarNagObserver } from "renderer/routes/_authenticated/components/StarNagObserver";
 import {
 	V1AutoMigration,
 	V1MigrationContinuity,
@@ -301,6 +302,7 @@ function AuthenticatedLayout() {
 							<FileMenuListener />
 							<V2NotificationController />
 							<DockBadgeController />
+							<StarNagObserver />
 							<DaemonAutoUpdateFailureDialog />
 							<Outlet />
 							<V1ImportModal />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
@@ -10,7 +10,12 @@ interface GithubStarRowProps {
 }
 
 export function GithubStarRow({ searchQuery }: GithubStarRowProps) {
-	const { state, activate, isBusy } = useGithubStarAction();
+	// A status row the user navigated to specifically to check, not an
+	// ambient surface — worth a fresh check on every visit rather than
+	// trusting up to 10 minutes of staleness.
+	const { state, activate, isBusy } = useGithubStarAction({
+		alwaysFreshOnMount: true,
+	});
 
 	function handleClick() {
 		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {

--- a/apps/desktop/src/renderer/stores/star-nag/index.ts
+++ b/apps/desktop/src/renderer/stores/star-nag/index.ts
@@ -1,1 +1,5 @@
-export { STAR_NAG_INITIAL_THRESHOLD, useStarNagStore } from "./store";
+export {
+	recordV1WorkspaceCreatedIfNew,
+	STAR_NAG_INITIAL_THRESHOLD,
+	useStarNagStore,
+} from "./store";

--- a/apps/desktop/src/renderer/stores/star-nag/store.test.ts
+++ b/apps/desktop/src/renderer/stores/star-nag/store.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { STAR_NAG_INITIAL_THRESHOLD, useStarNagStore } from "./store";
+import {
+	recordV1WorkspaceCreatedIfNew,
+	STAR_NAG_INITIAL_THRESHOLD,
+	useStarNagStore,
+} from "./store";
 
 function resetStore() {
 	useStarNagStore.setState({
 		completed: false,
+		completedAt: null,
 		workspacesCreatedSinceBaseline: 0,
 		nextThreshold: STAR_NAG_INITIAL_THRESHOLD,
 		deferredUntil: null,
@@ -64,7 +69,7 @@ describe("useStarNagStore", () => {
 		expect(useStarNagStore.getState().shouldShowThresholdCard()).toBe(true);
 	});
 
-	test("markCompleted() permanently mutes the card regardless of count or cooldown", () => {
+	test("markCompleted() mutes the card regardless of count or cooldown, and stamps completedAt", () => {
 		for (let i = 0; i < STAR_NAG_INITIAL_THRESHOLD; i++) {
 			useStarNagStore.getState().recordWorkspaceCreated();
 		}
@@ -73,10 +78,37 @@ describe("useStarNagStore", () => {
 		expect(useStarNagStore.getState().shouldShowThresholdCard()).toBe(false);
 		expect(useStarNagStore.getState().isEligible()).toBe(false);
 		expect(useStarNagStore.getState().completed).toBe(true);
+		expect(useStarNagStore.getState().completedAt).toBeGreaterThan(0);
 		expect(useStarNagStore.getState().deferredUntil).toBeNull();
+	});
+
+	test("markUnstarred() clears completed and completedAt, restoring eligibility", () => {
+		useStarNagStore.getState().markCompleted();
+		useStarNagStore.getState().markUnstarred();
+
+		expect(useStarNagStore.getState().completed).toBe(false);
+		expect(useStarNagStore.getState().completedAt).toBeNull();
+		expect(useStarNagStore.getState().isEligible()).toBe(true);
 	});
 
 	test("isEligible() is true with no completion and no active cooldown", () => {
 		expect(useStarNagStore.getState().isEligible()).toBe(true);
+	});
+
+	test("snoozeThresholdCard() starts a cooldown without doubling the threshold", () => {
+		useStarNagStore.getState().snoozeThresholdCard();
+
+		const state = useStarNagStore.getState();
+		expect(state.nextThreshold).toBe(STAR_NAG_INITIAL_THRESHOLD);
+		expect(state.deferredUntil).toBeGreaterThan(Date.now());
+		expect(state.isEligible()).toBe(false);
+	});
+
+	test("recordV1WorkspaceCreatedIfNew() only counts genuinely new workspaces", () => {
+		recordV1WorkspaceCreatedIfNew(true);
+		expect(useStarNagStore.getState().workspacesCreatedSinceBaseline).toBe(0);
+
+		recordV1WorkspaceCreatedIfNew(false);
+		expect(useStarNagStore.getState().workspacesCreatedSinceBaseline).toBe(1);
 	});
 });

--- a/apps/desktop/src/renderer/stores/star-nag/store.test.ts
+++ b/apps/desktop/src/renderer/stores/star-nag/store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
+	backfillCompletedAt,
 	recordV1WorkspaceCreatedIfNew,
 	STAR_NAG_INITIAL_THRESHOLD,
 	useStarNagStore,
@@ -82,13 +83,23 @@ describe("useStarNagStore", () => {
 		expect(useStarNagStore.getState().deferredUntil).toBeNull();
 	});
 
-	test("markUnstarred() clears completed and completedAt, restoring eligibility", () => {
+	test("markUnstarred() clears completed and completedAt, but starts a cooldown instead of reopening immediately", () => {
+		for (let i = 0; i < STAR_NAG_INITIAL_THRESHOLD; i++) {
+			useStarNagStore.getState().recordWorkspaceCreated();
+		}
 		useStarNagStore.getState().markCompleted();
 		useStarNagStore.getState().markUnstarred();
 
-		expect(useStarNagStore.getState().completed).toBe(false);
-		expect(useStarNagStore.getState().completedAt).toBeNull();
-		expect(useStarNagStore.getState().isEligible()).toBe(true);
+		const state = useStarNagStore.getState();
+		expect(state.completed).toBe(false);
+		expect(state.completedAt).toBeNull();
+		// Not immediately eligible: workspacesCreatedSinceBaseline/nextThreshold
+		// are still frozen at their completion-time values, so without a
+		// cooldown the card would pop straight back up the instant the unstar
+		// is detected — a real bug this test guards against regressing to.
+		expect(state.deferredUntil).toBeGreaterThan(Date.now());
+		expect(state.isEligible()).toBe(false);
+		expect(state.shouldShowThresholdCard()).toBe(false);
 	});
 
 	test("isEligible() is true with no completion and no active cooldown", () => {
@@ -110,5 +121,30 @@ describe("useStarNagStore", () => {
 
 		recordV1WorkspaceCreatedIfNew(false);
 		expect(useStarNagStore.getState().workspacesCreatedSinceBaseline).toBe(1);
+	});
+});
+
+describe("backfillCompletedAt", () => {
+	test("stamps completedAt for a pre-timestamp-schema profile (completed true, completedAt null)", () => {
+		const now = 1_000_000;
+		expect(
+			backfillCompletedAt({ completed: true, completedAt: null }, now),
+		).toEqual({ completed: true, completedAt: now });
+	});
+
+	test("leaves an already-timestamped profile untouched", () => {
+		const result = backfillCompletedAt(
+			{ completed: true, completedAt: 42 },
+			1_000_000,
+		);
+		expect(result.completedAt).toBe(42);
+	});
+
+	test("leaves a never-completed profile's null completedAt alone", () => {
+		const result = backfillCompletedAt(
+			{ completed: false, completedAt: null },
+			1_000_000,
+		);
+		expect(result.completedAt).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/stores/star-nag/store.ts
+++ b/apps/desktop/src/renderer/stores/star-nag/store.ts
@@ -8,7 +8,7 @@ const STAR_NAG_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000;
 interface StarNagState {
 	/** Muted — starred from any surface (or detected already-starred). Cleared if the repo is later confirmed unstarred, see useGithubStarAction. */
 	completed: boolean;
-	/** When `completed` last became true; `null` if never completed (or completed under the pre-timestamp schema — treated as long-ago). */
+	/** When `completed` last became true; `null` only if never completed — the persist `merge` config backfills this to "now" on rehydration for pre-timestamp-schema profiles, so a null here always means "never". */
 	completedAt: number | null;
 	/** New (never previously seen) workspaces created since the last reset. */
 	workspacesCreatedSinceBaseline: number;
@@ -25,7 +25,7 @@ interface StarNagState {
 	/** A trigger the user never actually engaged with timed out on its own (e.g. the onboarding toast's auto-dismiss) — starts the same cooldown as `dismiss()` but, since there was no real "no thanks", doesn't also double the threshold. */
 	snoozeThresholdCard: () => void;
 	markCompleted: () => void;
-	/** Repo confirmed unstarred after previously being completed — unmutes every surface. */
+	/** Repo confirmed unstarred after previously being completed — unmutes every surface and starts the standard cooldown before the threshold card can show again. */
 	markUnstarred: () => void;
 }
 
@@ -45,6 +45,27 @@ function isEligible(state: Pick<StarNagState, "completed" | "deferredUntil">) {
 	if (state.completed) return false;
 	if (state.deferredUntil && state.deferredUntil > Date.now()) return false;
 	return true;
+}
+
+/**
+ * Backfills `completedAt` for profiles rehydrated from the pre-timestamp
+ * schema (`completed: true`, no `completedAt`) — otherwise every
+ * pre-existing starred user is exposed to the flaky-204/404 checkStarred
+ * read on their very first post-rollout check, with none of the grace
+ * window that protects a newly-completed user. Exported standalone, like
+ * the other decision functions in this module, so it's unit-testable
+ * without exercising zustand's persist rehydration.
+ */
+export function backfillCompletedAt<
+	T extends Pick<StarNagState, "completed" | "completedAt">,
+>(
+	merged: T,
+	now: number,
+): Omit<T, "completedAt"> & { completedAt: number | null } {
+	if (merged.completed && merged.completedAt == null) {
+		return { ...merged, completedAt: now };
+	}
+	return merged;
 }
 
 export const useStarNagStore = create<StarNagState>()(
@@ -82,13 +103,40 @@ export const useStarNagStore = create<StarNagState>()(
 						completedAt: Date.now(),
 						deferredUntil: null,
 					}),
-				markUnstarred: () => set({ completed: false, completedAt: null }),
+				markUnstarred: () =>
+					set({
+						completed: false,
+						completedAt: null,
+						// workspacesCreatedSinceBaseline/nextThreshold are left exactly
+						// as they were at completion time, which — without a cooldown —
+						// could put the threshold card immediately back over its own
+						// bar the instant the unstar is detected. Give it the same
+						// grace period a real dismissal gets instead of popping back up
+						// the moment we notice.
+						deferredUntil: Date.now() + STAR_NAG_COOLDOWN_MS,
+					}),
 			}),
 			// Fixed-size singleton, not entity-keyed — no bound/deletion path needed
 			// per apps/desktop/AGENTS.md. If the star nag is ever removed (it's
 			// flag-killable by design), move "star-nag-v1" into DEAD_KEYS
 			// (renderer/lib/persisted-keys/persisted-keys.ts) in the same PR.
-			{ name: "star-nag-v1" },
+			{
+				name: "star-nag-v1",
+				// Profiles that completed under the pre-completedAt schema
+				// rehydrate with completed: true, completedAt: null.
+				// shouldUnmuteOnUnstarredRead treats a null completedAt as "trust
+				// the next not_starred read immediately" — reasonable for an
+				// account we truly can't date, but that describes every
+				// pre-existing starred user the instant this ships, exposing the
+				// whole existing population to the exact flaky-204/404 read this
+				// grace window exists to absorb. Stamping "now" here instead gives
+				// them the same fresh grace window a newly-completed user gets.
+				merge: (persisted, current) =>
+					backfillCompletedAt(
+						{ ...current, ...(persisted as Partial<StarNagState>) },
+						Date.now(),
+					),
+			},
 		),
 		{ name: "StarNagStore" },
 	),

--- a/apps/desktop/src/renderer/stores/star-nag/store.ts
+++ b/apps/desktop/src/renderer/stores/star-nag/store.ts
@@ -6,8 +6,10 @@ export const STAR_NAG_INITIAL_THRESHOLD = 5;
 const STAR_NAG_COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000;
 
 interface StarNagState {
-	/** Permanently muted — starred from any surface, or explicitly opted out. */
+	/** Muted — starred from any surface (or detected already-starred). Cleared if the repo is later confirmed unstarred, see useGithubStarAction. */
 	completed: boolean;
+	/** When `completed` last became true; `null` if never completed (or completed under the pre-timestamp schema — treated as long-ago). */
+	completedAt: number | null;
 	/** New (never previously seen) workspaces created since the last reset. */
 	workspacesCreatedSinceBaseline: number;
 	/** Doubles every time the threshold card is dismissed without starring. */
@@ -20,7 +22,23 @@ interface StarNagState {
 	shouldShowThresholdCard: () => boolean;
 	/** User saw the threshold card and said "later" (or dismissed it) without starring. */
 	dismiss: () => void;
+	/** A trigger the user never actually engaged with timed out on its own (e.g. the onboarding toast's auto-dismiss) — starts the same cooldown as `dismiss()` but, since there was no real "no thanks", doesn't also double the threshold. */
+	snoozeThresholdCard: () => void;
 	markCompleted: () => void;
+	/** Repo confirmed unstarred after previously being completed — unmutes every surface. */
+	markUnstarred: () => void;
+}
+
+/**
+ * A v1 workspace create/import/open result counts toward the star-nag
+ * threshold when it produced a genuinely new workspace (`wasExisting` is
+ * false). Centralized so every v1 creation path — create, createFromPr,
+ * openMainRepoWorkspace — stays in sync; previously only the plain create
+ * path called this, silently excluding PR- and main-repo-branch-driven
+ * creates from the threshold.
+ */
+export function recordV1WorkspaceCreatedIfNew(wasExisting: boolean): void {
+	if (!wasExisting) useStarNagStore.getState().recordWorkspaceCreated();
 }
 
 function isEligible(state: Pick<StarNagState, "completed" | "deferredUntil">) {
@@ -34,6 +52,7 @@ export const useStarNagStore = create<StarNagState>()(
 		persist(
 			(set, get) => ({
 				completed: false,
+				completedAt: null,
 				workspacesCreatedSinceBaseline: 0,
 				nextThreshold: STAR_NAG_INITIAL_THRESHOLD,
 				deferredUntil: null,
@@ -55,8 +74,20 @@ export const useStarNagStore = create<StarNagState>()(
 						workspacesCreatedSinceBaseline: 0,
 						deferredUntil: Date.now() + STAR_NAG_COOLDOWN_MS,
 					})),
-				markCompleted: () => set({ completed: true, deferredUntil: null }),
+				snoozeThresholdCard: () =>
+					set({ deferredUntil: Date.now() + STAR_NAG_COOLDOWN_MS }),
+				markCompleted: () =>
+					set({
+						completed: true,
+						completedAt: Date.now(),
+						deferredUntil: null,
+					}),
+				markUnstarred: () => set({ completed: false, completedAt: null }),
 			}),
+			// Fixed-size singleton, not entity-keyed — no bound/deletion path needed
+			// per apps/desktop/AGENTS.md. If the star nag is ever removed (it's
+			// flag-killable by design), move "star-nag-v1" into DEAD_KEYS
+			// (renderer/lib/persisted-keys/persisted-keys.ts) in the same PR.
 			{ name: "star-nag-v1" },
 		),
 		{ name: "StarNagStore" },


### PR DESCRIPTION
## Summary

Follow-up to #6469. The merged version had `completed` as a one-way latch — once any surface confirmed the repo starred, it stayed muted forever with no path back, so unstarring never re-showed the ask. This closes that gap and fixes several other issues found during review of the original PR.

- **Unstar re-shows the nag**: adds a `completedAt` timestamp + grace window before trusting a live "not_starred" read enough to unmute again — protects against GitHub's `checkStarred` API flapping 204/404 on rapid successive calls (the reason the latch existed in the first place) while still letting a genuine unstar clear it.
- **New `StarNagObserver`**, mounted once in the authenticated layout, owns every `checkResult -> store` side effect so the four independently-mounted surfaces (pill, card, toast, settings row) don't each run a copy of the same effect. It's also the only place that ever schedules a deliberate re-check — once per app session, right as the grace window closes, and a slow backstop interval while muted — never on window focus.
- **`checkStarred` off `refetchOnWindowFocus`**, onto a real `staleTime` instead — it was refetching (and shelling out to `gh`) on every mount and every window focus.
- **Fixed an optimistic-update race** in `activate()`: writing `"starred"` into the query cache before the mutation resolved let a failed star attempt get permanently marked completed with no way back.
- **Workspace-creation counting** hoisted into `recordV1WorkspaceCreatedIfNew()`, now called from all three v1 creation paths instead of just one (PR- and main-repo-branch-driven creates were previously never counted toward the threshold).
- Sidebar card's `checkStarred` query gated by `enabled`, so it stops firing in the background regardless of the feature flag or collapsed state.
- Onboarding toast's auto-dismiss no longer doubles the sidebar card's threshold (new `snoozeThresholdCard()` vs the real `dismiss()`).
- Assorted smaller fixes: double-fired `star_nag_shown` on the card, a ref-order bug in `AnimatedStarButton`'s confetti trigger, a one-frame flash of the pill for already-starred users.
- `AnimatedStarButton` redesigned to match this app's own design tokens (`color-mix` background off `--background`/`--foreground`, sharp corners, four plus marks relaying around the border on hover) instead of a bespoke inverted pill with an unrelated color palette.

## Test plan

- [x] `bun run typecheck` and the full star-nag/workspace-creation test suites pass
- [x] Live-verified via CDP against a real signed-in session: real unstar on GitHub → pill reappears live with no remount needed → store correctly flips `completed: false` → clicking the real "Star on GitHub" button → mutation succeeds → real GitHub star restored → store records a fresh `completedAt` → pill hides again after the success animation
- [x] Verified the corner-mark hover animation across a full rest → hover → leave → hover → leave cycle (numeric position checks, not just visual) after finding and fixing a stuck-mid-transition bug
- [ ] Product/design still needs to weigh in on the initial threshold, UI copy, and `FEATURE_FLAGS.STAR_NAG_CARD` rollout — flagged in the original PR, not new to this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmutes star-onboarding after a verified unstar and stops focus-driven polling. Previously a one-way completed latch kept all surfaces muted and `checkStarred` ran on every window focus; now a timestamped completion with a short grace window, a single observer, and a real staleTime enable safe unmute and reduce `gh` churn.

- StarNagObserver: centralizes checkStarred → store effects; schedules a recheck at grace-window close and a muted backstop (30 min); runs with refetchIntervalInBackground and keys effects on dataUpdatedAt to avoid silent no-ops.
- Query/mutation flow: uses staleTime and refetchOnWindowFocus: false; cancels in-flight checkStarred before writing confirmed results to the cache; no optimistic “starred” writes; failed/declined star sets “unknown” then marks the cache stale without refetch so the next mount rechecks; Settings forces a fresh read on mount; the card gates its query via enabled.
- Store: adds completedAt with persist backfill for legacy profiles; markUnstarred clears completion and starts the standard cooldown; new snoozeThresholdCard avoids doubling the threshold on toast auto-close; hoists workspace-created counting into recordV1WorkspaceCreatedIfNew(); persisted key remains star-nag-v1.
- Surfaces: pill renders live state and dissolves out after success; toast uses the button’s compact variant; both track “shown” once per showing.
- UI/tests: AnimatedStarButton updated to tokenized styling with reduced-motion support; unit tests cover unstar grace logic, scheduler timing, stale-state handling, and store backfill/cooldown.

<sup>Written for commit e3b8e40f0cc095d99a1ce4bf3fa9170b0fd4a72b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added refreshed GitHub star button visuals with compact layouts, animations, themed styling, and reduced-motion support.
  * Improved GitHub star prompts across cards and notifications with more consistent visibility, snoozing, and dismissal behavior.
* **Bug Fixes**
  * Prevented prompts from reappearing incorrectly after starring or unstarring.
  * Improved temporary status-check handling and fresh checks in Settings.
  * Workspace creation tracking now distinguishes new workspaces from existing ones.
* **Tests**
  * Added coverage for star-status transitions, confirmation timing, and prompt cooldown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->