### PR TITLE
feat(mobile): record 100% of mobile session replays

### DIFF
--- a/apps/mobile/lib/posthog/client.ts
+++ b/apps/mobile/lib/posthog/client.ts
@@ -6,6 +6,7 @@ export const posthogConfig = {
 	options: {
 		enableSessionReplay: true,
 		sessionReplayConfig: {
+			sampleRate: 1,
 			screenshotModeBackgroundCapture: true,
 		},
 		debug: env.NODE_ENV === "development",


### PR DESCRIPTION
## What

Pin the mobile PostHog session-replay sample rate to `1.0` (100%).

Mobile and web share the Production PostHog project, whose project-level replay sample rate is **5%** (set for web). Since a local `sampleRate` takes precedence over remote config, setting it in the app keeps **mobile at 100%** while leaving web's 5% untouched. 5% was too low to be useful while we're actively building mobile.

Follows #6574 (which left volume to PostHog remote config); this overrides only the sampling %. Other volume levers (retention, minimum duration, triggers) remain PostHog-controlled.

## Change
- `apps/mobile/lib/posthog/client.ts`: `sessionReplayConfig.sampleRate = 1`.

## Verification
- lint + typecheck clean; `sampleRate` is a valid `PostHogSessionReplayConfig` key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the mobile PostHog session-replay sample rate to 100% so we capture all mobile sessions during active development. Previously, mobile inherited the project’s 5% rate from remote config; now mobile records all sessions, while web remains at 5% because the local override takes precedence.

- Only change: set `sessionReplayConfig.sampleRate = 1`; retention, minimum duration, and triggers still come from PostHog remote config.
- Expect higher mobile replay volume; monitor PostHog usage and storage.
- To revert, remove the local override to fall back to remote config.

<sup>Written for commit f411df4b1376ab8d6e5de0dea9ab7d801be10093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled session replay for all sessions, improving visibility into in-app user experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->