### PR TITLE
feat(desktop): make sidebar groups reorderable anywhere in the project list

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -28,6 +28,7 @@ import { DashboardSidebarProjectSection } from "./components/DashboardSidebarPro
 import { DashboardSidebarSectionRenameProvider } from "./components/DashboardSidebarSectionRenameContext";
 import { DashboardSidebarSessionsSection } from "./components/DashboardSidebarSessionsSection";
 import { DashboardSidebarWorkspacesHeader } from "./components/DashboardSidebarWorkspacesHeader";
+import { SectionDragSpacer } from "./components/SectionDragSpacer";
 import { V2SetupScriptCard } from "./components/V2SetupScriptCard";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
@@ -291,6 +292,7 @@ export function DashboardSidebar({
 													))}
 												</SortableContext>
 											)}
+											<SectionDragSpacer />
 										</OverflowFadeContainer>
 										{!isCollapsed && !inlineWorkspacePortsEnabled && (
 											<DashboardSidebarPortsList />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -41,7 +41,10 @@ import {
 	DashboardSidebarWorkspaceStatusProvider,
 	type SidebarStatusWorkspaceRef,
 } from "./providers/DashboardSidebarWorkspaceStatusProvider";
-import type { DashboardSidebarProject } from "./types";
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarWorkspace,
+} from "./types";
 import { getProjectChildrenWorkspaces } from "./utils/projectChildren";
 
 interface DashboardSidebarProps {
@@ -158,21 +161,33 @@ export function DashboardSidebar({
 		orderedGroups,
 		sessionWorkspaces,
 	);
-	const selectableWorkspaceIds = useMemo(
-		() =>
-			new Set(
-				orderedGroups.flatMap((project) =>
-					getProjectChildrenWorkspaces(project.children)
-						.filter(
-							(workspace) =>
-								workspace.type === "worktree" &&
-								workspace.pendingTransaction?.type !== "insert",
-						)
-						.map((workspace) => workspace.id),
-				),
-			),
-		[orderedGroups],
-	);
+	const selectableWorkspaceIds = useMemo(() => {
+		const ids = new Set<string>();
+		const addWorkspace = (workspace: DashboardSidebarWorkspace) => {
+			if (
+				workspace.type === "worktree" &&
+				workspace.pendingTransaction?.type !== "insert"
+			) {
+				ids.add(workspace.id);
+			}
+		};
+		for (const project of orderedGroups) {
+			for (const child of project.children) {
+				if (child.type === "workspace") {
+					addWorkspace(child.workspace);
+					continue;
+				}
+				// Members of collapsed groups are hidden and unclickable; keeping
+				// them selected would leave invisible rows armed for bulk actions
+				// (including Delete), so collapsing prunes them from the selection.
+				if (child.section.isCollapsed) continue;
+				for (const workspace of child.section.workspaces) {
+					addWorkspace(workspace);
+				}
+			}
+		}
+		return ids;
+	}, [orderedGroups]);
 
 	// Every workspace the sidebar can render (pinned, sessions, project rows) —
 	// the status provider fans out bindings queries and event subscriptions for

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkActions/DashboardSidebarBulkActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkActions/DashboardSidebarBulkActions.tsx
@@ -86,7 +86,11 @@ export function DashboardSidebarBulkActions({
 				<div
 					role="toolbar"
 					aria-label="Selected workspace actions"
-					className="flex min-h-8 w-full shrink-0 items-center gap-0.5 py-1 pl-2 pr-2"
+					// Sticky: the toolbar's natural slot (the Workspaces header) can be
+					// scrolled far out of view when selecting rows at the bottom of a
+					// long sidebar — pin it to the scroller top so the selection always
+					// has visible actions.
+					className="sticky top-0 z-10 flex min-h-8 w-full shrink-0 items-center gap-0.5 bg-background/85 py-1 pl-2 pr-2 backdrop-blur-sm"
 				>
 					<Tooltip delayDuration={300}>
 						<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -2,7 +2,6 @@ import {
 	SortableContext,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import {
@@ -124,63 +123,48 @@ export function DashboardSidebarExpandedProjectContent({
 									const isInSection = !!group;
 									const isInCollapsedSection =
 										isInSection && collapsedSectionIds.has(group.sectionId);
+									const sectionDragActive =
+										activeType === "section" && activeContainer === projectId;
 									const hidden =
-										isInCollapsedSection ||
-										(activeType === "section" &&
-											activeContainer === projectId &&
-											isInSection);
+										isInCollapsedSection || (sectionDragActive && isInSection);
 									const canBulkSelect =
 										workspace.type === "worktree" &&
 										workspace.pendingTransaction?.type !== "insert";
 
-									// Rows collapse via a CSS grid-row transition instead of a
-									// per-row AnimatePresence/motion.div (~80 motion components
-									// cost real render time). Hidden rows stay mounted: `inert`
-									// removes them from focus/hit-testing and the disabled
-									// sortable unregisters their droppable, matching the old
-									// unmount behavior for DnD.
+									// The zero-height collapse lives inside the sortable wrapper
+									// (see SortableWorkspaceItem) so the clip box moves with the
+									// dnd translate — wrapping here would clip displaced rows
+									// out of view mid-drag.
 									return (
-										<div
+										<SortableWorkspaceItem
 											key={String(id)}
-											className={cn(
-												"grid transition-[grid-template-rows,opacity] duration-150 ease-out",
-												hidden
-													? "grid-rows-[0fr] opacity-0"
-													: "grid-rows-[1fr] opacity-100",
-											)}
-											inert={hidden}
-										>
-											<div className="min-h-0 overflow-hidden">
-												<SortableWorkspaceItem
-													sortableId={String(id)}
-													workspace={workspace}
-													accentColor={group?.color}
-													isInSection={isInSection}
-													onHoverCardOpen={onWorkspaceHover}
-													shortcutLabel={workspaceShortcutLabels.get(
-														parsed.realId,
-													)}
-													isSelected={
-														canBulkSelect && isWorkspaceSelected(parsed.realId)
-													}
-													onSelectionClick={
-														canBulkSelect
-															? (event) =>
-																	selectWorkspaceFromEvent(event, {
-																		workspaceId: parsed.realId,
-																		projectId,
-																		orderedWorkspaceIds: selectableWorkspaceIds,
-																	})
-															: undefined
-													}
-													disabled={
-														hidden ||
-														(workspace.type === "main" &&
-															workspace.hostType === "local-device")
-													}
-												/>
-											</div>
-										</div>
+											sortableId={String(id)}
+											workspace={workspace}
+											accentColor={group?.color}
+											isInSection={isInSection}
+											onHoverCardOpen={onWorkspaceHover}
+											shortcutLabel={workspaceShortcutLabels.get(parsed.realId)}
+											isSelected={
+												canBulkSelect && isWorkspaceSelected(parsed.realId)
+											}
+											onSelectionClick={
+												canBulkSelect
+													? (event) =>
+															selectWorkspaceFromEvent(event, {
+																workspaceId: parsed.realId,
+																projectId,
+																orderedWorkspaceIds: selectableWorkspaceIds,
+															})
+													: undefined
+											}
+											collapsed={hidden}
+											collapseInstantly={sectionDragActive}
+											disabled={
+												hidden ||
+												(workspace.type === "main" &&
+													workspace.hostType === "local-device")
+											}
+										/>
 									);
 								})}
 							</SortableContext>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SectionDragSpacer/SectionDragSpacer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SectionDragSpacer/SectionDragSpacer.tsx
@@ -1,0 +1,14 @@
+import { useDashboardSidebarDnd } from "../../hooks/useSidebarDnd";
+
+/**
+ * Keeps the sidebar scroller's scrollHeight constant while a section drag
+ * hides the group's member rows. Without it, the pickup shrinks the content;
+ * when scrolled near the bottom the browser clamps scrollTop, and dnd-kit
+ * folds that scroll delta into the DragOverlay transform — the ghost then
+ * tracks the collapsed height away from the cursor for the whole drag.
+ */
+export function SectionDragSpacer() {
+	const { sectionDragSpacerPx } = useDashboardSidebarDnd();
+	if (sectionDragSpacerPx === 0) return null;
+	return <div aria-hidden style={{ height: sectionDragSpacerPx }} />;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SectionDragSpacer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SectionDragSpacer/index.ts
@@ -1,0 +1,1 @@
+export { SectionDragSpacer } from "./SectionDragSpacer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -71,7 +71,12 @@ export function SortableSectionHeader({
 			style={{
 				transform: CSS.Translate.toString(transform),
 				transition,
-				opacity: isDragging ? 0.5 : undefined,
+				// Fully hidden while dragging (the DragOverlay ghost is the drag
+				// representation): the section pickup collapses the member rows,
+				// which invalidates dnd-kit's cached initial rect for this node —
+				// its in-list preview transform then points rows away from the
+				// real drop slot. Displaced siblings still open the correct gap.
+				opacity: isDragging ? 0 : undefined,
 				borderLeft: hasColor
 					? `2px solid ${section.color}`
 					: "2px solid var(--color-border)",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -1,5 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@superset/ui/utils";
 import { useMemo } from "react";
 import type { WorkspaceSelectionEvent } from "../../providers/DashboardSidebarSelectionProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
@@ -13,6 +14,21 @@ interface SortableWorkspaceItemProps {
 	onHoverCardOpen?: (workspaceId: string) => void | Promise<void>;
 	shortcutLabel?: string;
 	disabled?: boolean;
+	/**
+	 * Collapse the row to zero height (collapsed group / active section drag)
+	 * while keeping it mounted. Lives here — inside the sortable wrapper — so
+	 * the clip box moves WITH the dnd translate; an outer overflow-hidden
+	 * wrapper would clip displaced rows out of view mid-drag.
+	 */
+	collapsed?: boolean;
+	/**
+	 * Skip the collapse transition. Required while a section drag is active:
+	 * dnd-kit re-measures droppables when the hidden members unregister, and
+	 * an animated collapse means that measure runs mid-transition — every row
+	 * below the group then keeps a stale rect for the rest of the drag, so
+	 * downward drops target the wrong slot.
+	 */
+	collapseInstantly?: boolean;
 	isSelected?: boolean;
 	onSelectionClick?: (event: WorkspaceSelectionEvent) => boolean;
 	/** Set for rows rendered inside the top-level Pinned section. */
@@ -27,6 +43,8 @@ export function SortableWorkspaceItem({
 	onHoverCardOpen,
 	shortcutLabel,
 	disabled,
+	collapsed = false,
+	collapseInstantly = false,
 	isSelected = false,
 	onSelectionClick,
 	pinnedContext,
@@ -78,7 +96,24 @@ export function SortableWorkspaceItem({
 			{...attributes}
 			{...listeners}
 		>
-			{row}
+			{/* Rows collapse via a CSS grid-row transition instead of a per-row
+			    AnimatePresence/motion.div (~80 motion components cost real render
+			    time). Collapsed rows stay mounted: `inert` removes them from
+			    focus/hit-testing and the disabled sortable unregisters their
+			    droppable, matching the old unmount behavior for DnD. */}
+			<div
+				className={cn(
+					"grid",
+					!collapseInstantly &&
+						"transition-[grid-template-rows,opacity] duration-150 ease-out",
+					collapsed
+						? "grid-rows-[0fr] opacity-0"
+						: "grid-rows-[1fr] opacity-100",
+				)}
+				inert={collapsed}
+			>
+				<div className="min-h-0 overflow-hidden">{row}</div>
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useBulkWorkspaceMoveActions/useBulkWorkspaceMoveActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useBulkWorkspaceMoveActions/useBulkWorkspaceMoveActions.ts
@@ -80,7 +80,10 @@ export function useBulkWorkspaceMoveActions({
 
 	const ungroupSelection = () => {
 		if (!projectId) return;
-		for (const workspaceId of groupedWorkspaceIds) {
+		// Each move inserts directly below the row's former group, so processing
+		// in visual order would stack the rows reversed. Iterate back-to-front to
+		// keep the selection's visual order.
+		for (const workspaceId of [...groupedWorkspaceIds].reverse()) {
 			moveWorkspaceToSection(workspaceId, projectId, null);
 		}
 		clearSelection();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -150,6 +150,30 @@ describe("buildDashboardSidebarProjects", () => {
 		).toEqual(["section-b", "section-a"]);
 	});
 
+	it("keeps an ungrouped workspace top-level below a section instead of absorbing it", () => {
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "section-1", tabOrder: 2 })],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "ws-above", sectionId: null, tabOrder: 1 }),
+				makeWorkspace({ id: "ws-member", sectionId: "section-1", tabOrder: 1 }),
+				makeWorkspace({ id: "ws-below", sectionId: null, tabOrder: 3 }),
+			],
+		});
+
+		expect(
+			project.children.map((child) =>
+				child.type === "section"
+					? `section:${child.section.id}`
+					: child.workspace.id,
+			),
+		).toEqual(["ws-above", "section:section-1", "ws-below"]);
+		const section = project.children.find((child) => child.type === "section");
+		if (section?.type !== "section") throw new Error("expected section");
+		expect(section.section.workspaces.map((workspace) => workspace.id)).toEqual(
+			["ws-member"],
+		);
+	});
+
 	it("orders multiple orphaned workspaces by tabOrder above the sections", () => {
 		const [project] = build({
 			sidebarSections: [makeSection({ id: "section-1", tabOrder: 5 })],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -328,25 +328,11 @@ export function buildDashboardSidebarProjects({
 			})
 			.map(({ child }) => child);
 
-		// Ungrouped workspaces rendered after a section header are visually
-		// grouped with that section (shared accent, collapse-together) and will
-		// be committed into it on next DnD. Reparent them here so section counts
-		// match what the user sees.
-		const children: DashboardSidebarProjectChild[] = [];
-		let currentSection: DashboardSidebarSection | null = null;
-		for (const child of sortedChildren) {
-			if (child.type === "section") {
-				currentSection = child.section;
-				children.push(child);
-			} else if (currentSection) {
-				currentSection.workspaces.push({
-					...child.workspace,
-					accentColor: currentSection.color,
-				});
-			} else {
-				children.push(child);
-			}
-		}
+		// Section membership is explicit (sectionId): an ungrouped workspace
+		// keeps its top-level slot even when its tabOrder places it below a
+		// section header — groups reorder like any other item, so ungrouped
+		// rows and sections interleave freely.
+		const children: DashboardSidebarProjectChild[] = [...sortedChildren];
 
 		if (orphanedWorkspaces.length > 0) {
 			const firstSectionIndex = children.findIndex(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -633,40 +633,19 @@ export function useSidebarDnd({
 			}
 
 			if (type === "section") {
-				// A section pickup collapses every grouped row, which shrinks the
-				// list and can clamp the scroller's scrollTop in the same frame.
-				// dnd-kit then scroll-compensates the active rect against droppable
-				// rects that were re-measured post-clamp, leaving `over` offset by
-				// the collapsed height for the whole drag. Bypass the cached rect
-				// store: compare the live pointer against live DOM rects, minus
-				// each candidate's own preview translate (using transformed rects
-				// would re-trigger collisions from the displacement they caused).
+				// Stock closestCenter is safe here because SectionDragSpacer keeps
+				// scrollHeight constant at pickup (no scrollTop clamp to desync
+				// dnd-kit's scroll compensation) and the drag-collapse is instant
+				// (the member-unregister re-measure sees the final layout).
 				const container = containerByIdRef.current.get(args.active.id);
-				const pointer = args.pointerCoordinates;
-				if (container == null || pointer == null) return [];
-				let bestId: UniqueIdentifier | null = null;
-				let bestDistance = Number.POSITIVE_INFINITY;
-				for (const candidate of args.droppableContainers) {
-					if (containerByIdRef.current.get(candidate.id) !== container) {
-						continue;
-					}
-					const node = candidate.node.current;
-					if (!node) continue;
-					const rect = node.getBoundingClientRect();
-					if (rect.height === 0) continue;
-					let translateY = 0;
-					const transform = getComputedStyle(node).transform;
-					if (transform && transform !== "none") {
-						translateY = new DOMMatrixReadOnly(transform).m42;
-					}
-					const centerY = rect.top + rect.height / 2 - translateY;
-					const distance = Math.abs(pointer.y - centerY);
-					if (distance < bestDistance) {
-						bestDistance = distance;
-						bestId = candidate.id;
-					}
-				}
-				return bestId != null ? [{ id: bestId }] : [];
+				return closestCenter({
+					...args,
+					droppableContainers: args.droppableContainers.filter(
+						(candidate) =>
+							container != null &&
+							containerByIdRef.current.get(candidate.id) === container,
+					),
+				});
 			}
 
 			if (type === "workspace") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -307,7 +307,12 @@ export function useSidebarDnd({
 	} = useDashboardSidebarState();
 
 	const sensors = useSensors(
-		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		// 5px absorbs the 1-3px of jitter a real click carries without turning
+		// it into a pickup; anything smaller starts reordering rows on sloppy
+		// clicks. The trailing click after an activated drag is already
+		// swallowed by dnd-kit (capture-phase document click listener installed
+		// at activation, detached one event loop after the drag ends).
+		useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
 		useSensor(TouchSensor, {
 			activationConstraint: { delay: 200, tolerance: 5 },
 		}),
@@ -1045,6 +1050,27 @@ export function useSidebarDnd({
 	);
 
 	const onDragCancel = useCallback(() => {
+		// dnd-kit swallows the click that trails a drop (capture-phase document
+		// listener, detached ~50ms after the drag ends), but an Escape-cancel
+		// leaves the button held — the click fires on the later release and
+		// would navigate the row under the cursor. Mirror dnd-kit's technique
+		// for that one case: swallow the next click, disarming right after the
+		// release so a subsequent real click works normally.
+		const swallowClick = (event: Event) => {
+			event.stopPropagation();
+			disarm();
+		};
+		const onMouseUp = () => {
+			// The trailing click (if any) fires before this timeout runs.
+			setTimeout(disarm, 50);
+		};
+		const disarm = () => {
+			document.removeEventListener("click", swallowClick, { capture: true });
+			document.removeEventListener("mouseup", onMouseUp, { capture: true });
+		};
+		document.addEventListener("click", swallowClick, { capture: true });
+		document.addEventListener("mouseup", onMouseUp, { capture: true });
+
 		if (clonedRef.current) {
 			commitDragItems(clonedRef.current);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -73,6 +73,14 @@ interface SidebarDndItems {
 	pinned: UniqueIdentifier[];
 	sessions: UniqueIdentifier[];
 	byProject: Record<string, UniqueIdentifier[]>;
+	/**
+	 * Explicit section membership: flat workspace id → flat section id.
+	 * Membership is NOT positional — an ungrouped row may sit below a section
+	 * (groups reorder like any other top-level item), so "nearest header above"
+	 * can't be trusted. A row is in a section only if this map says so; drops
+	 * update the dragged row's entry from its landing neighbors.
+	 */
+	membership: Record<string, string>;
 }
 
 /**
@@ -140,27 +148,74 @@ function buildFlatItems(
 	return items;
 }
 
-// ── Parse flat list to determine section membership ──────────────────
+function collectMembership(
+	children: DashboardSidebarProjectChild[],
+	into: Record<string, string>,
+): void {
+	for (const child of children) {
+		if (child.type !== "section") continue;
+		for (const ws of child.section.workspaces) {
+			into[wsId(ws.id)] = secId(child.section.id);
+		}
+	}
+}
+
+function buildMembership(
+	projects: DashboardSidebarProject[],
+): Record<string, string> {
+	const membership: Record<string, string> = {};
+	for (const project of projects) {
+		collectMembership(project.children, membership);
+	}
+	return membership;
+}
+
+/**
+ * Section the row at `id` belongs to after landing in `list`: the section of
+ * the row directly above it (a header counts as its own section), or null when
+ * it sits at the top / below an ungrouped row.
+ */
+function membershipFromNeighbors(
+	list: UniqueIdentifier[],
+	membership: Record<string, string>,
+	id: UniqueIdentifier,
+): string | null {
+	const index = list.indexOf(id);
+	if (index <= 0) return null;
+	const above = list[index - 1];
+	if (isSec(above)) return String(above);
+	return membership[String(above)] ?? null;
+}
+
+// ── Parse flat list into top-level order + section membership ─────────
 
 interface ParsedFlatItems {
 	topLevel: Array<{ type: "workspace" | "section"; id: string }>;
 	sections: Record<string, string[]>;
 }
 
-function parseFlatItems(items: UniqueIdentifier[]): ParsedFlatItems {
+function parseFlatItems(
+	items: UniqueIdentifier[],
+	membership: Record<string, string>,
+): ParsedFlatItems {
 	const result: ParsedFlatItems = { topLevel: [], sections: {} };
-	let currentSection: string | null = null;
 
 	for (const id of items) {
 		const parsed = parseId(id);
 		if (!parsed) continue;
 		if (parsed.type === "section") {
-			currentSection = parsed.realId;
 			result.topLevel.push({ type: "section", id: parsed.realId });
-			result.sections[parsed.realId] = [];
+			result.sections[parsed.realId] ??= [];
 		} else if (parsed.type === "workspace") {
-			if (currentSection) {
-				result.sections[currentSection].push(parsed.realId);
+			const sectionFlatId = membership[String(id)];
+			const sectionRealId = sectionFlatId
+				? parseId(sectionFlatId)?.realId
+				: undefined;
+			// Headers precede their members in a well-formed list; membership
+			// pointing at a section absent from this list is stale — treat the
+			// row as ungrouped so the commit self-heals it.
+			if (sectionRealId && result.sections[sectionRealId]) {
+				result.sections[sectionRealId].push(parsed.realId);
 			} else {
 				result.topLevel.push({ type: "workspace", id: parsed.realId });
 			}
@@ -203,6 +258,14 @@ export interface DashboardSidebarDndValue {
 	projectsById: Map<string, DashboardSidebarProject>;
 	groupInfo: Map<string, { sectionId: string; color: string | null }>;
 	collapsedSectionIds: Set<string>;
+	/**
+	 * Height (px) of the rows hidden by an active section drag. Rendered as a
+	 * spacer at the end of the sidebar scroller so the pickup doesn't shrink
+	 * scrollHeight: a shrink clamps scrollTop when scrolled near the bottom,
+	 * and dnd-kit folds that scroll delta into the DragOverlay transform —
+	 * the ghost then rides the collapsed height away from the cursor.
+	 */
+	sectionDragSpacerPx: number;
 }
 
 const DashboardSidebarDndContext =
@@ -259,6 +322,7 @@ export function useSidebarDnd({
 		byProject: Object.fromEntries(
 			projects.map((project) => [project.id, buildFlatItems(project.children)]),
 		),
+		membership: buildMembership(projects),
 	}));
 	// Drag handlers read AND write these refs synchronously: pointer events can
 	// batch faster than React re-renders (especially under main-thread stalls),
@@ -332,6 +396,7 @@ export function useSidebarDnd({
 						buildFlatItems(project.children),
 					]),
 				),
+				membership: buildMembership(projects),
 			});
 		}
 	}, [
@@ -390,28 +455,37 @@ export function useSidebarDnd({
 	// Which section does each workspace belong to? (for visual grouping)
 	const groupInfo = useMemo(() => {
 		const map = new Map<string, { sectionId: string; color: string | null }>();
-		for (const list of Object.values(items.byProject)) {
-			let currentSection: { id: string; color: string | null } | null = null;
-			for (const id of list) {
-				const parsed = parseId(id);
-				if (!parsed) continue;
-				if (parsed.type === "section") {
-					const sec = sectionsById.get(parsed.realId);
-					currentSection = sec ? { id: sec.id, color: sec.color } : null;
-				} else if (currentSection) {
-					map.set(parsed.realId, {
-						sectionId: currentSection.id,
-						color: currentSection.color,
-					});
-				}
-			}
+		for (const [wsFlatId, secFlatId] of Object.entries(items.membership)) {
+			const wsParsed = parseId(wsFlatId);
+			const secParsed = parseId(secFlatId);
+			if (!wsParsed || !secParsed) continue;
+			const sec = sectionsById.get(secParsed.realId);
+			if (!sec) continue;
+			map.set(wsParsed.realId, { sectionId: sec.id, color: sec.color });
 		}
 		return map;
-	}, [items.byProject, sectionsById]);
+	}, [items.membership, sectionsById]);
 
 	const activeContainer = activeId
 		? (containerById.get(activeId) ?? null)
 		: null;
+
+	// Matches the sidebar workspace row height (h-8).
+	const SIDEBAR_ROW_PX = 32;
+	const sectionDragSpacerPx = useMemo(() => {
+		if (activeType !== "section" || !activeContainer) return 0;
+		const list = items.byProject[activeContainer] ?? [];
+		let hiddenRows = 0;
+		for (const id of list) {
+			const sectionFlatId = items.membership[String(id)];
+			if (!sectionFlatId) continue;
+			const parsed = parseId(sectionFlatId);
+			const section = parsed ? sectionsById.get(parsed.realId) : undefined;
+			// Members of collapsed sections are already zero-height before the drag.
+			if (section && !section.isCollapsed) hiddenRows++;
+		}
+		return hiddenRows * SIDEBAR_ROW_PX;
+	}, [activeType, activeContainer, items, sectionsById]);
 
 	const activeWorkspaceHome = useMemo(() => {
 		if (!activeId || activeType !== "workspace") return null;
@@ -439,7 +513,8 @@ export function useSidebarDnd({
 	}, [activeId, activeType, projectsById, workspacesById, sectionsById]);
 
 	// Color the active workspace's ghost should show based on where it would
-	// land. Only meaningful while it hovers inside a project list.
+	// land. Only meaningful while it hovers inside a project list. Mirrors the
+	// drop handler: simulate the arrayMove, then read the landing neighbors.
 	const predictedColor = useMemo(() => {
 		if (!activeId || !overId || activeType !== "workspace") return null;
 		if (
@@ -450,32 +525,35 @@ export function useSidebarDnd({
 			return null;
 		}
 		const list = items.byProject[activeContainer] ?? [];
+		const oldIndex = list.indexOf(activeId);
 		const overIndex = list.indexOf(overId);
-		if (overIndex === -1) return null;
-		// If over is a section header, the workspace lands ABOVE it,
-		// so look for the section above the over position (skip the over itself)
-		const startFrom = isSec(overId) ? overIndex - 1 : overIndex;
-		for (let i = startFrom; i >= 0; i--) {
-			const p = parseId(list[i]);
-			if (p?.type === "section") {
-				const sec = sectionsById.get(p.realId);
-				return sec?.color ?? null;
-			}
-		}
-		return null; // ungrouped — no section above
+		if (oldIndex === -1 || overIndex === -1) return null;
+		const moved =
+			oldIndex === overIndex ? list : arrayMove(list, oldIndex, overIndex);
+		const sectionFlatId = membershipFromNeighbors(
+			moved,
+			items.membership,
+			activeId,
+		);
+		if (!sectionFlatId) return null; // ungrouped landing spot
+		const parsed = parseId(sectionFlatId);
+		const sec = parsed ? sectionsById.get(parsed.realId) : undefined;
+		return sec?.color ?? null;
 	}, [activeId, overId, activeType, activeContainer, items, sectionsById]);
 
-	// When dragging a section, its project's SortableContext only has section
-	// IDs. Other projects (and idle projects) keep everything.
+	// When dragging a section, its project's SortableContext collapses to the
+	// top-level units — section headers and ungrouped rows — so the section can
+	// sort against both (grouped rows hide and move with their header). Other
+	// projects (and idle projects) keep everything.
 	const getProjectSortableItems = useCallback(
 		(projectId: string) => {
 			const list = items.byProject[projectId] ?? [];
 			if (activeType === "section" && activeContainer === projectId) {
-				return list.filter((id) => isSec(id));
+				return list.filter((id) => isSec(id) || !items.membership[String(id)]);
 			}
 			return list;
 		},
-		[items.byProject, activeType, activeContainer],
+		[items.byProject, items.membership, activeType, activeContainer],
 	);
 
 	// The sidebar data builder always sorts local main workspaces first,
@@ -550,15 +628,40 @@ export function useSidebarDnd({
 			}
 
 			if (type === "section") {
+				// A section pickup collapses every grouped row, which shrinks the
+				// list and can clamp the scroller's scrollTop in the same frame.
+				// dnd-kit then scroll-compensates the active rect against droppable
+				// rects that were re-measured post-clamp, leaving `over` offset by
+				// the collapsed height for the whole drag. Bypass the cached rect
+				// store: compare the live pointer against live DOM rects, minus
+				// each candidate's own preview translate (using transformed rects
+				// would re-trigger collisions from the displacement they caused).
 				const container = containerByIdRef.current.get(args.active.id);
-				return closestCenter({
-					...args,
-					droppableContainers: args.droppableContainers.filter(
-						(candidate) =>
-							container != null &&
-							containerByIdRef.current.get(candidate.id) === container,
-					),
-				});
+				const pointer = args.pointerCoordinates;
+				if (container == null || pointer == null) return [];
+				let bestId: UniqueIdentifier | null = null;
+				let bestDistance = Number.POSITIVE_INFINITY;
+				for (const candidate of args.droppableContainers) {
+					if (containerByIdRef.current.get(candidate.id) !== container) {
+						continue;
+					}
+					const node = candidate.node.current;
+					if (!node) continue;
+					const rect = node.getBoundingClientRect();
+					if (rect.height === 0) continue;
+					let translateY = 0;
+					const transform = getComputedStyle(node).transform;
+					if (transform && transform !== "none") {
+						translateY = new DOMMatrixReadOnly(transform).m42;
+					}
+					const centerY = rect.top + rect.height / 2 - translateY;
+					const distance = Math.abs(pointer.y - centerY);
+					if (distance < bestDistance) {
+						bestDistance = distance;
+						bestId = candidate.id;
+					}
+				}
+				return bestId != null ? [{ id: bestId }] : [];
 			}
 
 			if (type === "workspace") {
@@ -606,8 +709,12 @@ export function useSidebarDnd({
 	// ── Persistence ──────────────────────────────────────────────────
 
 	const commitProjectToDb = useCallback(
-		(projectId: string, list: UniqueIdentifier[]) => {
-			const parsed = parseFlatItems(list);
+		(
+			projectId: string,
+			list: UniqueIdentifier[],
+			membership: Record<string, string>,
+		) => {
+			const parsed = parseFlatItems(list, membership);
 
 			// Top-level order (ungrouped workspaces + sections interleaved)
 			reorderProjectChildren(projectId, parsed.topLevel);
@@ -627,6 +734,7 @@ export function useSidebarDnd({
 			workspaceId: string,
 			container: string,
 			containerList: UniqueIdentifier[],
+			membership: Record<string, string>,
 		) => {
 			const ws = workspacesById.get(workspaceId);
 			if (container === PINNED_CONTAINER) {
@@ -666,7 +774,7 @@ export function useSidebarDnd({
 				return;
 			}
 
-			commitProjectToDb(container, containerList);
+			commitProjectToDb(container, containerList, membership);
 		},
 		[
 			workspacesById,
@@ -725,13 +833,25 @@ export function useSidebarDnd({
 			}
 			target.splice(newIndex, 0, active.id);
 			freezeCollisionsForOneFrame();
-			commitDragItems(
-				withContainerList(
-					withContainerList(current, sourceContainer, source),
-					targetContainer,
-					target,
-				),
+			const next = withContainerList(
+				withContainerList(current, sourceContainer, source),
+				targetContainer,
+				target,
 			);
+			// Keep membership in step with the transfer so the row previews its
+			// landing group's accent (or none) while still mid-drag.
+			const membership = { ...next.membership };
+			const sectionFlatId =
+				targetContainer !== PINNED_CONTAINER &&
+				targetContainer !== SESSIONS_CONTAINER
+					? membershipFromNeighbors(target, membership, active.id)
+					: null;
+			if (sectionFlatId) {
+				membership[String(active.id)] = sectionFlatId;
+			} else {
+				delete membership[String(active.id)];
+			}
+			commitDragItems({ ...next, membership });
 		},
 		[typeOf, commitDragItems, freezeCollisionsForOneFrame],
 	);
@@ -775,43 +895,46 @@ export function useSidebarDnd({
 				}
 				const list = current.byProject[container] ?? [];
 
-				// Section drag: only section IDs were in the SortableContext.
-				// Reorder sections, then rebuild the full flat list with
-				// workspaces in their original positions under each section.
-				const sectionIds = list.filter((id) => isSec(id));
-				const oldIdx = sectionIds.indexOf(active.id);
-				const newIdx = sectionIds.indexOf(over.id);
-				if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return;
-
-				const reorderedSections = arrayMove(sectionIds, oldIdx, newIdx);
-
-				// Rebuild flat list: ungrouped workspaces first, then
-				// each section with its workspaces in new section order
-				const ungrouped: UniqueIdentifier[] = [];
-				const sectionGroups = new Map<string, UniqueIdentifier[]>();
-
-				let currentSec: string | null = null;
+				// Section drag: the SortableContext held top-level units — section
+				// headers and ungrouped rows. Collapse the flat list into those
+				// units (a section unit carries its member rows), reorder the
+				// dragged section among them, and flatten back out. Sections sort
+				// against ungrouped rows exactly like any other item.
+				interface TopLevelUnit {
+					key: UniqueIdentifier;
+					ids: UniqueIdentifier[];
+				}
+				const units: TopLevelUnit[] = [];
+				const unitBySection = new Map<string, TopLevelUnit>();
 				for (const id of list) {
 					if (isSec(id)) {
-						currentSec = String(id);
-						sectionGroups.set(currentSec, []);
-					} else if (currentSec) {
-						sectionGroups.get(currentSec)?.push(id);
+						const unit: TopLevelUnit = { key: id, ids: [id] };
+						units.push(unit);
+						unitBySection.set(String(id), unit);
+						continue;
+					}
+					const sectionFlatId = current.membership[String(id)];
+					const owner = sectionFlatId
+						? unitBySection.get(sectionFlatId)
+						: undefined;
+					if (owner) {
+						owner.ids.push(id);
 					} else {
-						ungrouped.push(id);
+						units.push({ key: id, ids: [id] });
 					}
 				}
 
-				const rebuilt: UniqueIdentifier[] = [...ungrouped];
-				for (const secSortId of reorderedSections) {
-					rebuilt.push(secSortId);
-					const wsInSec = sectionGroups.get(String(secSortId)) ?? [];
-					rebuilt.push(...wsInSec);
-				}
+				const oldIdx = units.findIndex((unit) => unit.key === active.id);
+				const newIdx = units.findIndex((unit) => unit.key === over.id);
+				if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return;
+
+				const rebuilt = arrayMove(units, oldIdx, newIdx).flatMap(
+					(unit) => unit.ids,
+				);
 
 				const newList = normalizeMainFirst(rebuilt);
 				commitDragItems(withContainerList(current, container, newList));
-				commitProjectToDb(container, newList);
+				commitProjectToDb(container, newList, current.membership);
 				return;
 			}
 
@@ -859,8 +982,6 @@ export function useSidebarDnd({
 					targetList = normalizeMainFirst(targetList);
 				}
 
-				commitDragItems(withContainerList(next, targetContainer, targetList));
-
 				// Skip the writes when the drop lands exactly where the drag
 				// started (same container, same order) — dropping in place must
 				// not rewrite pinnedAt/tabOrder rows.
@@ -871,8 +992,43 @@ export function useSidebarDnd({
 					startList != null &&
 					startList.length === targetList.length &&
 					startList.every((id, index) => id === targetList[index]);
+
+				const membership = { ...next.membership };
+				if (unchanged) {
+					// In-place drop: restore the pre-drag membership (mid-drag
+					// container transfers may have rewritten it) instead of
+					// re-deriving it — an in-place drop must change nothing.
+					const snapshotSection = snapshot?.membership[String(active.id)];
+					if (snapshotSection) {
+						membership[String(active.id)] = snapshotSection;
+					} else {
+						delete membership[String(active.id)];
+					}
+				} else {
+					const sectionFlatId =
+						targetContainer !== PINNED_CONTAINER &&
+						targetContainer !== SESSIONS_CONTAINER
+							? membershipFromNeighbors(targetList, membership, active.id)
+							: null;
+					if (sectionFlatId) {
+						membership[String(active.id)] = sectionFlatId;
+					} else {
+						delete membership[String(active.id)];
+					}
+				}
+
+				commitDragItems({
+					...withContainerList(next, targetContainer, targetList),
+					membership,
+				});
+
 				if (!unchanged) {
-					persistWorkspaceDrop(parsed.realId, targetContainer, targetList);
+					persistWorkspaceDrop(
+						parsed.realId,
+						targetContainer,
+						targetList,
+						membership,
+					);
 				}
 			}
 		},
@@ -913,6 +1069,7 @@ export function useSidebarDnd({
 			projectsById,
 			groupInfo,
 			collapsedSectionIds,
+			sectionDragSpacerPx,
 		}),
 		[
 			items,
@@ -926,6 +1083,7 @@ export function useSidebarDnd({
 			projectsById,
 			groupInfo,
 			collapsedSectionIds,
+			sectionDragSpacerPx,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarSelectionProvider/workspaceSelection.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarSelectionProvider/workspaceSelection.test.ts
@@ -129,12 +129,15 @@ describe("applyWorkspaceSelection", () => {
 		});
 	});
 
-	it("preserves hidden selected workspaces when toggling a visible row", () => {
+	it("drops stale ids missing from the ordered list", () => {
+		// The provider prunes ids whose rows leave the sidebar (deleted, pinned,
+		// group collapsed); any straggler that races a click is dropped rather
+		// than carried along invisibly.
 		expect(
 			applyWorkspaceSelection(
 				{
 					projectId: "project-a",
-					selectedIds: ["hidden", "three"],
+					selectedIds: ["stale", "three"],
 					anchorId: "three",
 				},
 				{
@@ -146,40 +149,18 @@ describe("applyWorkspaceSelection", () => {
 			),
 		).toEqual({
 			projectId: "project-a",
-			selectedIds: ["three", "five", "hidden"],
+			selectedIds: ["three", "five"],
 			anchorId: "five",
 		});
 	});
 
-	it("preserves hidden selected workspaces when adding a visible range", () => {
+	it("re-anchors an additive click when the anchor is no longer listed", () => {
 		expect(
 			applyWorkspaceSelection(
 				{
 					projectId: "project-a",
-					selectedIds: ["hidden", "two"],
-					anchorId: "two",
-				},
-				{
-					workspaceId: "four",
-					projectId: "project-a",
-					orderedWorkspaceIds,
-					mode: "add-range",
-				},
-			),
-		).toEqual({
-			projectId: "project-a",
-			selectedIds: ["two", "three", "four", "hidden"],
-			anchorId: "two",
-		});
-	});
-
-	it("preserves a hidden anchor when starting a new additive visible range", () => {
-		expect(
-			applyWorkspaceSelection(
-				{
-					projectId: "project-a",
-					selectedIds: ["hidden"],
-					anchorId: "hidden",
+					selectedIds: ["stale"],
+					anchorId: "stale",
 				},
 				{
 					workspaceId: "three",
@@ -190,7 +171,7 @@ describe("applyWorkspaceSelection", () => {
 			),
 		).toEqual({
 			projectId: "project-a",
-			selectedIds: ["three", "hidden"],
+			selectedIds: ["three"],
 			anchorId: "three",
 		});
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarSelectionProvider/workspaceSelection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarSelectionProvider/workspaceSelection.ts
@@ -19,17 +19,17 @@ export const EMPTY_WORKSPACE_SELECTION: WorkspaceSelectionState = {
 	anchorId: null,
 };
 
+/**
+ * The selection is always a subset of the visible ordered list: the provider
+ * prunes ids the moment their rows leave `availableWorkspaceIds` (deleted,
+ * pinned away, group collapsed). Ids missing from the ordered list are
+ * therefore stale and dropped here rather than carried along invisibly.
+ */
 function selectedIdsInVisualOrder(
 	orderedWorkspaceIds: string[],
 	selectedIds: ReadonlySet<string>,
-	preserveIds: readonly string[] = [],
 ): string[] {
-	const visibleIds = orderedWorkspaceIds.filter((id) => selectedIds.has(id));
-	const visibleIdSet = new Set(orderedWorkspaceIds);
-	const hiddenIds = preserveIds.filter(
-		(id) => selectedIds.has(id) && !visibleIdSet.has(id),
-	);
-	return [...visibleIds, ...hiddenIds];
+	return orderedWorkspaceIds.filter((id) => selectedIds.has(id));
 }
 
 function singleWorkspaceSelection(
@@ -71,11 +71,7 @@ export function applyWorkspaceSelection(
 
 		return {
 			projectId,
-			selectedIds: selectedIdsInVisualOrder(
-				orderedWorkspaceIds,
-				selectedIds,
-				state.selectedIds,
-			),
+			selectedIds: selectedIdsInVisualOrder(orderedWorkspaceIds, selectedIds),
 			anchorId: workspaceId,
 		};
 	}
@@ -89,11 +85,7 @@ export function applyWorkspaceSelection(
 			const selectedIds = new Set([...state.selectedIds, workspaceId]);
 			return {
 				projectId,
-				selectedIds: selectedIdsInVisualOrder(
-					orderedWorkspaceIds,
-					selectedIds,
-					state.selectedIds,
-				),
+				selectedIds: selectedIdsInVisualOrder(orderedWorkspaceIds, selectedIds),
 				anchorId: workspaceId,
 			};
 		}
@@ -110,11 +102,7 @@ export function applyWorkspaceSelection(
 
 	return {
 		projectId,
-		selectedIds: selectedIdsInVisualOrder(
-			orderedWorkspaceIds,
-			selectedIds,
-			mode === "add-range" ? state.selectedIds : [],
-		),
+		selectedIds: selectedIdsInVisualOrder(orderedWorkspaceIds, selectedIds),
 		anchorId: state.anchorId,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -380,10 +380,31 @@ export function useDashboardSidebarState() {
 			if (!existing) return;
 
 			if (sectionId === null) {
+				const currentSectionId = existing.sidebarState.sectionId;
+				const sameProject = existing.sidebarState.projectId === projectId;
+				// Already ungrouped in this project — nothing to move.
+				if (
+					currentSectionId === null &&
+					sameProject &&
+					isSidebarWorkspaceVisible(existing)
+				) {
+					return;
+				}
 				const topLevelItems = getProjectTopLevelItems(collections, projectId, {
 					excludeWorkspaceId: workspaceId,
 				});
-				const insertIndex = getFirstSectionIndex(topLevelItems);
+				// Groups interleave with ungrouped rows, so "before the first
+				// section" can be far from the row's group. Keep the row in
+				// place: land it directly below its former group.
+				const sectionIndex = sameProject
+					? topLevelItems.findIndex(
+							(item) => item.type === "section" && item.id === currentSectionId,
+						)
+					: -1;
+				const insertIndex =
+					sectionIndex === -1
+						? getFirstSectionIndex(topLevelItems)
+						: sectionIndex + 1;
 				topLevelItems.splice(insertIndex, 0, {
 					type: "workspace",
 					id: workspaceId,
@@ -420,10 +441,18 @@ export function useDashboardSidebarState() {
 			const section = collections.v2SidebarSections.get(sectionId);
 			if (!section) return;
 
-			const topLevelItems = getProjectTopLevelItems(
+			// Groups interleave with ungrouped rows, so replace the deleted
+			// section's own slot with its members instead of dumping them
+			// "before the first section" (which may be far away).
+			const withSection = getProjectTopLevelItems(
 				collections,
 				section.projectId,
-				{ excludeSectionId: sectionId },
+			);
+			const sectionIndex = withSection.findIndex(
+				(item) => item.type === "section" && item.id === sectionId,
+			);
+			const topLevelItems = withSection.filter(
+				(item) => !(item.type === "section" && item.id === sectionId),
 			);
 			const sectionWorkspaces = Array.from(
 				collections.v2WorkspaceLocalState.state.values(),
@@ -439,7 +468,10 @@ export function useDashboardSidebarState() {
 						left.sidebarState.tabOrder - right.sidebarState.tabOrder,
 				);
 
-			const insertIndex = getFirstSectionIndex(topLevelItems);
+			const insertIndex =
+				sectionIndex === -1
+					? getFirstSectionIndex(topLevelItems)
+					: sectionIndex;
 			topLevelItems.splice(
 				insertIndex,
 				0,


### PR DESCRIPTION
## Summary
- Sidebar groups (sections) can now be dragged anywhere in their project's list — above, between, and below ungrouped workspaces — instead of being stuck at the bottom. Group membership is now explicit instead of positional.
- Fixes a pre-existing drag bug from #6377 where rows displaced by any sidebar drag (including plain workspace drags on main) visually vanished mid-drag.
- Fixes `Delete group` / `Ungroup` context-menu actions teleporting rows to the top of the project.

## Why / Context
Groups were pinned to the bottom by three interlocking behaviors: section drags could only sort against other section headers, the drop handler rebuilt the list as "ungrouped first, then sections", and membership was positional — any ungrouped row rendered below a header was silently absorbed into that group, making "group above an ungrouped row" unrepresentable.

## How It Works
- `SidebarDndItems.membership` (flat workspace id → flat section id) carries explicit membership through the drag; `groupInfo`, commit parsing, and the ghost's predicted accent read the map instead of scanning position.
- Section drag-end collapses the flat list into top-level units (header + members move as one) and `arrayMove`s among units, ungrouped rows included. A dropped workspace joins the group of the row that ends up directly above it (`membershipFromNeighbors`); in-place drops restore the pre-drag membership so they write nothing.
- `buildDashboardSidebarProjects` no longer absorbs trailing ungrouped rows — interleaved orders round-trip through the existing tabOrder persistence.
- Drag-feel fixes (all rooted in the #6377 collapse wrapper + the layout shift a section pickup causes):
  - The dnd translate now sits outside each row's `overflow-hidden` collapse wrapper (moved into `SortableWorkspaceItem`), so displaced rows slide instead of clipping out of view.
  - Section pickups collapse members instantly, use a live-DOM pointer collision, hide the in-list header (the `DragOverlay` ghost is the drag representation), and render a `SectionDragSpacer` that keeps the scroller's scrollHeight constant — without it, the pickup shrink clamps scrollTop near the bottom and dnd-kit's cached rects/overlay transform desync (drops landed ~member-count rows off; ghost drifted 96px from the cursor, both measured).
- `deleteSection` replaces the deleted group's own slot with its members; `moveWorkspaceToSection(null)` lands the row directly below its former group.

## Manual QA (all driven end-to-end over CDP in the dev app, real trusted input, unstaged layout)
- [x] Group dragged above / between / below ungrouped rows, both directions — drop lands exactly at the pointer slot (verified numerically: ghost == pointer, gap adjacent, landed index exact)
- [x] Group ↔ group reorder; collapsed-group drag; empty-group lifecycle (drain by drag, drag empty group, drop a row back in)
- [x] Workspace into / out of a group by drag (accent + membership persist); `local` main row always stays on top
- [x] Pin a grouped row by drag, reorder, unpin back into its group by drag and via context menu (returns to the same slot; `sectionId` retained while pinned)
- [x] Context menus: Ungroup lands below its group; Delete group keeps members in place; New group from workspace appends at bottom
- [x] In-place drop writes nothing (byte-identical collections before/after)
- [x] Full reload reproduces the exact interleaved order; sidebar state survives across reloads after every scenario
- [x] Pinned + Sessions lanes re-verified after the row-wrapper restructure (render, reorder, cross-lane drags)
- [x] Stress battery on final code: 30 rapid random drags (8–18 ms steps), boundary oscillation with ~1 s dwells, full-sidebar autoscroll sweeps into the Pinned zone, 12 drags under induced 120 ms main-thread jank, Escape-cancels — integrity held (14 rows, no orphaned memberships), zero console errors, exact post-stress reload
- [x] Frame-by-frame visual review of slow drags: rows part around the ghost, no vanishing rows, no double header, WYSIWYG drop

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun test src/renderer/routes/_authenticated` (371 pass; includes a new builder test for interleaved layouts)

## Design Decisions
- **Explicit membership map instead of positional parsing**: positional absorption is what made groups-at-bottom load-bearing; the map lets ungrouped rows live below a group while keeping the drag-into-group gesture positional at drop time only.
- **Live-DOM collision for section drags instead of dnd-kit's rect store**: the pickup reflow invalidates cached rects and the scroll compensation double-counts; comparing the raw pointer against untransformed live rects is immune to both (transformed rects would oscillate — the known sidebar-DnD crash class).
- **Spacer instead of animated collapse**: keeping scrollHeight constant during the drag removes the scroll clamp entirely, which is what kept the overlay glued to the cursor; the collapse animation was cosmetic and its mid-animation re-measure was itself a source of stale geometry.

## Known Limitations
- Dropping a row at the very end of a project joins the last group (row-above rule); use `Ungroup` or drop below another ungrouped row to leave it ungrouped — inherent to flat lists without end-of-group markers.
- `SectionDragSpacer` assumes the 32 px sidebar row height; if row height changes it degrades to the old clamp behavior (cosmetic), not a failure.
- Keyboard-sensor sorting shares the fixed handlers but wasn't exercised separately.

## Follow-ups
- Legacy profiles that relied on positional absorption will render those trailing rows as ungrouped (their stored `sectionId` was always null) — this now shows the persisted truth, but counts in group headers may differ from what those users saw before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidebar groups reorderable anywhere in a project's list by replacing positional membership with an explicit map. This removes the “groups at bottom” constraint, fixes rows vanishing mid‑drag, prevents context‑action teleports, improves multiselect, and avoids stray clicks after canceled drags.

- Section drags reorder top‑level units (header + members) against ungrouped rows; grouped rows hide during drag, the in‑list header hides, `SectionDragSpacer` keeps scroll height constant, and collisions use dnd‑kit’s `closestCenter`.
- Workspace drops join the group of the row directly above the landing slot; in‑place drops restore pre‑drag membership; the ghost’s accent predicts using the same rule.
- The sidebar builder no longer absorbs trailing ungrouped rows; interleaved orders round‑trip via existing `tabOrder` persistence.
- Context menus: Ungroup lands directly below the former group; Delete group replaces the group’s slot with its members; no‑op when already ungrouped in the same project.
- Multiselect: the bulk‑actions toolbar is sticky; bulk Ungroup runs back‑to‑front to preserve visual order; collapsing a group prunes hidden members; stale ids drop and additive clicks re‑anchor if the previous anchor is gone.
- Drag feel: displaced rows no longer clip out of view (transform sits outside the collapse wrapper); mouse activation distance is 5 px; Escape‑canceled drags swallow the next click to prevent navigation.

- Rollout: profiles that relied on positional absorption will now show those rows as ungrouped; header counts may differ. Limitation: dropping at the very end joins the last group; use Ungroup or drop below an ungrouped row.

<sup>Written for commit a71560439a07d00c0421fcc4b28bec6824b52639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved sidebar drag-and-drop for sections and workspaces.
  - Sections move with their grouped workspaces while preserving layout.
  - Added smoother collapsing, spacing, and visual feedback during drag operations.
  - Bulk actions remain visible while scrolling.

- **Bug Fixes**
  - Ungrouped workspaces remain correctly ordered among sections.
  - Ungrouping workspaces or deleting sections better preserves sidebar order.
  - Improved workspace transfers, stale grouping recovery, and bulk ungrouping.
  - Workspace selection now excludes hidden or unavailable items.
  - Prevented accidental navigation after canceled drag operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->