### PR TITLE
docs(sandbox): point both sandbox docs at the Linear project

### DIFF
--- a/docs/cloud-sandbox-considerations.md
+++ b/docs/cloud-sandbox-considerations.md
@@ -1,5 +1,7 @@
 # Cloud sandboxes: what to settle before this leaves the team
 
+**Tickets live in the Linear "Sandboxes" project** (https://linear.app/superset-sh/project/sandboxes-a52055bc936e). This file is the reasoning — what a sandbox is and why it differs from a machine someone owns — and stays the thing to read before changing this code. When you find something new, write it here and file the ticket there; when an item is fixed, say so here rather than deleting it, so the next person can see the shape of the trap.
+
 Companion to `cloud-sandbox-mismatches.md`. That file is about where a sandbox
 doesn't behave like a machine someone owns; this one is about what we still owe
 before people outside the team can create one.

--- a/docs/cloud-sandbox-considerations.md
+++ b/docs/cloud-sandbox-considerations.md
@@ -105,6 +105,18 @@ the first thing to prove, ahead of any polish.
 **No fleet view.** Nothing in the product lists running sandboxes, their cost,
 or lets you stop one. Today that lives in the provider console.
 
+**Nothing reaps a row stuck in `provisioning`. Open.** A create that dies
+between inserting the row and reporting the sandbox leaves a `cloud_workspaces`
+row in `provisioning` forever: the sidebar shows a workspace that cannot open,
+`access` refuses it because the status isn't `ready`, and no code path ever looks
+at it again. It happened for real — a production create hit the API function's
+60s limit mid-bootstrap, and the row outlived the sandbox it named. Provisioning
+is ~5s now, so the window is small rather than gone; a killed function, a
+provider timeout or a crash still lands there. Wanted: a sweep that fails rows
+older than a few minutes and tears down any sandbox they name, plus the same
+teardown on the paths that can't currently reach it. One row from that incident
+had to be cleared by hand.
+
 **The Superset CLI is offered but not installed. Open.** A cloud workspace's
 agent row includes "Superset CLI" alongside Claude, Codex and Copilot, and
 picking it fails with command-not-found: the image installs the agent CLIs but

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -1,5 +1,7 @@
 # Where cloud sandboxes don't fit the app
 
+**Tickets live in the Linear "Sandboxes" project** (https://linear.app/superset-sh/project/sandboxes-a52055bc936e). This file is the reasoning — what a sandbox is and why it differs from a machine someone owns — and stays the thing to read before changing this code. When you find something new, write it here and file the ticket there; when an item is fixed, say so here rather than deleting it, so the next person can see the shape of the trap.
+
 A cloud workspace runs host-service inside a provider sandbox, which lets it
 reuse the whole v2 stack — panes, terminals, git, agents — for free. The price
 is a set of places where the app's assumptions were written for *a machine a


### PR DESCRIPTION
The open items in these two docs are now tickets in the Linear [Sandboxes](https://linear.app/superset-sh/project/sandboxes-a52055bc936e) project (SUPER-1892 … SUPER-1910).

Adds a line to each doc saying where the tickets live and what each artefact is for: Linear tracks the work, the docs carry the reasoning — what a sandbox is and why it differs from a machine someone owns — which is the context a ticket doesn't hold well and the thing to read before touching this code.

Also notes the convention: when an item is fixed, say so in the doc rather than deleting it, so the next person can still see the shape of the trap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point both cloud sandbox docs to the Linear “Sandboxes” project and define the docs-vs-tickets contract. Also documents an open gap: reaping stuck `cloud_workspaces` rows left in “provisioning” after failed creates.

- Adds a top note in `cloud-sandbox-considerations.md` and `cloud-sandbox-mismatches.md` linking to the Linear project and stating conventions: write new findings here, file tickets there, and mark fixed items instead of deleting.
- Captures the failure mode where a create dies after inserting the row; proposes a sweep to fail rows older than a few minutes and tear down any sandbox they name.

<sup>Written for commit 874ac32455de34e9f043abf9006f476cdeaee26e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for tracking cloud sandbox issues and maintaining related documentation.
  - Documented a failure case where interrupted sandbox creation can leave entries stuck in provisioning.
  - Added information about the visible impact and required cleanup and teardown handling.
  - Clarified how to record new and resolved sandbox mismatches while preserving historical entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->