### PR TITLE
feat(desktop,api,shared,trpc): Slack trigger provider

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/index.ts
@@ -1,0 +1,5 @@
+export {
+	isAutomationEvent,
+	processAutomationEvent,
+	type SlackAutomationEnvelope,
+} from "./process-automation-event";

--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
@@ -1,5 +1,3 @@
-import type { SlackMatchableEvent } from "@superset/shared/automation-matching";
-import { slackEventNames } from "@superset/shared/automation-matching";
 import type {
 	BotMessageEvent,
 	ChannelCreatedEvent,
@@ -9,6 +7,10 @@ import type {
 	ReactionAddedEvent,
 	ThreadBroadcastMessageEvent,
 } from "@slack/types";
+import {
+	type SlackMatchableEvent,
+	slackEventNames,
+} from "@superset/shared/automation-matching";
 
 /**
  * The message subtypes that are still "a message in the channel". Edits,

--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
@@ -1,0 +1,181 @@
+import type { SlackMatchableEvent } from "@superset/shared/automation-matching";
+import { slackEventNames } from "@superset/shared/automation-matching";
+import type {
+	BotMessageEvent,
+	ChannelCreatedEvent,
+	FileShareMessageEvent,
+	GenericMessageEvent,
+	MessageEvent,
+	ReactionAddedEvent,
+	ThreadBroadcastMessageEvent,
+} from "@slack/types";
+
+/**
+ * The message subtypes that are still "a message in the channel". Edits,
+ * deletes, joins and topic changes are also delivered as `message` events and
+ * are not.
+ */
+export type ChannelMessageEvent =
+	| GenericMessageEvent
+	| BotMessageEvent
+	| FileShareMessageEvent
+	| ThreadBroadcastMessageEvent;
+
+/**
+ * The three Slack events triggers can name, and the envelope they arrive in.
+ * The envelope's `authorizations` names the bot user the event was delivered
+ * for, which is how the bot's own messages are recognised without a lookup.
+ */
+export type SlackAutomationEvent =
+	| ChannelMessageEvent
+	| ReactionAddedEvent
+	| ChannelCreatedEvent;
+
+export type SlackAutomationEnvelope = {
+	team_id: string;
+	event_id: string;
+	api_app_id?: string;
+	authorizations?: Array<{ user_id?: string; is_bot?: boolean }>;
+	event: SlackAutomationEvent;
+};
+
+/**
+ * A Slack event flattened out of payloads whose shape differs per event: the
+ * matchable event triggers filter on, plus what the `automation_events` row
+ * needs beyond that.
+ */
+export type NormalizedSlackEvent = {
+	event: SlackMatchableEvent;
+	resourceKey: string;
+	title: string;
+	url: string;
+};
+
+const MESSAGE_SUBTYPES = new Set<string | undefined>([
+	undefined,
+	"bot_message",
+	"file_share",
+	"thread_broadcast",
+]);
+
+/**
+ * Whether a message event is one triggers should see: posted in a channel
+ * (public or private, not a DM), a real post rather than an edit, and not
+ * written by this app's own bot — an automation that replies in Slack must not
+ * wake itself up.
+ */
+export function isChannelMessage(
+	event: MessageEvent,
+	envelope: Pick<SlackAutomationEnvelope, "api_app_id" | "authorizations">,
+): event is ChannelMessageEvent {
+	// The union's members disagree on which of these they carry; read them
+	// loosely and let the subtype allow-list do the narrowing.
+	const message = event as {
+		subtype?: string;
+		channel_type?: string;
+		user?: string;
+		bot_profile?: { app_id?: string };
+	};
+	if (message.channel_type !== "channel" && message.channel_type !== "group") {
+		return false;
+	}
+	if (!MESSAGE_SUBTYPES.has(message.subtype)) return false;
+	const ownBotUserIds = (envelope.authorizations ?? [])
+		.map((a) => a.user_id)
+		.filter((id): id is string => typeof id === "string");
+	if (message.user && ownBotUserIds.includes(message.user)) return false;
+	if (
+		envelope.api_app_id !== undefined &&
+		message.bot_profile?.app_id === envelope.api_app_id
+	) {
+		return false;
+	}
+	return true;
+}
+
+/** Slack's canonical permalink; slack.com redirects to the workspace domain. */
+function permalink(channel: string, ts: string): string {
+	return `https://slack.com/archives/${channel}/p${ts.replace(".", "")}`;
+}
+
+/** `:bug::skin-tone-2:` arrives as `bug::skin-tone-2`; the trigger names `bug`. */
+export function reactionName(reaction: string): string {
+	return reaction.split("::")[0] ?? reaction;
+}
+
+const MAX_TITLE = 120;
+
+function titleFromText(text: string | undefined, fallback: string): string {
+	const firstLine = (text ?? "").split("\n").find((line) => line.trim());
+	if (!firstLine) return fallback;
+	const trimmed = firstLine.trim();
+	return trimmed.length > MAX_TITLE
+		? `${trimmed.slice(0, MAX_TITLE - 1)}…`
+		: trimmed;
+}
+
+function matchable(
+	eventType: "message" | "reaction_added" | "channel_created",
+	fields: Pick<
+		SlackMatchableEvent,
+		"channelId" | "actorId" | "body" | "reaction"
+	>,
+): SlackMatchableEvent {
+	return {
+		provider: "slack",
+		eventType,
+		names: slackEventNames(eventType),
+		// Slack events carry the user id and no handle; a lookup per message is
+		// not worth a display column.
+		actorLogin: fields.actorId,
+		...fields,
+	};
+}
+
+export function normalizeSlackEvent(
+	event: SlackAutomationEvent,
+): NormalizedSlackEvent {
+	switch (event.type) {
+		case "message": {
+			// A thread is one resource: replies key on the root, so a run in
+			// flight on a thread debounces its own follow-ups.
+			const root = event.thread_ts ?? event.ts;
+			return {
+				event: matchable("message", {
+					channelId: event.channel,
+					actorId: event.user ?? null,
+					body: event.text ?? null,
+					reaction: null,
+				}),
+				resourceKey: `slack:${event.channel}:${root}`,
+				title: titleFromText(event.text, `Message in ${event.channel}`),
+				url: permalink(event.channel, event.ts),
+			};
+		}
+		case "reaction_added":
+			return {
+				event: matchable("reaction_added", {
+					channelId: event.item.channel,
+					actorId: event.user ?? null,
+					body: null,
+					reaction: reactionName(event.reaction),
+				}),
+				resourceKey: `slack:${event.item.channel}:${event.item.ts}`,
+				title: `:${reactionName(event.reaction)}: reaction`,
+				url: permalink(event.item.channel, event.item.ts),
+			};
+		case "channel_created":
+			return {
+				event: matchable("channel_created", {
+					channelId: null,
+					actorId: event.channel.creator ?? null,
+					// The name is what a "matching" filter reads.
+					body: event.channel.name ?? null,
+					reaction: null,
+				}),
+				resourceKey: `slack:${event.channel.id}`,
+				title: `#${event.channel.name}`,
+				url: `https://slack.com/archives/${event.channel.id}`,
+			};
+	}
+}

--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/normalize.ts
@@ -120,7 +120,7 @@ function matchable(
 	eventType: "message" | "reaction_added" | "channel_created",
 	fields: Pick<
 		SlackMatchableEvent,
-		"channelId" | "actorId" | "body" | "reaction"
+		"channelId" | "actorId" | "body" | "reaction" | "isThreadReply"
 	>,
 ): SlackMatchableEvent {
 	return {
@@ -148,6 +148,10 @@ export function normalizeSlackEvent(
 					actorId: event.user ?? null,
 					body: event.text ?? null,
 					reaction: null,
+					// A reply carries its root's ts; a root's thread_ts, when set,
+					// is its own ts.
+					isThreadReply:
+						event.thread_ts !== undefined && event.thread_ts !== event.ts,
 				}),
 				resourceKey: `slack:${event.channel}:${root}`,
 				title: titleFromText(event.text, `Message in ${event.channel}`),
@@ -161,6 +165,7 @@ export function normalizeSlackEvent(
 					actorId: event.user ?? null,
 					body: null,
 					reaction: reactionName(event.reaction),
+					isThreadReply: false,
 				}),
 				resourceKey: `slack:${event.item.channel}:${event.item.ts}`,
 				title: `:${reactionName(event.reaction)}: reaction`,
@@ -174,6 +179,7 @@ export function normalizeSlackEvent(
 					// The name is what a "matching" filter reads.
 					body: event.channel.name ?? null,
 					reaction: null,
+					isThreadReply: false,
 				}),
 				resourceKey: `slack:${event.channel.id}`,
 				title: `#${event.channel.name}`,

