### PR TITLE
docs(shared): describe the prompt-cards flag's three arms

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -153,11 +153,17 @@ export const FEATURE_FLAGS = {
 	 */
 	NEW_WORKSPACE_SCREEN_OVERRIDE: "new-workspace-screen-override",
 	/**
-	 * Experiment flag (control/test) nested inside the shipped new-workspace
-	 * screen: control keeps the inline sample-prompt rows, test replaces them
-	 * with two cards above the composer. Prompt text is identical in both arms
-	 * so the comparison isolates presentation. Evaluated when the screen opens,
-	 * like NEW_WORKSPACE_SCREEN, so exposure matches the population that sees it.
+	 * Three-arm experiment flag nested inside the shipped new-workspace screen,
+	 * testing form factor only: `control` keeps the inline sample-prompt rows,
+	 * `cards2` shows two cards above the composer, `cards4` shows four in a 2x2
+	 * grid. Every arm slices a nested prefix of one fixed prompt pool and shares
+	 * the same selection rule, so content is identical and only layout and count
+	 * vary. Evaluated when the screen opens, like NEW_WORKSPACE_SCREEN, so
+	 * exposure matches the population that sees it.
+	 *
+	 * Anything other than `cards2`/`cards4` renders control — which is why the
+	 * flag must not go live before a build carrying those arms ships, or older
+	 * builds would be assigned a card arm and shown rows.
 	 *
 	 * Eligibility (new accounts only) is a release condition on the flag, not
 	 * code: a `created_at` person property cutoff, which the renderer sends with
@@ -166,7 +172,7 @@ export const FEATURE_FLAGS = {
 	 */
 	NEW_WORKSPACE_PROMPT_CARDS: "new-workspace-prompt-cards",
 	/**
-	 * Boolean override that forces the prompt cards without evaluating the
+	 * Boolean override that forces the `cards2` arm without evaluating the
 	 * experiment flag — no exposure event, so team and dev accounts can look at
 	 * the cards without entering the analysis. Checked before the experiment
 	 * flag, same as NEW_WORKSPACE_SCREEN_OVERRIDE.


### PR DESCRIPTION
The `NEW_WORKSPACE_PROMPT_CARDS` comment still described a two-arm control/test split with "two cards above the composer". It has been `control`/`cards2`/`cards4` since #6556, and the override comment said "forces the prompt cards" rather than naming the `cards2` arm it actually forces.

Also records the launch hazard in the place someone would look: anything other than `cards2`/`cards4` renders control, so activating the flag before a build carrying those arm keys ships would assign older builds a card arm and show them rows — silent cross-arm contamination.

Comment-only; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies docs for the `NEW_WORKSPACE_PROMPT_CARDS` flag: describes the three-arm experiment (`control`, `cards2`, `cards4`) and that the override forces `cards2`. Comment-only; no behavior change.

- Do not activate the flag until a build that understands `cards2`/`cards4` has shipped. Older builds treat any other value as control, which can assign a card arm but render rows, mixing arms.
- Only comment updates in `packages/shared/src/constants.ts`.

<sup>Written for commit 3fa1fb70aefa70d8b703967db38f705e89d04718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the three experiment variants and shared prompt selection behavior.
  * Documented fallback behavior for unsupported configuration values.
  * Clarified that the override selects the second variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->