### PR TITLE
fix(mobile): hide project sections with no workspaces

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -211,8 +211,10 @@ export function HomeScreen() {
 				project,
 				workspaces: (byProject.get(project.id) ?? []).sort(byPinThenActivity),
 			}))
-			// A search shouldn't advertise projects it found nothing in.
-			.filter((section) => !searching || section.workspaces.length > 0)
+			// An empty section is a row that says nothing and does nothing — the
+			// composer's project picker is where you start work in a project that
+			// has none yet.
+			.filter((section) => section.workspaces.length > 0)
 			.sort((a, b) => {
 				// Sections rank by their liveliest workspace, so the project you
 				// were last in leads; empty ones fall to the bottom alphabetically.

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/ProjectSectionHeader/ProjectSectionHeader.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/ProjectSectionHeader/ProjectSectionHeader.tsx
@@ -29,7 +29,7 @@ export function ProjectSectionHeader({
 	return (
 		<Pressable
 			onPress={onToggle}
-			accessibilityLabel={`${name}, ${count} workspaces`}
+			accessibilityLabel={`${name}, ${count} ${count === 1 ? "workspace" : "workspaces"}`}
 			accessibilityState={{ expanded: !collapsed }}
 			className="flex-row items-center gap-2.5 px-4 pb-1 pt-4 active:opacity-60"
 		>


### PR DESCRIPTION
## What & why

Project sections with no workspaces were being rendered — a header, a name and a `0`,
introducing nothing.

Showing them was a deliberate call in the original design, but the reasoning was *"a project
with nothing in it is exactly where you'd want to start one"* — which only held while the
section header carried a `+`. That button came out during layout review (it duplicated the
per-row `+` a row apart, at the same size and colour), and the justification left with it.
Nothing replaced it, so an empty section became a row that says nothing and does nothing.

Starting work in an empty project still works: the composer's project picker lists every
project on the host regardless of whether it has workspaces.

Also fixes the section header's VoiceOver label, which read "1 workspaces".

## How I tested it

On the simulator against a live host: the account has a project with zero workspaces
(`MASTRA-SUPERSET`). Before, it occupied a section; after, the list renders six sections and
every one has work in it — confirmed by dumping the accessibility tree rather than eyeballing
it, since the section that mattered was below the fold.

```
"Boid Home, 1 workspace"          "notion-clone, 1 workspace"
"Superset, 14 workspaces"         "presentations, 1 workspace"
"evidence, 1 workspace"           "frontend-interview, 1 workspace"
```

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty project sections on the mobile Home list and fix the header’s VoiceOver label. Previously we rendered empty sections (except during search); now we never render them and we say “1 workspace” when count is 1.

- HomeScreen: always filter out sections where `workspaces.length === 0` (was only filtered during search).
- ProjectSectionHeader: accessibilityLabel pluralizes “workspace(s)” correctly.
- Starting work in an empty project still goes through the composer’s project picker, which lists all projects.

<sup>Written for commit 9467be9fbee17ceb733ada719a79736a32db924b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty project sections are now hidden consistently, including when not searching.
  * Improved accessibility labels by using the correct singular or plural wording for workspace counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->