### PR TITLE
feat(sandbox): clone, seed and boot a workspace inside the sandbox

### DIFF
--- a/packages/host-service/src/env.ts
+++ b/packages/host-service/src/env.ts
@@ -20,6 +20,13 @@ export const env = createEnv({
 			.optional(),
 		PORT: z.coerce.number().int().positive().default(4879),
 		RELAY_URL: z.string().url().optional(),
+		/**
+		 * "sandbox" when running inside a cloud sandbox. A sandbox is reached
+		 * directly at its provider preview URL, so it must not register as a
+		 * host or hold a relay socket — that would put it in the device picker
+		 * and keep it awake against the provider's wake-on-inbound sleep.
+		 */
+		SUPERSET_HOST_RUN_MODE: z.enum(["local", "sandbox"]).default("local"),
 	},
 	runtimeEnv: process.env,
 	emptyStringAsUndefined: true,

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -114,7 +114,7 @@ async function main(): Promise<void> {
 
 		startTerminalReaper(db);
 
-		if (env.RELAY_URL) {
+		if (env.RELAY_URL && env.SUPERSET_HOST_RUN_MODE !== "sandbox") {
 			void connectRelay({
 				api,
 				relayUrl: env.RELAY_URL,

--- a/packages/trpc/src/lib/blaxel/bootstrap.ts
+++ b/packages/trpc/src/lib/blaxel/bootstrap.ts
@@ -1,0 +1,112 @@
+/**
+ * Gets a provisioned sandbox from empty to serving a workspace: clone the
+ * repo, seed the one project + one workspace row host-service expects, then
+ * start it.
+ *
+ * host.db is seeded by writing rows directly rather than calling
+ * host-service's own create procedures: those build worktrees off a base
+ * repo, and a sandbox's checkout *is* the workspace, with nothing to branch
+ * from yet.
+ */
+import { SandboxInstance } from "@blaxel/core";
+import { TRPCError } from "@trpc/server";
+
+/** Where the checkout lives, and therefore what every path in host.db points at. */
+const WORKSPACE_PATH = "/workspace";
+const HOST_DB_PATH = "/data/host.db";
+const HOST_SERVICE_PORT = 4879;
+
+export interface BootstrapArgs {
+	providerSandboxId: string;
+	repoCloneUrl: string;
+	/** Short-lived GitHub App installation token; never persisted in the sandbox. */
+	cloneToken: string | null;
+	branch: string;
+	organizationId: string;
+	projectName: string;
+	workspaceName: string;
+	hostServiceSecret: string;
+	apiUrl: string;
+	authToken: string;
+}
+
+function cloneUrlWithToken(repoCloneUrl: string, token: string | null): string {
+	if (!token) return repoCloneUrl;
+	return repoCloneUrl.replace(
+		/^https:\/\//,
+		`https://x-access-token:${token}@`,
+	);
+}
+
+async function exec(
+	sandbox: Awaited<ReturnType<typeof SandboxInstance.get>>,
+	command: string,
+	label: string,
+): Promise<string> {
+	const result = (await sandbox.process.exec({
+		command,
+		waitForCompletion: true,
+	})) as unknown as { exitCode?: number; status?: number; logs?: string };
+	const logs = (result.logs ?? "").toString();
+	const code = result.exitCode ?? result.status;
+	if (code !== 0) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: `Sandbox ${label} failed: ${logs.slice(-400)}`,
+		});
+	}
+	return logs;
+}
+
+export async function bootstrapSandbox(args: BootstrapArgs): Promise<void> {
+	const sandbox = await SandboxInstance.get(args.providerSandboxId);
+
+	// The token is interpolated into a single command rather than written to
+	// a credential file or env var, so it never outlives the clone.
+	await exec(
+		sandbox,
+		`rm -rf ${WORKSPACE_PATH} && git clone --branch ${args.branch} --single-branch ${cloneUrlWithToken(args.repoCloneUrl, args.cloneToken)} ${WORKSPACE_PATH} 2>&1 | tail -3 || git clone ${cloneUrlWithToken(args.repoCloneUrl, args.cloneToken)} ${WORKSPACE_PATH} 2>&1 | tail -3`,
+		"clone",
+	);
+
+	// host-service creates the schema on first boot, so it has to run once
+	// before the seed has tables to write into.
+	await exec(
+		sandbox,
+		`mkdir -p /data && cd /app && ORGANIZATION_ID=${args.organizationId} HOST_DB_PATH=${HOST_DB_PATH} HOST_MIGRATIONS_FOLDER=/app/drizzle AUTH_TOKEN=bootstrap SUPERSET_API_URL=${args.apiUrl} HOST_SERVICE_SECRET=${args.hostServiceSecret} SUPERSET_HOST_RUN_MODE=sandbox timeout 25 node host-service.js > /data/migrate.log 2>&1; grep -q "Initialized at" /data/migrate.log`,
+		"migrate",
+	);
+
+	// Written as a file rather than passed to `node -e`: the seed contains
+	// quotes and newlines that a shell round-trip mangles.
+	const seed = [
+		'const Database = require("better-sqlite3");',
+		`const db = new Database(${JSON.stringify(HOST_DB_PATH)});`,
+		"const now = Date.now();",
+		"const projectId = crypto.randomUUID();",
+		"const workspaceId = crypto.randomUUID();",
+		'db.prepare("INSERT INTO projects (id, repo_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")',
+		`  .run(projectId, ${JSON.stringify(WORKSPACE_PATH)}, ${JSON.stringify(args.projectName)}, now, now);`,
+		'db.prepare("INSERT INTO workspaces (id, project_id, worktree_path, branch, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)")',
+		`  .run(workspaceId, projectId, ${JSON.stringify(WORKSPACE_PATH)}, ${JSON.stringify(args.branch)}, ${JSON.stringify(args.workspaceName)}, now, now);`,
+		"console.log(JSON.stringify({ projectId, workspaceId }));",
+	].join("\n");
+	await sandbox.fs.write("/app/seed.cjs", seed);
+	await exec(sandbox, "mkdir -p /data && cd /app && node seed.cjs", "seed");
+
+	const env = [
+		`ORGANIZATION_ID=${args.organizationId}`,
+		`HOST_DB_PATH=${HOST_DB_PATH}`,
+		"HOST_MIGRATIONS_FOLDER=/app/drizzle",
+		`AUTH_TOKEN=${args.authToken}`,
+		`SUPERSET_API_URL=${args.apiUrl}`,
+		`HOST_SERVICE_SECRET=${args.hostServiceSecret}`,
+		"SUPERSET_HOST_RUN_MODE=sandbox",
+		`PORT=${HOST_SERVICE_PORT}`,
+	].join(" ");
+	await exec(
+		sandbox,
+		`cd /app && ${env} nohup node host-service.js > /data/host-service.log 2>&1 & sleep 8; grep -q listening /data/host-service.log`,
+		"start host-service",
+	);
+}

--- a/packages/trpc/src/lib/blaxel/index.ts
+++ b/packages/trpc/src/lib/blaxel/index.ts
@@ -5,3 +5,4 @@ export {
 	type ProvisionedSandbox,
 	provisionSandbox,
 } from "./blaxel";
+export { bootstrapSandbox } from "./bootstrap";


### PR DESCRIPTION
Fourth of five. **Stacked on #6500** → #6497 → #6489.

Gets a provisioned sandbox from empty to serving a real checkout. This is the walking skeleton working end to end.

## Verified against a live sandbox

```
1. provisioning …      https://70df19f5….preview.bl.run
2. bootstrapping (clone + seed + boot) …
3. querying workspaces over the preview URL …
   status 200
   {"name":"e2e sandbox","branch":"master","worktreePath":"/workspace",
    "worktreeExists":true,"projectName":"Hello-World"}
```

`worktreeExists: true` is the load-bearing bit — host-service can see the cloned repo on disk, so this is a workspace the client could actually open.

## Sandbox run mode

`SUPERSET_HOST_RUN_MODE=local|sandbox`. In sandbox mode host-service skips `connectRelay`, which is what keeps a sandbox out of `v2_hosts` and off the device picker, and lets it sleep — an outbound relay socket would hold it awake against the provider's wake-on-inbound behaviour.

Default is `local`, so nothing changes for desktop hosts.

## Bootstrap order

`clone → migrate → seed → start`, and the middle step is not optional: host-service creates host.db's schema on first boot, so it has to run once (with a timeout) before the seed has tables to write into.

Rows are written **directly** rather than through host-service's own create procedures. Those build a worktree off a base repo, and a sandbox's checkout *is* the workspace — there's nothing to branch from.

## Two things worth reviewing

**The clone token never persists.** It's interpolated into a single `git clone` command rather than written to a credential file or exported as an env var, so it doesn't outlive the command. `cloneToken` is nullable so public repos work without one.

**The seed is written as a file, not passed to `node -e`.** The first version shelled it in and the JS came back mangled — `Expected unicode escape`, with a `require('node:crypto')` fragment I never wrote. `sandbox.fs.write` sidesteps shell quoting entirely.

Also: the seed SQL originally referenced a `kind` column on `workspaces` that doesn't exist. Caught by reading the schema rather than at runtime.

## Verification

typecheck 0 · lint 0 · full provision → clone → seed → boot → query cycle run against production Blaxel, sandbox torn down after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps a provisioned sandbox to serve a real workspace and adds a sandbox run mode that disables relay registration. Previously `host-service` connected to the relay whenever `RELAY_URL` was set; in sandbox mode it now skips the relay so sandboxes stay off the device picker and can sleep.

- Adds `SUPERSET_HOST_RUN_MODE=local|sandbox` (default `local`) and guards relay connection in `host-service`.
- Introduces `bootstrapSandbox` to clone → migrate → seed → start a workspace: clones into `/workspace` with an optional short‑lived token embedded only in the `git clone` command (never persisted), runs `host-service` once with `SUPERSET_HOST_RUN_MODE=sandbox` to create the schema, seeds `/data/host.db` by writing and executing `/app/seed.cjs` (direct DB inserts), then starts `host-service` detached on port 4879 and verifies it is listening; exported from `packages/trpc/src/lib/blaxel`.

- Set `SUPERSET_HOST_RUN_MODE=sandbox` for cloud sandboxes; no other changes required.

<sup>Written for commit b037e8a7d018916b14362b798cf33c90535c2407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

