### PR TITLE
feat(sandbox): bundle host-service into the Blaxel image

### DIFF
--- a/scripts/sandbox/image.ts
+++ b/scripts/sandbox/image.ts
@@ -4,19 +4,11 @@
  *   BL_API_KEY=... BL_WORKSPACE=superset bun run scripts/sandbox/image.ts
  *   bun run scripts/sandbox/image.ts --dry   # print the Dockerfile only
  *
- * Two constraints discovered by probing a live sandbox, both load-bearing:
- *
- *  - **Debian, not Alpine.** node-pty's prebuilt binary links glibc
- *    (GLIBC_2.28 / GLIBCXX_3.4.22), so on Alpine's musl it falls back to
- *    compiling, which drags in build-essential + python3 (~315 MiB).
- *  - **The pinned node-pty version.** The stable release ships no prebuilds
- *    at all and compiles on any libc; only the beta this repo pins carries
- *    `prebuilds/linux-x64`. Installing plain `node-pty` reintroduces the
- *    toolchain requirement even on Debian.
- *
- * Versions are read from host-service's package.json rather than hardcoded:
- * a sandbox running a different better-sqlite3 than host-service was built
- * against is a native-ABI mismatch that surfaces as a runtime crash.
+ * Two constraints keep a compiler out of this image, and both must hold:
+ * node-pty's prebuilt binary links glibc, so Alpine's musl would force a
+ * source build; and only the node-pty version this repo pins ships prebuilds
+ * at all, so installing plain `node-pty` compiles even on Debian. A compile
+ * needs build-essential + python3, roughly 315 MiB.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -34,6 +26,11 @@ const HOST_SERVICE_PKG = join(
 const HOST_SERVICE_PORT = 4879;
 const IMAGE_NAME = process.env.SANDBOX_IMAGE_NAME ?? "superset-hostsvc";
 
+/**
+ * Read from host-service rather than hardcoded: a sandbox running a
+ * different better-sqlite3 than host-service was built against is a
+ * native-ABI mismatch that surfaces as a runtime crash.
+ */
 function pinnedVersion(dep: string): string {
 	const pkg = JSON.parse(readFileSync(HOST_SERVICE_PKG, "utf8")) as {
 		dependencies?: Record<string, string>;
@@ -53,14 +50,9 @@ const natives = [
 ];
 
 /**
- * Packages the bundle marks external and then imports at module load, so they
- * must merely *resolve* even where the code path never runs. Established by
- * booting the bundle in a sandbox and installing whatever it asked for until
- * it reached env validation.
- *
- * Most of this is mastra's storage/embedding stack reached through
- * provider-auth's credential store — onnxruntime and duckdb are not small,
- * and trimming that dependency would shrink this list to nearly nothing.
+ * Imported at module load but never executed, so they only need to resolve.
+ * Mostly mastra's storage stack reached via provider-auth's credential store;
+ * trimming that dependency would shrink both this list and the image.
  */
 const runtimeResolutionOnly = [
 	"@mastra/duckdb",
@@ -71,14 +63,14 @@ const runtimeResolutionOnly = [
 	"@xterm/headless",
 ];
 
-const HOST_SERVICE_DIR = join(REPO_ROOT, "packages", "host-service");
-const BUNDLE = join(HOST_SERVICE_DIR, "dist", "host-service.js");
+const BUNDLE = join(
+	REPO_ROOT,
+	"packages",
+	"host-service",
+	"dist",
+	"host-service.js",
+);
 
-/**
- * The bundle marks native addons external, so they resolve from
- * /app/node_modules at runtime — which is why the bundle lands in /app
- * alongside the npm install above rather than in its own directory.
- */
 function assertBuilt(): void {
 	if (!existsSync(BUNDLE)) {
 		throw new Error(
@@ -105,9 +97,7 @@ export const sandboxImage = ImageInstance.fromRegistry("node:24-bookworm-slim")
 	.runCommands(
 		"test -d node_modules/node-pty/prebuilds/linux-x64 || (echo 'node-pty prebuild missing — it would compile at runtime' && exit 1)",
 	)
-	// host-service itself: the bundle, its worker sibling (the pool resolves it
-	// by path next to host-service.js), and the host.db migrations createDb
-	// applies on first boot.
+	// Lands in /app so the externalised natives resolve from its node_modules.
 	// The third argument is the build-context name, which defaults to the
 	// source's basename — both `dist` directories would otherwise collide and
 	// silently ship host-service's bundle as the pty daemon.
@@ -120,10 +110,9 @@ export const sandboxImage = ImageInstance.fromRegistry("node:24-bookworm-slim")
 	// The supervisor resolves the daemon as ../../../pty-daemon/dist relative
 	// to its own source path, which from /app/host-service.js lands at /.
 	.addLocalDir("packages/pty-daemon/dist", "/pty-daemon/dist", "ptyd-dist")
-	// The daemon is spawned as its own process and imports node-pty, but Node
-	// resolves node_modules upward from /pty-daemon/dist and the install lives
-	// in /app. Link rather than install twice: one copy of the native addon,
-	// so the daemon and host-service can never diverge on its version.
+	// The daemon is a separate process importing node-pty, and Node resolves
+	// upward from /pty-daemon. Linked rather than installed twice so the two
+	// can never diverge on the native addon's version.
 	.runCommands("ln -s /app/node_modules /pty-daemon/node_modules")
 	.env({ NODE_ENV: "production", PORT: String(HOST_SERVICE_PORT) })
 	.expose(HOST_SERVICE_PORT);

--- a/scripts/sandbox/image.ts
+++ b/scripts/sandbox/image.ts
@@ -18,7 +18,7 @@
  * a sandbox running a different better-sqlite3 than host-service was built
  * against is a native-ABI mismatch that surfaces as a runtime crash.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ImageInstance } from "@blaxel/core";
 
@@ -52,18 +52,79 @@ const natives = [
 	`node-pty@${pinnedVersion("node-pty")}`,
 ];
 
+/**
+ * Packages the bundle marks external and then imports at module load, so they
+ * must merely *resolve* even where the code path never runs. Established by
+ * booting the bundle in a sandbox and installing whatever it asked for until
+ * it reached env validation.
+ *
+ * Most of this is mastra's storage/embedding stack reached through
+ * provider-auth's credential store — onnxruntime and duckdb are not small,
+ * and trimming that dependency would shrink this list to nearly nothing.
+ */
+const runtimeResolutionOnly = [
+	"@mastra/duckdb",
+	"@anush008/tokenizers",
+	"onnxruntime-node",
+	"libsql",
+	"@parcel/watcher",
+	"@xterm/headless",
+];
+
+const HOST_SERVICE_DIR = join(REPO_ROOT, "packages", "host-service");
+const BUNDLE = join(HOST_SERVICE_DIR, "dist", "host-service.js");
+
+/**
+ * The bundle marks native addons external, so they resolve from
+ * /app/node_modules at runtime — which is why the bundle lands in /app
+ * alongside the npm install above rather than in its own directory.
+ */
+function assertBuilt(): void {
+	if (!existsSync(BUNDLE)) {
+		throw new Error(
+			"packages/host-service/dist/host-service.js is missing — run `bun run --cwd packages/host-service build:host` first",
+		);
+	}
+}
+
 export const sandboxImage = ImageInstance.fromRegistry("node:24-bookworm-slim")
 	// git for the workspace checkout, openssh-client for SSH remotes, ca-certificates
 	// for HTTPS clones. Deliberately no build-essential/python3 — see the header.
 	.aptInstall("git", "ca-certificates", "openssh-client")
 	.workdir("/app")
 	.runCommands("npm init -y")
+	// The bundle is ESM; without this Node parses /app/*.js as CommonJS and
+	// dies on the first `import`.
+	.runCommands("npm pkg set type=module")
 	.runCommands(`npm install ${natives.join(" ")} --no-audit --no-fund`)
+	.runCommands(
+		`npm install ${runtimeResolutionOnly.join(" ")} --no-audit --no-fund`,
+	)
 	// Fail the build rather than ship an image whose natives only load because
 	// something silently compiled them.
 	.runCommands(
 		"test -d node_modules/node-pty/prebuilds/linux-x64 || (echo 'node-pty prebuild missing — it would compile at runtime' && exit 1)",
 	)
+	// host-service itself: the bundle, its worker sibling (the pool resolves it
+	// by path next to host-service.js), and the host.db migrations createDb
+	// applies on first boot.
+	// The third argument is the build-context name, which defaults to the
+	// source's basename — both `dist` directories would otherwise collide and
+	// silently ship host-service's bundle as the pty daemon.
+	.addLocalDir("packages/host-service/dist", "/app", "hostsvc-dist")
+	.addLocalDir(
+		"packages/host-service/drizzle",
+		"/app/drizzle",
+		"hostsvc-drizzle",
+	)
+	// The supervisor resolves the daemon as ../../../pty-daemon/dist relative
+	// to its own source path, which from /app/host-service.js lands at /.
+	.addLocalDir("packages/pty-daemon/dist", "/pty-daemon/dist", "ptyd-dist")
+	// The daemon is spawned as its own process and imports node-pty, but Node
+	// resolves node_modules upward from /pty-daemon/dist and the install lives
+	// in /app. Link rather than install twice: one copy of the native addon,
+	// so the daemon and host-service can never diverge on its version.
+	.runCommands("ln -s /app/node_modules /pty-daemon/node_modules")
 	.env({ NODE_ENV: "production", PORT: String(HOST_SERVICE_PORT) })
 	.expose(HOST_SERVICE_PORT);
 
@@ -71,6 +132,7 @@ if (import.meta.main) {
 	if (process.argv.includes("--dry")) {
 		console.log(sandboxImage.dockerfile);
 	} else {
+		assertBuilt();
 		console.log(`building ${IMAGE_NAME} with ${natives.join(", ")}`);
 		const built = await sandboxImage.build({
 			name: IMAGE_NAME,


### PR DESCRIPTION
Third of five. **Stacked on #6497** → #6489.

Puts host-service inside the sandbox image. After this a sandbox boots a working host-service with terminals; nothing in the desktop app talks to it yet.

## It works end to end

```
[host-service] listening on http://localhost:4879
[host-service:db] Initialized at /data/host.db, migrations from /app/drizzle
[pty-daemon] spawned pid=246 socket=/tmp/superset-ptyd-….sock daemonVersion=0.3.0
```

Through the private preview URL, `trpc/health.check` returns `{"status":"ok","cloudRegistered":false,…}`. `cloudRegistered: false` is expected — nothing registers as a host, by design.

## Auth is two independent layers

Verified against the running sandbox rather than assumed:

| Request | Result |
|---|---|
| no preview token | **401** — Blaxel's edge rejects |
| preview token, no PSK | **401 UNAUTHORIZED** — host-service rejects |
| preview token + PSK | **200** |

So a leaked preview token alone does **not** grant access to protected procedures. Consequence for PR 4: `cloudWorkspace.access` must return the host-service secret alongside the preview token, since clients need both.

## Four things the image has to get right

Each of these was a real failure found by booting the bundle, not by reading:

1. **`npm pkg set type=module`** — the bundle is ESM; without it Node parses `/app/*.js` as CommonJS and dies on the first `import`.
2. **A resolution-only package set.** The bundle marks several deps external and then imports them at module load, so they must *resolve* even where the code path never runs: `@mastra/duckdb`, `@anush008/tokenizers`, `onnxruntime-node`, `libsql`, `@parcel/watcher`, `@xterm/headless`. Found by booting and installing whatever it asked for until it reached env validation.
3. **Distinct build-context names.** `addLocalDir`'s third argument defaults to the source's basename, so `packages/host-service/dist` and `packages/pty-daemon/dist` both became `COPY dist` — silently shipping host-service's bundle *as* the pty daemon. Caught by reading the generated Dockerfile.
4. **`/pty-daemon/node_modules` symlink.** The daemon is a separate process importing node-pty, but Node resolves upward from `/pty-daemon/dist` while the install lives in `/app`. Symlinked rather than installed twice, so the daemon and host-service can't diverge on the native addon's version.

## Worth knowing

That resolution-only list is mostly **mastra's storage/embedding stack** reached through provider-auth's credential store. `onnxruntime-node` and duckdb are not small, and they exist purely to satisfy an import. Trimming host-service's mastra dependency would shrink both this list and the image materially — worth its own piece of work, not this PR.

Also: the Blaxel image build failed once with a generic `States.TaskFailed` and succeeded on retry with no changes. Second time I've seen that, so treat build failures as worth one retry before diagnosing.

## Verification

typecheck 0 · lint 0 · booted from the built image in a real sandbox · pty-daemon spawned · tRPC reachable through the preview URL with both auth layers exercised.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles `host-service` and `pty-daemon` into the Blaxel sandbox image so a sandbox boots a working `host-service` with terminals on 4879. Previously the image omitted them; now it ships their bundles and DB migrations, enforces ESM, and avoids native compilation.

- Copies the `host-service` bundle and `drizzle` migrations into `/app` and the `pty-daemon` bundle into `/pty-daemon/dist` using distinct build-context names to prevent `dist` collisions.
- Installs pinned native deps from the `host-service` package (`better-sqlite3`, `node-pty`) and a resolution-only set for externalized imports: `@mastra/duckdb`, `@anush008/tokenizers`, `onnxruntime-node`, `libsql`, `@parcel/watcher`, `@xterm/headless`; fails the build if `node-pty` prebuilds are missing.
- Sets `npm pkg set type=module`; symlinks `/pty-daemon/node_modules` to `/app/node_modules` so both processes resolve the same native addons.
- Requires a prebuilt `host-service` bundle. Action: run `bun run --cwd packages/host-service build:host`.
- No desktop app wiring changes.

<sup>Written for commit b273e1f895bd1b47e4146f302e308a209aaa865c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

