### PR TITLE
feat(automations): Notion trigger provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,13 @@ LINEAR_CLIENT_SECRET=
 LINEAR_WEBHOOK_SECRET=
 
 # -----------------------------------------------------------------------------
+# Notion Integration (public integration; webhook subscription in its settings)
+# -----------------------------------------------------------------------------
+NOTION_CLIENT_ID=
+NOTION_CLIENT_SECRET=
+NOTION_WEBHOOK_VERIFICATION_TOKEN=
+
+# -----------------------------------------------------------------------------
 # Slack Integration
 # -----------------------------------------------------------------------------
 SLACK_CLIENT_ID=

--- a/apps/api/src/app/api/integrations/notion/callback/route.ts
+++ b/apps/api/src/app/api/integrations/notion/callback/route.ts
@@ -1,0 +1,157 @@
+import { db } from "@superset/db/client";
+import {
+	integrationConnections,
+	members,
+	userIdentities,
+} from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { env } from "@/env";
+import { verifySignedState } from "@/lib/oauth-state";
+
+/**
+ * What Notion returns for an authorization code. `owner` is the person who
+ * clicked through — the only Notion identity the connection can vouch for.
+ */
+const tokenResponseSchema = z.object({
+	access_token: z.string().min(1),
+	refresh_token: z.string().nullish(),
+	bot_id: z.string(),
+	workspace_id: z.string().min(1),
+	workspace_name: z.string().nullish(),
+	owner: z.object({
+		type: z.string(),
+		user: z
+			.object({
+				id: z.string().min(1),
+				name: z.string().nullish(),
+			})
+			.optional(),
+	}),
+});
+
+const settingsUrl = `${env.NEXT_PUBLIC_WEB_URL}/integrations/notion`;
+
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const code = url.searchParams.get("code");
+	const state = url.searchParams.get("state");
+	const error = url.searchParams.get("error");
+
+	if (error) {
+		return Response.redirect(`${settingsUrl}?error=oauth_denied`);
+	}
+	if (!code || !state) {
+		return Response.redirect(`${settingsUrl}?error=missing_params`);
+	}
+	if (!env.NOTION_CLIENT_ID || !env.NOTION_CLIENT_SECRET) {
+		return Response.redirect(`${settingsUrl}?error=not_configured`);
+	}
+
+	const stateData = verifySignedState(state);
+	if (!stateData) {
+		return Response.redirect(`${settingsUrl}?error=invalid_state`);
+	}
+	const { organizationId, userId } = stateData;
+
+	// Re-verify membership at callback time (state was signed earlier).
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.organizationId, organizationId),
+			eq(members.userId, userId),
+		),
+	});
+	if (!membership) {
+		console.error("[notion/callback] Membership verification failed:", {
+			organizationId,
+			userId,
+		});
+		return Response.redirect(`${settingsUrl}?error=unauthorized`);
+	}
+
+	const basic = Buffer.from(
+		`${env.NOTION_CLIENT_ID}:${env.NOTION_CLIENT_SECRET}`,
+	).toString("base64");
+	const tokenResponse = await fetch("https://api.notion.com/v1/oauth/token", {
+		method: "POST",
+		headers: {
+			Authorization: `Basic ${basic}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: `${env.NEXT_PUBLIC_API_URL}/api/integrations/notion/callback`,
+		}),
+	});
+	if (!tokenResponse.ok) {
+		console.error(
+			"[notion/callback] Token exchange failed:",
+			tokenResponse.status,
+			await tokenResponse.text().catch(() => ""),
+		);
+		return Response.redirect(`${settingsUrl}?error=token_exchange_failed`);
+	}
+
+	const parsed = tokenResponseSchema.safeParse(await tokenResponse.json());
+	if (!parsed.success) {
+		console.error("[notion/callback] Unexpected token response:", parsed.error);
+		return Response.redirect(`${settingsUrl}?error=token_exchange_failed`);
+	}
+	const token = parsed.data;
+
+	await db
+		.insert(integrationConnections)
+		.values({
+			organizationId,
+			connectedByUserId: userId,
+			provider: "notion",
+			accessToken: token.access_token,
+			refreshToken: token.refresh_token ?? null,
+			externalOrgId: token.workspace_id,
+			externalOrgName: token.workspace_name ?? null,
+		})
+		.onConflictDoUpdate({
+			target: [
+				integrationConnections.organizationId,
+				integrationConnections.provider,
+			],
+			set: {
+				accessToken: token.access_token,
+				refreshToken: token.refresh_token ?? null,
+				externalOrgId: token.workspace_id,
+				externalOrgName: token.workspace_name ?? null,
+				connectedByUserId: userId,
+				disconnectedAt: null,
+				disconnectReason: null,
+				updatedAt: new Date(),
+			},
+		});
+
+	// The authorizing member's Notion user id, so `me` in a mention trigger
+	// resolves for them. Notion user ids are per workspace, hence the scope.
+	if (token.owner.user) {
+		await db
+			.insert(userIdentities)
+			.values({
+				userId,
+				organizationId,
+				provider: "notion",
+				externalId: token.owner.user.id,
+				externalScopeId: token.workspace_id,
+				displayName: token.owner.user.name ?? null,
+			})
+			.onConflictDoUpdate({
+				target: [
+					userIdentities.organizationId,
+					userIdentities.provider,
+					userIdentities.externalScopeId,
+					userIdentities.externalId,
+				],
+				set: { userId, displayName: token.owner.user.name ?? null },
+			});
+	}
+
+	return Response.redirect(settingsUrl);
+}

--- a/apps/api/src/app/api/integrations/notion/callback/route.ts
+++ b/apps/api/src/app/api/integrations/notion/callback/route.ts
@@ -4,6 +4,7 @@ import {
 	members,
 	userIdentities,
 } from "@superset/db/schema";
+import { NOTION_VERSION } from "@superset/trpc/integrations/notion";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -78,19 +79,26 @@ export async function GET(request: Request) {
 		headers: {
 			Authorization: `Basic ${basic}`,
 			"Content-Type": "application/json",
+			"Notion-Version": NOTION_VERSION,
 		},
 		body: JSON.stringify({
 			grant_type: "authorization_code",
 			code,
 			redirect_uri: `${env.NEXT_PUBLIC_API_URL}/api/integrations/notion/callback`,
 		}),
+		signal: AbortSignal.timeout(15_000),
+	}).catch((error: unknown) => {
+		console.error("[notion/callback] Token exchange request failed:", error);
+		return null;
 	});
-	if (!tokenResponse.ok) {
-		console.error(
-			"[notion/callback] Token exchange failed:",
-			tokenResponse.status,
-			await tokenResponse.text().catch(() => ""),
-		);
+	if (!tokenResponse?.ok) {
+		if (tokenResponse) {
+			console.error(
+				"[notion/callback] Token exchange failed:",
+				tokenResponse.status,
+				await tokenResponse.text().catch(() => ""),
+			);
+		}
 		return Response.redirect(`${settingsUrl}?error=token_exchange_failed`);
 	}
 

--- a/apps/api/src/app/api/integrations/notion/connect/route.ts
+++ b/apps/api/src/app/api/integrations/notion/connect/route.ts
@@ -1,0 +1,55 @@
+import { auth } from "@superset/auth/server";
+import { findOrgMembership } from "@superset/db/utils";
+
+import { env } from "@/env";
+import { createSignedState } from "@/lib/oauth-state";
+
+export async function GET(request: Request) {
+	if (!env.NOTION_CLIENT_ID) {
+		return Response.json(
+			{ error: "Notion integration is not configured" },
+			{ status: 503 },
+		);
+	}
+
+	const url = new URL(request.url);
+	const organizationId = url.searchParams.get("organizationId");
+	if (!organizationId) {
+		return Response.json(
+			{ error: "Missing organizationId parameter" },
+			{ status: 400 },
+		);
+	}
+
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const membership = await findOrgMembership({
+		userId: session.user.id,
+		organizationId,
+	});
+	if (!membership) {
+		return Response.json(
+			{ error: "User is not a member of this organization" },
+			{ status: 403 },
+		);
+	}
+
+	const state = createSignedState({ organizationId, userId: session.user.id });
+
+	const notionAuthUrl = new URL("https://api.notion.com/v1/oauth/authorize");
+	notionAuthUrl.searchParams.set("client_id", env.NOTION_CLIENT_ID);
+	notionAuthUrl.searchParams.set(
+		"redirect_uri",
+		`${env.NEXT_PUBLIC_API_URL}/api/integrations/notion/callback`,
+	);
+	notionAuthUrl.searchParams.set("response_type", "code");
+	// The only value Notion accepts; a workspace is authorized by one of its
+	// members, whose identity comes back as `owner`.
+	notionAuthUrl.searchParams.set("owner", "user");
+	notionAuthUrl.searchParams.set("state", state);
+
+	return Response.redirect(notionAuthUrl.toString());
+}

--- a/apps/api/src/app/api/integrations/notion/webhook/fetchNotionEvent.ts
+++ b/apps/api/src/app/api/integrations/notion/webhook/fetchNotionEvent.ts
@@ -1,0 +1,115 @@
+import {
+	mentionedUserIds,
+	type NotionComment,
+	type NotionDataSource,
+	type NotionPage,
+	pageTitle,
+	plainText,
+	retrieveComment,
+	retrieveDataSource,
+	retrievePage,
+} from "@superset/trpc/integrations/notion";
+import { z } from "zod";
+
+/**
+ * A Notion delivery names an entity and says what happened to it; it carries
+ * none of the content. Everything a trigger filters on — which data source,
+ * which page, who wrote it, who it mentions — is fetched here.
+ */
+
+export const notionWebhookEventSchema = z.object({
+	id: z.string().min(1),
+	timestamp: z.string(),
+	workspace_id: z.string().min(1),
+	workspace_name: z.string().nullish(),
+	type: z.string().min(1),
+	authors: z.array(z.object({ id: z.string(), type: z.string() })).optional(),
+	attempt_number: z.number().optional(),
+	entity: z.object({ id: z.string().min(1), type: z.string() }),
+	data: z
+		.object({
+			page_id: z.string().optional(),
+			parent: z.object({ id: z.string(), type: z.string() }).optional(),
+		})
+		.passthrough()
+		.optional(),
+});
+export type NotionWebhookEvent = z.infer<typeof notionWebhookEventSchema>;
+
+/** The delivery types this provider turns into automation events. */
+export const HANDLED_EVENT_TYPES = new Set([
+	"comment.created",
+	"data_source.content_updated",
+]);
+
+export type FetchedNotionEvent = {
+	dataSourceId: string | null;
+	pageId: string | null;
+	actorId: string | null;
+	mentionedUserIds: string[];
+	body: string | null;
+	title: string;
+	url: string | null;
+	/** Runs debounce per subject; a page's comments are one subject. */
+	resourceKey: string;
+	/** The delivery plus what was fetched, kept for the run's prompt. */
+	payload: {
+		event: NotionWebhookEvent;
+		comment?: NotionComment;
+		page?: NotionPage;
+		dataSource?: NotionDataSource;
+	};
+};
+
+function dataSourceOf(page: NotionPage): string | null {
+	const parent = page.parent;
+	if (parent.type === "data_source_id") return parent.data_source_id;
+	// Only older API versions answer with database_id; kept so a stale
+	// response still attributes the row to something rather than nothing.
+	if (parent.type === "database_id") return parent.database_id;
+	return null;
+}
+
+export async function fetchNotionEvent(
+	accessToken: string,
+	event: NotionWebhookEvent,
+): Promise<FetchedNotionEvent> {
+	switch (event.type) {
+		case "comment.created": {
+			const comment = await retrieveComment(accessToken, event.entity.id);
+			// The delivery names the page; a block comment's own parent is the
+			// block, so the page id has to come from the delivery when present.
+			const pageId =
+				event.data?.page_id ??
+				(comment.parent.type === "page_id" ? comment.parent.page_id : null);
+			const page = pageId ? await retrievePage(accessToken, pageId) : null;
+			return {
+				dataSourceId: page ? dataSourceOf(page) : null,
+				pageId,
+				actorId: comment.created_by.id,
+				mentionedUserIds: mentionedUserIds(comment.rich_text),
+				body: plainText(comment.rich_text) || null,
+				title: (page && pageTitle(page)) ?? "Untitled",
+				url: page?.url ?? null,
+				resourceKey: `notion:${pageId ?? comment.id}`,
+				payload: { event, comment, ...(page ? { page } : {}) },
+			};
+		}
+		case "data_source.content_updated": {
+			const dataSource = await retrieveDataSource(accessToken, event.entity.id);
+			return {
+				dataSourceId: event.entity.id,
+				pageId: null,
+				actorId: event.authors?.[0]?.id ?? null,
+				mentionedUserIds: [],
+				body: null,
+				title: plainText(dataSource.title) || "Untitled",
+				url: dataSource.url ?? null,
+				resourceKey: `notion:${event.entity.id}`,
+				payload: { event, dataSource },
+			};
+		}
+		default:
+			throw new Error(`Unhandled Notion event type ${event.type}`);
+	}
+}

--- a/apps/api/src/app/api/integrations/notion/webhook/fetchNotionEvent.ts
+++ b/apps/api/src/app/api/integrations/notion/webhook/fetchNotionEvent.ts
@@ -27,11 +27,10 @@ export const notionWebhookEventSchema = z.object({
 	attempt_number: z.number().optional(),
 	entity: z.object({ id: z.string().min(1), type: z.string() }),
 	data: z
-		.object({
+		.looseObject({
 			page_id: z.string().optional(),
 			parent: z.object({ id: z.string(), type: z.string() }).optional(),
 		})
-		.passthrough()
 		.optional(),
 });
 export type NotionWebhookEvent = z.infer<typeof notionWebhookEventSchema>;
@@ -89,7 +88,7 @@ export async function fetchNotionEvent(
 				actorId: comment.created_by.id,
 				mentionedUserIds: mentionedUserIds(comment.rich_text),
 				body: plainText(comment.rich_text) || null,
-				title: (page && pageTitle(page)) ?? "Untitled",
+				title: (page && pageTitle(page)) || "Untitled",
 				url: page?.url ?? null,
 				resourceKey: `notion:${pageId ?? comment.id}`,
 				payload: { event, comment, ...(page ? { page } : {}) },

--- a/apps/api/src/app/api/integrations/notion/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/notion/webhook/route.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { db } from "@superset/db/client";
 import type { SelectIntegrationConnection } from "@superset/db/schema";
 import {
@@ -42,24 +42,39 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
 	}
 
+	const token = env.NOTION_WEBHOOK_VERIFICATION_TOKEN;
+
 	// The one-time handshake. Notion posts the token unsigned when the
 	// subscription is created; it is pasted back into Notion's UI to verify,
 	// and then becomes NOTION_WEBHOOK_VERIFICATION_TOKEN. There is no other
-	// way to receive it than reading it here.
+	// way to receive it than reading it here, so it is logged in full only
+	// while the endpoint is still unconfigured — once a token is set, an
+	// unauthenticated caller can no longer write arbitrary strings here, and
+	// a fingerprint is enough to tell a re-verification apart.
 	if (
 		typeof json === "object" &&
 		json !== null &&
 		"verification_token" in json &&
 		typeof json.verification_token === "string"
 	) {
-		console.log(
-			"[notion/webhook] Verification token received; set NOTION_WEBHOOK_VERIFICATION_TOKEN to:",
-			json.verification_token,
-		);
+		if (token) {
+			const fingerprint = createHash("sha256")
+				.update(json.verification_token)
+				.digest("hex")
+				.slice(0, 12);
+			console.log(
+				"[notion/webhook] Verification handshake received while configured; token fingerprint",
+				fingerprint,
+			);
+		} else {
+			console.log(
+				"[notion/webhook] Verification token received; set NOTION_WEBHOOK_VERIFICATION_TOKEN to:",
+				json.verification_token,
+			);
+		}
 		return Response.json({ ok: true });
 	}
 
-	const token = env.NOTION_WEBHOOK_VERIFICATION_TOKEN;
 	if (!token) {
 		return Response.json(
 			{ error: "Notion webhook is not configured" },

--- a/apps/api/src/app/api/integrations/notion/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/notion/webhook/route.ts
@@ -1,0 +1,273 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { db } from "@superset/db/client";
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import {
+	automationEvents,
+	integrationConnections,
+	webhookEvents,
+} from "@superset/db/schema";
+import type { NotionMatchableEvent } from "@superset/shared/automation-matching";
+import { NotionApiError } from "@superset/trpc/integrations/notion";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+
+import { env } from "@/env";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import { stripNullChars } from "@/lib/strip-null-chars";
+import {
+	type FetchedNotionEvent,
+	fetchNotionEvent,
+	HANDLED_EVENT_TYPES,
+	type NotionWebhookEvent,
+	notionWebhookEventSchema,
+} from "./fetchNotionEvent";
+
+/**
+ * Notion signs every delivery with the verification token it sent when the
+ * subscription was created: `sha256=` + HMAC-SHA256(token, raw body).
+ */
+function signatureValid(body: string, signature: string, token: string) {
+	const expected = `sha256=${createHmac("sha256", token).update(body).digest("hex")}`;
+	const a = Buffer.from(expected);
+	const b = Buffer.from(signature);
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function POST(request: Request) {
+	const body = await request.text();
+
+	let json: unknown;
+	try {
+		json = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+
+	// The one-time handshake. Notion posts the token unsigned when the
+	// subscription is created; it is pasted back into Notion's UI to verify,
+	// and then becomes NOTION_WEBHOOK_VERIFICATION_TOKEN. There is no other
+	// way to receive it than reading it here.
+	if (
+		typeof json === "object" &&
+		json !== null &&
+		"verification_token" in json &&
+		typeof json.verification_token === "string"
+	) {
+		console.log(
+			"[notion/webhook] Verification token received; set NOTION_WEBHOOK_VERIFICATION_TOKEN to:",
+			json.verification_token,
+		);
+		return Response.json({ ok: true });
+	}
+
+	const token = env.NOTION_WEBHOOK_VERIFICATION_TOKEN;
+	if (!token) {
+		return Response.json(
+			{ error: "Notion webhook is not configured" },
+			{ status: 503 },
+		);
+	}
+	const signature = request.headers.get("x-notion-signature");
+	if (!signature || !signatureValid(body, signature, token)) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	const parsed = notionWebhookEventSchema.safeParse(json);
+	if (!parsed.success) {
+		console.error("[notion/webhook] Unexpected payload:", parsed.error);
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+	const event = parsed.data;
+
+	// The subscription may carry more event types than the product names;
+	// acknowledge those so Notion does not retry them.
+	if (!HANDLED_EVENT_TYPES.has(event.type)) {
+		return Response.json({ success: true, status: "ignored" });
+	}
+
+	const connections = await db.query.integrationConnections.findMany({
+		where: and(
+			eq(integrationConnections.provider, "notion"),
+			eq(integrationConnections.externalOrgId, event.workspace_id),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		orderBy: [asc(integrationConnections.id)],
+	});
+
+	if (connections.length === 0) {
+		console.log(
+			"[notion/webhook] No active connections for workspace:",
+			event.workspace_id,
+		);
+		return Response.json({ success: true, status: "no_subscribers" });
+	}
+
+	const results = await Promise.all(
+		connections.map((connection) =>
+			processForConnection(event, connection).catch((error) => ({
+				connectionId: connection.id,
+				outcome: "failed" as const,
+				error: error instanceof Error ? error.message : "Unknown error",
+			})),
+		),
+	);
+
+	const anyFailed = results.some((r) => r.outcome === "failed");
+	const allFailed = results.every((r) => r.outcome === "failed");
+	if (anyFailed) {
+		console.error("[notion/webhook] processing failures:", results);
+	}
+	return Response.json(
+		{
+			success: !allFailed,
+			status: allFailed
+				? "failed"
+				: anyFailed
+					? "partial_failure"
+					: "processed",
+		},
+		{ status: allFailed ? 500 : 200 },
+	);
+}
+
+async function processForConnection(
+	event: NotionWebhookEvent,
+	connection: SelectIntegrationConnection,
+): Promise<{
+	connectionId: string;
+	outcome: "processed" | "skipped" | "failed";
+	error?: string;
+}> {
+	// One ingest row per (delivery × connection): two organizations connected
+	// to the same workspace each get their own retryable processing state.
+	const eventId = `${connection.id}-${event.id}`;
+
+	const [webhookEvent] = await db
+		.insert(webhookEvents)
+		.values({
+			provider: "notion",
+			eventId,
+			eventType: event.type,
+			payload: stripNullChars(event),
+			status: "pending",
+		})
+		.onConflictDoUpdate({
+			target: [webhookEvents.provider, webhookEvents.eventId],
+			set: {
+				status: sql`CASE WHEN ${webhookEvents.status} = 'failed' THEN 'pending' ELSE ${webhookEvents.status} END`,
+				retryCount: sql`CASE WHEN ${webhookEvents.status} = 'failed' THEN ${webhookEvents.retryCount} + 1 ELSE ${webhookEvents.retryCount} END`,
+				error: sql`CASE WHEN ${webhookEvents.status} = 'failed' THEN NULL ELSE ${webhookEvents.error} END`,
+			},
+		})
+		.returning();
+
+	if (!webhookEvent) {
+		return {
+			connectionId: connection.id,
+			outcome: "failed",
+			error: "Failed to store event",
+		};
+	}
+	if (webhookEvent.status === "processed") {
+		return { connectionId: connection.id, outcome: "processed" };
+	}
+	if (webhookEvent.status !== "pending") {
+		return { connectionId: connection.id, outcome: "skipped" };
+	}
+
+	try {
+		let fetched: FetchedNotionEvent;
+		try {
+			fetched = await fetchNotionEvent(connection.accessToken, event);
+		} catch (error) {
+			// The entity is not shared with this connection, or the token no
+			// longer works. Retrying will not change that, so acknowledge it.
+			if (error instanceof NotionApiError && error.permanent) {
+				await db
+					.update(webhookEvents)
+					.set({
+						status: "skipped",
+						error: `${error.status} ${error.code}: ${error.message}`,
+						processedAt: new Date(),
+					})
+					.where(eq(webhookEvents.id, webhookEvent.id));
+				return { connectionId: connection.id, outcome: "skipped" };
+			}
+			throw error;
+		}
+
+		const [inserted] = await db
+			.insert(automationEvents)
+			.values({
+				organizationId: connection.organizationId,
+				integrationConnectionId: connection.id,
+				provider: "notion",
+				eventType: event.type,
+				externalEventId: event.id,
+				resourceKey: fetched.resourceKey,
+				title: fetched.title,
+				url: fetched.url,
+				repositoryId: null,
+				ref: null,
+				actorLogin: null,
+				actorIsExternal: null,
+				payload: stripNullChars(fetched.payload) as Record<string, unknown>,
+				webhookEventId: webhookEvent.id,
+			})
+			// A redelivery of the same Notion event id is the same event.
+			.onConflictDoNothing({
+				target: [
+					automationEvents.integrationConnectionId,
+					automationEvents.provider,
+					automationEvents.externalEventId,
+				],
+			})
+			.returning({ id: automationEvents.id });
+
+		// Not inside the failure path: the event row above already dedupes a
+		// redelivery, so failing the delivery here would make Notion retry
+		// something that can no longer dispatch. Same tradeoff as GitHub.
+		if (inserted) {
+			try {
+				const matchable: NotionMatchableEvent = {
+					provider: "notion",
+					eventType: event.type,
+					actorId: fetched.actorId,
+					actorLogin: null,
+					body: fetched.body,
+					dataSourceId: fetched.dataSourceId,
+					pageId: fetched.pageId,
+					mentionedUserIds: fetched.mentionedUserIds,
+				};
+				const result = await dispatchMatchingTriggers({
+					organizationId: connection.organizationId,
+					eventId: inserted.id,
+					event: matchable,
+				});
+				console.log(
+					`[notion/webhook] ${result.matched}/${result.considered} triggers matched:`,
+					event.id,
+				);
+			} catch (error) {
+				console.error("[notion/webhook] dispatch failed:", event.id, error);
+			}
+		}
+
+		await db
+			.update(webhookEvents)
+			.set({ status: "processed", processedAt: new Date() })
+			.where(eq(webhookEvents.id, webhookEvent.id));
+
+		return { connectionId: connection.id, outcome: "processed" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		await db
+			.update(webhookEvents)
+			.set({
+				status: "failed",
+				error: message,
+				retryCount: webhookEvent.retryCount + 1,
+			})
+			.where(eq(webhookEvents.id, webhookEvent.id));
+		return { connectionId: connection.id, outcome: "failed", error: message };
+	}
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -19,6 +19,13 @@ export const env = createEnv({
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
 		LINEAR_WEBHOOK_SECRET: z.string().min(1),
+		// Optional until the Notion integration is provisioned per environment;
+		// the Notion routes answer 503 while any of these is unset.
+		NOTION_CLIENT_ID: z.string().min(1).optional(),
+		NOTION_CLIENT_SECRET: z.string().min(1).optional(),
+		// The verification token Notion sends when the webhook subscription is
+		// created; it is also the HMAC key every later delivery is signed with.
+		NOTION_WEBHOOK_VERIFICATION_TOKEN: z.string().min(1).optional(),
 		GH_APP_SLUG: z.string().min(1),
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -1,5 +1,6 @@
 import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
 import { githubProvider } from "./github/github";
+import { notionProvider } from "./notion/notion";
 import { scheduleProvider } from "./schedule/schedule";
 import type { TriggerProvider } from "./types";
 import { webhookProvider } from "./webhook/webhook";
@@ -20,6 +21,7 @@ export type {
 export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	scheduleProvider as TriggerProvider,
 	githubProvider as TriggerProvider,
+	notionProvider as TriggerProvider,
 	webhookProvider as TriggerProvider,
 ];
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/grammar.ts
@@ -41,7 +41,7 @@ export const NOTION_SENTENCES: Record<NotionTriggerEvent, SentencePart[]> = {
 export const NOTION_MENU: TriggerMenuEntry<NotionConfig>[] = [
 	leaf("Rows changed", "data_source.content_updated"),
 	leaf("Comment added", "comment.created"),
-	leaf("Comment mentions me", "comment.mentioned"),
+	leaf("Comment mentions user", "comment.mentioned"),
 ];
 
 function leaf(label: string, event: NotionTriggerEvent) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/grammar.ts
@@ -1,0 +1,79 @@
+import type {
+	NotionTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type NotionConfig = Extract<TriggerConfigInput, { kind: "notion" }>;
+
+/**
+ * The sentence a Notion trigger reads as. Same shape as GitHub's grammar: each
+ * event names its own words and slots, and the row renders them in order.
+ */
+
+export type Slot = "dataSources" | "pages" | "actor" | "mentionedUser";
+
+export type SentencePart = { text: string } | { slot: Slot };
+
+export const NOTION_SENTENCES: Record<NotionTriggerEvent, SentencePart[]> = {
+	"data_source.content_updated": [
+		{ text: "Rows changed in" },
+		{ slot: "dataSources" },
+	],
+	"comment.created": [
+		{ text: "Comment added in" },
+		{ slot: "dataSources" },
+		{ text: "on" },
+		{ slot: "pages" },
+		{ text: "by" },
+		{ slot: "actor" },
+	],
+	"comment.mentioned": [
+		{ text: "Comment mentions" },
+		{ slot: "mentionedUser" },
+		{ text: "in" },
+		{ slot: "dataSources" },
+		{ text: "on" },
+		{ slot: "pages" },
+	],
+};
+
+export const NOTION_MENU: TriggerMenuEntry<NotionConfig>[] = [
+	leaf("Rows changed", "data_source.content_updated"),
+	leaf("Comment added", "comment.created"),
+	leaf("Comment mentions me", "comment.mentioned"),
+];
+
+function leaf(label: string, event: NotionTriggerEvent) {
+	return { label, create: () => createNotionConfig(event) };
+}
+
+/**
+ * A new trigger of this event: the data source still to be chosen, every
+ * optional filter wide open.
+ */
+export function createNotionConfig(event: NotionTriggerEvent): NotionConfig {
+	// Null matches nothing, so an unfinished trigger cannot fire on every data
+	// source; the form refuses to save until one is chosen.
+	const base = { kind: "notion" as const, dataSources: null };
+	switch (event) {
+		case "data_source.content_updated":
+			return { ...base, event };
+		case "comment.created":
+			// Pages are an optional narrowing, so they start at "any" — null here
+			// would read as "Any page" while matching nothing.
+			return {
+				...base,
+				event,
+				pages: { mode: "any" as const },
+				actor: "anyone" as const,
+			};
+		case "comment.mentioned":
+			return {
+				...base,
+				event,
+				pages: { mode: "any" as const },
+				mentionedUser: "me" as const,
+			};
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/notion.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/notion.tsx
@@ -1,0 +1,96 @@
+import { SiNotion } from "react-icons/si";
+import { ActorChip } from "../../TriggerSentence/components/ActorChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	NOTION_MENU,
+	NOTION_SENTENCES,
+	type NotionConfig,
+	type SentencePart,
+} from "./grammar";
+
+function renderPart(
+	config: NotionConfig,
+	part: SentencePart,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	// The slot list is derived from this event, so the fields it names are
+	// present on this config member even where the union type cannot say so.
+	const c = config as unknown as Record<string, never>;
+	switch (part.slot) {
+		case "dataSources":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.dataSources}
+					onChange={(v) => set({ dataSources: v })}
+					className={mark("dataSources")}
+					options={options.notion?.dataSources ?? []}
+					emptyLabel="Select data sources"
+					anyLabel="Any data source"
+					disabled={disabled}
+				/>
+			);
+		case "pages":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.pages}
+					// Clearing an optional filter means "any", not "none".
+					onChange={(v) => set({ pages: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any page"
+					anyLabel="Any page"
+					disabled={disabled}
+				/>
+			);
+		case "actor":
+			return (
+				<ActorChip
+					key={index}
+					actor={c.actor}
+					onChange={(v) => set({ actor: v })}
+					className={mark("actor")}
+					people={options.notion?.users ?? []}
+					disabled={disabled}
+				/>
+			);
+		case "mentionedUser":
+			return (
+				<ActorChip
+					key={index}
+					actor={c.mentionedUser}
+					onChange={(v) => set({ mentionedUser: v })}
+					className={mark("mentionedUser")}
+					people={options.notion?.users ?? []}
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const notionProvider: TriggerProvider<NotionConfig> = {
+	kind: "notion",
+	label: "Notion",
+	icon: SiNotion,
+	menu: NOTION_MENU,
+	renderSentence: (config, ctx) => {
+		const parts = NOTION_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/useNotionOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/useNotionOptions.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+
+/**
+ * The pickable values a Notion sentence needs: the data sources the connected
+ * workspace shares with the integration, and the workspace's people (Notion
+ * user ids — what a comment's author and mentions carry).
+ */
+export function useNotionOptions(organizationId: string): ProviderOptions {
+	const dataSources = cloudTrpc.integration.notion.listDataSources.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+	const users = cloudTrpc.integration.notion.listUsers.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+
+	return useMemo(
+		() => ({
+			notion: {
+				dataSources: dataSources.data ?? [],
+				users: users.data ?? [],
+			},
+		}),
+		[dataSources.data, users.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useGithubOptions } from "./github/useGithubOptions";
+import { useNotionOptions } from "./notion/useNotionOptions";
 import type { ProviderOptions } from "./types";
 
 /**
@@ -12,5 +13,6 @@ import type { ProviderOptions } from "./types";
  */
 export function useProviderOptions(organizationId: string): ProviderOptions {
 	const github = useGithubOptions(organizationId);
-	return useMemo(() => ({ ...github }), [github]);
+	const notion = useNotionOptions(organizationId);
+	return useMemo(() => ({ ...github, ...notion }), [github, notion]);
 }

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ConnectionControls/ConnectionControls.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ConnectionControls/ConnectionControls.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Unplug } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { env } from "@/env";
+import { useTRPC } from "@/trpc/react";
+
+interface ConnectionControlsProps {
+	organizationId: string;
+	isConnected: boolean;
+}
+
+export function ConnectionControls({
+	organizationId,
+	isConnected,
+}: ConnectionControlsProps) {
+	const trpc = useTRPC();
+	const router = useRouter();
+	const queryClient = useQueryClient();
+
+	const disconnectMutation = useMutation(
+		trpc.integration.notion.disconnect.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({
+					queryKey: trpc.integration.notion.getConnection.queryKey({
+						organizationId,
+					}),
+				});
+				router.refresh();
+			},
+		}),
+	);
+
+	const handleConnect = () => {
+		window.location.href = `${env.NEXT_PUBLIC_API_URL}/api/integrations/notion/connect?organizationId=${organizationId}`;
+	};
+
+	const handleDisconnect = () => {
+		disconnectMutation.mutate({ organizationId });
+	};
+
+	if (isConnected) {
+		return (
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button variant="outline" disabled={disconnectMutation.isPending}>
+						<Unplug className="mr-2 size-4" />
+						{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Disconnect Notion?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will remove the connection between your organization and
+							Notion. You can reconnect at any time.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={handleDisconnect}>
+							Disconnect
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
+	}
+
+	return <Button onClick={handleConnect}>Connect Notion</Button>;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ConnectionControls/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ConnectionControls/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionControls } from "./ConnectionControls";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ErrorHandler/ErrorHandler.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { toast } from "@superset/ui/sonner";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+	oauth_denied: "Authorization was denied. Please try again.",
+	missing_params: "Invalid OAuth response. Please try again.",
+	invalid_state: "Invalid state parameter. Please try again.",
+	token_exchange_failed: "Failed to connect to Notion. Please try again.",
+	not_configured: "Notion is not configured for this environment.",
+	unauthorized: "You are not authorized to perform this action.",
+};
+
+export function ErrorHandler() {
+	const searchParams = useSearchParams();
+
+	useEffect(() => {
+		const error = searchParams.get("error");
+		if (!error) return;
+
+		const message = ERROR_MESSAGES[error] ?? "Something went wrong.";
+
+		window.history.replaceState({}, "", "/integrations/notion");
+		const id = setTimeout(() => toast.error(message), 0);
+		return () => clearTimeout(id);
+	}, [searchParams]);
+
+	return null;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ErrorHandler/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/components/ErrorHandler/index.ts
@@ -1,0 +1,1 @@
+export { ErrorHandler } from "./ErrorHandler";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/page.tsx
@@ -1,0 +1,93 @@
+import { Badge } from "@superset/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@superset/ui/card";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { SiNotion } from "react-icons/si";
+import { api } from "@/trpc/server";
+import { ConnectionControls } from "./components/ConnectionControls";
+import { ErrorHandler } from "./components/ErrorHandler";
+
+export default async function NotionIntegrationPage() {
+	const trpc = await api();
+	const organization = await trpc.user.myOrganization.query();
+
+	if (!organization) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16">
+				<p className="text-muted-foreground">
+					You need to be part of an organization to use integrations.
+				</p>
+			</div>
+		);
+	}
+
+	const connection = await trpc.integration.notion.getConnection.query({
+		organizationId: organization.id,
+	});
+	const isConnected = !!connection;
+
+	return (
+		<div className="space-y-8">
+			<ErrorHandler />
+
+			<Link
+				href="/integrations"
+				className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ArrowLeft className="size-4" />
+				Back to Integrations
+			</Link>
+
+			<div className="flex items-start gap-6">
+				<div className="flex size-16 items-center justify-center rounded-xl border bg-card p-3">
+					<SiNotion className="size-10" />
+				</div>
+				<div className="flex-1">
+					<div className="flex items-center gap-3">
+						<h1 className="text-2xl font-semibold">Notion</h1>
+						{isConnected ? (
+							<Badge variant="default" className="gap-1">
+								<CheckCircle2 className="size-3" />
+								Connected
+							</Badge>
+						) : (
+							<Badge variant="secondary">Not Connected</Badge>
+						)}
+					</div>
+					<p className="mt-1 text-muted-foreground">
+						Connect Notion to run automations when rows change in a data source
+						or someone comments on a page.
+					</p>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Connection</CardTitle>
+					<CardDescription>
+						Connect your Notion workspace and share the pages and data sources
+						automations should watch.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ConnectionControls
+						organizationId={organization.id}
+						isConnected={isConnected}
+					/>
+					{connection && (
+						<div className="mt-4 text-sm text-muted-foreground">
+							Connected to{" "}
+							<span className="font-medium">{connection.externalOrgName}</span>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FaGithub, FaSlack } from "react-icons/fa";
-import { SiLinear } from "react-icons/si";
+import { SiLinear, SiNotion } from "react-icons/si";
 import {
 	IntegrationCard,
 	type IntegrationCardProps,
@@ -31,6 +31,14 @@ const integrations: IntegrationCardProps[] = [
 		category: "Communication",
 		accentColor: "#4A154B",
 		icon: <FaSlack className="size-8" />,
+	},
+	{
+		id: "notion",
+		name: "Notion",
+		description: "Run automations on data source and comment activity.",
+		category: "Knowledge",
+		accentColor: "#5F5E5B",
+		icon: <SiNotion className="size-8" />,
 	},
 ];
 

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -1,10 +1,12 @@
 import type { TriggerConfigInput } from "../automation-triggers";
 import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
 import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
+import { type NotionMatchableEvent, notionTriggerMatches } from "./notion";
 import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
 
 export * from "./core";
 export * from "./github";
+export * from "./notion";
 export * from "./webhook";
 
 /**
@@ -16,7 +18,10 @@ export * from "./webhook";
  * on the event, never on `MatchContext` — a Slack matcher must not need to
  * know that a GitHub context key exists.
  */
-export type MatchableEvent = GithubMatchableEvent | WebhookMatchableEvent;
+export type MatchableEvent =
+	| GithubMatchableEvent
+	| WebhookMatchableEvent
+	| NotionMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -50,6 +55,12 @@ export function triggerMatches(
 			);
 		case "webhook":
 			return webhookTriggerMatches();
+		case "notion":
+			return notionTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "notion" }>,
+				event,
+				context,
+			);
 	}
 	// Reached only when a provider is in the union but has no case above.
 	return {

--- a/packages/shared/src/automation-matching/notion.ts
+++ b/packages/shared/src/automation-matching/notion.ts
@@ -1,0 +1,90 @@
+import type {
+	NotionTriggerEvent,
+	TriggerActor,
+	TriggerConfigInput,
+	TriggerScope,
+} from "../automation-triggers";
+import {
+	actorAllows,
+	type BaseMatchableEvent,
+	type MatchContext,
+	type MatchResult,
+	scopeAllows,
+} from "./core";
+
+/**
+ * A Notion delivery, normalized to what Notion triggers filter on. The
+ * delivery itself carries only ids; everything here comes from the webhook
+ * route fetching the entity it names.
+ */
+export type NotionMatchableEvent = BaseMatchableEvent & {
+	provider: "notion";
+	/** The data source the page belongs to, or the data source itself. */
+	dataSourceId: string | null;
+	/** The page a comment sits on. Null for data source events. */
+	pageId: string | null;
+	/** Users @-mentioned in a comment's rich text. Empty for other events. */
+	mentionedUserIds: string[];
+};
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/**
+ * Maps a Notion delivery to the events a trigger names. A comment that
+ * mentions someone is both a comment and a mention.
+ */
+export function notionEventNames(eventType: string): NotionTriggerEvent[] {
+	switch (eventType) {
+		case "data_source.content_updated":
+			return ["data_source.content_updated"];
+		case "comment.created":
+			return ["comment.created", "comment.mentioned"];
+		default:
+			return [];
+	}
+}
+
+/** Whether a Notion trigger config accepts this event. */
+export function notionTriggerMatches(
+	config: Extract<TriggerConfigInput, { kind: "notion" }>,
+	event: NotionMatchableEvent,
+	context: MatchContext,
+): MatchResult {
+	if (!notionEventNames(event.eventType).includes(config.event)) {
+		return no("event");
+	}
+	if (!scopeAllows(config.dataSources, event.dataSourceId)) {
+		return no("dataSource");
+	}
+	// Pages only narrow when configured; null means the author did not choose
+	// to filter on them, which here is "any".
+	const pages: TriggerScope | undefined =
+		"pages" in config ? config.pages : undefined;
+	if (
+		pages !== undefined &&
+		pages !== null &&
+		!scopeAllows(pages, event.pageId)
+	) {
+		return no("page");
+	}
+	if (
+		"actor" in config &&
+		!actorAllows(config.actor, event.actorId, context.ownerIds)
+	) {
+		return no("actor");
+	}
+	if ("mentionedUser" in config) {
+		const mentionedUser: TriggerActor = config.mentionedUser;
+		// A comment that mentions nobody is not a mention, whoever the trigger
+		// is watching for.
+		if (event.mentionedUserIds.length === 0) return no("mention");
+		if (
+			!event.mentionedUserIds.some((id) =>
+				actorAllows(mentionedUser, id, context.ownerIds),
+			)
+		) {
+			return no("mentionedUser");
+		}
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -211,6 +211,54 @@ export const sentryTriggerConfigSchema = z.object({
 });
 
 /**
+ * Notion. `comment.mentioned` is not a Notion event: it is `comment.created`
+ * narrowed to comments whose rich text mentions a user, which the webhook
+ * route works out after fetching the comment.
+ */
+export const notionTriggerEventValues = [
+	"data_source.content_updated",
+	"comment.created",
+	"comment.mentioned",
+] as const;
+export type NotionTriggerEvent = (typeof notionTriggerEventValues)[number];
+
+const notionCommon = {
+	kind: z.literal("notion"),
+	dataSources: triggerScopeSchema,
+};
+
+const notionContentUpdatedEvent = z.object({
+	...notionCommon,
+	event: z.literal("data_source.content_updated"),
+});
+
+/**
+ * Comments live on a page, which may itself be a row of a data source, so
+ * both narrow: the data source the page belongs to and the page itself.
+ */
+const notionCommentCreatedEvent = z.object({
+	...notionCommon,
+	event: z.literal("comment.created"),
+	pages: triggerScopeSchema,
+	actor: triggerActorSchema,
+});
+
+const notionCommentMentionedEvent = z.object({
+	...notionCommon,
+	event: z.literal("comment.mentioned"),
+	pages: triggerScopeSchema,
+	// Who has to be @-mentioned for the comment to count. "me" is the common
+	// case; "anyone" fires on any comment that mentions somebody.
+	mentionedUser: triggerActorSchema,
+});
+
+export const notionTriggerConfigSchema = z.union([
+	notionContentUpdatedEvent,
+	notionCommentCreatedEvent,
+	notionCommentMentionedEvent,
+]);
+
+/**
  * Structurally valid — the shape is right, but a scope may still select nothing.
  * This is what the editor holds while someone is still filling a trigger in.
  */
@@ -227,6 +275,7 @@ export const draftTriggerSchema = z.object({
 		slackTriggerConfigSchema,
 		linearTriggerConfigSchema,
 		sentryTriggerConfigSchema,
+		notionTriggerConfigSchema,
 	]),
 });
 export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
@@ -280,6 +329,22 @@ export function describeTriggerProblems(
 				}
 				if (config.event === "reaction_added" && isEmptyScope(config.emoji)) {
 					add(index, "emoji", "Specify at least one reaction.");
+				}
+				break;
+			}
+			case "notion": {
+				if (isEmptyScope(config.dataSources)) {
+					add(index, "dataSources", "Specify at least one data source.");
+				}
+				if ("actor" in config && isEmptyActor(config.actor)) {
+					add(index, "actor", "Specify at least one person, or choose Anyone.");
+				}
+				if ("mentionedUser" in config && isEmptyActor(config.mentionedUser)) {
+					add(
+						index,
+						"mentionedUser",
+						"Specify at least one person, or choose Anyone.",
+					);
 				}
 				break;
 			}

--- a/packages/trpc/src/lib/integrations/notion/index.ts
+++ b/packages/trpc/src/lib/integrations/notion/index.ts
@@ -1,0 +1,17 @@
+export {
+	listDataSources,
+	listUsers,
+	mentionedUserIds,
+	NOTION_VERSION,
+	NotionApiError,
+	type NotionComment,
+	type NotionDataSource,
+	type NotionPage,
+	type NotionUser,
+	notionRequest,
+	pageTitle,
+	plainText,
+	retrieveComment,
+	retrieveDataSource,
+	retrievePage,
+} from "../../../router/integration/notion/client";

--- a/packages/trpc/src/router/integration/integration.ts
+++ b/packages/trpc/src/router/integration/integration.ts
@@ -6,12 +6,14 @@ import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
 import { githubRouter } from "./github";
 import { linearRouter } from "./linear";
+import { notionRouter } from "./notion";
 import { slackRouter } from "./slack";
 import { verifyOrgMembership } from "./utils";
 
 export const integrationRouter = {
 	github: githubRouter,
 	linear: linearRouter,
+	notion: notionRouter,
 	slack: slackRouter,
 
 	list: protectedProcedure

--- a/packages/trpc/src/router/integration/notion/client.ts
+++ b/packages/trpc/src/router/integration/notion/client.ts
@@ -7,6 +7,8 @@
 const NOTION_API = "https://api.notion.com";
 /** Data sources became first-class objects in this version. */
 export const NOTION_VERSION = "2025-09-03";
+/** A stalled Notion response must not hold a webhook delivery open indefinitely. */
+const REQUEST_TIMEOUT_MS = 15_000;
 
 export class NotionApiError extends Error {
 	constructor(
@@ -39,6 +41,7 @@ export async function notionRequest<T>(
 				: {}),
 		},
 		body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 	});
 	if (!response.ok) {
 		const error = (await response.json().catch(() => ({}))) as {
@@ -142,22 +145,28 @@ export function pageTitle(page: NotionPage): string | null {
 }
 
 export function retrieveComment(accessToken: string, commentId: string) {
-	return notionRequest<NotionComment>(accessToken, `/v1/comments/${commentId}`);
+	return notionRequest<NotionComment>(
+		accessToken,
+		`/v1/comments/${encodeURIComponent(commentId)}`,
+	);
 }
 
 export function retrievePage(accessToken: string, pageId: string) {
-	return notionRequest<NotionPage>(accessToken, `/v1/pages/${pageId}`);
+	return notionRequest<NotionPage>(
+		accessToken,
+		`/v1/pages/${encodeURIComponent(pageId)}`,
+	);
 }
 
 export function retrieveDataSource(accessToken: string, dataSourceId: string) {
 	return notionRequest<NotionDataSource>(
 		accessToken,
-		`/v1/data_sources/${dataSourceId}`,
+		`/v1/data_sources/${encodeURIComponent(dataSourceId)}`,
 	);
 }
 
-/** Bounds a picker list; a workspace with more than this is not pickable one by one anyway. */
-const MAX_LISTED = 500;
+/** Bounds a picker list at this many pages of 100; more is not pickable one by one anyway. */
+const MAX_PAGES = 5;
 
 /** Every data source the connection can see, by title. */
 export async function listDataSources(
@@ -165,6 +174,7 @@ export async function listDataSources(
 ): Promise<NotionDataSource[]> {
 	const results: NotionDataSource[] = [];
 	let cursor: string | undefined;
+	let pages = 0;
 	do {
 		const page = await notionRequest<Paginated<NotionDataSource>>(
 			accessToken,
@@ -179,8 +189,9 @@ export async function listDataSources(
 			},
 		);
 		results.push(...page.results);
+		pages += 1;
 		cursor = page.has_more && page.next_cursor ? page.next_cursor : undefined;
-	} while (cursor && results.length < MAX_LISTED);
+	} while (cursor && pages < MAX_PAGES);
 	return results;
 }
 
@@ -188,6 +199,7 @@ export async function listDataSources(
 export async function listUsers(accessToken: string): Promise<NotionUser[]> {
 	const results: NotionUser[] = [];
 	let cursor: string | undefined;
+	let pages = 0;
 	do {
 		const query = new URLSearchParams({ page_size: "100" });
 		if (cursor) query.set("start_cursor", cursor);
@@ -196,7 +208,8 @@ export async function listUsers(accessToken: string): Promise<NotionUser[]> {
 			`/v1/users?${query}`,
 		);
 		results.push(...page.results.filter((u) => u.type === "person"));
+		pages += 1;
 		cursor = page.has_more && page.next_cursor ? page.next_cursor : undefined;
-	} while (cursor && results.length < MAX_LISTED);
+	} while (cursor && pages < MAX_PAGES);
 	return results;
 }

--- a/packages/trpc/src/router/integration/notion/client.ts
+++ b/packages/trpc/src/router/integration/notion/client.ts
@@ -1,0 +1,202 @@
+/**
+ * The slice of Notion's REST API the integration uses. Plain fetch rather than
+ * the SDK: four endpoints, one header, and no dependency to keep in step with
+ * the API version pinned here.
+ */
+
+const NOTION_API = "https://api.notion.com";
+/** Data sources became first-class objects in this version. */
+export const NOTION_VERSION = "2025-09-03";
+
+export class NotionApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly code: string,
+		message: string,
+	) {
+		super(message);
+		this.name = "NotionApiError";
+	}
+
+	/** True when retrying will not help — the token, capability or entity is gone. */
+	get permanent(): boolean {
+		return [400, 401, 403, 404].includes(this.status);
+	}
+}
+
+export async function notionRequest<T>(
+	accessToken: string,
+	path: string,
+	init: { method?: "GET" | "POST"; body?: unknown } = {},
+): Promise<T> {
+	const response = await fetch(`${NOTION_API}${path}`, {
+		method: init.method ?? "GET",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Notion-Version": NOTION_VERSION,
+			...(init.body !== undefined
+				? { "Content-Type": "application/json" }
+				: {}),
+		},
+		body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+	});
+	if (!response.ok) {
+		const error = (await response.json().catch(() => ({}))) as {
+			code?: string;
+			message?: string;
+		};
+		throw new NotionApiError(
+			response.status,
+			error.code ?? "unknown",
+			error.message ?? `Notion API ${response.status}`,
+		);
+	}
+	return (await response.json()) as T;
+}
+
+export type NotionRichText = {
+	type: string;
+	plain_text?: string;
+	mention?: { type: string; user?: { id: string } };
+};
+
+export type NotionUser = {
+	object: "user";
+	id: string;
+	type?: "person" | "bot";
+	name?: string | null;
+	avatar_url?: string | null;
+	person?: { email?: string };
+};
+
+export type NotionComment = {
+	object: "comment";
+	id: string;
+	parent:
+		| { type: "page_id"; page_id: string }
+		| { type: "block_id"; block_id: string };
+	discussion_id: string;
+	created_time: string;
+	created_by: { object: "user"; id: string };
+	rich_text: NotionRichText[];
+	display_name?: { type: string; resolved_name: string | null };
+};
+
+export type NotionParent =
+	| { type: "data_source_id"; data_source_id: string; database_id?: string }
+	| { type: "database_id"; database_id: string }
+	| { type: "page_id"; page_id: string }
+	| { type: "block_id"; block_id: string }
+	| { type: "workspace"; workspace: true };
+
+export type NotionPage = {
+	object: "page";
+	id: string;
+	parent: NotionParent;
+	url?: string;
+	properties?: Record<
+		string,
+		{ type: string; title?: NotionRichText[] } | undefined
+	>;
+};
+
+export type NotionDataSource = {
+	object: "data_source";
+	id: string;
+	title?: NotionRichText[];
+	url?: string;
+	parent?: NotionParent;
+};
+
+type Paginated<T> = {
+	results: T[];
+	has_more: boolean;
+	next_cursor: string | null;
+};
+
+export function plainText(richText: NotionRichText[] | undefined): string {
+	return (richText ?? []).map((t) => t.plain_text ?? "").join("");
+}
+
+/** The user ids a comment @-mentions. Page and date mentions do not count. */
+export function mentionedUserIds(
+	richText: NotionRichText[] | undefined,
+): string[] {
+	const ids = new Set<string>();
+	for (const item of richText ?? []) {
+		if (item.type !== "mention") continue;
+		if (item.mention?.type !== "user") continue;
+		if (item.mention.user?.id) ids.add(item.mention.user.id);
+	}
+	return [...ids];
+}
+
+export function pageTitle(page: NotionPage): string | null {
+	for (const property of Object.values(page.properties ?? {})) {
+		if (property?.type === "title") {
+			const title = plainText(property.title);
+			if (title) return title;
+		}
+	}
+	return null;
+}
+
+export function retrieveComment(accessToken: string, commentId: string) {
+	return notionRequest<NotionComment>(accessToken, `/v1/comments/${commentId}`);
+}
+
+export function retrievePage(accessToken: string, pageId: string) {
+	return notionRequest<NotionPage>(accessToken, `/v1/pages/${pageId}`);
+}
+
+export function retrieveDataSource(accessToken: string, dataSourceId: string) {
+	return notionRequest<NotionDataSource>(
+		accessToken,
+		`/v1/data_sources/${dataSourceId}`,
+	);
+}
+
+/** Bounds a picker list; a workspace with more than this is not pickable one by one anyway. */
+const MAX_LISTED = 500;
+
+/** Every data source the connection can see, by title. */
+export async function listDataSources(
+	accessToken: string,
+): Promise<NotionDataSource[]> {
+	const results: NotionDataSource[] = [];
+	let cursor: string | undefined;
+	do {
+		const page = await notionRequest<Paginated<NotionDataSource>>(
+			accessToken,
+			"/v1/search",
+			{
+				method: "POST",
+				body: {
+					filter: { property: "object", value: "data_source" },
+					page_size: 100,
+					...(cursor ? { start_cursor: cursor } : {}),
+				},
+			},
+		);
+		results.push(...page.results);
+		cursor = page.has_more && page.next_cursor ? page.next_cursor : undefined;
+	} while (cursor && results.length < MAX_LISTED);
+	return results;
+}
+
+/** Every person in the workspace. Bots are left out: nobody filters on them. */
+export async function listUsers(accessToken: string): Promise<NotionUser[]> {
+	const results: NotionUser[] = [];
+	let cursor: string | undefined;
+	do {
+		const query = new URLSearchParams({ page_size: "100" });
+		if (cursor) query.set("start_cursor", cursor);
+		const page = await notionRequest<Paginated<NotionUser>>(
+			accessToken,
+			`/v1/users?${query}`,
+		);
+		results.push(...page.results.filter((u) => u.type === "person"));
+		cursor = page.has_more && page.next_cursor ? page.next_cursor : undefined;
+	} while (cursor && results.length < MAX_LISTED);
+	return results;
+}

--- a/packages/trpc/src/router/integration/notion/index.ts
+++ b/packages/trpc/src/router/integration/notion/index.ts
@@ -1,0 +1,1 @@
+export { notionRouter } from "./notion";

--- a/packages/trpc/src/router/integration/notion/notion.ts
+++ b/packages/trpc/src/router/integration/notion/notion.ts
@@ -1,0 +1,127 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure } from "../../../trpc";
+import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import {
+	listDataSources,
+	listUsers,
+	NotionApiError,
+	plainText,
+} from "./client";
+
+/**
+ * A picker with nothing in it beats a picker that errors: a token without the
+ * matching capability (or a personal token, which cannot list users) leaves
+ * the chip on its "anyone / me" entries rather than the whole editor red.
+ */
+async function listOrEmpty<T>(list: () => Promise<T[]>): Promise<T[]> {
+	try {
+		return await list();
+	} catch (error) {
+		if (error instanceof NotionApiError && error.permanent) {
+			console.warn("[integration.notion] list refused:", error.message);
+			return [];
+		}
+		throw error;
+	}
+}
+
+async function activeConnection(organizationId: string) {
+	return db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.organizationId, organizationId),
+			eq(integrationConnections.provider, "notion"),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		columns: { id: true, accessToken: true, externalOrgName: true },
+	});
+}
+
+export const notionRouter = {
+	getConnection: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "notion"),
+				),
+				columns: { id: true, externalOrgName: true, createdAt: true },
+			});
+
+			if (!connection) return null;
+
+			return {
+				id: connection.id,
+				externalOrgName: connection.externalOrgName,
+				connectedAt: connection.createdAt,
+			};
+		}),
+
+	disconnect: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+
+			const result = await db
+				.delete(integrationConnections)
+				.where(
+					and(
+						eq(integrationConnections.organizationId, input.organizationId),
+						eq(integrationConnections.provider, "notion"),
+					),
+				)
+				.returning({ id: integrationConnections.id });
+
+			if (result.length === 0) {
+				return { success: false, error: "No connection found" };
+			}
+
+			return { success: true };
+		}),
+
+	/**
+	 * The data sources the workspace has shared with the integration, for the
+	 * trigger editor's scope chip. Ids, not titles: a title can be renamed.
+	 */
+	listDataSources: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await activeConnection(input.organizationId);
+			if (!connection) return [];
+
+			const dataSources = await listOrEmpty(() =>
+				listDataSources(connection.accessToken),
+			);
+			return dataSources.map((source) => ({
+				id: source.id,
+				label: plainText(source.title) || "Untitled",
+			}));
+		}),
+
+	/**
+	 * The people in the connected workspace, for the actor and mention chips.
+	 * Notion user ids, since that is what a comment's author and mentions carry.
+	 */
+	listUsers: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await activeConnection(input.organizationId);
+			if (!connection) return [];
+
+			const users = await listOrEmpty(() => listUsers(connection.accessToken));
+			return users.map((user) => ({
+				id: user.id,
+				label: user.name || user.person?.email || user.id,
+			}));
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/integration/notion/notion.ts
+++ b/packages/trpc/src/router/integration/notion/notion.ts
@@ -50,6 +50,7 @@ export const notionRouter = {
 				where: and(
 					eq(integrationConnections.organizationId, input.organizationId),
 					eq(integrationConnections.provider, "notion"),
+					isNull(integrationConnections.disconnectedAt),
 				),
 				columns: { id: true, externalOrgName: true, createdAt: true },
 			});


### PR DESCRIPTION
## Summary

Adds the Notion trigger provider (`kind: "notion"`) — the tier-3 "connection + fetch-on-notify" shape.

**Events (exactly three, as briefed)**

| event | sentence | filters |
|---|---|---|
| `data_source.content_updated` | Rows changed in **[data sources]** | dataSources (ScopeChip, required) |
| `comment.created` | Comment added in **[data sources]** on **[Any page]** by **[Anyone]** | dataSources · pages (optional, `any` by default) · actor |
| `comment.mentioned` | Comment mentions **[Me]** in **[data sources]** on **[Any page]** | dataSources · pages · mentionedUser (ActorChip anyone/me/people, defaults to `me`) |

`comment.mentioned` is ours on top of `comment.created`: the route fetches the comment and reads `rich_text` for `mention` items of `type: "user"`; the matcher tests those ids against `mentionedUser` (`me` resolves through `user_identities` provider `notion`). Comments only — no page-body diffing.

**Pieces**
- `packages/shared`: `notionTriggerConfigSchema` (union on event) + `describeTriggerProblems` rules; `automation-matching/notion.ts` + one `case "notion"` in `triggerMatches` (`context.notion` carries `dataSourceId / pageId / mentionedUserIds / ownerIds`).
- Desktop: `providers/notion/{grammar,notion,useNotionOptions}` + registry line + hook in `useProviderOptions`. Two OptionKeys added (`dataSources`, `notionUsers`) — Notion user ids are their own id space so the actor chips can't reuse GitHub's `people`. *(The coordinator is landing a consolidated provider-namespaced options shape; I'll rebase onto it when it lands.)*
- tRPC: `integration.notion.{getConnection, disconnect, listDataSources, listUsers}`; a plain-fetch Notion client (`@superset/trpc/integrations/notion`, no SDK, no new package, API version `2025-09-03`).
- API: `integrations/notion/{connect,callback,webhook}`. Callback upserts `integration_connections` (`externalOrgId` = workspace id) and a `user_identities` row for the authorizing member. Webhook: answers the one-time `verification_token` handshake (logs the token) → verifies `X-Notion-Signature` (HMAC-SHA256 of the raw body, timing-safe) → fetches the entity (comment → page → parent data source; or the data source) → `automation_events` keyed on the Notion event id per connection → dispatch. Permanent Notion API errors (400/401/403/404) acknowledge the delivery as skipped; other errors 500 so Notion retries.
- Web: `/integrations/notion` page + card (copy of Slack's).

**Deviation from the brief (approved by the coordinator):** the verification token is a per-integration secret — the subscription lives in the integration's settings, the handshake carries no workspace id, and one token signs deliveries for every workspace — so it is `NOTION_WEBHOOK_VERIFICATION_TOKEN` (same shape as `LINEAR_WEBHOOK_SECRET`), not a column on the connection. The three Notion env vars are optional; the routes answer 503 until they're set, so nothing needs to change in the deploy workflows in this PR.

No migration: `automation_triggers.kind` / `integration_provider` already carry `notion` (#6581).

## Verification

Live Notion OAuth was not available (no public integration registered yet), so:
- **Editor over CDP** (this worktree's renderer, signed in as the org owner): added all three triggers, configured data sources (Product Roadmap) and `me`, saved, reloaded → rows persisted with `kind = notion` and rendered with resolved labels. Empty data source scope blocks Save with the shared banner.
- **Webhook**: with a local `NOTION_WEBHOOK_VERIFICATION_TOKEN` and a seeded connection using an internal-integration token for the same workspace, replayed self-signed payloads for a real comment (mentioning a workspace user) and a real data source:
  - handshake `{verification_token}` → 200; unsigned / bad signature → 401; unknown workspace → `no_subscribers`.
  - `comment.created` → `automation_events` row with the fetched comment (rich_text incl. the mention's user id), page title/url, `resource_key = notion:<pageId>`; dispatch selected **2/3** triggers (comment.mentioned via `me`, comment.created via the page's parent data source), not the rows-changed one.
  - `data_source.content_updated` → row for the data source; dispatch selected **1/3**.
  - Redelivery of the same event id → deduped (row count stays 1). Bad entity id → 400 from Notion → delivery acknowledged as skipped.
  - QStash publish itself cannot be proven locally (`invalid destination url: endpoint resolves to a loopback address`) — the selection log line is the evidence, same as the other providers.
- `bun run typecheck` → exit 0. `bun run lint` → exit 1 only on `TerminalAgentAutoResume.tsx:141` (pre-existing on main, being fixed there); nothing in this diff.

## To go live
Register the Notion public integration (capabilities: read content, read comments, read user info; redirect URI `<API_URL>/api/integrations/notion/callback`), set `NOTION_CLIENT_ID` / `NOTION_CLIENT_SECRET`, create the webhook subscription pointing at `<API_URL>/api/integrations/notion/webhook` with `comment.created` + `data_source.content_updated`, copy the token from the API log into `NOTION_WEBHOOK_VERIFICATION_TOKEN`, then add the three vars to the deploy workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Notion trigger provider (`kind: "notion"`) so automations can run on Notion data‑source updates and comments. Previously Notion events were unsupported; now we handle rows changed, comment created, and comments that mention a user, with OAuth connection and a verified webhook.

- Events and filters: `data_source.content_updated`, `comment.created` (filters: data sources · optional pages · actor), and `comment.mentioned` (derived from `comment.created` by scanning rich text; filters: data sources · optional pages · mentioned user). Resolves `me` via `user_identities` for provider `notion`.
- Webhook ingestion: `/api/integrations/notion/webhook` verifies `X-Notion-Signature` (HMAC‑SHA256 with `NOTION_WEBHOOK_VERIFICATION_TOKEN`), handles the one‑time verification handshake (logs full token only while unset; otherwise a fingerprint), applies 15s timeouts and URI‑encodes ids, fetches the referenced entity (comment → page → parent data source, or the data source), dedupes per Notion event id per connection, acknowledges permanent Notion API errors (400/401/403/404) as skipped, and records/dispatches automation events.
- Matching and schema in `@superset/shared`: adds `notionTriggerConfigSchema`, `automation-matching/notion.ts`, and a `case "notion"` in `triggerMatches`.
- OAuth connection: `/api/integrations/notion/{connect,callback}` completes public‑integration OAuth (sends Notion‑Version, survives fetch failures), upserts `integration_connections` (`externalOrgId` = workspace id) and a `user_identities` row for the authorizing member; `getConnection` ignores disconnected rows.
- tRPC in `@superset/trpc`: `integration.notion.{getConnection, disconnect, listDataSources, listUsers}`; lists are bounded (up to 5×100) and return empty on permanent capability errors.
- UI: Desktop trigger editor adds Notion with sentence grammar and chips; triggers must select at least one data source to save. Web adds `/integrations/notion` with connect/disconnect and error handling.
- Env vars (optional until provisioned): `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_WEBHOOK_VERIFICATION_TOKEN`. Notion routes return 503 until set. No DB migration.

**Rollout**
- Register the Notion public integration with capabilities read content, read comments, read user info; set redirect URI to `<API_URL>/api/integrations/notion/callback`.
- Create the webhook subscription to `<API_URL>/api/integrations/notion/webhook` for `comment.created` and `data_source.content_updated`. Paste the logged handshake token into `NOTION_WEBHOOK_VERIFICATION_TOKEN`.
- Set `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, and `NOTION_WEBHOOK_VERIFICATION_TOKEN` in deployment.

<sup>Written for commit e3021d99e3c846e5e3434df68653c4b381f0c569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Notion integration with secure connection and disconnection controls.
  * View connected workspace details and select Notion data sources and users.
  * Create automations triggered by data-source updates, comments, and mentions.
  * Added optional filters for pages, actors, and mentioned users.
  * Notion webhook events are processed to trigger automations automatically.
* **Improvements**
  * Added clear connection and authorization error messages.
  * Added support for retrieving Notion pages, comments, data sources, and workspace users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->