### PR TITLE
fix(api): advance the schedule trigger alongside the automation

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -1,5 +1,5 @@
 import { dbWs } from "@superset/db/client";
-import { automations } from "@superset/db/schema";
+import { automations, automationTriggers } from "@superset/db/schema";
 import { nextOccurrenceAfter } from "@superset/shared/rrule";
 import { Client, Receiver } from "@upstash/qstash";
 import { and, eq, lte } from "drizzle-orm";
@@ -70,17 +70,30 @@ export async function POST(request: Request): Promise<Response> {
 	);
 
 	const advanceResults = await Promise.allSettled(
-		due.map((automation) => {
+		due.map(async (automation) => {
 			const next = nextOccurrenceAfter({
 				rrule: automation.rrule,
 				dtstart: automation.dtstart,
 				timezone: automation.timezone,
 				after: automation.nextRunAt,
 			});
-			return dbWs
+			await dbWs
 				.update(automations)
 				.set(next ? { nextRunAt: next } : { enabled: false })
 				.where(eq(automations.id, automation.id));
+
+			// Keep the schedule trigger in lockstep so the cutover is a pure
+			// read-source switch. Writing `next` unconditionally also repairs a
+			// trigger that had drifted.
+			await dbWs
+				.update(automationTriggers)
+				.set(next ? { nextRunAt: next } : { enabled: false })
+				.where(
+					and(
+						eq(automationTriggers.automationId, automation.id),
+						eq(automationTriggers.kind, "schedule"),
+					),
+				);
 		}),
 	);
 


### PR DESCRIPTION
## The problem, observed in production

`0072` backfilled one schedule trigger per automation, copying `next_run_at` as it stood at migration time. But `automations.next_run_at` is still the authoritative column, and the dispatcher advances it every time an automation fires. The trigger copies go stale.

Production right now:

| | |
|---|---|
| Automations | 777 |
| Schedule triggers | 777 |
| Missing triggers | 0 |
| **Drifted `next_run_at`** | **9** |
| Drift direction | automation ahead of trigger, 100% |
| Drift magnitude | 20 minutes to 1 day |

The count grows every tick. At cutover the dispatcher would select those rows with a `next_run_at` already in the past, fire them immediately, then advance from the stale value.

## Fix

`evaluate` now writes the computed `next` to the schedule trigger as well as the automation. Because it writes the value unconditionally rather than incrementing, it also **repairs** a trigger that had already drifted, on that automation's next fire.

One file, 16 lines.

## No read change

The dispatcher still selects from `automations`. This is deliberately the *expand* half: write both, read the old one. The cutover then becomes a pure read-source switch with no accumulated staleness to inherit.

## Why the existing drift is not a migration

Closing the current 9 rows is a one-off sync run against production, not a migration in this PR.

Migrations run **before** the API deploys (`deploy-api` has `needs: deploy-database`), so a sync migration would be stale the moment the old code advanced anything during the deploy window. It would be one shot at a moving target. The code change above is what actually makes drift impossible, and it heals whatever the sync misses on next fire.

The general rule this came from: *a data migration touching a column with a live writer can only ever be best-effort — correctness has to live in the code that keeps writing.* `0072` broke that rule by treating a snapshot as authoritative, which is the bug being fixed here.

## Testing

`bun run typecheck` 37/37 · `bun run lint` clean · `bun test apps/api` 17 pass

The sync itself was rehearsed against Postgres 16 with the drift reproduced across three shapes — in sync, drifted forward, and disabled-since-backfill — going from 2 drifted to 0.

## How this was found

Verifying the merged migration against production instead of trusting the green CI check. The same pass also surfaced `dtstart` losing sub-second precision on 708 rows via the `to_char` format; reviewed and accepted as immaterial, since `dtstart` anchors an RRULE evaluated at minute granularity.