### PR TITLE
feat(desktop,trpc): make creating a cloud workspace feel immediate

### DIFF
--- a/apps/api/src/app/api/cloud-workspaces/provision/route.ts
+++ b/apps/api/src/app/api/cloud-workspaces/provision/route.ts
@@ -1,0 +1,58 @@
+import { provisionCloudWorkspace } from "@superset/trpc/cloud-workspace-provision";
+import { Receiver } from "@upstash/qstash";
+import { z } from "zod";
+
+import { env } from "@/env";
+
+// Provisioning is a second or two warm, but the first sandboxes after an image
+// rebuild pull the image and take tens of seconds.
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+const payloadSchema = z
+	.object({
+		cloudWorkspaceId: z.string().uuid(),
+		/** Absent when the user typed a name, which the row already holds. */
+		namingPrompt: z.string().max(20000).optional(),
+	})
+	.strict();
+
+/**
+ * Provisions the sandbox for a `cloud_workspaces` row that `cloudWorkspace.create`
+ * already wrote. The row's status is the only thing the client waits on, so
+ * this job is what turns the provisioning screen into a workspace.
+ */
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const signature = request.headers.get("upstash-signature");
+	if (!signature) {
+		return Response.json({ error: "Missing signature" }, { status: 401 });
+	}
+
+	const valid = await receiver.verify({
+		body,
+		signature,
+		url: `${env.NEXT_PUBLIC_API_URL}/api/cloud-workspaces/provision`,
+	});
+	if (!valid) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	const parsed = payloadSchema.safeParse(JSON.parse(body));
+	if (!parsed.success) {
+		console.error("[cloud-workspaces/provision] invalid payload", parsed.error);
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+
+	// A failure here is already recorded on the row and the sandbox already
+	// torn down, so answering 200 is right: a redelivery would repeat work that
+	// deliberately gave up. QStash's retries are for the deliveries that never
+	// reach this line.
+	const outcome = await provisionCloudWorkspace(parsed.data);
+	return Response.json({ ok: true, outcome });
+}

--- a/apps/api/src/app/api/cloud-workspaces/provision/route.ts
+++ b/apps/api/src/app/api/cloud-workspaces/provision/route.ts
@@ -34,11 +34,20 @@ export async function POST(request: Request): Promise<Response> {
 		return Response.json({ error: "Missing signature" }, { status: 401 });
 	}
 
-	const valid = await receiver.verify({
-		body,
-		signature,
-		url: `${env.NEXT_PUBLIC_API_URL}/api/cloud-workspaces/provision`,
-	});
+	// `verify` throws rather than returning false on a signature it can't even
+	// parse, so a malformed header answered 500 — reported as a server fault,
+	// noisy in Sentry, and a different answer than a well-formed wrong
+	// signature gets. Both are the same refusal.
+	let valid = false;
+	try {
+		valid = await receiver.verify({
+			body,
+			signature,
+			url: `${env.NEXT_PUBLIC_API_URL}/api/cloud-workspaces/provision`,
+		});
+	} catch {
+		valid = false;
+	}
 	if (!valid) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}

--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -4,6 +4,7 @@ import type {
 } from "@superset/host-service";
 import { TRPCClientError } from "@trpc/client";
 import { useCallback } from "react";
+import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -128,8 +129,12 @@ export function useDestroyWorkspace(workspaceId: string): UseDestroyWorkspace {
 		? "ready"
 		: hostTarget.status;
 
-	const isSandbox =
-		hostTarget.status === "ready" && hostTarget.kind === "sandbox";
+	// The cloud row decides this, not whether we currently hold an address for
+	// it: a workspace still provisioning, or one whose sandbox stopped
+	// answering, is no less a cloud workspace — and deleting it anywhere but at
+	// the API would leave the sandbox running.
+	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
+	const isSandbox = cloudWorkspaces.some((row) => row.id === workspaceId);
 	const utils = cloudTrpc.useUtils();
 
 	const destroy = useCallback(

--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
@@ -50,8 +50,12 @@ export function useWorkspaceHostTarget(
 	const cloudWorkspaces = cloudQuery.data ?? [];
 	const cloudPending =
 		Boolean(organizationId) && !match && !cloudQuery.isFetched;
+	// Only a `ready` row has an address to broker: the list carries workspaces
+	// that are still provisioning, and `access` refuses those.
 	const cloudMatch = workspaceId
-		? (cloudWorkspaces.find((w) => w.id === workspaceId) ?? null)
+		? (cloudWorkspaces.find(
+				(w) => w.id === workspaceId && w.status === "ready",
+			) ?? null)
 		: null;
 	const access = cloudTrpc.cloudWorkspace.access.useMutation();
 	const [sandboxUrl, setSandboxUrl] = useState<string | null>(null);

--- a/apps/desktop/src/renderer/hooks/useCloudWorkspaces/index.ts
+++ b/apps/desktop/src/renderer/hooks/useCloudWorkspaces/index.ts
@@ -1,0 +1,5 @@
+export {
+	type CloudWorkspaceRow,
+	type CloudWorkspacesValue,
+	useCloudWorkspaces,
+} from "./useCloudWorkspaces";

--- a/apps/desktop/src/renderer/hooks/useCloudWorkspaces/useCloudWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/useCloudWorkspaces/useCloudWorkspaces.ts
@@ -1,0 +1,50 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import type { RouterOutputs } from "@superset/trpc";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { authClient } from "renderer/lib/auth-client";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+
+export type CloudWorkspaceRow = RouterOutputs["cloudWorkspace"]["list"][number];
+
+/**
+ * Someone is watching a provisioning row, so poll like it: a warm sandbox is
+ * up in about a second, and this poll is now the longest part of the wait
+ * between pressing create and the workspace opening.
+ */
+const PROVISIONING_POLL_MS = 1_000;
+const IDLE_POLL_MS = 30_000;
+
+export interface CloudWorkspacesValue {
+	workspaces: CloudWorkspaceRow[];
+	organizationId: string | null;
+}
+
+/**
+ * Every cloud workspace in the active organization, including the ones still
+ * provisioning and the ones that failed. The row exists from the moment create
+ * returns, and both the sidebar and the workspace route render it long before
+ * a sandbox is behind it.
+ *
+ * Shared rather than queried per consumer so the polling cadence is one
+ * decision: while anything is provisioning there is a screen waiting on the
+ * flip to `ready`, and a 30s poll would leave it spinning for half a minute
+ * after the sandbox came up.
+ */
+export function useCloudWorkspaces(): CloudWorkspacesValue {
+	const enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES);
+	const { data: session } = authClient.useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? null;
+
+	const query = cloudTrpc.cloudWorkspace.list.useQuery(
+		{ organizationId: organizationId ?? "" },
+		{
+			enabled: Boolean(enabled && organizationId),
+			refetchInterval: (current) =>
+				current.state.data?.some((row) => row.status === "provisioning")
+					? PROVISIONING_POLL_MS
+					: IDLE_POLL_MS,
+		},
+	);
+
+	return { workspaces: query.data ?? [], organizationId };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -1,9 +1,6 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo } from "react";
-import { authClient } from "renderer/lib/auth-client";
-import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
@@ -30,14 +27,7 @@ export function DashboardSidebarCloudSection({
 	isCollapsed?: boolean;
 	onWorkspaceHover?: (workspaceId: string) => void | Promise<void>;
 }) {
-	const enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES);
-	const { data: session } = authClient.useSession();
-	const organizationId = session?.session?.activeOrganizationId ?? null;
-
-	const { data: cloudWorkspaces = [] } = cloudTrpc.cloudWorkspace.list.useQuery(
-		{ organizationId: organizationId ?? "" },
-		{ enabled: Boolean(enabled && organizationId), refetchInterval: 30_000 },
-	);
+	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
 
 	// Row visibility, pinning and order all live in the same local-state
@@ -102,12 +92,25 @@ export function DashboardSidebarCloudSection({
 					updatedAt: cloud.updatedAt,
 					taskId: null,
 					isPinned: false,
-					pendingTransaction: null,
+					// Same row treatment a local create gets while it is in flight —
+					// a spinner instead of a status dot, and no rename/delete menu
+					// on a workspace whose sandbox doesn't exist yet.
+					pendingTransaction:
+						cloud.status === "provisioning"
+							? {
+									id: cloud.id,
+									workspaceId: cloud.id,
+									type: "insert",
+									state: "pending",
+									createdAt: cloud.createdAt,
+									updatedAt: cloud.updatedAt,
+								}
+							: null,
 				};
 			});
 	}, [cloudWorkspaces, hostWorkspaces, localStateRows]);
 
