### PR TITLE
fix(desktop): give the Add Trigger button the same inset as the trigger rows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -193,7 +193,7 @@ export function TriggersEditor({
 							type="button"
 							variant="ghost"
 							size="sm"
-							className="h-10 w-full justify-start gap-2 rounded-[8px] px-2 font-normal text-[13px] text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
+							className="mb-1.5 h-10 w-full justify-start gap-2 rounded-[8px] px-2 font-normal text-[13px] text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
 						>
 							<LuCirclePlus className="size-4" />
 							Add Trigger


### PR DESCRIPTION
## Summary

The trigger editor surface (`rounded-[12px] bg-foreground/[0.04] p-1`) had visibly more room above its first row than below the "Add Trigger" button. Measured over CDP in the running app before touching anything:

| | before | after |
|---|---|---|
| surface top edge → first row's content (surface `p-1` 4px + row `py-1.5` 6px) | **10px** | 10px |
| "Add Trigger" button bottom edge → surface bottom edge | **4px** | **10px** |

The rows carry 6px of their own vertical padding; the button carried none, so the surface's uniform `p-1` came out uneven at the bottom.

## Change

One class: `mb-1.5` on the Add Trigger button. It goes on the button rather than as extra surface padding because it's the button that lacks what every row has, and the separator right above it already carries the same `mb-1.5` to match the row padding — the 6px unit is now consistent throughout the surface. Row padding, the separator, and the button's `h-10` are untouched.

Note: with no triggers (only the button in the surface) the button sits 4px from the top and 10px from the bottom; kept unconditional to keep this a one-class change.

## Verification

- CDP against this workspace's renderer (dark theme, 2× DPR), automation detail page: numbers above re-measured after the change (`getBoundingClientRect` on the surface, first row, and button); before/after screenshots confirm the only thing that moved is the surface's bottom edge, 6px lower.
- `bun run typecheck` → exit 0, `bun run lint` → exit 0 (repo root).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Balances vertical spacing in the Triggers Editor surface by adding `mb-1.5` to the Add Trigger button. Previously the bottom spacing was 4px; now top and bottom spacing are both 10px, matching row padding and improving visual consistency.

- Only change: add `mb-1.5` to the Add Trigger button in `apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx`; rows and separator remain unchanged.
- No functional behavior changes; layout spacing only. Button height (`h-10`) and hover styles are unchanged.
- With no triggers, the button remains 4px from the top and 10px from the bottom; this is intentional to keep the change minimal.

<sup>Written for commit 5e3d6eb3b2296f2c3179862d28e9d5e805ad67ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around the **Add Trigger** button for a cleaner layout in the automation trigger editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->