### PR TITLE
refactor(desktop,shared,db): make trigger providers additive

### DIFF
--- a/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
+++ b/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
@@ -2,13 +2,12 @@ import { dbWs } from "@superset/db/client";
 import {
 	automations,
 	automationTriggers,
-	type GithubTriggerConfig,
 	userIdentities,
 } from "@superset/db/schema";
 import {
 	githubEventNames,
-	githubTriggerMatches,
 	type MatchableEvent,
+	triggerMatches,
 } from "@superset/shared/automation-matching";
 import { Client } from "@upstash/qstash";
 import { and, eq } from "drizzle-orm";
@@ -128,17 +127,17 @@ export async function dispatchMatchingTriggers(params: {
 		params.ref,
 	);
 
-	const matched = candidates.filter((candidate) => {
-		const config = candidate.config as GithubTriggerConfig;
-		if (config.kind !== "github") return false;
-		return githubTriggerMatches(
-			config as never,
-			event,
-			// Resolved per candidate: two automations can watch the same event on
-			// behalf of different owners.
-			{ names, ownerIds: githubIdsByUser.get(candidate.ownerUserId) ?? [] },
-		).matches;
-	});
+	const matched = candidates.filter(
+		(candidate) =>
+			triggerMatches(candidate.config, event, {
+				// Resolved per candidate: two automations can watch the same event
+				// on behalf of different owners.
+				github: {
+					names,
+					ownerIds: githubIdsByUser.get(candidate.ownerUserId) ?? [],
+				},
+			}).matches,
+	);
 
 	if (matched.length === 0) {
 		return { matched: 0, considered: candidates.length };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
@@ -9,9 +9,9 @@ import { formatDistanceStrict } from "date-fns";
 import { useMemo } from "react";
 import { useRecentProjects } from "renderer/hooks/host-projects/useRecentProjects";
 import type { apiTrpcClient } from "renderer/lib/api-trpc-client";
-import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
 import { ProjectPicker } from "../../../components/ProjectPicker";
+import { useProviderOptions } from "../../../components/providers/useProviderOptions";
 import { RelayOfflineNotice } from "../../../components/RelayOfflineNotice";
 import { TriggersEditor } from "../../../components/TriggersEditor";
 import { WorkspacePicker } from "../../../components/WorkspacePicker";
@@ -43,25 +43,7 @@ export function TriggersCard({
 	onSaveTriggers,
 }: TriggersCardProps) {
 	const recentProjects = useRecentProjects();
-	// repoId is GitHub's numeric id, which is what the matcher compares against —
-	// a full name would stop matching the moment someone renames the repo.
-	const reposQuery = cloudTrpc.integration.github.listRepositories.useQuery(
-		{ organizationId: automation.organizationId },
-		{ enabled: Boolean(automation.organizationId) },
-	);
-	const peopleQuery = cloudTrpc.integration.github.listLinkedPeople.useQuery(
-		{ organizationId: automation.organizationId },
-		{ enabled: Boolean(automation.organizationId) },
-	);
-	const people = useMemo(() => peopleQuery.data ?? [], [peopleQuery.data]);
-	const repositories = useMemo(
-		() =>
-			(reposQuery.data ?? []).map((repo) => ({
-				id: repo.repoId,
-				label: repo.fullName,
-			})),
-		[reposQuery.data],
-	);
+	const options = useProviderOptions(automation.organizationId);
 	const selectedProject = recentProjects.find(
 		(p) => p.id === automation.v2ProjectId,
 	);
@@ -145,8 +127,7 @@ export function TriggersCard({
 					config: t.config as DraftTrigger["config"],
 				}))}
 				onChange={onSaveTriggers}
-				repositories={repositories}
-				people={people}
+				options={options}
 				renderNextRun={renderNextRun}
 				readOnly={readOnly}
 			/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -6,7 +6,6 @@ import {
 import { Input } from "@superset/ui/input";
 import { cn } from "@superset/ui/utils";
 import { type ReactNode, useMemo, useRef, useState } from "react";
-import { LuClock } from "react-icons/lu";
 import {
 	DAY_OPTIONS,
 	formatTimeInputValue,
@@ -94,8 +93,6 @@ export function ScheduleSentence({
 	return (
 		<div className={cn("flex flex-col gap-1.5", className)}>
 			<div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[13px]">
-				<LuClock className="mr-0.5 size-4 shrink-0 text-muted-foreground" />
-
 				<SelectChip
 					value={state.kind}
 					disabled={disabled}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/TriggerSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/TriggerSentence.tsx
@@ -4,22 +4,15 @@ import type {
 } from "@superset/shared/automation-triggers";
 import { Button } from "@superset/ui/button";
 import type { ReactNode } from "react";
-import { FaGithub } from "react-icons/fa";
-import { LuTrash2, LuWebhook } from "react-icons/lu";
-import { ScheduleSentence } from "../ScheduleSentence";
+import { LuTrash2 } from "react-icons/lu";
+import { type ProviderOptions, providerFor } from "../providers";
 import { CHIP_INVALID } from "./chipStyles";
-import { ActorChip } from "./components/ActorChip";
-import { ScopeChip } from "./components/ScopeChip";
-import { TextFilterChip } from "./components/TextFilterChip";
-import type { ScopeOption } from "./scopeOption";
-import { GITHUB_SENTENCES, type SentencePart } from "./sentence";
 
 interface TriggerSentenceProps {
 	trigger: DraftTrigger;
 	onChange: (next: DraftTrigger) => void;
 	onRemove: () => void;
-	repositories: ScopeOption[];
-	people: ScopeOption[];
+	options: ProviderOptions;
 	/** This row's problems, already filtered to it by the editor. */
 	problems?: TriggerProblem[];
 	/** Trailing "Next run ..." text for a schedule row. */
@@ -30,143 +23,40 @@ interface TriggerSentenceProps {
 /**
  * One trigger, rendered as a sentence.
  *
- * The grammar lives in `sentence.ts` so each event describes its own slots;
- * this only walks the parts and renders the matching control.
+ * This knows nothing about any provider. It finds the one that owns the config
+ * and hands it the row's state; the provider decides what words and chips the
+ * sentence is made of. Row chrome — the leading icon and the remove button —
+ * lives here so every provider's row looks the same.
  */
 export function TriggerSentence({
 	trigger,
 	onChange,
 	onRemove,
-	repositories,
-	people,
+	options,
 	problems,
 	nextRun,
 	disabled,
 }: TriggerSentenceProps) {
 	const config = trigger.config;
+	const provider = providerFor(config);
+	const Icon = provider.icon;
+
 	// A banner naming the row is not enough when a sentence has three chips that
 	// could each be the empty one.
 	const invalid = new Set((problems ?? []).map((p) => p.field));
-	const mark = (field: string) =>
-		invalid.has(field) ? CHIP_INVALID : undefined;
-	const set = (patch: Record<string, unknown>) =>
-		onChange({ ...trigger, config: { ...config, ...patch } as never });
-
-	const renderPart = (part: SentencePart, index: number) => {
-		if ("text" in part) {
-			return (
-				<span key={index} className="text-[13px] text-muted-foreground">
-					{part.text}
-				</span>
-			);
-		}
-		// The slot list is derived from this event, so the fields it names are
-		const c = config as unknown as Record<string, never>;
-		switch (part.slot) {
-			case "repositories":
-				return (
-					<ScopeChip
-						key={index}
-						scope={c.repositories}
-						onChange={(v) => set({ repositories: v })}
-						className={mark("repositories")}
-						options={repositories}
-						emptyLabel="Select repos"
-						anyLabel="Any repo"
-						disabled={disabled}
-					/>
-				);
-			case "branches":
-				return (
-					<ScopeChip
-						key={index}
-						scope={c.branches}
-						// Clearing an optional filter means "any", not "none": the chip
-						// says "Any branch" either way, and null would make that a lie.
-						onChange={(v) => set({ branches: v ?? { mode: "any" } })}
-						options={[]}
-						emptyLabel="Any branch"
-						anyLabel="Any branch"
-						disabled={disabled}
-					/>
-				);
-			case "labels":
-				return (
-					<ScopeChip
-						key={index}
-						scope={c.labels}
-						// Clearing an optional filter means "any", not "none": the chip
-						// says "Any label" either way, and null would make that a lie.
-						onChange={(v) => set({ labels: v ?? { mode: "any" } })}
-						options={[]}
-						emptyLabel="Any label"
-						anyLabel="Any label"
-						disabled={disabled}
-					/>
-				);
-			case "actor":
-				return (
-					<ActorChip
-						key={index}
-						actor={c.actor}
-						onChange={(v) => set({ actor: v })}
-						className={mark("actor")}
-						people={people}
-						disabled={disabled}
-					/>
-				);
-			case "subjectAuthor":
-				return (
-					<ActorChip
-						key={index}
-						actor={c.subjectAuthor}
-						onChange={(v) => set({ subjectAuthor: v })}
-						className={mark("subjectAuthor")}
-						people={people}
-						disabled={disabled}
-					/>
-				);
-			case "commentFilter":
-				return (
-					<TextFilterChip
-						key={index}
-						value={c.commentFilter}
-						onChange={(v) => set({ commentFilter: v })}
-						emptyLabel="Any comment"
-						placeholder="Contains this text..."
-						disabled={disabled}
-					/>
-				);
-		}
-	};
 
 	return (
 		<div className="group flex min-h-10 flex-wrap items-center gap-1.5 rounded-[8px] px-2 py-1.5 hover:bg-foreground/[0.03]">
-			{config.kind === "github" && (
-				<FaGithub className="size-4 shrink-0 text-muted-foreground" />
-			)}
-			{config.kind === "webhook" && (
-				<LuWebhook className="size-4 shrink-0 text-muted-foreground" />
-			)}
+			<Icon className="size-4 shrink-0 text-muted-foreground" />
 
-			{config.kind === "github" &&
-				GITHUB_SENTENCES[config.event].map(renderPart)}
-
-			{config.kind === "schedule" && (
-				<ScheduleSentence
-					rrule={config.rrule}
-					onRruleChange={(rrule) => set({ rrule })}
-					timezone={config.timezone}
-					nextRun={nextRun}
-					disabled={disabled}
-				/>
-			)}
-
-			{config.kind === "webhook" && (
-				<span className="text-muted-foreground text-sm">
-					Triggered by an incoming webhook
-				</span>
-			)}
+			{provider.renderSentence(config, {
+				set: (patch) =>
+					onChange({ ...trigger, config: { ...config, ...patch } as never }),
+				mark: (field) => (invalid.has(field) ? CHIP_INVALID : undefined),
+				options,
+				disabled,
+				nextRun,
+			})}
 
 			<Button
 				type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/index.ts
@@ -1,3 +1,2 @@
 export type { ScopeOption } from "./scopeOption";
-export { createGithubConfig, GITHUB_MENU } from "./sentence";
 export { TriggerSentence } from "./TriggerSentence";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggerMenuItems/TriggerMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggerMenuItems/TriggerMenuItems.tsx
@@ -6,14 +6,14 @@ import {
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
 } from "@superset/ui/dropdown-menu";
-import type { TriggerMenuEntry } from "../triggerMenu";
+import type { TriggerMenuEntry, TriggerProvider } from "../../providers";
 
 /**
- * Renders the trigger menu tree, at any depth.
+ * The top level of the Add Trigger menu: one row per provider.
  *
- * Recursive rather than one level per provider: GitHub already nests twice
- * ("PR review submitted…" → "Approved"), and the next provider will nest
- * differently.
+ * A provider with a single leaf becomes that leaf directly — "Scheduled" adds a
+ * schedule, it does not open a submenu containing "Scheduled". A provider with
+ * more than one becomes a submenu holding its own tree.
  *
  * `text-current` on the icons is load-bearing: DropdownMenuItem forces any svg
  * without a `text-` class to muted-foreground, so brand marks would render grey
@@ -21,6 +21,54 @@ import type { TriggerMenuEntry } from "../triggerMenu";
  * row's colour on hover.
  */
 export function TriggerMenuItems({
+	providers,
+	onPick,
+}: {
+	providers: TriggerProvider[];
+	onPick: (config: TriggerConfigInput) => void;
+}) {
+	return (
+		<>
+			{providers.map((provider) => {
+				const Icon = provider.icon;
+				const only = provider.menu.length === 1 ? provider.menu[0] : undefined;
+
+				if (only && "create" in only) {
+					return (
+						<DropdownMenuItem
+							key={provider.kind}
+							onSelect={() => onPick(only.create())}
+						>
+							<Icon className="size-3.5 text-current" />
+							{provider.label}
+						</DropdownMenuItem>
+					);
+				}
+
+				return (
+					<DropdownMenuSub key={provider.kind}>
+						<DropdownMenuSubTrigger>
+							<Icon className="size-3.5 text-current" />
+							{provider.label}
+						</DropdownMenuSubTrigger>
+						<DropdownMenuPortal>
+							<DropdownMenuSubContent className="max-h-96 overflow-y-auto">
+								<MenuEntries entries={provider.menu} onPick={onPick} />
+							</DropdownMenuSubContent>
+						</DropdownMenuPortal>
+					</DropdownMenuSub>
+				);
+			})}
+		</>
+	);
+}
+
+/**
+ * A provider's subtree, at any depth. Recursive rather than one level per
+ * provider: GitHub already nests twice ("PR review submitted…" → "Approved"),
+ * and the next provider will nest differently.
+ */
+function MenuEntries({
 	entries,
 	onPick,
 }: {
@@ -29,35 +77,25 @@ export function TriggerMenuItems({
 }) {
 	return (
 		<>
-			{entries.map((entry) => {
-				const Icon = entry.icon;
-
-				if (entry.children) {
-					return (
-						<DropdownMenuSub key={entry.label}>
-							<DropdownMenuSubTrigger>
-								{Icon && <Icon className="size-3.5 text-current" />}
-								{entry.label}
-							</DropdownMenuSubTrigger>
-							<DropdownMenuPortal>
-								<DropdownMenuSubContent className="max-h-96 overflow-y-auto">
-									<TriggerMenuItems entries={entry.children} onPick={onPick} />
-								</DropdownMenuSubContent>
-							</DropdownMenuPortal>
-						</DropdownMenuSub>
-					);
-				}
-
-				const config = entry.config;
-				if (!config) return null;
-
-				return (
-					<DropdownMenuItem key={entry.label} onSelect={() => onPick(config())}>
-						{Icon && <Icon className="size-3.5 text-current" />}
+			{entries.map((entry) =>
+				"children" in entry ? (
+					<DropdownMenuSub key={entry.label}>
+						<DropdownMenuSubTrigger>{entry.label}</DropdownMenuSubTrigger>
+						<DropdownMenuPortal>
+							<DropdownMenuSubContent>
+								<MenuEntries entries={entry.children} onPick={onPick} />
+							</DropdownMenuSubContent>
+						</DropdownMenuPortal>
+					</DropdownMenuSub>
+				) : (
+					<DropdownMenuItem
+						key={entry.label}
+						onSelect={() => onPick(entry.create())}
+					>
 						{entry.label}
 					</DropdownMenuItem>
-				);
-			})}
+				),
+			)}
 		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -14,16 +14,17 @@ import { Input } from "@superset/ui/input";
 import { Separator } from "@superset/ui/separator";
 import { type ReactNode, useMemo, useState } from "react";
 import { LuCirclePlus, LuTriangleAlert } from "react-icons/lu";
-import { type ScopeOption, TriggerSentence } from "../TriggerSentence";
+import { type ProviderOptions, TRIGGER_PROVIDERS } from "../providers";
+import { TriggerSentence } from "../TriggerSentence";
 import { TriggerMenuItems } from "./TriggerMenuItems";
-import { flattenTriggerMenu, matchesQuery, TRIGGER_MENU } from "./triggerMenu";
+import { flattenTriggerMenu, matchesQuery } from "./triggerMenu";
 
 interface TriggersEditorProps {
 	triggers: DraftTrigger[];
 	/** Resolves once the set is written; rejects if it was refused. */
 	onChange: (next: DraftTrigger[]) => undefined | Promise<unknown>;
-	repositories: ScopeOption[];
-	people: ScopeOption[];
+	/** Pickable values per provider, fetched by the card. */
+	options: ProviderOptions;
 	/** Trailing "Next run ..." text for one schedule row, by trigger id. */
 	renderNextRun?: (triggerId?: string) => ReactNode;
 	readOnly?: boolean;
@@ -40,8 +41,7 @@ interface TriggersEditorProps {
 export function TriggersEditor({
 	triggers,
 	onChange,
-	repositories,
-	people,
+	options,
 	renderNextRun,
 	readOnly,
 }: TriggersEditorProps) {
@@ -167,8 +167,7 @@ export function TriggersEditor({
 							edit(drafts.map((t, i) => (i === index ? next : t)))
 						}
 						onRemove={() => edit(drafts.filter((_, i) => i !== index))}
-						repositories={repositories}
-						people={people}
+						options={options}
 						problems={shownProblems.filter((p) => p.index === index)}
 						nextRun={
 							trigger.config.kind === "schedule"
@@ -223,11 +222,9 @@ export function TriggersEditor({
 									return (
 										<DropdownMenuItem
 											key={leaf.path.join(">")}
-											onSelect={() => add(leaf.config())}
+											onSelect={() => add(leaf.create())}
 										>
-											{Icon && (
-												<Icon className="size-3.5 shrink-0 text-current" />
-											)}
+											<Icon className="size-3.5 shrink-0 text-current" />
 											{/* The trail disambiguates "Approved" from the other three
 											    review outcomes, but it is the trail that gives way when
 											    the row is too narrow — truncating the leaf would hide
@@ -248,7 +245,7 @@ export function TriggersEditor({
 								)}
 							</>
 						) : (
-							<TriggerMenuItems entries={TRIGGER_MENU} onPick={add} />
+							<TriggerMenuItems providers={TRIGGER_PROVIDERS} onPick={add} />
 						)}
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/triggerMenu.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/triggerMenu.ts
@@ -1,86 +1,53 @@
 import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
 import type { IconType } from "react-icons";
-import { FaGithub } from "react-icons/fa";
-import { LuClock, LuWebhook } from "react-icons/lu";
-import { createGithubConfig, GITHUB_MENU } from "../TriggerSentence";
+import {
+	TRIGGER_PROVIDERS,
+	type TriggerMenuEntry,
+	type TriggerProvider,
+} from "../providers";
 
 /**
- * The Add Trigger menu.
- *
- * One recursive shape for every level, so the same table drives both the
- * browsable submenus and the flat list search falls back to — a second,
- * hand-maintained list of searchable events would drift the moment a provider
- * is added.
+ * A leaf of the Add Trigger menu, carrying the trail that leads to it so search
+ * can show the path — "GitHub › PR review submitted › Approved" is what tells
+ * Approved apart from the other three review outcomes.
  */
-export type TriggerMenuEntry = {
-	label: string;
-	/**
-	 * Brand marks for providers, matching the integrations settings page —
-	 * Lucide's outline glyphs are drawn to sit with the interface icons, so a
-	 * GitHub outline next to a real Slack logo reads as two different products.
-	 */
-	icon?: IconType;
-	/** Leaf: choosing it adds this trigger. */
-	config?: () => TriggerConfigInput;
-	children?: TriggerMenuEntry[];
-};
-
-/**
- * dtstart anchors the recurrence, so it is read when the trigger is added
- * rather than when this module loads — otherwise every schedule created in a
- * long-lived window shares the timestamp the app booted at.
- */
-function createScheduleConfig(): TriggerConfigInput {
-	return {
-		kind: "schedule",
-		rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
-		dtstart: new Date().toISOString(),
-		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
-	};
-}
-
-export const TRIGGER_MENU: TriggerMenuEntry[] = [
-	{ label: "Scheduled", icon: LuClock, config: createScheduleConfig },
-	{
-		label: "GitHub",
-		icon: FaGithub,
-		children: GITHUB_MENU.map((entry) => ({
-			label: entry.label,
-			...(entry.children
-				? {
-						children: entry.children.map((child) => ({
-							label: child.label,
-							config: () => createGithubConfig(child.event),
-						})),
-					}
-				: { config: () => createGithubConfig(entry.event as never) }),
-		})),
-	},
-	{
-		label: "Webhook Triggered",
-		icon: LuWebhook,
-		config: () => ({ kind: "webhook" }),
-	},
-];
-
-/** A leaf, carrying the trail that leads to it so search can show the path. */
 export type TriggerMenuLeaf = {
 	path: string[];
-	icon?: IconType;
-	config: () => TriggerConfigInput;
+	icon: IconType;
+	create: () => TriggerConfigInput;
 };
 
+/**
+ * Every leaf across every provider, for search. The submenus and this list are
+ * both read off the same registry, so they cannot drift apart.
+ *
+ * A provider whose menu is one leaf (Scheduled, Webhook) contributes a
+ * one-segment path; wrapping it under the provider label would only make the
+ * result read "Scheduled › Scheduled".
+ */
 export function flattenTriggerMenu(
-	entries: TriggerMenuEntry[] = TRIGGER_MENU,
-	trail: string[] = [],
-	icon?: IconType,
+	providers: TriggerProvider[] = TRIGGER_PROVIDERS,
+): TriggerMenuLeaf[] {
+	return providers.flatMap((provider) => {
+		const single =
+			provider.menu.length === 1 && "create" in (provider.menu[0] ?? {});
+		return flattenEntries(
+			provider.menu,
+			single ? [] : [provider.label],
+			provider.icon,
+		);
+	});
+}
+
+function flattenEntries(
+	entries: TriggerMenuEntry[],
+	trail: string[],
+	icon: IconType,
 ): TriggerMenuLeaf[] {
 	return entries.flatMap((entry) => {
 		const path = [...trail, entry.label.replace(/…$/, "")];
-		const carried = entry.icon ?? icon;
-		if (entry.children)
-			return flattenTriggerMenu(entry.children, path, carried);
-		return entry.config ? [{ path, icon: carried, config: entry.config }] : [];
+		if ("children" in entry) return flattenEntries(entry.children, path, icon);
+		return [{ path, icon, create: entry.create }];
 	});
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
@@ -111,8 +111,19 @@ export const githubProvider: TriggerProvider<GithubConfig> = {
 	label: "GitHub",
 	icon: FaGithub,
 	menu: GITHUB_MENU,
-	renderSentence: (config, ctx) =>
-		GITHUB_SENTENCES[config.event].map((part, index) =>
-			renderPart(config, part, index, ctx),
-		),
+	renderSentence: (config, ctx) => {
+		// The event comes from a persisted config. If its grammar entry is ever
+		// removed or renamed, the row must still render — a thrown error here
+		// takes the whole editor down with it — so an unknown event reads as
+		// its raw name rather than as nothing.
+		const parts = GITHUB_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
@@ -1,0 +1,118 @@
+import { FaGithub } from "react-icons/fa";
+import { ActorChip } from "../../TriggerSentence/components/ActorChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	GITHUB_MENU,
+	GITHUB_SENTENCES,
+	type GithubConfig,
+	type SentencePart,
+} from "./grammar";
+
+/**
+ * Renders one slot of a GitHub sentence. Each slot names the config field it
+ * edits, so `set` patches by that name and `mark` finds it in the problems.
+ */
+function renderPart(
+	config: GithubConfig,
+	part: SentencePart,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	// The slot list is derived from this event, so the fields it names are
+	// present on this config member even where the union type cannot say so.
+	const c = config as unknown as Record<string, never>;
+	switch (part.slot) {
+		case "repositories":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.repositories}
+					onChange={(v) => set({ repositories: v })}
+					className={mark("repositories")}
+					options={options.repositories ?? []}
+					emptyLabel="Select repos"
+					anyLabel="Any repo"
+					disabled={disabled}
+				/>
+			);
+		case "branches":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.branches}
+					// Clearing an optional filter means "any", not "none": the chip
+					// says "Any branch" either way, and null would make that a lie.
+					onChange={(v) => set({ branches: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any branch"
+					anyLabel="Any branch"
+					disabled={disabled}
+				/>
+			);
+		case "labels":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.labels}
+					onChange={(v) => set({ labels: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any label"
+					anyLabel="Any label"
+					disabled={disabled}
+				/>
+			);
+		case "actor":
+			return (
+				<ActorChip
+					key={index}
+					actor={c.actor}
+					onChange={(v) => set({ actor: v })}
+					className={mark("actor")}
+					people={options.people ?? []}
+					disabled={disabled}
+				/>
+			);
+		case "subjectAuthor":
+			return (
+				<ActorChip
+					key={index}
+					actor={c.subjectAuthor}
+					onChange={(v) => set({ subjectAuthor: v })}
+					className={mark("subjectAuthor")}
+					people={options.people ?? []}
+					disabled={disabled}
+				/>
+			);
+		case "commentFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={c.commentFilter}
+					onChange={(v) => set({ commentFilter: v })}
+					emptyLabel="Any comment"
+					placeholder="Contains this text..."
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const githubProvider: TriggerProvider<GithubConfig> = {
+	kind: "github",
+	label: "GitHub",
+	icon: FaGithub,
+	menu: GITHUB_MENU,
+	renderSentence: (config, ctx) =>
+		GITHUB_SENTENCES[config.event].map((part, index) =>
+			renderPart(config, part, index, ctx),
+		),
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/grammar.ts
@@ -1,4 +1,10 @@
-import type { GithubTriggerEvent } from "@superset/shared/automation-triggers";
+import type {
+	GithubTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type GithubConfig = Extract<TriggerConfigInput, { kind: "github" }>;
 
 /**
  * The sentence a GitHub trigger reads as.
@@ -140,57 +146,58 @@ export const GITHUB_SENTENCES: Record<GithubTriggerEvent, SentencePart[]> = {
 	],
 };
 
-/** The Add Trigger menu, grouped the way the events actually divide. */
-export const GITHUB_MENU: Array<{
-	label: string;
-	children?: Array<{ label: string; event: GithubTriggerEvent }>;
-	event?: GithubTriggerEvent;
-}> = [
-	{ label: "Draft opened", event: "draft_opened" },
+/**
+ * The Add Trigger subtree, grouped the way the events actually divide. Leaves
+ * create a config directly, so the menu renderer never needs to know what a
+ * GitHub event is.
+ */
+export const GITHUB_MENU: TriggerMenuEntry<GithubConfig>[] = [
+	leaf("Draft opened", "draft_opened"),
 	{
 		label: "Pull request…",
 		children: [
-			{ label: "Opened", event: "pull_request.opened" },
-			{ label: "Pushed", event: "pull_request.pushed" },
-			{ label: "Merged", event: "pull_request.merged" },
+			leaf("Opened", "pull_request.opened"),
+			leaf("Pushed", "pull_request.pushed"),
+			leaf("Merged", "pull_request.merged"),
 		],
 	},
-	{ label: "Comment added", event: "comment_added" },
-	{ label: "New push to branch", event: "push_to_branch" },
-	{ label: "Label change", event: "label_change" },
-	{ label: "Checks completed", event: "checks_completed" },
-	{ label: "Issue comment", event: "issue_comment" },
-	{ label: "PR review comment", event: "pr_review_comment" },
+	leaf("Comment added", "comment_added"),
+	leaf("New push to branch", "push_to_branch"),
+	leaf("Label change", "label_change"),
+	leaf("Checks completed", "checks_completed"),
+	leaf("Issue comment", "issue_comment"),
+	leaf("PR review comment", "pr_review_comment"),
 	{
 		label: "PR review submitted…",
 		children: [
-			{ label: "Approved", event: "pr_review_submitted.approved" },
-			{
-				label: "Changes requested",
-				event: "pr_review_submitted.changes_requested",
-			},
-			{ label: "Commented", event: "pr_review_submitted.commented" },
-			{ label: "Any review", event: "pr_review_submitted.any" },
+			leaf("Approved", "pr_review_submitted.approved"),
+			leaf("Changes requested", "pr_review_submitted.changes_requested"),
+			leaf("Commented", "pr_review_submitted.commented"),
+			leaf("Any review", "pr_review_submitted.any"),
 		],
 	},
 	{
 		label: "Review thread…",
 		children: [
-			{ label: "Resolved", event: "review_thread.resolved" },
-			{ label: "Unresolved", event: "review_thread.unresolved" },
-			{ label: "Any thread event", event: "review_thread.any" },
+			leaf("Resolved", "review_thread.resolved"),
+			leaf("Unresolved", "review_thread.unresolved"),
+			leaf("Any thread event", "review_thread.any"),
 		],
 	},
 	{
 		label: "Workflow run completed…",
 		children: [
-			{ label: "Success", event: "workflow_run.success" },
-			{ label: "Failure", event: "workflow_run.failure" },
-			{ label: "Cancelled", event: "workflow_run.cancelled" },
-			{ label: "Any conclusion", event: "workflow_run.any" },
+			leaf("Success", "workflow_run.success"),
+			leaf("Failure", "workflow_run.failure"),
+			leaf("Cancelled", "workflow_run.cancelled"),
+			leaf("Any conclusion", "workflow_run.any"),
 		],
 	},
 ];
+
+function leaf(label: string, event: GithubTriggerEvent) {
+	return { label, create: () => createGithubConfig(event) };
+}
 
 /** Events whose sentence carries a second person and a body filter. */
 const COMMENT_EVENTS = new Set<GithubTriggerEvent>([

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+
+/** The pickable values a GitHub sentence needs: repositories and linked people. */
+export function useGithubOptions(organizationId: string): ProviderOptions {
+	// repoId is GitHub's numeric id, which is what the matcher compares against —
+	// a full name would stop matching the moment someone renames the repo.
+	const repos = cloudTrpc.integration.github.listRepositories.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+	const people = cloudTrpc.integration.github.listLinkedPeople.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+
+	return useMemo(
+		() => ({
+			repositories: (repos.data ?? []).map((repo) => ({
+				id: repo.repoId,
+				label: repo.fullName,
+			})),
+			people: people.data ?? [],
+		}),
+		[repos.data, people.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -1,0 +1,40 @@
+import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import { githubProvider } from "./github/github";
+import { scheduleProvider } from "./schedule/schedule";
+import type { TriggerProvider } from "./types";
+import { webhookProvider } from "./webhook/webhook";
+
+export type {
+	OptionKey,
+	ProviderOptions,
+	SentenceContext,
+	TriggerMenuEntry,
+	TriggerProvider,
+} from "./types";
+
+/**
+ * Every provider the editor knows, in Add Trigger menu order.
+ *
+ * To add one: write a `TriggerProvider` under `providers/<name>/` and append it
+ * here. Nothing else in the editor should need to change.
+ */
+export const TRIGGER_PROVIDERS: TriggerProvider[] = [
+	scheduleProvider as TriggerProvider,
+	githubProvider as TriggerProvider,
+	webhookProvider as TriggerProvider,
+];
+
+const byKind = new Map(TRIGGER_PROVIDERS.map((p) => [p.kind, p]));
+
+/**
+ * The provider for a config. Throws rather than returning undefined: a config
+ * whose kind has no provider is a programming error the editor cannot render
+ * around, and a silent blank row would hide it.
+ */
+export function providerFor(config: TriggerConfigInput): TriggerProvider {
+	const provider = byKind.get(config.kind);
+	if (!provider) {
+		throw new Error(`No trigger provider registered for kind "${config.kind}"`);
+	}
+	return provider;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.tsx
@@ -1,0 +1,36 @@
+import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import { LuClock } from "react-icons/lu";
+import { ScheduleSentence } from "../../ScheduleSentence";
+import type { TriggerProvider } from "../types";
+
+type ScheduleConfig = Extract<TriggerConfigInput, { kind: "schedule" }>;
+
+/**
+ * dtstart anchors the recurrence, so it is read when the trigger is added
+ * rather than when this module loads — otherwise every schedule created in a
+ * long-lived window shares the timestamp the app booted at.
+ */
+function createScheduleConfig(): ScheduleConfig {
+	return {
+		kind: "schedule",
+		rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+		dtstart: new Date().toISOString(),
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+	};
+}
+
+export const scheduleProvider: TriggerProvider<ScheduleConfig> = {
+	kind: "schedule",
+	label: "Scheduled",
+	icon: LuClock,
+	menu: [{ label: "Scheduled", create: createScheduleConfig }],
+	renderSentence: (config, { set, nextRun, disabled }) => (
+		<ScheduleSentence
+			rrule={config.rrule}
+			onRruleChange={(rrule) => set({ rrule })}
+			timezone={config.timezone}
+			nextRun={nextRun}
+			disabled={disabled}
+		/>
+	),
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/types.ts
@@ -1,0 +1,65 @@
+import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import type { ReactNode } from "react";
+import type { IconType } from "react-icons";
+import type { ScopeOption } from "../TriggerSentence/scopeOption";
+
+/**
+ * Everything the trigger editor needs to know about one provider.
+ *
+ * Adding a provider means adding one of these and registering it — the menu,
+ * the sentence renderer and the search index all iterate the registry rather
+ * than naming providers. That is the point: before this, "add Slack" meant
+ * editing six files that GitHub had shaped, and two agents adding two providers
+ * would have collided on every one of them.
+ */
+export type TriggerProvider<
+	Config extends TriggerConfigInput = TriggerConfigInput,
+> = {
+	/** The discriminant on the trigger config. */
+	kind: Config["kind"];
+	/** How the provider appears in the Add Trigger menu and at the row start. */
+	label: string;
+	icon: IconType;
+	/**
+	 * The Add Trigger subtree. A single leaf for providers with one trigger
+	 * (Scheduled, Webhook); nested for those with many (GitHub).
+	 */
+	menu: TriggerMenuEntry<Config>[];
+	/** Renders the editable sentence for a config of this kind. */
+	renderSentence: (config: Config, ctx: SentenceContext) => ReactNode;
+};
+
+/**
+ * One entry in the Add Trigger menu. Either a leaf that creates a config, or a
+ * branch holding more entries. The same shape at every depth, so one renderer
+ * and one search flattener cover every provider.
+ */
+export type TriggerMenuEntry<
+	Config extends TriggerConfigInput = TriggerConfigInput,
+> =
+	| { label: string; create: () => Config }
+	| { label: string; children: TriggerMenuEntry<Config>[] };
+
+/**
+ * What a sentence renderer is handed. It never touches row state directly:
+ * `set` patches the config, `mark` returns the invalid class for a field the
+ * last save was refused on, `options` are the pickable values the card fetched
+ * for this provider.
+ */
+export type SentenceContext = {
+	set: (patch: Record<string, unknown>) => void;
+	mark: (field: string) => string | undefined;
+	options: ProviderOptions;
+	disabled?: boolean;
+	/** Trailing text for a schedule row ("Next run …"); other providers ignore it. */
+	nextRun?: ReactNode;
+};
+
+/**
+ * Pickable values, keyed by what they are rather than by provider — a Slack
+ * channel list and a GitHub repo list are both `ScopeOption[]`, and the chip
+ * that renders them does not care which.
+ */
+export type ProviderOptions = Partial<Record<OptionKey, ScopeOption[]>>;
+
+export type OptionKey = "repositories" | "people" | "channels" | "teams";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { useGithubOptions } from "./github/useGithubOptions";
+import type { ProviderOptions } from "./types";
+
+/**
+ * Every provider's pickable values, merged into one map for the editor.
+ *
+ * Hooks cannot be called from a registry loop, so each provider's hook is
+ * called here by name. Adding a provider with options means adding its hook to
+ * this list; the keys they fill are disjoint, so the merge is a spread.
+ */
+export function useProviderOptions(organizationId: string): ProviderOptions {
+	const github = useGithubOptions(organizationId);
+	return useMemo(() => ({ ...github }), [github]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/webhook/webhook.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/webhook/webhook.tsx
@@ -1,0 +1,17 @@
+import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import { LuWebhook } from "react-icons/lu";
+import type { TriggerProvider } from "../types";
+
+type WebhookConfig = Extract<TriggerConfigInput, { kind: "webhook" }>;
+
+export const webhookProvider: TriggerProvider<WebhookConfig> = {
+	kind: "webhook",
+	label: "Webhook Triggered",
+	icon: LuWebhook,
+	menu: [{ label: "Webhook Triggered", create: () => ({ kind: "webhook" }) }],
+	renderSentence: () => (
+		<span className="text-muted-foreground text-sm">
+			Triggered by an incoming webhook
+		</span>
+	),
+};

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -1,3 +1,9 @@
+import type {
+	TriggerActor as TriggerConfigActor,
+	TriggerConfigInput,
+	TriggerScope as TriggerConfigScope,
+} from "@superset/shared/automation-triggers";
+
 export type LinearConfig = {
 	provider: "linear";
 	newTasksTeamId?: string;
@@ -10,67 +16,25 @@ export type SlackConfig = {
 export type IntegrationConfig = LinearConfig | SlackConfig;
 
 /**
- * A trigger scope slot. `null` is unconfigured and never matches; it is
- * deliberately distinct from `{ mode: "any" }` so a half-filled trigger cannot
- * act on everything. Tagged rather than type-discriminated because ids are
- * user-defined strings, and a GitHub label named "any" is legal.
+ * The trigger config column, typed from the zod schema that validates every
+ * write to it. Derived rather than restated: a hand-written copy here had
+ * already drifted (`events: string[]` where the schema says `event: string`,
+ * an `"org_members"` actor the schema never had), and the only thing keeping
+ * it from a runtime mismatch was an `as never` at the read site.
  */
-export type TriggerScope =
-	| null
-	| { mode: "any" }
-	| { mode: "list"; ids: string[] };
+export type TriggerConfig = TriggerConfigInput;
+export type TriggerScope = TriggerConfigScope;
+export type TriggerActor = TriggerConfigActor;
 
-export type TriggerActor = "anyone" | "org_members" | { ids: string[] };
-
-export type ScheduleTriggerConfig = {
-	kind: "schedule";
-	rrule: string;
-	dtstart: string;
-	timezone: string;
-};
-
-export type WebhookTriggerConfig = { kind: "webhook" };
-
-export type GithubTriggerConfig = {
-	kind: "github";
-	events: string[];
-	repositories: TriggerScope;
-	branches: TriggerScope;
-	labels: TriggerScope;
-	actor: TriggerActor;
-	includeForks: false;
-};
-
-export type SlackTriggerConfig = {
-	kind: "slack";
-	events: string[];
-	channels: TriggerScope;
-	emoji: TriggerScope;
-	actor: TriggerActor;
-	keyword?: string;
-};
-
-export type LinearTriggerConfig = {
-	kind: "linear";
-	events: string[];
-	teams: TriggerScope;
-	projects: TriggerScope;
-};
-
-export type SentryTriggerConfig = {
-	kind: "sentry";
-	events: string[];
-	projects: TriggerScope;
-	level: TriggerScope;
-};
-
-export type TriggerConfig =
-	| ScheduleTriggerConfig
-	| WebhookTriggerConfig
-	| GithubTriggerConfig
-	| SlackTriggerConfig
-	| LinearTriggerConfig
-	| SentryTriggerConfig;
+export type ScheduleTriggerConfig = Extract<
+	TriggerConfig,
+	{ kind: "schedule" }
+>;
+export type WebhookTriggerConfig = Extract<TriggerConfig, { kind: "webhook" }>;
+export type GithubTriggerConfig = Extract<TriggerConfig, { kind: "github" }>;
+export type SlackTriggerConfig = Extract<TriggerConfig, { kind: "slack" }>;
+export type LinearTriggerConfig = Extract<TriggerConfig, { kind: "linear" }>;
+export type SentryTriggerConfig = Extract<TriggerConfig, { kind: "sentry" }>;
 
 /**
  * Provider-specific extras on a user identity.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,8 @@
 	"type": "module",
 	"exports": {
 		"./automation-matching": {
-			"types": "./src/automation-matching.ts",
-			"default": "./src/automation-matching.ts"
+			"types": "./src/automation-matching/index.ts",
+			"default": "./src/automation-matching/index.ts"
 		},
 		"./automation-triggers": {
 			"types": "./src/automation-triggers.ts",

--- a/packages/shared/src/automation-matching/core.ts
+++ b/packages/shared/src/automation-matching/core.ts
@@ -1,0 +1,101 @@
+import type { TriggerActor, TriggerScope } from "../automation-triggers";
+
+/**
+ * Decides whether a recorded event satisfies a trigger's config.
+ *
+ * Pure and provider-shaped rather than payload-shaped: it takes the normalized
+ * fields `automation_events` already carries, so the same function can be run
+ * over historical rows to see what *would* have matched before anything is
+ * allowed to dispatch.
+ */
+
+/** The normalized event, as recorded. */
+export type MatchableEvent = {
+	/** Qualified with its action, e.g. `pull_request.opened`. */
+	eventType: string;
+	repositoryId: string | null;
+	ref: string | null;
+	/** GitHub's numeric id; what people filters compare against. */
+	actorId: string | null;
+	/** Display only — a login can be renamed, the id cannot. */
+	actorLogin: string | null;
+	actorIsExternal: boolean | null;
+	labels: string[];
+	/** Comment or review body, when the event carries one. */
+	body: string | null;
+	/** Fork pull requests carry attacker-controlled content into a checkout. */
+	isFork: boolean;
+	/** Who opened the thing being commented on. */
+	subjectAuthorId: string | null;
+};
+
+export type MatchResult =
+	| { matches: true }
+	| { matches: false; reason: string };
+
+/**
+ * `null` matches nothing — an unconfigured filter should never fire. That is the
+ * opposite of the usual "empty means unrestricted" convention, and deliberate:
+ * a half-built trigger silently matching every repository is the worst
+ * available failure.
+ */
+export function scopeAllows(
+	scope: TriggerScope,
+	value: string | null,
+): boolean {
+	if (scope === null) return false;
+	if (scope.mode === "any") return true;
+	if (value === null) return false;
+	return scope.ids.includes(value);
+}
+
+/** Same, but for filters that are only meaningful on some events. */
+export function scopeAllowsAny(scope: TriggerScope, values: string[]): boolean {
+	if (scope === null) return false;
+	if (scope.mode === "any") return true;
+	return values.some((v) => scope.ids.includes(v));
+}
+
+/**
+ * `ownerIds` is a set: a person may link both a work and a personal account, and
+ * a pull request opened from either is still theirs.
+ */
+export function actorAllows(
+	actor: TriggerActor,
+	actorId: string | null,
+	ownerIds: string[],
+): boolean {
+	if (actor === "anyone") return true;
+	if (actorId === null) return false;
+	if (actor === "me") return ownerIds.includes(actorId);
+	return actor.ids.includes(actorId);
+}
+
+/**
+ * The body a filter is tested against is truncated first.
+ *
+ * A user-supplied pattern runs on the webhook path, and JavaScript's engine
+ * backtracks: `^(a+)+$` against a long non-matching body is exponential and
+ * would block the event loop. Truncation bounds the exponent; it does not
+ * remove it, which is why a linear-time engine is still wanted here.
+ */
+const MAX_FILTERED_BODY = 4096;
+
+/** Applies a comment filter, treating an invalid regex as no match. */
+export function bodyMatches(
+	filter: { pattern: string; isRegex: boolean } | null,
+	body: string | null,
+): boolean {
+	if (!filter || filter.pattern === "") return true;
+	if (body === null) return false;
+	const subject = body.slice(0, MAX_FILTERED_BODY);
+	if (!filter.isRegex) {
+		return subject.toLowerCase().includes(filter.pattern.toLowerCase());
+	}
+	try {
+		return new RegExp(filter.pattern, "i").test(subject);
+	} catch {
+		// A trigger whose regex does not compile must not match everything.
+		return false;
+	}
+}

--- a/packages/shared/src/automation-matching/github.ts
+++ b/packages/shared/src/automation-matching/github.ts
@@ -2,109 +2,17 @@ import type {
 	GithubTriggerEvent,
 	TriggerActor,
 	TriggerScope,
-} from "./automation-triggers";
-
-/**
- * Decides whether a recorded event satisfies a trigger's config.
- *
- * Pure and provider-shaped rather than payload-shaped: it takes the normalized
- * fields `automation_events` already carries, so the same function can be run
- * over historical rows to see what *would* have matched before anything is
- * allowed to dispatch.
- */
-
-/** The normalized event, as recorded. */
-export type MatchableEvent = {
-	/** Qualified with its action, e.g. `pull_request.opened`. */
-	eventType: string;
-	repositoryId: string | null;
-	ref: string | null;
-	/** GitHub's numeric id; what people filters compare against. */
-	actorId: string | null;
-	/** Display only — a login can be renamed, the id cannot. */
-	actorLogin: string | null;
-	actorIsExternal: boolean | null;
-	labels: string[];
-	/** Comment or review body, when the event carries one. */
-	body: string | null;
-	/** Fork pull requests carry attacker-controlled content into a checkout. */
-	isFork: boolean;
-	/** Who opened the thing being commented on. */
-	subjectAuthorId: string | null;
-};
-
-export type MatchResult =
-	| { matches: true }
-	| { matches: false; reason: string };
+} from "../automation-triggers";
+import {
+	actorAllows,
+	bodyMatches,
+	type MatchableEvent,
+	type MatchResult,
+	scopeAllows,
+	scopeAllowsAny,
+} from "./core";
 
 const no = (reason: string): MatchResult => ({ matches: false, reason });
-
-/**
- * `null` matches nothing — an unconfigured filter should never fire. That is the
- * opposite of the usual "empty means unrestricted" convention, and deliberate:
- * a half-built trigger silently matching every repository is the worst
- * available failure.
- */
-export function scopeAllows(
-	scope: TriggerScope,
-	value: string | null,
-): boolean {
-	if (scope === null) return false;
-	if (scope.mode === "any") return true;
-	if (value === null) return false;
-	return scope.ids.includes(value);
-}
-
-/** Same, but for filters that are only meaningful on some events. */
-export function scopeAllowsAny(scope: TriggerScope, values: string[]): boolean {
-	if (scope === null) return false;
-	if (scope.mode === "any") return true;
-	return values.some((v) => scope.ids.includes(v));
-}
-
-/**
- * `ownerIds` is a set: a person may link both a work and a personal account, and
- * a pull request opened from either is still theirs.
- */
-export function actorAllows(
-	actor: TriggerActor,
-	actorId: string | null,
-	ownerIds: string[],
-): boolean {
-	if (actor === "anyone") return true;
-	if (actorId === null) return false;
-	if (actor === "me") return ownerIds.includes(actorId);
-	return actor.ids.includes(actorId);
-}
-
-/**
- * The body a filter is tested against is truncated first.
- *
- * A user-supplied pattern runs on the webhook path, and JavaScript's engine
- * backtracks: `^(a+)+$` against a long non-matching body is exponential and
- * would block the event loop. Truncation bounds the exponent; it does not
- * remove it, which is why a linear-time engine is still wanted here.
- */
-const MAX_FILTERED_BODY = 4096;
-
-/** Applies a comment filter, treating an invalid regex as no match. */
-export function bodyMatches(
-	filter: { pattern: string; isRegex: boolean } | null,
-	body: string | null,
-): boolean {
-	if (!filter || filter.pattern === "") return true;
-	if (body === null) return false;
-	const subject = body.slice(0, MAX_FILTERED_BODY);
-	if (!filter.isRegex) {
-		return subject.toLowerCase().includes(filter.pattern.toLowerCase());
-	}
-	try {
-		return new RegExp(filter.pattern, "i").test(subject);
-	} catch {
-		// A trigger whose regex does not compile must not match everything.
-		return false;
-	}
-}
 
 /**
  * Maps a GitHub delivery to the event a trigger names. GitHub's wire events are

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -1,0 +1,37 @@
+import type { TriggerConfigInput } from "../automation-triggers";
+import type { MatchableEvent, MatchResult } from "./core";
+import { githubTriggerMatches } from "./github";
+
+export * from "./core";
+export * from "./github";
+
+/**
+ * Per-provider context the matcher needs beyond the event itself. Keyed by
+ * provider so a Slack matcher can carry different context without every
+ * caller learning about it.
+ */
+export type MatchContext = {
+	github?: Parameters<typeof githubTriggerMatches>[2];
+};
+
+/**
+ * Whether a trigger config accepts an event, whatever provider it belongs to.
+ *
+ * Dispatches on `config.kind` so the webhook route never names a provider. A
+ * kind with no matcher here does not match — an event arriving for a provider
+ * that cannot yet evaluate it must not fire the automation by default.
+ */
+export function triggerMatches(
+	config: TriggerConfigInput,
+	event: MatchableEvent,
+	context: MatchContext,
+): MatchResult {
+	switch (config.kind) {
+		case "github":
+			return context.github
+				? githubTriggerMatches(config, event, context.github)
+				: { matches: false, reason: "no github context" };
+		default:
+			return { matches: false, reason: `no matcher for ${config.kind}` };
+	}
+}


### PR DESCRIPTION
## Why

Adding a trigger provider meant editing six files GitHub had shaped: the sentence grammar, the menu table, the slot renderer, the card's option fetching, the matcher, and the dispatcher. Two agents adding Slack and Linear in parallel would collide on every one of them. This PR makes a provider one module plus registry lines, so those can proceed in parallel.

**Zero behaviour change is the bar.** Nothing user-visible should differ.

## What

**Desktop** — `providers/<name>/` owns a provider's config kind, icon, Add Trigger subtree, config factory and sentence renderer. Three things iterate `TRIGGER_PROVIDERS` instead of naming providers:
- `TriggerMenuItems` renders the menu (single-leaf providers become the leaf; multi-leaf become a submenu)
- `flattenTriggerMenu` builds the search index — same registry, so menu and search can't drift
- `TriggerSentence` hands the row's state (`set`, `mark`, `options`, `disabled`) to whichever provider owns the config

Pickable values move to per-provider hooks composed by `useProviderOptions`; the card no longer knows what a repository is.

**Shared** — `automation-matching` splits the same way: shared primitives in `core.ts`, GitHub's matcher in `github.ts`, and `triggerMatches(config, event, ctx)` dispatching on `config.kind`. A kind with no matcher does not match — an event for a provider that can't yet evaluate it must not fire by default.

**DB** — doing this exposed that `packages/db`'s hand-written `TriggerConfig` had drifted from the zod schema that validates every write (`events: string[]` vs `event: string`; an `"org_members"` actor the schema never had). The only thing keeping it from a runtime mismatch was an `as never` at the read site. DB types are now derived from the schema and that cast is gone.

## To add a provider

1. `providers/<name>/` implementing `TriggerProvider`
2. append to `TRIGGER_PROVIDERS`
3. a `case` in `triggerMatches`
4. if it has pickable values, its hook in `useProviderOptions`

## Verified in the running app

- menu lists the same 3 providers with icons; GitHub submenu has the same 11 entries
- search still flattens to `GitHub › PR review submitted › Approved`
- a comment trigger renders, configures and saves — `Triggers saved`, zero console errors
- schedule row shows one clock (provider-supplied) not two
- typecheck and lint pass with real exit codes

One intentional visual: the schedule row's clock now comes from the provider like every other row's icon, rather than `ScheduleSentence` drawing its own. Same pixel, one source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors triggers so providers are additive and registry-driven. Behavior is unchanged; an unknown persisted GitHub event that previously crashed the editor now renders as its raw name.

- Desktop: `providers/<name>/` owns a provider’s kind, icon, Add Trigger subtree, config factory, and sentence renderer. `TriggerMenuItems`, `flattenTriggerMenu`, and `TriggerSentence` iterate `TRIGGER_PROVIDERS`. Pickable values move to per-provider hooks composed by `useProviderOptions`, so `TriggersCard` no longer fetches repos/people directly. The schedule row’s clock icon now comes from the provider (same visual). Unknown GitHub events render as text to avoid an editor crash.
- Shared/API: `@superset/shared/automation-matching` splits into `core.ts` (shared primitives) and provider modules; `triggerMatches` dispatches on `config.kind`. The GitHub webhook route uses `triggerMatches` with provider context. A kind with no matcher does not match.
- DB: `TriggerConfig` and related types derive from the zod schema in `@superset/shared`, removing drift and unsafe casts.

**Migration**
- Add a provider by implementing `providers/<name>/` as a `TriggerProvider`, appending it to `TRIGGER_PROVIDERS`, adding its case to `triggerMatches`, and registering its options hook in `useProviderOptions` if needed. No data or user migration is required.

<sup>Written for commit 0884ca80f43de8d8b27ba2097bdfd068e000a429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified automation trigger editor for schedule, GitHub, and webhook triggers.
  * Added provider-based trigger menus with icons, grouped options, and sentence-style configuration.
  * Added GitHub repository, branch, label, actor, and comment filters.
  * Added schedule defaults, timezone handling, and next-run information.
* **Bug Fixes**
  * Improved trigger matching for scopes, actors, and text filters.
  * Invalid regular expressions now safely produce no match.
* **Style**
  * Removed the unused clock icon from schedule controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->