### PR TITLE
fix(desktop): carry a renderer heap-growth trajectory on the Sentry scope

### DIFF
--- a/apps/desktop/src/renderer/lib/heap-trajectory.ts
+++ b/apps/desktop/src/renderer/lib/heap-trajectory.ts
@@ -1,0 +1,118 @@
+// A renderer killed by heap exhaustion dies inside the allocator, so the
+// minidump carries no first-party frames and no history: it shows the heap
+// full, never how it got there. Chromium's own v8-oom crash keys already give
+// the sizes at the moment of death, and only for V8 heap-limit aborts — a
+// PartitionAlloc abort emits none of them. What no crash report can contain is
+// the shape of the climb, which is what separates a steady leak from a session
+// that sat flat for days and then ran away. These samples are kept on the
+// Sentry scope so whichever abort happens carries that shape with it.
+
+const MAX_HISTORY = 24;
+const INITIAL_STRIDE_MINUTES = 5;
+const BYTES_PER_MB = 1024 * 1024;
+
+export type HeapSample = {
+	minutes: number;
+	usedMb: number;
+};
+
+export type HeapReading = {
+	usedBytes: number;
+	uptimeMs: number;
+};
+
+export type HeapSeries = {
+	latest: HeapSample;
+	peakMb: number;
+	history: HeapSample[];
+	strideMinutes: number;
+};
+
+export type HeapTrajectory = {
+	used_mb: number;
+	limit_mb: number;
+	peak_mb: number;
+	uptime_minutes: number;
+	growth_mb_per_hour: number;
+	history: string;
+};
+
+/**
+ * Folds a reading into the series. The latest value and the peak track every
+ * reading; the history keeps at most `MAX_HISTORY` points, halving its
+ * resolution and doubling its interval each time it fills. Sessions run for
+ * days, so the history has to stay evenly spread over the whole session rather
+ * than drop its start — the start is what dates the growth.
+ */
+export function recordHeapSample(
+	series: HeapSeries | null,
+	reading: HeapReading,
+): HeapSeries {
+	const sample: HeapSample = {
+		minutes: Math.round(reading.uptimeMs / 60_000),
+		usedMb: Math.round(reading.usedBytes / BYTES_PER_MB),
+	};
+
+	if (!series) {
+		return {
+			latest: sample,
+			peakMb: sample.usedMb,
+			history: [sample],
+			strideMinutes: INITIAL_STRIDE_MINUTES,
+		};
+	}
+
+	const updated: HeapSeries = {
+		...series,
+		latest: sample,
+		peakMb: Math.max(series.peakMb, sample.usedMb),
+	};
+
+	const newest = series.history[series.history.length - 1];
+	if (newest && sample.minutes - newest.minutes < series.strideMinutes) {
+		return updated;
+	}
+
+	const history = [...series.history, sample];
+	if (history.length <= MAX_HISTORY) return { ...updated, history };
+
+	return {
+		...updated,
+		history: history.filter((_, index) => index % 2 === 0),
+		strideMinutes: series.strideMinutes * 2,
+	};
+}
+
+/**
+ * `history` is the retained series, oldest first, as `usedMb@uptimeMinutes`. It
+ * stops one stride short of the crash; `used_mb` at `uptime_minutes` is the
+ * live tail.
+ */
+export function summarizeHeap(
+	series: HeapSeries,
+	limitBytes: number,
+): HeapTrajectory {
+	const first = series.history[0] ?? series.latest;
+	const elapsedHours = (series.latest.minutes - first.minutes) / 60;
+
+	return {
+		used_mb: series.latest.usedMb,
+		limit_mb: Math.round(limitBytes / BYTES_PER_MB),
+		peak_mb: series.peakMb,
+		uptime_minutes: series.latest.minutes,
+		growth_mb_per_hour:
+			elapsedHours > 0
+				? Math.round((series.latest.usedMb - first.usedMb) / elapsedHours)
+				: 0,
+		history: series.history
+			.map((sample) => `${sample.usedMb}@${sample.minutes}`)
+			.join(" "),
+	};
+}
+
+/** Decile bucket, so the tag stays searchable without exploding cardinality. */
+export function heapUsedBucket(usedMb: number, limitMb: number): string {
+	if (limitMb <= 0) return "unknown";
+	const decile = Math.min(9, Math.floor((usedMb / limitMb) * 10));
+	return `${decile * 10}-${decile * 10 + 10}%`;
+}

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -1,7 +1,60 @@
 import { SENTRY_IGNORE_ERRORS } from "@superset/shared/sentry";
 import { env } from "../env.renderer";
+import {
+	type HeapSeries,
+	heapUsedBucket,
+	recordHeapSample,
+	summarizeHeap,
+} from "./heap-trajectory";
 
 let sentryInitialized = false;
