### PR TITLE
feat(desktop,host-service): discover agent capabilities at runtime

### DIFF
--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.test.ts
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAgentModelSelectValue } from "./AgentModelSelect";
+import { sortAgentModelOptions } from "./sortAgentModelOptions";
+
+const models = [
+	{ id: "model-a", label: "Model A" },
+	{ id: "model-b", label: "Model B" },
+];
+
+describe("resolveAgentModelSelectValue", () => {
+	test("uses a valid explicit selection", () => {
+		expect(resolveAgentModelSelectValue(models, "model-b", false)).toBe(
+			"model-b",
+		);
+	});
+
+	test("falls back to the first model when the synthetic default is omitted", () => {
+		expect(resolveAgentModelSelectValue(models, null, false)).toBe("model-a");
+	});
+
+	test("uses the synthetic default only when requested", () => {
+		expect(resolveAgentModelSelectValue(models, null, true)).toBe(
+			"__default_model__",
+		);
+	});
+});
+
+describe("sortAgentModelOptions", () => {
+	test("sorts model versions newest-first and known tiers consistently", () => {
+		const unsortedModels = [
+			{ id: "auto", label: "Auto" },
+			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+			{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
+			{ id: "gpt-oss-120b", label: "GPT OSS 120B" },
+			{ id: "gpt-5.5", label: "GPT-5.5" },
+			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+			{ id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+			{ id: "gpt-5.4", label: "GPT-5.4" },
+		];
+
+		expect(
+			sortAgentModelOptions(unsortedModels).map((model) => model.id),
+		).toEqual([
+			"auto",
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+			"gpt-oss-120b",
+		]);
+	});
+
+	test("applies tier ordering to other model families", () => {
+		const unsortedModels = [
+			{ id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+			{ id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+			{ id: "claude-fable-5", label: "Claude Fable 5" },
+			{ id: "claude-opus-5", label: "Claude Opus 5" },
+		];
+
+		expect(
+			sortAgentModelOptions(unsortedModels).map((model) => model.id),
+		).toEqual([
+			"claude-opus-5",
+			"claude-fable-5",
+			"claude-sonnet-5",
+			"claude-opus-4-8",
+		]);
+	});
+
+	test("preserves family order instead of comparing vendor version numbers", () => {
+		const unsortedModels = [
+			{ id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+			{ id: "gpt-5.4", label: "GPT-5.4" },
+			{ id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
+			{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+		];
+
+		expect(
+			sortAgentModelOptions(unsortedModels).map((model) => model.id),
+		).toEqual([
+			"claude-sonnet-4.6",
+			"claude-haiku-4.5",
+			"gpt-5.4",
+			"gpt-5.3-codex",
+		]);
+	});
+
+	test("preserves runtime order when models have no semantic distinction", () => {
+		const unsortedModels = [
+			{ id: "custom-beta", label: "Custom Beta" },
+			{ id: "custom-alpha", label: "Custom Alpha" },
+		];
+
+		expect(sortAgentModelOptions(unsortedModels)).toEqual(unsortedModels);
+	});
+});

--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -2,13 +2,29 @@ import type { AgentModelOption } from "@superset/shared/agent-models";
 import {
 	Select,
 	SelectContent,
+	SelectGroup,
 	SelectItem,
+	SelectLabel,
+	SelectSeparator,
 	SelectTrigger,
 	SelectValue,
 } from "@superset/ui/select";
+import { sortAgentModelOptions } from "./sortAgentModelOptions";
 
 // Radix Select reserves "" for clearing, so "Default" needs a sentinel.
 const DEFAULT_MODEL_VALUE = "__default_model__";
+
+export function resolveAgentModelSelectValue(
+	models: AgentModelOption[],
+	value: string | null,
+	includeDefault: boolean,
+): string | undefined {
+	if (value !== null && models.some((model) => model.id === value)) {
+		return value;
+	}
+	if (includeDefault) return DEFAULT_MODEL_VALUE;
+	return models[0]?.id;
+}
 
 interface AgentModelSelectProps {
 	models: AgentModelOption[];
@@ -20,6 +36,7 @@ interface AgentModelSelectProps {
 	/** Trigger/item text for the default option — two adjacent selects both
 	 * reading "Default" are indistinguishable, so callers name theirs. */
 	defaultLabel?: string;
+	includeDefault?: boolean;
 }
 
 export function AgentModelSelect({
@@ -30,11 +47,19 @@ export function AgentModelSelect({
 	triggerClassName,
 	contentClassName,
 	defaultLabel = "Default",
+	includeDefault = true,
 }: AgentModelSelectProps) {
-	const selectedValue =
-		value !== null && models.some((model) => model.id === value)
-			? value
-			: DEFAULT_MODEL_VALUE;
+	const selectedValue = resolveAgentModelSelectValue(
+		models,
+		value,
+		includeDefault,
+	);
+	const hasProviderGroups = models.some((model) => model.provider);
+	const providerGroups = Map.groupBy(
+		models,
+		(model) => model.provider ?? "Other",
+	);
+	const sortedModels = sortAgentModelOptions(models);
 
 	const handleValueChange = (nextValue: string) => {
 		onValueChange(nextValue === DEFAULT_MODEL_VALUE ? null : nextValue);
@@ -50,12 +75,28 @@ export function AgentModelSelect({
 				<SelectValue placeholder={defaultLabel} />
 			</SelectTrigger>
 			<SelectContent className={contentClassName}>
-				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
-				{models.map((model) => (
-					<SelectItem key={model.id} value={model.id}>
-						{model.label}
-					</SelectItem>
-				))}
+				{includeDefault && (
+					<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
+				)}
+				{hasProviderGroups
+					? Array.from(providerGroups.entries()).map(
+							([provider, providerModels], index) => (
+								<SelectGroup key={provider}>
+									{index > 0 && <SelectSeparator />}
+									<SelectLabel>{provider}</SelectLabel>
+									{sortAgentModelOptions(providerModels).map((model) => (
+										<SelectItem key={model.id} value={model.id}>
+											{model.label}
+										</SelectItem>
+									))}
+								</SelectGroup>
+							),
+						)
+					: sortedModels.map((model) => (
+							<SelectItem key={model.id} value={model.id}>
+								{model.label}
+							</SelectItem>
+						))}
 			</SelectContent>
 		</Select>
 	);

--- a/apps/desktop/src/renderer/components/AgentModelSelect/sortAgentModelOptions.ts
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/sortAgentModelOptions.ts
@@ -1,0 +1,89 @@
+import type { AgentModelOption } from "@superset/shared/agent-models";
+
+const MODEL_TIER_ORDER = new Map([
+	["sol", 0],
+	["terra", 1],
+	["luna", 2],
+	["opus", 0],
+	["fable", 1],
+	["sonnet", 2],
+	["haiku", 3],
+	["pro", 0],
+	["flash", 1],
+	["mini", 10],
+	["nano", 11],
+]);
+
+const FAMILY_TIER_TOKENS = new Set([
+	"sol",
+	"terra",
+	"luna",
+	"opus",
+	"fable",
+	"sonnet",
+	"haiku",
+	"pro",
+	"flash",
+	"mini",
+	"nano",
+]);
+
+function normalizedModelId(model: AgentModelOption): string {
+	return (model.id.split("/").at(-1) ?? model.id).toLowerCase();
+}
+
+function getModelFamily(model: AgentModelOption): string {
+	const id = normalizedModelId(model);
+	const prefix = id.match(/^[^0-9]+/)?.[0] ?? id;
+	const tokens = prefix
+		.split(/[^a-z]+/)
+		.filter(Boolean)
+		.filter((token) => !FAMILY_TIER_TOKENS.has(token));
+	return tokens.join("-") || id;
+}
+
+function getModelVersion(model: AgentModelOption): number[] {
+	const version = normalizedModelId(model).match(/\d+(?:[.-]\d+)*/)?.[0];
+	return version?.split(/[.-]/).map(Number) ?? [];
+}
+
+function compareVersions(left: number[], right: number[]): number {
+	for (let index = 0; index < Math.max(left.length, right.length); index++) {
+		const difference = (right[index] ?? 0) - (left[index] ?? 0);
+		if (difference !== 0) return difference;
+	}
+	return 0;
+}
+
+function getModelTier(model: AgentModelOption): number {
+	const tokens = `${model.id} ${model.label}`.toLowerCase().split(/[^a-z]+/);
+	for (const token of tokens) {
+		const rank = MODEL_TIER_ORDER.get(token);
+		if (rank !== undefined) return rank;
+	}
+	return 5;
+}
+
+function sortModelFamily(models: AgentModelOption[]): AgentModelOption[] {
+	return models
+		.map((model, index) => ({ model, index }))
+		.sort((left, right) => {
+			const versionOrder = compareVersions(
+				getModelVersion(left.model),
+				getModelVersion(right.model),
+			);
+			if (versionOrder !== 0) return versionOrder;
+
+			const tierOrder = getModelTier(left.model) - getModelTier(right.model);
+			return tierOrder !== 0 ? tierOrder : left.index - right.index;
+		})
+		.map(({ model }) => model);
+}
+
+export function sortAgentModelOptions(
+	models: AgentModelOption[],
+): AgentModelOption[] {
+	return Array.from(Map.groupBy(models, getModelFamily).values()).flatMap(
+		sortModelFamily,
+	);
+}

--- a/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
@@ -75,7 +75,7 @@ export function AgentSelect<T extends string>({
 
 	return (
 		<Select
-			value={selectedValue}
+			value={selectedValue ?? ""}
 			onValueChange={handleValueChange}
 			disabled={disabled}
 		>

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -575,8 +575,8 @@ function PromptGroupInner({
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({
 			agentStorageKey: AGENT_STORAGE_KEY,
 			defaultAgent: "claude",
-			fallbackAgent: "none",
-			validAgents: ["none", ...selectableAgentIds],
+			fallbackAgent: selectableAgentIds[0] ?? "none",
+			validAgents: selectableAgentIds,
 			agentsReady: agentPresetsQuery.isFetched,
 		});
 	const [gitHubIssueLinkOpen, setGitHubIssueLinkOpen] = useState(false);
@@ -1276,14 +1276,11 @@ ${sanitizeText(truncatedBody)}`;
 						<AgentSelect<WorkspaceCreateAgent>
 							agents={enabledAgentPresets}
 							value={selectedAgent}
-							placeholder="No agent"
+							placeholder="Select agent"
 							onValueChange={setSelectedAgent}
 							onBeforeConfigureAgents={closeModal}
 							triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							iconClassName="size-3 object-contain"
-							allowNone
-							noneLabel="No agent"
-							noneValue="none"
 						/>
 					</PromptInputTools>
 					<div className="flex items-center gap-2">

--- a/apps/desktop/src/renderer/hooks/useAgentContextWindowPreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentContextWindowPreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentContextWindowPreference } from "./useAgentContextWindowPreference";

--- a/apps/desktop/src/renderer/hooks/useAgentContextWindowPreference/useAgentContextWindowPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentContextWindowPreference/useAgentContextWindowPreference.ts
@@ -1,0 +1,86 @@
+import {
+	type AgentContextWindowSupport,
+	getAgentContextWindowSupport,
+} from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(storageKey);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return {};
+		}
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredContextWindow(
+	storageKey: string,
+	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentContextWindowSupport,
+): string | null {
+	if (!presetId || !model) return null;
+	const support =
+		supportOverride ?? getAgentContextWindowSupport(presetId, model);
+	if (!support) return null;
+	const stored =
+		readStoredMap(storageKey)[`${presetId}:${model}`] ??
+		support.defaultContextWindowId;
+	return support.contextWindows.some((option) => option.id === stored)
+		? stored
+		: support.defaultContextWindowId;
+}
+
+export function useAgentContextWindowPreference(
+	storageKey: string,
+	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentContextWindowSupport,
+) {
+	const [selectedContextWindow, setSelectedContextWindowState] = useState<
+		string | null
+	>(() =>
+		readStoredContextWindow(storageKey, presetId, model, supportOverride),
+	);
+
+	useEffect(() => {
+		setSelectedContextWindowState(
+			readStoredContextWindow(storageKey, presetId, model, supportOverride),
+		);
+	}, [storageKey, presetId, model, supportOverride]);
+
+	const setSelectedContextWindow = useCallback(
+		(contextWindow: string | null) => {
+			setSelectedContextWindowState(contextWindow);
+			if (typeof window === "undefined" || !presetId || !model) {
+				return;
+			}
+			const map = readStoredMap(storageKey);
+			const preferenceKey = `${presetId}:${model}`;
+			if (contextWindow) map[preferenceKey] = contextWindow;
+			else delete map[preferenceKey];
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// The active selection still applies when persistence is unavailable.
+			}
+		},
+		[storageKey, presetId, model],
+	);
+
+	return { selectedContextWindow, setSelectedContextWindow };
+}

--- a/apps/desktop/src/renderer/hooks/useAgentEffortPreference/useAgentEffortPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentEffortPreference/useAgentEffortPreference.ts
@@ -1,4 +1,7 @@
-import { getAgentEffortSupport } from "@superset/shared/agent-models";
+import {
+	type AgentEffortSupport,
+	getAgentEffortSupport,
+} from "@superset/shared/agent-models";
 import { useCallback, useEffect, useState } from "react";
 
 function readStoredMap(storageKey: string): Record<string, string> {
@@ -22,45 +25,52 @@ function readStoredMap(storageKey: string): Record<string, string> {
 function readStoredEffort(
 	storageKey: string,
 	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentEffortSupport,
 ): string | null {
 	if (!presetId) return null;
-	const stored = readStoredMap(storageKey)[presetId];
+	const preferenceKey = model ? `${presetId}:${model}` : presetId;
+	const stored = readStoredMap(storageKey)[preferenceKey];
 	if (!stored) return null;
 	// Drop ids that fell out of the curated registry — "Default" beats a
 	// flag value the CLI no longer accepts.
-	const support = getAgentEffortSupport(presetId);
+	const support = supportOverride ?? getAgentEffortSupport(presetId, model);
 	return support?.efforts.some((effort) => effort.id === stored)
 		? stored
 		: null;
 }
 
 /**
- * Last-selected reasoning effort per agent preset, persisted as a JSON map in
- * localStorage. Same contract as `useAgentModelPreference`: keyed by presetId
- * so the preference survives host switches; `null` means "Default" — no
- * stored entry, no effort flag at launch.
+ * Last-selected reasoning effort per agent model, persisted as a JSON map in
+ * localStorage. Model-scoped keys prevent a value supported by one model from
+ * leaking into another; `null` means no override flag at launch.
  */
 export function useAgentEffortPreference(
 	storageKey: string,
 	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentEffortSupport,
 ) {
 	const [selectedEffort, setSelectedEffortState] = useState<string | null>(() =>
-		readStoredEffort(storageKey, presetId),
+		readStoredEffort(storageKey, presetId, model, supportOverride),
 	);
 
 	useEffect(() => {
-		setSelectedEffortState(readStoredEffort(storageKey, presetId));
-	}, [storageKey, presetId]);
+		setSelectedEffortState(
+			readStoredEffort(storageKey, presetId, model, supportOverride),
+		);
+	}, [storageKey, presetId, model, supportOverride]);
 
 	const setSelectedEffort = useCallback(
 		(effort: string | null) => {
 			setSelectedEffortState(effort);
 			if (typeof window === "undefined" || !presetId) return;
 			const map = readStoredMap(storageKey);
+			const preferenceKey = model ? `${presetId}:${model}` : presetId;
 			if (effort) {
-				map[presetId] = effort;
+				map[preferenceKey] = effort;
 			} else {
-				delete map[presetId];
+				delete map[preferenceKey];
 			}
 			try {
 				window.localStorage.setItem(storageKey, JSON.stringify(map));
@@ -69,7 +79,7 @@ export function useAgentEffortPreference(
 				// the in-memory selection above still applies to this dialog.
 			}
 		},
-		[storageKey, presetId],
+		[storageKey, presetId, model],
 	);
 
 	return { selectedEffort, setSelectedEffort };

--- a/apps/desktop/src/renderer/hooks/useAgentModePreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModePreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentModePreference } from "./useAgentModePreference";

--- a/apps/desktop/src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts
@@ -1,0 +1,79 @@
+import {
+	type AgentModeSupport,
+	getAgentModeSupport,
+} from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const parsed = JSON.parse(window.localStorage.getItem(storageKey) ?? "{}");
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return {};
+		}
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredMode(
+	storageKey: string,
+	presetId: string | null,
+	supportOverride?: AgentModeSupport,
+	preferenceScope?: string | null,
+): string | null {
+	if (!presetId) return null;
+	const support = supportOverride ?? getAgentModeSupport(presetId);
+	const preferenceKey = preferenceScope
+		? `${presetId}:${preferenceScope}`
+		: presetId;
+	const stored = readStoredMap(storageKey)[preferenceKey];
+	return support?.modes.some((mode) => mode.id === stored) ? stored : null;
+}
+
+export function useAgentModePreference(
+	storageKey: string,
+	presetId: string | null,
+	supportOverride?: AgentModeSupport,
+	preferenceScope?: string | null,
+) {
+	const [selectedMode, setSelectedModeState] = useState<string | null>(() =>
+		readStoredMode(storageKey, presetId, supportOverride, preferenceScope),
+	);
+
+	useEffect(() => {
+		setSelectedModeState(
+			readStoredMode(storageKey, presetId, supportOverride, preferenceScope),
+		);
+	}, [storageKey, presetId, supportOverride, preferenceScope]);
+
+	const setSelectedMode = useCallback(
+		(mode: string | null) => {
+			setSelectedModeState(mode);
+			if (typeof window === "undefined" || !presetId) return;
+			const map = readStoredMap(storageKey);
+			const preferenceKey = preferenceScope
+				? `${presetId}:${preferenceScope}`
+				: presetId;
+			if (mode) map[preferenceKey] = mode;
+			else delete map[preferenceKey];
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// The active selection still applies when persistence is unavailable.
+			}
+		},
+		[storageKey, presetId, preferenceScope],
+	);
+
+	return { selectedMode, setSelectedMode };
+}

--- a/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
@@ -1,4 +1,7 @@
-import { getAgentModelSupport } from "@superset/shared/agent-models";
+import {
+	type AgentModelSupport,
+	getAgentModelSupport,
+} from "@superset/shared/agent-models";
 import { useCallback, useEffect, useState } from "react";
 
 function readStoredMap(storageKey: string): Record<string, string> {
@@ -22,38 +25,47 @@ function readStoredMap(storageKey: string): Record<string, string> {
 function readStoredModel(
 	storageKey: string,
 	presetId: string | null,
+	supportOverride?: AgentModelSupport,
 ): string | null {
 	if (!presetId) return null;
-	const stored = readStoredMap(storageKey)[presetId];
+	const support = supportOverride ?? getAgentModelSupport(presetId);
+	const stored = readStoredMap(storageKey)[presetId] ?? support?.defaultModelId;
 	if (!stored) return null;
-	// Drop ids that fell out of the curated registry — "Default" beats a
-	// flag value the CLI no longer accepts.
-	const support = getAgentModelSupport(presetId);
-	return support?.models.some((model) => model.id === stored) ? stored : null;
+	const resolvedStored = support?.modelAliases?.[stored] ?? stored;
+	// Drop ids that fell out of the curated registry so a stale preference
+	// cannot launch the CLI with an unsupported model.
+	return support?.models.some((model) => model.id === resolvedStored)
+		? resolvedStored
+		: null;
 }
 
 /**
  * Last-selected model per agent preset, persisted as a JSON map in
  * localStorage. Keyed by presetId (not config UUID) so the preference
- * survives host switches and agent-config re-creation. `null` means
- * "Default" — no stored entry, no model flag at launch.
+ * survives host switches and agent-config re-creation. Catalogs with an
+ * explicit default select it immediately; `null` omits the model flag for
+ * agents that still expose a synthetic default choice.
  */
 export function useAgentModelPreference(
 	storageKey: string,
 	presetId: string | null,
+	supportOverride?: AgentModelSupport,
 ) {
 	const [selectedModel, setSelectedModelState] = useState<string | null>(() =>
-		readStoredModel(storageKey, presetId),
+		readStoredModel(storageKey, presetId, supportOverride),
 	);
 
 	useEffect(() => {
-		setSelectedModelState(readStoredModel(storageKey, presetId));
-	}, [storageKey, presetId]);
+		setSelectedModelState(
+			readStoredModel(storageKey, presetId, supportOverride),
+		);
+	}, [storageKey, presetId, supportOverride]);
 
 	const setSelectedModel = useCallback(
 		(model: string | null) => {
+			if (!presetId) return;
 			setSelectedModelState(model);
-			if (typeof window === "undefined" || !presetId) return;
+			if (typeof window === "undefined") return;
 			const map = readStoredMap(storageKey);
 			if (model) {
 				map[presetId] = model;

--- a/apps/desktop/src/renderer/hooks/useAgentSpeedPreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentSpeedPreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentSpeedPreference } from "./useAgentSpeedPreference";

--- a/apps/desktop/src/renderer/hooks/useAgentSpeedPreference/useAgentSpeedPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentSpeedPreference/useAgentSpeedPreference.ts
@@ -1,0 +1,81 @@
+import {
+	type AgentSpeedSupport,
+	getAgentSpeedSupport,
+} from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(storageKey);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return {};
+		}
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredSpeed(
+	storageKey: string,
+	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentSpeedSupport,
+): string | null {
+	if (!presetId) return null;
+	const support = supportOverride ?? getAgentSpeedSupport(presetId, model);
+	if (!support) return null;
+	const preferenceKey = model ? `${presetId}:${model}` : presetId;
+	const stored =
+		readStoredMap(storageKey)[preferenceKey] ?? support.defaultSpeedId;
+	return support.speeds.some((speed) => speed.id === stored)
+		? (stored ?? null)
+		: (support.defaultSpeedId ?? null);
+}
+
+export function useAgentSpeedPreference(
+	storageKey: string,
+	presetId: string | null,
+	model: string | null,
+	supportOverride?: AgentSpeedSupport,
+) {
+	const [selectedSpeed, setSelectedSpeedState] = useState<string | null>(() =>
+		readStoredSpeed(storageKey, presetId, model, supportOverride),
+	);
+
+	useEffect(() => {
+		setSelectedSpeedState(
+			readStoredSpeed(storageKey, presetId, model, supportOverride),
+		);
+	}, [storageKey, presetId, model, supportOverride]);
+
+	const setSelectedSpeed = useCallback(
+		(speed: string | null) => {
+			setSelectedSpeedState(speed);
+			if (typeof window === "undefined" || !presetId) return;
+			const map = readStoredMap(storageKey);
+			const preferenceKey = model ? `${presetId}:${model}` : presetId;
+			if (speed) map[preferenceKey] = speed;
+			else delete map[preferenceKey];
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// The active selection still applies when persistence is unavailable.
+			}
+		},
+		[storageKey, presetId, model],
+	);
+
+	return { selectedSpeed, setSelectedSpeed };
+}

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/agentChoiceAvailability.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/agentChoiceAvailability.ts
@@ -1,0 +1,19 @@
+export function isAgentChoiceVisible<
+	TView extends {
+		health: { installed: boolean | null };
+	},
+>(capability: TView | undefined): boolean {
+	return capability?.health.installed !== false;
+}
+
+export function getCapabilityDisplayInventory<TInventory>(
+	capability:
+		| {
+				inventory: TInventory;
+				health: { installed: boolean | null };
+		  }
+		| undefined,
+): TInventory | null {
+	if (!capability || capability.health.installed === false) return null;
+	return capability.inventory;
+}

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/capabilityQueryKeys.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/capabilityQueryKeys.ts
@@ -1,0 +1,15 @@
+export const HOST_AGENT_CAPABILITY_SNAPSHOT_QUERY_KEY = [
+	"host-agent-capability-snapshots",
+] as const;
+
+export const HOST_AGENT_CAPABILITY_REFRESH_QUERY_KEY = [
+	"host-agent-capability-refresh",
+] as const;
+
+export function hostAgentCapabilitySnapshotQueryKey(hostUrl: string | null) {
+	return [...HOST_AGENT_CAPABILITY_SNAPSHOT_QUERY_KEY, hostUrl] as const;
+}
+
+export function hostAgentCapabilityRefreshQueryKey(hostUrl: string | null) {
+	return [...HOST_AGENT_CAPABILITY_REFRESH_QUERY_KEY, hostUrl] as const;
+}

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/index.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/index.ts
@@ -1,1 +1,21 @@
-export { useV2AgentChoices } from "./useV2AgentChoices";
+export {
+	getCapabilityDisplayInventory,
+	isAgentChoiceVisible,
+} from "./agentChoiceAvailability";
+export {
+	HOST_AGENT_CAPABILITY_REFRESH_QUERY_KEY,
+	HOST_AGENT_CAPABILITY_SNAPSHOT_QUERY_KEY,
+	hostAgentCapabilityRefreshQueryKey,
+	hostAgentCapabilitySnapshotQueryKey,
+} from "./capabilityQueryKeys";
+export {
+	classifyHostAgentUpdateInvalidation,
+	type HostAgentQueryInvalidation,
+	invalidateHostAgentQueries,
+	isDiscoveryChangingAgentPatch,
+} from "./invalidateHostAgentQueries";
+export {
+	type AgentChoiceCapability,
+	publishCapabilityRefresh,
+	useV2AgentChoices,
+} from "./useV2AgentChoices";

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/invalidateHostAgentQueries.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/invalidateHostAgentQueries.ts
@@ -1,0 +1,59 @@
+import type { HostAgentConfig } from "@superset/host-service/settings";
+import type { QueryClient } from "@tanstack/react-query";
+import { V2_AGENT_CONFIGS_QUERY_KEY } from "renderer/hooks/useV2AgentConfigs";
+import { hostAgentCapabilitySnapshotQueryKey } from "./capabilityQueryKeys";
+
+export type HostAgentQueryInvalidation = "config" | "config-and-capabilities";
+
+export function envsEqual(
+	left: Record<string, string>,
+	right: Record<string, string>,
+): boolean {
+	const leftEntries = Object.entries(left);
+	const rightEntries = Object.entries(right);
+	if (leftEntries.length !== rightEntries.length) return false;
+	return leftEntries.every(([key, value]) => right[key] === value);
+}
+
+function argsEqual(left: string[], right: string[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
+}
+
+export function isDiscoveryChangingAgentPatch(
+	current: Pick<HostAgentConfig, "command" | "args" | "env">,
+	patch: { command?: string; args?: string[]; env?: Record<string, string> },
+): boolean {
+	if (patch.command !== undefined && patch.command !== current.command) {
+		return true;
+	}
+	if (patch.args !== undefined && !argsEqual(current.args, patch.args)) {
+		return true;
+	}
+	return patch.env !== undefined && !envsEqual(current.env, patch.env);
+}
+
+export function classifyHostAgentUpdateInvalidation(
+	current: Pick<HostAgentConfig, "command" | "args" | "env">,
+	patch: { command?: string; args?: string[]; env?: Record<string, string> },
+): HostAgentQueryInvalidation {
+	return isDiscoveryChangingAgentPatch(current, patch)
+		? "config-and-capabilities"
+		: "config";
+}
+
+export function invalidateHostAgentQueries(
+	queryClient: QueryClient,
+	hostUrl: string,
+	scope: HostAgentQueryInvalidation,
+): void {
+	void queryClient.invalidateQueries({
+		queryKey: [...V2_AGENT_CONFIGS_QUERY_KEY, hostUrl],
+	});
+	if (scope !== "config-and-capabilities") return;
+	void queryClient.invalidateQueries({
+		queryKey: hostAgentCapabilitySnapshotQueryKey(hostUrl),
+	});
+}

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.concurrency.test.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.concurrency.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	focusManager,
+	QueryClient,
+	QueryObserver,
+} from "@tanstack/react-query";
+import { hostAgentCapabilityRefreshQueryKey } from "./capabilityQueryKeys";
+import type { AgentChoiceCapability } from "./useV2AgentChoices";
+
+function capability(): AgentChoiceCapability {
+	return {
+		agentId: "cfg-codex",
+		presetId: "codex",
+		inventory: null,
+		inventoryOrigin: "persisted",
+		health: {
+			status: "ready",
+			installed: true,
+			auth: "authenticated",
+			checkedAt: "2026-01-01T00:00:00.000Z",
+			errorKind: null,
+			message: null,
+		},
+		healthOrigin: "persisted",
+	};
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 1_000,
+): Promise<void> {
+	const started = Date.now();
+	while (!predicate()) {
+		if (Date.now() - started > timeoutMs) {
+			throw new Error("Timed out waiting for shared refresh");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+describe("useV2AgentChoices renderer-session capability refresh", () => {
+	afterEach(() => {
+		focusManager.setFocused(true);
+	});
+
+	test("two mounts and focus share one session refresh per host", async () => {
+		const hostUrl = "http://workspace-host";
+		const refreshCalls: string[] = [];
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		queryClient.mount();
+		const queryKey = hostAgentCapabilityRefreshQueryKey(hostUrl);
+		const options = {
+			queryKey,
+			queryFn: async () => {
+				refreshCalls.push("refresh");
+				return [
+					{
+						...capability(),
+						inventoryOrigin: "live" as const,
+						healthOrigin: "live" as const,
+					},
+				];
+			},
+			staleTime: Number.POSITIVE_INFINITY,
+			gcTime: Number.POSITIVE_INFINITY,
+			refetchOnMount: false,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
+		};
+
+		const firstMount = new QueryObserver(queryClient, options);
+		const secondMount = new QueryObserver(queryClient, options);
+		const unsubscribeFirst = firstMount.subscribe(() => {});
+		const unsubscribeSecond = secondMount.subscribe(() => {});
+
+		try {
+			await waitFor(() => firstMount.getCurrentResult().status === "success");
+			const initial = firstMount.getCurrentResult();
+			expect({
+				refreshCalls: refreshCalls.length,
+				status: initial.status,
+				fetchStatus: initial.fetchStatus,
+				isStale: initial.isStale,
+				error:
+					initial.error instanceof Error
+						? initial.error.message
+						: initial.error,
+			}).toEqual({
+				refreshCalls: 1,
+				status: "success",
+				fetchStatus: "idle",
+				isStale: false,
+				error: null,
+			});
+			await waitFor(() => refreshCalls.length === 1);
+			expect(refreshCalls).toHaveLength(1);
+
+			await queryClient.invalidateQueries({
+				queryKey,
+				refetchType: "none",
+			});
+			expect(refreshCalls).toHaveLength(1);
+
+			focusManager.setFocused(false);
+			focusManager.setFocused(true);
+
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(refreshCalls).toHaveLength(1);
+		} finally {
+			unsubscribeFirst();
+			unsubscribeSecond();
+			queryClient.clear();
+			queryClient.unmount();
+			focusManager.setFocused(true);
+		}
+	});
+
+	test("a new renderer QueryClient performs a new host refresh", async () => {
+		const hostUrl = "http://workspace-host";
+		let refreshCalls = 0;
+		const runRendererSession = async () => {
+			const queryClient = new QueryClient({
+				defaultOptions: { queries: { retry: false } },
+			});
+			const observer = new QueryObserver(queryClient, {
+				queryKey: hostAgentCapabilityRefreshQueryKey(hostUrl),
+				queryFn: async () => {
+					refreshCalls += 1;
+					return 1;
+				},
+				staleTime: Number.POSITIVE_INFINITY,
+				gcTime: Number.POSITIVE_INFINITY,
+				refetchOnMount: false,
+				refetchOnWindowFocus: false,
+				refetchOnReconnect: false,
+			});
+			const unsubscribe = observer.subscribe(() => {});
+			await waitFor(() => observer.getCurrentResult().status === "success");
+			unsubscribe();
+			queryClient.clear();
+		};
+
+		await runRendererSession();
+		await runRendererSession();
+
+		expect(refreshCalls).toBe(2);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.test.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import {
+	V2_AGENT_CONFIGS_QUERY_KEY,
+	V2_AGENT_CONFIGS_SESSION_QUERY_POLICY,
+} from "renderer/hooks/useV2AgentConfigs";
+import {
+	getCapabilityDisplayInventory,
+	isAgentChoiceVisible,
+} from "./agentChoiceAvailability";
+import {
+	HOST_AGENT_CAPABILITY_REFRESH_QUERY_KEY,
+	HOST_AGENT_CAPABILITY_SNAPSHOT_QUERY_KEY,
+	hostAgentCapabilityRefreshQueryKey,
+	hostAgentCapabilitySnapshotQueryKey,
+} from "./capabilityQueryKeys";
+import {
+	classifyHostAgentUpdateInvalidation,
+	invalidateHostAgentQueries,
+	isDiscoveryChangingAgentPatch,
+} from "./invalidateHostAgentQueries";
+import {
+	type AgentChoiceCapability,
+	publishCapabilityRefresh,
+} from "./useV2AgentChoices";
+
+function capability(
+	overrides: Partial<AgentChoiceCapability> &
+		Pick<AgentChoiceCapability, "agentId">,
+): AgentChoiceCapability {
+	const { health: healthOverrides, ...rest } = overrides;
+	return {
+		presetId: "codex",
+		inventory: null,
+		inventoryOrigin: "none",
+		health: {
+			status: "unknown",
+			installed: null,
+			auth: "unknown",
+			checkedAt: "2026-01-01T00:00:00.000Z",
+			errorKind: null,
+			message: null,
+			...healthOverrides,
+		},
+		healthOrigin: "none",
+		...rest,
+	};
+}
+
+function runtimeInventory(
+	agentId: string,
+	models: NonNullable<AgentChoiceCapability["inventory"]>["models"],
+): NonNullable<AgentChoiceCapability["inventory"]> {
+	return {
+		schemaVersion: 2,
+		agentId,
+		presetId: "codex",
+		configRevision: 1,
+		detectedVersion: "1.0.0",
+		modelSource: "runtime",
+		models,
+		inventoryCheckedAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("capability query keys", () => {
+	test("export host-scoped snapshot and refresh families", () => {
+		expect(HOST_AGENT_CAPABILITY_SNAPSHOT_QUERY_KEY).toEqual([
+			"host-agent-capability-snapshots",
+		]);
+		expect(HOST_AGENT_CAPABILITY_REFRESH_QUERY_KEY).toEqual([
+			"host-agent-capability-refresh",
+		]);
+		expect(hostAgentCapabilitySnapshotQueryKey("http://host-a")).toEqual([
+			"host-agent-capability-snapshots",
+			"http://host-a",
+		]);
+		expect(hostAgentCapabilityRefreshQueryKey("http://host-a")).toEqual([
+			"host-agent-capability-refresh",
+			"http://host-a",
+		]);
+	});
+
+	test("keeps host URLs isolated", () => {
+		expect(hostAgentCapabilitySnapshotQueryKey("http://host-a")).not.toEqual(
+			hostAgentCapabilitySnapshotQueryKey("http://host-b"),
+		);
+		expect(hostAgentCapabilityRefreshQueryKey("http://host-a")).not.toEqual(
+			hostAgentCapabilityRefreshQueryKey("http://host-b"),
+		);
+
+		const queryClient = new QueryClient();
+		const hostA = "http://host-a";
+		const hostB = "http://host-b";
+		const snapshotA = [capability({ agentId: "a" })];
+		const snapshotB = [capability({ agentId: "b" })];
+		queryClient.setQueryData(
+			hostAgentCapabilitySnapshotQueryKey(hostA),
+			snapshotA,
+		);
+		queryClient.setQueryData(
+			hostAgentCapabilitySnapshotQueryKey(hostB),
+			snapshotB,
+		);
+		queryClient.setQueryData(
+			hostAgentCapabilityRefreshQueryKey(hostA),
+			snapshotA,
+		);
+		queryClient.setQueryData(
+			hostAgentCapabilityRefreshQueryKey(hostB),
+			snapshotB,
+		);
+
+		invalidateHostAgentQueries(queryClient, hostA, "config-and-capabilities");
+
+		expect(
+			queryClient.getQueryState(hostAgentCapabilitySnapshotQueryKey(hostA))
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(hostAgentCapabilityRefreshQueryKey(hostA))
+				?.isInvalidated,
+		).toBe(false);
+		expect(
+			queryClient.getQueryState(hostAgentCapabilitySnapshotQueryKey(hostB))
+				?.isInvalidated,
+		).toBe(false);
+		expect(
+			queryClient.getQueryState(hostAgentCapabilityRefreshQueryKey(hostB))
+				?.isInvalidated,
+		).toBe(false);
+		expect(
+			queryClient.getQueryData<AgentChoiceCapability[]>(
+				hostAgentCapabilitySnapshotQueryKey(hostB),
+			),
+		).toEqual(snapshotB);
+	});
+});
+
+describe("agent config session policy", () => {
+	test("keeps external config changes aligned with the next renderer session", () => {
+		expect(V2_AGENT_CONFIGS_SESSION_QUERY_POLICY).toEqual({
+			staleTime: Number.POSITIVE_INFINITY,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
+		});
+	});
+});
+
+describe("publishCapabilityRefresh", () => {
+	test("prevents an older snapshot response from replacing refreshed data", async () => {
+		const queryClient = new QueryClient();
+		const hostUrl = "http://host-a";
+		const queryKey = hostAgentCapabilitySnapshotQueryKey(hostUrl);
+		let releaseSnapshot: (() => void) | undefined;
+		const oldRead = queryClient
+			.fetchQuery({
+				queryKey,
+				queryFn: async () => {
+					await new Promise<void>((resolve) => {
+						releaseSnapshot = resolve;
+					});
+					return [capability({ agentId: "old" })];
+				},
+			})
+			.catch(() => undefined);
+
+		const refreshed = [capability({ agentId: "new" })];
+		await publishCapabilityRefresh(queryClient, hostUrl, refreshed);
+		releaseSnapshot?.();
+		await oldRead;
+
+		expect(queryClient.getQueryData<AgentChoiceCapability[]>(queryKey)).toEqual(
+			refreshed,
+		);
+	});
+});
+
+describe("nested AgentChoiceCapability DTO", () => {
+	test("exposes inventory models, modelSource, and health without flattening", () => {
+		const view = capability({
+			agentId: "codex",
+			inventoryOrigin: "persisted",
+			healthOrigin: "persisted",
+			inventory: runtimeInventory("codex", [
+				{
+					id: "gpt-5",
+					label: "GPT-5",
+					reasoning: {
+						state: "supported",
+						options: [{ id: "high", label: "High" }],
+					},
+				},
+			]),
+			health: {
+				status: "ready",
+				installed: true,
+				auth: "authenticated",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: null,
+				message: null,
+			},
+		});
+
+		expect(view.inventory?.models.map((model) => model.id)).toEqual(["gpt-5"]);
+		expect(view.inventory?.modelSource).toBe("runtime");
+		expect(view.inventory?.inventoryCheckedAt).toBe("2026-01-01T00:00:00.000Z");
+		expect(view.health.installed).toBe(true);
+		expect(view.health.auth).toBe("authenticated");
+		expect(view.health.checkedAt).toBe("2026-01-01T00:00:00.000Z");
+		expect(view.health.errorKind).toBeNull();
+		expect(view.inventoryOrigin).toBe("persisted");
+		expect(view.healthOrigin).toBe("persisted");
+	});
+
+	test("preserves installed:null instead of coercing it to false", () => {
+		const view = capability({
+			agentId: "codex",
+			health: {
+				status: "unknown",
+				installed: null,
+				auth: "unknown",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: null,
+				message: null,
+			},
+		});
+		expect(view.health.installed).toBeNull();
+		expect(isAgentChoiceVisible(view)).toBe(true);
+	});
+});
+
+describe("agent choice availability", () => {
+	test("ready authenticated installed agents are enabled", () => {
+		const view = capability({
+			agentId: "codex",
+			health: {
+				status: "ready",
+				installed: true,
+				auth: "authenticated",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: null,
+				message: null,
+			},
+		});
+		expect(isAgentChoiceVisible(view)).toBe(true);
+	});
+
+	test("installed:false missing executable is hidden and drops inventory", () => {
+		const view = capability({
+			agentId: "codex",
+			inventory: runtimeInventory("codex", [
+				{
+					id: "gpt-5",
+					label: "GPT-5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+			health: {
+				status: "unavailable",
+				installed: false,
+				auth: "unknown",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: "missing_executable",
+				message: "Configured executable was not found",
+			},
+		});
+		expect(isAgentChoiceVisible(view)).toBe(false);
+		expect(getCapabilityDisplayInventory(view)).toBeNull();
+	});
+
+	test("installed:null is unknown but usable", () => {
+		const view = capability({
+			agentId: "codex",
+			inventory: runtimeInventory("codex", [
+				{
+					id: "gpt-5",
+					label: "GPT-5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+			health: {
+				status: "unknown",
+				installed: null,
+				auth: "unknown",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: null,
+				message: null,
+			},
+		});
+		expect(isAgentChoiceVisible(view)).toBe(true);
+		expect(getCapabilityDisplayInventory(view)?.models).toHaveLength(1);
+	});
+
+	test("authentication diagnostics do not disable installed agents", () => {
+		const view = capability({
+			agentId: "codex",
+			health: {
+				status: "authentication_required",
+				installed: true,
+				auth: "unauthenticated",
+				checkedAt: "2026-01-01T00:00:00.000Z",
+				errorKind: null,
+				message: "Authentication required",
+			},
+		});
+		expect(isAgentChoiceVisible(view)).toBe(true);
+	});
+});
+
+describe("mutation invalidation classification", () => {
+	const current = { command: "codex", args: ["exec"], env: { FOO: "1" } };
+
+	test("command, args, or env updates invalidate capabilities", () => {
+		expect(isDiscoveryChangingAgentPatch(current, { command: "claude" })).toBe(
+			true,
+		);
+		expect(isDiscoveryChangingAgentPatch(current, { env: { FOO: "2" } })).toBe(
+			true,
+		);
+		expect(isDiscoveryChangingAgentPatch(current, { args: ["run"] })).toBe(
+			true,
+		);
+		expect(
+			classifyHostAgentUpdateInvalidation(current, { command: "claude" }),
+		).toBe("config-and-capabilities");
+	});
+
+	test("display and launch-only updates do not invalidate capabilities", () => {
+		expect(isDiscoveryChangingAgentPatch(current, { command: "codex" })).toBe(
+			false,
+		);
+		expect(isDiscoveryChangingAgentPatch(current, { env: { FOO: "1" } })).toBe(
+			false,
+		);
+		expect(isDiscoveryChangingAgentPatch(current, { args: ["exec"] })).toBe(
+			false,
+		);
+		expect(classifyHostAgentUpdateInvalidation(current, {})).toBe("config");
+	});
+
+	test("config-only invalidation leaves capability families untouched", () => {
+		const queryClient = new QueryClient();
+		const hostUrl = "http://host-a";
+		queryClient.setQueryData([...V2_AGENT_CONFIGS_QUERY_KEY, hostUrl], []);
+		queryClient.setQueryData(hostAgentCapabilitySnapshotQueryKey(hostUrl), []);
+		queryClient.setQueryData(hostAgentCapabilityRefreshQueryKey(hostUrl), []);
+
+		invalidateHostAgentQueries(queryClient, hostUrl, "config");
+
+		expect(
+			queryClient.getQueryState([...V2_AGENT_CONFIGS_QUERY_KEY, hostUrl])
+				?.isInvalidated,
+		).toBe(true);
+		expect(
+			queryClient.getQueryState(hostAgentCapabilitySnapshotQueryKey(hostUrl))
+				?.isInvalidated,
+		).toBe(false);
+		expect(
+			queryClient.getQueryState(hostAgentCapabilityRefreshQueryKey(hostUrl))
+				?.isInvalidated,
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
@@ -1,38 +1,117 @@
+import type { AppRouter } from "@superset/host-service";
+import {
+	type QueryClient,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import type { inferRouterOutputs } from "@trpc/server";
 import { useMemo } from "react";
 import type { AgentSelectAgent } from "renderer/components/AgentSelect";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { isAgentChoiceVisible } from "./agentChoiceAvailability";
+import {
+	hostAgentCapabilityRefreshQueryKey,
+	hostAgentCapabilitySnapshotQueryKey,
+} from "./capabilityQueryKeys";
+
+type HostServiceRouterOutputs = inferRouterOutputs<AppRouter>;
+
+export type AgentChoiceCapability =
+	HostServiceRouterOutputs["settings"]["agentConfigs"]["listCapabilitySnapshots"][number];
 
 interface UseV2AgentChoicesResult {
 	agents: AgentSelectAgent[];
+	capabilitiesByAgentId: ReadonlyMap<string, AgentChoiceCapability>;
 	isFetched: boolean;
 }
 
-const SUPERSET_AGENT: AgentSelectAgent = {
-	id: "superset",
-	label: "Superset",
-	iconId: "superset",
-};
+interface UseV2AgentChoicesOptions {
+	refresh?: boolean;
+}
 
-// Superset chat isn't in the host's `host_agent_configs` table — it's
-// routed by id inside `runAgentInWorkspace`. Append after the host's
-// terminal rows so the user's preferred terminal agents stay on top.
+export async function publishCapabilityRefresh(
+	queryClient: QueryClient,
+	hostUrl: string,
+	refreshed: AgentChoiceCapability[],
+): Promise<void> {
+	const snapshotKey = hostAgentCapabilitySnapshotQueryKey(hostUrl);
+	// A cold snapshot read may still be in flight. Cancel it before publishing
+	// the newer refresh so its older response cannot win the race afterward.
+	await queryClient.cancelQueries({ queryKey: snapshotKey });
+	queryClient.setQueryData(snapshotKey, refreshed);
+}
+
 export function useV2AgentChoices(
 	hostUrl: string | null,
+	options: UseV2AgentChoicesOptions = {},
 ): UseV2AgentChoicesResult {
+	const queryClient = useQueryClient();
 	const query = useV2AgentConfigs(hostUrl);
+	const refreshEnabled = options.refresh !== false;
+	const snapshotsQuery = useQuery({
+		queryKey: hostAgentCapabilitySnapshotQueryKey(hostUrl),
+		enabled: !!hostUrl,
+		queryFn: () => {
+			if (!hostUrl) return [] satisfies AgentChoiceCapability[];
+			return getHostServiceClientByUrl(
+				hostUrl,
+			).settings.agentConfigs.listCapabilitySnapshots.query();
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnWindowFocus: false,
+	});
+	useQuery({
+		queryKey: hostAgentCapabilityRefreshQueryKey(hostUrl),
+		enabled: !!hostUrl && refreshEnabled,
+		queryFn: async () => {
+			if (!hostUrl) return 0;
+			const refreshed = await getHostServiceClientByUrl(
+				hostUrl,
+			).settings.agentConfigs.refreshCapabilities.mutate({});
+			await publishCapabilityRefresh(queryClient, hostUrl, refreshed);
+			return refreshed.length;
+		},
+		// One explicit refresh per host and renderer lifetime. Ctrl+R creates a new
+		// QueryClient, while focus, reconnects, and additional picker mounts reuse
+		// this settled session query.
+		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: Number.POSITIVE_INFINITY,
+		retry: false,
+		refetchOnMount: false,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+	});
+	const capabilitiesByAgentId = useMemo(
+		() =>
+			new Map(
+				(snapshotsQuery.data ?? []).map((capability) => [
+					capability.agentId,
+					capability,
+				]),
+			),
+		[snapshotsQuery.data],
+	);
+	const isFetched = query.isFetched;
 	const agents = useMemo<AgentSelectAgent[]>(() => {
-		const terminalAgents: AgentSelectAgent[] = (query.data ?? []).map(
-			(config) => ({
+		if (!query.data || !isFetched) return [];
+		return query.data
+			.filter((config) =>
+				isAgentChoiceVisible(capabilitiesByAgentId.get(config.id)),
+			)
+			.map((config) => ({
 				id: config.id,
 				label: config.label,
 				// Prefer the user's icon override (built-in key or uploaded data
 				// URI); fall back to the preset-implied icon.
 				iconId: config.iconId ?? config.presetId,
 				presetId: config.presetId,
-			}),
-		);
-		return [...terminalAgents, SUPERSET_AGENT];
-	}, [query.data]);
+			}));
+	}, [capabilitiesByAgentId, isFetched, query.data]);
 
-	return { agents, isFetched: query.isFetched };
+	return {
+		agents,
+		capabilitiesByAgentId,
+		isFetched,
+	};
 }

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/index.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/index.ts
@@ -1,4 +1,5 @@
 export {
 	useV2AgentConfigs,
 	V2_AGENT_CONFIGS_QUERY_KEY,
+	V2_AGENT_CONFIGS_SESSION_QUERY_POLICY,
 } from "./useV2AgentConfigs";

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -3,17 +3,20 @@ import { useQuery } from "@tanstack/react-query";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 
 export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
+export const V2_AGENT_CONFIGS_SESSION_QUERY_POLICY = {
+	staleTime: Number.POSITIVE_INFINITY,
+	refetchOnWindowFocus: false,
+	refetchOnReconnect: false,
+} as const;
 
 /**
  * Caller passes the host URL explicitly so this hook works for any host the
  * user is targeting (local, remote-via-relay, or whatever the new-workspace
  * modal has resolved). Cache is keyed on URL so distinct hosts don't share
- * entries. Settings → Agents mutations invalidate this key for instant
- * same-session updates; the bounded staleTime and unconditional focus refetch
- * exist for writes that bypass the renderer (CLI, host-service restarts, other
- * clients on the same host), which previously stayed invisible until an app
- * restart. Acting on an external edit means refocusing the app, so focus is
- * the earliest moment the fresh value can matter.
+ * entries. Settings mutations update or invalidate this key for same-session
+ * edits. External edits intentionally become visible on Ctrl+R with the next
+ * renderer session, keeping configs and their capability snapshots on the same
+ * lifecycle instead of mixing a focused config refetch with an older snapshot.
  */
 export function useV2AgentConfigs(hostUrl: string | null) {
 	return useQuery({
@@ -25,7 +28,6 @@ export function useV2AgentConfigs(hostUrl: string | null) {
 				hostUrl,
 			).settings.agentConfigs.list.query();
 		},
-		staleTime: 30_000,
-		refetchOnWindowFocus: "always",
+		...V2_AGENT_CONFIGS_SESSION_QUERY_POLICY,
 	});
 }

--- a/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
+++ b/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
@@ -142,6 +142,18 @@ export const PERSISTED_KEY_REGISTRY: ReadonlyArray<
 		["lastSelectedV2WorkspaceCreateEffortByPreset"],
 	],
 	[
+		"src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts",
+		["lastSelectedV2WorkspaceCreateModeByPreset"],
+	],
+	[
+		"src/renderer/hooks/useAgentSpeedPreference/useAgentSpeedPreference.ts",
+		["lastSelectedV2WorkspaceCreateSpeedByPreset"],
+	],
+	[
+		"src/renderer/hooks/useAgentContextWindowPreference/useAgentContextWindowPreference.ts",
+		["lastSelectedV2WorkspaceCreateContextWindowByModel"],
+	],
+	[
 		"src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts",
 		[
 			"lastSelectedV2WorkspaceCreateAgent",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/index.ts
@@ -1,1 +1,2 @@
+export { resolveLinkedPresetLaunchCommand } from "./resolveLinkedPresetLaunch";
 export { useV2PresetExecution } from "./useV2PresetExecution";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/resolveLinkedPresetLaunch.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/resolveLinkedPresetLaunch.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const resolveLaunchCommand = mock(async () => ({
+	command: "'claude'",
+	label: "Claude",
+}));
+
+mock.module("renderer/lib/host-service-client", () => ({
+	getHostServiceClientByUrl: () => ({
+		agents: {
+			resolveLaunchCommand: {
+				mutate: resolveLaunchCommand,
+			},
+		},
+	}),
+}));
+
+const { resolveLinkedPresetLaunchCommand } = await import(
+	"./resolveLinkedPresetLaunch"
+);
+
+describe("resolveLinkedPresetLaunchCommand", () => {
+	beforeEach(() => {
+		resolveLaunchCommand.mockClear();
+		resolveLaunchCommand.mockResolvedValue({
+			command: "'claude' '--dangerously-skip-permissions'",
+			label: "Claude",
+		});
+	});
+
+	it("asks the workspace host for a validated launch command", async () => {
+		await expect(
+			resolveLinkedPresetLaunchCommand({
+				hostUrl: "http://workspace-host",
+				agentId: "cfg-claude",
+			}),
+		).resolves.toBe("'claude' '--dangerously-skip-permissions'");
+		expect(resolveLaunchCommand).toHaveBeenCalledWith({
+			agent: "cfg-claude",
+		});
+	});
+
+	it("fails closed when the workspace host is missing", async () => {
+		await expect(
+			resolveLinkedPresetLaunchCommand({
+				hostUrl: null,
+				agentId: "cfg-claude",
+			}),
+		).rejects.toThrow("Workspace host is not ready");
+		expect(resolveLaunchCommand).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/resolveLinkedPresetLaunch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/resolveLinkedPresetLaunch.ts
@@ -1,0 +1,19 @@
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+export async function resolveLinkedPresetLaunchCommand({
+	hostUrl,
+	agentId,
+}: {
+	hostUrl: string | null;
+	agentId: string;
+}): Promise<string> {
+	if (!hostUrl) {
+		throw new Error("Workspace host is not ready");
+	}
+	const result = await getHostServiceClientByUrl(
+		hostUrl,
+	).agents.resolveLaunchCommand.mutate({
+		agent: agentId,
+	});
+	return result.command;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -12,7 +12,6 @@ import {
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
-import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import {
@@ -23,6 +22,7 @@ import { quote } from "shell-quote";
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
 import type { TerminalLauncher } from "../useV2TerminalLauncher";
+import { resolveLinkedPresetLaunchCommand } from "./resolveLinkedPresetLaunch";
 
 function makeTerminalPane(
 	terminalId: string,
@@ -31,8 +31,16 @@ function makeTerminalPane(
 	return {
 		kind: "terminal",
 		titleOverride,
-		data: { terminalId } as TerminalPaneData,
+		data: { terminalId },
 	};
+}
+
+function requireFirst<T>(items: T[]): [T, ...T[]] {
+	const [first, ...rest] = items;
+	if (first === undefined) {
+		throw new Error("Expected at least one item");
+	}
+	return [first, ...rest];
 }
 
 function resolveTarget(executionMode: V2TerminalPresetRow["executionMode"]) {
@@ -107,7 +115,7 @@ export function useV2PresetExecution({
 	store,
 	launcher,
 }: UseV2PresetExecutionArgs) {
-	const { workspace } = useWorkspace();
+	const { workspace, hostUrl } = useWorkspace();
 	const workspaceId = workspace.id;
 	const projectId = workspace.projectId;
 	const collections = useCollections();
@@ -128,11 +136,10 @@ export function useV2PresetExecution({
 		[collections],
 	);
 
-	// Read v2 agent configs from the host service — same data source as the
-	// /settings/agents page, so user edits there propagate here. The hook is
-	// already invalidated by mutations in the agents settings page.
-	const { activeHostUrl } = useLocalHostService();
-	const { data: agents = [] } = useV2AgentConfigs(activeHostUrl);
+	// Read v2 agent configs from the workspace host — same cached source as
+	// /settings/agents. Display/workspace-run still resolve snapshot commands
+	// from this list; linked preset launches validate on the host first.
+	const { data: agents = [] } = useV2AgentConfigs(hostUrl);
 
 	const matchedPresets = useMemo(
 		() => filterMatchingPresetsForProject(allPresets, projectId),
@@ -164,7 +171,28 @@ export function useV2PresetExecution({
 			const activeTabId = state.activeTabId;
 			const target = options?.target ?? resolveTarget(preset.executionMode);
 			const title = preset.name || undefined;
-			const commands = resolvePresetCommands(preset);
+			let commands: string[];
+			try {
+				if (preset.agentId) {
+					commands = [
+						await resolveLinkedPresetLaunchCommand({
+							hostUrl,
+							agentId: preset.agentId,
+						}),
+					];
+				} else {
+					commands = resolvePresetCommands(preset);
+				}
+			} catch (err) {
+				console.error("[useV2PresetExecution] Failed to execute preset:", err);
+				toast.error("Failed to run preset", {
+					description:
+						err instanceof Error
+							? err.message
+							: "Agent launch validation failed.",
+				});
+				return;
+			}
 			const activeTerminal =
 				target === "active-tab" && preset.executionMode === "sequential"
 					? getActiveTerminalPane(state)
@@ -238,10 +266,7 @@ export function useV2PresetExecution({
 								: [createTerminal()],
 						);
 						state.addTab({
-							panes: ids.map((id) => makeTerminalPane(id, title)) as [
-								CreatePaneInput<PaneViewerData>,
-								...CreatePaneInput<PaneViewerData>[],
-							],
+							panes: requireFirst(ids.map((id) => makeTerminalPane(id, title))),
 						});
 						break;
 					}
@@ -276,10 +301,7 @@ export function useV2PresetExecution({
 						const panes = ids.map((id) => makeTerminalPane(id, title));
 						if (!activeTabId) {
 							state.addTab({
-								panes: panes as [
-									CreatePaneInput<PaneViewerData>,
-									...CreatePaneInput<PaneViewerData>[],
-								],
+								panes: requireFirst(panes),
 							});
 							break;
 						}
@@ -303,6 +325,7 @@ export function useV2PresetExecution({
 			store,
 			launcher,
 			resolvePresetCommands,
+			hostUrl,
 			workspaceId,
 			workspaceQuery.data?.worktreePath,
 			writeInput,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -11,6 +11,8 @@ import {
 } from "@superset/ui/dialog";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
+import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-attachments";
 import {
 	useCloseNewWorkspaceModal,
@@ -43,6 +45,10 @@ function PromptInputResetSync() {
 }
 
 export function DashboardNewWorkspaceModal() {
+	const { activeHostUrl } = useLocalHostService();
+	// This component stays mounted for the authenticated shell, so it owns the
+	// single active-host capability refresh for this renderer session.
+	useV2AgentChoices(activeHostUrl);
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
 	const preSelectedProjectId = usePreSelectedProjectId();

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -53,6 +53,7 @@ import { ProjectPickerPill } from "./components/ProjectPickerPill";
 import { PromptHistoryCommand } from "./components/PromptHistoryCommand";
 import { UploadingAttachmentPill } from "./components/UploadingAttachmentPill";
 import { WorkspaceAgentTraitsPicker } from "./components/WorkspaceAgentTraitsPicker";
+import { getAgentSelectionBlocker } from "./getAgentSelectionBlocker";
 import { useBranchPickerController } from "./hooks/useBranchPickerController";
 import { useLinkedContext } from "./hooks/useLinkedContext";
 import { useSubmitWorkspace } from "./hooks/useSubmitWorkspace";
@@ -145,6 +146,10 @@ export function PromptGroup({
 			},
 		});
 	}, [closeModal, draft.hostId, machineId, navigate, selectedProject?.id]);
+	const handleConfigureAgents = useCallback(() => {
+		closeModal();
+		void navigate({ to: "/settings/agents" });
+	}, [closeModal, navigate]);
 	const {
 		baseBranch,
 		hostId,
@@ -191,6 +196,16 @@ export function PromptGroup({
 			validAgents: ["none", ...selectableAgentIds],
 			agentsReady: v2AgentsFetched,
 		});
+	const agentSelectionBlocker = getAgentSelectionBlocker({
+		isFetched: v2AgentsFetched,
+		selectableAgentIds,
+		selectedAgent,
+	});
+	const noSelectableAgents = v2AgentsFetched && selectableAgentIds.length === 0;
+	const agentPickerDisabled = !v2AgentsFetched || noSelectableAgents;
+	let agentSelectPlaceholder = "Select agent";
+	if (!v2AgentsFetched) agentSelectPlaceholder = "Loading agents...";
+	else if (noSelectableAgents) agentSelectPlaceholder = "No agents available";
 
 	// ── Model picker (per agent preset) ──────────────────────────────
 	// `presetId` is stable even when a host config uses a custom icon.
@@ -319,6 +334,7 @@ export function PromptGroup({
 	const { otherHosts } = useWorkspaceHostOptions();
 	const submitBlocker = useMemo<string | null>(() => {
 		if (!projectId && !draft.isSession) return "Select a project";
+		if (agentSelectionBlocker) return agentSelectionBlocker;
 		const selectedHostId = draft.hostId ?? machineId;
 		if (!selectedHostId) return "No active host";
 		if (selectedHostId !== machineId) {
@@ -331,6 +347,7 @@ export function PromptGroup({
 	}, [
 		projectId,
 		draft.isSession,
+		agentSelectionBlocker,
 		draft.hostId,
 		machineId,
 		activeHostUrl,
@@ -574,15 +591,25 @@ export function PromptGroup({
 						<AgentSelect<WorkspaceCreateAgent>
 							agents={v2Agents}
 							value={selectedAgent}
-							placeholder={
-								v2AgentsFetched ? "Select agent" : "Loading agents..."
-							}
-							disabled={!v2AgentsFetched}
+							placeholder={agentSelectPlaceholder}
+							disabled={agentPickerDisabled}
 							onValueChange={setSelectedAgent}
 							onBeforeConfigureAgents={closeModal}
 							triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							iconClassName="size-3 object-contain"
 						/>
+						{noSelectableAgents && (
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-muted-foreground`}
+								onClick={handleConfigureAgents}
+							>
+								<Settings2Icon className="size-3" />
+								Configure agents
+							</Button>
+						)}
 						{modelSupport && (
 							<AgentModelSelect
 								models={modelSupport.models}
@@ -669,7 +696,7 @@ export function PromptGroup({
 						/>
 						<PromptInputSubmit
 							className="size-[22px] rounded-full border border-transparent bg-foreground/10 shadow-none p-[5px] hover:bg-foreground/20"
-							disabled={needsSetup}
+							disabled={needsSetup || !!agentSelectionBlocker}
 							onClick={(e) => {
 								e.preventDefault();
 								handleSubmit();

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -1,7 +1,3 @@
-import {
-	getAgentEffortSupport,
-	getAgentModelSupport,
-} from "@superset/shared/agent-models";
 import { sanitizeUserBranchName } from "@superset/shared/workspace-launch";
 import {
 	PromptInput,
@@ -30,11 +26,12 @@ import { IssueLinkCommand } from "renderer/components/IssueLinkCommand";
 import { LinkedIssuePill } from "renderer/components/LinkedIssuePill";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
-import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
-import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
-import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import {
+	getCapabilityDisplayInventory,
+	useV2AgentChoices,
+} from "renderer/hooks/useV2AgentChoices";
 import { PLATFORM } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
@@ -43,6 +40,7 @@ import { useNewWorkspaceModalOpen } from "renderer/stores/new-workspace-modal";
 import { useNewWorkspacePromptContext } from "renderer/stores/new-workspace-prompt-context";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../../DashboardNewWorkspaceDraftContext";
+import { useWorkspaceAgentRuntimeSelection } from "../../../hooks/useWorkspaceAgentRuntimeSelection";
 import { DevicePicker } from "../components/DevicePicker";
 import { useWorkspaceHostOptions } from "../components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { AttachmentButtons } from "./components/AttachmentButtons";
@@ -54,6 +52,7 @@ import { PRLinkCommand } from "./components/PRLinkCommand";
 import { ProjectPickerPill } from "./components/ProjectPickerPill";
 import { PromptHistoryCommand } from "./components/PromptHistoryCommand";
 import { UploadingAttachmentPill } from "./components/UploadingAttachmentPill";
+import { WorkspaceAgentTraitsPicker } from "./components/WorkspaceAgentTraitsPicker";
 import { useBranchPickerController } from "./hooks/useBranchPickerController";
 import { useLinkedContext } from "./hooks/useLinkedContext";
 import { useSubmitWorkspace } from "./hooks/useSubmitWorkspace";
@@ -63,10 +62,13 @@ import {
 } from "./hooks/useUploadAttachments";
 import {
 	AGENT_STORAGE_KEY,
+	CONTEXT_WINDOW_STORAGE_KEY,
 	EFFORT_STORAGE_KEY,
+	MODE_TRAIT_STORAGE_KEY,
 	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
 	type ProjectOption,
+	SPEED_STORAGE_KEY,
 	type WorkspaceCreateAgent,
 } from "./types";
 
@@ -172,8 +174,11 @@ export function PromptGroup({
 			}) ?? null
 		);
 	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
-	const { agents: v2Agents, isFetched: v2AgentsFetched } =
-		useV2AgentChoices(launchHostUrl);
+	const {
+		agents: v2Agents,
+		capabilitiesByAgentId,
+		isFetched: v2AgentsFetched,
+	} = useV2AgentChoices(launchHostUrl);
 	const selectableAgentIds = useMemo(
 		() => v2Agents.map((agent) => agent.id),
 		[v2Agents],
@@ -188,41 +193,45 @@ export function PromptGroup({
 		});
 
 	// ── Model picker (per agent preset) ──────────────────────────────
-	// `iconId` carries the presetId for v2 agents ("superset" for chat).
-	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
-		[v2Agents, selectedAgent],
-	);
-	const modelSupport = selectedPresetId
-		? getAgentModelSupport(selectedPresetId)
-		: undefined;
-	const { selectedModel, setSelectedModel } = useAgentModelPreference(
-		MODEL_STORAGE_KEY,
-		modelSupport ? selectedPresetId : null,
-	);
-	const effortSupport = selectedPresetId
-		? getAgentEffortSupport(selectedPresetId)
-		: undefined;
-	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
-		EFFORT_STORAGE_KEY,
-		effortSupport ? selectedPresetId : null,
-	);
+	// `presetId` is stable even when a host config uses a custom icon.
+	const selectedPresetId = useMemo(() => {
+		const agent = v2Agents.find((candidate) => candidate.id === selectedAgent);
+		return agent?.presetId ?? agent?.iconId ?? null;
+	}, [v2Agents, selectedAgent]);
+	const selectedCapability = capabilitiesByAgentId.get(selectedAgent);
+	const displayInventory = getCapabilityDisplayInventory(selectedCapability);
+	const {
+		modelSupport,
+		resolvedModel,
+		launchModel,
+		setSelectedModel,
+		effortSupport,
+		modeSupport,
+		speedSupport,
+		contextWindowSupport,
+		resolvedEffort,
+		resolvedMode,
+		resolvedSpeed,
+		resolvedContextWindow,
+		onEffortChange,
+		onModeChange,
+		onSpeedChange,
+		onContextWindowChange,
+		traitsForLaunch,
+	} = useWorkspaceAgentRuntimeSelection(selectedPresetId, displayInventory, {
+		model: MODEL_STORAGE_KEY,
+		effort: EFFORT_STORAGE_KEY,
+		mode: MODE_TRAIT_STORAGE_KEY,
+		speed: SPEED_STORAGE_KEY,
+		contextWindow: CONTEXT_WINDOW_STORAGE_KEY,
+	});
 
-	// Promote the placeholder "none" → first configured agent whenever the
-	// current selection isn't a real agent and the user hasn't explicitly
-	// chosen "none". Fires on initial open (where useState init captured
-	// "none" before the query resolved) AND on host switch (where the
-	// previous host's UUID isn't valid here, so the corrective effect inside
-	// useAgentLaunchPreferences resets to "none"). The corrective effect
-	// can't rescue these on its own because "none" is always in validAgents.
+	// Promote the internal "none" placeholder to the first configured agent.
+	// The create-workspace picker no longer offers a no-agent choice, so stale
+	// preferences from the old UI must not leave the control unselectable.
 	useEffect(() => {
 		if (!v2AgentsFetched) return;
 		if (selectedAgent !== "none") return;
-		const stored =
-			typeof window !== "undefined"
-				? window.localStorage.getItem(AGENT_STORAGE_KEY)
-				: null;
-		if (stored === "none") return;
 		const first = selectableAgentIds[0];
 		if (first) setSelectedAgent(first);
 	}, [v2AgentsFetched, selectableAgentIds, selectedAgent, setSelectedAgent]);
@@ -340,8 +349,11 @@ export function PromptGroup({
 	const createWorkspace = useSubmitWorkspace(
 		projectId,
 		selectedAgent,
-		modelSupport ? selectedModel : null,
-		effortSupport ? selectedEffort : null,
+		modelSupport ? launchModel : null,
+		traitsForLaunch.effort,
+		traitsForLaunch.mode,
+		traitsForLaunch.speed,
+		traitsForLaunch.contextWindow,
 		uploadAttachments,
 		promptContext,
 	);
@@ -562,31 +574,43 @@ export function PromptGroup({
 						<AgentSelect<WorkspaceCreateAgent>
 							agents={v2Agents}
 							value={selectedAgent}
-							placeholder="No agent"
+							placeholder={
+								v2AgentsFetched ? "Select agent" : "Loading agents..."
+							}
+							disabled={!v2AgentsFetched}
 							onValueChange={setSelectedAgent}
 							onBeforeConfigureAgents={closeModal}
 							triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							iconClassName="size-3 object-contain"
-							allowNone
-							noneLabel="No agent"
-							noneValue="none"
 						/>
 						{modelSupport && (
 							<AgentModelSelect
 								models={modelSupport.models}
-								value={selectedModel}
+								value={resolvedModel ?? null}
 								onValueChange={setSelectedModel}
 								defaultLabel="Default model"
+								includeDefault={modelSupport.defaultModelId === undefined}
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}
-						{effortSupport && (
-							<AgentModelSelect
-								models={effortSupport.efforts}
-								value={selectedEffort}
-								onValueChange={setSelectedEffort}
-								defaultLabel="Default effort"
-								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+						{(effortSupport ||
+							modeSupport ||
+							speedSupport ||
+							contextWindowSupport) && (
+							<WorkspaceAgentTraitsPicker
+								effortSupport={effortSupport}
+								modeSupport={modeSupport}
+								speedSupport={speedSupport}
+								contextWindowSupport={contextWindowSupport}
+								effort={resolvedEffort}
+								mode={resolvedMode}
+								speed={resolvedSpeed}
+								contextWindow={resolvedContextWindow}
+								onEffortChange={onEffortChange}
+								onModeChange={onModeChange}
+								onSpeedChange={onSpeedChange}
+								onContextWindowChange={onContextWindowChange}
+								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[220px]`}
 							/>
 						)}
 					</PromptInputTools>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/WorkspaceAgentTraitsPicker.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/WorkspaceAgentTraitsPicker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+// biome-ignore lint/style/noRestrictedImports: regression test inspects the component source
+import { readFileSync } from "node:fs";
+// biome-ignore lint/style/noRestrictedImports: regression test resolves the colocated source
+import { join } from "node:path";
+
+describe("WorkspaceAgentTraitsPicker", () => {
+	const source = readFileSync(
+		join(import.meta.dir, "WorkspaceAgentTraitsPicker.tsx"),
+		"utf8",
+	);
+
+	test("uses actual defaults without a synthetic Default option", () => {
+		expect(source).toContain("defaultEffortId");
+		expect(source).not.toContain(">Default<");
+		expect(source).not.toContain('{ id: null, label: "Default" }');
+	});
+
+	test("keeps all launch traits in one compact menu", () => {
+		expect(source).toContain("speedSupport.speeds.map");
+		expect(source).toContain("modeSupport.modes.map");
+		expect(source).toContain("contextWindowSupport.contextWindows.map");
+		expect(source).toContain("w-44");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/WorkspaceAgentTraitsPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/WorkspaceAgentTraitsPicker.tsx
@@ -1,0 +1,212 @@
+import type {
+	AgentContextWindowSupport,
+	AgentEffortSupport,
+	AgentModeSupport,
+	AgentSpeedSupport,
+} from "@superset/shared/agent-models";
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { ChevronDownIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface WorkspaceAgentTraitsPickerProps {
+	effortSupport?: AgentEffortSupport;
+	modeSupport?: AgentModeSupport;
+	speedSupport?: AgentSpeedSupport;
+	contextWindowSupport?: AgentContextWindowSupport;
+	effort: string | null;
+	mode: string | null;
+	speed: string | null;
+	contextWindow: string | null;
+	onEffortChange: (effort: string | null) => void;
+	onModeChange: (mode: string | null) => void;
+	onSpeedChange: (speed: string | null) => void;
+	onContextWindowChange: (contextWindow: string | null) => void;
+	triggerClassName?: string;
+}
+
+export function WorkspaceAgentTraitsPicker({
+	effortSupport,
+	modeSupport,
+	speedSupport,
+	contextWindowSupport,
+	effort,
+	mode,
+	speed,
+	contextWindow,
+	onEffortChange,
+	onModeChange,
+	onSpeedChange,
+	onContextWindowChange,
+	triggerClassName,
+}: WorkspaceAgentTraitsPickerProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const activeItemRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (isOpen) activeItemRef.current?.focus();
+	}, [isOpen]);
+
+	const effectiveEffort =
+		effort ?? effortSupport?.defaultEffortId ?? effortSupport?.efforts[0]?.id;
+	const effectiveMode =
+		mode ?? modeSupport?.defaultModeId ?? modeSupport?.modes[0]?.id;
+	const effectiveSpeed =
+		speed ?? speedSupport?.defaultSpeedId ?? speedSupport?.speeds[0]?.id;
+	const effectiveContextWindow =
+		contextWindow ?? contextWindowSupport?.defaultContextWindowId;
+	const effortLabel = effortSupport?.efforts.find(
+		(option) => option.id === effectiveEffort,
+	)?.label;
+	const speedLabel = speedSupport?.speeds.find(
+		(option) => option.id === effectiveSpeed,
+	)?.label;
+	const modeLabel = modeSupport?.modes.find(
+		(option) => option.id === effectiveMode,
+	)?.label;
+	const contextWindowLabel = contextWindowSupport?.contextWindows.find(
+		(option) => option.id === effectiveContextWindow,
+	)?.label;
+	const isNonDefaultSpeed =
+		effectiveSpeed !== undefined &&
+		effectiveSpeed !== speedSupport?.defaultSpeedId;
+	const triggerLabel = [
+		effortLabel,
+		modeLabel,
+		contextWindowLabel,
+		isNonDefaultSpeed ? speedLabel : null,
+		!effortSupport && !contextWindowSupport ? speedLabel : null,
+	]
+		.filter(Boolean)
+		.join(" · ");
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					className={cn(triggerClassName, "justify-between")}
+				>
+					<span className="truncate">{triggerLabel}</span>
+					<ChevronDownIcon className="size-3 shrink-0 opacity-50" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				side="top"
+				sideOffset={6}
+				className="w-44 rounded-lg border-border/80 p-1.5 shadow-xl"
+			>
+				{effortSupport && (
+					<DropdownMenuRadioGroup
+						value={effectiveEffort}
+						onValueChange={onEffortChange}
+					>
+						<DropdownMenuLabel className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+							{effortSupport.label ?? "Reasoning"}
+						</DropdownMenuLabel>
+						{effortSupport.efforts.map((option) => (
+							<DropdownMenuRadioItem
+								key={option.id}
+								ref={option.id === effectiveEffort ? activeItemRef : undefined}
+								value={option.id}
+								className="py-1.5 pr-8 pl-2 text-xs [&>span:first-child]:right-2 [&>span:first-child]:left-auto"
+							>
+								{option.label}
+							</DropdownMenuRadioItem>
+						))}
+					</DropdownMenuRadioGroup>
+				)}
+				{speedSupport && (
+					<DropdownMenuRadioGroup
+						value={effectiveSpeed}
+						onValueChange={onSpeedChange}
+					>
+						{effortSupport && <DropdownMenuSeparator />}
+						<DropdownMenuLabel className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+							{speedSupport.label}
+						</DropdownMenuLabel>
+						{speedSupport.speeds.map((option) => (
+							<DropdownMenuRadioItem
+								key={option.id}
+								ref={
+									!effortSupport &&
+									!contextWindowSupport &&
+									option.id === effectiveSpeed
+										? activeItemRef
+										: undefined
+								}
+								value={option.id}
+								className="py-1.5 pr-8 pl-2 text-xs [&>span:first-child]:right-2 [&>span:first-child]:left-auto"
+							>
+								{option.label}
+							</DropdownMenuRadioItem>
+						))}
+					</DropdownMenuRadioGroup>
+				)}
+				{modeSupport && (
+					<DropdownMenuRadioGroup
+						value={effectiveMode}
+						onValueChange={onModeChange}
+					>
+						{(effortSupport || speedSupport) && <DropdownMenuSeparator />}
+						<DropdownMenuLabel className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+							{modeSupport.label}
+						</DropdownMenuLabel>
+						{modeSupport.modes.map((option) => (
+							<DropdownMenuRadioItem
+								key={option.id}
+								ref={
+									!effortSupport && !speedSupport && option.id === effectiveMode
+										? activeItemRef
+										: undefined
+								}
+								value={option.id}
+								className="py-1.5 pr-8 pl-2 text-xs [&>span:first-child]:right-2 [&>span:first-child]:left-auto"
+							>
+								{option.label}
+							</DropdownMenuRadioItem>
+						))}
+					</DropdownMenuRadioGroup>
+				)}
+				{contextWindowSupport && (
+					<DropdownMenuRadioGroup
+						value={effectiveContextWindow}
+						onValueChange={onContextWindowChange}
+					>
+						{(effortSupport || speedSupport || modeSupport) && (
+							<DropdownMenuSeparator />
+						)}
+						<DropdownMenuLabel className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+							Context Window
+						</DropdownMenuLabel>
+						{contextWindowSupport.contextWindows.map((option) => (
+							<DropdownMenuRadioItem
+								key={option.id}
+								ref={
+									!effortSupport && option.id === effectiveContextWindow
+										? activeItemRef
+										: undefined
+								}
+								value={option.id}
+								className="py-1.5 pr-8 pl-2 text-xs [&>span:first-child]:right-2 [&>span:first-child]:left-auto"
+							>
+								{option.label}
+							</DropdownMenuRadioItem>
+						))}
+					</DropdownMenuRadioGroup>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceAgentTraitsPicker } from "./WorkspaceAgentTraitsPicker";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/getAgentSelectionBlocker.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/getAgentSelectionBlocker.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { getAgentSelectionBlocker } from "./getAgentSelectionBlocker";
+
+describe("getAgentSelectionBlocker", () => {
+	it("blocks submission while agents are loading", () => {
+		expect(
+			getAgentSelectionBlocker({
+				isFetched: false,
+				selectableAgentIds: [],
+				selectedAgent: "none",
+			}),
+		).toBe("Loading agents");
+	});
+
+	it("blocks submission when no selectable agents are available", () => {
+		expect(
+			getAgentSelectionBlocker({
+				isFetched: true,
+				selectableAgentIds: [],
+				selectedAgent: "none",
+			}),
+		).toBe("No agents available");
+	});
+
+	it("allows submission only for a selectable agent", () => {
+		expect(
+			getAgentSelectionBlocker({
+				isFetched: true,
+				selectableAgentIds: ["claude"],
+				selectedAgent: "none",
+			}),
+		).toBe("Select an agent");
+		expect(
+			getAgentSelectionBlocker({
+				isFetched: true,
+				selectableAgentIds: ["claude"],
+				selectedAgent: "claude",
+			}),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/getAgentSelectionBlocker.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/getAgentSelectionBlocker.ts
@@ -1,0 +1,16 @@
+interface AgentSelectionState {
+	isFetched: boolean;
+	selectableAgentIds: readonly string[];
+	selectedAgent: string;
+}
+
+export function getAgentSelectionBlocker({
+	isFetched,
+	selectableAgentIds,
+	selectedAgent,
+}: AgentSelectionState): string | null {
+	if (!isFetched) return "Loading agents";
+	if (selectableAgentIds.length === 0) return "No agents available";
+	if (!selectableAgentIds.includes(selectedAgent)) return "Select an agent";
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -22,6 +22,9 @@ export function useSubmitWorkspace(
 	selectedAgent: WorkspaceCreateAgent,
 	selectedModel: string | null,
 	selectedEffort: string | null,
+	selectedMode: string | null,
+	selectedSpeed: string | null,
+	selectedContextWindow: string | null,
 	uploadAttachments: UseUploadAttachmentsApi,
 	promptContext: NewWorkspacePromptContextApi,
 ) {
@@ -99,6 +102,9 @@ export function useSubmitWorkspace(
 						attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
 						model: selectedModel ?? undefined,
 						effort: selectedEffort ?? undefined,
+						mode: selectedMode ?? undefined,
+						speed: selectedSpeed ?? undefined,
+						contextWindow: selectedContextWindow ?? undefined,
 					},
 				]
 			: undefined;
@@ -194,6 +200,9 @@ export function useSubmitWorkspace(
 		selectedAgent,
 		selectedModel,
 		selectedEffort,
+		selectedMode,
+		selectedSpeed,
+		selectedContextWindow,
 		submit,
 		uploadAttachments,
 	]);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -8,8 +8,19 @@ export const AGENT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateAgent";
 // preference survives host switches.
 export const MODEL_STORAGE_KEY = "lastSelectedV2WorkspaceCreateModelByPreset";
 
-// JSON map of presetId → effort id; same contract as MODEL_STORAGE_KEY.
+// JSON map of presetId:modelId → effort id (presetId for model-less agents).
 export const EFFORT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateEffortByPreset";
+
+// JSON map of presetId (or presetId:modelId for runtime variants) → mode id.
+export const MODE_TRAIT_STORAGE_KEY =
+	"lastSelectedV2WorkspaceCreateModeByPreset";
+
+// JSON map of presetId:modelId → performance mode.
+export const SPEED_STORAGE_KEY = "lastSelectedV2WorkspaceCreateSpeedByPreset";
+
+// JSON map of presetId:modelId → context-window id.
+export const CONTEXT_WINDOW_STORAGE_KEY =
+	"lastSelectedV2WorkspaceCreateContextWindowByModel";
 
 export const PILL_BUTTON_CLASS =
 	"!h-[22px] min-h-0 rounded-md border-[0.5px] border-border bg-foreground/[0.04] shadow-none text-[11px]";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -1,8 +1,4 @@
 import {
-	getAgentEffortSupport,
-	getAgentModelSupport,
-} from "@superset/shared/agent-models";
-import {
 	PromptInput,
 	PromptInputButton,
 	PromptInputFooter,
@@ -33,11 +29,12 @@ import { LinkedIssuePill } from "renderer/components/LinkedIssuePill";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
-import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
-import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
-import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import {
+	getCapabilityDisplayInventory,
+	useV2AgentChoices,
+} from "renderer/hooks/useV2AgentChoices";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -49,6 +46,7 @@ import { useNewWorkspacePromptContext } from "renderer/stores/new-workspace-prom
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../DashboardNewWorkspaceDraftContext";
 import { useNewWorkspacePromptCardsVariant } from "../../hooks/useNewWorkspacePromptCardsVariant";
+import { useWorkspaceAgentRuntimeSelection } from "../../hooks/useWorkspaceAgentRuntimeSelection";
 import { DevicePicker } from "../DashboardNewWorkspaceForm/components/DevicePicker";
 import { useWorkspaceHostOptions } from "../DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { CompareBaseBranchPicker } from "../DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker";
@@ -58,6 +56,7 @@ import { LinkedPRPill } from "../DashboardNewWorkspaceForm/PromptGroup/component
 import { PRLinkCommand } from "../DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand";
 import { ProjectPickerPill } from "../DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill";
 import { PromptHistoryCommand } from "../DashboardNewWorkspaceForm/PromptGroup/components/PromptHistoryCommand";
+import { WorkspaceAgentTraitsPicker } from "../DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceAgentTraitsPicker";
 import { useBranchPickerController } from "../DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController";
 import { useLinkedContext } from "../DashboardNewWorkspaceForm/PromptGroup/hooks/useLinkedContext";
 import { useSubmitWorkspace } from "../DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace";
@@ -67,9 +66,12 @@ import {
 } from "../DashboardNewWorkspaceForm/PromptGroup/hooks/useUploadAttachments";
 import {
 	AGENT_STORAGE_KEY,
+	CONTEXT_WINDOW_STORAGE_KEY,
 	EFFORT_STORAGE_KEY,
+	MODE_TRAIT_STORAGE_KEY,
 	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
+	SPEED_STORAGE_KEY,
 	type WorkspaceCreateAgent,
 } from "../DashboardNewWorkspaceForm/PromptGroup/types";
 import { useSelectedHostProjectIds } from "../DashboardNewWorkspaceModalContent/hooks/useSelectedHostProjectIds";
@@ -361,7 +363,6 @@ export function NewWorkspaceScreen({
 			}) ?? null
 		);
 	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
-
 	const promptCardsVariant = useNewWorkspacePromptCardsVariant(isOpen);
 	// Logged so the prompt-cards experiment can account for lost exposure.
 	const handleDismissSamplePrompts = useCallback(() => {
@@ -371,53 +372,56 @@ export function NewWorkspaceScreen({
 		setSamplePromptsDismissed(true);
 	}, [promptCardsVariant, setSamplePromptsDismissed]);
 
-	const { agents: v2Agents, isFetched: v2AgentsFetched } =
-		useV2AgentChoices(launchHostUrl);
+	const {
+		agents: v2Agents,
+		capabilitiesByAgentId,
+		isFetched: v2AgentsFetched,
+	} = useV2AgentChoices(launchHostUrl);
 	const selectableAgentIds = useMemo(
 		() => v2Agents.map((agent) => agent.id),
 		[v2Agents],
 	);
+	const firstSelectableAgent = selectableAgentIds[0] ?? "none";
 	const { selectedAgent, setSelectedAgent } =
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({
 			agentStorageKey: AGENT_STORAGE_KEY,
 			defaultAgent: "none",
-			fallbackAgent: "none",
-			validAgents: ["none", ...selectableAgentIds],
+			fallbackAgent: firstSelectableAgent,
+			validAgents: selectableAgentIds,
 			agentsReady: v2AgentsFetched,
 		});
 
-	// Same "none" → first-agent promotion as the control modal: new users land
-	// here with no stored preference, and the screen must not default to no agent.
-	useEffect(() => {
-		if (!v2AgentsFetched) return;
-		if (selectedAgent !== "none") return;
-		const stored =
-			typeof window !== "undefined"
-				? window.localStorage.getItem(AGENT_STORAGE_KEY)
-				: null;
-		if (stored === "none") return;
-		const first = selectableAgentIds[0];
-		if (first) setSelectedAgent(first);
-	}, [v2AgentsFetched, selectableAgentIds, selectedAgent, setSelectedAgent]);
-
-	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
-		[v2Agents, selectedAgent],
-	);
-	const modelSupport = selectedPresetId
-		? getAgentModelSupport(selectedPresetId)
-		: undefined;
-	const { selectedModel, setSelectedModel } = useAgentModelPreference(
-		MODEL_STORAGE_KEY,
-		modelSupport ? selectedPresetId : null,
-	);
-	const effortSupport = selectedPresetId
-		? getAgentEffortSupport(selectedPresetId)
-		: undefined;
-	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
-		EFFORT_STORAGE_KEY,
-		effortSupport ? selectedPresetId : null,
-	);
+	const selectedPresetId = useMemo(() => {
+		const agent = v2Agents.find((candidate) => candidate.id === selectedAgent);
+		return agent?.presetId ?? agent?.iconId ?? null;
+	}, [v2Agents, selectedAgent]);
+	const selectedCapability = capabilitiesByAgentId.get(selectedAgent);
+	const displayInventory = getCapabilityDisplayInventory(selectedCapability);
+	const {
+		modelSupport,
+		resolvedModel,
+		launchModel,
+		setSelectedModel,
+		effortSupport,
+		modeSupport,
+		speedSupport,
+		contextWindowSupport,
+		resolvedEffort,
+		resolvedMode,
+		resolvedSpeed,
+		resolvedContextWindow,
+		onEffortChange,
+		onModeChange,
+		onSpeedChange,
+		onContextWindowChange,
+		traitsForLaunch,
+	} = useWorkspaceAgentRuntimeSelection(selectedPresetId, displayInventory, {
+		model: MODEL_STORAGE_KEY,
+		effort: EFFORT_STORAGE_KEY,
+		mode: MODE_TRAIT_STORAGE_KEY,
+		speed: SPEED_STORAGE_KEY,
+		contextWindow: CONTEXT_WINDOW_STORAGE_KEY,
+	});
 
 	// ── Base branch ──────────────────────────────────────────────────
 	const { pickerProps } = useBranchPickerController({
@@ -457,8 +461,11 @@ export function NewWorkspaceScreen({
 	const createWorkspace = useSubmitWorkspace(
 		projectId,
 		selectedAgent,
-		modelSupport ? selectedModel : null,
-		effortSupport ? selectedEffort : null,
+		modelSupport ? launchModel : null,
+		traitsForLaunch.effort,
+		traitsForLaunch.mode,
+		traitsForLaunch.speed,
+		traitsForLaunch.contextWindow,
 		uploadAttachments,
 		promptContext,
 	);
@@ -725,31 +732,43 @@ export function NewWorkspaceScreen({
 							<AgentSelect<WorkspaceCreateAgent>
 								agents={v2Agents}
 								value={selectedAgent}
-								placeholder="No agent"
+								placeholder={
+									v2AgentsFetched ? "Select agent" : "Loading agents..."
+								}
+								disabled={!v2AgentsFetched}
 								onValueChange={setSelectedAgent}
 								onBeforeConfigureAgents={closeModal}
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 								iconClassName="size-3 object-contain"
-								allowNone
-								noneLabel="No agent"
-								noneValue="none"
 							/>
 							{modelSupport && (
 								<AgentModelSelect
 									models={modelSupport.models}
-									value={selectedModel}
+									value={resolvedModel ?? null}
 									onValueChange={setSelectedModel}
 									defaultLabel="Default model"
+									includeDefault={modelSupport.defaultModelId === undefined}
 									triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 								/>
 							)}
-							{effortSupport && (
-								<AgentModelSelect
-									models={effortSupport.efforts}
-									value={selectedEffort}
-									onValueChange={setSelectedEffort}
-									defaultLabel="Default effort"
-									triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+							{(effortSupport ||
+								modeSupport ||
+								speedSupport ||
+								contextWindowSupport) && (
+								<WorkspaceAgentTraitsPicker
+									effortSupport={effortSupport}
+									modeSupport={modeSupport}
+									speedSupport={speedSupport}
+									contextWindowSupport={contextWindowSupport}
+									effort={resolvedEffort}
+									mode={resolvedMode}
+									speed={resolvedSpeed}
+									contextWindow={resolvedContextWindow}
+									onEffortChange={onEffortChange}
+									onModeChange={onModeChange}
+									onSpeedChange={onSpeedChange}
+									onContextWindowChange={onContextWindowChange}
+									triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[220px]`}
 								/>
 							)}
 						</PromptInputTools>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useWorkspaceAgentRuntimeSelection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useWorkspaceAgentRuntimeSelection/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceAgentRuntimeSelection } from "./useWorkspaceAgentRuntimeSelection";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useWorkspaceAgentRuntimeSelection/useWorkspaceAgentRuntimeSelection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useWorkspaceAgentRuntimeSelection/useWorkspaceAgentRuntimeSelection.ts
@@ -1,0 +1,260 @@
+import {
+	getAgentContextWindowSupport,
+	getAgentModelSupport,
+	getAgentModeSupport,
+	getAgentSpeedSupport,
+	resolveAgentEffortSupport,
+} from "@superset/shared/agent-models";
+import { useCallback, useMemo } from "react";
+import { useAgentContextWindowPreference } from "renderer/hooks/useAgentContextWindowPreference";
+import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
+import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
+import { useAgentModePreference } from "renderer/hooks/useAgentModePreference";
+import { useAgentSpeedPreference } from "renderer/hooks/useAgentSpeedPreference";
+import type { AgentChoiceCapability } from "renderer/hooks/useV2AgentChoices";
+import {
+	buildCursorLaunchSelection,
+	buildCursorModelSupport,
+	buildCursorVariantSupports,
+	type CursorVariantDimension,
+	cursorFamilyVariants,
+	resolveCursorVariant,
+} from "../../utils/cursorModelVariants";
+
+interface PreferenceKeys {
+	model: string;
+	effort: string;
+	mode: string;
+	speed: string;
+	contextWindow: string;
+}
+
+type DisplayInventory = NonNullable<AgentChoiceCapability["inventory"]>;
+const EMPTY_RUNTIME_MODELS: DisplayInventory["models"] = [];
+
+function resolveSelectedOption(
+	selected: string | null,
+	options: readonly { id: string }[] | undefined,
+	defaultId?: string,
+): string | null {
+	if (selected && options?.some((option) => option.id === selected)) {
+		return selected;
+	}
+	return defaultId ?? null;
+}
+
+export function useWorkspaceAgentRuntimeSelection(
+	selectedPresetId: string | null,
+	displayInventory: DisplayInventory | null,
+	keys: PreferenceKeys,
+) {
+	const runtimeModels = displayInventory?.models ?? EMPTY_RUNTIME_MODELS;
+	const hasCursorVariants =
+		selectedPresetId === "cursor-agent" &&
+		displayInventory?.modelSource === "runtime" &&
+		runtimeModels.length > 0 &&
+		runtimeModels.every((model) => model.variant);
+	const modelSupport = useMemo(() => {
+		if (!selectedPresetId) return undefined;
+		const support = getAgentModelSupport(selectedPresetId);
+		if (!support || runtimeModels.length === 0) return support;
+		if (hasCursorVariants) {
+			return buildCursorModelSupport(support, runtimeModels);
+		}
+		const defaultModelId = runtimeModels.some(
+			(model) => model.id === support.defaultModelId,
+		)
+			? support.defaultModelId
+			: runtimeModels[0]?.id;
+		return {
+			...support,
+			defaultModelId,
+			models: runtimeModels.map(({ id, label, provider }) => ({
+				id,
+				label,
+				provider,
+			})),
+		};
+	}, [hasCursorVariants, runtimeModels, selectedPresetId]);
+	const { selectedModel, setSelectedModel } = useAgentModelPreference(
+		keys.model,
+		modelSupport ? selectedPresetId : null,
+		modelSupport,
+	);
+	const resolvedModel =
+		selectedModel ??
+		modelSupport?.defaultModelId ??
+		modelSupport?.models[0]?.id;
+	const cursorVariants = useMemo(
+		() =>
+			hasCursorVariants
+				? cursorFamilyVariants(runtimeModels, resolvedModel)
+				: [],
+		[hasCursorVariants, resolvedModel, runtimeModels],
+	);
+	const cursorSupports = useMemo(
+		() => buildCursorVariantSupports(cursorVariants),
+		[cursorVariants],
+	);
+	const effortSupport = useMemo(() => {
+		if (hasCursorVariants) return cursorSupports.effort;
+		if (!selectedPresetId) return undefined;
+		const runtimeModel = runtimeModels.find(
+			(model) => model.id === resolvedModel,
+		);
+		if (displayInventory?.modelSource !== "runtime") {
+			return resolveAgentEffortSupport(
+				selectedPresetId,
+				resolvedModel,
+				undefined,
+			);
+		}
+		return resolveAgentEffortSupport(
+			selectedPresetId,
+			resolvedModel,
+			runtimeModel?.reasoning,
+		);
+	}, [
+		cursorSupports.effort,
+		displayInventory?.modelSource,
+		hasCursorVariants,
+		resolvedModel,
+		runtimeModels,
+		selectedPresetId,
+	]);
+	const modeSupport = hasCursorVariants
+		? cursorSupports.mode
+		: getAgentModeSupport(selectedPresetId ?? "");
+	const speedSupport = hasCursorVariants
+		? cursorSupports.speed
+		: getAgentSpeedSupport(selectedPresetId ?? "", resolvedModel);
+	const contextWindowSupport = hasCursorVariants
+		? cursorSupports.contextWindow
+		: getAgentContextWindowSupport(selectedPresetId ?? "", resolvedModel);
+	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
+		keys.effort,
+		effortSupport ? selectedPresetId : null,
+		resolvedModel ?? null,
+		effortSupport,
+	);
+	const { selectedMode, setSelectedMode } = useAgentModePreference(
+		keys.mode,
+		modeSupport ? selectedPresetId : null,
+		modeSupport,
+		hasCursorVariants ? resolvedModel : null,
+	);
+	const { selectedSpeed, setSelectedSpeed } = useAgentSpeedPreference(
+		keys.speed,
+		speedSupport ? selectedPresetId : null,
+		resolvedModel ?? null,
+		speedSupport,
+	);
+	const { selectedContextWindow, setSelectedContextWindow } =
+		useAgentContextWindowPreference(
+			keys.contextWindow,
+			contextWindowSupport ? selectedPresetId : null,
+			resolvedModel ?? null,
+			contextWindowSupport,
+		);
+	const resolvedEffort = resolveSelectedOption(
+		selectedEffort,
+		effortSupport?.efforts,
+		hasCursorVariants ? effortSupport?.defaultEffortId : undefined,
+	);
+	const resolvedMode = resolveSelectedOption(
+		selectedMode,
+		modeSupport?.modes,
+		hasCursorVariants ? modeSupport?.defaultModeId : undefined,
+	);
+	const resolvedSpeed = resolveSelectedOption(
+		selectedSpeed,
+		speedSupport?.speeds,
+		speedSupport?.defaultSpeedId,
+	);
+	const resolvedContextWindow = resolveSelectedOption(
+		selectedContextWindow,
+		contextWindowSupport?.contextWindows,
+		contextWindowSupport?.defaultContextWindowId,
+	);
+	const cursorLaunchSelection = hasCursorVariants
+		? buildCursorLaunchSelection(cursorVariants, {
+				effort: resolvedEffort,
+				mode: resolvedMode,
+				speed: resolvedSpeed,
+				contextWindow: resolvedContextWindow,
+			})
+		: undefined;
+
+	const applyCursorDimension = useCallback(
+		(dimension: CursorVariantDimension, value: string | null) => {
+			const variant = resolveCursorVariant(
+				cursorVariants,
+				{
+					effort: dimension === "effort" ? value : resolvedEffort,
+					mode: dimension === "mode" ? value : resolvedMode,
+					speed: dimension === "speed" ? value : resolvedSpeed,
+					contextWindow:
+						dimension === "contextWindow" ? value : resolvedContextWindow,
+				},
+				dimension,
+			)?.variant;
+			if (!variant) return;
+			setSelectedEffort(variant.effort);
+			setSelectedMode(variant.mode);
+			setSelectedSpeed(variant.speed);
+			setSelectedContextWindow(variant.contextWindow);
+		},
+		[
+			cursorVariants,
+			resolvedContextWindow,
+			resolvedEffort,
+			resolvedMode,
+			resolvedSpeed,
+			setSelectedContextWindow,
+			setSelectedEffort,
+			setSelectedMode,
+			setSelectedSpeed,
+		],
+	);
+
+	return {
+		modelSupport,
+		resolvedModel,
+		launchModel: cursorLaunchSelection?.launchModel ?? resolvedModel ?? null,
+		setSelectedModel,
+		effortSupport,
+		modeSupport,
+		speedSupport,
+		contextWindowSupport,
+		resolvedEffort:
+			cursorLaunchSelection?.resolvedTraits.effort ?? resolvedEffort,
+		resolvedMode: cursorLaunchSelection?.resolvedTraits.mode ?? resolvedMode,
+		resolvedSpeed: cursorLaunchSelection?.resolvedTraits.speed ?? resolvedSpeed,
+		resolvedContextWindow:
+			cursorLaunchSelection?.resolvedTraits.contextWindow ??
+			resolvedContextWindow,
+		onEffortChange: hasCursorVariants
+			? (value: string | null) => applyCursorDimension("effort", value)
+			: (value: string | null) =>
+					setSelectedEffort(
+						value === effortSupport?.defaultEffortId ? null : value,
+					),
+		onModeChange: hasCursorVariants
+			? (value: string | null) => applyCursorDimension("mode", value)
+			: setSelectedMode,
+		onSpeedChange: hasCursorVariants
+			? (value: string | null) => applyCursorDimension("speed", value)
+			: setSelectedSpeed,
+		onContextWindowChange: hasCursorVariants
+			? (value: string | null) => applyCursorDimension("contextWindow", value)
+			: setSelectedContextWindow,
+		traitsForLaunch: cursorLaunchSelection
+			? cursorLaunchSelection.traitsForLaunch
+			: {
+					effort: effortSupport ? resolvedEffort : null,
+					mode: modeSupport ? resolvedMode : null,
+					speed: speedSupport ? resolvedSpeed : null,
+					contextWindow: contextWindowSupport ? resolvedContextWindow : null,
+				},
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/cursorModelVariants.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/cursorModelVariants.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import type {
+	AgentModelSupport,
+	AgentRuntimeModelVariant,
+} from "@superset/shared/agent-models";
+import {
+	buildCursorLaunchSelection,
+	buildCursorModelSupport,
+	buildCursorVariantSupports,
+	type CursorRuntimeModel,
+	resolveCursorVariant,
+} from "./cursorModelVariants";
+
+const transport: AgentModelSupport = {
+	presetId: "cursor-agent",
+	modelFlag: "--model",
+	models: [],
+};
+
+function runtimeModel(
+	id: string,
+	variant: Partial<AgentRuntimeModelVariant> = {},
+	metadata: Partial<Pick<CursorRuntimeModel, "label" | "provider">> = {},
+): CursorRuntimeModel {
+	return {
+		id,
+		label: metadata.label ?? id,
+		provider: metadata.provider ?? "OpenAI",
+		variant: {
+			familyId: "gpt-5.6-sol",
+			familyLabel: "GPT-5.6 Sol",
+			effort: "medium",
+			speed: "standard",
+			mode: "standard",
+			contextWindow: "default",
+			...variant,
+		},
+	};
+}
+
+const models: CursorRuntimeModel[] = [
+	runtimeModel(
+		"gpt-5.6-sol-medium",
+		{ contextWindow: "1m" },
+		{ label: "GPT-5.6 Sol 1M" },
+	),
+	runtimeModel(
+		"gpt-5.6-sol-medium-fast",
+		{ speed: "fast" },
+		{ label: "GPT-5.6 Sol Fast" },
+	),
+	runtimeModel(
+		"gpt-5.6-sol-high",
+		{ effort: "high", contextWindow: "1m" },
+		{ label: "GPT-5.6 Sol 1M High" },
+	),
+	runtimeModel(
+		"composer-2.5",
+		{
+			familyId: "composer-2.5",
+			familyLabel: "Composer 2.5",
+			effort: "default",
+		},
+		{ label: "Composer 2.5", provider: "Cursor" },
+	),
+];
+
+describe("Cursor model variants", () => {
+	test("collapses exact ids into provider-grouped model families", () => {
+		expect(buildCursorModelSupport(transport, models)).toMatchObject({
+			defaultModelId: "gpt-5.6-sol",
+			models: [
+				{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", provider: "OpenAI" },
+				{ id: "composer-2.5", label: "Composer 2.5", provider: "Cursor" },
+			],
+		});
+		expect(
+			buildCursorModelSupport(transport, models).modelAliases?.[
+				"gpt-5.6-sol-medium-fast"
+			],
+		).toBe("gpt-5.6-sol");
+	});
+
+	test("derives only dimensions with multiple account-available choices", () => {
+		const supports = buildCursorVariantSupports(models.slice(0, 3));
+		expect(supports.effort?.efforts.map((option) => option.id)).toEqual([
+			"medium",
+			"high",
+		]);
+		expect(supports.speed?.speeds.map((option) => option.id)).toEqual([
+			"standard",
+			"fast",
+		]);
+		expect(
+			supports.contextWindow?.contextWindows.map((option) => option.id),
+		).toEqual(["default", "1m"]);
+		expect(supports.mode).toBeUndefined();
+	});
+
+	test("prioritizes the changed dimension without inventing a combination", () => {
+		expect(
+			resolveCursorVariant(
+				models.slice(0, 3),
+				{
+					effort: "medium",
+					speed: "fast",
+					contextWindow: "1m",
+				},
+				"speed",
+			)?.id,
+		).toBe("gpt-5.6-sol-medium-fast");
+	});
+
+	test("returns the exact runtime id and clears separately launched traits", () => {
+		expect(
+			buildCursorLaunchSelection(models.slice(0, 3), {
+				effort: "medium",
+				speed: "fast",
+				mode: "standard",
+				contextWindow: "default",
+			}),
+		).toEqual({
+			launchModel: "gpt-5.6-sol-medium-fast",
+			resolvedTraits: {
+				effort: "medium",
+				speed: "fast",
+				mode: "standard",
+				contextWindow: "default",
+			},
+			traitsForLaunch: {
+				effort: null,
+				speed: null,
+				mode: null,
+				contextWindow: null,
+			},
+		});
+	});
+
+	test("keeps an unsuffixed runtime id as an explicit default effort", () => {
+		const defaultModels: CursorRuntimeModel[] = [
+			runtimeModel(
+				"gpt-5.2-low",
+				{
+					familyId: "gpt-5.2",
+					familyLabel: "GPT-5.2",
+					effort: "low",
+				},
+				{ label: "GPT-5.2 Low" },
+			),
+			runtimeModel(
+				"gpt-5.2",
+				{
+					familyId: "gpt-5.2",
+					familyLabel: "GPT-5.2",
+					effort: "default",
+				},
+				{ label: "GPT-5.2" },
+			),
+			runtimeModel(
+				"gpt-5.2-high",
+				{
+					familyId: "gpt-5.2",
+					familyLabel: "GPT-5.2",
+					effort: "high",
+				},
+				{ label: "GPT-5.2 High" },
+			),
+		];
+
+		expect(buildCursorVariantSupports(defaultModels).effort).toMatchObject({
+			defaultEffortId: "default",
+			efforts: [
+				{ id: "default", label: "Default" },
+				{ id: "low", label: "Low" },
+				{ id: "high", label: "High" },
+			],
+		});
+		expect(
+			resolveCursorVariant(
+				defaultModels,
+				{
+					effort: "default",
+					speed: "standard",
+					mode: "standard",
+					contextWindow: "default",
+				},
+				"effort",
+			)?.id,
+		).toBe("gpt-5.2");
+	});
+
+	test("selects a runtime default effort without treating it as absent", () => {
+		const grokModels: CursorRuntimeModel[] = [
+			runtimeModel(
+				"cursor-grok-4.6-high-fast",
+				{
+					familyId: "cursor-grok-4.6",
+					familyLabel: "Cursor Grok 4.6",
+					effort: "high",
+					speed: "fast",
+				},
+				{ label: "Cursor Grok 4.6 Fast" },
+			),
+			runtimeModel(
+				"cursor-grok-4.6-low",
+				{
+					familyId: "cursor-grok-4.6",
+					familyLabel: "Cursor Grok 4.6",
+					effort: "low",
+				},
+				{ label: "Cursor Grok 4.6 Low" },
+			),
+			runtimeModel(
+				"cursor-grok-4.6-high",
+				{
+					familyId: "cursor-grok-4.6",
+					familyLabel: "Cursor Grok 4.6",
+					effort: "high",
+				},
+				{ label: "Cursor Grok 4.6" },
+			),
+		];
+
+		expect(buildCursorVariantSupports(grokModels).speed).toMatchObject({
+			defaultSpeedId: "standard",
+		});
+		expect(
+			resolveCursorVariant(
+				grokModels,
+				{
+					effort: "high",
+					speed: "standard",
+					mode: "standard",
+					contextWindow: "default",
+				},
+				"effort",
+			)?.id,
+		).toBe("cursor-grok-4.6-high");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/cursorModelVariants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/cursorModelVariants.ts
@@ -1,0 +1,239 @@
+import type {
+	AgentContextWindowSupport,
+	AgentEffortSupport,
+	AgentModelOption,
+	AgentModelSupport,
+	AgentModeSupport,
+	AgentRuntimeModelVariant,
+	AgentSpeedSupport,
+} from "@superset/shared/agent-models";
+
+export interface CursorRuntimeModel extends AgentModelOption {
+	variant?: AgentRuntimeModelVariant;
+}
+
+export interface CursorVariantSelection {
+	effort?: string | null;
+	speed?: string | null;
+	mode?: string | null;
+	contextWindow?: string | null;
+}
+
+export type CursorVariantDimension = keyof CursorVariantSelection;
+
+export interface CursorLaunchSelection {
+	launchModel: string | null;
+	resolvedTraits: Required<CursorVariantSelection>;
+	traitsForLaunch: Required<CursorVariantSelection>;
+}
+
+const CURSOR_VARIANT_DIMENSIONS: readonly CursorVariantDimension[] = [
+	"effort",
+	"speed",
+	"mode",
+	"contextWindow",
+];
+
+const EFFORT_ORDER = [
+	"default",
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+
+const EFFORT_LABELS: Readonly<Record<string, string>> = {
+	default: "Default",
+	none: "None",
+	minimal: "Minimal",
+	low: "Low",
+	medium: "Medium",
+	high: "High",
+	xhigh: "Extra High",
+	max: "Max",
+};
+
+function uniqueValues(
+	models: readonly CursorRuntimeModel[],
+	read: (variant: AgentRuntimeModelVariant) => string,
+): string[] {
+	return [
+		...new Set(
+			models.flatMap((model) => (model.variant ? [read(model.variant)] : [])),
+		),
+	];
+}
+
+export function buildCursorModelSupport(
+	transport: AgentModelSupport,
+	models: readonly CursorRuntimeModel[],
+): AgentModelSupport {
+	const seen = new Set<string>();
+	const families = models.flatMap((model): AgentModelOption[] => {
+		const variant = model.variant;
+		if (!variant || seen.has(variant.familyId)) return [];
+		seen.add(variant.familyId);
+		return [
+			{
+				id: variant.familyId,
+				label: variant.familyLabel,
+				provider: model.provider,
+			},
+		];
+	});
+	return {
+		...transport,
+		defaultModelId:
+			families.find((model) => model.id === "auto")?.id ?? families[0]?.id,
+		models: families,
+		modelAliases: Object.fromEntries(
+			models.flatMap((model) =>
+				model.variant ? [[model.id, model.variant.familyId]] : [],
+			),
+		),
+	};
+}
+
+export function cursorFamilyVariants(
+	models: readonly CursorRuntimeModel[],
+	familyId: string | null | undefined,
+): CursorRuntimeModel[] {
+	if (!familyId) return [];
+	return models.filter((model) => model.variant?.familyId === familyId);
+}
+
+export function buildCursorVariantSupports(
+	models: readonly CursorRuntimeModel[],
+): {
+	effort?: AgentEffortSupport;
+	speed?: AgentSpeedSupport;
+	mode?: AgentModeSupport;
+	contextWindow?: AgentContextWindowSupport;
+} {
+	const first = models[0]?.variant;
+	if (!first) return {};
+	const defaultEffort = models.some(
+		(model) => model.variant?.effort === "default",
+	)
+		? "default"
+		: first.effort;
+	const defaultVariant =
+		resolveCursorVariant(models, {
+			effort: defaultEffort,
+			speed: "standard",
+			mode: "standard",
+			contextWindow: "default",
+		})?.variant ?? first;
+	const efforts = uniqueValues(models, (variant) => variant.effort).sort(
+		(a, b) =>
+			EFFORT_ORDER.indexOf(a as (typeof EFFORT_ORDER)[number]) -
+			EFFORT_ORDER.indexOf(b as (typeof EFFORT_ORDER)[number]),
+	);
+	const speeds = uniqueValues(models, (variant) => variant.speed);
+	const modes = uniqueValues(models, (variant) => variant.mode);
+	const contexts = uniqueValues(models, (variant) => variant.contextWindow);
+
+	return {
+		effort:
+			efforts.length > 1
+				? {
+						presetId: "cursor-agent",
+						effortFlag: "--model",
+						defaultEffortId: defaultVariant.effort,
+						efforts: efforts.map((id) => ({
+							id,
+							label: EFFORT_LABELS[id] ?? id,
+						})),
+					}
+				: undefined,
+		speed:
+			speeds.length > 1
+				? {
+						presetId: "cursor-agent",
+						label: "Fast Mode",
+						defaultSpeedId: defaultVariant.speed,
+						speeds: [
+							{ id: "standard", label: "Off", args: [] },
+							{ id: "fast", label: "Fast", args: [] },
+						].filter((option) => speeds.includes(option.id)),
+					}
+				: undefined,
+		mode:
+			modes.length > 1
+				? {
+						presetId: "cursor-agent",
+						label: "Thinking",
+						defaultModeId: defaultVariant.mode,
+						modes: [
+							{ id: "standard", label: "Off", args: [] },
+							{ id: "thinking", label: "Thinking", args: [] },
+						].filter((option) => modes.includes(option.id)),
+					}
+				: undefined,
+		contextWindow:
+			contexts.length > 1
+				? {
+						presetId: "cursor-agent",
+						defaultContextWindowId: defaultVariant.contextWindow,
+						contextWindows: [
+							{ id: "default", label: "Default" },
+							{ id: "1m", label: "1M" },
+						].filter((option) => contexts.includes(option.id)),
+					}
+				: undefined,
+	};
+}
+
+export function resolveCursorVariant(
+	models: readonly CursorRuntimeModel[],
+	selection: CursorVariantSelection,
+	preferredDimension?: CursorVariantDimension,
+): CursorRuntimeModel | undefined {
+	const candidates = models.filter((model) => model.variant);
+	if (candidates.length === 0) return undefined;
+	return candidates.reduce((best, candidate) => {
+		const score = scoreCursorVariant(candidate, selection, preferredDimension);
+		const bestScore = scoreCursorVariant(best, selection, preferredDimension);
+		return score > bestScore ? candidate : best;
+	}, candidates[0]);
+}
+
+export function buildCursorLaunchSelection(
+	models: readonly CursorRuntimeModel[],
+	selection: CursorVariantSelection,
+): CursorLaunchSelection {
+	const resolved = resolveCursorVariant(models, selection);
+	return {
+		launchModel: resolved?.id ?? null,
+		resolvedTraits: {
+			effort: resolved?.variant?.effort ?? selection.effort ?? null,
+			speed: resolved?.variant?.speed ?? selection.speed ?? null,
+			mode: resolved?.variant?.mode ?? selection.mode ?? null,
+			contextWindow:
+				resolved?.variant?.contextWindow ?? selection.contextWindow ?? null,
+		},
+		traitsForLaunch: {
+			effort: null,
+			speed: null,
+			mode: null,
+			contextWindow: null,
+		},
+	};
+}
+
+function scoreCursorVariant(
+	model: CursorRuntimeModel,
+	selection: CursorVariantSelection,
+	preferredDimension?: CursorVariantDimension,
+): number {
+	return CURSOR_VARIANT_DIMENSIONS.reduce((total, dimension) => {
+		const requested = selection[dimension];
+		if (requested == null || model.variant?.[dimension] !== requested) {
+			return total;
+		}
+		return total + (dimension === preferredDimension ? 100 : 10);
+	}, 0);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/utils/cursorModelVariants/index.ts
@@ -1,0 +1,13 @@
+export type {
+	CursorLaunchSelection,
+	CursorRuntimeModel,
+	CursorVariantDimension,
+	CursorVariantSelection,
+} from "./cursorModelVariants";
+export {
+	buildCursorLaunchSelection,
+	buildCursorModelSupport,
+	buildCursorVariantSupports,
+	cursorFamilyVariants,
+	resolveCursorVariant,
+} from "./cursorModelVariants";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -10,6 +10,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { Bot } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
+	type HostAgentQueryInvalidation,
+	invalidateHostAgentQueries,
+} from "renderer/hooks/useV2AgentChoices";
+import {
 	V2_AGENT_CONFIGS_QUERY_KEY as QUERY_KEY,
 	useV2AgentConfigs,
 } from "renderer/hooks/useV2AgentConfigs";
@@ -84,15 +88,14 @@ export function V2AgentsSettings({
 
 	const configsQuery = useV2AgentConfigs(activeHostUrl);
 	const queryKey = [...QUERY_KEY, activeHostUrl] as const;
-	const queryFamily = { queryKey: QUERY_KEY };
 
-	const invalidate = () => {
-		void queryClient.invalidateQueries(queryFamily);
-		void queryClient.refetchQueries(queryFamily);
+	const invalidate = (scope: HostAgentQueryInvalidation) => {
+		if (!activeHostUrl) return;
+		invalidateHostAgentQueries(queryClient, activeHostUrl, scope);
 	};
 
 	const updateCachedConfig = (updated: HostAgentConfig) => {
-		queryClient.setQueriesData<HostAgentConfig[]>(queryFamily, (current) =>
+		queryClient.setQueryData<HostAgentConfig[]>(queryKey, (current) =>
 			current?.map((config) =>
 				config.id === updated.id ? { ...config, ...updated } : config,
 			),
@@ -154,7 +157,7 @@ export function V2AgentsSettings({
 		},
 		onSuccess: (added) => {
 			setIsCreating(false);
-			invalidate();
+			invalidate("config-and-capabilities");
 			if (added?.id) {
 				setSelectedAgentId(added.id);
 				insertLinkedTerminalPreset(collections, added);
@@ -179,7 +182,7 @@ export function V2AgentsSettings({
 		},
 		onSuccess: (added) => {
 			setIsCreating(false);
-			invalidate();
+			invalidate("config-and-capabilities");
 			if (added?.id) {
 				setSelectedAgentId(added.id);
 				insertLinkedTerminalPreset(collections, added);
@@ -225,7 +228,7 @@ export function V2AgentsSettings({
 			}
 			toast.error(err instanceof Error ? err.message : "Failed to reorder");
 		},
-		onSettled: () => invalidate(),
+		onSettled: () => invalidate("config"),
 	});
 
 	const resetMutation = useMutation({
@@ -245,7 +248,7 @@ export function V2AgentsSettings({
 			setIsCreating(false);
 			setSelectedAgentId(null);
 			void navigate({ to: "/settings/agents" });
-			invalidate();
+			invalidate("config-and-capabilities");
 		},
 		onError: (err) =>
 			toast.error(err instanceof Error ? err.message : "Failed to reset"),
@@ -344,15 +347,15 @@ export function V2AgentsSettings({
 							DESCRIPTION_BY_PRESET_ID.get(selectedAgent.presetId) ??
 							"Terminal agent launch configuration"
 						}
-						onChanged={(updated) => {
+						onChanged={(updated, invalidation) => {
 							updateCachedConfig(updated);
 							syncLinkedPresetSnapshots(updated);
-							invalidate();
+							invalidate(invalidation);
 						}}
 						onDeleted={() => {
 							setSelectedAgentId(null);
 							void navigate({ to: "/settings/agents" });
-							invalidate();
+							invalidate("config-and-capabilities");
 						}}
 					/>
 				) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
@@ -22,6 +22,10 @@ import { useMutation } from "@tanstack/react-query";
 import { Info, RotateCcw, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
+	classifyHostAgentUpdateInvalidation,
+	type HostAgentQueryInvalidation,
+} from "renderer/hooks/useV2AgentChoices";
+import {
 	getAgentCommandText,
 	isAgentCommandPatchChanged,
 	parseAgentCommandText,
@@ -41,7 +45,10 @@ import { AgentIconPicker } from "../AgentIconPicker";
 interface AgentDetailProps {
 	config: HostAgentConfig;
 	description: string;
-	onChanged: (updated: HostAgentConfig) => void;
+	onChanged: (
+		updated: HostAgentConfig,
+		invalidation: HostAgentQueryInvalidation,
+	) => void;
 	onDeleted: () => void;
 }
 
@@ -129,7 +136,8 @@ export function AgentDetail({
 				activeHostUrl,
 			).settings.agentConfigs.update.mutate({ id: config.id, patch });
 		},
-		onSuccess: (updated) => onChanged(updated),
+		onSuccess: (updated, patch) =>
+			onChanged(updated, classifyHostAgentUpdateInvalidation(config, patch)),
 		onError: (err) =>
 			toast.error(err instanceof Error ? err.message : "Failed to save"),
 	});
@@ -166,7 +174,7 @@ export function AgentDetail({
 			).settings.agentConfigs.restoreDefault.mutate({ id: config.id });
 		},
 		onSuccess: (updated) => {
-			onChanged(updated);
+			onChanged(updated, "config-and-capabilities");
 			toast.success(`${updated.label} restored to defaults`);
 		},
 		onError: (err) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentIconPicker/agent-icon-options.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentIconPicker/agent-icon-options.ts
@@ -9,6 +9,7 @@ export interface AgentIconOption {
 }
 
 export const AGENT_ICON_OPTIONS: readonly AgentIconOption[] = [
+	{ id: "antigravity", label: "Antigravity" },
 	{ id: "claude", label: "Claude" },
 	{ id: "codex", label: "Codex" },
 	{ id: "cursor-agent", label: "Cursor" },

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -25,6 +25,10 @@ import { Link } from "@tanstack/react-router";
 import { ExternalLink, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { HiExclamationTriangle, HiOutlineFolderOpen } from "react-icons/hi2";
+import {
+	classifyHostAgentUpdateInvalidation,
+	invalidateHostAgentQueries,
+} from "renderer/hooks/useV2AgentChoices";
 import { V2_AGENT_CONFIGS_QUERY_KEY } from "renderer/hooks/useV2AgentConfigs";
 import {
 	findLinkedAgent,
@@ -226,7 +230,10 @@ export function PresetEditorDialog({
 	const hostService = useLocalHostService();
 	const { activeHostUrl } = hostService;
 	const queryClient = useQueryClient();
-	const queryFamily = { queryKey: V2_AGENT_CONFIGS_QUERY_KEY };
+	const agentConfigsQueryKey = [
+		...V2_AGENT_CONFIGS_QUERY_KEY,
+		activeHostUrl,
+	] as const;
 	const [linkedCommandText, setLinkedCommandText] = useState(() =>
 		linkedAgent ? getAgentCommandText(linkedAgent) : "",
 	);
@@ -256,13 +263,21 @@ export function PresetEditorDialog({
 				activeHostUrl,
 			).settings.agentConfigs.update.mutate({ id, patch });
 		},
-		onSuccess: (updated) => {
-			queryClient.setQueriesData<HostAgentConfig[]>(queryFamily, (current) =>
-				current?.map((config) =>
-					config.id === updated.id ? { ...config, ...updated } : config,
-				),
+		onSuccess: (updated, { patch }) => {
+			queryClient.setQueryData<HostAgentConfig[]>(
+				agentConfigsQueryKey,
+				(current) =>
+					current?.map((config) =>
+						config.id === updated.id ? { ...config, ...updated } : config,
+					),
 			);
-			void queryClient.invalidateQueries(queryFamily);
+			if (activeHostUrl && linkedAgent) {
+				invalidateHostAgentQueries(
+					queryClient,
+					activeHostUrl,
+					classifyHostAgentUpdateInvalidation(linkedAgent, patch),
+				);
+			}
 			onLinkedAgentSaved?.(updated);
 		},
 		onError: (err) =>

--- a/bun.lock
+++ b/bun.lock
@@ -910,6 +910,7 @@
       "name": "@superset/host-service",
       "version": "1.22.0",
       "dependencies": {
+        "@github/copilot-sdk": "1.0.9",
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
         "@hono/trpc-server": "0.3.4",
@@ -1267,7 +1268,7 @@
     },
   },
   "trustedDependencies": [
-    "koffi",
+    "workerd",
     "sharp",
     "node-pty",
     "utf-8-validate",
@@ -1275,7 +1276,7 @@
     "electron",
     "better-sqlite3",
     "bufferutil",
-    "workerd",
+    "koffi",
   ],
   "patchedDependencies": {
     "@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
@@ -1906,6 +1907,26 @@
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.1.1", "", { "peerDependencies": { "tailwindcss": "^4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-BnPe52UxSaG8yKlHMKBxXw8h6GpK5qO55ci6+Qd5JnquTvIw6SpfbC1P+qAi82PuPWv1KZAWY8bxRk4+x9ctXw=="],
 
+    "@github/copilot": ["@github/copilot@1.0.79", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.79", "@github/copilot-darwin-x64": "1.0.79", "@github/copilot-linux-arm64": "1.0.79", "@github/copilot-linux-x64": "1.0.79", "@github/copilot-linuxmusl-arm64": "1.0.79", "@github/copilot-linuxmusl-x64": "1.0.79", "@github/copilot-win32-arm64": "1.0.79", "@github/copilot-win32-x64": "1.0.79" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-uHBm2BYbKJgyfiKp1WokX7QUNHGvzEX0zaGeb3qM3CybP06rsJrX3JgQe95qwwma6vQz0ah9gV68ERW2JqaKRA=="],
+
+    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.79", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-rsw7JoMvlcxXb0yx08oIeEc0x2hUEwKSfhX9ESKfdMVt0Ckrzm4OEvNUyzOpOnLJ9+l3h/aI+u1w5g2ZU2K7UA=="],
+
+    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.79", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-D983e2lXYnq+KhjA8mTZXonY1+LGfJN9BM195J73shUvx49nRJmibDHWLvVtGeYc+43evGUOAQrOqOspAhhWPQ=="],
+
+    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.79", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-qqaNkvi92Wg+4OZk/kTWC2nUG72G0vV6eRAo5+PnKaPmjdX1GsI0a+lPxXPEbzX0zYLi/8yrUyANwyyNEsGgXA=="],
+
+    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.79", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-wzotZfvHkItutciLFMXZT2k9Qiii4Ta8tsVDCMQ7CP8hPxV91FyJ1yf3+FFSSfPvWrfYM6BOAiqIuX+LjgRuiw=="],
+
+    "@github/copilot-linuxmusl-arm64": ["@github/copilot-linuxmusl-arm64@1.0.79", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linuxmusl-arm64": "copilot" } }, "sha512-INtRSARl7DdNm2MXnn4GJuK+Y7QD24ANox02uH8htNQwRlNvdvg+YGS1V/mYgLDXFepeUjMjzTNC+i70+kh5uw=="],
+
+    "@github/copilot-linuxmusl-x64": ["@github/copilot-linuxmusl-x64@1.0.79", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linuxmusl-x64": "copilot" } }, "sha512-LxJAIfPP6Ok/9qpXGZuhnAft3W9JVcK9tbO3jWXcGDJT3v+2NtutyjmP/A7/cDXdTruXVQ4MybwAgacN8Gj/sg=="],
+
+    "@github/copilot-sdk": ["@github/copilot-sdk@1.0.9", "", { "dependencies": { "@github/copilot": "^1.0.78", "koffi": "^3.1.0", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-ZQJYbKhQTvpiUOU4rtPjppzVQv41gGymaD+AuWDbiZPYvSMSB4jZ/epvCrDs7jgqWa52r+j2D9eOQoSzdUMO6Q=="],
+
+    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.79", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-5wg/ayCBTVy4g4FdO/9BJZRVARY0sgjAn9rBkw5BSJMv4u7Mvxg5Sftlift+V5UWxTyCSHAELZ5IHKvox4Yi8w=="],
+
+    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.79", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-FTpThWwwCDYnLdE0pfdo5zpAQLLVg36kmC2IKyVMuCYv9iPe7rE1mz7ng/UITN9M3TAMBrwHSvCV3pITvw4W8Q=="],
+
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@gorhom/bottom-sheet": ["@gorhom/bottom-sheet@5.2.14", "", { "dependencies": { "@gorhom/portal": "1.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-native": "*", "react": "*", "react-native": "*", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.16.0 || >=4.0.0-" }, "optionalPeers": ["@types/react", "@types/react-native"] }, "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg=="],
@@ -2019,6 +2040,36 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@juggle/resize-observer": ["@juggle/resize-observer@3.4.0", "", {}, "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="],
+
+    "@koromix/koffi-darwin-arm64": ["@koromix/koffi-darwin-arm64@3.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA=="],
+
+    "@koromix/koffi-darwin-x64": ["@koromix/koffi-darwin-x64@3.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg=="],
+
+    "@koromix/koffi-freebsd-arm64": ["@koromix/koffi-freebsd-arm64@3.1.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A=="],
+
+    "@koromix/koffi-freebsd-ia32": ["@koromix/koffi-freebsd-ia32@3.1.4", "", { "os": "freebsd", "cpu": "ia32" }, "sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ=="],
+
+    "@koromix/koffi-freebsd-x64": ["@koromix/koffi-freebsd-x64@3.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw=="],
+
+    "@koromix/koffi-linux-arm64": ["@koromix/koffi-linux-arm64@3.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ=="],
+
+    "@koromix/koffi-linux-ia32": ["@koromix/koffi-linux-ia32@3.1.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw=="],
+
+    "@koromix/koffi-linux-loong64": ["@koromix/koffi-linux-loong64@3.1.4", "", { "os": "linux", "cpu": "none" }, "sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg=="],
+
+    "@koromix/koffi-linux-riscv64": ["@koromix/koffi-linux-riscv64@3.1.4", "", { "os": "linux", "cpu": "none" }, "sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA=="],
+
+    "@koromix/koffi-linux-x64": ["@koromix/koffi-linux-x64@3.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w=="],
+
+    "@koromix/koffi-openbsd-ia32": ["@koromix/koffi-openbsd-ia32@3.1.4", "", { "os": "openbsd", "cpu": "ia32" }, "sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw=="],
+
+    "@koromix/koffi-openbsd-x64": ["@koromix/koffi-openbsd-x64@3.1.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA=="],
+
+    "@koromix/koffi-win32-arm64": ["@koromix/koffi-win32-arm64@3.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA=="],
+
+    "@koromix/koffi-win32-ia32": ["@koromix/koffi-win32-ia32@3.1.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw=="],
+
+    "@koromix/koffi-win32-x64": ["@koromix/koffi-win32-x64@3.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -5044,7 +5095,7 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "koffi": ["koffi@2.16.3", "", {}, "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ=="],
+    "koffi": ["koffi@3.1.4", "", { "optionalDependencies": { "@koromix/koffi-darwin-arm64": "3.1.4", "@koromix/koffi-darwin-x64": "3.1.4", "@koromix/koffi-freebsd-arm64": "3.1.4", "@koromix/koffi-freebsd-ia32": "3.1.4", "@koromix/koffi-freebsd-x64": "3.1.4", "@koromix/koffi-linux-arm64": "3.1.4", "@koromix/koffi-linux-ia32": "3.1.4", "@koromix/koffi-linux-loong64": "3.1.4", "@koromix/koffi-linux-riscv64": "3.1.4", "@koromix/koffi-linux-x64": "3.1.4", "@koromix/koffi-openbsd-ia32": "3.1.4", "@koromix/koffi-openbsd-x64": "3.1.4", "@koromix/koffi-win32-arm64": "3.1.4", "@koromix/koffi-win32-ia32": "3.1.4", "@koromix/koffi-win32-x64": "3.1.4" } }, "sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg=="],
 
     "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
@@ -6972,6 +7023,8 @@
 
     "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@github/copilot/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "@gorhom/portal/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
@@ -6987,6 +7040,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@mariozechner/pi-tui/@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
+
+    "@mariozechner/pi-tui/koffi": ["koffi@2.16.3", "", {}, "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ=="],
 
     "@mariozechner/pi-tui/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 

--- a/packages/agent-setup/src/index.ts
+++ b/packages/agent-setup/src/index.ts
@@ -56,6 +56,8 @@ export function setupAgentIntegrations(
 
 export { setupSingleAgent, teardownSingleAgent };
 
+export { WRAPPER_MARKER } from "./agent-wrappers-common";
+
 export { getCommandShellArgs, getShellArgs, getShellEnv };
 
 export {

--- a/packages/host-service/drizzle/0024_agent_capability_snapshots.sql
+++ b/packages/host-service/drizzle/0024_agent_capability_snapshots.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `host_agent_capability_snapshots` (
+	`agent_id` text PRIMARY KEY NOT NULL,
+	`preset_id` text NOT NULL,
+	`config_revision` integer NOT NULL,
+	`schema_version` integer NOT NULL,
+	`inventory_json` text,
+	`status` text NOT NULL,
+	`installed` integer,
+	`auth` text NOT NULL,
+	`error_kind` text,
+	`message` text,
+	`resolver_source` text,
+	`inventory_checked_at` integer,
+	`status_checked_at` integer NOT NULL,
+	`written_at` integer NOT NULL,
+	FOREIGN KEY (`agent_id`) REFERENCES `host_agent_configs`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `host_agent_capability_snapshots_written_at_idx` ON `host_agent_capability_snapshots` (`written_at`);--> statement-breakpoint
+ALTER TABLE `host_agent_configs` ADD `capability_revision` integer DEFAULT 1 NOT NULL;

--- a/packages/host-service/drizzle/meta/0024_snapshot.json
+++ b/packages/host-service/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1051 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0ca3e752-efab-4449-a34a-e4b2fdef897d",
+  "prevId": "d781b875-abdd-499d-8f98-7894ec606fc7",
+  "tables": {
+    "host_agent_capability_snapshots": {
+      "name": "host_agent_capability_snapshots",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_revision": {
+          "name": "config_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inventory_json": {
+          "name": "inventory_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolver_source": {
+          "name": "resolver_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inventory_checked_at": {
+          "name": "inventory_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_checked_at": {
+          "name": "status_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_capability_snapshots_written_at_idx": {
+          "name": "host_agent_capability_snapshots_written_at_idx",
+          "columns": [
+            "written_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_agent_capability_snapshots_agent_id_host_agent_configs_id_fk": {
+          "name": "host_agent_capability_snapshots_agent_id_host_agent_configs_id_fk",
+          "tableFrom": "host_agent_capability_snapshots",
+          "tableTo": "host_agent_configs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "capability_revision": {
+          "name": "capability_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786681360097,
       "tag": "0023_gorgeous_pixie",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1786782532203,
+      "tag": "0024_agent_capability_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -66,6 +66,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
+		"@github/copilot-sdk": "1.0.9",
 		"@hono/node-server": "2.0.10",
 		"@hono/node-ws": "1.3.0",
 		"@hono/trpc-server": "0.3.4",

--- a/packages/host-service/src/agent-capabilities/agent-capabilities.test.ts
+++ b/packages/host-service/src/agent-capabilities/agent-capabilities.test.ts
@@ -1,0 +1,1157 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import {
+	type AgentCapabilityModel,
+	AgentCapabilityProbeAbortedError,
+	buildWindowsTreeKillArgs,
+	discoverCopilotModels,
+	inspectAgentCapability,
+	mapCopilotModels,
+	parseAntigravityModels,
+	parseCodexModelsCache,
+	parseCursorModels,
+	parseCursorModelVariant,
+	parseGrokModels,
+	parseKimiProviderModels,
+	parseLineModels,
+	parseOpenCodeModels,
+	parsePiModels,
+	parsePiRpcModels,
+	runCommand,
+	runCopilotOperation,
+} from "./agent-capabilities";
+
+const nodeErrorSchema = z.object({ code: z.string() });
+
+function expectedCursorModel(input: {
+	id: string;
+	label: string;
+	provider: string;
+	familyId: string;
+	familyLabel: string;
+	effort?: string;
+	speed?: "standard" | "fast";
+	mode?: "standard" | "thinking";
+	contextWindow?: "default" | "1m";
+}): AgentCapabilityModel {
+	return {
+		id: input.id,
+		label: input.label,
+		provider: input.provider,
+		reasoning: { state: "unknown" as const },
+		variant: {
+			familyId: input.familyId,
+			familyLabel: input.familyLabel,
+			effort: input.effort ?? "default",
+			speed: input.speed ?? "standard",
+			mode: input.mode ?? "standard",
+			contextWindow: input.contextWindow ?? "default",
+		},
+	};
+}
+
+describe("agent capabilities", () => {
+	test("builds a recursive forced Windows process-tree kill", () => {
+		expect(buildWindowsTreeKillArgs(1234)).toEqual([
+			"/pid",
+			"1234",
+			"/T",
+			"/F",
+		]);
+	});
+
+	test("passes the resolved Copilot runtime and configured args to the SDK", async () => {
+		let receivedRuntime:
+			| { executable: string; args: readonly string[] }
+			| undefined;
+		const client = {
+			start: async () => undefined,
+			getAuthStatus: async () => ({ isAuthenticated: true }),
+			listModels: async () => [],
+			stop: async () => undefined,
+			forceStop: async () => undefined,
+		};
+
+		await discoverCopilotModels(
+			{},
+			undefined,
+			{ executable: "/custom/copilot", args: ["--profile", "work"] },
+			(_env, runtime) => {
+				receivedRuntime = runtime;
+				return client;
+			},
+		);
+
+		expect(receivedRuntime).toEqual({
+			executable: "/custom/copilot",
+			args: ["--profile", "work"],
+		});
+	});
+
+	test("groups Antigravity effort variants without inventing unsupported levels", () => {
+		expect(
+			parseAntigravityModels(
+				[
+					"gemini-3.6-flash-high",
+					"gemini-3.6-flash-medium",
+					"gemini-3.6-flash-low",
+					"gemini-3.1-pro-high",
+					"gemini-3.1-pro-low",
+					"claude-sonnet-4-6",
+					"gpt-oss-120b-medium",
+				].join("\n"),
+			),
+		).toEqual([
+			{
+				id: "gemini-3.6-flash-high",
+				label: "Gemini 3.6 Flash",
+				reasoning: {
+					state: "supported",
+					defaultId: "high",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "medium", label: "Medium" },
+						{ id: "high", label: "High" },
+					],
+				},
+			},
+			{
+				id: "gemini-3.1-pro-high",
+				label: "Gemini 3.1 Pro",
+				reasoning: {
+					state: "supported",
+					defaultId: "high",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "high", label: "High" },
+					],
+				},
+			},
+			{
+				id: "claude-sonnet-4-6",
+				label: "Claude Sonnet 4.6",
+				reasoning: { state: "unsupported" },
+			},
+			{
+				id: "gpt-oss-120b-medium",
+				label: "GPT OSS 120b Medium",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("keeps only models returned for the authenticated Copilot account", () => {
+		expect(
+			mapCopilotModels([
+				{ id: "auto", name: "Auto" },
+				{
+					id: "no-reasoning",
+					name: "No Reasoning",
+					supportedReasoningEfforts: [],
+				},
+				{
+					id: "gpt-test",
+					name: "GPT Test",
+					defaultReasoningEffort: "medium",
+					supportedReasoningEfforts: ["low", "medium", "high"],
+				},
+			]),
+		).toEqual([
+			{ id: "auto", label: "Auto", reasoning: { state: "unknown" } },
+			{
+				id: "no-reasoning",
+				label: "No Reasoning",
+				reasoning: { state: "unsupported" },
+			},
+			{
+				id: "gpt-test",
+				label: "GPT Test",
+				reasoning: {
+					state: "supported",
+					defaultId: "medium",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "medium", label: "Medium" },
+						{ id: "high", label: "High" },
+					],
+				},
+			},
+		]);
+	});
+
+	test("reads versioned models and reasoning levels from the Codex cache", () => {
+		expect(
+			parseCodexModelsCache(
+				JSON.stringify({
+					models: [
+						{
+							slug: "gpt-6-codex-wm",
+							display_name: "GPT-6-Codex-WM",
+							visibility: "hide",
+						},
+						{
+							slug: "gpt-6-codex",
+							display_name: "GPT-6-Codex",
+							visibility: "list",
+							default_reasoning_level: "medium",
+							supported_reasoning_levels: [
+								{ effort: "low" },
+								{ effort: "xhigh" },
+							],
+						},
+						{
+							slug: "gpt-5-codex",
+							display_name: "GPT-5-Codex",
+							visibility: "list",
+							upgrade: "gpt-6-codex",
+						},
+					],
+				}),
+			),
+		).toEqual([
+			{
+				id: "gpt-6-codex",
+				label: "GPT-6 Codex",
+				provider: "Current Models",
+				reasoning: {
+					state: "supported",
+					defaultId: "medium",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "xhigh", label: "Extra High" },
+					],
+				},
+			},
+			{
+				id: "gpt-5-codex",
+				label: "GPT-5 Codex",
+				provider: "Legacy Models",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("normalizes line-based CLI model discovery", () => {
+		expect(
+			parseLineModels(
+				"anthropic/claude-opus-5\nopenai/gpt-5.6-sol\nanthropic/claude-opus-5\n",
+			),
+		).toEqual([
+			{
+				id: "anthropic/claude-opus-5",
+				label: "Claude Opus 5",
+				reasoning: { state: "unknown" },
+			},
+			{
+				id: "openai/gpt-5.6-sol",
+				label: "GPT-5.6 Sol",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("parses only Cursor model rows and groups them by provider", () => {
+		expect(
+			parseCursorModels(
+				[
+					"Available models",
+					"",
+					"auto - Auto (default)",
+					"claude-opus-5-thinking-high - Opus 5 1M Thinking",
+					"gpt-5.6-sol-high - GPT-5.6 Sol 1M High",
+					"gemini-3.7-flash-high - Gemini 3.7 Flash",
+					"cursor-grok-4.6-high - Cursor Grok 4.6",
+					"composer-2.5 - Composer 2.5",
+					"kimi-k3-max - Kimi K3",
+					"glm-5.2-max - GLM 5.2 Max",
+					"",
+					"Tip: use --model <id> to switch.",
+				].join("\n"),
+			),
+		).toEqual([
+			expectedCursorModel({
+				id: "auto",
+				label: "Auto (default)",
+				provider: "Recommended",
+				familyId: "auto",
+				familyLabel: "Auto",
+			}),
+			expectedCursorModel({
+				id: "claude-opus-5-thinking-high",
+				label: "Opus 5 1M Thinking",
+				provider: "Anthropic",
+				familyId: "claude-opus-5",
+				familyLabel: "Opus 5",
+				effort: "high",
+				mode: "thinking",
+				contextWindow: "1m",
+			}),
+			expectedCursorModel({
+				id: "gpt-5.6-sol-high",
+				label: "GPT-5.6 Sol 1M High",
+				provider: "OpenAI",
+				familyId: "gpt-5.6-sol",
+				familyLabel: "GPT-5.6 Sol",
+				effort: "high",
+				contextWindow: "1m",
+			}),
+			expectedCursorModel({
+				id: "gemini-3.7-flash-high",
+				label: "Gemini 3.7 Flash",
+				provider: "Google",
+				familyId: "gemini-3.7-flash",
+				familyLabel: "Gemini 3.7 Flash",
+				effort: "high",
+			}),
+			expectedCursorModel({
+				id: "cursor-grok-4.6-high",
+				label: "Cursor Grok 4.6",
+				provider: "xAI",
+				familyId: "cursor-grok-4.6",
+				familyLabel: "Cursor Grok 4.6",
+				effort: "high",
+			}),
+			expectedCursorModel({
+				id: "composer-2.5",
+				label: "Composer 2.5",
+				provider: "Cursor",
+				familyId: "composer-2.5",
+				familyLabel: "Composer 2.5",
+			}),
+			expectedCursorModel({
+				id: "kimi-k3-max",
+				label: "Kimi K3",
+				provider: "Moonshot AI",
+				familyId: "kimi-k3",
+				familyLabel: "Kimi K3",
+				effort: "max",
+			}),
+			expectedCursorModel({
+				id: "glm-5.2-max",
+				label: "GLM 5.2 Max",
+				provider: "Zhipu AI",
+				familyId: "glm-5.2",
+				familyLabel: "GLM 5.2",
+				effort: "max",
+			}),
+		]);
+	});
+
+	test("rejects Cursor headings, footers, and malformed prose", () => {
+		expect(
+			parseCursorModels(
+				"Available models\nnot a model\nauto - Auto (default)\nTip: use --model <id>\nfooter-model - Must not appear",
+			),
+		).toEqual([
+			expectedCursorModel({
+				id: "auto",
+				label: "Auto (default)",
+				provider: "Recommended",
+				familyId: "auto",
+				familyLabel: "Auto",
+			}),
+		]);
+	});
+
+	test("normalizes both Cursor thinking suffix orders", () => {
+		expect(
+			parseCursorModelVariant(
+				"claude-opus-5-thinking-xhigh-fast",
+				"Opus 5 1M Extra High Thinking Fast",
+			),
+		).toEqual({
+			familyId: "claude-opus-5",
+			familyLabel: "Opus 5",
+			effort: "xhigh",
+			speed: "fast",
+			mode: "thinking",
+			contextWindow: "1m",
+		});
+		expect(
+			parseCursorModelVariant(
+				"claude-4.6-opus-high-thinking",
+				"Opus 4.6 1M Thinking",
+			),
+		).toMatchObject({
+			familyId: "claude-4.6-opus",
+			effort: "high",
+			mode: "thinking",
+		});
+	});
+
+	test("reads only account-available models from Grok's authenticated list", () => {
+		expect(
+			parseGrokModels(
+				[
+					"You are logged in with grok.com.",
+					"",
+					"Default model: grok-4.6",
+					"",
+					"Available models:",
+					"  * grok-4.6 (default)",
+					"  - grok-4.5",
+				].join("\n"),
+			),
+		).toEqual([
+			{
+				id: "grok-4.6",
+				label: "Grok 4.6",
+				reasoning: { state: "unknown" },
+			},
+			{
+				id: "grok-4.5",
+				label: "Grok 4.5",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("reads Kimi's configured provider model aliases", () => {
+		expect(
+			parseKimiProviderModels(
+				JSON.stringify({
+					providers: { moonshot: { name: "Moonshot" } },
+					models: {
+						kimi_default: {
+							name: "Kimi Default",
+							provider: "moonshot",
+						},
+					},
+				}),
+			),
+		).toEqual([
+			{
+				id: "kimi_default",
+				label: "Kimi Default",
+				provider: "Moonshot",
+				reasoning: { state: "unknown" },
+			},
+		]);
+		expect(parseKimiProviderModels('{"providers":{},"models":{}}')).toEqual([]);
+	});
+
+	test("reads Pi's authenticated provider and model table", () => {
+		expect(
+			parsePiModels(
+				[
+					"provider      model                context  max-out  thinking  images",
+					"openai-codex  gpt-5.6-sol          272K     128K     yes       yes",
+				].join("\n"),
+			),
+		).toEqual([
+			{
+				id: "openai-codex/gpt-5.6-sol",
+				label: "GPT-5.6 Sol",
+				provider: "OpenAI Codex",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("reads Pi model-specific reasoning levels from RPC", () => {
+		expect(
+			parsePiRpcModels(
+				JSON.stringify({
+					type: "response",
+					command: "get_available_models",
+					success: true,
+					data: {
+						models: [
+							{
+								id: "gpt-5.6-sol",
+								name: "GPT-5.6 Sol",
+								provider: "openai-codex",
+								reasoning: true,
+								thinkingLevelMap: {
+									minimal: "low",
+									xhigh: "xhigh",
+									max: "max",
+								},
+							},
+						],
+					},
+				}),
+			),
+		).toEqual([
+			{
+				id: "openai-codex/gpt-5.6-sol",
+				label: "GPT-5.6 Sol",
+				provider: "OpenAI Codex",
+				reasoning: {
+					state: "supported",
+					options: [
+						{ id: "off", label: "Off" },
+						{ id: "minimal", label: "Minimal" },
+						{ id: "low", label: "Low" },
+						{ id: "medium", label: "Medium" },
+						{ id: "high", label: "High" },
+						{ id: "xhigh", label: "Extra High" },
+						{ id: "max", label: "Max" },
+					],
+				},
+			},
+		]);
+	});
+
+	test("distinguishes Pi unsupported and unknown reasoning metadata", () => {
+		const response = (
+			models: Array<{ id: string; provider: string; reasoning?: boolean }>,
+		) =>
+			JSON.stringify({
+				type: "response",
+				command: "get_available_models",
+				success: true,
+				data: { models },
+			});
+		expect(
+			parsePiRpcModels(
+				response([
+					{ id: "plain", provider: "test", reasoning: false },
+					{ id: "undocumented", provider: "test" },
+				]),
+			).map((model) => model.reasoning),
+		).toEqual([{ state: "unsupported" }, { state: "unknown" }]);
+	});
+
+	test("keeps OpenCode's authoritative model names from verbose output", () => {
+		expect(
+			parseOpenCodeModels(
+				[
+					"anthropic/claude-sonnet-4-6",
+					JSON.stringify({
+						id: "claude-sonnet-4-6",
+						providerID: "anthropic",
+						name: "Claude Sonnet 4.6",
+						variants: {
+							low: { reasoningEffort: "low" },
+							high: { reasoningEffort: "high" },
+						},
+					}),
+					"openrouter/qwen/qwen3-coder",
+					JSON.stringify({
+						id: "qwen/qwen3-coder",
+						providerID: "openrouter",
+						name: "Qwen3 Coder",
+					}),
+				].join("\n"),
+			),
+		).toEqual([
+			{
+				id: "anthropic/claude-sonnet-4-6",
+				label: "Claude Sonnet 4.6",
+				provider: "Anthropic",
+				reasoning: {
+					state: "supported",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "high", label: "High" },
+					],
+				},
+			},
+			{
+				id: "openrouter/qwen/qwen3-coder",
+				label: "Qwen3 Coder",
+				provider: "OpenRouter",
+				reasoning: { state: "unsupported" },
+			},
+		]);
+	});
+
+	test("keeps slug-only OpenCode reasoning metadata unknown", () => {
+		expect(parseOpenCodeModels("anthropic/claude-sonnet-4-6")).toEqual([
+			{
+				id: "anthropic/claude-sonnet-4-6",
+				label: "Claude Sonnet 4 6",
+				provider: "Anthropic",
+				reasoning: { state: "unknown" },
+			},
+		]);
+	});
+
+	test("rejects malformed non-empty Codex reasoning options", () => {
+		expect(
+			parseCodexModelsCache(
+				JSON.stringify({
+					models: [
+						{
+							slug: "bad-model",
+							supported_reasoning_levels: [{ effort: 42 }],
+						},
+					],
+				}),
+			),
+		).toEqual([]);
+	});
+
+	test("treats an explicit empty Codex reasoning list as unsupported", () => {
+		expect(
+			parseCodexModelsCache(
+				JSON.stringify({
+					models: [{ slug: "plain-model", supported_reasoning_levels: [] }],
+				}),
+			)[0]?.reasoning,
+		).toEqual({ state: "unsupported" });
+	});
+
+	test("marks missing configured agents unavailable", async () => {
+		const snapshot = await inspectAgentCapability({
+			id: "missing-agent",
+			presetId: "custom",
+			command: "superset-agent-that-does-not-exist",
+			env: {},
+		});
+
+		expect(snapshot).toMatchObject({
+			status: "unavailable",
+			installed: false,
+			models: [],
+			errorKind: "missing_executable",
+		});
+	});
+
+	test("classifies process and parse failures without exposing raw output", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-agent-errors-"));
+		const processFailure = join(directory, "process-failure");
+		const parseFailure = join(directory, "parse-failure");
+		await writeFile(
+			processFailure,
+			"#!/bin/sh\nprintf 'sensitive' >&2\nexit 2\n",
+		);
+		await writeFile(parseFailure, "#!/bin/sh\nexit 0\n");
+		await Promise.all([
+			chmod(processFailure, 0o755),
+			chmod(parseFailure, 0o755),
+		]);
+		try {
+			const [processSnapshot, parseSnapshot] = await Promise.all([
+				inspectAgentCapability(
+					{
+						id: "opencode-process-failure",
+						presetId: "opencode",
+						command: processFailure,
+						env: {},
+					},
+					{},
+				),
+				inspectAgentCapability(
+					{
+						id: "antigravity-parse-failure",
+						presetId: "antigravity",
+						command: parseFailure,
+						env: {},
+					},
+					{},
+				),
+			]);
+			expect(processSnapshot).toMatchObject({
+				errorKind: "process_failure",
+			});
+			expect(processSnapshot.message).not.toContain("sensitive");
+			expect(parseSnapshot).toMatchObject({ errorKind: "parse_failure" });
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps an installed but unverified agent visible as unavailable", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-droid-probe-"));
+		const executable = join(directory, "droid-test");
+		await writeFile(executable, "#!/bin/sh\nexit 0\n");
+		await chmod(executable, 0o755);
+		try {
+			const snapshot = await inspectAgentCapability(
+				{
+					id: "droid-test",
+					presetId: "droid",
+					command: executable,
+					env: {},
+				},
+				{},
+			);
+			expect(snapshot).toMatchObject({
+				status: "unavailable",
+				installed: true,
+				auth: "unknown",
+			});
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("does not pass Electron's Node mode into agent CLIs", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-agent-probe-"));
+		const executable = join(directory, "opencode-test");
+		await writeFile(
+			executable,
+			'#!/bin/sh\n[ "$ELECTRON_RUN_AS_NODE" = "1" ] && exit 42\n[ "$1" = "models" ] && printf "provider/model-1\\n"\n',
+		);
+		await chmod(executable, 0o755);
+		const previous = process.env.ELECTRON_RUN_AS_NODE;
+		process.env.ELECTRON_RUN_AS_NODE = "1";
+		try {
+			const snapshot = await inspectAgentCapability(
+				{
+					id: "opencode-test",
+					presetId: "opencode",
+					command: executable,
+					env: {},
+				},
+				{},
+			);
+			expect(snapshot).toMatchObject({
+				status: "ready",
+				modelSource: "runtime",
+				models: [{ id: "provider/model-1", label: "Model 1" }],
+			});
+		} finally {
+			if (previous === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+			else process.env.ELECTRON_RUN_AS_NODE = previous;
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("uses the configured PATH and prefixes configured wrapper arguments", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-agent-wrapper-"));
+		const executable = join(directory, "opencode-wrapper");
+		await writeFile(
+			executable,
+			'#!/bin/sh\n[ "$1" = "exec" ] || exit 41\n[ "$2" = "models" ] && printf "provider/model-1\\n"\n',
+		);
+		await chmod(executable, 0o755);
+		try {
+			const snapshot = await inspectAgentCapability({
+				id: "opencode-wrapper",
+				presetId: "opencode",
+				command: "opencode-wrapper",
+				args: ["exec"],
+				env: { PATH: directory },
+			});
+			expect(snapshot).toMatchObject({
+				status: "ready",
+				modelSource: "runtime",
+				models: [{ id: "provider/model-1", label: "Model 1" }],
+			});
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("cancels spawned CLI processes when the probe signal aborts", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-agent-cancel-"));
+		const executable = join(directory, "opencode-test");
+		const logPath = join(directory, "invocations.log");
+		await writeFile(
+			executable,
+			'#!/bin/sh\nprintf "x\\n" >> "$LOG_PATH"\nexec sleep 10\n',
+		);
+		await chmod(executable, 0o755);
+		const controller = new AbortController();
+		try {
+			const probe = inspectAgentCapability(
+				{
+					id: "opencode-cancel-test",
+					presetId: "opencode",
+					command: executable,
+					env: { LOG_PATH: logPath },
+					configRevision: 1,
+				},
+				{ signal: controller.signal },
+			);
+			for (let attempt = 0; attempt < 100; attempt += 1) {
+				try {
+					if ((await readFile(logPath, "utf8")).length > 0) break;
+				} catch {
+					// The child has not started yet.
+				}
+				await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+			}
+
+			controller.abort();
+
+			await expect(probe).rejects.toBeInstanceOf(
+				AgentCapabilityProbeAbortedError,
+			);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("force-stops an in-flight Copilot SDK operation on cancellation", async () => {
+		const controller = new AbortController();
+		let forceStops = 0;
+		const client = {
+			start: async () => {},
+			getAuthStatus: async () => ({ isAuthenticated: true }),
+			listModels: async () => [],
+			stop: async () => [],
+			forceStop: async () => {
+				forceStops += 1;
+			},
+		};
+		const operation = runCopilotOperation(
+			client,
+			() => new Promise<never>(() => {}),
+			controller.signal,
+		);
+		controller.abort();
+		await expect(operation).rejects.toBeInstanceOf(
+			AgentCapabilityProbeAbortedError,
+		);
+		expect(forceStops).toBe(1);
+	});
+
+	test("force-stops an in-flight Copilot SDK operation on timeout", async () => {
+		let forceStops = 0;
+		const client = {
+			start: async () => {},
+			getAuthStatus: async () => ({ isAuthenticated: true }),
+			listModels: async () => [],
+			stop: async () => [],
+			forceStop: async () => {
+				forceStops += 1;
+			},
+		};
+		await expect(
+			runCopilotOperation(
+				client,
+				() => new Promise<never>(() => {}),
+				undefined,
+				10,
+			),
+		).rejects.toThrow("Copilot model probe timed out");
+		expect(forceStops).toBe(1);
+	});
+
+	test("finishes Pi discovery as soon as its long-lived RPC returns models", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-pi-probe-"));
+		const executable = join(directory, "pi-test");
+		const argsPath = join(directory, "pi-args");
+		const response = JSON.stringify({
+			type: "response",
+			command: "get_available_models",
+			success: true,
+			data: {
+				models: [
+					{
+						id: "model-1",
+						name: "Model 1",
+						provider: "provider-1",
+						reasoning: false,
+					},
+				],
+			},
+		});
+		await writeFile(
+			executable,
+			`#!/bin/sh\nprintf '%s\\n' "$*" > '${argsPath}'\nprintf '%s\\n' '${response}'\nwhile :; do sleep 1; done\n`,
+		);
+		await chmod(executable, 0o755);
+		try {
+			const startedAt = Date.now();
+			const snapshot = await inspectAgentCapability(
+				{
+					id: "pi-test",
+					presetId: "pi",
+					command: executable,
+					env: {},
+				},
+				{},
+			);
+			expect(Date.now() - startedAt).toBeLessThan(1_000);
+			expect(snapshot).toMatchObject({
+				status: "ready",
+				modelSource: "runtime",
+				models: [
+					{
+						id: "provider-1/model-1",
+						label: "Model 1",
+						reasoning: { state: "unsupported" },
+					},
+				],
+			});
+			expect(await readFile(argsPath, "utf8")).toContain("--no-extensions");
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("proves no orphan process remains after timeout for a process ignoring SIGTERM", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-ignore-term-timeout-"),
+		);
+		try {
+			const { executable, parentPidFile, descendantPidFile } =
+				await writeIgnoreTermTreeScript(directory);
+			const startedAt = Date.now();
+			const result = await runCommand(
+				executable,
+				[],
+				{},
+				200,
+				undefined,
+				undefined,
+				undefined,
+				100,
+			);
+			expect(result.timedOut).toBe(true);
+			expect(Date.now() - startedAt).toBeLessThan(2_000);
+			const parentPid = await waitForPidFile(parentPidFile);
+			const descendantPid = await waitForPidFile(descendantPidFile);
+			await expectPidGone(parentPid);
+			await expectPidGone(descendantPid);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("proves no orphan process remains after abort for a process ignoring SIGTERM", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-ignore-term-abort-"),
+		);
+		const controller = new AbortController();
+		try {
+			const { executable, parentPidFile, descendantPidFile } =
+				await writeIgnoreTermTreeScript(directory);
+			const startedAt = Date.now();
+			const promise = runCommand(
+				executable,
+				[],
+				{},
+				10_000,
+				undefined,
+				undefined,
+				controller.signal,
+				100,
+			);
+			const parentPid = await waitForPidFile(parentPidFile);
+			const descendantPid = await waitForPidFile(descendantPidFile);
+			controller.abort();
+			await expect(promise).rejects.toBeInstanceOf(
+				AgentCapabilityProbeAbortedError,
+			);
+			expect(Date.now() - startedAt).toBeLessThan(2_000);
+			await expectPidGone(parentPid);
+			await expectPidGone(descendantPid);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("proves no orphan process remains after completion trigger for a process ignoring SIGTERM", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-ignore-term-complete-"),
+		);
+		try {
+			const { executable, parentPidFile, descendantPidFile } =
+				await writeIgnoreTermTreeScript(directory, 'printf "READY_TRIGGER\\n"');
+			const startedAt = Date.now();
+			const result = await runCommand(
+				executable,
+				[],
+				{},
+				10_000,
+				undefined,
+				(stdout) => stdout.includes("READY_TRIGGER"),
+				undefined,
+				100,
+			);
+			expect(result.timedOut).toBe(false);
+			expect(result.exitCode).toBe(0);
+			expect(Date.now() - startedAt).toBeLessThan(2_000);
+			const parentPid = await waitForPidFile(parentPidFile);
+			const descendantPid = await waitForPidFile(descendantPidFile);
+			await expectPidGone(parentPid);
+			await expectPidGone(descendantPid);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("does not settle until the child closes and its ignore-TERM descendant is gone", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-close-order-"),
+		);
+		const executable = join(directory, "stub-slow-close");
+		const parentPidFile = join(directory, "parent.pid");
+		const descendantPidFile = join(directory, "descendant.pid");
+		await writeFile(
+			executable,
+			`#!/bin/sh
+echo $$ > "${parentPidFile}"
+(
+  trap '' TERM
+  echo $$ > "${descendantPidFile}"
+  while true; do
+    sleep 1
+  done
+) &
+while [ ! -s "${descendantPidFile}" ]; do
+  sleep 0.05
+done
+printf 'PREFIX_OUTPUT\\n'
+trap 'dd if=/dev/zero bs=1024 count=32 2>/dev/null; printf "DRAINED_OUTPUT_TOKEN\\n"; exit 0' TERM
+while true; do
+  sleep 1
+done
+`,
+		);
+		await chmod(executable, 0o755);
+
+		const controller = new AbortController();
+		try {
+			const promise = runCommand(
+				executable,
+				[],
+				{},
+				10_000,
+				undefined,
+				undefined,
+				controller.signal,
+				500,
+			);
+			const parentPid = await waitForPidFile(parentPidFile);
+			const descendantPid = await waitForPidFile(descendantPidFile);
+			controller.abort();
+			await expect(promise).rejects.toBeInstanceOf(
+				AgentCapabilityProbeAbortedError,
+			);
+			await expectPidGone(parentPid);
+			await expectPidGone(descendantPid);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("captures the full stdout payload after a natural close", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-natural-drain-"),
+		);
+		const executable = join(directory, "stub-natural-drain");
+		const payloadPath = join(directory, "payload.txt");
+		const payload = `${"x".repeat(64 * 1024)}\nNATURAL_FINAL_SENTINEL\n`;
+		await writeFile(payloadPath, payload);
+		await writeFile(executable, `#!/bin/sh\ncat "${payloadPath}"\n`);
+		await chmod(executable, 0o755);
+		try {
+			const result = await runCommand(executable, [], {}, 4_000);
+			expect(result.timedOut).toBe(false);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.endsWith("NATURAL_FINAL_SENTINEL\n")).toBe(true);
+			expect(result.stdout.length).toBe(payload.length);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("includes post-SIGTERM stdout that lands before stdio close", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-agent-term-drain-"),
+		);
+		const executable = join(directory, "stub-term-drain");
+		await writeFile(
+			executable,
+			`#!/bin/sh
+trap 'printf "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY\\nDRAINED_OUTPUT_TOKEN\\n"; exit 0' TERM
+printf 'PREFIX_OUTPUT\\nREADY_TRIGGER\\n'
+while true; do
+  sleep 1
+done
+`,
+		);
+		await chmod(executable, 0o755);
+		try {
+			const result = await runCommand(
+				executable,
+				[],
+				{},
+				10_000,
+				undefined,
+				(stdout) => stdout.includes("READY_TRIGGER"),
+				undefined,
+				250,
+			);
+			expect(result.timedOut).toBe(false);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toContain("PREFIX_OUTPUT");
+			expect(result.stdout).toContain("READY_TRIGGER");
+			expect(result.stdout).toContain("DRAINED_OUTPUT_TOKEN");
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+});
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const parsed = nodeErrorSchema.safeParse(error);
+		return !parsed.success || parsed.data.code !== "ESRCH";
+	}
+}
+
+async function waitForPidFile(
+	pidFile: string,
+	timeoutMs = 1_000,
+): Promise<number> {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		try {
+			const pid = Number.parseInt((await readFile(pidFile, "utf8")).trim(), 10);
+			if (pid > 0) return pid;
+		} catch {
+			// Not written yet.
+		}
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+	}
+	throw new Error(`timed out waiting for pid file ${pidFile}`);
+}
+
+async function expectPidGone(pid: number, timeoutMs = 500): Promise<void> {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		if (!isPidAlive(pid)) return;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+	}
+	expect(isPidAlive(pid)).toBe(false);
+}
+
+async function writeIgnoreTermTreeScript(
+	directory: string,
+	extraPrelude = "",
+): Promise<{
+	executable: string;
+	parentPidFile: string;
+	descendantPidFile: string;
+}> {
+	const executable = join(directory, "stub-ignore-sigterm");
+	const parentPidFile = join(directory, "parent.pid");
+	const descendantPidFile = join(directory, "descendant.pid");
+	await writeFile(
+		executable,
+		`#!/bin/sh
+trap '' TERM
+echo $$ > "${parentPidFile}"
+(
+  trap '' TERM
+  echo $$ > "${descendantPidFile}"
+  while true; do
+    sleep 1
+  done
+) &
+while [ ! -s "${descendantPidFile}" ]; do
+  sleep 0.05
+done
+${extraPrelude}
+while true; do
+  sleep 1
+done
+`,
+	);
+	await chmod(executable, 0o755);
+	return { executable, parentPidFile, descendantPidFile };
+}

--- a/packages/host-service/src/agent-capabilities/agent-capabilities.test.ts
+++ b/packages/host-service/src/agent-capabilities/agent-capabilities.test.ts
@@ -681,6 +681,31 @@ describe("agent capabilities", () => {
 		}
 	});
 
+	test('does not treat "not logged in" as authenticated', async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-claude-auth-"));
+		const executable = join(directory, "claude-test");
+		await writeFile(
+			executable,
+			'#!/bin/sh\n[ "$1" = "auth" ] && printf "not logged in\\n"\nexit 0\n',
+		);
+		await chmod(executable, 0o755);
+		try {
+			const snapshot = await inspectAgentCapability({
+				id: "claude-test",
+				presetId: "claude",
+				command: executable,
+				env: {},
+			});
+			expect(snapshot).toMatchObject({
+				status: "authentication_required",
+				installed: true,
+				auth: "unauthenticated",
+			});
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
 	test("does not pass Electron's Node mode into agent CLIs", async () => {
 		const directory = await mkdtemp(join(tmpdir(), "superset-agent-probe-"));
 		const executable = join(directory, "opencode-test");

--- a/packages/host-service/src/agent-capabilities/agent-capabilities.ts
+++ b/packages/host-service/src/agent-capabilities/agent-capabilities.ts
@@ -52,7 +52,7 @@ export interface AgentCapabilitySnapshot {
 	agentId: string;
 	presetId: string;
 	status: AgentCapabilityStatus;
-	installed: boolean;
+	installed: boolean | null;
 	auth: "authenticated" | "unauthenticated" | "unknown";
 	version: string | null;
 	modelSource: AgentModelSource;
@@ -449,17 +449,17 @@ async function probeAuthentication(
 	);
 	const output = `${result.stdout}\n${result.stderr}`;
 	if (
-		result.exitCode === 0 &&
-		(/"loggedIn"\s*:\s*true/i.test(output) || /logged in/i.test(output))
-	) {
-		return "authenticated";
-	}
-	if (
 		/"loggedIn"\s*:\s*false|"success"\s*:\s*false[^\n]*"type"\s*:\s*"auth"|not logged in|authentication required|invalid or missing api key|run .*login/i.test(
 			output,
 		)
 	) {
 		return "unauthenticated";
+	}
+	if (
+		result.exitCode === 0 &&
+		(/"loggedIn"\s*:\s*true/i.test(output) || /logged in/i.test(output))
+	) {
+		return "authenticated";
 	}
 	return "unknown";
 }

--- a/packages/host-service/src/agent-capabilities/agent-capabilities.ts
+++ b/packages/host-service/src/agent-capabilities/agent-capabilities.ts
@@ -1,0 +1,1524 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	CopilotClient,
+	type ModelInfo,
+	RuntimeConnection,
+} from "@github/copilot-sdk";
+import {
+	collectProcessTree,
+	readProcessTableAsync,
+} from "@superset/pty-daemon/process-tree";
+import {
+	type AgentCapabilityTrait,
+	type AgentModelOption,
+	type AgentRuntimeModelVariant,
+	getAgentModelSupport,
+} from "@superset/shared/agent-models";
+import { z } from "zod";
+import {
+	getTerminalBaseEnv,
+	stripTerminalRuntimeEnv,
+	waitForTerminalBaseEnv,
+} from "../terminal/env";
+import {
+	type AgentExecutableSource,
+	resolveAgentExecutable,
+} from "./executable-resolver";
+
+export type AgentCapabilityStatus =
+	| "ready"
+	| "unavailable"
+	| "authentication_required";
+
+export type AgentModelSource = "runtime" | "fallback" | "none";
+export type AgentCapabilityErrorKind =
+	| "timeout"
+	| "process_failure"
+	| "parse_failure"
+	| "missing_executable";
+
+export interface AgentCapabilityModel {
+	id: string;
+	label: string;
+	provider?: string;
+	reasoning: AgentCapabilityTrait<AgentModelOption>;
+	variant?: AgentRuntimeModelVariant;
+}
+
+export interface AgentCapabilitySnapshot {
+	agentId: string;
+	presetId: string;
+	status: AgentCapabilityStatus;
+	installed: boolean;
+	auth: "authenticated" | "unauthenticated" | "unknown";
+	version: string | null;
+	modelSource: AgentModelSource;
+	models: AgentCapabilityModel[];
+	message: string | null;
+	checkedAt: string;
+	resolverSource?: AgentExecutableSource | null;
+	errorKind?: AgentCapabilityErrorKind | null;
+	inventoryCheckedAt?: string | null;
+	inventoryOrigin?: "live" | "persisted" | "none";
+	healthOrigin?: "live" | "persisted";
+}
+
+export interface AgentCapabilityConfig {
+	id: string;
+	presetId: string;
+	command: string;
+	args?: string[];
+	env: Record<string, string>;
+	configRevision?: number;
+}
+
+interface CommandResult {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+}
+
+export function buildWindowsTreeKillArgs(pid: number): string[] {
+	return ["/pid", String(pid), "/T", "/F"];
+}
+
+async function killWindowsProcessTree(pid: number): Promise<void> {
+	await new Promise<void>((resolve) => {
+		const killer = spawn("taskkill", buildWindowsTreeKillArgs(pid), {
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		let settled = false;
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve();
+		};
+		const timer = setTimeout(() => {
+			try {
+				killer.kill();
+			} catch {
+				// Already gone.
+			}
+			finish();
+		}, PROBE_KILL_SAFETY_MS);
+		timer.unref?.();
+		killer.once("error", finish);
+		killer.once("close", finish);
+	});
+}
+
+function classifyCommandFailure(
+	result: CommandResult,
+): AgentCapabilityErrorKind {
+	if (result.timedOut) return "timeout";
+	if (result.exitCode === 0) return "parse_failure";
+	return "process_failure";
+}
+
+export class AgentCapabilityProbeAbortedError extends Error {
+	constructor() {
+		super("Agent capability probe was cancelled");
+		this.name = "AgentCapabilityProbeAbortedError";
+	}
+}
+
+const PROBE_TIMEOUT_MS = 4_000;
+const MAX_OUTPUT_LENGTH = 1024 * 1024;
+const AUTH_DEPENDENT_PRESETS = new Set([
+	"amp",
+	"antigravity",
+	"claude",
+	"codex",
+	"copilot",
+	"cursor-agent",
+	"droid",
+	"gemini",
+	"grok",
+	"kimi",
+	"mastracode",
+	"opencode",
+	"pi",
+	"polygraph",
+	"vibe",
+]);
+const PROBE_GRACE_PERIOD_MS = 250;
+const PROBE_KILL_SAFETY_MS = 500;
+const nodeErrorSchema = z.object({ code: z.string() }).passthrough();
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const parsed = nodeErrorSchema.safeParse(error);
+		return parsed.success && parsed.data.code === "EPERM";
+	}
+}
+
+function signalPid(pid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(pid, signal);
+	} catch {
+		// Already gone, or not signalable.
+	}
+}
+
+function signalKnownPids(
+	knownPids: Iterable<number>,
+	signal: NodeJS.Signals,
+): void {
+	for (const pid of knownPids) signalPid(pid, signal);
+}
+
+async function expandProcessTree(knownPids: Set<number>): Promise<void> {
+	if (knownPids.size === 0) return;
+	const table = await readProcessTableAsync();
+	if (!table) return;
+	for (const root of [...knownPids]) {
+		for (const pid of collectProcessTree(root, table)) {
+			knownPids.add(pid);
+		}
+	}
+}
+
+export function runCommand(
+	command: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	timeoutMs = PROBE_TIMEOUT_MS,
+	input?: string,
+	completeWhenStdout?: (stdout: string) => boolean,
+	signal?: AbortSignal,
+	gracePeriodMs = PROBE_GRACE_PERIOD_MS,
+): Promise<CommandResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			env,
+			stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+		});
+
+		if (input !== undefined) child.stdin?.end(input);
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		let childClosed = false;
+		let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+		let graceTimer: ReturnType<typeof setTimeout> | undefined;
+		let safetyTimer: ReturnType<typeof setTimeout> | undefined;
+
+		const closeWaiters: Array<() => void> = [];
+
+		const markClosed = () => {
+			if (childClosed) return;
+			childClosed = true;
+			for (const waiter of closeWaiters) waiter();
+			closeWaiters.length = 0;
+		};
+
+		// `close` is the reap/stdio-drain boundary. `exit` can fire while
+		// buffered output is still in flight. Spawn failure has no process.
+		child.on("close", markClosed);
+		child.on("error", markClosed);
+
+		const waitForCloseOrTimeout = (
+			ms: number,
+			assignTimer: (timer: ReturnType<typeof setTimeout>) => void,
+		): Promise<"closed" | "timeout"> => {
+			if (childClosed) return Promise.resolve("closed");
+			return new Promise((resolveWait) => {
+				const timer = setTimeout(() => resolveWait("timeout"), ms);
+				timer.unref?.();
+				assignTimer(timer);
+				closeWaiters.push(() => {
+					clearTimeout(timer);
+					resolveWait("closed");
+				});
+				if (childClosed) {
+					clearTimeout(timer);
+					resolveWait("closed");
+				}
+			});
+		};
+
+		const clearAssignedTimer = (
+			timer: ReturnType<typeof setTimeout> | undefined,
+		) => {
+			if (timer) clearTimeout(timer);
+		};
+
+		const cleanupTimersAndListeners = () => {
+			clearAssignedTimer(timeoutTimer);
+			clearAssignedTimer(graceTimer);
+			clearAssignedTimer(safetyTimer);
+			timeoutTimer = undefined;
+			graceTimer = undefined;
+			safetyTimer = undefined;
+			signal?.removeEventListener("abort", handleAbort);
+		};
+
+		const killChildAndAwaitTermination = async (): Promise<void> => {
+			const rootPid = child.pid;
+			const knownPids = new Set<number>();
+			if (rootPid) knownPids.add(rootPid);
+
+			if (process.platform === "win32") {
+				if (rootPid) await killWindowsProcessTree(rootPid);
+				try {
+					child.kill();
+				} catch {
+					// Already gone.
+				}
+				await waitForCloseOrTimeout(PROBE_KILL_SAFETY_MS, (timer) => {
+					safetyTimer = timer;
+				});
+				clearAssignedTimer(safetyTimer);
+				safetyTimer = undefined;
+				return;
+			}
+
+			await expandProcessTree(knownPids);
+			signalKnownPids(knownPids, "SIGTERM");
+			try {
+				child.kill("SIGTERM");
+			} catch {
+				// Already gone.
+			}
+
+			await waitForCloseOrTimeout(gracePeriodMs, (timer) => {
+				graceTimer = timer;
+			});
+			clearAssignedTimer(graceTimer);
+			graceTimer = undefined;
+
+			await expandProcessTree(knownPids);
+			signalKnownPids([...knownPids].filter(isPidAlive), "SIGKILL");
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// Already gone.
+			}
+
+			if (!childClosed) {
+				await waitForCloseOrTimeout(PROBE_KILL_SAFETY_MS, (timer) => {
+					safetyTimer = timer;
+				});
+				clearAssignedTimer(safetyTimer);
+				safetyTimer = undefined;
+			}
+
+			signalKnownPids([...knownPids].filter(isPidAlive), "SIGKILL");
+		};
+
+		const finishNatural = (exitCode: number | null) => {
+			if (settled) return;
+			settled = true;
+			cleanupTimersAndListeners();
+			resolve({ exitCode, stdout, stderr, timedOut: false });
+		};
+
+		const finishWithKill = async (partial: {
+			exitCode: number | null;
+			timedOut: boolean;
+		}) => {
+			if (settled) return;
+			settled = true;
+			cleanupTimersAndListeners();
+			try {
+				await killChildAndAwaitTermination();
+			} catch {
+				// Settlement must stay bounded if termination helpers fail.
+			}
+			resolve({
+				exitCode: partial.exitCode,
+				stdout,
+				stderr,
+				timedOut: partial.timedOut,
+			});
+		};
+
+		const handleAbort = () => {
+			if (settled) return;
+			settled = true;
+			cleanupTimersAndListeners();
+			void (async () => {
+				try {
+					await killChildAndAwaitTermination();
+				} catch {
+					// Settlement must stay bounded if termination helpers fail.
+				}
+				reject(new AgentCapabilityProbeAbortedError());
+			})();
+		};
+
+		const append = (current: string, chunk: Buffer) =>
+			(current + chunk.toString()).slice(-MAX_OUTPUT_LENGTH);
+
+		child.stdout?.on("data", (chunk: Buffer) => {
+			stdout = append(stdout, chunk);
+			if (!settled && completeWhenStdout?.(stdout)) {
+				void finishWithKill({ exitCode: 0, timedOut: false });
+			}
+		});
+
+		child.stderr?.on("data", (chunk: Buffer) => {
+			stderr = append(stderr, chunk);
+		});
+
+		child.on("error", () => {
+			finishNatural(null);
+		});
+
+		child.on("close", (exitCode) => {
+			finishNatural(exitCode);
+		});
+
+		timeoutTimer = setTimeout(() => {
+			void finishWithKill({ exitCode: null, timedOut: true });
+		}, timeoutMs);
+
+		signal?.addEventListener("abort", handleAbort, { once: true });
+		if (signal?.aborted) {
+			handleAbort();
+		}
+	});
+}
+
+async function createProbeEnvironment(configEnv: Record<string, string>) {
+	await waitForTerminalBaseEnv();
+	let baseEnv: Record<string, string>;
+	try {
+		baseEnv = getTerminalBaseEnv();
+	} catch {
+		// Unit tests and standalone host helpers may not initialize the shell
+		// snapshot. Keep their fallback free from desktop/runtime variables too.
+		baseEnv = stripTerminalRuntimeEnv(
+			Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			),
+		);
+	}
+	const probeEnv = {
+		...baseEnv,
+		// Explicit agent configuration wins over the login-shell snapshot, so a
+		// wrapper manager such as mise or npx is resolved exactly as configured.
+		...configEnv,
+	};
+	return probeEnv;
+}
+
+async function probeAuthentication(
+	presetId: string,
+	executable: string,
+	commandArgs: string[],
+	env: NodeJS.ProcessEnv,
+	signal?: AbortSignal,
+): Promise<AgentCapabilitySnapshot["auth"]> {
+	let args: string[] | undefined;
+	switch (presetId) {
+		case "amp":
+			args = ["config", "model-providers", "list", "--no-color"];
+			break;
+		case "claude":
+			args = ["auth", "status", "--json"];
+			break;
+		case "codex":
+			args = ["login", "status"];
+			break;
+		case "polygraph":
+			args = ["whoami", "--json"];
+			break;
+	}
+	if (!args) return "unknown";
+	const result = await runCommand(
+		executable,
+		[...commandArgs, ...args],
+		env,
+		PROBE_TIMEOUT_MS,
+		undefined,
+		undefined,
+		signal,
+	);
+	const output = `${result.stdout}\n${result.stderr}`;
+	if (
+		result.exitCode === 0 &&
+		(/"loggedIn"\s*:\s*true/i.test(output) || /logged in/i.test(output))
+	) {
+		return "authenticated";
+	}
+	if (
+		/"loggedIn"\s*:\s*false|"success"\s*:\s*false[^\n]*"type"\s*:\s*"auth"|not logged in|authentication required|invalid or missing api key|run .*login/i.test(
+			output,
+		)
+	) {
+		return "unauthenticated";
+	}
+	return "unknown";
+}
+
+function titleFromModelId(id: string): string {
+	const model = id.split("/").at(-1) ?? id;
+	const title = model
+		.split("-")
+		.filter(Boolean)
+		.map((part) => {
+			if (/^\d+(?:\.\d+)*$/.test(part)) return part;
+			if (/^(gpt|ai|oss|v\d+)$/i.test(part)) return part.toUpperCase();
+			return `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
+		})
+		.join(" ");
+	if (title === "Xhigh") return "Extra High";
+	return title.replace(/^GPT (?=\d)/, "GPT-");
+}
+
+export function parseLineModels(output: string): AgentCapabilityModel[] {
+	const seen = new Set<string>();
+	const models: AgentCapabilityModel[] = [];
+	for (const rawLine of output.split(/\r?\n/)) {
+		const id = rawLine.trim().split(/\s+/)[0];
+		if (!id || id.startsWith("Error:") || seen.has(id)) continue;
+		seen.add(id);
+		models.push({
+			id,
+			label: titleFromModelId(id),
+			reasoning: { state: "unknown" },
+		});
+	}
+	return models;
+}
+
+function cursorModelProvider(id: string): string {
+	if (id === "auto") return "Recommended";
+	if (id.startsWith("claude-")) return "Anthropic";
+	if (id.startsWith("gpt-")) return "OpenAI";
+	if (id.startsWith("gemini-")) return "Google";
+	if (id.startsWith("cursor-grok-")) return "xAI";
+	if (id.startsWith("composer-")) return "Cursor";
+	if (id.startsWith("kimi-")) return "Moonshot AI";
+	if (id.startsWith("glm-")) return "Zhipu AI";
+	return "Other";
+}
+
+/**
+ * Cursor prints a human-readable inventory between an `Available models`
+ * heading and a `Tip:` footer. Parse only rows with its documented
+ * `<id> - <label>` shape so surrounding prose can never become a model.
+ */
+export function parseCursorModels(output: string): AgentCapabilityModel[] {
+	const models: AgentCapabilityModel[] = [];
+	const seen = new Set<string>();
+	let inInventory = false;
+
+	for (const rawLine of output.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (/^Available models:?$/i.test(line)) {
+			inInventory = true;
+			continue;
+		}
+		if (!inInventory) continue;
+		if (/^Tip:/i.test(line)) break;
+		if (!line) continue;
+
+		const match = line.match(/^(\S+)\s+-\s+(.+)$/);
+		const id = match?.[1];
+		const label = match?.[2]?.trim();
+		if (!id || !label || seen.has(id)) continue;
+		seen.add(id);
+		models.push({
+			id,
+			label,
+			provider: cursorModelProvider(id),
+			reasoning: { state: "unknown" },
+			variant: parseCursorModelVariant(id, label),
+		});
+	}
+
+	return models;
+}
+
+const CURSOR_EFFORT_SUFFIXES: ReadonlyArray<
+	readonly [suffix: string, effort: string]
+> = [
+	["extra-high", "xhigh"],
+	["minimal", "minimal"],
+	["medium", "medium"],
+	["xhigh", "xhigh"],
+	["high", "high"],
+	["none", "none"],
+	["low", "low"],
+	["max", "max"],
+];
+
+function cursorFamilyLabel(label: string): string {
+	const noZdr = /\(NO ZDR\)/i.test(label) ? " (NO ZDR)" : "";
+	const cleaned = label
+		.replace(/\s*\((?:NO ZDR|current|default)\)/gi, "")
+		.replace(/\b(?:Extra High|Minimal|Medium|High|Low|None|Max)\b/gi, "")
+		.replace(/\b(?:Thinking|Fast|1M)\b/gi, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	return `${cleaned}${noZdr}`;
+}
+
+export function parseCursorModelVariant(
+	id: string,
+	label: string,
+): AgentRuntimeModelVariant {
+	let familyId = id;
+	let effort: string | undefined;
+	let speed: AgentRuntimeModelVariant["speed"] = "standard";
+	let mode: AgentRuntimeModelVariant["mode"] = "standard";
+	let changed = true;
+
+	while (changed) {
+		changed = false;
+		if (speed === "standard" && familyId.endsWith("-fast")) {
+			speed = "fast";
+			familyId = familyId.slice(0, -"-fast".length);
+			changed = true;
+			continue;
+		}
+		if (mode === "standard" && familyId.endsWith("-thinking")) {
+			mode = "thinking";
+			familyId = familyId.slice(0, -"-thinking".length);
+			changed = true;
+			continue;
+		}
+		if (!effort) {
+			for (const [suffix, normalized] of CURSOR_EFFORT_SUFFIXES) {
+				const token = `-${suffix}`;
+				if (!familyId.endsWith(token)) continue;
+				effort = normalized;
+				familyId = familyId.slice(0, -token.length);
+				changed = true;
+				break;
+			}
+		}
+	}
+
+	return {
+		familyId,
+		familyLabel: cursorFamilyLabel(label),
+		effort: effort ?? "default",
+		speed,
+		mode,
+		contextWindow: /\b1M\b/i.test(label) ? "1m" : "default",
+	};
+}
+
+const ANTIGRAVITY_EFFORT_ORDER = ["low", "medium", "high"] as const;
+
+function titleAntigravityModelId(id: string): string {
+	return titleFromModelId(id.replace(/-(\d+)-(\d+)(?=-|$)/g, "-$1.$2"));
+}
+
+export function parseAntigravityModels(output: string): AgentCapabilityModel[] {
+	const discovered = parseLineModels(output);
+	const variantsByBaseId = new Map<
+		string,
+		Array<{ model: AgentCapabilityModel; effort: string }>
+	>();
+	const baseIdByModelId = new Map<string, string>();
+
+	for (const model of discovered) {
+		const match = model.id.match(/^(.*)-(low|medium|high)$/);
+		if (!match?.[1] || !match[2]) continue;
+		const baseId = match[1];
+		baseIdByModelId.set(model.id, baseId);
+		const variants = variantsByBaseId.get(baseId) ?? [];
+		variants.push({ model, effort: match[2] });
+		variantsByBaseId.set(baseId, variants);
+	}
+
+	const emittedBaseIds = new Set<string>();
+	return discovered.flatMap((model): AgentCapabilityModel[] => {
+		const baseId = baseIdByModelId.get(model.id);
+		if (!baseId)
+			return [
+				{
+					...model,
+					label: titleAntigravityModelId(model.id),
+					reasoning: { state: "unsupported" },
+				},
+			];
+		const variants = variantsByBaseId.get(baseId) ?? [];
+		if (variants.length < 2) {
+			return [{ ...model, label: titleAntigravityModelId(model.id) }];
+		}
+		if (emittedBaseIds.has(baseId)) return [];
+		emittedBaseIds.add(baseId);
+
+		const efforts = ANTIGRAVITY_EFFORT_ORDER.filter((effort) =>
+			variants.some((variant) => variant.effort === effort),
+		).map((effort) => ({ id: effort, label: titleFromModelId(effort) }));
+		const defaultVariant =
+			variants.find((variant) => variant.effort === "high") ?? variants[0];
+		if (!defaultVariant) return [];
+
+		return [
+			{
+				id: defaultVariant.model.id,
+				label: titleAntigravityModelId(baseId),
+				reasoning: {
+					state: "supported",
+					defaultId: defaultVariant.effort,
+					options: efforts,
+				},
+			},
+		];
+	});
+}
+
+export function parseGrokModels(output: string): AgentCapabilityModel[] {
+	return output.split(/\r?\n/).flatMap((rawLine) => {
+		const match = rawLine.match(
+			/^\s*(?:\*|-)\s+([^\s(]+)(?:\s+\(default\))?\s*$/,
+		);
+		if (!match?.[1]) return [];
+		return [
+			{
+				id: match[1],
+				label: titleFromModelId(match[1]),
+				reasoning: { state: "unknown" },
+			},
+		];
+	});
+}
+
+export function parseKimiProviderModels(
+	output: string,
+): AgentCapabilityModel[] | null {
+	let decoded: z.infer<typeof kimiProviderResponseSchema>;
+	try {
+		const parsed = kimiProviderResponseSchema.safeParse(JSON.parse(output));
+		if (!parsed.success) return null;
+		decoded = parsed.data;
+	} catch {
+		return null;
+	}
+	const models = kimiProviderModelsSchema.safeParse(decoded.models);
+	if (!models.success) return [];
+	return Object.entries(models.data).map(([id, model]) => {
+		const label = model?.label ?? model?.name ?? titleFromModelId(id);
+		const capability: AgentCapabilityModel = {
+			id,
+			label,
+			reasoning: { state: "unknown" },
+		};
+		if (model?.provider) capability.provider = labelProvider(model.provider);
+		return capability;
+	});
+}
+
+export function parsePiModels(output: string): AgentCapabilityModel[] {
+	return output.split(/\r?\n/).flatMap((rawLine) => {
+		const fields = rawLine.trim().split(/\s+/);
+		const provider = fields[0];
+		const model = fields[1];
+		if (!provider || !model || provider === "provider") return [];
+		return [
+			{
+				id: `${provider}/${model}`,
+				label: titleFromModelId(model),
+				provider: labelProvider(provider),
+				reasoning: { state: "unknown" },
+			},
+		];
+	});
+}
+
+const kimiProviderModelSchema = z
+	.object({
+		name: z.string().optional().catch(undefined),
+		label: z.string().optional().catch(undefined),
+		provider: z.string().optional().catch(undefined),
+	})
+	.passthrough()
+	.nullable()
+	.catch(null);
+const kimiProviderModelsSchema = z.record(z.string(), kimiProviderModelSchema);
+const kimiProviderResponseSchema = z
+	.object({
+		models: z.json().optional(),
+	})
+	.passthrough();
+
+const piRpcModelSchema = z
+	.object({
+		id: z.string(),
+		name: z.string().optional(),
+		provider: z.string(),
+		reasoning: z.boolean().optional(),
+		thinkingLevelMap: z.record(z.string(), z.json()).optional(),
+	})
+	.passthrough();
+type PiRpcModel = z.infer<typeof piRpcModelSchema>;
+const piRpcResponseSchema = z
+	.object({
+		type: z.literal("response"),
+		command: z.literal("get_available_models"),
+		success: z.literal(true),
+		data: z.object({ models: z.array(z.json()) }).passthrough(),
+	})
+	.passthrough();
+
+function getPiReasoning(
+	model: PiRpcModel,
+): AgentCapabilityTrait<AgentModelOption> {
+	if (model.reasoning === false) return { state: "unsupported" };
+	if (model.reasoning !== true) return { state: "unknown" };
+	const map = model.thinkingLevelMap ?? {};
+	const standard = ["off", "minimal", "low", "medium", "high"].filter(
+		(level) => map[level] !== null,
+	);
+	const advanced = ["xhigh", "max"].filter(
+		(level) => Object.hasOwn(map, level) && map[level] !== null,
+	);
+	return {
+		state: "supported",
+		options: [...standard, ...advanced].map((effort) => ({
+			id: effort,
+			label: titleFromModelId(effort),
+		})),
+	};
+}
+
+export function parsePiRpcModels(output: string): AgentCapabilityModel[] {
+	for (const rawLine of output.split(/\r?\n/)) {
+		let decoded: z.infer<typeof piRpcResponseSchema>;
+		try {
+			const response = piRpcResponseSchema.safeParse(JSON.parse(rawLine));
+			if (!response.success) continue;
+			decoded = response.data;
+		} catch {
+			continue;
+		}
+		return decoded.data.models.flatMap((raw): AgentCapabilityModel[] => {
+			const parsed = piRpcModelSchema.safeParse(raw);
+			if (!parsed.success) return [];
+			const model = parsed.data;
+			return [
+				{
+					id: `${model.provider}/${model.id}`,
+					label: model.name || titleFromModelId(model.id),
+					provider: labelProvider(model.provider),
+					reasoning: getPiReasoning(model),
+				},
+			];
+		});
+	}
+	return [];
+}
+
+const openCodeMetadataSchema = z
+	.object({
+		name: z.string().optional().catch(undefined),
+		providerID: z.string().optional().catch(undefined),
+		variants: z.record(z.string(), z.json()).optional().catch(undefined),
+	})
+	.passthrough();
+type OpenCodeCliModelMetadata = z.infer<typeof openCodeMetadataSchema>;
+
+function labelProvider(providerId: string): string {
+	switch (providerId) {
+		case "anthropic":
+			return "Anthropic";
+		case "opencode":
+			return "OpenCode";
+		case "openai":
+			return "OpenAI";
+		case "openai-codex":
+			return "OpenAI Codex";
+		case "openrouter":
+			return "OpenRouter";
+		default:
+			return titleFromModelId(providerId);
+	}
+}
+
+/**
+ * OpenCode's verbose inventory prints a provider/model slug followed by its
+ * JSON metadata. Keep the exact CLI name instead of rebuilding a lossy label
+ * from the slug. Plain slug-only output remains supported for older versions.
+ */
+export function parseOpenCodeModels(output: string): AgentCapabilityModel[] {
+	const models: AgentCapabilityModel[] = [];
+	const seen = new Set<string>();
+	let currentSlug: string | null = null;
+	const metadataLines: string[] = [];
+	const flush = () => {
+		if (!currentSlug || seen.has(currentSlug)) {
+			currentSlug = null;
+			metadataLines.length = 0;
+			return;
+		}
+		let metadata: OpenCodeCliModelMetadata | null = null;
+		try {
+			const parsed = openCodeMetadataSchema.safeParse(
+				JSON.parse(metadataLines.join("\n")),
+			);
+			if (parsed.success) metadata = parsed.data;
+		} catch {
+			// Older OpenCode releases emit only slugs.
+		}
+		seen.add(currentSlug);
+		const variantIds = metadata?.variants
+			? Object.keys(metadata.variants)
+			: null;
+		let reasoning: AgentCapabilityTrait<AgentModelOption> = {
+			state: "unknown",
+		};
+		if (metadata) reasoning = { state: "unsupported" };
+		if (variantIds?.length) {
+			reasoning = {
+				state: "supported",
+				options: variantIds.map((id) => ({
+					id,
+					label: titleFromModelId(id),
+				})),
+			};
+		}
+		models.push({
+			id: currentSlug,
+			label: metadata?.name?.trim() || titleFromModelId(currentSlug),
+			provider: labelProvider(
+				metadata?.providerID ?? currentSlug.split("/")[0] ?? currentSlug,
+			),
+			reasoning,
+		});
+		currentSlug = null;
+		metadataLines.length = 0;
+	};
+
+	for (const rawLine of output.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		const isSlug = !line.startsWith("{") && /^\S+\/\S+$/.test(line);
+		if (isSlug) {
+			flush();
+			currentSlug = line;
+		} else if (currentSlug) {
+			metadataLines.push(rawLine);
+		}
+	}
+	flush();
+	return models;
+}
+
+export function mapCopilotModels(
+	models: Pick<
+		ModelInfo,
+		"id" | "name" | "supportedReasoningEfforts" | "defaultReasoningEffort"
+	>[],
+): AgentCapabilityModel[] {
+	return models.map((model) => ({
+		id: model.id,
+		label: model.name,
+		reasoning: copilotModelReasoning(model),
+	}));
+}
+
+function copilotModelReasoning(
+	model: Pick<
+		ModelInfo,
+		"supportedReasoningEfforts" | "defaultReasoningEffort"
+	>,
+): AgentCapabilityTrait<AgentModelOption> {
+	if (!Array.isArray(model.supportedReasoningEfforts)) {
+		return { state: "unknown" };
+	}
+	if (model.supportedReasoningEfforts.length === 0) {
+		return { state: "unsupported" };
+	}
+	const reasoning: AgentCapabilityTrait<AgentModelOption> = {
+		state: "supported",
+		options: model.supportedReasoningEfforts.map((effort) => ({
+			id: effort,
+			label: titleFromModelId(effort),
+		})),
+	};
+	if (model.defaultReasoningEffort) {
+		reasoning.defaultId = model.defaultReasoningEffort;
+	}
+	return reasoning;
+}
+
+class CopilotProbeTimeoutError extends Error {
+	constructor() {
+		super("Copilot model probe timed out");
+	}
+}
+
+interface CopilotProbeClient {
+	start(): Promise<void>;
+	getAuthStatus(): Promise<{ isAuthenticated: boolean }>;
+	listModels(): Promise<ModelInfo[]>;
+	stop(): Promise<unknown>;
+	forceStop(): Promise<unknown>;
+}
+
+function stopCopilotClient(client: CopilotProbeClient): void {
+	void client
+		.stop()
+		.catch(() => client.forceStop())
+		.catch(() => undefined);
+}
+
+export async function runCopilotOperation<T>(
+	client: CopilotProbeClient,
+	operation: () => Promise<T>,
+	signal?: AbortSignal,
+	timeoutMs = PROBE_TIMEOUT_MS,
+): Promise<T> {
+	if (signal?.aborted) {
+		void client.forceStop().catch(() => undefined);
+		throw new AgentCapabilityProbeAbortedError();
+	}
+	return new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const finish = (callback: () => void) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abort);
+			callback();
+		};
+		const abort = () =>
+			finish(() => {
+				void client.forceStop().catch(() => undefined);
+				reject(new AgentCapabilityProbeAbortedError());
+			});
+		const timeout = setTimeout(
+			() =>
+				finish(() => {
+					void client.forceStop().catch(() => undefined);
+					reject(new CopilotProbeTimeoutError());
+				}),
+			timeoutMs,
+		);
+		signal?.addEventListener("abort", abort, { once: true });
+		void operation().then(
+			(value) => finish(() => resolve(value)),
+			(error: unknown) => finish(() => reject(error)),
+		);
+	});
+}
+
+export async function discoverCopilotModels(
+	env: NodeJS.ProcessEnv,
+	signal?: AbortSignal,
+	runtime?: { executable: string; args: readonly string[] },
+	clientFactory: (
+		env: NodeJS.ProcessEnv,
+		runtime?: { executable: string; args: readonly string[] },
+	) => CopilotProbeClient = (clientEnv, configuredRuntime) =>
+		new CopilotClient({
+			connection: configuredRuntime
+				? RuntimeConnection.forStdio({
+						path: configuredRuntime.executable,
+						args: configuredRuntime.args,
+					})
+				: undefined,
+			env: clientEnv,
+			logLevel: "none",
+		}),
+): Promise<{
+	models: AgentCapabilityModel[];
+	auth: AgentCapabilitySnapshot["auth"];
+	message: string | null;
+	errorKind: AgentCapabilityErrorKind | null;
+}> {
+	const client = clientFactory(env, runtime);
+	try {
+		return await runCopilotOperation(
+			client,
+			async () => {
+				await client.start();
+				const auth = await client.getAuthStatus();
+				if (!auth.isAuthenticated) {
+					return {
+						models: [],
+						auth: "unauthenticated" as const,
+						message: "Authentication required",
+						errorKind: null,
+					};
+				}
+				return {
+					models: mapCopilotModels(await client.listModels()),
+					auth: "authenticated" as const,
+					message: null,
+					errorKind: null,
+				};
+			},
+			signal,
+		);
+	} catch (error) {
+		if (error instanceof AgentCapabilityProbeAbortedError) throw error;
+		return {
+			models: [],
+			auth: "unknown",
+			message: "Could not query models from the Copilot runtime",
+			errorKind:
+				error instanceof CopilotProbeTimeoutError
+					? "timeout"
+					: "process_failure",
+		};
+	} finally {
+		stopCopilotClient(client);
+	}
+}
+
+const codexReasoningLevelSchema = z
+	.object({ effort: z.string() })
+	.passthrough();
+const codexCacheModelSchema = z
+	.object({
+		slug: z.string().min(1),
+		display_name: z.string().optional().catch(undefined),
+		visibility: z.string().optional().catch(undefined),
+		upgrade: z.json().optional().catch(undefined),
+		default_reasoning_level: z.string().optional().catch(undefined),
+		supported_reasoning_levels: z.array(z.json()).optional().catch(undefined),
+	})
+	.passthrough();
+type CodexCacheModel = z.infer<typeof codexCacheModelSchema>;
+const codexModelsCacheSchema = z
+	.object({ models: z.array(z.json()) })
+	.passthrough();
+
+function codexModelReasoning(
+	model: CodexCacheModel,
+	efforts: AgentModelOption[],
+): AgentCapabilityTrait<AgentModelOption> {
+	if (!model.supported_reasoning_levels) return { state: "unknown" };
+	if (efforts.length === 0) return { state: "unsupported" };
+	const reasoning: AgentCapabilityTrait<AgentModelOption> = {
+		state: "supported",
+		options: efforts,
+	};
+	if (model.default_reasoning_level) {
+		reasoning.defaultId = model.default_reasoning_level;
+	}
+	return reasoning;
+}
+
+export function parseCodexModelsCache(input: string): AgentCapabilityModel[] {
+	let decoded: z.infer<typeof codexModelsCacheSchema>;
+	try {
+		const parsed = codexModelsCacheSchema.safeParse(JSON.parse(input));
+		if (!parsed.success) return [];
+		decoded = parsed.data;
+	} catch {
+		return [];
+	}
+	return decoded.models.flatMap((raw): AgentCapabilityModel[] => {
+		const parsed = codexCacheModelSchema.safeParse(raw);
+		if (!parsed.success) return [];
+		const model = parsed.data;
+		// The cache also contains internal routing aliases such as Work Mode.
+		// Codex's own model/list response omits entries marked hidden, so mirror
+		// that contract instead of leaking implementation-only models into UI.
+		if (model.visibility === "hide") return [];
+		const efforts = Array.isArray(model.supported_reasoning_levels)
+			? model.supported_reasoning_levels.flatMap(
+					(level): Array<{ id: string; label: string }> => {
+						const parsedLevel = codexReasoningLevelSchema.safeParse(level);
+						if (!parsedLevel.success) return [];
+						const { effort } = parsedLevel.data;
+						return [{ id: effort, label: titleFromModelId(effort) }];
+					},
+				)
+			: [];
+		if (
+			Array.isArray(model.supported_reasoning_levels) &&
+			model.supported_reasoning_levels.length > 0 &&
+			efforts.length === 0
+		) {
+			return [];
+		}
+		return [
+			{
+				id: model.slug,
+				label: titleFromModelId(model.display_name || model.slug),
+				provider:
+					model.upgrade !== null && model.upgrade !== undefined
+						? "Legacy Models"
+						: "Current Models",
+				reasoning: codexModelReasoning(model, efforts),
+			},
+		];
+	});
+}
+
+function fallbackModels(presetId: string): AgentCapabilityModel[] {
+	return (getAgentModelSupport(presetId)?.models ?? []).map((model) => ({
+		...model,
+		reasoning: { state: "unknown" },
+	}));
+}
+
+function mergeAuthenticationObservations(
+	discovered: AgentCapabilitySnapshot["auth"],
+	probed: AgentCapabilitySnapshot["auth"],
+): AgentCapabilitySnapshot["auth"] {
+	if (discovered === "unauthenticated" || probed === "unauthenticated") {
+		return "unauthenticated";
+	}
+	if (discovered === "authenticated" || probed === "authenticated") {
+		return "authenticated";
+	}
+	return "unknown";
+}
+
+function probeArgs(config: AgentCapabilityConfig, args: string[]): string[] {
+	return [...(config.args ?? []), ...args];
+}
+
+function capabilityStatusForAuth(
+	auth: AgentCapabilitySnapshot["auth"],
+	presetId: string,
+): AgentCapabilityStatus {
+	if (auth === "unauthenticated") return "authentication_required";
+	if (auth === "unknown" && AUTH_DEPENDENT_PRESETS.has(presetId)) {
+		return "unavailable";
+	}
+	return "ready";
+}
+
+async function discoverModels(
+	config: AgentCapabilityConfig,
+	executable: string,
+	env: NodeJS.ProcessEnv,
+	signal?: AbortSignal,
+): Promise<{
+	models: AgentCapabilityModel[];
+	source: AgentModelSource;
+	auth: AgentCapabilitySnapshot["auth"];
+	message: string | null;
+	errorKind: AgentCapabilityErrorKind | null;
+}> {
+	let lastErrorKind: AgentCapabilityErrorKind | null = null;
+	if (config.presetId === "antigravity") {
+		const result = await runCommand(
+			executable,
+			probeArgs(config, ["models"]),
+			env,
+			PROBE_TIMEOUT_MS,
+			undefined,
+			undefined,
+			signal,
+		);
+		const models = parseAntigravityModels(result.stdout);
+		const output = `${result.stdout}\n${result.stderr}`;
+		if (
+			/not authenticated|authentication required|sign in|log in|logged out/i.test(
+				output,
+			)
+		) {
+			return {
+				models: [],
+				source: "none",
+				auth: "unauthenticated",
+				message: "Authentication required",
+				errorKind: null,
+			};
+		}
+		if (result.exitCode === 0 && models.length > 0) {
+			return {
+				models,
+				source: "runtime",
+				auth: "authenticated",
+				message: null,
+				errorKind: null,
+			};
+		}
+		return {
+			models: [],
+			source: "none",
+			auth: "unknown",
+			message: "Could not query models from the Antigravity runtime",
+			errorKind: classifyCommandFailure(result),
+		};
+	}
+
+	if (config.presetId === "copilot") {
+		const discovery = await discoverCopilotModels(env, signal, {
+			executable,
+			args: config.args ?? [],
+		});
+		return {
+			...discovery,
+			source: discovery.models.length > 0 ? "runtime" : "none",
+		};
+	}
+
+	if (config.presetId === "codex") {
+		const cachePath = join(
+			env.CODEX_HOME ?? join(homedir(), ".codex"),
+			"models_cache.json",
+		);
+		try {
+			const models = parseCodexModelsCache(await readFile(cachePath, "utf8"));
+			if (models.length > 0) {
+				return {
+					models,
+					source: "runtime",
+					auth: "authenticated",
+					message: null,
+					errorKind: null,
+				};
+			}
+		} catch {
+			// Fall through to the catalog bundled for this CLI family.
+		}
+	}
+
+	if (config.presetId === "pi") {
+		let result = await runCommand(
+			executable,
+			// Extensions are useful in interactive sessions but can initialize
+			// arbitrary user code before the RPC server begins accepting requests.
+			// Discovery only needs Pi's configured model registry.
+			probeArgs(config, ["--mode", "rpc", "--no-session", "--no-extensions"]),
+			env,
+			PROBE_TIMEOUT_MS,
+			'{"type":"get_available_models"}\n',
+			(output) => parsePiRpcModels(output).length > 0,
+			signal,
+		);
+		let models = parsePiRpcModels(result.stdout);
+		if (!result.timedOut && (result.exitCode !== 0 || models.length === 0)) {
+			result = await runCommand(
+				executable,
+				probeArgs(config, ["--list-models"]),
+				env,
+				PROBE_TIMEOUT_MS,
+				undefined,
+				undefined,
+				signal,
+			);
+			models = parsePiModels(result.stdout);
+		}
+		if (result.exitCode === 0 && models.length > 0) {
+			return {
+				models,
+				source: "runtime",
+				auth: "authenticated",
+				message: null,
+				errorKind: null,
+			};
+		}
+		return {
+			models: [],
+			source: "none",
+			auth: "unknown",
+			message: "No authenticated Pi models were found",
+			errorKind: classifyCommandFailure(result),
+		};
+	}
+
+	if (config.presetId === "grok") {
+		const result = await runCommand(
+			executable,
+			probeArgs(config, ["models"]),
+			env,
+			PROBE_TIMEOUT_MS,
+			undefined,
+			undefined,
+			signal,
+		);
+		const models = parseGrokModels(result.stdout);
+		const output = `${result.stdout}\n${result.stderr}`;
+		if (/not logged in|authentication required|run .*login/i.test(output)) {
+			return {
+				models: [],
+				source: "none",
+				auth: "unauthenticated",
+				message: "Authentication required",
+				errorKind: null,
+			};
+		}
+		if (result.exitCode === 0 && models.length > 0) {
+			return {
+				models,
+				source: "runtime",
+				auth: "authenticated",
+				message: null,
+				errorKind: null,
+			};
+		}
+		return {
+			models: [],
+			source: "none",
+			auth: "unknown",
+			message: "Could not query models from the Grok runtime",
+			errorKind: classifyCommandFailure(result),
+		};
+	}
+
+	if (config.presetId === "kimi") {
+		const result = await runCommand(
+			executable,
+			probeArgs(config, ["provider", "list", "--json"]),
+			env,
+			PROBE_TIMEOUT_MS,
+			undefined,
+			undefined,
+			signal,
+		);
+		const models = parseKimiProviderModels(result.stdout);
+		if (result.exitCode === 0 && models?.length) {
+			return {
+				models,
+				source: "runtime",
+				auth: "authenticated",
+				message: null,
+				errorKind: null,
+			};
+		}
+		if (result.exitCode === 0 && models) {
+			return {
+				models: [],
+				source: "none",
+				auth: "unauthenticated",
+				message: "Authentication required",
+				errorKind: null,
+			};
+		}
+		return {
+			models: [],
+			source: "none",
+			auth: "unknown",
+			message: "Could not query providers from the Kimi runtime",
+			errorKind: classifyCommandFailure(result),
+		};
+	}
+
+	if (config.presetId === "opencode" || config.presetId === "cursor-agent") {
+		const args = probeArgs(
+			config,
+			config.presetId === "opencode"
+				? ["models", "--verbose"]
+				: ["--list-models"],
+		);
+		const result = await runCommand(
+			executable,
+			args,
+			env,
+			PROBE_TIMEOUT_MS,
+			undefined,
+			undefined,
+			signal,
+		);
+		const models =
+			config.presetId === "opencode"
+				? parseOpenCodeModels(result.stdout)
+				: parseCursorModels(result.stdout);
+		const output = `${result.stdout}\n${result.stderr}`;
+		if (/authentication required|not authenticated|run .*login/i.test(output)) {
+			return {
+				models: [],
+				source: "none",
+				auth: "unauthenticated",
+				message: "Authentication required",
+				errorKind: null,
+			};
+		}
+		if (result.exitCode === 0 && models.length > 0) {
+			return {
+				models,
+				source: "runtime",
+				auth: "authenticated",
+				message: null,
+				errorKind: null,
+			};
+		}
+		lastErrorKind = classifyCommandFailure(result);
+	}
+
+	const models = fallbackModels(config.presetId);
+	return {
+		models,
+		source: models.length > 0 ? "fallback" : "none",
+		auth: "unknown",
+		message: models.length > 0 ? "Using the versioned fallback catalog" : null,
+		errorKind: lastErrorKind,
+	};
+}
+
+async function probeAgentCapability(
+	config: AgentCapabilityConfig,
+	now: number,
+	signal?: AbortSignal,
+): Promise<AgentCapabilitySnapshot> {
+	const env = await createProbeEnvironment(config.env);
+	const resolvedExecutable = await resolveAgentExecutable(config.command, env);
+	if (!resolvedExecutable) {
+		const snapshot: AgentCapabilitySnapshot = {
+			agentId: config.id,
+			presetId: config.presetId,
+			status: "unavailable",
+			installed: false,
+			auth: "unknown",
+			version: null,
+			modelSource: "none",
+			models: [],
+			message: `${config.command} was not found in PATH`,
+			checkedAt: new Date(now).toISOString(),
+			resolverSource: null,
+			errorKind: "missing_executable",
+			inventoryCheckedAt: null,
+			inventoryOrigin: "none",
+			healthOrigin: "live",
+		};
+		return snapshot;
+	}
+	const executable = resolvedExecutable.path;
+
+	const [discovery, probedAuth] = await Promise.all([
+		discoverModels(config, executable, env, signal),
+		probeAuthentication(
+			config.presetId,
+			executable,
+			config.args ?? [],
+			env,
+			signal,
+		),
+	]);
+	const auth = mergeAuthenticationObservations(discovery.auth, probedAuth);
+	const status = capabilityStatusForAuth(auth, config.presetId);
+	const snapshot: AgentCapabilitySnapshot = {
+		agentId: config.id,
+		presetId: config.presetId,
+		status,
+		installed: true,
+		auth,
+		version: null,
+		modelSource: discovery.source,
+		models: discovery.models,
+		message: discovery.message,
+		checkedAt: new Date(now).toISOString(),
+		resolverSource: resolvedExecutable.source,
+		errorKind: discovery.errorKind,
+		inventoryCheckedAt:
+			discovery.source === "none" ? null : new Date(now).toISOString(),
+		inventoryOrigin: discovery.source === "none" ? "none" : "live",
+		healthOrigin: "live",
+	};
+	return snapshot;
+}
+
+export function inspectAgentCapability(
+	config: AgentCapabilityConfig,
+	options: { now?: number; signal?: AbortSignal } = {},
+): Promise<AgentCapabilitySnapshot> {
+	const now = options.now ?? Date.now();
+	return probeAgentCapability(config, now, options.signal);
+}

--- a/packages/host-service/src/agent-capabilities/capability-refresh-service.test.ts
+++ b/packages/host-service/src/agent-capabilities/capability-refresh-service.test.ts
@@ -643,6 +643,33 @@ describe("capability refresh service", () => {
 		await service.dispose();
 	});
 
+	it("keeps installation unknown when the first probe throws", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const service = new CapabilityRefreshService(db);
+
+		const view = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS,
+			probe: async () => {
+				throw new Error("Provider explosion");
+			},
+		});
+
+		expect(view).toMatchObject({
+			health: {
+				status: "unavailable",
+				installed: null,
+				errorKind: "process_failure",
+			},
+			inventory: null,
+			inventoryOrigin: "none",
+			healthOrigin: "live",
+		});
+		expect(listCapabilitySnapshots(db)[0]?.installed).toBeNull();
+
+		await service.dispose();
+	});
+
 	it("preserves cancellation safety during batch refresh when signal is aborted", async () => {
 		const db = createTestDb();
 		const agent1 = seedConfig(db, "agent-1");

--- a/packages/host-service/src/agent-capabilities/capability-refresh-service.test.ts
+++ b/packages/host-service/src/agent-capabilities/capability-refresh-service.test.ts
@@ -1,0 +1,1091 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it, spyOn } from "bun:test";
+import * as childProcess from "node:child_process";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { z } from "zod";
+import type { HostDb } from "../db";
+import * as schema from "../db/schema";
+import {
+	type AgentCapabilityConfig,
+	AgentCapabilityProbeAbortedError,
+	type AgentCapabilitySnapshot,
+	runCommand,
+} from "./agent-capabilities";
+import {
+	CapabilityRefreshService,
+	ObsoleteCapabilityRefreshError,
+	type RevisionedAgentCapabilityConfig,
+	readPersistedCapabilitySnapshots,
+} from "./capability-refresh-service";
+import {
+	CAPABILITY_INVENTORY_SCHEMA_VERSION,
+	CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS,
+	CAPABILITY_SNAPSHOT_RETENTION_MS,
+	listCapabilitySnapshots,
+	SANITIZED_CAPABILITY_MESSAGES,
+	writeCapabilitySnapshotIfCurrentRevision,
+} from "./capability-snapshot-repository";
+import { initializeHostCapabilitySnapshots } from "./capability-startup";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../drizzle");
+const nodeErrorSchema = z.object({ code: z.string() });
+const CHECKED_AT = "2026-08-14T12:00:00.000Z";
+const CHECKED_AT_MS = Date.parse(CHECKED_AT);
+
+function createTestDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	const bunDb = drizzle(sqlite, { schema });
+	migrate(bunDb, { migrationsFolder: MIGRATIONS_FOLDER });
+	sqlite.exec("PRAGMA foreign_keys = ON");
+	// SAFETY: Tests use Bun's SQLite driver, whose run result differs nominally from HostDb; repository operations used here are otherwise identical.
+	return bunDb as unknown as HostDb;
+}
+
+const refreshServices = new WeakMap<HostDb, CapabilityRefreshService>();
+
+function getRefreshService(db: HostDb): CapabilityRefreshService {
+	const existing = refreshServices.get(db);
+	if (existing) return existing;
+	const service = new CapabilityRefreshService(db);
+	refreshServices.set(db, service);
+	return service;
+}
+
+function refreshAgentCapability(
+	db: HostDb,
+	config: RevisionedAgentCapabilityConfig,
+	options: Parameters<CapabilityRefreshService["refreshCapability"]>[1] = {},
+): ReturnType<CapabilityRefreshService["refreshCapability"]> {
+	return getRefreshService(db).refreshCapability(config, options);
+}
+
+function refreshAgentCapabilities(
+	db: HostDb,
+	configs: RevisionedAgentCapabilityConfig[],
+	options: Parameters<CapabilityRefreshService["refreshCapabilities"]>[1] = {},
+): ReturnType<CapabilityRefreshService["refreshCapabilities"]> {
+	return getRefreshService(db).refreshCapabilities(configs, options);
+}
+
+function seedConfig(
+	db: HostDb,
+	id = "agent-1",
+): RevisionedAgentCapabilityConfig {
+	const config = {
+		id,
+		presetId: "codex",
+		command: "codex",
+		args: [],
+		env: {},
+		configRevision: 1,
+	};
+	db.insert(schema.hostAgentConfigs)
+		.values({
+			id: config.id,
+			presetId: config.presetId,
+			label: "Codex",
+			command: config.command,
+			argsJson: "[]",
+			promptTransport: "argv",
+			promptArgsJson: "[]",
+			resumeArgsJson: "[]",
+			envJson: "{}",
+			capabilityRevision: config.configRevision,
+			displayOrder: 0,
+		})
+		.run();
+	return config;
+}
+
+function liveSnapshot(
+	config: RevisionedAgentCapabilityConfig,
+	overrides: Partial<AgentCapabilitySnapshot> = {},
+): AgentCapabilitySnapshot {
+	return {
+		agentId: config.id,
+		presetId: config.presetId,
+		status: "ready",
+		installed: true,
+		auth: "authenticated",
+		version: "1.0.0",
+		modelSource: "runtime",
+		models: [
+			{
+				id: "model-1",
+				label: "Model 1",
+				reasoning: { state: "unknown" },
+			},
+		],
+		message: null,
+		checkedAt: CHECKED_AT,
+		...overrides,
+	};
+}
+
+function persistSnapshot(
+	db: HostDb,
+	config: RevisionedAgentCapabilityConfig,
+	atMs = CHECKED_AT_MS,
+): void {
+	writeCapabilitySnapshotIfCurrentRevision(db, {
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.configRevision,
+		inventory: {
+			schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+			agentId: config.id,
+			presetId: config.presetId,
+			configRevision: config.configRevision,
+			detectedVersion: "1.0.0",
+			modelSource: "runtime",
+			models: liveSnapshot(config).models,
+			inventoryCheckedAt: new Date(atMs).toISOString(),
+		},
+		status: "ready",
+		installed: true,
+		auth: "authenticated",
+		inventoryCheckedAt: atMs,
+		statusCheckedAt: atMs,
+		writtenAt: atMs,
+	});
+}
+
+function rawSnapshotRow(db: HostDb, agentId: string) {
+	return db
+		.select()
+		.from(schema.hostAgentCapabilitySnapshots)
+		.where(eq(schema.hostAgentCapabilitySnapshots.agentId, agentId))
+		.get();
+}
+
+async function waitForPidFile(path: string): Promise<number> {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < 2_000) {
+		const contents = await Bun.file(path)
+			.text()
+			.catch(() => "");
+		const pid = Number.parseInt(contents.trim(), 10);
+		if (Number.isInteger(pid) && pid > 0) return pid;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+	}
+	throw new Error(`timed out waiting for pid file ${path}`);
+}
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const parsed = nodeErrorSchema.safeParse(error);
+		return parsed.success && parsed.data.code === "EPERM";
+	}
+}
+
+async function expectPidGone(pid: number): Promise<void> {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < 2_000) {
+		if (!isPidAlive(pid)) return;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+	}
+	throw new Error(`pid ${pid} was still alive`);
+}
+
+describe("capability refresh service", () => {
+	it("reads persisted snapshots without invoking a probe", () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		expect(readPersistedCapabilitySnapshots(db, CHECKED_AT_MS + 1_000)).toEqual(
+			[
+				{
+					agentId: config.id,
+					presetId: config.presetId,
+					inventory: {
+						schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+						agentId: config.id,
+						presetId: config.presetId,
+						configRevision: config.configRevision,
+						detectedVersion: "1.0.0",
+						modelSource: "runtime",
+						models: liveSnapshot(config).models,
+						inventoryCheckedAt: CHECKED_AT,
+					},
+					inventoryOrigin: "persisted",
+					health: {
+						status: "ready",
+						installed: true,
+						auth: "authenticated",
+						checkedAt: CHECKED_AT,
+						errorKind: null,
+						message: null,
+					},
+					healthOrigin: "persisted",
+				},
+			],
+		);
+	});
+
+	it("preserves unknown health and null installed without coercing", () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		writeCapabilitySnapshotIfCurrentRevision(db, {
+			agentId: config.id,
+			presetId: config.presetId,
+			configRevision: config.configRevision,
+			inventory: null,
+			status: "unknown",
+			installed: null,
+			auth: "unknown",
+			inventoryCheckedAt: null,
+			statusCheckedAt: CHECKED_AT_MS,
+			writtenAt: CHECKED_AT_MS,
+		});
+		const [view] = readPersistedCapabilitySnapshots(db, CHECKED_AT_MS + 1_000);
+		expect(view).toEqual({
+			agentId: config.id,
+			presetId: config.presetId,
+			inventory: null,
+			inventoryOrigin: "none",
+			health: {
+				status: "unknown",
+				installed: null,
+				auth: "unknown",
+				checkedAt: CHECKED_AT,
+				errorKind: null,
+				message: null,
+			},
+			healthOrigin: "persisted",
+		});
+	});
+
+	it("honors every explicit refresh after a transient failure", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const service = new CapabilityRefreshService(db);
+		let probes = 0;
+		const probe = async (
+			_config: AgentCapabilityConfig,
+			options: { now?: number },
+		) => {
+			probes += 1;
+			return liveSnapshot(config, {
+				status: probes < 3 ? "unavailable" : "ready",
+				auth: probes < 3 ? "unknown" : "authenticated",
+				modelSource: probes < 3 ? "none" : "runtime",
+				models: probes < 3 ? [] : liveSnapshot(config).models,
+				errorKind: probes < 3 ? "timeout" : null,
+				message: probes < 3 ? "secret stderr must not persist" : null,
+				resolverSource: "wrapper",
+				checkedAt: new Date(options.now ?? CHECKED_AT_MS).toISOString(),
+			});
+		};
+
+		await service.refreshCapability(config, { now: CHECKED_AT_MS, probe });
+		expect(listCapabilitySnapshots(db)[0]).toMatchObject({
+			errorKind: "timeout",
+			message: SANITIZED_CAPABILITY_MESSAGES.timeout,
+			resolverSource: "wrapper",
+		});
+		await service.refreshCapability(config, { now: CHECKED_AT_MS + 1, probe });
+		const recovered = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS + 2,
+			probe,
+		});
+		expect(recovered).toMatchObject({
+			health: { status: "ready", errorKind: null },
+		});
+		expect(probes).toBe(3);
+		await service.dispose();
+	});
+
+	it("refreshes a persisted observation without a picker TTL", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		let probeCalls = 0;
+		const result = await refreshAgentCapability(db, config, {
+			now: CHECKED_AT_MS + 5 * 60 * 1_000 - 1,
+			probe: async () => {
+				probeCalls += 1;
+				return liveSnapshot(config);
+			},
+		});
+		expect(probeCalls).toBe(1);
+		expect(result.inventory?.models).toHaveLength(1);
+	});
+
+	it("coalesces concurrent stale refreshes by agent revision", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		let probeCalls = 0;
+		const probe = async () => {
+			probeCalls += 1;
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+			return liveSnapshot(config);
+		};
+		const [first, second] = await Promise.all([
+			refreshAgentCapability(db, config, { probe }),
+			refreshAgentCapability(db, config, { probe }),
+		]);
+		expect(probeCalls).toBe(1);
+		expect(second).toEqual(first);
+	});
+
+	it("probes every sequential explicit refresh", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		let probes = 0;
+		const probe = async () => {
+			probes += 1;
+			return liveSnapshot(config);
+		};
+
+		await refreshAgentCapability(db, config, {
+			now: CHECKED_AT_MS,
+			probe,
+		});
+		await refreshAgentCapability(db, config, {
+			now: CHECKED_AT_MS + 29_999,
+			probe,
+		});
+
+		expect(probes).toBe(2);
+	});
+
+	it("cancels in-flight work and rejects new refreshes after disposal", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const service = new CapabilityRefreshService(db);
+		const refresh = service
+			.refreshCapability(config, {
+				probe: (_config, options) =>
+					new Promise((_resolve, reject) => {
+						options.signal?.addEventListener(
+							"abort",
+							() => reject(new AgentCapabilityProbeAbortedError()),
+							{ once: true },
+						);
+					}),
+			})
+			.catch((error: unknown) => error);
+
+		await service.dispose();
+
+		expect(await refresh).toBeInstanceOf(AgentCapabilityProbeAbortedError);
+		await expect(service.refreshCapability(config)).rejects.toBeInstanceOf(
+			AgentCapabilityProbeAbortedError,
+		);
+	});
+
+	it("isolates refresh state between app instances", async () => {
+		const firstDb = createTestDb();
+		const secondDb = createTestDb();
+		const firstConfig = seedConfig(firstDb);
+		const secondConfig = seedConfig(secondDb);
+		const firstService = new CapabilityRefreshService(firstDb);
+		const secondService = new CapabilityRefreshService(secondDb);
+		let probes = 0;
+
+		const first = await firstService.refreshCapability(firstConfig, {
+			probe: async () => {
+				probes += 1;
+				return liveSnapshot(firstConfig, { version: "first" });
+			},
+		});
+		const second = await secondService.refreshCapability(secondConfig, {
+			probe: async () => {
+				probes += 1;
+				return liveSnapshot(secondConfig, { version: "second" });
+			},
+		});
+
+		expect(probes).toBe(2);
+		expect(first.inventory?.detectedVersion).toBe("first");
+		expect(second.inventory?.detectedVersion).toBe("second");
+		await Promise.all([firstService.dispose(), secondService.dispose()]);
+	});
+
+	it("retains last-good inventory during a live auth failure", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const result = await refreshAgentCapability(db, config, {
+			now: CHECKED_AT_MS + 10_000,
+			probe: async () =>
+				liveSnapshot(config, {
+					status: "authentication_required",
+					auth: "unauthenticated",
+					modelSource: "none",
+					models: [],
+					checkedAt: "2026-08-14T12:00:10.000Z",
+				}),
+		});
+		expect(result).toMatchObject({
+			health: {
+				status: "authentication_required",
+				auth: "unauthenticated",
+				message: SANITIZED_CAPABILITY_MESSAGES.authenticationRequired,
+			},
+			inventory: { models: [{ id: "model-1" }] },
+			inventoryOrigin: "persisted",
+			healthOrigin: "live",
+		});
+		expect(listCapabilitySnapshots(db)[0]?.inventory?.models).toHaveLength(1);
+	});
+
+	it("clears inventory after a confirmed missing executable", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const view = await refreshAgentCapability(db, config, {
+			probe: async () =>
+				liveSnapshot(config, {
+					status: "unavailable",
+					installed: false,
+					auth: "unknown",
+					modelSource: "none",
+					models: [],
+					errorKind: "missing_executable",
+				}),
+		});
+		expect(view).toMatchObject({
+			inventory: null,
+			inventoryOrigin: "none",
+			health: {
+				status: "unavailable",
+				installed: false,
+				errorKind: "missing_executable",
+				message: SANITIZED_CAPABILITY_MESSAGES.missingExecutable,
+			},
+			healthOrigin: "live",
+		});
+		const persisted = listCapabilitySnapshots(db)[0];
+		expect(persisted).toMatchObject({
+			installed: false,
+			inventory: null,
+			status: "unavailable",
+			errorKind: "missing_executable",
+			message: SANITIZED_CAPABILITY_MESSAGES.missingExecutable,
+		});
+		expect(persisted?.inventoryCheckedAt).toBeNull();
+	});
+
+	it("rejects a probe result after the config revision changes", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		await expect(
+			refreshAgentCapability(db, config, {
+				probe: async () => {
+					db.update(schema.hostAgentConfigs)
+						.set({ capabilityRevision: 2 })
+						.where(eq(schema.hostAgentConfigs.id, config.id))
+						.run();
+					return liveSnapshot(config);
+				},
+			}),
+		).rejects.toBeInstanceOf(ObsoleteCapabilityRefreshError);
+	});
+
+	it("bounds concurrency while preserving config order", async () => {
+		const db = createTestDb();
+		const configs = Array.from({ length: 5 }, (_, index) =>
+			seedConfig(db, `agent-${index}`),
+		);
+		let active = 0;
+		let maxActive = 0;
+		const results = await refreshAgentCapabilities(db, configs, {
+			concurrency: 2,
+			probe: async (config) => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+				active -= 1;
+				return liveSnapshot(config as RevisionedAgentCapabilityConfig);
+			},
+		});
+		expect(maxActive).toBe(2);
+		expect(results.map((result) => result.agentId)).toEqual(
+			configs.map((config) => config.id),
+		);
+	});
+
+	it("converts oversized live inventory into parse_failure health while preserving last-good inventory", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+
+		const service = new CapabilityRefreshService(db);
+		const result = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS + 10_000,
+			probe: async () =>
+				liveSnapshot(config, {
+					models: Array.from({ length: 2_001 }, (_, index) => ({
+						id: `model-${index}`,
+						label: `Model ${index}`,
+						reasoning: { state: "unknown" as const },
+					})),
+				}),
+		});
+
+		expect(result).toMatchObject({
+			health: {
+				status: "unavailable",
+				errorKind: "parse_failure",
+				message: SANITIZED_CAPABILITY_MESSAGES.parseFailure,
+			},
+			inventory: { models: [{ id: "model-1" }] },
+			inventoryOrigin: "persisted",
+			healthOrigin: "live",
+		});
+
+		const persisted = listCapabilitySnapshots(db)[0];
+		expect(persisted).toMatchObject({
+			status: "unavailable",
+			errorKind: "parse_failure",
+			message: SANITIZED_CAPABILITY_MESSAGES.parseFailure,
+		});
+		expect(persisted?.inventory?.models).toHaveLength(1);
+
+		await service.dispose();
+	});
+
+	it("treats malformed live inventory as parse_failure while retaining last-good inventory", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const service = new CapabilityRefreshService(db);
+		const result = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS + 10_000,
+			probe: async () =>
+				liveSnapshot(config, {
+					models: [
+						{
+							id: "broken",
+							label: "Broken",
+							reasoning: {
+								state: "supported",
+								options: [],
+							},
+						},
+					],
+				}),
+		});
+		expect(result).toMatchObject({
+			health: {
+				status: "unavailable",
+				errorKind: "parse_failure",
+				message: SANITIZED_CAPABILITY_MESSAGES.parseFailure,
+			},
+			inventory: { models: [{ id: "model-1" }] },
+			inventoryOrigin: "persisted",
+			healthOrigin: "live",
+		});
+		expect(listCapabilitySnapshots(db)[0]?.inventory?.models).toHaveLength(1);
+		await service.dispose();
+	});
+
+	it("isolates per-agent failures in batch refresh without suppressing successful results or corrupting order", async () => {
+		const db = createTestDb();
+		const agent1 = seedConfig(db, "agent-1");
+		const agent2 = seedConfig(db, "agent-2");
+		const agent3 = seedConfig(db, "agent-3");
+		persistSnapshot(db, agent2);
+
+		const service = new CapabilityRefreshService(db);
+		const results = await service.refreshCapabilities(
+			[agent1, agent2, agent3],
+			{
+				now: CHECKED_AT_MS + 5_000,
+				probe: async (config) => {
+					if (config.id === "agent-2") {
+						throw new Error("Provider explosion");
+					}
+					return liveSnapshot(config as RevisionedAgentCapabilityConfig, {
+						version: `ver-${config.id}`,
+					});
+				},
+			},
+		);
+
+		expect(results).toHaveLength(3);
+		expect(results.map((r) => r.agentId)).toEqual([
+			"agent-1",
+			"agent-2",
+			"agent-3",
+		]);
+		expect(results[0]).toMatchObject({
+			agentId: "agent-1",
+			health: { status: "ready" },
+			inventory: { detectedVersion: "ver-agent-1" },
+		});
+		expect(results[1]).toMatchObject({
+			agentId: "agent-2",
+			health: {
+				status: "unavailable",
+				errorKind: "process_failure",
+				message: SANITIZED_CAPABILITY_MESSAGES.processFailure,
+			},
+			inventory: { detectedVersion: "1.0.0" },
+			inventoryOrigin: "persisted",
+			healthOrigin: "live",
+		});
+		expect(results[2]).toMatchObject({
+			agentId: "agent-3",
+			health: { status: "ready" },
+			inventory: { detectedVersion: "ver-agent-3" },
+		});
+
+		await service.dispose();
+	});
+
+	it("preserves cancellation safety during batch refresh when signal is aborted", async () => {
+		const db = createTestDb();
+		const agent1 = seedConfig(db, "agent-1");
+		const agent2 = seedConfig(db, "agent-2");
+		const service = new CapabilityRefreshService(db);
+
+		const refreshPromise = service
+			.refreshCapabilities([agent1, agent2], {
+				probe: (_config, options) =>
+					new Promise((_resolve, reject) => {
+						options.signal?.addEventListener(
+							"abort",
+							() => reject(new AgentCapabilityProbeAbortedError()),
+							{ once: true },
+						);
+					}),
+			})
+			.catch((err: unknown) => err);
+
+		await service.dispose();
+		expect(await refreshPromise).toBeInstanceOf(
+			AgentCapabilityProbeAbortedError,
+		);
+	});
+
+	it("keeps secret-bearing probe output out of the API view and SQLite", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const secret = "sk-secret-regression-token-9f3a";
+		const service = new CapabilityRefreshService(db);
+		const view = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS + 10_000,
+			probe: async () => {
+				throw new Error(
+					`provider boom stdout=${secret} stderr=${secret} message=${secret}`,
+				);
+			},
+		});
+
+		expect(JSON.stringify(view)).not.toContain(secret);
+		expect(view).toMatchObject({
+			health: {
+				status: "unavailable",
+				errorKind: "process_failure",
+				message: SANITIZED_CAPABILITY_MESSAGES.processFailure,
+			},
+			inventory: { models: [{ id: "model-1" }] },
+			inventoryOrigin: "persisted",
+			healthOrigin: "live",
+		});
+
+		const persisted = listCapabilitySnapshots(db)[0];
+		expect(persisted?.message).toBe(
+			SANITIZED_CAPABILITY_MESSAGES.processFailure,
+		);
+		const sqliteRow = db
+			.select()
+			.from(schema.hostAgentCapabilitySnapshots)
+			.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+			.get();
+		expect(JSON.stringify(sqliteRow)).not.toContain(secret);
+		expect(sqliteRow?.message).toBe(
+			SANITIZED_CAPABILITY_MESSAGES.processFailure,
+		);
+		expect(sqliteRow?.inventoryJson).not.toContain(secret);
+
+		await service.dispose();
+	});
+
+	it("rethrows ObsoleteCapabilityRefreshError from batch refresh instead of masking it", async () => {
+		const db = createTestDb();
+		const current = seedConfig(db, "agent-current");
+		const obsolete = seedConfig(db, "agent-obsolete");
+		const service = new CapabilityRefreshService(db);
+
+		await expect(
+			service.refreshCapabilities([current, obsolete], {
+				now: CHECKED_AT_MS,
+				probe: async (config) => {
+					if (config.id === obsolete.id) {
+						db.update(schema.hostAgentConfigs)
+							.set({ capabilityRevision: 2 })
+							.where(eq(schema.hostAgentConfigs.id, obsolete.id))
+							.run();
+					}
+					return liveSnapshot(config as RevisionedAgentCapabilityConfig);
+				},
+			}),
+		).rejects.toBeInstanceOf(ObsoleteCapabilityRefreshError);
+
+		await service.dispose();
+	});
+
+	it("returns the exact nested API view after a live refresh", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const service = new CapabilityRefreshService(db);
+		const view = await service.refreshCapability(config, {
+			now: CHECKED_AT_MS,
+			probe: async () => liveSnapshot(config),
+		});
+
+		expect(Object.keys(view).sort()).toEqual([
+			"agentId",
+			"health",
+			"healthOrigin",
+			"inventory",
+			"inventoryOrigin",
+			"presetId",
+		]);
+		expect(Object.keys(view.health).sort()).toEqual([
+			"auth",
+			"checkedAt",
+			"errorKind",
+			"installed",
+			"message",
+			"status",
+		]);
+		expect(view.inventory && Object.keys(view.inventory).sort()).toEqual([
+			"agentId",
+			"configRevision",
+			"detectedVersion",
+			"inventoryCheckedAt",
+			"modelSource",
+			"models",
+			"presetId",
+			"schemaVersion",
+		]);
+		expect(view).toEqual({
+			agentId: config.id,
+			presetId: config.presetId,
+			inventory: {
+				schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+				agentId: config.id,
+				presetId: config.presetId,
+				configRevision: config.configRevision,
+				detectedVersion: "1.0.0",
+				modelSource: "runtime",
+				models: liveSnapshot(config).models,
+				inventoryCheckedAt: CHECKED_AT,
+			},
+			inventoryOrigin: "live",
+			health: {
+				status: "ready",
+				installed: true,
+				auth: "authenticated",
+				checkedAt: CHECKED_AT,
+				errorKind: null,
+				message: null,
+			},
+			healthOrigin: "live",
+		});
+
+		await service.dispose();
+	});
+
+	it("preserves last-good inventory stored 7-30 days ago without making it displayable", async () => {
+		const cases = [
+			{
+				ageMs: CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS + 1,
+				errorKind: "timeout" as const,
+				message: SANITIZED_CAPABILITY_MESSAGES.timeout,
+			},
+			{
+				ageMs: 20 * 86_400_000,
+				errorKind: "process_failure" as const,
+				message: SANITIZED_CAPABILITY_MESSAGES.processFailure,
+			},
+			{
+				ageMs: CAPABILITY_SNAPSHOT_RETENTION_MS - 1,
+				errorKind: "parse_failure" as const,
+				message: SANITIZED_CAPABILITY_MESSAGES.parseFailure,
+			},
+		];
+		for (const { ageMs, errorKind, message } of cases) {
+			const db = createTestDb();
+			const config = seedConfig(db);
+			const storedAt = CHECKED_AT_MS - ageMs;
+			persistSnapshot(db, config, storedAt);
+
+			const view = await refreshAgentCapability(db, config, {
+				now: CHECKED_AT_MS,
+				probe: async () =>
+					liveSnapshot(config, {
+						status: "unavailable",
+						auth: "unknown",
+						modelSource: "none",
+						models: [],
+						errorKind,
+						checkedAt: CHECKED_AT,
+					}),
+			});
+
+			expect(view.inventory).toBeNull();
+			expect(view.inventoryOrigin).toBe("none");
+			expect(view.health).toMatchObject({
+				errorKind,
+				message,
+			});
+
+			const stored = listCapabilitySnapshots(db, {
+				now: CHECKED_AT_MS,
+				includeHiddenInventory: true,
+			})[0];
+			expect(stored?.inventory?.models).toHaveLength(1);
+			expect(stored?.inventoryCheckedAt).toBe(storedAt);
+			expect(rawSnapshotRow(db, config.id)?.inventoryJson).toContain("model-1");
+
+			const displayed = readPersistedCapabilitySnapshots(db, CHECKED_AT_MS);
+			expect(displayed[0]?.inventory).toBeNull();
+			expect(displayed[0]?.inventoryOrigin).toBe("none");
+			expect(displayed[0]?.health.errorKind).toBe(errorKind);
+		}
+	});
+
+	it("still displays last-good inventory within the 7-day display cap after a transient failure", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const storedAt = CHECKED_AT_MS - CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS + 1;
+		persistSnapshot(db, config, storedAt);
+
+		const view = await refreshAgentCapability(db, config, {
+			now: CHECKED_AT_MS,
+			probe: async () =>
+				liveSnapshot(config, {
+					status: "unavailable",
+					modelSource: "none",
+					models: [],
+					errorKind: "process_failure",
+					checkedAt: CHECKED_AT,
+				}),
+		});
+
+		expect(view.inventory?.models).toHaveLength(1);
+		expect(view.inventoryOrigin).toBe("persisted");
+		expect(
+			readPersistedCapabilitySnapshots(db, CHECKED_AT_MS)[0]?.inventory?.models,
+		).toHaveLength(1);
+	});
+
+	it("persists every unchanged explicit refresh observation", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const launchAt = CHECKED_AT_MS + 31_000;
+
+		await refreshAgentCapability(db, config, {
+			now: launchAt,
+			probe: async () =>
+				liveSnapshot(config, {
+					checkedAt: new Date(launchAt).toISOString(),
+				}),
+		});
+
+		const row = rawSnapshotRow(db, config.id);
+		expect(row?.writtenAt).toBe(launchAt);
+		expect(row?.statusCheckedAt).toBe(launchAt);
+		expect(row?.inventoryCheckedAt).toBe(launchAt);
+	});
+
+	it("writes immediately when an explicit refresh changes inventory", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const launchAt = CHECKED_AT_MS + 31_000;
+
+		await refreshAgentCapability(db, config, {
+			now: launchAt,
+			probe: async () =>
+				liveSnapshot(config, {
+					checkedAt: new Date(launchAt).toISOString(),
+					models: [
+						{
+							id: "model-2",
+							label: "Model 2",
+							reasoning: { state: "unknown" },
+						},
+					],
+				}),
+		});
+
+		const row = rawSnapshotRow(db, config.id);
+		expect(row?.writtenAt).toBe(launchAt);
+		expect(row?.statusCheckedAt).toBe(launchAt);
+		expect(row?.inventoryJson).toContain("model-2");
+		expect(row?.inventoryJson).not.toContain("model-1");
+	});
+
+	it("advances statusCheckedAt when a repeated transient failure is probed", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const firstAt = CHECKED_AT_MS + 10_000;
+		const secondAt = firstAt + 31_000;
+
+		const probe = async (
+			_config: AgentCapabilityConfig,
+			options: { now?: number },
+		): Promise<AgentCapabilitySnapshot> =>
+			liveSnapshot(config, {
+				status: "unavailable",
+				auth: "unknown",
+				modelSource: "none",
+				models: [],
+				errorKind: "timeout",
+				checkedAt: new Date(options.now ?? firstAt).toISOString(),
+			});
+
+		await refreshAgentCapability(db, config, {
+			now: firstAt,
+			probe,
+		});
+		expect(rawSnapshotRow(db, config.id)?.statusCheckedAt).toBe(firstAt);
+
+		await refreshAgentCapability(db, config, {
+			now: secondAt,
+			probe,
+		});
+		const row = rawSnapshotRow(db, config.id);
+		expect(row?.statusCheckedAt).toBe(secondAt);
+		expect(row?.writtenAt).toBe(secondAt);
+		expect(row?.errorKind).toBe("timeout");
+		expect(row?.inventoryJson).toContain("model-1");
+	});
+
+	it("rejects an obsolete revision on an explicit refresh", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		persistSnapshot(db, config);
+		const launchAt = CHECKED_AT_MS + 31_000;
+
+		await expect(
+			refreshAgentCapability(db, config, {
+				now: launchAt,
+				probe: async () => {
+					db.update(schema.hostAgentConfigs)
+						.set({ capabilityRevision: 2 })
+						.where(eq(schema.hostAgentConfigs.id, config.id))
+						.run();
+					return liveSnapshot(config, {
+						checkedAt: new Date(launchAt).toISOString(),
+					});
+				},
+			}),
+		).rejects.toBeInstanceOf(ObsoleteCapabilityRefreshError);
+
+		const row = rawSnapshotRow(db, config.id);
+		expect(row?.writtenAt).toBe(CHECKED_AT_MS);
+		expect(row?.configRevision).toBe(1);
+		expect(row?.inventoryJson).toContain("model-1");
+	});
+
+	it("startup helper prune and hydrate spawn no agent processes", async () => {
+		const spawnSpy = spyOn(childProcess, "spawn");
+		const db = createTestDb();
+		const recent = seedConfig(db, "agent-recent");
+		const expired = seedConfig(db, "agent-expired");
+		persistSnapshot(db, recent, CHECKED_AT_MS);
+		persistSnapshot(
+			db,
+			expired,
+			CHECKED_AT_MS - CAPABILITY_SNAPSHOT_RETENTION_MS - 1,
+		);
+
+		const { snapshots, capabilityRefresh } = initializeHostCapabilitySnapshots(
+			db,
+			CHECKED_AT_MS,
+		);
+
+		expect(spawnSpy).not.toHaveBeenCalled();
+		expect(snapshots.map((view) => view.agentId)).toEqual([recent.id]);
+		expect(rawSnapshotRow(db, expired.id)).toBeUndefined();
+		await capabilityRefresh.dispose();
+		spawnSpy.mockRestore();
+	});
+
+	it("settles aborted probe process trees before SQLite close", async () => {
+		const sqlite = new Database(":memory:");
+		const bunDb = drizzle(sqlite, { schema });
+		migrate(bunDb, { migrationsFolder: MIGRATIONS_FOLDER });
+		sqlite.exec("PRAGMA foreign_keys = ON");
+		// SAFETY: This test uses only schema-bound operations shared by both synchronous Drizzle SQLite drivers.
+		const db = bunDb as unknown as HostDb;
+		const config = seedConfig(db);
+		const service = new CapabilityRefreshService(db);
+		const directory = await mkdtemp(
+			join(tmpdir(), "superset-capability-dispose-"),
+		);
+		const executable = join(directory, "probe-tree");
+		const parentPidFile = join(directory, "parent.pid");
+		const childPidFile = join(directory, "child.pid");
+		await writeFile(
+			executable,
+			`#!/bin/sh
+echo $$ > "${parentPidFile}"
+sleep 30 &
+echo $! > "${childPidFile}"
+wait
+`,
+		);
+		await chmod(executable, 0o755);
+
+		try {
+			let sqliteClosedAt: number | null = null;
+			let abortedAt: number | null = null;
+			const refresh = service
+				.refreshCapability(config, {
+					probe: async (_probeConfig, options) => {
+						try {
+							await runCommand(
+								executable,
+								[],
+								{},
+								30_000,
+								undefined,
+								undefined,
+								options.signal,
+							);
+						} catch (error) {
+							abortedAt = Date.now();
+							expect(sqliteClosedAt).toBeNull();
+							throw error;
+						}
+						return liveSnapshot(config);
+					},
+				})
+				.catch((error: unknown) => error);
+
+			const parentPid = await waitForPidFile(parentPidFile);
+			const childPid = await waitForPidFile(childPidFile);
+			await service.dispose();
+			expect(sqliteClosedAt).toBeNull();
+			sqlite.close();
+			sqliteClosedAt = Date.now();
+
+			expect(await refresh).toBeInstanceOf(AgentCapabilityProbeAbortedError);
+			expect(abortedAt).not.toBeNull();
+			expect(sqliteClosedAt).toBeGreaterThanOrEqual(abortedAt ?? 0);
+			await expectPidGone(parentPid);
+			await expectPidGone(childPid);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/host-service/src/agent-capabilities/capability-refresh-service.ts
+++ b/packages/host-service/src/agent-capabilities/capability-refresh-service.ts
@@ -1,0 +1,433 @@
+import type { HostDb } from "../db";
+import {
+	type AgentCapabilityConfig,
+	type AgentCapabilityErrorKind,
+	AgentCapabilityProbeAbortedError,
+	type AgentCapabilitySnapshot,
+	inspectAgentCapability,
+} from "./agent-capabilities";
+import {
+	type AgentCapabilityInventory,
+	type AgentHealthStatus,
+	CAPABILITY_INVENTORY_SCHEMA_VERSION,
+	CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS,
+	CapabilityInventoryValidationError,
+	displayableCapabilityInventory,
+	encodeCapabilityInventory,
+	listCapabilitySnapshots,
+	type PersistedAgentCapabilitySnapshot,
+	SANITIZED_CAPABILITY_MESSAGES,
+	writeCapabilitySnapshotIfCurrentRevision,
+} from "./capability-snapshot-repository";
+
+export const CAPABILITY_REFRESH_CONCURRENCY = 4;
+
+export interface RevisionedAgentCapabilityConfig extends AgentCapabilityConfig {
+	configRevision: number;
+}
+
+export class ObsoleteCapabilityRefreshError extends Error {
+	constructor(agentId: string) {
+		super(`Capability refresh became obsolete for agent ${agentId}`);
+		this.name = "ObsoleteCapabilityRefreshError";
+	}
+}
+
+export interface AgentHealthObservation {
+	status: AgentHealthStatus;
+	installed: boolean | null;
+	auth: "authenticated" | "unauthenticated" | "unknown";
+	checkedAt: string;
+	errorKind: AgentCapabilityErrorKind | null;
+	message: string | null;
+}
+
+export interface AgentCapabilityView {
+	agentId: string;
+	presetId: string;
+	inventory: AgentCapabilityInventory | null;
+	inventoryOrigin: "live" | "persisted" | "none";
+	health: AgentHealthObservation;
+	healthOrigin: "live" | "persisted" | "none";
+}
+
+type CapabilityProbe = (
+	config: AgentCapabilityConfig,
+	options: { now?: number; signal?: AbortSignal },
+) => Promise<AgentCapabilitySnapshot>;
+
+interface CapabilityRefreshState {
+	abortController: AbortController;
+	disposed: boolean;
+	refreshInFlight: Map<string, Promise<AgentCapabilityView>>;
+}
+
+function createCapabilityRefreshState(): CapabilityRefreshState {
+	return {
+		abortController: new AbortController(),
+		disposed: false,
+		refreshInFlight: new Map(),
+	};
+}
+
+function refreshKey(config: RevisionedAgentCapabilityConfig): string {
+	return `${config.id}:${config.configRevision}`;
+}
+
+function inventoryOrigin(
+	liveInventory: AgentCapabilityInventory | null,
+	mergedInventory: AgentCapabilityInventory | null,
+): AgentCapabilityView["inventoryOrigin"] {
+	if (liveInventory !== null) return "live";
+	if (mergedInventory !== null) return "persisted";
+	return "none";
+}
+
+export function persistedCapabilityToView(
+	snapshot: PersistedAgentCapabilitySnapshot,
+	now = Date.now(),
+): AgentCapabilityView {
+	const inventory = displayableCapabilityInventory(snapshot.inventory, now);
+	return {
+		agentId: snapshot.agentId,
+		presetId: snapshot.presetId,
+		inventory,
+		inventoryOrigin: inventory ? "persisted" : "none",
+		health: {
+			status: snapshot.status,
+			installed: snapshot.installed,
+			auth: snapshot.auth,
+			checkedAt: new Date(snapshot.statusCheckedAt).toISOString(),
+			errorKind: snapshot.errorKind,
+			message: snapshot.message,
+		},
+		healthOrigin: "persisted",
+	};
+}
+
+function sanitizedDiagnosticMessage(
+	snapshot: Pick<AgentCapabilitySnapshot, "auth" | "errorKind">,
+): string | null {
+	if (snapshot.auth === "unauthenticated") {
+		return SANITIZED_CAPABILITY_MESSAGES.authenticationRequired;
+	}
+	switch (snapshot.errorKind) {
+		case "missing_executable":
+			return SANITIZED_CAPABILITY_MESSAGES.missingExecutable;
+		case "timeout":
+			return SANITIZED_CAPABILITY_MESSAGES.timeout;
+		case "process_failure":
+			return SANITIZED_CAPABILITY_MESSAGES.processFailure;
+		case "parse_failure":
+			return SANITIZED_CAPABILITY_MESSAGES.parseFailure;
+		default:
+			return null;
+	}
+}
+
+function isolatedProcessFailureView(
+	config: RevisionedAgentCapabilityConfig,
+	previous: PersistedAgentCapabilitySnapshot | undefined,
+	now: number,
+): AgentCapabilityView {
+	const checkedAt = new Date(now).toISOString();
+	if (!previous) {
+		return {
+			agentId: config.id,
+			presetId: config.presetId,
+			inventory: null,
+			inventoryOrigin: "none",
+			health: {
+				status: "unavailable",
+				installed: null,
+				auth: "unknown",
+				checkedAt,
+				errorKind: "process_failure",
+				message: SANITIZED_CAPABILITY_MESSAGES.processFailure,
+			},
+			healthOrigin: "live",
+		};
+	}
+	return {
+		...persistedCapabilityToView(previous, now),
+		health: {
+			status: "unavailable",
+			installed: previous.installed,
+			auth: "unknown",
+			checkedAt,
+			errorKind: "process_failure",
+			message: SANITIZED_CAPABILITY_MESSAGES.processFailure,
+		},
+		healthOrigin: "live",
+	};
+}
+
+export function readPersistedCapabilitySnapshots(
+	db: HostDb,
+	now = Date.now(),
+): AgentCapabilityView[] {
+	return listCapabilitySnapshots(db, {
+		now,
+		maxDisplayAgeMs: CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS,
+	}).map((snapshot) => persistedCapabilityToView(snapshot, now));
+}
+
+function inventoryFromLiveSnapshot(
+	config: RevisionedAgentCapabilityConfig,
+	live: AgentCapabilitySnapshot,
+): AgentCapabilityInventory | null {
+	if (live.modelSource === "none") return null;
+	return {
+		schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.configRevision,
+		detectedVersion: live.version,
+		modelSource: live.modelSource === "fallback" ? "curated" : "runtime",
+		models: live.models,
+		inventoryCheckedAt: live.checkedAt,
+	};
+}
+
+async function refreshCapabilityUncoalesced(
+	db: HostDb,
+	config: RevisionedAgentCapabilityConfig,
+	previous: PersistedAgentCapabilitySnapshot | undefined,
+	now: number,
+	probe: CapabilityProbe,
+	signal: AbortSignal,
+): Promise<AgentCapabilityView> {
+	let live: AgentCapabilitySnapshot;
+	try {
+		live = await probe(config, { now, signal });
+	} catch (error) {
+		if (signal.aborted || error instanceof AgentCapabilityProbeAbortedError) {
+			throw new AgentCapabilityProbeAbortedError();
+		}
+		const errorKind: AgentCapabilityErrorKind =
+			error instanceof CapabilityInventoryValidationError
+				? "parse_failure"
+				: "process_failure";
+		live = {
+			agentId: config.id,
+			presetId: config.presetId,
+			status: "unavailable",
+			installed: previous?.installed ?? true,
+			auth: "unknown",
+			version: null,
+			modelSource: "none",
+			models: [],
+			message: null,
+			checkedAt: new Date(now).toISOString(),
+			errorKind,
+		};
+	}
+
+	if (signal.aborted) throw new AgentCapabilityProbeAbortedError();
+
+	let liveInventory = inventoryFromLiveSnapshot(config, live);
+	if (liveInventory !== null) {
+		try {
+			encodeCapabilityInventory(liveInventory);
+		} catch {
+			liveInventory = null;
+			live = {
+				...live,
+				status: "unavailable",
+				auth: "unknown",
+				modelSource: "none",
+				models: [],
+				errorKind: "parse_failure",
+				message: null,
+			};
+		}
+	}
+
+	const inventory =
+		liveInventory ??
+		(live.installed === false ? null : (previous?.inventory ?? null));
+	const inventoryCheckedAt = inventory
+		? Date.parse(inventory.inventoryCheckedAt)
+		: null;
+	const message = sanitizedDiagnosticMessage(live);
+	const written = writeCapabilitySnapshotIfCurrentRevision(
+		db,
+		{
+			agentId: config.id,
+			presetId: config.presetId,
+			configRevision: config.configRevision,
+			inventory,
+			status: live.status,
+			installed: live.installed,
+			auth: live.auth,
+			inventoryCheckedAt,
+			statusCheckedAt: Date.parse(live.checkedAt),
+			writtenAt: Date.parse(live.checkedAt),
+			errorKind: live.errorKind ?? null,
+			message,
+			resolverSource: live.resolverSource ?? null,
+		},
+		{ persist: true },
+	);
+	if (!written) throw new ObsoleteCapabilityRefreshError(config.id);
+	const displayInventory = displayableCapabilityInventory(inventory, now);
+	return {
+		agentId: config.id,
+		presetId: config.presetId,
+		inventory: displayInventory,
+		inventoryOrigin: inventoryOrigin(liveInventory, displayInventory),
+		health: {
+			status: live.status,
+			installed: live.installed,
+			auth: live.auth,
+			checkedAt: live.checkedAt,
+			errorKind: live.errorKind ?? null,
+			message,
+		},
+		healthOrigin: "live",
+	};
+}
+
+function refreshAgentCapabilityWithState(
+	db: HostDb,
+	config: RevisionedAgentCapabilityConfig,
+	state: CapabilityRefreshState,
+	options: {
+		now?: number;
+		probe?: CapabilityProbe;
+	} = {},
+): Promise<AgentCapabilityView> {
+	if (state.disposed) {
+		return Promise.reject(new AgentCapabilityProbeAbortedError());
+	}
+	const now = options.now ?? Date.now();
+	const previous = listCapabilitySnapshots(db, {
+		now,
+		agentId: config.id,
+		includeHiddenInventory: true,
+	})[0];
+	const key = refreshKey(config);
+	const existing = state.refreshInFlight.get(key);
+	if (existing) return existing;
+	const refresh = refreshCapabilityUncoalesced(
+		db,
+		config,
+		previous,
+		now,
+		options.probe ?? inspectAgentCapability,
+		state.abortController.signal,
+	).finally(() => {
+		if (state.refreshInFlight.get(key) === refresh) {
+			state.refreshInFlight.delete(key);
+		}
+	});
+	state.refreshInFlight.set(key, refresh);
+	return refresh;
+}
+
+async function refreshAgentCapabilitiesWithState(
+	db: HostDb,
+	configs: RevisionedAgentCapabilityConfig[],
+	state: CapabilityRefreshState,
+	options: {
+		now?: number;
+		concurrency?: number;
+		probe?: CapabilityProbe;
+	} = {},
+): Promise<AgentCapabilityView[]> {
+	const results = new Array<AgentCapabilityView>(configs.length);
+	let nextIndex = 0;
+	const concurrency = Math.max(
+		1,
+		Math.min(
+			options.concurrency ?? CAPABILITY_REFRESH_CONCURRENCY,
+			configs.length,
+		),
+	);
+	async function worker(): Promise<void> {
+		while (nextIndex < configs.length) {
+			const resultIndex = nextIndex;
+			nextIndex += 1;
+			const config = configs[resultIndex];
+			if (!config) continue;
+			try {
+				results[resultIndex] = await refreshAgentCapabilityWithState(
+					db,
+					config,
+					state,
+					{
+						now: options.now,
+						probe: options.probe,
+					},
+				);
+			} catch (error) {
+				if (
+					state.disposed ||
+					state.abortController.signal.aborted ||
+					error instanceof AgentCapabilityProbeAbortedError ||
+					error instanceof ObsoleteCapabilityRefreshError
+				) {
+					throw error;
+				}
+				const previous = listCapabilitySnapshots(db, {
+					now: options.now,
+					agentId: config.id,
+					includeHiddenInventory: true,
+				})[0];
+				results[resultIndex] = isolatedProcessFailureView(
+					config,
+					previous,
+					options.now ?? Date.now(),
+				);
+			}
+		}
+	}
+	await Promise.all(Array.from({ length: concurrency }, () => worker()));
+	return results;
+}
+
+export class CapabilityRefreshService {
+	readonly #state = createCapabilityRefreshState();
+
+	constructor(readonly db: HostDb) {}
+
+	readPersisted(now = Date.now()): AgentCapabilityView[] {
+		return readPersistedCapabilitySnapshots(this.db, now);
+	}
+
+	refreshCapability(
+		config: RevisionedAgentCapabilityConfig,
+		options: { now?: number; probe?: CapabilityProbe } = {},
+	): Promise<AgentCapabilityView> {
+		return refreshAgentCapabilityWithState(
+			this.db,
+			config,
+			this.#state,
+			options,
+		);
+	}
+
+	refreshCapabilities(
+		configs: RevisionedAgentCapabilityConfig[],
+		options: {
+			now?: number;
+			concurrency?: number;
+			probe?: CapabilityProbe;
+		} = {},
+	): Promise<AgentCapabilityView[]> {
+		return refreshAgentCapabilitiesWithState(
+			this.db,
+			configs,
+			this.#state,
+			options,
+		);
+	}
+
+	async dispose(): Promise<void> {
+		if (this.#state.disposed) return;
+		this.#state.disposed = true;
+		this.#state.abortController.abort();
+		await Promise.allSettled(this.#state.refreshInFlight.values());
+		this.#state.refreshInFlight.clear();
+	}
+}

--- a/packages/host-service/src/agent-capabilities/capability-refresh-service.ts
+++ b/packages/host-service/src/agent-capabilities/capability-refresh-service.ts
@@ -212,7 +212,7 @@ async function refreshCapabilityUncoalesced(
 			agentId: config.id,
 			presetId: config.presetId,
 			status: "unavailable",
-			installed: previous?.installed ?? true,
+			installed: previous?.installed ?? null,
 			auth: "unknown",
 			version: null,
 			modelSource: "none",

--- a/packages/host-service/src/agent-capabilities/capability-snapshot-repository.test.ts
+++ b/packages/host-service/src/agent-capabilities/capability-snapshot-repository.test.ts
@@ -1,0 +1,569 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../db";
+import * as schema from "../db/schema";
+import {
+	type AgentCapabilityInventory,
+	CAPABILITY_INVENTORY_SCHEMA_VERSION,
+	CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS,
+	CAPABILITY_SNAPSHOT_RETENTION_MS,
+	CapabilityInventoryValidationError,
+	decodeCapabilityInventory,
+	encodeCapabilityInventory,
+	listCapabilitySnapshots,
+	pruneExpiredCapabilitySnapshots,
+	writeCapabilitySnapshotIfCurrentRevision,
+} from "./capability-snapshot-repository";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../drizzle");
+const testDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		testDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+function openDb(path = ":memory:") {
+	const sqlite = new Database(path);
+	const bunDb = drizzle(sqlite, { schema });
+	migrate(bunDb, { migrationsFolder: MIGRATIONS_FOLDER });
+	sqlite.exec("PRAGMA foreign_keys = ON");
+	// SAFETY: Tests use Bun's SQLite driver, whose run result differs nominally from HostDb; repository operations used here are otherwise identical.
+	return { sqlite, db: bunDb as unknown as HostDb };
+}
+
+function seedConfig(
+	db: HostDb,
+	input: { id?: string; presetId?: string; capabilityRevision?: number } = {},
+) {
+	const config = {
+		id: input.id ?? "agent-1",
+		presetId: input.presetId ?? "codex",
+		capabilityRevision: input.capabilityRevision ?? 1,
+	};
+	db.insert(schema.hostAgentConfigs)
+		.values({
+			...config,
+			label: "Test Agent",
+			command: "test-agent",
+			argsJson: "[]",
+			promptTransport: "argv",
+			promptArgsJson: "[]",
+			resumeArgsJson: "[]",
+			envJson: "{}",
+			displayOrder: 0,
+		})
+		.run();
+	return config;
+}
+
+function inventory(
+	config: ReturnType<typeof seedConfig>,
+	overrides: Partial<AgentCapabilityInventory> = {},
+): AgentCapabilityInventory {
+	return {
+		schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.capabilityRevision,
+		detectedVersion: "1.2.3",
+		modelSource: "runtime",
+		models: [
+			{
+				id: "model-1",
+				label: "Model 1",
+				reasoning: {
+					state: "supported",
+					defaultId: "high",
+					options: [
+						{ id: "low", label: "Low" },
+						{ id: "high", label: "High" },
+					],
+				},
+				variant: {
+					familyId: "model",
+					familyLabel: "Model",
+					effort: "high",
+					speed: "fast",
+					mode: "thinking",
+					contextWindow: "1m",
+				},
+			},
+		],
+		inventoryCheckedAt: "2026-08-14T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function writeSnapshot(
+	db: HostDb,
+	config: ReturnType<typeof seedConfig>,
+	overrides: Partial<
+		Parameters<typeof writeCapabilitySnapshotIfCurrentRevision>[1]
+	> = {},
+) {
+	const now = Date.parse("2026-08-14T12:00:00.000Z");
+	return writeCapabilitySnapshotIfCurrentRevision(db, {
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.capabilityRevision,
+		inventory: inventory(config),
+		status: "ready",
+		installed: true,
+		auth: "authenticated",
+		inventoryCheckedAt: now,
+		statusCheckedAt: now,
+		writtenAt: now,
+		...overrides,
+	});
+}
+
+describe("capability snapshot repository", () => {
+	it("hydrates a valid snapshot after reopening the SQLite database", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-capabilities-"));
+		testDirectories.push(directory);
+		const path = join(directory, "host.sqlite");
+		const first = openDb(path);
+		const config = seedConfig(first.db);
+		expect(writeSnapshot(first.db, config)).toBe(true);
+		first.sqlite.close();
+
+		const reopened = openDb(path);
+		const snapshots = listCapabilitySnapshots(reopened.db, {
+			now: Date.parse("2026-08-14T12:01:00.000Z"),
+		});
+		expect(snapshots).toHaveLength(1);
+		expect(snapshots[0]?.inventory?.models[0]).toMatchObject({
+			id: "model-1",
+			reasoning: { state: "supported", defaultId: "high" },
+			variant: {
+				familyId: "model",
+				familyLabel: "Model",
+				effort: "high",
+				speed: "fast",
+				mode: "thinking",
+				contextWindow: "1m",
+			},
+		});
+		reopened.sqlite.close();
+	});
+
+	it("persists unknown health without coercing installed null", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		expect(
+			writeSnapshot(db, config, {
+				inventory: null,
+				status: "unknown",
+				installed: null,
+				auth: "unknown",
+				inventoryCheckedAt: null,
+			}),
+		).toBe(true);
+		expect(
+			listCapabilitySnapshots(db, {
+				now: Date.parse("2026-08-14T12:01:00.000Z"),
+			})[0],
+		).toMatchObject({
+			status: "unknown",
+			installed: null,
+			auth: "unknown",
+			inventory: null,
+		});
+	});
+
+	it("rejects and deletes secret-bearing diagnostic messages", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		expect(() =>
+			writeSnapshot(db, config, {
+				message: "sk-secret-regression-token-9f3a leaked from stderr",
+			}),
+		).toThrow(CapabilityInventoryValidationError);
+
+		writeSnapshot(db, config);
+		db.update(schema.hostAgentCapabilitySnapshots)
+			.set({ message: "sk-secret-regression-token-9f3a leaked from stderr" })
+			.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+			.run();
+		expect(listCapabilitySnapshots(db)).toEqual([]);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("applies the generated snapshot migration on a fresh temp database", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "superset-cap-migrate-"));
+		testDirectories.push(directory);
+		const path = join(directory, "host.sqlite");
+		const first = openDb(path);
+		const columns = first.sqlite
+			.query("pragma table_info(host_agent_capability_snapshots)")
+			.all() as Array<{ name: string }>;
+		expect(columns.map((column) => column.name)).toEqual(
+			expect.arrayContaining([
+				"agent_id",
+				"preset_id",
+				"config_revision",
+				"schema_version",
+				"inventory_json",
+				"status",
+				"installed",
+				"auth",
+				"error_kind",
+				"message",
+				"resolver_source",
+				"inventory_checked_at",
+				"status_checked_at",
+				"written_at",
+			]),
+		);
+		const configColumns = first.sqlite
+			.query("pragma table_info(host_agent_configs)")
+			.all() as Array<{ name: string }>;
+		expect(configColumns.map((column) => column.name)).toContain(
+			"capability_revision",
+		);
+		const config = seedConfig(first.db);
+		expect(writeSnapshot(first.db, config)).toBe(true);
+		first.sqlite.close();
+
+		const reopened = openDb(path);
+		expect(
+			listCapabilitySnapshots(reopened.db, {
+				now: Date.parse("2026-08-14T12:01:00.000Z"),
+			}),
+		).toHaveLength(1);
+		reopened.sqlite.close();
+	});
+
+	it("keeps missing-executable health while clearing inventory", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		expect(
+			writeSnapshot(db, config, {
+				inventory: null,
+				status: "unavailable",
+				installed: false,
+				auth: "unknown",
+				inventoryCheckedAt: null,
+			}),
+		).toBe(true);
+		const snapshot = listCapabilitySnapshots(db, {
+			now: Date.parse("2026-08-14T12:01:00.000Z"),
+		})[0];
+		expect(snapshot).toMatchObject({
+			status: "unavailable",
+			installed: false,
+			auth: "unknown",
+			inventory: null,
+		});
+	});
+
+	it("rejects an obsolete probe after the config revision changes", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		db.update(schema.hostAgentConfigs)
+			.set({ capabilityRevision: config.capabilityRevision + 1 })
+			.where(eq(schema.hostAgentConfigs.id, config.id))
+			.run();
+
+		expect(writeSnapshot(db, config)).toBe(false);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("deletes corrupt and mismatched persisted rows", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		writeSnapshot(db, config);
+		db.update(schema.hostAgentCapabilitySnapshots)
+			.set({ inventoryJson: "{not-json" })
+			.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+			.run();
+		expect(listCapabilitySnapshots(db)).toEqual([]);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeUndefined();
+
+		writeSnapshot(db, config);
+		db.update(schema.hostAgentCapabilitySnapshots)
+			.set({ configRevision: config.capabilityRevision + 1 })
+			.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+			.run();
+		expect(listCapabilitySnapshots(db)).toEqual([]);
+	});
+
+	it("deletes rows with an unknown schema version", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		writeSnapshot(db, config);
+		db.update(schema.hostAgentCapabilitySnapshots)
+			.set({ schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION + 1 })
+			.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+			.run();
+		expect(listCapabilitySnapshots(db)).toEqual([]);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("strictly rejects duplicate ids, unknown fields, and oversized payloads", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		const duplicateModels = inventory(config, {
+			models: [...inventory(config).models, ...inventory(config).models],
+		});
+		expect(() => encodeCapabilityInventory(duplicateModels)).toThrow(
+			CapabilityInventoryValidationError,
+		);
+
+		const withSecret = {
+			...inventory(config),
+			env: { SECRET_TOKEN: "must-not-persist" },
+		};
+		expect(() => encodeCapabilityInventory(withSecret)).toThrow(
+			CapabilityInventoryValidationError,
+		);
+
+		const oversized = inventory(config, {
+			models: Array.from({ length: 2_000 }, (_, index) => ({
+				id: `model-${index}`,
+				label: `Model ${index} ${"x".repeat(300)}`,
+				reasoning: { state: "unknown" as const },
+			})),
+		});
+		expect(() => encodeCapabilityInventory(oversized)).toThrow(/size limit/);
+	});
+
+	it("rejects invalid defaults and duplicate reasoning options", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		const base = inventory(config).models[0];
+		expect(base).toBeDefined();
+		if (!base) return;
+		expect(() =>
+			encodeCapabilityInventory(
+				inventory(config, {
+					models: [
+						{
+							...base,
+							reasoning: {
+								state: "supported",
+								defaultId: "missing",
+								options: [{ id: "high", label: "High" }],
+							},
+						},
+					],
+				}),
+			),
+		).toThrow(CapabilityInventoryValidationError);
+		expect(() =>
+			decodeCapabilityInventory(
+				JSON.stringify(
+					inventory(config, {
+						models: [
+							{
+								...base,
+								reasoning: {
+									state: "supported",
+									options: [
+										{ id: "high", label: "High" },
+										{ id: "high", label: "High Again" },
+									],
+								},
+							},
+						],
+					}),
+				),
+			),
+		).toThrow(CapabilityInventoryValidationError);
+	});
+
+	it("keeps display-expired rows until retention cleanup", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		const storedAt = 1_000;
+		writeSnapshot(db, config, {
+			writtenAt: storedAt,
+			statusCheckedAt: storedAt,
+			inventoryCheckedAt: storedAt,
+			inventory: inventory(config, {
+				inventoryCheckedAt: new Date(storedAt).toISOString(),
+			}),
+		});
+		const listed = listCapabilitySnapshots(db, {
+			now: 10_000,
+			maxDisplayAgeMs: 1_000,
+		});
+		expect(listed).toHaveLength(1);
+		expect(listed[0]?.inventory).toBeNull();
+		expect(listed[0]?.inventoryCheckedAt).toBe(storedAt);
+		const stored = listCapabilitySnapshots(db, {
+			now: 10_000,
+			maxDisplayAgeMs: 1_000,
+			includeHiddenInventory: true,
+		})[0];
+		expect(stored?.inventory?.models).toHaveLength(1);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeDefined();
+		expect(
+			pruneExpiredCapabilitySnapshots(db, { now: 10_000, retentionMs: 1_000 }),
+		).toBe(1);
+	});
+
+	it("cascade-deletes a snapshot with its agent config", () => {
+		const { db } = openDb();
+		const config = seedConfig(db);
+		writeSnapshot(db, config);
+		db.delete(schema.hostAgentConfigs)
+			.where(eq(schema.hostAgentConfigs.id, config.id))
+			.run();
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("prunes retention-expired snapshots while respecting max display age", () => {
+		const { db } = openDb();
+		const config1 = seedConfig(db, { id: "agent-recent" });
+		const config2 = seedConfig(db, { id: "agent-old" });
+		const now = Date.parse("2026-08-14T12:00:00.000Z");
+		const recentAt = now - 5 * 86_400_000;
+		const oldAt = now - 10 * 86_400_000;
+
+		writeSnapshot(db, config1, {
+			writtenAt: recentAt,
+			statusCheckedAt: recentAt,
+			inventoryCheckedAt: recentAt,
+			inventory: inventory(config1, {
+				inventoryCheckedAt: new Date(recentAt).toISOString(),
+			}),
+		});
+		writeSnapshot(db, config2, {
+			writtenAt: oldAt,
+			statusCheckedAt: oldAt,
+			inventoryCheckedAt: oldAt,
+			inventory: inventory(config2, {
+				inventoryCheckedAt: new Date(oldAt).toISOString(),
+			}),
+		});
+
+		const displayable = listCapabilitySnapshots(db, { now });
+		expect(displayable).toHaveLength(2);
+		expect(
+			displayable.find((snapshot) => snapshot.agentId === "agent-recent")
+				?.inventory,
+		).not.toBeNull();
+		expect(
+			displayable.find((snapshot) => snapshot.agentId === "agent-old")
+				?.inventory,
+		).toBeNull();
+		expect(
+			listCapabilitySnapshots(db, { now, includeHiddenInventory: true }).find(
+				(snapshot) => snapshot.agentId === "agent-old",
+			)?.inventory?.models,
+		).toHaveLength(1);
+
+		expect(pruneExpiredCapabilitySnapshots(db, { now })).toBe(0);
+
+		const futureNow = now + 25 * 86_400_000;
+		expect(pruneExpiredCapabilitySnapshots(db, { now: futureNow })).toBe(1);
+		expect(
+			db
+				.select()
+				.from(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config2.id))
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("keeps the 7-day display cap distinct from 30-day retention", () => {
+		const { db } = openDb();
+		const displayableConfig = seedConfig(db, { id: "agent-displayable" });
+		const hiddenConfig = seedConfig(db, { id: "agent-hidden" });
+		const retainedConfig = seedConfig(db, { id: "agent-retained" });
+		const now = Date.parse("2026-08-14T12:00:00.000Z");
+		const displayableAt = now - CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS;
+		const hiddenAt = now - CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS - 1;
+		const retainedAt = now - CAPABILITY_SNAPSHOT_RETENTION_MS + 1;
+
+		for (const [config, storedAt] of [
+			[displayableConfig, displayableAt],
+			[hiddenConfig, hiddenAt],
+			[retainedConfig, retainedAt],
+		] as const) {
+			writeSnapshot(db, config, {
+				writtenAt: storedAt,
+				statusCheckedAt: storedAt,
+				inventoryCheckedAt: storedAt,
+				inventory: inventory(config, {
+					inventoryCheckedAt: new Date(storedAt).toISOString(),
+				}),
+			});
+		}
+
+		const displayed = listCapabilitySnapshots(db, { now });
+		expect(
+			displayed.find((snapshot) => snapshot.agentId === "agent-displayable")
+				?.inventory,
+		).not.toBeNull();
+		expect(
+			displayed.find((snapshot) => snapshot.agentId === "agent-hidden")
+				?.inventory,
+		).toBeNull();
+		expect(
+			displayed.find((snapshot) => snapshot.agentId === "agent-retained")
+				?.inventory,
+		).toBeNull();
+
+		const stored = listCapabilitySnapshots(db, {
+			now,
+			includeHiddenInventory: true,
+		});
+		expect(stored.map((snapshot) => snapshot.agentId).sort()).toEqual([
+			"agent-displayable",
+			"agent-hidden",
+			"agent-retained",
+		]);
+		expect(
+			stored.every((snapshot) => snapshot.inventory?.models.length === 1),
+		).toBe(true);
+		expect(pruneExpiredCapabilitySnapshots(db, { now })).toBe(0);
+	});
+});

--- a/packages/host-service/src/agent-capabilities/capability-snapshot-repository.ts
+++ b/packages/host-service/src/agent-capabilities/capability-snapshot-repository.ts
@@ -1,0 +1,514 @@
+import { Buffer } from "node:buffer";
+import type { AgentCapabilityTrait } from "@superset/shared/agent-models";
+import { eq, lt } from "drizzle-orm";
+import { z } from "zod";
+import type { HostDb } from "../db";
+import { hostAgentCapabilitySnapshots, hostAgentConfigs } from "../db/schema";
+import type {
+	AgentCapabilityErrorKind,
+	AgentCapabilityModel,
+	AgentCapabilityStatus,
+} from "./agent-capabilities";
+import type { AgentExecutableSource } from "./executable-resolver";
+
+export const CAPABILITY_INVENTORY_SCHEMA_VERSION = 2;
+export const MAX_CAPABILITY_INVENTORY_BYTES = 512 * 1024;
+export const MAX_CAPABILITY_MODELS = 2_000;
+export const MAX_CAPABILITY_STRING_LENGTH = 512;
+export const CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+export const CAPABILITY_SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+
+export const SANITIZED_CAPABILITY_MESSAGES = {
+	authenticationRequired: "Authentication required",
+	missingExecutable: "Configured executable was not found",
+	timeout: "Capability probe timed out",
+	processFailure: "Capability probe process failed",
+	parseFailure: "Capability response could not be parsed",
+} as const;
+
+export const SANITIZED_CAPABILITY_MESSAGE_VALUES: ReadonlySet<string> = new Set(
+	Object.values(SANITIZED_CAPABILITY_MESSAGES),
+);
+
+export type AgentHealthStatus = AgentCapabilityStatus | "unknown";
+
+type PersistedAuth = "authenticated" | "unauthenticated" | "unknown";
+
+export interface AgentCapabilityInventory {
+	schemaVersion: typeof CAPABILITY_INVENTORY_SCHEMA_VERSION;
+	agentId: string;
+	presetId: string;
+	configRevision: number;
+	detectedVersion: string | null;
+	modelSource: "runtime" | "curated";
+	models: AgentCapabilityModel[];
+	inventoryCheckedAt: string;
+}
+
+export interface PersistedAgentCapabilitySnapshot {
+	agentId: string;
+	presetId: string;
+	configRevision: number;
+	inventory: AgentCapabilityInventory | null;
+	status: AgentHealthStatus;
+	installed: boolean | null;
+	auth: PersistedAuth;
+	errorKind: AgentCapabilityErrorKind | null;
+	message: string | null;
+	resolverSource: AgentExecutableSource | null;
+	inventoryCheckedAt: number | null;
+	statusCheckedAt: number;
+	writtenAt: number;
+}
+
+export interface CapabilitySnapshotWrite {
+	agentId: string;
+	presetId: string;
+	configRevision: number;
+	inventory: AgentCapabilityInventory | null;
+	status: AgentHealthStatus;
+	installed: boolean | null;
+	auth: PersistedAuth;
+	errorKind?: AgentCapabilityErrorKind | null;
+	message?: string | null;
+	resolverSource?: AgentExecutableSource | null;
+	inventoryCheckedAt: number | null;
+	statusCheckedAt: number;
+	writtenAt: number;
+}
+
+export class CapabilityInventoryValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CapabilityInventoryValidationError";
+	}
+}
+
+const boundedString = z.string().min(1).max(MAX_CAPABILITY_STRING_LENGTH);
+const optionSchema = z
+	.object({
+		id: boundedString,
+		label: boundedString,
+	})
+	.strict();
+const traitSchema: z.ZodType<
+	AgentCapabilityTrait<{ id: string; label: string }>
+> = z.discriminatedUnion("state", [
+	z.object({ state: z.literal("unknown") }).strict(),
+	z.object({ state: z.literal("unsupported") }).strict(),
+	z
+		.object({
+			state: z.literal("supported"),
+			options: z.array(optionSchema).min(1).max(MAX_CAPABILITY_MODELS),
+			defaultId: boundedString.optional(),
+		})
+		.strict(),
+]);
+const modelSchema: z.ZodType<AgentCapabilityModel> = z
+	.object({
+		id: boundedString,
+		label: boundedString,
+		provider: boundedString.optional(),
+		reasoning: traitSchema,
+		variant: z
+			.object({
+				familyId: boundedString,
+				familyLabel: boundedString,
+				effort: boundedString,
+				speed: z.enum(["standard", "fast"]),
+				mode: z.enum(["standard", "thinking"]),
+				contextWindow: z.enum(["default", "1m"]),
+			})
+			.strict()
+			.optional(),
+	})
+	.strict();
+const inventorySchema: z.ZodType<AgentCapabilityInventory> = z
+	.object({
+		schemaVersion: z.literal(CAPABILITY_INVENTORY_SCHEMA_VERSION),
+		agentId: boundedString,
+		presetId: boundedString,
+		configRevision: z.number().int().positive(),
+		detectedVersion: boundedString.nullable(),
+		modelSource: z.enum(["runtime", "curated"]),
+		models: z.array(modelSchema).max(MAX_CAPABILITY_MODELS),
+		inventoryCheckedAt: z.string().datetime(),
+	})
+	.strict();
+
+function assertUniqueIds(inventory: AgentCapabilityInventory): void {
+	const modelIds = new Set<string>();
+	for (const model of inventory.models) {
+		if (modelIds.has(model.id)) {
+			throw new CapabilityInventoryValidationError(
+				`Duplicate capability model id: ${model.id}`,
+			);
+		}
+		modelIds.add(model.id);
+		if (model.reasoning.state !== "supported") continue;
+		const optionIds = new Set<string>();
+		for (const option of model.reasoning.options) {
+			if (optionIds.has(option.id)) {
+				throw new CapabilityInventoryValidationError(
+					`Duplicate reasoning option id for ${model.id}: ${option.id}`,
+				);
+			}
+			optionIds.add(option.id);
+		}
+		if (
+			model.reasoning.defaultId !== undefined &&
+			!optionIds.has(model.reasoning.defaultId)
+		) {
+			throw new CapabilityInventoryValidationError(
+				`Unknown default reasoning option for ${model.id}: ${model.reasoning.defaultId}`,
+			);
+		}
+	}
+}
+
+function validateInventory(
+	inventory: AgentCapabilityInventory,
+): AgentCapabilityInventory {
+	const result = inventorySchema.safeParse(inventory);
+	if (!result.success) {
+		throw new CapabilityInventoryValidationError(
+			`Invalid capability inventory: ${result.error.issues[0]?.message ?? "unknown error"}`,
+		);
+	}
+	assertUniqueIds(result.data);
+	return result.data;
+}
+
+export function encodeCapabilityInventory(
+	inventory: AgentCapabilityInventory,
+): string {
+	const parsed = validateInventory(inventory);
+	const encoded = JSON.stringify(parsed);
+	if (Buffer.byteLength(encoded, "utf8") > MAX_CAPABILITY_INVENTORY_BYTES) {
+		throw new CapabilityInventoryValidationError(
+			"Capability inventory exceeds the persistence size limit",
+		);
+	}
+	return encoded;
+}
+
+export function decodeCapabilityInventory(
+	encoded: string,
+): AgentCapabilityInventory {
+	if (Buffer.byteLength(encoded, "utf8") > MAX_CAPABILITY_INVENTORY_BYTES) {
+		throw new CapabilityInventoryValidationError(
+			"Capability inventory exceeds the persistence size limit",
+		);
+	}
+	let decoded: ReturnType<typeof JSON.parse>;
+	try {
+		decoded = JSON.parse(encoded);
+	} catch {
+		throw new CapabilityInventoryValidationError(
+			"Capability inventory is not valid JSON",
+		);
+	}
+	const result = inventorySchema.safeParse(decoded);
+	if (!result.success) {
+		throw new CapabilityInventoryValidationError(
+			`Invalid capability inventory: ${result.error.issues[0]?.message ?? "unknown error"}`,
+		);
+	}
+	assertUniqueIds(result.data);
+	return result.data;
+}
+
+function deleteSnapshot(db: HostDb, agentId: string): void {
+	db.delete(hostAgentCapabilitySnapshots)
+		.where(eq(hostAgentCapabilitySnapshots.agentId, agentId))
+		.run();
+}
+
+const capabilityStatusSchema = z.enum([
+	"ready",
+	"unavailable",
+	"authentication_required",
+	"unknown",
+]);
+const persistedAuthSchema = z.enum([
+	"authenticated",
+	"unauthenticated",
+	"unknown",
+]);
+const capabilityErrorKindSchema = z.enum([
+	"timeout",
+	"process_failure",
+	"parse_failure",
+	"missing_executable",
+]);
+const executableSourceSchema = z.enum(["explicit", "path", "wrapper"]);
+const persistedDiagnosticsSchema = z.object({
+	status: capabilityStatusSchema,
+	auth: persistedAuthSchema,
+	errorKind: capabilityErrorKindSchema.nullable(),
+	resolverSource: executableSourceSchema.nullable(),
+});
+
+function isTimestamp(value: number | null): value is number {
+	return value !== null && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function displayableCapabilityInventory(
+	inventory: AgentCapabilityInventory | null,
+	now: number,
+	maxDisplayAgeMs = CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS,
+): AgentCapabilityInventory | null {
+	if (!inventory) return null;
+	const checkedAt = Date.parse(inventory.inventoryCheckedAt);
+	if (!Number.isFinite(checkedAt) || now - checkedAt > maxDisplayAgeMs) {
+		return null;
+	}
+	return inventory;
+}
+
+export function listCapabilitySnapshots(
+	db: HostDb,
+	options: {
+		now?: number;
+		maxDisplayAgeMs?: number;
+		agentId?: string;
+		includeHiddenInventory?: boolean;
+	} = {},
+): PersistedAgentCapabilitySnapshot[] {
+	const now = options.now ?? Date.now();
+	const maxDisplayAgeMs =
+		options.maxDisplayAgeMs ?? CAPABILITY_SNAPSHOT_DISPLAY_MAX_AGE_MS;
+	const includeHiddenInventory = options.includeHiddenInventory === true;
+	const baseQuery = db
+		.select({
+			agentId: hostAgentCapabilitySnapshots.agentId,
+			presetId: hostAgentCapabilitySnapshots.presetId,
+			configRevision: hostAgentCapabilitySnapshots.configRevision,
+			schemaVersion: hostAgentCapabilitySnapshots.schemaVersion,
+			inventoryJson: hostAgentCapabilitySnapshots.inventoryJson,
+			status: hostAgentCapabilitySnapshots.status,
+			installed: hostAgentCapabilitySnapshots.installed,
+			auth: hostAgentCapabilitySnapshots.auth,
+			errorKind: hostAgentCapabilitySnapshots.errorKind,
+			message: hostAgentCapabilitySnapshots.message,
+			resolverSource: hostAgentCapabilitySnapshots.resolverSource,
+			inventoryCheckedAt: hostAgentCapabilitySnapshots.inventoryCheckedAt,
+			statusCheckedAt: hostAgentCapabilitySnapshots.statusCheckedAt,
+			writtenAt: hostAgentCapabilitySnapshots.writtenAt,
+			currentPresetId: hostAgentConfigs.presetId,
+			currentRevision: hostAgentConfigs.capabilityRevision,
+		})
+		.from(hostAgentCapabilitySnapshots)
+		.innerJoin(
+			hostAgentConfigs,
+			eq(hostAgentCapabilitySnapshots.agentId, hostAgentConfigs.id),
+		);
+
+	const rows = options.agentId
+		? baseQuery
+				.where(eq(hostAgentCapabilitySnapshots.agentId, options.agentId))
+				.all()
+		: baseQuery.all();
+
+	return rows.flatMap((row): PersistedAgentCapabilitySnapshot[] => {
+		if (row.schemaVersion !== CAPABILITY_INVENTORY_SCHEMA_VERSION) {
+			deleteSnapshot(db, row.agentId);
+			return [];
+		}
+		if (
+			row.presetId !== row.currentPresetId ||
+			row.configRevision !== row.currentRevision
+		) {
+			deleteSnapshot(db, row.agentId);
+			return [];
+		}
+		const diagnostics = persistedDiagnosticsSchema.safeParse(row);
+		if (
+			!diagnostics.success ||
+			(row.message !== null &&
+				!SANITIZED_CAPABILITY_MESSAGE_VALUES.has(row.message)) ||
+			!isTimestamp(row.statusCheckedAt) ||
+			!isTimestamp(row.writtenAt) ||
+			(row.inventoryCheckedAt !== null && !isTimestamp(row.inventoryCheckedAt))
+		) {
+			deleteSnapshot(db, row.agentId);
+			return [];
+		}
+		let inventory: AgentCapabilityInventory | null = null;
+		if (row.inventoryJson !== null) {
+			try {
+				inventory = decodeCapabilityInventory(row.inventoryJson);
+			} catch {
+				deleteSnapshot(db, row.agentId);
+				return [];
+			}
+			if (
+				row.inventoryCheckedAt === null ||
+				Date.parse(inventory.inventoryCheckedAt) !== row.inventoryCheckedAt ||
+				inventory.agentId !== row.agentId ||
+				inventory.presetId !== row.presetId ||
+				inventory.configRevision !== row.configRevision ||
+				inventory.schemaVersion !== row.schemaVersion
+			) {
+				deleteSnapshot(db, row.agentId);
+				return [];
+			}
+		} else if (row.inventoryCheckedAt !== null) {
+			deleteSnapshot(db, row.agentId);
+			return [];
+		}
+
+		let visibleInventory = inventory;
+		if (
+			!includeHiddenInventory &&
+			row.inventoryCheckedAt !== null &&
+			now - row.inventoryCheckedAt > maxDisplayAgeMs
+		) {
+			visibleInventory = null;
+		}
+
+		return [
+			{
+				agentId: row.agentId,
+				presetId: row.presetId,
+				configRevision: row.configRevision,
+				inventory: visibleInventory,
+				status: diagnostics.data.status,
+				installed: row.installed,
+				auth: diagnostics.data.auth,
+				errorKind: diagnostics.data.errorKind,
+				message: row.message,
+				resolverSource: diagnostics.data.resolverSource,
+				inventoryCheckedAt: row.inventoryCheckedAt,
+				statusCheckedAt: row.statusCheckedAt,
+				writtenAt: row.writtenAt,
+			},
+		];
+	});
+}
+
+export function writeCapabilitySnapshotIfCurrentRevision(
+	db: HostDb,
+	input: CapabilitySnapshotWrite,
+	options: { persist?: boolean } = {},
+): boolean {
+	const persist = options.persist !== false;
+	if (persist) {
+		if (
+			!isTimestamp(input.statusCheckedAt) ||
+			!isTimestamp(input.writtenAt) ||
+			(input.inventoryCheckedAt !== null &&
+				!isTimestamp(input.inventoryCheckedAt))
+		) {
+			throw new CapabilityInventoryValidationError(
+				"Capability snapshot contains an invalid timestamp",
+			);
+		}
+		if (
+			(input.message != null &&
+				!SANITIZED_CAPABILITY_MESSAGE_VALUES.has(input.message)) ||
+			(input.errorKind != null &&
+				!capabilityErrorKindSchema.safeParse(input.errorKind).success) ||
+			(input.resolverSource != null &&
+				!executableSourceSchema.safeParse(input.resolverSource).success) ||
+			!capabilityStatusSchema.safeParse(input.status).success
+		) {
+			throw new CapabilityInventoryValidationError(
+				"Capability snapshot contains invalid diagnostics",
+			);
+		}
+		if (input.inventory === null && input.inventoryCheckedAt !== null) {
+			throw new CapabilityInventoryValidationError(
+				"Capability snapshot without inventory must clear inventoryCheckedAt",
+			);
+		}
+		if (
+			input.inventory !== null &&
+			(input.inventory.agentId !== input.agentId ||
+				input.inventory.presetId !== input.presetId ||
+				input.inventory.configRevision !== input.configRevision)
+		) {
+			throw new CapabilityInventoryValidationError(
+				"Capability inventory identity does not match its snapshot",
+			);
+		}
+		if (
+			input.inventory !== null &&
+			(input.inventoryCheckedAt === null ||
+				Date.parse(input.inventory.inventoryCheckedAt) !==
+					input.inventoryCheckedAt)
+		) {
+			throw new CapabilityInventoryValidationError(
+				"Capability inventory timestamp does not match its snapshot",
+			);
+		}
+	}
+
+	let inventoryJson: string | null = null;
+	if (persist && input.inventory !== null) {
+		inventoryJson = encodeCapabilityInventory(input.inventory);
+	}
+
+	return db.transaction((tx) => {
+		const current = tx
+			.select({
+				presetId: hostAgentConfigs.presetId,
+				capabilityRevision: hostAgentConfigs.capabilityRevision,
+			})
+			.from(hostAgentConfigs)
+			.where(eq(hostAgentConfigs.id, input.agentId))
+			.get();
+		if (
+			!current ||
+			current.presetId !== input.presetId ||
+			current.capabilityRevision !== input.configRevision
+		) {
+			return false;
+		}
+		if (!persist) return true;
+
+		const values = {
+			agentId: input.agentId,
+			presetId: input.presetId,
+			configRevision: input.configRevision,
+			schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+			inventoryJson,
+			status: input.status,
+			installed: input.installed,
+			auth: input.auth,
+			errorKind: input.errorKind ?? null,
+			message: input.message ?? null,
+			resolverSource: input.resolverSource ?? null,
+			inventoryCheckedAt: input.inventoryCheckedAt,
+			statusCheckedAt: input.statusCheckedAt,
+			writtenAt: input.writtenAt,
+		};
+		tx.insert(hostAgentCapabilitySnapshots)
+			.values(values)
+			.onConflictDoUpdate({
+				target: hostAgentCapabilitySnapshots.agentId,
+				set: values,
+			})
+			.run();
+		return true;
+	});
+}
+
+export function invalidateCapabilitySnapshot(
+	db: HostDb,
+	agentId: string,
+): void {
+	deleteSnapshot(db, agentId);
+}
+
+export function pruneExpiredCapabilitySnapshots(
+	db: HostDb,
+	options: { now?: number; retentionMs?: number } = {},
+): number {
+	const now = options.now ?? Date.now();
+	const retentionMs = options.retentionMs ?? CAPABILITY_SNAPSHOT_RETENTION_MS;
+	return db
+		.delete(hostAgentCapabilitySnapshots)
+		.where(lt(hostAgentCapabilitySnapshots.writtenAt, now - retentionMs))
+		.run().changes;
+}

--- a/packages/host-service/src/agent-capabilities/capability-startup.ts
+++ b/packages/host-service/src/agent-capabilities/capability-startup.ts
@@ -1,0 +1,23 @@
+import type { HostDb } from "../db";
+import {
+	type AgentCapabilityView,
+	CapabilityRefreshService,
+	readPersistedCapabilitySnapshots,
+} from "./capability-refresh-service";
+import { pruneExpiredCapabilitySnapshots } from "./capability-snapshot-repository";
+
+export interface CapabilityStartupResult {
+	snapshots: AgentCapabilityView[];
+	capabilityRefresh: CapabilityRefreshService;
+}
+
+export function initializeHostCapabilitySnapshots(
+	db: HostDb,
+	now = Date.now(),
+): CapabilityStartupResult {
+	pruneExpiredCapabilitySnapshots(db, { now });
+	return {
+		snapshots: readPersistedCapabilitySnapshots(db, now),
+		capabilityRefresh: new CapabilityRefreshService(db),
+	};
+}

--- a/packages/host-service/src/agent-capabilities/executable-resolver.test.ts
+++ b/packages/host-service/src/agent-capabilities/executable-resolver.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { resolveAgentExecutable } from "./executable-resolver";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "superset-resolver-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+async function writeExecutable(
+	path: string,
+	contents: string | Uint8Array = "#!/bin/sh\nexit 0\n",
+) {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, contents);
+	await chmod(path, 0o755);
+}
+
+describe("resolveAgentExecutable", () => {
+	test("resolves an explicit executable path containing spaces", async () => {
+		const directory = await createTemporaryDirectory();
+		const executable = join(directory, "agent tools", "my agent");
+		await writeExecutable(executable);
+
+		await expect(resolveAgentExecutable(executable, {})).resolves.toEqual({
+			path: executable,
+			source: "explicit",
+		});
+	});
+
+	test("resolves commands from PATH", async () => {
+		const directory = await createTemporaryDirectory();
+		const executable = join(directory, "agent");
+		await writeExecutable(executable);
+
+		await expect(
+			resolveAgentExecutable("agent", { PATH: directory }),
+		).resolves.toEqual({ path: executable, source: "path" });
+	});
+
+	test("uses the first PATH executable, including a wrapper", async () => {
+		const directory = await createTemporaryDirectory();
+		const wrapperDirectory = join(directory, "wrapper");
+		const nativeDirectory = join(directory, "native");
+		const wrapper = join(wrapperDirectory, "agent");
+		const native = join(nativeDirectory, "agent");
+		await writeExecutable(
+			wrapper,
+			'#!/bin/sh\npackage="@example/agent"\ncommand="agent"\n',
+		);
+		await writeExecutable(native);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: `${wrapperDirectory}:${nativeDirectory}` },
+				{ pathDelimiter: ":", platform: "linux" },
+			),
+		).resolves.toEqual({ path: wrapper, source: "path" });
+	});
+
+	test("skips Superset's managed wrapper and resolves the real executable", async () => {
+		const directory = await createTemporaryDirectory();
+		const wrapperDirectory = join(directory, "superset");
+		const nativeDirectory = join(directory, "native");
+		const wrapper = join(wrapperDirectory, "agent");
+		const native = join(nativeDirectory, "agent");
+		await writeExecutable(
+			wrapper,
+			"#!/bin/sh\n# Superset agent-wrapper v3\nexit 127\n",
+		);
+		await writeExecutable(native);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: `${wrapperDirectory}:${nativeDirectory}` },
+				{ pathDelimiter: ":", platform: "linux" },
+			),
+		).resolves.toEqual({ path: native, source: "wrapper" });
+	});
+
+	test("treats an orphaned Superset wrapper as missing", async () => {
+		const directory = await createTemporaryDirectory();
+		const wrapper = join(directory, "agent");
+		await writeExecutable(
+			wrapper,
+			"#!/bin/sh\n# Superset agent-wrapper v3\nexit 127\n",
+		);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: directory },
+				{ pathDelimiter: ":", platform: "linux" },
+			),
+		).resolves.toBeNull();
+	});
+
+	test("ignores package dependency bins for implicit agent commands", async () => {
+		const directory = await createTemporaryDirectory();
+		const dependencyBin = join(directory, "node_modules", ".bin", "agent");
+		await writeExecutable(dependencyBin);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: dirname(dependencyBin) },
+				{ pathDelimiter: ":", platform: "linux" },
+			),
+		).resolves.toBeNull();
+		await expect(
+			resolveAgentExecutable(dependencyBin, {}, { platform: "linux" }),
+		).resolves.toEqual({ path: dependencyBin, source: "explicit" });
+	});
+
+	test("finds Windows cmd shims through PATHEXT", async () => {
+		const directory = await createTemporaryDirectory();
+		const executable = join(directory, "agent.CMD");
+		await writeExecutable(executable);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: directory, PATHEXT: ".CMD" },
+				{ pathDelimiter: ";", platform: "win32" },
+			),
+		).resolves.toEqual({ path: executable, source: "path" });
+	});
+
+	test("uses the first Windows CMD shim", async () => {
+		const directory = await createTemporaryDirectory();
+		const wrapperDirectory = join(directory, "wrapper");
+		const nativeDirectory = join(directory, "native");
+		const wrapper = join(wrapperDirectory, "agent.CMD");
+		const native = join(nativeDirectory, "agent.CMD");
+		await writeExecutable(
+			wrapper,
+			'@echo off\npackage="@example/agent"\ncommand="agent"\n',
+		);
+		await writeExecutable(native);
+
+		await expect(
+			resolveAgentExecutable(
+				"agent",
+				{ PATH: `${wrapperDirectory};${nativeDirectory}`, PATHEXT: ".CMD" },
+				{ pathDelimiter: ";", platform: "win32" },
+			),
+		).resolves.toEqual({ path: wrapper, source: "path" });
+	});
+});

--- a/packages/host-service/src/agent-capabilities/executable-resolver.ts
+++ b/packages/host-service/src/agent-capabilities/executable-resolver.ts
@@ -1,0 +1,111 @@
+import { constants } from "node:fs";
+import { access, open } from "node:fs/promises";
+import {
+	extname,
+	isAbsolute,
+	join,
+	resolve,
+	delimiter as systemPathDelimiter,
+} from "node:path";
+import { WRAPPER_MARKER } from "@superset/agent-setup";
+
+export type AgentExecutableSource = "explicit" | "path" | "wrapper";
+
+export interface ResolvedAgentExecutable {
+	path: string;
+	source: AgentExecutableSource;
+}
+
+interface ResolveAgentExecutableOptions {
+	pathDelimiter?: string;
+	platform?: NodeJS.Platform;
+}
+
+function executableNames(
+	command: string,
+	env: NodeJS.ProcessEnv,
+	platform: NodeJS.Platform,
+): string[] {
+	if (platform !== "win32" || extname(command) !== "") return [command];
+	const extensions = (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+		.split(";")
+		.filter(Boolean);
+	return [command, ...extensions.map((extension) => `${command}${extension}`)];
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function isSupersetManagedWrapper(path: string): Promise<boolean> {
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	try {
+		handle = await open(path, "r");
+		const buffer = Buffer.alloc(512);
+		const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+		return buffer.toString("utf8", 0, bytesRead).includes(WRAPPER_MARKER);
+	} catch {
+		return false;
+	} finally {
+		await handle?.close().catch(() => undefined);
+	}
+}
+
+function isPackageManagerBin(path: string): boolean {
+	return /[\\/]node_modules[\\/]\.bin[\\/]/.test(path);
+}
+
+export async function resolveAgentExecutable(
+	command: string,
+	env: NodeJS.ProcessEnv,
+	options: ResolveAgentExecutableOptions = {},
+): Promise<ResolvedAgentExecutable | null> {
+	const platform = options.platform ?? process.platform;
+	const pathDelimiter = options.pathDelimiter ?? systemPathDelimiter;
+	const explicit =
+		isAbsolute(command) || command.includes("/") || command.includes("\\");
+	const names = executableNames(command, env, platform);
+	const candidates = explicit
+		? names.map((name) => resolve(name))
+		: (env.PATH ?? "")
+				.split(pathDelimiter)
+				.filter(Boolean)
+				.flatMap((directory) => names.map((name) => join(directory, name)));
+	if (explicit) {
+		for (const candidate of candidates) {
+			if (await isExecutable(candidate)) {
+				if (await isSupersetManagedWrapper(candidate)) {
+					const commandName = candidate.split(/[\\/]/).at(-1);
+					if (!commandName) return null;
+					return resolveAgentExecutable(commandName, env, options);
+				}
+				return { path: candidate, source: "explicit" };
+			}
+		}
+		return null;
+	}
+
+	let skippedManagedWrapper = false;
+	for (const candidate of candidates) {
+		if (!(await isExecutable(candidate))) continue;
+		// Dev/package-manager launchers prepend dependency bins to PATH. Those
+		// executables are not available in the user's terminal and must not make a
+		// bundled SDK dependency look like an installed agent CLI. An explicitly
+		// configured path still remains valid through the branch above.
+		if (isPackageManagerBin(candidate)) continue;
+		if (await isSupersetManagedWrapper(candidate)) {
+			skippedManagedWrapper = true;
+			continue;
+		}
+		return {
+			path: candidate,
+			source: skippedManagedWrapper ? "wrapper" : "path",
+		};
+	}
+	return null;
+}

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -6,6 +6,7 @@ import { TRPCError } from "@trpc/server";
 import type { MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { initializeHostCapabilitySnapshots } from "./agent-capabilities/capability-startup";
 import { createApiClient } from "./api";
 import { createChatV3Mount, registerChatV3Routes } from "./chat-v3";
 import { createDb, type HostDb } from "./db";
@@ -76,6 +77,9 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		options.api ??
 		createApiClient(config.cloudApiUrl, providers.auth, config.organizationId);
 	const db = options.db ?? createDb(config.dbPath, config.migrationsFolder);
+	// Startup hydration is SQLite-only. Retention cleanup must never spawn an
+	// agent CLI or turn application startup into a capability refresh.
+	const { capabilityRefresh } = initializeHostCapabilitySnapshots(db);
 	const git = createGitFactory(providers.credentials);
 	const github =
 		options.github ??
@@ -210,6 +214,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 			execGh,
 			api,
 			db,
+			capabilityRefresh,
 			runtime,
 			eventBus,
 			terminalAgentStore,
@@ -254,6 +259,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 					execGh,
 					api,
 					db,
+					capabilityRefresh,
 					runtime,
 					eventBus,
 					terminalAgentStore,
@@ -290,6 +296,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 			gitWatcher.close();
 		} catch (err) {
 			console.warn("[host-service] gitWatcher.close failed:", err);
+		}
+		try {
+			await capabilityRefresh.dispose();
+		} catch (err) {
+			console.warn("[host-service] capability refresh dispose failed:", err);
 		}
 		if (ownsDb) {
 			try {

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -186,6 +186,7 @@ export const hostAgentConfigs = sqliteTable(
 		// them. Empty means the agent has no id-based resume.
 		resumeArgsJson: text("resume_args_json").notNull().default("[]"),
 		envJson: text("env_json").notNull().default("{}"),
+		capabilityRevision: integer("capability_revision").notNull().default(1),
 		displayOrder: integer("display_order").notNull(),
 		createdAt: integer("created_at")
 			.notNull()
@@ -196,6 +197,31 @@ export const hostAgentConfigs = sqliteTable(
 	},
 	(table) => [
 		index("host_agent_configs_display_order_idx").on(table.displayOrder),
+	],
+);
+
+export const hostAgentCapabilitySnapshots = sqliteTable(
+	"host_agent_capability_snapshots",
+	{
+		agentId: text("agent_id")
+			.primaryKey()
+			.references(() => hostAgentConfigs.id, { onDelete: "cascade" }),
+		presetId: text("preset_id").notNull(),
+		configRevision: integer("config_revision").notNull(),
+		schemaVersion: integer("schema_version").notNull(),
+		inventoryJson: text("inventory_json"),
+		status: text().notNull(),
+		installed: integer({ mode: "boolean" }),
+		auth: text().notNull(),
+		errorKind: text("error_kind"),
+		message: text(),
+		resolverSource: text("resolver_source"),
+		inventoryCheckedAt: integer("inventory_checked_at"),
+		statusCheckedAt: integer("status_checked_at").notNull(),
+		writtenAt: integer("written_at").notNull(),
+	},
+	(table) => [
+		index("host_agent_capability_snapshots_written_at_idx").on(table.writtenAt),
 	],
 );
 

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -462,6 +462,15 @@ describe("buildTerminalAgentLaunch", () => {
 	it("forwards a supported Claude context window in the model id", async () => {
 		const db = createTestDb();
 		const config = seedConfig(db);
+		db.update(schema.hostAgentConfigs)
+			.set({
+				envJson: JSON.stringify({
+					FOO: "bar",
+					CLAUDE_CODE_DISABLE_1M_CONTEXT: "1",
+				}),
+			})
+			.where(eq(schema.hostAgentConfigs.id, config.id))
+			.run();
 		const selection = { model: "claude-opus-5", contextWindow: "1m" };
 		const validated = await validateFromSnapshot(
 			db,
@@ -479,8 +488,32 @@ describe("buildTerminalAgentLaunch", () => {
 			validated,
 		);
 		expect(launch.fullCommand).toBe(
-			"FOO='bar' 'claude' '--dangerously-skip-permissions' '--model' 'claude-opus-5[1m]' 'do the thing'",
+			"FOO='bar' CLAUDE_CODE_DISABLE_1M_CONTEXT='0' 'claude' '--dangerously-skip-permissions' '--model' 'claude-opus-5[1m]' 'do the thing'",
 		);
+	});
+
+	it("enforces a selected 200k Claude context window in the launch environment", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const selection = { model: "claude-opus-5", contextWindow: "200k" };
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", ...selection },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toContain("CLAUDE_CODE_DISABLE_1M_CONTEXT='1'");
+		expect(launch.fullCommand).toContain("'--model' 'claude-opus-5'");
+		expect(launch.fullCommand).not.toContain("claude-opus-5[1m]");
 	});
 
 	it("resumes a previous session with an empty prompt", async () => {

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,15 +1,24 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
+import { getAgentModelSupport } from "@superset/shared/agent-models";
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { AgentCapabilitySnapshot } from "../../../agent-capabilities/agent-capabilities";
+import { writeCapabilitySnapshotIfCurrentRevision } from "../../../agent-capabilities/capability-snapshot-repository";
 import type { HostDb } from "../../../db";
 import * as schema from "../../../db/schema";
+import type { HostServiceContext } from "../../../types";
 import {
+	type AgentLaunchSelection,
+	agentsRouter,
 	buildAgentCommandString,
 	buildTerminalAgentLaunch,
+	type ValidatedLaunchSelection,
 	validateAgentEffortSelection,
+	validateAgentLaunchSelection,
 	validateAgentResumeSelection,
 } from "./agents";
 
@@ -23,6 +32,7 @@ const argvConfig = {
 	promptArgs: [],
 	resumeArgs: ["--resume"],
 	env: {},
+	capabilityRevision: 1,
 };
 
 const stdinConfig = {
@@ -35,6 +45,7 @@ const stdinConfig = {
 	promptArgs: [],
 	resumeArgs: ["threads", "continue"],
 	env: {},
+	capabilityRevision: 1,
 };
 
 const RANDOM_ID = "test-1234";
@@ -203,14 +214,110 @@ function createTestDb(): HostDb {
 	const sqlite = new Database(":memory:");
 	const db = drizzle(sqlite, { schema });
 	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	// SAFETY: Tests use Bun's SQLite driver, whose run result differs nominally from HostDb; router operations used here are otherwise identical.
 	return db as unknown as HostDb;
+}
+
+const CLAUDE_CONFIG_ID = "00000000-0000-0000-0000-00000000000a";
+const OPENCODE_CONFIG_ID = "00000000-0000-0000-0000-00000000000b";
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const CHECKED_AT = "2026-08-14T12:00:00.000Z";
+
+function persistLaunchSnapshot(
+	db: HostDb,
+	config: { id: string; presetId: string; capabilityRevision?: number },
+	snapshot: AgentCapabilitySnapshot,
+): void {
+	const checkedAt = Date.parse(snapshot.checkedAt);
+	writeCapabilitySnapshotIfCurrentRevision(db, {
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.capabilityRevision ?? 1,
+		inventory:
+			snapshot.modelSource === "none"
+				? null
+				: {
+						schemaVersion: 2,
+						agentId: config.id,
+						presetId: config.presetId,
+						configRevision: config.capabilityRevision ?? 1,
+						detectedVersion: snapshot.version,
+						modelSource:
+							snapshot.modelSource === "runtime" ? "runtime" : "curated",
+						models: snapshot.models,
+						inventoryCheckedAt:
+							snapshot.inventoryCheckedAt ?? snapshot.checkedAt,
+					},
+		status: snapshot.status,
+		installed: snapshot.installed,
+		auth: snapshot.auth,
+		inventoryCheckedAt: snapshot.modelSource === "none" ? null : checkedAt,
+		statusCheckedAt: checkedAt,
+		writtenAt: checkedAt,
+		errorKind: snapshot.errorKind ?? null,
+		message: snapshot.message,
+	});
+}
+
+async function validateFromSnapshot(
+	db: HostDb,
+	input: { agent: string } & AgentLaunchSelection,
+	snapshot: AgentCapabilitySnapshot,
+): Promise<ValidatedLaunchSelection> {
+	persistLaunchSnapshot(
+		db,
+		{ id: snapshot.agentId, presetId: snapshot.presetId },
+		snapshot,
+	);
+	return validateAgentLaunchSelection(db, input);
+}
+
+function fallbackSnapshot(
+	config: { id: string; presetId: string },
+	overrides: Partial<AgentCapabilitySnapshot> = {},
+): AgentCapabilitySnapshot {
+	return {
+		agentId: config.id,
+		presetId: config.presetId,
+		status: "ready",
+		installed: true,
+		auth: "authenticated",
+		version: "1.0.0",
+		modelSource: "fallback",
+		models: [],
+		message: null,
+		checkedAt: CHECKED_AT,
+		inventoryCheckedAt: CHECKED_AT,
+		...overrides,
+	};
+}
+
+function runtimeSnapshot(
+	config: { id: string; presetId: string },
+	models: AgentCapabilitySnapshot["models"],
+	overrides: Partial<AgentCapabilitySnapshot> = {},
+): AgentCapabilitySnapshot {
+	return {
+		agentId: config.id,
+		presetId: config.presetId,
+		status: "ready",
+		installed: true,
+		auth: "authenticated",
+		version: "1.0.0",
+		modelSource: "runtime",
+		models,
+		message: null,
+		checkedAt: CHECKED_AT,
+		inventoryCheckedAt: CHECKED_AT,
+		...overrides,
+	};
 }
 
 describe("buildTerminalAgentLaunch", () => {
 	function seedConfig(db: ReturnType<typeof createTestDb>) {
 		db.insert(schema.hostAgentConfigs)
 			.values({
-				id: "00000000-0000-0000-0000-00000000000a",
+				id: CLAUDE_CONFIG_ID,
 				presetId: "claude",
 				label: "Claude",
 				command: "claude",
@@ -222,43 +329,196 @@ describe("buildTerminalAgentLaunch", () => {
 				displayOrder: 0,
 			})
 			.run();
+		return {
+			id: CLAUDE_CONFIG_ID,
+			presetId: "claude",
+			label: "Claude",
+			capabilityRevision: 1,
+		};
 	}
 
-	it("resolves the agent config to a runnable command without a terminal", () => {
+	it("resolves the agent config to a runnable command without a terminal", async () => {
 		const db = createTestDb();
-		seedConfig(db);
-		const launch = buildTerminalAgentLaunch(db, {
-			workspaceId: "11111111-1111-1111-1111-111111111111",
-			agent: "claude",
-			prompt: "do the thing",
-		});
+		const config = seedConfig(db);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude" },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "do the thing",
+			},
+			validated,
+		);
 		expect(launch.label).toBe("Claude");
 		expect(launch.fullCommand).toBe(
 			"FOO='bar' 'claude' '--dangerously-skip-permissions' 'do the thing'",
 		);
 	});
 
-	it("resumes a previous session with an empty prompt", () => {
+	it("combines Claude Fast Mode and Ultracode settings", async () => {
 		const db = createTestDb();
-		seedConfig(db);
-		const launch = buildTerminalAgentLaunch(db, {
-			workspaceId: "11111111-1111-1111-1111-111111111111",
-			agent: "claude",
-			prompt: "",
-			resumeSessionId: "abc-123",
-		});
+		const config = seedConfig(db);
+		const selection = {
+			model: "claude-opus-5",
+			effort: "ultracode",
+			speed: "fast",
+		};
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", ...selection },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"FOO='bar' 'claude' '--dangerously-skip-permissions' '--model' 'claude-opus-5' '--effort' 'xhigh' '--settings' '{\"fastMode\":true,\"ultracode\":true}' 'do the thing'",
+		);
+	});
+
+	it("keeps OpenCode reasoning variants independent from agent modes", async () => {
+		const db = createTestDb();
+		const config = {
+			id: OPENCODE_CONFIG_ID,
+			presetId: "opencode",
+			label: "OpenCode",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "opencode",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+		const selection = {
+			model: "openai/gpt-5.6-sol",
+			effort: "high",
+			mode: "plan",
+		};
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "opencode", ...selection },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "opencode",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"'opencode' '--model' 'openai/gpt-5.6-sol' '--variant' 'high' '--agent' 'plan' 'do the thing'",
+		);
+	});
+
+	it("leaves Claude Code's one-turn ultrathink keyword in the user's prompt", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const selection = { model: "claude-opus-5" };
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", ...selection },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "ultrathink about this change",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"FOO='bar' 'claude' '--dangerously-skip-permissions' '--model' 'claude-opus-5' 'ultrathink about this change'",
+		);
+	});
+
+	it("forwards a supported Claude context window in the model id", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const selection = { model: "claude-opus-5", contextWindow: "1m" };
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", ...selection },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"FOO='bar' 'claude' '--dangerously-skip-permissions' '--model' 'claude-opus-5[1m]' 'do the thing'",
+		);
+	});
+
+	it("resumes a previous session with an empty prompt", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude" },
+			fallbackSnapshot(config),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "",
+				resumeSessionId: "abc-123",
+			},
+			validated,
+		);
 		expect(launch.fullCommand).toBe(
 			"FOO='bar' 'claude' '--dangerously-skip-permissions' '--resume' 'abc-123'",
 		);
 	});
 
-	it("rejects a resume when the agent config has no resume args", () => {
+	it("rejects a resume when the agent config has no resume args", async () => {
 		const db = createTestDb();
+		const config = {
+			id: OPENCODE_CONFIG_ID,
+			presetId: "custom",
+			label: "My Agent",
+			capabilityRevision: 1,
+		};
 		db.insert(schema.hostAgentConfigs)
 			.values({
-				id: "00000000-0000-0000-0000-00000000000b",
-				presetId: "custom",
-				label: "My Agent",
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
 				command: "my-agent",
 				argsJson: "[]",
 				promptTransport: "argv",
@@ -267,25 +527,282 @@ describe("buildTerminalAgentLaunch", () => {
 				displayOrder: 1,
 			})
 			.run();
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "custom" },
+			fallbackSnapshot(config),
+		);
 		expect(() =>
-			buildTerminalAgentLaunch(db, {
-				workspaceId: "11111111-1111-1111-1111-111111111111",
-				agent: "custom",
-				prompt: "",
-				resumeSessionId: "abc-123",
-			}),
+			buildTerminalAgentLaunch(
+				db,
+				{
+					workspaceId: WORKSPACE_ID,
+					agent: "custom",
+					prompt: "",
+					resumeSessionId: "abc-123",
+				},
+				validated,
+			),
 		).toThrow(/does not support resuming a session by id/);
 	});
 
-	it("throws NOT_FOUND for an unknown agent", () => {
+	it("throws NOT_FOUND for an unknown agent", async () => {
 		const db = createTestDb();
+		const config = seedConfig(db);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude" },
+			fallbackSnapshot(config),
+		);
 		expect(() =>
-			buildTerminalAgentLaunch(db, {
-				workspaceId: "11111111-1111-1111-1111-111111111111",
-				agent: "nope",
-				prompt: "p",
-			}),
+			buildTerminalAgentLaunch(
+				db,
+				{
+					workspaceId: WORKSPACE_ID,
+					agent: "nope",
+					prompt: "p",
+				},
+				validated,
+			),
 		).toThrow(/No host agent config matching 'nope'/);
+	});
+
+	it("rejects a model-A validation used to build model B", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", model: "claude-fable-5" },
+			fallbackSnapshot(config),
+		);
+		try {
+			buildTerminalAgentLaunch(
+				db,
+				{
+					workspaceId: WORKSPACE_ID,
+					agent: "claude",
+					prompt: "do the thing",
+					model: "claude-opus-5",
+				},
+				validated,
+			);
+			throw new Error("Expected launch to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("BAD_REQUEST");
+		}
+	});
+
+	it("rejects a validated selection after the agent config revision changes", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "claude", model: "claude-opus-5" },
+			fallbackSnapshot(config),
+		);
+		db.update(schema.hostAgentConfigs)
+			.set({ capabilityRevision: 2 })
+			.where(eq(schema.hostAgentConfigs.id, config.id))
+			.run();
+		try {
+			buildTerminalAgentLaunch(
+				db,
+				{
+					workspaceId: WORKSPACE_ID,
+					agent: "claude",
+					prompt: "do the thing",
+					model: "claude-opus-5",
+				},
+				validated,
+			);
+			throw new Error("Expected launch to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("PRECONDITION_FAILED");
+		}
+	});
+
+	it("launches a runtime Pi max effort advertised by the live inventory", async () => {
+		const db = createTestDb();
+		const config = {
+			id: "00000000-0000-0000-0000-00000000000c",
+			presetId: "pi",
+			label: "Pi",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "pi",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+		const selection = { model: "provider/model", effort: "max" };
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "pi", ...selection },
+			runtimeSnapshot(config, [
+				{
+					id: "provider/model",
+					label: "Provider Model",
+					reasoning: {
+						state: "supported",
+						defaultId: "max",
+						options: [{ id: "max", label: "Max" }],
+					},
+				},
+			]),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "pi",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"'pi' '--model' 'provider/model' '--thinking' 'max' 'do the thing'",
+		);
+	});
+
+	it("launches a newly advertised runtime Codex model", async () => {
+		const db = createTestDb();
+		const config = {
+			id: "00000000-0000-0000-0000-00000000000d",
+			presetId: "codex",
+			label: "Codex",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "codex",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+		const selection = { model: "gpt-6-codex" };
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "codex", ...selection },
+			runtimeSnapshot(config, [
+				{
+					id: "gpt-6-codex",
+					label: "GPT-6 Codex",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "codex",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"'codex' '--model' 'gpt-6-codex' 'do the thing'",
+		);
+	});
+
+	it("does not silently omit a retired runtime model and launch the CLI default", async () => {
+		const db = createTestDb();
+		const config = seedConfig(db);
+		await expect(
+			validateFromSnapshot(
+				db,
+				{ agent: "claude", model: "retired-model" },
+				runtimeSnapshot(config, [
+					{
+						id: "claude-opus-5",
+						label: "Opus 5",
+						reasoning: { state: "unknown" },
+					},
+				]),
+			),
+		).rejects.toThrow(/Model "retired-model" is not available/);
+		expect(
+			getAgentModelSupport("claude")?.models.some(
+				(model) => model.id === "retired-model",
+			),
+		).toBe(false);
+	});
+
+	it("honors a Vibe runtime inventory instead of the static catalog", async () => {
+		const db = createTestDb();
+		const config = {
+			id: "00000000-0000-0000-0000-00000000000e",
+			presetId: "vibe",
+			label: "Vibe",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "vibe",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+		const selection = { model: "vibe-runtime-model" };
+		const snapshot = runtimeSnapshot(config, [
+			{
+				id: "vibe-runtime-model",
+				label: "Vibe Runtime",
+				reasoning: { state: "unsupported" },
+			},
+		]);
+		const validated = await validateFromSnapshot(
+			db,
+			{ agent: "vibe", ...selection },
+			snapshot,
+		);
+		const launch = buildTerminalAgentLaunch(
+			db,
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "vibe",
+				prompt: "do the thing",
+				...selection,
+			},
+			validated,
+		);
+		expect(launch.fullCommand).toBe(
+			"VIBE_ACTIVE_MODEL='vibe-runtime-model' 'vibe' 'do the thing'",
+		);
+		await expect(
+			validateFromSnapshot(
+				db,
+				{ agent: "vibe", model: "mistral-medium-3.5" },
+				snapshot,
+			),
+		).rejects.toThrow(/Model "mistral-medium-3.5" is not available/);
 	});
 });
 
@@ -298,19 +815,36 @@ describe("validateAgentEffortSelection", () => {
 
 	it("accepts a supported effort for the selected agent", () => {
 		expect(() =>
-			validateAgentEffortSelection("codex", "Codex", "xhigh"),
+			validateAgentEffortSelection("codex", "Codex", "xhigh", "gpt-5.6-sol"),
 		).not.toThrow();
+	});
+
+	it("accepts a runtime effort outside the curated catalog", () => {
+		expect(() =>
+			validateAgentEffortSelection("pi", "Pi", "max", "provider/model", {
+				state: "supported",
+				options: [{ id: "max", label: "Max" }],
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects a curated effort when runtime reports unsupported", () => {
+		expect(() =>
+			validateAgentEffortSelection("codex", "Codex", "high", "gpt-5.6-sol", {
+				state: "unsupported",
+			}),
+		).toThrow(TRPCError);
 	});
 
 	it("rejects an invalid effort with the supported values", () => {
 		try {
-			validateAgentEffortSelection("codex", "Codex", "max");
+			validateAgentEffortSelection("codex", "Codex", "extreme", "gpt-5.6-sol");
 			throw new Error("Expected validation to fail");
 		} catch (error) {
 			expect(error).toBeInstanceOf(TRPCError);
 			expect((error as TRPCError).code).toBe("BAD_REQUEST");
 			expect((error as Error).message).toBe(
-				'Unsupported reasoning effort "max" for Codex. Choose one of: low, medium, high, xhigh.',
+				'Unsupported reasoning effort "extreme" for Codex. Choose one of: low, medium, high, xhigh, max, ultra.',
 			);
 		}
 	});
@@ -325,6 +859,353 @@ describe("validateAgentEffortSelection", () => {
 			expect((error as Error).message).toBe(
 				"Superset does not support a reasoning effort override. Omit effort to use the agent default.",
 			);
+		}
+	});
+});
+
+describe("validateAgentLaunchSelection", () => {
+	function seedClaude(db: HostDb) {
+		const config = {
+			id: CLAUDE_CONFIG_ID,
+			presetId: "claude",
+			label: "Claude",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				capabilityRevision: config.capabilityRevision,
+				displayOrder: 0,
+			})
+			.run();
+		return config;
+	}
+
+	it("validates a runtime model from the persisted inventory", async () => {
+		const db = createTestDb();
+		const config = seedClaude(db);
+		persistLaunchSnapshot(
+			db,
+			config,
+			runtimeSnapshot(config, [
+				{
+					id: "claude-opus-5",
+					label: "Opus 5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+
+		const validated = await validateAgentLaunchSelection(db, {
+			agent: "claude",
+			model: "claude-opus-5",
+		});
+
+		expect(validated).toMatchObject({
+			agentId: config.id,
+			presetId: "claude",
+			configRevision: 1,
+			selection: { model: "claude-opus-5" },
+			allowedModelIds: ["claude-opus-5"],
+		});
+	});
+
+	it("does not block launch on persisted authentication health", async () => {
+		const db = createTestDb();
+		const config = seedClaude(db);
+		persistLaunchSnapshot(
+			db,
+			config,
+			runtimeSnapshot(
+				config,
+				[
+					{
+						id: "claude-opus-5",
+						label: "Opus 5",
+						reasoning: { state: "unknown" },
+					},
+				],
+				{
+					status: "authentication_required",
+					auth: "unauthenticated",
+				},
+			),
+		);
+
+		await expect(
+			validateAgentLaunchSelection(db, {
+				agent: "claude",
+				model: "claude-opus-5",
+			}),
+		).resolves.toMatchObject({ agentId: config.id });
+	});
+
+	it("allows a curated model when no snapshot exists", async () => {
+		const db = createTestDb();
+		const config = seedClaude(db);
+		await expect(
+			validateAgentLaunchSelection(db, {
+				agent: "claude",
+				model: "claude-opus-5",
+			}),
+		).resolves.toMatchObject({ agentId: config.id });
+	});
+
+	it("rejects an unknown runtime-only model when no snapshot exists", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		try {
+			await validateAgentLaunchSelection(db, {
+				agent: "claude",
+				model: "runtime-only-model",
+			});
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+	});
+
+	it("does not revive a static effort when runtime reports unsupported", async () => {
+		const db = createTestDb();
+		const config = {
+			id: "00000000-0000-0000-0000-00000000000d",
+			presetId: "codex",
+			label: "Codex",
+			capabilityRevision: 1,
+		};
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: config.id,
+				presetId: config.presetId,
+				label: config.label,
+				command: "codex",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				capabilityRevision: 1,
+				displayOrder: 0,
+			})
+			.run();
+		persistLaunchSnapshot(
+			db,
+			config,
+			runtimeSnapshot(config, [
+				{
+					id: "gpt-5.6-sol",
+					label: "GPT-5.6 Sol",
+					reasoning: { state: "unsupported" },
+				},
+			]),
+		);
+		try {
+			await validateAgentLaunchSelection(db, {
+				agent: "codex",
+				model: "gpt-5.6-sol",
+				effort: "high",
+			});
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+	});
+});
+
+describe("agents.run launch contract", () => {
+	function seedWorkspace(db: HostDb) {
+		db.insert(schema.workspaces)
+			.values({
+				id: WORKSPACE_ID,
+				worktreePath: "/tmp/launch-contract-ws",
+				branch: "main",
+			})
+			.run();
+	}
+
+	function createRunCaller(db: HostDb, snapshot: AgentCapabilitySnapshot) {
+		persistLaunchSnapshot(
+			db,
+			{ id: snapshot.agentId, presetId: snapshot.presetId },
+			{
+				...snapshot,
+				checkedAt: new Date().toISOString(),
+				inventoryCheckedAt: new Date().toISOString(),
+			},
+		);
+		const context = {
+			db,
+			isAuthenticated: true,
+		};
+		// SAFETY: This router test exercises only the context services supplied above.
+		return agentsRouter.createCaller(context as HostServiceContext);
+	}
+
+	it("preflights a retired model on agents.run before creating a terminal", async () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: CLAUDE_CONFIG_ID,
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: JSON.stringify(["--resume"]),
+				envJson: "{}",
+				capabilityRevision: 1,
+				displayOrder: 0,
+			})
+			.run();
+		seedWorkspace(db);
+		const caller = createRunCaller(
+			db,
+			runtimeSnapshot({ id: CLAUDE_CONFIG_ID, presetId: "claude" }, [
+				{
+					id: "claude-opus-5",
+					label: "Opus 5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+		try {
+			await caller.run({
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "do the thing",
+				model: "retired-model",
+			});
+			throw new Error("Expected agents.run to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+	});
+
+	it("returns a trusted command from resolveLaunchCommand without creating a terminal", async () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: CLAUDE_CONFIG_ID,
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: JSON.stringify(["--dangerously-skip-permissions"]),
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: JSON.stringify(["--resume"]),
+				envJson: "{}",
+				capabilityRevision: 1,
+				displayOrder: 0,
+			})
+			.run();
+		const caller = createRunCaller(
+			db,
+			runtimeSnapshot({ id: CLAUDE_CONFIG_ID, presetId: "claude" }, [
+				{
+					id: "claude-opus-5",
+					label: "Opus 5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+		const result = await caller.resolveLaunchCommand({
+			agent: "claude",
+			model: "claude-opus-5",
+		});
+		expect(result.label).toBe("Claude");
+		expect(result.command).toContain("'claude'");
+		expect(result.command).toContain("'--model' 'claude-opus-5'");
+		expect(db.select().from(schema.terminalSessions).all()).toEqual([]);
+		expect(db.select().from(schema.workspaces).all()).toEqual([]);
+	});
+
+	it("rejects resolveLaunchCommand for a retired model before any terminal exists", async () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: CLAUDE_CONFIG_ID,
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: JSON.stringify(["--resume"]),
+				envJson: "{}",
+				capabilityRevision: 1,
+				displayOrder: 0,
+			})
+			.run();
+		const caller = createRunCaller(
+			db,
+			runtimeSnapshot({ id: CLAUDE_CONFIG_ID, presetId: "claude" }, [
+				{
+					id: "claude-opus-5",
+					label: "Opus 5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+		try {
+			await caller.resolveLaunchCommand({
+				agent: "claude",
+				model: "retired-model",
+			});
+			throw new Error("Expected resolveLaunchCommand to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+		expect(db.select().from(schema.terminalSessions).all()).toEqual([]);
+	});
+
+	it("preflights resume through the same launch validator", async () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: CLAUDE_CONFIG_ID,
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: JSON.stringify(["--resume"]),
+				envJson: "{}",
+				capabilityRevision: 1,
+				displayOrder: 0,
+			})
+			.run();
+		seedWorkspace(db);
+		const caller = createRunCaller(
+			db,
+			runtimeSnapshot({ id: CLAUDE_CONFIG_ID, presetId: "claude" }, [
+				{
+					id: "claude-opus-5",
+					label: "Opus 5",
+					reasoning: { state: "unknown" },
+				},
+			]),
+		);
+		try {
+			await caller.run({
+				workspaceId: WORKSPACE_ID,
+				agent: "claude",
+				prompt: "",
+				model: "retired-model",
+				resumeSessionId: "abc-123",
+			});
+			throw new Error("Expected resume preflight to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
 		}
 	});
 });

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,6 +1,7 @@
 import {
 	type AgentCapabilityTrait,
 	type AgentModelOption,
+	buildAgentContextWindowEnv,
 	buildAgentEffortArgs,
 	buildAgentModeArgs,
 	buildAgentModelArgs,
@@ -611,8 +612,21 @@ export function buildTerminalAgentLaunch(
 		input.model,
 		validated.allowedModelIds,
 	);
+	const contextWindowEnv = buildAgentContextWindowEnv(
+		config.presetId,
+		input.model,
+		input.contextWindow,
+	);
+	const launchEnv = {
+		...config.env,
+		...modelEnv,
+	};
+	if (contextWindowEnv.CLAUDE_CODE_DISABLE_1M_CONTEXT !== undefined) {
+		launchEnv.CLAUDE_CODE_DISABLE_1M_CONTEXT =
+			contextWindowEnv.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+	}
 	return {
-		fullCommand: `${envOverlayPrefix({ ...config.env, ...modelEnv })}${command}`,
+		fullCommand: `${envOverlayPrefix(launchEnv)}${command}`,
 		label: config.label,
 	};
 }

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,8 +1,16 @@
 import {
+	type AgentCapabilityTrait,
+	type AgentModelOption,
 	buildAgentEffortArgs,
+	buildAgentModeArgs,
 	buildAgentModelArgs,
 	buildAgentModelEnv,
-	getAgentEffortSupport,
+	buildAgentRuntimeTraitArgs,
+	getAgentContextWindowSupport,
+	getAgentModelSupport,
+	getAgentModeSupport,
+	getAgentSpeedSupport,
+	resolveAgentEffortSupport,
 } from "@superset/shared/agent-models";
 import {
 	buildArgvCommand,
@@ -13,12 +21,19 @@ import {
 import { TRPCError } from "@trpc/server";
 import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
+import type { AgentCapabilitySnapshot } from "../../../agent-capabilities/agent-capabilities";
+import { readPersistedCapabilitySnapshots } from "../../../agent-capabilities/capability-refresh-service";
 import type { HostDb } from "../../../db";
 import { hostAgentConfigs, workspaces } from "../../../db/schema";
 import { createTerminalSessionInternal } from "../../../terminal/terminal";
 import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 import { resolveAttachmentPath } from "../attachments/storage";
+import {
+	parseAgentArgv,
+	parseAgentEnv,
+	parsePromptTransport,
+} from "../settings/agent-config-parsers";
 import { toTerminalSessionError } from "../terminal/errors";
 
 interface ResolvedHostAgentConfig {
@@ -26,43 +41,12 @@ interface ResolvedHostAgentConfig {
 	presetId: string;
 	label: string;
 	command: string;
+	capabilityRevision: number;
 	args: string[];
 	promptTransport: "argv" | "stdin";
 	promptArgs: string[];
 	resumeArgs: string[];
 	env: Record<string, string>;
-}
-
-function parseArgv(value: string): string[] {
-	try {
-		const parsed = JSON.parse(value);
-		if (
-			!Array.isArray(parsed) ||
-			parsed.some((entry) => typeof entry !== "string")
-		) {
-			return [];
-		}
-		return parsed as string[];
-	} catch {
-		return [];
-	}
-}
-
-function parseEnv(value: string): Record<string, string> {
-	try {
-		const parsed = JSON.parse(value);
-		if (
-			parsed === null ||
-			typeof parsed !== "object" ||
-			Array.isArray(parsed) ||
-			Object.values(parsed).some((entry) => typeof entry !== "string")
-		) {
-			return {};
-		}
-		return parsed as Record<string, string>;
-	} catch {
-		return {};
-	}
 }
 
 function rowToConfig(
@@ -73,11 +57,12 @@ function rowToConfig(
 		presetId: row.presetId,
 		label: row.label,
 		command: row.command,
-		args: parseArgv(row.argsJson),
-		promptTransport: row.promptTransport as "argv" | "stdin",
-		promptArgs: parseArgv(row.promptArgsJson),
-		resumeArgs: parseArgv(row.resumeArgsJson),
-		env: parseEnv(row.envJson),
+		capabilityRevision: row.capabilityRevision,
+		args: parseAgentArgv(row.argsJson),
+		promptTransport: parsePromptTransport(row.promptTransport),
+		promptArgs: parseAgentArgv(row.promptArgsJson),
+		resumeArgs: parseAgentArgv(row.resumeArgsJson),
+		env: parseAgentEnv(row.envJson),
 	};
 }
 
@@ -176,6 +161,9 @@ export interface AgentRunInput {
 	attachmentIds?: string[];
 	model?: string;
 	effort?: string;
+	mode?: string;
+	speed?: string;
+	contextWindow?: string;
 	/** Session id of a previous run of this agent to restore (e.g. a killed
 	 * session's `agentSessionId`). The prompt may be empty when resuming. */
 	resumeSessionId?: string;
@@ -187,6 +175,80 @@ export type AgentRunResult = {
 	label: string;
 };
 
+export interface AgentLaunchSelection {
+	model?: string;
+	effort?: string;
+	mode?: string;
+	speed?: string;
+	contextWindow?: string;
+}
+
+const validatedLaunchSelectionBrand = Symbol("ValidatedLaunchSelection");
+
+export interface ValidatedLaunchSelection {
+	readonly [validatedLaunchSelectionBrand]: true;
+	readonly agentId: string;
+	readonly presetId: string;
+	readonly configRevision: number;
+	readonly selection: AgentLaunchSelection;
+	readonly allowedModelIds: readonly string[];
+	readonly modelSource: AgentCapabilitySnapshot["modelSource"];
+	readonly reasoning: AgentCapabilityTrait<AgentModelOption> | undefined;
+}
+
+export type AgentLaunchInput = Pick<
+	AgentRunInput,
+	"agent" | "model" | "effort" | "mode" | "speed" | "contextWindow"
+>;
+
+function capabilitySelectionError(
+	code: "BAD_REQUEST" | "PRECONDITION_FAILED",
+	message: string,
+): TRPCError {
+	return new TRPCError({
+		code,
+		message,
+	});
+}
+
+function launchSelectionOf(input: AgentLaunchSelection): AgentLaunchSelection {
+	const selection: AgentLaunchSelection = {};
+	if (input.model) selection.model = input.model;
+	if (input.effort) selection.effort = input.effort;
+	if (input.mode) selection.mode = input.mode;
+	if (input.speed) selection.speed = input.speed;
+	if (input.contextWindow) selection.contextWindow = input.contextWindow;
+	return selection;
+}
+
+function sameLaunchSelection(
+	left: AgentLaunchSelection,
+	right: AgentLaunchSelection,
+): boolean {
+	const a = launchSelectionOf(left);
+	const b = launchSelectionOf(right);
+	return (
+		a.model === b.model &&
+		a.effort === b.effort &&
+		a.mode === b.mode &&
+		a.speed === b.speed &&
+		a.contextWindow === b.contextWindow
+	);
+}
+
+export function resolveAllowedLaunchModelIds(
+	presetId: string,
+	capability: Pick<AgentCapabilitySnapshot, "modelSource" | "models">,
+): string[] {
+	if (capability.modelSource === "runtime") {
+		return capability.models.map((model) => model.id);
+	}
+	const staticIds =
+		getAgentModelSupport(presetId)?.models.map((model) => model.id) ?? [];
+	const snapshotIds = capability.models.map((model) => model.id);
+	return [...new Set([...staticIds, ...snapshotIds])];
+}
+
 /**
  * Validate an explicit effort override before launch. Omitting effort always
  * delegates to the underlying agent's own default.
@@ -195,22 +257,188 @@ export function validateAgentEffortSelection(
 	presetId: string,
 	label: string,
 	effort: string | undefined,
+	model?: string,
+	reasoning?: AgentCapabilityTrait<AgentModelOption>,
 ): void {
 	if (!effort) return;
 
-	const support = getAgentEffortSupport(presetId);
+	const support = resolveAgentEffortSupport(presetId, model, reasoning);
 	if (!support) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `${label} does not support a reasoning effort override. Omit effort to use the agent default.`,
-		});
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			`${label} does not support a reasoning effort override. Omit effort to use the agent default.`,
+		);
 	}
 
 	if (!support.efforts.some((option) => option.id === effort)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Unsupported reasoning effort "${effort}" for ${label}. Choose one of: ${support.efforts.map((option) => option.id).join(", ")}.`,
-		});
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			`Unsupported reasoning effort "${effort}" for ${label}. Choose one of: ${support.efforts.map((option) => option.id).join(", ")}.`,
+		);
+	}
+}
+
+export function validateAgentModelSelection(
+	presetId: string,
+	label: string,
+	model: string | undefined,
+	capability: Pick<AgentCapabilitySnapshot, "modelSource" | "models">,
+): void {
+	if (!model) return;
+	const transport = getAgentModelSupport(presetId);
+	if (!transport?.modelFlag && !transport?.modelEnv) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			`${label} does not support a model override. Omit model to use the agent default.`,
+		);
+	}
+	const allowed = resolveAllowedLaunchModelIds(presetId, capability);
+	if (!allowed.includes(model)) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			`Model "${model}" is not available for ${label}.`,
+		);
+	}
+}
+
+export function validateAgentModeSelection(
+	presetId: string,
+	label: string,
+	mode: string | undefined,
+): void {
+	if (!mode) return;
+	const support = getAgentModeSupport(presetId);
+	if (!support?.modes.some((option) => option.id === mode)) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			support
+				? `Unsupported mode "${mode}" for ${label}. Choose one of: ${support.modes.map((option) => option.id).join(", ")}.`
+				: `${label} does not support a mode override. Omit mode to use the agent default.`,
+		);
+	}
+}
+
+export function validateAgentSpeedSelection(
+	presetId: string,
+	label: string,
+	speed: string | undefined,
+	model?: string,
+): void {
+	if (!speed) return;
+	const support = getAgentSpeedSupport(presetId, model);
+	if (!support?.speeds.some((option) => option.id === speed)) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			support
+				? `Unsupported speed "${speed}" for ${label}. Choose one of: ${support.speeds.map((option) => option.id).join(", ")}.`
+				: `${label} does not support a speed override for the selected model. Omit speed to use the agent default.`,
+		);
+	}
+}
+
+export function validateAgentContextWindowSelection(
+	presetId: string,
+	label: string,
+	contextWindow: string | undefined,
+	model?: string,
+): void {
+	if (!contextWindow) return;
+	const support = getAgentContextWindowSupport(presetId, model);
+	if (!support?.contextWindows.some((option) => option.id === contextWindow)) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			support
+				? `Unsupported context window "${contextWindow}" for ${label}. Choose one of: ${support.contextWindows.map((option) => option.id).join(", ")}.`
+				: `${label} does not support a context window override for the selected model. Omit contextWindow to use the agent default.`,
+		);
+	}
+}
+
+function validateExplicitLaunchSelection(
+	presetId: string,
+	label: string,
+	selection: AgentLaunchSelection,
+	capability: Pick<AgentCapabilitySnapshot, "modelSource" | "models">,
+	reasoning?: AgentCapabilityTrait<AgentModelOption>,
+): void {
+	validateAgentModelSelection(presetId, label, selection.model, capability);
+	validateAgentEffortSelection(
+		presetId,
+		label,
+		selection.effort,
+		selection.model,
+		reasoning,
+	);
+	validateAgentModeSelection(presetId, label, selection.mode);
+	validateAgentSpeedSelection(
+		presetId,
+		label,
+		selection.speed,
+		selection.model,
+	);
+	validateAgentContextWindowSelection(
+		presetId,
+		label,
+		selection.contextWindow,
+		selection.model,
+	);
+}
+
+function issueValidatedLaunchSelection(
+	config: Pick<
+		ResolvedHostAgentConfig,
+		"id" | "presetId" | "capabilityRevision" | "label"
+	>,
+	selection: AgentLaunchSelection,
+	capability: Pick<AgentCapabilitySnapshot, "modelSource" | "models">,
+): ValidatedLaunchSelection {
+	const runtimeModel = capability.models.find(
+		(model) => model.id === selection.model,
+	);
+	const reasoning =
+		capability.modelSource === "runtime" ? runtimeModel?.reasoning : undefined;
+	validateExplicitLaunchSelection(
+		config.presetId,
+		config.label,
+		selection,
+		capability,
+		reasoning,
+	);
+	return {
+		[validatedLaunchSelectionBrand]: true,
+		agentId: config.id,
+		presetId: config.presetId,
+		configRevision: config.capabilityRevision,
+		selection: launchSelectionOf(selection),
+		allowedModelIds: resolveAllowedLaunchModelIds(config.presetId, capability),
+		modelSource: capability.modelSource,
+		reasoning,
+	};
+}
+
+function assertValidatedLaunchSelectionMatches(
+	config: Pick<
+		ResolvedHostAgentConfig,
+		"id" | "presetId" | "capabilityRevision" | "label"
+	>,
+	input: AgentLaunchSelection,
+	validated: ValidatedLaunchSelection,
+): void {
+	if (
+		validated.agentId !== config.id ||
+		validated.presetId !== config.presetId ||
+		validated.configRevision !== config.capabilityRevision
+	) {
+		throw capabilitySelectionError(
+			"PRECONDITION_FAILED",
+			`${config.label} changed while its capabilities were being validated. Retry the launch.`,
+		);
+	}
+	if (!sameLaunchSelection(validated.selection, input)) {
+		throw capabilitySelectionError(
+			"BAD_REQUEST",
+			`${config.label} validated selection does not match the requested launch selection.`,
+		);
 	}
 }
 
@@ -244,12 +472,11 @@ export function validateAgentResumeSelection(
  * Preflight a host-scoped launch before any larger workflow (such as
  * workspace creation) performs side effects.
  */
-export function validateAgentLaunchEffort(
+export async function validateAgentLaunchSelection(
 	db: HostDb,
-	input: Pick<AgentRunInput, "agent" | "effort">,
-): void {
-	if (!input.effort) return;
-
+	input: AgentLaunchInput,
+): Promise<ValidatedLaunchSelection> {
+	const selection = launchSelectionOf(input);
 	const config = resolveHostAgentConfig(db, input.agent);
 	if (!config) {
 		throw new TRPCError({
@@ -257,7 +484,25 @@ export function validateAgentLaunchEffort(
 			message: `No host agent config matching '${input.agent}' (tried instance id then preset id).`,
 		});
 	}
-	validateAgentEffortSelection(config.presetId, config.label, input.effort);
+	const view = readPersistedCapabilitySnapshots(db).find(
+		(capability) => capability.agentId === config.id,
+	);
+	const inventory =
+		view?.inventory?.agentId === config.id &&
+		view.inventory.presetId === config.presetId &&
+		view.inventory.configRevision === config.capabilityRevision
+			? view.inventory
+			: null;
+	const capability: Pick<AgentCapabilitySnapshot, "modelSource" | "models"> = {
+		modelSource:
+			inventory?.modelSource === "runtime"
+				? "runtime"
+				: inventory
+					? "fallback"
+					: "none",
+		models: inventory?.models ?? [],
+	};
+	return issueValidatedLaunchSelection(config, selection, capability);
 }
 
 /**
@@ -266,9 +511,43 @@ export function validateAgentLaunchEffort(
  * wait-for-setup gate, which chains this command behind the setup commands in
  * the setup terminal. Throws NOT_FOUND for unknown agents or attachments.
  */
+export async function buildValidatedTerminalAgentLaunch(
+	db: HostDb,
+	input: AgentRunInput,
+): Promise<{ fullCommand: string; label: string }> {
+	const validated = await validateAgentLaunchSelection(db, input);
+	return buildTerminalAgentLaunch(db, input, validated);
+}
+
+const LAUNCH_COMMAND_WORKSPACE_PLACEHOLDER =
+	"00000000-0000-0000-0000-000000000000";
+
+/**
+ * Validate a host agent and return its trusted command without creating a
+ * terminal. Preset execution uses this so
+ * sequential / active-terminal writes can keep the current pane.
+ */
+export async function resolveValidatedLaunchCommand(
+	db: HostDb,
+	input: AgentLaunchInput & { prompt?: string },
+): Promise<{ command: string; label: string }> {
+	const { fullCommand, label } = await buildValidatedTerminalAgentLaunch(db, {
+		workspaceId: LAUNCH_COMMAND_WORKSPACE_PLACEHOLDER,
+		agent: input.agent,
+		prompt: input.prompt ?? "",
+		model: input.model,
+		effort: input.effort,
+		mode: input.mode,
+		speed: input.speed,
+		contextWindow: input.contextWindow,
+	});
+	return { command: fullCommand, label };
+}
+
 export function buildTerminalAgentLaunch(
 	db: HostDb,
 	input: AgentRunInput,
+	validated: ValidatedLaunchSelection,
 ): { fullCommand: string; label: string } {
 	const config = resolveHostAgentConfig(db, input.agent);
 	if (!config) {
@@ -280,7 +559,7 @@ export function buildTerminalAgentLaunch(
 			message: `No host agent config matching '${input.agent}' — the agent may have been removed or this host's agents were reset. Re-select an agent (or use a preset id like "claude").`,
 		});
 	}
-	validateAgentEffortSelection(config.presetId, config.label, input.effort);
+	assertValidatedLaunchSelectionMatches(config, input, validated);
 	validateAgentResumeSelection(config, input.resumeSessionId);
 
 	const resolvedAttachments: Array<{ attachmentId: string; path: string }> = [];
@@ -296,15 +575,42 @@ export function buildTerminalAgentLaunch(
 	}
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
-	const modelArgs = buildAgentModelArgs(config.presetId, input.model);
-	const effortArgs = buildAgentEffortArgs(config.presetId, input.effort);
+	const modelArgs = buildAgentModelArgs(
+		config.presetId,
+		input.model,
+		input.contextWindow,
+		validated.allowedModelIds,
+	);
+	const effortArgs = buildAgentEffortArgs(
+		config.presetId,
+		input.effort,
+		input.model,
+		validated.reasoning?.state === "supported"
+			? {
+					defaultEffortId: validated.reasoning.defaultId,
+					efforts: validated.reasoning.options,
+				}
+			: validated.reasoning?.state === "unsupported"
+				? { efforts: [] }
+				: undefined,
+	);
+	const runtimeTraitArgs = buildAgentRuntimeTraitArgs(config.presetId, {
+		model: input.model,
+		effort: input.effort,
+		speed: input.speed,
+	});
+	const modeArgs = buildAgentModeArgs(config.presetId, input.mode);
 	const command = buildAgentCommandString(
 		config,
 		prompt,
-		[...modelArgs, ...effortArgs],
+		[...modelArgs, ...effortArgs, ...modeArgs, ...runtimeTraitArgs],
 		{ resumeSessionId: input.resumeSessionId },
 	);
-	const modelEnv = buildAgentModelEnv(config.presetId, input.model);
+	const modelEnv = buildAgentModelEnv(
+		config.presetId,
+		input.model,
+		validated.allowedModelIds,
+	);
 	return {
 		fullCommand: `${envOverlayPrefix({ ...config.env, ...modelEnv })}${command}`,
 		label: config.label,
@@ -312,10 +618,15 @@ export function buildTerminalAgentLaunch(
 }
 
 async function runTerminalAgent(
-	ctx: { db: HostDb; eventBus: import("../../../events").EventBus },
+	ctx: Pick<HostServiceContext, "db" | "eventBus">,
 	input: AgentRunInput,
+	validated: ValidatedLaunchSelection,
 ): Promise<AgentRunResult> {
-	const { fullCommand, label } = buildTerminalAgentLaunch(ctx.db, input);
+	const { fullCommand, label } = buildTerminalAgentLaunch(
+		ctx.db,
+		input,
+		validated,
+	);
 
 	const terminalId = crypto.randomUUID();
 	const result = await createTerminalSessionInternal({
@@ -352,23 +663,41 @@ export async function runAgentInWorkspace(
 			message: `Workspace ${input.workspaceId} not found on this host — it may have been deleted.`,
 		});
 	}
-	return runTerminalAgent(ctx, input);
+	const validated = await validateAgentLaunchSelection(ctx.db, input);
+	return runTerminalAgent(ctx, input, validated);
 }
+
+const agentLaunchSelectionInput = {
+	agent: z.string().min(1),
+	model: z.string().min(1).optional(),
+	effort: z.string().min(1).optional(),
+	mode: z.string().min(1).optional(),
+	speed: z.string().min(1).optional(),
+	contextWindow: z.string().min(1).optional(),
+};
 
 export const agentsRouter = router({
 	run: protectedProcedure
 		.input(
 			z.object({
 				workspaceId: z.string().uuid(),
-				agent: z.string().min(1),
 				// Optional: an empty prompt launches the bare agent (the builder
 				// drops promptArgs).
 				prompt: z.string().default(""),
 				attachmentIds: z.array(z.string().uuid()).optional(),
-				model: z.string().min(1).optional(),
-				effort: z.string().min(1).optional(),
 				resumeSessionId: z.string().min(1).optional(),
+				...agentLaunchSelectionInput,
 			}),
 		)
 		.mutation(async ({ ctx, input }) => runAgentInWorkspace(ctx, input)),
+	resolveLaunchCommand: protectedProcedure
+		.input(
+			z.object({
+				prompt: z.string().default(""),
+				...agentLaunchSelectionInput,
+			}),
+		)
+		.mutation(async ({ ctx, input }) =>
+			resolveValidatedLaunchCommand(ctx.db, input),
+		),
 });

--- a/packages/host-service/src/trpc/router/agents/index.ts
+++ b/packages/host-service/src/trpc/router/agents/index.ts
@@ -3,6 +3,9 @@ export {
 	type AgentRunResult,
 	agentsRouter,
 	buildTerminalAgentLaunch,
+	buildValidatedTerminalAgentLaunch,
+	resolveValidatedLaunchCommand,
 	runAgentInWorkspace,
-	validateAgentLaunchEffort,
+	type ValidatedLaunchSelection,
+	validateAgentLaunchSelection,
 } from "./agents";

--- a/packages/host-service/src/trpc/router/settings/agent-config-parsers.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-config-parsers.ts
@@ -1,0 +1,29 @@
+import type { PromptTransport } from "@superset/shared/agent-prompt-launch";
+import { z } from "zod";
+
+export const promptTransportSchema = z.enum(["argv", "stdin"]);
+export const agentArgvSchema = z.array(z.string());
+export const agentEnvSchema = z.record(z.string(), z.string());
+const storedArgvSchema = agentArgvSchema.catch([]);
+const storedEnvSchema = agentEnvSchema.catch({});
+const storedPromptTransportSchema = promptTransportSchema.catch("argv");
+
+export function parseAgentArgv(value: string): string[] {
+	try {
+		return storedArgvSchema.parse(JSON.parse(value));
+	} catch {
+		return [];
+	}
+}
+
+export function parseAgentEnv(value: string): Record<string, string> {
+	try {
+		return storedEnvSchema.parse(JSON.parse(value));
+	} catch {
+		return {};
+	}
+}
+
+export function parsePromptTransport(value: string): PromptTransport {
+	return storedPromptTransportSchema.parse(value);
+}

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -5,8 +5,12 @@ import {
 	getDefaultSeedPresets,
 	getPresetById,
 } from "@superset/shared/host-agent-presets";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { CapabilityRefreshService } from "../../../agent-capabilities/capability-refresh-service";
+import { CAPABILITY_INVENTORY_SCHEMA_VERSION } from "../../../agent-capabilities/capability-snapshot-repository";
+import type { HostDb } from "../../../db";
 import * as schema from "../../../db/schema";
 import type { HostServiceContext } from "../../../types";
 import { agentConfigsRouter } from "./agent-configs";
@@ -20,17 +24,53 @@ function presetBody(presetId: string) {
 
 const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../../drizzle");
 
-function createTestDb() {
+function createTestDb(): HostDb {
 	const sqlite = new Database(":memory:");
 	const db = drizzle(sqlite, { schema });
 	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
-	return db;
+	sqlite.exec("PRAGMA foreign_keys = ON");
+	// SAFETY: Tests use Bun's SQLite driver, whose run result differs nominally from HostDb; router operations used here are otherwise identical.
+	return db as unknown as HostDb;
+}
+
+function createCallerWithDb() {
+	const db = createTestDb();
+	const ctx = {
+		db,
+		capabilityRefresh: new CapabilityRefreshService(db),
+		isAuthenticated: true,
+	};
+	// SAFETY: agentConfigsRouter uses only the database, refresh service, and authentication flag supplied here.
+	const routerContext = ctx as HostServiceContext;
+	return { db, caller: agentConfigsRouter.createCaller(routerContext) };
 }
 
 function createCaller() {
-	const db = createTestDb();
-	const ctx = { db, isAuthenticated: true } as unknown as HostServiceContext;
-	return agentConfigsRouter.createCaller(ctx);
+	return createCallerWithDb().caller;
+}
+
+function insertHealthSnapshot(
+	db: ReturnType<typeof createTestDb>,
+	config: { id: string; presetId: string; capabilityRevision?: number },
+) {
+	db.delete(schema.hostAgentCapabilitySnapshots)
+		.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+		.run();
+	db.insert(schema.hostAgentCapabilitySnapshots)
+		.values({
+			agentId: config.id,
+			presetId: config.presetId,
+			configRevision: config.capabilityRevision ?? 1,
+			schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+			inventoryJson: null,
+			status: "ready",
+			installed: true,
+			auth: "authenticated",
+			inventoryCheckedAt: null,
+			statusCheckedAt: Date.now(),
+			writtenAt: Date.now(),
+		})
+		.run();
 }
 
 async function listFirst(
@@ -47,6 +87,13 @@ const DEFAULT_PRESET_ORDERS = DEFAULT_PRESET_IDS.map((_, i) => i);
 
 describe("agentConfigsRouter", () => {
 	describe("list()", () => {
+		it("seeds bundled defaults alphabetically", () => {
+			const labels = getDefaultSeedPresets().map((preset) => preset.label);
+			expect(labels).toEqual(
+				[...labels].sort((left, right) => left.localeCompare(right)),
+			);
+		});
+
 		it("seeds bundled defaults on first call", async () => {
 			const caller = createCaller();
 
@@ -119,6 +166,122 @@ describe("agentConfigsRouter", () => {
 				[...DEFAULT_PRESET_IDS].reverse(),
 			);
 			expect(reordered.map((row) => row.order)).toEqual(DEFAULT_PRESET_ORDERS);
+		});
+	});
+
+	describe("capability snapshots", () => {
+		it("reads persisted health without probing the configured command", async () => {
+			const { db, caller } = createCallerWithDb();
+			const config = await caller.add({
+				label: "Cached only",
+				command: "/definitely/not/an/executable",
+				args: [],
+				promptTransport: "argv",
+				promptArgs: [],
+				env: {},
+			});
+			insertHealthSnapshot(db, config);
+
+			const snapshots = await caller.listCapabilitySnapshots();
+
+			const snapshot = snapshots.find((entry) => entry.agentId === config.id);
+			expect(snapshot).toEqual({
+				agentId: config.id,
+				presetId: config.presetId,
+				inventory: null,
+				inventoryOrigin: "none",
+				health: {
+					status: "ready",
+					installed: true,
+					auth: "authenticated",
+					checkedAt: expect.any(String),
+					errorKind: null,
+					message: null,
+				},
+				healthOrigin: "persisted",
+			});
+			expect(Object.keys(snapshot ?? {}).sort()).toEqual([
+				"agentId",
+				"health",
+				"healthOrigin",
+				"inventory",
+				"inventoryOrigin",
+				"presetId",
+			]);
+		});
+
+		it("preserves unknown installed null on the read-only snapshot API", async () => {
+			const { db, caller } = createCallerWithDb();
+			const config = await caller.add({
+				label: "Unknown install",
+				command: "/definitely/not/an/executable",
+				args: [],
+				promptTransport: "argv",
+				promptArgs: [],
+				env: {},
+			});
+			db.delete(schema.hostAgentCapabilitySnapshots)
+				.where(eq(schema.hostAgentCapabilitySnapshots.agentId, config.id))
+				.run();
+			db.insert(schema.hostAgentCapabilitySnapshots)
+				.values({
+					agentId: config.id,
+					presetId: config.presetId,
+					configRevision: 1,
+					schemaVersion: CAPABILITY_INVENTORY_SCHEMA_VERSION,
+					inventoryJson: null,
+					status: "unknown",
+					installed: null,
+					auth: "unknown",
+					inventoryCheckedAt: null,
+					statusCheckedAt: Date.now(),
+					writtenAt: Date.now(),
+				})
+				.run();
+
+			const snapshots = await caller.listCapabilitySnapshots();
+			expect(
+				snapshots.find((snapshot) => snapshot.agentId === config.id),
+			).toMatchObject({
+				inventory: null,
+				inventoryOrigin: "none",
+				health: {
+					status: "unknown",
+					installed: null,
+					auth: "unknown",
+				},
+				healthOrigin: "persisted",
+			});
+		});
+
+		it("targeted refresh probes even with a recent persisted snapshot", async () => {
+			const { db, caller } = createCallerWithDb();
+			const config = await caller.add({
+				label: "Fresh cached agent",
+				command: "/definitely/not/an/executable",
+				args: [],
+				promptTransport: "argv",
+				promptArgs: [],
+				env: {},
+			});
+			insertHealthSnapshot(db, config);
+
+			const refreshed = await caller.refreshCapabilities({
+				agentIds: [config.id],
+			});
+
+			expect(refreshed).toHaveLength(1);
+			expect(refreshed[0]).toMatchObject({
+				agentId: config.id,
+				inventory: null,
+				inventoryOrigin: "none",
+				health: {
+					status: "unavailable",
+					installed: false,
+					auth: "unknown",
+				},
+				healthOrigin: "live",
+			});
 		});
 	});
 
@@ -355,6 +518,121 @@ describe("agentConfigsRouter", () => {
 			expect(cleared.iconId).toBeNull();
 		});
 
+		it("increments capability revision and deletes snapshots for command, args, and env changes", async () => {
+			const { db, caller } = createCallerWithDb();
+			const first = await listFirst(caller);
+			const original = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(original).toBeDefined();
+			if (!original) return;
+			insertHealthSnapshot(db, original);
+
+			await caller.update({
+				id: first.id,
+				patch: { command: `${first.command}-new` },
+			});
+			const afterCommand = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(afterCommand?.capabilityRevision).toBe(
+				original.capabilityRevision + 1,
+			);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, first.id))
+					.get()?.configRevision,
+			).toBe(afterCommand?.capabilityRevision);
+
+			if (!afterCommand) return;
+			insertHealthSnapshot(db, afterCommand);
+			await caller.update({
+				id: first.id,
+				patch: { args: [...first.args, "--new-discovery-arg"] },
+			});
+			const afterArgs = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(afterArgs?.capabilityRevision).toBe(
+				afterCommand.capabilityRevision + 1,
+			);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, first.id))
+					.get()?.configRevision,
+			).toBe(afterArgs?.capabilityRevision);
+
+			if (!afterArgs) return;
+			insertHealthSnapshot(db, afterArgs);
+			await caller.update({
+				id: first.id,
+				patch: { env: { TEST_CAPABILITY_ENV: "changed" } },
+			});
+			const afterEnv = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(afterEnv?.capabilityRevision).toBe(
+				afterArgs.capabilityRevision + 1,
+			);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, first.id))
+					.get()?.configRevision,
+			).toBe(afterEnv?.capabilityRevision);
+		});
+
+		it("preserves capability revision and snapshots for launch-only or display changes", async () => {
+			const { db, caller } = createCallerWithDb();
+			const first = await listFirst(caller);
+			const original = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(original).toBeDefined();
+			if (!original) return;
+			insertHealthSnapshot(db, original);
+
+			await caller.update({
+				id: first.id,
+				patch: {
+					label: "Display Only",
+					command: first.command,
+					promptArgs: ["--prompt"],
+					resumeArgs: ["--resume-new"],
+					iconId: "codex",
+					env: { ...first.env },
+				},
+			});
+			const updated = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(updated?.capabilityRevision).toBe(original.capabilityRevision);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, first.id))
+					.get(),
+			).toBeDefined();
+		});
+
 		it("rejects invalid promptTransport", async () => {
 			const caller = createCaller();
 			const first = await listFirst(caller);
@@ -407,14 +685,29 @@ describe("agentConfigsRouter", () => {
 
 	describe("remove()", () => {
 		it("deletes a config by id", async () => {
-			const caller = createCaller();
+			const { db, caller } = createCallerWithDb();
 			const first = await listFirst(caller);
+			const row = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, first.id))
+				.get();
+			expect(row).toBeDefined();
+			if (!row) return;
+			insertHealthSnapshot(db, row);
 
 			const result = await caller.remove({ id: first.id });
 
 			expect(result.success).toBe(true);
 			const remaining = await caller.list();
 			expect(remaining.find((row) => row.id === first.id)).toBeUndefined();
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, first.id))
+					.get(),
+			).toBeUndefined();
 		});
 
 		it("throws NOT_FOUND for an unknown id", async () => {
@@ -428,7 +721,7 @@ describe("agentConfigsRouter", () => {
 
 	describe("restoreDefault()", () => {
 		it("repairs a malformed built-in config without replacing its row", async () => {
-			const caller = createCaller();
+			const { db, caller } = createCallerWithDb();
 			const configs = await caller.list();
 			const codex = configs.find((row) => row.presetId === "codex");
 			expect(codex).toBeDefined();
@@ -452,6 +745,14 @@ describe("agentConfigsRouter", () => {
 					iconId: "claude",
 				},
 			});
+			const broken = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, codex.id))
+				.get();
+			expect(broken).toBeDefined();
+			if (!broken) return;
+			insertHealthSnapshot(db, broken);
 
 			const restored = await caller.restoreDefault({ id: codex.id });
 			const preset = getPresetById("codex");
@@ -471,6 +772,21 @@ describe("agentConfigsRouter", () => {
 				env: preset.env,
 				order: codex.order,
 			});
+			const restoredRow = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, codex.id))
+				.get();
+			expect(restoredRow?.capabilityRevision).toBe(
+				broken.capabilityRevision + 1,
+			);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, codex.id))
+					.get()?.configRevision,
+			).toBe(restoredRow?.capabilityRevision);
 		});
 
 		it("rejects custom agents and unknown ids", async () => {
@@ -495,14 +811,29 @@ describe("agentConfigsRouter", () => {
 
 	describe("reorder()", () => {
 		it("persists the submitted id order", async () => {
-			const caller = createCaller();
+			const { db, caller } = createCallerWithDb();
 			const seeded = await caller.list();
+			const firstRow = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, seeded[0]?.id ?? ""))
+				.get();
+			expect(firstRow).toBeDefined();
+			if (!firstRow) return;
+			insertHealthSnapshot(db, firstRow);
 			const reversed = [...seeded.map((row) => row.id)].reverse();
 
 			const result = await caller.reorder({ ids: reversed });
 
 			expect(result.map((row) => row.id)).toEqual(reversed);
 			expect(result.map((row) => row.order)).toEqual(DEFAULT_PRESET_ORDERS);
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, firstRow.id))
+					.get(),
+			).toBeDefined();
 		});
 
 		it("rejects when ids do not match existing configs", async () => {
@@ -527,8 +858,16 @@ describe("agentConfigsRouter", () => {
 
 	describe("resetToDefaults()", () => {
 		it("replaces current configs with bundled defaults", async () => {
-			const caller = createCaller();
+			const { db, caller } = createCallerWithDb();
 			const seedFirst = await listFirst(caller);
+			const originalRow = db
+				.select()
+				.from(schema.hostAgentConfigs)
+				.where(eq(schema.hostAgentConfigs.id, seedFirst.id))
+				.get();
+			expect(originalRow).toBeDefined();
+			if (!originalRow) return;
+			insertHealthSnapshot(db, originalRow);
 			await caller.update({
 				id: seedFirst.id,
 				patch: { label: "Renamed" },
@@ -542,6 +881,13 @@ describe("agentConfigsRouter", () => {
 			// `pi` is in defaults now, so reset re-seeds exactly one — the
 			// extra row added above is dropped.
 			expect(result.filter((row) => row.presetId === "pi")).toHaveLength(1);
-		});
+			expect(
+				db
+					.select()
+					.from(schema.hostAgentCapabilitySnapshots)
+					.where(eq(schema.hostAgentCapabilitySnapshots.agentId, seedFirst.id))
+					.get(),
+			).toBeUndefined();
+		}, 15_000);
 	});
 });

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -550,6 +550,7 @@ describe("agentConfigsRouter", () => {
 					.get()?.configRevision,
 			).toBe(afterCommand?.capabilityRevision);
 
+			expect(afterCommand).toBeDefined();
 			if (!afterCommand) return;
 			insertHealthSnapshot(db, afterCommand);
 			await caller.update({
@@ -572,6 +573,7 @@ describe("agentConfigsRouter", () => {
 					.get()?.configRevision,
 			).toBe(afterArgs?.capabilityRevision);
 
+			expect(afterArgs).toBeDefined();
 			if (!afterArgs) return;
 			insertHealthSnapshot(db, afterArgs);
 			await caller.update({

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -6,16 +6,23 @@ import {
 	type HostAgentPreset,
 } from "@superset/shared/host-agent-presets";
 import { TRPCError } from "@trpc/server";
-import { asc, eq, inArray } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
+import type { RevisionedAgentCapabilityConfig } from "../../../agent-capabilities/capability-refresh-service";
 import type { HostDb } from "../../../db";
-import { hostAgentConfigs } from "../../../db/schema";
+import {
+	hostAgentCapabilitySnapshots,
+	hostAgentConfigs,
+} from "../../../db/schema";
 import { protectedProcedure, router } from "../../index";
-
-const promptTransportSchema = z.enum(["argv", "stdin"]);
-
-const argvSchema = z.array(z.string());
-const envSchema = z.record(z.string(), z.string());
+import {
+	agentArgvSchema,
+	agentEnvSchema,
+	parseAgentArgv,
+	parseAgentEnv,
+	parsePromptTransport,
+	promptTransportSchema,
+} from "./agent-config-parsers";
 
 export interface HostAgentConfig {
 	id: string;
@@ -45,41 +52,8 @@ interface HostAgentConfigRow {
 	promptArgsJson: string;
 	resumeArgsJson: string;
 	envJson: string;
+	capabilityRevision: number;
 	displayOrder: number;
-}
-
-function parseArgv(value: string): string[] {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(value);
-	} catch {
-		return [];
-	}
-	if (
-		!Array.isArray(parsed) ||
-		parsed.some((item) => typeof item !== "string")
-	) {
-		return [];
-	}
-	return parsed as string[];
-}
-
-function parseEnv(value: string): Record<string, string> {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(value);
-	} catch {
-		return {};
-	}
-	if (
-		parsed === null ||
-		typeof parsed !== "object" ||
-		Array.isArray(parsed) ||
-		Object.values(parsed).some((item) => typeof item !== "string")
-	) {
-		return {};
-	}
-	return parsed as Record<string, string>;
 }
 
 function toOutput(row: HostAgentConfigRow): HostAgentConfig {
@@ -89,11 +63,11 @@ function toOutput(row: HostAgentConfigRow): HostAgentConfig {
 		iconId: row.iconId ?? null,
 		label: row.label,
 		command: row.command,
-		args: parseArgv(row.argsJson),
-		promptTransport: row.promptTransport as PromptTransport,
-		promptArgs: parseArgv(row.promptArgsJson),
-		resumeArgs: parseArgv(row.resumeArgsJson),
-		env: parseEnv(row.envJson),
+		args: parseAgentArgv(row.argsJson),
+		promptTransport: parsePromptTransport(row.promptTransport),
+		promptArgs: parseAgentArgv(row.promptArgsJson),
+		resumeArgs: parseAgentArgv(row.resumeArgsJson),
+		env: parseAgentEnv(row.envJson),
 		order: row.displayOrder,
 	};
 }
@@ -136,6 +110,37 @@ function seedDefaultsIfEmpty(db: HostDb): HostAgentConfigRow[] {
 	return listOrdered(db);
 }
 
+function toCapabilityConfig(
+	row: HostAgentConfigRow,
+): RevisionedAgentCapabilityConfig {
+	return {
+		id: row.id,
+		presetId: row.presetId,
+		command: row.command,
+		args: parseAgentArgv(row.argsJson),
+		env: parseAgentEnv(row.envJson),
+		configRevision: row.capabilityRevision,
+	};
+}
+
+function argsEqual(leftJson: string, right: string[]): boolean {
+	const left = parseAgentArgv(leftJson);
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
+}
+
+function envsEqual(leftJson: string, right: Record<string, string>): boolean {
+	const left = Object.entries(parseAgentEnv(leftJson)).sort(([a], [b]) =>
+		a.localeCompare(b),
+	);
+	const normalizedRight = Object.entries(right).sort(([a], [b]) =>
+		a.localeCompare(b),
+	);
+	return JSON.stringify(left) === JSON.stringify(normalizedRight);
+}
+
 // An icon override is either a built-in icon key ("claude") or an uploaded
 // `data:` image URI. Capped so an oversized upload can't bloat the per-machine
 // SQLite DB — the client downscales images before sending.
@@ -148,11 +153,11 @@ const updatePatchSchema = z
 	.object({
 		label: z.string().trim().min(1).optional(),
 		command: z.string().trim().min(1).optional(),
-		args: argvSchema.optional(),
+		args: agentArgvSchema.optional(),
 		promptTransport: promptTransportSchema.optional(),
-		promptArgs: argvSchema.optional(),
-		resumeArgs: argvSchema.optional(),
-		env: envSchema.optional(),
+		promptArgs: agentArgvSchema.optional(),
+		resumeArgs: agentArgvSchema.optional(),
+		env: agentEnvSchema.optional(),
 		iconId: iconIdPatchSchema.optional(),
 	})
 	.refine(
@@ -171,12 +176,12 @@ const updatePatchSchema = z
 const addInputSchema = z.object({
 	label: z.string().trim().min(1),
 	command: z.string().trim().min(1),
-	args: argvSchema,
+	args: agentArgvSchema,
 	promptTransport: promptTransportSchema,
-	promptArgs: argvSchema,
+	promptArgs: agentArgvSchema,
 	// Defaulted so an older desktop client that doesn't send it can still add.
-	resumeArgs: argvSchema.default([]),
-	env: envSchema,
+	resumeArgs: agentArgvSchema.default([]),
+	env: agentEnvSchema,
 	presetId: z.string().trim().min(1).optional(),
 	iconId: iconIdSchema.optional(),
 });
@@ -191,6 +196,29 @@ export const agentConfigsRouter = router({
 		return rows.map(toOutput);
 	}),
 
+	/** Read persisted capability snapshots without spawning an agent process. */
+	listCapabilitySnapshots: protectedProcedure.query(({ ctx }) => {
+		seedDefaultsIfEmpty(ctx.db);
+		return ctx.capabilityRefresh.readPersisted();
+	}),
+
+	/** Explicitly refresh all or the requested agents. Concurrent probes coalesce. */
+	refreshCapabilities: protectedProcedure
+		.input(
+			z
+				.object({
+					agentIds: z.array(z.string().min(1)).optional(),
+				})
+				.optional(),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const requestedIds = input?.agentIds ? new Set(input.agentIds) : null;
+			const configs = seedDefaultsIfEmpty(ctx.db)
+				.filter((row) => requestedIds === null || requestedIds.has(row.id))
+				.map(toCapabilityConfig);
+			return ctx.capabilityRefresh.refreshCapabilities(configs);
+		}),
+
 	/**
 	 * Insert a configured host-agent row. Callers pass the full launch shape;
 	 * `presetId` is a free-form metadata tag the client uses for description
@@ -199,42 +227,47 @@ export const agentConfigsRouter = router({
 	 * (used by user-authored agents, whose `presetId` is `"custom"`). Duplicate
 	 * `presetId` values are allowed — each row gets a fresh `id`.
 	 */
-	add: protectedProcedure.input(addInputSchema).mutation(({ ctx, input }) => {
-		const existing = listOrdered(ctx.db);
-		const nextOrder =
-			existing.length === 0
-				? 0
-				: Math.max(...existing.map((row) => row.displayOrder)) + 1;
-		const id = randomUUID();
-		ctx.db
-			.insert(hostAgentConfigs)
-			.values({
-				id,
-				presetId: input.presetId ?? "custom",
-				iconId: input.iconId ?? null,
-				label: input.label,
-				command: input.command,
-				argsJson: JSON.stringify(input.args),
-				promptTransport: input.promptTransport,
-				promptArgsJson: JSON.stringify(input.promptArgs),
-				resumeArgsJson: JSON.stringify(input.resumeArgs),
-				envJson: JSON.stringify(input.env),
-				displayOrder: nextOrder,
-			})
-			.run();
-		const created = ctx.db
-			.select()
-			.from(hostAgentConfigs)
-			.where(eq(hostAgentConfigs.id, id))
-			.get();
-		if (!created) {
-			throw new TRPCError({
-				code: "INTERNAL_SERVER_ERROR",
-				message: "Failed to read back inserted host agent config",
-			});
-		}
-		return toOutput(created);
-	}),
+	add: protectedProcedure
+		.input(addInputSchema)
+		.mutation(async ({ ctx, input }) => {
+			const existing = listOrdered(ctx.db);
+			const nextOrder =
+				existing.length === 0
+					? 0
+					: Math.max(...existing.map((row) => row.displayOrder)) + 1;
+			const id = randomUUID();
+			ctx.db
+				.insert(hostAgentConfigs)
+				.values({
+					id,
+					presetId: input.presetId ?? "custom",
+					iconId: input.iconId ?? null,
+					label: input.label,
+					command: input.command,
+					argsJson: JSON.stringify(input.args),
+					promptTransport: input.promptTransport,
+					promptArgsJson: JSON.stringify(input.promptArgs),
+					resumeArgsJson: JSON.stringify(input.resumeArgs),
+					envJson: JSON.stringify(input.env),
+					displayOrder: nextOrder,
+				})
+				.run();
+			const created = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, id))
+				.get();
+			if (!created) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to read back inserted host agent config",
+				});
+			}
+			await ctx.capabilityRefresh
+				.refreshCapability(toCapabilityConfig(created))
+				.catch(() => console.warn("[agent-capabilities] add refresh failed"));
+			return toOutput(created);
+		}),
 
 	/**
 	 * Update editable fields on an existing config. `presetId` and `order`
@@ -247,7 +280,7 @@ export const agentConfigsRouter = router({
 				patch: updatePatchSchema,
 			}),
 		)
-		.mutation(({ ctx, input }) => {
+		.mutation(async ({ ctx, input }) => {
 			const existing = ctx.db
 				.select()
 				.from(hostAgentConfigs)
@@ -259,6 +292,13 @@ export const agentConfigsRouter = router({
 					message: `Host agent config not found: ${input.id}`,
 				});
 			}
+			const discoveryIdentityChanged =
+				(input.patch.command !== undefined &&
+					input.patch.command !== existing.command) ||
+				(input.patch.args !== undefined &&
+					!argsEqual(existing.argsJson, input.patch.args)) ||
+				(input.patch.env !== undefined &&
+					!envsEqual(existing.envJson, input.patch.env));
 			const update: Partial<typeof hostAgentConfigs.$inferInsert> = {
 				updatedAt: Date.now(),
 			};
@@ -276,11 +316,24 @@ export const agentConfigsRouter = router({
 			if (input.patch.env !== undefined)
 				update.envJson = JSON.stringify(input.patch.env);
 			if (input.patch.iconId !== undefined) update.iconId = input.patch.iconId;
-			ctx.db
-				.update(hostAgentConfigs)
-				.set(update)
-				.where(eq(hostAgentConfigs.id, input.id))
-				.run();
+			ctx.db.transaction((tx) => {
+				tx.update(hostAgentConfigs)
+					.set(
+						discoveryIdentityChanged
+							? {
+									...update,
+									capabilityRevision: sql`${hostAgentConfigs.capabilityRevision} + 1`,
+								}
+							: update,
+					)
+					.where(eq(hostAgentConfigs.id, input.id))
+					.run();
+				if (discoveryIdentityChanged) {
+					tx.delete(hostAgentCapabilitySnapshots)
+						.where(eq(hostAgentCapabilitySnapshots.agentId, input.id))
+						.run();
+				}
+			});
 			const updated = ctx.db
 				.select()
 				.from(hostAgentConfigs)
@@ -292,6 +345,13 @@ export const agentConfigsRouter = router({
 					message: "Failed to read back updated host agent config",
 				});
 			}
+			if (discoveryIdentityChanged) {
+				await ctx.capabilityRefresh
+					.refreshCapability(toCapabilityConfig(updated))
+					.catch(() =>
+						console.warn("[agent-capabilities] config refresh failed"),
+					);
+			}
 			return toOutput(updated);
 		}),
 
@@ -302,7 +362,7 @@ export const agentConfigsRouter = router({
 	 */
 	restoreDefault: protectedProcedure
 		.input(z.object({ id: z.string().min(1) }))
-		.mutation(({ ctx, input }) => {
+		.mutation(async ({ ctx, input }) => {
 			const existing = ctx.db
 				.select()
 				.from(hostAgentConfigs)
@@ -323,21 +383,26 @@ export const agentConfigsRouter = router({
 				});
 			}
 
-			ctx.db
-				.update(hostAgentConfigs)
-				.set({
-					iconId: null,
-					label: preset.label,
-					command: preset.command,
-					argsJson: JSON.stringify(preset.args),
-					promptTransport: preset.promptTransport,
-					promptArgsJson: JSON.stringify(preset.promptArgs),
-					resumeArgsJson: JSON.stringify(preset.resumeArgs),
-					envJson: JSON.stringify(preset.env),
-					updatedAt: Date.now(),
-				})
-				.where(eq(hostAgentConfigs.id, input.id))
-				.run();
+			ctx.db.transaction((tx) => {
+				tx.update(hostAgentConfigs)
+					.set({
+						iconId: null,
+						label: preset.label,
+						command: preset.command,
+						argsJson: JSON.stringify(preset.args),
+						promptTransport: preset.promptTransport,
+						promptArgsJson: JSON.stringify(preset.promptArgs),
+						resumeArgsJson: JSON.stringify(preset.resumeArgs),
+						envJson: JSON.stringify(preset.env),
+						capabilityRevision: sql`${hostAgentConfigs.capabilityRevision} + 1`,
+						updatedAt: Date.now(),
+					})
+					.where(eq(hostAgentConfigs.id, input.id))
+					.run();
+				tx.delete(hostAgentCapabilitySnapshots)
+					.where(eq(hostAgentCapabilitySnapshots.agentId, input.id))
+					.run();
+			});
 
 			const restored = ctx.db
 				.select()
@@ -350,6 +415,11 @@ export const agentConfigsRouter = router({
 					message: "Failed to read back restored host agent config",
 				});
 			}
+			await ctx.capabilityRefresh
+				.refreshCapability(toCapabilityConfig(restored))
+				.catch(() =>
+					console.warn("[agent-capabilities] restore refresh failed"),
+				);
 			return toOutput(restored);
 		}),
 
@@ -419,7 +489,7 @@ export const agentConfigsRouter = router({
 	 * transaction so a crash between delete and insert can't leave the
 	 * table empty.
 	 */
-	resetToDefaults: protectedProcedure.mutation(({ ctx }) => {
+	resetToDefaults: protectedProcedure.mutation(async ({ ctx }) => {
 		ctx.db.transaction((tx) => {
 			const existing = tx
 				.select({ id: hostAgentConfigs.id })
@@ -442,6 +512,10 @@ export const agentConfigsRouter = router({
 				tx.insert(hostAgentConfigs).values(seeds).run();
 			}
 		});
-		return listOrdered(ctx.db).map(toOutput);
+		const rows = listOrdered(ctx.db);
+		await ctx.capabilityRefresh
+			.refreshCapabilities(rows.map(toCapabilityConfig))
+			.catch(() => console.warn("[agent-capabilities] reset refresh failed"));
+		return rows.map(toOutput);
 	}),
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.launch-contract.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.launch-contract.test.ts
@@ -1,0 +1,70 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { TRPCError } from "@trpc/server";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../../../../db";
+import * as schema from "../../../../db/schema";
+import type { HostServiceContext } from "../../../../types";
+import { workspacesRouter } from "../../workspaces/workspaces";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../../../drizzle");
+const CLAUDE_ID = "00000000-0000-0000-0000-00000000000a";
+
+function createTestDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
+}
+
+function seedClaude(db: HostDb) {
+	db.insert(schema.hostAgentConfigs)
+		.values({
+			id: CLAUDE_ID,
+			presetId: "claude",
+			label: "Claude",
+			command: "claude",
+			argsJson: "[]",
+			promptTransport: "argv",
+			promptArgsJson: "[]",
+			resumeArgsJson: "[]",
+			envJson: "{}",
+			capabilityRevision: 1,
+			displayOrder: 0,
+		})
+		.run();
+}
+
+function createCaller(db: HostDb) {
+	const ctx = {
+		db,
+		isAuthenticated: true,
+		organizationId: "org-1",
+	} as HostServiceContext;
+	return workspacesRouter.createCaller(ctx);
+}
+
+describe("createSession launch contract", () => {
+	it("rejects a retired model before creating a session folder", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		const caller = createCaller(db);
+		try {
+			await caller.createSession({
+				agents: [
+					{
+						agent: "claude",
+						prompt: "do the thing",
+						model: "retired-model",
+					},
+				],
+			});
+			throw new Error("Expected createSession to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+		expect(db.select().from(schema.workspaces).all()).toEqual([]);
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.launch-contract.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.launch-contract.test.ts
@@ -11,6 +11,7 @@ import { workspacesRouter } from "../../workspaces/workspaces";
 
 const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../../../drizzle");
 const CLAUDE_ID = "00000000-0000-0000-0000-00000000000a";
+const SESSION_ID = "22222222-2222-4222-8222-222222222222";
 
 function createTestDb(): HostDb {
 	const sqlite = new Database(":memory:");
@@ -47,6 +48,36 @@ function createCaller(db: HostDb) {
 }
 
 describe("createSession launch contract", () => {
+	it("returns an existing session before revalidating a retired model", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		db.insert(schema.workspaces)
+			.values({
+				id: SESSION_ID,
+				worktreePath: "/tmp/existing-session",
+				branch: "main",
+				name: "Existing session",
+				type: "session",
+			})
+			.run();
+
+		const result = await createCaller(db).createSession({
+			id: SESSION_ID,
+			agents: [
+				{
+					agent: "claude",
+					prompt: "do the thing",
+					model: "retired-model",
+				},
+			],
+		});
+
+		expect(result.workspace.id).toBe(SESSION_ID);
+		expect(result.workspace.name).toBe("Existing session");
+		expect(result.terminals).toEqual([]);
+		expect(result.agents).toEqual([]);
+	});
+
 	it("rejects a retired model before creating a session folder", async () => {
 		const db = createTestDb();
 		seedClaude(db);

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
@@ -14,7 +14,7 @@ import {
 	updateLocalWorkspace,
 } from "../../../../workspaces/local-workspace-store";
 import { protectedProcedure } from "../../../index";
-import { validateAgentLaunchEffort } from "../../agents";
+import { validateAgentLaunchSelection } from "../../agents";
 import { initEmptyRepo } from "../../project/utils/resolve-repo";
 import { startCommandTerminal } from "../shared/command-terminal";
 import {
@@ -68,7 +68,7 @@ export const createSession = protectedProcedure
 	.input(createSessionInputSchema)
 	.mutation(async ({ ctx, input }) => {
 		for (const launch of input.agents ?? []) {
-			validateAgentLaunchEffort(ctx.db, launch);
+			await validateAgentLaunchSelection(ctx.db, launch);
 		}
 
 		// Idempotency: a retry carrying the same optimistic id must return the

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
@@ -67,10 +67,6 @@ function claimedSessionNames(ctx: HostServiceContext): string[] {
 export const createSession = protectedProcedure
 	.input(createSessionInputSchema)
 	.mutation(async ({ ctx, input }) => {
-		for (const launch of input.agents ?? []) {
-			await validateAgentLaunchSelection(ctx.db, launch);
-		}
-
 		// Idempotency: a retry carrying the same optimistic id must return the
 		// existing row instead of allocating a second folder and then dying on
 		// the primary key (which would leak the freshly-created directory).
@@ -83,6 +79,10 @@ export const createSession = protectedProcedure
 					agents: [],
 				};
 			}
+		}
+
+		for (const launch of input.agents ?? []) {
+			await validateAgentLaunchSelection(ctx.db, launch);
 		}
 
 		// AI title, same contract as `workspaces.create`: only when the

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/dispatch-agents.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/dispatch-agents.ts
@@ -9,6 +9,9 @@ export const agentLaunchSchema = z
 		attachmentIds: z.array(z.string().uuid()).optional(),
 		model: z.string().optional(),
 		effort: z.string().optional(),
+		mode: z.string().optional(),
+		speed: z.string().optional(),
+		contextWindow: z.string().optional(),
 	})
 	.refine(
 		(value) =>
@@ -36,6 +39,9 @@ export async function dispatchSugarAgents(
 					attachmentIds: entry.attachmentIds,
 					model: entry.model,
 					effort: entry.effort,
+					mode: entry.mode,
+					speed: entry.speed,
+					contextWindow: entry.contextWindow,
 				});
 				return { ok: true as const, ...result };
 			} catch (err) {

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.launch-contract.test.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.launch-contract.test.ts
@@ -1,0 +1,142 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { TRPCError } from "@trpc/server";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../../../db";
+import * as schema from "../../../db/schema";
+import type { HostServiceContext } from "../../../types";
+import { buildValidatedTerminalAgentLaunch } from "../agents";
+import { workspacesRouter } from "./workspaces";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../../drizzle");
+const CLAUDE_ID = "00000000-0000-0000-0000-00000000000a";
+const PROJECT_ID = "11111111-1111-1111-1111-111111111111";
+
+function createTestDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
+}
+
+function seedClaude(db: HostDb) {
+	db.insert(schema.hostAgentConfigs)
+		.values({
+			id: CLAUDE_ID,
+			presetId: "claude",
+			label: "Claude",
+			command: "claude",
+			argsJson: "[]",
+			promptTransport: "argv",
+			promptArgsJson: "[]",
+			resumeArgsJson: "[]",
+			envJson: "{}",
+			capabilityRevision: 1,
+			displayOrder: 0,
+		})
+		.run();
+}
+
+function createCaller(db: HostDb) {
+	const ctx = {
+		db,
+		isAuthenticated: true,
+		organizationId: "org-1",
+	} as HostServiceContext;
+	return workspacesRouter.createCaller(ctx);
+}
+
+describe("workspaces launch contract", () => {
+	it("rejects create before project or filesystem work when the model is retired", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		const caller = createCaller(db);
+		try {
+			await caller.create({
+				projectId: PROJECT_ID,
+				agents: [
+					{
+						agent: "claude",
+						prompt: "do the thing",
+						model: "retired-model",
+					},
+				],
+			});
+			throw new Error("Expected create to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+		expect(db.select().from(schema.workspaces).all()).toEqual([]);
+	});
+
+	it("rejects createEnqueued before enqueueing when the model is retired", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		const caller = createCaller(db);
+		try {
+			await caller.createEnqueued({
+				id: "22222222-2222-4222-8222-222222222222",
+				projectId: PROJECT_ID,
+				agents: [
+					{
+						agent: "claude",
+						prompt: "do the thing",
+						model: "retired-model",
+					},
+				],
+			});
+			throw new Error("Expected createEnqueued to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+		}
+		expect(db.select().from(schema.workspaces).all()).toEqual([]);
+	});
+
+	it("preserves launch traits through the workspace-create schema", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		const caller = createCaller(db);
+		try {
+			await caller.create({
+				projectId: PROJECT_ID,
+				agents: [
+					{
+						agent: "claude",
+						prompt: "do the thing",
+						model: "claude-opus-5",
+						speed: "turbo",
+					},
+				],
+			});
+			throw new Error("Expected create to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as Error).message).toContain(
+				'Unsupported speed "turbo" for Claude',
+			);
+		}
+		expect(db.select().from(schema.workspaces).all()).toEqual([]);
+	});
+
+	it("setup-terminal chaining preserves the exact validated model", async () => {
+		const db = createTestDb();
+		seedClaude(db);
+		const launch = await buildValidatedTerminalAgentLaunch(db, {
+			workspaceId: "33333333-3333-4333-8333-333333333333",
+			agent: "claude",
+			prompt: "do the thing",
+			model: "claude-opus-5",
+			effort: "ultracode",
+			speed: "fast",
+			contextWindow: "1m",
+		});
+		expect(launch.fullCommand).toContain("'--model' 'claude-opus-5[1m]'");
+		expect(launch.fullCommand).toContain("'--effort' 'xhigh'");
+		expect(launch.fullCommand).toContain(
+			'\'{"fastMode":true,"ultracode":true}\'',
+		);
+		expect(launch.fullCommand).not.toContain("claude-fable-5");
+	});
+});

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -20,7 +20,10 @@ import {
 	toCloudShape,
 } from "../../../workspaces/local-workspace-store";
 import { createCallerFactory, protectedProcedure, router } from "../../index";
-import { buildTerminalAgentLaunch, validateAgentLaunchEffort } from "../agents";
+import {
+	buildValidatedTerminalAgentLaunch,
+	validateAgentLaunchSelection,
+} from "../agents";
 import { ensureMainWorkspace } from "../project/utils/ensure-main-workspace";
 import { getHostWorktreeBaseDir } from "../settings/worktree-location";
 import { createSession } from "../workspace-creation/procedures/create-session";
@@ -507,7 +510,7 @@ export const workspacesRouter = router({
 		.input(createInputSchema)
 		.mutation(async ({ ctx, input }) => {
 			for (const launch of input.agents ?? []) {
-				validateAgentLaunchEffort(ctx.db, launch);
+				await validateAgentLaunchSelection(ctx.db, launch);
 			}
 
 			const localProject = requireLocalProject(ctx, input.projectId);
@@ -1104,13 +1107,16 @@ export const workspacesRouter = router({
 			const soleLaunch = sugarLaunches.length === 1 ? sugarLaunches[0] : null;
 			if (!alreadyExists && input.waitForSetupBeforeAgents && soleLaunch) {
 				try {
-					chainAgent = buildTerminalAgentLaunch(ctx.db, {
+					chainAgent = await buildValidatedTerminalAgentLaunch(ctx.db, {
 						workspaceId: workspaceRow.id,
 						agent: soleLaunch.agent,
 						prompt: soleLaunch.prompt,
 						attachmentIds: soleLaunch.attachmentIds,
 						model: soleLaunch.model,
 						effort: soleLaunch.effort,
+						mode: soleLaunch.mode,
+						speed: soleLaunch.speed,
+						contextWindow: soleLaunch.contextWindow,
 					});
 				} catch (err) {
 					console.warn(
@@ -1214,7 +1220,7 @@ export const workspacesRouter = router({
 	 */
 	createEnqueued: protectedProcedure
 		.input(createInputSchema)
-		.mutation(({ ctx, input }) => {
+		.mutation(async ({ ctx, input }) => {
 			const workspaceId = input.id;
 			if (!workspaceId) {
 				throw new TRPCError({
@@ -1223,7 +1229,7 @@ export const workspacesRouter = router({
 				});
 			}
 			for (const launch of input.agents ?? []) {
-				validateAgentLaunchEffort(ctx.db, launch);
+				await validateAgentLaunchSelection(ctx.db, launch);
 			}
 			requireLocalProject(ctx, input.projectId);
 

--- a/packages/host-service/src/types.ts
+++ b/packages/host-service/src/types.ts
@@ -2,6 +2,7 @@ import type { Octokit } from "@octokit/rest";
 import type { ChatService } from "@superset/provider-auth/server";
 import type { AppRouter } from "@superset/trpc";
 import type { TRPCClient } from "@trpc/client";
+import type { CapabilityRefreshService } from "./agent-capabilities/capability-refresh-service";
 import type { HostDb } from "./db";
 import type { EventBus } from "./events";
 import type { WorkspaceFilesystemManager } from "./runtime/filesystem";
@@ -25,6 +26,7 @@ export interface HostServiceContext {
 	execGh: ExecGh;
 	api: ApiClient;
 	db: HostDb;
+	capabilityRefresh: CapabilityRefreshService;
 	runtime: HostServiceRuntime;
 	eventBus: EventBus;
 	terminalAgentStore: TerminalAgentStore;

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -8,6 +8,18 @@ import {
 import { getPresetById } from "./host-agent-presets";
 
 describe("buildAgentPromptCommand", () => {
+	it("launches Antigravity prompts interactively", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "hello",
+			randomId: "agy-1234",
+			agent: "antigravity",
+		});
+
+		expect(command).toStartWith(
+			"agy --mode=accept-edits --prompt-interactive \"$(cat <<'SUPERSET_PROMPT_agy1234'",
+		);
+	});
+
 	it("adds `--` before codex prompt payload", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "- Only modified file: runtime.ts",

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	AGENT_EFFORT_SUPPORT,
 	AGENT_MODEL_SUPPORT,
+	buildAgentContextWindowEnv,
 	buildAgentEffortArgs,
 	buildAgentModeArgs,
 	buildAgentModelArgs,
@@ -192,6 +193,27 @@ describe("buildAgentModelArgs", () => {
 		expect(buildAgentModelArgs("polygraph", undefined)).toEqual([]);
 		expect(buildAgentModelArgs("polygraph", "")).toEqual([]);
 		expect(buildAgentModelArgs("polygraph", "gemini")).toEqual([]);
+	});
+});
+
+describe("buildAgentContextWindowEnv", () => {
+	it("enforces an explicit 200k Claude context window", () => {
+		expect(
+			buildAgentContextWindowEnv("claude", "claude-opus-5", "200k"),
+		).toEqual({ CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" });
+	});
+
+	it("re-enables 1m when the inherited environment disables it", () => {
+		expect(buildAgentContextWindowEnv("claude", "claude-opus-5", "1m")).toEqual(
+			{ CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+		);
+	});
+
+	it("does not override the environment for omitted or unsupported contexts", () => {
+		expect(buildAgentContextWindowEnv("claude", "claude-opus-5")).toEqual({});
+		expect(buildAgentContextWindowEnv("codex", "gpt-5.6-sol", "200k")).toEqual(
+			{},
+		);
 	});
 });
 

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -3,10 +3,17 @@ import {
 	AGENT_EFFORT_SUPPORT,
 	AGENT_MODEL_SUPPORT,
 	buildAgentEffortArgs,
+	buildAgentModeArgs,
 	buildAgentModelArgs,
 	buildAgentModelEnv,
+	buildAgentRuntimeTraitArgs,
+	buildAgentSpeedArgs,
+	getAgentContextWindowSupport,
 	getAgentEffortSupport,
 	getAgentModelSupport,
+	getAgentModeSupport,
+	getAgentSpeedSupport,
+	resolveAgentEffortSupport,
 	SUPERSET_CHAT_MODELS,
 } from "./agent-models";
 import { BUILTIN_TERMINAL_AGENT_TYPES } from "./builtin-terminal-agents";
@@ -40,7 +47,11 @@ describe("AGENT_MODEL_SUPPORT", () => {
 
 	it("lists at least one model per entry", () => {
 		for (const entry of AGENT_MODEL_SUPPORT) {
-			expect(entry.models.length).toBeGreaterThan(0);
+			if (["antigravity", "pi", "grok", "kimi"].includes(entry.presetId)) {
+				expect(entry.models).toEqual([]);
+			} else {
+				expect(entry.models.length).toBeGreaterThan(0);
+			}
 		}
 	});
 });
@@ -64,13 +75,31 @@ describe("getAgentModelSupport", () => {
 		expect(getAgentModelSupport("amp")).toBeUndefined();
 		expect(getAgentModelSupport("nonexistent")).toBeUndefined();
 	});
+
+	it("keeps the versioned Claude catalog and known model defaults", () => {
+		const claude = getAgentModelSupport("claude");
+		expect(claude?.defaultModelId).toBe("claude-fable-5");
+		expect(claude?.models).toContainEqual({
+			id: "claude-sonnet-5",
+			label: "Sonnet 5",
+		});
+		expect(claude?.models.some((model) => model.id === "sonnet")).toBe(false);
+		expect(getAgentModelSupport("codex")?.defaultModelId).toBe("gpt-5.6-sol");
+	});
 });
 
 describe("buildAgentModelArgs", () => {
+	it("accepts a model returned by runtime discovery", () => {
+		expect(
+			buildAgentModelArgs("antigravity", "runtime-model", undefined, [
+				"runtime-model",
+			]),
+		).toEqual(["--model", "runtime-model"]);
+	});
 	it("builds flag + value tokens", () => {
-		expect(buildAgentModelArgs("claude", "sonnet")).toEqual([
+		expect(buildAgentModelArgs("claude", "claude-sonnet-5")).toEqual([
 			"--model",
-			"sonnet",
+			"claude-sonnet-5",
 		]);
 	});
 
@@ -94,10 +123,10 @@ describe("buildAgentModelArgs", () => {
 		).toEqual([]);
 	});
 
-	it("includes fable in claude's curated list", () => {
-		expect(buildAgentModelArgs("claude", "fable")).toEqual([
+	it("includes the versioned fable id in claude's curated list", () => {
+		expect(buildAgentModelArgs("claude", "claude-fable-5")).toEqual([
 			"--model",
-			"fable",
+			"claude-fable-5",
 		]);
 	});
 
@@ -109,10 +138,6 @@ describe("buildAgentModelArgs", () => {
 	});
 
 	it("includes fable for the other CLIs that support it", () => {
-		expect(buildAgentModelArgs("copilot", "claude-fable-5")).toEqual([
-			"--model",
-			"claude-fable-5",
-		]);
 		expect(
 			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-high"),
 		).toEqual(["--model", "claude-fable-5-thinking-high"]);
@@ -194,6 +219,47 @@ describe("getAgentEffortSupport", () => {
 		expect(getAgentEffortSupport("gemini")).toBeUndefined();
 		expect(getAgentEffortSupport("superset")).toBeUndefined();
 	});
+
+	it("keeps Codex fallback levels scoped to each model", () => {
+		expect(getAgentEffortSupport("codex", "gpt-5.6-sol")).toMatchObject({
+			defaultEffortId: "low",
+			efforts: expect.arrayContaining([
+				{ id: "max", label: "Max" },
+				{ id: "ultra", label: "Ultra" },
+			]),
+		});
+		expect(
+			getAgentEffortSupport("codex", "gpt-5.6-luna")?.efforts.map(
+				(effort) => effort.id,
+			),
+		).toEqual(["low", "medium", "high", "xhigh", "max"]);
+		expect(
+			getAgentEffortSupport("codex", "gpt-5.5")?.efforts.map(
+				(effort) => effort.id,
+			),
+		).toEqual(["low", "medium", "high", "xhigh"]);
+	});
+});
+
+describe("resolveAgentEffortSupport", () => {
+	it("uses runtime reasoning options with the curated transport", () => {
+		const support = resolveAgentEffortSupport("opencode", "runtime-model", {
+			state: "supported",
+			options: [{ id: "ultra", label: "Ultra" }],
+			defaultId: "ultra",
+		});
+
+		expect(support?.efforts).toEqual([{ id: "ultra", label: "Ultra" }]);
+		expect(support?.defaultEffortId).toBe("ultra");
+	});
+
+	it("does not fall back when runtime reports unsupported", () => {
+		expect(
+			resolveAgentEffortSupport("codex", "gpt-5.6-sol", {
+				state: "unsupported",
+			}),
+		).toBeUndefined();
+	});
 });
 
 describe("buildAgentEffortArgs", () => {
@@ -211,6 +277,14 @@ describe("buildAgentEffortArgs", () => {
 		]);
 	});
 
+	it("accepts runtime effort levels for newly discovered Codex models", () => {
+		expect(
+			buildAgentEffortArgs("codex", "ultra", "future-model", {
+				efforts: [{ id: "ultra", label: "Ultra" }],
+			}),
+		).toEqual(["-c", "model_reasoning_effort=ultra"]);
+	});
+
 	it("returns [] when no effort is set", () => {
 		expect(buildAgentEffortArgs("claude", undefined)).toEqual([]);
 		expect(buildAgentEffortArgs("claude", "")).toEqual([]);
@@ -223,6 +297,50 @@ describe("buildAgentEffortArgs", () => {
 	it("returns [] for effort ids outside the preset's curated list", () => {
 		expect(buildAgentEffortArgs("claude", "bogus")).toEqual([]);
 		expect(buildAgentEffortArgs("copilot", "max")).toEqual([]);
+	});
+});
+
+describe("agent launch traits", () => {
+	it("exposes Claude Ultracode, Fast Mode, and model-specific context", () => {
+		expect(
+			getAgentEffortSupport("claude", "claude-opus-5")?.efforts,
+		).toContainEqual({ id: "ultracode", label: "Ultracode" });
+		expect(getAgentSpeedSupport("claude", "claude-opus-5")).toMatchObject({
+			label: "Fast Mode",
+			defaultSpeedId: "standard",
+		});
+		expect(
+			getAgentContextWindowSupport("claude", "claude-opus-5")
+				?.defaultContextWindowId,
+		).toBe("1m");
+		expect(buildAgentModelArgs("claude", "claude-opus-5", "1m")).toEqual([
+			"--model",
+			"claude-opus-5[1m]",
+		]);
+		expect(
+			buildAgentRuntimeTraitArgs("claude", {
+				model: "claude-opus-5",
+				effort: "ultracode",
+				speed: "fast",
+			}),
+		).toEqual(["--settings", '{"fastMode":true,"ultracode":true}']);
+	});
+
+	it("exposes Codex Service Tier and maps it to the stable feature flag", () => {
+		expect(getAgentSpeedSupport("codex", "gpt-5.6-sol")).toMatchObject({
+			label: "Service Tier",
+			defaultSpeedId: "standard",
+		});
+		expect(buildAgentSpeedArgs("codex", "fast", "gpt-5.6-sol")).toEqual([
+			"--enable",
+			"fast_mode",
+		]);
+	});
+
+	it("keeps OpenCode reasoning variants separate from agent modes", () => {
+		expect(getAgentEffortSupport("opencode")?.label).toBe("Reasoning");
+		expect(getAgentModeSupport("opencode")?.label).toBe("Agent");
+		expect(buildAgentModeArgs("opencode", "plan")).toEqual(["--agent", "plan"]);
 	});
 });
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -15,17 +15,46 @@
 export interface AgentModelOption {
 	id: string;
 	label: string;
+	provider?: string;
 }
+
+/**
+ * Structured dimensions for an exact runtime model id. Some CLIs, notably
+ * Cursor, encode launch traits into the model id instead of accepting
+ * independent flags. Keeping the exact id alongside these dimensions lets the
+ * UI present compact pickers without synthesizing unsupported combinations.
+ */
+export interface AgentRuntimeModelVariant {
+	familyId: string;
+	familyLabel: string;
+	effort: string;
+	speed: "standard" | "fast";
+	mode: "standard" | "thinking";
+	contextWindow: "default" | "1m";
+}
+
+export type AgentCapabilityTrait<TOption> =
+	| { state: "unknown" }
+	| { state: "unsupported" }
+	| {
+			state: "supported";
+			options: TOption[];
+			defaultId?: string;
+	  };
 
 export interface AgentModelSupport {
 	presetId: string;
 	modelFlag: string | null;
+	/** Model selected when the picker intentionally has no synthetic default. */
+	defaultModelId?: string;
 	/**
 	 * Env var that carries the model when the CLI has no model flag (e.g. Vibe's
 	 * `VIBE_ACTIVE_MODEL`). Mutually exclusive with `modelFlag` in practice.
 	 */
 	modelEnv?: string;
 	models: AgentModelOption[];
+	/** Maps previously persisted exact runtime ids to their current UI family. */
+	modelAliases?: Readonly<Record<string, string>>;
 }
 
 export interface SupersetChatModel extends AgentModelOption {
@@ -67,17 +96,23 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	{
 		presetId: "claude",
 		modelFlag: "--model",
+		defaultModelId: "claude-fable-5",
 		models: [
-			{ id: "fable", label: "Fable" },
-			{ id: "opus", label: "Opus" },
+			{ id: "claude-fable-5", label: "Fable 5" },
 			{ id: "claude-opus-5", label: "Opus 5" },
-			{ id: "sonnet", label: "Sonnet" },
-			{ id: "haiku", label: "Haiku" },
+			{ id: "claude-sonnet-5", label: "Sonnet 5" },
+			{ id: "claude-opus-4-8", label: "Opus 4.8" },
+			{ id: "claude-opus-4-7", label: "Opus 4.7" },
+			{ id: "claude-opus-4-6", label: "Opus 4.6" },
+			{ id: "claude-opus-4-5", label: "Opus 4.5" },
+			{ id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+			{ id: "claude-haiku-4-5", label: "Haiku 4.5" },
 		],
 	},
 	{
 		presetId: "codex",
 		modelFlag: "--model",
+		defaultModelId: "gpt-5.6-sol",
 		models: [
 			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
 			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
@@ -92,17 +127,26 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "gemini",
 		modelFlag: "--model",
 		models: [
+			{ id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+			{ id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
 			{ id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
 			{ id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+			{ id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
 		],
 	},
+	{ presetId: "antigravity", modelFlag: "--model", models: [] },
 	{
 		presetId: "copilot",
 		modelFlag: "--model",
 		models: [
-			{ id: "claude-fable-5", label: "Claude Fable 5" },
-			{ id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
-			{ id: "gpt-5.1", label: "GPT-5.1" },
+			{ id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+			{ id: "gpt-5.4", label: "GPT-5.4" },
+			{ id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
+			{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+			{ id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+			{ id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
+			{ id: "gemini-3.6-flash", label: "Gemini 3.6 Flash" },
+			{ id: "mai-code-1-flash", label: "MAI-Code-1 Flash" },
 		],
 	},
 	{
@@ -137,12 +181,32 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			// no longer lists the old `openai/gpt-5`. anthropic ids follow the
 			// same models.dev catalog but need an authed anthropic provider to
 			// appear in that listing.
-			{ id: "anthropic/claude-opus-5", label: "Claude Opus 5" },
-			{ id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
-			{ id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-			{ id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" },
-			{ id: "openai/gpt-5.6-terra", label: "GPT-5.6 Terra" },
-			{ id: "openai/gpt-5.6-luna", label: "GPT-5.6 Luna" },
+			{
+				id: "anthropic/claude-opus-5",
+				label: "Claude Opus 5",
+				provider: "Anthropic",
+			},
+			{
+				id: "anthropic/claude-fable-5",
+				label: "Claude Fable 5",
+				provider: "Anthropic",
+			},
+			{
+				id: "anthropic/claude-sonnet-4-5",
+				label: "Claude Sonnet 4.5",
+				provider: "Anthropic",
+			},
+			{ id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol", provider: "OpenAI" },
+			{
+				id: "openai/gpt-5.6-terra",
+				label: "GPT-5.6 Terra",
+				provider: "OpenAI",
+			},
+			{
+				id: "openai/gpt-5.6-luna",
+				label: "GPT-5.6 Luna",
+				provider: "OpenAI",
+			},
 		],
 	},
 	{
@@ -154,6 +218,9 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			{ id: "devstral-small", label: "Devstral Small" },
 		],
 	},
+	{ presetId: "pi", modelFlag: "--model", models: [] },
+	{ presetId: "grok", modelFlag: "--model", models: [] },
+	{ presetId: "kimi", modelFlag: "--model", models: [] },
 	{
 		// Polygraph's picker selects the harness it launches, not a model: the
 		// selection rides `polygraph session start --agent <id>`. The launch
@@ -172,7 +239,10 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 
 export interface AgentEffortSupport {
 	presetId: string;
+	label?: string;
 	effortFlag: string;
+	/** Agent/model default. It is displayed without requiring an override flag. */
+	defaultEffortId?: string;
 	/**
 	 * Prepended to the selected effort id to form the flag's value token.
 	 * Codex has no dedicated effort flag, so effort rides a config override:
@@ -180,7 +250,103 @@ export interface AgentEffortSupport {
 	 */
 	effortValuePrefix?: string;
 	efforts: AgentModelOption[];
+	modelProfiles?: Readonly<
+		Record<
+			string,
+			{
+				defaultEffortId: string;
+				label?: string;
+				efforts: readonly AgentModelOption[];
+			}
+		>
+	>;
 }
+
+export interface AgentRuntimeEffortProfile {
+	defaultEffortId?: string;
+	efforts: readonly AgentModelOption[];
+}
+
+export interface AgentModeOption extends AgentModelOption {
+	/** Exact argv tokens appended when this mode is selected. */
+	args: readonly string[];
+}
+
+export interface AgentModeSupport {
+	presetId: string;
+	label: string;
+	defaultModeId?: string;
+	modes: readonly AgentModeOption[];
+}
+
+export interface AgentSpeedOption extends AgentModelOption {
+	/** Exact argv tokens appended when this speed is selected. */
+	args: readonly string[];
+}
+
+export interface AgentSpeedSupport {
+	presetId: string;
+	label: string;
+	defaultSpeedId?: string;
+	supportedModelIds?: readonly string[];
+	speeds: AgentSpeedOption[];
+}
+
+export interface AgentContextWindowSupport {
+	presetId: string;
+	defaultContextWindowId: string;
+	contextWindows: AgentModelOption[];
+}
+
+function createClaudeContextWindowSupport(
+	defaultContextWindowId: "200k" | "1m",
+): AgentContextWindowSupport {
+	return {
+		presetId: "claude",
+		defaultContextWindowId,
+		contextWindows: [
+			{ id: "200k", label: "200k" },
+			{ id: "1m", label: "1M" },
+		],
+	};
+}
+
+const LOW_TO_MAX_EFFORTS: readonly AgentModelOption[] = [
+	{ id: "low", label: "Low" },
+	{ id: "medium", label: "Medium" },
+	{ id: "high", label: "High" },
+	{ id: "xhigh", label: "Extra High" },
+	{ id: "max", label: "Max" },
+];
+
+const LOW_TO_MAX_WITH_ADVANCED_EFFORTS: readonly AgentModelOption[] = [
+	...LOW_TO_MAX_EFFORTS,
+	{ id: "ultracode", label: "Ultracode" },
+];
+
+const LOW_TO_HIGH_WITH_MAX_EFFORTS: readonly AgentModelOption[] = [
+	{ id: "low", label: "Low" },
+	{ id: "medium", label: "Medium" },
+	{ id: "high", label: "High" },
+	{ id: "max", label: "Max" },
+];
+
+const CODEX_STANDARD_EFFORTS: readonly AgentModelOption[] = [
+	{ id: "low", label: "Low" },
+	{ id: "medium", label: "Medium" },
+	{ id: "high", label: "High" },
+	{ id: "xhigh", label: "Extra High" },
+];
+
+const CODEX_MAX_EFFORTS: readonly AgentModelOption[] = [
+	...CODEX_STANDARD_EFFORTS,
+	{ id: "max", label: "Max" },
+];
+
+const CODEX_ULTRA_EFFORTS: readonly AgentModelOption[] = [
+	...CODEX_MAX_EFFORTS,
+	{ id: "ultra", label: "Ultra" },
+];
 
 /**
  * Curated per-agent reasoning-effort catalogs, mirroring
@@ -191,15 +357,75 @@ export interface AgentEffortSupport {
  */
 export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 	{
-		presetId: "claude",
+		presetId: "antigravity",
 		effortFlag: "--effort",
+		defaultEffortId: "high",
 		efforts: [
 			{ id: "low", label: "Low" },
 			{ id: "medium", label: "Medium" },
 			{ id: "high", label: "High" },
-			{ id: "xhigh", label: "xHigh" },
+		],
+	},
+	{
+		presetId: "opencode",
+		effortFlag: "--variant",
+		label: "Reasoning",
+		efforts: [
+			{ id: "none", label: "None" },
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "Extra High" },
 			{ id: "max", label: "Max" },
 		],
+	},
+	{
+		presetId: "claude",
+		effortFlag: "--effort",
+		label: "Reasoning",
+		efforts: [...LOW_TO_MAX_WITH_ADVANCED_EFFORTS],
+		modelProfiles: {
+			"claude-fable-5": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_MAX_WITH_ADVANCED_EFFORTS,
+			},
+			"claude-opus-5": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_MAX_WITH_ADVANCED_EFFORTS,
+			},
+			"claude-sonnet-5": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_MAX_EFFORTS,
+			},
+			"claude-opus-4-8": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_MAX_WITH_ADVANCED_EFFORTS,
+			},
+			"claude-opus-4-7": {
+				defaultEffortId: "xhigh",
+				efforts: LOW_TO_MAX_EFFORTS,
+			},
+			"claude-opus-4-6": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_HIGH_WITH_MAX_EFFORTS,
+			},
+			"claude-opus-4-5": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_HIGH_WITH_MAX_EFFORTS,
+			},
+			"claude-sonnet-4-6": {
+				defaultEffortId: "high",
+				efforts: LOW_TO_HIGH_WITH_MAX_EFFORTS,
+			},
+			"claude-haiku-4-5": {
+				defaultEffortId: "off",
+				label: "Thinking",
+				efforts: [
+					{ id: "off", label: "Off" },
+					{ id: "on", label: "On" },
+				],
+			},
+		},
 	},
 	{
 		presetId: "amp",
@@ -218,12 +444,30 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 		presetId: "codex",
 		effortFlag: "-c",
 		effortValuePrefix: "model_reasoning_effort=",
-		efforts: [
-			{ id: "low", label: "Low" },
-			{ id: "medium", label: "Medium" },
-			{ id: "high", label: "High" },
-			{ id: "xhigh", label: "xHigh" },
-		],
+		defaultEffortId: "low",
+		efforts: [...CODEX_ULTRA_EFFORTS],
+		modelProfiles: {
+			"gpt-5.6-sol": {
+				defaultEffortId: "low",
+				efforts: CODEX_ULTRA_EFFORTS,
+			},
+			"gpt-5.6-terra": {
+				defaultEffortId: "medium",
+				efforts: CODEX_ULTRA_EFFORTS,
+			},
+			"gpt-5.6-luna": {
+				defaultEffortId: "medium",
+				efforts: CODEX_MAX_EFFORTS,
+			},
+			"gpt-5.5": {
+				defaultEffortId: "medium",
+				efforts: CODEX_STANDARD_EFFORTS,
+			},
+			"gpt-5.4": {
+				defaultEffortId: "medium",
+				efforts: CODEX_STANDARD_EFFORTS,
+			},
+		},
 	},
 	{
 		presetId: "mastracode",
@@ -260,6 +504,100 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 	},
 ];
 
+/** Launch-time performance choices that are independent from reasoning. */
+export const AGENT_SPEED_SUPPORT: readonly AgentSpeedSupport[] = [
+	{
+		presetId: "codex",
+		label: "Service Tier",
+		defaultSpeedId: "standard",
+		supportedModelIds: [
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
+			"gpt-5.5",
+			"gpt-5.4",
+		],
+		speeds: [
+			{
+				id: "standard",
+				label: "Standard",
+				args: ["--disable", "fast_mode"],
+			},
+			{ id: "fast", label: "Fast", args: ["--enable", "fast_mode"] },
+		],
+	},
+	{
+		presetId: "claude",
+		label: "Fast Mode",
+		defaultSpeedId: "standard",
+		supportedModelIds: [
+			"claude-opus-5",
+			"claude-opus-4-8",
+			"claude-opus-4-7",
+			"claude-opus-4-6",
+			"claude-opus-4-5",
+		],
+		speeds: [
+			{
+				id: "standard",
+				label: "Off",
+				args: ["--settings", '{"fastMode":false}'],
+			},
+			{
+				id: "fast",
+				label: "On",
+				args: ["--settings", '{"fastMode":true}'],
+			},
+		],
+	},
+];
+
+/** Agent personas that are independent from model reasoning. */
+export const AGENT_MODE_SUPPORT: readonly AgentModeSupport[] = [
+	{
+		presetId: "opencode",
+		label: "Agent",
+		defaultModeId: "build",
+		modes: [
+			{ id: "build", label: "Build", args: ["--agent", "build"] },
+			{ id: "plan", label: "Plan", args: ["--agent", "plan"] },
+		],
+	},
+];
+
+const AGENT_CONTEXT_WINDOW_SUPPORT: Readonly<
+	Record<string, AgentContextWindowSupport>
+> = {
+	"claude:claude-fable-5": createClaudeContextWindowSupport("1m"),
+	"claude:claude-opus-5": createClaudeContextWindowSupport("1m"),
+	"claude:claude-opus-4-6": createClaudeContextWindowSupport("1m"),
+	"claude:claude-sonnet-5": createClaudeContextWindowSupport("200k"),
+	"claude:claude-sonnet-4-6": createClaudeContextWindowSupport("200k"),
+};
+
+function normalizeAgentEffort(
+	presetId: string,
+	model: string | undefined,
+	effort: string,
+): string {
+	if (presetId === "claude" && effort === "ultracode") return "xhigh";
+	if (
+		presetId === "claude" &&
+		model === "claude-opus-4-7" &&
+		effort === "xhigh"
+	) {
+		return "max";
+	}
+	if (
+		presetId === "claude" &&
+		model === "claude-sonnet-4-6" &&
+		effort === "max"
+	) {
+		return "high";
+	}
+	return effort;
+}
+
 export function getAgentModelSupport(
 	presetId: string,
 ): AgentModelSupport | undefined {
@@ -268,8 +606,94 @@ export function getAgentModelSupport(
 
 export function getAgentEffortSupport(
 	presetId: string,
+	model?: string | null,
 ): AgentEffortSupport | undefined {
-	return AGENT_EFFORT_SUPPORT.find((entry) => entry.presetId === presetId);
+	const support = AGENT_EFFORT_SUPPORT.find(
+		(entry) => entry.presetId === presetId,
+	);
+	if (!support?.modelProfiles) return support;
+	if (!model) return support;
+	const profile = support.modelProfiles[model];
+	if (!profile) return undefined;
+	return {
+		...support,
+		defaultEffortId: profile.defaultEffortId,
+		label: profile.label ?? support.label,
+		efforts: [...profile.efforts],
+	};
+}
+
+export function resolveAgentEffortSupport(
+	presetId: string,
+	model: string | null | undefined,
+	reasoning: AgentCapabilityTrait<AgentModelOption> | undefined,
+): AgentEffortSupport | undefined {
+	const staticSupport = getAgentEffortSupport(presetId, model);
+	if (!reasoning || reasoning.state === "unknown") return staticSupport;
+	if (reasoning.state === "unsupported") return undefined;
+	const transport = AGENT_EFFORT_SUPPORT.find(
+		(entry) => entry.presetId === presetId,
+	);
+	if (!transport) return undefined;
+	return reasoning.options.length > 0
+		? {
+				...transport,
+				defaultEffortId: reasoning.defaultId,
+				efforts: [...reasoning.options],
+			}
+		: undefined;
+}
+
+export function getAgentSpeedSupport(
+	presetId: string,
+	model?: string | null,
+): AgentSpeedSupport | undefined {
+	const support = AGENT_SPEED_SUPPORT.find(
+		(entry) => entry.presetId === presetId,
+	);
+	if (!support) return undefined;
+	if (
+		support.supportedModelIds &&
+		(!model || !support.supportedModelIds.includes(model))
+	) {
+		return undefined;
+	}
+	return support;
+}
+
+export function getAgentModeSupport(
+	presetId: string,
+): AgentModeSupport | undefined {
+	return AGENT_MODE_SUPPORT.find((entry) => entry.presetId === presetId);
+}
+
+export function getAgentContextWindowSupport(
+	presetId: string,
+	model?: string | null,
+): AgentContextWindowSupport | undefined {
+	if (!model) return undefined;
+	return AGENT_CONTEXT_WINDOW_SUPPORT[`${presetId}:${model}`];
+}
+
+export function buildAgentSpeedArgs(
+	presetId: string,
+	speed: string | undefined,
+	model?: string,
+): string[] {
+	if (!speed) return [];
+	const support = getAgentSpeedSupport(presetId, model);
+	const option = support?.speeds.find((candidate) => candidate.id === speed);
+	return option ? [...option.args] : [];
+}
+
+export function buildAgentModeArgs(
+	presetId: string,
+	mode: string | undefined,
+): string[] {
+	if (!mode) return [];
+	const support = getAgentModeSupport(presetId);
+	const option = support?.modes.find((candidate) => candidate.id === mode);
+	return option ? [...option.args] : [];
 }
 
 /**
@@ -281,12 +705,69 @@ export function getAgentEffortSupport(
 export function buildAgentEffortArgs(
 	presetId: string,
 	effort: string | undefined,
+	model?: string,
+	runtimeProfile?: AgentRuntimeEffortProfile,
 ): string[] {
 	if (!effort) return [];
-	const support = getAgentEffortSupport(presetId);
+	const transport = runtimeProfile
+		? AGENT_EFFORT_SUPPORT.find((entry) => entry.presetId === presetId)
+		: getAgentEffortSupport(presetId, model);
+	const support =
+		transport && runtimeProfile
+			? { ...transport, efforts: [...runtimeProfile.efforts] }
+			: transport;
 	if (!support) return [];
 	if (!support.efforts.some((option) => option.id === effort)) return [];
-	return [support.effortFlag, `${support.effortValuePrefix ?? ""}${effort}`];
+	if (presetId === "claude" && model === "claude-haiku-4-5") return [];
+	const normalizedEffort = normalizeAgentEffort(presetId, model, effort);
+	return [
+		support.effortFlag,
+		`${support.effortValuePrefix ?? ""}${normalizedEffort}`,
+	];
+}
+
+interface AgentRuntimeTraits {
+	model?: string;
+	effort?: string;
+	speed?: string;
+}
+
+/** Claude settings must be emitted once because repeated flags do not compose. */
+export function buildAgentRuntimeTraitArgs(
+	presetId: string,
+	traits: AgentRuntimeTraits,
+): string[] {
+	if (presetId !== "claude") {
+		return buildAgentSpeedArgs(presetId, traits.speed, traits.model);
+	}
+
+	const settings: Record<string, boolean> = {};
+	const speedSupport = getAgentSpeedSupport(presetId, traits.model);
+	if (
+		traits.speed &&
+		speedSupport?.speeds.some((option) => option.id === traits.speed)
+	) {
+		settings.fastMode = traits.speed === "fast";
+	}
+
+	const effortSupport = getAgentEffortSupport(presetId, traits.model);
+	const effortSupported = effortSupport?.efforts.some(
+		(option) => option.id === traits.effort,
+	);
+	if (effortSupported && traits.effort === "ultracode") {
+		settings.ultracode = true;
+	}
+	if (
+		effortSupported &&
+		traits.model === "claude-haiku-4-5" &&
+		(traits.effort === "on" || traits.effort === "off")
+	) {
+		settings.alwaysThinkingEnabled = traits.effort === "on";
+	}
+
+	return Object.keys(settings).length > 0
+		? ["--settings", JSON.stringify(settings)]
+		: [];
 }
 
 /**
@@ -300,12 +781,23 @@ export function buildAgentEffortArgs(
 export function buildAgentModelArgs(
 	presetId: string,
 	model: string | undefined,
+	contextWindow?: string,
+	runtimeModelIds?: readonly string[],
 ): string[] {
 	if (!model) return [];
 	const support = getAgentModelSupport(presetId);
 	if (!support?.modelFlag) return [];
-	if (!support.models.some((option) => option.id === model)) return [];
-	return [support.modelFlag, model];
+	const allowedModelIds =
+		runtimeModelIds ?? support.models.map((option) => option.id);
+	if (!allowedModelIds.includes(model)) return [];
+	const contextSupport = getAgentContextWindowSupport(presetId, model);
+	const resolvedModel =
+		contextSupport?.contextWindows.some(
+			(option) => option.id === contextWindow,
+		) && contextWindow === "1m"
+			? `${model}[1m]`
+			: model;
+	return [support.modelFlag, resolvedModel];
 }
 
 /**
@@ -317,10 +809,13 @@ export function buildAgentModelArgs(
 export function buildAgentModelEnv(
 	presetId: string,
 	model: string | undefined,
+	runtimeModelIds?: readonly string[],
 ): Record<string, string> {
 	if (!model) return {};
 	const support = getAgentModelSupport(presetId);
 	if (!support?.modelEnv) return {};
-	if (!support.models.some((option) => option.id === model)) return {};
+	const allowedModelIds =
+		runtimeModelIds ?? support.models.map((option) => option.id);
+	if (!allowedModelIds.includes(model)) return {};
 	return { [support.modelEnv]: model };
 }

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -298,6 +298,10 @@ export interface AgentContextWindowSupport {
 	contextWindows: AgentModelOption[];
 }
 
+interface AgentContextWindowEnv {
+	CLAUDE_CODE_DISABLE_1M_CONTEXT?: "0" | "1";
+}
+
 function createClaudeContextWindowSupport(
 	defaultContextWindowId: "200k" | "1m",
 ): AgentContextWindowSupport {
@@ -798,6 +802,28 @@ export function buildAgentModelArgs(
 			? `${model}[1m]`
 			: model;
 	return [support.modelFlag, resolvedModel];
+}
+
+/** Environment overrides required to honor an explicit context-window choice. */
+export function buildAgentContextWindowEnv(
+	presetId: string,
+	model: string | undefined,
+	contextWindow?: string,
+): AgentContextWindowEnv {
+	if (
+		presetId !== "claude" ||
+		!model ||
+		(contextWindow !== "200k" && contextWindow !== "1m")
+	) {
+		return {};
+	}
+	const support = getAgentContextWindowSupport(presetId, model);
+	if (!support?.contextWindows.some((option) => option.id === contextWindow)) {
+		return {};
+	}
+	return {
+		CLAUDE_CODE_DISABLE_1M_CONTEXT: contextWindow === "200k" ? "1" : "0",
+	};
 }
 
 /**

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -58,6 +58,17 @@ function createBuiltinTerminalAgent<
 
 export const BUILTIN_TERMINAL_AGENTS = [
 	createBuiltinTerminalAgent({
+		id: "antigravity",
+		label: "Antigravity",
+		description:
+			"Google's terminal agent for subscription-backed coding and multi-step workflows.",
+		command: "agy --mode=accept-edits",
+		promptCommand: "agy --mode=accept-edits --prompt-interactive",
+		resumeCommand: "agy --mode=accept-edits --conversation",
+		nonInteractiveCommand: "agy --mode=plan --print",
+		includeInDefaultTerminalPresets: true,
+	}),
+	createBuiltinTerminalAgent({
 		id: "claude",
 		label: "Claude",
 		description:

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -57,7 +57,7 @@ export const HOST_AGENT_PRESETS: readonly HostAgentPreset[] =
 			resumeArgs: deriveSuffixArgs(commandTokens, agent.resumeCommand),
 			env: {},
 		};
-	});
+	}).sort((left, right) => left.label.localeCompare(right.label));
 
 function clonePreset(preset: HostAgentPreset): HostAgentPreset {
 	return {

--- a/packages/ui/src/assets/icons/preset-icons/antigravity.svg
+++ b/packages/ui/src/assets/icons/preset-icons/antigravity.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 434 400" width="32" height="32">
+  <defs>
+    <linearGradient id="ag" x1="0" y1="0.5" x2="1" y2="0.5">
+      <stop offset="0%" stop-color="#4285F4"/>
+      <stop offset="33%" stop-color="#34A853"/>
+      <stop offset="66%" stop-color="#FBBC04"/>
+      <stop offset="100%" stop-color="#EA4335"/>
+    </linearGradient>
+  </defs>
+  <path d="M392.71,390.14c24.17,18.13,60.42,6.04,27.19-27.2C320.21,266.25,341.35.34,217.5.34S114.79,266.25,15.1,362.94c-36.25,36.26,3.02,45.33,27.19,27.2C135.93,326.68,129.89,214.88,217.5,214.88s81.56,111.8,175.21,175.26Z" fill="url(#ag)"/>
+</svg>

--- a/packages/ui/src/assets/icons/preset-icons/index.ts
+++ b/packages/ui/src/assets/icons/preset-icons/index.ts
@@ -1,4 +1,5 @@
 import ampIcon from "./amp.svg";
+import antigravityIcon from "./antigravity.svg";
 import claudeIcon from "./claude.svg";
 import codexIcon from "./codex.svg";
 import codexWhiteIcon from "./codex-white.svg";
@@ -30,6 +31,7 @@ export interface PresetIconSet {
 
 export const PRESET_ICONS: Record<string, PresetIconSet> = {
 	amp: { light: ampIcon, dark: ampIcon },
+	antigravity: { light: antigravityIcon, dark: antigravityIcon },
 	claude: { light: claudeIcon, dark: claudeIcon },
 	codex: { light: codexIcon, dark: codexWhiteIcon },
 	copilot: { light: copilotIcon, dark: copilotWhiteIcon },
@@ -68,6 +70,7 @@ export function getPresetIcon(
 
 export {
 	ampIcon,
+	antigravityIcon,
 	claudeIcon,
 	codexIcon,
 	codexWhiteIcon,


### PR DESCRIPTION
## What & why

Superset can launch configurable agent commands, but its model and trait pickers rely primarily on metadata shipped with the app. They cannot tell whether a configured executable is present or whether the installed CLI exposes a different, account-specific model catalog.

This PR makes the host service the source of truth for agent capabilities. It discovers availability and model metadata at runtime where the CLI supports it, persists a revisioned last-known-good snapshot, drives the desktop pickers from that snapshot, and validates the final selection again immediately before launch. Agents without runtime discovery keep their curated fallback metadata.

### Problem

- Configured agents remained selectable when their executable was unavailable.
- Model pickers could not reflect the catalog exposed to the installed and authenticated CLI.
- Reasoning effort, mode, service tier, and context-window options were not represented by one shared capability contract.

### Root cause

There was no host-owned capability source connecting agent configuration, renderer selection, and launch validation. The renderer combined configured agent rows with static model metadata, while launch entry points independently converted selected values into CLI arguments.

That left four missing pieces:

1. bounded, agent-specific discovery on the host;
2. a validated and revisioned snapshot of discovery results;
3. a renderer contract that distinguishes runtime inventory from curated fallback data; and
4. a shared host-side launch preflight that rejects stale or unsupported selections.

### Fix

#### 1. Discover capabilities on the host

- Adds bounded subprocess probes with a 4-second timeout, a 1 MB output limit, terminal-compatible environment construction, executable resolution, cancellation, and process-tree cleanup.
- Discovers runtime model inventories from Antigravity, Copilot, Codex, Cursor Agent, Grok, Kimi Code, OpenCode, and Pi using each provider's supported local interface.
- Separately records executable, authentication, version, inventory-source, and probe-health information so one failure does not collapse every capability into a single status.
- Sanitizes diagnostics before they cross the host boundary.
- Retains curated model catalogs as explicit fallback data for agents that do not expose a runtime inventory.

#### 2. Persist revisioned snapshots

- Adds `host_agent_capability_snapshots` and a capability revision on agent configs.
- Validates and bounds persisted inventories before storage, including model counts, string lengths, unique IDs, default values, and serialized size.
- Hydrates the picker from persisted snapshots without waiting for every CLI probe, then performs one explicit refresh per host and renderer lifetime.
- Cancels an in-flight cold snapshot read before publishing refreshed data so an older response cannot overwrite the new result.
- Invalidates stale snapshots when command, arguments, or environment configuration changes.
- Coalesces concurrent refreshes by agent and revision, limits probe concurrency, and prevents obsolete results from overwriting newer configuration.
- Preserves the last valid inventory during transient failures while still exposing the latest health result.
- Stops displaying inventory data after 7 days and prunes retained snapshots after 30 days.

#### 3. Validate every launch against the same contract

- Treats a runtime-discovered inventory as authoritative and combines persisted fallback inventory with the curated catalog when runtime discovery is unavailable.
- Validates explicit model, reasoning effort, mode, service tier, and context-window selections before command construction.
- Carries the agent, preset, and config revision through validation, then asserts that they are still current immediately before launch.
- Returns a precondition failure when configuration or selection changes race with launch.
- Applies the same validation path to direct agent terminals, workspace/session creation, and preset execution.

#### 4. Drive the desktop UI from discovered capabilities

- Hides an agent only when the host has confirmed that its executable is missing; unknown or temporarily unhealthy probes remain visible.
- Populates model choices from runtime snapshots and clearly groups current and legacy fallback models.
- Unifies reasoning effort, mode, service tier, and context-window controls in the traits picker.
- Resolves Cursor variant families to their concrete launch model and traits.
- Sanitizes and persists preferences per agent and model, including route changes and modal remounts.
- Adds the Antigravity built-in preset and icon.

### Data flow

```mermaid
flowchart LR
  A[Host agent config] --> B[Bounded capability probe]
  B --> C[Validated revisioned snapshot]
  G[Curated fallback metadata] --> C
  C --> D[Agent, model, and trait pickers]
  D --> E[Host launch preflight]
  A --> E
  E --> F[Terminal, workspace, or preset launch]
```

### Behavior notes

- Missing executables are filtered only after a conclusive host result; an auth prompt, timeout, or parse failure does not make an agent disappear.
- Runtime model inventories are authoritative for the config revision that produced them.
- Curated catalogs remain available as fallback and compatibility data.
- Omitting an explicit model still delegates to the agent's default behavior.
- Existing custom agent configs remain supported even when they have no discoverable model inventory.

### Review guide

The change is easiest to review in this order:

1. shared capability and launch-selection contracts in `packages/shared/src/agent-models.ts`;
2. discovery, persistence, and refresh coordination in `packages/host-service/src/agent-capabilities/`;
3. config invalidation and tRPC launch preflight in the host-service routers;
4. renderer hydration and availability in `useV2AgentChoices`; and
5. model ordering, trait selection, Cursor variants, and preference persistence in the desktop components and hooks.

### Demo


https://github.com/user-attachments/assets/41fee21b-55db-4459-b3c9-e4fe0e8091f7



The recording demonstrates switching among installed agents, loading provider-specific runtime models, selecting Codex reasoning and service-tier traits.

## How I tested it

### Automated validation

- `bun install --frozen-lockfile`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck` — 38/38 workspace tasks passed
- Focused capability, launch, and renderer test matrix — 255 tests across 16 files passed
- `bun run build` — desktop production build and AppImage packaging passed, including native runtime validation
- `git diff --check`

The focused matrix covers discovery parsers, executable resolution, timeouts and cleanup, snapshot schema and persistence, refresh concurrency and race protection, agent-config lifecycle changes, all launch entry points, renderer cache races, availability filtering, model ordering, Cursor variants, traits, and preference persistence.

### Manual desktop verification

Verified against the local desktop app through the real renderer and host API:

1. Opened the New Workspace agent picker and confirmed that known-missing agents were excluded.
2. Switched to Codex and confirmed that the runtime inventory exposed GPT-5.6 Sol, Terra, Luna, GPT-5.5, GPT-5.3 Codex Spark, and Daybreak Blue, with legacy fallback models grouped separately.
3. Selected GPT-5.6 Terra and confirmed the available reasoning levels and Standard/Fast service tiers.
4. Selected High reasoning and Fast service tier.
5. Navigated to Workspaces, reopened New Workspace, and confirmed that Codex / Terra / High / Fast persisted.
6. Confirmed that the renderer reported no console errors during the flow.
7. Restored the original local agent preferences after verification.

### Full monorepo test run

`bun run test` was also run, but the fully concurrent monorepo run did not complete green. It reported two isolation/load-sensitive failures outside the new capability assertions:

- `@superset/agent-setup`: the disabled-hooks suite observed another concurrent test's process-global `SUPERSET_HOME_DIR`; the file passes 4/4 in isolation.
- `@superset/host-service`: two existing agent-config tests exceeded their 5-second timeout under full-suite load; the focused agent-config suite passes.

The new discovery, snapshot, launch-contract, and renderer suites passed. This note intentionally does not claim that the root test command was green.

## Checklist

- [x] PR title follows conventional commits (`feat(desktop,host-service): discover agent capabilities at runtime`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is enabled after the fork PR is created



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discovers agent executables, auth, versions, and model catalogs at runtime on the host and makes that snapshot the source of truth for desktop pickers and launches. Previously the UI relied on app-shipped metadata; now the host hides only conclusively missing agents, requires selecting an available agent, and hardens pre-launch validation of model and traits (effort, mode, speed, context window).

- Migrate the host: adds `host_agent_capability_snapshots` and `host_agent_configs.capabilityRevision` (migration tag 0024). `packages/host-service` now depends on `@github/copilot-sdk`.
- No renderer migration required. Desktop hydrates from persisted snapshots and refreshes once per active host per session; curated catalogs remain as fallback while probes run.
- Editing an agent’s command, args, or env bumps its capability revision and invalidates stale snapshots automatically; renderer query invalidation handles same-session updates.
- Ensure installed CLIs are present and authenticated to populate runtime catalogs; agents without discovery continue to use curated fallback metadata.

<sup>Written for commit e5c8797c5c239428568f85f6468def833c6c8e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added runtime detection of installed agents, models, and supported launch options.
  - Added workspace controls for model, effort, mode, speed, and context-window settings.
  - Added Antigravity agent support and icon.
  - Added model grouping, provider labels, sorting, and variant selection.
  - Added capability-aware launch validation and command resolution.

- **Bug Fixes**
  - Improved fallback behavior for unavailable saved selections.
  - Prevented retired models and unsupported options from launching workspaces.
  - Improved capability refresh and configuration update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->