### PR TITLE
feat(automations): Microsoft Teams trigger provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,14 @@ SLACK_SIGNING_SECRET=
 SLACK_BILLING_WEBHOOK_URL=
 
 # -----------------------------------------------------------------------------
+# Microsoft Teams Integration (optional; Entra app registration with
+# application permissions ChannelMessage.Read.All, Channel.ReadBasic.All,
+# Team.ReadBasic.All)
+# -----------------------------------------------------------------------------
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+
+# -----------------------------------------------------------------------------
 # Anthropic (server-side AI features)
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=

--- a/apps/api/src/app/api/integrations/microsoft-teams/callback/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/callback/route.ts
@@ -1,0 +1,212 @@
+import { randomBytes } from "node:crypto";
+import { db } from "@superset/db/client";
+import type { MicrosoftTeamsConfig } from "@superset/db/schema";
+import { integrationConnections, members, users } from "@superset/db/schema";
+import {
+	acquireAppToken,
+	deleteTeamsSubscriptions,
+	ensureTeamsSubscriptions,
+	graphRequest,
+	microsoftCredentials,
+} from "@superset/trpc/integrations/microsoft-teams";
+import { and, eq, isNull, ne, sql } from "drizzle-orm";
+
+import { env } from "@/env";
+import { posthog } from "@/lib/analytics";
+import { createSignedState, verifySignedState } from "@/lib/oauth-state";
+import {
+	IDENTITY_REDIRECT_URI,
+	IDENTITY_SCOPES,
+} from "../identity/identityFlow";
+
+const SETTINGS_URL = `${env.NEXT_PUBLIC_WEB_URL}/integrations/microsoft-teams`;
+
+function fail(error: string, detail?: string): Response {
+	const url = new URL(SETTINGS_URL);
+	url.searchParams.set("error", error);
+	if (detail) url.searchParams.set("detail", detail.slice(0, 200));
+	return Response.redirect(url.toString());
+}
+
+/**
+ * The tenant's display name, if the app was also granted a directory read.
+ * That permission is not required for anything else, so a 403 here is the
+ * common case and the tenant id stands in.
+ */
+async function tenantDisplayName(
+	accessToken: string,
+	tenantId: string,
+): Promise<string> {
+	try {
+		const body = await graphRequest<{
+			value?: Array<{ displayName?: string | null }>;
+		}>(accessToken, "/organization?$select=displayName");
+		return body.value?.[0]?.displayName ?? tenantId;
+	} catch {
+		return tenantId;
+	}
+}
+
+/**
+ * Where Entra sends the admin after consent. There is no code to exchange:
+ * consent creates the app's service principal in the tenant, and from then on
+ * the client-credentials grant against that tenant yields tokens. Getting one
+ * here is what proves the tenant really consented — the `tenant` query
+ * parameter on its own is attacker-controlled.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const state = url.searchParams.get("state");
+	const tenantId = url.searchParams.get("tenant");
+	const error = url.searchParams.get("error");
+
+	if (error) {
+		console.error("[microsoft-teams/callback] consent refused:", {
+			error,
+			description: url.searchParams.get("error_description"),
+		});
+		return fail("oauth_denied");
+	}
+	if (!state || !tenantId) return fail("missing_params");
+
+	const stateData = verifySignedState(state);
+	if (!stateData) return fail("invalid_state");
+	const { organizationId, userId } = stateData;
+
+	// Re-verify membership at callback time (state was signed earlier)
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.organizationId, organizationId),
+			eq(members.userId, userId),
+		),
+	});
+	if (!membership) return fail("unauthorized");
+
+	let token: Awaited<ReturnType<typeof acquireAppToken>>;
+	try {
+		token = await acquireAppToken(tenantId);
+	} catch (error) {
+		console.error(
+			"[microsoft-teams/callback] token acquisition failed:",
+			error,
+		);
+		return fail(
+			"token_exchange_failed",
+			error instanceof Error ? error.message : undefined,
+		);
+	}
+
+	// One tenant, one organization: a second organization claiming the same
+	// tenant would receive that tenant's messages too.
+	const [conflict] = await db
+		.select({ email: users.email })
+		.from(integrationConnections)
+		.innerJoin(users, eq(users.id, integrationConnections.connectedByUserId))
+		.where(
+			and(
+				eq(integrationConnections.provider, "microsoft_teams"),
+				eq(integrationConnections.externalOrgId, tenantId),
+				isNull(integrationConnections.disconnectedAt),
+				ne(integrationConnections.organizationId, organizationId),
+			),
+		)
+		.limit(1);
+	if (conflict) return fail("tenant_already_linked", conflict.email);
+
+	// A reconnect replaces the clientState below, so whatever subscriptions the
+	// previous connection held would only ever be refused. Remove them from
+	// Graph while their ids are still on the row.
+	const previous = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.organizationId, organizationId),
+			eq(integrationConnections.provider, "microsoft_teams"),
+		),
+		columns: { id: true },
+	});
+	if (previous) await deleteTeamsSubscriptions(previous.id);
+
+	const config: MicrosoftTeamsConfig = {
+		provider: "microsoft_teams",
+		tenantId,
+		// 64 hex characters, under Graph's 128 limit. Fresh on every consent,
+		// so a reconnect also invalidates whatever the old subscriptions echo.
+		clientState: randomBytes(32).toString("hex"),
+		subscriptions: {},
+	};
+	const externalOrgName = await tenantDisplayName(token.accessToken, tenantId);
+
+	const [connection] = await db
+		.insert(integrationConnections)
+		.values({
+			organizationId,
+			connectedByUserId: userId,
+			provider: "microsoft_teams",
+			accessToken: token.accessToken,
+			tokenExpiresAt: token.expiresAt,
+			externalOrgId: tenantId,
+			externalOrgName,
+			config,
+		})
+		.onConflictDoUpdate({
+			target: [
+				integrationConnections.organizationId,
+				integrationConnections.provider,
+			],
+			// The org-scoped uniqueness is a partial index (Google connections
+			// are per user); Postgres only infers it when the predicate is named.
+			targetWhere: sql`${integrationConnections.provider} <> 'google'`,
+			set: {
+				accessToken: token.accessToken,
+				tokenExpiresAt: token.expiresAt,
+				externalOrgId: tenantId,
+				externalOrgName,
+				connectedByUserId: userId,
+				config,
+				disconnectedAt: null,
+				disconnectReason: null,
+				updatedAt: new Date(),
+			},
+		})
+		.returning({ id: integrationConnections.id });
+	if (!connection) return fail("token_exchange_failed");
+
+	posthog.capture({
+		distinctId: userId,
+		event: "microsoft_teams_connected",
+		properties: { tenant_id: tenantId },
+	});
+
+	// The connection is saved either way; the renew job retries subscriptions
+	// that could not be created here. But the person who just consented is the
+	// one who can fix a permission Graph refused, so tell them now.
+	const ensured = await ensureTeamsSubscriptions(connection.id);
+	const failure = ensured
+		? Object.values(ensured.failures).find(Boolean)
+		: "no access token";
+	if (failure) {
+		console.error("[microsoft-teams/callback] subscriptions:", ensured);
+		return fail("subscription_failed", failure);
+	}
+
+	console.log("[microsoft-teams/callback] Connected tenant:", {
+		organizationId,
+		tenantId,
+	});
+
+	// Consent named the tenant; the sign-in that follows names the admin, so
+	// `me` on their triggers can resolve. The connection is saved already, so
+	// this leg failing loses nothing but that.
+	const signIn = new URL(
+		"https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize",
+	);
+	signIn.searchParams.set("client_id", microsoftCredentials().clientId);
+	signIn.searchParams.set("response_type", "code");
+	signIn.searchParams.set("response_mode", "query");
+	signIn.searchParams.set("redirect_uri", IDENTITY_REDIRECT_URI);
+	signIn.searchParams.set("scope", IDENTITY_SCOPES);
+	signIn.searchParams.set(
+		"state",
+		createSignedState({ organizationId, userId }),
+	);
+	return Response.redirect(signIn.toString());
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/connect/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/connect/route.ts
@@ -1,0 +1,65 @@
+import { auth } from "@superset/auth/server";
+import { findOrgMembership } from "@superset/db/utils";
+
+import { env } from "@/env";
+import { createSignedState } from "@/lib/oauth-state";
+
+/**
+ * Starts the Teams connection: an Entra admin-consent flow, not a user
+ * sign-in. Everything the provider reads (channel messages, channels, teams)
+ * is an application permission, which only a tenant admin can grant and which
+ * grants the app the whole tenant at once. Delegated permissions are not
+ * supported for tenant-wide message notifications.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const organizationId = url.searchParams.get("organizationId");
+	if (!organizationId) {
+		return Response.json(
+			{ error: "Missing organizationId parameter" },
+			{ status: 400 },
+		);
+	}
+
+	if (!env.MICROSOFT_CLIENT_ID) {
+		return Response.json(
+			{ error: "Microsoft Teams integration is not configured" },
+			{ status: 503 },
+		);
+	}
+
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const membership = await findOrgMembership({
+		userId: session.user.id,
+		organizationId,
+	});
+	if (!membership) {
+		return Response.json(
+			{ error: "User is not a member of this organization" },
+			{ status: 403 },
+		);
+	}
+
+	const state = createSignedState({ organizationId, userId: session.user.id });
+
+	// `organizations`, not `common`: personal accounts cannot grant admin
+	// consent, and Microsoft's own guidance says not to use common here.
+	const consentUrl = new URL(
+		"https://login.microsoftonline.com/organizations/v2.0/adminconsent",
+	);
+	consentUrl.searchParams.set("client_id", env.MICROSOFT_CLIENT_ID);
+	// `.default` requests every application permission the app registration
+	// declares — the only way to request app permissions on this endpoint.
+	consentUrl.searchParams.set("scope", "https://graph.microsoft.com/.default");
+	consentUrl.searchParams.set(
+		"redirect_uri",
+		`${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams/callback`,
+	);
+	consentUrl.searchParams.set("state", state);
+
+	return Response.redirect(consentUrl.toString());
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/identity/callback/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/identity/callback/route.ts
@@ -1,0 +1,129 @@
+import { db } from "@superset/db/client";
+import { members, userIdentities } from "@superset/db/schema";
+import { microsoftCredentials } from "@superset/trpc/integrations/microsoft-teams";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { env } from "@/env";
+import { verifySignedState } from "@/lib/oauth-state";
+
+import { IDENTITY_REDIRECT_URI, IDENTITY_SCOPES } from "../identityFlow";
+
+const SETTINGS_URL = `${env.NEXT_PUBLIC_WEB_URL}/integrations/microsoft-teams`;
+
+function back(error?: string): Response {
+	const url = new URL(SETTINGS_URL);
+	if (error) url.searchParams.set("error", error);
+	return Response.redirect(url.toString());
+}
+
+const idTokenClaims = z.object({
+	aud: z.string(),
+	oid: z.string().min(1),
+	tid: z.string().min(1),
+	name: z.string().optional(),
+	preferred_username: z.string().optional(),
+});
+
+/**
+ * The second leg of connecting Teams: who the consenting admin is.
+ *
+ * Admin consent identifies a tenant, not a person, and `me` on a Teams
+ * trigger needs the person's Entra object id. So after consent the admin is
+ * sent through a plain OpenID sign-in, and the id token's `oid` is linked to
+ * their Superset user. The connection is already saved by the time this runs:
+ * declining here costs only "Me", not the integration.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const state = url.searchParams.get("state");
+	const code = url.searchParams.get("code");
+	if (url.searchParams.get("error")) return back("identity_denied");
+	if (!state || !code) return back("missing_params");
+
+	const stateData = verifySignedState(state);
+	if (!stateData) return back("invalid_state");
+	const { organizationId, userId } = stateData;
+
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.organizationId, organizationId),
+			eq(members.userId, userId),
+		),
+	});
+	if (!membership) return back("unauthorized");
+
+	const { clientId, clientSecret } = microsoftCredentials();
+	const response = await fetch(
+		"https://login.microsoftonline.com/organizations/oauth2/v2.0/token",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				client_id: clientId,
+				client_secret: clientSecret,
+				grant_type: "authorization_code",
+				code,
+				redirect_uri: IDENTITY_REDIRECT_URI,
+				scope: IDENTITY_SCOPES,
+			}),
+		},
+	);
+	const body: unknown = await response.json().catch(() => null);
+	const idToken =
+		typeof body === "object" && body !== null && "id_token" in body
+			? (body as { id_token?: unknown }).id_token
+			: undefined;
+	if (!response.ok || typeof idToken !== "string") {
+		console.error("[microsoft-teams/identity] token exchange failed:", body);
+		return back("identity_failed");
+	}
+
+	// Straight from the token endpoint over TLS with our client secret, so
+	// the payload is trusted the same way the access token is; only the
+	// audience is checked, so a token minted for another app cannot link.
+	const claims = idTokenClaims.safeParse(decodeJwtPayload(idToken));
+	if (!claims.success || claims.data.aud !== clientId) {
+		console.error("[microsoft-teams/identity] unexpected id token claims");
+		return back("identity_failed");
+	}
+
+	await db
+		.insert(userIdentities)
+		.values({
+			provider: "microsoft_teams",
+			externalId: claims.data.oid,
+			// Entra object ids are only meaningful within their tenant.
+			externalScopeId: claims.data.tid,
+			userId,
+			organizationId,
+			handle: claims.data.preferred_username ?? null,
+			displayName: claims.data.name ?? null,
+		})
+		// Re-linking claims the Entra account for whoever linked it last.
+		.onConflictDoUpdate({
+			target: [
+				userIdentities.organizationId,
+				userIdentities.provider,
+				userIdentities.externalScopeId,
+				userIdentities.externalId,
+			],
+			set: {
+				userId,
+				handle: claims.data.preferred_username ?? null,
+				displayName: claims.data.name ?? null,
+			},
+		});
+
+	return back();
+}
+
+function decodeJwtPayload(token: string): unknown {
+	const payload = token.split(".")[1];
+	if (!payload) return null;
+	try {
+		return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+	} catch {
+		return null;
+	}
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/identity/identityFlow.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/identity/identityFlow.ts
@@ -1,0 +1,9 @@
+import { env } from "@/env";
+
+/**
+ * The OpenID sign-in that follows admin consent. Shared by the consent
+ * callback, which starts it, and the identity callback, which finishes it —
+ * the redirect URI and scopes have to match on both legs.
+ */
+export const IDENTITY_REDIRECT_URI = `${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams/identity/callback`;
+export const IDENTITY_SCOPES = "openid profile email";

