### PR TITLE
fix(host-service,pty-daemon): keep tests out of the real daemon namespace and protect caller ancestry from group kills

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -1334,7 +1334,7 @@ describe("ptyDaemonSocketPath", () => {
 		return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 	};
 
-	test("every production home keeps the legacy org-only path", () => {
+	test("default production homes keep the legacy org-only path", () => {
 		expect(ptyDaemonSocketPath(ORG, { NODE_ENV: "production" })).toBe(
 			legacyPath(),
 		);
@@ -1344,12 +1344,44 @@ describe("ptyDaemonSocketPath", () => {
 				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
 			}),
 		).toBe(legacyPath());
+	});
+
+	test("any non-default home is namespaced, regardless of NODE_ENV", () => {
+		// Two instances of the same org must never share a socket — a test
+		// or custom-home instance on the org-only socket can adopt/reap/kill
+		// another instance's PTYs. Existing daemons stay adoptable through
+		// the manifest's stored socketPath, so this costs no continuity.
+		for (const NODE_ENV of ["production", "test", undefined]) {
+			expect(
+				ptyDaemonSocketPath(ORG, {
+					NODE_ENV,
+					SUPERSET_HOME_DIR: "/tmp/custom-home-a",
+				}),
+			).not.toBe(legacyPath());
+		}
+	});
+
+	test("test-runner contexts require an isolated home", () => {
+		expect(() => ptyDaemonSocketPath(ORG, { NODE_ENV: "test" })).toThrow(
+			/isolated temp dir/,
+		);
+		expect(() =>
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
+			}),
+		).toThrow(/isolated temp dir/);
+		expect(() =>
+			ptyDaemonSocketPath(ORG, {
+				NODE_TEST_CONTEXT: "child-v8",
+			} as NodeJS.ProcessEnv),
+		).toThrow(/isolated temp dir/);
 		expect(
 			ptyDaemonSocketPath(ORG, {
-				NODE_ENV: "production",
-				SUPERSET_HOME_DIR: "/tmp/custom-production-home",
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: "/tmp/isolated-test-home",
 			}),
-		).toBe(legacyPath());
+		).not.toBe(legacyPath());
 	});
 
 	test("non-default development homes get their own stable daemon socket", () => {

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -1346,6 +1346,25 @@ describe("ptyDaemonSocketPath", () => {
 		).toBe(legacyPath());
 	});
 
+	test("equivalent spellings of one custom home share a socket", () => {
+		const canonical = ptyDaemonSocketPath(ORG, {
+			NODE_ENV: "production",
+			SUPERSET_HOME_DIR: "/tmp/custom-home-alias",
+		});
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "production",
+				SUPERSET_HOME_DIR: "/tmp/custom-home-alias/",
+			}),
+		).toBe(canonical);
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "production",
+				SUPERSET_HOME_DIR: "/tmp/elsewhere/../custom-home-alias",
+			}),
+		).toBe(canonical);
+	});
+
 	test("any non-default home is namespaced, regardless of NODE_ENV", () => {
 		// Two instances of the same org must never share a socket — a test
 		// or custom-home instance on the org-only socket can adopt/reap/kill

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -154,7 +154,11 @@ export function ptyDaemonSocketPath(
 	const defaultHome = path.join(os.homedir(), ".superset");
 	const isDefaultHome =
 		!home || path.resolve(home) === path.resolve(defaultHome);
-	const key = isDefaultHome ? organizationId : `${organizationId}:${home}`;
+	// Hash the RESOLVED home so equivalent spellings of one custom home
+	// (trailing slash, relative segments) land on the same socket.
+	const key = isDefaultHome
+		? organizationId
+		: `${organizationId}:${path.resolve(home)}`;
 	const shortId = createHash("sha256").update(key).digest("hex").slice(0, 12);
 	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -31,6 +31,7 @@ import { DaemonClient } from "../terminal/DaemonClient/index.ts";
 import { EXPECTED_DAEMON_VERSION } from "./expected-version.ts";
 import { MAX_DAEMON_LOG_BYTES, openRotatingLogFd } from "./log-fd.ts";
 import {
+	assertIsolatedDaemonNamespaceInTests,
 	isProcessAlive,
 	type PtyDaemonManifest,
 	ptyDaemonManifestDir,
@@ -137,24 +138,23 @@ export function shouldKillStaleDaemonForDev(
  * file mode (0600, set by the daemon's Server.listen) is the auth boundary;
  * the directory permissions don't matter.
  *
- * Development manifests are per-home, so a home-agnostic socket lets a dev
- * instance adopt the packaged app's daemon through the manifest-missing
- * socket-probe fallback. Namespace only development worktrees with a
- * non-default `SUPERSET_HOME_DIR`; all production paths deliberately keep the
- * legacy org-only socket so existing packaged daemons remain adoptable.
+ * Any non-default `SUPERSET_HOME_DIR` (dev worktrees, test temp homes)
+ * namespaces the socket by home as well as org — two instances of the same
+ * org must never share a socket, or one instance's supervisor/reaper acts
+ * on the other's PTYs. All default-home (production) paths deliberately
+ * keep the legacy org-only socket so existing packaged daemons remain
+ * adoptable across updates.
  */
 export function ptyDaemonSocketPath(
 	organizationId: string,
 	env: NodeJS.ProcessEnv = process.env,
 ): string {
+	assertIsolatedDaemonNamespaceInTests(env);
 	const home = env.SUPERSET_HOME_DIR;
 	const defaultHome = path.join(os.homedir(), ".superset");
 	const isDefaultHome =
 		!home || path.resolve(home) === path.resolve(defaultHome);
-	const key =
-		env.NODE_ENV === "development" && !isDefaultHome
-			? `${organizationId}:${home}`
-			: organizationId;
+	const key = isDefaultHome ? organizationId : `${organizationId}:${home}`;
 	const shortId = createHash("sha256").update(key).digest("hex").slice(0, 12);
 	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }

--- a/packages/host-service/src/daemon/manifest.test.ts
+++ b/packages/host-service/src/daemon/manifest.test.ts
@@ -110,6 +110,24 @@ describe("assertIsolatedDaemonNamespaceInTests", () => {
 				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
 			}),
 		).toThrow(/isolated temp dir/);
+		// Aliases of the default home must not slip past the guard.
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: `${path.join(os.homedir(), ".superset")}${path.sep}`,
+			}),
+		).toThrow(/isolated temp dir/);
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: path.join(
+					os.homedir(),
+					"somewhere",
+					"..",
+					".superset",
+				),
+			}),
+		).toThrow(/isolated temp dir/);
 	});
 
 	test("passes with an isolated home, and outside test runners", () => {

--- a/packages/host-service/src/daemon/manifest.test.ts
+++ b/packages/host-service/src/daemon/manifest.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	assertIsolatedDaemonNamespaceInTests,
 	type PtyDaemonManifest,
 	readPtyDaemonManifest,
 	removePtyDaemonManifest,
@@ -90,5 +91,39 @@ describe("PtyDaemonManifest", () => {
 			JSON.stringify({ pid: 1 }),
 		);
 		expect(readPtyDaemonManifest(TEST_ORG)).toBeNull();
+	});
+});
+
+describe("assertIsolatedDaemonNamespaceInTests", () => {
+	test("throws for test-runner contexts on the default home", () => {
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({ NODE_ENV: "test" }),
+		).toThrow(/isolated temp dir/);
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({
+				NODE_TEST_CONTEXT: "child-v8",
+			} as NodeJS.ProcessEnv),
+		).toThrow(/isolated temp dir/);
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
+			}),
+		).toThrow(/isolated temp dir/);
+	});
+
+	test("passes with an isolated home, and outside test runners", () => {
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({
+				NODE_ENV: "test",
+				SUPERSET_HOME_DIR: "/tmp/isolated-home",
+			}),
+		).not.toThrow();
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({ NODE_ENV: "production" }),
+		).not.toThrow();
+		expect(() =>
+			assertIsolatedDaemonNamespaceInTests({ NODE_ENV: "development" }),
+		).not.toThrow();
 	});
 });

