### PR TITLE
fix(desktop): use <output> for the auto-resume status text so Lint passes on main

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalAgentAutoResume/TerminalAgentAutoResume.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalAgentAutoResume/TerminalAgentAutoResume.tsx
@@ -137,15 +137,14 @@ export function TerminalAgentAutoResume({
 					aria-hidden="true"
 					className="size-3.5 shrink-0 text-muted-foreground"
 				/>
-				<span
-					role="status"
+				<output
 					aria-live="polite"
 					className="whitespace-nowrap text-xs text-muted-foreground"
 				>
 					{failed
 						? `Failed to resume ${candidate.agentLabel}`
 						: `Resuming ${candidate.agentLabel}…`}
-				</span>
+				</output>
 				{failed && (
 					<>
 						<Button


### PR DESCRIPTION
## Summary
- `main` has failed the CI **Lint** job since #6572: biome `lint/a11y/useSemanticElements` flags `<span role="status">` in `TerminalAgentAutoResume.tsx` and asks for the semantic element. Swap it for `<output>`, which carries the `status` role implicitly. Same classes, same `aria-live`, no behaviour change.
- Because CI lints each PR's merge ref, this one line is currently turning every open PR's Lint check red.

## Testing
- `bunx @biomejs/biome@2.4.2 check <file>` (the CI-pinned version) — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing CI Lint on `main` by replacing the auto-resume status text element. Previously used `<span role="status">`; now uses `<output>` which implies `role="status"`. No UI or behavior change.

- Updates `TerminalAgentAutoResume.tsx` to satisfy Biome `lint/a11y/useSemanticElements`.
- Keeps `aria-live="polite"` and classes; status announcements remain the same.
- Verified clean with `@biomejs/biome@2.4.2`; unblocks red Lint checks on merge refs for all PRs.

<sup>Written for commit c28f0d20fb43fec4e43d0d79a0d7912642354157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated the terminal agent resume status message to use a semantic output element while preserving its live updates, styling, and displayed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->