-	if (!enabled || rows.length === 0) return null;
+	if (rows.length === 0) return null;
 
 	if (isCollapsed) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
@@ -1,7 +1,8 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
+import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -9,28 +10,28 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useSandboxAccess } from "renderer/routes/_authenticated/providers/SandboxAccessProvider";
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
-import { StateScreenShell } from "./components/StateScreenShell";
-import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
-import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
-import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
-import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
-import { useRemoteHostStatus } from "./hooks/useRemoteHostStatus";
-import { useWorkspaceMissVerdict } from "./hooks/useWorkspaceMissVerdict";
-import { WorkspaceProvider } from "./providers/WorkspaceProvider";
+import { CloudWorkspaceProvisioningState } from "../components/CloudWorkspaceProvisioningState";
+import { StateScreenShell } from "../components/StateScreenShell";
+import { WorkspaceCreateErrorState } from "../components/WorkspaceCreateErrorState";
+import { WorkspaceCreatingState } from "../components/WorkspaceCreatingState";
+import { WorkspaceHostIncompatibleState } from "../components/WorkspaceHostIncompatibleState";
+import { WorkspaceNotFoundState } from "../components/WorkspaceNotFoundState";
+import { useRemoteHostStatus } from "../hooks/useRemoteHostStatus";
+import { useWorkspaceMissVerdict } from "../hooks/useWorkspaceMissVerdict";
+import { WorkspaceProvider } from "../providers/WorkspaceProvider";
 
