### PR TITLE
feat(desktop): let users dismiss the new-workspace sample prompts

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -119,6 +119,12 @@ export function NewWorkspaceScreen({
 	const setLastHostId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.setLastHostId,
 	);
+	const samplePromptsDismissed = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.samplePromptsDismissed,
+	);
+	const setSamplePromptsDismissed = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setSamplePromptsDismissed,
+	);
 
 	useEffect(() => {
 		if (!isOpen) return;
@@ -357,6 +363,13 @@ export function NewWorkspaceScreen({
 	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 
 	const promptCardsVariant = useNewWorkspacePromptCardsVariant(isOpen);
+	// Logged so the prompt-cards experiment can account for lost exposure.
+	const handleDismissSamplePrompts = useCallback(() => {
+		track("new_workspace_sample_prompts_dismissed", {
+			layout: promptCardsVariant === "test" ? "cards" : "rows",
+		});
+		setSamplePromptsDismissed(true);
+	}, [promptCardsVariant, setSamplePromptsDismissed]);
 
 	const { agents: v2Agents, isFetched: v2AgentsFetched } =
 		useV2AgentChoices(launchHostUrl);
@@ -601,26 +614,32 @@ export function NewWorkspaceScreen({
 			</div>
 			<div className="relative flex w-full max-w-[640px] flex-col px-6 pb-8">
 				<AnimatePresence initial={false}>
-					{isPromptEmpty && promptCardsVariant !== null && (
-						<motion.div
-							key="sample-prompts"
-							initial={{ opacity: 0, y: 12 }}
-							animate={{ opacity: 1, y: 0 }}
-							exit={{ opacity: 0, transition: { duration: 0 } }}
-							transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
-							className="absolute inset-x-6 bottom-full mb-1"
-						>
-							{promptCardsVariant === "test" ? (
-								<SamplePromptCards
-									hostUrl={launchHostUrl}
-									projectId={projectId}
-									onSelect={applyPrompt}
-								/>
-							) : (
-								<SamplePrompts onSelect={applyPrompt} />
-							)}
-						</motion.div>
-					)}
+					{isPromptEmpty &&
+						promptCardsVariant !== null &&
+						!samplePromptsDismissed && (
+							<motion.div
+								key="sample-prompts"
+								initial={{ opacity: 0, y: 12 }}
+								animate={{ opacity: 1, y: 0 }}
+								exit={{ opacity: 0, transition: { duration: 0 } }}
+								transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
+								className="absolute inset-x-6 bottom-full mb-1"
+							>
+								{promptCardsVariant === "test" ? (
+									<SamplePromptCards
+										hostUrl={launchHostUrl}
+										projectId={projectId}
+										onSelect={applyPrompt}
+										onDismiss={handleDismissSamplePrompts}
+									/>
+								) : (
+									<SamplePrompts
+										onSelect={applyPrompt}
+										onDismiss={handleDismissSamplePrompts}
+									/>
+								)}
+							</motion.div>
+						)}
 				</AnimatePresence>
 				<PromptInput
 					onSubmit={handleSubmit}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -78,7 +78,7 @@ export function SamplePromptCards({
 			>
 				<XIcon className="size-3" />
 			</button>
-			<div className="grid grid-cols-2 gap-1.5 rounded-2xl border-[0.5px] border-border/60 bg-foreground/[0.03] p-1.5">
+			<div className="grid grid-cols-2 gap-1.5 rounded-2xl bg-foreground/[0.03] p-1.5">
 				{cards.map((sample) => {
 					const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
 					return (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -78,14 +78,14 @@ export function SamplePromptCards({
 			>
 				<XIcon className="size-3" />
 			</button>
-			<div className="grid grid-cols-2 gap-1.5 rounded-2xl bg-foreground/[0.03] p-1.5">
+			<div className="grid grid-cols-2 gap-2">
 				{cards.map((sample) => {
 					const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
 					return (
 						<button
 							key={sample.id}
 							type="button"
-							className="flex cursor-pointer flex-col items-start gap-1.5 rounded-[11px] bg-background/70 p-3 text-left transition-colors hover:bg-foreground/[0.06]"
+							className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl bg-foreground/[0.03] p-3 text-left transition-colors hover:bg-foreground/[0.06]"
 							onClick={() => {
 								track("new_workspace_sample_prompt_clicked", {
 									prompt_id: sample.id,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -6,6 +6,7 @@ import {
 	ListChecksIcon,
 	ScrollTextIcon,
 	WrenchIcon,
+	XIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { track } from "renderer/lib/analytics";
@@ -28,12 +29,14 @@ interface SamplePromptCardsProps {
 	hostUrl: string | null;
 	projectId: string | null;
 	onSelect: (prompt: string) => void;
+	onDismiss: () => void;
 }
 
 export function SamplePromptCards({
 	hostUrl,
 	projectId,
 	onSelect,
+	onDismiss,
 }: SamplePromptCardsProps) {
 	// Shuffled once per mount so every prompt in the pool gets exposure;
 	// re-shuffling per render would reorder cards under the pointer.
@@ -66,7 +69,15 @@ export function SamplePromptCards({
 	].slice(0, CARD_COUNT);
 
 	return (
-		<div className="px-1 pb-2">
+		<div className="group relative px-1 pb-2">
+			<button
+				type="button"
+				aria-label="Dismiss suggestions"
+				onClick={onDismiss}
+				className="absolute -top-2 right-0 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full border-[0.5px] border-border bg-popover text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+			>
+				<XIcon className="size-3" />
+			</button>
 			<div className="grid grid-cols-2 gap-1.5 rounded-2xl border-[0.5px] border-border/60 bg-foreground/[0.03] p-1.5">
 				{cards.map((sample) => {
 					const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from "lucide-react";
+import { SparklesIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import { track } from "renderer/lib/analytics";
 import { shuffledSamplePrompts } from "./constants";
@@ -8,15 +8,24 @@ const ROW_COUNT = 4;
 
 interface SamplePromptsProps {
 	onSelect: (prompt: string) => void;
+	onDismiss: () => void;
 }
 
-export function SamplePrompts({ onSelect }: SamplePromptsProps) {
+export function SamplePrompts({ onSelect, onDismiss }: SamplePromptsProps) {
 	// Shuffled once per mount so every prompt in the pool gets exposure;
 	// re-shuffling per render would reorder rows under the pointer.
 	const [shuffledPrompts] = useState(shuffledSamplePrompts);
 
 	return (
-		<div className="flex flex-col items-start gap-0.5 px-1 pb-2">
+		<div className="group relative flex flex-col items-start gap-0.5 px-1 pb-2">
+			<button
+				type="button"
+				aria-label="Dismiss suggestions"
+				onClick={onDismiss}
+				className="absolute -top-2 right-0 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full border-[0.5px] border-border bg-popover text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+			>
+				<XIcon className="size-3" />
+			</button>
 			{shuffledPrompts.slice(0, ROW_COUNT).map((sample) => (
 				<button
 					key={sample.id}

--- a/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.ts
+++ b/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.ts
@@ -12,6 +12,8 @@ interface V2WorkspaceCreateDefaultsState {
 	lastProjectId: string | null;
 	baseBranchesByProjectId: Record<string, V2WorkspaceCreateBaseBranchDefault>;
 	lastHostId: string | null;
+	/** User closed the sample-prompt suggestions on the create surface. */
+	samplePromptsDismissed: boolean;
 
 	setLastProjectId: (projectId: string | null) => void;
 	setBaseBranchDefault: (
@@ -21,6 +23,7 @@ interface V2WorkspaceCreateDefaultsState {
 	) => void;
 	clearBaseBranchDefault: (projectId: string) => void;
 	setLastHostId: (hostId: string | null) => void;
+	setSamplePromptsDismissed: (dismissed: boolean) => void;
 }
 
 export const useV2WorkspaceCreateDefaultsStore =
@@ -31,6 +34,7 @@ export const useV2WorkspaceCreateDefaultsStore =
 					lastProjectId: null,
 					baseBranchesByProjectId: {},
 					lastHostId: null,
+					samplePromptsDismissed: false,
 
 					setLastProjectId: (projectId) => set({ lastProjectId: projectId }),
 
@@ -54,6 +58,9 @@ export const useV2WorkspaceCreateDefaultsStore =
 						}),
 
 					setLastHostId: (hostId) => set({ lastHostId: hostId }),
+
+					setSamplePromptsDismissed: (dismissed) =>
+						set({ samplePromptsDismissed: dismissed }),
 				}),
 				{
 					name: "v2-workspace-create-defaults",


### PR DESCRIPTION
## Summary
- Adds a hover-reveal ✕ to the sample-prompt suggestions on the new-workspace screen (both experiment arms — cards tray and rows). Dismissing hides them permanently; the rotating ghost-text placeholder remains as the suggestion surface.

## Why / Context
Follow-up to #6537. The template cards target cold-start users, but they render for every user on every empty composer, forever — Codex, by comparison, only shows its template cards until you have task history. Power users get a way to clear them; the analytics keep measuring whether veterans use them at all.

## How It Works
- `samplePromptsDismissed` boolean on the existing `v2-workspace-create-defaults` persisted store (already allowlisted in the persisted-key registry; fixed-size singleton, zustand persist shallow-merges the new field to `false` for existing profiles — no version bump).
- `NewWorkspaceScreen` gates the suggestion block on the flag and passes `onDismiss` to both layouts; dismissal fires `new_workspace_sample_prompts_dismissed` with the active layout so the cards-vs-rows experiment can account for lost exposure.
- The ✕ is `opacity-0` until container hover (or keyboard focus), so it adds no visual noise.

## Manual QA Checklist
Verified live via CDP against the dev desktop:
- [x] ✕ appears on hover at the tray's top-right, hidden otherwise
- [x] Clicking it removes the suggestions; composer + ghost text unaffected
- [x] `samplePromptsDismissed: true` lands in the persisted store
- [x] Suggestions stay gone after `location.reload()`
- [x] Persisted-key registry tests pass (no unregistered writer)

## Testing
- `bun run typecheck`
- `biome check` on touched files
- `bun test src/renderer/lib/persisted-keys`

## Known Limitations
- No un-dismiss UI yet — deliberate until the dismissal-rate data says whether anyone wants them back (a Settings → Behavior toggle is the natural home if so).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users dismiss sample prompt suggestions on the new-workspace screen. Previously they showed on every empty composer; now a hover-reveal X hides them permanently while the rotating ghost-text placeholder remains. The sample-card container is removed so cards float directly on the canvas.

**Review notes**
- Persist `samplePromptsDismissed` in `v2-workspace-create-defaults` (default false; shallow-merged for existing profiles). No migration.
- Gate suggestions on this flag in both layouts; pass `onDismiss` through `SamplePromptCards` and `SamplePrompts`; show the close button on hover/focus only.
- Track `new_workspace_sample_prompts_dismissed` with the active layout to account for lost exposure.

<sup>Written for commit 5086ed2c332928dc21752b374eb2c1a13e6b4cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to dismiss sample prompt suggestions when creating a workspace.
  * Dismissal preferences are saved and persist across sessions.
  * Added accessible dismiss controls that appear on hover or keyboard focus.
  * Sample prompts now hide after dismissal and only appear when relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->