--- a/packages/host-service/src/daemon/manifest.ts
+++ b/packages/host-service/src/daemon/manifest.ts
@@ -30,7 +30,43 @@ export interface PtyDaemonManifest {
 	handoffSuccessorPid?: number;
 }
 
+/**
+ * True when running under a test runner: `bun test` sets NODE_ENV=test,
+ * `node --test` marks its spawned test processes with NODE_TEST_CONTEXT.
+ */
+export function isTestRunnerContext(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return env.NODE_ENV === "test" || env.NODE_TEST_CONTEXT !== undefined;
+}
+
+/**
+ * Tests must never resolve the REAL daemon namespace (`~/.superset`
+ * manifests, org-keyed sockets): a test that reads a real manifest or
+ * dials a real socket can adopt, reap, or kill daemons and shells that
+ * belong to running desktop instances — this has killed live dev stacks
+ * and their agents' terminals. Fail loudly instead: every test that
+ * touches the daemon layer must point SUPERSET_HOME_DIR at an isolated
+ * temp dir (and usually SUPERSET_PTY_DAEMON_SOCKET at a temp socket).
+ */
+export function assertIsolatedDaemonNamespaceInTests(
+	env: NodeJS.ProcessEnv = process.env,
+): void {
+	if (!isTestRunnerContext(env)) return;
+	const home = env.SUPERSET_HOME_DIR;
+	const defaultHome = join(homedir(), ".superset");
+	if (!home || home === defaultHome) {
+		throw new Error(
+			"refusing to touch the default ~/.superset daemon namespace from a " +
+				"test: set SUPERSET_HOME_DIR to an isolated temp dir (and " +
+				"SUPERSET_PTY_DAEMON_SOCKET to a temp socket) before using the " +
+				"daemon layer.",
+		);
+	}
+}
+
 function supersetHomeDir(): string {
+	assertIsolatedDaemonNamespaceInTests();
 	return process.env.SUPERSET_HOME_DIR || join(homedir(), ".superset");
 }
 

