### PR TITLE
fix(desktop): auto-place session workspaces in the sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.test.ts
@@ -34,4 +34,34 @@ describe("selectWorktreesToPlace", () => {
 
 		expect(result).toEqual([{ id: "wt-new", projectId: "p1" }]);
 	});
+
+	it("places session workspaces with no project (e.g. automation runs)", () => {
+		const result = selectWorktreesToPlace(
+			[{ id: "sess-1", projectId: null, type: "session" }],
+			new Set(),
+		);
+
+		expect(result).toEqual([{ id: "sess-1", projectId: null }]);
+	});
+
+	it("skips sessions that already have a row", () => {
+		const result = selectWorktreesToPlace(
+			[
+				{ id: "sess-seen", projectId: null, type: "session" },
+				{ id: "sess-new", projectId: null, type: "session" },
+			],
+			new Set(["sess-seen"]),
+		);
+
+		expect(result).toEqual([{ id: "sess-new", projectId: null }]);
+	});
+
+	it("never places a worktree missing its project", () => {
+		const result = selectWorktreesToPlace(
+			[{ id: "wt-broken", projectId: null, type: "worktree" }],
+			new Set(),
+		);
+
+		expect(result).toEqual([]);
+	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.ts
@@ -1,6 +1,6 @@
 export type LocalWorkspaceForPlacement = {
 	id: string;
-	/** Null for project-less "session" workspaces (never auto-placed here). */
+	/** Null for project-less "session" workspaces. */
 	projectId: string | null;
 	type: "main" | "worktree" | "session";
 };
@@ -9,9 +9,11 @@ export type LocalWorkspaceForPlacement = {
  * Chooses which of this device's workspaces the sidebar reconciler should
  * place. Kept free of React so it can be unit-tested directly.
  *
- * Only `worktree` workspaces are eligible: the host creates a `main` for every
- * project on the device, so placing those would drag locally-known projects the
- * user never added into the sidebar. Main workspaces surface instead via the
+ * `worktree` and `session` workspaces are eligible: both are always explicit
+ * creations (renderer, CLI, or automation), so they surface even when created
+ * outside the renderer. `main` workspaces are not — the host creates one for
+ * every project on the device, so placing those would drag locally-known
+ * projects the user never added into the sidebar; they surface instead via the
  * gated `isAutoIncludedLocalMainWorkspace` path. A workspace that already has a
  * local-state row is "already placed" and skipped, so nothing the user has
  * moved, hidden, or removed is re-added.
@@ -19,15 +21,17 @@ export type LocalWorkspaceForPlacement = {
 export function selectWorktreesToPlace(
 	localWorkspaces: readonly LocalWorkspaceForPlacement[],
 	placedWorkspaceIds: ReadonlySet<string>,
-): Array<{ id: string; projectId: string }> {
+): Array<{ id: string; projectId: string | null }> {
 	return localWorkspaces.flatMap((workspace) => {
-		if (
-			workspace.type !== "worktree" ||
-			workspace.projectId === null ||
-			placedWorkspaceIds.has(workspace.id)
-		) {
-			return [];
+		if (placedWorkspaceIds.has(workspace.id)) return [];
+		if (workspace.type === "worktree" && workspace.projectId !== null) {
+			return [{ id: workspace.id, projectId: workspace.projectId }];
 		}
-		return [{ id: workspace.id, projectId: workspace.projectId }];
+		// Sessions are project-less; they land in the top-level Sessions
+		// section, so placement carries no project.
+		if (workspace.type === "session") {
+			return [{ id: workspace.id, projectId: null }];
+		}
+		return [];
 	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/selectWorktreesToPlace.ts
@@ -22,16 +22,18 @@ export function selectWorktreesToPlace(
 	localWorkspaces: readonly LocalWorkspaceForPlacement[],
 	placedWorkspaceIds: ReadonlySet<string>,
 ): Array<{ id: string; projectId: string | null }> {
-	return localWorkspaces.flatMap((workspace) => {
-		if (placedWorkspaceIds.has(workspace.id)) return [];
-		if (workspace.type === "worktree" && workspace.projectId !== null) {
-			return [{ id: workspace.id, projectId: workspace.projectId }];
-		}
-		// Sessions are project-less; they land in the top-level Sessions
-		// section, so placement carries no project.
-		if (workspace.type === "session") {
-			return [{ id: workspace.id, projectId: null }];
-		}
-		return [];
-	});
+	return localWorkspaces.flatMap(
+		(workspace): Array<{ id: string; projectId: string | null }> => {
+			if (placedWorkspaceIds.has(workspace.id)) return [];
+			if (workspace.type === "worktree" && workspace.projectId !== null) {
+				return [{ id: workspace.id, projectId: workspace.projectId }];
+			}
+			// Sessions are project-less; they land in the top-level Sessions
+			// section, so placement carries no project.
+			if (workspace.type === "session") {
+				return [{ id: workspace.id, projectId: null }];
+			}
+			return [];
+		},
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/usePlaceLocalWorktreesInSidebar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceLocalWorktreesInSidebar/usePlaceLocalWorktreesInSidebar.ts
@@ -7,15 +7,17 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 import { selectWorktreesToPlace } from "./selectWorktreesToPlace";
 
 /**
- * Places deliberately-created worktrees into the sidebar exactly once.
+ * Places deliberately-created worktrees and sessions into the sidebar exactly
+ * once.
  *
- * A `worktree` is always an explicit creation (renderer, CLI, or automation),
- * so it should surface even when created outside the renderer — the CLI and
- * automations go through the host service and can't write renderer-local
- * sidebar state. An ambient `main` workspace is excluded: the host creates one
- * for every project on the device, so placing those would drag every
- * locally-known project into the sidebar. Main workspaces surface only under a
- * project already in the sidebar (`isAutoIncludedLocalMainWorkspace`).
+ * A `worktree` or `session` is always an explicit creation (renderer, CLI, or
+ * automation), so it should surface even when created outside the renderer —
+ * the CLI and automations go through the host service and can't write
+ * renderer-local sidebar state. An ambient `main` workspace is excluded: the
+ * host creates one for every project on the device, so placing those would
+ * drag every locally-known project into the sidebar. Main workspaces surface
+ * only under a project already in the sidebar
+ * (`isAutoIncludedLocalMainWorkspace`).
  *
  * "Placed once, then respected": a present `v2WorkspaceLocalState` row means
  * "already seen". Hiding a worktree keeps a hidden tombstone row, and removing


### PR DESCRIPTION
## Summary
- Workspaces created for **session-mode automations** (and CLI project-less sessions) never showed up in the sidebar's Sessions section. The sidebar's placement reconciler now auto-places `session`-type workspaces the same way it places worktrees.

## Why / Context
The sidebar only renders workspaces that have a renderer-local `v2WorkspaceLocalState` placement row. Creations that happen outside the renderer (automations dispatch `workspaces.createSession` on the host over the relay; the CLI goes through the host service too) can't write that row, so `usePlaceLocalWorktreesInSidebar` reconciles them in — but its gate (`selectWorktreesToPlace`) only admitted `type === "worktree"` with a project. A session-mode automation run produces `type: "session"`, `projectId: null`, which failed both clauses: the workspace existed on the host and in the fan-out, but the Sessions section never saw it unless you navigated to the workspace directly (the workspace route places on open). Baked in since project-less sessions shipped (#6274/#6280) — surfaced once automations started running in session mode.

## How It Works
- `selectWorktreesToPlace` now also returns `session` workspaces (with `projectId: null`, landing them in the top-level Sessions section). Return type widens to `projectId: string | null`; `ensureWorkspaceInSidebar` already accepts null for sessions.
- `main` stays excluded: the host mints one per locally-known project, so placing those would drag every known project into the sidebar. They keep surfacing via the gated `isAutoIncludedLocalMainWorkspace` path.
- "Placed once, then respected" is unchanged — hidden/moved/removed rows keep their tombstone and are never re-placed.

## Manual QA Checklist
Verified end-to-end over CDP against the dev desktop app (real host-service, same tRPC procedures automations hit):

- [x] **Pre-fix baseline (control alive):** `workspaces.createSession` + a control `workspaces.create` worktree issued side by side — control placed and rendered in ~7s; session never placed after 42s+ despite appearing in the renderer's host `workspace.list`
- [x] **Post-fix, existing orphans:** previously-created row-less sessions get placed on boot and render in the Sessions section
- [x] **Post-fix, live journey:** a new `createSession` while the app is running gets its `v2WorkspaceLocalState` row in ~195ms, `projectId: null`, row visible in the Sessions section with no reload
- [x] Worktree auto-placement unchanged (control workspace placed under its project)
- [x] Screenshots captured of Sessions section before (rows absent) and after (rows present)

## Testing
- `bun test selectWorktreesToPlace.test.ts` — 6 pass (3 new: session placed, already-placed session skipped, worktree-without-project still skipped)
- `bun run typecheck` (apps/desktop)
- `bunx biome check` on the touched directory

## Known Limitations
- The reconciler (pre-existing behavior) only places workspaces whose `hostId` matches this machine — an automation dispatched to a *different* host still won't auto-appear in this device's sidebar. Applies equally to worktrees; out of scope here.

## Follow-ups
- While verifying, found that `useHostWorkspaces.isReady` waits on every online-flagged host's `workspace.list`; a stale `v2_hosts.is_online = true` row for an unreachable relay host held it false indefinitely, which silences the reconciler for **all** workspace types. Worth a separate ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-places session workspaces in the sidebar’s Sessions section. Previously, sessions created via automations or the CLI never appeared unless opened directly; now they place automatically like worktrees.

- Expands selectWorktreesToPlace to include session workspaces and return { id, projectId: string | null }.
- Sessions place with projectId: null in the top-level Sessions section; main remains excluded; worktrees without a project remain skipped.
- Placement policy unchanged: placed once and respected; previously orphaned sessions are placed on boot.
- Adds unit tests for session placement and skip cases.
- Annotates the flatMap callback return to unify TypeScript inference; no runtime behavior change.

<sup>Written for commit 737900429fec657fec8a3eb5ac4bb8537ad515a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session workspaces can now appear in the sidebar alongside worktrees, including sessions without an associated project.
  - Sessions and worktrees are placed only once, while main and invalid workspaces remain excluded.

- **Tests**
  - Added coverage for project-less sessions, already displayed sessions, and worktrees without projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->