### PR TITLE
fix(desktop): default missing PR checks to an empty array at the host boundary

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
@@ -83,7 +83,7 @@ export function PullRequestsContent({
 				const firstProject = target.projects[0];
 				if (!target.hostUrl || !firstProject) return null;
 				const client = getHostServiceClientByUrl(target.hostUrl);
-				return client.workspaceCreation.searchPullRequests.query({
+				const result = await client.workspaceCreation.searchPullRequests.query({
 					projectId: firstProject.projectId,
 					projectIds: target.projects.map((project) => project.projectId),
 					query: debouncedQuery.trim() || undefined,
@@ -93,6 +93,18 @@ export function PullRequestsContent({
 					includeClosed,
 					page,
 				});
+				// The router types come from this build, the rows come from
+				// whichever host-service the host actually runs — hosts update
+				// independently and the list is not version-gated. Rows only
+				// gained `checks` in host-service 1.20.0, so an older host
+				// answers without it. Absent checks read as "none reported".
+				return {
+					...result,
+					pullRequests: result.pullRequests.map((pullRequest) => ({
+						...pullRequest,
+						checks: pullRequest.checks ?? [],
+					})),
+				};
 			},
 			enabled: !!target.hostUrl,
 			staleTime: 30_000,


### PR DESCRIPTION
## Problem

Opening **Pull Requests** throws `TypeError: checks.filter is not a function` during render, so the dashboard content pane is replaced by its error boundary (`DashboardContentError`) instead of showing the list. The whole screen is gone, not one row — a user whose project set includes a host running an older host-service cannot use the PR list at all, deterministically, on every visit.

## Root cause

Traced end to end rather than guessed:

- The list's rows come from one place only: `client.workspaceCreation.searchPullRequests.query(...)` in `PullRequestsContent`, through `useWorkItemsList` → `mergePaginatedProjectRows` (a pure pass-through merge — it never synthesises rows).
- That query is *not* persisted. `ElectronTRPCProvider`'s persist whitelist covers the `tasks` / `pull-request-detail` / `issue-detail` / `dashboard-sidebar` key prefixes; this query is keyed `pullRequests`, so restored cache is not a possible source. Verified the same key at the `desktop-v1.21.0` tag the event came from.
- Every branch of `searchPullRequests` **in this revision** assigns `checks` a real array (`[]` when unenriched), so the producer at head cannot emit the undefined.
- The producer only gained `checks` in `e4d05ce55` (#6201), first shipped in host-service **1.20.0**. Rows from any host-service older than that have no `checks` field.
- The renderer reaches remote hosts via `getHostServiceClientByUrl(target.hostUrl)`, and `useProjectQueryTargets` picks the serving host per project — so a project served by another machine is queried against *that machine's* host-service build. Those update independently of the desktop app, and the PR list is not version-gated at all (`MIN_HOST_SERVICE_VERSION` is `0.8.0`, and it only gates the v2 workspace UI via `useRemoteHostStatus`).

So the type stops being true at the renderer's tRPC boundary: `AppRouter` is compiled from *this* build while the bytes come from a foreign, older build. `summarizePullRequestChecks(checks: PullRequestCheck[])` believes the signature and calls `.filter` on `undefined`.

The fix cannot live in `packages/host-service`: the host that produces these rows is running an old binary and will never execute new host-service code. Only the renderer side can reach the failure.

## Fix

Normalise the page where it crosses that boundary — in the query function, once per fetch — so the cached data is sound for every reader and the render tree is untouched:

```ts
checks: pullRequest.checks ?? [],
```

An absent collection becomes `[]`, which `PullRequestChecksSummary` already renders as "No checks reported" / "No checks". The existing distinction between that and "All checks skipped or cancelled" (`checks.length === 0` vs a non-empty all-skipped list) is preserved, since an old host genuinely reported nothing.

Deliberately not done: no error boundary, no guards scattered through the render tree, no new Sentry capture, no Sentry-side suppression, no change to existing messages or behaviour.

## Verification

`bunx biome check` on the changed file (after `--write` for formatting):

```
Checked 1 file in 8ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

(clean — no diagnostics)

`bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests`:

```
bun test v1.3.14 (0d9b296a)
 11 pass
 0 fail
 22 expect() calls
Ran 11 tests across 4 files. [85.00ms]
```

`packages/host-service` is untouched, so its typecheck was not required or run.

## Adjacent, left alone

Same class of unguarded access on data from other producers, out of scope here: `pull-requests/$prNumber/page.tsx` (`pullRequests.getContent`), `WorkspaceHoverCard`, `DashboardSidebarWorkspaceHoverCardContent`, `ReviewPanel`, `ChangesView`, `V2WorkspacePrHoverCardContent`, `useReviewTab`. The sibling `checksStatus` field on these same rows is also absent from pre-1.20.0 hosts but is not read by this list, so it is left as is.

Refs DESKTOP-XZ

https://claude.ai/code/session_887adf56-417a-46f9-9882-b27914a23fcb


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Pull Requests list from crashing by defaulting missing PR checks to an empty array at the host boundary. Before: hosts running <1.20.0 returned rows without checks, causing a TypeError and the dashboard error boundary; Now: the query normalizes `checks` to `[]`, so the list renders and shows “No checks reported” where appropriate. Satisfies DESKTOP-XZ.

- Review notes
  - Change is isolated to `PullRequestsContent.tsx`: after `searchPullRequests`, map `pullRequests` to set `checks: pullRequest.checks ?? []`; normalized data is cached for all readers.
  - No changes to `packages/host-service` or UI copy; preserves the “none reported” vs “all skipped/cancelled” distinction.
  - Impacts mixed-version setups only; no migration or version gate required.

<sup>Written for commit db68d6234e902519e0b94f1be6e15548de9a24a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request display compatibility with older service versions.
  * Ensured missing checks information is handled gracefully without disrupting the pull request view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->