### PR TITLE
feat(desktop,host-service): provider account switching in the Usage tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
@@ -1,7 +1,14 @@
 import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { useState } from "react";
-import { LuRefreshCw } from "react-icons/lu";
+import { LuEllipsis, LuPlus, LuRefreshCw } from "react-icons/lu";
 import {
 	getPresetIcon,
 	useIsDarkTheme,
@@ -11,7 +18,12 @@ import type {
 	UsageQuotaWindow,
 } from "../../hooks/useHostUsageQuota";
 import { useHostUsageQuota } from "../../hooks/useHostUsageQuota";
+import { useRemoveUsageAccount } from "../../hooks/useRemoveUsageAccount";
+import { useSetDefaultUsageAccount } from "../../hooks/useSetDefaultUsageAccount";
 import { UsageHistorySection } from "../UsageHistorySection";
+import type { SwitchSignInTarget } from "./components/AddAccountDialog";
+import { AddAccountDialog } from "./components/AddAccountDialog";
+import { RemoveAccountDialog } from "./components/RemoveAccountDialog";
 import { formatResetIn, formatResetLabel } from "./utils/formatResetIn";
 
 const PROVIDER_LABELS: Record<UsageAccount["provider"], string> = {
@@ -62,12 +74,25 @@ function creditsLine(account: UsageAccount): string | null {
 	return null;
 }
 
-function AccountCard({ account }: { account: UsageAccount }) {
+function AccountCard({
+	account,
+	onUseForAgents,
+	onSwitchSignIn,
+	onRemove,
+	isSwitching,
+}: {
+	account: UsageAccount;
+	onUseForAgents: () => void;
+	onSwitchSignIn: () => void;
+	/** Null on the system-default card — the main login is never removable. */
+	onRemove: (() => void) | null;
+	isSwitching: boolean;
+}) {
 	const isDark = useIsDarkTheme();
 	const icon = getPresetIcon(account.provider, isDark);
 	const credits = creditsLine(account);
 	return (
-		<div className="rounded-lg border bg-card/40 p-2.5">
+		<div className="group rounded-lg border bg-card/40 p-2.5">
 			<div className="flex items-baseline gap-1.5">
 				{icon && <img src={icon} alt="" className="size-3.5 self-center" />}
 				<span className="truncate text-xs font-medium">
@@ -78,9 +103,45 @@ function AccountCard({ account }: { account: UsageAccount }) {
 						{account.plan}
 					</span>
 				)}
+				{account.isDefault && (
+					<span
+						className="rounded bg-primary/15 px-1 text-[9px] font-medium uppercase tracking-wide text-primary"
+						title="New terminals and agents use this account. Existing ones keep theirs."
+					>
+						Default
+					</span>
+				)}
 				<span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
-					{credits ?? account.sourceLabel}
+					{/* Source label always shows — it is the only thing that tells two
+					    profiles of the same account apart. */}
+					{credits ? `${credits} · ${account.sourceLabel}` : account.sourceLabel}
 				</span>
+				<DropdownMenu modal={false}>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="size-4 shrink-0 self-center opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+						>
+							<LuEllipsis className="size-3" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						{!account.isDefault && (
+							<DropdownMenuItem disabled={isSwitching} onClick={onUseForAgents}>
+								Use for new agents
+							</DropdownMenuItem>
+						)}
+						<DropdownMenuItem onClick={onSwitchSignIn}>
+							Switch sign-in…
+						</DropdownMenuItem>
+						{onRemove && (
+							<DropdownMenuItem variant="destructive" onClick={onRemove}>
+								Remove…
+							</DropdownMenuItem>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
 			</div>
 			{account.status === "ok" ? (
 				<div className="mt-2 flex flex-col gap-1.5">
@@ -102,10 +163,31 @@ function AccountCard({ account }: { account: UsageAccount }) {
 
 export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 	const quotaQuery = useHostUsageQuota(hostUrl);
+	const setDefault = useSetDefaultUsageAccount(hostUrl);
+	const removeAccount = useRemoveUsageAccount(hostUrl);
 	const [isRefreshing, setIsRefreshing] = useState(false);
+	const [isAddAccountOpen, setIsAddAccountOpen] = useState(false);
+	const [switchTarget, setSwitchTarget] = useState<SwitchSignInTarget | null>(
+		null,
+	);
+	const [removeTarget, setRemoveTarget] = useState<UsageAccount | null>(null);
 
 	const accounts = quotaQuery.data ?? [];
 	const isBusy = quotaQuery.isFetching || isRefreshing;
+
+	const makeDefaultAccount = (account: UsageAccount) => {
+		setDefault.mutate(
+			{ provider: account.provider, selection: account.selection },
+			{
+				onSuccess: () => {
+					toast.success(
+						`New ${PROVIDER_LABELS[account.provider]} terminals and agents will use ${account.email ?? account.sourceLabel}.`,
+					);
+				},
+				onError: (error) => toast.error(error.message),
+			},
+		);
+	};
 
 	return (
 		<div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-3 px-6 py-4">
@@ -113,6 +195,16 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 				<span className="ml-auto text-[10px] text-muted-foreground">
 					Official quota · refreshes every 5 min
 				</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-6 gap-1 px-1.5 text-[10px]"
+					disabled={!hostUrl}
+					onClick={() => setIsAddAccountOpen(true)}
+				>
+					<LuPlus className="size-3" />
+					Add account
+				</Button>
 				<Button
 					variant="ghost"
 					size="icon"
@@ -143,10 +235,74 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 			) : (
 				<div className="grid gap-2 md:grid-cols-2">
 					{accounts.map((account) => (
-						<AccountCard key={account.accountKey} account={account} />
+						<AccountCard
+							key={account.accountKey}
+							account={account}
+							onUseForAgents={() => makeDefaultAccount(account)}
+							onSwitchSignIn={() => {
+								setSwitchTarget({
+									provider: account.provider,
+									selection: account.selection,
+									label:
+										account.selection === null
+											? (account.email ?? account.sourceLabel)
+											: account.sourceLabel,
+								});
+								setIsAddAccountOpen(true);
+							}}
+							onRemove={
+								account.selection === null
+									? null
+									: () => setRemoveTarget(account)
+							}
+							isSwitching={setDefault.isPending}
+						/>
 					))}
 				</div>
 			)}
+
+			<RemoveAccountDialog
+				account={removeTarget}
+				onOpenChange={(open) => {
+					if (!open) setRemoveTarget(null);
+				}}
+				isRemoving={removeAccount.isPending}
+				onConfirm={() => {
+					if (!removeTarget || removeTarget.selection === null) return;
+					removeAccount.mutate(
+						{
+							provider: removeTarget.provider,
+							selection: removeTarget.selection,
+						},
+						{
+							onSuccess: () => {
+								toast.success(
+									`Removed ${removeTarget.email ?? removeTarget.sourceLabel}.`,
+								);
+								setRemoveTarget(null);
+							},
+							onError: (error) => toast.error(error.message),
+						},
+					);
+				}}
+			/>
+
+			<AddAccountDialog
+				open={isAddAccountOpen}
+				onOpenChange={(open) => {
+					setIsAddAccountOpen(open);
+					if (!open) setSwitchTarget(null);
+				}}
+				switchTarget={switchTarget}
+				hostUrl={hostUrl}
+				onAccountAdded={() => {
+					setIsRefreshing(true);
+					void quotaQuery
+						.refresh()
+						.catch(() => {})
+						.finally(() => setIsRefreshing(false));
+				}}
+			/>
 
 			<UsageHistorySection hostUrl={hostUrl} />
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
@@ -26,7 +26,11 @@ import { AddAccountDialog } from "./components/AddAccountDialog";
 import { RemoveAccountDialog } from "./components/RemoveAccountDialog";
 import { formatResetIn, formatResetLabel } from "./utils/formatResetIn";
 
-const PROVIDER_LABELS: Record<UsageAccount["provider"], string> = {
+type Provider = UsageAccount["provider"];
+
+const PROVIDERS: Provider[] = ["claude", "codex"];
+
+const PROVIDER_LABELS: Record<Provider, string> = {
 	claude: "Claude Code",
 	codex: "Codex",
 };
@@ -76,25 +80,22 @@ function creditsLine(account: UsageAccount): string | null {
 
 function AccountCard({
 	account,
-	onUseForAgents,
+	onMakeDefault,
 	onSwitchSignIn,
 	onRemove,
 	isSwitching,
 }: {
 	account: UsageAccount;
-	onUseForAgents: () => void;
+	onMakeDefault: () => void;
 	onSwitchSignIn: () => void;
 	/** Null on the system-default card — the main login is never removable. */
 	onRemove: (() => void) | null;
 	isSwitching: boolean;
 }) {
-	const isDark = useIsDarkTheme();
-	const icon = getPresetIcon(account.provider, isDark);
 	const credits = creditsLine(account);
 	return (
 		<div className="group rounded-lg border bg-card/40 p-2.5">
 			<div className="flex items-baseline gap-1.5">
-				{icon && <img src={icon} alt="" className="size-3.5 self-center" />}
 				<span className="truncate text-xs font-medium">
 					{account.email ?? PROVIDER_LABELS[account.provider]}
 				</span>
@@ -103,18 +104,38 @@ function AccountCard({
 						{account.plan}
 					</span>
 				)}
-				{account.isDefault && (
+				{account.status !== "ok" && (
+					<span className="rounded bg-amber-500/15 px-1 text-[9px] font-medium uppercase tracking-wide text-amber-500">
+						{account.status === "token_expired"
+							? "Sign-in expired"
+							: "Unavailable"}
+					</span>
+				)}
+				{account.isDefault ? (
 					<span
 						className="rounded bg-primary/15 px-1 text-[9px] font-medium uppercase tracking-wide text-primary"
 						title="New terminals and agents use this account. Existing ones keep theirs."
 					>
 						Default
 					</span>
+				) : (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-4 rounded px-1 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+						disabled={isSwitching}
+						title="Launch new terminals and agents on this account. Existing ones keep theirs."
+						onClick={onMakeDefault}
+					>
+						Make default
+					</Button>
 				)}
 				<span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
 					{/* Source label always shows — it is the only thing that tells two
 					    profiles of the same account apart. */}
-					{credits ? `${credits} · ${account.sourceLabel}` : account.sourceLabel}
+					{credits
+						? `${credits} · ${account.sourceLabel}`
+						: account.sourceLabel}
 				</span>
 				<DropdownMenu modal={false}>
 					<DropdownMenuTrigger asChild>
@@ -127,11 +148,6 @@ function AccountCard({
 						</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end">
-						{!account.isDefault && (
-							<DropdownMenuItem disabled={isSwitching} onClick={onUseForAgents}>
-								Use for new agents
-							</DropdownMenuItem>
-						)}
 						<DropdownMenuItem onClick={onSwitchSignIn}>
 							Switch sign-in…
 						</DropdownMenuItem>
@@ -165,8 +181,10 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 	const quotaQuery = useHostUsageQuota(hostUrl);
 	const setDefault = useSetDefaultUsageAccount(hostUrl);
 	const removeAccount = useRemoveUsageAccount(hostUrl);
+	const isDark = useIsDarkTheme();
 	const [isRefreshing, setIsRefreshing] = useState(false);
-	const [isAddAccountOpen, setIsAddAccountOpen] = useState(false);
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [dialogProvider, setDialogProvider] = useState<Provider>("claude");
 	const [switchTarget, setSwitchTarget] = useState<SwitchSignInTarget | null>(
 		null,
 	);
@@ -189,22 +207,31 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 		);
 	};
 
+	const openAddAccount = (provider: Provider) => {
+		setDialogProvider(provider);
+		setSwitchTarget(null);
+		setIsDialogOpen(true);
+	};
+
+	const openSwitchSignIn = (account: UsageAccount) => {
+		setDialogProvider(account.provider);
+		setSwitchTarget({
+			provider: account.provider,
+			selection: account.selection,
+			label:
+				account.selection === null
+					? (account.email ?? account.sourceLabel)
+					: account.sourceLabel,
+		});
+		setIsDialogOpen(true);
+	};
+
 	return (
 		<div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-3 px-6 py-4">
 			<div className="flex items-center gap-2">
 				<span className="ml-auto text-[10px] text-muted-foreground">
 					Official quota · refreshes every 5 min
 				</span>
-				<Button
-					variant="ghost"
-					size="sm"
-					className="h-6 gap-1 px-1.5 text-[10px]"
-					disabled={!hostUrl}
-					onClick={() => setIsAddAccountOpen(true)}
-				>
-					<LuPlus className="size-3" />
-					Add account
-				</Button>
 				<Button
 					variant="ghost"
 					size="icon"
@@ -227,38 +254,56 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 				<div className="py-4 text-center text-xs text-muted-foreground">
 					Reading subscription usage…
 				</div>
-			) : accounts.length === 0 ? (
-				<div className="py-4 text-center text-xs text-muted-foreground">
-					No AI subscription logins found on this host — sign in to Claude Code
-					or Codex and usage will appear here.
-				</div>
 			) : (
-				<div className="grid gap-2 md:grid-cols-2">
-					{accounts.map((account) => (
-						<AccountCard
-							key={account.accountKey}
-							account={account}
-							onUseForAgents={() => makeDefaultAccount(account)}
-							onSwitchSignIn={() => {
-								setSwitchTarget({
-									provider: account.provider,
-									selection: account.selection,
-									label:
-										account.selection === null
-											? (account.email ?? account.sourceLabel)
-											: account.sourceLabel,
-								});
-								setIsAddAccountOpen(true);
-							}}
-							onRemove={
-								account.selection === null
-									? null
-									: () => setRemoveTarget(account)
-							}
-							isSwitching={setDefault.isPending}
-						/>
-					))}
-				</div>
+				PROVIDERS.map((provider) => {
+					const providerAccounts = accounts.filter(
+						(account) => account.provider === provider,
+					);
+					const icon = getPresetIcon(provider, isDark);
+					return (
+						<section key={provider} className="flex flex-col gap-1.5">
+							<div className="flex items-center gap-1.5">
+								{icon && <img src={icon} alt="" className="size-3.5" />}
+								<span className="text-xs font-medium">
+									{PROVIDER_LABELS[provider]}
+								</span>
+								<Button
+									variant="ghost"
+									size="sm"
+									className="ml-auto h-5 gap-1 px-1.5 text-[10px] text-muted-foreground"
+									disabled={!hostUrl}
+									onClick={() => openAddAccount(provider)}
+								>
+									<LuPlus className="size-3" />
+									Add account
+								</Button>
+							</div>
+							{providerAccounts.length === 0 ? (
+								<div className="rounded-lg border border-dashed px-3 py-2 text-[11px] text-muted-foreground">
+									No {PROVIDER_LABELS[provider]} logins on this host — sign in
+									and usage appears here.
+								</div>
+							) : (
+								<div className="grid gap-2 md:grid-cols-2">
+									{providerAccounts.map((account) => (
+										<AccountCard
+											key={account.accountKey}
+											account={account}
+											onMakeDefault={() => makeDefaultAccount(account)}
+											onSwitchSignIn={() => openSwitchSignIn(account)}
+											onRemove={
+												account.selection === null
+													? null
+													: () => setRemoveTarget(account)
+											}
+											isSwitching={setDefault.isPending}
+										/>
+									))}
+								</div>
+							)}
+						</section>
+					);
+				})
 			)}
 
 			<RemoveAccountDialog
@@ -288,11 +333,12 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 			/>
 
 			<AddAccountDialog
-				open={isAddAccountOpen}
+				open={isDialogOpen}
 				onOpenChange={(open) => {
-					setIsAddAccountOpen(open);
+					setIsDialogOpen(open);
 					if (!open) setSwitchTarget(null);
 				}}
+				provider={dialogProvider}
 				switchTarget={switchTarget}
 				hostUrl={hostUrl}
 				onAccountAdded={() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
@@ -108,7 +108,9 @@ function AccountCard({
 					<span className="rounded bg-amber-500/15 px-1 text-[9px] font-medium uppercase tracking-wide text-amber-500">
 						{account.status === "token_expired"
 							? "Sign-in expired"
-							: "Unavailable"}
+							: account.status === "signed_out"
+								? "Signed out"
+								: "Unavailable"}
 					</span>
 				)}
 				{account.isDefault ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
@@ -202,6 +202,10 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 				onSuccess: () => {
 					toast.success(
 						`New ${PROVIDER_LABELS[account.provider]} terminals and agents will use ${account.email ?? account.sourceLabel}.`,
+						{
+							description:
+								"Running sessions keep their current account — restart them to switch.",
+						},
 					);
 				},
 				onError: (error) => toast.error(error.message),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
@@ -1,0 +1,339 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { toast } from "@superset/ui/sonner";
+import { useEffect, useRef, useState } from "react";
+import { LuCheck, LuCopy, LuLoaderCircle } from "react-icons/lu";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import type { UsageLogins } from "../../../../hooks/useHostUsageLogins";
+import { useHostUsageLogins } from "../../../../hooks/useHostUsageLogins";
+import { useSetDefaultUsageAccount } from "../../../../hooks/useSetDefaultUsageAccount";
+
+type Provider = "claude" | "codex";
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+	claude: "Claude Code",
+	codex: "Codex",
+};
+
+/** The login being re-signed by "Switch sign-in": a profile dir, or the
+ * system default when selection is null. */
+export interface SwitchSignInTarget {
+	provider: Provider;
+	selection: string | null;
+	/** Display name for the dialog copy ("~/.claude-2", an email, …). */
+	label: string;
+}
+
+function slugify(name: string): string {
+	return (
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9-]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "work"
+	);
+}
+
+// $HOME stays unexpanded on purpose — the user's shell resolves it, so the
+// same command works over SSH to a remote host.
+function addAccountCommand(provider: Provider, slug: string): string {
+	if (provider === "claude") {
+		return `CLAUDE_CONFIG_DIR="$HOME/.claude-${slug}" claude auth login`;
+	}
+	return `mkdir -p "$HOME/.codex-${slug}" && CODEX_HOME="$HOME/.codex-${slug}" codex login`;
+}
+
+// Re-signs an existing login in place: the system default runs the CLI bare,
+// a profile runs it against its own dir.
+function switchSignInCommand(target: SwitchSignInTarget): string {
+	if (target.provider === "claude") {
+		return target.selection === null
+			? "claude auth login"
+			: `CLAUDE_CONFIG_DIR="${target.selection}" claude auth login`;
+	}
+	return target.selection === null
+		? "codex login"
+		: `CODEX_HOME="${target.selection}" codex login`;
+}
+
+/** The sign-in that landed after the dialog opened, if any. */
+function findNewLogin(
+	provider: Provider,
+	baseline: UsageLogins,
+	current: UsageLogins,
+): { selection: string; label: string } | null {
+	if (provider === "claude") {
+		const known = new Set(baseline.claude.map((entry) => entry.configDir));
+		const fresh = current.claude.find((entry) => !known.has(entry.configDir));
+		return fresh
+			? { selection: fresh.configDir, label: fresh.email ?? fresh.configDir }
+			: null;
+	}
+	const known = new Set(baseline.codex.map((entry) => entry.home));
+	const fresh = current.codex.find((entry) => !known.has(entry.home));
+	return fresh ? { selection: fresh.home, label: fresh.home } : null;
+}
+
+/** A change of identity in the target login, if any. */
+function findSignInChange(
+	target: SwitchSignInTarget,
+	baseline: UsageLogins,
+	current: UsageLogins,
+): { label: string } | null {
+	if (target.provider === "claude") {
+		if (target.selection === null) {
+			return current.claudeDefaultEmail &&
+				current.claudeDefaultEmail !== baseline.claudeDefaultEmail
+				? { label: current.claudeDefaultEmail }
+				: null;
+		}
+		const before =
+			baseline.claude.find((entry) => entry.configDir === target.selection)
+				?.email ?? null;
+		const after =
+			current.claude.find((entry) => entry.configDir === target.selection)
+				?.email ?? null;
+		return after && after !== before ? { label: after } : null;
+	}
+	// Codex: identity isn't knowable locally, so compare auth.json content.
+	const home = target.selection ?? current.codex[0]?.home;
+	const before =
+		baseline.codex.find((entry) => entry.home === home)?.fingerprint ?? null;
+	const after =
+		current.codex.find((entry) => entry.home === home)?.fingerprint ?? null;
+	return after && after !== before ? { label: "The Codex sign-in" } : null;
+}
+
+interface AddAccountDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	hostUrl: string | null;
+	/** Called once when the new sign-in is detected, to refresh quota. */
+	onAccountAdded: () => void;
+	/** When set, the dialog re-signs this existing login instead of adding a
+	 * separate profile. */
+	switchTarget?: SwitchSignInTarget | null;
+}
+
+/**
+ * Two credential-free sign-in flows: adding another provider account as a
+ * separate profile dir, or re-signing an existing login (a profile, or the
+ * system default). Either way the user runs the provider's own login in a
+ * terminal and we only watch local state for the result — Superset never
+ * handles the credentials (see usage/default-account.ts).
+ */
+export function AddAccountDialog({
+	open,
+	onOpenChange,
+	hostUrl,
+	onAccountAdded,
+	switchTarget = null,
+}: AddAccountDialogProps) {
+	const [pickedProvider, setPickedProvider] = useState<Provider>("claude");
+	const provider = switchTarget?.provider ?? pickedProvider;
+	const [name, setName] = useState("work");
+	const [copied, setCopied] = useState(false);
+	const [found, setFound] = useState<{
+		selection: string | null;
+		label: string;
+	} | null>(null);
+	const baselineRef = useRef<UsageLogins | null>(null);
+
+	const loginsQuery = useHostUsageLogins(hostUrl, open && !found);
+	const setDefault = useSetDefaultUsageAccount(hostUrl);
+
+	// The first poll result after opening is the baseline; anything beyond it
+	// is the sign-in we are waiting for.
+	useEffect(() => {
+		if (!open) {
+			baselineRef.current = null;
+			setFound(null);
+			setCopied(false);
+			return;
+		}
+		const logins = loginsQuery.data;
+		if (!logins) return;
+		if (!baselineRef.current) {
+			baselineRef.current = logins;
+			return;
+		}
+		if (found) return;
+
+		const seedProfile = (configDir: string) => {
+			// A fresh (or re-signed) Claude profile may have the CLI's first-boot
+			// wizard armed; mark onboarding done so its first agent launch opens
+			// the prompt.
+			if (!hostUrl) return;
+			void getHostServiceClientByUrl(hostUrl)
+				.usage.prepareClaudeProfile.mutate({ configDir })
+				.catch(() => {});
+		};
+
+		if (switchTarget) {
+			const change = findSignInChange(
+				switchTarget,
+				baselineRef.current,
+				logins,
+			);
+			if (change) {
+				setFound({ selection: null, label: change.label });
+				onAccountAdded();
+				if (switchTarget.provider === "claude" && switchTarget.selection) {
+					seedProfile(switchTarget.selection);
+				}
+			}
+			return;
+		}
+		const fresh = findNewLogin(provider, baselineRef.current, logins);
+		if (fresh) {
+			setFound(fresh);
+			onAccountAdded();
+			if (provider === "claude") seedProfile(fresh.selection);
+		}
+	}, [
+		open,
+		loginsQuery.data,
+		provider,
+		switchTarget,
+		found,
+		onAccountAdded,
+		hostUrl,
+	]);
+
+	const slug = slugify(name);
+	const command = switchTarget
+		? switchSignInCommand(switchTarget)
+		: addAccountCommand(provider, slug);
+
+	const copyCommand = () => {
+		void navigator.clipboard.writeText(command).then(() => {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2_000);
+		});
+	};
+
+	const switchDescription = switchTarget
+		? switchTarget.selection === null
+			? `Sign the system-default ${PROVIDER_LABELS[switchTarget.provider]} login into a different account. It replaces the current default sign-in on this machine; profiles and running agents are unaffected.`
+			: `Sign the ${switchTarget.label} profile into a different account. Other profiles, the system default, and running agents are unaffected.`
+		: null;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>
+						{switchTarget ? "Switch sign-in" : "Add account"}
+					</DialogTitle>
+					<DialogDescription>
+						{switchDescription ??
+							"Sign in to a second subscription as a separate profile. Your current login is untouched."}
+					</DialogDescription>
+				</DialogHeader>
+
+				{found ? (
+					<div className="flex flex-col gap-3">
+						<div className="rounded-md border bg-card/40 p-3 text-sm">
+							<span className="font-medium">{found.label}</span>{" "}
+							{switchTarget
+								? "is now signed in here."
+								: "is signed in and will show its quota here."}
+						</div>
+						<div className="flex justify-end gap-2">
+							<Button variant="ghost" onClick={() => onOpenChange(false)}>
+								Done
+							</Button>
+							{!switchTarget && found.selection !== null && (
+								<Button
+									disabled={setDefault.isPending}
+									onClick={() => {
+										setDefault.mutate(
+											{ provider, selection: found.selection },
+											{
+												onSuccess: () => {
+													toast.success(`New agents will use ${found.label}.`);
+													onOpenChange(false);
+												},
+												onError: (error) => toast.error(error.message),
+											},
+										);
+									}}
+								>
+									Use for new agents
+								</Button>
+							)}
+						</div>
+					</div>
+				) : (
+					<div className="flex flex-col gap-3">
+						{!switchTarget && (
+							<>
+								<div className="flex gap-1">
+									{(Object.keys(PROVIDER_LABELS) as Provider[]).map(
+										(option) => (
+											<Button
+												key={option}
+												size="sm"
+												variant={provider === option ? "secondary" : "ghost"}
+												onClick={() => setPickedProvider(option)}
+											>
+												{PROVIDER_LABELS[option]}
+											</Button>
+										),
+									)}
+								</div>
+
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-muted-foreground">
+										Profile name
+									</span>
+									<Input
+										value={name}
+										onChange={(event) => setName(event.target.value)}
+										className="h-7 flex-1 text-xs"
+										placeholder="work"
+									/>
+								</div>
+							</>
+						)}
+
+						<div className="flex flex-col gap-1">
+							<span className="text-xs text-muted-foreground">
+								Run this in any terminal on this host, then finish the sign-in
+								in your browser:
+							</span>
+							<div className="flex items-start gap-1.5 rounded-md border bg-muted/40 p-2">
+								<code className="flex-1 whitespace-pre-wrap break-all font-mono text-[11px]">
+									{command}
+								</code>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-6 shrink-0"
+									onClick={copyCommand}
+								>
+									{copied ? (
+										<LuCheck className="size-3 text-green-500" />
+									) : (
+										<LuCopy className="size-3" />
+									)}
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+							<LuLoaderCircle className="size-3 animate-spin" />
+							Waiting for the sign-in to complete — this updates automatically.
+						</div>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
@@ -261,7 +261,10 @@ export function AddAccountDialog({
 											{ provider, selection: found.selection },
 											{
 												onSuccess: () => {
-													toast.success(`New agents will use ${found.label}.`);
+													toast.success(`New agents will use ${found.label}.`, {
+														description:
+															"Running sessions keep their current account — restart them to switch.",
+													});
 													onOpenChange(false);
 												},
 												onError: (error) => toast.error(error.message),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
@@ -114,6 +114,8 @@ interface AddAccountDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	hostUrl: string | null;
+	/** Provider being added; the per-provider Add buttons preselect it. */
+	provider: Provider;
 	/** Called once when the new sign-in is detected, to refresh quota. */
 	onAccountAdded: () => void;
 	/** When set, the dialog re-signs this existing login instead of adding a
@@ -132,11 +134,11 @@ export function AddAccountDialog({
 	open,
 	onOpenChange,
 	hostUrl,
+	provider: addProvider,
 	onAccountAdded,
 	switchTarget = null,
 }: AddAccountDialogProps) {
-	const [pickedProvider, setPickedProvider] = useState<Provider>("claude");
-	const provider = switchTarget?.provider ?? pickedProvider;
+	const provider = switchTarget?.provider ?? addProvider;
 	const [name, setName] = useState("work");
 	const [copied, setCopied] = useState(false);
 	const [found, setFound] = useState<{
@@ -229,7 +231,9 @@ export function AddAccountDialog({
 			<DialogContent className="max-w-md">
 				<DialogHeader>
 					<DialogTitle>
-						{switchTarget ? "Switch sign-in" : "Add account"}
+						{switchTarget
+							? "Switch sign-in"
+							: `Add ${PROVIDER_LABELS[provider]} account`}
 					</DialogTitle>
 					<DialogDescription>
 						{switchDescription ??
@@ -273,34 +277,17 @@ export function AddAccountDialog({
 				) : (
 					<div className="flex flex-col gap-3">
 						{!switchTarget && (
-							<>
-								<div className="flex gap-1">
-									{(Object.keys(PROVIDER_LABELS) as Provider[]).map(
-										(option) => (
-											<Button
-												key={option}
-												size="sm"
-												variant={provider === option ? "secondary" : "ghost"}
-												onClick={() => setPickedProvider(option)}
-											>
-												{PROVIDER_LABELS[option]}
-											</Button>
-										),
-									)}
-								</div>
-
-								<div className="flex items-center gap-2">
-									<span className="text-xs text-muted-foreground">
-										Profile name
-									</span>
-									<Input
-										value={name}
-										onChange={(event) => setName(event.target.value)}
-										className="h-7 flex-1 text-xs"
-										placeholder="work"
-									/>
-								</div>
-							</>
+							<div className="flex items-center gap-2">
+								<span className="text-xs text-muted-foreground">
+									Profile name
+								</span>
+								<Input
+									value={name}
+									onChange={(event) => setName(event.target.value)}
+									className="h-7 flex-1 text-xs"
+									placeholder="work"
+								/>
+							</div>
 						)}
 
 						<div className="flex flex-col gap-1">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/index.ts
@@ -1,0 +1,2 @@
+export type { SwitchSignInTarget } from "./AddAccountDialog";
+export { AddAccountDialog } from "./AddAccountDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/RemoveAccountDialog/RemoveAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/RemoveAccountDialog/RemoveAccountDialog.tsx
@@ -1,0 +1,64 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	EnterEnabledAlertDialogContent,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import type { UsageAccount } from "../../../../hooks/useHostUsageQuota";
+
+interface RemoveAccountDialogProps {
+	/** The profile to remove; null keeps the dialog closed. */
+	account: UsageAccount | null;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+	isRemoving: boolean;
+}
+
+export function RemoveAccountDialog({
+	account,
+	onOpenChange,
+	onConfirm,
+	isRemoving,
+}: RemoveAccountDialogProps) {
+	const label = account ? (account.email ?? account.sourceLabel) : "";
+	return (
+		<AlertDialog open={account !== null} onOpenChange={onOpenChange}>
+			<EnterEnabledAlertDialogContent className="max-w-[380px] gap-0 p-0">
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">
+						Remove {label}?
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						{account?.provider === "codex"
+							? `Deletes the ${account.sourceLabel} profile, its saved sign-in on this machine, and its local Codex session history. The account itself is unaffected.`
+							: `Deletes the ${account?.sourceLabel} profile and its saved sign-in on this machine. The account itself is unaffected.`}{" "}
+						Running agents on this profile lose access.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter className="flex-row justify-end gap-2 px-4 pt-2 pb-4">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<AlertDialogAction
+						variant="destructive"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						disabled={isRemoving}
+						onClick={onConfirm}
+					>
+						Remove
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</EnterEnabledAlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/RemoveAccountDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/RemoveAccountDialog/index.ts
@@ -1,0 +1,1 @@
+export { RemoveAccountDialog } from "./RemoveAccountDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useHostUsageLogins/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useHostUsageLogins/index.ts
@@ -1,0 +1,2 @@
+export type { UsageLogins } from "./useHostUsageLogins";
+export { useHostUsageLogins } from "./useHostUsageLogins";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useHostUsageLogins/useHostUsageLogins.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useHostUsageLogins/useHostUsageLogins.ts
@@ -1,0 +1,26 @@
+import type { AppRouter } from "@superset/host-service";
+import { useQuery } from "@tanstack/react-query";
+import type { inferRouterOutputs } from "@trpc/server";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+export type UsageLogins = inferRouterOutputs<AppRouter>["usage"]["logins"];
+
+const LOGIN_POLL_INTERVAL_MS = 3_000;
+
+/**
+ * Local-only login discovery on the host (no provider network calls), polled
+ * while an add-account sign-in is pending so the dialog can react the moment
+ * the new profile lands on disk.
+ */
+export function useHostUsageLogins(hostUrl: string | null, enabled: boolean) {
+	return useQuery({
+		queryKey: ["host-usage-logins", hostUrl],
+		enabled: !!hostUrl && enabled,
+		queryFn: () => {
+			if (!hostUrl) return null;
+			return getHostServiceClientByUrl(hostUrl).usage.logins.query();
+		},
+		refetchInterval: enabled ? LOGIN_POLL_INTERVAL_MS : false,
+		gcTime: 0,
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useRemoveUsageAccount/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useRemoveUsageAccount/index.ts
@@ -1,0 +1,1 @@
+export { useRemoveUsageAccount } from "./useRemoveUsageAccount";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useRemoveUsageAccount/useRemoveUsageAccount.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useRemoveUsageAccount/useRemoveUsageAccount.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { HOST_USAGE_QUOTA_QUERY_KEY } from "../useHostUsageQuota";
+
+/**
+ * Deletes a secondary provider profile (dir + scoped keychain items on the
+ * host). The system default is never removable — the host rejects it.
+ */
+export function useRemoveUsageAccount(hostUrl: string | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (input: {
+			provider: "claude" | "codex";
+			selection: string;
+		}) => {
+			if (!hostUrl) throw new Error("No host connection.");
+			return getHostServiceClientByUrl(hostUrl).usage.removeAccount.mutate(
+				input,
+			);
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: [...HOST_USAGE_QUOTA_QUERY_KEY, hostUrl],
+			});
+		},
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useSetDefaultUsageAccount/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useSetDefaultUsageAccount/index.ts
@@ -1,0 +1,1 @@
+export { useSetDefaultUsageAccount } from "./useSetDefaultUsageAccount";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useSetDefaultUsageAccount/useSetDefaultUsageAccount.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/hooks/useSetDefaultUsageAccount/useSetDefaultUsageAccount.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { HOST_USAGE_QUOTA_QUERY_KEY } from "../useHostUsageQuota";
+
+/**
+ * Points new agent launches at one of the discovered provider logins
+ * (null selection = the system-default login). The host recomputes the
+ * `isDefault` flags per query, so a plain invalidate reflects the switch
+ * without re-hitting provider quota endpoints.
+ */
+export function useSetDefaultUsageAccount(hostUrl: string | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (input: {
+			provider: "claude" | "codex";
+			selection: string | null;
+		}) => {
+			if (!hostUrl) throw new Error("No host connection.");
+			return getHostServiceClientByUrl(hostUrl).usage.setDefaultAccount.mutate(
+				input,
+			);
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: [...HOST_USAGE_QUOTA_QUERY_KEY, hostUrl],
+			});
+		},
+	});
+}

--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -129,6 +129,19 @@ export function removeClaudeManagedHooks(): void {
 	removeManagedJsonHooks(claudeHooksSpec(getNotifyScriptPath()));
 }
 
+/**
+ * Merges Superset hooks into `<configDir>/settings.json` for a secondary
+ * Claude profile (CLAUDE_CONFIG_DIR account). Without this, agents launched
+ * on a non-default account would lose lifecycle/status hooks — Claude reads
+ * settings exclusively from the active config dir.
+ */
+export function ensureClaudeManagedHooksAt(configDir: string): void {
+	ensureManagedJsonHooks({
+		...claudeHooksSpec(getNotifyScriptPath()),
+		getFilePath: () => path.join(configDir, "settings.json"),
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Codex ~/.codex/hooks.json direct merge
 // ---------------------------------------------------------------------------
@@ -207,6 +220,17 @@ export function createCodexHooksJson(): void {
  */
 export function removeCodexManagedHooks(): void {
 	removeManagedJsonHooks(codexHooksSpec(getNotifyScriptPath()));
+}
+
+/**
+ * Merges Superset hooks into `<codexHome>/hooks.json` for a secondary Codex
+ * home (CODEX_HOME account) — same rationale as ensureClaudeManagedHooksAt.
+ */
+export function ensureCodexManagedHooksAt(codexHome: string): void {
+	ensureManagedJsonHooks({
+		...codexHooksSpec(getNotifyScriptPath()),
+		getFilePath: () => path.join(codexHome, "hooks.json"),
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent-setup/src/index.ts
+++ b/packages/agent-setup/src/index.ts
@@ -56,6 +56,11 @@ export function setupAgentIntegrations(
 
 export { setupSingleAgent, teardownSingleAgent };
 
+export {
+	ensureClaudeManagedHooksAt,
+	ensureCodexManagedHooksAt,
+} from "./agent-wrappers-claude-codex-opencode";
+
 export { getCommandShellArgs, getShellArgs, getShellEnv };
 
 export {

--- a/packages/host-service/drizzle/0024_odd_war_machine.sql
+++ b/packages/host-service/drizzle/0024_odd_war_machine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `host_settings` ADD `default_claude_config_dir` text;--> statement-breakpoint
+ALTER TABLE `host_settings` ADD `default_codex_home` text;

--- a/packages/host-service/drizzle/meta/0024_snapshot.json
+++ b/packages/host-service/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,927 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "792828a4-edf9-4577-b8c5-6ea21e493743",
+  "prevId": "d781b875-abdd-499d-8f98-7894ec606fc7",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786681360097,
       "tag": "0023_gorgeous_pixie",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1787007811544,
+      "tag": "0024_odd_war_machine",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -117,6 +117,10 @@ export const hostSettings = sqliteTable("host_settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	branchPrefixMode: text("branch_prefix_mode").$type<BranchPrefixMode>(),
 	branchPrefixCustom: text("branch_prefix_custom"),
+	// Which provider login newly launched agents use, as the profile dir to
+	// inject (CLAUDE_CONFIG_DIR / CODEX_HOME). Null = the system default login.
+	defaultClaudeConfigDir: text("default_claude_config_dir"),
+	defaultCodexHome: text("default_codex_home"),
 });
 
 export const pullRequests = sqliteTable(

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -32,6 +32,7 @@ import type { EventBus } from "../events/index.ts";
 import { portManager } from "../ports/port-manager.ts";
 import { sweepAgentBindingsAfterDaemonLoss } from "../terminal-agents/daemon-loss-sweep.ts";
 import { markTerminalAgentBindingEnded } from "../terminal-agents/persistence.ts";
+import { resolveDefaultAccountTerminalEnv } from "../trpc/router/usage/default-account.ts";
 import {
 	DaemonClient,
 	type Signal as DaemonSignal,
@@ -2459,22 +2460,28 @@ export async function createTerminalSessionInternal({
 	const supersetHomeDir = resolveSupersetHomeDir();
 	const shell = resolveLaunchShell(baseEnv);
 	const shellArgs = getShellLaunchArgs({ shell, supersetHomeDir });
-	const ptyEnv = buildV2TerminalEnv({
-		baseEnv,
-		shell,
-		supersetHomeDir,
-		themeType,
-		cwd,
-		terminalId,
-		workspaceId,
-		workspacePath: workspace.worktreePath,
-		rootPath,
-		supersetEnv:
-			process.env.NODE_ENV === "development" ? "development" : "production",
-		agentHookPort: process.env.SUPERSET_AGENT_HOOK_PORT || "",
-		agentHookVersion: process.env.SUPERSET_AGENT_HOOK_VERSION || "",
-		hostAgentHookUrl: getHostAgentHookUrl(),
-	});
+	const ptyEnv = {
+		...buildV2TerminalEnv({
+			baseEnv,
+			shell,
+			supersetHomeDir,
+			themeType,
+			cwd,
+			terminalId,
+			workspaceId,
+			workspacePath: workspace.worktreePath,
+			rootPath,
+			supersetEnv:
+				process.env.NODE_ENV === "development" ? "development" : "production",
+			agentHookPort: process.env.SUPERSET_AGENT_HOOK_PORT || "",
+			agentHookVersion: process.env.SUPERSET_AGENT_HOOK_VERSION || "",
+			hostAgentHookUrl: getHostAgentHookUrl(),
+		}),
+		// Usage-tab default account: provider CLIs typed or preset-launched in
+		// this terminal run on the selected login. Baked at spawn — existing
+		// terminals keep the account they started with.
+		...resolveDefaultAccountTerminalEnv(db),
+	};
 
 	let daemon: DaemonClient;
 	try {

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,11 +1,13 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../../../db";
 import * as schema from "../../../db/schema";
+import { setDefaultAccountSelection } from "../usage/default-account";
 import {
 	buildAgentCommandString,
 	buildTerminalAgentLaunch,
@@ -286,6 +288,105 @@ describe("buildTerminalAgentLaunch", () => {
 				prompt: "p",
 			}),
 		).toThrow(/No host agent config matching 'nope'/);
+	});
+});
+
+describe("buildTerminalAgentLaunch default account env", () => {
+	// tmpdir always exists, which is all resolveDefaultAccountEnv checks.
+	const existingDir = tmpdir();
+
+	function seedClaude(db: HostDb, env: Record<string, string> = {}) {
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: "00000000-0000-0000-0000-00000000000c",
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				envJson: JSON.stringify(env),
+				displayOrder: 0,
+			})
+			.run();
+	}
+
+	it("injects CLAUDE_CONFIG_DIR for claude agents when a default account is set", () => {
+		const db = createTestDb();
+		seedClaude(db);
+		setDefaultAccountSelection(db, "claude", existingDir);
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "claude",
+			prompt: "hi",
+		});
+		expect(launch.fullCommand).toBe(
+			`CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
+		);
+	});
+
+	it("lets a per-agent CLAUDE_CONFIG_DIR beat the host default", () => {
+		const db = createTestDb();
+		seedClaude(db, { CLAUDE_CONFIG_DIR: "/pinned/profile" });
+		setDefaultAccountSelection(db, "claude", existingDir);
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "claude",
+			prompt: "hi",
+		});
+		expect(launch.fullCommand).toBe(
+			"CLAUDE_CONFIG_DIR='/pinned/profile' 'claude' 'hi'",
+		);
+	});
+
+	it("skips injection when the selected profile dir no longer exists", () => {
+		const db = createTestDb();
+		seedClaude(db);
+		setDefaultAccountSelection(db, "claude", "/no/such/profile-dir");
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "claude",
+			prompt: "hi",
+		});
+		expect(launch.fullCommand).toBe("'claude' 'hi'");
+	});
+
+	it("does not leak provider account env into other presets", () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: "00000000-0000-0000-0000-00000000000d",
+				presetId: "amp",
+				label: "Amp",
+				command: "amp",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+		setDefaultAccountSelection(db, "claude", existingDir);
+		setDefaultAccountSelection(db, "codex", existingDir);
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "amp",
+			prompt: "hi",
+		});
+		expect(launch.fullCommand).toBe("'amp' 'hi'");
+	});
+
+	it("clearing the default (null) restores the system login", () => {
+		const db = createTestDb();
+		seedClaude(db);
+		setDefaultAccountSelection(db, "claude", existingDir);
+		setDefaultAccountSelection(db, "claude", null);
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "claude",
+			prompt: "hi",
+		});
+		expect(launch.fullCommand).toBe("'claude' 'hi'");
 	});
 });
 

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -20,6 +20,7 @@ import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 import { resolveAttachmentPath } from "../attachments/storage";
 import { toTerminalSessionError } from "../terminal/errors";
+import { resolveDefaultAccountEnv } from "../usage/default-account";
 
 interface ResolvedHostAgentConfig {
 	id: string;
@@ -305,8 +306,11 @@ export function buildTerminalAgentLaunch(
 		{ resumeSessionId: input.resumeSessionId },
 	);
 	const modelEnv = buildAgentModelEnv(config.presetId, input.model);
+	// Host-default provider account (Usage tab switcher). Per-agent env wins,
+	// so a "Claude (work)" agent with its own CLAUDE_CONFIG_DIR stays pinned.
+	const accountEnv = resolveDefaultAccountEnv(db, config.presetId);
 	return {
-		fullCommand: `${envOverlayPrefix({ ...config.env, ...modelEnv })}${command}`,
+		fullCommand: `${envOverlayPrefix({ ...accountEnv, ...config.env, ...modelEnv })}${command}`,
 		label: config.label,
 	};
 }

--- a/packages/host-service/src/trpc/router/usage/claude.ts
+++ b/packages/host-service/src/trpc/router/usage/claude.ts
@@ -150,7 +150,10 @@ export async function readDefaultLoginEmail(): Promise<string | null> {
  * only the freshest of the three surfaces (a stale sibling would otherwise
  * render as a phantom expired account).
  */
-async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
+async function discoverClaudeCredentials(): Promise<{
+	credentials: ClaudeOauthCredential[];
+	signedOutProfiles: Awaited<ReturnType<typeof discoverClaudeProfiles>>;
+}> {
 	const home = homedir();
 	const defaultCandidates: Array<{ path: string; sourceLabel: string }> = [
 		{
@@ -229,7 +232,13 @@ async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
 			byToken.set(credential.accessToken, credential);
 		}
 	}
-	return [...byToken.values()];
+	// Profiles with an identity but no readable credential (logged out, or a
+	// login that died half-way) still surface so the UI can offer re-sign-in
+	// and removal — otherwise the dir exists but nothing shows it.
+	const signedOutProfiles = profiles.filter(
+		(_profile, index) => profiled[index] === null,
+	);
+	return { credentials: [...byToken.values()], signedOutProfiles };
 }
 
 interface ClaudeUsageWindow {
@@ -428,6 +437,25 @@ async function fetchClaudeAccount(
 }
 
 export async function fetchClaudeAccounts(): Promise<UsageAccount[]> {
-	const credentials = await discoverClaudeCredentials();
-	return Promise.all(credentials.map(fetchClaudeAccount));
+	const { credentials, signedOutProfiles } = await discoverClaudeCredentials();
+	const accounts = await Promise.all(credentials.map(fetchClaudeAccount));
+	for (const profile of signedOutProfiles) {
+		accounts.push({
+			provider: "claude",
+			accountKey: profile.configDir,
+			sourceLabel: profile.sourceLabel,
+			email: profile.email,
+			plan: null,
+			status: "signed_out",
+			statusDetail:
+				"Signed out — use Switch sign-in to reconnect, or Remove to delete this profile.",
+			windows: [],
+			creditsBalance: null,
+			extraUsage: null,
+			selection: profile.configDir,
+			isDefault: false,
+			fetchedAt: new Date(),
+		});
+	}
+	return accounts;
 }

--- a/packages/host-service/src/trpc/router/usage/claude.ts
+++ b/packages/host-service/src/trpc/router/usage/claude.ts
@@ -29,6 +29,9 @@ interface ClaudeOauthCredential {
 	subscriptionType: string | null;
 	accountKey: string;
 	sourceLabel: string;
+	/** Config dir to inject as CLAUDE_CONFIG_DIR to run on this login; null
+	 * for the system-default login. */
+	selection: string | null;
 	/** Identity from the profile's own state file, when known. */
 	email?: string | null;
 }
@@ -45,6 +48,7 @@ function parseCredential(
 	raw: string,
 	accountKey: string,
 	sourceLabel: string,
+	selection: string | null,
 ): ClaudeOauthCredential | null {
 	try {
 		const parsed: ClaudeCredentialFile = JSON.parse(raw);
@@ -59,6 +63,7 @@ function parseCredential(
 					: null,
 			accountKey,
 			sourceLabel,
+			selection,
 		};
 	} catch {
 		return null;
@@ -68,10 +73,11 @@ function parseCredential(
 async function readCredentialFile(
 	path: string,
 	sourceLabel: string,
+	selection: string | null,
 ): Promise<ClaudeOauthCredential | null> {
 	try {
 		const raw = await readFile(path, "utf-8");
-		return parseCredential(raw, path, sourceLabel);
+		return parseCredential(raw, path, sourceLabel, selection);
 	} catch {
 		return null;
 	}
@@ -89,6 +95,7 @@ async function readKeychainCredential(): Promise<ClaudeOauthCredential | null> {
 			stdout.trim(),
 			"keychain:Claude Code-credentials",
 			"Keychain",
+			null,
 		);
 	} catch {
 		return null;
@@ -120,7 +127,7 @@ function pickFreshest(
 }
 
 /** Identity of the default login, readable even when its token is expired. */
-async function readDefaultLoginEmail(): Promise<string | null> {
+export async function readDefaultLoginEmail(): Promise<string | null> {
 	try {
 		const parsed = JSON.parse(
 			await readFile(join(homedir(), ".claude.json"), "utf-8"),
@@ -155,13 +162,18 @@ async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
 			sourceLabel: "~/.config/claude",
 		},
 	];
-	const explicitCandidates: Array<{ path: string; sourceLabel: string }> = [];
+	const explicitCandidates: Array<{
+		path: string;
+		sourceLabel: string;
+		configDir: string;
+	}> = [];
 	for (const dir of (process.env.CLAUDE_CONFIG_DIR ?? "").split(",")) {
 		const configDir = dir.trim();
 		if (!configDir) continue;
 		explicitCandidates.push({
 			path: join(configDir, ".credentials.json"),
 			sourceLabel: configDir.replace(home, "~"),
+			configDir,
 		});
 	}
 
@@ -171,6 +183,7 @@ async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
 		const fromFile = await readCredentialFile(
 			profile.credentialsPath,
 			profile.sourceLabel,
+			profile.configDir,
 		);
 		if (fromFile) return { ...fromFile, email: profile.email };
 		for (const service of profile.keychainServices) {
@@ -180,6 +193,7 @@ async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
 				secret,
 				profile.configDir,
 				profile.sourceLabel,
+				profile.configDir,
 			);
 			if (parsed) return { ...parsed, email: profile.email };
 		}
@@ -193,12 +207,12 @@ async function discoverClaudeCredentials(): Promise<ClaudeOauthCredential[]> {
 			readKeychainCredential(),
 			Promise.all(
 				defaultCandidates.map(({ path, sourceLabel }) =>
-					readCredentialFile(path, sourceLabel),
+					readCredentialFile(path, sourceLabel, null),
 				),
 			),
 			Promise.all(
-				explicitCandidates.map(({ path, sourceLabel }) =>
-					readCredentialFile(path, sourceLabel),
+				explicitCandidates.map(({ path, sourceLabel, configDir }) =>
+					readCredentialFile(path, sourceLabel, configDir),
 				),
 			),
 			Promise.all(profiles.map(readProfileCredential)),
@@ -319,6 +333,9 @@ async function fetchClaudeAccount(
 		sourceLabel: credential.sourceLabel,
 		plan: credential.subscriptionType,
 		creditsBalance: null,
+		selection: credential.selection,
+		// Decorated per-query from host settings; the quota cache outlives it.
+		isDefault: false,
 		fetchedAt: new Date(),
 	};
 

--- a/packages/host-service/src/trpc/router/usage/codex.ts
+++ b/packages/host-service/src/trpc/router/usage/codex.ts
@@ -100,8 +100,13 @@ function mapWindows(usage: CodexUsageResponse): UsageQuotaWindow[] {
 
 export async function fetchCodexAccounts(): Promise<UsageAccount[]> {
 	const homes = await discoverCodexHomes();
+	// The first discovered home is what codex uses with no CODEX_HOME override
+	// (see discoverCodexHomes) — running on it needs no env injection.
+	const defaultHome = homes[0]?.home ?? null;
 	const accounts = await Promise.all(
-		homes.map((home) => fetchCodexAccountForHome(home.home)),
+		homes.map((home) =>
+			fetchCodexAccountForHome(home.home, home.home === defaultHome),
+		),
 	);
 	// Dedupe by account email — one login used from several homes is one
 	// account; keep the first (default home wins).
@@ -116,6 +121,7 @@ export async function fetchCodexAccounts(): Promise<UsageAccount[]> {
 
 async function fetchCodexAccountForHome(
 	codexHome: string,
+	isDefaultHome: boolean,
 ): Promise<UsageAccount[]> {
 	const authPath = join(codexHome, "auth.json");
 
@@ -133,6 +139,9 @@ async function fetchCodexAccountForHome(
 		accountKey: authPath,
 		sourceLabel: codexHome.replace(homedir(), "~"),
 		extraUsage: null,
+		selection: isDefaultHome ? null : codexHome,
+		// Decorated per-query from host settings; the quota cache outlives it.
+		isDefault: false,
 		fetchedAt: new Date(),
 	};
 

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -1,0 +1,85 @@
+/**
+ * Host-wide default provider account for newly launched agents. "Switching"
+ * an account never touches credential stores — it only records which profile
+ * dir to inject (CLAUDE_CONFIG_DIR / CODEX_HOME) when an agent starts, so the
+ * provider CLI itself keeps owning every login end to end.
+ */
+
+import { existsSync } from "node:fs";
+import type { HostDb } from "../../../db";
+import { hostSettings } from "../../../db/schema";
+import type { UsageProvider } from "./types";
+
+export interface DefaultAccountSelections {
+	/** CLAUDE_CONFIG_DIR to inject, or null for the system-default login. */
+	claudeConfigDir: string | null;
+	/** CODEX_HOME to inject, or null for the system-default login. */
+	codexHome: string | null;
+}
+
+export function getDefaultAccountSelections(
+	db: HostDb,
+): DefaultAccountSelections {
+	const row = db.select().from(hostSettings).get();
+	return {
+		claudeConfigDir: row?.defaultClaudeConfigDir ?? null,
+		codexHome: row?.defaultCodexHome ?? null,
+	};
+}
+
+export function setDefaultAccountSelection(
+	db: HostDb,
+	provider: UsageProvider,
+	selection: string | null,
+): void {
+	const values =
+		provider === "claude"
+			? { defaultClaudeConfigDir: selection }
+			: { defaultCodexHome: selection };
+	db.insert(hostSettings)
+		.values({ id: 1, ...values })
+		.onConflictDoUpdate({ target: hostSettings.id, set: values })
+		.run();
+}
+
+/**
+ * Env for a new terminal so provider CLIs typed or launched in it run on the
+ * host-default accounts. Both providers' vars — a shell can run either CLI.
+ * Baked at PTY spawn; existing terminals keep the account they started with.
+ */
+export function resolveDefaultAccountTerminalEnv(
+	db: HostDb,
+): Record<string, string> {
+	return {
+		...resolveDefaultAccountEnv(db, "claude"),
+		...resolveDefaultAccountEnv(db, "codex"),
+	};
+}
+
+/**
+ * Env to overlay on an agent launch so it runs on the host-default account.
+ * A pointer whose profile dir has vanished is skipped: falling back to the
+ * system-default login beats booting the agent signed out.
+ */
+export function resolveDefaultAccountEnv(
+	db: HostDb,
+	presetId: string,
+): Record<string, string> {
+	if (presetId !== "claude" && presetId !== "codex") return {};
+	const selections = getDefaultAccountSelections(db);
+	if (
+		presetId === "claude" &&
+		selections.claudeConfigDir &&
+		existsSync(selections.claudeConfigDir)
+	) {
+		return { CLAUDE_CONFIG_DIR: selections.claudeConfigDir };
+	}
+	if (
+		presetId === "codex" &&
+		selections.codexHome &&
+		existsSync(selections.codexHome)
+	) {
+		return { CODEX_HOME: selections.codexHome };
+	}
+	return {};
+}

--- a/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	assertRemovableProfileDir,
+	removeClaudeProfile,
+	removeCodexHome,
+} from "./profile-remove";
+
+// These guard a recursive delete — every rejection here is load-bearing.
+describe("assertRemovableProfileDir", () => {
+	it("rejects anything outside the home dir", () => {
+		expect(() => assertRemovableProfileDir("/")).toThrow(/outside the home/);
+		expect(() => assertRemovableProfileDir("/tmp/claude-profile")).toThrow(
+			/outside the home/,
+		);
+		expect(() => assertRemovableProfileDir(homedir())).toThrow();
+	});
+
+	it("rejects every system-default home", () => {
+		for (const dir of [
+			join(homedir(), ".claude"),
+			join(homedir(), ".config", "claude"),
+			join(homedir(), ".config"),
+			join(homedir(), ".codex"),
+		]) {
+			expect(() => assertRemovableProfileDir(dir)).toThrow(/system-default/);
+		}
+	});
+
+	it("rejects path traversal that resolves to a protected dir", () => {
+		expect(() =>
+			assertRemovableProfileDir(
+				join(homedir(), ".claude-work", "..", ".claude"),
+			),
+		).toThrow(/system-default/);
+		expect(() =>
+			assertRemovableProfileDir(join(homedir(), ".claude-work", "..", "..")),
+		).toThrow(/outside the home/);
+	});
+
+	it("accepts a profile dir under the home dir", () => {
+		const dir = join(homedir(), ".claude-unittest-profile");
+		expect(assertRemovableProfileDir(dir)).toBe(dir);
+	});
+});
+
+describe("remove functions refuse protected dirs before touching the disk", () => {
+	it("removeClaudeProfile throws on the default home", async () => {
+		await expect(
+			removeClaudeProfile(join(homedir(), ".claude")),
+		).rejects.toThrow(/system-default/);
+	});
+
+	it("removeCodexHome throws on the default home", async () => {
+		await expect(removeCodexHome(join(homedir(), ".codex"))).rejects.toThrow(
+			/system-default/,
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/profile-remove.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.ts
@@ -1,0 +1,65 @@
+/**
+ * Deletes a secondary provider profile: its dir and (Claude, macOS) its
+ * scoped keychain items, so no orphaned credentials linger. The system
+ * default homes are never removable — the guards here are belt to the
+ * router's braces (which only accepts currently discovered profiles).
+ */
+
+import { execFile } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+import { keychainServicesForConfigDir } from "./profiles";
+
+const execFileAsync = promisify(execFile);
+
+function protectedDirs(): Set<string> {
+	const home = homedir();
+	const dirs = new Set([
+		home,
+		join(home, ".claude"),
+		join(home, ".config", "claude"),
+		join(home, ".config"),
+		join(home, ".codex"),
+	]);
+	if (process.env.CODEX_HOME) dirs.add(resolve(process.env.CODEX_HOME));
+	return dirs;
+}
+
+function assertRemovableProfileDir(dir: string): string {
+	const resolved = resolve(dir);
+	const home = homedir();
+	if (!resolved.startsWith(home + sep)) {
+		throw new Error(
+			`Refusing to remove a profile outside the home dir: ${dir}`,
+		);
+	}
+	if (protectedDirs().has(resolved)) {
+		throw new Error(`Refusing to remove the system-default profile: ${dir}`);
+	}
+	return resolved;
+}
+
+export async function removeClaudeProfile(configDir: string): Promise<void> {
+	const dir = assertRemovableProfileDir(configDir);
+	if (platform() === "darwin") {
+		// The CLI scopes keychain items by config-dir hash; drop every spelling
+		// so no orphaned credential outlives the dir.
+		for (const service of keychainServicesForConfigDir(dir)) {
+			await execFileAsync("security", [
+				"delete-generic-password",
+				"-s",
+				service,
+			]).catch(() => {
+				// Item absent for this spelling — nothing to delete.
+			});
+		}
+	}
+	await rm(dir, { recursive: true, force: true });
+}
+
+export async function removeCodexHome(home: string): Promise<void> {
+	const dir = assertRemovableProfileDir(home);
+	await rm(dir, { recursive: true, force: true });
+}

--- a/packages/host-service/src/trpc/router/usage/profile-remove.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.ts
@@ -27,7 +27,7 @@ function protectedDirs(): Set<string> {
 	return dirs;
 }
 
-function assertRemovableProfileDir(dir: string): string {
+export function assertRemovableProfileDir(dir: string): string {
 	const resolved = resolve(dir);
 	const home = homedir();
 	if (!resolved.startsWith(home + sep)) {

--- a/packages/host-service/src/trpc/router/usage/profile-seed.test.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-seed.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { seedClaudeProfileOnboarding } from "./profile-seed";
+
+function makeProfile(state: unknown): string {
+	const dir = mkdtempSync(join(tmpdir(), "claude-profile-seed-"));
+	if (state !== undefined) {
+		writeFileSync(join(dir, ".claude.json"), JSON.stringify(state));
+	}
+	return dir;
+}
+
+function readState(dir: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(join(dir, ".claude.json"), "utf-8"));
+}
+
+describe("seedClaudeProfileOnboarding", () => {
+	it("marks onboarding complete and preserves the CLI's other state", () => {
+		const dir = makeProfile({
+			oauthAccount: { emailAddress: "a@b.c" },
+			numStartups: 3,
+		});
+		seedClaudeProfileOnboarding(dir);
+		const state = readState(dir);
+		expect(state.hasCompletedOnboarding).toBe(true);
+		expect(state.oauthAccount).toEqual({ emailAddress: "a@b.c" });
+		expect(state.numStartups).toBe(3);
+	});
+
+	it("never overwrites a theme the profile already chose", () => {
+		const dir = makeProfile({ theme: "light" });
+		seedClaudeProfileOnboarding(dir);
+		expect(readState(dir).theme).toBe("light");
+	});
+
+	it("does nothing when onboarding is already complete", () => {
+		const dir = makeProfile({ hasCompletedOnboarding: true, theme: "light" });
+		const before = readFileSync(join(dir, ".claude.json"), "utf-8");
+		seedClaudeProfileOnboarding(dir);
+		expect(readFileSync(join(dir, ".claude.json"), "utf-8")).toBe(before);
+	});
+
+	it("does not create a state file where none exists (no login yet)", () => {
+		const dir = makeProfile(undefined);
+		seedClaudeProfileOnboarding(dir);
+		expect(() => readState(dir)).toThrow();
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/profile-seed.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-seed.ts
@@ -1,0 +1,40 @@
+/**
+ * Marks a secondary Claude profile's onboarding as complete so its first
+ * agent launch goes straight to the prompt instead of the first-boot wizard
+ * (where a stray Enter can start a login that silently rebinds the profile).
+ *
+ * This edits the CLI's state file (`.claude.json`), never a credential
+ * store, and only ever adds two preference keys — everything else is left
+ * exactly as the CLI wrote it.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function seedClaudeProfileOnboarding(configDir: string): void {
+	const statePath = join(configDir, ".claude.json");
+	let state: Record<string, unknown>;
+	try {
+		state = JSON.parse(readFileSync(statePath, "utf-8"));
+	} catch {
+		// No parsable state file means no completed login yet — nothing to seed.
+		return;
+	}
+	if (state.hasCompletedOnboarding === true) return;
+	state.hasCompletedOnboarding = true;
+	if (state.theme === undefined) {
+		// Carry the default profile's theme so the first launch looks familiar.
+		try {
+			const defaultState = JSON.parse(
+				readFileSync(join(homedir(), ".claude.json"), "utf-8"),
+			) as { theme?: unknown };
+			if (typeof defaultState.theme === "string") {
+				state.theme = defaultState.theme;
+			}
+		} catch {
+			// Theme stays unset; the CLI falls back to its own default.
+		}
+	}
+	writeFileSync(statePath, JSON.stringify(state, null, 2));
+}

--- a/packages/host-service/src/trpc/router/usage/types.ts
+++ b/packages/host-service/src/trpc/router/usage/types.ts
@@ -9,7 +9,11 @@ export type UsageAccountStatus =
 	| "token_expired"
 	/** Credentials exist but the provider returned no usable quota data
 	 * (org-managed/education plans, endpoint changes, transient errors). */
-	| "unavailable";
+	| "unavailable"
+	/** A profile dir with an identity but no readable credential (logged out
+	 * or a half-finished login). Surfaced so it can be re-signed or removed;
+	 * a signed-out Codex home is undetectable (its auth.json is gone). */
+	| "signed_out";
 
 export interface UsageQuotaWindow {
 	/** Stable identifier within the account, e.g. "five_hour", "seven_day",

--- a/packages/host-service/src/trpc/router/usage/types.ts
+++ b/packages/host-service/src/trpc/router/usage/types.ts
@@ -37,5 +37,11 @@ export interface UsageAccount {
 	creditsBalance: number | null;
 	/** Claude extra-usage spend, in cents, when present. */
 	extraUsage: { usedCents: number; limitCents: number } | null;
+	/** Profile dir to inject into agent launches (CLAUDE_CONFIG_DIR /
+	 * CODEX_HOME) to run on this account. Null for the system-default login,
+	 * which needs no override. */
+	selection: string | null;
+	/** Whether newly launched agents use this account (host-wide default). */
+	isDefault: boolean;
 	fetchedAt: Date;
 }

--- a/packages/host-service/src/trpc/router/usage/usage.ts
+++ b/packages/host-service/src/trpc/router/usage/usage.ts
@@ -1,11 +1,25 @@
-import { basename } from "node:path";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import {
+	ensureClaudeManagedHooksAt,
+	ensureCodexManagedHooksAt,
+} from "@superset/agent-setup";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
 import { usageHistoryTask } from "../../../workers/tasks/usage";
-import { queryProcedure, router } from "../../index";
+import { protectedProcedure, queryProcedure, router } from "../../index";
 import { offLoop } from "../../off-loop";
-import { fetchClaudeAccounts } from "./claude";
+import { fetchClaudeAccounts, readDefaultLoginEmail } from "./claude";
 import { fetchCodexAccounts } from "./codex";
+import {
+	getDefaultAccountSelections,
+	setDefaultAccountSelection,
+} from "./default-account";
+import { removeClaudeProfile, removeCodexHome } from "./profile-remove";
+import { seedClaudeProfileOnboarding } from "./profile-seed";
+import { discoverClaudeProfiles, discoverCodexHomes } from "./profiles";
 import type { UsageAccount } from "./types";
 
 /**
@@ -49,7 +63,174 @@ export const usageRouter = router({
 	quota: queryProcedure
 		.meta({ timeoutMs: 15_000 })
 		.input(z.object({ forceRefresh: z.boolean().optional() }).optional())
-		.query(({ input }) => getQuota(input?.forceRefresh ?? false)),
+		.query(async ({ ctx, input }) => {
+			const accounts = await getQuota(input?.forceRefresh ?? false);
+			// isDefault is applied per query, not cached with the quota: changing
+			// the default must reflect immediately without re-hitting providers.
+			const defaults = getDefaultAccountSelections(ctx.db);
+			return accounts.map((account) => ({
+				...account,
+				isDefault:
+					account.selection ===
+					(account.provider === "claude"
+						? defaults.claudeConfigDir
+						: defaults.codexHome),
+			}));
+		}),
+
+	/**
+	 * Local-only login discovery (no provider network calls), safe to poll
+	 * while an add-account or switch-sign-in flow is pending in a terminal.
+	 * The default-slot fields let the UI notice a `/login` that re-signed the
+	 * system-default login (Claude by state-file email; Codex by auth.json
+	 * fingerprint, since its email is only knowable via the network).
+	 */
+	logins: queryProcedure.query(async () => {
+		const [profiles, codexHomes, claudeDefaultEmail] = await Promise.all([
+			discoverClaudeProfiles(),
+			discoverCodexHomes(),
+			readDefaultLoginEmail(),
+		]);
+		// auth.json fingerprints let the UI notice a re-login on any Codex home
+		// (its email is only knowable via the network). The first home is the
+		// system default.
+		const codex = await Promise.all(
+			codexHomes.map(async ({ home }) => {
+				let fingerprint: string | null = null;
+				try {
+					fingerprint = createHash("sha256")
+						.update(await readFile(join(home, "auth.json")))
+						.digest("hex");
+				} catch {
+					// No readable auth.json — fingerprint stays null.
+				}
+				return { home, fingerprint };
+			}),
+		);
+		return {
+			claude: profiles.map((profile) => ({
+				configDir: profile.configDir,
+				email: profile.email,
+			})),
+			codex,
+			claudeDefaultEmail,
+		};
+	}),
+
+	/**
+	 * Point new agent launches at one of the discovered logins (null = the
+	 * system default). Never touches credentials — see default-account.ts.
+	 */
+	setDefaultAccount: protectedProcedure
+		.input(
+			z.object({
+				provider: z.enum(["claude", "codex"]),
+				selection: z.string().nullable(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			if (input.selection !== null) {
+				// Only accept a discovered login: the value lands in a shell env
+				// overlay, and a typo'd dir would boot agents signed out.
+				const accounts = await getQuota(false);
+				const known = accounts.some(
+					(account) =>
+						account.provider === input.provider &&
+						account.selection === input.selection,
+				);
+				if (!known) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: `No ${input.provider} login found at ${input.selection} — refresh usage and pick again.`,
+					});
+				}
+			}
+			setDefaultAccountSelection(ctx.db, input.provider, input.selection);
+			// Secondary profiles read hooks from their own dir, so agents launched
+			// there would otherwise lose lifecycle/status reporting; fresh Claude
+			// profiles also need onboarding marked done or the first launch runs
+			// the first-boot wizard. Best-effort: a failed merge must not undo
+			// the switch.
+			if (input.selection !== null) {
+				try {
+					if (input.provider === "claude") {
+						ensureClaudeManagedHooksAt(input.selection);
+						seedClaudeProfileOnboarding(input.selection);
+					} else {
+						ensureCodexManagedHooksAt(input.selection);
+					}
+				} catch {
+					// Agents still run without hooks; provisioning retries on the
+					// next switch.
+				}
+			}
+			return { success: true as const };
+		}),
+
+	/**
+	 * Deletes a secondary profile: its dir plus, for Claude on macOS, its
+	 * scoped keychain items. The system default (selection null) is never
+	 * removable, and only currently discovered profiles are accepted. A
+	 * default pointer at the removed profile is cleared so agents fall back
+	 * to the system login instead of a dead dir.
+	 */
+	removeAccount: protectedProcedure
+		.input(
+			z.object({
+				provider: z.enum(["claude", "codex"]),
+				selection: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const accounts = await getQuota(false);
+			const known = accounts.some(
+				(account) =>
+					account.provider === input.provider &&
+					account.selection === input.selection,
+			);
+			if (!known) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No removable ${input.provider} profile at ${input.selection}.`,
+				});
+			}
+			if (input.provider === "claude") {
+				await removeClaudeProfile(input.selection);
+			} else {
+				await removeCodexHome(input.selection);
+			}
+			const defaults = getDefaultAccountSelections(ctx.db);
+			const pointer =
+				input.provider === "claude"
+					? defaults.claudeConfigDir
+					: defaults.codexHome;
+			if (pointer === input.selection) {
+				setDefaultAccountSelection(ctx.db, input.provider, null);
+			}
+			// The quota cache still lists the removed account; drop it so the
+			// next query re-discovers.
+			cachedQuota = null;
+			return { success: true as const };
+		}),
+
+	/**
+	 * One-time preparation for a freshly added Claude profile: mark onboarding
+	 * complete so the first agent launch doesn't open the first-boot wizard.
+	 * Only accepts discovered profile dirs.
+	 */
+	prepareClaudeProfile: protectedProcedure
+		.input(z.object({ configDir: z.string() }))
+		.mutation(async ({ input }) => {
+			const profiles = await discoverClaudeProfiles();
+			if (!profiles.some((profile) => profile.configDir === input.configDir)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No Claude profile found at ${input.configDir}.`,
+				});
+			}
+			seedClaudeProfileOnboarding(input.configDir);
+			return { success: true as const };
+		}),
 
 	/**
 	 * Token/cost history estimated from the providers' own transcript logs,


### PR DESCRIPTION
## Summary
- The Usage tab now manages multiple Claude Code / Codex logins: add a second subscription as its own profile, pick which account new terminals and agents launch with, re-sign any login into a different account, and remove a profile — all without Superset ever touching a credential store.
- The account view groups cards under provider sections (each with its own Add account button); cards carry a `Default` pill, a hover `Make default` action, status chips, and a `⋯` menu (Switch sign-in… / Remove…). The system-default login is never removable.

## Why / Context
People with two subscriptions (personal + work) hit session limits on one account while the other sits idle. Discovery already listed every login's quota side by side; this adds the ability to act on it. The most requested action from the token-spend feedback thread was exactly this: start new work on the account with headroom.

## How It Works
Switching is selection-by-env, not credential materialization:
- `host_settings` gains `default_claude_config_dir` / `default_codex_home` (migration 0024, plain ALTERs; null = system default).
- `buildTerminalAgentLaunch` and new-terminal PTY env (`createTerminalSessionInternal`) overlay `CLAUDE_CONFIG_DIR` / `CODEX_HOME` from that pointer, so preset launches, host-side agent runs, and a manually typed `claude` all follow it. Per-agent `env_json` still wins; a vanished profile dir falls back to the system default. Running sessions keep the account they spawned with (env is baked at spawn).
- `usage.quota` accounts now carry `selection` + `isDefault` (decorated per query, so switching reflects instantly without re-hitting provider endpoints).
- New host procedures: `usage.logins` (local-only discovery — pollable while a sign-in is pending; Codex homes carry an `auth.json` fingerprint since Codex identity isn't knowable offline), `usage.setDefaultAccount`, `usage.removeAccount`, `usage.prepareClaudeProfile`.
- Making a Claude profile the default (or detecting its sign-in) merges Superset's lifecycle hooks into the profile dir (`ensureClaudeManagedHooksAt` / `ensureCodexManagedHooksAt`, new agent-setup exports) and marks CLI onboarding complete — without these, agents on the profile lose status reporting, and the first launch opens the CLI's first-boot wizard where a stray Enter can start an unwanted login.
- Add account / Switch sign-in never automate OAuth: the dialog hands the user the provider's own login command for the right dir, then watches local state (profile discovery / state-file email / auth.json fingerprint) to detect completion.
- Removal deletes the profile dir plus its scoped keychain items (path guards: inside `$HOME`, never a default home), clears a default pointer aimed at it, and drops the host's quota cache.

## Manual QA (driven end-to-end over CDP against the dev app, two real Max accounts)
- [x] Two Claude accounts + Codex render with quota; `Default` pill sits on the system default for both providers
- [x] "Use for new agents" moves the pill, persists to host.db, and survives switching back (both directions)
- [x] Agent launched after switching runs with `CLAUDE_CONFIG_DIR='<profile>'` visible in the pty and boots on that profile
- [x] Brand-new terminal after switching: `echo $CLAUDE_CONFIG_DIR` shows the profile and `claude auth status` reports the selected account (the preset-strip launch path that bypasses the host agent launcher)
- [x] Add-account dialog detects a completed sign-in via the logins poll and offers "Use for new agents"
- [x] Switch sign-in on a profile card shows the dir-scoped login command; on the system-default card, the bare command
- [x] Remove: confirm dialog → card disappears → directory deleted on disk; system-default cards have no Remove
- [x] Hook merge lands in the profile's `settings.json` (all 8 events) on selection
- [x] Duplicate-account edge: two profiles holding the same email stay distinguishable (source label always shown)

Not exercised live: completing a Switch sign-in on the system default (would rotate my real default login mid-session); its detection is the same poll loop verified in add mode with a different comparator.

## Testing
- `bun run typecheck` (host-service, agent-setup, desktop)
- biome on all touched dirs
- `bun test` host-service: agents launch-env suite (5 new tests incl. precedence, mutation-tested to fail on regression) + profile-seed suite (4 tests)

## Design Decisions
- **Env injection over rewriting `~/.claude` + keychain on switch**: rewriting the shared stores means owning refresh-token races (they're single-use), live-session gating, and rollback. Injecting the profile dir per launch keeps the provider CLI the sole owner of every credential, scopes the switch to new sessions by construction, and fits an app whose agents it launches itself.
- **Guided command instead of automated OAuth for add/re-sign**: the CLI's login flow writes the right stores itself (including the config-dir-scoped keychain item); automating it would mean capturing credentials in transit.

## Known Limitations
- A shell rc file that exports its own `CLAUDE_CONFIG_DIR`/`CODEX_HOME` overrides the injected PTY env for manually typed CLIs (agent launches are unaffected — the command-line overlay wins).
- The default pointer follows the profile *dir*, not the account inside it: re-signing a profile into a different account silently changes what new agents use. Deliberate (a profile is a slot), but worth knowing.
- A signed-out Codex home is undetectable (its `auth.json` is gone), so unlike Claude profiles it cannot be surfaced for re-sign-in or removal.
- Claude re-sign detection compares the state-file email, so re-signing the same email into the same slot isn't detected (nothing changed to act on).
- `usage.history` (token spend) is not yet attributed per account.

## Follow-ups
- Account picker at agent-start time with headroom inline (choose the account with quota left at the moment it matters)
- Per-account attribution in usage history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account management for Claude Code and Codex usage cards.
  * Users can add accounts, switch sign-in, set defaults, and remove secondary accounts.
  * Account cards now show provider, status, and default indicators with management menus.
  * Defaults apply automatically to future terminals and agents.
  * Added provider-specific grouping, empty states, command copying, refresh handling, and notifications.

* **Bug Fixes**
  * Improved alternate account setup, onboarding, and profile preservation.
  * Added clearer handling for signed-out accounts and safer account removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
