### PR TITLE
feat(automations): Sentry trigger provider with internal-integration connection

### DIFF
--- a/apps/api/src/app/api/integrations/sentry/callback/route.ts
+++ b/apps/api/src/app/api/integrations/sentry/callback/route.ts
@@ -1,0 +1,132 @@
+import { db } from "@superset/db/client";
+import {
+	integrationConnections,
+	members,
+	type SentryConfig,
+} from "@superset/db/schema";
+import {
+	exchangeSentryCode,
+	fetchSentryOrganization,
+	verifySentryInstall,
+} from "@superset/trpc/integrations/sentry";
+import { and, eq, sql } from "drizzle-orm";
+
+import { env } from "@/env";
+import { verifySignedState } from "@/lib/oauth-state";
+import { SENTRY_STATE_COOKIE } from "../connect/route";
+
+const web = (params: string) =>
+	Response.redirect(`${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry${params}`);
+
+/**
+ * Finishes a Sentry install: exchanges the grant code for a token pair and
+ * writes the connection.
+ *
+ * This is the authoritative path — it is the only one that knows the Superset
+ * org (from the signed cookie the connect route set). The `installation.created`
+ * webhook that Sentry fires in parallel names no Superset org, so it can only
+ * ever update a row this route already wrote; the two never both create.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const code = url.searchParams.get("code");
+	const installationId = url.searchParams.get("installationId");
+	const error = url.searchParams.get("error");
+
+	if (error) return web("?error=oauth_denied");
+	if (!code || !installationId) return web("?error=missing_params");
+
+	const stateCookie = readCookie(
+		request.headers.get("cookie"),
+		SENTRY_STATE_COOKIE,
+	);
+	const stateData = stateCookie ? verifySignedState(stateCookie) : null;
+	if (!stateData) return web("?error=invalid_state");
+	const { organizationId, userId } = stateData;
+
+	// Re-verify membership at callback time (the cookie was signed earlier).
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.organizationId, organizationId),
+			eq(members.userId, userId),
+		),
+	});
+	if (!membership) return web("?error=unauthorized");
+
+	let token: Awaited<ReturnType<typeof exchangeSentryCode>>;
+	try {
+		token = await exchangeSentryCode({
+			installationUuid: installationId,
+			code,
+		});
+	} catch (e) {
+		console.error("[sentry/callback] Token exchange failed:", e);
+		return web("?error=token_exchange_failed");
+	}
+
+	const organization = await fetchSentryOrganization(token.token);
+	if (!organization) return web("?error=organization_lookup_failed");
+
+	const config: SentryConfig = {
+		provider: "sentry",
+		installationUuid: installationId,
+		regionUrl: organization.regionUrl,
+	};
+
+	await db
+		.insert(integrationConnections)
+		.values({
+			organizationId,
+			connectedByUserId: userId,
+			provider: "sentry",
+			accessToken: token.token,
+			refreshToken: token.refreshToken,
+			tokenExpiresAt: new Date(token.expiresAt),
+			externalOrgId: organization.slug,
+			externalOrgName: organization.name,
+			config,
+		})
+		.onConflictDoUpdate({
+			target: [
+				integrationConnections.organizationId,
+				integrationConnections.provider,
+			],
+			// The org-scoped uniqueness is a partial index (Google connections are
+			// per user); Postgres only infers it when the predicate is named.
+			targetWhere: sql`${integrationConnections.provider} <> 'google'`,
+			set: {
+				accessToken: token.token,
+				refreshToken: token.refreshToken,
+				tokenExpiresAt: new Date(token.expiresAt),
+				externalOrgId: organization.slug,
+				externalOrgName: organization.name,
+				connectedByUserId: userId,
+				config,
+				disconnectedAt: null,
+				disconnectReason: null,
+				updatedAt: new Date(),
+			},
+		});
+
+	// Verify Install, if the app has it on; best-effort, the token already works.
+	await verifySentryInstall(installationId, token.token);
+
+	// Clear the one-shot state cookie on the way back.
+	return new Response(null, {
+		status: 302,
+		headers: {
+			Location: `${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry`,
+			"Set-Cookie": `${SENTRY_STATE_COOKIE}=; HttpOnly; SameSite=Lax; Path=/api/integrations/sentry; Max-Age=0`,
+		},
+	});
+}
+
+/** One cookie value from a request's Cookie header. */
+function readCookie(header: string | null, name: string): string | null {
+	if (!header) return null;
+	for (const part of header.split(";")) {
+		const [key, ...rest] = part.trim().split("=");
+		if (key === name) return rest.join("=");
+	}
+	return null;
+}

--- a/apps/api/src/app/api/integrations/sentry/connect/route.ts
+++ b/apps/api/src/app/api/integrations/sentry/connect/route.ts
@@ -1,0 +1,70 @@
+import { auth } from "@superset/auth/server";
+import { findOrgMembership } from "@superset/db/utils";
+
+import { env } from "@/env";
+import { createSignedState } from "@/lib/oauth-state";
+
+/** How the callback recovers which Superset org started the install. */
+export const SENTRY_STATE_COOKIE = "sentry_oauth_state";
+
+/**
+ * Starts a Sentry install for the org's Sentry admin.
+ *
+ * A public Sentry integration is installed from Sentry's side, and Sentry
+ * redirects back to the app's one fixed Redirect URL with only a grant code and
+ * an install id — no state of ours. Sentry's install payload never names the
+ * Superset org either. So the one place the Superset org is known is right here,
+ * and it is carried to the callback in a signed, first-party cookie rather than
+ * through Sentry.
+ */
+export async function GET(request: Request) {
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const organizationId = new URL(request.url).searchParams.get(
+		"organizationId",
+	);
+	if (!organizationId) {
+		return Response.json(
+			{ error: "Missing organizationId parameter" },
+			{ status: 400 },
+		);
+	}
+
+	const membership = await findOrgMembership({
+		userId: session.user.id,
+		organizationId,
+	});
+	if (!membership) {
+		return Response.json(
+			{ error: "User is not a member of this organization" },
+			{ status: 403 },
+		);
+	}
+
+	if (!env.SENTRY_APP_SLUG || !env.SENTRY_CLIENT_ID) {
+		return Response.redirect(
+			`${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry?error=not_configured`,
+		);
+	}
+
+	const state = createSignedState({
+		organizationId,
+		userId: session.user.id,
+	});
+
+	const installUrl = `https://sentry.io/sentry-apps/${env.SENTRY_APP_SLUG}/external-install/`;
+
+	const secure = env.NEXT_PUBLIC_API_URL.startsWith("https") ? " Secure;" : "";
+	return new Response(null, {
+		status: 302,
+		headers: {
+			Location: installUrl,
+			// Scoped to the callback's path so it is sent on the top-level GET
+			// redirect back and nowhere else; short-lived, like the state's TTL.
+			"Set-Cookie": `${SENTRY_STATE_COOKIE}=${state}; HttpOnly;${secure} SameSite=Lax; Path=/api/integrations/sentry; Max-Age=600`,
+		},
+	});
+}

