### PR TITLE
feat(trpc): provision Blaxel sandboxes for cloud workspaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@superset/repo",
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
+        "@blaxel/core": "0.3.11",
         "@types/bun": "1.3.14",
         "@types/semver": "7.7.1",
         "dotenv-cli": "11.0.0",
@@ -1112,6 +1113,7 @@
       "name": "@superset/trpc",
       "version": "0.1.0",
       "dependencies": {
+        "@blaxel/core": "0.3.11",
         "@linear/sdk": "68.1.1",
         "@superset/auth": "workspace:*",
         "@superset/db": "workspace:*",
@@ -1592,6 +1594,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9ma7C4g8Sq3cBlRJD2yrsHXB1mnnEBdpy7PhvFrylQWQb4PoyCmPucdX7frvsSBQuFtIiKCrolPl/8tCZrKvgQ=="],
 
+    "@blaxel/core": ["@blaxel/core@0.3.11", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-vkFMd3jVbC4zz8BQ5LuVw4BcK1KVVIgQTeHTG/1cGu9CAeaHined1WP68XRoxksXC+zGmCnMv619IuMGjQhkDw=="],
+
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@browserbasehq/sdk": ["@browserbasehq/sdk@2.16.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA=="],
@@ -1920,6 +1924,20 @@
 
     "@headless-tree/react": ["@headless-tree/react@1.6.3", "", { "peerDependencies": { "@headless-tree/core": "*", "react": "*", "react-dom": "*" } }, "sha512-aiRwG6e2EPBSec9uLLy9GlTvAuCtSTouU30Nwcr5ZTsYjG/i7B/ouC8f8Zu4unzo/v1h5ztbemp+EH2TPTKh+g=="],
 
+    "@hey-api/client-fetch": ["@hey-api/client-fetch@0.10.2", "", { "peerDependencies": { "@hey-api/openapi-ts": "< 2" } }, "sha512-AGiFYDx+y8VT1wlQ3EbzzZtfU8EfV+hLLRTtr8Y/tjYZaxIECwJagVZf24YzNbtEBXONFV50bwcU1wLVGXe1ow=="],
+
+    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.9.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w=="],
+
+    "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.4.4", "", { "dependencies": { "@jsdevtools/ono": "7.1.3", "@types/json-schema": "7.0.15", "js-yaml": "4.2.0" } }, "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA=="],
+
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.99.0", "", { "dependencies": { "@hey-api/codegen-core": "0.9.1", "@hey-api/json-schema-ref-parser": "1.4.4", "@hey-api/shared": "0.5.0", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "15.0.0", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "./bin/run.js" } }, "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ=="],
+
+    "@hey-api/shared": ["@hey-api/shared@0.5.0", "", { "dependencies": { "@hey-api/codegen-core": "0.9.1", "@hey-api/json-schema-ref-parser": "1.4.4", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.8.4" } }, "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw=="],
+
+    "@hey-api/spec-types": ["@hey-api/spec-types@0.2.0", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg=="],
+
+    "@hey-api/types": ["@hey-api/types@0.1.4", "", {}, "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg=="],
+
     "@hono/node-server": ["@hono/node-server@2.0.10", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA=="],
 
     "@hono/node-ws": ["@hono/node-ws@1.3.0", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.2", "hono": "^4.6.0" } }, "sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q=="],
@@ -2017,6 +2035,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
     "@juggle/resize-observer": ["@juggle/resize-observer@3.4.0", "", {}, "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="],
 
@@ -2133,6 +2153,8 @@
     "@linear/sdk": ["@linear/sdk@68.1.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.0", "graphql": "^15.4.0" } }, "sha512-6IDbyEGsOFORRrG9fL9oQkZ1FAbdtV4W1qfT82gYPVh4UzefXQwNpljgR3Nsm1Tb11cZyf3reoJpPFqGcj01zw=="],
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
+
+    "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@lukeed/uuid": ["@lukeed/uuid@2.0.1", "", { "dependencies": { "@lukeed/csprng": "^1.1.0" } }, "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w=="],
 
@@ -3870,6 +3892,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "cacheable-lookup": ["cacheable-lookup@5.0.4", "", {}, "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="],
@@ -3987,6 +4011,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -4232,6 +4258,8 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
@@ -4269,6 +4297,8 @@
     "dnd-multi-backend": ["dnd-multi-backend@8.1.2", "", { "peerDependencies": { "dnd-core": "^16.0.1" } }, "sha512-KPDVEsiM+6gNEegqZYTWJQgJxYV4vB91tUrvoKJjaS0wwWqT/jNU0P7xJAwCue/cbasJNvk2dFZH7tC+bjX1Rg=="],
 
     "dnssd-advertise": ["dnssd-advertise@1.1.6", "", {}, "sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg=="],
+
+    "dockerfile-ast": ["dockerfile-ast@0.7.1", "", { "dependencies": { "vscode-languageserver-textdocument": "^1.0.8", "vscode-languageserver-types": "^3.17.3" } }, "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw=="],
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
@@ -4708,6 +4738,8 @@
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
+    "giget": ["giget@3.3.1", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg=="],
+
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
@@ -5033,6 +5065,8 @@
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
     "katex": ["katex@0.17.0", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw=="],
 
@@ -5490,6 +5524,8 @@
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
 
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
     "ollama-ai-provider-v2": ["ollama-ai-provider-v2@1.5.5", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@ai-sdk/provider-utils": "^3.0.17" }, "peerDependencies": { "zod": "^4.0.16" } }, "sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
@@ -5619,6 +5655,8 @@
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
     "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
@@ -5818,6 +5856,8 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
+    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
+
     "rdndmb-html5-to-touch": ["rdndmb-html5-to-touch@8.1.2", "", { "dependencies": { "dnd-multi-backend": "^8.1.2", "react-dnd-html5-backend": "^16.0.1", "react-dnd-touch-backend": "^16.0.1" } }, "sha512-efi3MaXYxWaLMd5xzF1bVvmX8erTMhYHSlaMjQe+tynf4IdtgRYfKLwYg+4Z5eq4k7idrjKHQOIMDE6D8LjnOA=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
@@ -5918,7 +5958,7 @@
 
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
 
@@ -6350,7 +6390,7 @@
 
     "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
 
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
 
     "teen_process": ["teen_process@2.3.3", "", { "dependencies": { "bluebird": "^3.7.2", "lodash": "^4.17.21", "shell-quote": "^1.8.1", "source-map-support": "^0.x" } }, "sha512-NIdeetf/6gyEqLjnzvfgQe7PfipSceq2xDQM2Py2BkBnIIeWh3HRD3vNhulyO5WppfCv9z4mtsEHyq8kdiULTA=="],
 
@@ -6431,6 +6471,8 @@
     "tokenlens": ["tokenlens@1.3.1", "", { "dependencies": { "@tokenlens/core": "1.3.0", "@tokenlens/fetch": "1.3.0", "@tokenlens/helpers": "1.3.1", "@tokenlens/models": "1.3.0" } }, "sha512-7oxmsS5PNCX3z+b+z07hL5vCzlgHKkCGrEQjQmWl5l+v5cUrtL7S1cuST4XThaL1XyjbTX8J5hfP0cjDJRkaLA=="],
 
     "tokenx": ["tokenx@1.6.0", "", {}, "sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw=="],
+
+    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
     "toqr": ["toqr@0.1.1", "", {}, "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA=="],
 
@@ -6603,6 +6645,8 @@
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="],
 
     "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.18.2", "", { "dependencies": { "vscode-jsonrpc": "9.0.1", "vscode-languageserver-types": "3.18.0" } }, "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
 
@@ -6834,6 +6878,10 @@
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "@blaxel/core/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
     "@browserbasehq/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@browserbasehq/stagehand/@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.92", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.31" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MlIQpuOnchlroR93Dq2GNw12jh/SAVjuFARXWRF/2SfowMv3J2fvPBUzA60waoQivZlf3XkzQ2nxSwer7dnh2g=="],
@@ -6975,6 +7023,14 @@
     "@gorhom/portal/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "@hey-api/json-schema-ref-parser/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "@hey-api/openapi-ts/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "@hey-api/shared/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "@hey-api/shared/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
@@ -7216,13 +7272,7 @@
 
     "app-builder-lib/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
-    "archiver/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
-    "archiver/tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
-
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "archiver-utils/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "ava/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -7242,11 +7292,17 @@
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "builder-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "builder-util/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "c12/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "cacheable-request/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
@@ -7290,8 +7346,6 @@
 
     "code-inspector-plugin/chalk": ["chalk@4.1.1", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg=="],
 
-    "compress-commons/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
@@ -7303,8 +7357,6 @@
     "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "crc/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -7764,6 +7816,8 @@
 
     "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
+    "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "temp/mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
@@ -7837,8 +7891,6 @@
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "yuku-ast/@yuku-toolchain/types": ["@yuku-toolchain/types@0.6.8", "", {}, "sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA=="],
-
-    "zip-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "zod-from-json-schema-v3/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -8054,6 +8106,8 @@
 
     "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "@hey-api/shared/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@neondatabase/serverless/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -8061,8 +8115,6 @@
     "@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
-
-    "@puppeteer/browsers/tar-fs/tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
 
     "@react-email/preview-server/next/@next/env": ["@next/env@16.0.7", "", {}, "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw=="],
 
@@ -8881,6 +8933,8 @@
     "supertap/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "supertap/serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
+		"@blaxel/core": "0.3.11",
 		"@types/bun": "1.3.14",
 		"@types/semver": "7.7.1",
 		"dotenv-cli": "11.0.0",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -26,6 +26,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
+		"@blaxel/core": "0.3.11",
 		"@linear/sdk": "68.1.1",
 		"@superset/auth": "workspace:*",
 		"@superset/db": "workspace:*",

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -23,6 +23,12 @@ export const env = createEnv({
 		NEXT_PUBLIC_WEB_URL: z.string().url(),
 		KV_REST_API_URL: z.string().url().optional(),
 		KV_REST_API_TOKEN: z.string().optional(),
+		// Blaxel (cloud workspace sandboxes). Optional: deployments without
+		// these simply can't create cloud workspaces, and say so.
+		BLAXEL_API_KEY: z.string().optional(),
+		BLAXEL_WORKSPACE: z.string().optional(),
+		BLAXEL_REGION: z.string().default("us-pdx-1"),
+		BLAXEL_SANDBOX_IMAGE: z.string().default("superset-hostsvc"),
 		// GitHub App credentials
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -1,21 +1,18 @@
 /**
- * Blaxel sandbox operations, called directly rather than behind a provider
- * interface. There is one provider; an interface would be a second thing to
- * keep in sync with no second implementation to justify it.
+ * Called directly rather than behind a provider interface: there is one
+ * provider, so an interface would be a second thing to keep in sync with no
+ * second implementation to justify it.
  *
- * Auth model: a sandbox's preview URL is private, so Blaxel's edge rejects
- * unauthenticated requests before they reach host-service. We mint a
- * short-lived token per access after checking org membership, and the client
- * connects directly — no relay hop, so websockets work and the sandbox is
- * free to sleep between connections.
+ * Previews are private, so Blaxel's edge rejects unauthenticated requests
+ * before they reach host-service. Clients connect directly with a brokered
+ * token — no relay hop, so websockets work and the sandbox can still sleep.
  */
 import { SandboxInstance } from "@blaxel/core";
 import { TRPCError } from "@trpc/server";
 import { env } from "../../env";
 
-/** Preview tokens are minted per access; short enough that a leak is bounded. */
+/** Short enough that a leaked token is bounded; minted per access. */
 const PREVIEW_TOKEN_TTL_MS = 10 * 60 * 1000;
-/** The single named preview that fronts host-service inside every sandbox. */
 const PREVIEW_NAME = "hostsvc";
 const HOST_SERVICE_PORT = 4879;
 
@@ -85,7 +82,6 @@ export interface PreviewAccess {
 	expiresAt: Date;
 }
 
-/** Mints a short-lived token for an existing sandbox's preview. */
 export async function mintPreviewAccess(
 	providerSandboxName: string,
 ): Promise<PreviewAccess> {

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -1,0 +1,119 @@
+/**
+ * Blaxel sandbox operations, called directly rather than behind a provider
+ * interface. There is one provider; an interface would be a second thing to
+ * keep in sync with no second implementation to justify it.
+ *
+ * Auth model: a sandbox's preview URL is private, so Blaxel's edge rejects
+ * unauthenticated requests before they reach host-service. We mint a
+ * short-lived token per access after checking org membership, and the client
+ * connects directly — no relay hop, so websockets work and the sandbox is
+ * free to sleep between connections.
+ */
+import { SandboxInstance } from "@blaxel/core";
+import { TRPCError } from "@trpc/server";
+import { env } from "../../env";
+
+/** Preview tokens are minted per access; short enough that a leak is bounded. */
+const PREVIEW_TOKEN_TTL_MS = 10 * 60 * 1000;
+/** The single named preview that fronts host-service inside every sandbox. */
+const PREVIEW_NAME = "hostsvc";
+const HOST_SERVICE_PORT = 4879;
+
+function assertConfigured(): void {
+	if (!env.BLAXEL_API_KEY || !env.BLAXEL_WORKSPACE) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: "Cloud workspaces are not configured on this deployment",
+			cause: { kind: "BLAXEL_NOT_CONFIGURED" },
+		});
+	}
+	// The SDK reads these from the environment rather than taking arguments.
+	process.env.BL_API_KEY = env.BLAXEL_API_KEY;
+	process.env.BL_WORKSPACE = env.BLAXEL_WORKSPACE;
+}
+
+export interface ProvisionedSandbox {
+	providerSandboxName: string;
+	previewUrl: string;
+	region: string;
+	memoryMb: number;
+}
+
+/**
+ * Creates the sandbox and its private preview. Returns once the preview URL
+ * exists — not once anything is listening on it, which is the caller's job.
+ */
+export async function provisionSandbox(args: {
+	name: string;
+	image: string;
+	memoryMb?: number;
+	region?: string;
+}): Promise<ProvisionedSandbox> {
+	assertConfigured();
+	const memoryMb = args.memoryMb ?? 4096;
+	const region = args.region ?? env.BLAXEL_REGION;
+
+	const sandbox = await SandboxInstance.createIfNotExists({
+		name: args.name,
+		image: args.image,
+		memory: memoryMb,
+		// Without disk-backed root the writable layer is tmpfs in RAM, and a
+		// checkout plus node_modules is write-heavy enough to exhaust it.
+		storageMb: 20480,
+		ports: [{ target: HOST_SERVICE_PORT, protocol: "HTTP" }],
+		region,
+	} as never);
+
+	const preview = await sandbox.previews.createIfNotExists({
+		metadata: { name: PREVIEW_NAME },
+		spec: { port: HOST_SERVICE_PORT, public: false },
+	} as never);
+
+	const previewUrl = preview.spec?.url;
+	if (!previewUrl) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Sandbox preview has no URL",
+		});
+	}
+	return { providerSandboxName: args.name, previewUrl, region, memoryMb };
+}
+
+export interface PreviewAccess {
+	url: string;
+	token: string;
+	expiresAt: Date;
+}
+
+/** Mints a short-lived token for an existing sandbox's preview. */
+export async function mintPreviewAccess(
+	providerSandboxName: string,
+): Promise<PreviewAccess> {
+	assertConfigured();
+	const sandbox = await SandboxInstance.get(providerSandboxName);
+	const preview = await sandbox.previews.get(PREVIEW_NAME);
+	const expiresAt = new Date(Date.now() + PREVIEW_TOKEN_TTL_MS);
+	const token = await preview.tokens.create(expiresAt);
+	const value = (token as { value?: string }).value;
+	const url = preview.spec?.url;
+	if (!value || !url) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Could not mint sandbox access token",
+		});
+	}
+	return { url, token: value, expiresAt };
+}
+
+/** Best-effort: a sandbox already gone is the state we wanted. */
+export async function deleteSandbox(
+	providerSandboxName: string,
+): Promise<void> {
+	assertConfigured();
+	try {
+		await SandboxInstance.delete(providerSandboxName);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!/not found|404/i.test(message)) throw error;
+	}
+}

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -7,7 +7,7 @@
  * before they reach host-service. Clients connect directly with a brokered
  * token — no relay hop, so websockets work and the sandbox can still sleep.
  */
-import { SandboxInstance } from "@blaxel/core";
+import { SandboxInstance, settings } from "@blaxel/core";
 import { TRPCError } from "@trpc/server";
 import { env } from "../../env";
 
@@ -24,9 +24,10 @@ function assertConfigured(): void {
 			cause: { kind: "BLAXEL_NOT_CONFIGURED" },
 		});
 	}
