### PR TITLE
fix(host-service): allow empty initialCommand when creating terminal sessions

### DIFF
--- a/packages/host-service/src/trpc/router/terminal/terminal.schema.test.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.schema.test.ts
@@ -1,0 +1,43 @@
+// Schema-only tests for the createSession input contract. The module chain
+// reads env at load (@t3-oss/env-core), so vars must be set before importing.
+process.env.ORGANIZATION_ID = "00000000-0000-4000-8000-000000000000";
+process.env.HOST_SERVICE_SECRET = "test-secret";
+process.env.HOST_DB_PATH = "/tmp/test-host.db";
+process.env.HOST_MIGRATIONS_FOLDER = "/tmp/test-migrations";
+process.env.AUTH_TOKEN = "test-auth-token";
+process.env.SUPERSET_API_URL = "https://cloud.example.com";
+
+import { describe, expect, test } from "bun:test";
+
+const { createSessionInputSchema } = await import("./terminal.ts");
+
+describe("createSessionInputSchema.initialCommand", () => {
+	test("keeps a non-empty command, trimmed", () => {
+		const parsed = createSessionInputSchema.parse({
+			workspaceId: "ws-1",
+			initialCommand: "  ls -la  ",
+		});
+		expect(parsed.initialCommand).toBe("ls -la");
+	});
+
+	test("normalizes an empty command to absent instead of erroring", () => {
+		const parsed = createSessionInputSchema.parse({
+			workspaceId: "ws-1",
+			initialCommand: "",
+		});
+		expect(parsed.initialCommand).toBeUndefined();
+	});
+
+	test("normalizes a whitespace-only command to absent instead of erroring", () => {
+		const parsed = createSessionInputSchema.parse({
+			workspaceId: "ws-1",
+			initialCommand: "   ",
+		});
+		expect(parsed.initialCommand).toBeUndefined();
+	});
+
+	test("stays optional", () => {
+		const parsed = createSessionInputSchema.parse({ workspaceId: "ws-1" });
+		expect(parsed.initialCommand).toBeUndefined();
+	});
+});

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -19,10 +19,17 @@ import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 import { toTerminalSessionError } from "./errors";
 
-const createSessionInputSchema = z.object({
+export const createSessionInputSchema = z.object({
 	workspaceId: z.string(),
 	terminalId: z.string().optional(),
-	initialCommand: z.string().trim().min(1).optional(),
+	// An empty or whitespace-only command means "open a shell with no initial
+	// command" (e.g. a preset with no command), so normalize it to absent
+	// instead of rejecting. `launchSession` still requires a non-empty command.
+	initialCommand: z
+		.string()
+		.trim()
+		.optional()
+		.transform((value) => (value ? value : undefined)),
 	cwd: z.string().optional(),
 	themeType: z.string().optional(),
 	cols: z.number().int().positive().optional(),


### PR DESCRIPTION
## Problem

Users cannot create "empty" presets (a preset-bar button that just opens a terminal, no command). Launching such a preset fails: the renderer sends the preset's command string verbatim as `terminal.createSession`'s `initialCommand`, and the input schema in `packages/host-service/src/trpc/router/terminal/terminal.ts` declared it as `z.string().trim().min(1).optional()`. So both `""` and `" "` (the space workaround users tried) are trimmed to an empty string and rejected with a zod "expected string to have >=1 characters" error, surfaced as a "Failed to run preset" toast. The current workaround is putting a throwaway command like `ls` in the preset.

## Where the strip lives / history

- The `trim().min(1)` constraint dates back to the introduction of `createSessionInputSchema` in #4056 ("Split terminal creation from websocket attach", May 2026) and was carried forward unchanged by #4335. There is no comment, linked bug, or safety concern attached to it in either PR — it reads as defensive input hygiene, not an intentional ban on command-less launches.
- Nothing downstream requires the constraint: the internal session code guards with `if (initialCommand)`, so an absent command simply opens a plain shell (that's exactly how ordinary terminal tabs are created — `initialCommand` is optional).
- Preset creation/persistence itself never rejected empty commands (the v2 collection schema and the settings editor both allow them); only the launch call failed.

## Fix

Surgical, at the boundary that errored: `createSession` now normalizes an empty or whitespace-only `initialCommand` to `undefined`, meaning "open the terminal with no initial command". Trimming of real commands is preserved, and `launchSession` — whose whole contract is "launch a session running this command" — keeps its required non-empty `initialCommand`. Name/label trimming elsewhere (preset display names, agent labels/commands in `settings/agent-configs`) is untouched, since empty values are genuinely invalid there.

## Testing

- New `terminal.schema.test.ts`: non-empty commands pass through trimmed; `""`, `"   "`, and omitted all parse to `initialCommand: undefined`.
- `bun test` on the terminal router dir and `bun run typecheck` in `packages/host-service` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow terminal sessions to start with no initial command by normalizing empty or whitespace-only `initialCommand` to undefined. Previously, trimmed empty values failed validation and blocked launching “empty” presets; now they open a plain shell.

- Updated `createSessionInputSchema` in `packages/host-service/src/trpc/router/terminal/terminal.ts` to trim and transform empty strings to `undefined`, and exported the schema for tests.
- Preserved behavior: non-empty commands are still trimmed; `launchSession` still requires a non-empty `initialCommand`.
- Added `terminal.schema.test.ts` to cover non-empty, empty, whitespace-only, and omitted cases.
- No rollouts or migrations required; existing session logic already skips falsy commands.

<sup>Written for commit 562073de87f651105d3915d1c55d7439e7672265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session command handling by trimming extra whitespace.
  * Empty or whitespace-only initial commands are now treated as omitted instead of causing validation errors.
  * Session launches still require a valid, non-empty command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->