### PR TITLE
fix(desktop): resolve workspaces before declaring "not found" + stop host-service manifest steals

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -34,6 +34,7 @@ import { env } from "./env";
 
 const SHUTDOWN_GRACE_MS = 3_000;
 const WATCHDOG_INTERVAL_MS = 2_000;
+const MANIFEST_RECLAIM_INTERVAL_MS = 15_000;
 
 type Server = ReturnType<typeof serve>;
 
@@ -128,15 +129,26 @@ async function main(): Promise<void> {
 			startTerminalReaper(db);
 
 			if (env.ORGANIZATION_ID) {
-				void claimManifest({
+				const manifest: HostServiceManifest = {
 					pid: process.pid,
 					endpoint: `http://127.0.0.1:${info.port}`,
 					authToken: env.HOST_SERVICE_SECRET,
 					startedAt,
 					organizationId: env.ORGANIZATION_ID,
-				}).catch((error) => {
+				};
+				void claimManifest(manifest).catch((error) => {
 					console.error("[host-service] Failed to write manifest:", error);
 				});
+				// Yielding at boot must not be permanent: when the holder later
+				// quits (removing its manifest) or dies, re-claim so the CLI's
+				// routing table always names a live instance.
+				const reclaim = setInterval(() => {
+					if (readManifest(manifest.organizationId)?.pid === process.pid) {
+						return;
+					}
+					void claimManifest(manifest).catch(() => {});
+				}, MANIFEST_RECLAIM_INTERVAL_MS);
+				reclaim.unref();
 			}
 
 			if (env.RELAY_URL && env.ORGANIZATION_ID) {

--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -23,7 +23,13 @@ import {
 } from "@superset/host-service/terminal-env";
 import { connectRelay } from "@superset/host-service/tunnel";
 import { loadToken } from "lib/trpc/routers/auth/utils/auth-functions";
-import { writeManifest } from "main/lib/host-service-manifest";
+import {
+	type HostServiceManifest,
+	isProcessAlive,
+	readManifest,
+	shouldYieldManifest,
+	writeManifest,
+} from "main/lib/host-service-manifest";
 import { env } from "./env";
 
 const SHUTDOWN_GRACE_MS = 3_000;
@@ -122,17 +128,15 @@ async function main(): Promise<void> {
 			startTerminalReaper(db);
 
 			if (env.ORGANIZATION_ID) {
-				try {
-					writeManifest({
-						pid: process.pid,
-						endpoint: `http://127.0.0.1:${info.port}`,
-						authToken: env.HOST_SERVICE_SECRET,
-						startedAt,
-						organizationId: env.ORGANIZATION_ID,
-					});
-				} catch (error) {
+				void claimManifest({
+					pid: process.pid,
+					endpoint: `http://127.0.0.1:${info.port}`,
+					authToken: env.HOST_SERVICE_SECRET,
+					startedAt,
+					organizationId: env.ORGANIZATION_ID,
+				}).catch((error) => {
 					console.error("[host-service] Failed to write manifest:", error);
-				}
+				});
 			}
 
 			if (env.RELAY_URL && env.ORGANIZATION_ID) {
@@ -158,6 +162,40 @@ function isParentAlive(parentPid: number): boolean {
 		return process.ppid === parentPid;
 	} catch {
 		return false;
+	}
+}
+
+async function claimManifest(manifest: HostServiceManifest): Promise<void> {
+	const existing = readManifest(manifest.organizationId);
+	const yieldToHolder = await shouldYieldManifest(existing, process.pid, {
+		isAlive: isProcessAlive,
+		probeHealthy: probeManifestHolder,
+	});
+	if (yieldToHolder) {
+		console.warn(
+			`[host-service] manifest for ${manifest.organizationId} held by live pid ${existing?.pid} at ${existing?.endpoint}; not claiming`,
+		);
+		return;
+	}
+	writeManifest(manifest);
+}
+
+async function probeManifestHolder(
+	endpoint: string,
+	authToken: string,
+): Promise<boolean> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 1_500);
+	try {
+		const res = await fetch(`${endpoint}/trpc/health.check`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		return res.ok;
+	} catch {
+		return false;
+	} finally {
+		clearTimeout(timeout);
 	}
 }
 

--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -30,6 +30,7 @@ import {
 	shouldYieldManifest,
 	writeManifest,
 } from "main/lib/host-service-manifest";
+import { pollHealthCheck } from "main/lib/host-service-utils";
 import { env } from "./env";
 
 const SHUTDOWN_GRACE_MS = 3_000;
@@ -46,9 +47,13 @@ async function main(): Promise<void> {
 	// serve() returns; shutdown handles both pre- and post-bind states.
 	const serverRef: { current: Server | null } = { current: null };
 	let shuttingDown = false;
+	let manifestReclaimTimer: NodeJS.Timeout | null = null;
 	const shutdown = (reason: string) => {
 		if (shuttingDown) return;
 		shuttingDown = true;
+		// A reclaim tick during the drain window would resurrect the manifest
+		// the coordinator just removed, leaving it naming a dead pid.
+		if (manifestReclaimTimer) clearInterval(manifestReclaimTimer);
 		console.log(`[host-service] shutdown (${reason}), draining connections`);
 		const server = serverRef.current;
 		if (!server) {
@@ -142,13 +147,13 @@ async function main(): Promise<void> {
 				// Yielding at boot must not be permanent: when the holder later
 				// quits (removing its manifest) or dies, re-claim so the CLI's
 				// routing table always names a live instance.
-				const reclaim = setInterval(() => {
+				manifestReclaimTimer = setInterval(() => {
 					if (readManifest(manifest.organizationId)?.pid === process.pid) {
 						return;
 					}
 					void claimManifest(manifest).catch(() => {});
 				}, MANIFEST_RECLAIM_INTERVAL_MS);
-				reclaim.unref();
+				manifestReclaimTimer.unref();
 			}
 
 			if (env.RELAY_URL && env.ORGANIZATION_ID) {
@@ -177,11 +182,16 @@ function isParentAlive(parentPid: number): boolean {
 	}
 }
 
+// Same retrying probe the coordinator's adopt decision uses — a holder that
+// is momentarily slow (mid-GC, DB migration) must not get its claim taken.
+const MANIFEST_HOLDER_PROBE_TIMEOUT_MS = 2_500;
+
 async function claimManifest(manifest: HostServiceManifest): Promise<void> {
 	const existing = readManifest(manifest.organizationId);
 	const yieldToHolder = await shouldYieldManifest(existing, process.pid, {
 		isAlive: isProcessAlive,
-		probeHealthy: probeManifestHolder,
+		probeHealthy: (endpoint, authToken) =>
+			pollHealthCheck(endpoint, authToken, MANIFEST_HOLDER_PROBE_TIMEOUT_MS),
 	});
 	if (yieldToHolder) {
 		console.warn(
@@ -190,25 +200,6 @@ async function claimManifest(manifest: HostServiceManifest): Promise<void> {
 		return;
 	}
 	writeManifest(manifest);
-}
-
-async function probeManifestHolder(
-	endpoint: string,
-	authToken: string,
-): Promise<boolean> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), 1_500);
-	try {
-		const res = await fetch(`${endpoint}/trpc/health.check`, {
-			signal: controller.signal,
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
-		return res.ok;
-	} catch {
-		return false;
-	} finally {
-		clearTimeout(timeout);
-	}
 }
 
 void main().catch(async (error) => {

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -571,6 +571,7 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 			status: "running",
 			owned: true,
 		});
+		manifestStore.current = baseManifest(4321);
 
 		coordinator.stop("org-1");
 
@@ -880,12 +881,15 @@ describe("HostServiceCoordinator.stop manifest ownership", () => {
 	let coordinator: InstanceType<typeof HostServiceCoordinator>;
 	let internals: { instances: Map<string, unknown> };
 
-	function trackOwned(pid: number): void {
+	function trackOwned(
+		pid: number,
+		status: "running" | "starting" = "running",
+	): void {
 		internals.instances.set("org-1", {
 			pid,
 			port: 55555,
 			secret: "secret",
-			status: "running",
+			status,
 			spawnedAt: Date.now(),
 			outputTail: "",
 			redactions: ["secret"],
@@ -930,13 +934,51 @@ describe("HostServiceCoordinator.stop manifest ownership", () => {
 		expect(killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
 	});
 
-	test("removes an unreadable manifest so a corrupt file cannot linger", () => {
+	test("leaves an unreadable manifest alone (a torn read of a concurrent claim must not be deleted)", () => {
 		trackOwned(4242);
 		manifestStore.current = null;
 
 		coordinator.stop("org-1");
 
+		expect(removeManifestMock).not.toHaveBeenCalled();
+	});
+
+	test("handleChildExit removes only a manifest the dead child held", () => {
+		const internalsWithExit = coordinator as unknown as {
+			instances: Map<string, unknown>;
+			handleChildExit(
+				organizationId: string,
+				childPid: number,
+				code: number | null,
+				signal: NodeJS.Signals | null,
+			): void;
+		};
+		trackOwned(4242, "starting");
+		manifestStore.current = baseManifest(9999);
+
+		internalsWithExit.handleChildExit("org-1", 4242, null, "SIGKILL");
+
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(manifestStore.current?.pid).toBe(9999);
+	});
+
+	test("handleChildExit removes the dead child's own manifest", () => {
+		const internalsWithExit = coordinator as unknown as {
+			instances: Map<string, unknown>;
+			handleChildExit(
+				organizationId: string,
+				childPid: number,
+				code: number | null,
+				signal: NodeJS.Signals | null,
+			): void;
+		};
+		trackOwned(4242, "starting");
+		manifestStore.current = baseManifest(4242);
+
+		internalsWithExit.handleChildExit("org-1", 4242, null, "SIGKILL");
+
 		expect(removeManifestMock).toHaveBeenCalled();
+		expect(manifestStore.current).toBeNull();
 	});
 });
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -876,6 +876,70 @@ describe("HostServiceCoordinator respawn after a crash", () => {
 	});
 });
 
+describe("HostServiceCoordinator.stop manifest ownership", () => {
+	let coordinator: InstanceType<typeof HostServiceCoordinator>;
+	let internals: { instances: Map<string, unknown> };
+
+	function trackOwned(pid: number): void {
+		internals.instances.set("org-1", {
+			pid,
+			port: 55555,
+			secret: "secret",
+			status: "running",
+			spawnedAt: Date.now(),
+			outputTail: "",
+			redactions: ["secret"],
+			owned: true,
+		});
+	}
+
+	beforeEach(() => {
+		resetMocks();
+		testManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsc-test-"));
+		coordinator = new HostServiceCoordinator();
+		internals = coordinator as unknown as typeof internals;
+		coordinator.setConfigProvider(async () => spawnConfig);
+	});
+
+	afterEach(() => {
+		coordinator.stopAll();
+		if (testManifestRoot) {
+			fs.rmSync(testManifestRoot, { recursive: true, force: true });
+			testManifestRoot = "";
+		}
+	});
+
+	test("removes the manifest our own child wrote", () => {
+		trackOwned(4242);
+		manifestStore.current = baseManifest(4242);
+
+		coordinator.stop("org-1");
+
+		expect(removeManifestMock).toHaveBeenCalled();
+		expect(manifestStore.current).toBeNull();
+	});
+
+	test("leaves a manifest claimed by another live instance, but still kills our child", () => {
+		trackOwned(4242);
+		manifestStore.current = baseManifest(9999);
+
+		coordinator.stop("org-1");
+
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(manifestStore.current?.pid).toBe(9999);
+		expect(killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+	});
+
+	test("removes an unreadable manifest so a corrupt file cannot linger", () => {
+		trackOwned(4242);
+		manifestStore.current = null;
+
+		coordinator.stop("org-1");
+
+		expect(removeManifestMock).toHaveBeenCalled();
+	});
+});
+
 afterAll(() => {
 	mock.restore();
 });

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -312,7 +312,14 @@ export class HostServiceCoordinator extends EventEmitter {
 			try {
 				if (instance.pid > 0) killProcess(instance.pid, "SIGTERM");
 			} catch {}
-			removeManifest(organizationId);
+			// Another live instance may have claimed the manifest since we
+			// spawned; deleting its claim would strand the CLI ("host service
+			// isn't running") while that instance still serves. Remove only a
+			// manifest our own child wrote (or an unreadable one).
+			const manifest = readManifest(organizationId);
+			if (manifest === null || manifest.pid === instance.pid) {
+				removeManifest(organizationId);
+			}
 		}
 
 		this.instances.delete(organizationId);

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -793,7 +793,10 @@ export class HostServiceCoordinator extends EventEmitter {
 			if (this.instances.get(organizationId) === instance) {
 				this.instances.delete(organizationId);
 			}
-			if (!isStartAllowed() && childPid != null) {
+			// Whether cancelled or failed-to-start, the dying child must not
+			// leave a manifest naming its dead pid (the CLI would report
+			// "manifest is stale" instead of the clean no-manifest path).
+			if (childPid != null) {
 				this.removeManifestIfHeldBy(organizationId, childPid);
 			}
 			throw new Error(

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -312,18 +312,23 @@ export class HostServiceCoordinator extends EventEmitter {
 			try {
 				if (instance.pid > 0) killProcess(instance.pid, "SIGTERM");
 			} catch {}
-			// Another live instance may have claimed the manifest since we
-			// spawned; deleting its claim would strand the CLI ("host service
-			// isn't running") while that instance still serves. Remove only a
-			// manifest our own child wrote (or an unreadable one).
-			const manifest = readManifest(organizationId);
-			if (manifest === null || manifest.pid === instance.pid) {
-				removeManifest(organizationId);
-			}
+			this.removeManifestIfHeldBy(organizationId, instance.pid);
 		}
 
 		this.instances.delete(organizationId);
 		this.emitStatus(organizationId, "stopped", previousStatus);
+	}
+
+	/**
+	 * Remove the manifest only when `pid` holds it. Another live instance may
+	 * have claimed it since we spawned; deleting that claim would strand the
+	 * CLI ("host service isn't running") while the claimant still serves. An
+	 * unreadable manifest is left alone too — a torn read of a concurrent
+	 * writer's claim must not read as license to delete.
+	 */
+	private removeManifestIfHeldBy(organizationId: string, pid: number): void {
+		if (readManifest(organizationId)?.pid !== pid) return;
+		removeManifest(organizationId);
 	}
 
 	stopAll(): void {
@@ -788,7 +793,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			if (this.instances.get(organizationId) === instance) {
 				this.instances.delete(organizationId);
 			}
-			if (!isStartAllowed()) removeManifest(organizationId);
+			if (!isStartAllowed() && childPid != null) {
+				this.removeManifestIfHeldBy(organizationId, childPid);
+			}
 			throw new Error(
 				!isStartAllowed()
 					? "Host service start cancelled"
@@ -925,7 +932,7 @@ export class HostServiceCoordinator extends EventEmitter {
 		const previousStatus = current.status;
 		this.rememberPort(organizationId, current.port);
 		this.instances.delete(organizationId);
-		removeManifest(organizationId);
+		this.removeManifestIfHeldBy(organizationId, childPid);
 		this.emitStatus(organizationId, "stopped", previousStatus);
 
 		if (previousStatus !== "running") return;

--- a/apps/desktop/src/main/lib/host-service-manifest.test.ts
+++ b/apps/desktop/src/main/lib/host-service-manifest.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	type HostServiceManifest,
+	shouldYieldManifest,
+} from "./host-service-manifest";
+
+function manifest(pid: number): HostServiceManifest {
+	return {
+		pid,
+		endpoint: "http://127.0.0.1:55555",
+		authToken: "holder-secret",
+		startedAt: 0,
+		organizationId: "org-1",
+	};
+}
+
+const SELF_PID = 100;
+const HOLDER_PID = 200;
+
+function deps(overrides?: { alive?: boolean; healthy?: boolean }): {
+	isAlive: ReturnType<typeof mock>;
+	probeHealthy: ReturnType<typeof mock>;
+} {
+	return {
+		isAlive: mock(() => overrides?.alive ?? true),
+		probeHealthy: mock(() => Promise.resolve(overrides?.healthy ?? true)),
+	};
+}
+
+describe("shouldYieldManifest", () => {
+	it("yields to a live, healthy holder", async () => {
+		const d = deps();
+		expect(await shouldYieldManifest(manifest(HOLDER_PID), SELF_PID, d)).toBe(
+			true,
+		);
+		expect(d.probeHealthy).toHaveBeenCalledWith(
+			"http://127.0.0.1:55555",
+			"holder-secret",
+		);
+	});
+
+	it("claims when no manifest exists", async () => {
+		const d = deps();
+		expect(await shouldYieldManifest(null, SELF_PID, d)).toBe(false);
+		expect(d.isAlive).not.toHaveBeenCalled();
+		expect(d.probeHealthy).not.toHaveBeenCalled();
+	});
+
+	it("claims over its own prior manifest", async () => {
+		const d = deps();
+		expect(await shouldYieldManifest(manifest(SELF_PID), SELF_PID, d)).toBe(
+			false,
+		);
+		expect(d.probeHealthy).not.toHaveBeenCalled();
+	});
+
+	it("claims from a dead holder without probing", async () => {
+		const d = deps({ alive: false });
+		expect(await shouldYieldManifest(manifest(HOLDER_PID), SELF_PID, d)).toBe(
+			false,
+		);
+		expect(d.probeHealthy).not.toHaveBeenCalled();
+	});
+
+	it("claims from a live but unhealthy holder", async () => {
+		const d = deps({ healthy: false });
+		expect(await shouldYieldManifest(manifest(HOLDER_PID), SELF_PID, d)).toBe(
+			false,
+		);
+		expect(d.probeHealthy).toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/main/lib/host-service-manifest.ts
+++ b/apps/desktop/src/main/lib/host-service-manifest.ts
@@ -2,6 +2,7 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	renameSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -29,14 +30,16 @@ export function writeManifest(manifest: HostServiceManifest): void {
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true, mode: 0o700 });
 	}
-	writeFileSync(
-		manifestPath(manifest.organizationId),
-		JSON.stringify(manifest),
-		{
-			encoding: "utf-8",
-			mode: 0o600,
-		},
-	);
+	// Write-then-rename so concurrent readers (the CLI, other instances'
+	// claim/ownership checks) never see a torn file — a torn read parses as
+	// null, which callers must not mistake for "no claim".
+	const finalPath = manifestPath(manifest.organizationId);
+	const tempPath = `${finalPath}.${process.pid}.tmp`;
+	writeFileSync(tempPath, JSON.stringify(manifest), {
+		encoding: "utf-8",
+		mode: 0o600,
+	});
+	renameSync(tempPath, finalPath);
 }
 
 export function readManifest(

--- a/apps/desktop/src/main/lib/host-service-manifest.ts
+++ b/apps/desktop/src/main/lib/host-service-manifest.ts
@@ -65,6 +65,27 @@ export function readManifest(
 	}
 }
 
+/**
+ * Whether a booting host-service must leave the manifest alone. The manifest
+ * is the CLI's routing table; stealing it from a live, healthy instance
+ * routes CLI writes to a host-service the desktop renderer isn't listening
+ * to — its broadcasts become invisible and CLI-created workspaces render
+ * "not found" until a fallback refetch. A dead or unhealthy holder forfeits
+ * its claim.
+ */
+export async function shouldYieldManifest(
+	existing: HostServiceManifest | null,
+	selfPid: number,
+	deps: {
+		isAlive: (pid: number) => boolean;
+		probeHealthy: (endpoint: string, authToken: string) => Promise<boolean>;
+	},
+): Promise<boolean> {
+	if (!existing || existing.pid === selfPid) return false;
+	if (!deps.isAlive(existing.pid)) return false;
+	return deps.probeHealthy(existing.endpoint, existing.authToken);
+}
+
 export function removeManifest(organizationId: string): void {
 	const filePath = manifestPath(organizationId);
 	try {

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -1,6 +1,6 @@
 import { getEventBus } from "@superset/workspace-client";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useKnownHosts } from "renderer/hooks/known-hosts/useKnownHosts";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
@@ -54,6 +54,13 @@ export interface UseHostWorkspacesResult {
 	 * empty states only — existing rows always render (cache-first rule).
 	 */
 	isReady: boolean;
+	/**
+	 * The org's host list itself is trustworthy (useKnownHosts settled) —
+	 * weaker than isReady: it does not wait for any host's list to answer, so
+	 * one unreachable host cannot hold it. Until this is true the fan-out may
+	 * cover only the local host.
+	 */
+	hostsSettled: boolean;
 	cache: HostWorkspacesCacheOps;
 }
 
@@ -196,6 +203,8 @@ export function useHostWorkspacesSource(
 		})),
 	});
 
+	const busEverOpenedRef = useRef<Set<string>>(new Set());
+
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
 	useEffect(() => {
@@ -250,10 +259,19 @@ export function useHostWorkspacesSource(
 			// all of this host's mirrors — workspaces, projects, ports share the
 			// "host-service" key prefix + machineId. Flap cost is bounded by the
 			// bus's own reconnect backoff (≥1s) and scoped to the one host.
-			let hasOpened = bus.getConnectionStatus().state === "open";
+			// Whether this bus ever opened must survive effect re-runs: targets
+			// churn on presence flips, which correlate with outages — a re-run
+			// mid-outage that re-derived "never opened" from current state would
+			// silently skip the gap resync on the next reopen.
+			if (bus.getConnectionStatus().state === "open") {
+				busEverOpenedRef.current.add(hostUrl);
+			}
 			const removeStatusListener = bus.subscribeConnectionStatus((status) => {
-				const reopened = isEventBusReopen(hasOpened, status.state);
-				if (status.state === "open") hasOpened = true;
+				const reopened = isEventBusReopen(
+					busEverOpenedRef.current.has(hostUrl),
+					status.state,
+				);
+				if (status.state === "open") busEverOpenedRef.current.add(hostUrl);
 				if (!reopened) return;
 				void queryClient.invalidateQueries({
 					predicate: (query) =>
@@ -381,5 +399,5 @@ export function useHostWorkspacesSource(
 		};
 	}, [targets, queryClient]);
 
-	return { workspaces, isReady, cache };
+	return { workspaces, isReady, hostsSettled: knownHostsSettled, cache };
 }

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -12,6 +12,7 @@ import {
 	getHostWorkspacesQueryKey,
 	type HostWorkspaceItem,
 	type HostWorkspaceRow,
+	isEventBusReopen,
 	loadHostWorkspacesSnapshot,
 	mergeHostWorkspaces,
 	saveHostWorkspacesSnapshot,
@@ -244,9 +245,26 @@ export function useHostWorkspacesSource(
 					}
 				},
 			);
+			// Resync on reopen: events broadcast while the socket was down are
+			// lost (no replay), so every reopen is a potential gap. Invalidate
+			// all of this host's mirrors — workspaces, projects, ports share the
+			// "host-service" key prefix + machineId. Flap cost is bounded by the
+			// bus's own reconnect backoff (≥1s) and scoped to the one host.
+			let hasOpened = bus.getConnectionStatus().state === "open";
+			const removeStatusListener = bus.subscribeConnectionStatus((status) => {
+				const reopened = isEventBusReopen(hasOpened, status.state);
+				if (status.state === "open") hasOpened = true;
+				if (!reopened) return;
+				void queryClient.invalidateQueries({
+					predicate: (query) =>
+						query.queryKey[0] === "host-service" &&
+						query.queryKey.includes(target.machineId),
+				});
+			});
 			const releaseBus = bus.retain();
 			cleanups.push(() => {
 				removeListener();
+				removeStatusListener();
 				releaseBus();
 			});
 		}

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -34,6 +34,16 @@ export interface HostWorkspacesCacheOps {
 	removeWorkspace: (hostId: string, workspaceId: string) => void;
 	/** Rollback hammer: refetch a host's list after a failed write. */
 	invalidateHost: (hostId: string) => void;
+	/** True once at least one host resolved to a reachable URL. */
+	hasLiveTargets: boolean;
+	/**
+	 * Force-refetch every reachable host's live list; resolves when all
+	 * settle (success or error). The workspace route's miss verdict awaits
+	 * this so "not found" is never declared from data older than the request
+	 * — the mirror converges through fire-and-forget events plus a slow
+	 * fallback refetch, so a just-created row can trail its own deep link.
+	 */
+	refetchAll: () => Promise<void>;
 }
 
 export interface UseHostWorkspacesResult {
@@ -337,6 +347,18 @@ export function useHostWorkspacesSource(
 				void queryClient.invalidateQueries({
 					queryKey: getHostWorkspacesQueryKey(target),
 				});
+			},
+			hasLiveTargets: targets.some((target) => target.hostUrl !== null),
+			refetchAll: async () => {
+				await Promise.all(
+					targets
+						.filter((target) => target.hostUrl !== null)
+						.map((target) =>
+							queryClient.refetchQueries({
+								queryKey: getHostWorkspacesQueryKey(target),
+							}),
+						),
+				);
 			},
 		};
 	}, [targets, queryClient]);

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { isEventBusReopen } from "./useHostWorkspaces.utils";
+
+describe("isEventBusReopen", () => {
+	it("treats any open after the first as a reopen", () => {
+		expect(isEventBusReopen(true, "open")).toBe(true);
+	});
+
+	it("does not treat the first open as a reopen", () => {
+		expect(isEventBusReopen(false, "open")).toBe(false);
+	});
+
+	it("ignores transitions that do not land on open", () => {
+		expect(isEventBusReopen(true, "reconnecting")).toBe(false);
+		expect(isEventBusReopen(true, "closed")).toBe(false);
+		expect(isEventBusReopen(true, "connecting")).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -1,6 +1,9 @@
 import type { SelectV2Workspace } from "@superset/db/schema";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import type { WorkspaceSnapshotPayload } from "@superset/workspace-client";
+import type {
+	HostConnectionState,
+	WorkspaceSnapshotPayload,
+} from "@superset/workspace-client";
 import { get as idbGet, set as idbSet } from "idb-keyval";
 
 /**
@@ -154,6 +157,22 @@ export function saveHostWorkspacesSnapshot(
 ): void {
 	if (!organizationId) return;
 	void idbSet(snapshotKey(organizationId, machineId), rows).catch(() => {});
+}
+
+/**
+ * Whether a connection-status transition means the socket came back up after
+ * being down. Events broadcast while down are unrecoverable (the bus has no
+ * replay), so every open after the first is a potential gap and the host's
+ * mirrors must resync. Keyed on "has opened before", not the previous state:
+ * a manual `reconnect()` publishes "connecting" (same as the initial dial)
+ * before reopening, so state pairs can't distinguish retry from boot. The
+ * first open is not a reopen — the queries' first fetch covers it.
+ */
+export function isEventBusReopen(
+	hasOpenedBefore: boolean,
+	next: HostConnectionState,
+): boolean {
+	return next === "open" && hasOpenedBefore;
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceMissVerdict } from "./useWorkspaceMissVerdict";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.test.ts
@@ -1,52 +1,58 @@
 import { describe, expect, it } from "bun:test";
 import {
 	type MissVerdictInput,
+	planVerdictAction,
 	runVerdictWindow,
-	shouldStartResolution,
 } from "./useWorkspaceMissVerdict";
 
 const base: MissVerdictInput = {
 	workspaceId: "ws-1",
 	workspaceFound: false,
 	suspended: false,
+	hostsEnumerated: true,
 	hasLiveTargets: true,
+	mirrorSettled: true,
 };
 
-describe("shouldStartResolution", () => {
-	it("starts for a routed, unfound, unsuspended id with live targets", () => {
-		expect(shouldStartResolution(base, null)).toBe(true);
+describe("planVerdictAction", () => {
+	it("opens a window for a routed, unfound, unsuspended id with live targets", () => {
+		expect(planVerdictAction(base)).toBe("open-window");
 	});
 
-	it("does not start without a routed workspaceId", () => {
-		expect(shouldStartResolution({ ...base, workspaceId: null }, null)).toBe(
-			false,
-		);
+	it("does nothing without a routed workspaceId", () => {
+		expect(planVerdictAction({ ...base, workspaceId: null })).toBe("none");
 	});
 
-	it("does not start when the row is already in the mirror", () => {
-		expect(shouldStartResolution({ ...base, workspaceFound: true }, null)).toBe(
-			false,
-		);
+	it("does nothing when the row is already in the mirror", () => {
+		expect(planVerdictAction({ ...base, workspaceFound: true })).toBe("none");
 	});
 
-	it("does not start while a create transaction or failed entry owns the id", () => {
-		expect(shouldStartResolution({ ...base, suspended: true }, null)).toBe(
-			false,
-		);
+	it("does nothing while a create transaction or failed entry owns the id", () => {
+		expect(planVerdictAction({ ...base, suspended: true })).toBe("none");
 	});
 
-	it("waits for a reachable host before starting", () => {
+	it("waits for the host list to settle before judging (remote hosts may be unenumerated)", () => {
+		expect(planVerdictAction({ ...base, hostsEnumerated: false })).toBe("none");
+	});
+
+	it("waits while no host is reachable and the mirror has not settled (boot)", () => {
 		expect(
-			shouldStartResolution({ ...base, hasLiveTargets: false }, null),
-		).toBe(false);
+			planVerdictAction({
+				...base,
+				hasLiveTargets: false,
+				mirrorSettled: false,
+			}),
+		).toBe("none");
 	});
 
-	it("does not restart an already-attempted id", () => {
-		expect(shouldStartResolution(base, "ws-1")).toBe(false);
-	});
-
-	it("restarts when the routed id changes", () => {
-		expect(shouldStartResolution(base, "ws-0")).toBe(true);
+	it("declares an immediate miss when offline with a settled mirror", () => {
+		expect(
+			planVerdictAction({
+				...base,
+				hasLiveTargets: false,
+				mirrorSettled: true,
+			}),
+		).toBe("immediate-miss");
 	});
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type MissVerdictInput,
+	runVerdictWindow,
+	shouldStartResolution,
+} from "./useWorkspaceMissVerdict";
+
+const base: MissVerdictInput = {
+	workspaceId: "ws-1",
+	workspaceFound: false,
+	suspended: false,
+	hasLiveTargets: true,
+};
+
+describe("shouldStartResolution", () => {
+	it("starts for a routed, unfound, unsuspended id with live targets", () => {
+		expect(shouldStartResolution(base, null)).toBe(true);
+	});
+
+	it("does not start without a routed workspaceId", () => {
+		expect(shouldStartResolution({ ...base, workspaceId: null }, null)).toBe(
+			false,
+		);
+	});
+
+	it("does not start when the row is already in the mirror", () => {
+		expect(shouldStartResolution({ ...base, workspaceFound: true }, null)).toBe(
+			false,
+		);
+	});
+
+	it("does not start while a create transaction or failed entry owns the id", () => {
+		expect(shouldStartResolution({ ...base, suspended: true }, null)).toBe(
+			false,
+		);
+	});
+
+	it("waits for a reachable host before starting", () => {
+		expect(
+			shouldStartResolution({ ...base, hasLiveTargets: false }, null),
+		).toBe(false);
+	});
+
+	it("does not restart an already-attempted id", () => {
+		expect(shouldStartResolution(base, "ws-1")).toBe(false);
+	});
+
+	it("restarts when the routed id changes", () => {
+		expect(shouldStartResolution(base, "ws-0")).toBe(true);
+	});
+});
+
+describe("runVerdictWindow", () => {
+	it("settles when the refetch settles and cancels the cap", async () => {
+		let capCancelled = false;
+		const schedule = () => () => {
+			capCancelled = true;
+		};
+		await runVerdictWindow(() => Promise.resolve(), 5_000, schedule);
+		expect(capCancelled).toBe(true);
+	});
+
+	it("settles even when the refetch rejects", async () => {
+		await runVerdictWindow(
+			() => Promise.reject(new Error("host unreachable")),
+			5_000,
+			() => () => {},
+		);
+	});
+
+	it("settles at the cap when the refetch hangs", async () => {
+		let fireCap = () => {};
+		const schedule = (fn: () => void) => {
+			fireCap = fn;
+			return () => {};
+		};
+		const window = runVerdictWindow(
+			() => new Promise<void>(() => {}),
+			5_000,
+			schedule,
+		);
+		fireCap();
+		await window;
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 const DEFAULT_CAP_MS = 5_000;
 
@@ -11,22 +11,38 @@ export interface MissVerdictInput {
 	 * their own states and must never be judged missing.
 	 */
 	suspended: boolean;
-	/** No host has resolved to a reachable URL yet — nobody to ask. */
+	/**
+	 * The org's host list is trustworthy (useKnownHosts settled). Before this,
+	 * targets cover only the local host, so a refetch that misses proves
+	 * nothing about workspaces on not-yet-enumerated remote hosts — judging
+	 * then would flash not-found right after boot or an org switch.
+	 */
+	hostsEnumerated: boolean;
+	/** At least one host resolved to a reachable URL. */
 	hasLiveTargets: boolean;
+	/**
+	 * Every host answered, errored, or served a snapshot
+	 * (useHostWorkspaces.isReady). With no live targets AND a settled mirror,
+	 * absence is already authoritative (offline with snapshots); before
+	 * settlement it means boot — keep waiting.
+	 */
+	mirrorSettled: boolean;
 }
 
-/** Pure gate: whether a fresh resolution attempt should start. */
-export function shouldStartResolution(
-	input: MissVerdictInput,
-	attemptedId: string | null,
-): boolean {
-	return (
-		input.workspaceId !== null &&
-		!input.workspaceFound &&
-		!input.suspended &&
-		input.hasLiveTargets &&
-		attemptedId !== input.workspaceId
-	);
+export type MissVerdictAction = "none" | "immediate-miss" | "open-window";
+
+/** Pure decision: what a verdict pass should do for the current input. */
+export function planVerdictAction(input: MissVerdictInput): MissVerdictAction {
+	if (!input.workspaceId || input.workspaceFound || input.suspended) {
+		return "none";
+	}
+	if (!input.hostsEnumerated) {
+		return "none";
+	}
+	if (!input.hasLiveTargets) {
+		return input.mirrorSettled ? "immediate-miss" : "none";
+	}
+	return "open-window";
 }
 
 /**
@@ -66,41 +82,65 @@ function scheduleTimeout(fn: () => void, ms: number): () => void {
  * host-service instance, stale boot snapshot). Verdict rule: not-found only
  * after a refetch that started after this route asked has settled without the
  * row (or the cap expired) — never from pre-existing cache state alone, and
- * independent of `isReady`, which one hanging host can hold false for minutes.
+ * independent of `isReady`'s blank-shell hold (one hanging host can pin that
+ * false for minutes).
+ *
+ * The window is cancelled whenever the input changes (navigation, row
+ * arrival), and the verdict is keyed by id and reset on navigation, so a
+ * revisited id always re-verifies and a superseded window can never clobber
+ * the current route's verdict.
  */
 export function useWorkspaceMissVerdict(
 	input: MissVerdictInput,
 	refetchAll: () => Promise<void>,
 	capMs: number = DEFAULT_CAP_MS,
 ): boolean {
-	const { workspaceId, workspaceFound, suspended, hasLiveTargets } = input;
+	const {
+		workspaceId,
+		workspaceFound,
+		suspended,
+		hostsEnumerated,
+		hasLiveTargets,
+		mirrorSettled,
+	} = input;
+	/** The workspaceId whose miss was confirmed by a completed window. */
 	const [missedId, setMissedId] = useState<string | null>(null);
-	const attemptedIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
-		if (
-			workspaceId === null ||
-			!shouldStartResolution(
-				{ workspaceId, workspaceFound, suspended, hasLiveTargets },
-				attemptedIdRef.current,
-			)
-		) {
+		// A verdict must not outlive navigation: entering a different id drops
+		// the previous one so the route re-verifies instead of trusting state
+		// from an earlier visit.
+		setMissedId((prev) =>
+			prev === null || prev === workspaceId ? prev : null,
+		);
+		const action = planVerdictAction({
+			workspaceId,
+			workspaceFound,
+			suspended,
+			hostsEnumerated,
+			hasLiveTargets,
+			mirrorSettled,
+		});
+		if (action === "none" || workspaceId === null) return;
+		if (action === "immediate-miss") {
+			setMissedId(workspaceId);
 			return;
 		}
-		const attemptId = workspaceId;
-		attemptedIdRef.current = attemptId;
+		let cancelled = false;
 		void runVerdictWindow(refetchAll, capMs).then(() => {
-			setMissedId((prev) => (prev === attemptId ? prev : attemptId));
+			if (cancelled) return;
+			setMissedId(workspaceId);
 		});
-		// Deliberately no cleanup: cache-identity churn re-runs this effect
-		// mid-window, and cancelling the window then would strand the route on
-		// the loading shell. A late verdict for a stale id is inert — the
-		// return value compares against the current workspaceId.
+		return () => {
+			cancelled = true;
+		};
 	}, [
 		workspaceId,
 		workspaceFound,
 		suspended,
+		hostsEnumerated,
 		hasLiveTargets,
+		mirrorSettled,
 		refetchAll,
 		capMs,
 	]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useWorkspaceMissVerdict/useWorkspaceMissVerdict.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react";
+
+const DEFAULT_CAP_MS = 5_000;
+
+export interface MissVerdictInput {
+	workspaceId: string | null;
+	/** The row is already in the mirror — nothing to resolve. */
+	workspaceFound: boolean;
+	/**
+	 * A create transaction or failed-create entry owns this id; those render
+	 * their own states and must never be judged missing.
+	 */
+	suspended: boolean;
+	/** No host has resolved to a reachable URL yet — nobody to ask. */
+	hasLiveTargets: boolean;
+}
+
+/** Pure gate: whether a fresh resolution attempt should start. */
+export function shouldStartResolution(
+	input: MissVerdictInput,
+	attemptedId: string | null,
+): boolean {
+	return (
+		input.workspaceId !== null &&
+		!input.workspaceFound &&
+		!input.suspended &&
+		input.hasLiveTargets &&
+		attemptedId !== input.workspaceId
+	);
+}
+
+/**
+ * Wait for one post-request refetch to settle, bounded by the cap so a
+ * hanging host can't hold the route on the loading shell forever. Resolves on
+ * refetch failure too — the verdict needs settlement, not success.
+ */
+export function runVerdictWindow(
+	refetchAll: () => Promise<void>,
+	capMs: number,
+	schedule: (fn: () => void, ms: number) => () => void = scheduleTimeout,
+): Promise<void> {
+	return new Promise((resolve) => {
+		let settled = false;
+		let cancelCap = () => {};
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			cancelCap();
+			resolve();
+		};
+		cancelCap = schedule(finish, capMs);
+		refetchAll().then(finish, finish);
+	});
+}
+
+function scheduleTimeout(fn: () => void, ms: number): () => void {
+	const timer = setTimeout(fn, ms);
+	return () => clearTimeout(timer);
+}
+
+/**
+ * Decides when a routed-to workspace id may be declared missing. The mirror
+ * (useHostWorkspaces) converges through fire-and-forget events plus a slow
+ * fallback refetch, so "not in the mirror" proves nothing at route time — a
+ * CLI-created workspace can trail its own deep link (missed broadcast, second
+ * host-service instance, stale boot snapshot). Verdict rule: not-found only
+ * after a refetch that started after this route asked has settled without the
+ * row (or the cap expired) — never from pre-existing cache state alone, and
+ * independent of `isReady`, which one hanging host can hold false for minutes.
+ */
+export function useWorkspaceMissVerdict(
+	input: MissVerdictInput,
+	refetchAll: () => Promise<void>,
+	capMs: number = DEFAULT_CAP_MS,
+): boolean {
+	const { workspaceId, workspaceFound, suspended, hasLiveTargets } = input;
+	const [missedId, setMissedId] = useState<string | null>(null);
+	const attemptedIdRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (
+			workspaceId === null ||
+			!shouldStartResolution(
+				{ workspaceId, workspaceFound, suspended, hasLiveTargets },
+				attemptedIdRef.current,
+			)
+		) {
+			return;
+		}
+		const attemptId = workspaceId;
+		attemptedIdRef.current = attemptId;
+		void runVerdictWindow(refetchAll, capMs).then(() => {
+			setMissedId((prev) => (prev === attemptId ? prev : attemptId));
+		});
+		// Deliberately no cleanup: cache-identity churn re-runs this effect
+		// mid-window, and cancelling the window then would strand the route on
+		// the loading shell. A late verdict for a stale id is inert — the
+		// return value compares against the current workspaceId.
+	}, [
+		workspaceId,
+		workspaceFound,
+		suspended,
+		hasLiveTargets,
+		refetchAll,
+		capMs,
+	]);
+
+	return (
+		workspaceId !== null &&
+		!workspaceFound &&
+		!suspended &&
+		missedId === workspaceId
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -14,6 +14,7 @@ import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
 import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { useRemoteHostStatus } from "./hooks/useRemoteHostStatus";
+import { useWorkspaceMissVerdict } from "./hooks/useWorkspaceMissVerdict";
 import { WorkspaceProvider } from "./providers/WorkspaceProvider";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/v2-workspace")(
@@ -48,7 +49,7 @@ function V2WorkspaceLayout() {
 		},
 	});
 
-	const { workspaces: hostWorkspaces, isReady } = useHostWorkspaces();
+	const { workspaces: hostWorkspaces, cache } = useHostWorkspaces();
 	const workspace = useMemo(
 		() =>
 			workspaceId != null
@@ -76,7 +77,21 @@ function V2WorkspaceLayout() {
 
 	const hostStatus = useRemoteHostStatus(workspace);
 
-	if (!workspaceId || (!workspace && !isReady)) {
+	// "Not found" is a verdict, not a cache read: a CLI-created workspace can
+	// trail its own deep link (missed broadcast, second host-service instance,
+	// stale boot snapshot), so the route forces a refetch and waits for it —
+	// bounded — before declaring the id missing.
+	const missConfirmed = useWorkspaceMissVerdict(
+		{
+			workspaceId,
+			workspaceFound: workspace !== null,
+			suspended: pendingTransaction !== null || failedEntry !== null,
+			hasLiveTargets: cache.hasLiveTargets,
+		},
+		cache.refetchAll,
+	);
+
+	if (!workspaceId) {
 		return <StateScreenShell>{null}</StateScreenShell>;
 	}
 
@@ -87,6 +102,9 @@ function V2WorkspaceLayout() {
 					<WorkspaceCreateErrorState entry={failedEntry} />
 				</StateScreenShell>
 			);
+		}
+		if (!missConfirmed) {
+			return <StateScreenShell>{null}</StateScreenShell>;
 		}
 		return (
 			<StateScreenShell>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -49,7 +49,12 @@ function V2WorkspaceLayout() {
 		},
 	});
 
-	const { workspaces: hostWorkspaces, cache } = useHostWorkspaces();
+	const {
+		workspaces: hostWorkspaces,
+		isReady,
+		hostsSettled,
+		cache,
+	} = useHostWorkspaces();
 	const workspace = useMemo(
 		() =>
 			workspaceId != null
@@ -86,7 +91,9 @@ function V2WorkspaceLayout() {
 			workspaceId,
 			workspaceFound: workspace !== null,
 			suspended: pendingTransaction !== null || failedEntry !== null,
+			hostsEnumerated: hostsSettled,
 			hasLiveTargets: cache.hasLiveTargets,
+			mirrorSettled: isReady,
 		},
 		cache.refetchAll,
 	);

--- a/plans/20260815-cli-workspace-open-race.md
+++ b/plans/20260815-cli-workspace-open-race.md
@@ -145,6 +145,23 @@ our own child. This would have prevented the DMG specimen outright.
 4. **Drop `txid` from workspace create responses** (dead since local-first #5731) —
    it actively misled this investigation.
 
+## Adversarial review round (2026-08-16, commit 2ef8329)
+
+A 12-finding multi-agent review (9 confirmed) drove a rework: the verdict hook's
+cross-navigation latch was replaced with per-id state + effect cancellation (fixed
+stale-verdict-on-revisit, late-window clobber → permanent blank, offline permanent
+shell), the verdict now waits for `knownHostsSettled` (no remote-host not-found flash
+after boot/org switch), reopen tracking moved to a host-keyed ref (effect re-runs no
+longer skip gap resyncs), and the manifest lifecycle was hardened (all removal sites
+ownership-guarded, atomic writes, reclaim timer cleared on shutdown, shared
+pollHealthCheck probe). Deferred: the stable split-brain topology (see refactor #5).
+
+5. **Single-instance topology for host-service.** The coordinator can bind a renderer
+   to its own child while a foreign healthy holder keeps the manifest — a stable
+   split-brain the yield protocol cannot resolve. One lock-owning supervisor per org
+   dir (or handoff-on-claim like the pty-daemon socket adoption) removes the whole
+   multi-writer class; the manifest guards in this PR are the pragmatic interim.
+
 ## Known residual gaps (accepted)
 
 - Remote-host (relay) workspaces: a host slower than the 5s cap can briefly show

--- a/plans/20260815-cli-workspace-open-race.md
+++ b/plans/20260815-cli-workspace-open-race.md
@@ -112,13 +112,25 @@ shared DB), mode D at boot, mode B collapses from a 51s blank to a bounded
 shell→verdict. Also kills the in-app dispatch flash. `WorkspaceNotFoundState` here is
 the only place the app draws a "doesn't exist" conclusion from the mirror (checked).
 
-### PR 2 — single-instance the host-service (source fix for mode C)
+### PR 2 — manifest claim protocol (source fix for mode C's CLI routing)
 
-The host-service child takes an exclusive `flock` on its org dir at boot and exits
-when it's held (flock releases on process death — no stale-lock mode; updates still
-work because the coordinator kills its old child before spawning). Include the
-one-line coordinator fix: `stop()` removes the manifest only when `manifest.pid` is
-our own child. This would have prevented the DMG specimen outright.
+As implemented (flock was considered but Node has no native flock; the claim
+protocol below approximates it without new dependencies):
+
+- Boot: the child yields the manifest to a live, health-probed holder; dead or
+  unhealthy holders forfeit (`shouldYieldManifest`, probe = the coordinator's
+  retrying `pollHealthCheck`).
+- A 15s reclaim tick re-runs the claim whenever the manifest doesn't name us, so a
+  yielded instance takes over when the holder quits or dies; cleared during
+  shutdown so a tick in the drain window can't resurrect a dying pid.
+- Every coordinator removal site (`stop`, `handleChildExit`, failed/cancelled
+  start) deletes the manifest only when it names the child being torn down;
+  unreadable manifests are left alone, and writes are atomic (tmp+rename) so torn
+  reads can't occur.
+
+Residual TOCTOU: read→probe→write and read→unlink are not one atomic operation, so
+two instances racing the same dead holder can both claim briefly (converges within
+one reclaim tick). The full fix is the single-instance topology — refactor #5.
 
 ### Optional hygiene (fold into PR 1 if trivial, else skip)
 

--- a/plans/20260815-cli-workspace-open-race.md
+++ b/plans/20260815-cli-workspace-open-race.md
@@ -1,0 +1,155 @@
+# CLI workspace create → open race: dead screen until the 30s fallback refetch
+
+**Status:** implemented 2026-08-15 (one PR: verdict invariant + manifest claim/ownership guards) · repro + failure-mode matrix verified · owner: Kiet
+
+## Problem
+
+Rosh (wattdata) had an agent recycle a workspace via the CLI (`superset workspaces
+delete` → `create --local` → `open`). The desktop routed to the new workspace ID and
+showed a dead screen — "Workspace not found" in his case — for tens of seconds.
+Opening the same workspace later from the Workspaces list worked fine. His words:
+"from the CLI creation path there seems to be some time in space where you get routed
+to where it's supposed to be and maybe it's not existing."
+
+The same gate causes the known ~0.5s "Workspace not found" flash right after the
+in-app new-workspace dispatch (seen during README film staging, 2026-08-12).
+
+## Root cause
+
+The renderer's host-workspace cache (`useHostWorkspaces`) converges by exactly two
+paths:
+
+1. `workspace:changed` WS broadcast — fire-and-forget. `eventBus.ts` replays only
+   fs-watches on reconnect; a broadcast that fires while the socket is down is lost
+   forever.
+2. A 30s fallback refetch (`WORKSPACES_FALLBACK_REFETCH_INTERVAL_MS`).
+
+`v2-workspace/layout.tsx:79-96` treats "row not in cache" as terminal: blank
+`StateScreenShell` when `!isReady`, `WorkspaceNotFoundState` when `isReady`. Nothing
+attempts to resolve an explicitly-requested workspace ID. So any missed broadcast
+opens an up-to-30s window where a deep link (`superset://v2-workspace/<id>`, fired by
+`workspaces open`) or sidebar click lands on a dead screen.
+
+## Repro (verified, CDP against dev desktop)
+
+Healthy event bus: broadcast lands ~280ms into the create mutation, **before** the
+CLI even gets its response — no repro, not even a flash. The bug requires a missed
+broadcast:
+
+1. `hs.workspaces.create.mutate(...)` and `bus.reconnect()` ~280ms into the in-flight
+   create → the `created` event fires into the closed socket and is lost.
+2. Navigate to the new ID (same as the deep link's `router.navigate`).
+3. Renderer shows a dead screen for **27.3s**, then the fallback refetch heals it and
+   the workspace renders normally.
+
+## Failure-mode matrix (all verified 2026-08-15 unless noted)
+
+**A. Missed broadcast → dead screen ≤30s.** Socket down when `created` fires (the
+event is unrecoverable; only fs-watches replay on reconnect). Repro: drop the bus
+280ms into an in-flight create, navigate → 27.3s dead screen, healed exactly by the
+fallback refetch.
+
+**B. Hanging host queries hold `isReady` false → blank shell for ~a minute.**
+`retry: 1` bounds attempts, not duration: a known host whose relay fetch blackholes
+hangs ~25s per attempt. Measured: navigating to an unknown ID rendered a **blank**
+pane for 50.7s, then flipped to "Workspace not found" when the hanging query finally
+errored. In a team org (Rosh's wattdata knows teammates' hosts) this is routine — it
+explains both of his rendered states, and it means `WorkspaceNotFoundState` can be
+unreachable for the first minute after any window reload.
+
+**C. Manifest points at a different host-service instance → EVERY CLI create
+misses.** The host-service child unconditionally overwrites
+`~/.superset/host/<org>/manifest.json` at boot (`host-service/index.ts:126`, last
+writer wins); the CLI trusts it (`resolveHostTarget.ts`). Coordinator adoption only
+defends the boot ordering — an instance that boots *after* the desktop steals the
+manifest while the desktop keeps its own child. Verified live: a create through a
+second instance lands in the **shared host.db** (so the renderer's refetch eventually
+serves it) while broadcasting on an event bus the renderer never listens to.
+**Found a wild specimen on this machine**: the prod manifest pointed at a host-service
+belonging to the Superset 1.22.0 app run **from the mounted DMG** a day earlier, still
+alive; the installed apps had adopted it. Triggers: DMG test-drives, canary+stable,
+`superset start`, update-surviving instances.
+
+**D. Stale snapshot at boot.** Snapshot hydration counts as "settled" for `isReady`,
+so right after a reload the gate can pass judgment from a stale list while the live
+query is still in flight → not-found for a row that exists. (Code-read; same gate.)
+
+Related defect found on the way: coordinator `stop()` removes the org manifest
+unconditionally — quitting one desktop deletes a manifest now owned by another live
+instance, leaving the CLI with "host service isn't running". Fix separately (only
+remove when `manifest.pid` is the coordinator's own child).
+
+## Not the bug (ruled out during investigation)
+
+- `txId: null` in CLI create output — always null since local-first (#5731), nothing
+  consumes it. Consider deleting the dead field separately.
+- The "spinner" in Rosh's video — that's `superset-empty-state-wordmark.svg`, the
+  static empty-state art. His workspace was open and healthy in those frames.
+- "Workspace not found" after deleting the currently-viewed workspace — by design
+  (`layout.tsx:91`), no auto-navigation.
+
+## Fix
+
+All four modes are different ways the renderer's mirror goes stale, but the bug
+materializes at exactly one line: where the route concludes "this workspace doesn't
+exist" from that mirror. host.db is shared and authoritative, so in every mode the
+row is one refetch away. Fix the verdict site (PR 1); fix mode C's topology at its
+own source (PR 2) because a second instance silences ALL bus-driven UI (ports, git,
+agent status), not just this screen.
+
+### PR 1 — the verdict invariant (`v2-workspace/layout.tsx`, fixes Rosh)
+
+**Never declare not-found from data older than the request.** When the route mounts
+for an ID not in the mirror and there's no `failedEntry`: fire one forced refetch of
+the host workspace lists (add `refetchAll()` to `HostWorkspacesCacheOps`), render the
+loading shell, and render `WorkspaceNotFoundState` only once a fetch that started
+after the route mounted has settled without the row — hard cap ~5s, **independent of
+`isReady`** (mode B holds `isReady` false ~51s via one hanging host; the local host's
+answer is all the verdict needs). Ref-guard one refetch per workspaceId — no loops.
+
+Coverage: mode A heals in ~100ms (was ≤30s), mode C in ~100ms (refetch reads the
+shared DB), mode D at boot, mode B collapses from a 51s blank to a bounded
+shell→verdict. Also kills the in-app dispatch flash. `WorkspaceNotFoundState` here is
+the only place the app draws a "doesn't exist" conclusion from the mirror (checked).
+
+### PR 2 — single-instance the host-service (source fix for mode C)
+
+The host-service child takes an exclusive `flock` on its org dir at boot and exits
+when it's held (flock releases on process death — no stale-lock mode; updates still
+work because the coordinator kills its old child before spawning). Include the
+one-line coordinator fix: `stop()` removes the manifest only when `manifest.pid` is
+our own child. This would have prevented the DMG specimen outright.
+
+### Optional hygiene (fold into PR 1 if trivial, else skip)
+
+- Reconnect heal: on event-bus reopen (not initial connect), invalidate that host's
+  list — background staleness (sidebar rows) heals in ~100ms instead of ≤30s.
+- `AbortSignal.timeout(~10s)` on `workspace.list` fetches so unreachable hosts settle
+  into `isError` in seconds — shrinks mode B for every other `isReady` consumer.
+- `superset doctor` check: multiple live host-services for one org dir, or manifest
+  endpoint ≠ the desktop's active instance.
+
+### Explicitly not doing
+
+- Host-side event queue/replay (protocol change, disproportionate).
+- Auto-navigate away when the viewed workspace is deleted (separate UX decision).
+
+## Tests
+
+- Layout (PR 1): unknown-but-requested ID → loading shell + exactly one forced
+  refetch; post-mount fetch settles with row → workspace renders; without row →
+  not-found; cap expiry → not-found; `isReady` false throughout must not block the
+  verdict. Mutate the fix out to prove each test fails.
+- Host-service (PR 2): second boot on a locked org dir exits without touching the
+  manifest; lock released on process death; coordinator `stop()` leaves a foreign
+  manifest in place.
+
+## Verification
+
+Done 2026-08-15 against the running dev app (ghost-row insert = deterministic
+missed-broadcast sim): before-fix heal at t=26.9s (blank the whole time); with the
+fix the same scenario renders at t=0.6s and a genuinely-missing id reaches
+not-found in 248ms (was 50.7s blank). Normal create→open unchanged (214ms).
+
+Before/after video: `~/Downloads/workspace-notfound-before-after.mp4` (27s, timer
+overlay shows real elapsed time; before segment played at 4x, after in real time).

--- a/plans/20260815-cli-workspace-open-race.md
+++ b/plans/20260815-cli-workspace-open-race.md
@@ -129,6 +129,30 @@ our own child. This would have prevented the DMG specimen outright.
 - `superset doctor` check: multiple live host-services for one org dir, or manifest
   endpoint ≠ the desktop's active instance.
 
+## Future refactors this investigation argues for (not in the PR)
+
+1. **Event-bus resync contract.** Fire-and-forget events with no catch-up is the
+   class bug; the verdict fix covers workspace existence only. Ports, git status,
+   agent lifecycle, and project events all go silently stale on a missed frame. A
+   sequence number (or generation id) in the stream + invalidate-on-gap/reopen would
+   retire the whole class; the fs-watch replay-on-open is precedent.
+2. **Client-level fetch timeouts.** The 2×~25s hang lives in
+   `getHostServiceClientByUrl` consumers generally, not just workspace.list — one
+   `AbortSignal.timeout` at the client link level beats per-query patches.
+3. **Per-host readiness.** `isReady` = "every known host settled" makes any one
+   unreachable teammate host degrade unrelated UI. Most consumers care about one
+   host; per-host readiness (or reachable-quorum semantics) would localize failures.
+4. **Drop `txid` from workspace create responses** (dead since local-first #5731) —
+   it actively misled this investigation.
+
+## Known residual gaps (accepted)
+
+- Remote-host (relay) workspaces: a host slower than the 5s cap can briefly show
+  not-found before self-correcting when its row lands — strictly better than the
+  old 0s-grace behavior; untested live (no second machine in the loop).
+- Windows/Linux deep-link delivery (`second-instance` argv path) — code untouched,
+  not exercised on this macOS pass.
+
 ### Explicitly not doing
 
 - Host-side event queue/replay (protocol change, disproportionate).


### PR DESCRIPTION
**Links**
- Plan/investigation: `plans/20260815-cli-workspace-open-race.md`

## Summary
- A workspace opened right after CLI creation (or any time the renderer's mirror is stale) showed **"Workspace not found" / a blank screen for up to 30–50s**. The route now actively resolves the ID against the hosts before judging: forced refetch, verdict only after a post-request fetch settles (capped 5s). Measured: missed-broadcast open **27s → 0.6s**, dead-ID verdict **51s → 0.2s**, normal open unchanged (0.2s).
- Host-service instances could silently steal each other's CLI routing manifest (last-writer-wins) or delete it on quit, rerouting every CLI write to an instance the desktop renderer isn't listening to. Booting instances now **yield to a live healthy holder**, and the coordinator only removes a manifest its own child wrote.

## Why / Context
Reported by Roshvan (wattdata): an agent recycled a workspace via `superset workspaces delete/create/open`; the deep link landed on "Workspace not found" until he manually reopened it later. Root cause chain (full failure-mode matrix in the plan doc):

- The renderer's workspace mirror converges only via fire-and-forget `workspace:changed` events (no replay on reconnect) plus a **30s fallback refetch** — a just-created row can trail its own deep link.
- `isReady` waits on *every* known host's list; one unreachable teammate host hangs the fetch ~25s×2 (`retry: 1` bounds attempts, not duration), blanking every not-in-cache route for ~50s. Both of Rosh's rendered states reproduce from these two paths.
- A second live host-service (DMG test-drive, canary+stable, `superset start`, update-survivor) overwrote the manifest, making **every** CLI create broadcast-invisible to the renderer. Found live in the wild: a prod manifest pointing at a host-service run from a mounted 1.22.0 DMG a day earlier.

## How It Works
- `useWorkspaceMissVerdict` (new, co-located with the v2-workspace route): on routing to an ID the mirror lacks, fire one `cache.refetchAll()` and hold the loading shell; render `WorkspaceNotFoundState` only once a fetch that started after the request settles without the row, or the 5s cap fires — never from pre-existing cache state, and independent of `isReady`. Suspended while a create transaction or failed-create entry owns the ID.
- `useHostWorkspaces` cache ops gain `refetchAll()` / `hasLiveTargets`.
- Host-service boot: `shouldYieldManifest` — yield to a live + health-probed holder; dead or unhealthy holders forfeit. Coordinator `stop()` checks `manifest.pid` before `removeManifest`.

## Manual QA Checklist
- [x] Missed-broadcast repro (row inserted on host with no event, then routed to): renders in ~0.6s, never flashes not-found — was blank 27s (verified over CDP against the dev app; before/after captured on video)
- [x] Genuinely nonexistent ID: "Workspace not found" in ~0.2s — was ~51s blank
- [x] Normal create → open: unchanged (~0.2s)
- [x] Deleting the currently-viewed workspace still lands on not-found (existing behavior)

Before/after screen recording available (27s, timer overlay): ask Kiet or see `~/Downloads/workspace-notfound-before-after.mp4` — will attach below.

## Testing
- `bun run typecheck` (desktop green)
- `biome check` on all touched files
- `bun test` — 53 tests across the three touched suites: verdict gate/window unit tests, `shouldYieldManifest` matrix, 3 new coordinator stop-ownership tests. Each fix was mutated out to confirm its test fails.

## Design Decisions
- **Verdict at the route instead of hardening the event bus**: every failure mode (missed event, wrong instance, stale snapshot, hanging host) is one refetch away from the shared host.db, so the single choke point where the wrong conclusion is drawn covers them all; host-side event replay would be a protocol change for the same outcome.
- **Yield-to-healthy-holder instead of flock single-instancing**: no Node-native flock; pid-alive + health probe reuses the exact adoption semantics the coordinator already trusts, and a wedged holder still forfeits.

## Known Limitations
- Two host-services on one org dir still both *serve* (only the manifest is protected); cross-instance UI staleness heals via the route verdict + 30s refetch. A `superset doctor` duplicate-instance check is listed as follow-up in the plan doc.
- The ~5s verdict cap trades a slightly slower "not found" for never falsely declaring it; hosts that answer fast verdict in ~0.2s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false or slow “Workspace not found,” heals gaps after event‑bus reopen, and prevents host‑service instances from stealing or deleting the CLI routing manifest. The route now verifies against live hosts before declaring a miss; the manifest is owned, yielded to a healthy holder, reclaimed safely, and only removed by its owner.

- Renderer: adds `useWorkspaceMissVerdict` to defer “not found” until a post‑mount `cache.refetchAll()` settles; caps at 5s, declares an immediate miss when offline with a settled mirror, waits for host enumeration to avoid remote‑host flashes, and cancels stale windows on navigation. `useHostWorkspaces` exposes `cache.refetchAll()`, `cache.hasLiveTargets`, and `hostsSettled`, and invalidates a host’s `host-service` queries on any bus reopen (tracked per host URL).
- Host‑service: yields the manifest to a live, healthy holder (`shouldYieldManifest` via `isProcessAlive` + `pollHealthCheck`), reclaims every 15s if the holder goes away, and clears the reclaim timer on shutdown. Coordinator removes a manifest only when held by its own child (on stop, cancelled or failed start, and child exit). Manifest writes are atomic (write‑then‑rename), and unreadable manifests are left untouched.

- Rollout: “not found” may delay up to 5s on slow hosts; verify routing in multi‑host orgs and when quitting one desktop while another runs. No migrations or config changes.

<sup>Written for commit 4b983ae05908fe24bcd6f12b5c7c4e6c58d5e691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace opening after CLI-created workspaces, reducing stale, delayed, or incorrect workspace screens.
  - Workspace pages now verify that a workspace is genuinely unavailable before showing a not-found state.
  - Improved refresh handling when workspace data is delayed or temporarily unavailable.
  - Prevented active desktop instances from overwriting each other’s host-service ownership information.
  - Preserved valid host-service registrations during shutdown while removing stale entries.
  - Improved recovery after host reconnection and refreshed workspace data more reliably.

- **Documentation**
  - Added an implementation plan documenting workspace-opening race conditions, safeguards, and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->