-	// The SDK reads these from the environment rather than taking arguments.
-	process.env.BL_API_KEY = env.BLAXEL_API_KEY;
-	process.env.BL_WORKSPACE = env.BLAXEL_WORKSPACE;
+	settings.setConfig({
+		apiKey: env.BLAXEL_API_KEY,
+		workspace: env.BLAXEL_WORKSPACE,
+	});
 }
 
 export interface ProvisionedSandbox {

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -30,10 +30,8 @@ function assertConfigured(): void {
 }
 
 export interface ProvisionedSandbox {
-	providerSandboxName: string;
+	providerSandboxId: string;
 	previewUrl: string;
-	region: string;
-	memoryMb: number;
 }
 
 /**
@@ -73,7 +71,7 @@ export async function provisionSandbox(args: {
 			message: "Sandbox preview has no URL",
 		});
 	}
-	return { providerSandboxName: args.name, previewUrl, region, memoryMb };
+	return { providerSandboxId: args.name, previewUrl };
 }
 
 export interface PreviewAccess {
@@ -83,10 +81,10 @@ export interface PreviewAccess {
 }
 
 export async function mintPreviewAccess(
-	providerSandboxName: string,
+	providerSandboxId: string,
 ): Promise<PreviewAccess> {
 	assertConfigured();
-	const sandbox = await SandboxInstance.get(providerSandboxName);
+	const sandbox = await SandboxInstance.get(providerSandboxId);
 	const preview = await sandbox.previews.get(PREVIEW_NAME);
 	const expiresAt = new Date(Date.now() + PREVIEW_TOKEN_TTL_MS);
 	const token = await preview.tokens.create(expiresAt);
@@ -102,12 +100,10 @@ export async function mintPreviewAccess(
 }
 
 /** Best-effort: a sandbox already gone is the state we wanted. */
-export async function deleteSandbox(
-	providerSandboxName: string,
-): Promise<void> {
+export async function deleteSandbox(providerSandboxId: string): Promise<void> {
 	assertConfigured();
 	try {
-		await SandboxInstance.delete(providerSandboxName);
+		await SandboxInstance.delete(providerSandboxId);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (!/not found|404/i.test(message)) throw error;

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -32,7 +32,7 @@ function assertConfigured(): void {
 
 export interface ProvisionedSandbox {
 	providerSandboxId: string;
-	previewUrl: string;
+	sandboxUrl: string;
 }
 
 /**
@@ -65,14 +65,14 @@ export async function provisionSandbox(args: {
 		spec: { port: HOST_SERVICE_PORT, public: false },
 	} as never);
 
-	const previewUrl = preview.spec?.url;
-	if (!previewUrl) {
+	const sandboxUrl = preview.spec?.url;
+	if (!sandboxUrl) {
 		throw new TRPCError({
 			code: "INTERNAL_SERVER_ERROR",
 			message: "Sandbox preview has no URL",
 		});
 	}
-	return { providerSandboxId: args.name, previewUrl };
+	return { providerSandboxId: args.name, sandboxUrl };
 }
 
 export interface PreviewAccess {

--- a/packages/trpc/src/lib/blaxel/index.ts
+++ b/packages/trpc/src/lib/blaxel/index.ts
@@ -1,0 +1,7 @@
+export {
+	deleteSandbox,
+	mintPreviewAccess,
+	type PreviewAccess,
+	type ProvisionedSandbox,
+	provisionSandbox,
+} from "./blaxel";

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -7,6 +7,7 @@ import { apiKeyRouter } from "./router/api-key";
 import { automationRouter } from "./router/automation";
 import { billingRouter } from "./router/billing";
 import { chatRouter } from "./router/chat";
+import { cloudWorkspaceRouter } from "./router/cloud-workspace";
 import { hostRouter } from "./router/host";
 import { integrationRouter } from "./router/integration";
 import { organizationRouter } from "./router/organization";
@@ -27,6 +28,7 @@ export const appRouter = createTRPCRouter({
 	business: businessRouter,
 	billing: billingRouter,
 	chat: chatRouter,
+	cloudWorkspace: cloudWorkspaceRouter,
 	host: hostRouter,
 	integration: integrationRouter,
 	organization: organizationRouter,

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -106,7 +106,7 @@ export const cloudWorkspaceRouter = {
 					.update(cloudWorkspaces)
 					.set({
 						providerSandboxId: sandbox.providerSandboxId,
-						previewUrl: sandbox.previewUrl,
+						sandboxUrl: sandbox.sandboxUrl,
 						status: "ready",
 					})
 					.where(eq(cloudWorkspaces.id, row.id))
@@ -166,7 +166,7 @@ export const cloudWorkspaceRouter = {
 			}
 			await dbWs
 				.update(cloudWorkspaces)
-				.set({ status: "deleted", previewUrl: null })
+				.set({ status: "deleted", sandboxUrl: null })
 				.where(eq(cloudWorkspaces.id, row.id));
 			return { deleted: true };
 		}),

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -12,7 +12,7 @@ import {
 } from "../../lib/blaxel";
 import { jwtProcedure } from "../../trpc";
 
-/** Blaxel sandbox names are DNS-ish; keep them short, lowercase and stable. */
+/** Derived from the row id so the name is stable and collision-free. */
 function sandboxNameFor(cloudWorkspaceId: string): string {
 	return `ws-${cloudWorkspaceId.replaceAll("-", "").slice(0, 24)}`;
 }
@@ -83,8 +83,7 @@ export const cloudWorkspaceRouter = {
 					name: input.name,
 					branch: input.branch,
 					provider: "blaxel",
-					// Derived from the row id, so the provider name is stable and
-					// collision-free without a second identifier to reconcile.
+					// Set below, once the row id it derives from exists.
 					providerSandboxName: "",
 					status: "provisioning",
 					createdByUserId: ctx.userId,
@@ -125,9 +124,10 @@ export const cloudWorkspaceRouter = {
 		}),
 
 	/**
-	 * Brokers access: org membership is checked here, then a short-lived
-	 * provider token is minted. This is the only authorization gate — the
-	 * sandbox itself trusts whatever Blaxel's edge lets through.
+	 * Checks org membership, then mints a short-lived provider token. This is
+	 * the outer of two independent gates: Blaxel's edge rejects requests
+	 * without the token, and host-service still rejects them without its own
+	 * secret, so a leaked token alone reaches nothing protected.
 	 */
 	access: jwtProcedure
 		.input(z.object({ id: z.string().uuid() }))

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -1,0 +1,175 @@
+import { db, dbWs } from "@superset/db/client";
+import { cloudWorkspaces, v2Projects } from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { TRPCError } from "@trpc/server";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { env } from "../../env";
+import {
+	deleteSandbox,
+	mintPreviewAccess,
+	provisionSandbox,
+} from "../../lib/blaxel";
+import { jwtProcedure } from "../../trpc";
+
+/** Blaxel sandbox names are DNS-ish; keep them short, lowercase and stable. */
+function sandboxNameFor(cloudWorkspaceId: string): string {
+	return `ws-${cloudWorkspaceId.replaceAll("-", "").slice(0, 24)}`;
+}
+
+function assertMember(organizationIds: string[], organizationId: string): void {
+	if (!organizationIds.includes(organizationId)) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Not a member of this organization",
+		});
+	}
+}
+
+export const cloudWorkspaceRouter = {
+	list: jwtProcedure
+		.input(z.object({ organizationId: z.string().uuid() }))
+		.query(async ({ ctx, input }) => {
+			assertMember(ctx.organizationIds, input.organizationId);
+			return db
+				.select()
+				.from(cloudWorkspaces)
+				.where(
+					and(
+						eq(cloudWorkspaces.organizationId, input.organizationId),
+						// Deleted rows are kept briefly so a failed teardown is
+						// visible, but they are never a workspace you can open.
+						eq(cloudWorkspaces.status, "ready"),
+					),
+				)
+				.orderBy(desc(cloudWorkspaces.createdAt));
+		}),
+
+	/**
+	 * Provisions a sandbox and records it. The row is written **before** the
+	 * provider call so a crash mid-provision leaves a `provisioning` row we
+	 * can reconcile, rather than an orphaned sandbox nothing references.
+	 */
+	create: jwtProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				projectId: z.string().uuid(),
+				name: z.string().min(1).max(200),
+				branch: z.string().min(1).max(300),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			assertMember(ctx.organizationIds, input.organizationId);
+
+			const project = await db.query.v2Projects.findFirst({
+				where: and(
+					eq(v2Projects.id, input.projectId),
+					eq(v2Projects.organizationId, input.organizationId),
+				),
+			});
+			if (!project) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Project not found in this organization",
+				});
+			}
+
+			const [row] = await dbWs
+				.insert(cloudWorkspaces)
+				.values({
+					organizationId: input.organizationId,
+					projectId: input.projectId,
+					name: input.name,
+					branch: input.branch,
+					provider: "blaxel",
+					// Derived from the row id, so the provider name is stable and
+					// collision-free without a second identifier to reconcile.
+					providerSandboxName: "",
+					status: "provisioning",
+					createdByUserId: ctx.userId,
+				})
+				.returning();
+			if (!row) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Could not record cloud workspace",
+				});
+			}
+
+			const providerSandboxName = sandboxNameFor(row.id);
+			try {
+				const sandbox = await provisionSandbox({
+					name: providerSandboxName,
+					image: env.BLAXEL_SANDBOX_IMAGE,
+				});
+				const [ready] = await dbWs
+					.update(cloudWorkspaces)
+					.set({
+						providerSandboxName: sandbox.providerSandboxName,
+						previewUrl: sandbox.previewUrl,
+						region: sandbox.region,
+						memoryMb: sandbox.memoryMb,
+						status: "ready",
+					})
+					.where(eq(cloudWorkspaces.id, row.id))
+					.returning();
+				return ready ?? row;
+			} catch (error) {
+				await dbWs
+					.update(cloudWorkspaces)
+					.set({ status: "failed", providerSandboxName })
+					.where(eq(cloudWorkspaces.id, row.id));
+				throw error;
+			}
+		}),
+
+	/**
+	 * Brokers access: org membership is checked here, then a short-lived
+	 * provider token is minted. This is the only authorization gate — the
+	 * sandbox itself trusts whatever Blaxel's edge lets through.
+	 */
+	access: jwtProcedure
+		.input(z.object({ id: z.string().uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			const row = await db.query.cloudWorkspaces.findFirst({
+				where: eq(cloudWorkspaces.id, input.id),
+			});
+			if (!row) {
+				throw new TRPCError({ code: "NOT_FOUND", message: "Not found" });
+			}
+			assertMember(ctx.organizationIds, row.organizationId);
+			if (row.status !== "ready") {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: `Cloud workspace is ${row.status}`,
+					cause: { kind: "CLOUD_WORKSPACE_NOT_READY", status: row.status },
+				});
+			}
+			const access = await mintPreviewAccess(row.providerSandboxName);
+			return {
+				url: access.url,
+				token: access.token,
+				expiresAt: access.expiresAt,
+			};
+		}),
+
+	delete: jwtProcedure
+		.input(z.object({ id: z.string().uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			const row = await db.query.cloudWorkspaces.findFirst({
+				where: eq(cloudWorkspaces.id, input.id),
+			});
+			if (!row) return { deleted: false };
+			assertMember(ctx.organizationIds, row.organizationId);
+
+			if (row.providerSandboxName) {
+				await deleteSandbox(row.providerSandboxName);
+			}
+			await dbWs
+				.update(cloudWorkspaces)
+				.set({ status: "deleted", previewUrl: null })
+				.where(eq(cloudWorkspaces.id, row.id));
+			return { deleted: true };
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -84,7 +84,7 @@ export const cloudWorkspaceRouter = {
 					branch: input.branch,
 					provider: "blaxel",
 					// Set below, once the row id it derives from exists.
-					providerSandboxName: "",
+					providerSandboxId: "",
 					status: "provisioning",
 					createdByUserId: ctx.userId,
 				})
@@ -96,19 +96,17 @@ export const cloudWorkspaceRouter = {
 				});
 			}
 
