### PR TITLE
fix(host-service): discard untracked and staged directories recursively

### DIFF
--- a/packages/host-service/src/trpc/router/git/discard-changes.test.ts
+++ b/packages/host-service/src/trpc/router/git/discard-changes.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TRPCError } from "@trpc/server";
+import simpleGit, { type SimpleGit } from "simple-git";
+import type { HostServiceContext } from "../../../types";
+import { gitRouter } from "./git";
+
+/**
+ * Real repos on a real filesystem — only the db lookup and the git factory are
+ * stubbed, because `discardChanges` is otherwise pure git + fs.
+ */
+function createCaller(worktreePath: string | undefined) {
+	const ctx = {
+		isAuthenticated: true,
+		db: {
+			query: {
+				workspaces: {
+					findFirst: () => ({ sync: () => ({ worktreePath }) }),
+				},
+			},
+		},
+		git: async (path: string) => simpleGit(path),
+	} as unknown as HostServiceContext;
+	return gitRouter.createCaller(ctx);
+}
+
+async function initRepo(path: string): Promise<SimpleGit> {
+	const git = simpleGit(path);
+	await git.init();
+	await git.raw(["config", "user.email", "test@example.com"]);
+	await git.raw(["config", "user.name", "test"]);
+	await git.raw(["config", "commit.gpgsign", "false"]);
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+	return git;
+}
+
+describe("gitRouter.discardChanges", () => {
+	let root: string;
+	let repo: string;
+	let git: SimpleGit;
+
+	beforeEach(async () => {
+		root = mkdtempSync(join(tmpdir(), "superset-discard-"));
+		repo = join(root, "worktree");
+		await mkdir(repo);
+		git = await initRepo(repo);
+		await writeFile(join(repo, "tracked.txt"), "committed\n");
+		await git.raw(["add", "--", "tracked.txt"]);
+		await git.raw(["commit", "-m", "init"]);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	test("discards an untracked directory", async () => {
+		// An embedded git repository is the case that reaches `discardChanges`
+		// as a directory: git reports it as a single `dir/` entry even under
+		// `-uall`, because it will not descend into another repository.
+		const embedded = join(repo, "embedded");
+		await mkdir(embedded);
+		await initRepo(embedded);
+		await writeFile(join(embedded, "notes.txt"), "scratch\n");
+
+		expect((await git.status()).not_added).toContain("embedded/");
+
+		const result = await createCaller(repo).discardChanges({
+			workspaceId: "ws-1",
+			filePath: "embedded/",
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(existsSync(embedded)).toBe(false);
+		expect((await git.status()).not_added).toEqual([]);
+	});
+
+	test("discards an untracked file", async () => {
+		await writeFile(join(repo, "scratch.txt"), "temporary\n");
+
+		const result = await createCaller(repo).discardChanges({
+			workspaceId: "ws-1",
+			filePath: "scratch.txt",
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(existsSync(join(repo, "scratch.txt"))).toBe(false);
+	});
+
+	test("restores a tracked file from HEAD instead of deleting it", async () => {
+		await writeFile(join(repo, "tracked.txt"), "local edit\n");
+
+		await createCaller(repo).discardChanges({
+			workspaceId: "ws-1",
+			filePath: "tracked.txt",
+		});
+
+		expect(await readFile(join(repo, "tracked.txt"), "utf8")).toBe(
+			"committed\n",
+		);
+	});
+
+	describe("containment", () => {
+		let outsideFile: string;
+
+		beforeEach(async () => {
+			const outside = join(root, "outside");
+			await mkdir(outside);
+			outsideFile = join(outside, "precious.txt");
+			await writeFile(outsideFile, "not ours to delete\n");
+		});
+
+		for (const filePath of [
+			"../outside",
+			"../outside/precious.txt",
+			"embedded/../../outside",
+			"./../../outside",
+		]) {
+			test(`rejects ${filePath} before deleting anything`, async () => {
+				await expect(
+					createCaller(repo).discardChanges({
+						workspaceId: "ws-1",
+						filePath,
+					}),
+				).rejects.toMatchObject({ code: "BAD_REQUEST" });
+				expect(existsSync(outsideFile)).toBe(true);
+			});
+		}
+
+		test("rejects an absolute path before deleting anything", async () => {
+			await expect(
+				createCaller(repo).discardChanges({
+					workspaceId: "ws-1",
+					filePath: join(root, "outside"),
+				}),
+			).rejects.toMatchObject({ code: "BAD_REQUEST" });
+			expect(existsSync(outsideFile)).toBe(true);
+		});
+
+		test("rejects the worktree root", async () => {
+			await expect(
+				createCaller(repo).discardChanges({
+					workspaceId: "ws-1",
+					filePath: ".",
+				}),
+			).rejects.toBeInstanceOf(TRPCError);
+			expect(existsSync(join(repo, "tracked.txt"))).toBe(true);
+		});
+
+		test("unlinks an untracked symlink without following it", async () => {
+			await symlink(join(root, "outside"), join(repo, "link"));
+
+			await createCaller(repo).discardChanges({
+				workspaceId: "ws-1",
+				filePath: "link",
+			});
+
+			expect(existsSync(join(repo, "link"))).toBe(false);
+			expect(existsSync(outsideFile)).toBe(true);
+		});
+	});
+});
+
+describe("gitRouter.discardAllStaged", () => {
+	let root: string;
+	let repo: string;
+	let git: SimpleGit;
+
+	beforeEach(async () => {
+		root = mkdtempSync(join(tmpdir(), "superset-discard-staged-"));
+		repo = join(root, "worktree");
+		await mkdir(repo);
+		git = await initRepo(repo);
+		await writeFile(join(repo, "tracked.txt"), "committed\n");
+		await git.raw(["add", "--", "tracked.txt"]);
+		await git.raw(["commit", "-m", "init"]);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	test("discards a staged directory entry", async () => {
+		// A staged gitlink (embedded repo added to the index) is the staged-as-
+		// added path that is a directory on disk.
+		const embedded = join(repo, "embedded");
+		await mkdir(embedded);
+		const embeddedGit = await initRepo(embedded);
+		await writeFile(join(embedded, "notes.txt"), "scratch\n");
+		await embeddedGit.raw(["add", "--", "notes.txt"]);
+		await embeddedGit.raw(["commit", "-m", "embedded"]);
+		await git.raw(["add", "--", "embedded"]);
+
+		const result = await createCaller(repo).discardAllStaged({
+			workspaceId: "ws-1",
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(existsSync(embedded)).toBe(false);
+	});
+
+	test("discards a staged file", async () => {
+		await writeFile(join(repo, "added.txt"), "new\n");
+		await git.raw(["add", "--", "added.txt"]);
+
+		await createCaller(repo).discardAllStaged({ workspaceId: "ws-1" });
+
+		expect(existsSync(join(repo, "added.txt"))).toBe(false);
+		expect((await git.status()).staged).toEqual([]);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -109,6 +109,18 @@ function assertSafeRelativePath(filePath: string): void {
 	}
 }
 
+/** Delete for a discard. Recursive because an untracked or staged-as-added
+ * path can be a directory (an embedded git repository is reported as one
+ * entry, never expanded into files), and confined to the worktree because
+ * assertSafeRelativePath runs on the caller-relative path first. */
+async function removeFromWorktree(
+	worktreePath: string,
+	relativePath: string,
+): Promise<void> {
+	assertSafeRelativePath(relativePath);
+	await rm(join(worktreePath, relativePath), { recursive: true, force: true });
+}
+
 /** Upper bound for one getDiffStatsByWorkspaces call — a page's host rarely
  * has more than a few dozen workspaces; anything larger is a runaway caller. */
 export const MAX_DIFF_STATS_BATCH = 500;
@@ -463,7 +475,7 @@ export const gitRouter = router({
 			const status = await git.status();
 			const isUntracked = status.not_added.includes(input.filePath);
 			if (isUntracked) {
-				await rm(join(worktreePath, input.filePath), { force: true });
+				await removeFromWorktree(worktreePath, input.filePath);
 			} else {
 				await git.raw(["checkout", "HEAD", "--", input.filePath]);
 			}
@@ -527,7 +539,7 @@ export const gitRouter = router({
 				await git.raw(["checkout", "HEAD", "--", ...checkoutHeadPaths]);
 			}
 			for (const filePath of deletePaths) {
-				await rm(join(worktreePath, filePath), { force: true });
+				await removeFromWorktree(worktreePath, filePath);
 			}
 			return { success: true };
 		}),


### PR DESCRIPTION
## Problem

Discarding an untracked path from the changes panel fails with an internal error when that path is a directory. The user clicks discard, nothing is discarded, and they get a 500 — no partial state, just a failure. Deterministic: every untracked directory fails this way, every time.

```
SystemError: Path is a directory: rm returned EISDIR (is a directory) <path>/
POST /trpc/git.discardChanges  →  INTERNAL_SERVER_ERROR
```

**Who is worse off:** anyone who has a directory listed as an untracked change and tries to discard it. In practice that means an embedded git repository — a repo cloned or `git init`'d inside the workspace worktree. Rare, but 100% reproducible for the people who hit it, and the only recovery is to delete the directory by hand in a terminal.

**Will this change reach the reported failure:** yes. The events are host-service 1.21.0; the defect is present unchanged on main (1.22.0) at both call sites, and the fix ships to every user in the next desktop release, since host-service is bundled with the desktop app.

**Why code rather than archiving or filtering:** the error is not noise — the user's action silently does nothing. An inbound Sentry filter or an archive would hide a broken button. The code path can't be deleted (discard-untracked is the feature), and no other layer can help: the renderer is sending exactly the path git reported. The fix is one option flag.

## Root cause

`git status` reports an embedded git repository as a single collapsed entry `dir/` — even under `-uall`, because git will not descend into another repository. Verified:

```
$ git status --porcelain -uall
?? nestedrepo/
?? plaindir/sub/f.txt        # a plain untracked directory IS expanded to files
```

`getGitStatusSnapshot` tries to expand collapsed entries via `ls-files --others`, which for an embedded repo returns the directory itself, so `dir/` survives to the panel. The client sends it back to `discardChanges`, `status.not_added.includes("dir/")` matches, and the delete runs — without `recursive`, so the OS refuses to unlink a directory.

Two call sites had the same defect, and both were reachable:

- `discardChanges` — untracked embedded repo (the reported events).
- `discardAllStaged` — a staged gitlink (`git add` on an embedded repo) is a staged-as-added path that is a directory on disk.

## Fix

Both deletes go through one helper that is recursive and asserts containment first:

```ts
async function removeFromWorktree(worktreePath: string, relativePath: string) {
	assertSafeRelativePath(relativePath);
	await rm(join(worktreePath, relativePath), { recursive: true, force: true });
}
```

Nothing else changes: same return shape, same messages, no classifier, no new capture, tracked files still go through `git checkout HEAD --`.

### What stops this deleting something outside the worktree

The delete is now a directory-tree delete, so containment matters. Three independent things hold it, and the first is the one being relied on:

1. **`assertSafeRelativePath`, already in this file, now invoked by the delete itself.** It rejects absolute paths (`isAbsolute`), rejects any path whose *normalized* form contains a `..` segment — so `a/../../x` is caught after normalization collapses it, not just a literal leading `../` — and rejects `""` and `.` so the worktree root can never be the target. `discardChanges` already called it at the top of the procedure; moving the call into the delete means `discardAllStaged`, which had no check at all, gets it too, and containment is now a property of the delete rather than of the distance between two lines.
2. **Symlinks cannot be used to escape.** `fs.rm` with `recursive` lstats the target: a symlink is unlinked, never followed, so a symlinked directory's contents are untouched. This is asserted by a test rather than assumed.
3. **The path must be one git reported.** `discardChanges` only deletes when the path is in `status.not_added`; `discardAllStaged` takes no caller path at all, only index entries from `git status`. Git paths are worktree-relative and cannot contain `..`, so an escaping path can never reach either delete even if (1) were removed.

It can't be bypassed by the caller because the assert is the first statement of the helper, before `join` and before `rm` — the negative tests below assert both the `BAD_REQUEST` rejection and that the file outside the worktree still exists afterwards.

### One consequence worth flagging to the reviewer

For an embedded git repository, discard now deletes the whole directory, including that repo's own history and any uncommitted work inside it. That is what "discard this untracked path" means and it is what the user asked for, but it is more destructive than `git clean -fd`, which skips embedded repos unless given `-ff`. Guarding against it would leave the reported bug unfixed, since embedded repos are precisely the reported case.

## Verification

All commands run in `packages/host-service`. Temp-directory prefixes elided as `$TMPDIR`.

**Before the change** — the new tests fail at both call sites (Bun surfaces the same non-recursive `rm` refusal as `EFAULT` where Node reports `EISDIR`; both are the OS refusing to unlink a directory):

```
$ bun test src/trpc/router/git/discard-changes.test.ts
461 | 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
462 | 			const git = await ctx.git(worktreePath);
463 | 			const status = await git.status();
464 | 			const isUntracked = status.not_added.includes(input.filePath);
465 | 			if (isUntracked) {
466 | 				await rm(join(worktreePath, input.filePath), { force: true });
                ^
EFAULT: bad address in system call argument, rm '$TMPDIR/superset-discard-BI7sMV/worktree/embedded/'
(fail) gitRouter.discardChanges > discards an untracked directory [717.77ms]

EFAULT: bad address in system call argument, rm '$TMPDIR/superset-discard-staged-hZJ8ou/worktree/embedded'
(fail) gitRouter.discardAllStaged > discards a staged directory entry [862.55ms]

 10 pass
 2 fail
```

The 10 that passed before include every containment negative and the untracked-file case, so those are genuine regression guards rather than tests written to match the new behaviour — containment already held, and this locks it in now that the delete recurses.

**After the change:**

```
$ bun test src/trpc/router/git/discard-changes.test.ts
 12 pass
 0 fail
 25 expect() calls
Ran 12 tests across 1 file. [5.91s]
```

**Whole git router suite:**

```
$ bun test src/trpc/router/git
 102 pass
 0 fail
 221 expect() calls
Ran 102 tests across 9 files. [30.28s]
```

**Typecheck:**

```
$ bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false
(no output)
```

**Lint** (`--write` reformatted one test block, re-check clean):

```
$ bunx biome check --write src/trpc/router/git/git.ts src/trpc/router/git/discard-changes.test.ts
Checked 2 files in 26ms. Fixed 1 file.
$ bunx biome check src/trpc/router/git/git.ts src/trpc/router/git/discard-changes.test.ts
Checked 2 files in 14ms. No fixes applied.
```

Tests cover: untracked directory discarded; untracked file unchanged; tracked file still restored from HEAD rather than deleted; `../outside`, `../outside/precious.txt`, `embedded/../../outside`, `./../../outside` and an absolute path all rejected `BAD_REQUEST` with the outside file intact; worktree root rejected; symlink unlinked without following; staged gitlink and staged file both discarded.

Refs HOST-SERVICE-30
Refs HOST-SERVICE-2Z

https://claude.ai/code/session_30669470-7931-4382-9d81-178918448aaa


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discarding untracked or staged directory paths now succeeds by removing them recursively within the worktree. Previously, discarding such entries (e.g., an embedded repo reported as `dir/`) attempted a non-recursive delete, returned 500 (EISDIR), and removed nothing; now it deletes the directory tree with containment checks.

**Reviewer notes**
- Both `discardChanges` and `discardAllStaged` use a new `removeFromWorktree` helper that calls `assertSafeRelativePath` and runs `fs.rm` with `{ recursive: true, force: true }`.
- Tracked files are unchanged: restored via `git checkout HEAD --`; return shapes and messages are unchanged.
- Safety: rejects absolute/traversal paths and the worktree root; does not follow symlinks; `discardAllStaged` gains the same containment check.
- Tests added cover untracked directory, staged gitlink, symlink unlinking (no follow), and containment negatives.
- Impact: Discarding an embedded repo now deletes that repo’s directory and history; this meets the intent of discarding the untracked path and satisfies HOST-SERVICE-30 and HOST-SERVICE-2Z.

<sup>Written for commit 1facbe562f22f133b023e1d6cf46f15bd200edc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discarding changes so untracked files and directories, including embedded repositories, are removed correctly.
  * Restored tracked files and removed staged files or directories more reliably.
  * Added safeguards to prevent unsafe paths from affecting files outside the worktree.
  * Symlinks are safely removed without following them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->