--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/process-automation-event.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/process-automation-event.ts
@@ -1,0 +1,79 @@
+import type { SlackEvent } from "@slack/types";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import {
+	isChannelMessage,
+	normalizeSlackEvent,
+	type SlackAutomationEnvelope,
+} from "./normalize";
+import { recordSlackAutomationEvent } from "./record-automation-event";
+
+export type { SlackAutomationEnvelope } from "./normalize";
+
+/**
+ * Whether this delivery is one triggers can name. Narrows the envelope so the
+ * route can hand it over without re-checking the event type.
+ */
+export function isAutomationEvent(envelope: {
+	team_id: string;
+	event_id: string;
+	api_app_id?: string;
+	authorizations?: SlackAutomationEnvelope["authorizations"];
+	event: SlackEvent;
+}): envelope is SlackAutomationEnvelope {
+	const { event } = envelope;
+	switch (event.type) {
+		case "message":
+			return isChannelMessage(event, envelope);
+		case "reaction_added":
+		case "channel_created":
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Records a Slack event and enqueues a run for every trigger it satisfies.
+ *
+ * Awaited by the route rather than queued: it is a handful of indexed reads
+ * and one insert, well inside Slack's three-second window, and queueing would
+ * add a job route only to defer the same work by a few hundred milliseconds.
+ */
+export async function processAutomationEvent(
+	envelope: SlackAutomationEnvelope,
+): Promise<
+	| { recorded: false; reason: string }
+	| { recorded: true; eventId: string; matched: number; considered: number }
+> {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.provider, "slack"),
+			eq(integrationConnections.externalOrgId, envelope.team_id),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		columns: { id: true, organizationId: true },
+	});
+	if (!connection) return { recorded: false, reason: "unknown workspace" };
+
+	const normalized = normalizeSlackEvent(envelope.event);
+	const recorded = await recordSlackAutomationEvent({
+		organizationId: connection.organizationId,
+		integrationConnectionId: connection.id,
+		envelope,
+		normalized,
+	});
+	if ("duplicate" in recorded) {
+		return { recorded: false, reason: "duplicate delivery" };
+	}
+
+	const result = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: recorded.eventId,
+		event: normalized.event,
+	});
+	return { recorded: true, eventId: recorded.eventId, ...result };
+}

--- a/apps/api/src/app/api/integrations/slack/events/process-automation-event/record-automation-event.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-automation-event/record-automation-event.ts
@@ -1,0 +1,53 @@
+import { db } from "@superset/db/client";
+import { automationEvents } from "@superset/db/schema";
+
+import { stripNullChars } from "@/lib/strip-null-chars";
+import type {
+	NormalizedSlackEvent,
+	SlackAutomationEnvelope,
+} from "./normalize";
+
+/**
+ * Records a Slack event as an `automation_events` row — the normalized stream
+ * triggers are matched against. Idempotent on Slack's `event_id`: a retried
+ * delivery is the same event, and the first one already dispatched.
+ */
+export async function recordSlackAutomationEvent(params: {
+	organizationId: string;
+	integrationConnectionId: string;
+	envelope: SlackAutomationEnvelope;
+	normalized: NormalizedSlackEvent;
+}): Promise<{ eventId: string } | { duplicate: true }> {
+	const { normalized } = params;
+	const [inserted] = await db
+		.insert(automationEvents)
+		.values({
+			organizationId: params.organizationId,
+			integrationConnectionId: params.integrationConnectionId,
+			provider: "slack",
+			eventType: normalized.event.eventType,
+			externalEventId: params.envelope.event_id,
+			resourceKey: normalized.resourceKey,
+			title: normalized.title,
+			url: normalized.url,
+			repositoryId: null,
+			ref: null,
+			actorLogin: normalized.event.actorLogin,
+			actorIsExternal: null,
+			// jsonb rejects U+0000, and a payload carrying one would otherwise
+			// throw and lose the event.
+			payload: stripNullChars(params.envelope) as Record<string, unknown>,
+			webhookEventId: null,
+		})
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		})
+		.returning({ id: automationEvents.id });
+
+	if (!inserted) return { duplicate: true };
+	return { eventId: inserted.id };
+}

--- a/apps/api/src/app/api/integrations/slack/events/route.test.ts
+++ b/apps/api/src/app/api/integrations/slack/events/route.test.ts
@@ -22,6 +22,11 @@ mock.module("./process-app-home-opened", () => ({
 	processAppHomeOpened: mock(async () => ({})),
 }));
 
+mock.module("./process-automation-event", () => ({
+	isAutomationEvent: () => false,
+	processAutomationEvent: mock(async () => ({ recorded: false })),
+}));
+
 mock.module("./process-entity-details", () => ({
 	processEntityDetails: mock(async () => ({})),
 }));

--- a/apps/api/src/app/api/integrations/slack/events/route.ts
+++ b/apps/api/src/app/api/integrations/slack/events/route.ts
@@ -4,6 +4,10 @@ import { Client } from "@upstash/qstash";
 import { env } from "@/env";
 import { verifySlackSignature } from "../verify-signature";
 import { processAppHomeOpened } from "./process-app-home-opened";
+import {
+	isAutomationEvent,
+	processAutomationEvent,
+} from "./process-automation-event";
 import { processEntityDetails } from "./process-entity-details";
 import { processLinkShared } from "./process-link-shared";
 
@@ -14,6 +18,8 @@ type SlackEventEnvelope = {
 	challenge?: string;
 	team_id?: string;
 	event_id?: string;
+	api_app_id?: string;
+	authorizations?: Array<{ user_id?: string; is_bot?: boolean }>;
 	event?: SlackEvent | null;
 };
 
