### PR TITLE
feat(trpc): validate trigger configs and expose trigger CRUD

### DIFF
--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -35,6 +35,7 @@ import {
 	setAutomationPromptSchema,
 	updateAutomationSchema,
 } from "./schema";
+import { automationTriggersRouter } from "./triggers";
 import { automationVersionsRouter } from "./versions";
 
 function escapeLikePattern(value: string): string {
@@ -114,6 +115,7 @@ async function verifyWorkspaceInOrg(
 
 export const automationRouter = {
 	versions: automationVersionsRouter,
+	triggers: automationTriggersRouter,
 
 	/**
 	 * List automations scoped to the caller's active organization. The

--- a/packages/trpc/src/router/automation/triggerSchema.ts
+++ b/packages/trpc/src/router/automation/triggerSchema.ts
@@ -1,0 +1,112 @@
+import { automationTriggerKindValues } from "@superset/db/schema";
+import { z } from "zod";
+
+/**
+ * Three states, deliberately tagged rather than inferred from the JSON shape:
+ * `null` matches nothing, `{mode:"any"}` matches everything, and a list matches
+ * those ids. A bare string array can't express "any" without reserving a magic
+ * value, and every id space here is user-controlled — a GitHub label really can
+ * be named "any" — so the tag is what keeps that legal.
+ */
+const triggerScope = z
+	.union([
+		z.null(),
+		z.object({ mode: z.literal("any") }),
+		z.object({
+			mode: z.literal("list"),
+			ids: z.array(z.string().min(1)).min(1).max(200),
+		}),
+	])
+	.describe("null = nothing, {mode:'any'} = everything, or an explicit list");
+
+const triggerActor = z
+	.union([
+		z.literal("anyone"),
+		z.literal("org_members"),
+		z.object({ ids: z.array(z.string().min(1)).min(1).max(200) }),
+	])
+	.describe("Who may cause this trigger to fire");
+
+/** Non-empty so a trigger can't be saved in a state that matches nothing. */
+const events = z.array(z.string().min(1).max(100)).min(1).max(50);
+
+export const scheduleTriggerConfigSchema = z.object({
+	kind: z.literal("schedule"),
+	rrule: z.string().min(1).max(500),
+	dtstart: z.string().datetime(),
+	timezone: z.string().min(1),
+});
+
+export const webhookTriggerConfigSchema = z.object({
+	kind: z.literal("webhook"),
+});
+
+export const githubTriggerConfigSchema = z.object({
+	kind: z.literal("github"),
+	events,
+	repositories: triggerScope,
+	branches: triggerScope,
+	labels: triggerScope,
+	actor: triggerActor,
+	// Fork payloads carry attacker-controlled content into a checkout the agent
+	// runs in. Typed as a constant so enabling it is a deliberate schema change
+	// with a threat model attached, not a checkbox.
+	includeForks: z.literal(false),
+});
+
+export const slackTriggerConfigSchema = z.object({
+	kind: z.literal("slack"),
+	events,
+	channels: triggerScope,
+	emoji: triggerScope,
+	actor: triggerActor,
+	keyword: z.string().min(1).max(200).optional(),
+});
+
+export const linearTriggerConfigSchema = z.object({
+	kind: z.literal("linear"),
+	events,
+	teams: triggerScope,
+	projects: triggerScope,
+});
+
+export const sentryTriggerConfigSchema = z.object({
+	kind: z.literal("sentry"),
+	events,
+	projects: triggerScope,
+	level: triggerScope,
+});
+
+export const triggerConfigSchema = z.discriminatedUnion("kind", [
+	scheduleTriggerConfigSchema,
+	webhookTriggerConfigSchema,
+	githubTriggerConfigSchema,
+	slackTriggerConfigSchema,
+	linearTriggerConfigSchema,
+	sentryTriggerConfigSchema,
+]);
+
+export const triggerKindSchema = z.enum(automationTriggerKindValues);
+
+export const createTriggerSchema = z
+	.object({
+		automationId: z.string().uuid(),
+		config: triggerConfigSchema,
+		enabled: z.boolean().default(true),
+	})
+	// The column and the config both carry the kind, and a CHECK constraint
+	// rejects any row where they disagree. Deriving it here means a caller can
+	// never be the one to disagree.
+	.transform((input) => ({ ...input, kind: input.config.kind }));
+
+export const updateTriggerSchema = z.object({
+	id: z.string().uuid(),
+	config: triggerConfigSchema.optional(),
+	enabled: z.boolean().optional(),
+});
+
+export const deleteTriggerSchema = z.object({ id: z.string().uuid() });
+
+export const listTriggersSchema = z.object({
+	automationId: z.string().uuid().optional(),
+});

--- a/packages/trpc/src/router/automation/triggers.ts
+++ b/packages/trpc/src/router/automation/triggers.ts
@@ -1,0 +1,172 @@
+import { db, dbWs } from "@superset/db/client";
+import { automationTriggers, type TriggerConfig } from "@superset/db/schema";
+import { nextOccurrenceAfter } from "@superset/shared/rrule";
+import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
+import { and, asc, eq } from "drizzle-orm";
+
+import { protectedProcedure } from "../../trpc";
+import { requireActiveOrgMembership } from "../utils/active-org";
+import { getAutomationForUser } from "./helpers";
+import {
+	createTriggerSchema,
+	deleteTriggerSchema,
+	listTriggersSchema,
+	updateTriggerSchema,
+} from "./triggerSchema";
+
+/**
+ * Schedule triggers carry their next firing time in a column so the dispatcher
+ * can index it; every other kind fires on an event and has none.
+ */
+function nextRunAtFor(config: TriggerConfig): Date | null {
+	if (config.kind !== "schedule") return null;
+	return nextOccurrenceAfter({
+		rrule: config.rrule,
+		dtstart: new Date(config.dtstart),
+		timezone: config.timezone,
+		after: new Date(),
+	});
+}
+
+/** Ownership is checked against the automation — triggers have no owner. */
+async function requireTriggerForUser(
+	userId: string,
+	organizationId: string,
+	triggerId: string,
+) {
+	const [trigger] = await db
+		.select()
+		.from(automationTriggers)
+		.where(
+			and(
+				eq(automationTriggers.id, triggerId),
+				eq(automationTriggers.organizationId, organizationId),
+			),
+		)
+		.limit(1);
+
+	if (!trigger) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Trigger not found" });
+	}
+	await getAutomationForUser(userId, organizationId, trigger.automationId);
+	return trigger;
+}
+
+export const automationTriggersRouter = {
+	list: protectedProcedure
+		.input(listTriggersSchema)
+		.query(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			return db
+				.select()
+				.from(automationTriggers)
+				.where(
+					and(
+						eq(automationTriggers.organizationId, organizationId),
+						input.automationId
+							? eq(automationTriggers.automationId, input.automationId)
+							: undefined,
+					),
+				)
+				.orderBy(asc(automationTriggers.createdAt));
+		}),
+
+	create: protectedProcedure
+		.input(createTriggerSchema)
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			// Ownership, and it proves the automation is in this org — the composite
+			// FK would reject a mismatch anyway, as a 500 rather than a 404.
+			await getAutomationForUser(
+				ctx.session.user.id,
+				organizationId,
+				input.automationId,
+			);
+
+			if (input.kind === "schedule") {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						"An automation's schedule is edited through automation.update",
+				});
+			}
+
+			const [created] = await dbWs
+				.insert(automationTriggers)
+				.values({
+					automationId: input.automationId,
+					organizationId,
+					kind: input.kind,
+					config: input.config,
+					enabled: input.enabled,
+					nextRunAt: nextRunAtFor(input.config),
+				})
+				.returning();
+
+			return created;
+		}),
+
+	update: protectedProcedure
+		.input(updateTriggerSchema)
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			const existing = await requireTriggerForUser(
+				ctx.session.user.id,
+				organizationId,
+				input.id,
+			);
+
+			if (input.config && input.config.kind !== existing.kind) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Cannot change a ${existing.kind} trigger into a ${input.config.kind} trigger`,
+				});
+			}
+			if (existing.kind === "schedule" && input.config) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						"An automation's schedule is edited through automation.update",
+				});
+			}
+
+			const [updated] = await dbWs
+				.update(automationTriggers)
+				.set({
+					config: input.config ?? existing.config,
+					enabled: input.enabled ?? existing.enabled,
+					...(input.config ? { nextRunAt: nextRunAtFor(input.config) } : {}),
+				})
+				.where(eq(automationTriggers.id, input.id))
+				.returning();
+
+			return updated;
+		}),
+
+	delete: protectedProcedure
+		.input(deleteTriggerSchema)
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			const existing = await requireTriggerForUser(
+				ctx.session.user.id,
+				organizationId,
+				input.id,
+			);
+
+			// Deleting it would leave the automation with nothing to fire it, and
+			// the dispatcher inner-joins the schedule trigger, so the automation
+			// would silently vanish from every listing.
+			if (existing.kind === "schedule") {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						"An automation's schedule trigger cannot be removed; disable the automation instead",
+				});
+			}
+
+			await dbWs
+				.delete(automationTriggers)
+				.where(eq(automationTriggers.id, input.id));
+			return { success: true };
+		}),
+} satisfies TRPCRouterRecord;


### PR DESCRIPTION
The trigger tables have existed since the cutover with nothing able to write a non-schedule row. This is the unblocker: config validation plus `automation.triggers.{list,create,update,delete}`.

No migration.

## Validation

One zod schema per trigger kind, combined as a discriminated union on `kind`, mirroring the TS types in `packages/db/src/schema/types.ts`.

**`create` derives the `kind` column from `config.kind`** rather than accepting it. The database has a `CHECK (config->>'kind' = kind::text)`, and deriving means a caller can never be the one to violate it — the two can't disagree because only one is an input.

**Scope stays the tagged three-state union** (`null` / `{mode:"any"}` / `{mode:"list", ids}`). Verified the reason it exists: a GitHub label literally named `"any"` parses correctly inside a list, which a bare `string[] | "any"` encoding could not express without reserving a magic value in a namespace users control.

**`includeForks` is typed as the literal `false`.** Fork payloads carry attacker-controlled content into a checkout an agent then runs in, so enabling it should be a deliberate schema change with a threat model attached, not a boolean someone can pass.

## Schedule triggers are read-only through this router

- `create` rejects `kind: "schedule"` — an automation's schedule is edited via `automation.update`, which keeps the trigger in sync.
- `update` rejects a config change on a schedule trigger, and rejects changing any trigger's kind.
- `delete` rejects schedule triggers outright: the dispatcher **inner-joins** the schedule trigger, so removing one wouldn't just stop the automation firing, it would make it disappear from every listing.

That last one is the failure mode worth calling out — it's silent, and it looks like data loss from the UI.

## Verified

17 validation cases run against the real schemas:

| | |
|---|---|
| github minimal / webhook / linear / schedule configs | pass |
| scope `null`, `{mode:"any"}`, `{mode:"list"}` | pass |
| **a label literally named `"any"` inside a list** | pass |
| bare `string[]` scope (the shape we rejected) | rejected |
| empty scope list, empty events | rejected |
| `includeForks: true` | rejected |
| actor `anyone` / `org_members` / id list | pass |
| bogus actor, unknown kind, bad `dtstart` | rejected |
| `create` derives kind from config, `enabled` defaults true | pass |

Ownership resolves through the automation via `getAutomationForUser`, since triggers have no owner of their own; org scoping is checked on the trigger row too, so a cross-org id 404s rather than reaching the composite FK and surfacing as a 500.

Typecheck, lint and the full suite pass.

## Next

Webhook ingestion — the acceptance/processing split, adapter registry, and key generation — is what makes these fire. Then the GitHub connector.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trigger config validation and exposes `automation.triggers.{list,create,update,delete}` so non‑schedule triggers can be managed. Previously, only schedule rows existed and no endpoint could create or modify other kinds.

- Validate trigger configs with per‑kind zod schemas (discriminated by `kind`). `create` derives `kind` from `config.kind`; compute `nextRunAt` only for schedule configs.
- Keep schedule triggers read‑only in this router: reject `create` with `kind: "schedule"`, reject config updates on schedules, and reject deleting schedules.
- Prevent kind changes on `update`. `list` optionally filters by `automationId` and orders by creation time.
- Enforce safe shapes: tagged three‑state `scope` (`null` / `{mode:"any"}` / `{mode:"list"}`), strict `actor` union, and `includeForks` fixed to `false`.

**Review notes**
- No migration; the `config.kind = kind` CHECK already exists.
- Access control: require active org membership; resolve ownership via the automation; cross‑org ids return NOT_FOUND.

<sup>Written for commit 083f74724100803fdcaefc6487390f565737eee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added automation trigger management with support for listing, creating, updating, and deleting triggers.
- Added trigger configurations for schedules, webhooks, GitHub, Slack, Linear, and Sentry.
- Added validation for trigger-specific settings, filters, actor restrictions, event limits, and disabled forks.
- Schedule triggers now calculate their next run time automatically.
- Added access controls to ensure only authorized automation owners can manage triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->