### PR TITLE
feat(desktop): richer new-workspace templates + labeled model/effort pills

### DIFF
--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -17,6 +17,9 @@ interface AgentModelSelectProps {
 	disabled?: boolean;
 	triggerClassName?: string;
 	contentClassName?: string;
+	/** Trigger/item text for the default option — two adjacent selects both
+	 * reading "Default" are indistinguishable, so callers name theirs. */
+	defaultLabel?: string;
 }
 
 export function AgentModelSelect({
@@ -26,6 +29,7 @@ export function AgentModelSelect({
 	disabled,
 	triggerClassName,
 	contentClassName,
+	defaultLabel = "Default",
 }: AgentModelSelectProps) {
 	const selectedValue =
 		value !== null && models.some((model) => model.id === value)
@@ -43,10 +47,10 @@ export function AgentModelSelect({
 			disabled={disabled}
 		>
 			<SelectTrigger className={triggerClassName}>
-				<SelectValue placeholder="Default" />
+				<SelectValue placeholder={defaultLabel} />
 			</SelectTrigger>
 			<SelectContent className={contentClassName}>
-				<SelectItem value={DEFAULT_MODEL_VALUE}>Default</SelectItem>
+				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
 				{models.map((model) => (
 					<SelectItem key={model.id} value={model.id}>
 						{model.label}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -576,6 +576,7 @@ export function PromptGroup({
 								models={modelSupport.models}
 								value={selectedModel}
 								onValueChange={setSelectedModel}
+								defaultLabel="Default model"
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}
@@ -584,6 +585,7 @@ export function PromptGroup({
 								models={effortSupport.efforts}
 								value={selectedEffort}
 								onValueChange={setSelectedEffort}
+								defaultLabel="Default effort"
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -76,6 +76,7 @@ import { useSelectedHostProjectIds } from "../DashboardNewWorkspaceModalContent/
 import { AttachmentCard } from "./components/AttachmentCard";
 import { SamplePromptCards } from "./components/SamplePromptCards";
 import { SamplePrompts } from "./components/SamplePrompts";
+import { PROMPT_PLACEHOLDERS } from "./components/SamplePrompts/constants";
 
 interface NewWorkspaceScreenProps {
 	isOpen: boolean;
@@ -257,6 +258,17 @@ export function NewWorkspaceScreen({
 		selectSession,
 		updateDraft,
 	]);
+
+	// One suggestion per open: the tiptap Placeholder extension freezes its
+	// text at editor mount, so rotation rides the resetKey remount.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-roll per draft reset
+	const promptPlaceholder = useMemo(
+		() =>
+			PROMPT_PLACEHOLDERS[
+				Math.floor(Math.random() * PROMPT_PLACEHOLDERS.length)
+			] ?? "What do you want to do?",
+		[resetKey],
+	);
 
 	const projectId = draft.selectedProjectId;
 	const selectedProject = projects.find((project) => project.id === projectId);
@@ -670,7 +682,7 @@ export function NewWorkspaceScreen({
 						onPasteFiles={(files) => attachments.add(files)}
 						onEnterSubmit={handleSubmit}
 						autoFocus={draft.prompt ? "end" : "start"}
-						placeholder="What do you want to do?"
+						placeholder={promptPlaceholder}
 						className="flex flex-col min-h-[80px] max-h-[200px] px-3 pt-3"
 						editorClassName="overflow-y-auto text-sm"
 						features={{
@@ -699,6 +711,7 @@ export function NewWorkspaceScreen({
 									models={modelSupport.models}
 									value={selectedModel}
 									onValueChange={setSelectedModel}
+									defaultLabel="Default model"
 									triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 								/>
 							)}
@@ -707,6 +720,7 @@ export function NewWorkspaceScreen({
 									models={effortSupport.efforts}
 									value={selectedEffort}
 									onValueChange={setSelectedEffort}
+									defaultLabel="Default effort"
 									triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 								/>
 							)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -259,15 +259,24 @@ export function NewWorkspaceScreen({
 		updateDraft,
 	]);
 
-	// One suggestion per open: the tiptap Placeholder extension freezes its
-	// text at editor mount, so rotation rides the resetKey remount.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: re-roll per draft reset
+	// One suggestion per open. resetKey only bumps on resetDraft, so ordinary
+	// modal reopens roll their own counter; the tiptap Placeholder extension
+	// freezes its text at editor mount, so the roll also rides the editor key.
+	const [placeholderRoll, setPlaceholderRoll] = useState(0);
+	const wasOpenRef = useRef(isOpen);
+	useEffect(() => {
+		if (isOpen && !wasOpenRef.current) {
+			setPlaceholderRoll((roll) => roll + 1);
+		}
+		wasOpenRef.current = isOpen;
+	}, [isOpen]);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-roll per draft reset and per open
 	const promptPlaceholder = useMemo(
 		() =>
 			PROMPT_PLACEHOLDERS[
 				Math.floor(Math.random() * PROMPT_PLACEHOLDERS.length)
 			] ?? "What do you want to do?",
-		[resetKey],
+		[resetKey, placeholderRoll],
 	);
 
 	const projectId = draft.selectedProjectId;
@@ -676,7 +685,7 @@ export function NewWorkspaceScreen({
 						</div>
 					)}
 					<MarkdownEditor
-						key={`${resetKey}-${promptSeed}`}
+						key={`${resetKey}-${promptSeed}-${placeholderRoll}`}
 						content={draft.prompt}
 						onChange={(markdown) => updateDraft({ prompt: markdown })}
 						onPasteFiles={(files) => attachments.add(files)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -1,5 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { BookOpenIcon, BugIcon, WrenchIcon } from "lucide-react";
+import {
+	BookOpenIcon,
+	BugIcon,
+	FlaskConicalIcon,
+	ListChecksIcon,
+	ScrollTextIcon,
+	WrenchIcon,
+} from "lucide-react";
 import { track } from "renderer/lib/analytics";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { SAMPLE_PROMPTS } from "../SamplePrompts/constants";
@@ -8,9 +15,12 @@ const CARD_ICONS: Record<string, typeof WrenchIcon> = {
 	"set-up-project": WrenchIcon,
 	"explain-repo": BookOpenIcon,
 	"fix-small-bug": BugIcon,
+	"improve-agent-docs": ScrollTextIcon,
+	"add-missing-tests": FlaskConicalIcon,
+	"clean-up-todos": ListChecksIcon,
 };
 
-const CARD_COUNT = 2;
+const CARD_COUNT = 4;
 
 interface SamplePromptCardsProps {
 	hostUrl: string | null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -7,6 +7,7 @@ import {
 	ScrollTextIcon,
 	WrenchIcon,
 } from "lucide-react";
+import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { track } from "renderer/lib/analytics";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { SAMPLE_PROMPTS } from "../SamplePrompts/constants";
@@ -21,6 +22,24 @@ const CARD_ICONS: Record<string, typeof WrenchIcon> = {
 };
 
 const CARD_COUNT = 4;
+
+/** Overlapping real agent logos — the agent-docs card is about the agents
+ * themselves, so their marks carry more signal than a generic glyph. */
+function AgentLogoCluster() {
+	const claudeIcon = usePresetIcon("claude");
+	const codexIcon = usePresetIcon("codex");
+	if (!claudeIcon || !codexIcon) {
+		return (
+			<ScrollTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
+		);
+	}
+	return (
+		<span className="flex shrink-0 items-center">
+			<img src={claudeIcon} alt="" className="size-3.5 object-contain" />
+			<img src={codexIcon} alt="" className="-ml-1 size-3.5 object-contain" />
+		</span>
+	);
+}
 
 interface SamplePromptCardsProps {
 	hostUrl: string | null;
@@ -56,32 +75,38 @@ export function SamplePromptCards({
 	).slice(0, CARD_COUNT);
 
 	return (
-		<div className="grid grid-cols-2 gap-2 px-1 pb-2">
-			{cards.map((sample) => {
-				const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
-				return (
-					<button
-						key={sample.id}
-						type="button"
-						className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl border-[0.5px] border-border bg-foreground/[0.02] p-3 text-left transition-colors hover:border-foreground/20 hover:bg-foreground/[0.05]"
-						onClick={() => {
-							track("new_workspace_sample_prompt_clicked", {
-								prompt_id: sample.id,
-								layout: "cards",
-							});
-							onSelect(sample.prompt);
-						}}
-					>
-						<Icon className="size-3.5 shrink-0 text-muted-foreground" />
-						<span className="text-sm font-medium text-foreground/90">
-							{sample.label}
-						</span>
-						<span className="text-xs text-muted-foreground">
-							{sample.description}
-						</span>
-					</button>
-				);
-			})}
+		<div className="px-1 pb-2">
+			<div className="grid grid-cols-2 gap-1.5 rounded-2xl border-[0.5px] border-border/60 bg-foreground/[0.03] p-1.5">
+				{cards.map((sample) => {
+					const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
+					return (
+						<button
+							key={sample.id}
+							type="button"
+							className="flex cursor-pointer flex-col items-start gap-1.5 rounded-[11px] bg-background/70 p-3 text-left transition-colors hover:bg-foreground/[0.06]"
+							onClick={() => {
+								track("new_workspace_sample_prompt_clicked", {
+									prompt_id: sample.id,
+									layout: "cards",
+								});
+								onSelect(sample.prompt);
+							}}
+						>
+							{sample.id === "improve-agent-docs" ? (
+								<AgentLogoCluster />
+							) : (
+								<Icon className="size-3.5 shrink-0 text-muted-foreground" />
+							)}
+							<span className="text-sm font-medium text-foreground/90">
+								{sample.label}
+							</span>
+							<span className="text-xs text-muted-foreground">
+								{sample.description}
+							</span>
+						</button>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -7,10 +7,11 @@ import {
 	ScrollTextIcon,
 	WrenchIcon,
 } from "lucide-react";
-import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
+import { useState } from "react";
 import { track } from "renderer/lib/analytics";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
-import { SAMPLE_PROMPTS } from "../SamplePrompts/constants";
+import { shuffledSamplePrompts } from "../SamplePrompts/constants";
+import { AgentLogoCluster } from "./components/AgentLogoCluster";
 
 const CARD_ICONS: Record<string, typeof WrenchIcon> = {
 	"set-up-project": WrenchIcon,
@@ -23,24 +24,6 @@ const CARD_ICONS: Record<string, typeof WrenchIcon> = {
 
 const CARD_COUNT = 4;
 
-/** Overlapping real agent logos — the agent-docs card is about the agents
- * themselves, so their marks carry more signal than a generic glyph. */
-function AgentLogoCluster() {
-	const claudeIcon = usePresetIcon("claude");
-	const codexIcon = usePresetIcon("codex");
-	if (!claudeIcon || !codexIcon) {
-		return (
-			<ScrollTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
-		);
-	}
-	return (
-		<span className="flex shrink-0 items-center">
-			<img src={claudeIcon} alt="" className="size-3.5 object-contain" />
-			<img src={codexIcon} alt="" className="-ml-1 size-3.5 object-contain" />
-		</span>
-	);
-}
-
 interface SamplePromptCardsProps {
 	hostUrl: string | null;
 	projectId: string | null;
@@ -52,6 +35,10 @@ export function SamplePromptCards({
 	projectId,
 	onSelect,
 }: SamplePromptCardsProps) {
+	// Shuffled once per mount so every prompt in the pool gets exposure;
+	// re-shuffling per render would reorder cards under the pointer.
+	const [shuffledPrompts] = useState(shuffledSamplePrompts);
+
 	// Setup takes 75% of all prompt clicks, so it leads — but pitching setup for
 	// a project that already has setup/teardown/run commands reads as noise.
 	// Same query the v2 sidebar setup card uses.
@@ -70,9 +57,13 @@ export function SamplePromptCards({
 	// Deciding mid-flight would swap a card out from under the pointer.
 	if (canCheckSetup && isPending) return null;
 
-	const cards = SAMPLE_PROMPTS.filter(
-		(sample) => sample.id !== "set-up-project" || needsSetupScripts === true,
-	).slice(0, CARD_COUNT);
+	const setupCard = shuffledPrompts.find(
+		(sample) => sample.id === "set-up-project",
+	);
+	const cards = [
+		...(needsSetupScripts === true && setupCard ? [setupCard] : []),
+		...shuffledPrompts.filter((sample) => sample.id !== "set-up-project"),
+	].slice(0, CARD_COUNT);
 
 	return (
 		<div className="px-1 pb-2">

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/components/AgentLogoCluster/AgentLogoCluster.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/components/AgentLogoCluster/AgentLogoCluster.tsx
@@ -1,0 +1,20 @@
+import { ScrollTextIcon } from "lucide-react";
+import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
+
+/** Overlapping real agent logos — the agent-docs card is about the agents
+ * themselves, so their marks carry more signal than a generic glyph. */
+export function AgentLogoCluster() {
+	const claudeIcon = usePresetIcon("claude");
+	const codexIcon = usePresetIcon("codex");
+	if (!claudeIcon || !codexIcon) {
+		return (
+			<ScrollTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
+		);
+	}
+	return (
+		<span className="flex shrink-0 items-center">
+			<img src={claudeIcon} alt="" className="size-3.5 object-contain" />
+			<img src={codexIcon} alt="" className="-ml-1 size-3.5 object-contain" />
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/components/AgentLogoCluster/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/components/AgentLogoCluster/index.ts
@@ -1,0 +1,1 @@
+export { AgentLogoCluster } from "./AgentLogoCluster";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -6,10 +6,13 @@ interface SamplePromptsProps {
 	onSelect: (prompt: string) => void;
 }
 
+/** The rows layout stays scannable at 4; the pool is bigger for the cards. */
+const ROW_COUNT = 4;
+
 export function SamplePrompts({ onSelect }: SamplePromptsProps) {
 	return (
 		<div className="flex flex-col items-start gap-0.5 px-1 pb-2">
-			{SAMPLE_PROMPTS.map((sample) => (
+			{SAMPLE_PROMPTS.slice(0, ROW_COUNT).map((sample) => (
 				<button
 					key={sample.id}
 					type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -1,18 +1,23 @@
 import { SparklesIcon } from "lucide-react";
+import { useState } from "react";
 import { track } from "renderer/lib/analytics";
-import { SAMPLE_PROMPTS } from "./constants";
+import { shuffledSamplePrompts } from "./constants";
+
+/** The rows layout stays scannable at 4; the pool is bigger for variety. */
+const ROW_COUNT = 4;
 
 interface SamplePromptsProps {
 	onSelect: (prompt: string) => void;
 }
 
-/** The rows layout stays scannable at 4; the pool is bigger for the cards. */
-const ROW_COUNT = 4;
-
 export function SamplePrompts({ onSelect }: SamplePromptsProps) {
+	// Shuffled once per mount so every prompt in the pool gets exposure;
+	// re-shuffling per render would reorder rows under the pointer.
+	const [shuffledPrompts] = useState(shuffledSamplePrompts);
+
 	return (
 		<div className="flex flex-col items-start gap-0.5 px-1 pb-2">
-			{SAMPLE_PROMPTS.slice(0, ROW_COUNT).map((sample) => (
+			{shuffledPrompts.slice(0, ROW_COUNT).map((sample) => (
 				<button
 					key={sample.id}
 					type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -32,4 +32,42 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 		prompt:
 			"Find a small, low-risk bug or papercut in this codebase and fix it. Keep the change minimal, explain what the bug was, and describe how you verified the fix.",
 	},
+	{
+		id: "improve-agent-docs",
+		label: "Improve the agent instructions",
+		description:
+			"Audit AGENTS.md / CLAUDE.md against the codebase and fill the gaps.",
+		prompt:
+			"Review this repository's agent instruction files (AGENTS.md, CLAUDE.md, or similar). Compare them against how the codebase actually works today: commands, structure, conventions. Fix anything stale, and add the few things a coding agent most often needs and can't easily discover. Create the file if none exists. Keep it concise.",
+	},
+	{
+		id: "add-missing-tests",
+		label: "Add tests where they're missing",
+		description:
+			"Find recently changed code with weak coverage and test it properly.",
+		prompt:
+			"Look at recently changed or complex code in this repository that lacks test coverage. Pick the highest-risk gap, write focused tests for it following the project's existing test conventions, and make sure they pass. Explain what you covered and why it mattered most.",
+	},
+	{
+		id: "clean-up-todos",
+		label: "Knock out some TODOs",
+		description: "Find stale TODO/FIXME comments and resolve the quick ones.",
+		prompt:
+			"Search this codebase for TODO and FIXME comments. Triage them: resolve the ones that are quick and low-risk, delete the ones that are obsolete, and list the ones that need a real project. Keep each fix minimal and explain what you did.",
+	},
+];
+
+/**
+ * Composer ghost text: one is picked per screen-open so the empty state
+ * suggests a concrete next action instead of a static question.
+ */
+export const PROMPT_PLACEHOLDERS: string[] = [
+	"What do you want to do?",
+	"Find a small bug and fix it…",
+	"Add tests for the riskiest untested code…",
+	"Explain how this repository works…",
+	"Track down that flaky test…",
+	"Upgrade a dependency and fix what breaks…",
+	"Clean up stale TODOs…",
+	"Write docs for the part everyone asks about…",
 ];

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -58,6 +58,22 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 ];
 
 /**
+ * Fisher-Yates over a copy — the pool is bigger than either layout shows, so
+ * a fixed slice would leave the tail prompts permanently unreachable.
+ */
+export function shuffledSamplePrompts(): SamplePrompt[] {
+	const prompts = [...SAMPLE_PROMPTS];
+	for (let i = prompts.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[prompts[i], prompts[j]] = [
+			prompts[j] as SamplePrompt,
+			prompts[i] as SamplePrompt,
+		];
+	}
+	return prompts;
+}
+
+/**
  * Composer ghost text: one is picked per screen-open so the empty state
  * suggests a concrete next action instead of a static question.
  */


### PR DESCRIPTION
## Summary
- The composer's model and effort selects both rendered a bare "Default" — two identical, indistinguishable pills. `AgentModelSelect` now takes a `defaultLabel` prop and the create surfaces pass "Default model" / "Default effort".
- The create screen's empty state gets livelier: the sample-prompt pool grows from 3 to 6 (agent-docs audit, missing-tests, TODO cleanup), the cards experiment arm shows 4 in a 2×2 grid (rows arm capped at 4), and the composer placeholder rotates through 8 ghost-text suggestions, one per open.

## Why / Context
From a Mobbin pass over competitor create surfaces (Cursor Cloud Agents, Codex, Claude Code web): every one of them names the model in the select trigger, seeds the empty state with rotating prompt suggestions, and offers more than two outcome templates. These were the two cheapest gaps to close; the bigger finding (multi-agent fan-out) is deliberately not in this PR.

## How It Works
- `AgentModelSelect` gets an optional `defaultLabel` (default `"Default"`, so other future callers are unaffected); it's used for both the trigger placeholder and the default item. Applied at both call sites — `NewWorkspaceScreen` and the control modal's `PromptGroup`.
- New prompts live in the existing `SAMPLE_PROMPTS` pool; the cards arm slices 4 (setup card still leads only when the project needs setup), the rows arm slices 4.
- `PROMPT_PLACEHOLDERS` ghost text is picked per open, keyed on the draft `resetKey`: the tiptap Placeholder extension freezes its text at editor mount, so rotation rides the same remount the prompt-insertion path already uses.

## Manual QA Checklist
Verified live via CDP against the dev desktop:
- [x] Pills read "Default model" / "Default effort"; dropdowns open and list the named default first
- [x] 4 sample cards render (2×2) with correct icons; clicking inserts the full prompt
- [x] Placeholder differs across app opens (observed two different suggestions on consecutive boots)
- [x] Cards still hide once the prompt is non-empty; submit flow unchanged
- [x] No renderer console errors

## Testing
- `bun run typecheck`
- `biome check` on touched dirs
- `bun test` on touched dirs (PromptGroup util tests pass)

## Known Limitations
- Placeholder rotates per open, not on a timer — a live timer would either remount the editor under the user's cursor or need a tiptap Placeholder rework.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies model/effort selects and makes the new‑workspace empty state dynamic. Previously both pills read “Default” and the empty state was static; now pills read “Default model”/“Default effort”, the template pool expands and shuffles, cards render as a 2×2 tray (setup leads only when needed), and the composer placeholder rotates per open.

- `AgentModelSelect` adds a `defaultLabel` prop (defaults to "Default"); `NewWorkspaceScreen` and the control modal `PromptGroup` pass "Default model"/"Default effort". Other callers are unaffected.
- Sample prompts grow from 3 to 6 (adds agent‑docs audit, missing tests, TODO cleanup). The pool shuffles once per mount; the card layout shows 4 in a rounded tray with the setup card only if the project needs it; the row layout shows 4 from the same shuffled pool.
- The agent‑docs card shows Claude+Codex logos when available (falls back to a generic icon).
- The composer placeholder picks one of 8 suggestions on modal open or draft reset and stays fixed after mount.
- Submit flow and card‑hiding behavior are unchanged. No migration required.

<sup>Written for commit eb2fb9e4cd1cc047a1678fc591f9c3ba872d6539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sample prompts for improving instructions, adding tests, resolving TODOs, and fixing bugs.
  * Expanded sample prompts to four shuffled cards with refreshed icons, layout, and hover styling.
  * Added rotating placeholder suggestions when starting or resetting a new workspace.
  * Added clearer default labels for model and effort selections.
  * Limited the sample prompt display to four cards for a more focused experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->