--- a/apps/api/src/app/api/integrations/microsoft-teams/jobs/renew-subscriptions/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/jobs/renew-subscriptions/route.ts
@@ -1,0 +1,76 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { ensureTeamsSubscriptions } from "@superset/trpc/integrations/microsoft-teams";
+import { Receiver } from "@upstash/qstash";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { env } from "@/env";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+/**
+ * Keeps every Teams connection's Graph subscriptions alive.
+ *
+ * Run by a QStash schedule (hourly is plenty: subscriptions last two days and
+ * renew with twelve hours left). Walks every active connection and lets
+ * `ensureTeamsSubscriptions` decide what each needs — nothing, a renewal, or a
+ * recreate for one that lapsed while the API was down. A connection whose
+ * token can no longer be acquired is marked disconnected on the way.
+ */
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const signature = request.headers.get("upstash-signature");
+	if (!signature) {
+		return Response.json({ error: "Missing signature" }, { status: 401 });
+	}
+	const valid = await receiver.verify({
+		body,
+		signature,
+		url: `${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams/jobs/renew-subscriptions`,
+	});
+	if (!valid) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	const connections = await db
+		.select({ id: integrationConnections.id })
+		.from(integrationConnections)
+		.where(
+			and(
+				eq(integrationConnections.provider, "microsoft_teams"),
+				isNull(integrationConnections.disconnectedAt),
+			),
+		);
+
+	const results = await Promise.allSettled(
+		connections.map((connection) => ensureTeamsSubscriptions(connection.id)),
+	);
+
+	const failures = results.flatMap((result, index) => {
+		const connectionId = connections[index]?.id;
+		if (result.status === "rejected") {
+			return [{ connectionId, reason: String(result.reason) }];
+		}
+		const value = result.value;
+		if (!value) return [{ connectionId, reason: "no access token" }];
+		return Object.entries(value.failures).map(([key, reason]) => ({
+			connectionId,
+			key,
+			reason,
+		}));
+	});
+	if (failures.length > 0) {
+		console.error("[microsoft-teams/renew-subscriptions] failures", failures);
+	}
+
+	return Response.json({
+		connections: connections.length,
+		failed: failures.length,
+	});
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/lifecycle/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/lifecycle/route.ts
@@ -1,0 +1,75 @@
+import {
+	authenticateNotification,
+	collectionSchema,
+	lifecycleNotificationSchema,
+	validationResponse,
+} from "../notify/notifications";
+import { enqueueTeamsWork, type TeamsWork } from "../notify/queue";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Graph's lifecycle channel for the subscriptions the notify route depends on.
+ *
+ * `reauthorizationRequired` means renew now or lose it; `subscriptionRemoved`
+ * means it is already gone and must be recreated; `missed` means deliveries
+ * were dropped, and with no delta to replay from there is nothing to do but
+ * note it. The renewals go through the queue like everything else, so this
+ * answers inside Graph's window whatever Graph is doing on the other side.
+ */
+export async function POST(request: Request) {
+	const validation = validationResponse(request);
+	if (validation) return validation;
+
+	const body = await request.text();
+	let json: unknown;
+	try {
+		json = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+	const parsed = collectionSchema(lifecycleNotificationSchema).safeParse(json);
+	if (!parsed.success) {
+		return Response.json({ error: "Unrecognised payload" }, { status: 400 });
+	}
+
+	const accepted: TeamsWork[] = [];
+	const ignored: Array<{ subscriptionId: string; reason: string }> = [];
+	for (const notification of parsed.data.value) {
+		const auth = await authenticateNotification(notification);
+		if (!auth.ok) {
+			console.warn("[microsoft-teams/lifecycle] refused:", auth.reason);
+			ignored.push({
+				subscriptionId: notification.subscriptionId,
+				reason: auth.reason,
+			});
+			continue;
+		}
+		if (
+			notification.lifecycleEvent !== "reauthorizationRequired" &&
+			notification.lifecycleEvent !== "subscriptionRemoved"
+		) {
+			if (notification.lifecycleEvent === "missed") {
+				console.warn(
+					"[microsoft-teams/lifecycle] notifications missed for",
+					auth.connection.id,
+					notification.subscriptionId,
+				);
+			}
+			ignored.push({
+				subscriptionId: notification.subscriptionId,
+				reason: notification.lifecycleEvent,
+			});
+			continue;
+		}
+		accepted.push({
+			kind: "lifecycle",
+			connectionId: auth.connection.id,
+			notification,
+		});
+	}
+
+	await enqueueTeamsWork(accepted);
+
+	return Response.json({ accepted: accepted.length, ignored }, { status: 202 });
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/notify/handleNotification.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/notify/handleNotification.ts
@@ -1,0 +1,189 @@
+import {
+	type GraphChannel,
+	type GraphChatMessage,
+	getChannel,
+	getChannelMessage,
+	getGraphAccessToken,
+	plainTextOf,
+} from "@superset/trpc/integrations/microsoft-teams";
+
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import {
+	type AuthenticatedConnection,
+	type ChangeNotification,
+	parseTeamsResource,
+} from "./notifications";
+import { recordTeamsEvent } from "./recordTeamsEvent";
+
+const TITLE_LENGTH = 120;
+
+export type NotificationOutcome =
+	| {
+			outcome: "recorded";
+			eventId: string;
+			matched: number;
+			considered: number;
+	  }
+	| { outcome: "skipped"; reason: string };
+
+/**
+ * Turns one authenticated change notification into an automation event.
+ *
+ * The notification says only what changed; the resource is fetched, recorded
+ * with the fetched payload, then matched. Ordering matters: the row is
+ * written before dispatch so a run always has an event to point at, and the
+ * dedupe on that row is what makes a Graph redelivery a no-op.
+ */
+export async function handleNotification(
+	connection: AuthenticatedConnection,
+	notification: ChangeNotification,
+): Promise<NotificationOutcome> {
+	if (notification.changeType !== "created") {
+		return {
+			outcome: "skipped",
+			reason: `changeType ${notification.changeType}`,
+		};
+	}
+	const resource = parseTeamsResource(notification.resource);
+	if (!resource) {
+		return { outcome: "skipped", reason: "unrecognised resource" };
+	}
+	const type = (notification.resourceData?.["@odata.type"] ?? "").toLowerCase();
+
+	const accessToken = await getGraphAccessToken(connection.id);
+	if (!accessToken) return { outcome: "skipped", reason: "no access token" };
+
+	if (type.endsWith(".chatmessage") && resource.messageId) {
+		const message = await getChannelMessage(
+			accessToken,
+			resource.teamId,
+			resource.channelId,
+			resource.messageId,
+			resource.replyId,
+		);
+		return ingestChannelMessage(
+			connection,
+			{ ...resource, messageId: resource.messageId },
+			message,
+		);
+	}
+
+	if (type.endsWith(".channel") && !resource.messageId) {
+		const channel = await getChannel(
+			accessToken,
+			resource.teamId,
+			resource.channelId,
+		);
+		return ingestChannel(connection, resource, channel);
+	}
+
+	return { outcome: "skipped", reason: `unhandled resource type ${type}` };
+}
+
+/** Records a fetched channel message and dispatches what it matches. */
+export async function ingestChannelMessage(
+	connection: AuthenticatedConnection,
+	resource: {
+		teamId: string;
+		channelId: string;
+		messageId: string;
+		replyId?: string;
+	},
+	message: GraphChatMessage,
+): Promise<NotificationOutcome> {
+	// Membership changes and the like arrive as messages too; nobody means
+	// those when they say "a message in the channel".
+	if (message.messageType && message.messageType !== "message") {
+		return {
+			outcome: "skipped",
+			reason: `messageType ${message.messageType}`,
+		};
+	}
+	const messageId = resource.replyId ?? resource.messageId;
+	const text = plainTextOf(message.body);
+	const actorLogin =
+		message.from?.user?.displayName ??
+		message.from?.application?.displayName ??
+		null;
+
+	const recorded = await recordTeamsEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		eventType: "message_in_channel",
+		externalEventId: `${resource.channelId}:${messageId}`,
+		// The thread, so replies debounce with the message they answer.
+		resourceKey: `microsoft_teams:${resource.teamId}:${resource.channelId}:${message.replyToId ?? resource.messageId}`,
+		title: titleFor(message.subject, text),
+		url: message.webUrl ?? null,
+		actorLogin,
+		payload: {
+			teamId: resource.teamId,
+			channelId: resource.channelId,
+			message,
+		},
+	});
+	if (!recorded.recorded) {
+		return { outcome: "skipped", reason: "duplicate delivery" };
+	}
+	const result = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: recorded.eventId,
+		event: {
+			provider: "microsoft_teams",
+			eventType: "message_in_channel",
+			teamId: resource.teamId,
+			channelId: resource.channelId,
+			actorId: message.from?.user?.id ?? null,
+			actorLogin,
+			body: text,
+		},
+	});
+	return { outcome: "recorded", eventId: recorded.eventId, ...result };
+}
+
+/** Records a fetched channel and dispatches what it matches. */
+export async function ingestChannel(
+	connection: AuthenticatedConnection,
+	resource: { teamId: string; channelId: string },
+	channel: GraphChannel,
+): Promise<NotificationOutcome> {
+	const name = channel.displayName ?? resource.channelId;
+	const recorded = await recordTeamsEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		eventType: "channel_created",
+		externalEventId: resource.channelId,
+		resourceKey: `microsoft_teams:${resource.teamId}:${resource.channelId}`,
+		title: name,
+		url: channel.webUrl ?? null,
+		actorLogin: null,
+		payload: { teamId: resource.teamId, channel },
+	});
+	if (!recorded.recorded) {
+		return { outcome: "skipped", reason: "duplicate delivery" };
+	}
+	const result = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: recorded.eventId,
+		event: {
+			provider: "microsoft_teams",
+			eventType: "channel_created",
+			teamId: resource.teamId,
+			channelId: resource.channelId,
+			actorId: null,
+			actorLogin: null,
+			body: name,
+		},
+	});
+	return { outcome: "recorded", eventId: recorded.eventId, ...result };
+}
+
+function titleFor(subject: string | null | undefined, text: string | null) {
+	if (subject) return subject;
+	const line = text
+		?.split("\n")
+		.find((l) => l.trim())
+		?.trim();
+	if (!line) return "Teams message";
+	return line.length > TITLE_LENGTH ? `${line.slice(0, TITLE_LENGTH)}…` : line;
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/notify/notifications.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/notify/notifications.ts
@@ -1,0 +1,173 @@
+import { timingSafeEqual } from "node:crypto";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * What Graph POSTs to a notification URL, and how it is authenticated.
+ *
+ * Without resource data there is no signed token on a notification: the only
+ * proof it came from Graph is the `clientState` the subscription was created
+ * with, echoed back on every delivery. So a notification is looked up by
+ * tenant, and its clientState compared to the connection's before anything
+ * else is done with it.
+ */
+
+export const changeNotificationSchema = z.object({
+	subscriptionId: z.string(),
+	clientState: z.string().optional(),
+	tenantId: z.string(),
+	changeType: z.string(),
+	resource: z.string(),
+	resourceData: z
+		.object({
+			"@odata.type": z.string().optional(),
+			"@odata.id": z.string().optional(),
+			id: z.string().optional(),
+		})
+		.passthrough()
+		.optional(),
+	subscriptionExpirationDateTime: z.string().optional(),
+});
+export type ChangeNotification = z.infer<typeof changeNotificationSchema>;
+
+export const lifecycleNotificationSchema = z.object({
+	subscriptionId: z.string(),
+	clientState: z.string().optional(),
+	tenantId: z.string(),
+	lifecycleEvent: z.string(),
+	subscriptionExpirationDateTime: z.string().optional(),
+});
+export type LifecycleNotification = z.infer<typeof lifecycleNotificationSchema>;
+
+export function collectionSchema<T extends z.ZodTypeAny>(item: T) {
+	return z.object({ value: z.array(item) });
+}
+
+/**
+ * Graph validates a notification URL by POSTing `?validationToken=` and
+ * expecting the token back as text/plain within 10 seconds. It does this on
+ * subscription create and again on renew, so both routes answer it.
+ */
+export function validationResponse(request: Request): Response | null {
+	const token = new URL(request.url).searchParams.get("validationToken");
+	if (token === null) return null;
+	return new Response(token, {
+		status: 200,
+		headers: { "Content-Type": "text/plain" },
+	});
+}
+
+function equalClientState(expected: string, provided: string | undefined) {
+	if (provided === undefined) return false;
+	const a = Buffer.from(expected);
+	const b = Buffer.from(provided);
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export type AuthenticatedConnection = {
+	id: string;
+	organizationId: string;
+	tenantId: string;
+	clientState: string;
+	subscriptions: Record<string, { id: string; expiresAt: string } | undefined>;
+};
+
+/** An active Teams connection by id, in the shape the handlers take. */
+export async function loadConnection(
+	connectionId: string,
+): Promise<AuthenticatedConnection | null> {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.id, connectionId),
+			eq(integrationConnections.provider, "microsoft_teams"),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		columns: {
+			id: true,
+			organizationId: true,
+			externalOrgId: true,
+			config: true,
+		},
+	});
+	if (
+		!connection ||
+		!connection.externalOrgId ||
+		connection.config?.provider !== "microsoft_teams"
+	) {
+		return null;
+	}
+	return {
+		id: connection.id,
+		organizationId: connection.organizationId,
+		tenantId: connection.externalOrgId,
+		clientState: connection.config.clientState,
+		subscriptions: connection.config.subscriptions,
+	};
+}
+
+/**
+ * The connection a notification belongs to, or a reason it was refused. Refused
+ * notifications are still acknowledged to Graph — a 4xx would only make it
+ * retry something that will never verify.
+ */
+export async function authenticateNotification(notification: {
+	tenantId: string;
+	clientState?: string;
+}): Promise<
+	| { ok: true; connection: AuthenticatedConnection }
+	| { ok: false; reason: string }
+> {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.provider, "microsoft_teams"),
+			eq(integrationConnections.externalOrgId, notification.tenantId),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		columns: {
+			id: true,
+			organizationId: true,
+			externalOrgId: true,
+			config: true,
+		},
+	});
+	if (!connection || connection.config?.provider !== "microsoft_teams") {
+		return { ok: false, reason: "unknown tenant" };
+	}
+	if (
+		!equalClientState(connection.config.clientState, notification.clientState)
+	) {
+		return { ok: false, reason: "clientState mismatch" };
+	}
+	return {
+		ok: true,
+		connection: {
+			id: connection.id,
+			organizationId: connection.organizationId,
+			tenantId: notification.tenantId,
+			clientState: connection.config.clientState,
+			subscriptions: connection.config.subscriptions,
+		},
+	};
+}
+
+/**
+ * The ids inside a Teams resource path:
+ * `teams('{team}')/channels('{channel}')[/messages('{message}')[/replies('{reply}')]]`.
+ */
+export function parseTeamsResource(resource: string): {
+	teamId: string;
+	channelId: string;
+	messageId?: string;
+	replyId?: string;
+} | null {
+	const match =
+		/^teams\('([^']+)'\)\/channels\('([^']+)'\)(?:\/messages\('([^']+)'\)(?:\/replies\('([^']+)'\))?)?$/.exec(
+			resource,
+		);
+	if (!match) return null;
+	const [, teamId, channelId, messageId, replyId] = match;
+	if (!teamId || !channelId) return null;
+	return { teamId, channelId, messageId, replyId };
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/notify/queue.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/notify/queue.ts
@@ -1,0 +1,65 @@
+import { createHash } from "node:crypto";
+import { Client } from "@upstash/qstash";
+import { z } from "zod";
+
+import { env } from "@/env";
+import {
+	changeNotificationSchema,
+	lifecycleNotificationSchema,
+} from "./notifications";
+
+/**
+ * Graph gives a notification endpoint three seconds to answer, and marks it
+ * slow — then starts dropping — once a tenth of responses take longer. A
+ * notification means a Graph GET, two writes and a QStash publish, which a
+ * cold function will not fit in three seconds. So the notify and lifecycle
+ * routes do only what proves the request is Graph's, hand the work to QStash
+ * and answer 202; `process/route.ts` does the rest with retries.
+ */
+
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+});
+
+export const PROCESS_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams/process`;
+
+export const teamsWorkSchema = z.discriminatedUnion("kind", [
+	z.object({
+		kind: z.literal("change"),
+		connectionId: z.string().uuid(),
+		notification: changeNotificationSchema,
+	}),
+	z.object({
+		kind: z.literal("lifecycle"),
+		connectionId: z.string().uuid(),
+		notification: lifecycleNotificationSchema,
+	}),
+]);
+export type TeamsWork = z.infer<typeof teamsWorkSchema>;
+
+/**
+ * One QStash message per notification. Change notifications dedupe on what
+ * they point at, so a Graph redelivery inside the dedup window is dropped
+ * before it costs a function; the `automation_events` unique index catches
+ * anything that gets past.
+ */
+export async function enqueueTeamsWork(items: TeamsWork[]): Promise<void> {
+	if (items.length === 0) return;
+	await qstash.batchJSON(
+		items.map((item) => ({
+			url: PROCESS_URL,
+			body: item,
+			retries: 3,
+			...(item.kind === "change"
+				? {
+						deduplicationId: createHash("sha256")
+							.update(
+								`${item.notification.subscriptionId}:${item.notification.changeType}:${item.notification.resource}`,
+							)
+							.digest("hex"),
+					}
+				: {}),
+		})),
+	);
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/notify/recordTeamsEvent.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/notify/recordTeamsEvent.ts
@@ -1,0 +1,55 @@
+import { db } from "@superset/db/client";
+import { automationEvents } from "@superset/db/schema";
+
+import { stripNullChars } from "@/lib/strip-null-chars";
+
+/**
+ * Records one Teams notification, resolved to the resource behind it, as an
+ * `automation_events` row.
+ *
+ * The payload stored is what Graph returned for the resource, not the
+ * notification — the notification is a pointer, and a prompt built from a
+ * pointer would have nothing to say. Idempotent on the resource id within
+ * the connection: Graph retries deliveries it did not get a 2xx for.
+ */
+export async function recordTeamsEvent(params: {
+	organizationId: string;
+	connectionId: string;
+	eventType: "message_in_channel" | "channel_created";
+	externalEventId: string;
+	resourceKey: string;
+	title: string;
+	url: string | null;
+	actorLogin: string | null;
+	payload: Record<string, unknown>;
+}): Promise<{ recorded: true; eventId: string } | { recorded: false }> {
+	const [inserted] = await db
+		.insert(automationEvents)
+		.values({
+			organizationId: params.organizationId,
+			integrationConnectionId: params.connectionId,
+			provider: "microsoft_teams",
+			eventType: params.eventType,
+			externalEventId: params.externalEventId,
+			resourceKey: params.resourceKey,
+			title: params.title,
+			url: params.url,
+			repositoryId: null,
+			ref: null,
+			actorLogin: params.actorLogin,
+			actorIsExternal: null,
+			payload: stripNullChars(params.payload),
+			webhookEventId: null,
+		})
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		})
+		.returning({ id: automationEvents.id });
+
+	if (!inserted) return { recorded: false };
+	return { recorded: true, eventId: inserted.id };
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/notify/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/notify/route.ts
@@ -1,0 +1,57 @@
+import {
+	authenticateNotification,
+	changeNotificationSchema,
+	collectionSchema,
+	validationResponse,
+} from "./notifications";
+import { enqueueTeamsWork, type TeamsWork } from "./queue";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Where Graph posts change notifications for every Teams connection.
+ *
+ * Fast by design: verify each notification's clientState against its
+ * tenant's connection, queue the accepted ones, answer 202 — Graph allows
+ * three seconds and throttles endpoints that miss it. Refused notifications
+ * are acknowledged too, since a forged or stale one will not verify on retry
+ * either. The work itself happens in `../process/route.ts`.
+ */
+export async function POST(request: Request) {
+	const validation = validationResponse(request);
+	if (validation) return validation;
+
+	const body = await request.text();
+	let json: unknown;
+	try {
+		json = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+	const parsed = collectionSchema(changeNotificationSchema).safeParse(json);
+	if (!parsed.success) {
+		return Response.json({ error: "Unrecognised payload" }, { status: 400 });
+	}
+
+	const accepted: TeamsWork[] = [];
+	const refused: Array<{ resource: string; reason: string }> = [];
+	for (const notification of parsed.data.value) {
+		const auth = await authenticateNotification(notification);
+		if (!auth.ok) {
+			console.warn("[microsoft-teams/notify] refused:", auth.reason);
+			refused.push({ resource: notification.resource, reason: auth.reason });
+			continue;
+		}
+		accepted.push({
+			kind: "change",
+			connectionId: auth.connection.id,
+			notification,
+		});
+	}
+
+	// A queue failure is the one case worth a 5xx: Graph will redeliver, and
+	// nothing has been recorded yet.
+	await enqueueTeamsWork(accepted);
+
+	return Response.json({ accepted: accepted.length, refused }, { status: 202 });
+}

--- a/apps/api/src/app/api/integrations/microsoft-teams/process/route.ts
+++ b/apps/api/src/app/api/integrations/microsoft-teams/process/route.ts
@@ -1,0 +1,81 @@
+import {
+	ensureTeamsSubscriptions,
+	type SubscriptionKey,
+} from "@superset/trpc/integrations/microsoft-teams";
+import { Receiver } from "@upstash/qstash";
+
+import { env } from "@/env";
+import { handleNotification } from "../notify/handleNotification";
+import { loadConnection } from "../notify/notifications";
+import { PROCESS_URL, teamsWorkSchema } from "../notify/queue";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+/**
+ * The slow half of a Teams notification, run by QStash after the notify or
+ * lifecycle route has verified it came from Graph and answered 202.
+ *
+ * A non-2xx here makes QStash retry, which is what a Graph hiccup on the
+ * fetch deserves. Anything that will never succeed — the connection is gone,
+ * the resource type is unknown — returns 200 with the reason so it is not
+ * retried into the ground.
+ */
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const signature = request.headers.get("upstash-signature");
+	if (!signature) {
+		return Response.json({ error: "Missing signature" }, { status: 401 });
+	}
+	const valid = await receiver.verify({ body, signature, url: PROCESS_URL });
+	if (!valid) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	const parsed = teamsWorkSchema.safeParse(JSON.parse(body));
+	if (!parsed.success) {
+		return Response.json({ error: "Unrecognised work item" }, { status: 400 });
+	}
+	const work = parsed.data;
+
+	// Re-read rather than trust the enqueued copy: the connection may have been
+	// disconnected, or reconnected with a new clientState, since it was queued.
+	const connection = await loadConnection(work.connectionId);
+	if (!connection || connection.clientState !== work.notification.clientState) {
+		return Response.json({ skipped: "connection changed" });
+	}
+
+	if (work.kind === "change") {
+		const outcome = await handleNotification(connection, work.notification);
+		if (outcome.outcome === "recorded" && outcome.matched > 0) {
+			console.log(
+				`[microsoft-teams/process] ${outcome.matched}/${outcome.considered} triggers matched:`,
+				outcome.eventId,
+			);
+		}
+		return Response.json(outcome);
+	}
+
+	const key = (
+		Object.entries(connection.subscriptions) as Array<
+			[SubscriptionKey, { id: string } | undefined]
+		>
+	).find(([, sub]) => sub?.id === work.notification.subscriptionId)?.[0];
+	const ensured = await ensureTeamsSubscriptions(connection.id, {
+		force: true,
+		only: key ? [key] : undefined,
+	});
+	const failure = ensured
+		? Object.values(ensured.failures).find(Boolean)
+		: null;
+	if (failure) {
+		console.error("[microsoft-teams/process] renew failed:", ensured);
+		return Response.json({ error: failure }, { status: 500 });
+	}
+	return Response.json({ renewed: ensured?.subscriptions ?? null });
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -33,6 +33,10 @@ export const env = createEnv({
 		SLACK_CLIENT_ID: z.string().min(1),
 		SLACK_CLIENT_SECRET: z.string().min(1),
 		SLACK_SIGNING_SECRET: z.string(),
+		// Optional: the Teams integration is off wherever these are unset, and
+		// every other environment keeps booting.
+		MICROSOFT_CLIENT_ID: z.string().min(1).optional(),
+		MICROSOFT_CLIENT_SECRET: z.string().min(1).optional(),
 		ANTHROPIC_API_KEY: z.string(),
 		QSTASH_TOKEN: z.string().min(1),
 		QSTASH_URL: z.string().url(),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -2,6 +2,7 @@ import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
 import { circlebackProvider } from "./circleback/circleback";
 import { githubProvider } from "./github/github";
 import { linearProvider } from "./linear/linear";
+import { microsoftTeamsProvider } from "./microsoftTeams/microsoftTeams";
 import { notionProvider } from "./notion/notion";
 import { scheduleProvider } from "./schedule/schedule";
 import { slackProvider } from "./slack/slack";
@@ -29,6 +30,7 @@ export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	slackProvider as TriggerProvider,
 	webhookProvider as TriggerProvider,
 	circlebackProvider as TriggerProvider,
+	microsoftTeamsProvider as TriggerProvider,
 ];
 
 const byKind = new Map(TRIGGER_PROVIDERS.map((p) => [p.kind, p]));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/grammar.ts
@@ -1,0 +1,72 @@
+import type {
+	MicrosoftTeamsTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type MicrosoftTeamsConfig = Extract<
+	TriggerConfigInput,
+	{ kind: "microsoft_teams" }
+>;
+
+/**
+ * The sentence a Teams trigger reads as. Same shape as GitHub's grammar: each
+ * event names its words and slots, the renderer knows only slots.
+ */
+export type Slot =
+	| "teams"
+	| "channels"
+	| "actor"
+	| "messageFilter"
+	| "nameFilter";
+
+export type SentencePart = { text: string } | { slot: Slot };
+
+export const TEAMS_SENTENCES: Record<
+	MicrosoftTeamsTriggerEvent,
+	SentencePart[]
+> = {
+	message_in_channel: [
+		{ slot: "messageFilter" },
+		{ text: "in" },
+		{ slot: "teams" },
+		{ text: "›" },
+		{ slot: "channels" },
+		{ text: "by" },
+		{ slot: "actor" },
+	],
+	channel_created: [
+		{ text: "Channel created in" },
+		{ slot: "teams" },
+		{ slot: "nameFilter" },
+	],
+};
+
+export const TEAMS_MENU: TriggerMenuEntry<MicrosoftTeamsConfig>[] = [
+	leaf("Message in channel", "message_in_channel"),
+	leaf("Channel created", "channel_created"),
+];
+
+function leaf(label: string, event: MicrosoftTeamsTriggerEvent) {
+	return { label, create: () => createTeamsConfig(event) };
+}
+
+/**
+ * A new trigger of this event: the team still to be chosen, and for a message
+ * the channel too. Null for both, so a half-built trigger matches nothing
+ * until someone picks — the same safety property as GitHub's repositories.
+ */
+export function createTeamsConfig(
+	event: MicrosoftTeamsTriggerEvent,
+): MicrosoftTeamsConfig {
+	return {
+		kind: "microsoft_teams",
+		event,
+		teams: null,
+		// A created channel has no channel to filter on; the slot is absent from
+		// its sentence and the matcher ignores the field.
+		channels: event === "message_in_channel" ? null : { mode: "any" },
+		actor: "anyone",
+		messageFilter: null,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/microsoftTeams.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/microsoftTeams.tsx
@@ -1,0 +1,108 @@
+import { BsMicrosoftTeams } from "react-icons/bs";
+import { ActorChip } from "../../TriggerSentence/components/ActorChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	type MicrosoftTeamsConfig,
+	type SentencePart,
+	TEAMS_MENU,
+	TEAMS_SENTENCES,
+} from "./grammar";
+
+function renderPart(
+	config: MicrosoftTeamsConfig,
+	part: SentencePart,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	switch (part.slot) {
+		case "teams":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.teams}
+					onChange={(v) => set({ teams: v })}
+					className={mark("teams")}
+					options={options.microsoftTeams?.teams ?? []}
+					emptyLabel="Select teams"
+					anyLabel="Any team"
+					disabled={disabled}
+				/>
+			);
+		case "channels":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.channels}
+					onChange={(v) => set({ channels: v })}
+					className={mark("channels")}
+					options={options.microsoftTeams?.channels ?? []}
+					emptyLabel="Select channels"
+					anyLabel="Any channel"
+					disabled={disabled}
+				/>
+			);
+		case "actor":
+			// Anyone or Me only. The shared people list holds GitHub ids, which is
+			// the wrong id space; Teams people are Entra object ids, resolved for
+			// `me` through user_identities at match time.
+			return (
+				<ActorChip
+					key={index}
+					actor={config.actor}
+					onChange={(v) => set({ actor: v })}
+					className={mark("actor")}
+					people={[]}
+					disabled={disabled}
+				/>
+			);
+		case "messageFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={config.messageFilter}
+					onChange={(v) => set({ messageFilter: v })}
+					emptyLabel="Any message"
+					placeholder="Contains this text..."
+					disabled={disabled}
+				/>
+			);
+		case "nameFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={config.messageFilter}
+					onChange={(v) => set({ messageFilter: v })}
+					emptyLabel="Any name"
+					placeholder="Name contains..."
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const microsoftTeamsProvider: TriggerProvider<MicrosoftTeamsConfig> = {
+	kind: "microsoft_teams",
+	label: "Microsoft Teams",
+	icon: BsMicrosoftTeams,
+	menu: TEAMS_MENU,
+	renderSentence: (config, ctx) => {
+		const parts = TEAMS_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/useTeamsOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/useTeamsOptions.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+
+/**
+ * The pickable values a Teams sentence needs: the tenant's teams, and every
+ * channel in them labelled "Team › Channel". Both come from Graph through the
+ * connection's app token; without a connection both are empty and the chips
+ * say so.
+ */
+export function useTeamsOptions(organizationId: string): ProviderOptions {
+	const teams = cloudTrpc.integration.microsoftTeams.listTeams.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId), staleTime: 5 * 60 * 1000 },
+	);
+	const channels = cloudTrpc.integration.microsoftTeams.listChannels.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId), staleTime: 5 * 60 * 1000 },
+	);
+
+	return useMemo(
+		() => ({
+			microsoftTeams: {
+				teams: teams.data ?? [],
+				channels: (channels.data ?? []).map((channel) => ({
+					id: channel.id,
+					label: channel.label,
+				})),
+			},
+		}),
+		[teams.data, channels.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useGithubOptions } from "./github/useGithubOptions";
 import { useLinearOptions } from "./linear/useLinearOptions";
+import { useTeamsOptions } from "./microsoftTeams/useTeamsOptions";
 import { useNotionOptions } from "./notion/useNotionOptions";
 import { useSlackOptions } from "./slack/useSlackOptions";
 import type { ProviderOptions } from "./types";
@@ -18,8 +19,9 @@ export function useProviderOptions(organizationId: string): ProviderOptions {
 	const linear = useLinearOptions(organizationId);
 	const notion = useNotionOptions(organizationId);
 	const slack = useSlackOptions(organizationId);
+	const teams = useTeamsOptions(organizationId);
 	return useMemo(
-		() => ({ ...github, ...linear, ...notion, ...slack }),
-		[github, linear, notion, slack],
+		() => ({ ...github, ...linear, ...notion, ...slack, ...teams }),
+		[github, linear, notion, slack, teams],
 	);
 }

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ConnectionControls/ConnectionControls.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ConnectionControls/ConnectionControls.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Unplug } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { env } from "@/env";
+import { useTRPC } from "@/trpc/react";
+
+interface ConnectionControlsProps {
+	organizationId: string;
+	isConnected: boolean;
+}
+
+export function ConnectionControls({
+	organizationId,
+	isConnected,
+}: ConnectionControlsProps) {
+	const trpc = useTRPC();
+	const router = useRouter();
+	const queryClient = useQueryClient();
+
+	const disconnectMutation = useMutation(
+		trpc.integration.microsoftTeams.disconnect.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({
+					queryKey: trpc.integration.microsoftTeams.getConnection.queryKey({
+						organizationId,
+					}),
+				});
+				router.refresh();
+			},
+		}),
+	);
+
+	const handleConnect = () => {
+		window.location.href = `${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams/connect?organizationId=${organizationId}`;
+	};
+
+	if (isConnected) {
+		return (
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button variant="outline" disabled={disconnectMutation.isPending}>
+						<Unplug className="mr-2 size-4" />
+						{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Disconnect Microsoft Teams?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This stops every Teams trigger in your organization and removes
+							the notification subscriptions from your tenant. You can reconnect
+							at any time.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => disconnectMutation.mutate({ organizationId })}
+						>
+							Disconnect
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
+	}
+
+	return <Button onClick={handleConnect}>Connect Microsoft Teams</Button>;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ConnectionControls/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ConnectionControls/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionControls } from "./ConnectionControls";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ErrorHandler/ErrorHandler.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { toast } from "@superset/ui/sonner";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+	oauth_denied:
+		"Consent was not granted. A tenant administrator has to approve.",
+	missing_params: "Invalid consent response. Please try again.",
+	invalid_state: "Invalid state parameter. Please try again.",
+	token_exchange_failed:
+		"Consent finished but Microsoft did not issue a token for the tenant.",
+	subscription_failed:
+		"Connected, but Microsoft Graph refused the notification subscriptions.",
+	identity_denied:
+		'Connected. Sign-in was cancelled, so triggers by "Me" will not match your Teams account until you reconnect.',
+	identity_failed:
+		'Connected, but your Microsoft account could not be linked. Triggers by "Me" will not match until you reconnect.',
+	unauthorized: "You are not authorized to perform this action.",
+};
+
+export function ErrorHandler() {
+	const searchParams = useSearchParams();
+
+	useEffect(() => {
+		const error = searchParams.get("error");
+		if (!error) return;
+
+		const detail = searchParams.get("detail");
+		let message: string;
+		if (error === "tenant_already_linked") {
+			message = detail
+				? `This Microsoft tenant is already connected by ${detail}. Ask them to disconnect first.`
+				: "This Microsoft tenant is already connected by another Superset organization.";
+		} else {
+			message = ERROR_MESSAGES[error] ?? "Something went wrong.";
+			// Graph's own words are the useful part of a refused subscription —
+			// they name the missing permission or the protected-API approval.
+			if (detail) message = `${message} ${detail}`;
+		}
+
+		window.history.replaceState({}, "", "/integrations/microsoft-teams");
+		const id = setTimeout(() => toast.error(message), 0);
+		return () => clearTimeout(id);
+	}, [searchParams]);
+
+	return null;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ErrorHandler/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/components/ErrorHandler/index.ts
@@ -1,0 +1,1 @@
+export { ErrorHandler } from "./ErrorHandler";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/page.tsx
@@ -1,0 +1,107 @@
+import { Badge } from "@superset/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@superset/ui/card";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { BsMicrosoftTeams } from "react-icons/bs";
+import { api } from "@/trpc/server";
+import { ConnectionControls } from "./components/ConnectionControls";
+import { ErrorHandler } from "./components/ErrorHandler";
+
+export default async function MicrosoftTeamsIntegrationPage() {
+	const trpc = await api();
+	const organization = await trpc.user.myOrganization.query();
+
+	if (!organization) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16">
+				<p className="text-muted-foreground">
+					You need to be part of an organization to use integrations.
+				</p>
+			</div>
+		);
+	}
+
+	const connection = await trpc.integration.microsoftTeams.getConnection.query({
+		organizationId: organization.id,
+	});
+	const isConnected = !!connection;
+	const listening =
+		!!connection?.subscriptions.channelMessages &&
+		!!connection?.subscriptions.channels;
+
+	return (
+		<div className="space-y-8">
+			<ErrorHandler />
+
+			<Link
+				href="/integrations"
+				className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ArrowLeft className="size-4" />
+				Back to Integrations
+			</Link>
+
+			<div className="flex items-start gap-6">
+				<div className="flex size-16 items-center justify-center rounded-xl border bg-card p-3">
+					<BsMicrosoftTeams className="size-10" />
+				</div>
+				<div className="flex-1">
+					<div className="flex items-center gap-3">
+						<h1 className="text-2xl font-semibold">Microsoft Teams</h1>
+						{isConnected ? (
+							<Badge variant="default" className="gap-1">
+								<CheckCircle2 className="size-3" />
+								Connected
+							</Badge>
+						) : (
+							<Badge variant="secondary">Not Connected</Badge>
+						)}
+					</div>
+					<p className="mt-1 text-muted-foreground">
+						Run automations when messages are posted or channels are created in
+						your Microsoft Teams tenant. Connecting requires a tenant
+						administrator, who grants the app permission to read channel
+						messages and channels across the tenant.
+					</p>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Connection</CardTitle>
+					<CardDescription>
+						Connect your Microsoft Teams tenant. A tenant admin signs in and
+						grants consent once for the whole tenant.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ConnectionControls
+						organizationId={organization.id}
+						isConnected={isConnected}
+					/>
+					{connection && (
+						<div className="mt-4 space-y-1 text-sm text-muted-foreground">
+							<p>
+								Connected to{" "}
+								<span className="font-medium">
+									{connection.externalOrgName ?? connection.tenantId}
+								</span>
+							</p>
+							<p>
+								{listening
+									? "Listening for channel messages and new channels."
+									: "Not receiving events yet: Microsoft Graph refused the notification subscriptions. Check the app's admin consent and protected API approval, then reconnect."}
+							</p>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BsMicrosoftTeams } from "react-icons/bs";
 import { FaGithub, FaSlack } from "react-icons/fa";
 import { SiLinear, SiNotion } from "react-icons/si";
 import {
@@ -39,6 +40,14 @@ const integrations: IntegrationCardProps[] = [
 		category: "Knowledge",
 		accentColor: "#5F5E5B",
 		icon: <SiNotion className="size-8" />,
+	},
+	{
+		id: "microsoft-teams",
+		name: "Microsoft Teams",
+		description: "Trigger automations from Teams channel messages.",
+		category: "Communication",
+		accentColor: "#5B5FC7",
+		icon: <BsMicrosoftTeams className="size-8" />,
 	},
 ];
 

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -13,7 +13,32 @@ export type SlackConfig = {
 	provider: "slack";
 };
 
-export type IntegrationConfig = LinearConfig | SlackConfig;
+/**
+ * One Graph change-notification subscription this connection holds. Kept on
+ * the connection because it is the connection's: renewed by the cron, replaced
+ * on reconnect, deleted on disconnect.
+ */
+export type MicrosoftTeamsSubscription = {
+	id: string;
+	expiresAt: string;
+};
+
+export type MicrosoftTeamsConfig = {
+	provider: "microsoft_teams";
+	tenantId: string;
+	// Graph echoes this in every notification; it is the only thing that says a
+	// POST to the notify route came from Graph and not from anyone with the URL.
+	clientState: string;
+	subscriptions: {
+		channelMessages?: MicrosoftTeamsSubscription;
+		channels?: MicrosoftTeamsSubscription;
+	};
+};
+
+export type IntegrationConfig =
+	| LinearConfig
+	| SlackConfig
+	| MicrosoftTeamsConfig;
 
 /**
  * The trigger config column, typed from the zod schema that validates every
@@ -35,6 +60,10 @@ export type GithubTriggerConfig = Extract<TriggerConfig, { kind: "github" }>;
 export type SlackTriggerConfig = Extract<TriggerConfig, { kind: "slack" }>;
 export type LinearTriggerConfig = Extract<TriggerConfig, { kind: "linear" }>;
 export type SentryTriggerConfig = Extract<TriggerConfig, { kind: "sentry" }>;
+export type MicrosoftTeamsTriggerConfig = Extract<
+	TriggerConfig,
+	{ kind: "microsoft_teams" }
+>;
 
 /**
  * Provider-specific extras on a user identity.

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -6,6 +6,10 @@ import {
 import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
 import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
 import { type LinearMatchableEvent, linearTriggerMatches } from "./linear";
+import {
+	type MicrosoftTeamsMatchableEvent,
+	microsoftTeamsTriggerMatches,
+} from "./microsoft-teams";
 import { type NotionMatchableEvent, notionTriggerMatches } from "./notion";
 import { type SlackMatchableEvent, slackTriggerMatches } from "./slack";
 import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
@@ -14,6 +18,7 @@ export * from "./circleback";
 export * from "./core";
 export * from "./github";
 export * from "./linear";
+export * from "./microsoft-teams";
 export * from "./notion";
 export * from "./slack";
 export * from "./webhook";
@@ -33,7 +38,8 @@ export type MatchableEvent =
 	| NotionMatchableEvent
 	| LinearMatchableEvent
 	| SlackMatchableEvent
-	| CirclebackMatchableEvent;
+	| CirclebackMatchableEvent
+	| MicrosoftTeamsMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -88,6 +94,12 @@ export function triggerMatches(
 		case "circleback":
 			return circlebackTriggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "circleback" }>,
+				event,
+				context,
+			);
+		case "microsoft_teams":
+			return microsoftTeamsTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "microsoft_teams" }>,
 				event,
 				context,
 			);

--- a/packages/shared/src/automation-matching/microsoft-teams.ts
+++ b/packages/shared/src/automation-matching/microsoft-teams.ts
@@ -1,0 +1,57 @@
+import type {
+	MicrosoftTeamsTriggerEvent,
+	TriggerActor,
+	TriggerScope,
+} from "../automation-triggers";
+import {
+	actorAllows,
+	type BaseMatchableEvent,
+	bodyMatches,
+	type MatchContext,
+	type MatchResult,
+	scopeAllows,
+} from "./core";
+
+/**
+ * A Teams change notification, resolved to the resource behind it and
+ * normalized to what Teams triggers filter on. `body` is the message text for
+ * a message and the new channel's name for a channel.
+ */
+export type MicrosoftTeamsMatchableEvent = BaseMatchableEvent & {
+	provider: "microsoft_teams";
+	eventType: MicrosoftTeamsTriggerEvent;
+	teamId: string | null;
+	channelId: string | null;
+};
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/** Whether a Teams trigger config accepts this event. */
+export function microsoftTeamsTriggerMatches(
+	config: {
+		event: MicrosoftTeamsTriggerEvent;
+		teams: TriggerScope;
+		channels: TriggerScope;
+		actor: TriggerActor;
+		messageFilter?: { pattern: string; isRegex: boolean } | null;
+	},
+	event: MicrosoftTeamsMatchableEvent,
+	context: MatchContext,
+): MatchResult {
+	if (event.eventType !== config.event) return no("event");
+	if (!scopeAllows(config.teams, event.teamId)) return no("team");
+
+	// For channel_created the channel is the subject, not a filter, and nobody
+	// is named as the actor: the sentence has neither slot.
+	if (config.event === "message_in_channel") {
+		if (!scopeAllows(config.channels, event.channelId)) return no("channel");
+		if (!actorAllows(config.actor, event.actorId, context.ownerIds)) {
+			return no("actor");
+		}
+	}
+
+	if (!bodyMatches(config.messageFilter ?? null, event.body)) {
+		return no("messageFilter");
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -302,6 +302,30 @@ export const notionTriggerConfigSchema = z.union([
 	notionCommentMentionedEvent,
 ]);
 
+export const microsoftTeamsTriggerEventValues = [
+	"message_in_channel",
+	"channel_created",
+] as const;
+export type MicrosoftTeamsTriggerEvent =
+	(typeof microsoftTeamsTriggerEventValues)[number];
+
+/**
+ * Teams triggers scope by team, then by channel within it. `channel_created`
+ * has no channel to filter on — the channel is the thing being created — so it
+ * carries `channels: null` and reads `messageFilter` as a pattern over the new
+ * channel's name.
+ */
+export const microsoftTeamsTriggerConfigSchema = z.object({
+	kind: z.literal("microsoft_teams"),
+	event: z.enum(microsoftTeamsTriggerEventValues),
+	teams: triggerScopeSchema,
+	// Only meaningful for message_in_channel; null elsewhere.
+	channels: triggerScopeSchema,
+	// Only meaningful for message_in_channel; "anyone" elsewhere.
+	actor: triggerActorSchema,
+	messageFilter: textFilterSchema.nullable().default(null),
+});
+
 /**
  * Structurally valid — the shape is right, but a scope may still select nothing.
  * This is what the editor holds while someone is still filling a trigger in.
@@ -321,6 +345,7 @@ export const draftTriggerSchema = z.object({
 		sentryTriggerConfigSchema,
 		notionTriggerConfigSchema,
 		circlebackTriggerConfigSchema,
+		microsoftTeamsTriggerConfigSchema,
 	]),
 });
 export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
@@ -415,6 +440,21 @@ export function describeTriggerProblems(
 						"assignee",
 						"Specify at least one person, or choose Anyone.",
 					);
+				}
+				break;
+			}
+			case "microsoft_teams": {
+				if (isEmptyScope(config.teams)) {
+					add(index, "teams", "Specify at least one team.");
+				}
+				if (
+					config.event === "message_in_channel" &&
+					isEmptyScope(config.channels)
+				) {
+					add(index, "channels", "Specify at least one channel.");
+				}
+				if (isEmptyActor(config.actor)) {
+					add(index, "actor", "Specify at least one person, or choose Anyone.");
 				}
 				break;
 			}

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -37,6 +37,10 @@ export const env = createEnv({
 		RELAY_URL: z.string().url(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
+		// Optional: the Teams integration is off wherever these are unset, and
+		// every other environment keeps booting.
+		MICROSOFT_CLIENT_ID: z.string().min(1).optional(),
+		MICROSOFT_CLIENT_SECRET: z.string().min(1).optional(),
 		STRIPE_SECRET_KEY: z.string().optional(),
 		MERCURY_API_TOKEN: z.string().optional(),
 	},

--- a/packages/trpc/src/lib/integrations/microsoft-teams/index.ts
+++ b/packages/trpc/src/lib/integrations/microsoft-teams/index.ts
@@ -1,0 +1,27 @@
+export {
+	acquireAppToken,
+	findTeamsConnection,
+	GraphError,
+	getGraphAccessToken,
+	graphList,
+	graphRequest,
+	isGraphAuthError,
+	microsoftCredentials,
+} from "../../../router/integration/microsoft-teams/graph";
+export {
+	type GraphChannel,
+	type GraphChatMessage,
+	type GraphTeam,
+	getChannel,
+	getChannelMessage,
+	plainTextOf,
+} from "../../../router/integration/microsoft-teams/resources";
+export {
+	deleteTeamsSubscriptions,
+	type EnsureResult,
+	ensureTeamsSubscriptions,
+	RENEW_WITHIN_MS,
+	type SubscriptionKey,
+	TEAMS_SUBSCRIPTION_RESOURCES,
+	teamsNotificationUrls,
+} from "../../../router/integration/microsoft-teams/subscriptions";

--- a/packages/trpc/src/router/integration/integration.ts
+++ b/packages/trpc/src/router/integration/integration.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
 import { githubRouter } from "./github";
 import { linearRouter } from "./linear";
+import { microsoftTeamsRouter } from "./microsoft-teams";
 import { notionRouter } from "./notion";
 import { slackRouter } from "./slack";
 import { verifyOrgMembership } from "./utils";
@@ -13,6 +14,7 @@ import { verifyOrgMembership } from "./utils";
 export const integrationRouter = {
 	github: githubRouter,
 	linear: linearRouter,
+	microsoftTeams: microsoftTeamsRouter,
 	notion: notionRouter,
 	slack: slackRouter,
 

--- a/packages/trpc/src/router/integration/microsoft-teams/graph.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/graph.ts
@@ -1,0 +1,248 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { withConnectionLock } from "@superset/db/utils";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { env } from "../../../env";
+
+/**
+ * Microsoft Graph, app-only.
+ *
+ * The connection holds no user's token: it holds the app's own token for the
+ * tenant that consented, acquired with the client credentials grant and cached
+ * on the row until it is close to expiring. Nothing here is per user, which is
+ * why teams and channels can be listed and messages fetched with no one signed
+ * in on the Microsoft side.
+ */
+
+export const GRAPH_URL = "https://graph.microsoft.com/v1.0";
+const REQUEST_TIMEOUT_MS = 15_000;
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const MAX_PAGES = 20;
+
+export class GraphError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly code: string | null,
+		message: string,
+	) {
+		super(message);
+		this.name = "GraphError";
+	}
+}
+
+/** The failures that mean the app can no longer act in this tenant at all. */
+export function isGraphAuthError(error: unknown): boolean {
+	return (
+		error instanceof GraphError &&
+		(error.status === 401 || error.status === 403)
+	);
+}
+
+export function microsoftCredentials(): {
+	clientId: string;
+	clientSecret: string;
+} {
+	if (!env.MICROSOFT_CLIENT_ID || !env.MICROSOFT_CLIENT_SECRET) {
+		throw new Error("Microsoft Teams integration is not configured");
+	}
+	return {
+		clientId: env.MICROSOFT_CLIENT_ID,
+		clientSecret: env.MICROSOFT_CLIENT_SECRET,
+	};
+}
+
+const tokenResponseSchema = z.object({
+	access_token: z.string().min(1),
+	expires_in: z.number(),
+});
+
+const tokenErrorSchema = z.object({
+	error: z.string(),
+	error_description: z.string().optional(),
+});
+
+async function fetchWithTimeout(
+	input: string,
+	init: RequestInit,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+	try {
+		return await fetch(input, { ...init, signal: controller.signal });
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Asks Entra for an app-only token in `tenantId`. Fails when the tenant has
+ * not consented (the app has no service principal there) or the secret is
+ * wrong; both surface as a GraphError so callers can tell them from outages.
+ */
+export async function acquireAppToken(
+	tenantId: string,
+): Promise<{ accessToken: string; expiresAt: Date }> {
+	const { clientId, clientSecret } = microsoftCredentials();
+	const response = await fetchWithTimeout(
+		`https://login.microsoftonline.com/${encodeURIComponent(tenantId)}/oauth2/v2.0/token`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				client_id: clientId,
+				client_secret: clientSecret,
+				scope: "https://graph.microsoft.com/.default",
+				grant_type: "client_credentials",
+			}),
+		},
+	);
+	const json: unknown = await response.json().catch(() => null);
+	if (!response.ok) {
+		const parsed = tokenErrorSchema.safeParse(json);
+		throw new GraphError(
+			response.status,
+			parsed.success ? parsed.data.error : null,
+			parsed.success
+				? (parsed.data.error_description ?? parsed.data.error)
+				: `Token request failed with ${response.status}`,
+		);
+	}
+	const token = tokenResponseSchema.parse(json);
+	return {
+		accessToken: token.access_token,
+		expiresAt: new Date(Date.now() + token.expires_in * 1000),
+	};
+}
+
+/**
+ * The cached app token for a connection, refreshed under the connection lock
+ * when it is within the buffer of expiring. Null when the connection is gone
+ * or has been marked disconnected.
+ */
+export async function getGraphAccessToken(
+	connectionId: string,
+): Promise<string | null> {
+	return withConnectionLock(connectionId, async (tx) => {
+		const [connection] = await tx
+			.select({
+				accessToken: integrationConnections.accessToken,
+				tokenExpiresAt: integrationConnections.tokenExpiresAt,
+				externalOrgId: integrationConnections.externalOrgId,
+				disconnectedAt: integrationConnections.disconnectedAt,
+			})
+			.from(integrationConnections)
+			.where(eq(integrationConnections.id, connectionId))
+			.limit(1);
+		if (!connection || connection.disconnectedAt || !connection.externalOrgId) {
+			return null;
+		}
+		if (
+			connection.tokenExpiresAt &&
+			connection.tokenExpiresAt.getTime() > Date.now() + TOKEN_REFRESH_BUFFER_MS
+		) {
+			return connection.accessToken;
+		}
+
+		try {
+			const token = await acquireAppToken(connection.externalOrgId);
+			await tx
+				.update(integrationConnections)
+				.set({
+					accessToken: token.accessToken,
+					tokenExpiresAt: token.expiresAt,
+					updatedAt: new Date(),
+				})
+				.where(eq(integrationConnections.id, connectionId));
+			return token.accessToken;
+		} catch (error) {
+			// The tenant admin removed the app, or the secret rotated: no amount
+			// of retrying gets a token, so stop pretending the connection works.
+			if (
+				error instanceof GraphError &&
+				(error.code === "unauthorized_client" ||
+					error.code === "invalid_client" ||
+					error.code === "invalid_grant")
+			) {
+				await tx
+					.update(integrationConnections)
+					.set({
+						disconnectedAt: new Date(),
+						disconnectReason: error.code,
+						updatedAt: new Date(),
+					})
+					.where(eq(integrationConnections.id, connectionId));
+				return null;
+			}
+			throw error;
+		}
+	});
+}
+
+/** The active Teams connection for an organization, or null. */
+export async function findTeamsConnection(organizationId: string) {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.organizationId, organizationId),
+			eq(integrationConnections.provider, "microsoft_teams"),
+		),
+	});
+	if (!connection || connection.disconnectedAt) return null;
+	return connection;
+}
+
+const graphErrorSchema = z.object({
+	error: z.object({
+		code: z.string().optional(),
+		message: z.string().optional(),
+	}),
+});
+
+/** One Graph call. Throws GraphError on a non-2xx; undefined on 204. */
+export async function graphRequest<T>(
+	accessToken: string,
+	path: string,
+	init: { method?: string; body?: unknown } = {},
+): Promise<T> {
+	const url = path.startsWith("https://") ? path : `${GRAPH_URL}${path}`;
+	const response = await fetchWithTimeout(url, {
+		method: init.method ?? "GET",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			Accept: "application/json",
+			...(init.body !== undefined
+				? { "Content-Type": "application/json" }
+				: {}),
+		},
+		body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+	});
+	if (response.status === 204) return undefined as T;
+	const json: unknown = await response.json().catch(() => null);
+	if (!response.ok) {
+		const parsed = graphErrorSchema.safeParse(json);
+		throw new GraphError(
+			response.status,
+			parsed.success ? (parsed.data.error.code ?? null) : null,
+			parsed.success
+				? (parsed.data.error.message ?? `Graph ${response.status}`)
+				: `Graph ${response.status} on ${path}`,
+		);
+	}
+	return json as T;
+}
+
+/** A collection, following `@odata.nextLink` up to a page cap. */
+export async function graphList<T>(
+	accessToken: string,
+	path: string,
+): Promise<T[]> {
+	const items: T[] = [];
+	let next: string | undefined = path;
+	for (let page = 0; next && page < MAX_PAGES; page++) {
+		const body: { value?: T[]; "@odata.nextLink"?: string } =
+			await graphRequest(accessToken, next);
+		items.push(...(body.value ?? []));
+		next = body["@odata.nextLink"];
+	}
+	return items;
+}

