### PR TITLE
fix(relay,discord-triage): align turbo on 2.10.9 so pruned builds resolve

### DIFF
--- a/apps/discord-triage/Dockerfile
+++ b/apps/discord-triage/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Stage 1: Prune monorepo to discord-triage's dependency graph
 FROM base AS prune
 COPY . .
-RUN bunx turbo@2.8.7 prune @superset/discord-triage --docker
+RUN bunx turbo@2.10.9 prune @superset/discord-triage --docker
 
 # Stage 2: Install deps + copy full source
 FROM base AS builder

--- a/apps/relay/Dockerfile
+++ b/apps/relay/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Stage 1: Prune monorepo to relay's dependency graph
 FROM base AS prune
 COPY . .
-RUN bunx turbo@2.8.7 prune @superset/relay --docker
+RUN bunx turbo@2.10.9 prune @superset/relay --docker
 
 # Stage 2: Install deps + copy full source
 FROM base AS builder

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "dotenv-cli": "11.0.0",
         "semver": "7.7.4",
         "sherif": "1.11.0",
-        "turbo": "2.9.14",
+        "turbo": "2.10.9",
         "typescript": "6.0.3",
       },
     },
@@ -3275,17 +3275,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.14", "", { "os": "linux", "cpu": "x64" }, "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.14", "", { "os": "win32", "cpu": "x64" }, "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.9", "", { "os": "win32", "cpu": "x64" }, "sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -6519,7 +6519,7 @@
 
     "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
-    "turbo": ["turbo@2.9.14", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.14", "@turbo/darwin-arm64": "2.9.14", "@turbo/linux-64": "2.9.14", "@turbo/linux-arm64": "2.9.14", "@turbo/windows-64": "2.9.14", "@turbo/windows-arm64": "2.9.14" }, "bin": { "turbo": "bin/turbo" } }, "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw=="],
+    "turbo": ["turbo@2.10.9", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.9", "@turbo/darwin-arm64": "2.10.9", "@turbo/linux-64": "2.10.9", "@turbo/linux-arm64": "2.10.9", "@turbo/windows-64": "2.10.9", "@turbo/windows-arm64": "2.10.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"dotenv-cli": "11.0.0",
 		"semver": "7.7.4",
 		"sherif": "1.11.0",
-		"turbo": "2.9.14",
+		"turbo": "2.10.9",
 		"typescript": "6.0.3"
 	},
 	"description": "Superset Monorepo",


### PR DESCRIPTION
`Deploy Relay` has been failing on `main` since #6505 merged:

```
error: lockfile had changes, but lockfile is frozen
```

**Cause.** Both the relay and discord-triage images prune the monorepo with `turbo prune` and then run `bun install --frozen-lockfile`. #6505 deduped `@octokit/app`, which reshuffled hoisting in the root lockfile and dropped some top-level entries (`readable-stream@3.6.2`, `tar-stream@2.2.0`, and several nested overrides). turbo 2.8.7's pruned lockfile no longer covers the relay graph, so bun re-resolves and the frozen check fails.

**Bisected by prune version** against one unchanged checkout of `main`, so the only variable is turbo:

| turbo | pruned frozen install |
|---|---|
| 2.8.7 | fails |
| 2.9.14 | fails |
| 2.10.9 | succeeds, 1284 packages |

**One version everywhere.** Root was 2.9.14, relay 2.8.7, discord-triage 2.8.7 — all three are 2.10.9 now. discord-triage carried the same latent bug and would have broken on its next build.

Not 2.10.10: it is younger than `bunfig.toml`'s `minimumReleaseAge` (3 days), which blocks it inside the image build as well as locally.

**Not a dependency bump.** turbo runs only to produce the pruned tree; the installed set is unchanged. Regenerating the root lockfile also fixes the prune, but only by re-resolving 59 packages to newer versions (`ai` 5.0.220 → 5.0.236, `esbuild`, `undici`, `electron-to-chromium`…) — a silent mass upgrade that belongs in its own reviewed PR, not in a deploy fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to use Turbo version 2.10.9.
  * Updated the project’s Turbo development dependency to version 2.10.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->