### PR TITLE
feat: fire automations from GitHub events

### DIFF
--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -16,10 +16,22 @@ const receiver = new Receiver({
 	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
 });
 
-const payloadSchema = z.object({
-	automationId: z.string().uuid(),
-	scheduledFor: z.string().datetime(),
-});
+/**
+ * A run comes from a schedule or from an event, never both. Scheduled runs
+ * carry the minute they were due, which is also their dedupe key; event runs
+ * carry the trigger and the event instead, and have no scheduled time.
+ */
+const payloadSchema = z.union([
+	z.object({
+		automationId: z.string().uuid(),
+		scheduledFor: z.string().datetime(),
+	}),
+	z.object({
+		automationId: z.string().uuid(),
+		triggerId: z.string().uuid(),
+		eventId: z.string().uuid(),
+	}),
+]);
 
 export async function POST(
 	request: Request,
@@ -60,13 +72,25 @@ export async function POST(
 		return Response.json({ ok: true, skipped: "disabled" });
 	}
 
-	const outcome = await dispatchAutomation({
-		automation,
-		scheduledFor: new Date(parsed.data.scheduledFor),
-		// The owner's host may be on an overridden relay (relay-url-override);
-		// env.RELAY_URL alone reaches only hosts still on the default relay.
-		relayUrl: await getRelayUrl(automation.ownerUserId),
-	});
+	// The owner's host may be on an overridden relay (relay-url-override);
+	// env.RELAY_URL alone reaches only hosts still on the default relay.
+	const relayUrl = await getRelayUrl(automation.ownerUserId);
+	const outcome = await dispatchAutomation(
+		"scheduledFor" in parsed.data
+			? {
+					automation,
+					relayUrl,
+					scheduledFor: new Date(parsed.data.scheduledFor),
+				}
+			: {
+					automation,
+					relayUrl,
+					trigger: {
+						triggerId: parsed.data.triggerId,
+						eventId: parsed.data.eventId,
+					},
+				},
+	);
 
 	return Response.json({ ok: true, outcome });
 }

