### PR TITLE
refactor(desktop,shared,api): consolidate the three GitHub-shaped seam surfaces

### DIFF
--- a/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
+++ b/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
@@ -1,37 +1,32 @@
-import { dbWs } from "@superset/db/client";
 import {
-	automations,
-	automationTriggers,
-	userIdentities,
-} from "@superset/db/schema";
-import {
+	type GithubMatchableEvent,
 	githubEventNames,
-	type MatchableEvent,
-	triggerMatches,
 } from "@superset/shared/automation-matching";
-import { Client } from "@upstash/qstash";
-import { and, eq } from "drizzle-orm";
-
-import { env } from "@/env";
+import { dispatchMatchingTriggers as dispatch } from "@/lib/automations/dispatchMatchingTriggers";
 import type { GithubPayload } from "./recordAutomationEvent";
 
-const qstash = new Client({
-	token: env.QSTASH_TOKEN,
-	baseUrl: env.QSTASH_URL,
-});
-
 /**
- * Fields the matcher needs that are not columns on `automation_events` — they
- * only exist inside the payload, and only for some events.
+ * Normalizes a GitHub delivery into what GitHub triggers filter on. Every
+ * field here exists only inside the payload, and only for some events — the
+ * columns on `automation_events` are what every provider shares; this is what
+ * GitHub adds.
  */
 function matchableFrom(
 	payload: GithubPayload,
 	eventType: string,
 	repositoryId: string | null,
 	ref: string | null,
-): MatchableEvent {
+): GithubMatchableEvent {
 	return {
+		provider: "github",
 		eventType,
+		names: githubEventNames({
+			eventType,
+			isDraft: payload.pull_request?.draft === true,
+			reviewState: payload.review?.state ?? null,
+			runConclusion: payload.workflow_run?.conclusion ?? null,
+			threadResolved: null,
+		}),
 		repositoryId,
 		ref,
 		actorId:
@@ -54,11 +49,9 @@ function matchableFrom(
 }
 
 /**
- * Finds the triggers an event satisfies and enqueues a run for each.
- *
- * Only automations that are enabled are considered — that toggle is the gate a
- * person actually controls, so an automation someone paused stops firing
- * without needing its triggers disabled one by one.
+ * GitHub's entry into the shared dispatcher: normalize, then hand off. The
+ * candidate query, identity lookup and QStash publish live in
+ * `@/lib/automations/dispatchMatchingTriggers`, once, for every provider.
  */
 export async function dispatchMatchingTriggers(params: {
 	organizationId: string;
@@ -68,95 +61,18 @@ export async function dispatchMatchingTriggers(params: {
 	ref: string | null;
 	payload: GithubPayload;
 }): Promise<{ matched: number; considered: number }> {
-	const names = githubEventNames({
-		eventType: params.eventType,
-		isDraft: params.payload.pull_request?.draft === true,
-		reviewState: params.payload.review?.state ?? null,
-		runConclusion: params.payload.workflow_run?.conclusion ?? null,
-		threadResolved: null,
-	});
-	// Nothing in the product names this delivery, so there is nothing to match.
-	if (names.length === 0) return { matched: 0, considered: 0 };
-
-	const candidates = await dbWs
-		.select({
-			triggerId: automationTriggers.id,
-			config: automationTriggers.config,
-			automationId: automations.id,
-			ownerUserId: automations.ownerUserId,
-		})
-		.from(automationTriggers)
-		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
-		.where(
-			and(
-				eq(automationTriggers.organizationId, params.organizationId),
-				eq(automationTriggers.kind, "github"),
-				eq(automationTriggers.enabled, true),
-				eq(automations.enabled, true),
-			),
-		);
-
-	if (candidates.length === 0) return { matched: 0, considered: 0 };
-
-	// Every GitHub identity linked in this org, so `me` can resolve to the
-	// automation owner. A person may link more than one account — work and
-	// personal — so this is a set per user, not a value.
-	const identities = await dbWs
-		.select({
-			userId: userIdentities.userId,
-			externalId: userIdentities.externalId,
-		})
-		.from(userIdentities)
-		.where(
-			and(
-				eq(userIdentities.organizationId, params.organizationId),
-				eq(userIdentities.provider, "github"),
-			),
-		);
-	const githubIdsByUser = new Map<string, string[]>();
-	for (const row of identities) {
-		const existing = githubIdsByUser.get(row.userId);
-		if (existing) existing.push(row.externalId);
-		else githubIdsByUser.set(row.userId, [row.externalId]);
-	}
-
 	const event = matchableFrom(
 		params.payload,
 		params.eventType,
 		params.repositoryId,
 		params.ref,
 	);
+	// Nothing in the product names this delivery, so there is nothing to match.
+	if (event.names.length === 0) return { matched: 0, considered: 0 };
 
-	const matched = candidates.filter(
-		(candidate) =>
-			triggerMatches(candidate.config, event, {
-				// Resolved per candidate: two automations can watch the same event
-				// on behalf of different owners.
-				github: {
-					names,
-					ownerIds: githubIdsByUser.get(candidate.ownerUserId) ?? [],
-				},
-			}).matches,
-	);
-
-	if (matched.length === 0) {
-		return { matched: 0, considered: candidates.length };
-	}
-
-	await qstash.batchJSON(
-		matched.map((candidate) => ({
-			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${candidate.automationId}`,
-			body: {
-				automationId: candidate.automationId,
-				triggerId: candidate.triggerId,
-				eventId: params.eventId,
-			},
-			// One run per trigger per event, however many times GitHub redelivers.
-			deduplicationId: `${candidate.triggerId}_${params.eventId}`,
-			retries: 2,
-			failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
-		})),
-	);
-
-	return { matched: matched.length, considered: candidates.length };
+	return dispatch({
+		organizationId: params.organizationId,
+		eventId: params.eventId,
+		event,
+	});
 }

--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -1,0 +1,116 @@
+import { dbWs } from "@superset/db/client";
+import {
+	automations,
+	automationTriggers,
+	userIdentities,
+} from "@superset/db/schema";
+import {
+	type MatchableEvent,
+	triggerMatches,
+} from "@superset/shared/automation-matching";
+import { Client } from "@upstash/qstash";
+import { and, eq } from "drizzle-orm";
+import { env } from "@/env";
+
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+});
+
+/**
+ * Finds the triggers an event satisfies and enqueues a run for each.
+ *
+ * Provider-agnostic: the caller has already normalized its payload into a
+ * `MatchableEvent`, whose `provider` selects both the trigger kind to consider
+ * and the identity provider `me` resolves through. Every inbound route —
+ * GitHub, Slack, Linear, a raw webhook — ends in this one function, so the
+ * candidate query, the owner-identity lookup, and the QStash publish exist
+ * exactly once.
+ *
+ * Only automations that are enabled are considered — that toggle is the gate a
+ * person actually controls, so an automation someone paused stops firing
+ * without needing its triggers disabled one by one.
+ */
+export async function dispatchMatchingTriggers(params: {
+	organizationId: string;
+	eventId: string;
+	event: MatchableEvent;
+}): Promise<{ matched: number; considered: number }> {
+	const { event } = params;
+
+	const candidates = await dbWs
+		.select({
+			triggerId: automationTriggers.id,
+			config: automationTriggers.config,
+			automationId: automations.id,
+			ownerUserId: automations.ownerUserId,
+		})
+		.from(automationTriggers)
+		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
+		.where(
+			and(
+				eq(automationTriggers.organizationId, params.organizationId),
+				// The kind enum and the provider discriminant share values by
+				// construction; a provider whose kind name differed would need a
+				// map here, and none does.
+				eq(automationTriggers.kind, event.provider as never),
+				eq(automationTriggers.enabled, true),
+				eq(automations.enabled, true),
+			),
+		);
+
+	if (candidates.length === 0) return { matched: 0, considered: 0 };
+
+	// Every identity linked in this org for this provider, so `me` can resolve
+	// to the automation owner. A person may link more than one account — work
+	// and personal — so this is a set per user, not a value.
+	const identities = await dbWs
+		.select({
+			userId: userIdentities.userId,
+			externalId: userIdentities.externalId,
+		})
+		.from(userIdentities)
+		.where(
+			and(
+				eq(userIdentities.organizationId, params.organizationId),
+				eq(userIdentities.provider, event.provider),
+			),
+		);
+	const idsByUser = new Map<string, string[]>();
+	for (const row of identities) {
+		const existing = idsByUser.get(row.userId);
+		if (existing) existing.push(row.externalId);
+		else idsByUser.set(row.userId, [row.externalId]);
+	}
+
+	const matched = candidates.filter(
+		(candidate) =>
+			triggerMatches(candidate.config, event, {
+				// Resolved per candidate: two automations can watch the same event
+				// on behalf of different owners.
+				ownerIds: idsByUser.get(candidate.ownerUserId) ?? [],
+			}).matches,
+	);
+
+	if (matched.length === 0) {
+		return { matched: 0, considered: candidates.length };
+	}
+
+	await qstash.batchJSON(
+		matched.map((candidate) => ({
+			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${candidate.automationId}`,
+			body: {
+				automationId: candidate.automationId,
+				triggerId: candidate.triggerId,
+				eventId: params.eventId,
+			},
+			// One run per trigger per event, however many times the provider
+			// redelivers.
+			deduplicationId: `${candidate.triggerId}_${params.eventId}`,
+			retries: 2,
+			failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
+		})),
+	);
+
+	return { matched: matched.length, considered: candidates.length };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/TriggerSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/TriggerSentence.tsx
@@ -50,6 +50,7 @@ export function TriggerSentence({
 			<Icon className="size-4 shrink-0 text-muted-foreground" />
 
 			{provider.renderSentence(config, {
+				triggerId: trigger.id,
 				set: (patch) =>
 					onChange({ ...trigger, config: { ...config, ...patch } as never }),
 				mark: (field) => (invalid.has(field) ? CHIP_INVALID : undefined),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/github.tsx
@@ -38,7 +38,7 @@ function renderPart(
 					scope={c.repositories}
 					onChange={(v) => set({ repositories: v })}
 					className={mark("repositories")}
-					options={options.repositories ?? []}
+					options={options.github?.repositories ?? []}
 					emptyLabel="Select repos"
 					anyLabel="Any repo"
 					disabled={disabled}
@@ -77,7 +77,7 @@ function renderPart(
 					actor={c.actor}
 					onChange={(v) => set({ actor: v })}
 					className={mark("actor")}
-					people={options.people ?? []}
+					people={options.github?.people ?? []}
 					disabled={disabled}
 				/>
 			);
@@ -88,7 +88,7 @@ function renderPart(
 					actor={c.subjectAuthor}
 					onChange={(v) => set({ subjectAuthor: v })}
 					className={mark("subjectAuthor")}
-					people={options.people ?? []}
+					people={options.github?.people ?? []}
 					disabled={disabled}
 				/>
 			);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
@@ -17,11 +17,13 @@ export function useGithubOptions(organizationId: string): ProviderOptions {
 
 	return useMemo(
 		() => ({
-			repositories: (repos.data ?? []).map((repo) => ({
-				id: repo.repoId,
-				label: repo.fullName,
-			})),
-			people: people.data ?? [],
+			github: {
+				repositories: (repos.data ?? []).map((repo) => ({
+					id: repo.repoId,
+					label: repo.fullName,
+				})),
+				people: people.data ?? [],
+			},
 		}),
 		[repos.data, people.data],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -5,7 +5,6 @@ import type { TriggerProvider } from "./types";
 import { webhookProvider } from "./webhook/webhook";
 
 export type {
-	OptionKey,
 	ProviderOptions,
 	SentenceContext,
 	TriggerMenuEntry,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/types.ts
@@ -47,6 +47,12 @@ export type TriggerMenuEntry<
  * for this provider.
  */
 export type SentenceContext = {
+	/**
+	 * The saved trigger's id, absent until first save. Providers whose row
+	 * shows something keyed on the row itself — a webhook URL, a per-trigger
+	 * secret — need it; everything else ignores it.
+	 */
+	triggerId?: string;
 	set: (patch: Record<string, unknown>) => void;
 	mark: (field: string) => string | undefined;
 	options: ProviderOptions;
@@ -56,10 +62,17 @@ export type SentenceContext = {
 };
 
 /**
- * Pickable values, keyed by what they are rather than by provider — a Slack
- * channel list and a GitHub repo list are both `ScopeOption[]`, and the chip
- * that renders them does not care which.
+ * Pickable values, namespaced by provider: `options.github.repositories`,
+ * `options.slack.channels`. Each provider declares its own keys and never
+ * touches this type again.
+ *
+ * Not a flat "kind of thing" namespace — that was tried, and it doesn't hold:
+ * `people` for GitHub is numeric GitHub ids while `people` for Slack is Slack
+ * user ids, and `projects` means different things to Linear and Sentry. A flat
+ * key either clobbers on merge or forces every provider to invent a prefixed
+ * key and edit this file to add it, which is the merge collision the seam
+ * exists to prevent.
  */
-export type ProviderOptions = Partial<Record<OptionKey, ScopeOption[]>>;
-
-export type OptionKey = "repositories" | "people" | "channels" | "teams";
+export type ProviderOptions = Partial<
+	Record<string, Record<string, ScopeOption[] | undefined>>
+>;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -7,7 +7,8 @@ import type { ProviderOptions } from "./types";
  *
  * Hooks cannot be called from a registry loop, so each provider's hook is
  * called here by name. Adding a provider with options means adding its hook to
- * this list; the keys they fill are disjoint, so the merge is a spread.
+ * this list. Each hook returns its own top-level key (`{ github: {...} }`), so
+ * the merge is a spread and cannot clobber.
  */
 export function useProviderOptions(organizationId: string): ProviderOptions {
 	const github = useGithubOptions(organizationId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalAgentAutoResume/TerminalAgentAutoResume.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalAgentAutoResume/TerminalAgentAutoResume.tsx
@@ -137,15 +137,14 @@ export function TerminalAgentAutoResume({
 					aria-hidden="true"
 					className="size-3.5 shrink-0 text-muted-foreground"
 				/>
-				<span
-					role="status"
+				<output
 					aria-live="polite"
 					className="whitespace-nowrap text-xs text-muted-foreground"
 				>
 					{failed
 						? `Failed to resume ${candidate.agentLabel}`
 						: `Resuming ${candidate.agentLabel}…`}
-				</span>
+				</output>
 				{failed && (
 					<>
 						<Button

--- a/packages/shared/src/automation-matching/core.ts
+++ b/packages/shared/src/automation-matching/core.ts
@@ -9,24 +9,32 @@ import type { TriggerActor, TriggerScope } from "../automation-triggers";
  * allowed to dispatch.
  */
 
-/** The normalized event, as recorded. */
-export type MatchableEvent = {
+/**
+ * The fields every provider's event carries. A provider's own event type
+ * extends this with what its filters compare against — see
+ * `GithubMatchableEvent`. Matchers receive their provider's type, never this
+ * base; the `provider` discriminant is what narrows the union in
+ * `triggerMatches`.
+ */
+export type BaseMatchableEvent = {
+	provider: string;
 	/** Qualified with its action, e.g. `pull_request.opened`. */
 	eventType: string;
-	repositoryId: string | null;
-	ref: string | null;
-	/** GitHub's numeric id; what people filters compare against. */
+	/** The provider's id for whoever caused the event; what people filters compare against. */
 	actorId: string | null;
-	/** Display only — a login can be renamed, the id cannot. */
+	/** Display only — a handle can be renamed, the id cannot. */
 	actorLogin: string | null;
-	actorIsExternal: boolean | null;
-	labels: string[];
-	/** Comment or review body, when the event carries one. */
+	/** Comment, message, or review body when the event carries one. */
 	body: string | null;
-	/** Fork pull requests carry attacker-controlled content into a checkout. */
-	isFork: boolean;
-	/** Who opened the thing being commented on. */
-	subjectAuthorId: string | null;
+};
+
+/**
+ * What matchers need beyond the event: the automation owner's linked ids for
+ * this provider, so `me` resolves. One shape for every provider — anything
+ * provider-specific belongs on that provider's event type, not here.
+ */
+export type MatchContext = {
+	ownerIds: string[];
 };
 
 export type MatchResult =

--- a/packages/shared/src/automation-matching/github.ts
+++ b/packages/shared/src/automation-matching/github.ts
@@ -5,12 +5,28 @@ import type {
 } from "../automation-triggers";
 import {
 	actorAllows,
+	type BaseMatchableEvent,
 	bodyMatches,
-	type MatchableEvent,
+	type MatchContext,
 	type MatchResult,
 	scopeAllows,
 	scopeAllowsAny,
 } from "./core";
+
+/** A GitHub delivery, normalized to what GitHub triggers filter on. */
+export type GithubMatchableEvent = BaseMatchableEvent & {
+	provider: "github";
+	repositoryId: string | null;
+	ref: string | null;
+	actorIsExternal: boolean | null;
+	labels: string[];
+	/** Fork pull requests carry attacker-controlled content into a checkout. */
+	isFork: boolean;
+	/** Who opened the thing being commented on. */
+	subjectAuthorId: string | null;
+	/** The product-level names this delivery maps to; see githubEventNames. */
+	names: GithubTriggerEvent[];
+};
 
 const no = (reason: string): MatchResult => ({ matches: false, reason });
 
@@ -90,10 +106,10 @@ export function githubTriggerMatches(
 		commentFilter?: { pattern: string; isRegex: boolean } | null;
 		includeForks: boolean;
 	},
-	event: MatchableEvent,
-	context: { names: GithubTriggerEvent[]; ownerIds: string[] },
+	event: GithubMatchableEvent,
+	context: MatchContext,
 ): MatchResult {
-	if (!context.names.includes(config.event as GithubTriggerEvent)) {
+	if (!event.names.includes(config.event as GithubTriggerEvent)) {
 		return no("event");
 	}
 	if (!scopeAllows(config.repositories, event.repositoryId)) {

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -1,37 +1,58 @@
 import type { TriggerConfigInput } from "../automation-triggers";
-import type { MatchableEvent, MatchResult } from "./core";
-import { githubTriggerMatches } from "./github";
+import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
+import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
 
 export * from "./core";
 export * from "./github";
 
 /**
- * Per-provider context the matcher needs beyond the event itself. Keyed by
- * provider so a Slack matcher can carry different context without every
- * caller learning about it.
+ * Every provider's normalized event, discriminated by `provider`.
+ *
+ * Adding a provider: define `<Name>MatchableEvent = BaseMatchableEvent & {
+ * provider: "<kind>"; …fields its filters compare against }` in its own module,
+ * add it to this union, and add a `case` below. Provider-specific fields live
+ * on the event, never on `MatchContext` — a Slack matcher must not need to
+ * know that a GitHub context key exists.
  */
-export type MatchContext = {
-	github?: Parameters<typeof githubTriggerMatches>[2];
-};
+export type MatchableEvent = GithubMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
  *
- * Dispatches on `config.kind` so the webhook route never names a provider. A
- * kind with no matcher here does not match — an event arriving for a provider
- * that cannot yet evaluate it must not fire the automation by default.
+ * Dispatches on `config.kind` and requires the event to be from the same
+ * provider — a Slack trigger never sees a GitHub event, so a mismatched pair
+ * is a caller bug and is refused rather than silently matched. A kind with no
+ * matcher does not match: an event arriving for a provider that cannot yet
+ * evaluate it must not fire the automation by default.
  */
 export function triggerMatches(
 	config: TriggerConfigInput,
 	event: MatchableEvent,
 	context: MatchContext,
 ): MatchResult {
-	switch (config.kind) {
-		case "github":
-			return context.github
-				? githubTriggerMatches(config, event, context.github)
-				: { matches: false, reason: "no github context" };
-		default:
-			return { matches: false, reason: `no matcher for ${config.kind}` };
+	if (config.kind !== event.provider) {
+		return {
+			matches: false,
+			reason: `${config.kind} trigger cannot match a ${event.provider} event`,
+		};
 	}
+	// Narrow on the event's discriminant, not the config's: with the union at
+	// one member the config-side switch collapses `default` to `never`, and
+	// the event is the thing that actually carries provider-shaped fields.
+	switch (event.provider) {
+		case "github":
+			return githubTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "github" }>,
+				event,
+				context,
+			);
+	}
+	// Reached only when a provider is in the union but has no case above.
+	return {
+		matches: false,
+		reason: `no matcher for ${(event as BaseMatchableEvent).provider}`,
+	};
 }
+
+/** Guard for provider modules that need the base shape without the union. */
+export type { BaseMatchableEvent };


### PR DESCRIPTION
## Why

Eight provider agents building in parallel off #6571 all hit the same three walls in the first hour, and each patched them differently. This lands one answer so they rebase onto it instead of merging eight divergent copies. **Every provider PR (#6586, #6587, #6589, #6591, #6592, #6593 + Google, Circleback) rebases onto this.**

## The three surfaces

**1. Options → namespaced by provider.** `OptionKey` was a flat "kind of thing" namespace; `people` for GitHub is numeric ids and for Slack is Slack user ids, `projects` means different things to Linear and Sentry. Five agents each added a key to `types.ts`. Now `options.github.repositories`, `options.slack.channels`; nobody touches `types.ts` again.

**2. MatchableEvent → provider-typed, discriminated by `provider`.** It was GitHub's normalized event under a generic name (`repositoryId`, `isFork`, `subjectAuthorId` mean nothing to Slack), so every agent stuffed real fields into `MatchContext.<provider>`. Now `BaseMatchableEvent` holds only what's shared (`eventType`, `actorId`, `actorLogin`, `body`), each provider defines `<Name>MatchableEvent`, and `MatchContext` is just `{ ownerIds }` — the one genuinely cross-provider thing, since it's how `me` resolves. `triggerMatches` switches on `event.provider` and refuses a config/event provider mismatch.

**3. One dispatcher.** `dispatchMatchingTriggers` was `GithubPayload`-typed, so three agents forked it. Its body is provider-agnostic — candidate query, identity map, match loop, QStash publish. Lifted to `apps/api/src/lib/automations/dispatchMatchingTriggers.ts` selecting by `kind = event.provider`; GitHub's file is now a ~60-line normalizer that calls it.

Also `SentenceContext.triggerId` (three agents needed it) and main's a11y lint failure in `TerminalAgentAutoResume` (was painting every provider PR red).

## Verification
Zero behaviour change for GitHub. Typecheck and lint clean across all 38 packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the provider seam: options are namespaced by provider, events are provider-typed, and dispatching is centralized. This removes GitHub-shaped assumptions and unblocks new providers without divergent copies. GitHub behavior is unchanged.

- Provider options: `ProviderOptions` is now namespaced (e.g. `options.github.repositories`, `options.github.people`). Update reads/writes from flat keys to namespaced keys. Each hook returns its own top-level key (e.g. `{ github: {...} }`).
- Events and matching: `MatchableEvent` is a union discriminated by `event.provider`; shared fields live on `BaseMatchableEvent`. `MatchContext` is now `{ ownerIds }` only. GitHub adds `names`, `repositoryId`, `isFork`, etc. `triggerMatches` switches on `event.provider` and rejects a config/event provider mismatch.
- Dispatching: Introduces `apps/api/src/lib/automations/dispatchMatchingTriggers.ts`, a provider-agnostic dispatcher; the GitHub webhook normalizes then calls it. Candidate query, identity lookup, and QStash publish now exist once.
- UI: `SentenceContext` includes optional `triggerId` for rows that render per-trigger artifacts. Fixes an a11y lint by replacing a `span role="status"` with `output`.

<sup>Written for commit b6b688ae78a07b542e3592a5941159c0200e9af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

