### PR TITLE
fix(desktop): stop holding a socket to every cloud workspace

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -26,6 +26,13 @@ export interface HostWorkspacesCacheOps {
 	/** Resolve the URL to reach the host owning `hostId` (null = unreachable). */
 	resolveHostUrl: (hostId: string) => string | null;
 	/**
+	 * Whether `hostId` is a cloud sandbox. Callers that hold a socket per host
+	 * ask this before subscribing: the provider counts a held connection as
+	 * activity, so a background subscription keeps a sandbox's VM awake for as
+	 * long as the app is open. Connect to a sandbox only while it is in view.
+	 */
+	isSandboxHost: (hostId: string) => boolean;
+	/**
 	 * Optimistically upsert a row into a host's cached list. The host's
 	 * `workspace:changed` broadcast (or the next refetch) converges the
 	 * cache onto the real row.
@@ -217,10 +224,20 @@ export function useHostWorkspacesSource(
 
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
+	//
+	// Not for sandboxes. The provider counts a held connection as activity, so
+	// subscribing here would keep every cloud workspace's VM awake for as long
+	// as the app is open — ten in the sidebar, ten warm machines, whether or not
+	// anyone is looking at them. And there is nothing to be gained: a sandbox
+	// holds exactly one workspace whose identity the cloud row owns; the only
+	// field read off its served row is the branch, which has a fallback and can
+	// only change while someone is inside it — when the open workspace's own
+	// subscribers hold a socket anyway. Sandboxes are polled, and connected to
+	// only while open.
 	useEffect(() => {
 		const cleanups: Array<() => void> = [];
 		for (const target of targets) {
-			if (!target.hostUrl) continue;
+			if (!target.hostUrl || target.isSandbox) continue;
 			const hostUrl = target.hostUrl;
 			const bus = getHostEventBus(hostUrl);
 			const removeListener = bus.on(
@@ -366,6 +383,7 @@ export function useHostWorkspacesSource(
 			targets.find((target) => target.machineId === hostId);
 		return {
 			resolveHostUrl: (hostId) => targetFor(hostId)?.hostUrl ?? null,
+			isSandboxHost: (hostId) => targetFor(hostId)?.isSandbox === true,
 			upsertWorkspace: (row) => {
 				const target = targetFor(row.hostId);
 				if (!target) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
@@ -176,7 +176,13 @@ export function DashboardSidebarWorkspaceStatusProvider({
 		() =>
 			workspaces.map((workspace) => ({
 				workspaceId: workspace.id,
-				hostUrl: hostWorkspacesCache.resolveHostUrl(workspace.hostId),
+				// A sandbox row gets no live subscription from the sidebar: holding
+				// a socket to it keeps its VM awake for as long as the app is open,
+				// and the sidebar is open all day. Its status goes live when the
+				// workspace itself is opened and its own subscribers connect.
+				hostUrl: hostWorkspacesCache.isSandboxHost(workspace.hostId)
+					? null
+					: hostWorkspacesCache.resolveHostUrl(workspace.hostId),
 			})),
 		[workspaces, hostWorkspacesCache],
 	);


### PR DESCRIPTION
Found while trying to test sandbox standby for SUPER-1908: the sandbox under test could never idle, because **the app was the thing keeping it awake.**

## What was happening

Two always-on subscribers open an event-bus WebSocket to every host in the fan-out. Cloud sandboxes became hosts in #6505, so that meant every cloud workspace in the sidebar — for as long as the app is open. Blaxel defines activity as "has an active connection" (its docs: *"sandboxes remain active as long as there's an active connection to them, typically through a WebSocket"*). So no cloud workspace can ever idle while Superset is running.

Measured: two sandboxes untouched for **2h+** still read `RUNNING` in the provider, `lastUsedAt` never advancing past the last real use — because a desktop with them in its sidebar was holding a socket the whole time. Ten cloud workspaces in the sidebar would be ten warm VMs, billing, whether or not anyone is looking at them.

## Why neither subscription is needed for a sandbox

- **`useHostWorkspaces`** listens for `workspace:changed` to patch the cached list. A sandbox holds exactly one workspace whose identity the cloud row owns; the only field the sidebar reads off its served row is `branch`, which falls back to the cloud row and can only change while someone is *inside* the workspace — at which point the open workspace's own subscribers hold a socket anyway.
- **`DashboardSidebarWorkspaceStatusProvider`** retains a bus per host for agent-status and git badges. For a sandbox that is a warm VM to keep a badge fresh on a row nobody is looking at.

## Change

Sandboxes are polled at the fan-out level and connected to only while open. `HostWorkspacesCacheOps` gains `isSandboxHost(hostId)` so callers that hold a socket per host can make that decision without learning anything else about cloud workspaces. Two files, ~26 lines.

## What this does *not* do

- The open workspace still connects (`useWorkspaceEvent`, `useHostReachability`, file store, terminals) — that's correct; you're looking at it.
- Agent-status and git badges on a *closed* cloud row will lag until the workspace is opened. That's the trade, and it's the right one. If we want them live, the shape is a cheap poll, not a held socket.

## Verification

Typecheck clean, `bun test` in apps/desktop 2593 pass / 0 fail. The idle behaviour itself can only be confirmed by a build that a desktop with cloud rows actually runs — my dev app is on the local DB and can't see the prod sandboxes. So: merge, canary, then check the provider shows those two sandboxes' `lastUsedAt` advancing to standby. I'll follow up with that measurement.

Also worth knowing: this is what makes SUPER-1908 (standby/resume behaviour) *testable* at all. Until now the test subject could never sleep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the desktop app from holding an event-bus WebSocket to every cloud sandbox. Previously the app kept a socket per host, which the provider counts as activity, preventing sandboxes from idling; now sandboxes are polled and only connect while open. Closed cloud rows may show stale agent and git badges until opened. Enables standby/resume testability for SUPER-1908.

**Review notes**
- Adds `isSandboxHost(hostId)` to `HostWorkspacesCacheOps` so socket holders can skip sandbox hosts.
- `useHostWorkspaces` no longer subscribes to `workspace:changed` for sandbox hosts; relies on polling.
- `DashboardSidebarWorkspaceStatusProvider` passes `null` `hostUrl` for sandbox rows, deferring live status until the workspace is opened.
- No migrations or config changes required.

<sup>Written for commit 7cc0b2e0ebe4e1cef0f76ef01b77f77b57b3d3bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox workspace handling in the dashboard.
  * Sandbox workspaces no longer display stale live status updates in the sidebar.
  * Sandbox workspace data continues to update through polling and active-view connections.
  * Live status monitoring resumes when a sandbox workspace is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->