### PR TITLE
fix(desktop): match light theme sidebar, background, and muted text to design spec

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -62,7 +62,7 @@
 
 /* Light theme fallback values - applied before hydration if user has light theme saved */
 :root.light {
-	--background: oklch(1 0 0);
+	--background: #f9f9fa;
 	--foreground: oklch(0.145 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.145 0 0);
@@ -73,7 +73,7 @@
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
 	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.556 0 0);
+	--muted-foreground: #4a4847;
 	--accent: oklch(0.97 0 0);
 	--accent-foreground: oklch(0.205 0 0);
 	--tertiary: oklch(0.95 0.003 40);
@@ -88,7 +88,7 @@
 	--chart-3: oklch(0.398 0.07 227.392);
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
-	--sidebar: oklch(0.985 0 0);
+	--sidebar: #ececec;
 	--sidebar-foreground: oklch(0.145 0 0);
 	--sidebar-primary: oklch(0.205 0 0);
 	--sidebar-primary-foreground: oklch(0.985 0 0);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -265,7 +265,7 @@ export function DashboardSidebar({
 									workspaceShortcutLabels={workspaceShortcutLabels}
 									onReorderProjects={handleReorderProjects}
 								>
-									<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
+									<div className="flex h-full flex-col border-r border-border bg-sidebar dark:bg-muted/35">
 										<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
 										<OverflowFadeContainer

--- a/packages/shared/src/themes/built-in/light.ts
+++ b/packages/shared/src/themes/built-in/light.ts
@@ -11,7 +11,7 @@ export const lightTheme: Theme = {
 	isBuiltIn: true,
 
 	ui: {
-		background: "oklch(1 0 0)",
+		background: "#f9f9fa",
 		foreground: "oklch(0.145 0 0)",
 		card: "oklch(0.97 0 0)",
 		cardForeground: "oklch(0.145 0 0)",
@@ -22,7 +22,7 @@ export const lightTheme: Theme = {
 		secondary: "oklch(0.97 0 0)",
 		secondaryForeground: "oklch(0.205 0 0)",
 		muted: "oklch(0.97 0 0)",
-		mutedForeground: "oklch(0.556 0 0)",
+		mutedForeground: "#4a4847",
 		accent: "oklch(0.93 0 0)",
 		accentForeground: "oklch(0.205 0 0)",
 		tertiary: "oklch(0.95 0.003 40)",
@@ -32,7 +32,7 @@ export const lightTheme: Theme = {
 		border: "oklch(0.922 0 0)",
 		input: "oklch(0.922 0 0)",
 		ring: "oklch(0.708 0 0)",
-		sidebar: "oklch(0.985 0 0)",
+		sidebar: "#ececec",
 		sidebarForeground: "oklch(0.145 0 0)",
 		sidebarPrimary: "oklch(0.205 0 0)",
 		sidebarPrimaryForeground: "oklch(0.985 0 0)",


### PR DESCRIPTION
## Summary
- Sidebar background, main content background, and muted text color in the light theme now match the Figma design reference: `sidebar` → `#ececec`, `background` → `#f9f9fa`, `mutedForeground` → `#4a4847` (previously near-white/mid-gray `oklch` values that didn't match).
- Fixed `DashboardSidebar` to actually consume the `sidebar` theme token (`bg-sidebar`) instead of a translucent `bg-muted/45` overlay that never referenced it — the earlier color value was silently unused by the app's primary nav rail.

## Why / Context
The light theme's sidebar/background/muted-text colors had drifted from the design spec. Verified against the Figma reference node directly (`Sidebar` and `MainContainer` frame fills, and the six top nav-item text node fills) rather than guessing conversions.

## Manual QA Checklist
- [x] Live-verified via CDP against the running dev app: `DashboardSidebar` container resolves to exactly `#ececec`, app background resolves to exactly `#f9f9fa`
- [x] Screenshotted the running app to confirm visually
- [x] Confirmed all 6 Figma nav-item text nodes (New Workspace, Search, Workspaces, Automations, Tasks, Pull requests) use `#4a4847`
- [ ] Dark theme not touched/affected (only `light.ts` and the `:root.light` CSS block were edited; `DashboardSidebar`'s `dark:bg-muted/35` left as-is)

## Testing
- `bunx tsc --noEmit -p apps/desktop/tsconfig.json` (clean)
- `bun run lint` on all changed files (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the desktop light theme with the design spec and ensures the sidebar uses the intended token. Previously, light mode used near-white OKLCH grays and the sidebar rendered a translucent muted overlay; now `background` is #f9f9fa, `sidebar` is #ececec, and `mutedForeground` is #4a4847, with `DashboardSidebar` using `bg-sidebar`.

- `packages/shared/src/themes/built-in/light.ts` and `:root.light` in `globals.css` use the same hex values to match pre-hydration and runtime.
- `DashboardSidebar` replaces `bg-muted/45` with `bg-sidebar`; `dark:bg-muted/35` is unchanged.
- Scope: light theme only; dark theme unaffected. Verify light mode renders the exact hex values for background, sidebar, and muted text.

<sup>Written for commit 2482783cbd3d3818c6d8dda8c53e2a7c339751ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the light theme’s background, muted text, and sidebar colors for more consistent visual rendering.
  - Updated the dashboard sidebar to use the designated sidebar color in light mode while preserving its dark-mode appearance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->