### PR TITLE
fix(mobile): submit terminal messages through terminal.send, add a newline button

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/ProjectSectionHeader/ProjectSectionHeader.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/ProjectSectionHeader/ProjectSectionHeader.tsx
@@ -13,9 +13,10 @@ interface ProjectSectionHeaderProps {
 }
 
 /**
- * A quiet band, not a title: the workspaces under it are what you came to tap,
- * so the header labels them rather than competing with them. The count is what
- * keeps a collapsed section informative.
+ * Reads as the parent of the rows under it through the type scale alone —
+ * `large` against their 15px — rather than through caps and letterspacing,
+ * which shout at a list you're meant to scan. The count is what keeps a
+ * collapsed section informative.
  */
 export function ProjectSectionHeader({
 	name,
@@ -39,10 +40,7 @@ export function ProjectSectionHeader({
 			<View className="size-6 items-center justify-center">
 				<ProjectAvatar name={name} iconUrl={iconUrl} size={20} />
 			</View>
-			<Text
-				className="text-foreground font-semibold text-[15px] uppercase tracking-wider"
-				numberOfLines={1}
-			>
+			<Text variant="large" numberOfLines={1}>
 				{name}
 			</Text>
 			<Text className="text-muted-foreground font-mono text-[13px]">

--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@expo/ui/swift-ui";
 import {
 	Animation,
+	accessibilityLabel,
 	animation,
 	aspectRatio,
 	buttonBorderShape,
@@ -146,7 +147,6 @@ export const GlassComposer = forwardRef<
 	// The draft lives in a ref, never state — otherwise each keystroke
 	// re-renders the SwiftUI Host.
 	const draftRef = useRef("");
-	const selectionRef = useRef({ start: 0, end: 0 });
 	const [hasText, setHasText] = useState(false);
 
 	const writeDraft = (text: string) => {
@@ -154,20 +154,16 @@ export const GlassComposer = forwardRef<
 		setHasText(text.trim().length > 0);
 	};
 
-	// Replaces the current selection (or splits at the caret) and leaves the
-	// caret after the inserted text.
-	const replaceSelection = (insert: string) => {
-		const text = draftRef.current;
-		const length = text.length;
-		const start = Math.min(selectionRef.current.start, length);
-		const end = Math.min(Math.max(selectionRef.current.end, start), length);
-		const next = text.slice(0, start) + insert + text.slice(end);
-		const caret = start + insert.length;
+	// Appends to the draft and leaves the caret after it. The field never
+	// reports where its cursor actually is — both onSelectionChange and a
+	// `selection` state read back {0,0} once you've typed — so the end is the
+	// only position an insert can be sure of. Setting the caret does work.
+	const appendToDraft = (insert: string) => {
+		const next = draftRef.current + insert;
 		writeDraft(next);
-		selectionRef.current = { start: caret, end: caret };
 		void fieldRef.current
 			?.setText(next)
-			.then(() => fieldRef.current?.setSelection(caret, caret));
+			.then(() => fieldRef.current?.setSelection(next.length, next.length));
 	};
 
 	const attachments = showAttachments
@@ -201,7 +197,6 @@ export const GlassComposer = forwardRef<
 		},
 		clear: () => {
 			writeDraft("");
-			selectionRef.current = { start: 0, end: 0 };
 			controller.attachments.clear();
 			void fieldRef.current?.clear();
 		},
@@ -258,7 +253,6 @@ export const GlassComposer = forwardRef<
 		read: () => draftRef.current,
 		write: (text) => {
 			writeDraft(text);
-			selectionRef.current = { start: text.length, end: text.length };
 			void fieldRef.current
 				?.setText(text)
 				.then(() => fieldRef.current?.setSelection(text.length, text.length));
@@ -295,6 +289,7 @@ export const GlassComposer = forwardRef<
 				buttonStyle("bordered"),
 				buttonBorderShape("circle"),
 				tint(FOREGROUND),
+				accessibilityLabel("Add attachment"),
 			]}
 		>
 			<Image
@@ -312,12 +307,13 @@ export const GlassComposer = forwardRef<
 		<Button
 			onPress={() => {
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				replaceSelection("\n");
+				appendToDraft("\n");
 			}}
 			modifiers={[
 				buttonStyle("bordered"),
 				buttonBorderShape("circle"),
 				tint(FOREGROUND),
+				accessibilityLabel("New line"),
 			]}
 		>
 			<Image
@@ -340,6 +336,9 @@ export const GlassComposer = forwardRef<
 				buttonBorderShape("circle"),
 				tint("#ffffff"),
 				disabled(isSending),
+				// Distinct from the terminal quick-key row's up arrow, which is
+				// otherwise the same `arrow.up` symbol to VoiceOver.
+				accessibilityLabel("Send"),
 			]}
 		>
 			<Image
@@ -500,9 +499,6 @@ export const GlassComposer = forwardRef<
 								placeholder={placeholder ?? "Plan, ask, build..."}
 								onTextChange={writeDraft}
 								onFocusChange={setFocused}
-								onSelectionChange={(selection) => {
-									selectionRef.current = selection;
-								}}
 								modifiers={[
 									padding({ horizontal: expanded ? 12 : 4 }),
 									frame({ minHeight: expanded ? 56 : 38 }),

--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -146,11 +146,28 @@ export const GlassComposer = forwardRef<
 	// The draft lives in a ref, never state — otherwise each keystroke
 	// re-renders the SwiftUI Host.
 	const draftRef = useRef("");
+	const selectionRef = useRef({ start: 0, end: 0 });
 	const [hasText, setHasText] = useState(false);
 
 	const writeDraft = (text: string) => {
 		draftRef.current = text;
 		setHasText(text.trim().length > 0);
+	};
+
+	// Replaces the current selection (or splits at the caret) and leaves the
+	// caret after the inserted text.
+	const replaceSelection = (insert: string) => {
+		const text = draftRef.current;
+		const length = text.length;
+		const start = Math.min(selectionRef.current.start, length);
+		const end = Math.min(Math.max(selectionRef.current.end, start), length);
+		const next = text.slice(0, start) + insert + text.slice(end);
+		const caret = start + insert.length;
+		writeDraft(next);
+		selectionRef.current = { start: caret, end: caret };
+		void fieldRef.current
+			?.setText(next)
+			.then(() => fieldRef.current?.setSelection(caret, caret));
 	};
 
 	const attachments = showAttachments
@@ -184,6 +201,7 @@ export const GlassComposer = forwardRef<
 		},
 		clear: () => {
 			writeDraft("");
+			selectionRef.current = { start: 0, end: 0 };
 			controller.attachments.clear();
 			void fieldRef.current?.clear();
 		},
@@ -240,6 +258,7 @@ export const GlassComposer = forwardRef<
 		read: () => draftRef.current,
 		write: (text) => {
 			writeDraft(text);
+			selectionRef.current = { start: text.length, end: text.length };
 			void fieldRef.current
 				?.setText(text)
 				.then(() => fieldRef.current?.setSelection(text.length, text.length));
@@ -280,6 +299,29 @@ export const GlassComposer = forwardRef<
 		>
 			<Image
 				systemName="plus"
+				size={16}
+				modifiers={[frame({ width: 16, height: 16 })]}
+			/>
+		</Button>
+	);
+
+	// Explicit line break for multi-line messages: expo-ui's TextField exposes
+	// nothing for the soft keyboard's return key, so this is the only way to
+	// put a newline in a draft.
+	const newlineButton = (
+		<Button
+			onPress={() => {
+				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+				replaceSelection("\n");
+			}}
+			modifiers={[
+				buttonStyle("bordered"),
+				buttonBorderShape("circle"),
+				tint(FOREGROUND),
+			]}
+		>
+			<Image
+				systemName="return"
 				size={16}
 				modifiers={[frame({ width: 16, height: 16 })]}
 			/>
@@ -458,6 +500,9 @@ export const GlassComposer = forwardRef<
 								placeholder={placeholder ?? "Plan, ask, build..."}
 								onTextChange={writeDraft}
 								onFocusChange={setFocused}
+								onSelectionChange={(selection) => {
+									selectionRef.current = selection;
+								}}
 								modifiers={[
 									padding({ horizontal: expanded ? 12 : 4 }),
 									frame({ minHeight: expanded ? 56 : 38 }),
@@ -495,6 +540,7 @@ export const GlassComposer = forwardRef<
 							>
 								{plusButton}
 							</HStack>
+							{newlineButton}
 							{toolbarLeading}
 							<Spacer />
 							{/* Bordered buttons carry ~6pt of invisible tap-target inset

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -198,12 +198,25 @@ export function WorkspaceScreen() {
 		[invalidateTerminals],
 	);
 
-	const handleSubmit = useCallback((text: string) => {
-		const framed = text.includes("\n")
-			? `\u001b[200~${text}\u001b[201~\r`
-			: `${text}\r`;
-		terminalRef.current?.sendInput(framed);
-	}, []);
+	// Submits go through the host's terminal.send instead of the attached
+	// stream. An Enter written together with the text arrives in the same read,
+	// and a TUI agent takes that burst for a paste — the message lands in the
+	// draft with a newline appended instead of being submitted (#6284). The host
+	// separates and delays the Enter, and frames the text as a bracketed paste
+	// only when the running program actually has that mode on.
+	const handleSubmit = useCallback(
+		async (text: string) => {
+			if (!hostUrl || !activeTerminalId || !id) {
+				throw new Error("Terminal is not connected");
+			}
+			await getHostServiceClientByUrl(hostUrl).terminal.send.mutate({
+				terminalId: activeTerminalId,
+				workspaceId: id,
+				text,
+			});
+		},
+		[hostUrl, activeTerminalId, id],
+	);
 
 	const handleQuickKey = useCallback((key: TerminalQuickKey) => {
 		if (key.data) terminalRef.current?.sendInput(key.data);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import { Alert, View } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
@@ -14,8 +14,8 @@ import {
 
 interface TerminalComposerProps {
 	placeholder?: string;
-	/** Submit the current draft to the PTY. */
-	onSubmit: (text: string) => void;
+	/** Submit the current draft to the PTY. Rejects if it never got there. */
+	onSubmit: (text: string) => Promise<void>;
 	onQuickKey: (key: TerminalQuickKey) => void;
 	/** Where attachments land; null while the workspace or host is unresolved. */
 	attachmentTarget: TerminalAttachmentTarget | null;
@@ -61,25 +61,36 @@ export const TerminalComposer = forwardRef<
 	}));
 	const writeAttachments = useWriteTerminalAttachments();
 
-	const submit = ({ text, attachments }: PromptInputMessage) => {
-		if (attachments.length === 0) {
-			onSubmit(text);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const submit = async ({ text, attachments }: PromptInputMessage) => {
+		let body = text;
+		if (attachments.length > 0) {
+			if (!attachmentTarget) {
+				Alert.alert("Attachments need an online host");
+				return;
+			}
+			// A PTY takes bytes, not files: the agent gets the attachments as
+			// worktree-relative paths appended to the message. The hook alerts on
+			// its own failures.
+			const paths = await writeAttachments
+				.mutateAsync({ target: attachmentTarget, attachments })
+				.catch(() => null);
+			if (!paths) return;
+			body = text ? `${text}\n\n${paths.join("\n")}` : paths.join("\n");
+		}
+		setIsSubmitting(true);
+		try {
+			await onSubmit(body);
 			composerRef.current?.clear();
-			return;
+		} catch (cause) {
+			Alert.alert(
+				"Could not send",
+				cause instanceof Error ? cause.message : String(cause),
+			);
+		} finally {
+			setIsSubmitting(false);
 		}
-		if (!attachmentTarget) {
-			Alert.alert("Attachments need an online host");
-			return;
-		}
-		writeAttachments
-			.mutateAsync({ target: attachmentTarget, attachments })
-			.then((paths) => {
-				// A PTY takes bytes, not files: the agent gets the attachments as
-				// worktree-relative paths appended to the message.
-				onSubmit(text ? `${text}\n\n${paths.join("\n")}` : paths.join("\n"));
-				composerRef.current?.clear();
-			})
-			.catch(() => {});
 	};
 
 	return (
@@ -87,7 +98,7 @@ export const TerminalComposer = forwardRef<
 			<GlassComposer
 				ref={composerRef}
 				above={<QuickKeysRow onKey={onQuickKey} />}
-				isSending={writeAttachments.isPending}
+				isSending={writeAttachments.isPending || isSubmitting}
 				showAttachments={allowAttachments}
 				onActiveChange={onActiveChange}
 				onSubmit={submit}


### PR DESCRIPTION
## Problem

Sending a message to an agent from the mobile terminal composer didn't submit it. The text arrived in Claude's input box fully typed, with a newline appended, and just sat there.

`WorkspaceScreen.handleSubmit` wrote the message and its Enter into the attached stream as a **single write**:

```ts
const framed = text.includes("\n") ? `\x1b[200~${text}\x1b[201~\r` : `${text}\r`;
terminalRef.current?.sendInput(framed);
```

TUI agents treat bytes that arrive together as one paste burst, so the trailing `\r` was absorbed into the draft as a newline rather than read as a keypress. Host-service already fixed this class for follow-up sends in #6284. The `text.includes("\n")` heuristic was wrong in both directions too — it can't know whether the running program actually has bracketed-paste mode on.

## Fix

Submits go through the host's `terminal.send` — the path FinishReviewSheet, the CLI and the SDK already use. The host writes the Enter as its own delayed write, frames the text as a bracketed paste only when the session's mode tracker says the program has that mode on, and serialises concurrent sends. Quick keys still go over the stream as raw bytes; they're control bytes, not submissions.

The composer now clears only once the send resolves, per `GlassComposer`'s `onSubmit` contract — a failed send keeps the draft and alerts instead of eating it.

## Newline button

expo-ui's SwiftUI `TextField` exposes nothing for the soft keyboard's return key, so there was no way to get a line break into a draft at all. Adds a `return` button to the expanded toolbar next to `+`, in the shared `GlassComposer`, so the home composer gets multi-line prompts too.

It appends rather than inserting at the caret, which is deliberate: **the field never reports where its cursor is.** Both `onSelectionChange` and a `selection` `ObservableState` read back `{0,0}` once you've typed (confirmed on device — the first cut put every line break at position 0). Writing the caret does work, so it appends and then places the caret after the insert.

Also labels `+`, the newline button and send for VoiceOver. Send and the terminal's quick-key up arrow were both a bare `arrow.up` symbol — indistinguishable to assistive tech, and to a UI test.

## Also: home project headers

Separate commit, unrelated to the above but shipping in the same build. The headers were `text-[15px] uppercase tracking-wider` — none of which is in the design system, and at 15px identical in size to the workspace row title, so the caps carried the entire parent/child signal. Now the `large` text variant, so hierarchy comes off the type scale.

## Verification

**In the app, on the simulator**, against a real Claude Code session: composed a two-line message using the ↵ button, tapped send → submitted as one prompt, agent answered `4`, composer cleared. Screenshots of the two-line draft and the cleared state were reviewed.

**Against the host directly**, via `superset terminals send` (same `terminal.send` procedure):

| sent | result |
|---|---|
| `What is 7 times 6? Reply with only the number.` | submitted, `⏺ 42`, input box empty |
| two-line message | submitted as one prompt with the break preserved, `⏺ 4` |

`bun run lint` clean; `tsc --noEmit` clean for `apps/mobile` (remaining errors are pre-existing, in port-scanner/pty-daemon/workspace-fs). Host behaviour also has an existing regression test — `terminal.send-snapshot.node-test.ts`, *"submit Enter is a separate write, delayed past the paste burst"*.

## Note

Depends on the host running host-service ≥ 1.22.0 (where #6284 landed, 2026-08-09). Older hosts bundle the Enter server-side and will still swallow it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Terminal messages are now submitted through the active workspace terminal more reliably.
  * Messages remain in the composer until delivery succeeds.
  * Attachment uploads complete before sending, with uploaded files included in the message.
  * Sending status now covers both uploads and message delivery.
  * Expanded composers support inserting new lines and appending text to drafts.
  * Added accessibility labels to composer controls.
* **Bug Fixes**
  * Added clearer alerts for unavailable terminals, upload failures, and submission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->