--- a/apps/api/src/app/api/integrations/sentry/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/integrations/sentry/webhook/recordAutomationEvent.ts
@@ -1,0 +1,132 @@
+import { db } from "@superset/db/client";
+import { automationEvents } from "@superset/db/schema";
+import {
+	type SentryMatchableEvent,
+	sentryEventNames,
+} from "@superset/shared/automation-matching";
+
+import { stripNullChars } from "@/lib/strip-null-chars";
+
+/**
+ * Records a Sentry issue webhook as an `automation_events` row.
+ *
+ * Same role as the GitHub recorder: the normalized stream triggers are matched
+ * against, keeping its own copy of the payload and flattening the fields the
+ * matcher and a prompt need. Sentry payloads have one shape for every issue
+ * action, so there is much less to flatten.
+ */
+
+/** The parts of a Sentry issue webhook this route reads. */
+export type SentryIssuePayload = {
+	action?: string;
+	// installation.created carries the grant code; every delivery carries the
+	// uuid, which is how the webhook route finds the connection.
+	installation?: { uuid?: string };
+	data?: {
+		installation?: { uuid?: string };
+		issue?: {
+			id?: string | number;
+			shortId?: string;
+			title?: string;
+			web_url?: string;
+			permalink?: string;
+			level?: string;
+			project?: { id?: string | number; slug?: string; name?: string };
+		};
+	};
+	actor?: { type?: string; id?: string | number; name?: string };
+};
+
+function projectIdFor(payload: SentryIssuePayload): string | null {
+	const id = payload.data?.issue?.project?.id;
+	// The numeric id, not the slug: a project can be renamed and triggers must
+	// keep matching it afterwards.
+	return id !== undefined ? String(id) : null;
+}
+
+/**
+ * Normalizes an issue webhook into what Sentry triggers filter on. Sentry
+ * triggers have no person filter, so the actor is display-only: a person is
+ * worth naming, Sentry itself (which resolves and archives) is not.
+ */
+export function matchableFrom(
+	payload: SentryIssuePayload,
+	eventType: string,
+): SentryMatchableEvent {
+	const actor = payload.actor;
+	const person = actor?.type === "user";
+	return {
+		provider: "sentry",
+		eventType,
+		names: sentryEventNames(eventType),
+		projectId: projectIdFor(payload),
+		level: payload.data?.issue?.level ?? null,
+		actorId: person && actor.id !== undefined ? String(actor.id) : null,
+		actorLogin: person ? (actor.name ?? null) : null,
+		body: null,
+	};
+}
+
+/**
+ * The issue a run would act on. Runs key debounce and in-flight limits off
+ * this, so a resolve and an unresolve of one issue are the same resource.
+ */
+function resourceKeyFor(payload: SentryIssuePayload): string | null {
+	const project = projectIdFor(payload);
+	const issue = payload.data?.issue?.id;
+	if (!project || issue === undefined) return null;
+	return `sentry:${project}#${issue}`;
+}
+
+function titleFor(payload: SentryIssuePayload, eventType: string): string {
+	return (
+		payload.data?.issue?.title ?? payload.data?.issue?.shortId ?? eventType
+	);
+}
+
+export async function recordAutomationEvent(params: {
+	organizationId: string;
+	connectionId: string;
+	event: SentryMatchableEvent;
+	deliveryId: string;
+	payload: SentryIssuePayload;
+}): Promise<{ recorded: boolean; reason?: string; eventId?: string }> {
+	const { payload, event } = params;
+
+	const [inserted] = await db
+		.insert(automationEvents)
+		.values({
+			organizationId: params.organizationId,
+			integrationConnectionId: params.connectionId,
+			provider: "sentry",
+			eventType: event.eventType,
+			externalEventId: params.deliveryId,
+			resourceKey: resourceKeyFor(payload),
+			title: titleFor(payload, event.eventType),
+			url:
+				payload.data?.issue?.web_url ?? payload.data?.issue?.permalink ?? null,
+			repositoryId: null,
+			ref: null,
+			actorLogin: event.actorLogin,
+			actorIsExternal: null,
+			// jsonb rejects NUL, and a payload carrying one would otherwise throw
+			// and lose the event.
+			payload: stripNullChars(payload) as Record<string, unknown>,
+			webhookEventId: null,
+		})
+		// A redelivery of the same Sentry request id is the same event.
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		})
+		.returning({ id: automationEvents.id });
+
+	// Empty on a redelivery the dedupe swallowed; the first delivery already
+	// dispatched whatever this event matches.
+	if (!inserted) return { recorded: false, reason: "duplicate delivery" };
+
+	return { recorded: true, eventId: inserted.id };
+}

