### PR TITLE
fix(mobile): move the newline button into the quick-key row

### DIFF
--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -324,6 +324,29 @@ export const GlassComposer = forwardRef<
 		</Button>
 	);
 
+	// Same chip shape as the quick keys it sits beside, rather than the circular
+	// bottom-row buttons — it belongs to that row visually, not to send/mic.
+	const newlineChip = (
+		<Button
+			onPress={() => {
+				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+				appendToDraft("\n");
+			}}
+			modifiers={[
+				buttonStyle("bordered"),
+				buttonBorderShape("roundedRectangle", 10),
+				tint(FOREGROUND),
+				accessibilityLabel("New line"),
+			]}
+		>
+			<Image
+				systemName="return"
+				size={13}
+				modifiers={[frame({ width: 24, height: 17 })]}
+			/>
+		</Button>
+	);
+
 	const voiceControl = <VoiceControl dictation={dictation} />;
 
 	// Inserted beside the mic when a draft exists: the animated layout change
@@ -369,7 +392,12 @@ export const GlassComposer = forwardRef<
 						onGeometryChange(reportHeight),
 					]}
 				>
-					{above}
+					{above ? (
+						<HStack spacing={8} modifiers={[padding({ horizontal: 2 })]}>
+							{newlineChip}
+							{above}
+						</HStack>
+					) : null}
 					<VStack
 						spacing={0}
 						modifiers={[
@@ -536,7 +564,7 @@ export const GlassComposer = forwardRef<
 							>
 								{plusButton}
 							</HStack>
-							{newlineButton}
+							{above ? null : newlineButton}
 							{toolbarLeading}
 							<Spacer />
 							{/* Bordered buttons carry ~6pt of invisible tap-target inset


### PR DESCRIPTION
The newline button sat in the composer's bottom row beside the attachment button, where it reads as a send-adjacent action. It belongs with `esc` / `tab` / arrows — the keys the soft keyboard doesn't have.

| before | after |
|---|---|
| bottom row, circular, next to `+` | quick-key row, chip-shaped, beside `esc` |

Three details:

- **Shaped like the keys it sits with** — bordered rounded rectangle at the same size, not the circular treatment used for send and mic.
- **Pinned left of the scrolling row**, so it stays reachable however far the keys are scrolled.
- **Not a quick key.** Those write raw bytes into the PTY; this appends to the draft. It's rendered beside them rather than added to `QUICK_KEYS`, which would have sent a carriage return to the terminal and submitted instead of inserting a line break.

Surfaces with no key row — the home composer — keep it in the bottom row, since there's nothing else to put it with.

Typecheck and lint pass. Not exercised on a simulator; it's a layout move within an existing SwiftUI stack, but worth a glance on device before merge if you want certainty.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the newline button from the composer’s bottom row (next to the attachment button) into the quick-key row beside esc. This clarifies that it inserts a line break rather than a send-adjacent action; surfaces without a key row keep it in the bottom row.

- Renders as a bordered rounded-rectangle chip matching the quick keys, not the circular send/mic style.
- Pinned to the left edge of the horizontally scrolling quick-key row so it stays reachable.
- Not a quick key: appends "\n" to the draft; does not write raw bytes to the PTY or submit.
- Preserves light haptic feedback and the "New line" accessibility label; give the layout a quick on‑device glance for spacing during the animated insertion.

<sup>Written for commit 97a2ad335ed063079bb199790d0920c5b5deb9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact rounded newline control to the composer’s upper action row.
  * The control inserts a newline and provides haptic feedback.

* **Improvements**
  * Prevented duplicate newline controls when upper-row content is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->