### PR TITLE
docs(cli,skills): finish the no-em-dash sweep in user-facing copy

### DIFF
--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -41,7 +41,7 @@ Use this mode when the user wants to review existing code step by step.
    - `## Step N: <title>`
    - One or two sentences explaining what changed and why
    - A focused real-code excerpt with file and line references
-   - One interactive verdict question: `Looks good: next step (Recommended)`, `Push back: change this`, and, only for non-trivial code, `Pause: explain more`
+   - One interactive verdict question: `Looks good, next step (Recommended)`, `Push back, change this`, and, only for non-trivial code, `Pause, explain more`
 4. Wait for the verdict before showing the next step.
 5. Log approvals, collect requested changes, and finish with a `| # | Step | Verdict |` table.
 

--- a/.agents/skills/decide/SKILL.md
+++ b/.agents/skills/decide/SKILL.md
@@ -41,7 +41,7 @@ Use this mode when the user wants to review existing code step by step.
    - `## Step N: <title>`
    - One or two sentences explaining what changed and why
    - A focused real-code excerpt with file and line references
-   - One interactive verdict question: `Looks good, next step (Recommended)`, `Push back, change this`, and, only for non-trivial code, `Pause, explain more`
+   - One interactive verdict question: `Looks good: next step (Recommended)`, `Push back: change this`, and, only for non-trivial code, `Pause: explain more`
 4. Wait for the verdict before showing the next step.
 5. Log approvals, collect requested changes, and finish with a `| # | Step | Verdict |` table.
 

--- a/apps/docs/content/docs/automations.mdx
+++ b/apps/docs/content/docs/automations.mdx
@@ -87,7 +87,7 @@ superset automations create --name "Nightly audit" --rrule "FREQ=DAILY;BYHOUR=3;
 superset automations create --name "Scratch triage" --rrule "FREQ=DAILY;BYHOUR=8;BYMINUTE=0" --prompt "…"
 
 # Each run's workspace carries the automation's tags and groups into the matching
-# sidebar folders. Default tag: "automation" — runs collect in an "automation"
+# sidebar folders. Default tag: "automation"; runs collect in an "automation"
 # folder per project. --tag (repeatable) files them elsewhere; clearing the tags
 # in the editor opts out of grouping.
 superset automations create --name "Nightly audit" --rrule "FREQ=DAILY;BYHOUR=3;BYMINUTE=0" --project <projectId> --prompt "…" --tag audits

--- a/apps/docs/content/docs/browser.mdx
+++ b/apps/docs/content/docs/browser.mdx
@@ -50,7 +50,7 @@ For workspaces on a [remote host](/remote-access), ports listen on that host and
 
 ## Drive it from the CLI and agents
 
