### PR TITLE
fix(desktop): stop new-workspace suggestions overlapping the heading

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -667,7 +667,11 @@ export function NewWorkspaceScreen({
 								animate={{ opacity: 1, y: 0 }}
 								exit={{ opacity: 0, transition: { duration: 0 } }}
 								transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
-								className="absolute inset-x-6 bottom-full mb-1"
+								// In flow, not absolute: the heading above is the flex-1
+								// spacer, so it absorbs this block's height and the composer
+								// stays put. Positioning it out of flow let tall suggestion
+								// sets overlap the heading instead.
+								className="mb-1"
 							>
 								{promptCardsVariant === "control" ? (
 									<SamplePrompts

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/SamplePrompts/constants.ts
@@ -61,7 +61,7 @@ export const SAMPLE_PROMPTS: Record<string, SamplePrompt> = {
 	},
 	"explain-superset": {
 		id: "explain-superset",
-		label: "Show me how to get more out of Superset",
+		label: "Get more out of Superset",
 		description:
 			"Learn the workflow that fits this repo — parallel workspaces and agent setup.",
 		prompt:


### PR DESCRIPTION
The suggestion cards render straight through the "What should we build next?" heading:

<img width="600" alt="cards overlapping the heading" src="https://github.com/user-attachments/assets/placeholder" />

## Cause

The suggestion block is positioned `absolute inset-x-6 bottom-full`, so it takes no layout space. The heading above it is the `flex-1` spacer — it centers itself into whatever room is left, which includes the room the suggestions then draw on top of.

Latent since the screen shipped in #5907; it just needed a tall enough suggestion set to surface. The returning-tier `explain-superset` card wrapped its title to two lines, which was enough.

## Fix

Put the block back in flow. The `flex-1` heading absorbs its height, so nothing overlaps at any window height.

The composer does **not** move as a result: the composer block is bottom-anchored by `pb-8` and `PromptInput` sits *below* the suggestions inside it, so only the heading recenters. On typing, the suggestions unmount and the heading drifts back down. The root is already `overflow-y-auto`, so a window too short for both scrolls rather than collides.

Also shortens the `explain-superset` label to "Get more out of Superset" — one line instead of two, better copy, and it keeps the block shorter regardless of the layout fix.

## Verification

`bun run typecheck` and `./scripts/lint.sh` pass. **Not visually confirmed in the running app yet** — flagging that explicitly rather than implying otherwise. Worth an eyeball on all three arms (`control` / `cards2` / `cards4`) before this is relied on, since `cards4` is the tallest case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents new-workspace suggestion cards from overlapping the "What should we build next?" heading. Previously the suggestions were absolutely positioned and drew over the heading; now the suggestions are in normal flow, so the heading absorbs their height and the composer stays bottom-anchored.

- Verify layout across prompt card variants (`control`, `cards2`, `cards4`) at various window heights; `PromptInput` position should be unchanged and the root should scroll when space is tight.
- Copy tweak: the `explain-superset` card label is shortened to "Get more out of Superset" to reduce card height.

<sup>Written for commit f538316b13e63d3c5259cebb5dfdabdf875c1e54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sample prompt suggestions now display in normal flow, preventing taller lists from overlapping the heading.
- **UI Updates**
  - Shortened the Superset sample prompt label to “Get more out of Superset.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->