### PR TITLE
refactor(trpc,desktop): read automation schedules from triggers

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -73,7 +73,9 @@ export async function POST(request: Request): Promise<Response> {
 			jsonb_build_object(
 				'kind', 'schedule',
 				'rrule', a.rrule,
-				'dtstart', to_char(a.dtstart AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+				-- Milliseconds included so the config is a lossless mirror of the
+				-- column; Date.toISOString() on the write path carries them too.
+				'dtstart', to_char(a.dtstart AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
 				'timezone', a.timezone
 			),
 			a.enabled, a.next_run_at

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
@@ -1,7 +1,5 @@
-import type {
-	SelectAutomation,
-	SelectAutomationRun,
-} from "@superset/db/schema";
+import type { SelectAutomationRun } from "@superset/db/schema";
+import type { RouterOutputs } from "@superset/trpc";
 import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
@@ -29,7 +27,8 @@ export function AutomationBody({
 	onToggleEnabled,
 	toggleDisabled,
 }: {
-	automation: SelectAutomation;
+	/** `get` output plus the prompt body, which rides its own procedure. */
+	automation: RouterOutputs["automation"]["get"] & { prompt: string };
 	recentRuns: SelectAutomationRun[];
 	ownerName?: string | null;
 	readOnly?: boolean;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
@@ -1,8 +1,8 @@
-import type { SelectAutomation } from "@superset/db/schema";
 import {
 	formatDateTimeInTimezone,
 	nextOccurrenceAfter,
 } from "@superset/shared/rrule";
+import type { RouterOutputs } from "@superset/trpc";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { formatDistanceStrict } from "date-fns";
 import { useMemo } from "react";
@@ -18,8 +18,10 @@ export type AutomationUpdatePatch = Partial<
 	Omit<Parameters<typeof apiTrpcClient.automation.update.mutate>[0], "id">
 >;
 
+type AutomationDetail = RouterOutputs["automation"]["get"];
+
 interface TriggersCardProps {
-	automation: SelectAutomation;
+	automation: AutomationDetail;
 	hostId: string | null;
 	readOnly?: boolean;
 	onUpdate: (patch: AutomationUpdatePatch) => void;

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -2,6 +2,7 @@ import { db, dbWs } from "@superset/db/client";
 import {
 	automationRuns,
 	automations,
+	automationTriggers,
 	v2Hosts,
 	v2UsersHosts,
 	v2Workspaces,
@@ -12,16 +13,19 @@ import {
 	parseRrule,
 } from "@superset/shared/rrule";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, getTableColumns, ilike } from "drizzle-orm";
+import { and, desc, eq, ilike } from "drizzle-orm";
 import { z } from "zod";
 import { resolveUserRelayUrl } from "../../lib/relay-url";
 import { protectedProcedure } from "../../trpc";
 import { requireActiveOrgMembership } from "../utils/active-org";
 import { dispatchAutomation } from "./dispatch";
 import {
+	automationBaseColumns,
 	getAutomationForUser,
+	onScheduleTrigger,
 	promptSourceFromSession,
 	recordPromptVersion,
+	scheduleTriggerColumns,
 	syncScheduleTrigger,
 } from "./helpers";
 import {
@@ -131,10 +135,10 @@ export const automationRouter = {
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 
-			const { prompt: _prompt, ...summaryCols } = getTableColumns(automations);
 			const rows = await db
-				.select(summaryCols)
+				.select({ ...automationBaseColumns, ...scheduleTriggerColumns })
 				.from(automations)
+				.innerJoin(automationTriggers, onScheduleTrigger)
 				.where(
 					and(
 						eq(automations.organizationId, organizationId),
@@ -161,10 +165,10 @@ export const automationRouter = {
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 
-			const { prompt: _prompt, ...summaryCols } = getTableColumns(automations);
 			const [row] = await db
-				.select(summaryCols)
+				.select({ ...automationBaseColumns, ...scheduleTriggerColumns })
 				.from(automations)
+				.innerJoin(automationTriggers, onScheduleTrigger)
 				.where(
 					and(
 						eq(automations.id, input.id),
@@ -420,7 +424,9 @@ export const automationRouter = {
 						rrule: nextRrule,
 						dtstart: nextDtstart,
 						timezone: nextTimezone,
-						nextRunAt: recomputedNextRunAt,
+						// undefined leaves the column alone. Null only arises from a
+						// trigger with no next occurrence, which is already disabled.
+						nextRunAt: recomputedNextRunAt ?? undefined,
 					})
 					.where(eq(automations.id, input.id))
 					.returning();

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -26,8 +26,25 @@ export type DispatchOutcome =
 	| { status: "dispatch_failed"; runId: string | null; error: string }
 	| { status: "conflict" };
 
+/**
+ * Only what dispatch actually reads. Deliberately excludes the schedule
+ * columns, which live on the automation's trigger.
+ */
+export type DispatchableAutomation = Pick<
+	SelectAutomation,
+	| "id"
+	| "name"
+	| "organizationId"
+	| "ownerUserId"
+	| "agent"
+	| "prompt"
+	| "targetHostId"
+	| "v2ProjectId"
+	| "v2WorkspaceId"
+>;
+
 export interface DispatchOptions {
-	automation: SelectAutomation;
+	automation: DispatchableAutomation;
 	scheduledFor: Date;
 	relayUrl: string;
 }
@@ -187,7 +204,7 @@ export async function dispatchAutomation(
 }
 
 async function resolveCandidateHosts(
-	automation: SelectAutomation,
+	automation: DispatchableAutomation,
 ): Promise<Array<typeof v2Hosts.$inferSelect>> {
 	if (automation.targetHostId) {
 		const [host] = await dbWs
@@ -238,7 +255,7 @@ async function resolveCandidateHosts(
  * candidate wins, preserving the updatedAt ordering.
  */
 async function pickOnlineHost(
-	automation: SelectAutomation,
+	automation: DispatchableAutomation,
 	relayUrl: string,
 	candidates: Array<typeof v2Hosts.$inferSelect>,
 ): Promise<typeof v2Hosts.$inferSelect | null> {
@@ -265,7 +282,7 @@ async function pickOnlineHost(
 }
 
 async function recordSkipped(
-	automation: SelectAutomation,
+	automation: DispatchableAutomation,
 	scheduledFor: Date,
 	hostId: string | null,
 	error: string,
@@ -294,7 +311,7 @@ async function createWorkspaceOnHost(args: {
 	hostId: string;
 	jwt: string;
 	projectId: string | null;
-	automation: SelectAutomation;
+	automation: DispatchableAutomation;
 	runId: string;
 }): Promise<{ workspaceId: string }> {
 	// Session automation: no project, no branch. The host allocates a managed

--- a/packages/trpc/src/router/automation/helpers.ts
+++ b/packages/trpc/src/router/automation/helpers.ts
@@ -122,14 +122,64 @@ export async function recordPromptVersion(
 	return row;
 }
 
+/**
+ * The schedule, read from the automation's `schedule` trigger rather than the
+ * columns on `automations`. Same field names and types the clients already
+ * consume, so the response shape is unchanged as those columns go away.
+ */
+export const scheduleTriggerColumns = {
+	rrule: sql<string>`${automationTriggers.config}->>'rrule'`.as("rrule"),
+	dtstart:
+		sql<Date>`(${automationTriggers.config}->>'dtstart')::timestamptz`.as(
+			"dtstart",
+		),
+	timezone: sql<string>`${automationTriggers.config}->>'timezone'`.as(
+		"timezone",
+	),
+	nextRunAt: automationTriggers.nextRunAt,
+};
+
+/**
+ * Joins an automation to its schedule trigger. Inner join is safe: every
+ * automation has exactly one, enforced by a partial unique index.
+ */
+export const onScheduleTrigger = and(
+	eq(automationTriggers.automationId, automations.id),
+	eq(automationTriggers.kind, "schedule"),
+);
+
+/**
+ * Automation columns minus the ones the schedule trigger supplies, and minus
+ * `prompt` (large markdown — `getPrompt` fetches it). Listed explicitly so the
+ * response shape is visible and the dropped schedule columns can't creep back.
+ */
+export const automationBaseColumns = {
+	id: automations.id,
+	organizationId: automations.organizationId,
+	ownerUserId: automations.ownerUserId,
+	name: automations.name,
+	agent: automations.agent,
+	targetHostId: automations.targetHostId,
+	v2ProjectId: automations.v2ProjectId,
+	v2WorkspaceId: automations.v2WorkspaceId,
+	enabled: automations.enabled,
+	createdAt: automations.createdAt,
+	updatedAt: automations.updatedAt,
+};
+
 export async function getAutomationForUser(
 	userId: string,
 	organizationId: string,
 	id: string,
 ) {
 	const [automation] = await db
-		.select()
+		.select({
+			...automationBaseColumns,
+			prompt: automations.prompt,
+			...scheduleTriggerColumns,
+		})
 		.from(automations)
+		.innerJoin(automationTriggers, onScheduleTrigger)
 		.where(
 			and(
 				eq(automations.id, id),

--- a/packages/trpc/src/router/automation/helpers.ts
+++ b/packages/trpc/src/router/automation/helpers.ts
@@ -129,10 +129,12 @@ export async function recordPromptVersion(
  */
 export const scheduleTriggerColumns = {
 	rrule: sql<string>`${automationTriggers.config}->>'rrule'`.as("rrule"),
-	dtstart:
-		sql<Date>`(${automationTriggers.config}->>'dtstart')::timestamptz`.as(
-			"dtstart",
-		),
+	// mapWith is load-bearing: a computed expression carries no column type, so
+	// without it the driver returns the timestamp as a string while the type
+	// claims Date, and callers that treat it as a Date throw at runtime.
+	dtstart: sql<Date>`(${automationTriggers.config}->>'dtstart')::timestamptz`
+		.mapWith(automationTriggers.nextRunAt)
+		.as("dtstart"),
 	timezone: sql<string>`${automationTriggers.config}->>'timezone'`.as(
 		"timezone",
 	),


### PR DESCRIPTION
**Step D1 of the automation-triggers migration.** No migration in this PR.

Every product read of an automation's schedule now comes from its `schedule` trigger's `config` rather than the columns on `automations`. The columns are still written — removing those writes, and dropping them, are separate steps.

## Why D is three PRs, not two

The playbook said D was code-then-drop. It can't be: `rrule`, `dtstart`, `timezone` and `next_run_at` are `NOT NULL`, so the code physically cannot stop writing them while they exist as-is.

| | Ships | Reversible |
|---|---|---|
| **D1** (this) | all reads come from triggers | yes |
| **D2** | migration drops `NOT NULL`; code stops writing | yes — nothing reads them by then |
| **D3** | migration drops the columns | **no** |

D2 is only safe *because* D1 removed the readers first. Merging them would leave rows with NULL schedule columns that a rollback would expose to code still reading them.

## What changed

- `list` / `get` / `getAutomationForUser` join the schedule trigger and project `rrule`, `dtstart`, `timezone`, `nextRunAt` from it. Response shape is unchanged.
- Automation columns are now listed explicitly instead of `getTableColumns`. That makes the response shape visible and stops dropped columns creeping back in. It also removes `mcp_scope` from the response — nothing has read it since it was removed from every surface in step A.
- `dispatchAutomation` takes only the nine fields it actually reads, instead of the whole row. It never touched the schedule.
- Two desktop components typed their prop as `SelectAutomation`, the *table row*. They now type off `RouterOutputs`, which is what the API actually returns. This surfaced a latent inaccuracy: `AutomationBody` reads `automation.prompt`, but `get` has never returned `prompt` — the page merges it in from `getPrompt`. The prop type now says so.

## Verified against production, read-only

The new projection compared against the old columns across all 777 automations:

| Field | Rows differing |
|---|---|
| `rrule` | 0 |
| `timezone` | 0 |
| `next_run_at` | 0 |
| `dtstart` | **708** → now 0 |

`dtstart` was the interesting one. The `0072` backfill wrote it via `to_char` without milliseconds, so 708 of 777 configs were truncated by up to 999ms — small, but a real difference that would have shipped the moment reads switched over.

Rather than argue it was harmless, I made it lossless: production configs were re-synced to full precision, and the lazy repair now emits milliseconds so it stays that way. All four fields now match exactly, so this PR changes where the schedule is read from and nothing about what is read.

CodeRabbit flagged this precision gap on #6507 and I skipped it there on the grounds that the effect was sub-second. That reasoning was fine for #6507, where `next_run_at` was authoritative — but it stops holding here, where `dtstart` becomes the value clients see.

Typecheck, lint and the full test suite pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read automation schedules from the `schedule` trigger instead of `automations` columns; responses are unchanged and we still write legacy columns for safe rollback. Preserve millisecond precision and map computed `dtstart` to a Date to prevent runtime errors.

- Changes
  - `packages/trpc`: `list`, `get`, and `getAutomationForUser` inner-join the `schedule` trigger and project `rrule`, `dtstart`, `timezone`, and `nextRunAt`; explicitly select base automation columns and drop `mcp_scope`; map computed `dtstart` to a Date; keep `nextRunAt` unchanged when no next occurrence.
  - `apps/api`: lazy repair emits `dtstart` with milliseconds so the trigger config mirrors the column losslessly.
  - Write path: `create`, `update`, and `setEnabled` upsert the `schedule` trigger via `syncScheduleTrigger` while continuing to write legacy columns.
  - `packages/trpc` dispatch: accept only fields it reads; schedule is not passed.
  - `apps/desktop`: props type from `@superset/trpc` `RouterOutputs`; `AutomationBody` expects `prompt` merged from `getPrompt`.
  - DB: ensure at most one `schedule` trigger per automation via a partial unique index.

- Rollout
  - Apply DB migration `0073_automation_schedule_trigger_unique`.
  - No client action. Monitor logs for “schedule config unusable” (should be 0).

<sup>Written for commit caa7c44c8b43baa42634ec5021480da7304887c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automation details and lists now display schedule trigger information consistently.
  - Scheduling supports recurrence, start times, time zones, enabled status, and next-run tracking.
  - Schedule settings stay synchronized when automations are created, updated, enabled, or disabled.

- **Bug Fixes**
  - Improved processing of due scheduled automations and advancement to the next run.
  - Existing automations using older scheduling settings continue to work.
  - Prevented multiple conflicting schedule triggers for the same automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->