-Browser panes can be driven programmatically with the [`superset browser`](/cli/cli-reference#browser) commands, so an agent can open a page, read it, screenshot it, and interact with it, in the same pane you're watching.
+Browser panes can be driven programmatically with the [`superset browser`](/cli/cli-reference#browser) commands, so an agent can open a page, read it, screenshot it, and interact with it in the same pane you're watching.
 
 ```bash
 # Open a page and get its pane id back

--- a/apps/docs/content/docs/browser.mdx
+++ b/apps/docs/content/docs/browser.mdx
@@ -50,7 +50,7 @@ For workspaces on a [remote host](/remote-access), ports listen on that host and
 
 ## Drive it from the CLI and agents
 
-Browser panes can be driven programmatically with the [`superset browser`](/cli/cli-reference#browser) commands, so an agent can open a page, read it, screenshot it, and interact with it — in the same pane you're watching.
+Browser panes can be driven programmatically with the [`superset browser`](/cli/cli-reference#browser) commands, so an agent can open a page, read it, screenshot it, and interact with it, in the same pane you're watching.
 
 ```bash
 # Open a page and get its pane id back
@@ -62,31 +62,31 @@ superset browser screenshot --workspace <id> --pane <paneId> --out shot.png
 superset browser console --workspace <id> --pane <paneId>
 ```
 
-For full interaction — clicking, typing, scrolling, form flows — `superset browser cdp` prints a raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) WebSocket endpoint you can point a browser-use / Playwright-class client at. The endpoint drives only that pane's page (never the Superset app itself), and pane operations are scoped to their workspace.
+For full interaction (clicking, typing, scrolling, form flows), `superset browser cdp` prints a raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) WebSocket endpoint you can point a browser-use / Playwright-class client at. The endpoint drives only that pane's page (never the Superset app itself), and pane operations are scoped to their workspace.
 
-Agents pick this up automatically through the [`superset:browser` skill](/skills). A pane runs against the browser's real, logged-in session — agents are instructed to treat it accordingly and to confirm before consequential actions.
+Agents pick this up automatically through the [`superset:browser` skill](/skills). A pane runs against the browser's real, logged-in session, so agents are instructed to treat it accordingly and to confirm before consequential actions.
 
 ## Pane or standalone browser?
 
-The `superset:browser` skill is engine-generic with the in-app pane as the default: when a page is (or can be) open in a workspace pane — previewing a dev server, verifying UI you're watching, clicking through a flow — agents use the `superset browser` commands above.
+The `superset:browser` skill is engine-generic with the in-app pane as the default: when a page is (or can be) open in a workspace pane (previewing a dev server, verifying UI you're watching, clicking through a flow), agents use the `superset browser` commands above.
 
 Some targets are out of the panes' reach: a real Chrome window outside Superset, a host running without the desktop app attached, or work that needs an isolated or cloud browser. For those, the skill routes to [Browser Use 3.0](https://docs.browser-use.com/open-source/browser-use-cli) as a second engine.
 
 ### Browser Use 3.0
 
 <Callout type="info" title="Optional third-party software">
-	Browser Use is built by [Browser Use](https://browser-use.com), not by Superset, and nothing in Superset requires it — the in-app pane engine works with no extra install. Only add it if you want standalone automation, and note that attaching it to your running Chrome hands agents your signed-in sessions.
+	Browser Use is built by [Browser Use](https://browser-use.com), not by Superset, and nothing in Superset requires it: the in-app pane engine works with no extra install. Only add it if you want standalone automation, and note that attaching it to your running Chrome hands agents your signed-in sessions.
 </Callout>
 
-Browser Use 3.0 is a CLI that lets agents execute Python against a browser over the Chrome DevTools Protocol. It isn't bundled with Superset — agents check for it and ask before installing. To install it yourself (requires [uv](https://docs.astral.sh/uv/)) so the `browser-use` command lands on your `PATH`:
+Browser Use 3.0 is a CLI that lets agents execute Python against a browser over the Chrome DevTools Protocol. It isn't bundled with Superset, so agents check for it and ask before installing. To install it yourself (requires [uv](https://docs.astral.sh/uv/)) so the `browser-use` command lands on your `PATH`:
 
 ```bash
 uv tool install browser-use
 browser-use --help
 ```
 
-You can also run it ephemerally with `uvx --from 'browser-use[cli]' browser-use …`, but that doesn't add `browser-use` to your `PATH` — each call needs the full `uvx --from` prefix.
+You can also run it ephemerally with `uvx --from 'browser-use[cli]' browser-use …`, but that doesn't add `browser-use` to your `PATH`, so each call needs the full `uvx --from` prefix.
 
-By default it attaches to your running Chrome — your real, signed-in profile — so the skill requires your explicit consent before taking that path; otherwise agents use a scratch browser or a Browser Use cloud browser (which bills until stopped, so they ask first and stop it after). `browser-use --doctor` diagnoses connection problems, and `browser-use skill` prints the engine's own usage reference.
+By default it attaches to your running Chrome (your real, signed-in profile), so the skill requires your explicit consent before taking that path; otherwise agents use a scratch browser or a Browser Use cloud browser (which bills until stopped, so they ask first and stop it after). `browser-use --doctor` diagnoses connection problems, and `browser-use skill` prints the engine's own usage reference.
 
 Browser Use can also drive an in-app pane: point it at the pane's endpoint from `superset browser cdp` (as `BU_CDP_WS`) and the pane presents itself as a single page target. For panes the `superset browser` verbs are the simpler default, but this lets Browser Use's harness reach the same pane when you want it.

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -685,7 +685,7 @@ superset workspaces create \
 # Project-less session with an agent
 superset workspaces create --local --agent claude --prompt "…"
 
-# Tags group the workspace into sidebar folders — no folder setup needed
+# Tags group the workspace into sidebar folders, no folder setup needed
 superset workspaces create --project prj_… --name "perf-spike" --branch perf/spike --local --tag perf
 ```
 </Command>
@@ -757,7 +757,7 @@ superset workspaces get --field branch   # inside a workspace
 	output="Workspace"
 >
 Update a workspace on its host (default: this machine). `--tag` replaces the
-whole tag set — tagging is how workspaces group into sidebar folders, so
+whole tag set; tagging is how workspaces group into sidebar folders, so
 retagging moves the workspace between folders.
 
 ```bash

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -1086,7 +1086,7 @@ Capture a PNG screenshot of the pane's page.
 	]}
 	output={`{ result: unknown }`}
 >
-Evaluate JavaScript in the page and return the result, the ergonomic path for
+Evaluate JavaScript in the page and return the result: the ergonomic path for
 reading or nudging the DOM.
 
 ```bash

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -1011,7 +1011,7 @@ screenshot, read console, evaluate JavaScript, and get a raw Chrome DevTools
 Protocol endpoint for click/type/scroll automation. Every operation runs in the
 pane the user sees, against the browser's real session. Browser panes live in
 the desktop app, so a standalone host with no desktop attached has no panes and
-these commands error. A `paneId` is scoped to its workspace — pass the same
+these commands error. A `paneId` is scoped to its workspace, so pass the same
 `--workspace` it was opened under. See the [`browser` skill](/skills) for the
 agent-facing protocol.
 
@@ -1086,7 +1086,7 @@ Capture a PNG screenshot of the pane's page.
 	]}
 	output={`{ result: unknown }`}
 >