--- a/packages/trpc/src/router/integration/microsoft-teams/index.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/index.ts
@@ -1,0 +1,1 @@
+export { microsoftTeamsRouter } from "./microsoft-teams";

--- a/packages/trpc/src/router/integration/microsoft-teams/microsoft-teams.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/microsoft-teams.ts
@@ -1,0 +1,143 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure } from "../../../trpc";
+import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { findTeamsConnection, getGraphAccessToken } from "./graph";
+import { listChannels, listTeams } from "./resources";
+import { deleteTeamsSubscriptions } from "./subscriptions";
+
+/** How many teams' channel lists are fetched at once when building the
+ * channel picker. Graph throttles per app per tenant; a tenant with hundreds
+ * of teams is walked in batches rather than all at once. */
+const CHANNEL_FETCH_CONCURRENCY = 5;
+
+async function requireAccessToken(organizationId: string): Promise<{
+	connectionId: string;
+	accessToken: string;
+} | null> {
+	const connection = await findTeamsConnection(organizationId);
+	if (!connection) return null;
+	const accessToken = await getGraphAccessToken(connection.id);
+	if (!accessToken) return null;
+	return { connectionId: connection.id, accessToken };
+}
+
+export const microsoftTeamsRouter = {
+	getConnection: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "microsoft_teams"),
+				),
+				columns: {
+					id: true,
+					externalOrgId: true,
+					externalOrgName: true,
+					config: true,
+					createdAt: true,
+					disconnectedAt: true,
+					disconnectReason: true,
+				},
+			});
+			if (!connection || connection.disconnectedAt) return null;
+
+			const config =
+				connection.config?.provider === "microsoft_teams"
+					? connection.config
+					: null;
+			return {
+				id: connection.id,
+				tenantId: connection.externalOrgId,
+				externalOrgName: connection.externalOrgName,
+				connectedAt: connection.createdAt,
+				// Whether Graph is actually delivering: a connection whose
+				// subscriptions never got created is consented but deaf.
+				subscriptions: {
+					channelMessages: config?.subscriptions.channelMessages ?? null,
+					channels: config?.subscriptions.channels ?? null,
+				},
+			};
+		}),
+
+	disconnect: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "microsoft_teams"),
+				),
+				columns: { id: true },
+			});
+			if (!connection) {
+				return { success: false, error: "No connection found" };
+			}
+
+			// Before the row goes: the subscription ids live on it, and Graph
+			// would otherwise keep posting to the notify route for two more days.
+			await deleteTeamsSubscriptions(connection.id);
+			await db
+				.delete(integrationConnections)
+				.where(eq(integrationConnections.id, connection.id));
+
+			return { success: true };
+		}),
+
+	listTeams: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			const auth = await requireAccessToken(input.organizationId);
+			if (!auth) return [];
+
+			const teams = await listTeams(auth.accessToken);
+			return teams
+				.map((team) => ({ id: team.id, label: team.displayName ?? team.id }))
+				.sort((a, b) => a.label.localeCompare(b.label));
+		}),
+
+	listChannels: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			const auth = await requireAccessToken(input.organizationId);
+			if (!auth) return [];
+
+			const teams = await listTeams(auth.accessToken);
+			const channels: Array<{ id: string; teamId: string; label: string }> = [];
+			for (let i = 0; i < teams.length; i += CHANNEL_FETCH_CONCURRENCY) {
+				const batch = teams.slice(i, i + CHANNEL_FETCH_CONCURRENCY);
+				const results = await Promise.allSettled(
+					batch.map(async (team) => {
+						const list = await listChannels(auth.accessToken, team.id);
+						return list.map((channel) => ({
+							id: channel.id,
+							teamId: team.id,
+							// Channel names repeat across teams ("General" is in every
+							// one), so the picker shows which team a channel belongs to.
+							label: `${team.displayName ?? team.id} › ${channel.displayName ?? channel.id}`,
+						}));
+					}),
+				);
+				for (const result of results) {
+					if (result.status === "fulfilled") channels.push(...result.value);
+					else {
+						console.error(
+							"[microsoft-teams] listChannels failed for a team",
+							result.reason,
+						);
+					}
+				}
+			}
+			return channels.sort((a, b) => a.label.localeCompare(b.label));
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/integration/microsoft-teams/resources.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/resources.ts
@@ -1,0 +1,96 @@
+import { graphList, graphRequest } from "./graph";
+
+/**
+ * The Graph resources the Teams provider reads, typed down to the fields it
+ * uses. Graph returns far more; the rest is carried in the recorded payload
+ * as-is and never named here.
+ */
+
+export type GraphTeam = { id: string; displayName: string | null };
+export type GraphChannel = {
+	id: string;
+	displayName: string | null;
+	webUrl?: string | null;
+	membershipType?: string | null;
+	createdDateTime?: string | null;
+};
+
+export type GraphChatMessage = {
+	id: string;
+	replyToId?: string | null;
+	messageType?: string | null;
+	createdDateTime?: string | null;
+	subject?: string | null;
+	webUrl?: string | null;
+	from?: {
+		user?: { id?: string | null; displayName?: string | null } | null;
+		application?: { id?: string | null; displayName?: string | null } | null;
+	} | null;
+	body?: { contentType?: string | null; content?: string | null } | null;
+	channelIdentity?: {
+		teamId?: string | null;
+		channelId?: string | null;
+	} | null;
+};
+
+export function listTeams(accessToken: string): Promise<GraphTeam[]> {
+	return graphList<GraphTeam>(accessToken, "/teams?$select=id,displayName");
+}
+
+export function listChannels(
+	accessToken: string,
+	teamId: string,
+): Promise<GraphChannel[]> {
+	return graphList<GraphChannel>(
+		accessToken,
+		`/teams/${encodeURIComponent(teamId)}/channels?$select=id,displayName,membershipType`,
+	);
+}
+
+export function getChannel(
+	accessToken: string,
+	teamId: string,
+	channelId: string,
+): Promise<GraphChannel> {
+	return graphRequest<GraphChannel>(
+		accessToken,
+		`/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`,
+	);
+}
+
+/** A channel message, or a reply to one when `replyId` is set. */
+export function getChannelMessage(
+	accessToken: string,
+	teamId: string,
+	channelId: string,
+	messageId: string,
+	replyId?: string,
+): Promise<GraphChatMessage> {
+	const base = `/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`;
+	return graphRequest<GraphChatMessage>(
+		accessToken,
+		replyId ? `${base}/replies/${encodeURIComponent(replyId)}` : base,
+	);
+}
+
+/**
+ * The text a filter is tested against. Teams bodies are usually HTML; the
+ * tags are dropped and the handful of entities Teams emits are decoded so
+ * "contains" means what the person typing the pattern sees.
+ */
+export function plainTextOf(body: GraphChatMessage["body"]): string | null {
+	const content = body?.content;
+	if (!content) return null;
+	if (body?.contentType !== "html") return content;
+	return content
+		.replace(/<br\s*\/?>/gi, "\n")
+		.replace(/<\/(p|div|li)>/gi, "\n")
+		.replace(/<[^>]+>/g, "")
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.trim();
+}

