### PR TITLE
feat(shared,trpc): save triggers as a set with the automation

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
 	"private": true,
 	"type": "module",
 	"exports": {
+		"./automation-triggers": {
+			"types": "./src/automation-triggers.ts",
+			"default": "./src/automation-triggers.ts"
+		},
 		"./constants": {
 			"types": "./src/constants.ts",
 			"default": "./src/constants.ts"

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -33,7 +33,9 @@ export type TriggerScope = z.infer<typeof triggerScopeSchema>;
 
 export const triggerActorSchema = z.union([
 	z.literal("anyone"),
-	z.literal("org_members"),
+	// Resolves to the automation's owner at match time rather than being
+	// expanded to an id on save, so it survives the owner being renamed.
+	z.literal("me"),
 	z.object({ ids: z.array(z.string().min(1)).max(200) }),
 ]);
 export type TriggerActor = z.infer<typeof triggerActorSchema>;
@@ -50,24 +52,40 @@ export function isEmptyActor(actor: TriggerActor): boolean {
 const rrule = z.string().min(1).max(500);
 const iana = z.string().min(1);
 
+/** A free-text match over a comment body, optionally as a regex. */
+export const textFilterSchema = z.object({
+	pattern: z.string().max(500),
+	isRegex: z.boolean().default(false),
+});
+export type TextFilter = z.infer<typeof textFilterSchema>;
+
 /**
  * GitHub events carry different filters, so the config is a union on the event
- * rather than one flat shape: a comment has both a comment author and a PR
- * author, and a push has neither.
+ * rather than one flat shape: a comment filters on two independent people and a
+ * body pattern, while a push filters on neither.
  */
 export const githubTriggerEventValues = [
+	"draft_opened",
 	"pull_request.opened",
-	"pull_request.draft_opened",
-	"pull_request.ready_for_review",
-	"pull_request.closed",
+	"pull_request.pushed",
 	"pull_request.merged",
-	"pull_request.labeled",
-	"pull_request.review_submitted",
-	"pull_request.comment_created",
-	"issue.opened",
-	"issue.comment_created",
-	"push",
-	"check_suite.failed",
+	"comment_added",
+	"push_to_branch",
+	"label_change",
+	"checks_completed",
+	"issue_comment",
+	"pr_review_comment",
+	"pr_review_submitted.approved",
+	"pr_review_submitted.changes_requested",
+	"pr_review_submitted.commented",
+	"pr_review_submitted.any",
+	"review_thread.resolved",
+	"review_thread.unresolved",
+	"review_thread.any",
+	"workflow_run.success",
+	"workflow_run.failure",
+	"workflow_run.cancelled",
+	"workflow_run.any",
 ] as const;
 export type GithubTriggerEvent = (typeof githubTriggerEventValues)[number];
 
@@ -82,36 +100,47 @@ const githubCommon = {
 	includeForks: z.literal(false).default(false),
 };
 
-const githubPullRequestEvent = z.object({
+/** Events describing one action by one person. */
+const githubSimpleEvent = z.object({
 	...githubCommon,
 	event: z.enum([
+		"draft_opened",
 		"pull_request.opened",
-		"pull_request.draft_opened",
-		"pull_request.ready_for_review",
-		"pull_request.closed",
+		"pull_request.pushed",
 		"pull_request.merged",
-		"pull_request.labeled",
-		"push",
-		"check_suite.failed",
-		"issue.opened",
+		"push_to_branch",
+		"label_change",
+		"checks_completed",
+		"pr_review_comment",
+		"pr_review_submitted.approved",
+		"pr_review_submitted.changes_requested",
+		"pr_review_submitted.commented",
+		"pr_review_submitted.any",
+		"review_thread.resolved",
+		"review_thread.unresolved",
+		"review_thread.any",
+		"workflow_run.success",
+		"workflow_run.failure",
+		"workflow_run.cancelled",
+		"workflow_run.any",
 	]),
 	actor: triggerActorSchema,
 });
 
-/** Comments and reviews filter on two independent people. */
+/**
+ * Comments filter on two independent people — who wrote the comment, and who
+ * opened the thing it is on — plus an optional pattern over the body.
+ */
 const githubCommentEvent = z.object({
 	...githubCommon,
-	event: z.enum([
-		"pull_request.comment_created",
-		"pull_request.review_submitted",
-		"issue.comment_created",
-	]),
+	event: z.enum(["comment_added", "issue_comment"]),
 	actor: triggerActorSchema,
 	subjectAuthor: triggerActorSchema,
+	commentFilter: textFilterSchema.nullable().default(null),
 });
 
 export const githubTriggerConfigSchema = z.union([
-	githubPullRequestEvent,
+	githubSimpleEvent,
 	githubCommentEvent,
 ]);
 
@@ -126,25 +155,47 @@ export const webhookTriggerConfigSchema = z.object({
 	kind: z.literal("webhook"),
 });
 
+export const slackTriggerEventValues = [
+	"message_in_channel",
+	"reaction_added",
+	"channel_created",
+] as const;
+
 export const slackTriggerConfigSchema = z.object({
 	kind: z.literal("slack"),
-	events: z.array(z.string().min(1)).max(50),
+	event: z.enum(slackTriggerEventValues),
 	channels: triggerScopeSchema,
+	// Only meaningful for reaction_added; null elsewhere.
 	emoji: triggerScopeSchema,
 	actor: triggerActorSchema,
-	keyword: z.string().min(1).max(200).optional(),
+	messageFilter: textFilterSchema.nullable().default(null),
 });
+
+export const linearTriggerEventValues = [
+	"issue.created",
+	"issue.status_changed",
+	"cycle.ended",
+] as const;
 
 export const linearTriggerConfigSchema = z.object({
 	kind: z.literal("linear"),
-	events: z.array(z.string().min(1)).max(50),
+	event: z.enum(linearTriggerEventValues),
 	teams: triggerScopeSchema,
 	projects: triggerScopeSchema,
 });
 
+export const sentryTriggerEventValues = [
+	"issue.created",
+	"issue.resolved",
+	"issue.assigned",
+	"issue.archived",
+	"issue.unresolved",
+	"issue.any",
+] as const;
+
 export const sentryTriggerConfigSchema = z.object({
 	kind: z.literal("sentry"),
-	events: z.array(z.string().min(1)).max(50),
+	event: z.enum(sentryTriggerEventValues),
 	projects: triggerScopeSchema,
 	level: triggerScopeSchema,
 });
@@ -223,26 +274,17 @@ export function describeTriggerProblems(
 				break;
 			}
 			case "slack": {
-				if (config.events.length === 0) {
-					add(index, "events", "Choose at least one Slack event.");
-				}
 				if (isEmptyScope(config.channels)) {
 					add(index, "channels", "Specify at least one channel.");
 				}
-				break;
-			}
-			case "linear": {
-				if (config.events.length === 0) {
-					add(index, "events", "Choose at least one Linear event.");
+				if (config.event === "reaction_added" && isEmptyScope(config.emoji)) {
+					add(index, "emoji", "Specify at least one reaction.");
 				}
 				break;
 			}
-			case "sentry": {
-				if (config.events.length === 0) {
-					add(index, "events", "Choose at least one Sentry event.");
-				}
+			case "linear":
+			case "sentry":
 				break;
-			}
 			case "schedule":
 			case "webhook":
 				break;

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -1,0 +1,263 @@
+import { z } from "zod";
+
+/**
+ * Trigger validation, shared by the editor and the API so a form can block Save
+ * on exactly what the server would reject.
+ *
+ * Two levels, and the distinction is the point:
+ *
+ * - `draftTriggerSchema` accepts a half-configured trigger. The editor has to be
+ *   able to hold "Draft opened in [Select Repos]" with nothing selected yet.
+ * - `triggerSchema` is what may be saved. Everything the draft form left empty
+ *   is required here.
+ *
+ * `describeTriggerProblems` returns the same messages the form shows, so the
+ * client isn't reimplementing rules the server enforces.
+ */
+
+/**
+ * Three states, tagged rather than inferred from shape: `null` matches nothing,
+ * `{mode:"any"}` matches everything, a list matches those ids. Every id space
+ * here is user-controlled — a GitHub label really can be named "any" — so a bare
+ * `string[] | "any"` would collide with legal values.
+ */
+export const triggerScopeSchema = z.union([
+	z.null(),
+	z.object({ mode: z.literal("any") }),
+	z.object({
+		mode: z.literal("list"),
+		ids: z.array(z.string().min(1)).max(200),
+	}),
+]);
+export type TriggerScope = z.infer<typeof triggerScopeSchema>;
+
+export const triggerActorSchema = z.union([
+	z.literal("anyone"),
+	z.literal("org_members"),
+	z.object({ ids: z.array(z.string().min(1)).max(200) }),
+]);
+export type TriggerActor = z.infer<typeof triggerActorSchema>;
+
+/** A scope that is set but selects nothing — the "Select Repos" empty state. */
+export function isEmptyScope(scope: TriggerScope): boolean {
+	return scope === null || (scope.mode === "list" && scope.ids.length === 0);
+}
+
+export function isEmptyActor(actor: TriggerActor): boolean {
+	return typeof actor !== "string" && actor.ids.length === 0;
+}
+
+const rrule = z.string().min(1).max(500);
+const iana = z.string().min(1);
+
+/**
+ * GitHub events carry different filters, so the config is a union on the event
+ * rather than one flat shape: a comment has both a comment author and a PR
+ * author, and a push has neither.
+ */
+export const githubTriggerEventValues = [
+	"pull_request.opened",
+	"pull_request.draft_opened",
+	"pull_request.ready_for_review",
+	"pull_request.closed",
+	"pull_request.merged",
+	"pull_request.labeled",
+	"pull_request.review_submitted",
+	"pull_request.comment_created",
+	"issue.opened",
+	"issue.comment_created",
+	"push",
+	"check_suite.failed",
+] as const;
+export type GithubTriggerEvent = (typeof githubTriggerEventValues)[number];
+
+const githubCommon = {
+	kind: z.literal("github"),
+	repositories: triggerScopeSchema,
+	branches: triggerScopeSchema,
+	labels: triggerScopeSchema,
+	// Fork payloads carry attacker-controlled content into a checkout the agent
+	// runs in. A literal rather than a boolean, so enabling it is a schema change
+	// with a threat model attached rather than a checkbox someone can tick.
+	includeForks: z.literal(false).default(false),
+};
+
+const githubPullRequestEvent = z.object({
+	...githubCommon,
+	event: z.enum([
+		"pull_request.opened",
+		"pull_request.draft_opened",
+		"pull_request.ready_for_review",
+		"pull_request.closed",
+		"pull_request.merged",
+		"pull_request.labeled",
+		"push",
+		"check_suite.failed",
+		"issue.opened",
+	]),
+	actor: triggerActorSchema,
+});
+
+/** Comments and reviews filter on two independent people. */
+const githubCommentEvent = z.object({
+	...githubCommon,
+	event: z.enum([
+		"pull_request.comment_created",
+		"pull_request.review_submitted",
+		"issue.comment_created",
+	]),
+	actor: triggerActorSchema,
+	subjectAuthor: triggerActorSchema,
+});
+
+export const githubTriggerConfigSchema = z.union([
+	githubPullRequestEvent,
+	githubCommentEvent,
+]);
+
+export const scheduleTriggerConfigSchema = z.object({
+	kind: z.literal("schedule"),
+	rrule,
+	dtstart: z.string().datetime(),
+	timezone: iana,
+});
+
+export const webhookTriggerConfigSchema = z.object({
+	kind: z.literal("webhook"),
+});
+
+export const slackTriggerConfigSchema = z.object({
+	kind: z.literal("slack"),
+	events: z.array(z.string().min(1)).max(50),
+	channels: triggerScopeSchema,
+	emoji: triggerScopeSchema,
+	actor: triggerActorSchema,
+	keyword: z.string().min(1).max(200).optional(),
+});
+
+export const linearTriggerConfigSchema = z.object({
+	kind: z.literal("linear"),
+	events: z.array(z.string().min(1)).max(50),
+	teams: triggerScopeSchema,
+	projects: triggerScopeSchema,
+});
+
+export const sentryTriggerConfigSchema = z.object({
+	kind: z.literal("sentry"),
+	events: z.array(z.string().min(1)).max(50),
+	projects: triggerScopeSchema,
+	level: triggerScopeSchema,
+});
+
+/**
+ * Structurally valid — the shape is right, but a scope may still select nothing.
+ * This is what the editor holds while someone is still filling a trigger in.
+ */
+export const draftTriggerSchema = z.object({
+	// Absent on a row that has not been saved yet. Present rows keep their id so
+	// a save updates in place rather than deleting and recreating, which would
+	// otherwise roll a webhook trigger's key and lose a schedule's next run.
+	id: z.string().uuid().optional(),
+	enabled: z.boolean().default(true),
+	config: z.union([
+		scheduleTriggerConfigSchema,
+		webhookTriggerConfigSchema,
+		githubTriggerConfigSchema,
+		slackTriggerConfigSchema,
+		linearTriggerConfigSchema,
+		sentryTriggerConfigSchema,
+	]),
+});
+export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
+export type TriggerConfigInput = DraftTrigger["config"];
+
+/** One problem, addressed to a specific trigger so the form can mark that row. */
+export type TriggerProblem = {
+	index: number;
+	field: string;
+	message: string;
+};
+
+/**
+ * The rules a draft must satisfy before it can be saved. Kept as explicit checks
+ * rather than schema refinements so each one carries a message the form can put
+ * next to the field it belongs to.
+ */
+export function describeTriggerProblems(
+	triggers: DraftTrigger[],
+): TriggerProblem[] {
+	const problems: TriggerProblem[] = [];
+	const add = (index: number, field: string, message: string) =>
+		problems.push({ index, field, message });
+
+	if (triggers.length === 0) {
+		add(-1, "triggers", "Add at least one trigger.");
+	}
+
+	// A partial unique index enforces this in the database; catching it here
+	// turns a save-time constraint violation into a message next to the row.
+	const scheduleIndexes = triggers.flatMap((t, i) =>
+		t.config.kind === "schedule" ? [i] : [],
+	);
+	for (const index of scheduleIndexes.slice(1)) {
+		add(index, "config", "An automation can only have one schedule.");
+	}
+
+	triggers.forEach((trigger, index) => {
+		const config = trigger.config;
+		switch (config.kind) {
+			case "github": {
+				if (isEmptyScope(config.repositories)) {
+					add(index, "repositories", "Specify at least one repository.");
+				}
+				if (isEmptyActor(config.actor)) {
+					add(index, "actor", "Specify at least one person, or choose Anyone.");
+				}
+				if ("subjectAuthor" in config && isEmptyActor(config.subjectAuthor)) {
+					add(
+						index,
+						"subjectAuthor",
+						"Specify at least one person, or choose Anyone.",
+					);
+				}
+				break;
+			}
+			case "slack": {
+				if (config.events.length === 0) {
+					add(index, "events", "Choose at least one Slack event.");
+				}
+				if (isEmptyScope(config.channels)) {
+					add(index, "channels", "Specify at least one channel.");
+				}
+				break;
+			}
+			case "linear": {
+				if (config.events.length === 0) {
+					add(index, "events", "Choose at least one Linear event.");
+				}
+				break;
+			}
+			case "sentry": {
+				if (config.events.length === 0) {
+					add(index, "events", "Choose at least one Sentry event.");
+				}
+				break;
+			}
+			case "schedule":
+			case "webhook":
+				break;
+		}
+	});
+
+	return problems;
+}
+
+/** The banner shown above the trigger list, or null when there is nothing wrong. */
+export function summarizeTriggerProblems(
+	problems: TriggerProblem[],
+): string | null {
+	if (problems.length === 0) return null;
+	const missingTriggers = problems.find((p) => p.field === "triggers");
+	if (missingTriggers) return missingTriggers.message;
+	return "Some triggers need additional configuration";
+}

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -35,6 +35,7 @@ import {
 	setAutomationPromptSchema,
 	updateAutomationSchema,
 } from "./schema";
+import { saveTriggerSet } from "./triggerSet";
 import { automationVersionsRouter } from "./versions";
 
 function escapeLikePattern(value: string): string {
@@ -272,15 +273,24 @@ export const automationRouter = {
 					});
 				}
 
-				await syncScheduleTrigger(tx, {
-					automationId: row.id,
-					organizationId,
-					rrule: input.rrule,
-					dtstart,
-					timezone: input.timezone,
-					nextRunAt,
-					enabled: row.enabled,
-				});
+				if (input.triggers) {
+					await saveTriggerSet(tx, {
+						automationId: row.id,
+						organizationId,
+						triggers: input.triggers,
+					});
+				} else {
+					// Legacy shape: a top-level rrule becomes the schedule trigger.
+					await syncScheduleTrigger(tx, {
+						automationId: row.id,
+						organizationId,
+						rrule: input.rrule,
+						dtstart,
+						timezone: input.timezone,
+						nextRunAt,
+						enabled: row.enabled,
+					});
+				}
 
 				await recordPromptVersion(tx, {
 					automationId: row.id,
@@ -437,15 +447,23 @@ export const automationRouter = {
 					});
 				}
 
-				await syncScheduleTrigger(tx, {
-					automationId: row.id,
-					organizationId,
-					rrule: nextRrule,
-					dtstart: nextDtstart,
-					timezone: nextTimezone,
-					nextRunAt: recomputedNextRunAt,
-					enabled: row.enabled,
-				});
+				if (input.triggers) {
+					await saveTriggerSet(tx, {
+						automationId: row.id,
+						organizationId,
+						triggers: input.triggers,
+					});
+				} else {
+					await syncScheduleTrigger(tx, {
+						automationId: row.id,
+						organizationId,
+						rrule: nextRrule,
+						dtstart: nextDtstart,
+						timezone: nextTimezone,
+						nextRunAt: recomputedNextRunAt,
+						enabled: row.enabled,
+					});
+				}
 
 				return row;
 			});

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -7,8 +7,10 @@ import {
 	v2UsersHosts,
 	v2Workspaces,
 } from "@superset/db/schema";
+import type { DraftTrigger } from "@superset/shared/automation-triggers";
 import {
 	describeSchedule,
+	nextOccurrenceAfter,
 	nextOccurrences,
 	parseRrule,
 } from "@superset/shared/rrule";
@@ -113,6 +115,62 @@ async function verifyWorkspaceInOrg(
 	};
 }
 
+/**
+ * Builds the schedule half of a mutation response from what was actually saved.
+ *
+ * An automation may now have no schedule at all — an event-only trigger set is
+ * the normal case for a GitHub or Slack automation — so every schedule field is
+ * nullable here, and reporting the input back would describe a schedule that was
+ * never written.
+ */
+function withSchedule<T>(
+	row: T,
+	triggers: DraftTrigger[] | null,
+	legacy: {
+		rrule: string;
+		dtstart: Date;
+		timezone: string;
+		nextRunAt: Date;
+	} | null,
+) {
+	const scheduled = triggers?.find((t) => t.config.kind === "schedule");
+	if (scheduled && scheduled.config.kind === "schedule") {
+		const { rrule, dtstart, timezone } = scheduled.config;
+		return {
+			...row,
+			rrule,
+			dtstart: new Date(dtstart),
+			timezone,
+			nextRunAt: nextOccurrenceAfter({
+				rrule,
+				dtstart: new Date(dtstart),
+				timezone,
+				after: new Date(),
+			}),
+			scheduleText: safeDescribeRrule({ rrule }),
+		};
+	}
+	if (triggers) {
+		// Event-only: no schedule to report.
+		return {
+			...row,
+			rrule: null,
+			dtstart: null,
+			timezone: null,
+			nextRunAt: null,
+			scheduleText: null,
+		};
+	}
+	return {
+		...row,
+		rrule: legacy?.rrule ?? null,
+		dtstart: legacy?.dtstart ?? null,
+		timezone: legacy?.timezone ?? null,
+		nextRunAt: legacy?.nextRunAt ?? null,
+		scheduleText: legacy ? safeDescribeRrule({ rrule: legacy.rrule }) : null,
+	};
+}
+
 export const automationRouter = {
 	versions: automationVersionsRouter,
 
@@ -139,7 +197,7 @@ export const automationRouter = {
 			const rows = await db
 				.select({ ...automationBaseColumns, ...scheduleTriggerColumns })
 				.from(automations)
-				.innerJoin(automationTriggers, onScheduleTrigger)
+				.leftJoin(automationTriggers, onScheduleTrigger)
 				.where(
 					and(
 						eq(automations.organizationId, organizationId),
@@ -169,7 +227,7 @@ export const automationRouter = {
 			const [row] = await db
 				.select({ ...automationBaseColumns, ...scheduleTriggerColumns })
 				.from(automations)
-				.innerJoin(automationTriggers, onScheduleTrigger)
+				.leftJoin(automationTriggers, onScheduleTrigger)
 				.where(
 					and(
 						eq(automations.id, input.id),
@@ -243,12 +301,23 @@ export const automationRouter = {
 				);
 			}
 
-			const dtstart = input.dtstart ?? new Date();
-			const { nextRunAt } = parseRrule({
-				rrule: input.rrule,
-				dtstart,
-				timezone: input.timezone,
-			});
+			// Only the legacy shape carries a top-level schedule; a trigger set
+			// describes its own, or has none at all.
+			const legacySchedule = input.rrule
+				? (() => {
+						const dtstart = input.dtstart ?? new Date();
+						return {
+							rrule: input.rrule,
+							dtstart,
+							timezone: input.timezone ?? "UTC",
+							nextRunAt: parseRrule({
+								rrule: input.rrule,
+								dtstart,
+								timezone: input.timezone ?? "UTC",
+							}).nextRunAt,
+						};
+					})()
+				: null;
 
 			const created = await dbWs.transaction(async (tx) => {
 				const inserted = await tx
@@ -279,15 +348,12 @@ export const automationRouter = {
 						organizationId,
 						triggers: input.triggers,
 					});
-				} else {
+				} else if (legacySchedule) {
 					// Legacy shape: a top-level rrule becomes the schedule trigger.
 					await syncScheduleTrigger(tx, {
 						automationId: row.id,
 						organizationId,
-						rrule: input.rrule,
-						dtstart,
-						timezone: input.timezone,
-						nextRunAt,
+						...legacySchedule,
 						enabled: row.enabled,
 					});
 				}
@@ -302,16 +368,9 @@ export const automationRouter = {
 				return row;
 			});
 
-			// The schedule comes from the input rather than the row: it now lives on
-			// the trigger, so the columns on `created` are null.
-			return {
-				...created,
-				rrule: input.rrule,
-				dtstart,
-				timezone: input.timezone,
-				nextRunAt,
-				scheduleText: describeSchedule(input.rrule),
-			};
+			// Reported from what was actually written, not from the input: a
+			// trigger set may describe a different schedule, or none at all.
+			return withSchedule(created, input.triggers ?? null, legacySchedule);
 		}),
 
 	update: protectedProcedure
@@ -468,14 +527,20 @@ export const automationRouter = {
 				return row;
 			});
 
-			return {
-				...updated,
-				rrule: nextRrule,
-				dtstart: nextDtstart,
-				timezone: nextTimezone,
-				nextRunAt: recomputedNextRunAt,
-				scheduleText: describeSchedule(nextRrule),
-			};
+			// Same as create: a trigger set may have replaced or removed the
+			// schedule, so the response reflects what was saved.
+			return withSchedule(
+				updated,
+				input.triggers ?? null,
+				nextRrule && recomputedNextRunAt
+					? {
+							rrule: nextRrule,
+							dtstart: nextDtstart,
+							timezone: nextTimezone,
+							nextRunAt: recomputedNextRunAt,
+						}
+					: null,
+			);
 		}),
 
 	getPrompt: protectedProcedure

--- a/packages/trpc/src/router/automation/helpers.ts
+++ b/packages/trpc/src/router/automation/helpers.ts
@@ -142,8 +142,11 @@ export const scheduleTriggerColumns = {
 };
 
 /**
- * Joins an automation to its schedule trigger. Inner join is safe: every
- * automation has exactly one, enforced by a partial unique index.
+ * Joins an automation to its schedule trigger, if it has one.
+ *
+ * Left, not inner: an automation whose triggers are all event-based has no
+ * schedule row, and an inner join would drop it from every listing — the
+ * automation would look deleted rather than event-driven.
  */
 export const onScheduleTrigger = and(
 	eq(automationTriggers.automationId, automations.id),
@@ -181,7 +184,7 @@ export async function getAutomationForUser(
 			...scheduleTriggerColumns,
 		})
 		.from(automations)
-		.innerJoin(automationTriggers, onScheduleTrigger)
+		.leftJoin(automationTriggers, onScheduleTrigger)
 		.where(
 			and(
 				eq(automations.id, id),

--- a/packages/trpc/src/router/automation/schema.ts
+++ b/packages/trpc/src/router/automation/schema.ts
@@ -34,21 +34,32 @@ const rruleBody = z
 	.max(500)
 	.describe("RFC 5545 RRULE body, no DTSTART prefix");
 
-export const createAutomationSchema = z.object({
-	name: z.string().min(1).max(200),
-	prompt: z.string().min(1).max(100_000),
-	agent: agentSchema,
-	targetHostId: z.string().min(1).nullish(),
-	// Null/omitted with no workspace pin = session automation: each run
-	// creates a project-less session workspace (same convention as
-	// workspaces.create — no project means session).
-	v2ProjectId: z.string().uuid().nullish(),
-	v2WorkspaceId: z.string().uuid().nullish(),
-	rrule: rruleBody,
-	dtstart: z.coerce.date().optional(),
-	timezone: iana,
-	triggers,
-});
+export const createAutomationSchema = z
+	.object({
+		name: z.string().min(1).max(200),
+		prompt: z.string().min(1).max(100_000),
+		agent: agentSchema,
+		targetHostId: z.string().min(1).nullish(),
+		// Null/omitted with no workspace pin = session automation: each run
+		// creates a project-less session workspace (same convention as
+		// workspaces.create — no project means session).
+		v2ProjectId: z.string().uuid().nullish(),
+		v2WorkspaceId: z.string().uuid().nullish(),
+		// Optional because an automation may be entirely event-driven. Required
+		// only when no trigger set is supplied, which is the older client shape.
+		rrule: rruleBody.optional(),
+		dtstart: z.coerce.date().optional(),
+		timezone: iana.optional(),
+		triggers,
+	})
+	.refine((v) => v.triggers !== undefined || v.rrule !== undefined, {
+		message: "Provide either a trigger set or a schedule",
+		path: ["triggers"],
+	})
+	.refine((v) => v.rrule === undefined || v.timezone !== undefined, {
+		message: "A schedule needs a timezone",
+		path: ["timezone"],
+	});
 
 export const updateAutomationSchema = z.object({
 	id: z.string().uuid(),

--- a/packages/trpc/src/router/automation/schema.ts
+++ b/packages/trpc/src/router/automation/schema.ts
@@ -1,5 +1,16 @@
 import { automationSessionKindValues } from "@superset/db/schema";
+import { draftTriggerSchema } from "@superset/shared/automation-triggers";
 import { z } from "zod";
+
+/**
+ * The full trigger set, saved with the automation rather than edited one row at
+ * a time — the editor holds the whole automation and Save commits it.
+ *
+ * Optional while the older clients (CLI, SDK, MCP, desktop) still send a
+ * top-level `rrule`; those are folded into a single schedule trigger server-side
+ * so both shapes converge on the same rows.
+ */
+const triggers = z.array(draftTriggerSchema).max(25).optional();
 
 const agentSchema = z.string().min(1).max(200);
 
@@ -36,6 +47,7 @@ export const createAutomationSchema = z.object({
 	rrule: rruleBody,
 	dtstart: z.coerce.date().optional(),
 	timezone: iana,
+	triggers,
 });
 
 export const updateAutomationSchema = z.object({
@@ -50,6 +62,7 @@ export const updateAutomationSchema = z.object({
 	rrule: rruleBody.optional(),
 	dtstart: z.coerce.date().optional(),
 	timezone: iana.optional(),
+	triggers,
 });
 
 export const setAutomationPromptSchema = z.object({

--- a/packages/trpc/src/router/automation/triggerSet.ts
+++ b/packages/trpc/src/router/automation/triggerSet.ts
@@ -1,0 +1,131 @@
+import { automationTriggers, type TriggerConfig } from "@superset/db/schema";
+import {
+	type DraftTrigger,
+	describeTriggerProblems,
+	summarizeTriggerProblems,
+} from "@superset/shared/automation-triggers";
+import { nextOccurrenceAfter } from "@superset/shared/rrule";
+import { TRPCError } from "@trpc/server";
+import { and, eq, inArray, notInArray } from "drizzle-orm";
+
+import type { AutomationDbExecutor } from "./helpers";
+
+/** Schedules carry their next firing time in a column so the dispatcher can
+ * index it. Event triggers fire on arrival and have none. */
+function nextRunAtFor(config: DraftTrigger["config"]): Date | null {
+	if (config.kind !== "schedule") return null;
+	return nextOccurrenceAfter({
+		rrule: config.rrule,
+		dtstart: new Date(config.dtstart),
+		timezone: config.timezone,
+		after: new Date(),
+	});
+}
+
+function recurrenceChanged(
+	next: DraftTrigger["config"],
+	previous: TriggerConfig | null,
+): boolean {
+	if (next.kind !== "schedule") return false;
+	if (!previous || previous.kind !== "schedule") return true;
+	return (
+		previous.rrule !== next.rrule ||
+		previous.dtstart !== next.dtstart ||
+		previous.timezone !== next.timezone
+	);
+}
+
+/**
+ * Replaces an automation's triggers with `triggers`, in place.
+ *
+ * Rows are matched by id rather than cleared and reinserted, because a trigger
+ * row carries state the editor never sees: a webhook's signing key, and a
+ * schedule's next run. Recreating them would silently roll the key someone
+ * already configured upstream, and reschedule an automation that was only
+ * renamed.
+ */
+export async function saveTriggerSet(
+	tx: AutomationDbExecutor,
+	params: {
+		automationId: string;
+		organizationId: string;
+		triggers: DraftTrigger[];
+	},
+) {
+	const problems = describeTriggerProblems(params.triggers);
+	if (problems.length > 0) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				summarizeTriggerProblems(problems) ?? "Triggers are not configured",
+			cause: problems,
+		});
+	}
+
+	const existing = await tx
+		.select({
+			id: automationTriggers.id,
+			config: automationTriggers.config,
+			nextRunAt: automationTriggers.nextRunAt,
+		})
+		.from(automationTriggers)
+		.where(eq(automationTriggers.automationId, params.automationId));
+	const existingById = new Map(existing.map((row) => [row.id, row]));
+
+	const keptIds = params.triggers.flatMap((t) =>
+		t.id && existingById.has(t.id) ? [t.id] : [],
+	);
+
+	// Anything the editor dropped. Scoped to this automation, so a stray id from
+	// another automation can never widen the delete.
+	await tx
+		.delete(automationTriggers)
+		.where(
+			keptIds.length > 0
+				? and(
+						eq(automationTriggers.automationId, params.automationId),
+						notInArray(automationTriggers.id, keptIds),
+					)
+				: eq(automationTriggers.automationId, params.automationId),
+		);
+
+	const saved: string[] = [];
+	for (const trigger of params.triggers) {
+		const previous = trigger.id ? existingById.get(trigger.id) : undefined;
+		const config = trigger.config as TriggerConfig;
+
+		if (previous) {
+			// Only recompute the next run when the recurrence actually moved;
+			// otherwise renaming an automation would reschedule it.
+			const nextRunAt = recurrenceChanged(trigger.config, previous.config)
+				? nextRunAtFor(trigger.config)
+				: previous.nextRunAt;
+
+			const [row] = await tx
+				.update(automationTriggers)
+				.set({ config, enabled: trigger.enabled, nextRunAt })
+				.where(eq(automationTriggers.id, previous.id))
+				.returning({ id: automationTriggers.id });
+			if (row) saved.push(row.id);
+			continue;
+		}
+
+		const [row] = await tx
+			.insert(automationTriggers)
+			.values({
+				automationId: params.automationId,
+				organizationId: params.organizationId,
+				kind: config.kind,
+				config,
+				enabled: trigger.enabled,
+				nextRunAt: nextRunAtFor(trigger.config),
+			})
+			.returning({ id: automationTriggers.id });
+		if (row) saved.push(row.id);
+	}
+
+	return tx
+		.select()
+		.from(automationTriggers)
+		.where(inArray(automationTriggers.id, saved));
+}


### PR DESCRIPTION
Replaces the per-trigger CRUD approach in #6531 (now draft). Triggers are edited as part of the automation, so the surface is a **replace-the-set** on `automation.create`/`update`.

No migration.

## Shared validation

Lives in `@superset/shared/automation-triggers`, imported by both the editor and the API, so the form blocks Save on exactly what the server would reject rather than reimplementing the rules.

It deliberately has two levels:

- **`draftTriggerSchema`** accepts a half-configured trigger. The editor has to be able to hold *"Draft opened in [Select Repos]"* with nothing chosen yet — if the schema refused to represent that, the form couldn't hold its own in-progress state.
- **`describeTriggerProblems`** reports what blocks Save, per trigger and per field, so a message can sit next to the control it belongs to. `summarizeTriggerProblems` produces the banner.

The messages match the mockups: *"Some triggers need additional configuration"* and *"Specify at least one repository."*

It also catches **more than one schedule per automation**, which the partial unique index enforces in the database — better as a message next to the row than a constraint violation at save time.

## Matched by id, not cleared and reinserted

A trigger row carries state the editor never sees: a webhook's signing key, and a schedule's next run. Clearing and reinserting would silently roll a key someone had already configured upstream, and reschedule an automation that was only renamed.

So rows present in the set are updated in place, rows absent are deleted, and the next run is only recomputed when the recurrence actually changed.

## GitHub configs are a union on the event

The filters differ per event — *"Any Comment by [Anyone] on a PR by [Anyone] in [Repos]"* carries two independent actor scopes where *"Draft opened"* carries one. A single flat config with one `actor` can't express that, so the config discriminates on `event`.

`includeForks` stays the literal `false`: fork payloads carry attacker-controlled content into a checkout the agent runs in, so enabling it should be a schema change with a threat model attached.

## Verified against a real database

The actual `saveTriggerSet` executed against Postgres 16, not reasoned about:

| | |
|---|---|
| Initial save creates the set | 2 triggers |
| **Webhook signing key survives an unrelated save** | preserved |
| **Schedule not rescheduled by an unrelated save** | preserved |
| Row ids stable across saves | stable |
| Trigger dropped from the set is deleted | deleted |
| Recurrence change *does* reschedule | reschedules |
| Unconfigured GitHub trigger rejected server-side | rejected |

Plus the shared validation itself: a half-configured trigger parses but reports a problem; a comment event requires both actors; `includeForks: true`, unknown events, and an unknown kind are all rejected.

## Compatibility

Top-level `rrule` still works and folds into a single schedule trigger, so the CLI, SDK, MCP and desktop keep working until they move to sending a set. Same expand-contract shape as the column migration.

Typecheck, lint and the full suite pass.

## Next

The editor UI, then webhook ingestion so event triggers actually fire.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Saves automation triggers as a replace-the-set on create/update and makes event-only automations first‑class. Previously list/get assumed every automation had a schedule; now schedule is optional and responses reflect what was actually saved.

- API: `createAutomation`/`updateAutomation` accept optional `triggers: DraftTrigger[]` (max 25). Create requires either `triggers` or `rrule`; if `rrule` is provided, `timezone` is required. If `triggers` are absent, the legacy top‑level `rrule` folds into a single schedule trigger. Invalid sets return 400 with per‑field problems.
- Schedule handling: list/get/getAutomationForUser use a left join; schedule fields in responses are nullable. Create/update now build schedule fields from saved triggers, not the input.
- Validation (`@superset/shared/automation-triggers`): shared draft+save checks; enforces at most one schedule; GitHub config discriminates on `event`; Slack `reaction_added` requires an emoji; actor is `anyone` | `me` | specific people.
- Persistence: new `saveTriggerSet` matches rows by id, deletes dropped rows, and only recomputes `nextRunAt` when the schedule’s recurrence changes. Webhook signing keys and existing `nextRunAt` are preserved across unrelated edits.
- Packages: `packages/shared` exports `./automation-triggers`. No migration.

<sup>Written for commit bb284341f6d3e7bfea061c6a5201da04c79a3e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring up to 25 automation triggers, including schedules and event-driven integrations.
  * Automation creation and updates now save, update, and remove trigger configurations reliably.
  * Event-only automations can be created without a schedule.
  * Existing schedule configurations remain supported for compatibility.
  * Added validation for trigger requirements and provider-specific settings, with clear summaries of configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->