### PR TITLE
feat(desktop): three-arm new-workspace prompt form-factor experiment

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -43,12 +43,16 @@ import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
 import { SupersetIcon } from "renderer/routes/_authenticated/onboarding/providers/components/SupersetIcon";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { newWorkspaceAttachmentPaths } from "renderer/stores/new-workspace-attachments";
 import { useNewWorkspacePromptContext } from "renderer/stores/new-workspace-prompt-context";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../DashboardNewWorkspaceDraftContext";
-import { useNewWorkspacePromptCardsVariant } from "../../hooks/useNewWorkspacePromptCardsVariant";
+import {
+	type PromptCardsVariant,
+	useNewWorkspacePromptCardsVariant,
+} from "../../hooks/useNewWorkspacePromptCardsVariant";
 import { DevicePicker } from "../DashboardNewWorkspaceForm/components/DevicePicker";
 import { CLOUD_HOST_ID } from "../DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker";
 import { useWorkspaceHostOptions } from "../DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
@@ -78,6 +82,20 @@ import { AttachmentCard } from "./components/AttachmentCard";
 import { SamplePromptCards } from "./components/SamplePromptCards";
 import { SamplePrompts } from "./components/SamplePrompts";
 import { PROMPT_PLACEHOLDERS } from "./components/SamplePrompts/constants";