--- a/packages/trpc/src/router/integration/microsoft-teams/subscriptions.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/subscriptions.ts
@@ -1,0 +1,222 @@
+import { db } from "@superset/db/client";
+import {
+	integrationConnections,
+	type MicrosoftTeamsConfig,
+	type MicrosoftTeamsSubscription,
+} from "@superset/db/schema";
+import { withConnectionLock } from "@superset/db/utils";
+import { eq } from "drizzle-orm";
+import { env } from "../../../env";
+import { GraphError, getGraphAccessToken, graphRequest } from "./graph";
+
+/**
+ * Graph change-notification subscriptions for a Teams connection.
+ *
+ * Two per connection, both tenant-wide: every channel message and every
+ * channel. Tenant-wide rather than per team so a trigger on a team created
+ * after the connection still fires, and so there is one thing to renew.
+ *
+ * Subscriptions expire. Graph allows three days for these resources; they are
+ * requested for two and renewed once they are within half a day, so a missed
+ * cron tick costs nothing and a Graph outage has hours to recover in.
+ */
+
+const SUBSCRIPTION_LIFETIME_MS = 2 * 24 * 60 * 60 * 1000;
+export const RENEW_WITHIN_MS = 12 * 60 * 60 * 1000;
+
+export type SubscriptionKey = keyof MicrosoftTeamsConfig["subscriptions"];
+
+/**
+ * `/teams/getAllMessages` with no `model` query parameter runs in Graph's
+ * evaluation mode, capped at 500 messages per app per tenant per month. Going
+ * past that means choosing a payment model (`?model=A` needs E5 licences,
+ * `?model=B` bills per message to an Azure subscription), which is a
+ * commercial decision rather than a code one — the resource is a constant so
+ * that decision changes one line.
+ */
+export const TEAMS_SUBSCRIPTION_RESOURCES: Record<
+	SubscriptionKey,
+	{ resource: string; changeType: string }
+> = {
+	channelMessages: { resource: "/teams/getAllMessages", changeType: "created" },
+	channels: { resource: "/teams/getAllChannels", changeType: "created" },
+};
+
+export function teamsNotificationUrls() {
+	const base = `${env.NEXT_PUBLIC_API_URL}/api/integrations/microsoft-teams`;
+	return {
+		notificationUrl: `${base}/notify`,
+		lifecycleNotificationUrl: `${base}/lifecycle`,
+	};
+}
+
+type GraphSubscription = { id: string; expirationDateTime: string };
+
+async function createSubscription(
+	accessToken: string,
+	key: SubscriptionKey,
+	clientState: string,
+): Promise<MicrosoftTeamsSubscription> {
+	const { resource, changeType } = TEAMS_SUBSCRIPTION_RESOURCES[key];
+	const created = await graphRequest<GraphSubscription>(
+		accessToken,
+		"/subscriptions",
+		{
+			method: "POST",
+			body: {
+				changeType,
+				resource,
+				...teamsNotificationUrls(),
+				expirationDateTime: new Date(
+					Date.now() + SUBSCRIPTION_LIFETIME_MS,
+				).toISOString(),
+				clientState,
+				includeResourceData: false,
+			},
+		},
+	);
+	return { id: created.id, expiresAt: created.expirationDateTime };
+}
+
+async function renewSubscription(
+	accessToken: string,
+	subscriptionId: string,
+): Promise<MicrosoftTeamsSubscription> {
+	const renewed = await graphRequest<GraphSubscription>(
+		accessToken,
+		`/subscriptions/${encodeURIComponent(subscriptionId)}`,
+		{
+			method: "PATCH",
+			body: {
+				expirationDateTime: new Date(
+					Date.now() + SUBSCRIPTION_LIFETIME_MS,
+				).toISOString(),
+			},
+		},
+	);
+	return { id: renewed.id, expiresAt: renewed.expirationDateTime };
+}
+
+export type EnsureResult = {
+	connectionId: string;
+	subscriptions: MicrosoftTeamsConfig["subscriptions"];
+	/** Per subscription, why it could not be created or renewed. */
+	failures: Partial<Record<SubscriptionKey, string>>;
+};
+
+/**
+ * Creates what is missing and renews what is close to expiring, for one
+ * connection. `force` renews regardless of the remaining time — what a
+ * `reauthorizationRequired` lifecycle event asks for.
+ *
+ * Under the connection lock, because the cron, the consent callback and the
+ * lifecycle route can all arrive at once and each would otherwise create its
+ * own subscription and overwrite the others' ids.
+ */
+export async function ensureTeamsSubscriptions(
+	connectionId: string,
+	options: { force?: boolean; only?: SubscriptionKey[] } = {},
+): Promise<EnsureResult | null> {
+	const accessToken = await getGraphAccessToken(connectionId);
+	if (!accessToken) return null;
+
+	return withConnectionLock(connectionId, async (tx) => {
+		const [connection] = await tx
+			.select({ config: integrationConnections.config })
+			.from(integrationConnections)
+			.where(eq(integrationConnections.id, connectionId))
+			.limit(1);
+		const config = connection?.config;
+		if (!config || config.provider !== "microsoft_teams") return null;
+
+		const subscriptions = { ...config.subscriptions };
+		const failures: EnsureResult["failures"] = {};
+		const keys =
+			options.only ??
+			(Object.keys(TEAMS_SUBSCRIPTION_RESOURCES) as SubscriptionKey[]);
+
+		for (const key of keys) {
+			const existing = subscriptions[key];
+			const remaining = existing
+				? new Date(existing.expiresAt).getTime() - Date.now()
+				: -1;
+			if (existing && !options.force && remaining > RENEW_WITHIN_MS) continue;
+
+			try {
+				if (existing) {
+					try {
+						subscriptions[key] = await renewSubscription(
+							accessToken,
+							existing.id,
+						);
+						continue;
+					} catch (error) {
+						// Graph forgot it — it expired, or the tenant removed it. A new
+						// one is the only way forward.
+						if (!(error instanceof GraphError && error.status === 404)) {
+							throw error;
+						}
+					}
+				}
+				subscriptions[key] = await createSubscription(
+					accessToken,
+					key,
+					config.clientState,
+				);
+			} catch (error) {
+				failures[key] =
+					error instanceof Error ? error.message : "Unknown error";
+			}
+		}
+
+		const next: MicrosoftTeamsConfig = { ...config, subscriptions };
+		await tx
+			.update(integrationConnections)
+			.set({ config: next, updatedAt: new Date() })
+			.where(eq(integrationConnections.id, connectionId));
+
+		return { connectionId, subscriptions, failures };
+	});
+}
+
+/** Removes the connection's subscriptions from Graph. Best effort: a missing
+ * one is already gone, and a token failure means the tenant already revoked
+ * the app, which takes its subscriptions with it. */
+export async function deleteTeamsSubscriptions(
+	connectionId: string,
+): Promise<void> {
+	const [connection] = await db
+		.select({ config: integrationConnections.config })
+		.from(integrationConnections)
+		.where(eq(integrationConnections.id, connectionId))
+		.limit(1);
+	const config = connection?.config;
+	if (!config || config.provider !== "microsoft_teams") return;
+
+	let accessToken: string | null = null;
+	try {
+		accessToken = await getGraphAccessToken(connectionId);
+	} catch {
+		return;
+	}
+	if (!accessToken) return;
+
+	await Promise.all(
+		Object.values(config.subscriptions).map(async (subscription) => {
+			try {
+				await graphRequest(
+					accessToken,
+					`/subscriptions/${encodeURIComponent(subscription.id)}`,
+					{ method: "DELETE" },
+				);
+			} catch (error) {
+				if (error instanceof GraphError && error.status === 404) return;
+				console.error(
+					"[microsoft-teams] failed to delete subscription",
+					subscription.id,
+					error,
+				);
+			}
+		}),
+	);
+}