@@ -75,6 +81,32 @@ export async function POST(request: Request) {
 		) {
 			console.error("[slack/events] Invalid event payload shape");
 			return Response.json({ error: "Invalid payload shape" }, { status: 400 });
+		}
+
+		// Channel messages, reactions and new channels are recorded as automation
+		// events and matched against Slack triggers. Awaited, like GitHub's route:
+		// a few indexed queries, and Slack's three-second budget is not at risk.
+		// Failures are logged rather than surfaced — Slack would only retry, and a
+		// redelivery of the same event_id is deduped anyway.
+		const envelope = {
+			team_id,
+			event_id,
+			api_app_id: payload.api_app_id,
+			authorizations: payload.authorizations,
+			event,
+		};
+		if (isAutomationEvent(envelope)) {
+			try {
+				const result = await processAutomationEvent(envelope);
+				if (result.recorded && result.matched > 0) {
+					console.log(
+						`[slack/events] ${result.matched}/${result.considered} triggers matched:`,
+						event_id,
+					);
+				}
+			} catch (error) {
+				console.error("[slack/events] processAutomationEvent failed:", error);
+			}
 		}
 
 		if (event.type === "app_mention") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -3,6 +3,7 @@ import { githubProvider } from "./github/github";
 import { linearProvider } from "./linear/linear";
 import { notionProvider } from "./notion/notion";
 import { scheduleProvider } from "./schedule/schedule";
+import { slackProvider } from "./slack/slack";
 import type { TriggerProvider } from "./types";
 import { webhookProvider } from "./webhook/webhook";
 
@@ -24,6 +25,7 @@ export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	githubProvider as TriggerProvider,
 	linearProvider as TriggerProvider,
 	notionProvider as TriggerProvider,
+	slackProvider as TriggerProvider,
 	webhookProvider as TriggerProvider,
 ];
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/components/EmojiNameChip/EmojiNameChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/components/EmojiNameChip/EmojiNameChip.tsx
@@ -1,0 +1,79 @@
+import { Input } from "@superset/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { useState } from "react";
+import { ChipButton } from "../../../../TriggerSentence/components/ChipButton";
+import { emojiLabel, parseEmojiNames } from "../../emoji";
+
+/**
+ * One or more emoji names, typed rather than picked.
+ *
+ * Slack has no API that lists standard emoji, and a workspace's custom emoji
+ * are the ones people most want to react with, so a picker would always be
+ * missing the one that matters. Typing ":deployparrot:" or "bug, eyes" is the
+ * whole interaction; the chip normalizes it to the bare names Slack sends.
+ */
+export function EmojiNameChip({
+	names,
+	onChange,
+	emptyLabel,
+	placeholder,
+	disabled,
+	className,
+}: {
+	names: string[];
+	onChange: (names: string[]) => void;
+	emptyLabel: string;
+	placeholder: string;
+	disabled?: boolean;
+	className?: string;
+}) {
+	const [open, setOpen] = useState(false);
+	// The field holds whatever was typed until the popover closes, so a
+	// trailing comma or colon does not vanish under the person's cursor.
+	const [draft, setDraft] = useState<string | null>(null);
+
+	const label =
+		names.length === 0
+			? emptyLabel
+			: names.length === 1
+				? emojiLabel(names[0] ?? "")
+				: `${names.length} reactions`;
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(next) => {
+				if (disabled) return;
+				setOpen(next);
+				if (!next) setDraft(null);
+			}}
+		>
+			<PopoverTrigger asChild>
+				<span>
+					<ChipButton
+						label={label}
+						empty={names.length === 0}
+						disabled={disabled}
+						className={className}
+					/>
+				</span>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-64 p-2">
+				<Input
+					autoFocus
+					value={draft ?? names.map((n) => `:${n}:`).join(" ")}
+					placeholder={placeholder}
+					disabled={disabled}
+					onChange={(event) => {
+						setDraft(event.target.value);
+						onChange(parseEmojiNames(event.target.value));
+					}}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") setOpen(false);
+					}}
+					className="h-8 text-[13px]"
+				/>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/components/EmojiNameChip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/components/EmojiNameChip/index.ts
@@ -1,0 +1,1 @@
+export { EmojiNameChip } from "./EmojiNameChip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/emoji.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/emoji.ts
@@ -1,0 +1,42 @@
+import type { ScopeOption } from "../../TriggerSentence/scopeOption";
+
+/**
+ * The reactions a trigger can be scoped to, by Slack short name — what a
+ * `reaction_added` event carries. Standard emoji, since there is no API that
+ * lists them; workspace custom emoji would need `emoji.list` and its scope.
+ */
+export const SLACK_REACTION_OPTIONS: ScopeOption[] = [
+	["+1", "👍"],
+	["-1", "👎"],
+	["eyes", "👀"],
+	["white_check_mark", "✅"],
+	["heavy_check_mark", "✔️"],
+	["x", "❌"],
+	["bug", "🐛"],
+	["fire", "🔥"],
+	["rocket", "🚀"],
+	["tada", "🎉"],
+	["raised_hands", "🙌"],
+	["pray", "🙏"],
+	["heart", "❤️"],
+	["100", "💯"],
+	["warning", "⚠️"],
+	["rotating_light", "🚨"],
+	["question", "❓"],
+	["memo", "📝"],
+	["pushpin", "📌"],
+	["bookmark", "🔖"],
+	["mag", "🔍"],
+	["wrench", "🔧"],
+	["bulb", "💡"],
+	["thinking_face", "🤔"],
+	["clap", "👏"],
+	["wave", "👋"],
+	["ok_hand", "👌"],
+	["hourglass_flowing_sand", "⏳"],
+	["zap", "⚡"],
+	["boom", "💥"],
+	["sos", "🆘"],
+	["robot_face", "🤖"],
+	["ship", "🚢"],
+].map(([id, glyph]) => ({ id, label: `${glyph} ${id}` }));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/emoji.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/emoji.ts
@@ -1,42 +1,60 @@
-import type { ScopeOption } from "../../TriggerSentence/scopeOption";
+/**
+ * Glyphs for the standard reactions people type most, keyed by Slack short
+ * name, so the chip can show "🐛 bug" instead of ":bug:". Display only: any
+ * name is accepted — a workspace's custom emoji have no glyph here and read
+ * as `:name:`.
+ */
+const SLACK_EMOJI_GLYPHS: Record<string, string> = {
+	"+1": "👍",
+	"-1": "👎",
+	eyes: "👀",
+	white_check_mark: "✅",
+	heavy_check_mark: "✔️",
+	x: "❌",
+	bug: "🐛",
+	fire: "🔥",
+	rocket: "🚀",
+	tada: "🎉",
+	raised_hands: "🙌",
+	pray: "🙏",
+	heart: "❤️",
+	100: "💯",
+	warning: "⚠️",
+	rotating_light: "🚨",
+	question: "❓",
+	memo: "📝",
+	pushpin: "📌",
+	bookmark: "🔖",
+	mag: "🔍",
+	wrench: "🔧",
+	bulb: "💡",
+	thinking_face: "🤔",
+	clap: "👏",
+	wave: "👋",
+	ok_hand: "👌",
+	hourglass_flowing_sand: "⏳",
+	zap: "⚡",
+	boom: "💥",
+	sos: "🆘",
+	robot_face: "🤖",
+	ship: "🚢",
+};
+
+/** How one emoji name reads in a chip: "🐛 bug", or ":deployparrot:" for a custom one. */
+export function emojiLabel(name: string): string {
+	const glyph = SLACK_EMOJI_GLYPHS[name];
+	return glyph ? `${glyph} ${name}` : `:${name}:`;
+}
 
 /**
- * The reactions a trigger can be scoped to, by Slack short name — what a
- * `reaction_added` event carries. Standard emoji, since there is no API that
- * lists them; workspace custom emoji would need `emoji.list` and its scope.
+ * Emoji names as a person types them — ":bug:", "bug", "bug, eyes",
+ * ":bug: :eyes:" — normalized to what Slack sends: bare names, no colons.
  */