--- a/packages/host-service/src/daemon/manifest.ts
+++ b/packages/host-service/src/daemon/manifest.ts
@@ -11,7 +11,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 export interface PtyDaemonManifest {
 	pid: number;
@@ -55,7 +55,9 @@ export function assertIsolatedDaemonNamespaceInTests(
 	if (!isTestRunnerContext(env)) return;
 	const home = env.SUPERSET_HOME_DIR;
 	const defaultHome = join(homedir(), ".superset");
-	if (!home || home === defaultHome) {
+	// Resolve before comparing: a trailing-slash or relative alias of the
+	// default home must not slip past the guard.
+	if (!home || resolve(home) === resolve(defaultHome)) {
 		throw new Error(
 			"refusing to touch the default ~/.superset daemon namespace from a " +
 				"test: set SUPERSET_HOME_DIR to an isolated temp dir (and " +

--- a/packages/host-service/test/helpers/createTestHost.ts
+++ b/packages/host-service/test/helpers/createTestHost.ts
@@ -80,6 +80,18 @@ export async function createTestHost(
 	const dataDir = mkdtempSync(join(tmpdir(), "host-service-test-db-"));
 	const dbPath = join(dataDir, "host.db");
 
+	// Isolate the daemon namespace for the lifetime of this host: any code
+	// path that resolves manifests or sockets (reaper, adoption, dispose)
+	// must land in this temp home, never `~/.superset` — a test host that
+	// reads real manifests can reap or kill daemons belonging to running
+	// desktop instances. The manifest layer throws in test runs without
+	// this. Restored (not deleted) on dispose so nested harnesses keep
+	// their own isolation.
+	const priorHomeDir = process.env.SUPERSET_HOME_DIR;
+	if (!priorHomeDir) {
+		process.env.SUPERSET_HOME_DIR = dataDir;
+	}
+
 	const sqlite = new BunDatabase(dbPath, { create: true, readwrite: true });
 	sqlite.exec("PRAGMA journal_mode = WAL");
 	sqlite.exec("PRAGMA foreign_keys = ON");
@@ -156,6 +168,9 @@ export async function createTestHost(
 		try {
 			await result.dispose();
 		} finally {
+			if (!priorHomeDir && process.env.SUPERSET_HOME_DIR === dataDir) {
+				delete process.env.SUPERSET_HOME_DIR;
+			}
 			try {
 				sqlite.close();
 			} catch {

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -50,9 +50,13 @@ describe("terminal router integration", () => {
 		await disposeDaemonClient();
 		resetTerminalBaseEnvForTests();
 		__setAccountShellForTesting(undefined);
+		// Dispose BEFORE dropping the isolation env: cleanup paths resolve
+		// daemon manifests/sockets, and without SUPERSET_HOME_DIR they would
+		// hit the real ~/.superset namespace (the manifest layer now throws
+		// on that in tests).
+		await scenario?.dispose();
 		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
 		delete process.env.SUPERSET_HOME_DIR;
-		await scenario?.dispose();
 	});
 
 	test("list returns empty when no sessions exist", async () => {

--- a/packages/pty-daemon/src/process-tree.test.ts
+++ b/packages/pty-daemon/src/process-tree.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { parseProcessTable } from "./process-tree.ts";
+import {
+	collectProcessSignalTargets,
+	parseProcessTable,
+} from "./process-tree.ts";
 
 describe("parseProcessTable", () => {
 	test("parses pid/ppid/pgid/tty columns", () => {
@@ -36,5 +39,55 @@ describe("parseProcessTable", () => {
 			["garbage", "  0  1  1 ?? S", "  100  1  0 ?? S", ""].join("\n"),
 		);
 		expect(rows).toEqual([]);
+	});
+});
+
+describe("collectProcessSignalTargets — caller-ancestry protection", () => {
+	const row = (
+		pid: number,
+		ppid: number,
+		pgid: number,
+		tty: string | null = null,
+	) => ({ pid, ppid, pgid, tty });
+
+	test("never signals a group the caller's ancestor chain belongs to", () => {
+		// A target-tree member sharing a pgid with the caller's ancestor
+		// (a process that never called setsid) must not drag the invoking
+		// shell/terminal/test-runner into a killpg — this has SIGKILLed
+		// developer sessions.
+		const table = [
+			row(process.pid, 4000, 5000),
+			row(4000, 1, 4500), // caller's ancestor
+			row(100, 1, 100), // kill root
+			row(101, 100, 4500), // tree member colliding with ancestor's group
+			row(102, 100, 102), // tree member in its own group
+		];
+		const targets = collectProcessSignalTargets(100, { table });
+		const pgids = targets.filter((t) => t.target === "pgid").map((t) => t.id);
+		const pids = targets.filter((t) => t.target === "pid").map((t) => t.id);
+		expect(pgids).not.toContain(4500);
+		expect(pgids).not.toContain(5000);
+		expect(pgids).toEqual(expect.arrayContaining([100, 102]));
+		// The colliding tree member itself is still signalled by pid.
+		expect(pids).toEqual(expect.arrayContaining([100, 101, 102]));
+		expect(pids).not.toContain(4000);
+		expect(pids).not.toContain(process.pid);
+	});
+
+	test("tty straggler matching never adds the caller's ancestors", () => {
+		const table = [
+			row(process.pid, 4000, 5000, "ttys009"),
+			row(4000, 1, 4500, "ttys009"), // ancestor on the same tty
+			row(100, 1, 100, "ttys009"), // kill root on the session tty
+			row(900, 1, 900, "ttys009"), // unrelated straggler on the tty
+		];
+		const targets = collectProcessSignalTargets(100, {
+			table,
+			ttyName: "ttys009",
+		});
+		const pids = targets.filter((t) => t.target === "pid").map((t) => t.id);
+		expect(pids).toEqual(expect.arrayContaining([100, 900]));
+		expect(pids).not.toContain(4000);
+		expect(pids).not.toContain(process.pid);
 	});
 });

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -72,15 +72,33 @@ export function collectProcessSignalTargets(
 	const signalPids = options.signalPids ?? true;
 	const excludeCurrentProcessGroup = options.excludeCurrentProcessGroup ?? true;
 	const table = options.table ?? readProcessTable();
-	const currentPgid = excludeCurrentProcessGroup
-		? getProcessGroupId(process.pid, table)
-		: null;
+	// Protected set: our own process group AND every ancestor's pid + group.
+	// A kill target's tree never legitimately contains the caller's shell,
+	// terminal, test runner, or CI job — but group collisions (a tree member
+	// that never called setsid) can put them in a target pgid, and one killpg
+	// then takes out the invoking session. This has SIGKILLed developer
+	// shells; treat the ancestor chain as untouchable.
+	const protectedPids = new Set<number>();
+	const protectedPgids = new Set<number>();
+	if (excludeCurrentProcessGroup) {
+		const infoByPidForAncestors = new Map(table.map((row) => [row.pid, row]));
+		let cursor: number | undefined = process.pid;
+		while (cursor !== undefined && cursor > 1 && !protectedPids.has(cursor)) {
+			protectedPids.add(cursor);
+			const row = infoByPidForAncestors.get(cursor);
+			if (!row) break;
+			if (row.pgid > 1) protectedPgids.add(row.pgid);
+			cursor = row.ppid;
+		}
+	}
 	const rootPgid = getProcessGroupId(rootPid, table);
 	const pids = collectProcessTree(rootPid, table);
+	for (const pid of protectedPids) pids.delete(pid);
 	for (const row of table) {
 		if (pids.has(row.pid)) continue;
 		if (row.pid === process.pid) continue;
-		if (currentPgid !== null && row.pgid === currentPgid) continue;
+		if (protectedPids.has(row.pid)) continue;
+		if (protectedPgids.has(row.pgid)) continue;
 		const onSessionTty = options.ttyName != null && row.tty === options.ttyName;
 		const inKnownGroup = options.knownPgids?.has(row.pgid) ?? false;
 		if (onSessionTty || inKnownGroup) pids.add(row.pid);
@@ -94,7 +112,7 @@ export function collectProcessSignalTargets(
 		const info = infoByPid.get(pid);
 		if (!info) continue;
 		if (info.pgid <= 1) continue;
-		if (currentPgid !== null && info.pgid === currentPgid) continue;
+		if (protectedPgids.has(info.pgid)) continue;
 		if (!includeRoot && rootPgid !== null && info.pgid === rootPgid) {
 			continue;
 		}


### PR DESCRIPTION
## Summary
- The host-service test suite could kill **real** daemons and shells on the developer's machine. This PR makes that structurally impossible with three independent guards, then proves it by running the previously-lethal suite with live daemons pid-verified untouched.

## Why / Context
Discovered the hard way while verifying an unrelated fix: running `bun test` in `packages/host-service` on a machine with live dev stacks killed every dev pty-daemon on the box (other agents' worktrees included) and SIGKILLed the invoking shell twice. Three escape routes:

1. **Shared sockets.** `ptyDaemonSocketPath` only namespaced by home dir under `NODE_ENV=development`. Test runners use `test`/unset, so a test computed the org-only socket — the same path a real instance can own.
2. **The real `~/.superset`.** `supersetHomeDir()` silently fell back to the default home, and `reachableDaemonSocketPath()` picks its org from the inherited `ORGANIZATION_ID` env var — so a test host's **terminal reaper** could connect to a real daemon via its real manifest and reap every session that had no row in the *test* DB. This is the specific mechanism that killed the dev stacks.
3. **Group-kill collateral.** `collectProcessSignalTargets` killpg'd every process group any target-tree member belonged to. A tree member that never called `setsid` shares a group with the invoking shell/terminal/test runner — one killpg and the developer's session is gone (observed twice as exit-137 on the test shell itself).

## How It Works
- **Universal socket namespacing**: any non-default `SUPERSET_HOME_DIR` keys the socket by `org:home`, regardless of NODE_ENV. Default-home (production) paths are byte-identical to before, and existing daemons remain adoptable through the manifest's stored `socketPath`.
- **`assertIsolatedDaemonNamespaceInTests`**: under a test runner (bun sets `NODE_ENV=test`; `node --test` sets `NODE_TEST_CONTEXT`), resolving daemon manifests or sockets without an isolated home **throws loudly** with instructions, instead of silently reaching `~/.superset`. Wired into both manifest resolution and socket derivation, covering the reaper/adoption/dispose paths.
- **Ancestor protection in the kill primitive**: the caller's ancestor chain (pids + their pgids) is excluded from group targets and tty-straggler matching. Colliding tree members are still killed by pid — only the killpg that would take the invoking session with them is off the table.
- Test hygiene: `createTestHost` provisions a temp home for its lifetime (restored on dispose); the integration suite's `afterEach` disposes *before* dropping the isolation env vars.

## Manual QA
- Ran the exact previously-lethal file (`terminal.integration.test.ts`) and then the **full 1110-test host-service suite** bracketed by pid checks on the live production daemons: identical before/after, no stray daemons leaked, invoking shell survived (it did not before).

## Testing
- `bun run typecheck` (host-service, pty-daemon)
- `bun test` full host-service suite: 1110 pass / 0 fail
- New unit tests: guard throws for test contexts on the default home (both runner detections); socket namespacing for non-default homes across NODE_ENV values; ancestor-guard behavior on synthetic process tables (group excluded, colliding pid still signalled, tty-straggler never adds ancestors)

## Risks / Rollout
- Risk: a production install running with a **custom** `SUPERSET_HOME_DIR` changes socket path on upgrade; adoption still works because `tryAdopt` reads the manifest's stored `socketPath` rather than recomputing. Default-home installs are unaffected.
- Rollback: revert cleanly; no schema or wire-protocol changes.

## Notes
- Independent of #6582 (disjoint files) — this one is about making the test suite safe to run anywhere; that one fixes the cursor bug the investigation started from.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps tests out of the real pty-daemon namespace and protects the invoking session from group kills. Previously, tests could resolve `~/.superset` and hit org-only sockets and killpg could include the caller’s shell; now non‑default homes are resolved and namespaced, test contexts require an isolated `SUPERSET_HOME_DIR`, and caller ancestry is excluded from group targets.

- `packages/host-service`: `ptyDaemonSocketPath` namespaces sockets by the resolved `SUPERSET_HOME_DIR` whenever the home is non‑default, regardless of `NODE_ENV`. Equivalent aliases of one custom home share a socket; default homes keep the legacy org‑only path; existing daemons remain adoptable via the manifest’s stored `socketPath`.
- `packages/host-service`: `assertIsolatedDaemonNamespaceInTests` (triggered when `NODE_ENV=test` or `NODE_TEST_CONTEXT` is set) uses resolved paths and throws if `SUPERSET_HOME_DIR` is unset or aliases the default `~/.superset`. Wired into manifest and socket resolution so reaper/adoption/dispose paths cannot touch the real namespace.
- Test hygiene: `createTestHost` provisions a temp `SUPERSET_HOME_DIR` for the host lifetime, and the terminal integration suite disposes scenarios before clearing isolation env vars.
- `packages/pty-daemon`: `collectProcessSignalTargets` treats the caller’s ancestor chain (pids and their pgids) as untouchable for group and tty-based targeting; colliding processes still get signalled by pid.

**Rollout and migration**
- Production installs using a custom `SUPERSET_HOME_DIR` will get a new socket path; no action is required for adoption because the manifest stores the previous `socketPath`. Update any external scripts that hardcode the socket path.
- Tests that touch the daemon must set `SUPERSET_HOME_DIR` to an isolated temp dir or use `createTestHost`, which provisions it automatically.

<sup>Written for commit 04ac2f9029ce2c977f47285436eed31cbb267b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal process cleanup to avoid signaling the invoking process, parent processes, or their process groups.
  * Prevented daemon socket namespace collisions across isolated environments.
  * Test-runner environments now require an isolated home directory, helping protect real daemon state.
  * Improved cleanup reliability for isolated terminal sessions and temporary environments.
* **Tests**
  * Expanded coverage for process-tree protection, daemon namespace isolation, path normalization, and environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->