--- a/apps/api/src/app/api/integrations/sentry/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/sentry/webhook/route.ts
@@ -1,0 +1,146 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { disconnectSentry } from "@superset/trpc/integrations/sentry";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { env } from "@/env";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import {
+	matchableFrom,
+	recordAutomationEvent,
+	type SentryIssuePayload,
+} from "./recordAutomationEvent";
+
+/**
+ * Webhooks from the public Sentry integration.
+ *
+ * Every delivery is signed with the app's one client secret, an env var, so the
+ * signature is verified before anything is looked up. The payload names no
+ * Superset org, only the installation's uuid — and that uuid is what the
+ * install callback stored on the connection, so it is how a delivery finds the
+ * org it belongs to. (`?organization=` stays a fallback for a delivery that
+ * somehow carries no installation.)
+ */
+
+/** Constant-time compare of Sentry's hex HMAC-SHA256 against ours. */
+function signatureMatches(
+	body: string,
+	signature: string,
+	secret: string,
+): boolean {
+	const expected = createHmac("sha256", secret).update(body, "utf8").digest();
+	const received = Buffer.from(signature, "hex");
+	return (
+		received.length === expected.length && timingSafeEqual(received, expected)
+	);
+}
+
+/** The connection an installation uuid belongs to, active or not. */
+async function connectionByInstallation(installationUuid: string) {
+	return db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.provider, "sentry"),
+			sql`${integrationConnections.config}->>'installationUuid' = ${installationUuid}`,
+		),
+		columns: { id: true, organizationId: true, disconnectedAt: true },
+	});
+}
+
+export async function POST(request: Request) {
+	const body = await request.text();
+	const signature = request.headers.get("sentry-hook-signature");
+	const resource = request.headers.get("sentry-hook-resource");
+	const requestId = request.headers.get("request-id");
+
+	const secret = env.SENTRY_CLIENT_SECRET;
+	if (!secret || !signature || !signatureMatches(body, signature, secret)) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	let payload: SentryIssuePayload;
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+
+	const installationUuid =
+		payload.installation?.uuid ?? payload.data?.installation?.uuid ?? null;
+
+	// installation.deleted / .created only touch connection state; a deletion
+	// drops the token so a later issue delivery for the same install is refused.
+	if (resource === "installation") {
+		if (installationUuid && payload.action === "deleted") {
+			const connection = await connectionByInstallation(installationUuid);
+			if (connection) {
+				await disconnectSentry(connection.id, "Integration removed in Sentry");
+			}
+		}
+		// installation.created is a no-op: the callback, which alone knows the
+		// Superset org, is what writes the connection.
+		return Response.json({ success: true });
+	}
+
+	if (resource !== "issue" || !payload.action) {
+		return Response.json({ success: true, message: "Ignored" });
+	}
+
+	// The install uuid picks the connection; the URL param is only a fallback.
+	const urlOrg = new URL(request.url).searchParams.get("organization");
+	const connection = installationUuid
+		? await connectionByInstallation(installationUuid)
+		: urlOrg && z.uuid().safeParse(urlOrg).success
+			? await db.query.integrationConnections.findFirst({
+					where: and(
+						eq(integrationConnections.organizationId, urlOrg),
+						eq(integrationConnections.provider, "sentry"),
+						isNull(integrationConnections.disconnectedAt),
+					),
+					columns: { id: true, organizationId: true, disconnectedAt: true },
+				})
+			: null;
+
+	// No active connection for this install: nothing to attribute the event to.
+	if (!connection || connection.disconnectedAt) {
+		return Response.json({ success: true, message: "No connection" });
+	}
+
+	const event = matchableFrom(payload, `issue.${payload.action}`);
+	const deliveryId = requestId ?? `sentry-${crypto.randomUUID()}`;
+
+	const recorded = await recordAutomationEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		event,
+		deliveryId,
+		payload,
+	});
+	if (!recorded.recorded || !recorded.eventId) {
+		console.log(
+			`[sentry/webhook] Not recorded as automation event (${recorded.reason}):`,
+			deliveryId,
+		);
+		return Response.json({ success: true, message: recorded.reason });
+	}
+
+	// Nothing in the product names this action, so there is nothing to match.
+	if (event.names.length === 0) {
+		return Response.json({ success: true, message: "Recorded" });
+	}
+
+	const result = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: recorded.eventId,
+		event,
+	});
+	if (result.matched > 0) {
+		console.log(
+			`[sentry/webhook] ${result.matched}/${result.considered} triggers matched:`,
+			deliveryId,
+		);
+	}
+
+	return Response.json({ success: true });
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -52,6 +52,12 @@ export const env = createEnv({
 		STRIPE_PRO_YEARLY_PRICE_ID: z.string(),
 		SLACK_BILLING_WEBHOOK_URL: z.string().url(),
 		SENTRY_AUTH_TOKEN: z.string().optional(),
+		// Public Sentry integration (OAuth app). Optional: unset where the app
+		// is not registered yet, in which case the connect flow 400s.
+		SENTRY_CLIENT_ID: z.string().optional(),
+		SENTRY_CLIENT_SECRET: z.string().optional(),
+		// The published app's slug, used to build the install URL.
+		SENTRY_APP_SLUG: z.string().optional(),
 		RELAY_URL: z.string().url(),
 	},
 	client: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -5,6 +5,7 @@ import { linearProvider } from "./linear/linear";
 import { microsoftTeamsProvider } from "./microsoftTeams/microsoftTeams";
 import { notionProvider } from "./notion/notion";
 import { scheduleProvider } from "./schedule/schedule";
+import { sentryProvider } from "./sentry/sentry";
 import { slackProvider } from "./slack/slack";
 import type { TriggerProvider } from "./types";
 import { webhookProvider } from "./webhook/webhook";
@@ -25,6 +26,7 @@ export type {
 export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	scheduleProvider as TriggerProvider,
 	githubProvider as TriggerProvider,
+	sentryProvider as TriggerProvider,
 	linearProvider as TriggerProvider,
 	notionProvider as TriggerProvider,
 	slackProvider as TriggerProvider,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/grammar.ts
@@ -1,0 +1,73 @@
+import type {
+	SentryTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type SentryConfig = Extract<TriggerConfigInput, { kind: "sentry" }>;
+
+/**
+ * The sentence a Sentry trigger reads as. Every event carries the same two
+ * slots — which projects, and which levels — so the grammar only varies in
+ * its opening words.
+ */
+
+export type Slot = "projects" | "level";
+
+export type SentencePart = { text: string } | { slot: Slot };
+
+function sentence(opening: string): SentencePart[] {
+	return [
+		{ text: opening },
+		{ slot: "projects" },
+		{ text: "with level" },
+		{ slot: "level" },
+	];
+}
+
+export const SENTRY_SENTENCES: Record<SentryTriggerEvent, SentencePart[]> = {
+	"issue.created": sentence("Sentry issue created in"),
+	"issue.resolved": sentence("Sentry issue resolved in"),
+	"issue.assigned": sentence("Sentry issue assigned in"),
+	"issue.archived": sentence("Sentry issue archived in"),
+	"issue.unresolved": sentence("Sentry issue unresolved in"),
+	"issue.any": sentence("Any Sentry issue event in"),
+};
+
+export const SENTRY_MENU: TriggerMenuEntry<SentryConfig>[] = [
+	leaf("Issue created", "issue.created"),
+	leaf("Issue resolved", "issue.resolved"),
+	leaf("Issue assigned", "issue.assigned"),
+	leaf("Issue archived", "issue.archived"),
+	leaf("Issue unresolved", "issue.unresolved"),
+	leaf("Any issue event", "issue.any"),
+];
+
+function leaf(label: string, event: SentryTriggerEvent) {
+	return { label, create: () => createSentryConfig(event) };
+}
+
+/** Sentry's fixed severity levels; the ids are what the webhook payload carries. */
+export const SENTRY_LEVELS = [
+	{ id: "fatal", label: "Fatal" },
+	{ id: "error", label: "Error" },
+	{ id: "warning", label: "Warning" },
+	{ id: "info", label: "Info" },
+	{ id: "debug", label: "Debug" },
+];
+
+/**
+ * A new trigger of this event: the project still to be chosen, the level
+ * filter wide open.
+ */
+export function createSentryConfig(event: SentryTriggerEvent): SentryConfig {
+	return {
+		kind: "sentry",
+		event,
+		// Null matches nothing: an unfinished trigger must not fire on every
+		// project, and the form refuses to save until one is chosen.
+		projects: null,
+		// An optional narrowing, so it starts at "any" — shown or not.
+		level: { mode: "any" },
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/sentry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/sentry.tsx
@@ -1,0 +1,73 @@
+import { SiSentry } from "react-icons/si";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	SENTRY_MENU,
+	SENTRY_SENTENCES,
+	type SentencePart,
+	type SentryConfig,
+} from "./grammar";
+
+function renderPart(
+	config: SentryConfig,
+	part: SentencePart,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	switch (part.slot) {
+		case "projects":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.projects}
+					onChange={(v) => set({ projects: v })}
+					className={mark("projects")}
+					options={options.sentry?.projects ?? []}
+					emptyLabel="Select projects"
+					anyLabel="Any project"
+					disabled={disabled}
+				/>
+			);
+		case "level":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.level}
+					// Clearing an optional filter means "any", not "none": the chip
+					// says "Any level" either way, and null would make that a lie.
+					onChange={(v) => set({ level: v ?? { mode: "any" } })}
+					options={options.sentry?.levels ?? []}
+					emptyLabel="Any level"
+					anyLabel="Any level"
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const sentryProvider: TriggerProvider<SentryConfig> = {
+	kind: "sentry",
+	label: "Sentry",
+	icon: SiSentry,
+	menu: SENTRY_MENU,
+	renderSentence: (config, ctx) => {
+		// A persisted config whose event has since been renamed must still
+		// render, so an unknown event reads as its raw name rather than as nothing.
+		const parts = SENTRY_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/useSentryOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/sentry/useSentryOptions.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+import { SENTRY_LEVELS } from "./grammar";
+
+/** The pickable values a Sentry sentence needs: projects, and the fixed levels. */
+export function useSentryOptions(organizationId: string): ProviderOptions {
+	// The numeric project id is what the matcher compares against — a slug would
+	// stop matching the moment someone renames the project.
+	const projects = cloudTrpc.integration.sentry.listProjects.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId) },
+	);
+
+	return useMemo(
+		() => ({
+			sentry: {
+				projects: (projects.data ?? []).map((project) => ({
+					id: project.id,
+					label: project.slug,
+				})),
+				levels: SENTRY_LEVELS,
+			},
+		}),
+		[projects.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -3,6 +3,7 @@ import { useGithubOptions } from "./github/useGithubOptions";
 import { useLinearOptions } from "./linear/useLinearOptions";
 import { useTeamsOptions } from "./microsoftTeams/useTeamsOptions";
 import { useNotionOptions } from "./notion/useNotionOptions";
+import { useSentryOptions } from "./sentry/useSentryOptions";
 import { useSlackOptions } from "./slack/useSlackOptions";
 import type { ProviderOptions } from "./types";
 
@@ -16,12 +17,13 @@ import type { ProviderOptions } from "./types";
  */
 export function useProviderOptions(organizationId: string): ProviderOptions {
 	const github = useGithubOptions(organizationId);
+	const sentry = useSentryOptions(organizationId);
 	const linear = useLinearOptions(organizationId);
 	const notion = useNotionOptions(organizationId);
 	const slack = useSlackOptions(organizationId);
 	const teams = useTeamsOptions(organizationId);
 	return useMemo(
-		() => ({ ...github, ...linear, ...notion, ...slack, ...teams }),
-		[github, linear, notion, slack, teams],
+		() => ({ ...github, ...sentry, ...linear, ...notion, ...slack, ...teams }),
+		[github, sentry, linear, notion, slack, teams],
 	);
 }

--- a/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
@@ -2,7 +2,7 @@
 
 import { BsMicrosoftTeams } from "react-icons/bs";
 import { FaGithub, FaSlack } from "react-icons/fa";
-import { SiLinear, SiNotion } from "react-icons/si";
+import { SiLinear, SiNotion, SiSentry } from "react-icons/si";
 import {
 	IntegrationCard,
 	type IntegrationCardProps,
@@ -48,6 +48,14 @@ const integrations: IntegrationCardProps[] = [
 		category: "Communication",
 		accentColor: "#5B5FC7",
 		icon: <BsMicrosoftTeams className="size-8" />,
+	},
+	{
+		id: "sentry",
+		name: "Sentry",
+		description: "Run automations when Sentry issues change.",
+		category: "Monitoring",
+		accentColor: "#362D59",
+		icon: <SiSentry className="size-8" />,
 	},
 ];
 

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ConnectionControls/ConnectionControls.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ConnectionControls/ConnectionControls.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Unplug } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { env } from "@/env";
+import { useTRPC } from "@/trpc/react";
+
+interface ConnectionControlsProps {
+	organizationId: string;
+	isConnected: boolean;
+}
+
+/**
+ * Connecting Sentry is an OAuth install — the button sends the admin to
+ * Sentry's install flow, which redirects back through the API callback. There
+ * is nothing to paste.
+ */
+export function ConnectionControls({
+	organizationId,
+	isConnected,
+}: ConnectionControlsProps) {
+	const trpc = useTRPC();
+	const router = useRouter();
+	const queryClient = useQueryClient();
+
+	const disconnectMutation = useMutation(
+		trpc.integration.sentry.disconnect.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({
+					queryKey: trpc.integration.sentry.getConnection.queryKey({
+						organizationId,
+					}),
+				});
+				router.refresh();
+			},
+		}),
+	);
+
+	const handleConnect = () => {
+		window.location.href = `${env.NEXT_PUBLIC_API_URL}/api/integrations/sentry/connect?organizationId=${organizationId}`;
+	};
+
+	if (isConnected) {
+		return (
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button variant="outline" disabled={disconnectMutation.isPending}>
+						<Unplug className="mr-2 size-4" />
+						{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Disconnect Sentry?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Sentry triggers stop firing until you connect again. The
+							integration stays installed in Sentry — uninstall it there to
+							revoke access entirely.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => disconnectMutation.mutate({ organizationId })}
+						>
+							Disconnect
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
+	}
+
+	return <Button onClick={handleConnect}>Connect Sentry</Button>;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ConnectionControls/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ConnectionControls/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionControls } from "./ConnectionControls";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ErrorHandler/ErrorHandler.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { toast } from "@superset/ui/sonner";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+	not_configured:
+		"Sentry isn't available yet — the Superset app hasn't been registered with Sentry.",
+	oauth_denied: "The install was cancelled. Please try again.",
+	missing_params: "Invalid response from Sentry. Please try again.",
+	invalid_state: "Your session expired. Start the connection again.",
+	unauthorized: "You are not authorized to perform this action.",
+	token_exchange_failed:
+		"Failed to complete the Sentry install. Please try again.",
+	organization_lookup_failed:
+		"Connected, but couldn't read your Sentry organization. Please reconnect.",
+};
+
+export function ErrorHandler() {
+	const searchParams = useSearchParams();
+
+	useEffect(() => {
+		const error = searchParams.get("error");
+		if (!error) return;
+		const message = ERROR_MESSAGES[error] ?? "Something went wrong.";
+		window.history.replaceState({}, "", "/integrations/sentry");
+		const id = setTimeout(() => toast.error(message), 0);
+		return () => clearTimeout(id);
+	}, [searchParams]);
+
+	return null;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ErrorHandler/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/components/ErrorHandler/index.ts
@@ -1,0 +1,1 @@
+export { ErrorHandler } from "./ErrorHandler";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/page.tsx
@@ -1,0 +1,94 @@
+import { Badge } from "@superset/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@superset/ui/card";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { SiSentry } from "react-icons/si";
+import { api } from "@/trpc/server";
+import { ConnectionControls } from "./components/ConnectionControls";
+import { ErrorHandler } from "./components/ErrorHandler";
+
+export default async function SentryIntegrationPage() {
+	const trpc = await api();
+	const organization = await trpc.user.myOrganization.query();
+
+	if (!organization) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16">
+				<p className="text-muted-foreground">
+					You need to be part of an organization to use integrations.
+				</p>
+			</div>
+		);
+	}
+
+	const connection = await trpc.integration.sentry.getConnection.query({
+		organizationId: organization.id,
+	});
+	const isConnected = !!connection;
+
+	return (
+		<div className="space-y-8">
+			<ErrorHandler />
+
+			<Link
+				href="/integrations"
+				className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ArrowLeft className="size-4" />
+				Back to Integrations
+			</Link>
+
+			<div className="flex items-start gap-6">
+				<div className="flex size-16 items-center justify-center rounded-xl border bg-card p-3">
+					<SiSentry className="size-10" />
+				</div>
+				<div className="flex-1">
+					<div className="flex items-center gap-3">
+						<h1 className="text-2xl font-semibold">Sentry</h1>
+						{isConnected ? (
+							<Badge variant="default" className="gap-1">
+								<CheckCircle2 className="size-3" />
+								Connected
+							</Badge>
+						) : (
+							<Badge variant="secondary">Not Connected</Badge>
+						)}
+					</div>
+					<p className="mt-1 text-muted-foreground">
+						Connect Sentry to run automations when issues are created, resolved,
+						assigned, archived or unresolved.
+					</p>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Connection</CardTitle>
+					<CardDescription>
+						Install the Superset app in your Sentry organization.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ConnectionControls
+						organizationId={organization.id}
+						isConnected={isConnected}
+					/>
+					{connection && (
+						<div className="mt-4 text-sm text-muted-foreground">
+							Connected to{" "}
+							<span className="font-medium">
+								{connection.organizationName ?? connection.organizationSlug}
+							</span>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -35,10 +35,26 @@ export type MicrosoftTeamsConfig = {
 	};
 };
 
+/**
+ * A public Sentry integration is one app with one client secret (an env var),
+ * so unlike Linear/Slack there is no per-connection secret here. What is per
+ * connection is the installation uuid: it is how an inbound webhook, which
+ * names no Superset org, finds the connection it belongs to. Never select
+ * `config` into a client-facing response.
+ */
+export type SentryConfig = {
+	provider: "sentry";
+	/** Sentry's per-install id; the webhook's only link back to this row. */
+	installationUuid?: string;
+	/** The org's region API origin, e.g. https://us.sentry.io. */
+	regionUrl?: string;
+};
+
 export type IntegrationConfig =
 	| LinearConfig
 	| SlackConfig
-	| MicrosoftTeamsConfig;
+	| MicrosoftTeamsConfig
+	| SentryConfig;
 
 /**
  * The trigger config column, typed from the zod schema that validates every

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -11,6 +11,7 @@ import {
 	microsoftTeamsTriggerMatches,
 } from "./microsoft-teams";
 import { type NotionMatchableEvent, notionTriggerMatches } from "./notion";
+import { type SentryMatchableEvent, sentryTriggerMatches } from "./sentry";
 import { type SlackMatchableEvent, slackTriggerMatches } from "./slack";
 import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
 
@@ -20,6 +21,7 @@ export * from "./github";
 export * from "./linear";
 export * from "./microsoft-teams";
 export * from "./notion";
+export * from "./sentry";
 export * from "./slack";
 export * from "./webhook";
 
@@ -39,7 +41,8 @@ export type MatchableEvent =
 	| LinearMatchableEvent
 	| SlackMatchableEvent
 	| CirclebackMatchableEvent
-	| MicrosoftTeamsMatchableEvent;
+	| MicrosoftTeamsMatchableEvent
+	| SentryMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -68,6 +71,12 @@ export function triggerMatches(
 		case "github":
 			return githubTriggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "github" }>,
+				event,
+				context,
+			);
+		case "sentry":
+			return sentryTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "sentry" }>,
 				event,
 				context,
 			);

--- a/packages/shared/src/automation-matching/sentry.ts
+++ b/packages/shared/src/automation-matching/sentry.ts
@@ -1,0 +1,61 @@
+import type { SentryTriggerEvent, TriggerScope } from "../automation-triggers";
+import {
+	type BaseMatchableEvent,
+	type MatchContext,
+	type MatchResult,
+	scopeAllows,
+} from "./core";
+
+/** A Sentry issue webhook, normalized to what Sentry triggers filter on. */
+export type SentryMatchableEvent = BaseMatchableEvent & {
+	provider: "sentry";
+	/** Sentry's numeric project id, as a string. */
+	projectId: string | null;
+	/** fatal / error / warning / info / debug. */
+	level: string | null;
+	/** The product-level names this delivery maps to; see sentryEventNames. */
+	names: SentryTriggerEvent[];
+};
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/**
+ * Maps a Sentry issue webhook to the events a trigger can name. The wire event
+ * is `issue.<action>`; every one of them also satisfies `issue.any`.
+ */
+export function sentryEventNames(eventType: string): SentryTriggerEvent[] {
+	switch (eventType) {
+		case "issue.created":
+		case "issue.resolved":
+		case "issue.assigned":
+		case "issue.archived":
+		case "issue.unresolved":
+			return [eventType, "issue.any"];
+		default:
+			return [];
+	}
+}
+
+/** Whether a Sentry trigger config accepts this event. */
+export function sentryTriggerMatches(
+	config: {
+		event: string;
+		projects: TriggerScope;
+		level: TriggerScope;
+	},
+	event: SentryMatchableEvent,
+	_context: MatchContext,
+): MatchResult {
+	if (!event.names.includes(config.event as SentryTriggerEvent)) {
+		return no("event");
+	}
+	if (!scopeAllows(config.projects, event.projectId)) {
+		return no("project");
+	}
+	// Level only narrows when configured; null means the trigger author did not
+	// choose to filter on it, which for this is "any".
+	if (config.level !== null && !scopeAllows(config.level, event.level)) {
+		return no("level");
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -230,11 +230,14 @@ export const sentryTriggerEventValues = [
 	"issue.unresolved",
 	"issue.any",
 ] as const;
+export type SentryTriggerEvent = (typeof sentryTriggerEventValues)[number];
 
 export const sentryTriggerConfigSchema = z.object({
 	kind: z.literal("sentry"),
 	event: z.enum(sentryTriggerEventValues),
+	// Sentry's numeric project ids: a slug can be renamed, the id cannot.
 	projects: triggerScopeSchema,
+	// Optional narrowing over fatal/error/warning/info/debug; "any" by default.
 	level: triggerScopeSchema,
 });
 
@@ -458,7 +461,12 @@ export function describeTriggerProblems(
 				}
 				break;
 			}
-			case "sentry":
+			case "sentry": {
+				if (isEmptyScope(config.projects)) {
+					add(index, "projects", "Specify at least one project.");
+				}
+				break;
+			}
 			case "circleback":
 				break;
 			case "schedule":

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -37,6 +37,8 @@ export const env = createEnv({
 		RELAY_URL: z.string().url(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
+		SENTRY_CLIENT_ID: z.string().optional(),
+		SENTRY_CLIENT_SECRET: z.string().optional(),
 		// Optional: the Teams integration is off wherever these are unset, and
 		// every other environment keeps booting.
 		MICROSOFT_CLIENT_ID: z.string().min(1).optional(),

--- a/packages/trpc/src/lib/integrations/sentry/index.ts
+++ b/packages/trpc/src/lib/integrations/sentry/index.ts
@@ -1,0 +1,13 @@
+export {
+	disconnectSentry,
+	exchangeSentryCode,
+	fetchSentryOrganization,
+	fetchSentryProjects,
+	getSentryAccessToken,
+	SENTRY_URL,
+	type SentryOrganization,
+	type SentryProject,
+	type SentryTokenResponse,
+	sentryTokenResponseSchema,
+	verifySentryInstall,
+} from "../../../router/integration/sentry/utils";

--- a/packages/trpc/src/router/integration/integration.ts
+++ b/packages/trpc/src/router/integration/integration.ts
@@ -8,6 +8,7 @@ import { githubRouter } from "./github";
 import { linearRouter } from "./linear";
 import { microsoftTeamsRouter } from "./microsoft-teams";
 import { notionRouter } from "./notion";
+import { sentryRouter } from "./sentry";
 import { slackRouter } from "./slack";
 import { verifyOrgMembership } from "./utils";
 
@@ -16,6 +17,7 @@ export const integrationRouter = {
 	linear: linearRouter,
 	microsoftTeams: microsoftTeamsRouter,
 	notion: notionRouter,
+	sentry: sentryRouter,
 	slack: slackRouter,
 
 	list: protectedProcedure
@@ -30,7 +32,6 @@ export const integrationRouter = {
 					provider: true,
 					externalOrgId: true,
 					externalOrgName: true,
-					config: true,
 					createdAt: true,
 					updatedAt: true,
 				},

--- a/packages/trpc/src/router/integration/sentry/index.ts
+++ b/packages/trpc/src/router/integration/sentry/index.ts
@@ -1,0 +1,1 @@
+export { sentryRouter } from "./sentry";

--- a/packages/trpc/src/router/integration/sentry/sentry.ts
+++ b/packages/trpc/src/router/integration/sentry/sentry.ts
@@ -1,0 +1,99 @@
+import { db } from "@superset/db/client";
+import { integrationConnections, type SentryConfig } from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure } from "../../../trpc";
+import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { fetchSentryProjects, getSentryAccessToken, SENTRY_URL } from "./utils";
+
+/**
+ * A Sentry connection is a public integration the org installs through Sentry's
+ * OAuth flow — the connect/callback routes under `apps/api` do the install and
+ * token exchange. This router is the read/manage surface the editor and the
+ * settings page use.
+ */
+export const sentryRouter = {
+	getConnection: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "sentry"),
+					isNull(integrationConnections.disconnectedAt),
+				),
+				columns: {
+					id: true,
+					externalOrgId: true,
+					externalOrgName: true,
+					createdAt: true,
+				},
+			});
+
+			if (!connection) return null;
+
+			return {
+				id: connection.id,
+				organizationSlug: connection.externalOrgId,
+				organizationName: connection.externalOrgName,
+				connectedAt: connection.createdAt,
+			};
+		}),
+
+	disconnect: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+
+			const result = await db
+				.delete(integrationConnections)
+				.where(
+					and(
+						eq(integrationConnections.organizationId, input.organizationId),
+						eq(integrationConnections.provider, "sentry"),
+					),
+				)
+				.returning({ id: integrationConnections.id });
+
+			if (result.length === 0) {
+				return { success: false, error: "No connection found" };
+			}
+
+			return { success: true };
+		}),
+
+	/** The org's Sentry projects, as the trigger editor's project chip lists them. */
+	listProjects: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "sentry"),
+					isNull(integrationConnections.disconnectedAt),
+				),
+				columns: { id: true, externalOrgId: true, config: true },
+			});
+			if (!connection?.externalOrgId) return [];
+
+			const token = await getSentryAccessToken(connection.id);
+			if (token.disconnected) return [];
+
+			const config = connection.config as SentryConfig | null;
+			const projects = await fetchSentryProjects(
+				config?.regionUrl ?? SENTRY_URL,
+				connection.externalOrgId,
+				token.accessToken,
+			);
+			return projects.map((project) => ({
+				id: project.id,
+				slug: project.slug,
+				name: project.name,
+			}));
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/integration/sentry/utils.ts
+++ b/packages/trpc/src/router/integration/sentry/utils.ts
@@ -1,0 +1,261 @@
+import { db } from "@superset/db/client";
+import { integrationConnections, type SentryConfig } from "@superset/db/schema";
+import { withConnectionLock } from "@superset/db/utils";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { env } from "../../../env";
+
+/**
+ * The public Sentry integration's REST surface, as far as this provider needs
+ * it: exchange/refresh an installation's token, verify an install, and list a
+ * region's projects.
+ *
+ * sentry.io is the control silo (organizations, app-installation
+ * authorizations); anything scoped to one organization — its projects — must
+ * go to that organization's region URL.
+ */
+export const SENTRY_URL = "https://sentry.io";
+
+/** Refresh a token this many ms before it actually expires. */
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export type SentryProject = { id: string; slug: string; name: string };
+
+export type SentryOrganization = {
+	slug: string;
+	name: string;
+	regionUrl: string;
+};
+
+/**
+ * The single organization an installation's token belongs to, with its region
+ * URL. A public-app token is scoped to one org, so `/organizations/` returns
+ * exactly the one this install is for — which is how the org slug is learned
+ * from the callback, whose query params carry only the code and install id.
+ */
+export async function fetchSentryOrganization(
+	token: string,
+): Promise<SentryOrganization | null> {
+	const response = await fetch(`${SENTRY_URL}/api/0/organizations/`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!response.ok) return null;
+	const orgs = (await response.json()) as Array<{
+		slug: string;
+		name: string;
+		links?: { regionUrl?: string };
+	}>;
+	const [org] = orgs;
+	if (!org) return null;
+	return {
+		slug: org.slug,
+		name: org.name,
+		regionUrl: org.links?.regionUrl ?? SENTRY_URL,
+	};
+}
+
+/**
+ * The token grant Sentry returns from both the authorization-code exchange and
+ * a refresh. Note the camelCase and `expiresAt` (an ISO date), unlike the
+ * snake_case `expires_in` of most OAuth providers.
+ */
+export const sentryTokenResponseSchema = z.object({
+	token: z.string(),
+	refreshToken: z.string(),
+	expiresAt: z.string(),
+});
+export type SentryTokenResponse = z.infer<typeof sentryTokenResponseSchema>;
+
+function authorizationsUrl(installationUuid: string): string {
+	return `${SENTRY_URL}/api/0/sentry-app-installations/${installationUuid}/authorizations/`;
+}
+
+/** Exchange the install's grant code for the first token pair. */
+export async function exchangeSentryCode(params: {
+	installationUuid: string;
+	code: string;
+}): Promise<SentryTokenResponse> {
+	if (!env.SENTRY_CLIENT_ID || !env.SENTRY_CLIENT_SECRET) {
+		throw new Error("Sentry app is not configured");
+	}
+	const response = await fetch(authorizationsUrl(params.installationUuid), {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			grant_type: "authorization_code",
+			code: params.code,
+			client_id: env.SENTRY_CLIENT_ID,
+			client_secret: env.SENTRY_CLIENT_SECRET,
+		}),
+	});
+	if (!response.ok) {
+		throw new Error(`Sentry code exchange failed: ${response.status}`);
+	}
+	return sentryTokenResponseSchema.parse(await response.json());
+}
+
+/** Mark an install "installed" — required when the app has Verify Install on. */
+export async function verifySentryInstall(
+	installationUuid: string,
+	token: string,
+) {
+	await fetch(
+		`${SENTRY_URL}/api/0/sentry-app-installations/${installationUuid}/`,
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({ status: "installed" }),
+		},
+	).catch(() => {
+		// Verify Install is best-effort: the token already works, and a failure
+		// here only leaves the install in "pending" on Sentry's side.
+	});
+}
+
+type TokenResult =
+	| { disconnected: true }
+	| { disconnected: false; accessToken: string };
+
+/**
+ * A usable access token for a connection, refreshing it first when it is within
+ * the buffer of expiry. Public-app tokens live ~8h, so anything cached longer
+ * than a session needs this. Serialized per connection so two callers do not
+ * both burn the one-time refresh token.
+ */
+export async function getSentryAccessToken(
+	connectionId: string,
+): Promise<TokenResult> {
+	return withConnectionLock(connectionId, async (tx) => {
+		const [connection] = await tx
+			.select({
+				accessToken: integrationConnections.accessToken,
+				refreshToken: integrationConnections.refreshToken,
+				tokenExpiresAt: integrationConnections.tokenExpiresAt,
+				disconnectedAt: integrationConnections.disconnectedAt,
+				config: integrationConnections.config,
+			})
+			.from(integrationConnections)
+			.where(eq(integrationConnections.id, connectionId))
+			.limit(1);
+
+		if (!connection || connection.disconnectedAt) return { disconnected: true };
+		if (
+			connection.tokenExpiresAt &&
+			connection.tokenExpiresAt.getTime() > Date.now() + REFRESH_BUFFER_MS
+		) {
+			return { disconnected: false, accessToken: connection.accessToken };
+		}
+		if (!connection.refreshToken || !env.SENTRY_CLIENT_ID) {
+			return { disconnected: false, accessToken: connection.accessToken };
+		}
+
+		// The install uuid is the token endpoint's path segment; without it there
+		// is nothing to refresh against, so the current token is all there is.
+		const installationUuid = (connection.config as SentryConfig | null)
+			?.installationUuid;
+		if (!installationUuid) {
+			return { disconnected: false, accessToken: connection.accessToken };
+		}
+
+		const response = await fetch(authorizationsUrl(installationUuid), {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: connection.refreshToken,
+				client_id: env.SENTRY_CLIENT_ID,
+				client_secret: env.SENTRY_CLIENT_SECRET,
+			}),
+		});
+		if (!response.ok) {
+			if (response.status === 401 || response.status === 403) {
+				await tx
+					.update(integrationConnections)
+					.set({
+						disconnectedAt: new Date(),
+						disconnectReason: "invalid_grant",
+					})
+					.where(eq(integrationConnections.id, connectionId));
+				return { disconnected: true };
+			}
+			throw new Error(`Sentry token refresh failed: ${response.status}`);
+		}
+		const data = sentryTokenResponseSchema.parse(await response.json());
+		await tx
+			.update(integrationConnections)
+			.set({
+				accessToken: data.token,
+				refreshToken: data.refreshToken,
+				tokenExpiresAt: new Date(data.expiresAt),
+			})
+			.where(eq(integrationConnections.id, connectionId));
+		return { disconnected: false, accessToken: data.token };
+	});
+}
+
+const MAX_PAGES = 10;
+
+/** `Link: <url>; rel="next"; results="true"` is Sentry's next-page cursor. */
+function nextLink(response: Response): string | null {
+	const header = response.headers.get("link");
+	if (!header) return null;
+	for (const part of header.split(",")) {
+		if (part.includes('rel="next"') && part.includes('results="true"')) {
+			return part.match(/<([^>]+)>/)?.[1] ?? null;
+		}
+	}
+	return null;
+}
+
+/** Every project in the org, following pagination. */
+export async function fetchSentryProjects(
+	regionUrl: string,
+	organizationSlug: string,
+	token: string,
+): Promise<SentryProject[]> {
+	const items: SentryProject[] = [];
+	let cursor: string | null =
+		`${regionUrl}/api/0/organizations/${encodeURIComponent(
+			organizationSlug,
+		)}/projects/`;
+	for (let page = 0; cursor && page < MAX_PAGES; page++) {
+		const response: Response = await fetch(cursor, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (response.status === 401 || response.status === 403) {
+			throw new TRPCError({
+				code: "UNAUTHORIZED",
+				message: "Sentry rejected the token",
+			});
+		}
+		if (!response.ok) {
+			throw new TRPCError({
+				code: "BAD_GATEWAY",
+				message: `Sentry returned ${response.status}`,
+			});
+		}
+		items.push(...((await response.json()) as SentryProject[]));
+		cursor = nextLink(response);
+	}
+	return items;
+}
+
+/** Mark a connection disconnected and drop its tokens. */
+export async function disconnectSentry(
+	connectionId: string,
+	reason: string,
+): Promise<void> {
+	await db
+		.update(integrationConnections)
+		.set({
+			disconnectedAt: new Date(),
+			disconnectReason: reason,
+			accessToken: "",
+			refreshToken: null,
+		})
+		.where(eq(integrationConnections.id, connectionId));
+}


### PR DESCRIPTION
## Summary

Sentry trigger provider (kind `sentry`): a **public Sentry integration** (OAuth app) connection, the inbound webhook, the editor provider, and the matcher — in one PR, rebased onto the consolidated seam (#6594).

> Product note: an earlier revision of this PR used a Sentry *internal* integration (paste a token + per-connection secret). Satya's call is that internal is too clunky for users, so this is now the public OAuth app. The commit history reflects that pivot.

**Connection — public OAuth app.**
- `GET /api/integrations/sentry/connect?organizationId=` verifies membership and redirects the admin to Sentry's install URL (`/sentry-apps/<slug>/external-install/`). Because Sentry's install redirect echoes no state of ours and its webhooks name no Superset org, the Superset org is carried to the callback in a **signed, first-party cookie** scoped to `/api/integrations/sentry`.
- `GET /api/integrations/sentry/callback` reads `code` + `installationId`, recovers the org from the cookie (re-verifies membership), exchanges the code at `/sentry-app-installations/{id}/authorizations/` for `{token, refreshToken, expiresAt}`, learns the Sentry org slug/region from `/organizations/` with the fresh token, upserts the connection (`installationUuid` + `regionUrl` in `config`), and does the Verify-Install `PUT`.
- Tokens live ~8h; `getSentryAccessToken` refreshes within a 5-min buffer under an advisory lock (Linear's pattern) so `listProjects` keeps working. `getConnection` / `disconnect` / `listProjects` round out the tRPC router.

**Webhook — `POST /api/integrations/sentry/webhook`.** One fixed URL for the app. Verified first with the app's single client secret (`SENTRY_CLIENT_SECRET`, env) via constant-time HMAC-SHA256 over the raw body. The delivery is attributed by `installation.uuid` (the callback stored it on the connection); `?organization=` remains a fallback only if a payload carries no installation. `installation.created` is a no-op (the callback is the only writer that knows the org); `installation.deleted` disconnects the connection **and drops its tokens**, so a later issue delivery for that install is refused. Issue deliveries are recorded (`recordAutomationEvent`, connection-scoped dedupe) and dispatched via the shared `@/lib/automations/dispatchMatchingTriggers`.

**The create race (called out because it bites in prod).** Sentry fires `installation.created` and redirects the browser in parallel; either can land first. Only the callback knows the Superset org, so it is the sole creator (upsert on `(org, provider)`); the webhook only ever updates a row the callback already wrote, or no-ops if it hasn't yet. Both orders — and an issue delivery arriving before the callback finishes — are handled without a "row exists"/"row not found" failure. Verified both orders below.

**Desktop.** `providers/sentry/` — sentence `Sentry issue [created|resolved|assigned|archived|unresolved|any] in [projects] with level [levels]`; menu Sentry › the six events; `projects` starts `null` (save-blocked until chosen), `level` starts `{mode:"any"}` (a set, not a threshold). Namespaced options: `useSentryOptions` → `{ sentry: { projects, levels } }`.

**Shared.** `automation-matching/sentry.ts` (`SentryMatchableEvent`, `sentryEventNames`, `sentryTriggerMatches`), added to the `MatchableEvent` union + a `case` in `triggerMatches`; sentry rules in `describeTriggerProblems`. No edits to `providers/types.ts`, `automation-matching/core.ts`, or the shared dispatcher.

### Security bullet
- **`integration.list` no longer returns `config`.** It handed the whole `config` jsonb to every org member; Sentry stores its `installationUuid` there (the webhook's link back to the row). Nothing read `config` from `list`.

## Verification (workspace Neon branch; API-only, `SENTRY_CLIENT_SECRET` set in env; desktop editor unchanged from the prior rebase, so its screenshots stand — `s17-after-reload.png`, `s18-post-rebase-level-menu.png`)

Signed replays (HMAC over the exact body with the env client secret):
- Bad signature → **401**. `installation.created` (row already present) → **200** no-op, connection unchanged.
- Valid `issue.created` level `error`, matching install uuid → **matched** → reaches the shared dispatcher's `qstash.batchJSON` (fails locally with QStash's `endpoint resolves to a loopback address` — the standard local "matched" signal) and writes an `automation_events` row (`provider=sentry`, `event_type=issue.created`, `external_event_id=<Request-ID>`, `resource_key=sentry:<projectId>#<issueId>`, `integration_connection_id`).
- Same Request-ID again → **200 `duplicate delivery`**, no second row. Level `info` (trigger filters fatal+error) → **200**, not matched. Unknown install uuid → **200 `No connection`**.
- `installation.deleted` → connection `disconnected_at` set, reason recorded, `access_token` emptied, `refresh_token` nulled; a subsequent issue delivery for that install → **200 `No connection`** (refused).
- `bun run typecheck` → exit 0; `bun run lint` → exit 0.

Not exercised locally (needs a registered Sentry app, which is the external item below): the browser install/redirect, the real code→token exchange and refresh, `listProjects` against a live token, and Verify-Install. The token exchange / refresh / org-lookup calls are structured to Sentry's documented public-app contract.

## External item (for Satya)
Register the Superset public integration in Sentry: name, **Redirect URL** = `<API>/api/integrations/sentry/callback`, **Webhook URL** = `<API>/api/integrations/sentry/webhook`, permissions Organization/Project/Issue&Event: Read, the `issue` webhook, Verify Install on. Then set `SENTRY_CLIENT_ID` / `SENTRY_CLIENT_SECRET` / `SENTRY_APP_SLUG`. **Until Sentry publishes the app, only Superset's own Sentry org can install it** — that's inherent to Sentry's public-integration model.

## Follow-ups
- Marketplace-initiated installs (from Sentry, not our Connect button) have no org cookie and currently error to "start from Superset"; a Sentry-side install landing page could attribute via the authenticated session's active org later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentry integration with OAuth connection and disconnection flows.
  * Added Sentry organization and project browsing.
  * Added Sentry automation triggers with project and severity-level filters.
  * Added webhook processing for Sentry issue events, including duplicate prevention and trigger dispatch.
  * Added Sentry to the integrations directory with connection status and error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->