--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -22,15 +22,21 @@ const receiver = new Receiver({
  * carry the trigger and the event instead, and have no scheduled time.
  */
 const payloadSchema = z.union([
-	z.object({
-		automationId: z.string().uuid(),
-		scheduledFor: z.string().datetime(),
-	}),
-	z.object({
-		automationId: z.string().uuid(),
-		triggerId: z.string().uuid(),
-		eventId: z.string().uuid(),
-	}),
+	// Strict, so a payload carrying both causes is rejected rather than
+	// silently treated as whichever branch happens to match first.
+	z
+		.object({
+			automationId: z.string().uuid(),
+			scheduledFor: z.string().datetime(),
+		})
+		.strict(),
+	z
+		.object({
+			automationId: z.string().uuid(),
+			triggerId: z.string().uuid(),
+			eventId: z.string().uuid(),
+		})
+		.strict(),
 ]);
 
 export async function POST(

--- a/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
+++ b/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
@@ -40,6 +40,7 @@ function matchableFrom(
 			.map((l) => l?.name)
 			.filter((n): n is string => typeof n === "string"),
 		body: payload.comment?.body ?? payload.review?.body ?? null,
+		isFork: payload.pull_request?.head?.repo?.fork === true,
 		// Who opened the thing being commented on, which is a different person
 		// from whoever wrote the comment.
 		subjectAuthorLogin:
@@ -105,9 +106,10 @@ export async function dispatchMatchingTriggers(params: {
 		return githubTriggerMatches(
 			config as never,
 			event,
-			// `me` means the automation's owner, resolved per candidate rather than
-			// per event: two automations can watch the same event for different people.
-			{ names, ownerLogin: candidate.ownerUserId },
+			// `me` cannot resolve yet: the owner is a Superset user id and the
+			// event carries a GitHub login, so there is nothing to compare. Passing
+			// null makes `me` match nobody rather than match the wrong person.
+			{ names, ownerLogin: null },
 		).matches;
 	});
 

--- a/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
+++ b/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
@@ -1,0 +1,134 @@
+import { dbWs } from "@superset/db/client";
+import {
+	automations,
+	automationTriggers,
+	type GithubTriggerConfig,
+} from "@superset/db/schema";
+import {
+	githubEventNames,
+	githubTriggerMatches,
+	type MatchableEvent,
+} from "@superset/shared/automation-matching";
+import { Client } from "@upstash/qstash";
+import { and, eq } from "drizzle-orm";
+
+import { env } from "@/env";
+import type { GithubPayload } from "./recordAutomationEvent";
+
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+});
+
+/**
+ * Fields the matcher needs that are not columns on `automation_events` — they
+ * only exist inside the payload, and only for some events.
+ */
+function matchableFrom(
+	payload: GithubPayload,
+	eventType: string,
+	repositoryId: string | null,
+	ref: string | null,
+): MatchableEvent {
+	return {
+		eventType,
+		repositoryId,
+		ref,
+		actorLogin: payload.sender?.login ?? null,
+		actorIsExternal: null,
+		labels: (payload.pull_request?.labels ?? payload.issue?.labels ?? [])
+			.map((l) => l?.name)
+			.filter((n): n is string => typeof n === "string"),
+		body: payload.comment?.body ?? payload.review?.body ?? null,
+		// Who opened the thing being commented on, which is a different person
+		// from whoever wrote the comment.
+		subjectAuthorLogin:
+			payload.pull_request?.user?.login ?? payload.issue?.user?.login ?? null,
+	};
+}
+
+/**
+ * Finds the triggers an event satisfies and enqueues a run for each.
+ *
+ * Only automations that are enabled are considered — that toggle is the gate a
+ * person actually controls, so an automation someone paused stops firing
+ * without needing its triggers disabled one by one.
+ */
+export async function dispatchMatchingTriggers(params: {
+	organizationId: string;
+	eventId: string;
+	eventType: string;
+	repositoryId: string | null;
+	ref: string | null;
+	payload: GithubPayload;
+}): Promise<{ matched: number; considered: number }> {
+	const names = githubEventNames({
+		eventType: params.eventType,
+		isDraft: params.payload.pull_request?.draft === true,
+		reviewState: params.payload.review?.state ?? null,
+		runConclusion: params.payload.workflow_run?.conclusion ?? null,
+		threadResolved: null,
+	});
+	// Nothing in the product names this delivery, so there is nothing to match.
+	if (names.length === 0) return { matched: 0, considered: 0 };
+
+	const candidates = await dbWs
+		.select({
+			triggerId: automationTriggers.id,
+			config: automationTriggers.config,
+			automationId: automations.id,
+			ownerUserId: automations.ownerUserId,
+		})
+		.from(automationTriggers)
+		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
+		.where(
+			and(
+				eq(automationTriggers.organizationId, params.organizationId),
+				eq(automationTriggers.kind, "github"),
+				eq(automationTriggers.enabled, true),
+				eq(automations.enabled, true),
+			),
+		);
+
+	if (candidates.length === 0) return { matched: 0, considered: 0 };
+
+	const event = matchableFrom(
+		params.payload,
+		params.eventType,
+		params.repositoryId,
+		params.ref,
+	);
+
+	const matched = candidates.filter((candidate) => {
+		const config = candidate.config as GithubTriggerConfig;
+		if (config.kind !== "github") return false;
+		return githubTriggerMatches(
+			config as never,
+			event,
+			// `me` means the automation's owner, resolved per candidate rather than
+			// per event: two automations can watch the same event for different people.
+			{ names, ownerLogin: candidate.ownerUserId },
+		).matches;
+	});
+
+	if (matched.length === 0) {
+		return { matched: 0, considered: candidates.length };
+	}
+
+	await qstash.batchJSON(
+		matched.map((candidate) => ({
+			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${candidate.automationId}`,
+			body: {
+				automationId: candidate.automationId,
+				triggerId: candidate.triggerId,
+				eventId: params.eventId,
+			},
+			// One run per trigger per event, however many times GitHub redelivers.
+			deduplicationId: `${candidate.triggerId}_${params.eventId}`,
+			retries: 2,
+			failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
+		})),
+	);
+
+	return { matched: matched.length, considered: candidates.length };
+}

--- a/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
@@ -30,7 +30,7 @@ export type GithubPayload = {
 		labels?: Array<{ name?: string }>;
 		title?: string;
 		html_url?: string;
-		head?: { ref?: string };
+		head?: { ref?: string; repo?: { fork?: boolean } };
 		user?: { login?: string };
 		draft?: boolean;
 		author_association?: string;

--- a/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
@@ -27,6 +27,7 @@ export type GithubPayload = {
 	author_association?: string;
 	pull_request?: {
 		number?: number;
+		labels?: Array<{ name?: string }>;
 		title?: string;
 		html_url?: string;
 		head?: { ref?: string };
@@ -36,6 +37,7 @@ export type GithubPayload = {
 	};
 	issue?: {
 		number?: number;
+		labels?: Array<{ name?: string }>;
 		title?: string;
 		html_url?: string;
 		user?: { login?: string };
@@ -46,7 +48,12 @@ export type GithubPayload = {
 		user?: { login?: string };
 		author_association?: string;
 	};
-	review?: { state?: string; html_url?: string; user?: { login?: string } };
+	review?: {
+		state?: string;
+		body?: string;
+		html_url?: string;
+		user?: { login?: string };
+	};
 	ref?: string;
 	workflow_run?: { conclusion?: string; html_url?: string; name?: string };
 	check_suite?: { conclusion?: string };
@@ -102,6 +109,17 @@ export function actorIsExternalFor(payload: GithubPayload): boolean | null {
 	return !["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 }
 
+/**
+ * `action` is what distinguishes opened from closed from labeled; the bare
+ * event name is too coarse to match on.
+ */
+export function qualifiedEventType(
+	eventType: string,
+	payload: GithubPayload,
+): string {
+	return payload.action ? `${eventType}.${payload.action}` : eventType;
+}
+
 export function urlFor(payload: GithubPayload): string | null {
 	return (
 		payload.comment?.html_url ??
@@ -118,7 +136,14 @@ export async function recordAutomationEvent(params: {
 	deliveryId: string;
 	payload: unknown;
 	webhookEventId: string;
-}): Promise<{ recorded: boolean; reason?: string }> {
+}): Promise<{
+	recorded: boolean;
+	reason?: string;
+	eventId?: string;
+	organizationId?: string;
+	repositoryId?: string | null;
+	ref?: string | null;
+}> {
 	const payload = params.payload as GithubPayload;
 
 	const installationId = payload.installation?.id;
@@ -138,13 +163,13 @@ export async function recordAutomationEvent(params: {
 		return { recorded: false, reason: "unknown installation" };
 	}
 
-	// `action` is what distinguishes opened from closed from labeled; the bare
-	// event name is too coarse to match on.
-	const qualified = payload.action
-		? `${params.eventType}.${payload.action}`
-		: params.eventType;
+	const qualified = qualifiedEventType(params.eventType, payload);
 
-	await db
+	const repositoryId =
+		payload.repository?.id !== undefined ? String(payload.repository.id) : null;
+	const ref = payload.pull_request?.head?.ref ?? payload.ref ?? null;
+
+	const [inserted] = await db
 		.insert(automationEvents)
 		.values({
 			organizationId: installation.organizationId,
@@ -159,11 +184,8 @@ export async function recordAutomationEvent(params: {
 			url: urlFor(payload),
 			// The numeric id, not the full name: a repository can be renamed and
 			// triggers must keep matching it afterwards.
-			repositoryId:
-				payload.repository?.id !== undefined
-					? String(payload.repository.id)
-					: null,
-			ref: payload.pull_request?.head?.ref ?? payload.ref ?? null,
+			repositoryId,
+			ref,
 			actorLogin: payload.sender?.login ?? null,
 			actorIsExternal: actorIsExternalFor(payload),
 			// jsonb rejects \u0000, and a payload carrying one would otherwise
@@ -178,7 +200,18 @@ export async function recordAutomationEvent(params: {
 				automationEvents.provider,
 				automationEvents.externalEventId,
 			],
-		});
+		})
+		.returning({ id: automationEvents.id });
 
-	return { recorded: true };
+	// Empty on a redelivery the dedupe swallowed; the first delivery already
+	// dispatched whatever this event matches.
+	if (!inserted) return { recorded: false, reason: "duplicate delivery" };
+
+	return {
+		recorded: true,
+		eventId: inserted.id,
+		organizationId: installation.organizationId,
+		repositoryId,
+		ref,
+	};
 }

--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -2,7 +2,12 @@ import { db } from "@superset/db/client";
 import { webhookEvents } from "@superset/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { stripNullChars } from "@/lib/strip-null-chars";
-import { recordAutomationEvent } from "./recordAutomationEvent";
+import { dispatchMatchingTriggers } from "./dispatchMatchingTriggers";
+import {
+	type GithubPayload,
+	qualifiedEventType,
+	recordAutomationEvent,
+} from "./recordAutomationEvent";
 import { webhooks } from "./webhooks";
 
 export async function POST(request: Request) {
@@ -86,7 +91,25 @@ export async function POST(request: Request) {
 				payload,
 				webhookEventId: webhookEvent.id,
 			});
-			if (!recorded.recorded) {
+			if (recorded.recorded && recorded.eventId && recorded.organizationId) {
+				const result = await dispatchMatchingTriggers({
+					organizationId: recorded.organizationId,
+					eventId: recorded.eventId,
+					eventType: qualifiedEventType(
+						eventType ?? "unknown",
+						payload as GithubPayload,
+					),
+					repositoryId: recorded.repositoryId ?? null,
+					ref: recorded.ref ?? null,
+					payload: payload as GithubPayload,
+				});
+				if (result.matched > 0) {
+					console.log(
+						`[github/webhook] ${result.matched}/${result.considered} triggers matched:`,
+						eventId,
+					);
+				}
+			} else {
 				console.log(
 					`[github/webhook] Not recorded as automation event (${recorded.reason}):`,
 					eventId,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
 	"private": true,
 	"type": "module",
 	"exports": {
+		"./automation-matching": {
+			"types": "./src/automation-matching.ts",
+			"default": "./src/automation-matching.ts"
+		},
 		"./automation-triggers": {
 			"types": "./src/automation-triggers.ts",
 			"default": "./src/automation-triggers.ts"

--- a/packages/shared/src/automation-matching.ts
+++ b/packages/shared/src/automation-matching.ts
@@ -1,0 +1,199 @@
+import type {
+	GithubTriggerEvent,
+	TriggerActor,
+	TriggerScope,
+} from "./automation-triggers";
+
+/**
+ * Decides whether a recorded event satisfies a trigger's config.
+ *
+ * Pure and provider-shaped rather than payload-shaped: it takes the normalized
+ * fields `automation_events` already carries, so the same function can be run
+ * over historical rows to see what *would* have matched before anything is
+ * allowed to dispatch.
+ */
+
+/** The normalized event, as recorded. */
+export type MatchableEvent = {
+	/** Qualified with its action, e.g. `pull_request.opened`. */
+	eventType: string;
+	repositoryId: string | null;
+	ref: string | null;
+	actorLogin: string | null;
+	actorIsExternal: boolean | null;
+	labels: string[];
+	/** Comment or review body, when the event carries one. */
+	body: string | null;
+	/** Who opened the thing being commented on. */
+	subjectAuthorLogin: string | null;
+};
+
+export type MatchResult =
+	| { matches: true }
+	| { matches: false; reason: string };
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/**
+ * `null` matches nothing — an unconfigured filter should never fire. That is the
+ * opposite of the usual "empty means unrestricted" convention, and deliberate:
+ * a half-built trigger silently matching every repository is the worst
+ * available failure.
+ */
+export function scopeAllows(
+	scope: TriggerScope,
+	value: string | null,
+): boolean {
+	if (scope === null) return false;
+	if (scope.mode === "any") return true;
+	if (value === null) return false;
+	return scope.ids.includes(value);
+}
+
+/** Same, but for filters that are only meaningful on some events. */
+export function scopeAllowsAny(scope: TriggerScope, values: string[]): boolean {
+	if (scope === null) return false;
+	if (scope.mode === "any") return true;
+	return values.some((v) => scope.ids.includes(v));
+}
+
+export function actorAllows(
+	actor: TriggerActor,
+	login: string | null,
+	ownerLogin: string | null,
+): boolean {
+	if (actor === "anyone") return true;
+	if (actor === "me") return login !== null && login === ownerLogin;
+	if (login === null) return false;
+	return actor.ids.includes(login);
+}
+
+/** Applies a comment filter, treating an invalid regex as no match. */
+export function bodyMatches(
+	filter: { pattern: string; isRegex: boolean } | null,
+	body: string | null,
+): boolean {
+	if (!filter || filter.pattern === "") return true;
+	if (body === null) return false;
+	if (!filter.isRegex) {
+		return body.toLowerCase().includes(filter.pattern.toLowerCase());
+	}
+	try {
+		return new RegExp(filter.pattern, "i").test(body);
+	} catch {
+		// A trigger whose regex does not compile must not match everything.
+		return false;
+	}
+}
+
+/**
+ * Maps a GitHub delivery to the event a trigger names. GitHub's wire events are
+ * coarser than the product's: `pull_request.opened` is a draft opening or a
+ * normal one depending on a field in the payload.
+ */
+export function githubEventNames(event: {
+	eventType: string;
+	isDraft: boolean;
+	reviewState: string | null;
+	runConclusion: string | null;
+	threadResolved: boolean | null;
+}): GithubTriggerEvent[] {
+	const t = event.eventType;
+	switch (t) {
+		case "pull_request.opened":
+			return event.isDraft ? ["draft_opened"] : ["pull_request.opened"];
+		case "pull_request.ready_for_review":
+			return ["pull_request.opened"];
+		case "pull_request.synchronize":
+			return ["pull_request.pushed"];
+		case "pull_request.closed":
+			return ["pull_request.merged"];
+		case "pull_request.labeled":
+		case "pull_request.unlabeled":
+			return ["label_change"];
+		case "push":
+			return ["push_to_branch"];
+		case "check_suite.completed":
+			return ["checks_completed"];
+		case "issue_comment.created":
+			return ["comment_added", "issue_comment"];
+		case "pull_request_review_comment.created":
+			return ["pr_review_comment", "comment_added"];
+		case "pull_request_review.submitted": {
+			const any: GithubTriggerEvent[] = ["pr_review_submitted.any"];
+			if (event.reviewState === "approved") {
+				any.push("pr_review_submitted.approved");
+			}
+			if (event.reviewState === "changes_requested") {
+				any.push("pr_review_submitted.changes_requested");
+			}
+			if (event.reviewState === "commented") {
+				any.push("pr_review_submitted.commented");
+			}
+			return any;
+		}
+		case "pull_request_review_thread.resolved":
+			return ["review_thread.resolved", "review_thread.any"];
+		case "pull_request_review_thread.unresolved":
+			return ["review_thread.unresolved", "review_thread.any"];
+		case "workflow_run.completed": {
+			const any: GithubTriggerEvent[] = ["workflow_run.any"];
+			if (event.runConclusion === "success") any.push("workflow_run.success");
+			if (event.runConclusion === "failure") any.push("workflow_run.failure");
+			if (event.runConclusion === "cancelled") {
+				any.push("workflow_run.cancelled");
+			}
+			return any;
+		}
+		default:
+			return [];
+	}
+}
+
+/** Whether a GitHub trigger config accepts this event. */
+export function githubTriggerMatches(
+	config: {
+		event: string;
+		repositories: TriggerScope;
+		branches: TriggerScope;
+		labels: TriggerScope;
+		actor: TriggerActor;
+		subjectAuthor?: TriggerActor;
+		commentFilter?: { pattern: string; isRegex: boolean } | null;
+		includeForks: boolean;
+	},
+	event: MatchableEvent,
+	context: { names: GithubTriggerEvent[]; ownerLogin: string | null },
+): MatchResult {
+	if (!context.names.includes(config.event as GithubTriggerEvent)) {
+		return no("event");
+	}
+	if (!scopeAllows(config.repositories, event.repositoryId)) {
+		return no("repository");
+	}
+	// Branches and labels only narrow when configured; null means the trigger
+	// author did not choose to filter on them, which for these is "any".
+	if (config.branches !== null && !scopeAllows(config.branches, event.ref)) {
+		return no("branch");
+	}
+	if (config.labels !== null && !scopeAllowsAny(config.labels, event.labels)) {
+		return no("label");
+	}
+	if (!actorAllows(config.actor, event.actorLogin, context.ownerLogin)) {
+		return no("actor");
+	}
+	if (
+		config.subjectAuthor !== undefined &&
+		!actorAllows(
+			config.subjectAuthor,
+			event.subjectAuthorLogin,
+			context.ownerLogin,
+		)
+	) {
+		return no("subjectAuthor");
+	}
+	if (!bodyMatches(config.commentFilter ?? null, event.body)) {
+		return no("commentFilter");
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-matching.ts
+++ b/packages/shared/src/automation-matching.ts
@@ -24,6 +24,8 @@ export type MatchableEvent = {
 	labels: string[];
 	/** Comment or review body, when the event carries one. */
 	body: string | null;
+	/** Fork pull requests carry attacker-controlled content into a checkout. */
+	isFork: boolean;
 	/** Who opened the thing being commented on. */
 	subjectAuthorLogin: string | null;
 };
@@ -68,6 +70,16 @@ export function actorAllows(
 	return actor.ids.includes(login);
 }
 
+/**
+ * The body a filter is tested against is truncated first.
+ *
+ * A user-supplied pattern runs on the webhook path, and JavaScript's engine
+ * backtracks: `^(a+)+$` against a long non-matching body is exponential and
+ * would block the event loop. Truncation bounds the exponent; it does not
+ * remove it, which is why a linear-time engine is still wanted here.
+ */
+const MAX_FILTERED_BODY = 4096;
+
 /** Applies a comment filter, treating an invalid regex as no match. */
 export function bodyMatches(
 	filter: { pattern: string; isRegex: boolean } | null,
@@ -75,11 +87,12 @@ export function bodyMatches(
 ): boolean {
 	if (!filter || filter.pattern === "") return true;
 	if (body === null) return false;
+	const subject = body.slice(0, MAX_FILTERED_BODY);
 	if (!filter.isRegex) {
-		return body.toLowerCase().includes(filter.pattern.toLowerCase());
+		return subject.toLowerCase().includes(filter.pattern.toLowerCase());
 	}
 	try {
-		return new RegExp(filter.pattern, "i").test(body);
+		return new RegExp(filter.pattern, "i").test(subject);
 	} catch {
 		// A trigger whose regex does not compile must not match everything.
 		return false;
@@ -191,6 +204,9 @@ export function githubTriggerMatches(
 		)
 	) {
 		return no("subjectAuthor");
+	}
+	if (!config.includeForks && event.isFork) {
+		return no("fork");
 	}
 	if (!bodyMatches(config.commentFilter ?? null, event.body)) {
 		return no("commentFilter");

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -52,10 +52,20 @@ export function isEmptyActor(actor: TriggerActor): boolean {
 const rrule = z.string().min(1).max(500);
 const iana = z.string().min(1);
 
-/** A free-text match over a comment body, optionally as a regex. */
+/**
+ * A free-text match over a comment body.
+ *
+ * `isRegex` is pinned to false. A user-supplied pattern is evaluated on the
+ * webhook path, and JavaScript's engine backtracks: `^(a+)+$` against a
+ * non-matching body doubles in cost every two characters — 408ms at 28
+ * characters, and never finishing at a realistic comment length. Truncating the
+ * body bounds nothing, because the blowup happens within the first few dozen
+ * characters. Substring matching covers the common case; regex returns with a
+ * linear-time engine.
+ */
 export const textFilterSchema = z.object({
 	pattern: z.string().max(500),
-	isRegex: z.boolean().default(false),
+	isRegex: z.literal(false).default(false),
 });
 export type TextFilter = z.infer<typeof textFilterSchema>;
 

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -43,11 +43,15 @@ export type DispatchableAutomation = Pick<
 	| "v2WorkspaceId"
 >;
 
-export interface DispatchOptions {
+/** What caused this run: a schedule with a due minute, or a matched event. */
+export type DispatchCause =
+	| { scheduledFor: Date; trigger?: null }
+	| { scheduledFor?: null; trigger: { triggerId: string; eventId: string } };
+
+export type DispatchOptions = {
 	automation: DispatchableAutomation;
-	scheduledFor: Date;
 	relayUrl: string;
-}
+} & DispatchCause;
 
 /**
  * Run one automation: resolve host, (maybe) create a workspace, start the
@@ -59,7 +63,9 @@ export interface DispatchOptions {
 export async function dispatchAutomation(
 	opts: DispatchOptions,
 ): Promise<DispatchOutcome> {
-	const { automation, scheduledFor, relayUrl } = opts;
+	const { automation, relayUrl } = opts;
+	const scheduledFor = opts.scheduledFor ?? null;
+	const trigger = opts.trigger ?? null;
 
 	const candidates = await resolveCandidateHosts(automation);
 	if (candidates.length === 0) {
@@ -87,6 +93,8 @@ export async function dispatchAutomation(
 			organizationId: automation.organizationId,
 			title: automation.name,
 			scheduledFor,
+			triggerId: trigger?.triggerId ?? null,
+			eventId: trigger?.eventId ?? null,
 			hostId: host.machineId,
 			status: "dispatching",
 		})
@@ -283,7 +291,7 @@ async function pickOnlineHost(
 
 async function recordSkipped(
 	automation: DispatchableAutomation,
-	scheduledFor: Date,
+	scheduledFor: Date | null,
 	hostId: string | null,
 	error: string,
 ): Promise<{ id: string } | undefined> {


### PR DESCRIPTION
**Completes the loop.** A GitHub delivery is recorded, matched against the org's enabled triggers, and dispatched as a run. Until now a trigger could be saved but nothing read it.

Supersedes the util-only version of this PR — that had no caller, so there was nothing to actually review.

No migration: `automation_runs.trigger_id` / `event_id` and a nullable `scheduled_for` were added in the earlier migration and finally have writers.

## The path

```
GitHub delivery
  → ingest.webhook_events        (existing, unchanged)
  → automation_events            (normalized, org resolved via installation)
  → match enabled github triggers for that org
  → QStash → /api/automations/dispatch/:id  { triggerId, eventId }
  → automation_runs              (scheduled_for null, trigger_id + event_id set)
```

## Two deliberate inversions in matching

**An unconfigured scope matches nothing.** Usually an empty filter means unrestricted. Here `null` is a closed door, because the failure it prevents is worse: a half-built trigger silently firing on every repository in the org. Branches and labels are the documented exception — `null` there means the author chose not to filter.

**A regex that does not compile matches nothing**, so a typo narrows rather than widens.

## One delivery, several named events

| delivery | matches |
|---|---|
| `pull_request.opened`, `draft: true` | `draft_opened` |
| `pull_request.opened` otherwise | `pull_request.opened` |
| review submitted, approved | `pr_review_submitted.any` **and** `.approved` |
| workflow run failed | `workflow_run.any` **and** `.failure` |

This is why the schema names these separately rather than one event plus a filter — "any review" and "approved only" must both fire on one delivery.

## What stops it running away

- **Disabled automations are skipped.** That toggle is the gate a person actually controls, so pausing an automation stops it without disabling each trigger.
- **Duplicates die twice before a run exists:** a redelivered GitHub delivery is swallowed by the `automation_events` dedupe and never reaches matching, and QStash dedupes on `triggerId_eventId`.
- **Recording and dispatch run outside the existing processing `try`**, so a failure here can't fail a delivery GitHub would retry.
- Nothing has event triggers configured yet — the editor UI doesn't exist — so the live blast radius today is zero.

## Verified

13 matching cases: repository scoping including `null` and `any`; regex hit, miss and invalid; case-insensitive substring; actor allow-list; `me` resolving to the automation owner and rejecting others; `subjectAuthor` filtering independently of `actor`; wrong event kind. Plus the four mappings above, and the event recorder's normalization and dedupe from the previous PR.

Each rejection carries a reason (`repository`, `actor`, `commentFilter`, …), which is what will make "why didn't my automation run" answerable.

Typecheck, lint and the full suite pass.

## Known gap

`me` resolves against `automations.ownerUserId`, which is a Superset user id, while the event carries a GitHub login. That comparison won't match until GitHub identities are linked to users — so `me` behaves as "nobody" today rather than misfiring. Worth fixing with the editor work, when there's a way to pick people at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable automation-trigger matching across normalized GitHub event types.
  - Added filtering by repository, branch, labels, actors, subject authors, fork status, and comment content.
  - Added automatic dispatch of matching automations from GitHub webhook events.
  - Added support for event-triggered automation runs alongside scheduled runs.
  - Exposed automation-matching capabilities for shared application features.

- **Updates**
  - Limited configurable comment and message filters to case-insensitive literal text matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->