+
+// Chromium refreshes `performance.memory` at most every 20 minutes and rounds
+// it into buckets unless the app runs with --enable-precise-memory-info, which
+// we deliberately do not set: it hands precise heap readings to any web content
+// the app renders. Sampling more often than the source updates buys nothing.
+const HEAP_SAMPLE_INTERVAL_MS = 5 * 60 * 1000;
+
+type PerformanceWithMemory = Performance & {
+	memory?: { usedJSHeapSize: number; jsHeapSizeLimit: number };
+};
+
+/**
+ * Keeps a bounded heap-growth series on the Sentry scope. The Electron SDK
+ * forwards renderer scope tags and extras to the main process on every change,
+ * and the main process is what files the minidump — so this is on the report
+ * before the renderer dies. Nothing here sends an event of its own.
+ */
+function trackHeapTrajectory(
+	Sentry: typeof import("@sentry/electron/renderer"),
+): void {
+	// `performance.memory` returns a fresh reading per access, so it has to be
+	// read inside the interval rather than captured once.
+	if (!(performance as PerformanceWithMemory).memory) return;
+
+	let series: HeapSeries | null = null;
+
+	const sample = (): void => {
+		const memory = (performance as PerformanceWithMemory).memory;
+		if (!memory) return;
+
+		series = recordHeapSample(series, {
+			usedBytes: memory.usedJSHeapSize,
+			uptimeMs: performance.now(),
+		});
+
+		const trajectory = summarizeHeap(series, memory.jsHeapSizeLimit);
+
+		Sentry.setExtra("renderer_heap", trajectory);
+		Sentry.setTag(
+			"renderer.heap_used",
+			heapUsedBucket(trajectory.used_mb, trajectory.limit_mb),
+		);
+	};
+
+	sample();
+	setInterval(sample, HEAP_SAMPLE_INTERVAL_MS);
+}
 
 export async function initSentry(): Promise<void> {
 	if (sentryInitialized) return;
@@ -30,6 +83,8 @@ export async function initSentry(): Promise<void> {
 				return event;
 			},
 		});
+
+		trackHeapTrajectory(Sentry);
 
 		sentryInitialized = true;
 		console.log("[sentry] Initialized in renderer process");


### PR DESCRIPTION
## Problem

Two renderer OOM aborts on 1.20.2, one event each. Both are native minidumps with
no first-party JavaScript frames — the process dies inside the allocator, so every
frame is Electron, Chromium or V8. They are undiagnosable as they stand: the report
shows a full heap, never what filled it or how fast.

**User-visible harm:** the renderer is killed outright. The window disappears
mid-session and every unsaved renderer-side state goes with it — twice in the
1.20.2 population so far, after 75h (macOS) and 5h (WSL2) of uptime.

**Will this reach the reported failure?** The crash kills the renderer from inside
the allocator, so nothing can be *transmitted* at crash time — it has to be
attached beforehand. Traced through `@sentry/electron` 7.16.0:

- `scopeToMainIntegration` (renderer) pushes the merged scope to main on every
  scope change.
- `handleScope` (main, `main/ipc.js`) applies **only** `user`, `tags`, `extra`,
  `attachments` and `breadcrumbs` from that message. `contexts` is dropped, so
  `Sentry.setContext` in the renderer would be worthless here — this uses
  `setExtra` and `setTag`.
- `sentryMinidumpIntegration` files the minidump from the **main** process via
  `core.captureEvent`, which applies main's current scope. On the other path
  (minidump found at next startup) it applies the persisted `scope_v3` store via
  `applyScopeDataToEvent`, which also carries tags and extra. Both paths keep it.

DESKTOP-Y3 came through the live `render-process-gone` path (it has
`electron.crashed_url` and `details`); DESKTOP-Y8 came through the startup path
(it has neither). The enrichment survives both.

**Why now, rather than archiving or waiting:** these are the first two events of a
family that only appears after long uptime, so waiting means waiting days per data
point and still getting a bare minidump each time. Archiving discards a crash that
kills the window. The enrichment costs nothing per event and makes the *next*
occurrence — whenever it lands — carry its own history.

## Root cause

Not addressed here, and deliberately not guessed at: the renderer heap grows
without bound during long sessions until V8 aborts. Both issues stay open as
trackers.

What the current reports already contain, and therefore what this must *not*
duplicate:

- **DESKTOP-Y3** ships Chromium's full `v8-oom-*` crash-key set — old-space
  3761/3930 MB, allocator 4036/4096 MB, the trailing GC log. Point-in-time heap
  statistics are already there, more precisely than any JS-side reading.
- **DESKTOP-Y8** ships none of them: those keys are written by V8's
  `FatalProcessOutOfMemory` path, and that abort came from PartitionAlloc failing
  to commit inside `JSON.stringify`. It has no JS heap figures at all.