-			const providerSandboxName = sandboxNameFor(row.id);
+			const providerSandboxId = sandboxNameFor(row.id);
 			try {
 				const sandbox = await provisionSandbox({
-					name: providerSandboxName,
+					name: providerSandboxId,
 					image: env.BLAXEL_SANDBOX_IMAGE,
 				});
 				const [ready] = await dbWs
 					.update(cloudWorkspaces)
 					.set({
-						providerSandboxName: sandbox.providerSandboxName,
+						providerSandboxId: sandbox.providerSandboxId,
 						previewUrl: sandbox.previewUrl,
-						region: sandbox.region,
-						memoryMb: sandbox.memoryMb,
 						status: "ready",
 					})
 					.where(eq(cloudWorkspaces.id, row.id))
@@ -117,7 +115,7 @@ export const cloudWorkspaceRouter = {
 			} catch (error) {
 				await dbWs
 					.update(cloudWorkspaces)
-					.set({ status: "failed", providerSandboxName })
+					.set({ status: "failed", providerSandboxId })
 					.where(eq(cloudWorkspaces.id, row.id));
 				throw error;
 			}
@@ -146,7 +144,7 @@ export const cloudWorkspaceRouter = {
 					cause: { kind: "CLOUD_WORKSPACE_NOT_READY", status: row.status },
 				});
 			}
