### PR TITLE
fix(host-service): resync terminal modes on attach and rebuild the mode tracker on adoption

### DIFF
--- a/packages/host-service/src/terminal/DaemonClient/DaemonClient.ts
+++ b/packages/host-service/src/terminal/DaemonClient/DaemonClient.ts
@@ -224,13 +224,15 @@ export class DaemonClient {
 		// Only the first subscribe per session id sends the wire `subscribe`.
 		// Subsequent local callbacks just register into the existing entry.
 		// The daemon's ring buffer is delivered once, on the first subscribe
-		// — so `replay: true` only makes sense on a fresh subscription.
-		// Loud-fail the surprising case where a later subscriber asks for
-		// replay; the caller needs to replay from a server-side cache
-		// instead (see terminal.ts replayBuffer).
+		// — so `replay: true` is best-effort: a later subscriber joins the
+		// live stream without it (the ring was already consumed by the first
+		// subscriber in this process — e.g. an in-process re-adoption after
+		// the sessions map was rebuilt). Callers that need history for such
+		// clients replay from the server-side cache instead (see terminal.ts
+		// replayBuffer).
 		if (!wasFirst && opts.replay) {
-			throw new Error(
-				`subscribe(${id}): replay is not available on a second subscribe; the daemon's buffer was already consumed.`,
+			console.warn(
+				`[daemon-client] subscribe(${id}): ring replay unavailable on a repeat subscribe; joining live stream only`,
 			);
 		}
 		if (wasFirst) {

--- a/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
@@ -9,10 +9,21 @@ function preambleString(tracker: ReturnType<typeof createModeTracker>): string {
 	return bytes ? dec.decode(bytes) : "";
 }
 
+/**
+ * The full sync emitted when every tracked mode is at its default. The
+ * preamble asserts modes in both directions (the attaching xterm may hold
+ * non-default state from a restored snapshot), so defaults are explicit
+ * disables — except DECOM (`?6`, homes the cursor) and synchronized output
+ * (`?2026h` would suspend rendering), which are asymmetric by design.
+ */
+const DEFAULT_SYNC =
+	"\x1b[?1l\x1b[?66l\x1b[?2004l\x1b[4l\x1b[?45l\x1b[?1004l" +
+	"\x1b[?25h\x1b[?7h\x1b[?2026l\x1b[?1003l\x1b[=0;1u";
+
 describe("createModeTracker", () => {
-	test("default state needs no preamble", () => {
+	test("default state emits the full both-directions sync", () => {
 		const t = createModeTracker(120, 32);
-		expect(t.buildPreamble()).toBeNull();
+		expect(preambleString(t)).toBe(DEFAULT_SYNC);
 		t.dispose();
 	});
 
@@ -27,34 +38,38 @@ describe("createModeTracker", () => {
 			t.feed(enc.encode(filler));
 		}
 
-		expect(preambleString(t)).toBe("\x1b[=7;1u");
+		expect(preambleString(t)).toContain("\x1b[=7;1u");
 		t.dispose();
 	});
 
-	test("preamble drops kitty after explicit pop", () => {
+	test("preamble disarms kitty after explicit pop", () => {
 		const t = createModeTracker(120, 32);
 		t.feed(enc.encode("\x1b[>7u"));
-		expect(preambleString(t)).toBe("\x1b[=7;1u");
+		expect(preambleString(t)).toContain("\x1b[=7;1u");
 
 		t.feed(enc.encode("\x1b[<u"));
-		expect(t.buildPreamble()).toBeNull();
+		expect(preambleString(t)).toContain("\x1b[=0;1u");
+		expect(preambleString(t)).not.toContain("\x1b[=7;1u");
 		t.dispose();
 	});
 
-	test("preamble drops kitty after explicit set-to-zero", () => {
+	test("preamble disarms kitty after explicit set-to-zero", () => {
 		const t = createModeTracker(120, 32);
 		t.feed(enc.encode("\x1b[>7u"));
 		t.feed(enc.encode("\x1b[=0;1u"));
-		expect(t.buildPreamble()).toBeNull();
+		expect(preambleString(t)).toContain("\x1b[=0;1u");
+		expect(preambleString(t)).not.toContain("\x1b[=7;1u");
 		t.dispose();
 	});
 
-	test("bracketed paste mode is captured", () => {
+	test("bracketed paste mode is asserted in both directions", () => {
 		const t = createModeTracker(120, 32);
 		t.feed(enc.encode("\x1b[?2004h"));
 		expect(preambleString(t)).toContain("\x1b[?2004h");
 		t.feed(enc.encode("\x1b[?2004l"));
-		expect(preambleString(t)).not.toContain("?2004");
+		// Explicit disable, not silence: the attaching xterm may still be
+		// armed from before a reattach gap.
+		expect(preambleString(t)).toContain("\x1b[?2004l");
 		t.dispose();
 	});
 
@@ -69,6 +84,16 @@ describe("createModeTracker", () => {
 		const preamble = preambleString(t);
 		expect(preamble).toContain("\x1b[?1004h");
 		expect(preamble).toContain("\x1b[?1002h");
+		expect(preamble).not.toContain("\x1b[?1004l");
+		expect(preamble).not.toContain("\x1b[?1003l");
+		t.dispose();
+	});
+
+	test("mouse tracking off is an explicit disarm", () => {
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode("\x1b[?1002h"));
+		t.feed(enc.encode("\x1b[?1002l"));
+		expect(preambleString(t)).toContain("\x1b[?1003l");
 		t.dispose();
 	});
 
@@ -85,12 +110,52 @@ describe("createModeTracker", () => {
 		t.dispose();
 	});
 
-	test("show-cursor only emitted when explicitly hidden", () => {
+	test("cursor visibility is asserted in both directions", () => {
 		const t = createModeTracker(120, 32);
-		expect(t.buildPreamble()).toBeNull();
 		t.feed(enc.encode("\x1b[?25l"));
 		expect(preambleString(t)).toContain("\x1b[?25l");
+		// A show must be re-asserted too: the attaching xterm may hold a
+		// hidden cursor from a restored snapshot or an earlier preamble.
+		t.feed(enc.encode("\x1b[?25h"));
+		const p = preambleString(t);
+		expect(p).toContain("\x1b[?25h");
+		expect(p).not.toContain("\x1b[?25l");
 		t.dispose();
+	});
+
+	test("preamble is a fixpoint: applying it to a fresh peer reproduces it", () => {
+		// The property the resync depends on: after a peer consumes the
+		// preamble, its mode state equals the tracker's — so a second
+		// preamble built from the peer is byte-identical.
+		const source = createModeTracker(120, 32);
+		source.feed(
+			enc.encode("\x1b[?2004h\x1b[?1004h\x1b[?1002h\x1b[?25l\x1b[?1h\x1b[>7u"),
+		);
+		const peer = createModeTracker(120, 32);
+		const preamble = source.buildPreamble();
+		if (!preamble) throw new Error("expected a preamble");
+		peer.feed(preamble);
+		expect(preambleString(peer)).toBe(dec.decode(preamble));
+		source.dispose();
+		peer.dispose();
+	});
+
+	test("default-state preamble does not move the peer's cursor", () => {
+		// Guards the DECOM exception: `?6h`/`?6l` home the cursor, so the
+		// preamble must never emit `?6l` for a default-state program. A
+		// regression here teleports the cursor of every idle terminal on
+		// every silent reconnect.
+		const source = createModeTracker(120, 32);
+		const peer = createModeTracker(120, 32);
+		peer.feed(enc.encode("line one\r\nab"));
+		const before = peer.cursorPosition();
+		expect(before).toEqual({ x: 2, y: 1 });
+		const preamble = source.buildPreamble();
+		if (!preamble) throw new Error("expected a preamble");
+		peer.feed(preamble);
+		expect(peer.cursorPosition()).toEqual(before);
+		source.dispose();
+		peer.dispose();
 	});
 
 	test("resize is idempotent and doesn't reset mode state", () => {
@@ -99,7 +164,7 @@ describe("createModeTracker", () => {
 		t.resize(80, 24);
 		t.resize(80, 24);
 		t.resize(160, 50);
-		expect(preambleString(t)).toBe("\x1b[=7;1u");
+		expect(preambleString(t)).toContain("\x1b[=7;1u");
 		t.dispose();
 	});
 
@@ -108,7 +173,7 @@ describe("createModeTracker", () => {
 		t.feed(enc.encode("\x1b["));
 		t.feed(enc.encode(">7"));
 		t.feed(enc.encode("u"));
-		expect(preambleString(t)).toBe("\x1b[=7;1u");
+		expect(preambleString(t)).toContain("\x1b[=7;1u");
 		t.dispose();
 	});
 });

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -1,8 +1,9 @@
 // Tracks terminal-mode state (kitty keyboard, bracketed paste, focus, mouse,
-// app cursor, …) by feeding every PTY-output chunk through a headless
-// xterm.js. `buildPreamble()` returns the byte sequence that brings a freshly
-// reattached renderer xterm back to the modes the running program already
-// believes are active.
+// app cursor, cursor visibility, …) by feeding every PTY-output chunk through
+// a headless xterm.js. `buildPreamble()` returns the byte sequence that brings
+// an attaching renderer xterm — fresh, rebuilt from a persisted snapshot, or
+// long-lived with arbitrarily diverged mode state — to the modes the running
+// program believes are active.
 //
 // Live programs typically set these modes ONCE at startup (e.g. codex emits
 // `\x1b[>7u` to enable kitty keyboard). Those bytes are broadcast straight to
@@ -91,18 +92,33 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		const m = term.modes;
 		const parts: string[] = [];
 
-		if (m.applicationCursorKeysMode) parts.push("\x1b[?1h");
-		if (m.applicationKeypadMode) parts.push("\x1b[?66h");
-		if (m.bracketedPasteMode) parts.push("\x1b[?2004h");
-		if (m.insertMode) parts.push("\x1b[4h");
+		// The preamble is an authoritative resync, not a diff against xterm
+		// defaults: the attaching xterm is not always fresh. It may be rebuilt
+		// from a persisted SerializeAddon snapshot (which bakes in whatever
+		// modes were active at capture — e.g. `?25l` when the snapshot caught
+		// an agent CLI mid-repaint, stranding the cursor invisible), or be a
+		// long-lived xterm reattaching after a gap whose mode restores were
+		// lost. So every mode is asserted in BOTH directions, the way tmux
+		// resyncs a client tty on attach (tty.c: tty->mode = ALL_MODES, then
+		// diff down). The two exceptions below are modes whose set/reset has
+		// side effects beyond the flag itself.
+		parts.push(m.applicationCursorKeysMode ? "\x1b[?1h" : "\x1b[?1l");
+		parts.push(m.applicationKeypadMode ? "\x1b[?66h" : "\x1b[?66l");
+		parts.push(m.bracketedPasteMode ? "\x1b[?2004h" : "\x1b[?2004l");
+		parts.push(m.insertMode ? "\x1b[4h" : "\x1b[4l");
+		// Exception: DECOM (?6) is asserted only when set — both DECSET and
+		// DECRST home the cursor, so an unconditional `?6l` would teleport
+		// the client's cursor on every attach.
 		if (m.originMode) parts.push("\x1b[?6h");
-		if (m.reverseWraparoundMode) parts.push("\x1b[?45h");
-		if (m.sendFocusMode) parts.push("\x1b[?1004h");
-		// Inverted: defaults true, only emit when explicitly disabled.
-		if (!m.showCursor) parts.push("\x1b[?25l");
-		if (!m.wraparoundMode) parts.push("\x1b[?7l");
-		// synchronizedOutputMode intentionally omitted — re-asserting it on
-		// attach would suspend rendering until the next end-marker.
+		parts.push(m.reverseWraparoundMode ? "\x1b[?45h" : "\x1b[?45l");
+		parts.push(m.sendFocusMode ? "\x1b[?1004h" : "\x1b[?1004l");
+		parts.push(m.showCursor ? "\x1b[?25h" : "\x1b[?25l");
+		parts.push(m.wraparoundMode ? "\x1b[?7h" : "\x1b[?7l");
+		// Exception: synchronized output (?2026) is only ever cleared —
+		// re-asserting `h` would suspend the client's rendering until the
+		// program's next end-marker, while `l` un-wedges a client whose
+		// end-marker was lost in a reattach gap.
+		if (!m.synchronizedOutputMode) parts.push("\x1b[?2026l");
 
 		switch (m.mouseTrackingMode) {
 			case "x10":
@@ -118,17 +134,18 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 				parts.push("\x1b[?1003h");
 				break;
 			case "none":
+				// Any mouse level's reset clears the whole protocol, so one
+				// `?1003l` disarms a client whose TUI died with tracking on.
+				parts.push("\x1b[?1003l");
 				break;
 		}
 
 		const kittyFlags = internals._core?.coreService?.kittyKeyboard?.flags ?? 0;
-		if (kittyFlags > 0) {
-			// `=N;1u` sets flags directly — restoring effective state to a
-			// fresh peer, not modeling the program's push/pop stack.
-			parts.push(`\x1b[=${kittyFlags};1u`);
-		}
+		// `=N;1u` sets flags directly — restoring effective state to the
+		// peer, not modeling the program's push/pop stack. `=0;1u` likewise
+		// disarms a client left CSI-u encoded by an uncleanly killed TUI.
+		parts.push(`\x1b[=${kittyFlags};1u`);
 
-		if (parts.length === 0) return null;
 		return new TextEncoder().encode(parts.join(""));
 	};
 

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -728,14 +728,16 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
-	test("replayOnAdoption: false suppresses ring-buffer replay on reconnect", async () => {
-		// Regression for the duplicated-output-on-daemon-swap bug: when the
-		// renderer's xterm scrollback survives the WS reconnect (which it
-		// does), replaying the daemon's ring buffer rewrites bytes the user
-		// has already seen and the conversation appears doubled. This test
-		// drives the createTerminalSessionInternal layer that the WS upgrade
-		// handler maps to.
-		const terminalId = `e2e-noreplay-${randomUUID().slice(0, 8)}`;
+	test("adoption always replays the ring so the mode tracker is rebuilt", async () => {
+		// Regression for the blind-tracker bug: adopting without the daemon's
+		// ring replay left the fresh ModeTracker at defaults, so it never
+		// learned the running program's modes — attach preambles asserted the
+		// wrong state and host-side focus forwarding (gated on
+		// isFocusReportingActive) silently died until the program happened to
+		// re-arm. Client-side double-paint protection now lives at the attach
+		// layer (seq reanchor accounting; legacy `?replay=0` FIFO drop), not
+		// by starving the tracker.
+		const terminalId = `e2e-trackerreplay-${randomUUID().slice(0, 8)}`;
 
 		const first = await createTerminalSessionInternal({
 			terminalId,
@@ -746,11 +748,14 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		assert.ok(!("error" in first));
 		if ("error" in first) return;
 
-		// Seed the daemon's ring buffer with a sentinel — that's what would
-		// be replayed on a normal adoption.
-		const SENTINEL = `noreplay-sentinel-${randomUUID().slice(0, 6)}`;
-		first.pty.write(`echo ${SENTINEL}\n`);
+		// Make the "program" arm modes and hide the cursor — bytes that only
+		// exist in the daemon's ring by the time we adopt.
+		const SENTINEL = `tracker-sentinel-${randomUUID().slice(0, 6)}`;
+		first.pty.write(
+			`printf '\\033[?2004h\\033[?1004h\\033[?25l'; echo ${SENTINEL}\n`,
+		);
 		await waitForOutput(first.pty, SENTINEL, 3000);
+		await waitFor(() => first.modeTracker.isBracketedPasteActive(), 3000);
 
 		// Simulate onDaemonDisconnect: host-service drops its in-memory
 		// sessions; the daemon (and its ring buffer) survives.
@@ -762,7 +767,6 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			workspaceId,
 			db,
 			listed: true,
-			replayOnAdoption: false,
 		});
 		assert.ok(!("error" in second));
 		if ("error" in second) return;
@@ -772,18 +776,33 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			"adopted session should have same shell pid",
 		);
 
-		// The shell may still produce live prompt bytes after reconnect, but
-		// the daemon ring-buffer sentinel from the previous host lifetime must
-		// not be replayed when replayOnAdoption=false.
-		await new Promise((r) => setTimeout(r, 500));
+		// The attach path awaits this before building any preamble.
+		await second.adoptionReplaySettled;
 
-		const bufferedAfterAdoption = Buffer.concat(
+		const replayed = Buffer.concat(
 			second.buffer.map((b) => Buffer.from(b)),
 		).toString("utf8");
 		assert.equal(
-			bufferedAfterAdoption.includes(SENTINEL),
-			false,
-			`adopted session replayed prior output despite replayOnAdoption=false: ${JSON.stringify(bufferedAfterAdoption.slice(0, 200))}`,
+			replayed.includes(SENTINEL),
+			true,
+			"daemon ring must be replayed into the adopted session",
+		);
+		assert.equal(
+			second.modeTracker.isBracketedPasteActive(),
+			true,
+			"rebuilt mode tracker must have learned bracketed paste from the ring",
+		);
+		assert.equal(
+			second.modeTracker.isFocusReportingActive(),
+			true,
+			"rebuilt mode tracker must have learned focus reporting from the ring",
+		);
+		const preamble = new TextDecoder().decode(
+			second.modeTracker.buildPreamble() ?? new Uint8Array(),
+		);
+		assert.ok(
+			preamble.includes("\x1b[?25l"),
+			"preamble must re-hide the cursor the program hid before the restart",
 		);
 
 		// Sanity check: live output still flows post-reattach.

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -536,6 +536,15 @@ interface TerminalSession {
 	modeTracker: ModeTracker;
 
 	/**
+	 * Resolves once the daemon's post-adoption ring-buffer replay has
+	 * quiesced (immediately for non-adopted sessions). Attach paths await it
+	 * before delivering to a socket, so the mode preamble is built from a
+	 * tracker that has actually seen the program's mode bytes and replayed
+	 * bytes never broadcast to a just-attached client.
+	 */
+	adoptionReplaySettled: Promise<void>;
+
+	/**
 	 * Stream identity for seq-aware clients. Fresh per TerminalSession object
 	 * (create, adopt, respawn) — a client anchored to a different epoch has an
 	 * unknowable position (the byte counter restarted) and gets a reanchor.
@@ -979,7 +988,7 @@ async function getOrAdoptSession({
 			});
 			if ("error" in adopted) return adopted;
 
-			await waitForAdoptionReplay(adopted);
+			await adopted.adoptionReplaySettled;
 			return adopted;
 		})();
 		adoptionsInFlight.set(terminalId, attempt);
@@ -2316,13 +2325,6 @@ interface CreateTerminalSessionOptions {
 	/** Only recover an already-live daemon session; never spawn a new PTY. */
 	adoptOnly?: boolean;
 	/**
-	 * Replay the daemon's ring buffer on subscribe. Default true. Pass false
-	 * when the renderer's xterm already has the scrollback — replaying then
-	 * doubles the visible output. Tradeoff: bytes the PTY produced during
-	 * the WS-down window are dropped (sub-second on a daemon swap).
-	 */
-	replayOnAdoption?: boolean;
-	/**
 	 * Deliver a "session restored" separator ahead of the first replay. Set on
 	 * the cold-restore respawn path, where the renderer paints stale scrollback
 	 * above a brand-new shell.
@@ -2376,7 +2378,6 @@ export async function createTerminalSessionInternal({
 	cols: requestedCols,
 	rows: requestedRows,
 	adoptOnly = false,
-	replayOnAdoption = true,
 	restoredNotice = false,
 }: CreateTerminalSessionOptions): Promise<
 	TerminalSession | CreateSessionError
@@ -2638,6 +2639,7 @@ export async function createTerminalSessionInternal({
 		launchShellName: basename(shell),
 		portHintDecoder: new StringDecoder("utf8"),
 		modeTracker: createModeTracker(cols, rows),
+		adoptionReplaySettled: Promise.resolve(),
 		epoch: randomBytes(8).toString("hex"),
 		outputSeq: 0,
 		retained: [],
@@ -2666,9 +2668,17 @@ export async function createTerminalSessionInternal({
 		);
 	}
 
+	// Always request the daemon's ring on subscribe: it is the only way to
+	// rebuild the mode tracker after adoption (a tracker that never sees the
+	// program's `?25l`/`?1004h`/kitty bytes builds wrong preambles and
+	// disables host-side focus forwarding). Whether the replayed BYTES reach
+	// any client is decided per-attach: seq clients are protected by
+	// reanchor/anchor accounting, legacy `?replay=0` clients get the FIFO
+	// dropped at attach. Fresh (non-adopted) sessions have an empty ring, so
+	// replay is a no-op there.
 	session.unsubscribeDaemon = daemon.subscribe(
 		terminalId,
-		{ replay: replayOnAdoption },
+		{ replay: true },
 		{
 			onOutput(chunk) {
 				// Bytes flow daemon → host → xterm without UTF-8 decoding;
@@ -2776,6 +2786,12 @@ export async function createTerminalSessionInternal({
 			},
 		},
 	);
+
+	// The ring replay lands asynchronously after subscribe; attach paths
+	// await this so the first preamble reflects the rebuilt tracker.
+	if (isAdopted) {
+		session.adoptionReplaySettled = waitForAdoptionReplay(session);
+	}
 
 	if (initialCommand) {
 		queueInitialCommand(session, initialCommand);
@@ -2904,6 +2920,14 @@ export function registerWorkspaceTerminalRoute({
 
 				sendMessage(ws, { type: "title", title: session.title });
 				if (seqRequest.kind === "legacy") {
+					// Pre-seq contract: `?replay=0` means "my xterm already has
+					// the scrollback". Adoption now always pulls the daemon ring
+					// (the mode tracker needs it), so drop the FIFO here instead
+					// of double-painting this client.
+					if (c.req.query("replay") === "0") {
+						session.buffer.length = 0;
+						session.bufferBytes = 0;
+					}
 					replayBuffer(session, ws);
 				} else {
 					sendSeqAttach(session, ws, seqRequest);
@@ -3009,13 +3033,6 @@ export function registerWorkspaceTerminalRoute({
 					db,
 					eventBus,
 					adoptOnly: true,
-					// Only a client with an empty xterm wants the daemon ring
-					// dumped at it. Anchored/reanchor clients keep their own
-					// (better) copy; legacy clients signal via `?replay=0`.
-					replayOnAdoption:
-						seqRequest.kind === "legacy"
-							? c.req.query("replay") !== "0"
-							: seqRequest.kind === "new",
 				});
 				if (!("error" in adopted)) return adopted;
 				// Daemon unreachable ≠ PTY lost: the shell may still be alive behind
@@ -3069,6 +3086,12 @@ export function registerWorkspaceTerminalRoute({
 							ws.close(transient ? 1013 : 1011, toWsCloseReason(session.error));
 							return;
 						}
+						// A just-adopted session may still be receiving the daemon's
+						// ring replay: wait for it to quiesce so the mode preamble
+						// reflects the program's real state and the replayed bytes
+						// don't broadcast to this socket. Resolved immediately in
+						// every other case.
+						await session.adoptionReplaySettled;
 						if (ws.readyState !== SOCKET_OPEN) return;
 						attachSocketToSession(session, ws);
 					})().catch((error) => {


### PR DESCRIPTION
## Summary
- Fixes the intermittent "cursor disappears in my agent CLI until I tab away and back" bug, reproduced end-to-end with the real Cursor agent CLI.
- Two host-side root causes: the attach mode-preamble only asserted non-default modes (assuming a factory-fresh xterm), and daemon-session adoption after a host-service restart could leave the rebuilt ModeTracker blind (never fed the ring), silently disabling focus forwarding.

## Why / Context
Users reported cursors vanishing in agent CLIs (Cursor agent specifically), fixed by tabbing out of the terminal and back in. Investigation found two distinct strands with one shared shape — the renderer xterm's mode state diverging from the program's, with nothing repairing it:

1. **Real-cursor programs** (shells, vim, TUIs): serialize snapshots legitimately end in `?25l` when captured mid-repaint. A rebuilt xterm restores that hidden state, and the old preamble emitted nothing when the tracker said "shown" — stranded until the program happened to repaint.
2. **Cursor agent itself** draws its own cursor gated on focus reports (`?1004`). After every host-service restart (i.e. every app update), adoption skipped the ring replay for anchored clients, so the rebuilt tracker never learned `?1004h` → `syncPtyFocus` gated off → the attach-time focus re-assert (#6300) never reached the CLI → its stale "unfocused" belief stuck and the cursor stayed gone while typing. Tabbing panes fired in-band reports from the (snapshot-restored, still-armed) xterm, which is exactly why the workaround worked.

## How It Works
- `buildPreamble()` is now an authoritative both-directions resync — every tracked mode asserted `h` or `l` (the way tmux resets `tty->mode = ALL_MODES` and diffs down on client attach). Two documented exceptions: DECOM (`?6l` homes the cursor) and synchronized output (`?2026h` would suspend rendering; `?2026l` is emitted to un-wedge).
- Adoption always subscribes with `replay: true` so the tracker is rebuilt from the daemon ring; a per-session `adoptionReplaySettled` promise gates the first attach so preambles reflect the fed tracker and replay bytes never broadcast to a just-attached socket. Seq clients stay double-paint-safe via existing reanchor accounting; legacy `?replay=0` clients get the FIFO dropped at attach.
- `DaemonClient.subscribe` degrades a repeat replay request to live-only (warn) instead of throwing — in-process re-adoption is now a legitimate caller.

## Manual QA (done, real app over CDP)
- Real-cursor strand: staged hide-mid-repaint → snapshot persist → reload → 3MB gap (ring eviction) → reanchor. Pre-fix: focused prompt with no cursor (`isCursorHidden=true`); post-fix: cursor present. Screenshots captured.
- Cursor agent (v2026.08.11): blur → detach-persist → `hostServiceCoordinator.restart` (daemon adopted) → reload → reattach → type with zero focus events. Pre-fix: no cursor while typing (reattach `seq=0`, tracker blind), tab-out/in heals it — the reported behavior exactly. Post-fix: cursor present immediately (reattach `seq=6840`, tracker fed).
- Full evidence page with before/after screenshots and numeric ground truth: private artifact (ask @hoakiet98), https://claude.ai/code/artifact/eed01d35-7d8d-40cf-9ea2-2955cb1cd40a

## Testing
- `bun run typecheck` (host-service, pty-daemon)
- `bun test` full host-service suite: 1110 pass / 0 fail
- `node --test` terminal.adoption + terminal.seq-catchup: 23/23, including a new regression test that the rebuilt tracker re-learns `?2004h`/`?1004h`/`?25l` from the ring
- Mode-tracker unit tests rewritten: full default-sync pin, round-trip fixpoint (preamble fed to a fresh tracker reproduces itself), no-cursor-teleport guard for the DECOM exception
- Not run locally: `DaemonClient.node-test.ts` (daemon-spawning; CI covers it)

## Design Decisions
- **Both-directions preamble instead of renderer-side snapshot sanitizing**: the preamble is the one resync point that repairs *every* divergence source (stale snapshot, prior preamble, missed bytes), matching tmux/wezterm semantics rather than string-scanning replay payloads.
- **Adoption replay always feeds the tracker, delivery decided per-client**: the old `replayOnAdoption` flag conflated "client wants bytes" with "tracker needs history".

## Risks / Rollout
- Risk: preamble is now sent on every attach (~60 bytes, idempotent assertions) to all client types including mobile; adoption attaches wait ≤500ms for ring replay to settle (bounded, matches the existing headless path).
- Rollback: revert cleanly; no schema or protocol changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resyncs terminal modes on every attach and rebuilds the mode tracker on adoption to stop disappearing cursors in agent CLIs. Previously, the attach preamble only asserted non‑default modes and adoption could skip ring replay, leaving the tracker at defaults and disabling focus forwarding; now the preamble asserts each tracked mode on or off (with safe exceptions) and adoption always replays the daemon ring to feed the tracker before the first attach.

- Preamble: `buildPreamble()` emits a both‑directions resync for application cursor/keyboard, bracketed paste, insert, reverse wrap, focus, cursor visibility, wraparound, mouse, and kitty keyboard. Exceptions: do not emit `?6l` (DECOM homes cursor) and only emit `?2026l` (avoid suspending rendering).
- Adoption: always subscribe with `{ replay: true }` and expose `adoptionReplaySettled`; attach paths await it so preambles reflect learned modes and replay bytes do not broadcast to the new socket. Seq clients rely on reanchor accounting; legacy clients with `?replay=0` have the FIFO dropped at attach.
- `DaemonClient.subscribe`: a repeat replay request now logs a warning and joins the live stream instead of throwing.
- Side effects and rollout: each attach sends ~60B of idempotent mode assertions; adoption attaches may wait up to ~500ms for ring replay. No schema or protocol changes; clean rollback.

<sup>Written for commit 09b34bc5d14ecf29521331c0861163abdc33c0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal session adoption so existing output and terminal modes are reliably restored.
  - Prevented duplicate subscription requests from interrupting live event delivery.
  - Fixed terminal mode synchronization for mouse tracking, keyboard input, bracketed paste, focus reporting, cursor visibility, and synchronized output.
  - Preserved cursor position during terminal state restoration.
  - Prevented duplicate scrollback when reconnecting to an existing terminal session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->