-export const Route = createFileRoute("/_authenticated/_dashboard/v2-workspace")(
-	{
-		component: V2WorkspaceLayout,
-	},
-);
+export const Route = createFileRoute(
+	"/_authenticated/_dashboard/v2-workspace/$workspaceId",
+)({
+	component: V2WorkspaceLayout,
+});
 
 function V2WorkspaceLayout() {
-	const matchRoute = useMatchRoute();
-	const workspaceMatch = matchRoute({
-		to: "/v2-workspace/$workspaceId",
-	});
-	const workspaceId =
-		workspaceMatch !== false ? workspaceMatch.workspaceId : null;
+	// Owned by this segment, so the param is available by definition. This used
+	// to live on the parent route, which had to match its own child to recover
+	// the id and then render an empty shell for the "no id" case that route
+	// could always reach and this one cannot.
+	const { workspaceId } = Route.useParams();
 	const collections = useCollections();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const pendingTransaction = useWorkspaceTransactionsStore((state) =>
@@ -71,6 +72,11 @@ function V2WorkspaceLayout() {
 	const isCloud = sandboxes.some(
 		(sandbox) => sandbox.workspaceId === workspaceId,
 	);
+	// The cloud row exists from the moment the workspace is created, which is
+	// well before there is a sandbox to serve it.
+	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
+	const cloudWorkspace =
+		cloudWorkspaces.find((row) => row.id === workspaceId) ?? null;
 	const { data: failedEntries } = useLiveQuery(
 		(q) =>
 			q
@@ -108,8 +114,23 @@ function V2WorkspaceLayout() {
 		cache.refetchAll,
 	);
 
-	if (!workspaceId) {
-		return <StateScreenShell>{null}</StateScreenShell>;
+	// Before "not found": a cloud workspace is navigated to as soon as its row
+	// exists, so for the first seconds of its life there is nothing in the
+	// fan-out to find. The same screen covers a ready sandbox that hasn't been
+	// addressed yet (access minting, host-service booting) — that gap used to
+	// be a blank frame, and letting it reach the host-unreachable takeover
+	// would tell the user their machine is down while it is simply starting.
+	if (!workspace && cloudWorkspace) {
+		return (
+			<StateScreenShell>
+				<CloudWorkspaceProvisioningState
+					workspaceId={cloudWorkspace.id}
+					name={cloudWorkspace.name}
+					branch={cloudWorkspace.branch}
+					status={cloudWorkspace.status}
+				/>
+			</StateScreenShell>
+		);
 	}
 
 	if (!workspace) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/CloudWorkspaceProvisioningState/CloudWorkspaceProvisioningState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/CloudWorkspaceProvisioningState/CloudWorkspaceProvisioningState.tsx
@@ -1,0 +1,268 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { AlertCircle, Check, Cloud, GitBranch, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { CloudWorkspaceRow } from "renderer/hooks/useCloudWorkspaces";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+
+/**
+ * A warm sandbox is up in a second or two; the first ones after an image
+ * rebuild pull the image and take tens of seconds. Past this, it is more
+ * likely stuck than slow.
+ */
+const STUCK_AFTER_SECONDS = 45;
+
+interface CloudWorkspaceProvisioningStateProps {
+	workspaceId: string;
+	name: string;
+	branch: string;
+	status: CloudWorkspaceRow["status"];
+}
+
+/**
+ * What a cloud workspace shows between "created" and "openable".
+ *
+ * The route navigates here the moment the row exists, so this screen — not a
+ * toast, and not the host-unreachable takeover — is where the sandbox coming
+ * up is visible. Its steps are read off the row's status and the host fan-out
+ * rather than a timer, so they can't claim progress that hasn't happened.
+ */
+export function CloudWorkspaceProvisioningState({
+	workspaceId,
+	name,
+	branch,
+	status,
+}: CloudWorkspaceProvisioningStateProps) {
+	const elapsed = useElapsedSeconds();
+
+	if (status === "failed") {
+		return (
+			<CloudWorkspaceFailedState
+				workspaceId={workspaceId}
+				name={name}
+				branch={branch}
+			/>
+		);
+	}
+
+	// `ready` means the provider handed back a preview URL, which is a step
+	// short of host-service answering on it. Until the workspace shows up in
+	// the fan-out this route keeps rendering, so the second step is the honest
+	// place to be.
+	const sandboxReady = status !== "provisioning";
+
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div
+				className="flex w-full max-w-sm flex-col items-start gap-5"
+				aria-live="polite"
+			>
+				<Cloud
+					className="size-5 text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Starting cloud workspace
+					</h1>
+					<p className="truncate text-[13px] leading-relaxed text-muted-foreground">
+						{name || "Untitled workspace"}
+					</p>
+				</div>
+
+				{branch && (
+					<div className="flex w-full items-center gap-2">
+						<GitBranch
+							className="size-3 shrink-0 text-muted-foreground/80"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						<code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{branch}
+						</code>
+					</div>
+				)}
+
+				<ul className="flex w-full flex-col gap-2">
+					<StepRow
+						label="Creating sandbox"
+						state={sandboxReady ? "done" : "active"}
+					/>
+					<StepRow
+						label="Connecting to the workspace"
+						state={sandboxReady ? "active" : "pending"}
+					/>
+				</ul>
+
+				<span className="font-mono text-[11px] tabular-nums text-muted-foreground/80">
+					{formatElapsed(elapsed)}
+				</span>
+
+				{elapsed >= STUCK_AFTER_SECONDS && (
+					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4 animate-in fade-in slide-in-from-bottom-1 duration-500">
+						<p className="select-text cursor-text text-[12px] leading-relaxed text-muted-foreground">
+							This is taking longer than usual. The sandbox may still be pulling
+							its image — it keeps going whether this window is open or not.
+						</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Provisioning gave up. The row is all that is left of the workspace — the
+ * sandbox behind it was torn down when it failed — so the only thing to offer
+ * is disposing of it, which is also the only way to clear it from the sidebar.
+ */
+function CloudWorkspaceFailedState({
+	workspaceId,
+	name,
+	branch,
+}: {
+	workspaceId: string;
+	name: string;
+	branch: string;
+}) {
+	const navigate = useNavigate();
+	const utils = cloudTrpc.useUtils();
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const handleDelete = async () => {
+		setIsDeleting(true);
+		try {
+			await apiTrpcClient.cloudWorkspace.delete.mutate({ id: workspaceId });
+			await utils.cloudWorkspace.list.invalidate();
+			await navigate({ to: "/v2-workspaces" });
+		} catch (error) {
+			console.error("[cloud-workspace] failed to delete", error);
+			setIsDeleting(false);
+		}
+	};
+
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div
+				role="alert"
+				aria-live="assertive"
+				className="flex w-full max-w-sm flex-col items-start gap-5"
+			>
+				<AlertCircle
+					className="size-5 text-destructive"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Couldn't start cloud workspace
+					</h1>
+					<p className="truncate text-[13px] leading-relaxed text-muted-foreground">
+						{name || "Untitled workspace"}
+					</p>
+				</div>
+
+				{branch && (
+					<div className="flex w-full items-center gap-2">
+						<GitBranch
+							className="size-3 shrink-0 text-muted-foreground/80"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						<code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{branch}
+						</code>
+					</div>
+				)}
+
+				<div className="w-full rounded-md border border-destructive/20 bg-destructive/[0.04] px-3 py-2.5">
+					<p className="select-text cursor-text text-[12px] leading-relaxed text-destructive/90">
+						Provisioning failed and the sandbox was torn down. Nothing is
+						running, and this workspace can't be opened — create a new one to
+						try again.
+					</p>
+				</div>
+
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={isDeleting}
+					onClick={() => void handleDelete()}
+				>
+					{isDeleting ? "Removing…" : "Remove workspace"}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+type StepState = "done" | "active" | "pending";
+
+function StepRow({ label, state }: { label: string; state: StepState }) {
+	return (
+		<li
+			className={cn(
+				"flex items-center gap-2.5 text-[13px] leading-tight transition-colors duration-300",
+				state === "done" && "text-foreground/80",
+				state === "active" && "text-foreground",
+				state === "pending" && "text-muted-foreground/55",
+			)}
+		>
+			<StepIcon state={state} />
+			<span>{label}</span>
+		</li>
+	);
+}
+
+function StepIcon({ state }: { state: StepState }) {
+	if (state === "done") {
+		return (
+			<span className="grid size-3.5 shrink-0 place-items-center rounded-full bg-foreground/85 text-background">
+				<Check className="size-2" strokeWidth={3.5} aria-hidden="true" />
+			</span>
+		);
+	}
+	if (state === "active") {
+		return (
+			<Loader2
+				className="size-3.5 shrink-0 animate-spin text-foreground/70"
+				strokeWidth={2}
+				aria-hidden="true"
+			/>
+		);
+	}
+	return (
+		<span className="grid size-3.5 shrink-0 place-items-center">
+			<span className="size-1.5 rounded-full bg-muted-foreground/35" />
+		</span>
+	);
+}
+
+function formatElapsed(seconds: number): string {
+	const total = Math.max(0, Math.floor(seconds));
+	const minutes = Math.floor(total / 60);
+	return `${minutes}:${(total % 60).toString().padStart(2, "0")}`;
+}
+
+/**
+ * Counts from when this screen appeared, not from the row's `createdAt`: an
+ * hours-old cloud workspace renders this too while its sleeping sandbox wakes,
+ * and "1:47:12" would be describing the workspace's age, not the wait.
+ */
+function useElapsedSeconds(): number {
+	const [elapsed, setElapsed] = useState(0);
+	useEffect(() => {
+		const startedAt = Date.now();
+		const id = window.setInterval(
+			() => setElapsed((Date.now() - startedAt) / 1000),
+			250,
+		);
+		return () => window.clearInterval(id);
+	}, []);
+	return elapsed;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/CloudWorkspaceProvisioningState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/CloudWorkspaceProvisioningState/index.ts
@@ -1,0 +1,1 @@
+export { CloudWorkspaceProvisioningState } from "./CloudWorkspaceProvisioningState";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -15,6 +15,7 @@ import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { toast } from "@superset/ui/sonner";
+import { Spinner } from "@superset/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
@@ -654,11 +655,10 @@ export function PromptGroup({
 								e.preventDefault();
 								handleSubmit();
 							}}
-							status={isCreating ? "submitted" : undefined}
 						>
-							{/* PromptInputSubmit renders `children ?? statusIcon`, so the
-							    arrow has to stand aside for the spinner to show. */}
-							{isCreating ? null : (
+							{isCreating ? (
+								<Spinner className="size-3.5 text-muted-foreground" />
+							) : (
 								<ArrowUpIcon className="size-3.5 text-muted-foreground" />
 							)}
 						</PromptInputSubmit>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -33,6 +33,7 @@ export function useSubmitWorkspace(
 	const { submit } = useWorkspaceCreates();
 	const { machineId } = useLocalHostService();
 	const createCloudWorkspace = cloudTrpc.cloudWorkspace.create.useMutation();
+	const utils = cloudTrpc.useUtils();
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 
@@ -79,13 +80,12 @@ export function useSubmitWorkspace(
 				toast.error("Cloud workspaces require a project");
 				return;
 			}
-			// Provisioning takes several seconds and the prompt has no progress
-			// affordance of its own, so the toast is the only signal the click
-			// registered.
 			try {
 				// A typed name wins; otherwise the API names it from the prompt,
 				// since nothing about a cloud workspace runs on this device.
-				await createCloudWorkspace.mutateAsync({
+				// Returns as soon as the row exists — the sandbox is still being
+				// provisioned behind it, which the workspace screen renders.
+				const created = await createCloudWorkspace.mutateAsync({
 					organizationId: activeOrganizationId,
 					projectId,
 					name: workspaceName ?? undefined,
@@ -93,6 +93,31 @@ export function useSubmitWorkspace(
 					branch: branchName ?? "main",
 				});
 				closeAndResetDraft();
+				// The cloud list is what both the sidebar and the workspace route
+				// read, and nothing used to tell it a workspace had been created —
+				// the row appeared whenever the poll next came round, which is why
+				// creating one felt like nothing had happened. Seeded rather than
+				// only invalidated because the route we're about to open decides
+				// between "provisioning" and "doesn't exist" off this list, and
+				// even one refetch round trip is long enough to flash the wrong
+				// one. Cancelled first so an in-flight fetch from before the
+				// create can't land on top of the patch.
+				const listInput = { organizationId: activeOrganizationId };
+				await utils.cloudWorkspace.list.cancel(listInput);
+				utils.cloudWorkspace.list.setData(listInput, (rows) =>
+					rows ? [created, ...rows] : [created],
+				);
+				void navigate({
+					to: "/v2-workspace/$workspaceId",
+					params: { workspaceId: created.id },
+				}).catch((error) => {
+					console.error(
+						"[useSubmitWorkspace] failed to open cloud workspace",
+						error,
+					);
+				});
+				// Server truth on top of the patch — the generated name lands here.
+				void utils.cloudWorkspace.list.invalidate();
 			} catch (error) {
 				toast.error(
 					error instanceof Error
@@ -231,11 +256,12 @@ export function useSubmitWorkspace(
 		selectedEffort,
 		submit,
 		uploadAttachments,
+		utils,
 	]);
 
-	// Cloud creation is the one path the user waits on — a sandbox is
-	// provisioned before this resolves. Returned so the submit control can
-	// carry its own pending state, instead of progress appearing in a toast in
-	// the corner, detached from the button that was pressed.
+	// Cloud creation is the one path the user waits on, now only for as long as
+	// it takes to record the workspace — the sandbox comes up behind the
+	// workspace screen. Returned so the submit control can carry its own
+	// pending state for that moment rather than looking inert.
 	return { submitWorkspace, isCreating: createCloudWorkspace.isPending };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { cn } from "@superset/ui/utils";
 import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useEffect } from "react";
 import {
 	HiCheck,
 	HiChevronUpDown,
@@ -95,6 +96,14 @@ export function DevicePicker({
 	const cloudEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES);
 	const { currentDeviceName, localHostIsOnline, otherHosts } =
 		useWorkspaceHostOptions();
+	// A remembered cloud target outlives the flag that offers it, and the menu
+	// then has no cloud entry to point at what the trigger claims is selected.
+	// Undefined means the flags haven't resolved, which is not a "no".
+	useEffect(() => {
+		if (hostId === CLOUD_HOST_ID && cloudEnabled === false) {
+			onSelectHostId(machineId);
+		}
+	}, [cloudEnabled, hostId, machineId, onSelectHostId]);
 	const isLocal = hostId === null || hostId === machineId;
 	const selectedLabel = getSelectedLabel(
 		hostId,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@superset/ui/button";
 import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { toast } from "@superset/ui/sonner";
+import { Spinner } from "@superset/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
@@ -862,14 +863,14 @@ export function NewWorkspaceScreen({
 							<PromptInputSubmit
 								className="size-[22px] rounded-full border border-transparent bg-foreground/10 shadow-none p-[5px] hover:bg-foreground/20"
 								disabled={needsSetup || isCreating}
-								status={isCreating ? "submitted" : undefined}
 								onClick={(e) => {
 									e.preventDefault();
 									handleSubmit();
 								}}
 							>
-								{/* children win over the status icon, so stand aside for the spinner */}
-								{isCreating ? null : (
+								{isCreating ? (
+									<Spinner className="size-3.5 text-muted-foreground" />
+								) : (
 									<ArrowUpIcon className="size-3.5 text-muted-foreground" />
 								)}
 							</PromptInputSubmit>

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
@@ -1,10 +1,7 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useQueries } from "@tanstack/react-query";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
-import { authClient } from "renderer/lib/auth-client";
-import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { setSandboxCredentials } from "renderer/lib/host-service-auth";
 
 /** Re-mint with time to spare; the provider's token is short-lived. */
@@ -37,13 +34,14 @@ const SandboxAccessContext = createContext<SandboxAccessValue | null>(null);
  * one they light up with no cloud-specific code.
  */
 export function SandboxAccessProvider({ children }: { children: ReactNode }) {
-	const enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES);
-	const { data: session } = authClient.useSession();
-	const organizationId = session?.session?.activeOrganizationId ?? null;
+	const { workspaces: cloudWorkspaces, organizationId } = useCloudWorkspaces();
 
-	const { data: workspaces = [] } = cloudTrpc.cloudWorkspace.list.useQuery(
-		{ organizationId: organizationId ?? "" },
-		{ enabled: Boolean(enabled && organizationId), refetchInterval: 30_000 },
+	// Only a `ready` row has a sandbox to address: `access` refuses anything
+	// else, and a provisioning workspace asking for a token every few seconds
+	// would be a retry loop against a guaranteed rejection.
+	const workspaces = useMemo(
+		() => cloudWorkspaces.filter((workspace) => workspace.status === "ready"),
+		[cloudWorkspaces],
 	);
 
 	const results = useQueries({

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -124,9 +124,15 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 				),
 			})),
 		// set() merges, so the store's actions survive the reset.
+		// hostId is a target preference, not draft content: someone who just
+		// created in the cloud means the next one to go there too. The persisted
+		// lastHostId only re-seeds a draft once per create surface open, and the
+		// main create surface never closes, so the reset has to carry it — the
+		// alternative is a silent create on the wrong machine.
 		resetDraft: () =>
 			set((state) => ({
 				...buildInitialDraft(),
+				hostId: state.hostId,
 				resetKey: state.resetKey + 1,
 			})),
 	}),

--- a/docs/cloud-sandbox-considerations.md
+++ b/docs/cloud-sandbox-considerations.md
@@ -105,6 +105,18 @@ the first thing to prove, ahead of any polish.
 **No fleet view.** Nothing in the product lists running sandboxes, their cost,
 or lets you stop one. Today that lives in the provider console.
 
+**Nothing reaps a row stuck in `provisioning`. Open.** A create that dies
+between inserting the row and reporting the sandbox leaves a `cloud_workspaces`
+row in `provisioning` forever: the sidebar shows a workspace that cannot open,
+`access` refuses it because the status isn't `ready`, and no code path ever looks
+at it again. It happened for real — a production create hit the API function's
+60s limit mid-bootstrap, and the row outlived the sandbox it named. Provisioning
+is ~5s now, so the window is small rather than gone; a killed function, a
+provider timeout or a crash still lands there. Wanted: a sweep that fails rows
+older than a few minutes and tears down any sandbox they name, plus the same
+teardown on the paths that can't currently reach it. One row from that incident
+had to be cleared by hand.
+
 **The Superset CLI is offered but not installed. Open.** A cloud workspace's
 agent row includes "Superset CLI" alongside Claude, Codex and Copilot, and
 picking it fails with command-not-found: the image installs the agent CLIs but

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -12,6 +12,10 @@
 			"types": "./src/lib/integrations/*/index.ts",
 			"default": "./src/lib/integrations/*/index.ts"
 		},
+		"./cloud-workspace-provision": {
+			"types": "./src/router/cloud-workspace/provision.ts",
+			"default": "./src/router/cloud-workspace/provision.ts"
+		},
 		"./automation-dispatch": {
 			"types": "./src/router/automation/dispatch.ts",
 			"default": "./src/router/automation/dispatch.ts"

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -1,30 +1,35 @@
 import { db, dbWs } from "@superset/db/client";
 import { cloudWorkspaces, v2Projects } from "@superset/db/schema";
-import {
-	SANDBOX_HOST_DB_PATH,
-	SANDBOX_WORKSPACE_PATH,
-} from "@superset/shared/constants";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq } from "drizzle-orm";
+import { Client } from "@upstash/qstash";
+import { and, desc, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
 import {
 	deleteSandbox,
 	mintPreviewAccess,
-	provisionSandbox,
 	repoForProject,
 } from "../../lib/blaxel";
-import { resolveCloneTarget } from "../../lib/blaxel/clone-token";
 import { jwtProcedure } from "../../trpc";
-import { generateCloudWorkspaceName } from "./generate-name";
+import {
+	FALLBACK_NAME,
+	provisionCloudWorkspace,
+	sandboxNameFor,
+} from "./provision";
 
-const FALLBACK_NAME = "Cloud workspace";
+const qstash = new Client({ token: env.QSTASH_TOKEN });
 
-/** Derived from the row id so the name is stable and collision-free. */
-function sandboxNameFor(cloudWorkspaceId: string): string {
-	return `ws-${cloudWorkspaceId.replaceAll("-", "").slice(0, 24)}`;
-}
+const PROVISION_JOB_URL = `${env.NEXT_PUBLIC_API_URL}/api/cloud-workspaces/provision`;
+
+/**
+ * QStash only calls public URLs, so a local API would queue a job nothing ever
+ * delivers. Run it in-process there instead — still detached, so the create
+ * returns as fast as it does in production and the UI behaves the same.
+ */
+const isLocalApi = /^https?:\/\/(localhost|127\.0\.0\.1)/.test(
+	env.NEXT_PUBLIC_API_URL,
+);
 
 /**
  * Cloud workspaces are internal-only while the sandbox path is unproven: a
@@ -63,7 +68,10 @@ export const cloudWorkspaceRouter = {
 						eq(cloudWorkspaces.organizationId, input.organizationId),
 						// Deleted rows are kept briefly so a failed teardown is
 						// visible, but they are never a workspace you can open.
-						eq(cloudWorkspaces.status, "ready"),
+						// Everything else is listed from the moment it is created:
+						// the client renders provisioning and failed rows off
+						// `status` rather than being told they don't exist yet.
+						ne(cloudWorkspaces.status, "deleted"),
 					),
 				)
 				.orderBy(desc(cloudWorkspaces.createdAt));
@@ -87,9 +95,16 @@ export const cloudWorkspaceRouter = {
 		}),
 
 	/**
-	 * Provisions a sandbox and records it. The row is written **before** the
-	 * provider call so a crash mid-provision leaves a `provisioning` row we
-	 * can reconcile, rather than an orphaned sandbox nothing references.
+	 * Records a cloud workspace and hands the sandbox off to a background job.
+	 *
+	 * Returns as soon as the row exists — in `provisioning`, with no sandbox
+	 * behind it yet — because the client opens the workspace on this id and
+	 * shows the provisioning screen itself. Nobody should watch a spinner on a
+	 * submit button while a sandbox and a naming model call happen behind it.
+	 *
+	 * The row is still written **before** anything is provisioned, so a crash
+	 * mid-provision leaves a `provisioning` row we can reconcile, rather than
+	 * an orphaned sandbox nothing references.
 	 */
 	create: jwtProcedure
 		.input(
@@ -119,12 +134,6 @@ export const cloudWorkspaceRouter = {
 				});
 			}
 
-			// Naming is a model call and provisioning takes seconds, so start it
-			// here and await it during provisioning rather than before it.
-			const namePromise: Promise<string | null> = input.name
-				? Promise.resolve(input.name)
-				: generateCloudWorkspaceName(input.prompt ?? "");
-
 			// The id is generated here rather than by the database so the sandbox
 			// name can be derived before the insert. A placeholder would briefly
 			// leave two rows sharing ("blaxel", ""), which the unique constraint
@@ -152,69 +161,51 @@ export const cloudWorkspaceRouter = {
 				});
 			}
 
-			try {
-				const resolvedName = (await namePromise) ?? FALLBACK_NAME;
-				const clone = await resolveCloneTarget(input.projectId);
-				if (!clone) {
-					throw new TRPCError({
-						code: "PRECONDITION_FAILED",
-						message: "Project has no repository to clone",
-					});
-				}
-				// The sandbox configures itself from these on boot: the image
-				// already holds the repo and the schema, so there is nothing to
-				// run inside it and nothing to wait for. Provisioning is one call.
-				const sandbox = await provisionSandbox({
-					name: providerSandboxId,
-					image: env.BLAXEL_SANDBOX_IMAGE,
-					workspaceEnv: {
-						ORGANIZATION_ID: input.organizationId,
-						HOST_DB_PATH: SANDBOX_HOST_DB_PATH,
-						HOST_MIGRATIONS_FOLDER: "/app/drizzle",
-						AUTH_TOKEN: "sandbox",
-						SUPERSET_API_URL: env.NEXT_PUBLIC_API_URL,
-						SUPERSET_HOST_RUN_MODE: "sandbox",
-						SUPERSET_SANDBOX_WORKSPACE_ID: row.id,
-						SUPERSET_SANDBOX_WORKSPACE_NAME: resolvedName,
-						SUPERSET_SANDBOX_PROJECT_NAME: project.name,
-						SUPERSET_SANDBOX_BRANCH: input.branch,
-						SUPERSET_SANDBOX_WORKSPACE_PATH: SANDBOX_WORKSPACE_PATH,
-						// Compared against the URL baked into the image: a workspace
-						// for any other project clones instead of fetching, rather
-						// than silently serving the baked repo's code.
-						SUPERSET_SANDBOX_REPO_URL: clone.cloneUrl,
-						...(clone.token ? { SUPERSET_SANDBOX_GIT_TOKEN: clone.token } : {}),
-					},
-				});
-				const [ready] = await dbWs
-					.update(cloudWorkspaces)
-					.set({
-						name: resolvedName,
-						providerSandboxId: sandbox.providerSandboxId,
-						sandboxUrl: sandbox.sandboxUrl,
-						status: "ready",
-					})
-					.where(eq(cloudWorkspaces.id, row.id))
-					.returning();
-				return ready ?? row;
-			} catch (error) {
-				// Billing starts at provision, not at ready: everything after that
-				// call — resolving the repo, cloning, booting — can fail with a
-				// sandbox already running. Without this the failure is silent and
-				// permanent, because nothing else ever looks at a `failed` row.
-				// The row survives as the record of what went wrong.
-				await deleteSandbox(providerSandboxId).catch((teardownError) => {
+			// Naming reads the prompt, and only when the user didn't type a name.
+			const job = {
+				cloudWorkspaceId: row.id,
+				...(input.name ? {} : { namingPrompt: input.prompt ?? "" }),
+			};
+
+			if (isLocalApi) {
+				void provisionCloudWorkspace(job).catch((error) => {
 					console.error(
-						`[cloud-workspace] leaked sandbox ${providerSandboxId}`,
-						teardownError,
+						`[cloud-workspace] provisioning threw for ${row.id}`,
+						error,
 					);
 				});
+				return row;
+			}
+
+			try {
+				// Queued rather than fired off after the response: this runs on
+				// Vercel, where the function is frozen the moment it replies, and
+				// an unawaited promise dies with it. QStash also retries a delivery
+				// the function never finished, which is exactly the failure that
+				// stranded a row in `provisioning` when create still ran inline.
+				await qstash.publishJSON({
+					url: PROVISION_JOB_URL,
+					body: job,
+					retries: 2,
+				});
+			} catch (error) {
+				// Nothing was provisioned, so there is no sandbox to tear down —
+				// but the row must not sit in `provisioning` with no job coming.
 				await dbWs
 					.update(cloudWorkspaces)
 					.set({ status: "failed" })
 					.where(eq(cloudWorkspaces.id, row.id));
-				throw error;
+				console.error(
+					`[cloud-workspace] could not queue provisioning for ${row.id}`,
+					error,
+				);
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Could not start cloud workspace provisioning",
+				});
 			}
+
+			return row;
 		}),
 
 	/**

--- a/packages/trpc/src/router/cloud-workspace/provision.ts
+++ b/packages/trpc/src/router/cloud-workspace/provision.ts
@@ -1,0 +1,156 @@
+import { db, dbWs } from "@superset/db/client";
+import { cloudWorkspaces, v2Projects } from "@superset/db/schema";
+import {
+	SANDBOX_HOST_DB_PATH,
+	SANDBOX_WORKSPACE_PATH,
+} from "@superset/shared/constants";
+import { and, eq } from "drizzle-orm";
+import { env } from "../../env";
+import { deleteSandbox, provisionSandbox } from "../../lib/blaxel";
+import { resolveCloneTarget } from "../../lib/blaxel/clone-token";
+import { generateCloudWorkspaceName } from "./generate-name";
+
+export const FALLBACK_NAME = "Cloud workspace";
+
+/** Derived from the row id so the name is stable and collision-free. */
+export function sandboxNameFor(cloudWorkspaceId: string): string {
+	return `ws-${cloudWorkspaceId.replaceAll("-", "").slice(0, 24)}`;
+}
+
+export interface ProvisionCloudWorkspaceInput {
+	cloudWorkspaceId: string;
+	/**
+	 * Set only when the user didn't type a name, in which case the row holds
+	 * `FALLBACK_NAME` and this is what the workspace gets named from.
+	 */
+	namingPrompt?: string;
+}
+
+export type ProvisionCloudWorkspaceOutcome =
+	| "provisioned"
+	| "skipped"
+	| "failed";
+
+/**
+ * Everything a cloud workspace needs after its row exists: a name, a sandbox,
+ * and the `ready` status that makes it openable.
+ *
+ * Runs detached from the create that asked for it — a job, not a request — so
+ * nobody waits on the provider (about a second warm; tens of seconds when the
+ * image still has to be pulled). That means it owns the row's terminal state:
+ * it must leave `ready` or `failed` behind, because nothing else ever looks at
+ * a `provisioning` row.
+ *
+ * Safe to run twice on the same row: the provider calls are create-if-missing
+ * and an already-`ready` row is left alone, so a retried delivery costs a
+ * couple of no-op API calls rather than a second sandbox.
+ */
+export async function provisionCloudWorkspace(
+	input: ProvisionCloudWorkspaceInput,
+): Promise<ProvisionCloudWorkspaceOutcome> {
+	const row = await db.query.cloudWorkspaces.findFirst({
+		where: eq(cloudWorkspaces.id, input.cloudWorkspaceId),
+	});
+	if (!row) return "skipped";
+	// `deleted` means the user disposed of it mid-provision; `ready` means a
+	// delivery already did this work. Either way there is nothing to do, and
+	// provisioning anyway would leave a sandbox nothing references.
+	if (row.status !== "provisioning") return "skipped";
+
+	const project = await db.query.v2Projects.findFirst({
+		where: and(
+			eq(v2Projects.id, row.projectId),
+			eq(v2Projects.organizationId, row.organizationId),
+		),
+	});
+
+	const providerSandboxId = sandboxNameFor(row.id);
+	try {
+		if (!project) {
+			throw new Error("Project not found in this organization");
+		}
+		// Naming is a model call (~0.7s) and the sandbox itself now comes up in
+		// about that long, so it is the longest thing here. Run it alongside the
+		// clone lookup rather than ahead of it; it can't overlap the provision
+		// call itself, which bakes the name into the sandbox's environment.
+		const [resolvedName, clone] = await Promise.all([
+			input.namingPrompt === undefined
+				? Promise.resolve(row.name)
+				: generateCloudWorkspaceName(input.namingPrompt).then(
+						(generated) => generated ?? row.name,
+					),
+			resolveCloneTarget(row.projectId),
+		]);
+		if (!clone) {
+			throw new Error("Project has no repository to clone");
+		}
+
+		// Written before the sandbox exists rather than with the final status:
+		// the workspace is already on screen by now, so the generated name is
+		// worth its own write to land ahead of `ready` rather than with it.
+		const nameWrite =
+			resolvedName === row.name
+				? Promise.resolve()
+				: dbWs
+						.update(cloudWorkspaces)
+						.set({ name: resolvedName })
+						.where(eq(cloudWorkspaces.id, row.id));
+		// The sandbox configures itself from these on boot: the image already
+		// holds the repo and the schema, so there is nothing to run inside it
+		// and nothing to wait for. Provisioning is one call.
+		const [sandbox] = await Promise.all([
+			provisionSandbox({
+				name: providerSandboxId,
+				image: env.BLAXEL_SANDBOX_IMAGE,
+				workspaceEnv: {
+					ORGANIZATION_ID: row.organizationId,
+					HOST_DB_PATH: SANDBOX_HOST_DB_PATH,
+					HOST_MIGRATIONS_FOLDER: "/app/drizzle",
+					AUTH_TOKEN: "sandbox",
+					SUPERSET_API_URL: env.NEXT_PUBLIC_API_URL,
+					SUPERSET_HOST_RUN_MODE: "sandbox",
+					SUPERSET_SANDBOX_WORKSPACE_ID: row.id,
+					SUPERSET_SANDBOX_WORKSPACE_NAME: resolvedName,
+					SUPERSET_SANDBOX_PROJECT_NAME: project.name,
+					SUPERSET_SANDBOX_BRANCH: row.branch,
+					SUPERSET_SANDBOX_WORKSPACE_PATH: SANDBOX_WORKSPACE_PATH,
+					// Compared against the URL baked into the image: a workspace for
+					// any other project clones instead of fetching, rather than
+					// silently serving the baked repo's code.
+					SUPERSET_SANDBOX_REPO_URL: clone.cloneUrl,
+					...(clone.token ? { SUPERSET_SANDBOX_GIT_TOKEN: clone.token } : {}),
+				},
+			}),
+			nameWrite,
+		]);
+
+		await dbWs
+			.update(cloudWorkspaces)
+			.set({
+				providerSandboxId: sandbox.providerSandboxId,
+				sandboxUrl: sandbox.sandboxUrl,
+				status: "ready",
+			})
+			.where(eq(cloudWorkspaces.id, row.id));
+		return "provisioned";
+	} catch (error) {
+		// Billing starts at provision, not at ready: everything after that call
+		// — resolving the repo, cloning, booting — can fail with a sandbox
+		// already running. Without this the failure is silent and permanent,
+		// because nothing else ever looks at a `failed` row. The row survives as
+		// the record of what went wrong, and as the thing the workspace screen
+		// renders its failure from.
+		await deleteSandbox(providerSandboxId).catch((teardownError) => {
+			console.error(
+				`[cloud-workspace] leaked sandbox ${providerSandboxId}`,
+				teardownError,
+			);
+		});
+		await dbWs
+			.update(cloudWorkspaces)
+			.set({ status: "failed" })
+			.where(eq(cloudWorkspaces.id, row.id));
+		console.error(`[cloud-workspace] provisioning failed for ${row.id}`, error);
+		return "failed";
+	}
+}


### PR DESCRIPTION
Four things reported from actually using cloud workspaces, plus one refactor that fell out of the third.

## Create no longer blocks on provisioning

`cloudWorkspace.create` inserts the row and returns; provisioning runs as a queued job (QStash, signature-verified at `/api/cloud-workspaces/provision`).

Queued rather than fired off after the response because Vercel freezes the function the moment it replies, so an unawaited promise dies with it — the exact failure that stranded a row in `provisioning` when create ran inline and hit the 60s function limit. QStash can't call localhost, so a local API runs the same job in-process, which keeps dev and prod behaving the same from the UI's point of view.

**Open question worth a reviewer's opinion:** `after()` from `next/server` would do this with ~3 lines and no public endpoint, at the cost of no retries and one code path that differs between local and prod. I lean `after()` + the reaper (SUPER-1900); this PR keeps QStash because the retry is worth something while provisioning is unproven. Easy to swap.

## The client lands you in the workspace

Seeds the list cache with the new row, navigates, then invalidates for server truth. Seeded rather than only invalidated because the route decides between "provisioning" and "doesn't exist" from that list, and one refetch round trip is long enough to flash the wrong one.

**Nothing invalidated `cloudWorkspace.list` on create before.** It polls every 30s (`SandboxAccessProvider.tsx`, `DashboardSidebarCloudSection.tsx`), so a created workspace could take that long to appear. That — not backend latency — is why creating one felt like a minute of nothing: the image was warm and sandbox create measured 0.3s throughout. Corroborated by four sandboxes in the provider created 57–66s apart, i.e. someone retrying into a void.

## A provisioning screen instead of a blank frame or a lie

`CloudWorkspaceProvisioningState` covers a row whose sandbox isn't up yet, and a ready sandbox not yet addressable (access minting, host-service booting). That gap previously reached the host-unreachable takeover, which tells you your machine is down while it is simply starting.

## The create target survives a create

`resetDraft()` cleared `hostId`, and `draft.hostId ?? machineId` reads null as "this machine" — so a second cloud create silently landed on the user's laptop. A persisted `lastHostId` already existed; the gap was that re-seeding it is guarded by a ref that is set once and never cleared, on a surface that never unmounts. Carrying `hostId` through the reset fixes every caller at once. DevicePicker additionally drops a remembered cloud target if the flag offering it disappears (`=== false`, because `undefined` means the flags haven't loaded).

## The submit spinner was invisible

`PromptInputSubmit` renders `children ?? Icon`; passing `children={null}` still fell through to its own `size-4 Loader2Icon`, which is too big for the 12px content box and inherits `text-primary-foreground` — dark in dark mode. Now renders the shared `Spinner` at the arrow's size and colour.

## Route refactor

The state-screen gate moved from `v2-workspace/layout.tsx` to `$workspaceId/layout.tsx`, where the param is available by definition. Deletes a parent route that matched its own child to recover the id, and an unreachable "no id" branch. `page.tsx` needed no change — it already declared itself that layout's index.

## Verification

End to end against real sandboxes through the app (CDP), not just unit tests:

| | create #1 | create #2 |
|---|---|---|
| target before submit | Cloud | **Cloud** (the bug) |
| navigated | 0.9s | 0.9s |
| "Creating sandbox" visible | 1.1s | 1.1s |
| usable | 7.5s | 7.7s |

Not-found and unreachable screens never appeared. Every sandbox created while testing was deleted; provider shows none of mine running.

`bun test` in apps/desktop: 2583 pass, 0 fail. Typecheck clean in apps/desktop and packages/trpc. Lint clean across 5,717 files.

## Not covered

QStash delivery itself has only run via the local in-process path — the queued path needs a production create to be trusted, and it's unknown whether a QStash job can reach a preview deployment's URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating a cloud workspace now returns immediately and opens the workspace; provisioning runs as a background job. Old behavior awaited provider calls and the UI polled (often showing not-found or host-unreachable). New behavior inserts the row, queues provisioning, seeds the list, navigates, and renders a provisioning screen until the sandbox is ready. Side effects: the list includes `provisioning`/`failed`, polling is 1s while anything is provisioning, and access/host URLs are only minted for `ready`. The provisioning API now returns 401 for missing or malformed QStash signatures.

- API: `cloudWorkspace.create` writes the row and queues provisioning via QStash at `/api/cloud-workspaces/provision` (local API runs the same job in-process); `cloudWorkspace.list` returns all non-`deleted` rows; signature verification for provisioning replies 401 on missing/invalid headers; provisioning is idempotent and safe to retry.
- Desktop: `useCloudWorkspaces` centralizes the cloud list and polling; create seeds the list, navigates to `/v2-workspace/$workspaceId`, then invalidates; `CloudWorkspaceProvisioningState` covers provisioning and failure with a remove action; the route gate moved to `$workspaceId/layout.tsx`; access and host URL hooks only broker addresses for `ready`; destroy uses the cloud list to decide sandbox vs local; create target persists across reset; submit buttons render a visible `Spinner`. Consumers that assumed `list` was `ready`-only must account for `provisioning`/`failed`.

**Rollout**
- Set `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY`, `NEXT_PUBLIC_API_URL`, `BLAXEL_SANDBOX_IMAGE`.
- Ensure QStash can reach `NEXT_PUBLIC_API_URL`; local development runs provisioning in-process.
- Update imports to use `@superset/trpc/cloud-workspace-provision`.

<sup>Written for commit f0f66504d72c96fde14a269bdc727fb3429865b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous cloud workspace provisioning with visible progress and status updates.
  * Added a provisioning screen with elapsed time, progress steps, warnings, and failure recovery.
  * Cloud workspaces appear immediately after creation and refresh automatically as provisioning progresses.
  * Added secure background processing for workspace provisioning.

* **Bug Fixes**
  * Improved handling of provisioning and unavailable cloud workspaces.
  * Prevented non-ready workspaces from entering the access flow.
  * Preserved the selected host when resetting the new workspace form.
  * Added loading indicators during workspace creation.

* **Documentation**
  * Documented cleanup requirements for failed or stalled cloud workspace creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->