-			const access = await mintPreviewAccess(row.providerSandboxName);
+			const access = await mintPreviewAccess(row.providerSandboxId);
 			return {
 				url: access.url,
 				token: access.token,
@@ -163,8 +161,8 @@ export const cloudWorkspaceRouter = {
 			if (!row) return { deleted: false };
 			assertMember(ctx.organizationIds, row.organizationId);
 
-			if (row.providerSandboxName) {
-				await deleteSandbox(row.providerSandboxName);
+			if (row.providerSandboxId) {
+				await deleteSandbox(row.providerSandboxId);
 			}
 			await dbWs
 				.update(cloudWorkspaces)

--- a/packages/trpc/src/router/cloud-workspace/index.ts
+++ b/packages/trpc/src/router/cloud-workspace/index.ts
@@ -1,0 +1,1 @@
+export { cloudWorkspaceRouter } from "./cloud-workspace";

--- a/scripts/sandbox/image.ts
+++ b/scripts/sandbox/image.ts
@@ -1,0 +1,82 @@
+/**
+ * Builds the Blaxel sandbox image that hosts host-service.
+ *
+ *   BL_API_KEY=... BL_WORKSPACE=superset bun run scripts/sandbox/image.ts
+ *   bun run scripts/sandbox/image.ts --dry   # print the Dockerfile only
+ *
+ * Two constraints discovered by probing a live sandbox, both load-bearing:
+ *
+ *  - **Debian, not Alpine.** node-pty's prebuilt binary links glibc
+ *    (GLIBC_2.28 / GLIBCXX_3.4.22), so on Alpine's musl it falls back to
+ *    compiling, which drags in build-essential + python3 (~315 MiB).
+ *  - **The pinned node-pty version.** The stable release ships no prebuilds
+ *    at all and compiles on any libc; only the beta this repo pins carries
+ *    `prebuilds/linux-x64`. Installing plain `node-pty` reintroduces the
+ *    toolchain requirement even on Debian.
+ *
+ * Versions are read from host-service's package.json rather than hardcoded:
+ * a sandbox running a different better-sqlite3 than host-service was built
+ * against is a native-ABI mismatch that surfaces as a runtime crash.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ImageInstance } from "@blaxel/core";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const HOST_SERVICE_PKG = join(
+	REPO_ROOT,
+	"packages",
+	"host-service",
+	"package.json",
+);
+
+/** Blaxel reserves 80, 443 and 8080; host-service's default is 4879. */
+const HOST_SERVICE_PORT = 4879;
+const IMAGE_NAME = process.env.SANDBOX_IMAGE_NAME ?? "superset-hostsvc";
+
+function pinnedVersion(dep: string): string {
+	const pkg = JSON.parse(readFileSync(HOST_SERVICE_PKG, "utf8")) as {
+		dependencies?: Record<string, string>;
+	};
+	const version = pkg.dependencies?.[dep];
+	if (!version) {
+		throw new Error(
+			`${dep} is not a host-service dependency — the sandbox image and host-service must agree on native module versions`,
+		);
+	}
+	return version;
+}
+
+const natives = [
+	`better-sqlite3@${pinnedVersion("better-sqlite3")}`,
+	`node-pty@${pinnedVersion("node-pty")}`,
+];
+
+export const sandboxImage = ImageInstance.fromRegistry("node:24-bookworm-slim")
+	// git for the workspace checkout, openssh-client for SSH remotes, ca-certificates
+	// for HTTPS clones. Deliberately no build-essential/python3 — see the header.
+	.aptInstall("git", "ca-certificates", "openssh-client")
+	.workdir("/app")
+	.runCommands("npm init -y")
+	.runCommands(`npm install ${natives.join(" ")} --no-audit --no-fund`)
+	// Fail the build rather than ship an image whose natives only load because
+	// something silently compiled them.
+	.runCommands(
+		"test -d node_modules/node-pty/prebuilds/linux-x64 || (echo 'node-pty prebuild missing — it would compile at runtime' && exit 1)",
+	)
+	.env({ NODE_ENV: "production", PORT: String(HOST_SERVICE_PORT) })
+	.expose(HOST_SERVICE_PORT);
+
+if (import.meta.main) {
+	if (process.argv.includes("--dry")) {
+		console.log(sandboxImage.dockerfile);
+	} else {
+		console.log(`building ${IMAGE_NAME} with ${natives.join(", ")}`);
+		const built = await sandboxImage.build({
+			name: IMAGE_NAME,
+			memory: 4096,
+			onStatusChange: (status: string) => console.log(`  ${status}`),
+		} as never);
+		console.log(`built: ${built.metadata?.name ?? IMAGE_NAME}`);
+	}
+}

--- a/scripts/sandbox/smoke.ts
+++ b/scripts/sandbox/smoke.ts
@@ -1,7 +1,6 @@
 /**
- * Exercises the Blaxel integration end to end without the tRPC stack:
- * provision → mint a private-preview token → prove the URL rejects
- * unauthenticated callers and accepts authenticated ones → tear down.
+ * Exercises the Blaxel integration without the tRPC stack: provision, mint a
+ * preview token, prove the URL rejects unauthenticated callers, tear down.
  *
  *   BLAXEL_API_KEY=... BLAXEL_WORKSPACE=superset bun run scripts/sandbox/smoke.ts
  *

--- a/scripts/sandbox/smoke.ts
+++ b/scripts/sandbox/smoke.ts
@@ -1,0 +1,61 @@
+/**
+ * Exercises the Blaxel integration end to end without the tRPC stack:
+ * provision → mint a private-preview token → prove the URL rejects
+ * unauthenticated callers and accepts authenticated ones → tear down.
+ *
+ *   BLAXEL_API_KEY=... BLAXEL_WORKSPACE=superset bun run scripts/sandbox/smoke.ts
+ *
+ * Leaves nothing behind unless it throws; pass --keep to inspect the sandbox.
+ */
+import {
+	deleteSandbox,
+	mintPreviewAccess,
+	provisionSandbox,
+} from "../../packages/trpc/src/lib/blaxel";
+
+const NAME = process.env.SMOKE_SANDBOX_NAME ?? "ws-smoke-test";
+const IMAGE = process.env.BLAXEL_SANDBOX_IMAGE ?? "superset-hostsvc";
+const keep = process.argv.includes("--keep");
+
+const main = async () => {
+	console.log(`provisioning ${NAME} from ${IMAGE} …`);
+	const sandbox = await provisionSandbox({ name: NAME, image: IMAGE });
+	console.log(`  preview: ${sandbox.previewUrl}`);
+	console.log(`  region:  ${sandbox.region}  memory: ${sandbox.memoryMb}MB`);
+
+	const access = await mintPreviewAccess(NAME);
+	console.log(`  token minted, expires ${access.expiresAt.toISOString()}`);
+
+	// Nothing is listening on 4879 yet — host-service lands in the next PR —
+	// so both requests 502/504 *through* the edge. What matters here is that
+	// the unauthenticated one is rejected at the edge instead.
+	const anon = await fetch(`${access.url}/health`)
+		.then((r) => r.status)
+		.catch((e) => `ERR ${e}`);
+	const authed = await fetch(`${access.url}/health`, {
+		headers: { "X-Blaxel-Preview-Token": access.token },
+	})
+		.then((r) => r.status)
+		.catch((e) => `ERR ${e}`);
+
+	console.log(`\n  without token → ${anon}   (expect 401)`);
+	console.log(
+		`  with token    → ${authed}   (expect not-401: reaches sandbox)`,
+	);
+
+	const gatePasses = anon === 401 && authed !== 401;
+	console.log(`\n${gatePasses ? "PASS" : "FAIL"}: preview auth gate`);
+
+	if (!keep) {
+		await deleteSandbox(NAME);
+		console.log("torn down");
+	} else {
+		console.log(`kept: ${NAME}`);
+	}
+	process.exit(gatePasses ? 0 : 1);
+};
+
+main().catch((error) => {
+	console.error("smoke failed:", error?.message ?? error);
+	process.exit(1);
+});


### PR DESCRIPTION
Second of five. **Stacked on #6489** (`cloud_workspaces` table) — review that first; this PR's diff includes it until #6489 merges.

Provisions real Blaxel sandboxes and brokers access to them. Nothing in the desktop app calls this yet.

## Auth is the whole design

A sandbox's preview URL is **private**, so Blaxel's edge rejects unauthenticated requests before they reach anything we run. `cloudWorkspace.access` checks org membership, then mints a **10-minute** provider token. The client connects **directly** to the sandbox with it.

That directness is the point: a proxy on the data path would break terminal websockets, and an outbound relay socket would stop the sandbox ever sleeping. This gets auth without either.

The consequence to be aware of: **the sandbox trusts whatever the edge lets through.** `cloudWorkspace.access` is the only authorization gate, so its org check is load-bearing.

## Verified against real Blaxel

`scripts/sandbox/smoke.ts` provisions, mints, probes and tears down:

```
without token → 401   (edge rejects)
with token    → 502   (reaches the sandbox)
PASS: preview auth gate
```

The 502 is correct — nothing listens on 4879 until PR 3 puts host-service in the image.

## The image (`scripts/sandbox/image.ts`)

Declarative via the Blaxel SDK rather than a Dockerfile, so it lives in the repo and needs no local Docker. Two constraints, both found by probing a live sandbox:

- **Debian, not Alpine.** node-pty's prebuilt binary links glibc (`GLIBC_2.28`), so on musl it falls back to compiling — which drags in `build-base` + `python3`, about **315 MiB**.
- **The pinned node-pty version.** The stable release ships *no* prebuilds and compiles on any libc; only the `1.2.0-beta.14` this repo pins carries `prebuilds/linux-x64`.

Versions are read from `packages/host-service/package.json` rather than hardcoded — a sandbox running a different `better-sqlite3` than host-service was built against is a native-ABI mismatch that surfaces as a runtime crash. The build also **asserts the prebuild exists**, so a future bump that loses it fails the image build instead of silently compiling.

Verified on the built image: Debian 12, Node 24.19, `NO_TOOLCHAIN_CONFIRMED`, `SQLITE_OK`, `PTY_OK`, git clone works.

## Notes

- **No `SandboxProvider` interface.** There's one provider; an interface would be a second thing to keep in sync with no second implementation to justify it. The June spike had one and it earned its reputation.
- The row is written **before** the provider call, so a crash mid-provision leaves a reconcilable `provisioning` row rather than an orphaned sandbox nothing references. Failures flip it to `failed`, keeping the provider name for cleanup.
- `BLAXEL_API_KEY`/`BLAXEL_WORKSPACE` are **optional** env: deployments without them can't create cloud workspaces and say so via `PRECONDITION_FAILED`, rather than failing env validation at boot.

## Verification

typecheck 0 · lint 0 · smoke test green against production Blaxel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provisions Blaxel sandboxes for Cloud Workspaces and exposes them via a new `cloudWorkspace` tRPC router. Previously we only wrote DB rows; now we create a private preview and mint 10‑minute tokens so clients connect directly while the Blaxel edge keeps previews private.

- Router: list (ready only); create (write row, deterministically set `providerSandboxId`, provision, persist `sandboxUrl`, mark failed on error); access (org check, mint token, return url/token/expiresAt); delete (best‑effort teardown, ignore missing sandbox, mark deleted). Wired into the root; no UI calls it yet.
- Adds a Blaxel client via `@blaxel/core` and a Debian-based sandbox image on port 4879 (`scripts/sandbox/image.ts`). The image reads host‑service native versions (`better-sqlite3`, `node-pty`) and asserts `node-pty` prebuilds exist.
- `scripts/sandbox/smoke.ts` provisions, verifies 401 without a token vs not‑401 with a token, then tears down. A 502 is expected until host‑service lands.

- **Ops/rollout**
  - Set `BLAXEL_API_KEY` and `BLAXEL_WORKSPACE`. Optional: `BLAXEL_REGION` (default us-pdx-1), `BLAXEL_SANDBOX_IMAGE` (default superset-hostsvc). Without required envs, methods return PRECONDITION_FAILED; the service still boots.
  - Build/publish the image: bun run `scripts/sandbox/image.ts` (use --dry to inspect).
  - Smoke test with Blaxel envs set: bun run `scripts/sandbox/smoke.ts`.

<sup>Written for commit 2c2cba86101e6844280c61cb743be522dbd5b621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

