### PR TITLE
fix(desktop): deliver first click on unfocused window to the renderer

### DIFF
--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -117,6 +117,10 @@ export async function MainWindow() {
 		center: initialBounds.center,
 		movable: true,
 		resizable: true,
+		// macOS: deliver the first click on an unfocused window to the renderer
+		// (otherwise it only activates the window and pane focus needs a second
+		// click).
+		acceptFirstMouse: true,
 		alwaysOnTop: false,
 		autoHideMenuBar: true,
 		frame: false,


### PR DESCRIPTION
## Summary

On macOS, clicking a terminal pane while the Superset window is unfocused only activated the window — the click itself was swallowed, so the previously active pane kept focus and a second click was needed (reported by a fork user; especially annoying on multi-monitor setups).

This is Electron's macOS default (`acceptFirstMouse: false` — `acceptsFirstMouse` is never forwarded to the web contents). Pane activation is `onMouseDown`-driven in `@superset/panes`, so the first click never reached it. Setting `acceptFirstMouse: true` on the main BrowserWindow makes the focusing click also land in the renderer, matching iTerm2/Terminal.app/Chrome behavior.

Tradeoff: the focusing click can now also press buttons/links anywhere in the window. Destructive actions in the app sit behind confirm dialogs; if a specific control ever bites, it can individually ignore mousedowns arriving within ~150ms of window focus.

## Test Plan

- [x] Repro before fix (dev build, real CGEvent OS clicks, app unfocused via Dock-frontmost): single click on inactive pane → `window-focus` fired, **no** mouse events delivered, old pane stayed active; second click required.
- [x] After fix, same scripted interaction: single click delivers `window-focus` + `mousedown` together → clicked pane activates and its xterm takes keyboard focus.
- [x] Focused-window behavior unchanged (single click activates pane).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers the first click on an unfocused macOS window to the renderer by setting `BrowserWindow` option `acceptFirstMouse: true`. Previously, the first click only activated the window and the previously active pane kept focus; now the first click also activates the clicked pane.

**Review notes**
- Scope: macOS only; focused-window behavior is unchanged.
- Risk: the focusing click can trigger buttons/links; destructive actions remain behind confirms. Controls can ignore `mousedown` events shortly after `window-focus` if needed.
- Verify: in an unfocused window, single-click a terminal pane and expect pane activation and keyboard focus. Change is in `apps/desktop/src/main/windows/main.ts`.

<sup>Written for commit b33c3dbc9d401172f9058f8b61f849fb1e5c26c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On macOS, the first click on an unfocused app window now reaches the interface immediately instead of only activating the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->