### PR TITLE
fix(mobile): drop third-party marks from App Store keywords

### DIFF
--- a/apps/mobile/store.config.js
+++ b/apps/mobile/store.config.js
@@ -12,19 +12,19 @@ module.exports = {
 				subtitle: "Run AI agents from anywhere",
 				description:
 					"Superset lets you run and manage AI coding agents from anywhere. Kick off tasks, review progress, and chat with agents working across your projects — all from your phone.\n\n- Start and monitor agent sessions in isolated workspaces\n- Chat with agents and attach images to your messages\n- Track tasks and pull requests across your organization\n- Stay in sync with your team in real time",
+				// No third-party marks: naming other vendors' products here is a
+				// standard metadata rejection, and App Store Connect already
+				// carries a cleaned list — keep this in step with it, since
+				// `eas metadata:push` overwrites ASC from this file.
 				keywords: [
-					"coding agents",
-					"AI",
+					"coding agent",
+					"AI agent",
 					"developer tools",
-					"claude",
-					"codex",
-					"vibe",
-					"mistral",
-					"kimi",
-					"grok",
-					"xai",
 					"pair programming",
 					"automation",
+					"terminal",
+					"code review",
+					"remote dev",
 				],
 				marketingUrl: "https://superset.sh",
 				supportUrl: "https://superset.sh",

--- a/apps/mobile/store.config.js
+++ b/apps/mobile/store.config.js
@@ -12,10 +12,6 @@ module.exports = {
 				subtitle: "Run AI agents from anywhere",
 				description:
 					"Superset lets you run and manage AI coding agents from anywhere. Kick off tasks, review progress, and chat with agents working across your projects — all from your phone.\n\n- Start and monitor agent sessions in isolated workspaces\n- Chat with agents and attach images to your messages\n- Track tasks and pull requests across your organization\n- Stay in sync with your team in real time",
-				// No third-party marks: naming other vendors' products here is a
-				// standard metadata rejection, and App Store Connect already
-				// carries a cleaned list — keep this in step with it, since
-				// `eas metadata:push` overwrites ASC from this file.
 				keywords: [
 					"coding agent",
 					"AI agent",


### PR DESCRIPTION
## What & why

`store.config.js` listed **claude, codex, mistral, kimi, grok, xai** as App Store keywords —
other vendors' product names. Naming third-party marks in metadata is a routine rejection.

App Store Connect was already cleaned by hand on 2026-08-14, but this file wasn't, and
`eas metadata:push` pushes *this file over ASC*. So the next metadata push would have silently
undone that fix and reintroduced the rejection risk right before submission.

New list, 97/100 characters (Apple counts the comma-joined string):

```
coding agent,AI agent,developer tools,pair programming,automation,terminal,code review,remote dev
```

⚠️ **This will overwrite whatever is currently in ASC on the next `eas metadata:push`.** If the
hand-edited ASC list differs from this and you prefer it, paste it here instead — the point is
that the two stop disagreeing, not that mine wins.

Also checked while in here, no change needed:

- `supportUrl` → `https://superset.sh` — deliberate: `https://superset.sh/support` still 404s, so
  the homepage is the correct target until a support page exists
- `privacyPolicyUrl` → 200
- Demo credentials still resolve from `APP_REVIEW_EMAIL` / `APP_REVIEW_PASSWORD` and stay out of
  the repo (verified the config loads with empty strings when unset)

## How I tested it

`node -e "require('./store.config.js')"` loads clean with 8 keywords; keyword string asserted
under Apple's 100-character limit; `bun run lint` passes. Not pushed to ASC — this only changes
what a future `metadata:push` would send.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes third-party product names from App Store keywords in `apps/mobile/store.config.js` to avoid metadata rejection. Old keywords included vendor marks; new keywords are generic and fit within 97/100 characters.

**Review and rollout**
- The next `eas metadata:push` will overwrite App Store Connect keywords with this list; update `apps/mobile/store.config.js` first if you prefer different keywords.
- Drops an obsolete inline comment; no other metadata changes. `supportUrl` remains `https://superset.sh`; `privacyPolicyUrl` is valid.

<sup>Written for commit 07085a6935934a562b712793ecf6e263eae1132c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated App Store keyword metadata with clearer, more relevant search terms.
  * Added keywords for terminal, code review, remote development, and AI agents.
  * Removed references to third-party products and vendors.
  * Refined existing keyword wording to improve consistency across the App Store listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->