-Evaluate JavaScript in the page and return the result — the ergonomic path for
+Evaluate JavaScript in the page and return the result, the ergonomic path for
 reading or nudging the DOM.
 
 ```bash
@@ -1119,7 +1119,7 @@ Read the pane's captured console output.
 >
 Print a raw Chrome DevTools Protocol WebSocket endpoint for the pane, for
 browser-use / Playwright-class tools (mouse, keyboard, scroll, DOM, network).
-The URL embeds an auth token — treat it as a secret.
+The URL embeds an auth token, so treat it as a secret.
 </Command>
 
 ---

--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -12,7 +12,7 @@ native menus, and verify the resulting UI state on macOS, Windows, and Linux.
 
 The skill's workflow is driver-agnostic; [Cua
 Driver](https://cua.ai/docs/cua-driver) is the default. On macOS,
-[Peekaboo](https://peekaboo.sh) works as an alternative — agents use whichever
+[Peekaboo](https://peekaboo.sh) works as an alternative; agents use whichever
 supported driver you have installed, and ask before installing one.
 
 The agent works in the actual app window you can see. Cua Driver targets a
@@ -23,12 +23,12 @@ bring the target app to the front.
 ## Install a driver
 
 <Callout type="info" title="Optional third-party software">
-	Drivers are not built or maintained by Superset — Cua Driver comes from
+	Drivers are not built or maintained by Superset. Cua Driver comes from
 	[Cua](https://cua.ai) and Peekaboo from [its open-source
-	project](https://peekaboo.sh) — and nothing in Superset requires one:
+	project](https://peekaboo.sh), and nothing in Superset requires one:
 	without a driver installed, this skill simply isn't used. Installing a
 	driver and granting it Accessibility and Screen Recording gives it, and
-	agents driving it, deep control of your machine — extend it the same trust
+	agents driving it, deep control of your machine, so extend it the same trust
 	as any system-level tool.
 </Callout>
 

--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -28,8 +28,8 @@ bring the target app to the front.
 	project](https://peekaboo.sh), and nothing in Superset requires one:
 	without a driver installed, this skill simply isn't used. Installing a
 	driver and granting it Accessibility and Screen Recording gives it, and
-	agents driving it, deep control of your machine, so extend it the same trust
-	as any system-level tool.
+	agents driving it, deep control of your machine. Extend it the same trust as
+	any system-level tool.
 </Callout>
 
 The skill is bundled with Superset, but the driver runtime is installed

--- a/apps/docs/content/docs/pull-requests.mdx
+++ b/apps/docs/content/docs/pull-requests.mdx
@@ -3,7 +3,7 @@ title: Pull Requests
 description: Review, check, and merge PRs from your projects without leaving the app
 ---
 
-The **Pull requests** view brings the PRs from your projects' GitHub repositories into Superset, so the loop of reviewing, fixing, and merging agent work never leaves the app. It's a destination in the dashboard sidebar with a resizable split view: the PR list on the left, and a full detail view — rendered description, CI checks, and the complete diff — on the right.
+The **Pull requests** view brings the PRs from your projects' GitHub repositories into Superset, so the loop of reviewing, fixing, and merging agent work never leaves the app. It's a destination in the dashboard sidebar with a resizable split view: the PR list on the left, and a full detail view (rendered description, CI checks, and the complete diff) on the right.
 
 ![The Pull requests split view: filterable list on the left, detail with rendered markdown on the right](/images/pull-requests-view.png)
 
@@ -14,7 +14,7 @@ The list shows every PR from the repositories behind your projects. Each row car
 - **State tabs**: **All**, **Open**, or **Merged**
 - **Repository**: multi-select across your projects' repos
 - **Author**: filter to a specific GitHub author
-- **Reviews**: review-status filter — *No reviews*, *Review required*, *Approved review*, *Changes requested*, *Reviewed by you*, *Not reviewed by you*, *Awaiting review from you*, or *Awaiting review from you or your team*
+- **Reviews**: review-status filter: *No reviews*, *Review required*, *Approved review*, *Changes requested*, *Reviewed by you*, *Not reviewed by you*, *Awaiting review from you*, or *Awaiting review from you or your team*
 - **Search**: find PRs by title or number
 
 Filters persist, so the view comes back the way you left it. Active filters show a count badge next to the search box.
@@ -25,7 +25,7 @@ Selecting a PR opens it in the right pane, with **Summary** and **Code** tabs. T
 
 ### Summary
 
-The PR description renders as full markdown — headings, lists, code spans, and links. Alongside it:
+The PR description renders as full markdown: headings, lists, code spans, and links. Alongside it:
 
 - **Checks**: every CI check with its status and a link to the run on GitHub. The header summarizes the state at a glance ("All 12 passed"). Cancelled checks count as failures, not successes.
 - Review status and reviewers for the PR
@@ -41,7 +41,7 @@ The **Code** tab is a complete diff viewer: a file tree with per-file added/dele
 
 ### Comment Straight to an Agent
 
-Select lines in the Code tab and write a comment — then send it to an agent instead of (or as well as) leaving it on GitHub. The comment goes out with the file, line range, and side baked in:
+Select lines in the Code tab and write a comment, then send it to an agent instead of (or as well as) leaving it on GitHub. The comment goes out with the file, line range, and side baked in:
 
 - If a workspace is already linked to the PR, send it to one of its **running agent terminals**, or start a **new agent session** there
 - If no workspace exists yet, Superset **creates a PR-checkout workspace** and launches the agent with your comment as its first prompt
@@ -63,4 +63,4 @@ Merging, closing, and commenting act on the real PR through your GitHub connecti
 
 ## Where PRs Come From
 
-PRs sync from the GitHub repositories of your connected projects; connect GitHub under project settings and the list stays fresh automatically. PR-based workspaces also surface review status and checks on their sidebar entries — see [PR Status](/workspaces#pr-status) — and the [PR feedback recipe](/recipes/pr-feedback) shows the full loop of turning review comments into agent runs.
+PRs sync from the GitHub repositories of your connected projects; connect GitHub under project settings and the list stays fresh automatically. PR-based workspaces also surface review status and checks on their sidebar entries (see [PR Status](/workspaces#pr-status)), and the [PR feedback recipe](/recipes/pr-feedback) shows the full loop of turning review comments into agent runs.

--- a/apps/docs/content/docs/remote-access.mdx
+++ b/apps/docs/content/docs/remote-access.mdx
@@ -90,11 +90,11 @@ Only ports that the workspace started are forwarded. Other services on the host 
 
 If a local process already uses the port, the row shows **local port busy** and offers two actions: stop the local process (only when a Superset workspace started it) or **Use another port**, which maps the remote port to a free local port and shows the mapping, for example `3000 → localhost:54321`.
 
-The remote server sees each forwarded connection as coming from its own loopback address — there is no real client IP. Only TCP is carried; anything UDP (WebRTC media, mDNS) does not ride the forward.
+The remote server sees each forwarded connection as coming from its own loopback address; there is no real client IP. Only TCP is carried; anything UDP (WebRTC media, mDNS) does not ride the forward.
 
 Forwarding needs a host on the current relay running host-service 1.25 or newer. For a host you reach some other way, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
 
-Forwarded traffic passes through the Superset relay, like terminal traffic does. A browser talking to a forwarded dev server sends whatever it normally would — cookies, auth headers, query strings — so treat a forwarded port like the remote service it reaches, not like localhost.
+Forwarded traffic passes through the Superset relay, like terminal traffic does. A browser talking to a forwarded dev server sends whatever it normally would (cookies, auth headers, query strings), so treat a forwarded port like the remote service it reaches, not like localhost.
 
 ## Turning access off
 

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -30,8 +30,8 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:setup` | Makes a repo Superset-ready: authors `.superset/config.json` and project lifecycle scripts, then verifies with a real workspace |
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
-| `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
-| `superset:computer` | Drives [native desktop apps](/computer) through an accessibility-first driver (Cua Driver by default) — inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
+| `superset:browser` | Drives a workspace's [in-app browser](/browser) panes (open, navigate, screenshot, eval, read console, and raw CDP for click/type automation) and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
+| `superset:computer` | Drives [native desktop apps](/computer) through an accessibility-first driver (Cua Driver by default): inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
 | `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -3,7 +3,7 @@ title: Tasks
 description: Track work items and delegate them to agents without leaving the app
 ---
 