+import { useSamplePromptSelection } from "./hooks/useSamplePromptSelection";
+
+/** Nested prefixes of one fixed pool — only the form factor varies by arm. */
+const PROMPT_COUNTS: Record<PromptCardsVariant, number> = {
+	control: 3,
+	cards2: 2,
+	cards4: 4,
+};
+
+const PROMPT_LAYOUTS: Record<PromptCardsVariant, string> = {
+	control: "rows",
+	cards2: "cards2",
+	cards4: "cards4",
+};
 
 interface NewWorkspaceScreenProps {
 	isOpen: boolean;
@@ -367,13 +385,29 @@ export function NewWorkspaceScreen({
 	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 
 	const promptCardsVariant = useNewWorkspacePromptCardsVariant(isOpen);
+	const promptLayout =
+		promptCardsVariant === null ? "rows" : PROMPT_LAYOUTS[promptCardsVariant];
+	const { prompts: samplePrompts, isPending: samplePromptsPending } =
+		useSamplePromptSelection(
+			launchHostUrl,
+			projectId,
+			promptCardsVariant === null ? 0 : PROMPT_COUNTS[promptCardsVariant],
+		);
+
+	// The experiment measures the cold-start population, and dismissal removes
+	// the surface it measures — so the escape hatch only appears once the user
+	// has a real workspace. `main` is auto-created for every new account, so
+	// gating on it would open this for everyone immediately.
+	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const canDismissSamplePrompts = hostWorkspaces.some(
+		(workspace) => workspace.type !== "main",
+	);
+
 	// Logged so the prompt-cards experiment can account for lost exposure.
 	const handleDismissSamplePrompts = useCallback(() => {
-		track("new_workspace_sample_prompts_dismissed", {
-			layout: promptCardsVariant === "test" ? "cards" : "rows",
-		});
+		track("new_workspace_sample_prompts_dismissed", { layout: promptLayout });
 		setSamplePromptsDismissed(true);
-	}, [promptCardsVariant, setSamplePromptsDismissed]);
+	}, [promptLayout, setSamplePromptsDismissed]);
 
 	const { agents: v2Agents, isFetched: v2AgentsFetched } =
 		useV2AgentChoices(launchHostUrl);
@@ -623,6 +657,7 @@ export function NewWorkspaceScreen({
 				<AnimatePresence initial={false}>
 					{isPromptEmpty &&
 						promptCardsVariant !== null &&
+						!samplePromptsPending &&
 						!samplePromptsDismissed && (
 							<motion.div
 								key="sample-prompts"
@@ -632,17 +667,20 @@ export function NewWorkspaceScreen({
 								transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
 								className="absolute inset-x-6 bottom-full mb-1"
 							>
-								{promptCardsVariant === "test" ? (
-									<SamplePromptCards
-										hostUrl={launchHostUrl}
-										projectId={projectId}
+								{promptCardsVariant === "control" ? (
+									<SamplePrompts
+										prompts={samplePrompts}
 										onSelect={applyPrompt}
 										onDismiss={handleDismissSamplePrompts}
+										canDismiss={canDismissSamplePrompts}
 									/>
 								) : (
-									<SamplePrompts
+									<SamplePromptCards
+										prompts={samplePrompts}
 										onSelect={applyPrompt}
 										onDismiss={handleDismissSamplePrompts}
+										canDismiss={canDismissSamplePrompts}
+										layout={promptLayout}
 									/>
 								)}
 							</motion.div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -387,21 +387,23 @@ export function NewWorkspaceScreen({
 	const promptCardsVariant = useNewWorkspacePromptCardsVariant(isOpen);
 	const promptLayout =
 		promptCardsVariant === null ? "rows" : PROMPT_LAYOUTS[promptCardsVariant];
+
+	// One signal drives both the prompt tier and the dismiss affordance: has
+	// this person shipped anything yet. `main` is auto-created for every new
+	// account, so it cannot count.
+	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const hasRealWorkspace = hostWorkspaces.some(
+		(workspace) => workspace.type !== "main",
+	);
+
+	const samplePromptTier = hasRealWorkspace ? "returning" : "first-run";
 	const { prompts: samplePrompts, isPending: samplePromptsPending } =
 		useSamplePromptSelection(
+			samplePromptTier,
 			launchHostUrl,
 			projectId,
 			promptCardsVariant === null ? 0 : PROMPT_COUNTS[promptCardsVariant],
 		);
-
-	// The experiment measures the cold-start population, and dismissal removes
-	// the surface it measures — so the escape hatch only appears once the user
-	// has a real workspace. `main` is auto-created for every new account, so
-	// gating on it would open this for everyone immediately.
-	const { workspaces: hostWorkspaces } = useHostWorkspaces();
-	const canDismissSamplePrompts = hostWorkspaces.some(
-		(workspace) => workspace.type !== "main",
-	);
 
 	// Logged so the prompt-cards experiment can account for lost exposure.
 	const handleDismissSamplePrompts = useCallback(() => {
@@ -672,15 +674,17 @@ export function NewWorkspaceScreen({
 										prompts={samplePrompts}
 										onSelect={applyPrompt}
 										onDismiss={handleDismissSamplePrompts}
-										canDismiss={canDismissSamplePrompts}
+										canDismiss={hasRealWorkspace}
+										tier={samplePromptTier}
 									/>
 								) : (
 									<SamplePromptCards
 										prompts={samplePrompts}
 										onSelect={applyPrompt}
 										onDismiss={handleDismissSamplePrompts}
-										canDismiss={canDismissSamplePrompts}
+										canDismiss={hasRealWorkspace}
 										layout={promptLayout}
+										tier={samplePromptTier}
 									/>
 								)}
 							</motion.div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/DismissSuggestionsButton/DismissSuggestionsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/DismissSuggestionsButton/DismissSuggestionsButton.tsx
@@ -1,0 +1,26 @@
+import { XIcon } from "lucide-react";
+
+interface DismissSuggestionsButtonProps {
+	onDismiss: () => void;
+}
+
+/**
+ * Hover-reveal escape hatch on the suggestion surface. Callers gate this behind
+ * the user's first real workspace: dismissal permanently removes the surface
+ * the prompt-cards experiment measures, so letting the cold-start population
+ * reach it would let the treatment erase itself.
+ */
+export function DismissSuggestionsButton({
+	onDismiss,
+}: DismissSuggestionsButtonProps) {
+	return (
+		<button
+			type="button"
+			aria-label="Dismiss suggestions"
+			onClick={onDismiss}
+			className="absolute -top-2 right-0 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full border-[0.5px] border-border bg-popover text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+		>
+			<XIcon className="size-3" />
+		</button>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/DismissSuggestionsButton/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/DismissSuggestionsButton/index.ts
@@ -1,0 +1,1 @@
+export { DismissSuggestionsButton } from "./DismissSuggestionsButton";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -7,7 +7,10 @@ import {
 } from "lucide-react";
 import { track } from "renderer/lib/analytics";
 import { DismissSuggestionsButton } from "../DismissSuggestionsButton";
-import type { SamplePrompt } from "../SamplePrompts/constants";
+import type {
+	SamplePrompt,
+	SamplePromptTier,
+} from "../SamplePrompts/constants";
 import { AgentLogoCluster } from "./components/AgentLogoCluster";
 
 const CARD_ICONS: Record<string, typeof WrenchIcon> = {
@@ -25,6 +28,7 @@ interface SamplePromptCardsProps {
 	canDismiss: boolean;
 	/** Distinguishes the 2-card and 4-card arms in the click event. */
 	layout: string;
+	tier: SamplePromptTier;
 }
 
 export function SamplePromptCards({
@@ -33,6 +37,7 @@ export function SamplePromptCards({
 	onDismiss,
 	canDismiss,
 	layout,
+	tier,
 }: SamplePromptCardsProps) {
 	return (
 		<div className="group relative px-1 pb-2">
@@ -49,6 +54,7 @@ export function SamplePromptCards({
 								track("new_workspace_sample_prompt_clicked", {
 									prompt_id: sample.id,
 									layout,
+									tier,
 								});
 								onSelect(sample.prompt);
 							}}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePromptCards/SamplePromptCards.tsx
@@ -1,95 +1,54 @@
-import { useQuery } from "@tanstack/react-query";
 import {
 	BookOpenIcon,
 	BugIcon,
 	FlaskConicalIcon,
-	ListChecksIcon,
 	ScrollTextIcon,
 	WrenchIcon,
-	XIcon,
 } from "lucide-react";
-import { useState } from "react";
 import { track } from "renderer/lib/analytics";
-import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
-import { shuffledSamplePrompts } from "../SamplePrompts/constants";
+import { DismissSuggestionsButton } from "../DismissSuggestionsButton";
+import type { SamplePrompt } from "../SamplePrompts/constants";
 import { AgentLogoCluster } from "./components/AgentLogoCluster";
 
 const CARD_ICONS: Record<string, typeof WrenchIcon> = {
 	"set-up-project": WrenchIcon,
 	"explain-repo": BookOpenIcon,
 	"fix-small-bug": BugIcon,
-	"improve-agent-docs": ScrollTextIcon,
 	"add-missing-tests": FlaskConicalIcon,
-	"clean-up-todos": ListChecksIcon,
+	"improve-agent-docs": ScrollTextIcon,
 };
 
-const CARD_COUNT = 4;
-
 interface SamplePromptCardsProps {
-	hostUrl: string | null;
-	projectId: string | null;
+	prompts: SamplePrompt[];
 	onSelect: (prompt: string) => void;
 	onDismiss: () => void;
+	canDismiss: boolean;
+	/** Distinguishes the 2-card and 4-card arms in the click event. */
+	layout: string;
 }
 
 export function SamplePromptCards({
-	hostUrl,
-	projectId,
+	prompts,
 	onSelect,
 	onDismiss,
+	canDismiss,
+	layout,
 }: SamplePromptCardsProps) {
-	// Shuffled once per mount so every prompt in the pool gets exposure;
-	// re-shuffling per render would reorder cards under the pointer.
-	const [shuffledPrompts] = useState(shuffledSamplePrompts);
-
-	// Setup takes 75% of all prompt clicks, so it leads — but pitching setup for
-	// a project that already has setup/teardown/run commands reads as noise.
-	// Same query the v2 sidebar setup card uses.
-	const canCheckSetup = Boolean(hostUrl && projectId);
-	const { data: needsSetupScripts, isPending } = useQuery({
-		queryKey: ["host-config", "shouldShowSetupCard", hostUrl, projectId],
-		queryFn: () =>
-			hostUrl && projectId
-				? getHostServiceClientByUrl(hostUrl).config.shouldShowSetupCard.query({
-						projectId,
-					})
-				: false,
-		enabled: canCheckSetup,
-	});
-
-	// Deciding mid-flight would swap a card out from under the pointer.
-	if (canCheckSetup && isPending) return null;
-
-	const setupCard = shuffledPrompts.find(
-		(sample) => sample.id === "set-up-project",
-	);
-	const cards = [
-		...(needsSetupScripts === true && setupCard ? [setupCard] : []),
-		...shuffledPrompts.filter((sample) => sample.id !== "set-up-project"),
-	].slice(0, CARD_COUNT);
-
 	return (
 		<div className="group relative px-1 pb-2">
-			<button
-				type="button"
-				aria-label="Dismiss suggestions"
-				onClick={onDismiss}
-				className="absolute -top-2 right-0 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full border-[0.5px] border-border bg-popover text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-			>
-				<XIcon className="size-3" />
-			</button>
+			{canDismiss && <DismissSuggestionsButton onDismiss={onDismiss} />}
 			<div className="grid grid-cols-2 gap-2">
-				{cards.map((sample) => {
+				{prompts.map((sample) => {
 					const Icon = CARD_ICONS[sample.id] ?? WrenchIcon;
 					return (
 						<button
 							key={sample.id}
 							type="button"
-							className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl bg-foreground/[0.03] p-3 text-left transition-colors hover:bg-foreground/[0.06]"
+							className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl border-[0.5px] border-border bg-foreground/[0.02] p-3 text-left transition-colors hover:border-foreground/20 hover:bg-foreground/[0.05]"
 							onClick={() => {
 								track("new_workspace_sample_prompt_clicked", {
 									prompt_id: sample.id,
-									layout: "cards",
+									layout,
 								});
 								onSelect(sample.prompt);
 							}}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -1,13 +1,14 @@
 import { SparklesIcon } from "lucide-react";
 import { track } from "renderer/lib/analytics";
 import { DismissSuggestionsButton } from "../DismissSuggestionsButton";
-import type { SamplePrompt } from "./constants";
+import type { SamplePrompt, SamplePromptTier } from "./constants";
 
 interface SamplePromptsProps {
 	prompts: SamplePrompt[];
 	onSelect: (prompt: string) => void;
 	onDismiss: () => void;
 	canDismiss: boolean;
+	tier: SamplePromptTier;
 }
 
 export function SamplePrompts({
@@ -15,6 +16,7 @@ export function SamplePrompts({
 	onSelect,
 	onDismiss,
 	canDismiss,
+	tier,
 }: SamplePromptsProps) {
 	return (
 		<div className="group relative flex flex-col items-start gap-0.5 px-1 pb-2">
@@ -28,6 +30,7 @@ export function SamplePrompts({
 						track("new_workspace_sample_prompt_clicked", {
 							prompt_id: sample.id,
 							layout: "rows",
+							tier,
 						});
 						onSelect(sample.prompt);
 					}}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/SamplePrompts.tsx
@@ -1,32 +1,25 @@
-import { SparklesIcon, XIcon } from "lucide-react";
-import { useState } from "react";
+import { SparklesIcon } from "lucide-react";
 import { track } from "renderer/lib/analytics";
-import { shuffledSamplePrompts } from "./constants";
-
-/** The rows layout stays scannable at 4; the pool is bigger for variety. */
-const ROW_COUNT = 4;
+import { DismissSuggestionsButton } from "../DismissSuggestionsButton";
+import type { SamplePrompt } from "./constants";
 
 interface SamplePromptsProps {
+	prompts: SamplePrompt[];
 	onSelect: (prompt: string) => void;
 	onDismiss: () => void;
+	canDismiss: boolean;
 }
 
-export function SamplePrompts({ onSelect, onDismiss }: SamplePromptsProps) {
-	// Shuffled once per mount so every prompt in the pool gets exposure;
-	// re-shuffling per render would reorder rows under the pointer.
-	const [shuffledPrompts] = useState(shuffledSamplePrompts);
-
+export function SamplePrompts({
+	prompts,
+	onSelect,
+	onDismiss,
+	canDismiss,
+}: SamplePromptsProps) {
 	return (
 		<div className="group relative flex flex-col items-start gap-0.5 px-1 pb-2">
-			<button
-				type="button"
-				aria-label="Dismiss suggestions"
-				onClick={onDismiss}
-				className="absolute -top-2 right-0 z-10 flex size-5 cursor-pointer items-center justify-center rounded-full border-[0.5px] border-border bg-popover text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-			>
-				<XIcon className="size-3" />
-			</button>
-			{shuffledPrompts.slice(0, ROW_COUNT).map((sample) => (
+			{canDismiss && <DismissSuggestionsButton onDismiss={onDismiss} />}
+			{prompts.map((sample) => (
 				<button
 					key={sample.id}
 					type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -9,24 +9,18 @@ export interface SamplePrompt {
 }
 
 /**
- * Fixed, curated order — every arm of the prompt-cards experiment slices a
- * prefix of this list, so the sets are nested (2 cards ⊂ 3 rows ⊂ 4 cards) and
- * the only thing that varies between arms is form factor, not content.
- *
- * Setup leads when the project needs it and drops out entirely when it does
- * not, which shifts everything up by one — that is why the pool is five and
- * not four: the last entry is only reachable in the 4-card arm of an
- * already-configured project.
+ * Every prompt we can show. Order here carries no meaning — the tier lists
+ * below decide what appears and in what order.
  */
-export const SAMPLE_PROMPTS: SamplePrompt[] = [
-	{
+export const SAMPLE_PROMPTS: Record<string, SamplePrompt> = {
+	"set-up-project": {
 		id: "set-up-project",
 		label: "Set up this project for Superset",
 		description:
 			"Write setup and teardown scripts so every new workspace starts ready to run.",
 		prompt: `Set up this repository to work well with Superset workspaces. Read https://docs.superset.sh/setup-teardown-scripts and create a .superset/config.json with: setup commands that install dependencies and copy untracked files (like .env) from "$SUPERSET_ROOT_PATH" into new workspaces, teardown commands that stop anything setup starts, and a run command that launches the dev server. If parallel workspaces would collide on dev-server ports, make the scripts pick a free port per workspace (see https://docs.superset.sh/ports). When you're done, summarize what you configured and how to use it.`,
 	},
-	{
+	"explain-repo": {
 		id: "explain-repo",
 		label: "Explain to me how this repository works",
 		description:
@@ -34,7 +28,7 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 		prompt:
 			"Explain how this repository works: the overall architecture, the main entry points, how to run it locally, and what I should read first to get productive. Keep it practical and concrete.",
 	},
-	{
+	"fix-small-bug": {
 		id: "fix-small-bug",
 		label: "Find and fix a small bug",
 		description:
@@ -42,7 +36,7 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 		prompt:
 			"Find a small, low-risk bug or papercut in this codebase and fix it. Keep the change minimal, explain what the bug was, and describe how you verified the fix.",
 	},
-	{
+	"add-missing-tests": {
 		id: "add-missing-tests",
 		label: "Add tests where they're missing",
 		description:
@@ -50,7 +44,7 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 		prompt:
 			"Look at recently changed or complex code in this repository that lacks test coverage. Pick the highest-risk gap, write focused tests for it following the project's existing test conventions, and make sure they pass. Explain what you covered and why it mattered most.",
 	},
-	{
+	"improve-agent-docs": {
 		id: "improve-agent-docs",
 		label: "Improve the agent instructions",
 		description:
@@ -58,21 +52,72 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 		prompt:
 			"Review this repository's agent instruction files (AGENTS.md, CLAUDE.md, or similar). Compare them against how the codebase actually works today: commands, structure, conventions. Fix anything stale, and add the few things a coding agent most often needs and can't easily discover. Create the file if none exists. Keep it concise.",
 	},
-];
+	"clean-up-todos": {
+		id: "clean-up-todos",
+		label: "Knock out some TODOs",
+		description: "Find stale TODO/FIXME comments and resolve the quick ones.",
+		prompt:
+			"Search this codebase for TODO and FIXME comments. Triage them: resolve the ones that are quick and low-risk, delete the ones that are obsolete, and list the ones that need a real project. Keep each fix minimal and explain what you did.",
+	},
+	"explain-superset": {
+		id: "explain-superset",
+		label: "Show me how to get more out of Superset",
+		description:
+			"Learn the workflow that fits this repo — parallel workspaces and agent setup.",
+		prompt:
+			"Read https://docs.superset.sh and figure out how I should be using Superset for this specific repository. Cover how to run several workspaces in parallel without them colliding, what belongs in .superset/config.json, and which agent settings suit this codebase. Be concrete about this repo rather than generic, and end with the two or three changes worth making first.",
+	},
+};
 
 /**
- * The prompts an arm should show, in order. `needsSetup` is the project's
- * `shouldShowSetupCard` verdict: pitching setup at a project that already has
- * setup/teardown/run commands reads as noise, so it is dropped rather than
- * demoted.
+ * Which prompts an audience sees, in order.
+ *
+ * `first-run` is orientation for someone who has not shipped anything yet.
+ * `returning` swaps the orientation prompts for real work once they have a
+ * workspace behind them — repeating "find a small bug" at someone who just
+ * watched an agent do exactly that wastes the slot.
+ *
+ * Both lists are five long on purpose: an arm shows at most four, and the
+ * setup prompt drops out once the project is configured, which shifts
+ * everything up one and makes the fifth entry reachable.
+ */
+export const SAMPLE_PROMPT_TIERS = {
+	"first-run": [
+		"set-up-project",
+		"explain-repo",
+		"fix-small-bug",
+		"add-missing-tests",
+		"improve-agent-docs",
+	],
+	returning: [
+		"set-up-project",
+		"explain-superset",
+		"improve-agent-docs",
+		"add-missing-tests",
+		"clean-up-todos",
+	],
+} satisfies Record<string, string[]>;
+
+export type SamplePromptTier = keyof typeof SAMPLE_PROMPT_TIERS;
+
+/**
+ * The prompts an arm should show, in order. Every arm slices a prefix of the
+ * same tier list, so arms differ only in how many they show and how they are
+ * laid out — never in content.
+ *
+ * `needsSetup` is the project's `shouldShowSetupCard` verdict: pitching setup
+ * at a project that already has setup/teardown/run commands reads as noise, so
+ * it is dropped rather than demoted.
  */
 export function selectSamplePrompts(
+	tier: SamplePromptTier,
 	needsSetup: boolean,
 	count: number,
 ): SamplePrompt[] {
-	return SAMPLE_PROMPTS.filter(
-		(sample) => sample.id !== "set-up-project" || needsSetup,
-	).slice(0, count);
+	return SAMPLE_PROMPT_TIERS[tier]
+		.filter((id) => id !== "set-up-project" || needsSetup)
+		.slice(0, count)
+		.map((id) => SAMPLE_PROMPTS[id] as SamplePrompt);
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -8,6 +8,16 @@ export interface SamplePrompt {
 	prompt: string;
 }
 
+/**
+ * Fixed, curated order — every arm of the prompt-cards experiment slices a
+ * prefix of this list, so the sets are nested (2 cards ⊂ 3 rows ⊂ 4 cards) and
+ * the only thing that varies between arms is form factor, not content.
+ *
+ * Setup leads when the project needs it and drops out entirely when it does
+ * not, which shifts everything up by one — that is why the pool is five and
+ * not four: the last entry is only reachable in the 4-card arm of an
+ * already-configured project.
+ */
 export const SAMPLE_PROMPTS: SamplePrompt[] = [
 	{
 		id: "set-up-project",
@@ -33,14 +43,6 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 			"Find a small, low-risk bug or papercut in this codebase and fix it. Keep the change minimal, explain what the bug was, and describe how you verified the fix.",
 	},
 	{
-		id: "improve-agent-docs",
-		label: "Improve the agent instructions",
-		description:
-			"Audit AGENTS.md / CLAUDE.md against the codebase and fill the gaps.",
-		prompt:
-			"Review this repository's agent instruction files (AGENTS.md, CLAUDE.md, or similar). Compare them against how the codebase actually works today: commands, structure, conventions. Fix anything stale, and add the few things a coding agent most often needs and can't easily discover. Create the file if none exists. Keep it concise.",
-	},
-	{
 		id: "add-missing-tests",
 		label: "Add tests where they're missing",
 		description:
@@ -49,28 +51,28 @@ export const SAMPLE_PROMPTS: SamplePrompt[] = [
 			"Look at recently changed or complex code in this repository that lacks test coverage. Pick the highest-risk gap, write focused tests for it following the project's existing test conventions, and make sure they pass. Explain what you covered and why it mattered most.",
 	},
 	{
-		id: "clean-up-todos",
-		label: "Knock out some TODOs",
-		description: "Find stale TODO/FIXME comments and resolve the quick ones.",
+		id: "improve-agent-docs",
+		label: "Improve the agent instructions",
+		description:
+			"Audit AGENTS.md / CLAUDE.md against the codebase and fill the gaps.",
 		prompt:
-			"Search this codebase for TODO and FIXME comments. Triage them: resolve the ones that are quick and low-risk, delete the ones that are obsolete, and list the ones that need a real project. Keep each fix minimal and explain what you did.",
+			"Review this repository's agent instruction files (AGENTS.md, CLAUDE.md, or similar). Compare them against how the codebase actually works today: commands, structure, conventions. Fix anything stale, and add the few things a coding agent most often needs and can't easily discover. Create the file if none exists. Keep it concise.",
 	},
 ];
 
 /**
- * Fisher-Yates over a copy — the pool is bigger than either layout shows, so
- * a fixed slice would leave the tail prompts permanently unreachable.
+ * The prompts an arm should show, in order. `needsSetup` is the project's
+ * `shouldShowSetupCard` verdict: pitching setup at a project that already has
+ * setup/teardown/run commands reads as noise, so it is dropped rather than
+ * demoted.
  */
-export function shuffledSamplePrompts(): SamplePrompt[] {
-	const prompts = [...SAMPLE_PROMPTS];
-	for (let i = prompts.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1));
-		[prompts[i], prompts[j]] = [
-			prompts[j] as SamplePrompt,
-			prompts[i] as SamplePrompt,
-		];
-	}
-	return prompts;
+export function selectSamplePrompts(
+	needsSetup: boolean,
+	count: number,
+): SamplePrompt[] {
+	return SAMPLE_PROMPTS.filter(
+		(sample) => sample.id !== "set-up-project" || needsSetup,
+	).slice(0, count);
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/index.ts
@@ -1,0 +1,1 @@
+export { useSamplePromptSelection } from "./useSamplePromptSelection";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/useSamplePromptSelection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/useSamplePromptSelection.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import {
+	type SamplePrompt,
+	selectSamplePrompts,
+} from "../../components/SamplePrompts/constants";
+
+interface SamplePromptSelection {
+	prompts: SamplePrompt[];
+	/**
+	 * The setup verdict has not landed yet. Every arm holds on this together —
+	 * rendering rows immediately while cards waited would make the suggestion
+	 * surface appear at different times per arm, which is a timing difference
+	 * the experiment would read as a form-factor effect.
+	 */
+	isPending: boolean;
+}
+
+/**
+ * Picks the prompts every arm shows. Selection lives here rather than in each
+ * layout so the arms can only differ in form factor: same pool, same order,
+ * same setup-first rule, only `count` changes.
+ */
+export function useSamplePromptSelection(
+	hostUrl: string | null,
+	projectId: string | null,
+	count: number,
+): SamplePromptSelection {
+	const canCheckSetup = Boolean(hostUrl && projectId);
+
+	// Same query the v2 sidebar setup card uses.
+	const { data: needsSetupScripts, isPending } = useQuery({
+		queryKey: ["host-config", "shouldShowSetupCard", hostUrl, projectId],
+		queryFn: () =>
+			hostUrl && projectId
+				? getHostServiceClientByUrl(hostUrl).config.shouldShowSetupCard.query({
+						projectId,
+					})
+				: false,
+		enabled: canCheckSetup,
+	});
+
+	if (canCheckSetup && isPending) return { prompts: [], isPending: true };
+
+	return {
+		prompts: selectSamplePrompts(needsSetupScripts === true, count),
+		isPending: false,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/useSamplePromptSelection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/hooks/useSamplePromptSelection/useSamplePromptSelection.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import {
 	type SamplePrompt,
+	type SamplePromptTier,
 	selectSamplePrompts,
 } from "../../components/SamplePrompts/constants";
 
@@ -22,6 +23,7 @@ interface SamplePromptSelection {
  * same setup-first rule, only `count` changes.
  */
 export function useSamplePromptSelection(
+	tier: SamplePromptTier,
 	hostUrl: string | null,
 	projectId: string | null,
 	count: number,
@@ -43,7 +45,7 @@ export function useSamplePromptSelection(
 	if (canCheckSetup && isPending) return { prompts: [], isPending: true };
 
 	return {
-		prompts: selectSamplePrompts(needsSetupScripts === true, count),
+		prompts: selectSamplePrompts(tier, needsSetupScripts === true, count),
 		isPending: false,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/index.ts
@@ -1,1 +1,4 @@
-export { useNewWorkspacePromptCardsVariant } from "./useNewWorkspacePromptCardsVariant";
+export {
+	type PromptCardsVariant,
+	useNewWorkspacePromptCardsVariant,
+} from "./useNewWorkspacePromptCardsVariant";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useNewWorkspacePromptCardsVariant/useNewWorkspacePromptCardsVariant.ts
@@ -3,10 +3,23 @@ import { usePostHog } from "posthog-js/react";
 import { useLayoutEffect, useState } from "react";
 
 /**
- * Assigns the prompt-cards arm for the new-workspace screen. Same imperative
- * `getFeatureFlag` shape as `useNewWorkspaceScreenVariant`: exposure fires only
- * once the screen is actually open, and only after flags have loaded — reading
- * the flag earlier returns undefined, which would show control to a test user.
+ * Arms of the new-workspace prompt form-factor experiment:
+ * - `control`  three inline prompt rows (what ships today)
+ * - `cards2`   two cards above the composer
+ * - `cards4`   four cards in a 2x2 grid
+ *
+ * The prompt sets are nested prefixes of one fixed pool, so the only thing
+ * that varies is form factor. `cards2` vs `cards4` is the decision-paralysis
+ * question — read it as "do the extra two prompts earn their slot", since
+ * count and the marginal prompts' quality move together.
+ */
+export type PromptCardsVariant = "control" | "cards2" | "cards4";
+
+/**
+ * Assigns the prompt-cards arm. Same imperative `getFeatureFlag` shape as
+ * `useNewWorkspaceScreenVariant`: exposure fires only once the screen is
+ * actually open, and only after flags have loaded — reading the flag earlier
+ * returns undefined, which would show control to a test user.
  *
  * Both flags are read inside the loaded callback rather than through
  * `useFeatureFlagEnabled`: that hook returns undefined until its own passive
@@ -21,9 +34,9 @@ import { useLayoutEffect, useState } from "react";
  */
 export function useNewWorkspacePromptCardsVariant(
 	isOpen: boolean,
-): "control" | "test" | null {
+): PromptCardsVariant | null {
 	const posthog = usePostHog();
-	const [variant, setVariant] = useState<"control" | "test" | null>(null);
+	const [variant, setVariant] = useState<PromptCardsVariant | null>(null);
 
 	useLayoutEffect(() => {
 		if (!isOpen) return;
@@ -33,13 +46,13 @@ export function useNewWorkspacePromptCardsVariant(
 					FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS_OVERRIDE,
 				)
 			) {
-				setVariant("test");
+				setVariant("cards2");
 				return;
 			}
 			const value = posthog.getFeatureFlag(
 				FEATURE_FLAGS.NEW_WORKSPACE_PROMPT_CARDS,
 			);
-			setVariant(value === "test" ? "test" : "control");
+			setVariant(value === "cards2" || value === "cards4" ? value : "control");
 		};
 		const unsubscribe = posthog.onFeatureFlags(evaluate);
 		const fallback = window.setTimeout(


### PR DESCRIPTION
Reworks the new-workspace sample prompts so the prompt-cards experiment measures form factor and nothing else, and adds a third arm to test whether four cards cost more than they earn.

## Why this is safe to change

The experiment (PostHog [419092](https://us.posthog.com/project/264803/experiments/419092)) **never launched** — still `draft`, flag `active: false`. All 639 `$feature_flag_called` evaluations since `desktop-v1.22.0` returned `null`, so nobody has ever been bucketed into an arm. **Zero experiment data exists**, and #6537 / #6540 are in no shipped desktop tag.

## What had drifted

Pre-registration said *control = today's three inline rows, unchanged; test = two cards*. On `main`:

| | Pre-registered | On `main` before this PR |
|---|---|---|
| control | 3 fixed rows | 4 shuffled from a pool of 6 |
| test | 2 bordered cards | 4 borderless cards, shuffled |
| selection | identical across arms | setup-first in cards only |

That last row is the blocker: the cards arm got a curated setup-first list and rows got a random slice, so the arms differed in *content* inside a *layout* test.

## Premises, validated against production

- Setup is **69.5%** of clicks, not 75% — but it always renders first, so share and position are perfectly confounded.
- Setup clickers create ~3x more workspaces (medians), and only **12.7%** of those predate the click. But the cold-start cell is **n=17**, and `fix-small-bug` — the *least*-clicked prompt — shows the *highest* count, which is a selection signature. Suggestive, not established.
- Eligible population is **~840 new accounts/week** at a stable **13.5–14.1%** click rate. Activation can't resolve a realistic form-factor effect in under ~10 weeks; click rate resolves a large relative effect in ~2–3 weeks across three arms.

**So click rate becomes the primary metric and activation is demoted to directional.** Powering this on activation is what made a 3-arm test look unaffordable.

## Changes

- **Fixed five-prompt pool**, curated order. Arms slice nested prefixes (`cards2` ⊂ `control` ⊂ `cards4`), so only form factor varies. `clean-up-todos` cut — with fixed order and nesting, only five prompts are ever reachable.
- **Shared `useSamplePromptSelection`** — setup-first rule and its pending gate now apply identically to every arm. Previously cards held for the setup query while rows rendered instantly, a timing difference the experiment would have read as a layout effect.
- **Three arms**: `control` (3 rows) / `cards2` / `cards4`. `layout` on the click event distinguishes them.
- **Card border restored** — prominence is the manipulation under test; #6540 had slid it to borderless across three commits.
- **Shuffle dropped** — randomizes content against a tight power budget and breaks the nesting.
- **Dismiss gated** behind the user's first non-`main` workspace. It permanently removes the measured surface, and asymmetric dismissal would bias the primary metric toward null. (`main` is auto-created for every account, hence the `!= main` condition.)

Kept from #6537/#6540: the expanded pool (a 4-card arm can't be filled from three prompts), per-card icons, `AgentLogoCluster`, and the labeled model/effort pills.

## Before this can launch

1. Rename the flag's variants `control` / `cards2` / `cards4` at 33/33/33 and re-register the experiment with click rate primary. **Not done in this PR** — no unapproved tracker writes.
2. Bump the flag's `created_at` cutoff to the carrying build's publish time (currently `2026-08-17T07:00Z`, already in the past).

@Kitenite — this reworks parts of #6537 and #6540, so please take a look. The reasoning is measurement-driven rather than taste-driven; your cards and icons are kept.

`bun run typecheck`, `./scripts/lint.sh`, and 2583 desktop tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the new-workspace prompt experiment to measure form factor only, adds a third arm, and introduces tiered prompts keyed on whether the user has shipped a workspace. Old behavior randomized content and timing with one cold-start pool; new behavior fixes order, shares selection and timing across arms, restores card borders, distinguishes `cards2` vs `cards4`, and switches between `first-run` and `returning` tiers to avoid repeating cold-start prompts.

- Arms: control shows 3 rows; `cards2` shows 2 cards; `cards4` shows 4 cards. All arms slice nested prefixes of one ordered tier list; the setup prompt drops if the project is configured.
- Shared `useSamplePromptSelection` applies the same setup-first rule and pending gate to every arm, so rows no longer appear earlier than cards.
- Tiering: `first-run` keeps orientation; `returning` adds `explain-superset` and restores `clean-up-todos`. Click events carry `layout` (`rows`/`cards2`/`cards4`) and `tier`.
- Shuffle is dropped; cards regain borders; dismiss events use the same `layout`. The dismiss button appears only after the user has a non-`main` workspace.
- Flag reading accepts `cards2`/`cards4` variants; the manual override maps to `cards2`.

**Rollout**
- Rename the flag’s variants to `control`, `cards2`, `cards4` at 33/33/33 and re-register the experiment with click rate as the primary metric.
- Bump the flag’s `created_at` cutoff to the carrying build’s publish time.

<sup>Written for commit e1045e1b0bbadf7a725b6f7a597504d931856f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added updated workspace suggestion layouts, including two- and four-card formats.
  - Suggestions now adapt to project setup and whether you’re creating a workspace for the first time or returning.
  - Added an accessible dismiss button for hiding suggestions.

- **Bug Fixes**
  - Improved prompt loading behavior to prevent incomplete suggestions from appearing.
  - Dismissal is available only when appropriate and accurately tracks the displayed layout.
  - Updated prompt cards with refreshed styling and clearer actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->