### PR TITLE
docs(sandbox): file the provisioning-row reaper as an open task

### DIFF
--- a/docs/cloud-sandbox-considerations.md
+++ b/docs/cloud-sandbox-considerations.md
@@ -105,6 +105,18 @@ the first thing to prove, ahead of any polish.
 **No fleet view.** Nothing in the product lists running sandboxes, their cost,
 or lets you stop one. Today that lives in the provider console.
 
+**Nothing reaps a row stuck in `provisioning`. Open.** A create that dies
+between inserting the row and reporting the sandbox leaves a `cloud_workspaces`
+row in `provisioning` forever: the sidebar shows a workspace that cannot open,
+`access` refuses it because the status isn't `ready`, and no code path ever looks
+at it again. It happened for real — a production create hit the API function's
+60s limit mid-bootstrap, and the row outlived the sandbox it named. Provisioning
+is ~5s now, so the window is small rather than gone; a killed function, a
+provider timeout or a crash still lands there. Wanted: a sweep that fails rows
+older than a few minutes and tears down any sandbox they name, plus the same
+teardown on the paths that can't currently reach it. One row from that incident
+had to be cleared by hand.
+
 **The Superset CLI is offered but not installed. Open.** A cloud workspace's
 agent row includes "Superset CLI" alongside Claude, Codex and Copilot, and
 picking it fails with command-not-found: the image installs the agent CLIs but


### PR DESCRIPTION
Adds the missing task to `docs/cloud-sandbox-considerations.md`.

A create that dies between inserting the `cloud_workspaces` row and reporting the sandbox leaves that row in `provisioning` forever: the sidebar shows a workspace that can't open, `access` refuses it because the status isn't `ready`, and nothing ever looks at the row again.

This isn't hypothetical — a production create hit the API function's 60s limit mid-bootstrap (fixed in #6555), and the row outlived the sandbox it named. Provisioning is ~5s now, so the window is small rather than closed: a killed function, a provider timeout or a crash still lands there.

Wanted: a sweep that fails rows older than a few minutes and tears down any sandbox they name, plus the same teardown on the paths that can't currently reach it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the open task to reap `cloud_workspaces` rows stuck in `provisioning` after a failed create, to prevent unusable workspaces and orphaned sandboxes. This records a real incident and outlines the desired sweep/teardown behavior.

- Describes the failure mode: the create inserts the row but dies before reporting the sandbox (e.g., API function 60s timeout).
- Specifies the fix: periodically fail rows older than a few minutes and tear down any named sandbox; apply the same teardown on error paths that cannot reach the sandbox.
- Notes current impact: the sidebar lists a workspace that cannot open, `access` rejects it as not `ready`, and the row persists until manual cleanup.

<sup>Written for commit 183ec67222e5b3e9059a28ae8c34cd6e230a83d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a failure scenario where sandboxes may remain stuck in provisioning.
  * Added guidance on handling inaccessible workspaces, cleanup gaps, timeout incidents, and stale sandbox removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->