-The **Tasks** view brings your issue tracker into Superset, so delegating a task to an agent doesn't start with a copy-paste from Linear or GitHub. It's a destination in the dashboard sidebar with independent filters that are restored when you come back. Pull requests have their own view — see [Pull Requests](/pull-requests).
+The **Tasks** view brings your issue tracker into Superset, so delegating a task to an agent doesn't start with a copy-paste from Linear or GitHub. It's a destination in the dashboard sidebar with independent filters that are restored when you come back. Pull requests have their own view; see [Pull Requests](/pull-requests).
 
 ![The Tasks view on the GitHub issues source, with per-row Add to workspace actions](/images/task-list.png)
 
@@ -22,11 +22,11 @@ The Linear source lists issues from the whole connected workspace; filter by pro
 - **Filters** for project, task state, and assignee; empty filters mean everything
 - **Semantic search**: find tasks by meaning, not just keywords
 - **Multi-select**: check several tasks and act on them together
-- **Create tasks** from the desktop with the **New task** modal — title, description, status, priority, and assignee
+- **Create tasks** from the desktop with the **New task** modal: title, description, status, priority, and assignee
 
 ![Creating a task from the desktop](/images/create-task.png)
 
-Opening a task shows its full detail: an editable title, description, activity, and a properties sidebar for status, priority, and assignee — plus quick actions without switching to Linear.
+Opening a task shows its full detail: an editable title, description, activity, and a properties sidebar for status, priority, and assignee, plus quick actions without switching to Linear.
 
 ## From Task to Workspace
 
