### PR TITLE
feat(desktop): show GitHub star pill on the new workspace screen

### DIFF
--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -89,9 +89,9 @@ export function GitHubStarPill({
 	// and reset again if `surface` itself changes so a re-purposed mounted
 	// instance still gets its own impression instead of inheriting the prior
 	// surface's guard.
-	const trackedShownSurfaceRef = useRef<
-		NonNullable<GitHubStarPillProps["surface"]> | null
-	>(null);
+	const trackedShownSurfaceRef = useRef<NonNullable<
+		GitHubStarPillProps["surface"]
+	> | null>(null);
 	useEffect(() => {
 		if (state === "starred") {
 			trackedShownSurfaceRef.current = null;

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -125,6 +125,7 @@ export function GitHubStarPill({
 				transition={{ duration: 0.32, ease: "easeOut" }}
 				style={{ pointerEvents: isVisible ? "auto" : "none" }}
 				aria-hidden={!isVisible}
+				inert={!isVisible}
 				className={cn("flex items-center justify-center", className)}
 			>
 				<AnimatedStarButton

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -11,21 +11,26 @@ import { track } from "renderer/lib/analytics";
 
 interface GitHubStarPillProps {
 	className?: string;
+	/** Analytics surface tag; defaults to "empty_state" for the original callers. */
+	surface?: "empty_state" | "new_workspace";
 }
 
 /**
  * Small, always-optional "Star Superset on GitHub" pill for the empty
- * "no pane open" screens (v1 EmptyTabView and v2 WorkspaceEmptyState).
- * Renders straight from live `state`, with no nag-suppression layer — unlike
- * the sidebar card/toast, this is a low-key status indicator, not an
- * interruptive campaign, so it's allowed to be fully truthful: it hides the
- * instant `state` is "starred" and reappears the instant a later unstar is
- * confirmed, without waiting on any mute grace window. It briefly stays
- * mounted past that point so the confetti/label animation on a fresh star
- * has time to play, then dissolves out (fade + soft blur) instead of
- * vanishing instantly.
+ * "no pane open" screens (v1 EmptyTabView and v2 WorkspaceEmptyState) and
+ * the new-workspace screen. Renders straight from live `state`, with no
+ * nag-suppression layer — unlike the sidebar card/toast, this is a low-key
+ * status indicator, not an interruptive campaign, so it's allowed to be
+ * fully truthful: it hides the instant `state` is "starred" and reappears
+ * the instant a later unstar is confirmed, without waiting on any mute
+ * grace window. It briefly stays mounted past that point so the
+ * confetti/label animation on a fresh star has time to play, then
+ * dissolves out (fade + soft blur) instead of vanishing instantly.
  */
-export function GitHubStarPill({ className }: GitHubStarPillProps) {
+export function GitHubStarPill({
+	className,
+	surface = "empty_state",
+}: GitHubStarPillProps) {
 	const { state, activate, isBusy } = useGithubStarAction();
 	const prevStateRef = useRef<GithubStarActionState | null>(null);
 
@@ -81,8 +86,8 @@ export function GitHubStarPill({ className }: GitHubStarPillProps) {
 		if (trackedShownRef.current) return;
 		if (state !== "not_starred" && state !== "unknown") return;
 		trackedShownRef.current = true;
-		track("star_nag_shown", { surface: "empty_state" });
-	}, [state]);
+		track("star_nag_shown", { surface });
+	}, [state, surface]);
 
 	if (state === "loading") return null;
 
@@ -94,7 +99,7 @@ export function GitHubStarPill({ className }: GitHubStarPillProps) {
 
 	const handleClick = () => {
 		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
-			surface: "empty_state",
+			surface,
 		});
 		activate();
 	};

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -13,6 +13,15 @@ interface GitHubStarPillProps {
 	className?: string;
 	/** Analytics surface tag; defaults to "empty_state" for the original callers. */
 	surface?: "empty_state" | "new_workspace";
+	/**
+	 * Keep the pill's layout box mounted (just faded to invisible) instead of
+	 * unmounting it once starred. The empty-state screens sit at the bottom of
+	 * a plain block, so a height collapse there is harmless; the new-workspace
+	 * screen centers its content with `justify-center`, where that same
+	 * collapse re-centers everything above it. Off by default so the two
+	 * existing callers keep their original unmount-on-hide behavior.
+	 */
+	reserveSpace?: boolean;
 }
 
 /**
@@ -30,6 +39,7 @@ interface GitHubStarPillProps {
 export function GitHubStarPill({
 	className,
 	surface = "empty_state",
+	reserveSpace = false,
 }: GitHubStarPillProps) {
 	const { state, activate, isBusy } = useGithubStarAction();
 	const prevStateRef = useRef<GithubStarActionState | null>(null);
@@ -89,13 +99,11 @@ export function GitHubStarPill({
 		track("star_nag_shown", { surface });
 	}, [state, surface]);
 
-	if (state === "loading") return null;
+	if (state === "loading" && !reserveSpace) return null;
 
-	const isVisible = !(
-		state === "starred" &&
-		!justStarred &&
-		!staysVisibleForAnimation
-	);
+	const isVisible =
+		state !== "loading" &&
+		!(state === "starred" && !justStarred && !staysVisibleForAnimation);
 
 	const handleClick = () => {
 		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
@@ -103,6 +111,26 @@ export function GitHubStarPill({
 		});
 		activate();
 	};
+
+	if (reserveSpace) {
+		// Always mounted so the button's box keeps occupying its slot — only
+		// opacity/interactivity change, never the layout.
+		return (
+			<motion.div
+				animate={{ opacity: isVisible ? 1 : 0 }}
+				transition={{ duration: 0.32, ease: "easeOut" }}
+				style={{ pointerEvents: isVisible ? "auto" : "none" }}
+				aria-hidden={!isVisible}
+				className={cn("flex items-center justify-center", className)}
+			>
+				<AnimatedStarButton
+					state={state}
+					busy={isBusy}
+					onActivate={handleClick}
+				/>
+			</motion.div>
+		);
+	}
 
 	return (
 		<AnimatePresence>

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -84,18 +84,22 @@ export function GitHubStarPill({
 		}
 	}, [state]);
 
-	// Fire at most once per showing — reset once starred so a later unstar
-	// that re-shows the pill tracks a fresh "shown" impression instead of
-	// staying silent forever after the first one.
-	const trackedShownRef = useRef(false);
+	// Fire at most once per showing per surface — reset once starred so a
+	// later unstar re-shows the pill and tracks a fresh "shown" impression,
+	// and reset again if `surface` itself changes so a re-purposed mounted
+	// instance still gets its own impression instead of inheriting the prior
+	// surface's guard.
+	const trackedShownSurfaceRef = useRef<
+		NonNullable<GitHubStarPillProps["surface"]> | null
+	>(null);
 	useEffect(() => {
 		if (state === "starred") {
-			trackedShownRef.current = false;
+			trackedShownSurfaceRef.current = null;
 			return;
 		}
-		if (trackedShownRef.current) return;
+		if (trackedShownSurfaceRef.current === surface) return;
 		if (state !== "not_starred" && state !== "unknown") return;
-		trackedShownRef.current = true;
+		trackedShownSurfaceRef.current = surface;
 		track("star_nag_shown", { surface });
 	}, [state, surface]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -656,7 +656,7 @@ export function NewWorkspaceScreen({
 				<h1 className="text-center text-3xl font-medium text-foreground/90">
 					What should we build next?
 				</h1>
-				<GitHubStarPill surface="new_workspace" />
+				<GitHubStarPill surface="new_workspace" reserveSpace />
 			</div>
 			<div className="relative flex w-full max-w-[640px] flex-col px-6 pb-8">
 				<AnimatePresence initial={false}>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -29,6 +29,7 @@ import { LuGitPullRequest } from "react-icons/lu";
 import { SiLinear } from "react-icons/si";
 import { AgentModelSelect } from "renderer/components/AgentModelSelect";
 import { AgentSelect } from "renderer/components/AgentSelect";
+import { GitHubStarPill } from "renderer/components/GitHubStarPill";
 import { IssueLinkCommand } from "renderer/components/IssueLinkCommand";
 import { LinkedIssuePill } from "renderer/components/LinkedIssuePill";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
@@ -655,6 +656,7 @@ export function NewWorkspaceScreen({
 				<h1 className="text-center text-3xl font-medium text-foreground/90">
 					What should we build next?
 				</h1>
+				<GitHubStarPill surface="new_workspace" />
 			</div>
 			<div className="relative flex w-full max-w-[640px] flex-col px-6 pb-8">
 				<AnimatePresence initial={false}>


### PR DESCRIPTION
## Summary
- Show the existing `GitHubStarPill` on the new full-screen "new workspace" screen (the `new-workspace-screen` PostHog-flagged variant), under the "What should we build next?" heading.

## Why / Context
The new workspace screen is one of the highest-traffic surfaces in the app but had no star nudge, unlike the empty paneless views (`EmptyTabView`, `WorkspaceEmptyState`).

## How It Works
- `GitHubStarPill` already encapsulates the "only show if not starred" behavior via `useGithubStarAction()` — it hides itself once `state === "starred"`, so no new star-check logic was needed. It's rendered here the same way it is on the two existing empty-state screens.
- Added an optional `surface` prop to `GitHubStarPill` (default `"empty_state"`, preserving existing behavior for the two current callers) so the `star_nag_shown` / `star_nag_starred` / `star_nag_opened_web` analytics events can distinguish this new placement (`"new_workspace"`) from the original ones.

## Manual QA Checklist
- [x] App launches without errors (dev mode)
- [x] No console errors during Electron main/renderer build
- [x] Pill hides automatically once starred (existing `GitHubStarPill` behavior, unchanged)

## Testing
- `npx tsc --noEmit -p apps/desktop/tsconfig.json` — no new errors introduced by either changed file (pre-existing unrelated errors come from a missing generated `routeTree.gen` in this worktree)
- Manual: ran `bun run dev:desktop` end-to-end; API + Electron renderer + local DB all started cleanly with the new import/component in place

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the GitHub star pill on the PostHog‑flagged new workspace screen and keeps layout and focus stable when it hides. Differentiates analytics by surface and fixes missed “shown” impressions when the surface changes.

- Adds optional `surface` prop (default "empty_state") to `GitHubStarPill`; tracks `star_nag_shown`, `star_nag_starred`, and `star_nag_opened_web` with this surface; resets the shown‑impression guard per surface and after starring.
- Adds optional `reserveSpace` prop (default false) to keep the pill’s wrapper mounted and fade opacity; disables interaction and focus when hidden (`pointer-events: none`, `aria-hidden`, `inert`), preventing re-centering and focus traps; holds space during loading.
- Renders `GitHubStarPill` on `NewWorkspaceScreen` with `surface="new_workspace"` and `reserveSpace`; pill still auto‑hides after starring.

<sup>Written for commit 0fbc0e5ec617614e4d1d3ce5a17ad3a5d72b846c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GitHub star prompt to the new workspace screen.
  - Improved tracking for GitHub star prompt impressions and clicks across different app surfaces.
  - Preserved layout space while the prompt loads or reflects a starred state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->