- Uptime is derivable on both from `app.app_start_time` versus the event time.

So the gap is not the sizes and not the uptime. It is that **no crash report can
contain history**. A steady leak and a session that sat flat for three days then
ran away produce the same endpoint and the same average rate, and they point at
completely different code.

## Fix

`apps/desktop/src/renderer/lib/heap-trajectory.ts` — a pure, bounded series:
`recordHeapSample` folds a reading in, keeping the latest value and the peak on
every tick and at most 24 history points. When the history fills it halves its
resolution and doubles its interval, so the retained points stay evenly spread
over the whole session instead of collapsing onto the last hour.

`apps/desktop/src/renderer/lib/sentry.ts` — reads `performance.memory` every 5
minutes after `Sentry.init` and writes `renderer_heap` (extra) and
`renderer.heap_used` (tag). No `captureException`, no `beforeSend` filter, no
behaviour or message changes.

Sampling interval is 5 minutes because Chromium refreshes `performance.memory` at
most every 20 minutes and rounds it into buckets unless the app runs with
`--enable-precise-memory-info` — which is deliberately not set, as it hands
precise heap readings to any web content the app renders (`webviewTag` is on).
Bucketed 20-minute values resolve a multi-day, multi-GB climb fine.

**What it must not report:** nothing, ever, as an event. There is no threshold and
no sampler that transmits. It only mutates scope state that rides along on reports
that were going to be filed anyway, so no input can turn it into quota. Its only
runtime cost is one local IPC scope message per 5 minutes, in an app that already
emits one per breadcrumb.

## Verification

`bunx biome check` on both changed files, from the repo root:

```
Checked 2 files in 37ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

`bun test src/renderer/lib` (from `apps/desktop`):

```
 508 pass
 0 fail
 2455 expect() calls
Ran 508 tests across 38 files. [658.00ms]
```

`apps/desktop/src/no-main-process-blocking.test.ts` is not applicable — no git
client code is touched.

Replaying two synthetic 75-hour sessions through the series, both ending at the
cap that DESKTOP-Y3 actually hit, both with the same ~46 MB/h average — the shape
separates them, which is the entire point:

```
steady leak:
  used_mb 3765  limit_mb 3930  peak_mb 3765  uptime_minutes 4500  growth_mb_per_hour 46
  history "300@0 546@320 793@640 1039@960 1286@1280 1532@1600 1778@1920 2025@2240
           2271@2560 2518@2880 2764@3200 3010@3520 3257@3840 3503@4160 3750@4480"

late runaway:
  used_mb 3810  limit_mb 3930  peak_mb 3810  uptime_minutes 4500  growth_mb_per_hour 47
  history "300@0 300@320 300@640 300@960 300@1280 300@1600 300@1920 300@2240
           300@2560 300@2880 300@3200 300@3520 300@3840 1600@4160 3680@4480"

first sample:  used_mb 180 peak_mb 180 uptime_minutes 0 growth_mb_per_hour 0 history "180@0"
tag buckets:   90-100% for both; "unknown" when jsHeapSizeLimit is 0
```

An earlier revision decimated the array without widening the sampling stride,
which decayed old points exponentially and left the first 71 hours as a single
sample. That is what the replay above was written to catch, and the committed
version is the corrected one.

Not verified end-to-end against a live crash: reproducing it means exhausting a
4 GB heap in a packaged production build. The transmission path is established by
reading the SDK source, cited above, rather than by observation.

Refs DESKTOP-Y3
Refs DESKTOP-Y8

https://claude.ai/code/session_f97cca1f-a6b1-47bf-b456-22bba1e67a4b


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach a renderer heap-growth trajectory to the Sentry scope so OOM renderer crashes carry history. Previously minidumps had no heap history; now each report includes a bounded series and a decile tag without sending new events.

- New `heap-trajectory.ts` keeps a 24-point bounded series, doubles stride when full, and summarizes used_mb, limit_mb, peak_mb, growth rate, and history.
- `sentry.ts` samples `performance.memory` every 5 minutes after `Sentry.init`, sets `renderer_heap` (extra) and `renderer.heap_used` (tag), and no-ops if memory is unavailable.
- Uses tags/extras because `@sentry/electron` forwards them from renderer to main and the minidump path applies them; avoids contexts.
- No config or user-visible behavior changes. No event volume increase. Minimal overhead (one scope update per 5 minutes). Addresses DESKTOP-Y3 and DESKTOP-Y8.

<sup>Written for commit 507946799dcc667b8e2d73066c0c9cf34304fb29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heap usage monitoring for the desktop app.
  * Sentry now records current and peak memory usage, uptime, growth trends, and bounded usage history.
  * Added memory utilization categories for easier performance analysis.
  * Monitoring samples memory immediately and periodically when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->