### PR TITLE
feat(marketing): add /mcp-install page for connecting AI agents to Superset

### DIFF
--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -37,6 +37,7 @@ const PRODUCT_LINKS: FooterLink[] = [
 	{ href: "/#how-it-works", label: "How it works" },
 	{ href: "/#features", label: "Features" },
 	{ href: "/#security", label: "Security" },
+	{ href: "/mcp-install", label: "MCP" },
 	{ href: "/marketplace", label: "Marketplace" },
 	{ href: "/compare", label: "Compare" },
 ];

--- a/apps/marketing/src/app/components/Header/constants.ts
+++ b/apps/marketing/src/app/components/Header/constants.ts
@@ -23,6 +23,11 @@ export const PRODUCT_LINKS: NavLink[] = [
 		label: "Roadmap",
 		description: "What we're building now and next.",
 	},
+	{
+		href: "/mcp-install",
+		label: "MCP",
+		description: "Connect any AI agent to Superset.",
+	},
 ];
 
 export const RESOURCE_LINKS: NavLink[] = [

--- a/apps/marketing/src/app/mcp-install/components/McpCapabilities/McpCapabilities.tsx
+++ b/apps/marketing/src/app/mcp-install/components/McpCapabilities/McpCapabilities.tsx
@@ -1,0 +1,21 @@
+import { MCP_CAPABILITIES } from "./constants";
+
+export function McpCapabilities() {
+	return (
+		<div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-8">
+			{MCP_CAPABILITIES.map((capability) => (
+				<div
+					key={capability.category}
+					className="space-y-2 border-t border-border pt-4"
+				>
+					<h3 className="text-sm font-mono text-brand">
+						{capability.category}
+					</h3>
+					<p className="text-sm text-muted-foreground leading-relaxed">
+						{capability.description}
+					</p>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/marketing/src/app/mcp-install/components/McpCapabilities/constants.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpCapabilities/constants.ts
@@ -1,0 +1,42 @@
+export interface McpCapability {
+	category: string;
+	description: string;
+}
+
+export const MCP_CAPABILITIES: McpCapability[] = [
+	{
+		category: "Tasks",
+		description: "List, get, create, update, and delete tasks; track status.",
+	},
+	{
+		category: "Workspaces",
+		description: "List, create, update, and delete workspaces on a host.",
+	},
+	{
+		category: "Agents",
+		description:
+			"List agents configured on a host and launch an agent session in a workspace.",
+	},
+	{
+		category: "Terminals",
+		description:
+			"Create, list, send input to, read the screen of, and close terminal sessions.",
+	},
+	{
+		category: "Automations",
+		description:
+			"Schedule recurring runs, run on demand, pause, resume, and read logs.",
+	},
+	{
+		category: "Projects",
+		description: "List the projects (checked-out repos) available on a host.",
+	},
+	{
+		category: "Hosts",
+		description: "List the machines you have access to run workspaces on.",
+	},
+	{
+		category: "Organization",
+		description: "List members of your active organization.",
+	},
+];

--- a/apps/marketing/src/app/mcp-install/components/McpCapabilities/index.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpCapabilities/index.ts
@@ -1,0 +1,1 @@
+export { McpCapabilities } from "./McpCapabilities";

--- a/apps/marketing/src/app/mcp-install/components/McpExamples/McpExamples.tsx
+++ b/apps/marketing/src/app/mcp-install/components/McpExamples/McpExamples.tsx
@@ -1,0 +1,16 @@
+import { MCP_EXAMPLE_PROMPTS } from "./constants";
+
+export function McpExamples() {
+	return (
+		<ul className="grid sm:grid-cols-2 gap-3">
+			{MCP_EXAMPLE_PROMPTS.map((prompt) => (
+				<li
+					key={prompt}
+					className="border border-border rounded-[2px] bg-foreground/[0.03] px-4 py-3 font-mono text-sm text-foreground"
+				>
+					&ldquo;{prompt}&rdquo;
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/apps/marketing/src/app/mcp-install/components/McpExamples/constants.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpExamples/constants.ts
@@ -1,0 +1,8 @@
+export const MCP_EXAMPLE_PROMPTS: string[] = [
+	"Create a task for fixing the login bug",
+	"List all my assigned tasks",
+	"Create a workspace for the auth feature on my MacBook",
+	"Schedule a daily automation that triages new Linear issues at 9am",
+	"Pause the nightly cleanup automation",
+	"Show me the last 10 runs of my Linear triage automation",
+];

--- a/apps/marketing/src/app/mcp-install/components/McpExamples/index.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpExamples/index.ts
@@ -1,0 +1,1 @@
+export { McpExamples } from "./McpExamples";

--- a/apps/marketing/src/app/mcp-install/components/McpInstall/McpInstall.tsx
+++ b/apps/marketing/src/app/mcp-install/components/McpInstall/McpInstall.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_MCP_INSTALL_TAB, MCP_INSTALL_TABS } from "./constants";
 export function McpInstall() {
 	const [activeTabId, setActiveTabId] = useState(DEFAULT_MCP_INSTALL_TAB.id);
 	const [copied, setCopied] = useState(false);
+	const [copyError, setCopyError] = useState<string | null>(null);
 
 	const activeTab =
 		MCP_INSTALL_TABS.find((tab) => tab.id === activeTabId) ??
@@ -15,10 +16,11 @@ export function McpInstall() {
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(activeTab.content);
+			setCopyError(null);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		} catch {
-			// Clipboard unavailable (e.g. insecure context); ignore
+			setCopyError("Copy failed. Select the text and copy it manually.");
 		}
 	};
 
@@ -33,6 +35,7 @@ export function McpInstall() {
 							onClick={() => {
 								setActiveTabId(tab.id);
 								setCopied(false);
+								setCopyError(null);
 							}}
 							className={`px-3 py-2 text-xs font-mono whitespace-nowrap transition-colors ${
 								tab.id === activeTabId
@@ -57,6 +60,11 @@ export function McpInstall() {
 					)}
 				</button>
 			</div>
+			{copyError && (
+				<output className="block px-4 py-2 text-xs text-destructive border-b border-border">
+					{copyError}
+				</output>
+			)}
 			<div className="px-4 py-3.5 font-mono text-sm overflow-x-auto">
 				{activeTab.kind === "cli" ? (
 					<div className="flex items-start gap-2">

--- a/apps/marketing/src/app/mcp-install/components/McpInstall/McpInstall.tsx
+++ b/apps/marketing/src/app/mcp-install/components/McpInstall/McpInstall.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { DEFAULT_MCP_INSTALL_TAB, MCP_INSTALL_TABS } from "./constants";
+
+export function McpInstall() {
+	const [activeTabId, setActiveTabId] = useState(DEFAULT_MCP_INSTALL_TAB.id);
+	const [copied, setCopied] = useState(false);
+
+	const activeTab =
+		MCP_INSTALL_TABS.find((tab) => tab.id === activeTabId) ??
+		DEFAULT_MCP_INSTALL_TAB;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(activeTab.content);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// Clipboard unavailable (e.g. insecure context); ignore
+		}
+	};
+
+	return (
+		<div className="w-full border border-border rounded-[2px] bg-foreground/[0.03] text-left">
+			<div className="flex items-center justify-between border-b border-border pl-2 pr-1">
+				<div className="flex items-center overflow-x-auto">
+					{MCP_INSTALL_TABS.map((tab) => (
+						<button
+							key={tab.id}
+							type="button"
+							onClick={() => {
+								setActiveTabId(tab.id);
+								setCopied(false);
+							}}
+							className={`px-3 py-2 text-xs font-mono whitespace-nowrap transition-colors ${
+								tab.id === activeTabId
+									? "text-foreground border-b border-brand -mb-px"
+									: "text-muted-foreground hover:text-foreground"
+							}`}
+						>
+							{tab.label}
+						</button>
+					))}
+				</div>
+				<button
+					type="button"
+					onClick={handleCopy}
+					className="p-2 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+					aria-label="Copy to clipboard"
+				>
+					{copied ? (
+						<Check className="size-3.5 text-brand" />
+					) : (
+						<Copy className="size-3.5" />
+					)}
+				</button>
+			</div>
+			<div className="px-4 py-3.5 font-mono text-sm overflow-x-auto">
+				{activeTab.kind === "cli" ? (
+					<div className="flex items-start gap-2">
+						<span className="text-muted-foreground select-none">$</span>
+						<code className="text-foreground whitespace-nowrap">
+							{activeTab.content}
+						</code>
+					</div>
+				) : (
+					<>
+						{activeTab.filename && (
+							<div className="text-xs text-muted-foreground mb-2">
+								{activeTab.filename}
+							</div>
+						)}
+						<pre className="text-foreground whitespace-pre">
+							<code>{activeTab.content}</code>
+						</pre>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/mcp-install/components/McpInstall/constants.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpInstall/constants.ts
@@ -1,0 +1,65 @@
+import { MCP_SERVER_URL } from "@/lib/api-url";
+
+export interface McpInstallTab {
+	id: string;
+	label: string;
+	kind: "cli" | "config";
+	content: string;
+	filename?: string;
+}
+
+export const DEFAULT_MCP_INSTALL_TAB: McpInstallTab = {
+	id: "claude-code",
+	label: "Claude Code",
+	kind: "cli",
+	content: `claude mcp add superset --transport http ${MCP_SERVER_URL}`,
+};
+
+export const MCP_INSTALL_TABS: McpInstallTab[] = [
+	DEFAULT_MCP_INSTALL_TAB,
+	{
+		id: "codex",
+		label: "Codex",
+		kind: "cli",
+		content: `codex mcp add superset --url ${MCP_SERVER_URL}`,
+	},
+	{
+		id: "gemini",
+		label: "Gemini CLI",
+		kind: "cli",
+		content: `gemini mcp add --transport http superset ${MCP_SERVER_URL}`,
+	},
+	{
+		id: "amp",
+		label: "Amp CLI",
+		kind: "cli",
+		content: `amp mcp add --workspace superset ${MCP_SERVER_URL}`,
+	},
+	{
+		id: "claude-desktop",
+		label: "Claude Desktop",
+		kind: "config",
+		filename: "claude_desktop_config.json",
+		content: `{
+  "mcpServers": {
+    "superset": {
+      "type": "http",
+      "url": "${MCP_SERVER_URL}"
+    }
+  }
+}`,
+	},
+	{
+		id: "cursor",
+		label: "Cursor",
+		kind: "config",
+		filename: ".cursor/mcp.json",
+		content: `{
+  "mcpServers": {
+    "superset": {
+      "url": "${MCP_SERVER_URL}"
+    }
+  }
+}`,
+	},
+];

--- a/apps/marketing/src/app/mcp-install/components/McpInstall/index.ts
+++ b/apps/marketing/src/app/mcp-install/components/McpInstall/index.ts
@@ -1,0 +1,1 @@
+export { McpInstall } from "./McpInstall";

--- a/apps/marketing/src/app/mcp-install/page.tsx
+++ b/apps/marketing/src/app/mcp-install/page.tsx
@@ -1,0 +1,133 @@
+import { COMPANY } from "@superset/shared/constants";
+import type { Metadata } from "next";
+import { GridCross } from "@/app/blog/components/GridCross";
+import { MCP_SERVER_URL } from "@/lib/api-url";
+import { McpCapabilities } from "./components/McpCapabilities";
+import { McpExamples } from "./components/McpExamples";
+import { McpInstall } from "./components/McpInstall";
+
+export const metadata: Metadata = {
+	title: "MCP Server",
+	description: `Connect Claude, Codex, Cursor, or any MCP client to ${COMPANY.NAME}. Create tasks, spin up workspaces, launch agents, and run automations straight from your AI agent.`,
+	alternates: {
+		canonical: `${COMPANY.MARKETING_URL}/mcp-install`,
+	},
+};
+
+export default function McpPage() {
+	return (
+		<main className="relative min-h-screen">
+			{/* Header + Install section */}
+			<header className="relative border-b border-border">
+				<div className="max-w-3xl mx-auto px-6 pt-16 pb-12 md:pt-20 md:pb-16 relative">
+					<GridCross className="top-0 left-0" />
+					<GridCross className="top-0 right-0" />
+
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						MCP Server
+					</span>
+					<h1 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground mt-4">
+						Install Superset MCP in your client
+					</h1>
+					<p className="text-muted-foreground mt-3 max-w-lg">
+						Connect Claude, Codex, Cursor, or any{" "}
+						<a
+							href="https://modelcontextprotocol.io"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-brand hover:text-brand-light transition-colors"
+						>
+							MCP
+						</a>{" "}
+						client and let your agent create tasks, spin up workspaces, launch
+						agents, and run automations on your behalf.
+					</p>
+					<p className="mt-6 inline-flex items-center gap-2 text-xs font-mono text-muted-foreground border border-border rounded-[2px] px-3 py-1.5 bg-foreground/[0.03]">
+						{MCP_SERVER_URL}
+					</p>
+
+					<div className="mt-8">
+						<McpInstall />
+						<p className="text-sm text-muted-foreground mt-4">
+							Pick your agent for a one-line install, or copy the config by
+							hand. Every client, including OAuth and API key setup, is covered
+							in the{" "}
+							<a
+								href={`${COMPANY.DOCS_URL}/mcp-server`}
+								className="text-brand hover:text-brand-light transition-colors"
+							>
+								full MCP server docs
+							</a>
+							.
+						</p>
+					</div>
+
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+				</div>
+			</header>
+
+			{/* Capabilities */}
+			<section className="relative border-b border-border">
+				<div className="max-w-3xl mx-auto px-6 py-12 md:py-16">
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						Capabilities
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4 mb-8">
+						What your agent can do
+					</h2>
+					<McpCapabilities />
+					<p className="text-sm text-muted-foreground mt-10">
+						See the{" "}
+						<a
+							href={`${COMPANY.DOCS_URL}/mcp-server#available-tools`}
+							className="text-brand hover:text-brand-light transition-colors"
+						>
+							available tools reference
+						</a>{" "}
+						for every tool name and parameter.
+					</p>
+				</div>
+			</section>
+
+			{/* Example usage */}
+			<section className="relative border-b border-border">
+				<div className="max-w-3xl mx-auto px-6 py-12 md:py-16">
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						Try it
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4 mb-8">
+						Just ask
+					</h2>
+					<McpExamples />
+				</div>
+			</section>
+
+			{/* Authentication */}
+			<section className="relative">
+				<div className="max-w-3xl mx-auto px-6 py-12 md:py-16">
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						Authentication
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4 mb-3">
+						OAuth by default, API keys for CI
+					</h2>
+					<p className="text-muted-foreground max-w-lg">
+						Interactive clients authorize over OAuth 2.1 in your browser, scoped
+						to your active organization. For headless environments and CI,
+						generate an API key from Settings → API Keys in the desktop app and
+						pass it as a Bearer token instead. Full setup, including header
+						config for Claude Code, is in the{" "}
+						<a
+							href={`${COMPANY.DOCS_URL}/mcp-server#authentication`}
+							className="text-brand hover:text-brand-light transition-colors"
+						>
+							authentication docs
+						</a>
+						.
+					</p>
+				</div>
+			</section>
+		</main>
+	);
+}

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -90,6 +90,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/mcp-install`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/roadmap`,
 			lastModified: new Date(),
 			changeFrequency: "weekly",

--- a/apps/marketing/src/lib/api-url.ts
+++ b/apps/marketing/src/lib/api-url.ts
@@ -1,0 +1,2 @@
+export const API_URL = "https://api.superset.sh";
+export const MCP_SERVER_URL = `${API_URL}/mcp`;

--- a/apps/marketing/src/lib/llms.ts
+++ b/apps/marketing/src/lib/llms.ts
@@ -1,10 +1,10 @@
 import { COMPANY } from "@superset/shared/constants";
 import { FAQ_ITEMS } from "@/app/components/FAQSection/constants";
+import { API_URL, MCP_SERVER_URL } from "./api-url";
 import { getBlogPosts } from "./blog";
 import { getComparisonPages } from "./compare";
 
-export const API_URL = "https://api.superset.sh";
-export const MCP_SERVER_URL = `${API_URL}/mcp`;
+export { API_URL, MCP_SERVER_URL };
 
 export function stripMdxSyntax(content: string): string {
 	return (


### PR DESCRIPTION
## Summary
- Adds a human-facing `/mcp-install` page: per-client one-line install (Claude Code, Codex, Gemini CLI, Amp CLI) and manual JSON config (Claude Desktop, Cursor), a capabilities overview, example prompts, and an auth summary — linking out to the full [MCP server docs](https://docs.superset.sh/mcp-server) for complete details.
- Wires the page into the header nav (Product dropdown), footer, and sitemap.
- Extracts `API_URL`/`MCP_SERVER_URL` into a new client-safe `apps/marketing/src/lib/api-url.ts` so the client-side install-tabs component doesn't drag the `fs`-based blog/compare helpers from `lib/llms.ts` into the browser bundle.
- Deliberately at `/mcp-install`, not `/mcp` — `/mcp` already 307-redirects to the real MCP server (`api.superset.sh/mcp`) for MCP clients that guess the root-domain convention; left that redirect untouched.

## Test plan
- [x] `bun run --filter=@superset/marketing typecheck`
- [x] `bunx biome check` on all changed/new files
- [x] Verified in dev server: `/mcp-install` renders 200, `/mcp` still redirects (307) to `https://api.superset.sh/mcp`
- [x] Verified via headless Chrome + CDP: install tabs switch correctly (CLI one-liners vs. JSON config), copy button matches existing `InstallCommand` behavior, header "Product" dropdown and footer both show the new MCP link

https://claude.ai/code/session_01Pnq3fCZ258ZM6UvQPFC7Jg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `/mcp-install` page that gives one-line installs and config snippets for popular MCP clients so users can connect agents to Superset quickly. Fixes the copy button to show inline errors instead of failing silently, and moves `API_URL`/`MCP_SERVER_URL` to a browser-safe module to avoid bundling server-only code in the client.

- New route includes per-client CLI installs (Claude Code, Codex, Gemini CLI, Amp CLI), manual configs (Claude Desktop, Cursor), a capabilities overview, examples, and an auth summary with doc links.
- Adds an “MCP” link to the Header Product dropdown and Footer; includes `/mcp-install` in the sitemap; keeps the existing `/mcp` 307 redirect to `https://api.superset.sh/mcp` unchanged.
- Clipboard behavior: previously copy failures were swallowed; now an inline error message is shown and a success check appears on copy.
- Introduces `apps/marketing/src/lib/api-url.ts`; `API_URL` and `MCP_SERVER_URL` are re-exported from `lib/llms.ts` to prevent bundling `fs` consumers in client code.

<sup>Written for commit 391fdc86f5204e3882c18a14d19b47337a46f896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP Server installation page with setup instructions for multiple developer tools.
  * Included one-click copying for installation commands and configuration snippets.
  * Added MCP capability overviews, example prompts, server URL details, and authentication guidance.
  * Added MCP links to the website header and footer navigation.
* **Documentation**
  * Added the MCP installation page to the sitemap for discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->