@@ -37,4 +37,4 @@ The point of having tasks in Superset is delegation. Launch an agent from a task
 - The **Task Prompt Template** (per agent, under **Settings → Agents**) controls how a task is turned into the agent's prompt
 - On the GitHub issues source, **Add to workspace** does the same for a single issue
 
-When the agents finish, their branches come back as PRs — review and merge them from [Pull Requests](/pull-requests).
+When the agents finish, their branches come back as PRs; review and merge them from [Pull Requests](/pull-requests).

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -22,12 +22,12 @@ Run different agents on different subscriptions from one machine:
 ![Two Claude Code accounts with quota meters, one marked as the default](/images/usage-accounts.png)
 
 - **Add account** creates a second profile: pick a profile name, then run the shown sign-in command (e.g. `CLAUDE_CONFIG_DIR="$HOME/.claude-work" claude auth login`) in any terminal on this host. The dialog detects the sign-in automatically.
-- **Make default** picks which account new agent launches use — when a provider has several accounts, the cards read as a radio group with the default checked. Switching reaches terminals you already have open too: a running agent keeps its account until you relaunch it.
-- Your setup comes along: skills, plugins, MCP servers, and settings are shared across accounts, and for Claude Code there's one conversation history — `--resume` shows the same sessions whichever account is active.
-- Logins, credentials, and account identity stay per account. The **…** menu on a card offers **Switch sign-in…** (re-login that profile to a different account) and, for secondary profiles, **Remove…** — which deletes that profile and its credentials, never your shared setup or history. The system-default login can't be removed.
+- **Make default** picks which account new agent launches use. When a provider has several accounts, the cards read as a radio group with the default checked. Switching reaches terminals you already have open too: a running agent keeps its account until you relaunch it.
+- Your setup comes along: skills, plugins, MCP servers, and settings are shared across accounts, and for Claude Code there's one conversation history: `--resume` shows the same sessions whichever account is active.
+- Logins, credentials, and account identity stay per account. The **…** menu on a card offers **Switch sign-in…** (re-login that profile to a different account) and, for secondary profiles, **Remove…**, which deletes that profile and its credentials, never your shared setup or history. The system-default login can't be removed.
 - If a sign-in expires, the card shows the exact login command to run, with click-to-copy.
 
