### PR TITLE
feat(mobile): "Rate Superset" settings row and App Store rating prompt after positive moments

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -95,6 +95,7 @@
 		"expo-secure-store": "56.0.4",
 		"expo-speech-recognition": "56.0.1",
 		"expo-status-bar": "56.0.4",
+		"expo-store-review": "56.0.3",
 		"expo-system-ui": "56.0.5",
 		"expo-web-browser": "56.0.6",
 		"katex": "0.17.0",

--- a/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/index.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/index.ts
@@ -1,0 +1,1 @@
+export { type AppReviewMoment, useAppReviewPrompt } from "./useAppReviewPrompt";

--- a/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/useAppReviewPrompt.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/useAppReviewPrompt.ts
@@ -16,7 +16,9 @@ const SETTLE_MS = 1500;
  * or opened a session an agent finished for them (qualifies on the third
  * distinct one). The only UI is Apple's own sheet, which may decline to show,
  * caps itself at three a year, and honours the system-wide opt-out; on top of
- * that we never ask twice about the same build or within 90 days.
+ * that we never ask twice about the same version or within 90 days. The
+ * prompted mark is written before the settle delay so two qualifying moments
+ * in quick succession can't both schedule a request.
  */
 export function useAppReviewPrompt() {
 	const posthog = usePostHog();
@@ -37,10 +39,10 @@ export function useAppReviewPrompt() {
 			) {
 				return;
 			}
+			store.markPrompted(now, version);
 			setTimeout(() => {
 				void StoreReview.isAvailableAsync().then((available) => {
 					if (!available) return;
-					useAppReviewStore.getState().markPrompted(now, version);
 					posthog.capture("app_review_prompt_requested", {
 						moment,
 						positive_moments: moments,

--- a/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/useAppReviewPrompt.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useAppReviewPrompt/useAppReviewPrompt.ts
@@ -1,0 +1,54 @@
+import * as Application from "expo-application";
+import * as StoreReview from "expo-store-review";
+import { usePostHog } from "posthog-react-native";
+import { useCallback } from "react";
+import { useAppReviewStore } from "@/screens/(authenticated)/stores/appReviewStore";
+
+export type AppReviewMoment = "pr_merged" | "session_completed";
+
+const SESSIONS_BEFORE_PROMPT = 3;
+const PROMPT_COOLDOWN_MS = 90 * 24 * 60 * 60 * 1000;
+const SETTLE_MS = 1500;
+
+/**
+ * Asks for an App Store rating only right after Superset did something for
+ * the user: they merged a pull request from their phone (qualifies at once)
+ * or opened a session an agent finished for them (qualifies on the third
+ * distinct one). The only UI is Apple's own sheet, which may decline to show,
+ * caps itself at three a year, and honours the system-wide opt-out; on top of
+ * that we never ask twice about the same build or within 90 days.
+ */
+export function useAppReviewPrompt() {
+	const posthog = usePostHog();
+	return useCallback(
+		(moment: AppReviewMoment) => {
+			if (!useAppReviewStore.persist.hasHydrated()) return;
+			const now = Date.now();
+			const store = useAppReviewStore.getState();
+			const moments = store.recordPositiveMoment(now);
+			if (moment === "session_completed" && moments < SESSIONS_BEFORE_PROMPT) {
+				return;
+			}
+			const version = Application.nativeApplicationVersion ?? "0.0.0";
+			if (store.lastPromptedVersion === version) return;
+			if (
+				store.lastPromptedAt !== null &&
+				now - store.lastPromptedAt < PROMPT_COOLDOWN_MS
+			) {
+				return;
+			}
+			setTimeout(() => {
+				void StoreReview.isAvailableAsync().then((available) => {
+					if (!available) return;
+					useAppReviewStore.getState().markPrompted(now, version);
+					posthog.capture("app_review_prompt_requested", {
+						moment,
+						positive_moments: moments,
+					});
+					return StoreReview.requestReview();
+				});
+			}, SETTLE_MS);
+		},
+		[posthog],
+	);
+}

--- a/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import { SettingsSection } from "./components/SettingsSection";
 import { UserAvatar } from "./components/UserAvatar";
 
 const BILLING_URL = `${env.EXPO_PUBLIC_WEB_URL ?? COMPANY.MARKETING_URL}/settings/billing`;
+const WRITE_REVIEW_URL = `${COMPANY.APP_STORE_URL}?action=write-review`;
 
 function openUrl(url: string) {
 	Linking.openURL(url).catch(() => {
@@ -229,6 +230,18 @@ export function SettingsScreen() {
 				<ListRow
 					icon={
 						<Ionicons
+							name="logo-discord"
+							size={20}
+							color={theme.mutedForeground}
+						/>
+					}
+					label="Community"
+					trailing={<ExternalIcon color={theme.mutedForeground} />}
+					onPress={() => openUrl(COMPANY.DISCORD_URL)}
+				/>
+				<ListRow
+					icon={
+						<Ionicons
 							name="mail-outline"
 							size={20}
 							color={theme.mutedForeground}
@@ -241,14 +254,14 @@ export function SettingsScreen() {
 				<ListRow
 					icon={
 						<Ionicons
-							name="logo-discord"
+							name="star-outline"
 							size={20}
 							color={theme.mutedForeground}
 						/>
 					}
-					label="Community"
+					label="Rate Superset"
 					trailing={<ExternalIcon color={theme.mutedForeground} />}
-					onPress={() => openUrl(COMPANY.DISCORD_URL)}
+					onPress={() => openUrl(WRITE_REVIEW_URL)}
 					isLast
 				/>
 			</SettingsSection>

--- a/apps/mobile/screens/(authenticated)/stores/appReviewStore/appReviewStore.ts
+++ b/apps/mobile/screens/(authenticated)/stores/appReviewStore/appReviewStore.ts
@@ -1,0 +1,46 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const MOMENT_DEDUPE_MS = 60 * 60 * 1000;
+
+/**
+ * Tally of moments Superset did something for the user (a merged pull
+ * request, a session an agent finished for them) plus when we last asked
+ * for an App Store rating. Moments closer than an hour apart count once, so
+ * an agent stopping several times while the user watches is one moment.
+ */
+interface AppReviewStore {
+	positiveMoments: number;
+	lastMomentAt: number | null;
+	lastPromptedAt: number | null;
+	lastPromptedVersion: string | null;
+	recordPositiveMoment: (now: number) => number;
+	markPrompted: (now: number, version: string) => void;
+}
+
+export const useAppReviewStore = create<AppReviewStore>()(
+	persist(
+		(set, get) => ({
+			positiveMoments: 0,
+			lastMomentAt: null,
+			lastPromptedAt: null,
+			lastPromptedVersion: null,
+			recordPositiveMoment: (now) => {
+				const { positiveMoments, lastMomentAt } = get();
+				if (lastMomentAt !== null && now - lastMomentAt < MOMENT_DEDUPE_MS) {
+					return positiveMoments;
+				}
+				const next = positiveMoments + 1;
+				set({ positiveMoments: next, lastMomentAt: now });
+				return next;
+			},
+			markPrompted: (now, version) =>
+				set({ lastPromptedAt: now, lastPromptedVersion: version }),
+		}),
+		{
+			name: "app-review-v1",
+			storage: createJSONStorage(() => AsyncStorage),
+		},
+	),
+);

--- a/apps/mobile/screens/(authenticated)/stores/appReviewStore/index.ts
+++ b/apps/mobile/screens/(authenticated)/stores/appReviewStore/index.ts
@@ -1,0 +1,1 @@
+export { useAppReviewStore } from "./appReviewStore";

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
 import type { GlassComposerHandle } from "@/screens/(authenticated)/components/GlassComposer";
 import { PressableScale } from "@/screens/(authenticated)/components/PressableScale";
+import { useAppReviewPrompt } from "@/screens/(authenticated)/hooks/useAppReviewPrompt";
 import { useTerminalSeenStore } from "@/screens/(authenticated)/stores/terminalSeenStore";
 import { useTerminalTabOrderStore } from "@/screens/(authenticated)/stores/terminalTabOrderStore";
 import { PullRequestsButton } from "../components/PullRequestsButton";
@@ -127,12 +128,14 @@ export function WorkspaceScreen() {
 	const markTerminalSeen = useTerminalSeenStore(
 		(state) => state.markTerminalSeen,
 	);
+	const requestAppReview = useAppReviewPrompt();
 	const activeRow = rows.find((row) => row.terminalId === activeTerminalId);
 	useEffect(() => {
 		if (activeRow?.attention !== "review") return;
 		if (activeRow.lastEventAt === null) return;
 		markTerminalSeen(activeRow.terminalId, activeRow.lastEventAt);
-	}, [activeRow, markTerminalSeen]);
+		requestAppReview("session_completed");
+	}, [activeRow, markTerminalSeen, requestAppReview]);
 
 	const invalidateTerminals = useCallback(() => {
 		if (!host) return;

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/PullRequestScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/PullRequestScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
+import { useAppReviewPrompt } from "@/screens/(authenticated)/hooks/useAppReviewPrompt";
 import { HeaderNotice } from "./components/HeaderNotice";
 import { PullRequestCard } from "./components/PullRequestCard";
 import { PullRequestDescription } from "./components/PullRequestDescription";
@@ -38,12 +39,16 @@ export function PullRequestScreen() {
 		repo,
 	} = usePullRequestRoute();
 
+	const requestAppReview = useAppReviewPrompt();
 	const merge = useMergePullRequest({
 		workspaceId,
 		owner,
 		repo,
 		pullNumber,
-		onMerged: refetch,
+		onMerged: () => {
+			void refetch();
+			requestAppReview("pr_merged");
+		},
 	});
 
 	const [notice, setNotice] = useState<string | null>(null);

--- a/bun.lock
+++ b/bun.lock
@@ -561,6 +561,7 @@
         "expo-secure-store": "56.0.4",
         "expo-speech-recognition": "56.0.1",
         "expo-status-bar": "56.0.4",
+        "expo-store-review": "56.0.3",
         "expo-system-ui": "56.0.5",
         "expo-web-browser": "56.0.6",
         "katex": "0.17.0",
@@ -4560,6 +4561,8 @@
     "expo-speech-recognition": ["expo-speech-recognition@56.0.1", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-TpP1KCiq3vYfSQF0XpUkWLXp4mTw6MLuyMGPzVVKwqzs7oiKlJ/e0q3PNNjfqs058X47ftqT+31lTaWRWRbmPg=="],
 
     "expo-status-bar": ["expo-status-bar@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA=="],
+
+    "expo-store-review": ["expo-store-review@56.0.3", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-pLlSmizlcXC3dYdydKpYtNslEEr1pyUMHH4YV/zc/HmnEIAIG752N0NadAQ+jxX5i5B8iDwOfYc9iJe9Qyc0UA=="],
 
     "expo-symbols": ["expo-symbols@56.0.7", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-OddQ8qWSHaTN8UvyVkcwZSGw0NEH/XRXsofA8pjX4aThyKH60Q3U0tcoberb0cCBCTbfd8SuyjYMbtwnQeYh3g=="],
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -37,6 +37,7 @@ export const COMPANY = {
 	FOUNDERS_MAIL_TO: `mailto:founders@${ROOT_DOMAIN}`,
 	REPORT_ISSUE_URL: "https://github.com/superset-sh/superset/issues/new",
 	DISCORD_URL: "https://discord.gg/cZeD9WYcV7",
+	APP_STORE_URL: "https://apps.apple.com/app/id6788926383",
 	STATUS_URL: `https://status.${ROOT_DOMAIN}`,
 	TRUST_URL: `https://trust.${ROOT_DOMAIN}`,
 	JOIN_US_URL: `${MARKETING_URL}/join-us`,


### PR DESCRIPTION
## Summary
- Settings → Support gets a **Rate Superset** row directly under Contact Support (last row of the group, same star + external-link treatment as the other outbound rows). Tapping opens the App Store write-review page for the live listing (`apps.apple.com/app/id6788926383?action=write-review`).
- Apple's native rating sheet (`expo-store-review`) is requested only right after Superset did something for the user: immediately when a pull request is merged from the phone; on the third session an agent finished for them.
- Never asked twice for the same build or within 90 days; Apple's own 3-per-year cap and the system-wide opt-out apply on top. `app_review_prompt_requested` fires in PostHog so we can see it working.

## Why / Context
We want more 5-star reviews without an in-app banner. Well-regarded iOS apps do two things: a passive "Rate …" row next to Contact Support in Settings, and Apple's system prompt at a peak moment (Duolingo after a lesson, Halide after real usage). The system sheet is the only mechanism that actually moves the rating count and is also the least intrusive one available — it's Apple's small card, capped and user-disableable.

## How It Works
- `packages/shared/src/constants.ts` — `COMPANY.APP_STORE_URL` (id from `eas.json` `ascAppId`).
- `screens/(authenticated)/stores/appReviewStore` — persisted tally of positive moments (deduped to one per hour so an agent stopping several times while the user watches counts once), plus last-prompted time and version.
- `screens/(authenticated)/hooks/useAppReviewPrompt` — `requestAppReview("pr_merged" | "session_completed")`: applies the gates above, waits 1.5s for the screen to settle, checks `isAvailableAsync`, marks prompted, captures the PostHog event, calls `requestReview()`.
- Wired into `WorkspaceScreen` (the existing `attention === "review"` → seen transition) and `PullRequestScreen` `onMerged`.

## Manual QA Checklist
- [x] Settings renders the new row under Contact Support (screenshots: https://claude.ai/code/artifact/f8b180a9-088f-4d61-b599-baa13772bbf8)
- [x] Fresh dev client with `expo-store-review@56.0.3` boots against `expo-modules-core@56.0.23` (no DYLD missing-symbol crash)
- [ ] Rating sheet appears after merging a PR from the phone (dev build shows it every call; TestFlight never shows it; production is where Apple's cap applies)

## Testing
- `bun run lint` (root, clean)
- `bunx tsc --noEmit` in apps/mobile — no errors in touched files; total error count unchanged vs. baseline (pre-existing host-service / workspace-fs type noise)

## Design Decisions
- **Settings row opens the store URL instead of calling `requestReview()`**: Apple says not to tie the sheet to a button, since it may not show. The URL is deterministic.
- **Community moved above Contact Support**: so the rating row is adjacent to Contact Support *and* the last row of the group.

## Notes
- Native module added → dev clients need a rebuild after pulling this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Rate Superset” row in Settings and requests Apple’s rating sheet after positive moments to drive App Store reviews without in‑app banners. Previously there was no entry point or prompt; now the row opens the write‑review page and we request the native sheet at targeted moments with strict caps and an immediate reservation to avoid double prompts.

- Adds `expo-store-review@56.0.3`. Dev clients must rebuild after pulling.
- Settings → Support: moves Community above Contact Support; adds “Rate Superset” directly under Contact Support (last in the group). Tapping opens the write‑review page for the live App Store listing.
- Requests the system rating sheet after merging a PR on device (immediate) and after the third distinct “agent finished” session. Moments dedupe within 1h.
- Never prompts again for the same app version or within 90 days; still subject to Apple’s 3/year cap and OS opt‑out. Reserves the prompt before the 1.5s settle delay to prevent back‑to‑back moments from double‑requesting.
- Wires into `PullRequestScreen` merge callback and `WorkspaceScreen` when `attention === "review"`. Dev builds show the sheet on each call; TestFlight often suppresses it; production follows Apple’s caps.
- Captures `app_review_prompt_requested` in PostHog.

<sup>Written for commit 274eb368f32abecd17082347d27cdefc8752e903. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompts to rate the app after a pull request is merged or a session is successfully completed.
  * Added “Rate Superset” and “Community” options in Settings.
  * Review prompts are limited by availability, app version, and a 90-day cooldown to avoid interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->