### PR TITLE
feat(api): record GitHub deliveries as automation events

### DIFF
--- a/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
@@ -2,6 +2,8 @@ import { db } from "@superset/db/client";
 import { automationEvents, githubInstallations } from "@superset/db/schema";
 import { eq } from "drizzle-orm";
 
+import { stripNullChars } from "@/lib/strip-null-chars";
+
 /**
  * Records an incoming GitHub delivery as an `automation_events` row.
  *
@@ -20,6 +22,9 @@ export type GithubPayload = {
 	installation?: { id?: number | string };
 	repository?: { id?: number | string; full_name?: string };
 	sender?: { login?: string; type?: string };
+	// GitHub's own membership signal, present on comment, PR and review
+	// payloads. The only trustworthy source for "is this person one of us".
+	author_association?: string;
 	pull_request?: {
 		number?: number;
 		title?: string;
@@ -27,6 +32,7 @@ export type GithubPayload = {
 		head?: { ref?: string };
 		user?: { login?: string };
 		draft?: boolean;
+		author_association?: string;
 	};
 	issue?: {
 		number?: number;
@@ -34,7 +40,12 @@ export type GithubPayload = {
 		html_url?: string;
 		user?: { login?: string };
 	};
-	comment?: { body?: string; html_url?: string; user?: { login?: string } };
+	comment?: {
+		body?: string;
+		html_url?: string;
+		user?: { login?: string };
+		author_association?: string;
+	};
 	review?: { state?: string; html_url?: string; user?: { login?: string } };
 	ref?: string;
 	workflow_run?: { conclusion?: string; html_url?: string; name?: string };
@@ -51,7 +62,12 @@ export function resourceKeyFor(
 	payload: GithubPayload,
 	eventType: string,
 ): string | null {
-	const repo = payload.repository?.full_name;
+	// The numeric id for the same reason as repositoryId: a rename must not
+	// change the key, or an in-flight run stops matching its own subject.
+	const repo =
+		payload.repository?.id !== undefined
+			? String(payload.repository.id)
+			: undefined;
 	if (!repo) return null;
 	const pr = payload.pull_request?.number ?? payload.issue?.number;
 	if (pr !== undefined) return `github:${repo}#${pr}`;
@@ -67,6 +83,23 @@ export function titleFor(payload: GithubPayload, eventType: string): string {
 	if (payload.workflow_run?.name) return payload.workflow_run.name;
 	if (eventType === "push" && payload.ref) return payload.ref;
 	return payload.repository?.full_name ?? eventType;
+}
+
+/**
+ * Whether the actor is outside the repository's circle of trust.
+ *
+ * Derived from GitHub's `author_association`, which is the only field that
+ * actually states membership. `sender.type` does not: it distinguishes a bot
+ * from a human, and would mark a genuine outside contributor as internal.
+ * Null when no payload on this event carries the association.
+ */
+export function actorIsExternalFor(payload: GithubPayload): boolean | null {
+	const association =
+		payload.comment?.author_association ??
+		payload.pull_request?.author_association ??
+		payload.author_association;
+	if (!association) return null;
+	return !["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 }
 
 export function urlFor(payload: GithubPayload): string | null {
@@ -124,15 +157,18 @@ export async function recordAutomationEvent(params: {
 			resourceKey: resourceKeyFor(payload, params.eventType),
 			title: titleFor(payload, params.eventType),
 			url: urlFor(payload),
-			repositoryId: payload.repository?.full_name ?? null,
+			// The numeric id, not the full name: a repository can be renamed and
+			// triggers must keep matching it afterwards.
+			repositoryId:
+				payload.repository?.id !== undefined
+					? String(payload.repository.id)
+					: null,
 			ref: payload.pull_request?.head?.ref ?? payload.ref ?? null,
 			actorLogin: payload.sender?.login ?? null,
-			// Bots and outside contributors are the payloads worth treating with
-			// suspicion; recorded now so matching can filter on it later.
-			actorIsExternal: payload.sender?.type
-				? payload.sender.type !== "User"
-				: null,
-			payload: payload as Record<string, unknown>,
+			actorIsExternal: actorIsExternalFor(payload),
+			// jsonb rejects \u0000, and a payload carrying one would otherwise
+			// throw and lose the event.
+			payload: stripNullChars(payload) as Record<string, unknown>,
 			webhookEventId: params.webhookEventId,
 		})
 		// A redelivery of the same GitHub delivery id is the same event.

--- a/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
@@ -1,0 +1,148 @@
+import { db } from "@superset/db/client";
+import { automationEvents, githubInstallations } from "@superset/db/schema";
+import { eq } from "drizzle-orm";
+
+/**
+ * Records an incoming GitHub delivery as an `automation_events` row.
+ *
+ * This is the normalized event stream triggers are matched against. It keeps
+ * its own copy of the payload because `ingest.webhook_events` is pruned, and
+ * flattens the handful of fields matching and prompting actually need out of
+ * payloads whose shape differs per event.
+ *
+ * Recording is deliberately separate from matching: nothing reads these rows
+ * yet, so a mistake here shows up as a wrong row rather than an agent running
+ * on the wrong pull request.
+ */
+
+export type GithubPayload = {
+	action?: string;
+	installation?: { id?: number | string };
+	repository?: { id?: number | string; full_name?: string };
+	sender?: { login?: string; type?: string };
+	pull_request?: {
+		number?: number;
+		title?: string;
+		html_url?: string;
+		head?: { ref?: string };
+		user?: { login?: string };
+		draft?: boolean;
+	};
+	issue?: {
+		number?: number;
+		title?: string;
+		html_url?: string;
+		user?: { login?: string };
+	};
+	comment?: { body?: string; html_url?: string; user?: { login?: string } };
+	review?: { state?: string; html_url?: string; user?: { login?: string } };
+	ref?: string;
+	workflow_run?: { conclusion?: string; html_url?: string; name?: string };
+	check_suite?: { conclusion?: string };
+	label?: { name?: string };
+};
+
+/**
+ * The subject a run would act on — a pull request, an issue, a branch. Runs key
+ * debounce and in-flight limits off this, so two comments on one PR are the
+ * same resource rather than two.
+ */
+export function resourceKeyFor(
+	payload: GithubPayload,
+	eventType: string,
+): string | null {
+	const repo = payload.repository?.full_name;
+	if (!repo) return null;
+	const pr = payload.pull_request?.number ?? payload.issue?.number;
+	if (pr !== undefined) return `github:${repo}#${pr}`;
+	if (eventType === "push" && payload.ref) {
+		return `github:${repo}@${payload.ref}`;
+	}
+	return `github:${repo}`;
+}
+
+export function titleFor(payload: GithubPayload, eventType: string): string {
+	const subject = payload.pull_request?.title ?? payload.issue?.title;
+	if (subject) return subject;
+	if (payload.workflow_run?.name) return payload.workflow_run.name;
+	if (eventType === "push" && payload.ref) return payload.ref;
+	return payload.repository?.full_name ?? eventType;
+}
+
+export function urlFor(payload: GithubPayload): string | null {
+	return (
+		payload.comment?.html_url ??
+		payload.review?.html_url ??
+		payload.pull_request?.html_url ??
+		payload.issue?.html_url ??
+		payload.workflow_run?.html_url ??
+		null
+	);
+}
+
+export async function recordAutomationEvent(params: {
+	eventType: string;
+	deliveryId: string;
+	payload: unknown;
+	webhookEventId: string;
+}): Promise<{ recorded: boolean; reason?: string }> {
+	const payload = params.payload as GithubPayload;
+
+	const installationId = payload.installation?.id;
+	if (installationId === undefined) {
+		// Pings and a few org-level events carry no installation, so there is no
+		// organization to attribute them to.
+		return { recorded: false, reason: "no installation" };
+	}
+
+	const [installation] = await db
+		.select({ organizationId: githubInstallations.organizationId })
+		.from(githubInstallations)
+		.where(eq(githubInstallations.installationId, String(installationId)))
+		.limit(1);
+
+	if (!installation) {
+		return { recorded: false, reason: "unknown installation" };
+	}
+
+	// `action` is what distinguishes opened from closed from labeled; the bare
+	// event name is too coarse to match on.
+	const qualified = payload.action
+		? `${params.eventType}.${payload.action}`
+		: params.eventType;
+
+	await db
+		.insert(automationEvents)
+		.values({
+			organizationId: installation.organizationId,
+			// GitHub installs are their own connection record, not an
+			// integration_connections row, so provenance is the delivery below.
+			integrationConnectionId: null,
+			provider: "github",
+			eventType: qualified,
+			externalEventId: params.deliveryId,
+			resourceKey: resourceKeyFor(payload, params.eventType),
+			title: titleFor(payload, params.eventType),
+			url: urlFor(payload),
+			repositoryId: payload.repository?.full_name ?? null,
+			ref: payload.pull_request?.head?.ref ?? payload.ref ?? null,
+			actorLogin: payload.sender?.login ?? null,
+			// Bots and outside contributors are the payloads worth treating with
+			// suspicion; recorded now so matching can filter on it later.
+			actorIsExternal: payload.sender?.type
+				? payload.sender.type !== "User"
+				: null,
+			payload: payload as Record<string, unknown>,
+			webhookEventId: params.webhookEventId,
+		})
+		// A redelivery of the same GitHub delivery id is the same event.
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		});
+
+	return { recorded: true };
+}

--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -1,8 +1,8 @@
 import { db } from "@superset/db/client";
 import { webhookEvents } from "@superset/db/schema";
 import { eq, sql } from "drizzle-orm";
-
 import { stripNullChars } from "@/lib/strip-null-chars";
+import { recordAutomationEvent } from "./recordAutomationEvent";
 import { webhooks } from "./webhooks";
 
 export async function POST(request: Request) {
@@ -75,6 +75,26 @@ export async function POST(request: Request) {
 			payload,
 			// biome-ignore lint/suspicious/noExplicitAny: GitHub webhook event types are complex unions
 		} as any);
+
+		// Recorded after processing and deliberately not inside the try above:
+		// nothing reads these rows yet, so a failure here must not fail a
+		// delivery GitHub would then retry.
+		try {
+			const recorded = await recordAutomationEvent({
+				eventType: eventType ?? "unknown",
+				deliveryId: eventId,
+				payload,
+				webhookEventId: webhookEvent.id,
+			});
+			if (!recorded.recorded) {
+				console.log(
+					`[github/webhook] Not recorded as automation event (${recorded.reason}):`,
+					eventId,
+				);
+			}
+		} catch (error) {
+			console.error("[github/webhook] recordAutomationEvent failed:", error);
+		}
 
 		await db
 			.update(webhookEvents)


### PR DESCRIPTION
First half of making event triggers fire. Populates `automation_events` — the normalized stream triggers get matched against. **No matching or dispatch yet**, deliberately.

No migration.

## Why recording lands before matching

Nothing reads these rows yet, so a mistake here shows up as a wrong row rather than an agent running on the wrong pull request. It also means the matcher gets written against real recorded events instead of a third round of inferring payload shapes — the last two rounds both got things wrong.

`automation_events` has existed since the cutover and is still empty. This fills it.

## What it records

- **Organization** resolved through `github_installations` by installation id. No installation (pings, some org-level events) or an unknown one is skipped with a logged reason rather than treated as an error.
- **Event type qualified with its action** — `pull_request.opened` rather than `pull_request`, because the bare name can't distinguish opened from closed from labeled, and that's exactly the granularity the trigger configs match on.
- **Flattened fields** — title, url, repository, ref, actor — pulled out of payloads whose shape differs per event, so matching doesn't dig through jsonb.
- **`actorIsExternal`** for bots and non-user senders. Not used yet, but it's the field that lets matching treat attacker-influenced payloads differently, and it can't be backfilled.
- **Its own payload copy**, because `ingest.webhook_events` is now pruned at 14 days and a dispatch needs the payload.

## Resource key

A comment on PR #42 and the PR itself both produce `github:acme/web#42`. That's what makes debounce and in-flight limits coherent later — two comments on one pull request are one subject, not two.

Verified:

| event | resource key | title | url |
|---|---|---|---|
| `pull_request.opened` | `github:acme/web#42` | Add login | PR url |
| `issue_comment.created` | `github:acme/web#7` | Bug report | comment url |
| `push` | `github:acme/web@refs/heads/main` | refs/heads/main | — |
| `workflow_run.completed` | `github:acme/web` | CI | run url |
| `installation_repositories.added` | — | (event name) | — |

## Dedupe

A redelivery of the same GitHub delivery id must not produce a second event. Verified against Postgres 16 that `ON CONFLICT (integration_connection_id, provider, external_event_id) DO NOTHING` **fires with a NULL connection id** — GitHub installs aren't `integration_connections` rows, so that column is always null here, and the dedupe only works because the constraint is `NULLS NOT DISTINCT`. Worth checking explicitly given `ON CONFLICT` inference has broken twice on this feature.

## Failure isolation

Recording runs outside the existing processing `try`. A failure here logs and moves on rather than marking the delivery failed — GitHub would otherwise retry a delivery whose real work already succeeded.

Typecheck, lint and the full suite pass.

## Next

The matcher: recorded event → enabled triggers whose config matches → `automation_runs` with `trigger_id` and `event_id`. By then there will be real rows to test against.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records GitHub webhook deliveries as normalized `automation_events` without triggering matching or dispatch. Previously nothing was recorded; now each processed delivery creates a deduped, stable event, and recording failures do not affect delivery success.

- Resolves organization via `github_installations` by installation id; skips and logs when installation is missing or unknown.
- Qualifies event types with their action (e.g., `pull_request.opened`).
- Uses stable repository identifiers: `repositoryId` and `resourceKey` use the numeric repository id, so renames do not change matching (e.g., `github:12345#42`, `github:12345@refs/heads/main`).
- Flattens title, url, repository id, ref, and actor; stores a payload copy and strips null chars; includes `webhookEventId` for provenance.
- Derives `actorIsExternal` from `author_association`; null when the payload lacks it.
- Ensures idempotency: dedupes on `(integration_connection_id, provider, external_event_id)` with `NULLS NOT DISTINCT`, covering `NULL` connection ids.
- Isolates failures by recording outside the main processing try, so GitHub does not retry already-processed deliveries.

**Rollout**
- No migration. Matching and dispatch come later; current behavior only appends rows to `automation_events`.

<sup>Written for commit 1e36cd43423ae93df729b63dade18cfec002867e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub webhook activity is now recorded as automation events with relevant titles, links, metadata, external-actor information, and original event details.
  * Events are qualified by type and action for clearer activity records.
  * Duplicate webhook deliveries are safely ignored.
  * Events from missing or unrecognized installations are rejected from recording.

* **Reliability**
  * Webhook delivery continues successfully even if automation-event recording encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->