-Under the hood, a profile is just a config dir the CLI is pointed at (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`). Superset's agent wrappers re-resolve the current default every time the agent starts in a Superset terminal — so switching works for agents you launch by hand too, and a value you export yourself always wins.
+Under the hood, a profile is just a config dir the CLI is pointed at (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`). Superset's agent wrappers re-resolve the current default every time the agent starts in a Superset terminal, so switching works for agents you launch by hand too, and a value you export yourself always wins.
 
 ## Token Costs
 

--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -147,7 +147,7 @@ export default command({
 	skipMiddleware: true,
 	options: {
 		organization: string().desc(
-			"Organization id or slug, required for non-TTY logins when you belong to multiple orgs",
+			"Organization id or slug (required for non-TTY logins when you belong to multiple orgs)",
 		),
 		apiKey: string().desc(
 			"Store a Superset API key (sk_live_…) at ~/.superset/config.json instead of running the OAuth flow",

--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -147,7 +147,7 @@ export default command({
 	skipMiddleware: true,
 	options: {
 		organization: string().desc(
-			"Organization id or slug — required for non-TTY logins when you belong to multiple orgs",
+			"Organization id or slug, required for non-TTY logins when you belong to multiple orgs",
 		),
 		apiKey: string().desc(
 			"Store a Superset API key (sk_live_…) at ~/.superset/config.json instead of running the OAuth flow",

--- a/packages/cli/src/commands/automations/create/command.ts
+++ b/packages/cli/src/commands/automations/create/command.ts
@@ -23,7 +23,7 @@ export default command({
 		project: string().desc(
 			"v2 project id for new-workspace-per-run mode. Omit (with no --workspace) to create a project-less session per run",
 		),
-		workspace: string().desc("existing v2 workspace id, reuses it every run"),
+		workspace: string().desc("existing v2 workspace id (reuses it every run)"),
 		host: string().desc(
 			"Host the target project/workspace lives on (default: this machine)",
 		),

--- a/packages/cli/src/commands/automations/create/command.ts
+++ b/packages/cli/src/commands/automations/create/command.ts
@@ -23,7 +23,7 @@ export default command({
 		project: string().desc(
 			"v2 project id for new-workspace-per-run mode. Omit (with no --workspace) to create a project-less session per run",
 		),
-		workspace: string().desc("existing v2 workspace id — reuses it every run"),
+		workspace: string().desc("existing v2 workspace id, reuses it every run"),
 		host: string().desc(
 			"Host the target project/workspace lives on (default: this machine)",
 		),

--- a/packages/cli/src/commands/browser/cdp/command.ts
+++ b/packages/cli/src/commands/browser/cdp/command.ts
@@ -30,7 +30,7 @@ export default command({
 			data: { url },
 			// The URL embeds a bearer token — treat it as a credential (keep it out
 			// of shared logs / screenshots).
-			message: `${url}\n\nNote: this URL contains an auth token, treat it as a secret.`,
+			message: `${url}\n\nNote: this URL contains an auth token. Treat it as a secret.`,
 		};
 	},
 });

--- a/packages/cli/src/commands/browser/cdp/command.ts
+++ b/packages/cli/src/commands/browser/cdp/command.ts
@@ -30,7 +30,7 @@ export default command({
 			data: { url },
 			// The URL embeds a bearer token — treat it as a credential (keep it out
 			// of shared logs / screenshots).
-			message: `${url}\n\nNote: this URL contains an auth token — treat it as a secret.`,
+			message: `${url}\n\nNote: this URL contains an auth token, treat it as a secret.`,
 		};
 	},
 });

--- a/packages/cli/src/commands/browser/import-login/command.ts
+++ b/packages/cli/src/commands/browser/import-login/command.ts
@@ -74,7 +74,7 @@ export default command({
 		if (result.keyUnavailable) {
 			return {
 				data: result,
-				message: `Could not read logins from ${describe(source)} — the Keychain key was unavailable. Quit that browser and grant Keychain access, then retry.`,
+				message: `Could not read logins from ${describe(source)} . The Keychain key was unavailable. Quit that browser and grant Keychain access, then retry.`,
 			};
 		}
 

--- a/packages/cli/src/commands/browser/import-login/command.ts
+++ b/packages/cli/src/commands/browser/import-login/command.ts
@@ -74,7 +74,7 @@ export default command({
 		if (result.keyUnavailable) {
 			return {
 				data: result,
-				message: `Could not read logins from ${describe(source)} . The Keychain key was unavailable. Quit that browser and grant Keychain access, then retry.`,
+				message: `Could not read logins from ${describe(source)}. The Keychain key was unavailable. Quit that browser and grant Keychain access, then retry.`,
 			};
 		}
 

--- a/packages/cli/src/commands/pages/comments/reply/command.ts
+++ b/packages/cli/src/commands/pages/comments/reply/command.ts
@@ -4,7 +4,7 @@ import { agentSessionId } from "../agentSession";
 
 export default command({
 	description:
-		"Reply to a comment thread — answer only threads handed off to this session",
+		"Reply to a comment thread (answer only threads handed off to this session)",
 	options: {
 		threadId: string().alias("thread").required().desc("Thread id to reply to"),
 	},

--- a/packages/cli/src/commands/pages/comments/resolve/command.ts
+++ b/packages/cli/src/commands/pages/comments/resolve/command.ts
@@ -3,7 +3,7 @@ import { command } from "../../../../lib/command";
 
 export default command({
 	description:
-		"Mark a comment thread resolved — reply first, so the reader sees what changed",
+		"Mark a comment thread resolved (reply first, so the reader sees what changed)",
 	options: {
 		threadId: string().alias("thread").required().desc("Thread id to resolve"),
 		reopen: boolean().desc("Reopen the thread instead of resolving it"),

--- a/packages/cli/src/commands/pages/publish/command.ts
+++ b/packages/cli/src/commands/pages/publish/command.ts
@@ -122,7 +122,7 @@ export default command({
 				});
 				watching = true;
 				watchNote =
-					"\nWatching for comments — they will be sent to this session";
+					"\nWatching for comments; they will be sent to this session";
 			} catch (error) {
 				watchNote = `\nNot watching for comments: ${
 					error instanceof Error ? error.message : "could not reach the host"

--- a/packages/cli/src/commands/settings/theme/export/command.ts
+++ b/packages/cli/src/commands/settings/theme/export/command.ts
@@ -5,7 +5,7 @@ import { exportTheme } from "../../../../lib/settings";
 
 export default command({
 	description:
-		"Export a theme (built-in or custom) as JSON, a starting point for custom themes",
+		"Export a theme (built-in or custom) as JSON: a starting point for custom themes",
 	args: [
 		positional("id").required().desc("Theme id (see: settings theme list)"),
 	],

--- a/packages/cli/src/commands/settings/theme/export/command.ts
+++ b/packages/cli/src/commands/settings/theme/export/command.ts
@@ -5,7 +5,7 @@ import { exportTheme } from "../../../../lib/settings";
 
 export default command({
 	description:
-		"Export a theme (built-in or custom) as JSON — a starting point for custom themes",
+		"Export a theme (built-in or custom) as JSON, a starting point for custom themes",
 	args: [
 		positional("id").required().desc("Theme id (see: settings theme list)"),
 	],

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -46,7 +46,7 @@ export default command({
 			spinner.stop(
 				`Host service running on port ${result.port} (pid ${result.pid})`,
 			);
-			p.log.info("Connected to relay — machine is now accessible.");
+			p.log.info("Connected to relay. Machine is now accessible.");
 
 			if (options.daemon) {
 				p.outro("Running in background.");

--- a/packages/cli/src/commands/status/command.ts
+++ b/packages/cli/src/commands/status/command.ts
@@ -119,7 +119,7 @@ export default command({
 			health.healthy && cloudRegistered === false
 				? `\nWarning: not registered with the cloud for ${organization.name}${
 						health.registrationError ? ` (${health.registrationError})` : ""
-					} — hosts list and automations won't see this machine\nHint: check host-service.log; registration retries automatically, or run: superset stop && superset start`
+					}; hosts list and automations won't see this machine\nHint: check host-service.log; registration retries automatically, or run: superset stop && superset start`
 				: "";
 
 		return {
@@ -139,7 +139,7 @@ export default command({
 				uptimeSec: Math.floor((Date.now() - manifest.startedAt) / 1000),
 			},
 			message: `${organization.name}: ${cloudHost.name ? `${cloudHost.name} (${localHostId.slice(0, 8)}…)` : `host ${localHostId.slice(0, 8)}…`} running (pid ${manifest.pid}, up ${uptime})${
-				health.healthy ? "" : " — not responding to health check"
+				health.healthy ? "" : " (not responding to health check)"
 			}${registrationWarning}`,
 		};
 	},

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -13,7 +13,7 @@ export default command({
 		),
 		name: string().desc("Workspace name"),
 		branch: string().desc("Git branch (required unless --pr or --task is set)"),
-		pr: number().desc("PR number — checks out the verified PR head"),
+		pr: number().desc("PR number, checks out the verified PR head"),
 		task: string().desc(
 			"Task ID to link. When --branch is omitted, the task's provider branch name (e.g. Linear's) is used verbatim",
 		),

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -13,7 +13,7 @@ export default command({
 		),
 		name: string().desc("Workspace name"),
 		branch: string().desc("Git branch (required unless --pr or --task is set)"),
-		pr: number().desc("PR number, checks out the verified PR head"),
+		pr: number().desc("PR number (checks out the verified PR head)"),
 		task: string().desc(
 			"Task ID to link. When --branch is omitted, the task's provider branch name (e.g. Linear's) is used verbatim",
 		),

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -144,7 +144,7 @@ function waitForCallback({
 				response
 					.writeHead(400, { "Content-Type": "text/html" })
 					.end("<h1>State mismatch</h1>");
-				finish(new CLIError("State mismatch — possible CSRF"));
+				finish(new CLIError("State mismatch (possible CSRF)"));
 				return;
 			}
 			response

--- a/packages/cli/src/lib/resolve-org.ts
+++ b/packages/cli/src/lib/resolve-org.ts
@@ -62,7 +62,7 @@ export async function resolveOrganization<T extends OrgChoice>(
 
 	if (isAgentMode() || !process.stdout.isTTY) {
 		throw new CLIError(
-			"Multiple organizations — pass --org <id|slug|name>",
+			"Multiple organizations: pass --org <id|slug|name>",
 			`Available: ${orgs.map(label).join(", ")}`,
 		);
 	}


### PR DESCRIPTION
## What & why

#6425 codified AGENTS.md rule 12 (no em dashes in user-facing copy, code comments exempt) and cleaned the settings docs. This finishes the sweep in the other scopes the rule names: CLI output strings, skill docs, and the docs site.

27 lines across 16 files, all prose punctuation. No behavior change.

## Left alone deliberately

- **Code comments.** The rule exempts them, so they are untouched.
- **The bare `"—"` empty-value placeholder** in table output (`tasks get`, `tasks list`, `workspaces get`, `automations format`, `automations logs`). That is a glyph standing in for "no value", not prose: swapping it for a comma would print a stray comma in the cell.

## How I tested it

- `biome check` clean, `bun run typecheck` 38/38 tasks, `bun test packages/cli/src` 101 passing.
- Confirmed no prose em dash remains in `.agents/skills`, `apps/docs/content`, `apps/marketing/content`, or non-comment CLI strings.
- Checked that no test asserts on the changed substrings. The closest is `resolve-org.test.ts`, which matches `/Multiple organizations/` (the prefix), so it is unaffected.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the no–em-dash sweep in user-facing copy across the CLI, skills, and docs to comply with AGENTS.md rule 12. No functional change; user-visible strings now use periods, colons, parentheses, or semicolons instead of em dashes to avoid comma splices.

- Scope: CLI strings and option descriptions in `packages/cli`, skills in `.agents/skills`, and docs in `apps/docs` (including copy added since the rebase).
- Message tweaks: CDP URL warning is two sentences ("Treat it as a secret."); OAuth callback reads "State mismatch (possible CSRF)"; health/registration and start logs use periods/semicolons/parentheses; org-resolution error now says "Multiple organizations: pass --org …"; import-login Keychain error is split into two sentences and drops a stray space.
- Docs: browser/computer/usage and CLI reference split clauses previously joined by an em dash; option descriptions use parentheses for trailing clarifications.
- Exceptions kept: code comments; the bare "—" empty-value placeholder in table output; the `${browserName} — ${profileName}` label separator in import-login; upstream's own punctuation in `decide/SKILL.md`.
- Validation: lint and typecheck pass; CLI tests pass; no tests assert on modified substrings.

<sup>Written for commit 3fc6e4b9a3106357b1394d961b59cd372b5b1fae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved readability and consistency across browser, computer-control, CLI, skills, usage, and account documentation.
  - Clarified computer-control safety guidance and machine-control access.

- **Bug Fixes**
  - Improved authentication error messaging by identifying potential CSRF issues.
  - Clarified browser login import and multiple-organization error messages.

- **Style**
  - Standardized punctuation and wording across CLI descriptions, warnings, status messages, and command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->