-export const SLACK_REACTION_OPTIONS: ScopeOption[] = [
-	["+1", "👍"],
-	["-1", "👎"],
-	["eyes", "👀"],
-	["white_check_mark", "✅"],
-	["heavy_check_mark", "✔️"],
-	["x", "❌"],
-	["bug", "🐛"],
-	["fire", "🔥"],
-	["rocket", "🚀"],
-	["tada", "🎉"],
-	["raised_hands", "🙌"],
-	["pray", "🙏"],
-	["heart", "❤️"],
-	["100", "💯"],
-	["warning", "⚠️"],
-	["rotating_light", "🚨"],
-	["question", "❓"],
-	["memo", "📝"],
-	["pushpin", "📌"],
-	["bookmark", "🔖"],
-	["mag", "🔍"],
-	["wrench", "🔧"],
-	["bulb", "💡"],
-	["thinking_face", "🤔"],
-	["clap", "👏"],
-	["wave", "👋"],
-	["ok_hand", "👌"],
-	["hourglass_flowing_sand", "⏳"],
-	["zap", "⚡"],
-	["boom", "💥"],
-	["sos", "🆘"],
-	["robot_face", "🤖"],
-	["ship", "🚢"],
-].map(([id, glyph]) => ({ id, label: `${glyph} ${id}` }));
+export function parseEmojiNames(text: string): string[] {
+	const seen = new Set<string>();
+	for (const raw of text.split(/[\s,]+/)) {
+		const name = raw.replace(/^:+|:+$/g, "").trim();
+		if (name) seen.add(name);
+	}
+	return [...seen];
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/grammar.ts
@@ -1,0 +1,68 @@
+import type {
+	SlackTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type SlackConfig = Extract<TriggerConfigInput, { kind: "slack" }>;
+
+/**
+ * The sentence a Slack trigger reads as. Same shape as GitHub's grammar: the
+ * words and slots per event, so the row renders one way and every event
+ * describes itself.
+ */
+
+export type Slot = "channels" | "emoji" | "actor" | "messageFilter";
+
+export type SentencePart = { text: string } | { slot: Slot };
+
+export const SLACK_SENTENCES: Record<SlackTriggerEvent, SentencePart[]> = {
+	message_in_channel: [
+		{ text: "Message" },
+		{ slot: "messageFilter" },
+		{ text: "in" },
+		{ slot: "channels" },
+		{ text: "by" },
+		{ slot: "actor" },
+	],
+	reaction_added: [
+		{ text: "Reaction" },
+		{ slot: "emoji" },
+		{ text: "on a message in" },
+		{ slot: "channels" },
+		{ text: "by" },
+		{ slot: "actor" },
+	],
+	channel_created: [{ text: "Channel created" }, { slot: "messageFilter" }],
+};
+
+export const SLACK_MENU: TriggerMenuEntry<SlackConfig>[] = [
+	leaf("Message in channel", "message_in_channel"),
+	leaf("Reaction added", "reaction_added"),
+	leaf("Channel created", "channel_created"),
+];
+
+function leaf(label: string, event: SlackTriggerEvent) {
+	return { label, create: () => createSlackConfig(event) };
+}
+
+/**
+ * A new trigger of this event: the channel still to be chosen, every optional
+ * filter wide open.
+ */
+export function createSlackConfig(event: SlackTriggerEvent): SlackConfig {
+	return {
+		kind: "slack",
+		event,
+		// Null matches nothing, which is the safety property for channels: an
+		// unfinished trigger must not fire on every channel, and the form refuses
+		// to save until one is chosen. A created channel is not "in" one, so that
+		// event has no channel to choose and the field stays null.
+		channels: null,
+		// The reaction is an optional narrowing, so it starts at "any". Null
+		// here would render as "Any reaction" while matching nothing.
+		emoji: event === "reaction_added" ? { mode: "any" } : null,
+		actor: "anyone",
+		messageFilter: null,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/grammar.ts
@@ -12,7 +12,13 @@ export type SlackConfig = Extract<TriggerConfigInput, { kind: "slack" }>;
  * describes itself.
  */
 
-export type Slot = "channels" | "emoji" | "actor" | "messageFilter";
+export type Slot =
+	| "channels"
+	| "emoji"
+	| "actor"
+	| "messageFilter"
+	| "topLevelOnly"
+	| "completionReaction";
 
 export type SentencePart = { text: string } | { slot: Slot };
 
@@ -24,6 +30,10 @@ export const SLACK_SENTENCES: Record<SlackTriggerEvent, SentencePart[]> = {
 		{ slot: "channels" },
 		{ text: "by" },
 		{ slot: "actor" },
+		{ slot: "topLevelOnly" },
+		{ text: "; react with" },
+		{ slot: "completionReaction" },
+		{ text: "upon completion" },
 	],
 	reaction_added: [
 		{ text: "Reaction" },
@@ -64,5 +74,11 @@ export function createSlackConfig(event: SlackTriggerEvent): SlackConfig {
 		emoji: event === "reaction_added" ? { mode: "any" } : null,
 		actor: "anyone",
 		messageFilter: null,
+		// A busy thread would otherwise fire once per reply.
+		topLevelOnly: true,
+		// The message trigger acknowledges the post it ran for; the others have
+		// no single message to react to.
+		completionReaction:
+			event === "message_in_channel" ? "white_check_mark" : null,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
@@ -1,0 +1,112 @@
+import { FaSlack } from "react-icons/fa";
+import { ActorChip } from "../../TriggerSentence/components/ActorChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import { SLACK_REACTION_OPTIONS } from "./emoji";
+import {
+	type SentencePart,
+	SLACK_MENU,
+	SLACK_SENTENCES,
+	type SlackConfig,
+} from "./grammar";
+
+/**
+ * Renders one slot of a Slack sentence. Each slot names the config field it
+ * edits, so `set` patches by that name and `mark` finds it in the problems.
+ */
+function renderPart(
+	config: SlackConfig,
+	part: SentencePart,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	switch (part.slot) {
+		case "channels":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.channels}
+					onChange={(v) => set({ channels: v })}
+					className={mark("channels")}
+					options={options.slack?.channels ?? []}
+					emptyLabel="Select channels"
+					anyLabel="Any channel"
+					disabled={disabled}
+				/>
+			);
+		case "emoji":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.emoji}
+					// Clearing an optional filter means "any", not "none": the chip
+					// says "Any reaction" either way, and null would make that a lie.
+					onChange={(v) => set({ emoji: v ?? { mode: "any" } })}
+					className={mark("emoji")}
+					options={SLACK_REACTION_OPTIONS}
+					emptyLabel="Any reaction"
+					anyLabel="Any reaction"
+					disabled={disabled}
+				/>
+			);
+		case "actor":
+			return (
+				<ActorChip
+					key={index}
+					actor={config.actor}
+					onChange={(v) => set({ actor: v })}
+					className={mark("actor")}
+					people={options.slack?.people ?? []}
+					disabled={disabled}
+				/>
+			);
+		case "messageFilter": {
+			// The same field filters a message's text or a new channel's name;
+			// only the words around it change.
+			const isChannelName = config.event === "channel_created";
+			return (
+				<TextFilterChip
+					key={index}
+					value={config.messageFilter}
+					onChange={(v) => set({ messageFilter: v })}
+					emptyLabel={isChannelName ? "Any name" : "Any message"}
+					placeholder={
+						isChannelName
+							? "Name contains this text..."
+							: "Contains this text..."
+					}
+					disabled={disabled}
+				/>
+			);
+		}
+	}
+}
+
+export const slackProvider: TriggerProvider<SlackConfig> = {
+	kind: "slack",
+	label: "Slack",
+	icon: FaSlack,
+	menu: SLACK_MENU,
+	renderSentence: (config, ctx) => {
+		// The event comes from a persisted config. If its grammar entry is ever
+		// removed or renamed, the row must still render rather than take the
+		// editor down, so an unknown event reads as its raw name.
+		const parts = SLACK_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
@@ -108,11 +108,18 @@ function renderPart(
 					disabled={disabled}
 				/>
 			);
-		case "completionReaction":
+		case "completionReaction": {
+			// A row saved before this field existed has no key at all; the schema
+			// defaults it on save, so the chip must show the same default rather
+			// than "No reaction" for a value that will save as a check mark.
+			const reaction =
+				"completionReaction" in config
+					? config.completionReaction
+					: "white_check_mark";
 			return (
 				<EmojiNameChip
 					key={index}
-					names={config.completionReaction ? [config.completionReaction] : []}
+					names={reaction ? [reaction] : []}
 					// One reaction: the last name typed wins, so ":eyes: :bug:" ends
 					// as bug rather than silently reacting twice.
 					onChange={(names) =>
@@ -123,6 +130,7 @@ function renderPart(
 					disabled={disabled}
 				/>
 			);
+		}
 	}
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/slack.tsx
@@ -1,15 +1,21 @@
 import { FaSlack } from "react-icons/fa";
 import { ActorChip } from "../../TriggerSentence/components/ActorChip";
 import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { SelectChip } from "../../TriggerSentence/components/SelectChip";
 import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
 import type { SentenceContext, TriggerProvider } from "../types";
-import { SLACK_REACTION_OPTIONS } from "./emoji";
+import { EmojiNameChip } from "./components/EmojiNameChip";
 import {
 	type SentencePart,
 	SLACK_MENU,
 	SLACK_SENTENCES,
 	type SlackConfig,
 } from "./grammar";
+
+const THREAD_OPTIONS = [
+	{ value: "top", label: "top-level only" },
+	{ value: "replies", label: "including replies" },
+] as const;
 
 /**
  * Renders one slot of a Slack sentence. Each slot names the config field it
@@ -44,16 +50,21 @@ function renderPart(
 			);
 		case "emoji":
 			return (
-				<ScopeChip
+				<EmojiNameChip
 					key={index}
-					scope={config.emoji}
+					names={config.emoji?.mode === "list" ? config.emoji.ids : []}
 					// Clearing an optional filter means "any", not "none": the chip
 					// says "Any reaction" either way, and null would make that a lie.
-					onChange={(v) => set({ emoji: v ?? { mode: "any" } })}
+					onChange={(names) =>
+						set({
+							emoji: names.length
+								? { mode: "list", ids: names }
+								: { mode: "any" },
+						})
+					}
 					className={mark("emoji")}
-					options={SLACK_REACTION_OPTIONS}
 					emptyLabel="Any reaction"
-					anyLabel="Any reaction"
+					placeholder=":bug: or bug, eyes"
 					disabled={disabled}
 				/>
 			);
@@ -87,6 +98,31 @@ function renderPart(
 				/>
 			);
 		}
+		case "topLevelOnly":
+			return (
+				<SelectChip
+					key={index}
+					value={config.topLevelOnly === false ? "replies" : "top"}
+					onChange={(v) => set({ topLevelOnly: v === "top" })}
+					options={THREAD_OPTIONS}
+					disabled={disabled}
+				/>
+			);
+		case "completionReaction":
+			return (
+				<EmojiNameChip
+					key={index}
+					names={config.completionReaction ? [config.completionReaction] : []}
+					// One reaction: the last name typed wins, so ":eyes: :bug:" ends
+					// as bug rather than silently reacting twice.
+					onChange={(names) =>
+						set({ completionReaction: names[names.length - 1] ?? null })
+					}
+					emptyLabel="No reaction"
+					placeholder=":white_check_mark:"
+					disabled={disabled}
+				/>
+			);
 	}
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/useSlackOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/useSlackOptions.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+
+/** The pickable values a Slack sentence needs: channels and linked people. */
+export function useSlackOptions(organizationId: string): ProviderOptions {
+	// Channel ids, not names — a channel can be renamed and the trigger must
+	// keep matching it afterwards. Same for people: Slack user ids.
+	const channels = cloudTrpc.integration.slack.listChannels.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+	const people = cloudTrpc.integration.slack.listLinkedPeople.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+
+	return useMemo(
+		() => ({
+			slack: {
+				channels: (channels.data ?? []).map((channel) => ({
+					id: channel.id,
+					label: `#${channel.name}`,
+				})),
+				people: people.data ?? [],
+			},
+		}),
+		[channels.data, people.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useGithubOptions } from "./github/useGithubOptions";
 import { useLinearOptions } from "./linear/useLinearOptions";
 import { useNotionOptions } from "./notion/useNotionOptions";
+import { useSlackOptions } from "./slack/useSlackOptions";
 import type { ProviderOptions } from "./types";
 
 /**
@@ -16,8 +17,9 @@ export function useProviderOptions(organizationId: string): ProviderOptions {
 	const github = useGithubOptions(organizationId);
 	const linear = useLinearOptions(organizationId);
 	const notion = useNotionOptions(organizationId);
+	const slack = useSlackOptions(organizationId);
 	return useMemo(
-		() => ({ ...github, ...linear, ...notion }),
-		[github, linear, notion],
+		() => ({ ...github, ...linear, ...notion, ...slack }),
+		[github, linear, notion, slack],
 	);
 }

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -3,12 +3,14 @@ import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
 import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
 import { type LinearMatchableEvent, linearTriggerMatches } from "./linear";
 import { type NotionMatchableEvent, notionTriggerMatches } from "./notion";
+import { type SlackMatchableEvent, slackTriggerMatches } from "./slack";
 import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
 
 export * from "./core";
 export * from "./github";
 export * from "./linear";
 export * from "./notion";
+export * from "./slack";
 export * from "./webhook";
 
 /**
@@ -24,7 +26,8 @@ export type MatchableEvent =
 	| GithubMatchableEvent
 	| WebhookMatchableEvent
 	| NotionMatchableEvent
-	| LinearMatchableEvent;
+	| LinearMatchableEvent
+	| SlackMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -67,6 +70,12 @@ export function triggerMatches(
 		case "linear":
 			return linearTriggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "linear" }>,
+				event,
+				context,
+			);
+		case "slack":
+			return slackTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "slack" }>,
 				event,
 				context,
 			);

--- a/packages/shared/src/automation-matching/slack.ts
+++ b/packages/shared/src/automation-matching/slack.ts
@@ -1,0 +1,85 @@
+import type {
+	SlackTriggerEvent,
+	TriggerActor,
+	TriggerScope,
+} from "../automation-triggers";
+import {
+	actorAllows,
+	type BaseMatchableEvent,
+	bodyMatches,
+	type MatchContext,
+	type MatchResult,
+	scopeAllows,
+} from "./core";
+
+/**
+ * A normalized Slack event: the shared columns plus what Slack triggers
+ * filter on. `body` is the message text, or the channel name for
+ * channel_created.
+ */
+export type SlackMatchableEvent = BaseMatchableEvent & {
+	provider: "slack";
+	/** Where the message or reaction happened; null for channel_created. */
+	channelId: string | null;
+	/** The reaction's emoji name, without a skin-tone suffix; null otherwise. */
+	reaction: string | null;
+	/** The product-level names this delivery maps to; see slackEventNames. */
+	names: SlackTriggerEvent[];
+};
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/**
+ * Maps a Slack event type to the event a trigger names. Only `message` differs
+ * from its wire name; the route has already dropped DMs and edits before it
+ * gets here, so a `message` that arrives is a message in a channel.
+ */
+export function slackEventNames(eventType: string): SlackTriggerEvent[] {
+	switch (eventType) {
+		case "message":
+			return ["message_in_channel"];
+		case "reaction_added":
+			return ["reaction_added"];
+		case "channel_created":
+			return ["channel_created"];
+		default:
+			return [];
+	}
+}
+
+/** Whether a Slack trigger config accepts this event. */
+export function slackTriggerMatches(
+	config: {
+		event: string;
+		channels: TriggerScope;
+		emoji: TriggerScope;
+		actor: TriggerActor;
+		messageFilter?: { pattern: string; isRegex: boolean } | null;
+	},
+	event: SlackMatchableEvent,
+	context: MatchContext,
+): MatchResult {
+	if (!event.names.includes(config.event as SlackTriggerEvent)) {
+		return no("event");
+	}
+	// A created channel is not "in" a channel, so the scope has nothing to say.
+	if (
+		config.event !== "channel_created" &&
+		!scopeAllows(config.channels, event.channelId)
+	) {
+		return no("channel");
+	}
+	if (
+		config.event === "reaction_added" &&
+		!scopeAllows(config.emoji, event.reaction)
+	) {
+		return no("emoji");
+	}
+	if (!actorAllows(config.actor, event.actorId, context.ownerIds)) {
+		return no("actor");
+	}
+	if (!bodyMatches(config.messageFilter ?? null, event.body)) {
+		return no("messageFilter");
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-matching/slack.ts
+++ b/packages/shared/src/automation-matching/slack.ts
@@ -23,6 +23,8 @@ export type SlackMatchableEvent = BaseMatchableEvent & {
 	channelId: string | null;
 	/** The reaction's emoji name, without a skin-tone suffix; null otherwise. */
 	reaction: string | null;
+	/** A message posted inside a thread rather than at the top level. */
+	isThreadReply: boolean;
 	/** The product-level names this delivery maps to; see slackEventNames. */
 	names: SlackTriggerEvent[];
 };
@@ -55,6 +57,7 @@ export function slackTriggerMatches(
 		emoji: TriggerScope;
 		actor: TriggerActor;
 		messageFilter?: { pattern: string; isRegex: boolean } | null;
+		topLevelOnly?: boolean;
 	},
 	event: SlackMatchableEvent,
 	context: MatchContext,
@@ -74,6 +77,14 @@ export function slackTriggerMatches(
 		!scopeAllows(config.emoji, event.reaction)
 	) {
 		return no("emoji");
+	}
+	// Absent on older configs; the default has always been top-level only.
+	if (
+		config.event === "message_in_channel" &&
+		config.topLevelOnly !== false &&
+		event.isThreadReply
+	) {
+		return no("threadReply");
 	}
 	if (!actorAllows(config.actor, event.actorId, context.ownerIds)) {
 		return no("actor");

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -172,18 +172,29 @@ export const slackTriggerEventValues = [
 ] as const;
 export type SlackTriggerEvent = (typeof slackTriggerEventValues)[number];
 
+/** An emoji short name as Slack sends it: `bug`, `white_check_mark`, `+1`. */
+const slackEmojiName = z.string().min(1).max(100);
+
 export const slackTriggerConfigSchema = z.object({
 	kind: z.literal("slack"),
 	event: z.enum(slackTriggerEventValues),
 	// The channel a message or reaction lands in. Not meaningful for
 	// channel_created — the channel does not exist yet — so null there.
 	channels: triggerScopeSchema,
-	// Only meaningful for reaction_added; null elsewhere.
+	// Only meaningful for reaction_added; null elsewhere. The ids are emoji
+	// short names typed by the person, so a workspace's custom emoji work
+	// without any list of them existing.
 	emoji: triggerScopeSchema,
 	actor: triggerActorSchema,
 	// A pattern over the message text, or over the channel name for
 	// channel_created.
 	messageFilter: textFilterSchema.nullable().default(null),
+	// message_in_channel only: whether a reply inside a thread counts. Defaults
+	// to top-level posts, since a busy thread would otherwise fire once a reply.
+	topLevelOnly: z.boolean().default(true),
+	// message_in_channel only: the reaction to add to the triggering message
+	// when the run completes; null for none.
+	completionReaction: slackEmojiName.nullable().default("white_check_mark"),
 });
 
 export const linearTriggerEventValues = [

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -170,14 +170,19 @@ export const slackTriggerEventValues = [
 	"reaction_added",
 	"channel_created",
 ] as const;
+export type SlackTriggerEvent = (typeof slackTriggerEventValues)[number];
 
 export const slackTriggerConfigSchema = z.object({
 	kind: z.literal("slack"),
 	event: z.enum(slackTriggerEventValues),
+	// The channel a message or reaction lands in. Not meaningful for
+	// channel_created — the channel does not exist yet — so null there.
 	channels: triggerScopeSchema,
 	// Only meaningful for reaction_added; null elsewhere.
 	emoji: triggerScopeSchema,
 	actor: triggerActorSchema,
+	// A pattern over the message text, or over the channel name for
+	// channel_created.
 	messageFilter: textFilterSchema.nullable().default(null),
 });
 
@@ -336,11 +341,17 @@ export function describeTriggerProblems(
 				break;
 			}
 			case "slack": {
-				if (isEmptyScope(config.channels)) {
+				if (
+					config.event !== "channel_created" &&
+					isEmptyScope(config.channels)
+				) {
 					add(index, "channels", "Specify at least one channel.");
 				}
 				if (config.event === "reaction_added" && isEmptyScope(config.emoji)) {
 					add(index, "emoji", "Specify at least one reaction.");
+				}
+				if (isEmptyActor(config.actor)) {
+					add(index, "actor", "Specify at least one person, or choose Anyone.");
 				}
 				break;
 			}

--- a/packages/trpc/src/router/integration/slack/list-channels.ts
+++ b/packages/trpc/src/router/integration/slack/list-channels.ts
@@ -1,0 +1,59 @@
+/**
+ * The channels a Slack bot token can see, for the trigger editor's channel
+ * picker.
+ *
+ * A direct call rather than `@slack/web-api`: this package does not depend on
+ * it, and one paginated GET does not justify adding it. Public and private
+ * channels both — a private channel the bot has been invited to is where "a
+ * message in #incidents" most often means something.
+ */
+
+type ConversationsListResponse = {
+	ok: boolean;
+	error?: string;
+	channels?: Array<{ id?: string; name?: string; is_archived?: boolean }>;
+	response_metadata?: { next_cursor?: string };
+};
+
+/** Enough for any workspace this is likely to be pointed at; a hard stop, not a page size. */
+const MAX_PAGES = 10;
+
+export async function listSlackChannels(
+	accessToken: string,
+): Promise<Array<{ id: string; name: string }>> {
+	const channels: Array<{ id: string; name: string }> = [];
+	let cursor: string | undefined;
+
+	for (let page = 0; page < MAX_PAGES; page++) {
+		const params = new URLSearchParams({
+			types: "public_channel,private_channel",
+			exclude_archived: "true",
+			limit: "200",
+		});
+		if (cursor) params.set("cursor", cursor);
+
+		const response = await fetch(
+			`https://slack.com/api/conversations.list?${params.toString()}`,
+			{ headers: { Authorization: `Bearer ${accessToken}` } },
+		);
+		const data = (await response.json()) as ConversationsListResponse;
+		if (!data.ok) {
+			// `missing_scope` until the app is reinstalled with channels:read; an
+			// empty picker is the honest state, not an error the editor can act on.
+			console.error(
+				"[slack/listChannels] conversations.list failed:",
+				data.error,
+			);
+			return channels;
+		}
+		for (const channel of data.channels ?? []) {
+			if (channel.id && channel.name) {
+				channels.push({ id: channel.id, name: channel.name });
+			}
+		}
+		cursor = data.response_metadata?.next_cursor || undefined;
+		if (!cursor) break;
+	}
+
+	return channels.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/trpc/src/router/integration/slack/list-channels.ts
+++ b/packages/trpc/src/router/integration/slack/list-channels.ts
@@ -32,11 +32,22 @@ export async function listSlackChannels(
 		});
 		if (cursor) params.set("cursor", cursor);
 
-		const response = await fetch(
-			`https://slack.com/api/conversations.list?${params.toString()}`,
-			{ headers: { Authorization: `Bearer ${accessToken}` } },
-		);
-		const data = (await response.json()) as ConversationsListResponse;
+		let data: ConversationsListResponse;
+		try {
+			const response = await fetch(
+				`https://slack.com/api/conversations.list?${params.toString()}`,
+				{
+					headers: { Authorization: `Bearer ${accessToken}` },
+					signal: AbortSignal.timeout(5_000),
+				},
+			);
+			data = (await response.json()) as ConversationsListResponse;
+		} catch (error) {
+			// Slack unreachable or answering with something other than JSON: the
+			// picker shows what was fetched so far rather than the query failing.
+			console.error("[slack/listChannels] conversations.list failed:", error);
+			return channels;
+		}
 		if (!data.ok) {
 			// `missing_scope` until the app is reinstalled with channels:read; an
 			// empty picker is the honest state, not an error the editor can act on.

--- a/packages/trpc/src/router/integration/slack/slack.ts
+++ b/packages/trpc/src/router/integration/slack/slack.ts
@@ -1,10 +1,15 @@
 import { db } from "@superset/db/client";
-import { integrationConnections } from "@superset/db/schema";
+import {
+	integrationConnections,
+	userIdentities,
+	users,
+} from "@superset/db/schema";
 import type { TRPCRouterRecord } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { listSlackChannels } from "./list-channels";
 
 export const slackRouter = {
 	getConnection: protectedProcedure
@@ -31,6 +36,57 @@ export const slackRouter = {
 				externalOrgName: connection.externalOrgName,
 				connectedAt: connection.createdAt,
 			};
+		}),
+
+	/** Channels the trigger editor can scope a Slack trigger to. */
+	listChannels: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "slack"),
+					isNull(integrationConnections.disconnectedAt),
+				),
+				columns: { accessToken: true },
+			});
+			if (!connection) return [];
+
+			return listSlackChannels(connection.accessToken);
+		}),
+
+	/**
+	 * People in this organization who have linked a Slack account, keyed by
+	 * Slack user id — what the matcher compares an event's `user` against.
+	 */
+	listLinkedPeople: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const rows = await db
+				.select({
+					slackUserId: userIdentities.externalId,
+					handle: userIdentities.handle,
+					displayName: userIdentities.displayName,
+					name: users.name,
+					email: users.email,
+				})
+				.from(userIdentities)
+				.innerJoin(users, eq(users.id, userIdentities.userId))
+				.where(
+					and(
+						eq(userIdentities.organizationId, input.organizationId),
+						eq(userIdentities.provider, "slack"),
+					),
+				);
+
+			return rows.map((row) => ({
+				id: row.slackUserId,
+				label: row.displayName ?? row.handle ?? row.name ?? row.email,
+			}));
 		}),
 
 	disconnect: protectedProcedure

--- a/packages/trpc/src/router/integration/slack/slack.ts
+++ b/packages/trpc/src/router/integration/slack/slack.ts
@@ -66,6 +66,18 @@ export const slackRouter = {
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
 
+			// A Slack user id is only unique within a workspace, so only identities
+			// from the connected workspace can ever match an event from it.
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "slack"),
+					isNull(integrationConnections.disconnectedAt),
+				),
+				columns: { externalOrgId: true },
+			});
+			if (!connection?.externalOrgId) return [];
+
 			const rows = await db
 				.select({
 					slackUserId: userIdentities.externalId,
@@ -80,6 +92,7 @@ export const slackRouter = {
 					and(
 						eq(userIdentities.organizationId, input.organizationId),
 						eq(userIdentities.provider, "slack"),
+						eq(userIdentities.externalScopeId, connection.externalOrgId),
 					),
 				);
 


### PR DESCRIPTION
## Summary

Adds the **Slack** trigger provider to automations — three events, wired through the seam GitHub established in #6571.

| event | sentence | filters |
|---|---|---|
| `message_in_channel` | Message [containing "…"] in **#channel** by **Anyone** [top-level only / including replies]; react with **✅** upon completion | channels · actor · messageFilter · topLevelOnly · completionReaction |
| `reaction_added` | Reaction [🐛 bug / any] on a message in **#channel** by **Anyone** | channels · emoji (typed name) · actor |
| `channel_created` | Channel created [matching "…"] | messageFilter over the channel name |

**Desktop** — `providers/slack/{grammar,slack,useSlackOptions,emoji,components/EmojiNameChip}` + one registry line + one `useProviderOptions` line; options namespaced as `options.slack.{channels,people}`. Channels via new `integration.slack.listChannels`; people via `listLinkedPeople` (`user_identities` where provider = slack, scoped to the connected workspace). Reactions are **typed emoji names** (`EmojiNameChip`: ":bug:", "bug, eyes", a custom ":deployparrot:") normalized to the bare names Slack sends; the scope shape is kept so schema and matcher don't move, and a static glyph map only makes known names read as "🐛 bug".

Matches the reference implementation read off the wire: `topLevelOnly` (default true — a busy thread would otherwise fire once per reply; "top-level only" / "including replies") and `completionReaction` (default `white_check_mark`, nullable — "; react with ✅ upon completion"). **`completionReaction` is stored and rendered; writing the reaction requires a run-completed hook that does not yet exist — follow-up.**

**Shared** — `automation-matching/slack.ts`: `SlackMatchableEvent = BaseMatchableEvent & { provider: "slack"; channelId; reaction; isThreadReply; names }` (per the consolidated seam in #6594), `slackEventNames`, `slackTriggerMatches(config, event, { ownerIds })`; one union member and one `case "slack"` in `triggerMatches`. `describeTriggerProblems`: channel required except for `channel_created`; actor non-empty. Null channels match nothing; emoji is an optional narrowing starting at `{mode:"any"}`; `isRegex` pinned false.

**API** — `slack/events/process-automation-event/`: normalize into a `SlackMatchableEvent` → `recordSlackAutomationEvent` (idempotent on Slack `event_id`, `integration_connection_id` set) → the shared `@/lib/automations/dispatchMatchingTriggers`. Route branches: `message` (channel/group only, subtype ∈ {none, bot_message, file_share, thread_broadcast}, this app's own bot skipped via `authorizations`/`api_app_id`), `reaction_added`, `channel_created`. Awaited inline like GitHub's route.

**tRPC** — `integration.slack.listChannels` (`conversations.list` via fetch with a 5s timeout — no new dep; logs and returns what it has on `missing_scope`/failure), `listLinkedPeople` (scoped by the active connection's team id).

## Needs applying outside this PR (Slack app manifest)

- `settings.event_subscriptions.bot_events` add: `message.channels`, `message.groups`, `reaction_added`, `channel_created`
- `oauth_config.scopes.bot` add: `reactions:read`, `channels:read`, `groups:read`

Until the app is reinstalled with `channels:read`, the channel picker is empty (route logs `conversations.list failed: missing_scope`); "Any channel" still works. Bot receives message/reaction events only in channels it is a member of; `channel_created` is public channels only.

## Verification

Running app over CDP (this workspace's renderer, signed in, Superset org):
- Add Trigger › Slack › Message in channel / Reaction added / Channel created — all three rows render, configure (Any channel, filter `ERROR`, actor Me; 🐛 bug; name `incident`) and save; reload persists.
- Half-configured reaction row (no channel) blocks Save with the chip marked and the banner shown.

Route, signature-valid replays at the local API (QStash pointed at a local mock so nothing hit Upstash):
- 6 events → 6 `automation_events` rows (`provider='slack'`), `[slack/events] 1/3 triggers matched` for exactly the three expected (message by me containing ERROR; `bug::skin-tone-2` reaction; channel `incident-2026-08-17`), and the batch carried the right `automationId`/`triggerId`.
- Ignored: DM, `message_changed`, this app's own bot, unknown team, redelivered `event_id` (recorded once, matched once), bad signature (401, no row).
- 18 pure-matcher edge cases (list-scoped channel hit/miss, null channels, me/people, filter, emoji list/any/custom name, channel_created, thread reply blocked/allowed, provider mismatch refused) pass.

`bun run typecheck` exit 0 in shared/trpc/api/desktop; biome clean on the changed files (repo-wide lint has one pre-existing failure on main in `TerminalAgentAutoResume.tsx`, untouched here).

No migration: the `slack` enum values already exist (#6581).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slack as an automation trigger provider with three events (Message in channel, Reaction added, Channel created) and records/dispatches Slack events; previously Slack could not trigger automations. Events are normalized, deduped by Slack event_id, and DMs and this app’s bot messages are ignored.

- Desktop (`apps/desktop`): adds `slack` provider with sentence chips; typed emoji names (e.g., :bug:, deployparrot); “top‑level only / including replies”; “react with … upon completion” with default check mark and correct display for legacy rows; options from `integration.slack.listChannels` and `integration.slack.listLinkedPeople`; saving requires a channel (except Channel created) and a non‑empty actor.
- Shared (`packages/shared`): adds `slackEventNames` and `slackTriggerMatches`; matchable fields include `channelId`, `reaction` (skin‑tone stripped), `isThreadReply`, and `names`; `describeTriggerProblems` enforces channel/emoji/actor; `messageFilter` over message text or channel name; `topLevelOnly` (default true) and `completionReaction` (default `white_check_mark`) in schema.
- API (`apps/api`): `isAutomationEvent` filters deliverable events; normalization keys threads by root, sets `isThreadReply`, builds permalinks; records once per Slack `event_id` and dispatches matches; route awaits this for `message` (channels/groups only; real posts; not this app’s bot), `reaction_added`, and `channel_created`, with console logging of matched counts.
- tRPC (`packages/trpc`): `integration.slack.listChannels` calls `conversations.list` with a 5s timeout and returns partial results (empty on `missing_scope`); `listLinkedPeople` limits Slack identities to the connected workspace.
- No DB migration.

**Rollout**
- Update and reinstall the Slack app manifest:
  - Subscribe to bot events: `message.channels`, `message.groups`, `reaction_added`, `channel_created`.
  - Add bot scopes: `reactions:read`, `channels:read`, `groups:read`.
- Until `channels:read` is granted, the channel picker is empty; “Any channel” still matches. Message/reaction events fire only in channels the bot has joined; `channel_created` is public channels only.

<sup>Written for commit f412ab54c1ca536bd93e8c2fca72bc324d8273cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack automation triggers for messages, reactions, channel creation, threading, actors, channels, and message filters.
  * Added Slack channel and linked-person selection options.
  * Added emoji parsing and editing controls for reaction-based triggers.
  * Added support for completion reactions and top-level message matching.
  * Added reliable Slack event processing, duplicate prevention, and trigger matching.
* **Bug Fixes**
  * Improved handling of unsupported, duplicate, and malformed Slack events.
* **Tests**
  * Updated Slack event route coverage for automation event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