### PR DESCRIPTION
## What

Adds `microsoft_teams` as a trigger provider for automations, following the additive seam from #6571. Enum values are already on main (#6581) — no migration.

**Events** (fixed list from the brief):
| event | sentence |
|---|---|
| `message_in_channel` | *[Any message / containing "…"] in **team › channel** by **Anyone/Me*** |
| `channel_created` | *Channel created in **team** [name contains "…"]* |

## Shape — Google-shaped, fetch-on-notify

- **Connection = tenant admin consent**, not a user sign-in. `connect` redirects to Entra's `organizations/v2.0/adminconsent` with `.default`; `callback` proves consent by acquiring an app-only client-credentials token for the returned tenant (the `tenant` param alone is attacker-controlled), upserts `integration_connections` (`externalOrgId` = tenant id, token cached with expiry, `config` = `{tenantId, clientState, subscriptions}`), creates the Graph subscriptions, then chains an OpenID auth-code sign-in (`identity/callback`) so the consenting admin's Entra `oid` lands in `user_identities` (provider `microsoft_teams`, `externalScopeId` = tenant) — that is what `me` resolves through. Declining that leg costs only "Me", not the connection.
- **Subscriptions**: two tenant-wide per connection — `/teams/getAllMessages` and `/teams/getAllChannels`, `changeType: created`, `includeResourceData: false` (no encryption certificate). Requested for 2 days (Graph allows 3 for these), renewed once within 12h by `POST /api/integrations/microsoft-teams/jobs/renew-subscriptions` (QStash-signed, same pattern as `automations/evaluate`). All subscription writes go through the per-connection advisory lock.
- **Notify + lifecycle routes** answer inside Graph's 3-second window: echo `?validationToken=` as `text/plain`; otherwise parse the collection, look up the connection by tenant, compare `clientState` with `timingSafeEqual` (the only auth Graph offers without resource data), enqueue each accepted notification to QStash (deduped on subscription + changeType + resource), and answer 202. Refused notifications are acknowledged too — they will not verify on retry either.
- **Process route** (`/api/integrations/microsoft-teams/process`, QStash-signed) does the slow half: re-reads the connection and re-checks clientState, GETs the chatMessage / channel from Graph, records it in `automation_events` (idempotent on connection + channel + message id; payload is the fetched resource) and dispatches through `triggerMatches`. For lifecycle items (`reauthorizationRequired` / `subscriptionRemoved`) it forces the renew/recreate step. Non-2xx → QStash retries. System messages (`messageType != "message"`, e.g. "X added Y") are skipped.
- **Matcher** `automation-matching/microsoft-teams.ts` + one `case`: `null` team/channel scope matches nothing; `channel_created` ignores channel + actor (its sentence has neither); `messageFilter` is substring over the message text (HTML stripped) or the new channel's name. `MatchContext.microsoftTeams = {teamId, channelId, ownerIds}`.
- **Desktop**: `providers/microsoftTeams/` (grammar, renderer, `useTeamsOptions` → `integration.microsoftTeams.listTeams/listChannels`, channels labelled "Team › Channel"), one registry line, one `useProviderOptions` line. ActorChip offers Anyone/Me only — the shared people list is GitHub ids. (Option keys will move to the provider-namespaced shape once the consolidated seam lands.)
- **Web**: `/integrations/microsoft-teams` page (copy of Slack's) with Connect/Disconnect and subscription state; card on `/integrations`.

## Prerequisites (documented, not yet provisioned)

1. Entra app registration, multi-tenant, with **application** permissions `ChannelMessage.Read.All`, `Channel.ReadBasic.All`, `Team.ReadBasic.All` (`Organization.Read.All` optional — only the tenant display name). Redirect URIs: `{API}/api/integrations/microsoft-teams/callback` and `{API}/api/integrations/microsoft-teams/identity/callback`.
2. `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` in api + trpc env (both **optional** — unset means the integration is off and nothing else changes).
3. App-only channel-message reads are a Microsoft **protected API**: Graph 403s subscription create until the app id is approved via Microsoft's request form.
4. A QStash schedule hitting `/api/integrations/microsoft-teams/jobs/renew-subscriptions` hourly.
5. `/teams/getAllMessages` is subscribed **without `?model=`** → Graph evaluation mode, capped at **500 messages / app / tenant / month**. Flipping to model A (E5 licences) or B (per-message billing) is one constant in `subscriptions.ts`.

## Verification

- typecheck 0: shared, db, trpc, api, desktop, web. Lint: clean except the pre-existing `TerminalAgentAutoResume` a11y failure on main.
- Desktop over CDP (this worktree's renderer, vite :8865, api :8861): Add Trigger → Microsoft Teams → both events; Save with empty scopes refused with team/channel chips marked; configured (Any team › Any channel, filter "deploy"; Channel created in Any team, "incident"), saved, persisted across a full reload; DB rows carry the expected config.
- Notify route: `?validationToken=abc%20123%2Bxyz` → 200 `text/plain` `abc 123+xyz` (lifecycle route too); bad JSON 400; unknown tenant refused; wrong `clientState` refused; correct `clientState` accepted (before the queue split, the same request reached the real Graph GET and got the expected 401 on a placeholder token; with the queue, QStash rejects loopback URLs locally, as it does for every other automation route).
- Ingest (`ingestChannelMessage` / `ingestChannel`, what the process route calls after the Graph GET) with Graph-shaped chatMessage / channel payloads against the real DB: rows recorded with title/url/actor/resourceKey, redelivery deduped, matcher selects 1/2 triggers for a "deploy" message and 1/2 for an "incident-…" channel, 0/2 for non-matching.
- **Not verified live**: consent flow, identity leg, subscription create/renew, and a real Graph push — need the tenant + protected-API approval above.
