### PR TITLE
feat(automations): Google Calendar + Gmail trigger providers on one Google connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,8 @@ SECRETS_ENCRYPTION_KEY=
 # -----------------------------------------------------------------------------
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+GOOGLE_PUBSUB_TOPIC=
+GOOGLE_PUBSUB_PUSH_TOKEN=
 GH_CLIENT_ID=
 GH_CLIENT_SECRET=
 

--- a/apps/api/src/app/api/integrations/google/calendar/push/route.ts
+++ b/apps/api/src/app/api/integrations/google/calendar/push/route.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { db } from "@superset/db/client";
 import { integrationConnections } from "@superset/db/schema";
 import { googleConfigOf } from "@superset/trpc/integrations/google";
@@ -50,12 +50,15 @@ export async function POST(request: Request) {
 	const entry = Object.entries(calendars).find(
 		([, s]) => s.channelId === channelId,
 	);
-	const expected = entry?.[1].channelToken;
+	// Only the hash is stored (the config column reaches every member's
+	// client); the token Google echoes is hashed the same way and compared.
+	const expected = entry?.[1].channelTokenHash;
+	const presented = createHash("sha256").update(token).digest("hex");
 	if (
 		!entry ||
 		!expected ||
-		expected.length !== token.length ||
-		!timingSafeEqual(Buffer.from(expected), Buffer.from(token))
+		expected.length !== presented.length ||
+		!timingSafeEqual(Buffer.from(expected), Buffer.from(presented))
 	) {
 		return Response.json({ error: "Invalid channel token" }, { status: 401 });
 	}

--- a/apps/api/src/app/api/integrations/google/calendar/push/route.ts
+++ b/apps/api/src/app/api/integrations/google/calendar/push/route.ts
@@ -1,0 +1,80 @@
+import { timingSafeEqual } from "node:crypto";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { googleConfigOf } from "@superset/trpc/integrations/google";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { syncCalendar } from "../../lib/syncCalendar";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+/**
+ * Google Calendar push notifications.
+ *
+ * The body is empty and nothing is signed: the request is trusted because it
+ * names a channel we opened and carries the token we chose for it. State
+ * `sync` is the channel's hello; anything else means the calendar changed and
+ * the sync token turns that into the actual events.
+ */
+export async function POST(request: Request) {
+	const channelId = request.headers.get("x-goog-channel-id");
+	const token = request.headers.get("x-goog-channel-token");
+	const state = request.headers.get("x-goog-resource-state");
+	if (!channelId || !token) {
+		return Response.json({ error: "Missing channel headers" }, { status: 400 });
+	}
+
+	// One channel per calendar per connection: find the connection whose
+	// calendar state holds this channel id.
+	const [connection] = await db
+		.select()
+		.from(integrationConnections)
+		.where(
+			and(
+				eq(integrationConnections.provider, "google"),
+				isNull(integrationConnections.disconnectedAt),
+				sql`EXISTS (
+					SELECT 1 FROM jsonb_each(coalesce(${integrationConnections.config} -> 'calendars', '{}'::jsonb)) AS c
+					WHERE c.value ->> 'channelId' = ${channelId}
+				)`,
+			),
+		)
+		.limit(1);
+	if (!connection) {
+		// A channel from a disconnected account, or one this deploy never
+		// opened. 404 tells Google to stop retrying it; the channel expires.
+		return Response.json({ error: "Unknown channel" }, { status: 404 });
+	}
+
+	const calendars = googleConfigOf(connection.config).calendars ?? {};
+	const entry = Object.entries(calendars).find(
+		([, s]) => s.channelId === channelId,
+	);
+	const expected = entry?.[1].channelToken;
+	if (
+		!entry ||
+		!expected ||
+		expected.length !== token.length ||
+		!timingSafeEqual(Buffer.from(expected), Buffer.from(token))
+	) {
+		return Response.json({ error: "Invalid channel token" }, { status: 401 });
+	}
+	const [calendarId] = entry;
+
+	if (state === "sync") return Response.json({ ok: true, state });
+
+	try {
+		const result = await syncCalendar(connection, calendarId);
+		if (result.recorded > 0) {
+			console.log(
+				`[google/calendar/push] ${calendarId}: ${result.recorded} recorded, ${result.matched} matched`,
+			);
+		}
+		return Response.json({ ok: true, ...result });
+	} catch (error) {
+		console.error("[google/calendar/push] sync failed:", error);
+		// Non-2xx makes Google retry with backoff, which is what a transient
+		// failure wants; the sync token is only advanced on success.
+		return Response.json({ error: "Sync failed" }, { status: 500 });
+	}
+}

--- a/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
+++ b/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import {
 	accountDomain,
+	accountEmail,
 	calendarPayload,
 	matchableCalendarEvent,
 	resourceKeyFor,
@@ -70,6 +71,7 @@ export async function POST(request: Request) {
 		fire.fire === "starting_soon" ? "event.starting_soon" : "event.ended";
 	const matchable = matchableCalendarEvent({
 		eventType,
+		accountEmail: accountEmail(connection),
 		calendarId: fire.calendarId,
 		event,
 		domain: accountDomain(connection),

--- a/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
+++ b/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
@@ -1,0 +1,103 @@
+import {
+	eventEnd,
+	eventStart,
+	findGoogleConnectionById,
+	getEvent,
+} from "@superset/trpc/integrations/google";
+import { z } from "zod";
+import {
+	accountDomain,
+	calendarPayload,
+	matchableCalendarEvent,
+	resourceKeyFor,
+} from "../../lib/calendarEvents";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import { recordGoogleEvent } from "../../lib/recordGoogleEvent";
+import { verifyQstashRequest } from "../../lib/verifyQstash";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+const fireSchema = z.object({
+	connectionId: z.string().uuid(),
+	calendarId: z.string().min(1),
+	eventId: z.string().min(1),
+	fire: z.enum(["starting_soon", "ended"]),
+	minutesBefore: z.number().int().positive().nullable(),
+	expectedAt: z.string().datetime(),
+});
+
+/**
+ * A `starting_soon` or `ended` fire, delivered by QStash at the moment it was
+ * scheduled for. The event is read again before anything is recorded: if it
+ * was moved or cancelled after the fire was scheduled, this delivery is stale
+ * and the sweep has (or will have) scheduled the right one.
+ */
+export async function POST(request: Request) {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(
+		request,
+		body,
+		"/api/integrations/google/calendar/scheduled",
+	);
+	if (rejected) return rejected;
+
+	const parsed = fireSchema.safeParse(JSON.parse(body));
+	if (!parsed.success) {
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+	const fire = parsed.data;
+
+	const connection = await findGoogleConnectionById(fire.connectionId);
+	if (!connection || connection.disconnectedAt) {
+		return Response.json({ ok: true, skipped: "disconnected" });
+	}
+
+	const event = await getEvent(connection.id, fire.calendarId, fire.eventId);
+	if (!event || event.status === "cancelled") {
+		return Response.json({ ok: true, skipped: "cancelled" });
+	}
+	const anchor =
+		fire.fire === "starting_soon" ? eventStart(event) : eventEnd(event);
+	if (
+		!anchor ||
+		anchor.toISOString() !== new Date(fire.expectedAt).toISOString()
+	) {
+		return Response.json({ ok: true, skipped: "moved" });
+	}
+
+	const eventType =
+		fire.fire === "starting_soon" ? "event.starting_soon" : "event.ended";
+	const matchable = matchableCalendarEvent({
+		eventType,
+		calendarId: fire.calendarId,
+		event,
+		domain: accountDomain(connection),
+		minutesBefore: fire.minutesBefore ?? undefined,
+	});
+	const inserted = await recordGoogleEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		provider: "google_calendar",
+		eventType,
+		externalEventId: `${fire.calendarId}:${fire.eventId}:${fire.expectedAt}:${fire.fire}:${fire.minutesBefore ?? ""}`,
+		resourceKey: resourceKeyFor(connection.id, fire.calendarId, fire.eventId),
+		title: event.summary ?? fire.eventId,
+		url: event.htmlLink ?? null,
+		actorLogin: event.organizer?.email?.toLowerCase() ?? null,
+		actorIsExternal: matchable.hasExternalAttendee,
+		payload: calendarPayload(fire.calendarId, event, matchable, {
+			fire: fire.fire,
+			minutesBefore: fire.minutesBefore,
+			expectedAt: fire.expectedAt,
+		}),
+	});
+	if (!inserted) return Response.json({ ok: true, skipped: "duplicate" });
+
+	const result = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: inserted.eventId,
+		event: matchable,
+	});
+	return Response.json({ ok: true, eventId: inserted.eventId, ...result });
+}

--- a/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
+++ b/apps/api/src/app/api/integrations/google/calendar/scheduled/route.ts
@@ -5,13 +5,13 @@ import {
 	getEvent,
 } from "@superset/trpc/integrations/google";
 import { z } from "zod";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import {
 	accountDomain,
 	calendarPayload,
 	matchableCalendarEvent,
 	resourceKeyFor,
 } from "../../lib/calendarEvents";
-import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import { recordGoogleEvent } from "../../lib/recordGoogleEvent";
 import { verifyQstashRequest } from "../../lib/verifyQstash";
 

--- a/apps/api/src/app/api/integrations/google/callback/route.ts
+++ b/apps/api/src/app/api/integrations/google/callback/route.ts
@@ -1,0 +1,188 @@
+import { db } from "@superset/db/client";
+import {
+	integrationConnections,
+	members,
+	userIdentities,
+} from "@superset/db/schema";
+import { googleTokenResponseSchema } from "@superset/trpc/integrations/google";
+import { Client } from "@upstash/qstash";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { env } from "@/env";
+import { verifySignedState } from "@/lib/oauth-state";
+
+const qstash = new Client({ token: env.QSTASH_TOKEN, baseUrl: env.QSTASH_URL });
+
+const userInfoSchema = z.object({
+	sub: z.string().min(1),
+	email: z.string().email(),
+	name: z.string().optional(),
+});
+
+const REQUIRED_SCOPES = [
+	"https://www.googleapis.com/auth/calendar.readonly",
+	"https://www.googleapis.com/auth/gmail.readonly",
+];
+
+function fail(reason: string): Response {
+	return Response.redirect(
+		`${env.NEXT_PUBLIC_WEB_URL}/integrations/google?error=${reason}`,
+	);
+}
+
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const code = url.searchParams.get("code");
+	const state = url.searchParams.get("state");
+	if (url.searchParams.get("error")) return fail("oauth_denied");
+	if (!code || !state) return fail("missing_params");
+
+	const stateData = verifySignedState(state);
+	if (!stateData) return fail("invalid_state");
+	const { organizationId, userId } = stateData;
+
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.organizationId, organizationId),
+			eq(members.userId, userId),
+		),
+	});
+	if (!membership) {
+		console.error("[google/callback] membership verification failed", {
+			organizationId,
+			userId,
+		});
+		return fail("unauthorized");
+	}
+
+	const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			client_id: env.GOOGLE_CLIENT_ID,
+			client_secret: env.GOOGLE_CLIENT_SECRET,
+			redirect_uri: `${env.NEXT_PUBLIC_API_URL}/api/integrations/google/callback`,
+			code,
+		}),
+	});
+	if (!tokenResponse.ok) {
+		console.error(
+			"[google/callback] token exchange failed",
+			tokenResponse.status,
+			await tokenResponse.text(),
+		);
+		return fail("token_exchange_failed");
+	}
+	const tokens = googleTokenResponseSchema.parse(await tokenResponse.json());
+
+	// Someone can untick a scope on the consent screen. Half a connection —
+	// calendars but no mail — would save fine and then silently never fire
+	// Gmail triggers, so it is refused up front.
+	const granted = new Set((tokens.scope ?? "").split(" "));
+	if (!REQUIRED_SCOPES.every((scope) => granted.has(scope))) {
+		return fail("missing_scopes");
+	}
+	if (!tokens.refresh_token) return fail("no_refresh_token");
+
+	const infoResponse = await fetch(
+		"https://openidconnect.googleapis.com/v1/userinfo",
+		{ headers: { Authorization: `Bearer ${tokens.access_token}` } },
+	);
+	if (!infoResponse.ok) return fail("userinfo_failed");
+	const info = userInfoSchema.parse(await infoResponse.json());
+	const email = info.email.toLowerCase();
+
+	const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+	const [connection] = await db
+		.insert(integrationConnections)
+		.values({
+			organizationId,
+			connectedByUserId: userId,
+			provider: "google",
+			accessToken: tokens.access_token,
+			refreshToken: tokens.refresh_token,
+			tokenExpiresAt,
+			// The account's address, not an organization: Calendar and Gmail are
+			// one person's, and everything downstream treats them as theirs.
+			externalOrgId: email,
+			externalOrgName: email,
+			config: { provider: "google" },
+		})
+		.onConflictDoUpdate({
+			target: [
+				integrationConnections.organizationId,
+				integrationConnections.provider,
+			],
+			set: {
+				accessToken: tokens.access_token,
+				refreshToken: tokens.refresh_token,
+				tokenExpiresAt,
+				disconnectedAt: null,
+				disconnectReason: null,
+				externalOrgId: email,
+				externalOrgName: email,
+				connectedByUserId: userId,
+				// Reconnecting the same account keeps its sync tokens and channels;
+				// a different account starts over. The old account's channels are
+				// then unknown to the push route and expire within a week.
+				config: sql`CASE WHEN ${integrationConnections.externalOrgId} = ${email} THEN ${integrationConnections.config} ELSE '{"provider":"google"}'::jsonb END`,
+				updatedAt: new Date(),
+			},
+		})
+		.returning({ id: integrationConnections.id });
+
+	// The linked identity is what lets an attendee filter of "me" resolve to
+	// this person, and it names the address that a calendar event would.
+	await db
+		.insert(userIdentities)
+		.values({
+			provider: "google",
+			externalId: info.sub,
+			externalScopeId: null,
+			userId,
+			organizationId,
+			handle: email,
+			displayName: info.name ?? null,
+			metadata: { provider: "google" },
+		})
+		.onConflictDoUpdate({
+			target: [
+				userIdentities.organizationId,
+				userIdentities.provider,
+				userIdentities.externalScopeId,
+				userIdentities.externalId,
+			],
+			set: { userId, handle: email, displayName: info.name ?? null },
+		});
+
+	if (connection) await enqueueWatchSetup(connection.id);
+
+	return Response.redirect(`${env.NEXT_PUBLIC_WEB_URL}/integrations/google`);
+}
+
+/**
+ * Watches are set up out of band: they take several Google calls per
+ * calendar, and a failure there (an unreachable push address, say) must not
+ * turn a successful authorization into an error page.
+ */
+async function enqueueWatchSetup(connectionId: string): Promise<void> {
+	const jobUrl = `${env.NEXT_PUBLIC_API_URL}/api/integrations/google/jobs/renew-watches`;
+	const body = { connectionId };
+	if (env.NODE_ENV === "development") {
+		fetch(jobUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}).catch((error) => {
+			console.error("[google/callback] dev watch setup failed:", error);
+		});
+		return;
+	}
+	try {
+		await qstash.publishJSON({ url: jobUrl, body, retries: 3 });
+	} catch (error) {
+		console.error("[google/callback] failed to queue watch setup:", error);
+	}
+}

--- a/apps/api/src/app/api/integrations/google/callback/route.ts
+++ b/apps/api/src/app/api/integrations/google/callback/route.ts
@@ -14,6 +14,8 @@ import { verifySignedState } from "@/lib/oauth-state";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN, baseUrl: env.QSTASH_URL });
 
+const GOOGLE_CALL_TIMEOUT_MS = 10 * 1000;
+
 const userInfoSchema = z.object({
 	sub: z.string().min(1),
 	email: z.string().email(),
@@ -59,6 +61,7 @@ export async function GET(request: Request) {
 	const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		signal: AbortSignal.timeout(GOOGLE_CALL_TIMEOUT_MS),
 		body: new URLSearchParams({
 			grant_type: "authorization_code",
 			client_id: env.GOOGLE_CLIENT_ID,
@@ -75,7 +78,11 @@ export async function GET(request: Request) {
 		);
 		return fail("token_exchange_failed");
 	}
-	const tokens = googleTokenResponseSchema.parse(await tokenResponse.json());
+	const parsedTokens = googleTokenResponseSchema.safeParse(
+		await tokenResponse.json().catch(() => null),
+	);
+	if (!parsedTokens.success) return fail("token_exchange_failed");
+	const tokens = parsedTokens.data;
 
 	// Someone can untick a scope on the consent screen. Half a connection —
 	// calendars but no mail — would save fine and then silently never fire
@@ -88,10 +95,17 @@ export async function GET(request: Request) {
 
 	const infoResponse = await fetch(
 		"https://openidconnect.googleapis.com/v1/userinfo",
-		{ headers: { Authorization: `Bearer ${tokens.access_token}` } },
+		{
+			headers: { Authorization: `Bearer ${tokens.access_token}` },
+			signal: AbortSignal.timeout(GOOGLE_CALL_TIMEOUT_MS),
+		},
 	);
 	if (!infoResponse.ok) return fail("userinfo_failed");
-	const info = userInfoSchema.parse(await infoResponse.json());
+	const parsedInfo = userInfoSchema.safeParse(
+		await infoResponse.json().catch(() => null),
+	);
+	if (!parsedInfo.success) return fail("userinfo_failed");
+	const info = parsedInfo.data;
 	const email = info.email.toLowerCase();
 
 	const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);

--- a/apps/api/src/app/api/integrations/google/callback/route.ts
+++ b/apps/api/src/app/api/integrations/google/callback/route.ts
@@ -134,18 +134,20 @@ export async function GET(request: Request) {
 		.returning({ id: integrationConnections.id });
 
 	// The linked identity is what lets an attendee filter of "me" resolve to
-	// this person, and it names the address that a calendar event would.
+	// this person. Its external id is the address rather than Google's subject
+	// id because the matcher compares owner ids against what events carry, and
+	// calendar events name people by address.
 	await db
 		.insert(userIdentities)
 		.values({
 			provider: "google",
-			externalId: info.sub,
+			externalId: email,
 			externalScopeId: null,
 			userId,
 			organizationId,
 			handle: email,
 			displayName: info.name ?? null,
-			metadata: { provider: "google" },
+			metadata: { provider: "google", sub: info.sub },
 		})
 		.onConflictDoUpdate({
 			target: [
@@ -154,7 +156,12 @@ export async function GET(request: Request) {
 				userIdentities.externalScopeId,
 				userIdentities.externalId,
 			],
-			set: { userId, handle: email, displayName: info.name ?? null },
+			set: {
+				userId,
+				handle: email,
+				displayName: info.name ?? null,
+				metadata: { provider: "google", sub: info.sub },
+			},
 		});
 
 	if (connection) await enqueueWatchSetup(connection.id);

--- a/apps/api/src/app/api/integrations/google/callback/route.ts
+++ b/apps/api/src/app/api/integrations/google/callback/route.ts
@@ -125,10 +125,14 @@ export async function GET(request: Request) {
 			config: { provider: "google" },
 		})
 		.onConflictDoUpdate({
+			// One Google connection per member: the partial index on
+			// (org, provider, connected_by_user_id) WHERE provider = 'google'.
 			target: [
 				integrationConnections.organizationId,
 				integrationConnections.provider,
+				integrationConnections.connectedByUserId,
 			],
+			targetWhere: sql`${integrationConnections.provider} = 'google'`,
 			set: {
 				accessToken: tokens.access_token,
 				refreshToken: tokens.refresh_token,
@@ -137,7 +141,6 @@ export async function GET(request: Request) {
 				disconnectReason: null,
 				externalOrgId: email,
 				externalOrgName: email,
-				connectedByUserId: userId,
 				// Reconnecting the same account keeps its sync tokens and channels;
 				// a different account starts over. The old account's channels are
 				// then unknown to the push route and expire within a week.

--- a/apps/api/src/app/api/integrations/google/connect/route.ts
+++ b/apps/api/src/app/api/integrations/google/connect/route.ts
@@ -1,0 +1,52 @@
+import { auth } from "@superset/auth/server";
+import { findOrgMembership } from "@superset/db/utils";
+import { GOOGLE_SCOPES } from "@superset/trpc/integrations/google";
+
+import { env } from "@/env";
+import { createSignedState } from "@/lib/oauth-state";
+
+export async function GET(request: Request) {
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const url = new URL(request.url);
+	const organizationId = url.searchParams.get("organizationId");
+	if (!organizationId) {
+		return Response.json(
+			{ error: "Missing organizationId parameter" },
+			{ status: 400 },
+		);
+	}
+
+	const membership = await findOrgMembership({
+		userId: session.user.id,
+		organizationId,
+	});
+	if (!membership) {
+		return Response.json(
+			{ error: "User is not a member of this organization" },
+			{ status: 403 },
+		);
+	}
+
+	const state = createSignedState({ organizationId, userId: session.user.id });
+
+	const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+	authUrl.searchParams.set("client_id", env.GOOGLE_CLIENT_ID);
+	authUrl.searchParams.set(
+		"redirect_uri",
+		`${env.NEXT_PUBLIC_API_URL}/api/integrations/google/callback`,
+	);
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("scope", GOOGLE_SCOPES.join(" "));
+	// A refresh token is only issued with offline access, and only on a
+	// consent screen — a silent re-authorization returns none.
+	authUrl.searchParams.set("access_type", "offline");
+	authUrl.searchParams.set("prompt", "consent");
+	authUrl.searchParams.set("include_granted_scopes", "true");
+	authUrl.searchParams.set("state", state);
+
+	return Response.redirect(authUrl.toString());
+}

--- a/apps/api/src/app/api/integrations/google/connect/route.ts
+++ b/apps/api/src/app/api/integrations/google/connect/route.ts
@@ -1,9 +1,6 @@
 import { auth } from "@superset/auth/server";
-import { db } from "@superset/db/client";
-import { integrationConnections } from "@superset/db/schema";
 import { findOrgMembership } from "@superset/db/utils";
 import { GOOGLE_SCOPES } from "@superset/trpc/integrations/google";
-import { and, eq } from "drizzle-orm";
 
 import { env } from "@/env";
 import { createSignedState } from "@/lib/oauth-state";
@@ -30,24 +27,6 @@ export async function GET(request: Request) {
 	if (!membership) {
 		return Response.json(
 			{ error: "User is not a member of this organization" },
-			{ status: 403 },
-		);
-	}
-
-	// One connection per organization for now, and it is personal: whoever
-	// connected it (or an admin) may replace it, anyone else would be
-	// silently swapping a colleague's calendars for their own.
-	const existing = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.organizationId, organizationId),
-			eq(integrationConnections.provider, "google"),
-		),
-		columns: { connectedByUserId: true },
-	});
-	const isAdmin = membership.role === "admin" || membership.role === "owner";
-	if (existing && existing.connectedByUserId !== session.user.id && !isAdmin) {
-		return Response.json(
-			{ error: "Google is already connected by another member" },
 			{ status: 403 },
 		);
 	}

--- a/apps/api/src/app/api/integrations/google/connect/route.ts
+++ b/apps/api/src/app/api/integrations/google/connect/route.ts
@@ -1,6 +1,9 @@
 import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
 import { findOrgMembership } from "@superset/db/utils";
 import { GOOGLE_SCOPES } from "@superset/trpc/integrations/google";
+import { and, eq } from "drizzle-orm";
 
 import { env } from "@/env";
 import { createSignedState } from "@/lib/oauth-state";
@@ -27,6 +30,24 @@ export async function GET(request: Request) {
 	if (!membership) {
 		return Response.json(
 			{ error: "User is not a member of this organization" },
+			{ status: 403 },
+		);
+	}
+
+	// One connection per organization for now, and it is personal: whoever
+	// connected it (or an admin) may replace it, anyone else would be
+	// silently swapping a colleague's calendars for their own.
+	const existing = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.organizationId, organizationId),
+			eq(integrationConnections.provider, "google"),
+		),
+		columns: { connectedByUserId: true },
+	});
+	const isAdmin = membership.role === "admin" || membership.role === "owner";
+	if (existing && existing.connectedByUserId !== session.user.id && !isAdmin) {
+		return Response.json(
+			{ error: "Google is already connected by another member" },
 			{ status: 403 },
 		);
 	}

--- a/apps/api/src/app/api/integrations/google/gmail/push/route.ts
+++ b/apps/api/src/app/api/integrations/google/gmail/push/route.ts
@@ -1,0 +1,95 @@
+import { timingSafeEqual } from "node:crypto";
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { env } from "@/env";
+import { syncMailbox } from "../../lib/syncMailbox";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+const pushSchema = z.object({
+	message: z.object({
+		data: z.string().min(1),
+		messageId: z.string().optional(),
+	}),
+	subscription: z.string().optional(),
+});
+
+const notificationSchema = z.object({
+	emailAddress: z.string().email(),
+	historyId: z.union([z.string(), z.number()]),
+});
+
+/**
+ * Gmail's change notification, delivered by Cloud Pub/Sub push.
+ *
+ * The subscription appends a shared secret to this URL; that is what
+ * authenticates it. The payload names the mailbox and a history id, and only
+ * the mailbox is used — the sync continues from the last id it processed, so
+ * a dropped or reordered push costs nothing.
+ */
+export async function POST(request: Request) {
+	const secret = env.GOOGLE_PUBSUB_PUSH_TOKEN;
+	if (!secret) {
+		return Response.json(
+			{ error: "Gmail push not configured" },
+			{ status: 404 },
+		);
+	}
+	const token = new URL(request.url).searchParams.get("token") ?? "";
+	if (
+		token.length !== secret.length ||
+		!timingSafeEqual(Buffer.from(token), Buffer.from(secret))
+	) {
+		return Response.json({ error: "Invalid token" }, { status: 401 });
+	}
+
+	const body = await request.text();
+	let notification: z.infer<typeof notificationSchema>;
+	try {
+		const envelope = pushSchema.parse(JSON.parse(body));
+		notification = notificationSchema.parse(
+			JSON.parse(Buffer.from(envelope.message.data, "base64").toString()),
+		);
+	} catch {
+		// Malformed messages are acknowledged: Pub/Sub would otherwise redeliver
+		// them until the retention window closes.
+		return Response.json({ ok: true, skipped: "malformed" });
+	}
+
+	const connections = await db
+		.select()
+		.from(integrationConnections)
+		.where(
+			and(
+				eq(integrationConnections.provider, "google"),
+				eq(
+					integrationConnections.externalOrgId,
+					notification.emailAddress.toLowerCase(),
+				),
+				isNull(integrationConnections.disconnectedAt),
+			),
+		);
+	if (connections.length === 0) {
+		return Response.json({ ok: true, skipped: "no connection" });
+	}
+
+	try {
+		const results = [];
+		for (const connection of connections) {
+			const result = await syncMailbox(connection);
+			if (result.recorded > 0) {
+				console.log(
+					`[google/gmail/push] ${connection.id}: ${result.recorded} recorded, ${result.matched} matched`,
+				);
+			}
+			results.push({ connectionId: connection.id, ...result });
+		}
+		return Response.json({ ok: true, results });
+	} catch (error) {
+		console.error("[google/gmail/push] sync failed:", error);
+		return Response.json({ error: "Sync failed" }, { status: 500 });
+	}
+}

--- a/apps/api/src/app/api/integrations/google/gmail/push/route.ts
+++ b/apps/api/src/app/api/integrations/google/gmail/push/route.ts
@@ -76,9 +76,13 @@ export async function POST(request: Request) {
 		return Response.json({ ok: true, skipped: "no connection" });
 	}
 
-	try {
-		const results = [];
-		for (const connection of connections) {
+	// Per connection, so one mailbox failing does not make Pub/Sub replay the
+	// ones that already advanced their history ids. Any failure still answers
+	// non-2xx, which is what asks for the redelivery.
+	const results = [];
+	let failed = 0;
+	for (const connection of connections) {
+		try {
 			const result = await syncMailbox(connection);
 			if (result.recorded > 0) {
 				console.log(
@@ -86,10 +90,14 @@ export async function POST(request: Request) {
 				);
 			}
 			results.push({ connectionId: connection.id, ...result });
+		} catch (error) {
+			failed += 1;
+			console.error(`[google/gmail/push] ${connection.id} sync failed:`, error);
+			results.push({ connectionId: connection.id, error: "sync failed" });
 		}
-		return Response.json({ ok: true, results });
-	} catch (error) {
-		console.error("[google/gmail/push] sync failed:", error);
-		return Response.json({ error: "Sync failed" }, { status: 500 });
 	}
+	return Response.json(
+		{ ok: failed === 0, results },
+		{ status: failed === 0 ? 200 : 500 },
+	);
 }

--- a/apps/api/src/app/api/integrations/google/jobs/renew-watches/route.ts
+++ b/apps/api/src/app/api/integrations/google/jobs/renew-watches/route.ts
@@ -1,0 +1,64 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { reconcileWatches } from "../../lib/reconcileWatches";
+import { verifyQstashRequest } from "../../lib/verifyQstash";
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({ connectionId: z.string().uuid().optional() });
+
+/**
+ * Daily: renew every connection's Calendar channels and Gmail watch before
+ * they expire. Also run once for a single connection right after it connects.
+ */
+export async function POST(request: Request) {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(
+		request,
+		body,
+		"/api/integrations/google/jobs/renew-watches",
+	);
+	if (rejected) return rejected;
+
+	const parsed = bodySchema.safeParse(body ? JSON.parse(body) : {});
+	if (!parsed.success) {
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+
+	const connections = await db
+		.select({ id: integrationConnections.id })
+		.from(integrationConnections)
+		.where(
+			and(
+				eq(integrationConnections.provider, "google"),
+				isNull(integrationConnections.disconnectedAt),
+				...(parsed.data.connectionId
+					? [eq(integrationConnections.id, parsed.data.connectionId)]
+					: []),
+			),
+		);
+
+	const results = [];
+	for (const connection of connections) {
+		try {
+			const result = await reconcileWatches(connection.id);
+			if (result.errors.length > 0) {
+				console.error(
+					`[google/renew-watches] ${connection.id}:`,
+					result.errors.join("; "),
+				);
+			}
+			results.push({ connectionId: connection.id, ...result });
+		} catch (error) {
+			console.error(`[google/renew-watches] ${connection.id} failed:`, error);
+			results.push({
+				connectionId: connection.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+	return Response.json({ connections: connections.length, results });
+}

--- a/apps/api/src/app/api/integrations/google/jobs/renew-watches/route.ts
+++ b/apps/api/src/app/api/integrations/google/jobs/renew-watches/route.ts
@@ -23,7 +23,15 @@ export async function POST(request: Request) {
 	);
 	if (rejected) return rejected;
 
-	const parsed = bodySchema.safeParse(body ? JSON.parse(body) : {});
+	let json: unknown = {};
+	if (body) {
+		try {
+			json = JSON.parse(body);
+		} catch {
+			return Response.json({ error: "Invalid JSON" }, { status: 400 });
+		}
+	}
+	const parsed = bodySchema.safeParse(json);
 	if (!parsed.success) {
 		return Response.json({ error: "Invalid payload" }, { status: 400 });
 	}

--- a/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
+++ b/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
@@ -1,0 +1,90 @@
+import { dbWs } from "@superset/db/client";
+import { automations, automationTriggers } from "@superset/db/schema";
+import {
+	findGoogleConnection,
+	googleConfigOf,
+	listUpcomingInstances,
+} from "@superset/trpc/integrations/google";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import {
+	loadFirePlan,
+	scheduleFires,
+	sweepWindow,
+} from "../../lib/scheduleCalendarFires";
+import { verifyQstashRequest } from "../../lib/verifyQstash";
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+/**
+ * Every fifteen minutes: for each org with an enabled `starting_soon` or
+ * `ended` trigger, list the instances due inside the fire horizon on every
+ * watched calendar and hand their fires to QStash. This is what catches
+ * triggers created after the event was synced, and recurring instances the
+ * incremental sync never sees individually.
+ */
+export async function POST(request: Request) {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(
+		request,
+		body,
+		"/api/integrations/google/jobs/sweep-schedules",
+	);
+	if (rejected) return rejected;
+
+	const organizations = await dbWs
+		.selectDistinct({ organizationId: automationTriggers.organizationId })
+		.from(automationTriggers)
+		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
+		.where(
+			and(
+				eq(automationTriggers.kind, "google_calendar"),
+				eq(automationTriggers.enabled, true),
+				eq(automations.enabled, true),
+				inArray(sql`${automationTriggers.config}->>'event'`, [
+					"event.starting_soon",
+					"event.ended",
+				]),
+			),
+		);
+
+	const now = new Date();
+	const results = [];
+	for (const { organizationId } of organizations) {
+		try {
+			const connection = await findGoogleConnection(organizationId);
+			const plan = await loadFirePlan(organizationId);
+			if (!connection || !plan) continue;
+			const window = sweepWindow(plan, now);
+			let scheduled = 0;
+			for (const calendarId of Object.keys(
+				googleConfigOf(connection.config).calendars ?? {},
+			)) {
+				if (!plan.allows(calendarId)) continue;
+				const instances = await listUpcomingInstances(
+					connection.id,
+					calendarId,
+					window,
+				);
+				scheduled += await scheduleFires({
+					connectionId: connection.id,
+					calendarId,
+					instances,
+					plan,
+					now,
+				});
+			}
+			results.push({ organizationId, scheduled });
+		} catch (error) {
+			console.error(
+				`[google/sweep-schedules] ${organizationId} failed:`,
+				error,
+			);
+			results.push({
+				organizationId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+	return Response.json({ organizations: organizations.length, results });
+}

--- a/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
+++ b/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
@@ -17,9 +17,9 @@ export const maxDuration = 300;
 export const dynamic = "force-dynamic";
 
 /**
- * Every fifteen minutes: for each org with an enabled `starting_soon` or
- * `ended` trigger, list the instances due inside the fire horizon on every
- * watched calendar and hand their fires to QStash. This is what catches
+ * Every fifteen minutes: for each member with an enabled `starting_soon` or
+ * `ended` trigger and a Google connection, list the instances due inside the
+ * fire horizon on every watched calendar and hand their fires to QStash. This is what catches
  * triggers created after the event was synced, and recurring instances the
  * incremental sync never sees individually.
  */
@@ -32,8 +32,11 @@ export async function POST(request: Request) {
 	);
 	if (rejected) return rejected;
 
-	const organizations = await dbWs
-		.selectDistinct({ organizationId: automationTriggers.organizationId })
+	const owners = await dbWs
+		.selectDistinct({
+			organizationId: automationTriggers.organizationId,
+			ownerUserId: automations.ownerUserId,
+		})
 		.from(automationTriggers)
 		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
 		.where(
@@ -50,10 +53,13 @@ export async function POST(request: Request) {
 
 	const now = new Date();
 	const results = [];
-	for (const { organizationId } of organizations) {
+	for (const { organizationId, ownerUserId } of owners) {
 		try {
-			const connection = await findGoogleConnection(organizationId);
-			const plan = await loadFirePlan(organizationId);
+			const connection = await findGoogleConnection(
+				organizationId,
+				ownerUserId,
+			);
+			const plan = await loadFirePlan(organizationId, ownerUserId);
 			if (!connection || !plan) continue;
 			const window = sweepWindow(plan, now);
 			let scheduled = 0;
@@ -74,17 +80,18 @@ export async function POST(request: Request) {
 					now,
 				});
 			}
-			results.push({ organizationId, scheduled });
+			results.push({ organizationId, ownerUserId, scheduled });
 		} catch (error) {
 			console.error(
-				`[google/sweep-schedules] ${organizationId} failed:`,
+				`[google/sweep-schedules] ${organizationId}/${ownerUserId} failed:`,
 				error,
 			);
 			results.push({
 				organizationId,
+				ownerUserId,
 				error: error instanceof Error ? error.message : String(error),
 			});
 		}
 	}
-	return Response.json({ organizations: organizations.length, results });
+	return Response.json({ owners: owners.length, results });
 }

--- a/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
+++ b/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
@@ -1,0 +1,70 @@
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import type { GoogleCalendarMatchableEvent } from "@superset/shared/automation-matching";
+import type { GoogleCalendarTriggerEvent } from "@superset/shared/automation-triggers";
+import {
+	eventAttendeeEmails,
+	type GoogleCalendarEvent,
+} from "@superset/trpc/integrations/google";
+
+/** The domain of the connected account: what "external" is measured against. */
+export function accountDomain(
+	connection: Pick<SelectIntegrationConnection, "externalOrgId">,
+): string | null {
+	const at = connection.externalOrgId?.lastIndexOf("@") ?? -1;
+	if (at < 0) return null;
+	return connection.externalOrgId?.slice(at + 1).toLowerCase() ?? null;
+}
+
+export function resourceKeyFor(
+	connectionId: string,
+	calendarId: string,
+	eventId: string,
+): string {
+	return `google_calendar:${connectionId}:${calendarId}:${eventId}`;
+}
+
+/**
+ * What triggers filter on, pulled out of a Google event once. The same
+ * function serves synced changes and the fires scheduled off them.
+ */
+export function matchableCalendarEvent(params: {
+	eventType: GoogleCalendarTriggerEvent;
+	calendarId: string;
+	event: GoogleCalendarEvent;
+	domain: string | null;
+	minutesBefore?: number;
+}): GoogleCalendarMatchableEvent {
+	const attendeeEmails = eventAttendeeEmails(params.event);
+	const organizer = params.event.organizer?.email?.toLowerCase() ?? null;
+	return {
+		provider: "google_calendar",
+		identityProvider: "google",
+		eventType: params.eventType,
+		actorId: organizer,
+		actorLogin: organizer,
+		body: params.event.description ?? null,
+		calendarId: params.calendarId,
+		attendeeEmails,
+		title: params.event.summary ?? null,
+		hasExternalAttendee: attendeeEmails.some(
+			(email) => !email.endsWith(`@${params.domain}`),
+		),
+		minutesBefore: params.minutesBefore ?? null,
+	};
+}
+
+/** The row payload: the event as Google sent it plus what was derived. */
+export function calendarPayload(
+	calendarId: string,
+	event: GoogleCalendarEvent,
+	matchable: GoogleCalendarMatchableEvent,
+	extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		calendarId,
+		event,
+		attendeeEmails: matchable.attendeeEmails,
+		hasExternalAttendee: matchable.hasExternalAttendee,
+		...extra,
+	};
+}

--- a/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
+++ b/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
@@ -46,9 +46,11 @@ export function matchableCalendarEvent(params: {
 		calendarId: params.calendarId,
 		attendeeEmails,
 		title: params.event.summary ?? null,
-		hasExternalAttendee: attendeeEmails.some(
-			(email) => !email.endsWith(`@${params.domain}`),
-		),
+		// Unknown domain means "external" cannot be judged; false rather than
+		// everyone, so an external-attendee trigger does not fire on every event.
+		hasExternalAttendee:
+			params.domain !== null &&
+			attendeeEmails.some((email) => !email.endsWith(`@${params.domain}`)),
 		minutesBefore: params.minutesBefore ?? null,
 	};
 }

--- a/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
+++ b/apps/api/src/app/api/integrations/google/lib/calendarEvents.ts
@@ -7,6 +7,13 @@ import {
 } from "@superset/trpc/integrations/google";
 
 /** The domain of the connected account: what "external" is measured against. */
+/** The connected account's address, as the identity table stores it. */
+export function accountEmail(
+	connection: Pick<SelectIntegrationConnection, "externalOrgId">,
+): string {
+	return (connection.externalOrgId ?? "").toLowerCase();
+}
+
 export function accountDomain(
 	connection: Pick<SelectIntegrationConnection, "externalOrgId">,
 ): string | null {
@@ -29,6 +36,7 @@ export function resourceKeyFor(
  */
 export function matchableCalendarEvent(params: {
 	eventType: GoogleCalendarTriggerEvent;
+	accountEmail: string;
 	calendarId: string;
 	event: GoogleCalendarEvent;
 	domain: string | null;
@@ -40,6 +48,7 @@ export function matchableCalendarEvent(params: {
 		provider: "google_calendar",
 		identityProvider: "google",
 		eventType: params.eventType,
+		accountEmail: params.accountEmail,
 		actorId: organizer,
 		actorLogin: organizer,
 		body: params.event.description ?? null,

--- a/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
+++ b/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
@@ -45,9 +45,15 @@ export async function reconcileWatches(
 	};
 	if (!connection || connection.disconnectedAt) return result;
 
-	const calendars = (await listCalendars(connectionId))
+	// Deterministic before the cap — primary first, then by id — so the
+	// retained set is the same on every run rather than churning channels and
+	// re-baselining calendars each time Google returns the list in a new order.
+	const listed = (await listCalendars(connectionId))
 		.filter((calendar) => !calendar.deleted)
-		.slice(0, MAX_WATCHED_CALENDARS);
+		.sort((a, b) =>
+			a.primary === b.primary ? a.id.localeCompare(b.id) : a.primary ? -1 : 1,
+		);
+	const calendars = listed.slice(0, MAX_WATCHED_CALENDARS);
 	result.calendars = calendars.length;
 	const known = googleConfigOf(connection.config).calendars ?? {};
 	const now = Date.now();
@@ -83,7 +89,20 @@ export async function reconcileWatches(
 				channelId: channel.id,
 				channelToken: channel.token,
 			});
-			const watched = await watchCalendar(connectionId, calendar.id, channel);
+			let watched: Awaited<ReturnType<typeof watchCalendar>>;
+			try {
+				watched = await watchCalendar(connectionId, calendar.id, channel);
+			} catch (error) {
+				// The new channel never opened; put the previous one back so its
+				// pushes keep being accepted until the next renewal succeeds.
+				if (state?.channelId && state.channelToken) {
+					await patchCalendarState(connectionId, calendar.id, {
+						channelId: state.channelId,
+						channelToken: state.channelToken,
+					});
+				}
+				throw error;
+			}
 			await patchCalendarState(connectionId, calendar.id, {
 				resourceId: watched.resourceId,
 				channelExpiresAt: watched.expiration,
@@ -104,8 +123,9 @@ export async function reconcileWatches(
 	}
 
 	// Calendars that left the account's list: stop their channels and forget
-	// them, so a stale channel does not keep a dead sync token alive.
-	const current = new Set(calendars.map((calendar) => calendar.id));
+	// them, so a stale channel does not keep a dead sync token alive. Ones the
+	// cap dropped are still on the account and keep their state.
+	const current = new Set(listed.map((calendar) => calendar.id));
 	for (const [calendarId, state] of Object.entries(known)) {
 		if (current.has(calendarId)) continue;
 		if (state.channelId && state.resourceId) {

--- a/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
+++ b/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
@@ -1,0 +1,149 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import {
+	findGoogleConnectionById,
+	googleConfigOf,
+	listCalendars,
+	patchCalendarState,
+	patchGmailState,
+	removeCalendarState,
+	stopChannel,
+	WATCH_RENEW_WINDOW_MS,
+	watchCalendar,
+	watchMailbox,
+} from "@superset/trpc/integrations/google";
+import { env } from "@/env";
+import { syncCalendar } from "./syncCalendar";
+
+/** More calendars than this and the long tail is holiday feeds, not signal. */
+const MAX_WATCHED_CALENDARS = 50;
+
+export type ReconcileResult = {
+	calendars: number;
+	watched: number;
+	baselined: number;
+	gmailWatched: boolean;
+	errors: string[];
+};
+
+/**
+ * Brings one connection's watches up to date: a channel on every calendar
+ * the account can see, a baseline sync token for each, the Gmail watch when
+ * a topic is configured. Idempotent; the daily cron and the connect callback
+ * both call it. Google renews nothing itself.
+ */
+export async function reconcileWatches(
+	connectionId: string,
+): Promise<ReconcileResult> {
+	const connection = await findGoogleConnectionById(connectionId);
+	const result: ReconcileResult = {
+		calendars: 0,
+		watched: 0,
+		baselined: 0,
+		gmailWatched: false,
+		errors: [],
+	};
+	if (!connection || connection.disconnectedAt) return result;
+
+	const calendars = (await listCalendars(connectionId))
+		.filter((calendar) => !calendar.deleted)
+		.slice(0, MAX_WATCHED_CALENDARS);
+	result.calendars = calendars.length;
+	const known = googleConfigOf(connection.config).calendars ?? {};
+	const now = Date.now();
+	const address = `${env.NEXT_PUBLIC_API_URL}/api/integrations/google/calendar/push`;
+
+	for (const calendar of calendars) {
+		const state = known[calendar.id];
+		try {
+			if (!state?.syncToken) {
+				// The baseline before the channel: a push that arrives for a
+				// calendar with no token would otherwise be the first sync and
+				// would record nothing.
+				const fresh = await findGoogleConnectionById(connectionId);
+				if (fresh) await syncCalendar(fresh, calendar.id);
+				result.baselined += 1;
+			}
+			await patchCalendarState(connectionId, calendar.id, {
+				summary: calendar.summary,
+			});
+
+			const expiresSoon =
+				(state?.channelExpiresAt ?? 0) - now < WATCH_RENEW_WINDOW_MS;
+			if (state?.channelId && !expiresSoon) continue;
+
+			// Token first, watch second: Google's initial "sync" push can land
+			// before `watch` returns, and the route needs the token to accept it.
+			const channel = {
+				id: randomUUID(),
+				token: randomBytes(24).toString("hex"),
+				address,
+			};
+			await patchCalendarState(connectionId, calendar.id, {
+				channelId: channel.id,
+				channelToken: channel.token,
+			});
+			const watched = await watchCalendar(connectionId, calendar.id, channel);
+			await patchCalendarState(connectionId, calendar.id, {
+				resourceId: watched.resourceId,
+				channelExpiresAt: watched.expiration,
+			});
+			result.watched += 1;
+
+			if (state?.channelId && state.resourceId) {
+				await stopChannel(connectionId, {
+					id: state.channelId,
+					resourceId: state.resourceId,
+				}).catch(() => undefined);
+			}
+		} catch (error) {
+			result.errors.push(
+				`calendar ${calendar.id}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	// Calendars that left the account's list: stop their channels and forget
+	// them, so a stale channel does not keep a dead sync token alive.
+	const current = new Set(calendars.map((calendar) => calendar.id));
+	for (const [calendarId, state] of Object.entries(known)) {
+		if (current.has(calendarId)) continue;
+		if (state.channelId && state.resourceId) {
+			await stopChannel(connectionId, {
+				id: state.channelId,
+				resourceId: state.resourceId,
+			}).catch(() => undefined);
+		}
+		await removeCalendarState(connectionId, calendarId);
+	}
+
+	if (env.GOOGLE_PUBSUB_TOPIC) {
+		try {
+			await reconcileGmailWatch(connection, env.GOOGLE_PUBSUB_TOPIC, now);
+			result.gmailWatched = true;
+		} catch (error) {
+			result.errors.push(
+				`gmail: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	return result;
+}
+
+async function reconcileGmailWatch(
+	connection: SelectIntegrationConnection,
+	topicName: string,
+	now: number,
+): Promise<void> {
+	const state = googleConfigOf(connection.config).gmail;
+	const expiresSoon =
+		(state?.watchExpiresAt ?? 0) - now < WATCH_RENEW_WINDOW_MS;
+	if (!expiresSoon) return;
+	const watched = await watchMailbox(connection.id, topicName);
+	await patchGmailState(connection.id, {
+		watchExpiresAt: watched.expiration,
+		// Continue from where we were; only a first watch starts from now.
+		historyId: state?.historyId ?? watched.historyId,
+	});
+}

--- a/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
+++ b/apps/api/src/app/api/integrations/google/lib/reconcileWatches.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { SelectIntegrationConnection } from "@superset/db/schema";
 import {
 	findGoogleConnectionById,
@@ -87,7 +87,9 @@ export async function reconcileWatches(
 			};
 			await patchCalendarState(connectionId, calendar.id, {
 				channelId: channel.id,
-				channelToken: channel.token,
+				channelTokenHash: createHash("sha256")
+					.update(channel.token)
+					.digest("hex"),
 			});
 			let watched: Awaited<ReturnType<typeof watchCalendar>>;
 			try {
@@ -95,10 +97,10 @@ export async function reconcileWatches(
 			} catch (error) {
 				// The new channel never opened; put the previous one back so its
 				// pushes keep being accepted until the next renewal succeeds.
-				if (state?.channelId && state.channelToken) {
+				if (state?.channelId && state.channelTokenHash) {
 					await patchCalendarState(connectionId, calendar.id, {
 						channelId: state.channelId,
-						channelToken: state.channelToken,
+						channelTokenHash: state.channelTokenHash,
 					});
 				}
 				throw error;

--- a/apps/api/src/app/api/integrations/google/lib/recordGoogleEvent.ts
+++ b/apps/api/src/app/api/integrations/google/lib/recordGoogleEvent.ts
@@ -1,0 +1,52 @@
+import { db } from "@superset/db/client";
+import { automationEvents } from "@superset/db/schema";
+import { stripNullChars } from "@/lib/strip-null-chars";
+
+/**
+ * Records one Google-derived event as an `automation_events` row.
+ *
+ * Idempotent on (connection, provider, externalEventId): a calendar change
+ * seen by two overlapping syncs, or a Pub/Sub redelivery, inserts once and
+ * dispatches once. Returns null when the row already existed.
+ */
+export async function recordGoogleEvent(params: {
+	organizationId: string;
+	connectionId: string;
+	provider: "google_calendar" | "gmail";
+	eventType: string;
+	externalEventId: string;
+	resourceKey: string;
+	title: string;
+	url: string | null;
+	actorLogin: string | null;
+	actorIsExternal: boolean | null;
+	payload: Record<string, unknown>;
+}): Promise<{ eventId: string } | null> {
+	const [inserted] = await db
+		.insert(automationEvents)
+		.values({
+			organizationId: params.organizationId,
+			integrationConnectionId: params.connectionId,
+			provider: params.provider,
+			eventType: params.eventType,
+			externalEventId: params.externalEventId,
+			resourceKey: params.resourceKey,
+			title: params.title,
+			url: params.url,
+			repositoryId: null,
+			ref: null,
+			actorLogin: params.actorLogin,
+			actorIsExternal: params.actorIsExternal,
+			payload: stripNullChars(params.payload),
+			webhookEventId: null,
+		})
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		})
+		.returning({ id: automationEvents.id });
+	return inserted ? { eventId: inserted.id } : null;
+}

--- a/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
+++ b/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
@@ -30,10 +30,15 @@ export const FIRE_HORIZON_MS = 35 * 60 * 1000;
 const LATE_TOLERANCE_MS = 60 * 1000;
 
 /**
- * What the org's enabled triggers want fired, so the sweep lists only as far
- * ahead as the longest lead time and schedules nothing nobody asked for.
+ * What one member's enabled triggers want fired, so the sweep lists only as
+ * far ahead as the longest lead time and schedules nothing nobody asked for.
+ * Per owner because a Google connection is one member's: their automations
+ * are the only ones that will ever match fires off it.
  */
-export async function loadFirePlan(organizationId: string): Promise<{
+export async function loadFirePlan(
+	organizationId: string,
+	ownerUserId: string,
+): Promise<{
 	minutesBefore: number[];
 	ended: boolean;
 	allows: (calendarId: string) => boolean;
@@ -45,6 +50,7 @@ export async function loadFirePlan(organizationId: string): Promise<{
 		.where(
 			and(
 				eq(automationTriggers.organizationId, organizationId),
+				eq(automations.ownerUserId, ownerUserId),
 				eq(automationTriggers.kind, "google_calendar"),
 				eq(automationTriggers.enabled, true),
 				eq(automations.enabled, true),

--- a/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
+++ b/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import { dbWs } from "@superset/db/client";
+import { automations, automationTriggers } from "@superset/db/schema";
+import { scopeAllows } from "@superset/shared/automation-matching";
+import type { TriggerScope } from "@superset/shared/automation-triggers";
+import {
+	eventEnd,
+	eventStart,
+	type GoogleCalendarEvent,
+} from "@superset/trpc/integrations/google";
+import { Client } from "@upstash/qstash";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { env } from "@/env";
+
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+});
+
+/**
+ * How far ahead a fire is handed to QStash. The sweep runs every fifteen
+ * minutes; anything due inside this window is scheduled by it, so the horizon
+ * only has to outlast one sweep interval plus slack. Keeping it short means a
+ * moved or cancelled event has at most one stale fire outstanding, and that
+ * one is caught by the callback re-reading the event.
+ */
+export const FIRE_HORIZON_MS = 35 * 60 * 1000;
+
+/** A fire scheduled a moment late is still worth firing; older ones are not. */
+const LATE_TOLERANCE_MS = 60 * 1000;
+
+/**
+ * What the org's enabled triggers want fired, so the sweep lists only as far
+ * ahead as the longest lead time and schedules nothing nobody asked for.
+ */
+export async function loadFirePlan(organizationId: string): Promise<{
+	minutesBefore: number[];
+	ended: boolean;
+	allows: (calendarId: string) => boolean;
+} | null> {
+	const rows = await dbWs
+		.select({ config: automationTriggers.config })
+		.from(automationTriggers)
+		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
+		.where(
+			and(
+				eq(automationTriggers.organizationId, organizationId),
+				eq(automationTriggers.kind, "google_calendar"),
+				eq(automationTriggers.enabled, true),
+				eq(automations.enabled, true),
+				inArray(sql`${automationTriggers.config}->>'event'`, [
+					"event.starting_soon",
+					"event.ended",
+				]),
+			),
+		);
+	if (rows.length === 0) return null;
+
+	const minutesBefore = new Set<number>();
+	let ended = false;
+	const scopes: TriggerScope[] = [];
+	for (const row of rows) {
+		const config = row.config;
+		if (config.kind !== "google_calendar") continue;
+		scopes.push(config.calendars);
+		if (config.event === "event.starting_soon") {
+			minutesBefore.add(config.minutesBefore);
+		}
+		if (config.event === "event.ended") ended = true;
+	}
+	return {
+		minutesBefore: [...minutesBefore],
+		ended,
+		allows: (calendarId) => scopes.some((s) => scopeAllows(s, calendarId)),
+	};
+}
+
+export type ScheduledFire = {
+	connectionId: string;
+	calendarId: string;
+	eventId: string;
+	fire: "starting_soon" | "ended";
+	minutesBefore: number | null;
+	/** The start (or end) the fire was computed from; re-checked when it lands. */
+	expectedAt: string;
+};
+
+/**
+ * Hands QStash every fire due within the horizon for these instances.
+ *
+ * Idempotency is layered: the deduplication id stops QStash holding two copies
+ * of one fire at once, and the `automation_events` unique index stops a second
+ * delivery of the same fire recording twice.
+ */
+export async function scheduleFires(params: {
+	connectionId: string;
+	calendarId: string;
+	instances: GoogleCalendarEvent[];
+	plan: NonNullable<Awaited<ReturnType<typeof loadFirePlan>>>;
+	now?: Date;
+}): Promise<number> {
+	if (!params.plan.allows(params.calendarId)) return 0;
+	const now = params.now ?? new Date();
+	const fires: Array<{ fire: ScheduledFire; at: Date }> = [];
+
+	for (const instance of params.instances) {
+		if (instance.status === "cancelled") continue;
+		// All-day events carry a date and no time; "starting soon" has no
+		// meaning for them and "ended" would fire at a timezone's midnight.
+		const start = eventStart(instance);
+		const end = eventEnd(instance);
+		if (!start || !end) continue;
+
+		for (const minutesBefore of params.plan.minutesBefore) {
+			const at = new Date(start.getTime() - minutesBefore * 60_000);
+			if (!withinHorizon(at, now)) continue;
+			fires.push({
+				at,
+				fire: {
+					connectionId: params.connectionId,
+					calendarId: params.calendarId,
+					eventId: instance.id,
+					fire: "starting_soon",
+					minutesBefore,
+					expectedAt: start.toISOString(),
+				},
+			});
+		}
+		if (params.plan.ended && withinHorizon(end, now)) {
+			fires.push({
+				at: end,
+				fire: {
+					connectionId: params.connectionId,
+					calendarId: params.calendarId,
+					eventId: instance.id,
+					fire: "ended",
+					minutesBefore: null,
+					expectedAt: end.toISOString(),
+				},
+			});
+		}
+	}
+
+	if (fires.length === 0) return 0;
+
+	await qstash.batchJSON(
+		fires.map(({ fire, at }) => ({
+			url: `${env.NEXT_PUBLIC_API_URL}/api/integrations/google/calendar/scheduled`,
+			body: fire,
+			notBefore: Math.max(
+				Math.floor(at.getTime() / 1000),
+				Math.floor(now.getTime() / 1000),
+			),
+			deduplicationId: fireDedupId(fire),
+			retries: 2,
+		})),
+	);
+	return fires.length;
+}
+
+function withinHorizon(at: Date, now: Date): boolean {
+	const delta = at.getTime() - now.getTime();
+	return delta >= -LATE_TOLERANCE_MS && delta <= FIRE_HORIZON_MS;
+}
+
+/** Stable across sweeps for the same fire, and short enough for QStash. */
+export function fireDedupId(fire: ScheduledFire): string {
+	return createHash("sha256")
+		.update(
+			[
+				fire.connectionId,
+				fire.calendarId,
+				fire.eventId,
+				fire.fire,
+				String(fire.minutesBefore ?? ""),
+				fire.expectedAt,
+			].join("|"),
+		)
+		.digest("hex")
+		.slice(0, 48);
+}
+
+/** The listing window a sweep needs so every fire in the horizon is seen. */
+export function sweepWindow(
+	plan: { minutesBefore: number[] },
+	now: Date,
+): { from: Date; to: Date } {
+	const maxLead = Math.max(0, ...plan.minutesBefore) * 60_000;
+	return {
+		from: new Date(now.getTime() - LATE_TOLERANCE_MS),
+		to: new Date(now.getTime() + FIRE_HORIZON_MS + maxLead),
+	};
+}

--- a/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
@@ -232,7 +232,9 @@ async function recordChange(params: {
 		connectionId: connection.id,
 		provider: "google_calendar",
 		eventType,
-		externalEventId: `${calendarId}:${item.id}:${item.updated ?? item.etag ?? Date.now()}`,
+		// A stable key: an item carrying neither `updated` nor `etag` collapses
+		// onto one row per status rather than one per delivery.
+		externalEventId: `${calendarId}:${item.id}:${item.updated ?? item.etag ?? item.status ?? "unknown"}`,
 		resourceKey,
 		title: event.summary ?? item.id,
 		url: event.htmlLink ?? null,

--- a/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
@@ -13,13 +13,13 @@ import {
 	patchCalendarState,
 } from "@superset/trpc/integrations/google";
 import { and, desc, eq } from "drizzle-orm";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import {
 	accountDomain,
 	calendarPayload,
 	matchableCalendarEvent,
 	resourceKeyFor,
 } from "./calendarEvents";
-import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import { recordGoogleEvent } from "./recordGoogleEvent";
 import {
 	loadFirePlan,

--- a/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
@@ -1,0 +1,251 @@
+import { db } from "@superset/db/client";
+import {
+	automationEvents,
+	type SelectIntegrationConnection,
+} from "@superset/db/schema";
+import type { GoogleCalendarTriggerEvent } from "@superset/shared/automation-triggers";
+import {
+	eventStart,
+	type GoogleCalendarEvent,
+	googleConfigOf,
+	listEventChanges,
+	listEventInstances,
+	patchCalendarState,
+} from "@superset/trpc/integrations/google";
+import { and, desc, eq } from "drizzle-orm";
+import {
+	accountDomain,
+	calendarPayload,
+	matchableCalendarEvent,
+	resourceKeyFor,
+} from "./calendarEvents";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import { recordGoogleEvent } from "./recordGoogleEvent";
+import {
+	loadFirePlan,
+	scheduleFires,
+	sweepWindow,
+} from "./scheduleCalendarFires";
+
+export type CalendarSyncResult = {
+	/** Nothing was recorded: the calendar had no sync token yet, or lost it. */
+	baseline: boolean;
+	changed: number;
+	recorded: number;
+	matched: number;
+	/** starting_soon/ended fires handed to QStash off these changes. */
+	scheduled: number;
+};
+
+/**
+ * Pulls what changed on one calendar since the last sync and records each
+ * change as an automation event.
+ *
+ * Google's push says only that something changed. The stored sync token is
+ * what turns that into a list, and the first sync of a calendar — or the one
+ * after a token expires — records nothing: it exists to obtain the token, and
+ * replaying a whole calendar's history as "created" would fire every trigger
+ * on it at once.
+ */
+export async function syncCalendar(
+	connection: SelectIntegrationConnection,
+	calendarId: string,
+): Promise<CalendarSyncResult> {
+	const state = googleConfigOf(connection.config).calendars?.[calendarId];
+	const result = await listEventChanges(
+		connection.id,
+		calendarId,
+		state?.syncToken,
+	);
+
+	if (result.expired) {
+		const fresh = await listEventChanges(connection.id, calendarId, undefined);
+		if (fresh.expired) {
+			throw new Error(`Calendar ${calendarId}: full sync returned 410`);
+		}
+		await patchCalendarState(connection.id, calendarId, {
+			syncToken: fresh.nextSyncToken,
+			watchedSince: state?.watchedSince ?? new Date().toISOString(),
+		});
+		return {
+			baseline: true,
+			changed: 0,
+			recorded: 0,
+			matched: 0,
+			scheduled: 0,
+		};
+	}
+
+	if (!state?.syncToken) {
+		await patchCalendarState(connection.id, calendarId, {
+			syncToken: result.nextSyncToken,
+			watchedSince: new Date().toISOString(),
+		});
+		return {
+			baseline: true,
+			changed: 0,
+			recorded: 0,
+			matched: 0,
+			scheduled: 0,
+		};
+	}
+
+	const applied = await applyCalendarChanges(
+		connection,
+		calendarId,
+		result.items,
+		{
+			watchedSince: state.watchedSince
+				? new Date(state.watchedSince)
+				: new Date(0),
+		},
+	);
+
+	await patchCalendarState(connection.id, calendarId, {
+		syncToken: result.nextSyncToken,
+	});
+
+	return { baseline: false, changed: result.items.length, ...applied };
+}
+
+/**
+ * Records and dispatches a list of changed events, as `events.list` returned
+ * them. Separate from the listing so the same path runs over a captured page.
+ */
+export async function applyCalendarChanges(
+	connection: SelectIntegrationConnection,
+	calendarId: string,
+	items: GoogleCalendarEvent[],
+	options: { watchedSince: Date; now?: Date },
+): Promise<{ recorded: number; matched: number; scheduled: number }> {
+	const domain = accountDomain(connection);
+	const plan = await loadFirePlan(connection.organizationId);
+	const now = options.now ?? new Date();
+
+	let recorded = 0;
+	let matched = 0;
+	let scheduled = 0;
+	for (const item of items) {
+		const outcome = await recordChange({
+			connection,
+			calendarId,
+			item,
+			watchedSince: options.watchedSince,
+			domain,
+		});
+		if (!outcome) continue;
+		recorded += 1;
+		matched += outcome.matched;
+
+		// A change inside the horizon may move a fire; the sweep would catch it
+		// eventually, but a meeting created for twenty minutes from now needs
+		// its "starting soon" before the next sweep.
+		if (plan && item.status !== "cancelled" && eventStart(item)) {
+			// Best effort: the sweep reschedules anything missed here, whereas a
+			// failure that aborted the loop would leave the rest of this page
+			// unrecorded until Google retried the push.
+			try {
+				const instances = item.recurrence
+					? await listEventInstances(
+							connection.id,
+							calendarId,
+							item.id,
+							sweepWindow(plan, now),
+						)
+					: [item];
+				scheduled += await scheduleFires({
+					connectionId: connection.id,
+					calendarId,
+					instances,
+					plan,
+					now,
+				});
+			} catch (error) {
+				console.error(
+					`[google/calendar] scheduling fires for ${calendarId}/${item.id} failed:`,
+					error,
+				);
+			}
+		}
+	}
+	return { recorded, matched, scheduled };
+}
+
+/**
+ * Created, updated or cancelled, decided from what we already recorded.
+ *
+ * "Created" needs two things: no prior row for this event on this calendar,
+ * and Google's `created` timestamp after we started watching. Without the
+ * second, editing an event that predates the connection would read as its
+ * creation; without the first, every later edit of a new event would.
+ */
+async function recordChange(params: {
+	connection: SelectIntegrationConnection;
+	calendarId: string;
+	item: GoogleCalendarEvent;
+	watchedSince: Date;
+	domain: string | null;
+}): Promise<{ matched: number } | null> {
+	const { connection, calendarId, item } = params;
+	const resourceKey = resourceKeyFor(connection.id, calendarId, item.id);
+
+	const [previous] = await db
+		.select({ payload: automationEvents.payload })
+		.from(automationEvents)
+		.where(
+			and(
+				eq(automationEvents.organizationId, connection.organizationId),
+				eq(automationEvents.provider, "google_calendar"),
+				eq(automationEvents.resourceKey, resourceKey),
+			),
+		)
+		.orderBy(desc(automationEvents.receivedAt))
+		.limit(1);
+
+	let eventType: GoogleCalendarTriggerEvent;
+	// A cancellation in an incremental sync carries little more than the id and
+	// status; the title and attendees come from what was recorded before it.
+	let event = item;
+	if (item.status === "cancelled") {
+		eventType = "event.cancelled";
+		const before = (previous?.payload as { event?: GoogleCalendarEvent } | null)
+			?.event;
+		if (before) event = { ...before, ...item, status: "cancelled" };
+	} else if (
+		!previous &&
+		item.created &&
+		new Date(item.created).getTime() >= params.watchedSince.getTime()
+	) {
+		eventType = "event.created";
+	} else {
+		eventType = "event.updated";
+	}
+
+	const matchable = matchableCalendarEvent({
+		eventType,
+		calendarId,
+		event,
+		domain: params.domain,
+	});
+	const inserted = await recordGoogleEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		provider: "google_calendar",
+		eventType,
+		externalEventId: `${calendarId}:${item.id}:${item.updated ?? item.etag ?? Date.now()}`,
+		resourceKey,
+		title: event.summary ?? item.id,
+		url: event.htmlLink ?? null,
+		actorLogin: event.organizer?.email?.toLowerCase() ?? null,
+		actorIsExternal: matchable.hasExternalAttendee,
+		payload: calendarPayload(calendarId, event, matchable),
+	});
+	if (!inserted) return null;
+
+	const { matched } = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: inserted.eventId,
+		event: matchable,
+	});
+	return { matched };
+}

--- a/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncCalendar.ts
@@ -16,6 +16,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import {
 	accountDomain,
+	accountEmail,
 	calendarPayload,
 	matchableCalendarEvent,
 	resourceKeyFor,
@@ -119,7 +120,10 @@ export async function applyCalendarChanges(
 	options: { watchedSince: Date; now?: Date },
 ): Promise<{ recorded: number; matched: number; scheduled: number }> {
 	const domain = accountDomain(connection);
-	const plan = await loadFirePlan(connection.organizationId);
+	const plan = await loadFirePlan(
+		connection.organizationId,
+		connection.connectedByUserId,
+	);
 	const now = options.now ?? new Date();
 
 	let recorded = 0;
@@ -223,6 +227,7 @@ async function recordChange(params: {
 
 	const matchable = matchableCalendarEvent({
 		eventType,
+		accountEmail: accountEmail(connection),
 		calendarId,
 		event,
 		domain: params.domain,

--- a/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
@@ -91,6 +91,7 @@ export async function recordMessage(
 		provider: "gmail",
 		identityProvider: "google",
 		eventType: "message.received",
+		accountEmail: (connection.externalOrgId ?? "").toLowerCase(),
 		actorId: fromAddress,
 		actorLogin: fromAddress,
 		// The body stays in the mailbox; the subject is the filterable text.

--- a/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
@@ -1,0 +1,141 @@
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import type { GmailMatchableEvent } from "@superset/shared/automation-matching";
+import {
+	type GmailMessage,
+	getMessage,
+	getProfile,
+	googleConfigOf,
+	headerValue,
+	listAddedMessages,
+	messageHasAttachment,
+	parseAddresses,
+	patchGmailState,
+} from "@superset/trpc/integrations/google";
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import { recordGoogleEvent } from "./recordGoogleEvent";
+
+/** Labels that mean the message left this mailbox rather than arrived in it. */
+const OUTGOING_LABELS = new Set(["SENT", "DRAFT"]);
+
+export type MailboxSyncResult = {
+	/** No history id to diff from yet, or the stored one was too old. */
+	baseline: boolean;
+	added: number;
+	recorded: number;
+	matched: number;
+};
+
+/**
+ * Records every message that arrived since the stored history id.
+ *
+ * The push from Pub/Sub carries a history id too, but Google's guidance is to
+ * ignore it and always continue from the last one processed, so a dropped
+ * push costs nothing. A history id Gmail no longer holds (404) resets from
+ * the profile; whatever arrived in the gap is not replayed.
+ */
+export async function syncMailbox(
+	connection: SelectIntegrationConnection,
+): Promise<MailboxSyncResult> {
+	const state = googleConfigOf(connection.config).gmail;
+	if (!state?.historyId) {
+		const profile = await getProfile(connection.id);
+		await patchGmailState(connection.id, { historyId: profile.historyId });
+		return { baseline: true, added: 0, recorded: 0, matched: 0 };
+	}
+
+	const result = await listAddedMessages(connection.id, state.historyId);
+	if (result.expired) {
+		const profile = await getProfile(connection.id);
+		await patchGmailState(connection.id, { historyId: profile.historyId });
+		return { baseline: true, added: 0, recorded: 0, matched: 0 };
+	}
+
+	let recorded = 0;
+	let matched = 0;
+	for (const added of result.messages) {
+		if (added.labelIds.some((label) => OUTGOING_LABELS.has(label))) continue;
+		const message = await getMessage(connection.id, added.id);
+		if (!message) continue;
+		if ((message.labelIds ?? []).some((label) => OUTGOING_LABELS.has(label))) {
+			continue;
+		}
+		const outcome = await recordMessage(connection, message);
+		if (!outcome) continue;
+		recorded += 1;
+		matched += outcome.matched;
+	}
+
+	await patchGmailState(connection.id, { historyId: result.historyId });
+	return {
+		baseline: false,
+		added: result.messages.length,
+		recorded,
+		matched,
+	};
+}
+
+/**
+ * Headers and label ids are all a trigger filters on, and all that is stored:
+ * the body stays in the mailbox.
+ */
+export async function recordMessage(
+	connection: SelectIntegrationConnection,
+	message: GmailMessage,
+): Promise<{ matched: number } | null> {
+	const from = headerValue(message, "From");
+	const to = headerValue(message, "To");
+	const cc = headerValue(message, "Cc");
+	const subject = headerValue(message, "Subject");
+	const fromAddress = parseAddresses(from)[0] ?? null;
+	const matchable: GmailMatchableEvent = {
+		provider: "gmail",
+		identityProvider: "google",
+		eventType: "message.received",
+		actorId: fromAddress,
+		actorLogin: fromAddress,
+		body: message.snippet ?? null,
+		fromAddress,
+		toAddresses: [...parseAddresses(to), ...parseAddresses(cc)],
+		subject,
+		labelIds: message.labelIds ?? [],
+		hasAttachment: messageHasAttachment(message),
+	};
+
+	const inserted = await recordGoogleEvent({
+		organizationId: connection.organizationId,
+		connectionId: connection.id,
+		provider: "gmail",
+		eventType: "message.received",
+		externalEventId: message.id,
+		resourceKey: `gmail:${connection.id}:${message.threadId}`,
+		title: subject ?? "(no subject)",
+		url: `https://mail.google.com/mail/#all/${message.threadId}`,
+		actorLogin: matchable.fromAddress,
+		actorIsExternal: null,
+		payload: {
+			id: message.id,
+			threadId: message.threadId,
+			historyId: message.historyId ?? null,
+			internalDate: message.internalDate ?? null,
+			labelIds: matchable.labelIds,
+			snippet: message.snippet ?? null,
+			from,
+			fromAddress: matchable.fromAddress,
+			to,
+			cc,
+			toAddresses: matchable.toAddresses,
+			subject,
+			date: headerValue(message, "Date"),
+			messageId: headerValue(message, "Message-ID"),
+			hasAttachment: matchable.hasAttachment,
+		},
+	});
+	if (!inserted) return null;
+
+	const { matched } = await dispatchMatchingTriggers({
+		organizationId: connection.organizationId,
+		eventId: inserted.eventId,
+		event: matchable,
+	});
+	return { matched };
+}

--- a/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
@@ -93,7 +93,8 @@ export async function recordMessage(
 		eventType: "message.received",
 		actorId: fromAddress,
 		actorLogin: fromAddress,
-		body: message.snippet ?? null,
+		// The body stays in the mailbox; the subject is the filterable text.
+		body: null,
 		fromAddress,
 		toAddresses: [...parseAddresses(to), ...parseAddresses(cc)],
 		subject,
@@ -118,7 +119,6 @@ export async function recordMessage(
 			historyId: message.historyId ?? null,
 			internalDate: message.internalDate ?? null,
 			labelIds: matchable.labelIds,
-			snippet: message.snippet ?? null,
 			from,
 			fromAddress: matchable.fromAddress,
 			to,

--- a/apps/api/src/app/api/integrations/google/lib/verifyQstash.ts
+++ b/apps/api/src/app/api/integrations/google/lib/verifyQstash.ts
@@ -1,0 +1,41 @@
+import { Receiver } from "@upstash/qstash";
+import { env } from "@/env";
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+/**
+ * Rejects anything QStash did not sign for this exact URL. In development the
+ * jobs are invoked directly (QStash cannot reach localhost) so the check is
+ * skipped there, as the other job routes do.
+ */
+export async function verifyQstashRequest(
+	request: Request,
+	body: string,
+	path: string,
+): Promise<Response | null> {
+	if (env.NODE_ENV === "development") return null;
+	const signature = request.headers.get("upstash-signature");
+	if (!signature) {
+		return Response.json({ error: "Missing signature" }, { status: 401 });
+	}
+	try {
+		const valid = await receiver.verify({
+			body,
+			signature,
+			url: `${env.NEXT_PUBLIC_API_URL}${path}`,
+		});
+		if (!valid) {
+			return Response.json({ error: "Invalid signature" }, { status: 401 });
+		}
+	} catch (error) {
+		console.error(`[google${path}] signature verification failed:`, error);
+		return Response.json(
+			{ error: "Signature verification failed" },
+			{ status: 401 },
+		);
+	}
+	return null;
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -15,6 +15,11 @@ export const env = createEnv({
 		GOOGLE_CLIENT_SECRET: z.string().min(1),
 		GH_CLIENT_ID: z.string().min(1),
 		GH_CLIENT_SECRET: z.string().min(1),
+		// Gmail push: the Pub/Sub topic `users.watch` publishes to, and the
+		// shared secret the push subscription appends to our URL. Absent means
+		// Gmail triggers are configured but never watched.
+		GOOGLE_PUBSUB_TOPIC: z.string().min(1).optional(),
+		GOOGLE_PUBSUB_PUSH_TOKEN: z.string().min(1).optional(),
 		BETTER_AUTH_SECRET: z.string(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/gmail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/gmail.tsx
@@ -1,0 +1,100 @@
+import { SiGmail } from "react-icons/si";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { SelectChip } from "../../TriggerSentence/components/SelectChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	ATTACHMENT_OPTIONS,
+	GMAIL_MENU,
+	GMAIL_SENTENCE,
+	type GmailConfig,
+	type GmailSlot,
+	type SentencePart,
+} from "./grammar";
+
+function renderPart(
+	config: GmailConfig,
+	part: SentencePart<GmailSlot>,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	switch (part.slot) {
+		case "from":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.from}
+					onChange={(v) => set({ from: v })}
+					className={mark("from")}
+					options={[]}
+					emptyLabel="Select senders"
+					anyLabel="Any sender"
+					allowCustom={{ placeholder: "Add address or domain…" }}
+					disabled={disabled}
+				/>
+			);
+		case "to":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.to}
+					// Clearing an optional filter means "any", not "none".
+					onChange={(v) => set({ to: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any recipient"
+					anyLabel="Any recipient"
+					allowCustom={{ placeholder: "Add address or domain…" }}
+					disabled={disabled}
+				/>
+			);
+		case "subjectFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={config.subjectFilter}
+					onChange={(v) => set({ subjectFilter: v })}
+					emptyLabel="anything"
+					placeholder="Subject contains..."
+					disabled={disabled}
+				/>
+			);
+		case "labels":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.labels}
+					onChange={(v) => set({ labels: v ?? { mode: "any" } })}
+					options={options.google?.gmailLabels ?? []}
+					emptyLabel="Any label"
+					anyLabel="Any label"
+					disabled={disabled}
+				/>
+			);
+		case "hasAttachment":
+			return (
+				<SelectChip
+					key={index}
+					value={config.hasAttachment ? "attachment" : "any"}
+					onChange={(v) => set({ hasAttachment: v === "attachment" })}
+					options={ATTACHMENT_OPTIONS}
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const gmailProvider: TriggerProvider<GmailConfig> = {
+	kind: "gmail",
+	label: "Gmail",
+	icon: SiGmail,
+	menu: GMAIL_MENU,
+	renderSentence: (config, ctx) =>
+		GMAIL_SENTENCE.map((part, index) => renderPart(config, part, index, ctx)),
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/googleCalendar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/googleCalendar.tsx
@@ -1,0 +1,108 @@
+import { SiGooglecalendar } from "react-icons/si";
+import { ActorChip } from "../../TriggerSentence/components/ActorChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { SelectChip } from "../../TriggerSentence/components/SelectChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import {
+	CALENDAR_MENU,
+	CALENDAR_SENTENCES,
+	type CalendarSlot,
+	EXTERNAL_ATTENDEE_OPTIONS,
+	type GoogleCalendarConfig,
+	MINUTES_BEFORE_OPTIONS,
+	type SentencePart,
+} from "./grammar";
+
+function renderPart(
+	config: GoogleCalendarConfig,
+	part: SentencePart<CalendarSlot>,
+	index: number,
+	{ set, mark, options, disabled }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	// The slot list is derived from this event, so the fields it names are
+	// present on this config member even where the union type cannot say so.
+	const c = config as unknown as Record<string, never>;
+	switch (part.slot) {
+		case "calendars":
+			return (
+				<ScopeChip
+					key={index}
+					scope={c.calendars}
+					onChange={(v) => set({ calendars: v })}
+					className={mark("calendars")}
+					options={options.google?.calendars ?? []}
+					emptyLabel="Select calendars"
+					anyLabel="Any calendar"
+					disabled={disabled}
+				/>
+			);
+		case "attendee":
+			return (
+				<ActorChip
+					key={index}
+					actor={c.attendee}
+					onChange={(v) => set({ attendee: v })}
+					className={mark("attendee")}
+					people={options.google?.people ?? []}
+					disabled={disabled}
+				/>
+			);
+		case "titleFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={c.titleFilter}
+					onChange={(v) => set({ titleFilter: v })}
+					emptyLabel="anything"
+					placeholder="Title contains..."
+					disabled={disabled}
+				/>
+			);
+		case "hasExternalAttendee":
+			return (
+				<SelectChip
+					key={index}
+					value={c.hasExternalAttendee ? "external" : "any"}
+					onChange={(v) => set({ hasExternalAttendee: v === "external" })}
+					options={EXTERNAL_ATTENDEE_OPTIONS}
+					disabled={disabled}
+				/>
+			);
+		case "minutesBefore":
+			return (
+				<SelectChip
+					key={index}
+					value={String(c.minutesBefore)}
+					onChange={(v) => set({ minutesBefore: Number(v) })}
+					options={MINUTES_BEFORE_OPTIONS}
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const googleCalendarProvider: TriggerProvider<GoogleCalendarConfig> = {
+	kind: "google_calendar",
+	label: "Google Calendar",
+	icon: SiGooglecalendar,
+	menu: CALENDAR_MENU,
+	renderSentence: (config, ctx) => {
+		const parts = CALENDAR_SENTENCES[config.event];
+		if (!parts) {
+			return (
+				<span className="text-[13px] text-muted-foreground">
+					{config.event}
+				</span>
+			);
+		}
+		return parts.map((part, index) => renderPart(config, part, index, ctx));
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/grammar.ts
@@ -1,0 +1,177 @@
+import type {
+	GoogleCalendarTriggerEvent,
+	TriggerConfigInput,
+} from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type GoogleCalendarConfig = Extract<
+	TriggerConfigInput,
+	{ kind: "google_calendar" }
+>;
+export type GmailConfig = Extract<TriggerConfigInput, { kind: "gmail" }>;
+
+/**
+ * The sentences a Google trigger reads as, as data. Same shape as GitHub's:
+ * every event names its own words and slots, and one renderer walks them.
+ */
+
+export type CalendarSlot =
+	| "calendars"
+	| "attendee"
+	| "titleFilter"
+	| "hasExternalAttendee"
+	| "minutesBefore";
+
+export type GmailSlot =
+	| "from"
+	| "to"
+	| "subjectFilter"
+	| "labels"
+	| "hasAttachment";
+
+export type SentencePart<Slot extends string> =
+	| { text: string }
+	| { slot: Slot };
+
+export const CALENDAR_SENTENCES: Record<
+	GoogleCalendarTriggerEvent,
+	SentencePart<CalendarSlot>[]
+> = {
+	"event.created": [
+		{ text: "Event created in" },
+		{ slot: "calendars" },
+		{ text: "with" },
+		{ slot: "attendee" },
+		{ text: "titled" },
+		{ slot: "titleFilter" },
+		{ slot: "hasExternalAttendee" },
+	],
+	"event.updated": [
+		{ text: "Event updated in" },
+		{ slot: "calendars" },
+		{ text: "with" },
+		{ slot: "attendee" },
+		{ text: "titled" },
+		{ slot: "titleFilter" },
+		{ slot: "hasExternalAttendee" },
+	],
+	"event.cancelled": [
+		{ text: "Event cancelled in" },
+		{ slot: "calendars" },
+		{ text: "with" },
+		{ slot: "attendee" },
+		{ text: "titled" },
+		{ slot: "titleFilter" },
+	],
+	"event.starting_soon": [
+		{ text: "Event starting in" },
+		{ slot: "minutesBefore" },
+		{ text: "on" },
+		{ slot: "calendars" },
+		{ text: "with" },
+		{ slot: "attendee" },
+		{ text: "titled" },
+		{ slot: "titleFilter" },
+	],
+	"event.ended": [
+		{ text: "Event ended in" },
+		{ slot: "calendars" },
+		{ text: "with" },
+		{ slot: "attendee" },
+		{ text: "titled" },
+		{ slot: "titleFilter" },
+	],
+};
+
+export const GMAIL_SENTENCE: SentencePart<GmailSlot>[] = [
+	{ text: "Email received from" },
+	{ slot: "from" },
+	{ text: "to" },
+	{ slot: "to" },
+	{ text: "with subject" },
+	{ slot: "subjectFilter" },
+	{ text: "labeled" },
+	{ slot: "labels" },
+	{ slot: "hasAttachment" },
+];
+
+export const MINUTES_BEFORE_OPTIONS = [
+	{ value: "5", label: "5 minutes" },
+	{ value: "10", label: "10 minutes" },
+	{ value: "15", label: "15 minutes" },
+	{ value: "30", label: "30 minutes" },
+	{ value: "60", label: "1 hour" },
+	{ value: "120", label: "2 hours" },
+] as const;
+
+export const EXTERNAL_ATTENDEE_OPTIONS = [
+	{ value: "any", label: "with any attendees" },
+	{ value: "external", label: "with external attendees" },
+] as const;
+
+export const ATTACHMENT_OPTIONS = [
+	{ value: "any", label: "with or without attachments" },
+	{ value: "attachment", label: "with an attachment" },
+] as const;
+
+export const CALENDAR_MENU: TriggerMenuEntry<GoogleCalendarConfig>[] = [
+	leaf("Event created", "event.created"),
+	leaf("Event updated", "event.updated"),
+	leaf("Event cancelled", "event.cancelled"),
+	leaf("Event starting soon", "event.starting_soon"),
+	leaf("Event ended", "event.ended"),
+];
+
+// One leaf, so the Add Trigger menu shows the provider row itself; the label
+// only surfaces in search, where "gmail" has to find it.
+export const GMAIL_MENU: TriggerMenuEntry<GmailConfig>[] = [
+	{ label: "Email received in Gmail", create: createGmailConfig },
+];
+
+function leaf(label: string, event: GoogleCalendarTriggerEvent) {
+	return { label, create: () => createCalendarConfig(event) };
+}
+
+/**
+ * A new calendar trigger: the calendar still to be chosen (null matches
+ * nothing, and the form refuses to save until one is picked), every optional
+ * narrowing wide open.
+ */
+export function createCalendarConfig(
+	event: GoogleCalendarTriggerEvent,
+): GoogleCalendarConfig {
+	const base = {
+		kind: "google_calendar" as const,
+		calendars: null,
+		attendee: "anyone" as const,
+		titleFilter: null,
+	};
+	// Branching rather than spreading conditionally: the config is a union on
+	// the event, and an optional field would not narrow it.
+	switch (event) {
+		case "event.created":
+		case "event.updated":
+			return { ...base, event, hasExternalAttendee: false };
+		case "event.starting_soon":
+			return { ...base, event, minutesBefore: 15 };
+		case "event.cancelled":
+		case "event.ended":
+			return { ...base, event };
+	}
+}
+
+/**
+ * The sender is the primary scope and starts unchosen for the same reason a
+ * GitHub repository does; the rest default to "any".
+ */
+export function createGmailConfig(): GmailConfig {
+	return {
+		kind: "gmail",
+		event: "message.received",
+		from: null,
+		to: { mode: "any" },
+		subjectFilter: null,
+		labels: { mode: "any" },
+		hasAttachment: false,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/grammar.ts
@@ -44,6 +44,7 @@ export const CALENDAR_SENTENCES: Record<
 		{ slot: "attendee" },
 		{ text: "titled" },
 		{ slot: "titleFilter" },
+		{ text: "including" },
 		{ slot: "hasExternalAttendee" },
 	],
 	"event.updated": [
@@ -53,6 +54,7 @@ export const CALENDAR_SENTENCES: Record<
 		{ slot: "attendee" },
 		{ text: "titled" },
 		{ slot: "titleFilter" },
+		{ text: "including" },
 		{ slot: "hasExternalAttendee" },
 	],
 	"event.cancelled": [
@@ -105,8 +107,8 @@ export const MINUTES_BEFORE_OPTIONS = [
 ] as const;
 
 export const EXTERNAL_ATTENDEE_OPTIONS = [
-	{ value: "any", label: "with any attendees" },
-	{ value: "external", label: "with external attendees" },
+	{ value: "any", label: "anyone" },
+	{ value: "external", label: "someone external" },
 ] as const;
 
 export const ATTACHMENT_OPTIONS = [

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/useGoogleOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/useGoogleOptions.ts
@@ -8,18 +8,21 @@ import type { ProviderOptions } from "../types";
  * attendee filter. Empty until an account is connected.
  */
 export function useGoogleOptions(organizationId: string): ProviderOptions {
-	const enabled = Boolean(organizationId);
+	// Calendars and labels are read live from Google, not from a synced table
+	// like GitHub's repositories, so a stale-time keeps opening a card from
+	// spending two Google calls every time.
+	const query = { enabled: Boolean(organizationId), staleTime: 5 * 60_000 };
 	const calendars = cloudTrpc.integration.google.listCalendars.useQuery(
 		{ organizationId },
-		{ enabled },
+		query,
 	);
 	const labels = cloudTrpc.integration.google.listLabels.useQuery(
 		{ organizationId },
-		{ enabled },
+		query,
 	);
 	const people = cloudTrpc.integration.google.listLinkedPeople.useQuery(
 		{ organizationId },
-		{ enabled },
+		query,
 	);
 
 	return useMemo(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/useGoogleOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/useGoogleOptions.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { ProviderOptions } from "../types";
+
+/**
+ * The pickable values the Google sentences need: the connected account's
+ * calendars and mail labels, and the org's linked Google addresses for the
+ * attendee filter. Empty until an account is connected.
+ */
+export function useGoogleOptions(organizationId: string): ProviderOptions {
+	const enabled = Boolean(organizationId);
+	const calendars = cloudTrpc.integration.google.listCalendars.useQuery(
+		{ organizationId },
+		{ enabled },
+	);
+	const labels = cloudTrpc.integration.google.listLabels.useQuery(
+		{ organizationId },
+		{ enabled },
+	);
+	const people = cloudTrpc.integration.google.listLinkedPeople.useQuery(
+		{ organizationId },
+		{ enabled },
+	);
+
+	return useMemo(
+		() => ({
+			google: {
+				calendars: calendars.data ?? [],
+				gmailLabels: labels.data ?? [],
+				people: people.data ?? [],
+			},
+		}),
+		[calendars.data, labels.data, people.data],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -1,6 +1,8 @@
 import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
 import { circlebackProvider } from "./circleback/circleback";
 import { githubProvider } from "./github/github";
+import { gmailProvider } from "./google/gmail";
+import { googleCalendarProvider } from "./google/googleCalendar";
 import { linearProvider } from "./linear/linear";
 import { microsoftTeamsProvider } from "./microsoftTeams/microsoftTeams";
 import { notionProvider } from "./notion/notion";
@@ -33,6 +35,8 @@ export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	webhookProvider as TriggerProvider,
 	circlebackProvider as TriggerProvider,
 	microsoftTeamsProvider as TriggerProvider,
+	googleCalendarProvider as TriggerProvider,
+	gmailProvider as TriggerProvider,
 ];
 
 const byKind = new Map(TRIGGER_PROVIDERS.map((p) => [p.kind, p]));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/useProviderOptions.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useGithubOptions } from "./github/useGithubOptions";
+import { useGoogleOptions } from "./google/useGoogleOptions";
 import { useLinearOptions } from "./linear/useLinearOptions";
 import { useTeamsOptions } from "./microsoftTeams/useTeamsOptions";
 import { useNotionOptions } from "./notion/useNotionOptions";
@@ -22,8 +23,17 @@ export function useProviderOptions(organizationId: string): ProviderOptions {
 	const notion = useNotionOptions(organizationId);
 	const slack = useSlackOptions(organizationId);
 	const teams = useTeamsOptions(organizationId);
+	const google = useGoogleOptions(organizationId);
 	return useMemo(
-		() => ({ ...github, ...sentry, ...linear, ...notion, ...slack, ...teams }),
-		[github, sentry, linear, notion, slack, teams],
+		() => ({
+			...github,
+			...sentry,
+			...linear,
+			...notion,
+			...slack,
+			...teams,
+			...google,
+		}),
+		[github, sentry, linear, notion, slack, teams, google],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -42,6 +42,14 @@ export function IntegrationsSettings({
 			{ enabled: !!activeOrganizationId },
 		);
 
+	// Google is per member, not per org, so the caller's own connection rather
+	// than whichever row integration.list happens to return first.
+	const { data: googleConnection, isPending: isGooglePending } =
+		cloudTrpc.integration.google.getConnection.useQuery(
+			{ organizationId: activeOrganizationId ?? "" },
+			{ enabled: !!activeOrganizationId },
+		);
+
 	const [githubInstallation, setGithubInstallation] =
 		useState<GithubInstallation | null>(null);
 	const [isLoadingGithub, setIsLoadingGithub] = useState(true);
@@ -80,10 +88,10 @@ export function IntegrationsSettings({
 
 	const linearConnection = integrations?.find((i) => i.provider === "linear");
 	const slackConnection = integrations?.find((i) => i.provider === "slack");
-	const googleConnection = integrations?.find((i) => i.provider === "google");
 	const isLinearConnected = !!linearConnection;
 	const isSlackConnected = !!slackConnection;
-	const isGoogleConnected = !!googleConnection;
+	const isGoogleConnected =
+		!!googleConnection && !googleConnection.needsReconnect;
 	const isGithubConnected =
 		!!githubInstallation && !githubInstallation.suspended;
 	const showSlack = isItemVisible(
@@ -167,8 +175,8 @@ export function IntegrationsSettings({
 						description="Trigger automations from Google Calendar and Gmail."
 						icon={<FaGoogle className="size-5" />}
 						isConnected={isGoogleConnected}
-						connectedOrgName={googleConnection?.externalOrgName}
-						isLoading={isIntegrationsPending}
+						connectedOrgName={googleConnection?.email}
+						isLoading={isGooglePending}
 						onManage={() => handleOpenWeb("/integrations/google")}
 					/>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Skeleton } from "@superset/ui/skeleton";
 import { useCallback, useEffect, useState } from "react";
-import { FaGithub, FaSlack } from "react-icons/fa";
+import { FaGithub, FaGoogle, FaSlack } from "react-icons/fa";
 import { HiOutlineArrowTopRightOnSquare } from "react-icons/hi2";
 import { SiLinear } from "react-icons/si";
 import { env } from "renderer/env.renderer";
@@ -80,12 +80,18 @@ export function IntegrationsSettings({
 
 	const linearConnection = integrations?.find((i) => i.provider === "linear");
 	const slackConnection = integrations?.find((i) => i.provider === "slack");
+	const googleConnection = integrations?.find((i) => i.provider === "google");
 	const isLinearConnected = !!linearConnection;
 	const isSlackConnected = !!slackConnection;
+	const isGoogleConnected = !!googleConnection;
 	const isGithubConnected =
 		!!githubInstallation && !githubInstallation.suspended;
 	const showSlack = isItemVisible(
 		SETTING_ITEM_ID.INTEGRATIONS_SLACK,
+		visibleItems,
+	);
+	const showGoogle = isItemVisible(
+		SETTING_ITEM_ID.INTEGRATIONS_GOOGLE,
 		visibleItems,
 	);
 
@@ -152,6 +158,18 @@ export function IntegrationsSettings({
 						connectedOrgName={slackConnection?.externalOrgName}
 						isLoading={isIntegrationsPending}
 						onManage={() => handleOpenWeb("/integrations/slack")}
+					/>
+				)}
+
+				{showGoogle && (
+					<IntegrationRow
+						name={<HighlightText text="Google" query={searchQuery} />}
+						description="Trigger automations from Google Calendar and Gmail."
+						icon={<FaGoogle className="size-5" />}
+						isConnected={isGoogleConnected}
+						connectedOrgName={googleConnection?.externalOrgName}
+						isLoading={isIntegrationsPending}
+						onManage={() => handleOpenWeb("/integrations/google")}
 					/>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -65,6 +65,7 @@ export const SETTING_ITEM_ID = {
 	INTEGRATIONS_LINEAR: "integrations-linear",
 	INTEGRATIONS_GITHUB: "integrations-github",
 	INTEGRATIONS_SLACK: "integrations-slack",
+	INTEGRATIONS_GOOGLE: "integrations-google",
 
 	BILLING_OVERVIEW: "billing-overview",
 	BILLING_PLANS: "billing-plans",
@@ -185,6 +186,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.INTEGRATIONS_LINEAR]: "shared",
 	[SETTING_ITEM_ID.INTEGRATIONS_GITHUB]: "shared",
 	[SETTING_ITEM_ID.INTEGRATIONS_SLACK]: "shared",
+	[SETTING_ITEM_ID.INTEGRATIONS_GOOGLE]: "shared",
 
 	[SETTING_ITEM_ID.BILLING_OVERVIEW]: "shared",
 	[SETTING_ITEM_ID.BILLING_PLANS]: "shared",
@@ -1183,6 +1185,25 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"connect",
 			"connected",
 			"communication",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.INTEGRATIONS_GOOGLE,
+		section: "integrations",
+		title: "Google",
+		description: "Trigger automations from Google Calendar and Gmail",
+		keywords: [
+			"integrations",
+			"google",
+			"calendar",
+			"gmail",
+			"email",
+			"mail",
+			"events",
+			"triggers",
+			"automations",
+			"connect",
+			"connected",
 		],
 	},
 	{

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ConnectionControls/ConnectionControls.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ConnectionControls/ConnectionControls.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RefreshCw, Unplug } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { env } from "@/env";
+import { useTRPC } from "@/trpc/react";
+
+interface ConnectionControlsProps {
+	organizationId: string;
+	isConnected: boolean;
+	needsReconnect: boolean;
+}
+
+export function ConnectionControls({
+	organizationId,
+	isConnected,
+	needsReconnect,
+}: ConnectionControlsProps) {
+	const trpc = useTRPC();
+	const router = useRouter();
+	const queryClient = useQueryClient();
+
+	const disconnectMutation = useMutation(
+		trpc.integration.google.disconnect.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({
+					queryKey: trpc.integration.google.getConnection.queryKey({
+						organizationId,
+					}),
+				});
+				router.refresh();
+			},
+		}),
+	);
+
+	const handleConnect = () => {
+		window.location.href = `${env.NEXT_PUBLIC_API_URL}/api/integrations/google/connect?organizationId=${organizationId}`;
+	};
+
+	if (needsReconnect) {
+		return (
+			<div className="flex gap-2">
+				<Button onClick={handleConnect}>
+					<RefreshCw className="mr-2 size-4" />
+					Reconnect Google
+				</Button>
+				<Button
+					variant="outline"
+					onClick={() => disconnectMutation.mutate({ organizationId })}
+					disabled={disconnectMutation.isPending}
+				>
+					<Unplug className="mr-2 size-4" />
+					Remove
+				</Button>
+			</div>
+		);
+	}
+
+	if (isConnected) {
+		return (
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button variant="outline" disabled={disconnectMutation.isPending}>
+						<Unplug className="mr-2 size-4" />
+						{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Disconnect Google?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Calendar and Gmail triggers in this organization will stop firing
+							until an account is connected again.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => disconnectMutation.mutate({ organizationId })}
+						>
+							Disconnect
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
+	}
+
+	return <Button onClick={handleConnect}>Connect Google</Button>;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ConnectionControls/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ConnectionControls/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionControls } from "./ConnectionControls";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/ErrorHandler.tsx
@@ -24,9 +24,10 @@ export function ErrorHandler() {
 		const error = searchParams.get("error");
 		if (!error) return;
 		const message = ERROR_MESSAGES[error] ?? "Something went wrong.";
+		// Toast first: replacing the URL re-runs this effect through Next's
+		// patched history, and a deferred toast can be cleaned up before it shows.
+		toast.error(message);
 		window.history.replaceState({}, "", "/integrations/google");
-		const id = setTimeout(() => toast.error(message), 0);
-		return () => clearTimeout(id);
 	}, [searchParams]);
 
 	return null;

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/ErrorHandler.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { toast } from "@superset/ui/sonner";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+	oauth_denied: "Authorization was denied. Please try again.",
+	missing_params: "Invalid OAuth response. Please try again.",
+	invalid_state: "Invalid state parameter. Please try again.",
+	token_exchange_failed: "Failed to connect to Google. Please try again.",
+	missing_scopes:
+		"Both Calendar and Gmail access are required. Please allow both when asked.",
+	no_refresh_token:
+		"Google did not grant lasting access. Remove Superset from your Google account's third-party access and try again.",
+	userinfo_failed: "Could not read the Google account. Please try again.",
+	unauthorized: "You are not authorized to perform this action.",
+};
+
+export function ErrorHandler() {
+	const searchParams = useSearchParams();
+
+	useEffect(() => {
+		const error = searchParams.get("error");
+		if (!error) return;
+		const message = ERROR_MESSAGES[error] ?? "Something went wrong.";
+		window.history.replaceState({}, "", "/integrations/google");
+		const id = setTimeout(() => toast.error(message), 0);
+		return () => clearTimeout(id);
+	}, [searchParams]);
+
+	return null;
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/components/ErrorHandler/index.ts
@@ -1,0 +1,1 @@
+export { ErrorHandler } from "./ErrorHandler";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/page.tsx
@@ -1,0 +1,101 @@
+import { Badge } from "@superset/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@superset/ui/card";
+import { AlertTriangle, ArrowLeft, CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { FaGoogle } from "react-icons/fa";
+import { api } from "@/trpc/server";
+import { ConnectionControls } from "./components/ConnectionControls";
+import { ErrorHandler } from "./components/ErrorHandler";
+
+export default async function GoogleIntegrationPage() {
+	const trpc = await api();
+	const organization = await trpc.user.myOrganization.query();
+
+	if (!organization) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16">
+				<p className="text-muted-foreground">
+					You need to be part of an organization to use integrations.
+				</p>
+			</div>
+		);
+	}
+
+	const connection = await trpc.integration.google.getConnection.query({
+		organizationId: organization.id,
+	});
+	const isConnected = !!connection && !connection.needsReconnect;
+	const needsReconnect = !!connection?.needsReconnect;
+
+	return (
+		<div className="space-y-8">
+			<ErrorHandler />
+
+			<Link
+				href="/integrations"
+				className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ArrowLeft className="size-4" />
+				Back to Integrations
+			</Link>
+
+			<div className="flex items-start gap-6">
+				<div className="flex size-16 items-center justify-center rounded-xl border bg-card p-3">
+					<FaGoogle className="size-10" />
+				</div>
+				<div className="flex-1">
+					<div className="flex items-center gap-3">
+						<h1 className="text-2xl font-semibold">Google</h1>
+						{needsReconnect ? (
+							<Badge variant="destructive" className="gap-1">
+								<AlertTriangle className="size-3" />
+								Reconnect required
+							</Badge>
+						) : isConnected ? (
+							<Badge variant="default" className="gap-1">
+								<CheckCircle2 className="size-3" />
+								Connected
+							</Badge>
+						) : (
+							<Badge variant="secondary">Not Connected</Badge>
+						)}
+					</div>
+					<p className="mt-1 text-muted-foreground">
+						Trigger automations from Google Calendar and Gmail: events created,
+						updated, cancelled, starting soon or ended, and email arriving in
+						the connected inbox.
+					</p>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Connection</CardTitle>
+					<CardDescription>
+						Connect a Google account. Its calendars and mailbox are read-only,
+						and triggers run for the person who connected it.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ConnectionControls
+						organizationId={organization.id}
+						isConnected={isConnected}
+						needsReconnect={needsReconnect}
+					/>
+					{connection?.email && (
+						<div className="mt-4 text-sm text-muted-foreground">
+							Connected as{" "}
+							<span className="font-medium">{connection.email}</span>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BsMicrosoftTeams } from "react-icons/bs";
-import { FaGithub, FaSlack } from "react-icons/fa";
+import { FaGithub, FaGoogle, FaSlack } from "react-icons/fa";
 import { SiLinear, SiNotion, SiSentry } from "react-icons/si";
 import {
 	IntegrationCard,
@@ -56,6 +56,14 @@ const integrations: IntegrationCardProps[] = [
 		category: "Monitoring",
 		accentColor: "#362D59",
 		icon: <SiSentry className="size-8" />,
+	},
+	{
+		id: "google",
+		name: "Google",
+		description: "Trigger automations from Google Calendar and Gmail.",
+		category: "Productivity",
+		accentColor: "#4285F4",
+		icon: <FaGoogle className="size-8" />,
 	},
 ];
 

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -127,4 +127,6 @@ export type GmailTriggerConfig = Extract<TriggerConfig, { kind: "gmail" }>;
 export type UserIdentityMetadata =
 	| { provider: "slack"; modelPreference?: string }
 	| { provider: "github" }
-	| { provider: "google" };
+	// The external id is the account address, since that is what calendar
+	// events and mail headers name people by; the stable subject id rides here.
+	| { provider: "google"; sub?: string };

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -50,11 +50,41 @@ export type SentryConfig = {
 	regionUrl?: string;
 };
 
+/**
+ * One watched calendar's sync state. Google's push carries no payload, only
+ * "something changed"; the sync token is what turns that into a diff, and the
+ * channel is what has to be renewed before it expires.
+ */
+export type GoogleCalendarWatchState = {
+	summary?: string;
+	syncToken?: string;
+	/** When the calendar was first synced; earlier events are never "created". */
+	watchedSince?: string;
+	channelId?: string;
+	resourceId?: string;
+	/** Compared against `X-Goog-Channel-Token` on every push. */
+	channelToken?: string;
+	/** Epoch milliseconds, as Google reports it. */
+	channelExpiresAt?: number;
+};
+
+export type GoogleConfig = {
+	provider: "google";
+	calendars?: Record<string, GoogleCalendarWatchState>;
+	gmail?: {
+		/** Where the next history.list starts. */
+		historyId?: string;
+		/** Epoch milliseconds; users.watch lasts seven days at most. */
+		watchExpiresAt?: number;
+	};
+};
+
 export type IntegrationConfig =
 	| LinearConfig
 	| SlackConfig
 	| MicrosoftTeamsConfig
-	| SentryConfig;
+	| SentryConfig
+	| GoogleConfig;
 
 /**
  * The trigger config column, typed from the zod schema that validates every
@@ -80,6 +110,11 @@ export type MicrosoftTeamsTriggerConfig = Extract<
 	TriggerConfig,
 	{ kind: "microsoft_teams" }
 >;
+export type GoogleCalendarTriggerConfig = Extract<
+	TriggerConfig,
+	{ kind: "google_calendar" }
+>;
+export type GmailTriggerConfig = Extract<TriggerConfig, { kind: "gmail" }>;
 
 /**
  * Provider-specific extras on a user identity.

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -62,8 +62,12 @@ export type GoogleCalendarWatchState = {
 	watchedSince?: string;
 	channelId?: string;
 	resourceId?: string;
-	/** Compared against `X-Goog-Channel-Token` on every push. */
-	channelToken?: string;
+	/**
+	 * SHA-256 of the token Google echoes back as `X-Goog-Channel-Token`. A
+	 * hash because this column is read by every member's client through
+	 * `integration.list`; the token itself is what authenticates a push.
+	 */
+	channelTokenHash?: string;
 	/** Epoch milliseconds, as Google reports it. */
 	channelExpiresAt?: number;
 };

--- a/packages/shared/src/automation-matching/google.ts
+++ b/packages/shared/src/automation-matching/google.ts
@@ -26,6 +26,11 @@ export type GoogleCalendarMatchableEvent = BaseMatchableEvent & {
 	/** Both Google kinds share one connection, so `me` resolves through it. */
 	identityProvider: "google";
 	eventType: GoogleCalendarTriggerEvent;
+	/**
+	 * The Google account the event came from, lower-cased. Connections are
+	 * per member, so a trigger only sees events from its owner's account.
+	 */
+	accountEmail: string;
 	calendarId: string;
 	/** Organizer, creator and invitees together — everyone on the event. */
 	attendeeEmails: string[];
@@ -41,6 +46,7 @@ export type GmailMatchableEvent = BaseMatchableEvent & {
 	provider: "gmail";
 	identityProvider: "google";
 	eventType: GmailTriggerEvent;
+	accountEmail: string;
 	fromAddress: string | null;
 	toAddresses: string[];
 	subject: string | null;
@@ -51,8 +57,17 @@ export type GmailMatchableEvent = BaseMatchableEvent & {
 /**
  * `context.ownerIds` are addresses here: a calendar event names people by
  * email, so the Google identity's external id is the account address and `me`
- * resolves to the automation owner's linked addresses.
+ * resolves to the automation owner's linked addresses. The same ids say whose
+ * account the event came from — a Google connection is one member's, and only
+ * that member's automations see its events.
  */
+export function ownsAccount(
+	event: { accountEmail: string },
+	context: MatchContext,
+): boolean {
+	return context.ownerIds.includes(event.accountEmail);
+}
+
 export function googleCalendarTriggerMatches(
 	config: {
 		event: string;
@@ -66,6 +81,7 @@ export function googleCalendarTriggerMatches(
 	context: MatchContext,
 ): MatchResult {
 	if (config.event !== event.eventType) return no("event");
+	if (!ownsAccount(event, context)) return no("account");
 	if (!scopeAllows(config.calendars, event.calendarId)) return no("calendar");
 	if (
 		!attendeeAllows(config.attendee, event.attendeeEmails, context.ownerIds)
@@ -110,8 +126,10 @@ export function gmailTriggerMatches(
 		hasAttachment: boolean;
 	},
 	event: GmailMatchableEvent,
+	context: MatchContext,
 ): MatchResult {
 	if (config.event !== event.eventType) return no("event");
+	if (!ownsAccount(event, context)) return no("account");
 	if (
 		!addressScopeAllows(
 			config.from,

--- a/packages/shared/src/automation-matching/google.ts
+++ b/packages/shared/src/automation-matching/google.ts
@@ -120,11 +120,20 @@ export function gmailTriggerMatches(
 	) {
 		return no("from");
 	}
-	if (!addressScopeAllows(config.to, event.toAddresses)) return no("to");
+	// Recipients and labels only narrow when configured; null means the trigger
+	// author did not choose to filter on them, which for these is "any".
+	if (config.to !== null && !addressScopeAllows(config.to, event.toAddresses)) {
+		return no("to");
+	}
 	if (!bodyMatches(config.subjectFilter, event.subject)) {
 		return no("subjectFilter");
 	}
-	if (!scopeAllowsAny(config.labels, event.labelIds)) return no("label");
+	if (
+		config.labels !== null &&
+		!scopeAllowsAny(config.labels, event.labelIds)
+	) {
+		return no("label");
+	}
 	if (config.hasAttachment && !event.hasAttachment) return no("hasAttachment");
 	return { matches: true };
 }

--- a/packages/shared/src/automation-matching/google.ts
+++ b/packages/shared/src/automation-matching/google.ts
@@ -1,0 +1,149 @@
+import type {
+	GmailTriggerEvent,
+	GoogleCalendarTriggerEvent,
+	TriggerActor,
+	TriggerScope,
+} from "../automation-triggers";
+import {
+	actorAllows,
+	type BaseMatchableEvent,
+	bodyMatches,
+	type MatchContext,
+	type MatchResult,
+	scopeAllows,
+	scopeAllowsAny,
+} from "./core";
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+/**
+ * A synced calendar change or a fire we scheduled off one, normalized to what
+ * the triggers filter on. Emails are lower-cased at record time so the
+ * comparison here is exact.
+ */
+export type GoogleCalendarMatchableEvent = BaseMatchableEvent & {
+	provider: "google_calendar";
+	/** Both Google kinds share one connection, so `me` resolves through it. */
+	identityProvider: "google";
+	eventType: GoogleCalendarTriggerEvent;
+	calendarId: string;
+	/** Organizer, creator and invitees together — everyone on the event. */
+	attendeeEmails: string[];
+	title: string | null;
+	/** Someone on the event is outside the connected account's domain. */
+	hasExternalAttendee: boolean;
+	/** Set on `event.starting_soon`; how far ahead the fire was scheduled. */
+	minutesBefore: number | null;
+};
+
+/** An arriving mail, normalized from its headers and label ids. */
+export type GmailMatchableEvent = BaseMatchableEvent & {
+	provider: "gmail";
+	identityProvider: "google";
+	eventType: GmailTriggerEvent;
+	fromAddress: string | null;
+	toAddresses: string[];
+	subject: string | null;
+	labelIds: string[];
+	hasAttachment: boolean;
+};
+
+/**
+ * `context.ownerIds` are addresses here: a calendar event names people by
+ * email, so the Google identity's external id is the account address and `me`
+ * resolves to the automation owner's linked addresses.
+ */
+export function googleCalendarTriggerMatches(
+	config: {
+		event: string;
+		calendars: TriggerScope;
+		attendee: TriggerActor;
+		titleFilter: { pattern: string; isRegex: boolean } | null;
+		hasExternalAttendee?: boolean;
+		minutesBefore?: number;
+	},
+	event: GoogleCalendarMatchableEvent,
+	context: MatchContext,
+): MatchResult {
+	if (config.event !== event.eventType) return no("event");
+	if (!scopeAllows(config.calendars, event.calendarId)) return no("calendar");
+	if (
+		!attendeeAllows(config.attendee, event.attendeeEmails, context.ownerIds)
+	) {
+		return no("attendee");
+	}
+	if (!bodyMatches(config.titleFilter, event.title)) return no("titleFilter");
+	if (config.hasExternalAttendee && !event.hasExternalAttendee) {
+		return no("hasExternalAttendee");
+	}
+	// The fire was scheduled for one lead time; a trigger asking for another
+	// gets its own fire rather than this one.
+	if (
+		config.minutesBefore !== undefined &&
+		config.minutesBefore !== event.minutesBefore
+	) {
+		return no("minutesBefore");
+	}
+	return { matches: true };
+}
+
+/**
+ * The actor filter over a list of people rather than one: an event is a match
+ * when any of its attendees satisfies it.
+ */
+function attendeeAllows(
+	actor: TriggerActor,
+	attendeeEmails: string[],
+	ownerEmails: string[],
+): boolean {
+	if (actor === "anyone") return true;
+	return attendeeEmails.some((email) => actorAllows(actor, email, ownerEmails));
+}
+
+export function gmailTriggerMatches(
+	config: {
+		event: string;
+		from: TriggerScope;
+		to: TriggerScope;
+		subjectFilter: { pattern: string; isRegex: boolean } | null;
+		labels: TriggerScope;
+		hasAttachment: boolean;
+	},
+	event: GmailMatchableEvent,
+): MatchResult {
+	if (config.event !== event.eventType) return no("event");
+	if (
+		!addressScopeAllows(
+			config.from,
+			event.fromAddress ? [event.fromAddress] : [],
+		)
+	) {
+		return no("from");
+	}
+	if (!addressScopeAllows(config.to, event.toAddresses)) return no("to");
+	if (!bodyMatches(config.subjectFilter, event.subject)) {
+		return no("subjectFilter");
+	}
+	if (!scopeAllowsAny(config.labels, event.labelIds)) return no("label");
+	if (config.hasAttachment && !event.hasAttachment) return no("hasAttachment");
+	return { matches: true };
+}
+
+/**
+ * A scope over addresses where each id is either a full address or a bare
+ * domain, so "acme.com" admits everyone there. Both sides are compared
+ * lower-cased; the recorded addresses already are.
+ */
+export function addressScopeAllows(
+	scope: TriggerScope,
+	addresses: string[],
+): boolean {
+	if (scope === null) return false;
+	if (scope.mode === "any") return true;
+	const wanted = scope.ids.map((id) => id.trim().toLowerCase());
+	return addresses.some((address) =>
+		wanted.some((id) =>
+			id.includes("@") ? address === id : address.endsWith(`@${id}`),
+		),
+	);
+}

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -5,6 +5,12 @@ import {
 } from "./circleback";
 import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
 import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
+import {
+	type GmailMatchableEvent,
+	type GoogleCalendarMatchableEvent,
+	gmailTriggerMatches,
+	googleCalendarTriggerMatches,
+} from "./google";
 import { type LinearMatchableEvent, linearTriggerMatches } from "./linear";
 import {
 	type MicrosoftTeamsMatchableEvent,
@@ -18,6 +24,7 @@ import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
 export * from "./circleback";
 export * from "./core";
 export * from "./github";
+export * from "./google";
 export * from "./linear";
 export * from "./microsoft-teams";
 export * from "./notion";
@@ -42,7 +49,9 @@ export type MatchableEvent =
 	| SlackMatchableEvent
 	| CirclebackMatchableEvent
 	| MicrosoftTeamsMatchableEvent
-	| SentryMatchableEvent;
+	| SentryMatchableEvent
+	| GoogleCalendarMatchableEvent
+	| GmailMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -111,6 +120,17 @@ export function triggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "microsoft_teams" }>,
 				event,
 				context,
+			);
+		case "google_calendar":
+			return googleCalendarTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "google_calendar" }>,
+				event,
+				context,
+			);
+		case "gmail":
+			return gmailTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "gmail" }>,
+				event,
 			);
 	}
 	// Reached only when a provider is in the union but has no case above.

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -131,6 +131,7 @@ export function triggerMatches(
 			return gmailTriggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "gmail" }>,
 				event,
+				context,
 			);
 	}
 	// Reached only when a provider is in the union but has no case above.

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -330,6 +330,71 @@ export const microsoftTeamsTriggerConfigSchema = z.object({
 });
 
 /**
+ * Google Calendar events carry different filters, so the config is a union on
+ * the event: a change carries the external-attendee narrowing, a starting-soon
+ * fire carries how far ahead it fires, and a cancellation carries neither.
+ */
+export const googleCalendarTriggerEventValues = [
+	"event.created",
+	"event.updated",
+	"event.cancelled",
+	"event.starting_soon",
+	"event.ended",
+] as const;
+export type GoogleCalendarTriggerEvent =
+	(typeof googleCalendarTriggerEventValues)[number];
+
+const googleCalendarCommon = {
+	kind: z.literal("google_calendar"),
+	calendars: triggerScopeSchema,
+	// Anyone on the event: organizer, creator or invitee. Ids are email
+	// addresses, since that is what a calendar event names people by.
+	attendee: triggerActorSchema,
+	titleFilter: textFilterSchema.nullable().default(null),
+};
+
+const googleCalendarChangeEvent = z.object({
+	...googleCalendarCommon,
+	event: z.enum(["event.created", "event.updated"]),
+	// A boolean rather than a scope: false is "do not narrow", true requires
+	// someone from outside the connected account's domain to be on the event.
+	hasExternalAttendee: z.boolean().default(false),
+});
+
+const googleCalendarStartingSoonEvent = z.object({
+	...googleCalendarCommon,
+	event: z.literal("event.starting_soon"),
+	minutesBefore: z.number().int().min(1).max(1440).default(15),
+});
+
+const googleCalendarSimpleEvent = z.object({
+	...googleCalendarCommon,
+	event: z.enum(["event.cancelled", "event.ended"]),
+});
+
+export const googleCalendarTriggerConfigSchema = z.union([
+	googleCalendarChangeEvent,
+	googleCalendarStartingSoonEvent,
+	googleCalendarSimpleEvent,
+]);
+
+export const gmailTriggerEventValues = ["message.received"] as const;
+export type GmailTriggerEvent = (typeof gmailTriggerEventValues)[number];
+
+export const gmailTriggerConfigSchema = z.object({
+	kind: z.literal("gmail"),
+	event: z.enum(gmailTriggerEventValues),
+	// Addresses or bare domains ("acme.com"), free-form: a sender is not a
+	// pickable value the way a channel is.
+	from: triggerScopeSchema,
+	to: triggerScopeSchema,
+	subjectFilter: textFilterSchema.nullable().default(null),
+	// Gmail label ids, not names: a label can be renamed, its id cannot.
+	labels: triggerScopeSchema,
+	hasAttachment: z.boolean().default(false),
+});
+
+/**
  * Structurally valid — the shape is right, but a scope may still select nothing.
  * This is what the editor holds while someone is still filling a trigger in.
  */
@@ -349,6 +414,8 @@ export const draftTriggerSchema = z.object({
 		notionTriggerConfigSchema,
 		circlebackTriggerConfigSchema,
 		microsoftTeamsTriggerConfigSchema,
+		googleCalendarTriggerConfigSchema,
+		gmailTriggerConfigSchema,
 	]),
 });
 export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
@@ -464,6 +531,32 @@ export function describeTriggerProblems(
 			case "sentry": {
 				if (isEmptyScope(config.projects)) {
 					add(index, "projects", "Specify at least one project.");
+				}
+				break;
+			}
+			case "google_calendar": {
+				if (isEmptyScope(config.calendars)) {
+					add(index, "calendars", "Specify at least one calendar.");
+				}
+				if (isEmptyActor(config.attendee)) {
+					add(
+						index,
+						"attendee",
+						"Specify at least one person, or choose Anyone.",
+					);
+				}
+				break;
+			}
+			case "gmail": {
+				// The sender is the primary scope, as the repository is for GitHub:
+				// a mailbox-wide trigger has to be chosen ("Any sender"), never
+				// arrived at by leaving the chip empty.
+				if (isEmptyScope(config.from)) {
+					add(
+						index,
+						"from",
+						"Specify at least one sender, or choose Any sender.",
+					);
 				}
 				break;
 			}

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -37,6 +37,8 @@ export const env = createEnv({
 		RELAY_URL: z.string().url(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
+		GOOGLE_CLIENT_ID: z.string().min(1),
+		GOOGLE_CLIENT_SECRET: z.string().min(1),
 		SENTRY_CLIENT_ID: z.string().optional(),
 		SENTRY_CLIENT_SECRET: z.string().optional(),
 		// Optional: the Teams integration is off wherever these are unset, and

--- a/packages/trpc/src/lib/integrations/google/index.ts
+++ b/packages/trpc/src/lib/integrations/google/index.ts
@@ -1,0 +1,47 @@
+export {
+	eventAttendeeEmails,
+	eventEnd,
+	eventStart,
+	type GoogleCalendarEvent,
+	type GoogleCalendarListEntry,
+	getEvent,
+	listCalendars,
+	listEventChanges,
+	listEventInstances,
+	listUpcomingInstances,
+	stopChannel,
+	watchCalendar,
+} from "../../../router/integration/google/calendar";
+export {
+	CALENDAR_CHANNEL_TTL_MS,
+	GMAIL_WATCH_TTL_MS,
+	GOOGLE_SCOPES,
+	WATCH_RENEW_WINDOW_MS,
+} from "../../../router/integration/google/constants";
+export {
+	type GmailMessage,
+	getMessage,
+	getProfile,
+	headerValue,
+	listAddedMessages,
+	listLabels,
+	messageHasAttachment,
+	parseAddresses,
+	stopMailboxWatch,
+	watchMailbox,
+} from "../../../router/integration/google/gmail";
+export {
+	GoogleApiError,
+	getGoogleAccessToken,
+	googleFetch,
+	googleTokenResponseSchema,
+	refreshGoogleToken,
+} from "../../../router/integration/google/refresh";
+export {
+	findGoogleConnection,
+	findGoogleConnectionById,
+	googleConfigOf,
+	patchCalendarState,
+	patchGmailState,
+	removeCalendarState,
+} from "../../../router/integration/google/state";

--- a/packages/trpc/src/router/integration/google/calendar.ts
+++ b/packages/trpc/src/router/integration/google/calendar.ts
@@ -156,16 +156,23 @@ export async function listEventInstances(
 	eventId: string,
 	window: { from: Date; to: Date },
 ): Promise<GoogleCalendarEvent[]> {
-	const params = new URLSearchParams({
-		timeMin: window.from.toISOString(),
-		timeMax: window.to.toISOString(),
-		maxResults: "250",
-	});
-	const page = await googleFetch<EventsPage>(
-		connectionId,
-		`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/instances?${params}`,
-	);
-	return page.items ?? [];
+	const items: GoogleCalendarEvent[] = [];
+	let pageToken: string | undefined;
+	do {
+		const params = new URLSearchParams({
+			timeMin: window.from.toISOString(),
+			timeMax: window.to.toISOString(),
+			maxResults: "250",
+		});
+		if (pageToken) params.set("pageToken", pageToken);
+		const page = await googleFetch<EventsPage>(
+			connectionId,
+			`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/instances?${params}`,
+		);
+		items.push(...(page.items ?? []));
+		pageToken = page.nextPageToken;
+	} while (pageToken);
+	return items;
 }
 
 /** Null when the event no longer exists at all (404), as opposed to cancelled. */

--- a/packages/trpc/src/router/integration/google/calendar.ts
+++ b/packages/trpc/src/router/integration/google/calendar.ts
@@ -1,0 +1,260 @@
+import { CALENDAR_CHANNEL_TTL_MS } from "./constants";
+import { GoogleApiError, googleFetch } from "./refresh";
+
+const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
+
+export type GoogleCalendarListEntry = {
+	id: string;
+	summary?: string;
+	primary?: boolean;
+	accessRole?: string;
+	deleted?: boolean;
+	timeZone?: string;
+};
+
+export type GoogleCalendarPerson = {
+	email?: string;
+	displayName?: string;
+	self?: boolean;
+	organizer?: boolean;
+	responseStatus?: string;
+};
+
+export type GoogleCalendarEvent = {
+	id: string;
+	status?: "confirmed" | "tentative" | "cancelled" | string;
+	etag?: string;
+	htmlLink?: string;
+	summary?: string;
+	description?: string;
+	location?: string;
+	created?: string;
+	updated?: string;
+	start?: { date?: string; dateTime?: string; timeZone?: string };
+	end?: { date?: string; dateTime?: string; timeZone?: string };
+	recurrence?: string[];
+	recurringEventId?: string;
+	organizer?: GoogleCalendarPerson;
+	creator?: GoogleCalendarPerson;
+	attendees?: GoogleCalendarPerson[];
+	hangoutLink?: string;
+	eventType?: string;
+};
+
+type EventsPage = {
+	items?: GoogleCalendarEvent[];
+	nextPageToken?: string;
+	nextSyncToken?: string;
+};
+
+export async function listCalendars(
+	connectionId: string,
+): Promise<GoogleCalendarListEntry[]> {
+	const items: GoogleCalendarListEntry[] = [];
+	let pageToken: string | undefined;
+	do {
+		const params = new URLSearchParams({
+			maxResults: "250",
+			showDeleted: "false",
+		});
+		if (pageToken) params.set("pageToken", pageToken);
+		const page = await googleFetch<{
+			items?: GoogleCalendarListEntry[];
+			nextPageToken?: string;
+		}>(connectionId, `${CALENDAR_API}/users/me/calendarList?${params}`);
+		items.push(...(page.items ?? []));
+		pageToken = page.nextPageToken;
+	} while (pageToken);
+	return items;
+}
+
+/**
+ * The changes since `syncToken`, or the whole calendar when there is none.
+ *
+ * `showDeleted` is what makes cancellations visible; without it a deleted
+ * event simply stops appearing. Recurring events come back as their master
+ * plus any individually edited instances rather than expanded, so a busy
+ * calendar's full sync is a handful of pages rather than every occurrence
+ * until the end of time.
+ */
+export async function listEventChanges(
+	connectionId: string,
+	calendarId: string,
+	syncToken: string | undefined,
+): Promise<
+	| { expired: true }
+	| { expired: false; items: GoogleCalendarEvent[]; nextSyncToken: string }
+> {
+	const items: GoogleCalendarEvent[] = [];
+	let pageToken: string | undefined;
+	let nextSyncToken: string | undefined;
+	do {
+		const params = new URLSearchParams({
+			showDeleted: "true",
+			maxResults: syncToken ? "250" : "2500",
+		});
+		if (syncToken) params.set("syncToken", syncToken);
+		if (pageToken) params.set("pageToken", pageToken);
+		let page: EventsPage;
+		try {
+			page = await googleFetch<EventsPage>(
+				connectionId,
+				`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+			);
+		} catch (error) {
+			// 410 Gone: the token is too old to diff from. Google's protocol is to
+			// drop it and start over with a full sync.
+			if (error instanceof GoogleApiError && error.status === 410) {
+				return { expired: true };
+			}
+			throw error;
+		}
+		items.push(...(page.items ?? []));
+		pageToken = page.nextPageToken;
+		nextSyncToken = page.nextSyncToken;
+	} while (pageToken);
+	if (!nextSyncToken) {
+		throw new Error(`Calendar sync of ${calendarId} returned no sync token`);
+	}
+	return { expired: false, items, nextSyncToken };
+}
+
+/**
+ * Concrete occurrences starting in a window, recurring ones expanded, so a
+ * fire can be scheduled off each start and end time.
+ */
+export async function listUpcomingInstances(
+	connectionId: string,
+	calendarId: string,
+	window: { from: Date; to: Date },
+): Promise<GoogleCalendarEvent[]> {
+	const items: GoogleCalendarEvent[] = [];
+	let pageToken: string | undefined;
+	do {
+		const params = new URLSearchParams({
+			singleEvents: "true",
+			orderBy: "startTime",
+			timeMin: window.from.toISOString(),
+			timeMax: window.to.toISOString(),
+			maxResults: "250",
+		});
+		if (pageToken) params.set("pageToken", pageToken);
+		const page = await googleFetch<EventsPage>(
+			connectionId,
+			`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+		);
+		items.push(...(page.items ?? []));
+		pageToken = page.nextPageToken;
+	} while (pageToken);
+	return items;
+}
+
+/** The instances of one recurring event inside a window. */
+export async function listEventInstances(
+	connectionId: string,
+	calendarId: string,
+	eventId: string,
+	window: { from: Date; to: Date },
+): Promise<GoogleCalendarEvent[]> {
+	const params = new URLSearchParams({
+		timeMin: window.from.toISOString(),
+		timeMax: window.to.toISOString(),
+		maxResults: "250",
+	});
+	const page = await googleFetch<EventsPage>(
+		connectionId,
+		`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/instances?${params}`,
+	);
+	return page.items ?? [];
+}
+
+/** Null when the event no longer exists at all (404), as opposed to cancelled. */
+export async function getEvent(
+	connectionId: string,
+	calendarId: string,
+	eventId: string,
+): Promise<GoogleCalendarEvent | null> {
+	try {
+		return await googleFetch<GoogleCalendarEvent>(
+			connectionId,
+			`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+		);
+	} catch (error) {
+		if (error instanceof GoogleApiError && error.status === 404) return null;
+		throw error;
+	}
+}
+
+/**
+ * Opens a push channel on a calendar. Google will POST to `address` with the
+ * channel id and this token on every change; the token is what the push route
+ * checks, since Google signs nothing.
+ */
+export async function watchCalendar(
+	connectionId: string,
+	calendarId: string,
+	channel: { id: string; token: string; address: string },
+): Promise<{ resourceId: string; expiration: number }> {
+	const result = await googleFetch<{ resourceId: string; expiration?: string }>(
+		connectionId,
+		`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/watch`,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				id: channel.id,
+				type: "web_hook",
+				address: channel.address,
+				token: channel.token,
+				expiration: String(Date.now() + CALENDAR_CHANNEL_TTL_MS),
+			}),
+		},
+	);
+	return {
+		resourceId: result.resourceId,
+		expiration: Number(
+			result.expiration ?? Date.now() + CALENDAR_CHANNEL_TTL_MS,
+		),
+	};
+}
+
+/** Best effort: a channel that is already gone is not an error worth raising. */
+export async function stopChannel(
+	connectionId: string,
+	channel: { id: string; resourceId: string },
+): Promise<void> {
+	try {
+		await googleFetch<undefined>(
+			connectionId,
+			`${CALENDAR_API}/channels/stop`,
+			{
+				method: "POST",
+				body: JSON.stringify(channel),
+			},
+		);
+	} catch (error) {
+		if (error instanceof GoogleApiError && error.status === 404) return;
+		throw error;
+	}
+}
+
+/** RFC 3339 for timed events; all-day events carry a date and no time. */
+export function eventStart(event: GoogleCalendarEvent): Date | null {
+	return event.start?.dateTime ? new Date(event.start.dateTime) : null;
+}
+
+export function eventEnd(event: GoogleCalendarEvent): Date | null {
+	return event.end?.dateTime ? new Date(event.end.dateTime) : null;
+}
+
+/** Everyone on the event — organizer, creator and invitees — lower-cased. */
+export function eventAttendeeEmails(event: GoogleCalendarEvent): string[] {
+	const emails = new Set<string>();
+	for (const person of [
+		event.organizer,
+		event.creator,
+		...(event.attendees ?? []),
+	]) {
+		if (person?.email) emails.add(person.email.toLowerCase());
+	}
+	return [...emails];
+}

--- a/packages/trpc/src/router/integration/google/constants.ts
+++ b/packages/trpc/src/router/integration/google/constants.ts
@@ -1,0 +1,20 @@
+export const GOOGLE_SCOPES = [
+	"openid",
+	"email",
+	"https://www.googleapis.com/auth/calendar.readonly",
+	"https://www.googleapis.com/auth/gmail.readonly",
+] as const;
+
+export const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+export const REFRESH_TOKEN_TIMEOUT_MS = 10 * 1000;
+export const GOOGLE_API_TIMEOUT_MS = 20 * 1000;
+
+/**
+ * Calendar channels can be asked for up to a month; a week keeps a stuck
+ * renewal from leaving a dead channel around for long, and Gmail's watch is
+ * capped at seven days anyway.
+ */
+export const CALENDAR_CHANNEL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const GMAIL_WATCH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** Renew anything that would expire within this window on the next cron. */
+export const WATCH_RENEW_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;

--- a/packages/trpc/src/router/integration/google/gmail.ts
+++ b/packages/trpc/src/router/integration/google/gmail.ts
@@ -1,0 +1,186 @@
+import { GMAIL_WATCH_TTL_MS } from "./constants";
+import { GoogleApiError, googleFetch } from "./refresh";
+
+const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
+
+export type GmailLabel = {
+	id: string;
+	name: string;
+	type?: "system" | "user" | string;
+};
+
+export type GmailHeader = { name: string; value: string };
+
+export type GmailMessagePart = {
+	partId?: string;
+	mimeType?: string;
+	filename?: string;
+	headers?: GmailHeader[];
+	body?: { attachmentId?: string; size?: number; data?: string };
+	parts?: GmailMessagePart[];
+};
+
+export type GmailMessage = {
+	id: string;
+	threadId: string;
+	labelIds?: string[];
+	snippet?: string;
+	historyId?: string;
+	internalDate?: string;
+	sizeEstimate?: number;
+	payload?: GmailMessagePart;
+};
+
+export async function listLabels(connectionId: string): Promise<GmailLabel[]> {
+	const result = await googleFetch<{ labels?: GmailLabel[] }>(
+		connectionId,
+		`${GMAIL_API}/labels`,
+	);
+	return result.labels ?? [];
+}
+
+export async function getProfile(
+	connectionId: string,
+): Promise<{ emailAddress: string; historyId: string }> {
+	return googleFetch(connectionId, `${GMAIL_API}/profile`);
+}
+
+/**
+ * Message ids added since `startHistoryId`, and the mailbox's current history
+ * id to continue from. `expired` when Google no longer holds history that far
+ * back (a week or so): the caller resets from the profile and accepts the gap.
+ */
+export async function listAddedMessages(
+	connectionId: string,
+	startHistoryId: string,
+): Promise<
+	| { expired: true }
+	| {
+			expired: false;
+			historyId: string;
+			messages: Array<{ id: string; threadId: string; labelIds: string[] }>;
+	  }
+> {
+	const byId = new Map<
+		string,
+		{ id: string; threadId: string; labelIds: string[] }
+	>();
+	let pageToken: string | undefined;
+	let historyId: string | undefined;
+	do {
+		const params = new URLSearchParams({
+			startHistoryId,
+			historyTypes: "messageAdded",
+			maxResults: "500",
+		});
+		if (pageToken) params.set("pageToken", pageToken);
+		let page: {
+			history?: Array<{
+				messagesAdded?: Array<{
+					message?: { id?: string; threadId?: string; labelIds?: string[] };
+				}>;
+			}>;
+			historyId?: string;
+			nextPageToken?: string;
+		};
+		try {
+			page = await googleFetch(connectionId, `${GMAIL_API}/history?${params}`);
+		} catch (error) {
+			if (error instanceof GoogleApiError && error.status === 404) {
+				return { expired: true };
+			}
+			throw error;
+		}
+		for (const record of page.history ?? []) {
+			for (const added of record.messagesAdded ?? []) {
+				const message = added.message;
+				if (!message?.id || !message.threadId) continue;
+				// The same message can appear in several records as labels
+				// change; the last record's labels are the current ones.
+				byId.set(message.id, {
+					id: message.id,
+					threadId: message.threadId,
+					labelIds: message.labelIds ?? [],
+				});
+			}
+		}
+		historyId = page.historyId ?? historyId;
+		pageToken = page.nextPageToken;
+	} while (pageToken);
+	if (!historyId) {
+		throw new Error("Gmail history.list returned no history id");
+	}
+	return { expired: false, historyId, messages: [...byId.values()] };
+}
+
+/** Null when the message was deleted between the history record and now. */
+export async function getMessage(
+	connectionId: string,
+	messageId: string,
+): Promise<GmailMessage | null> {
+	try {
+		return await googleFetch<GmailMessage>(
+			connectionId,
+			`${GMAIL_API}/messages/${encodeURIComponent(messageId)}?format=full`,
+		);
+	} catch (error) {
+		if (error instanceof GoogleApiError && error.status === 404) return null;
+		throw error;
+	}
+}
+
+/**
+ * Asks Gmail to publish `{emailAddress, historyId}` to the topic on every
+ * mailbox change. Lasts a week at most and never renews itself.
+ */
+export async function watchMailbox(
+	connectionId: string,
+	topicName: string,
+): Promise<{ historyId: string; expiration: number }> {
+	const result = await googleFetch<{ historyId: string; expiration?: string }>(
+		connectionId,
+		`${GMAIL_API}/watch`,
+		{ method: "POST", body: JSON.stringify({ topicName }) },
+	);
+	return {
+		historyId: result.historyId,
+		expiration: Number(result.expiration ?? Date.now() + GMAIL_WATCH_TTL_MS),
+	};
+}
+
+export async function stopMailboxWatch(connectionId: string): Promise<void> {
+	await googleFetch<undefined>(connectionId, `${GMAIL_API}/stop`, {
+		method: "POST",
+	});
+}
+
+export function headerValue(
+	message: GmailMessage,
+	name: string,
+): string | null {
+	const wanted = name.toLowerCase();
+	const header = message.payload?.headers?.find(
+		(h) => h.name.toLowerCase() === wanted,
+	);
+	return header?.value ?? null;
+}
+
+/**
+ * The bare addresses in a header like `"Ada" <ada@acme.com>, bob@acme.com`,
+ * lower-cased. Display names are dropped; matching is on the address.
+ */
+export function parseAddresses(header: string | null): string[] {
+	if (!header) return [];
+	const found = header.match(/[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi) ?? [];
+	return [...new Set(found.map((address) => address.toLowerCase()))];
+}
+
+/** A part with a filename or an attachment id is an attachment. */
+export function messageHasAttachment(message: GmailMessage): boolean {
+	const walk = (part: GmailMessagePart | undefined): boolean => {
+		if (!part) return false;
+		if (part.filename || part.body?.attachmentId) return true;
+		return (part.parts ?? []).some(walk);
+	};
+	return walk(message.payload);
+}

--- a/packages/trpc/src/router/integration/google/gmail.ts
+++ b/packages/trpc/src/router/integration/google/gmail.ts
@@ -113,15 +113,34 @@ export async function listAddedMessages(
 	return { expired: false, historyId, messages: [...byId.values()] };
 }
 
+/**
+ * `format=full` is the only format that carries the MIME tree, which is where
+ * attachments show; the field mask then leaves the body data itself out, so
+ * what crosses the wire is headers, labels and part metadata. Four levels of
+ * parts covers ordinary multipart mail; anything deeper simply reports no
+ * attachment.
+ */
+const MESSAGE_FIELDS = (() => {
+	let parts = "mimeType,filename,body(attachmentId,size)";
+	for (let depth = 0; depth < 4; depth += 1) {
+		parts = `mimeType,filename,body(attachmentId,size),parts(${parts})`;
+	}
+	return `id,threadId,labelIds,historyId,internalDate,sizeEstimate,payload(headers,${parts})`;
+})();
+
 /** Null when the message was deleted between the history record and now. */
 export async function getMessage(
 	connectionId: string,
 	messageId: string,
 ): Promise<GmailMessage | null> {
 	try {
+		const params = new URLSearchParams({
+			format: "full",
+			fields: MESSAGE_FIELDS,
+		});
 		return await googleFetch<GmailMessage>(
 			connectionId,
-			`${GMAIL_API}/messages/${encodeURIComponent(messageId)}?format=full`,
+			`${GMAIL_API}/messages/${encodeURIComponent(messageId)}?${params}`,
 		);
 	} catch (error) {
 		if (error instanceof GoogleApiError && error.status === 404) return null;

--- a/packages/trpc/src/router/integration/google/google.ts
+++ b/packages/trpc/src/router/integration/google/google.ts
@@ -1,0 +1,162 @@
+import { db } from "@superset/db/client";
+import {
+	integrationConnections,
+	userIdentities,
+	users,
+} from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure } from "../../../trpc";
+import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { listCalendars, stopChannel } from "./calendar";
+import { listLabels, stopMailboxWatch } from "./gmail";
+import { findGoogleConnection, googleConfigOf } from "./state";
+
+export const googleRouter = {
+	getConnection: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const connection = await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, input.organizationId),
+					eq(integrationConnections.provider, "google"),
+				),
+				columns: {
+					id: true,
+					externalOrgId: true,
+					connectedByUserId: true,
+					disconnectedAt: true,
+					disconnectReason: true,
+					createdAt: true,
+				},
+			});
+			if (!connection) return null;
+
+			return {
+				id: connection.id,
+				// The Google account's address; the connection is that person's
+				// calendars and mailbox, not the organization's.
+				email: connection.externalOrgId,
+				connectedByUserId: connection.connectedByUserId,
+				connectedAt: connection.createdAt,
+				needsReconnect: connection.disconnectedAt !== null,
+			};
+		}),
+
+	disconnect: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+
+			const connection = await findGoogleConnection(input.organizationId);
+			if (connection) {
+				// Best effort: Google keeps pushing to a channel until it is stopped
+				// or expires, and the push route would only reject those with a
+				// missing connection. A failure here must not block the disconnect.
+				const config = googleConfigOf(connection.config);
+				await Promise.allSettled([
+					...Object.values(config.calendars ?? {}).flatMap((state) =>
+						state.channelId && state.resourceId
+							? [
+									stopChannel(connection.id, {
+										id: state.channelId,
+										resourceId: state.resourceId,
+									}),
+								]
+							: [],
+					),
+					config.gmail?.watchExpiresAt
+						? stopMailboxWatch(connection.id)
+						: Promise.resolve(),
+				]);
+			}
+
+			const result = await db
+				.delete(integrationConnections)
+				.where(
+					and(
+						eq(integrationConnections.organizationId, input.organizationId),
+						eq(integrationConnections.provider, "google"),
+					),
+				)
+				.returning({ id: integrationConnections.id });
+
+			if (result.length === 0) {
+				return { success: false, error: "No connection found" };
+			}
+			return { success: true };
+		}),
+
+	/** The connected account's calendars, as scope options. */
+	listCalendars: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			const connection = await findGoogleConnection(input.organizationId);
+			if (!connection) return [];
+			const calendars = await listCalendars(connection.id);
+			return calendars
+				.filter((calendar) => !calendar.deleted)
+				.map((calendar) => ({
+					id: calendar.id,
+					label: calendar.primary
+						? `${calendar.summary ?? calendar.id} (primary)`
+						: (calendar.summary ?? calendar.id),
+				}));
+		}),
+
+	/** The connected mailbox's labels. Ids, since names can be renamed. */
+	listLabels: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			const connection = await findGoogleConnection(input.organizationId);
+			if (!connection) return [];
+			const labels = await listLabels(connection.id);
+			return (
+				labels
+					// Gmail's internal category and chat labels are noise in a picker.
+					.filter((label) => !label.id.startsWith("CATEGORY_"))
+					.map((label) => ({ id: label.id, label: label.name }))
+			);
+		}),
+
+	/**
+	 * People an attendee filter can name, as Google addresses. Org members who
+	 * have connected or linked a Google account; the id is the address because
+	 * that is what a calendar event names people by.
+	 */
+	listLinkedPeople: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const rows = await db
+				.select({
+					email: userIdentities.handle,
+					name: users.name,
+				})
+				.from(userIdentities)
+				.innerJoin(users, eq(users.id, userIdentities.userId))
+				.where(
+					and(
+						eq(userIdentities.organizationId, input.organizationId),
+						eq(userIdentities.provider, "google"),
+					),
+				);
+
+			return rows.flatMap((row) =>
+				row.email
+					? [
+							{
+								id: row.email.toLowerCase(),
+								label: row.name ? `${row.name} (${row.email})` : row.email,
+							},
+						]
+					: [],
+			);
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/integration/google/google.ts
+++ b/packages/trpc/src/router/integration/google/google.ts
@@ -58,6 +58,10 @@ export const googleRouter = {
 				// missing connection. A failure here must not block the disconnect.
 				const config = googleConfigOf(connection.config);
 				await Promise.allSettled([
+					// The grant outlives the row unless it is revoked: without this
+					// the refresh token would be gone from our side and the app would
+					// still hold read access on Google's.
+					revokeGrant(connection.refreshToken ?? connection.accessToken),
 					...Object.values(config.calendars ?? {}).flatMap((state) =>
 						state.channelId && state.resourceId
 							? [
@@ -154,3 +158,10 @@ export const googleRouter = {
 			}));
 		}),
 } satisfies TRPCRouterRecord;
+
+async function revokeGrant(token: string): Promise<void> {
+	await fetch(
+		`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(token)}`,
+		{ method: "POST", signal: AbortSignal.timeout(10_000) },
+	);
+}

--- a/packages/trpc/src/router/integration/google/google.ts
+++ b/packages/trpc/src/router/integration/google/google.ts
@@ -8,7 +8,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
-import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { verifyOrgMembership } from "../utils";
 import { listCalendars, stopChannel } from "./calendar";
 import { listLabels, stopMailboxWatch } from "./gmail";
 import { findGoogleConnection, googleConfigOf } from "./state";
@@ -19,10 +19,13 @@ export const googleRouter = {
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
 
+			// The caller's own connection: Google is per member, so another
+			// member's account is not this person's to see or manage.
 			const connection = await db.query.integrationConnections.findFirst({
 				where: and(
 					eq(integrationConnections.organizationId, input.organizationId),
 					eq(integrationConnections.provider, "google"),
+					eq(integrationConnections.connectedByUserId, ctx.session.user.id),
 				),
 				columns: {
 					id: true,
@@ -49,9 +52,12 @@ export const googleRouter = {
 	disconnect: protectedProcedure
 		.input(z.object({ organizationId: z.uuid() }))
 		.mutation(async ({ ctx, input }) => {
-			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
 
-			const connection = await findGoogleConnection(input.organizationId);
+			const connection = await findGoogleConnection(
+				input.organizationId,
+				ctx.session.user.id,
+			);
 			if (connection) {
 				// Best effort: Google keeps pushing to a channel until it is stopped
 				// or expires, and the push route would only reject those with a
@@ -84,6 +90,7 @@ export const googleRouter = {
 					and(
 						eq(integrationConnections.organizationId, input.organizationId),
 						eq(integrationConnections.provider, "google"),
+						eq(integrationConnections.connectedByUserId, ctx.session.user.id),
 					),
 				)
 				.returning({ id: integrationConnections.id });
@@ -99,7 +106,10 @@ export const googleRouter = {
 		.input(z.object({ organizationId: z.uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
-			const connection = await findGoogleConnection(input.organizationId);
+			const connection = await findGoogleConnection(
+				input.organizationId,
+				ctx.session.user.id,
+			);
 			if (!connection) return [];
 			const calendars = await listCalendars(connection.id);
 			return calendars
@@ -117,7 +127,10 @@ export const googleRouter = {
 		.input(z.object({ organizationId: z.uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
-			const connection = await findGoogleConnection(input.organizationId);
+			const connection = await findGoogleConnection(
+				input.organizationId,
+				ctx.session.user.id,
+			);
 			if (!connection) return [];
 			const labels = await listLabels(connection.id);
 			return (

--- a/packages/trpc/src/router/integration/google/google.ts
+++ b/packages/trpc/src/router/integration/google/google.ts
@@ -136,7 +136,7 @@ export const googleRouter = {
 
 			const rows = await db
 				.select({
-					email: userIdentities.handle,
+					email: userIdentities.externalId,
 					name: users.name,
 				})
 				.from(userIdentities)
@@ -148,15 +148,9 @@ export const googleRouter = {
 					),
 				);
 
-			return rows.flatMap((row) =>
-				row.email
-					? [
-							{
-								id: row.email.toLowerCase(),
-								label: row.name ? `${row.name} (${row.email})` : row.email,
-							},
-						]
-					: [],
-			);
+			return rows.map((row) => ({
+				id: row.email.toLowerCase(),
+				label: row.name ? `${row.name} (${row.email})` : row.email,
+			}));
 		}),
 } satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/integration/google/index.ts
+++ b/packages/trpc/src/router/integration/google/index.ts
@@ -1,0 +1,1 @@
+export { googleRouter } from "./google";

--- a/packages/trpc/src/router/integration/google/refresh.ts
+++ b/packages/trpc/src/router/integration/google/refresh.ts
@@ -1,0 +1,214 @@
+import { db } from "@superset/db/client";
+import { integrationConnections } from "@superset/db/schema";
+import { withConnectionLock } from "@superset/db/utils";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { env } from "../../../env";
+import {
+	GOOGLE_API_TIMEOUT_MS,
+	REFRESH_BUFFER_MS,
+	REFRESH_TOKEN_TIMEOUT_MS,
+} from "./constants";
+
+export const googleTokenResponseSchema = z.object({
+	access_token: z.string(),
+	expires_in: z.number(),
+	// Only on the initial exchange, and on a refresh when Google chooses to
+	// rotate. Absent means keep the one already stored.
+	refresh_token: z.string().optional(),
+	scope: z.string().optional(),
+	token_type: z.string().optional(),
+	id_token: z.string().optional(),
+});
+export type GoogleTokenResponse = z.infer<typeof googleTokenResponseSchema>;
+
+export class GoogleApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly url: string,
+		readonly body: string,
+	) {
+		super(`Google API ${status} for ${url}: ${body.slice(0, 300)}`);
+		this.name = "GoogleApiError";
+	}
+}
+
+type RefreshResult =
+	| { disconnected: true }
+	| { disconnected: false; accessToken: string };
+
+/**
+ * Refreshes under the connection's advisory lock so two concurrent callers do
+ * not both spend the refresh token. Google's refresh tokens do not usually
+ * rotate, but when the response carries one it replaces the stored one.
+ */
+export async function refreshGoogleToken(
+	connectionId: string,
+	// After a 401 the stored expiry is not to be trusted — the token was
+	// revoked or the clock is off — so the caller forces a real refresh.
+	options: { force?: boolean } = {},
+): Promise<RefreshResult> {
+	return withConnectionLock(connectionId, async (tx) => {
+		const [connection] = await tx
+			.select({
+				accessToken: integrationConnections.accessToken,
+				refreshToken: integrationConnections.refreshToken,
+				tokenExpiresAt: integrationConnections.tokenExpiresAt,
+				disconnectedAt: integrationConnections.disconnectedAt,
+			})
+			.from(integrationConnections)
+			.where(eq(integrationConnections.id, connectionId))
+			.limit(1);
+
+		if (!connection?.refreshToken || connection.disconnectedAt) {
+			return { disconnected: true };
+		}
+		if (
+			!options.force &&
+			connection.tokenExpiresAt &&
+			connection.tokenExpiresAt.getTime() > Date.now() + REFRESH_BUFFER_MS
+		) {
+			return { disconnected: false, accessToken: connection.accessToken };
+		}
+
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(),
+			REFRESH_TOKEN_TIMEOUT_MS,
+		);
+		let response: Response;
+		try {
+			response = await fetch("https://oauth2.googleapis.com/token", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				signal: controller.signal,
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: connection.refreshToken,
+					client_id: env.GOOGLE_CLIENT_ID,
+					client_secret: env.GOOGLE_CLIENT_SECRET,
+				}),
+			});
+		} finally {
+			clearTimeout(timeout);
+		}
+
+		if (!response.ok) {
+			const body = (await response.json().catch(() => ({}))) as {
+				error?: string;
+			};
+			// The grant was revoked (or the app's access removed in the account
+			// settings). Nothing here can recover it; the person has to reconnect.
+			if (body?.error === "invalid_grant") {
+				await tx
+					.update(integrationConnections)
+					.set({
+						disconnectedAt: new Date(),
+						disconnectReason: "invalid_grant",
+					})
+					.where(eq(integrationConnections.id, connectionId));
+				return { disconnected: true };
+			}
+			throw new Error(
+				`Google token refresh failed: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		const data = googleTokenResponseSchema.parse(await response.json());
+		const tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
+
+		await tx
+			.update(integrationConnections)
+			.set({
+				accessToken: data.access_token,
+				refreshToken: data.refresh_token ?? connection.refreshToken,
+				tokenExpiresAt,
+				disconnectedAt: null,
+				disconnectReason: null,
+			})
+			.where(eq(integrationConnections.id, connectionId));
+
+		return { disconnected: false, accessToken: data.access_token };
+	});
+}
+
+/** A token good for at least the refresh buffer, or null if disconnected. */
+export async function getGoogleAccessToken(
+	connectionId: string,
+): Promise<string | null> {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: eq(integrationConnections.id, connectionId),
+		columns: {
+			accessToken: true,
+			refreshToken: true,
+			tokenExpiresAt: true,
+			disconnectedAt: true,
+		},
+	});
+	if (!connection || connection.disconnectedAt) return null;
+
+	const expiresSoon =
+		!connection.tokenExpiresAt ||
+		connection.tokenExpiresAt.getTime() - Date.now() < REFRESH_BUFFER_MS;
+	if (!expiresSoon) return connection.accessToken;
+
+	if (!connection.refreshToken) {
+		await db
+			.update(integrationConnections)
+			.set({ disconnectedAt: new Date(), disconnectReason: "no_refresh_token" })
+			.where(eq(integrationConnections.id, connectionId));
+		return null;
+	}
+	const result = await refreshGoogleToken(connectionId);
+	return result.disconnected ? null : result.accessToken;
+}
+
+/**
+ * One authenticated call against a Google API. A 401 is retried once after a
+ * forced refresh; anything else non-2xx throws a `GoogleApiError` carrying the
+ * status so callers can treat 404/410 as the protocol signals they are.
+ */
+export async function googleFetch<T>(
+	connectionId: string,
+	url: string,
+	init: RequestInit = {},
+): Promise<T> {
+	const token = await getGoogleAccessToken(connectionId);
+	if (!token) throw new GoogleApiError(401, url, "connection disconnected");
+
+	let response = await send(url, init, token);
+	if (response.status === 401) {
+		const refreshed = await refreshGoogleToken(connectionId, { force: true });
+		if (refreshed.disconnected) {
+			throw new GoogleApiError(401, url, "connection disconnected");
+		}
+		response = await send(url, init, refreshed.accessToken);
+	}
+	if (!response.ok) {
+		throw new GoogleApiError(response.status, url, await response.text());
+	}
+	if (response.status === 204) return undefined as T;
+	return (await response.json()) as T;
+}
+
+async function send(
+	url: string,
+	init: RequestInit,
+	token: string,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), GOOGLE_API_TIMEOUT_MS);
+	try {
+		return await fetch(url, {
+			...init,
+			signal: controller.signal,
+			headers: {
+				...(init.headers as Record<string, string> | undefined),
+				Authorization: `Bearer ${token}`,
+				...(init.body ? { "Content-Type": "application/json" } : {}),
+			},
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/packages/trpc/src/router/integration/google/state.ts
+++ b/packages/trpc/src/router/integration/google/state.ts
@@ -1,0 +1,96 @@
+import { db } from "@superset/db/client";
+import {
+	type GoogleCalendarWatchState,
+	type GoogleConfig,
+	integrationConnections,
+} from "@superset/db/schema";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+/**
+ * The per-connection sync state lives in `integration_connections.config`.
+ * Every write here is a jsonb merge in SQL rather than a read-modify-write in
+ * JavaScript, because two calendars on one connection can be syncing at once
+ * and the second write must not undo the first.
+ */
+
+export function googleConfigOf(config: unknown): GoogleConfig {
+	if (config && typeof config === "object" && "provider" in config) {
+		const candidate = config as { provider?: string };
+		if (candidate.provider === "google") return config as GoogleConfig;
+	}
+	return { provider: "google" };
+}
+
+/** Active Google connection for an org, or null. */
+export async function findGoogleConnection(organizationId: string) {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.organizationId, organizationId),
+			eq(integrationConnections.provider, "google"),
+			isNull(integrationConnections.disconnectedAt),
+		),
+	});
+	return connection ?? null;
+}
+
+export async function findGoogleConnectionById(connectionId: string) {
+	const connection = await db.query.integrationConnections.findFirst({
+		where: and(
+			eq(integrationConnections.id, connectionId),
+			eq(integrationConnections.provider, "google"),
+		),
+	});
+	return connection ?? null;
+}
+
+/** Merges `patch` into `config.calendars[calendarId]`, creating as needed. */
+export async function patchCalendarState(
+	connectionId: string,
+	calendarId: string,
+	patch: Partial<GoogleCalendarWatchState>,
+): Promise<void> {
+	const json = JSON.stringify(patch);
+	await db
+		.update(integrationConnections)
+		.set({
+			config: sql`jsonb_set(
+				jsonb_set(
+					coalesce(${integrationConnections.config}, '{"provider":"google"}'::jsonb),
+					'{calendars}',
+					coalesce(${integrationConnections.config} -> 'calendars', '{}'::jsonb)
+				),
+				ARRAY['calendars', ${calendarId}]::text[],
+				coalesce(${integrationConnections.config} #> ARRAY['calendars', ${calendarId}]::text[], '{}'::jsonb) || ${json}::jsonb
+			)`,
+		})
+		.where(eq(integrationConnections.id, connectionId));
+}
+
+export async function removeCalendarState(
+	connectionId: string,
+	calendarId: string,
+): Promise<void> {
+	await db
+		.update(integrationConnections)
+		.set({
+			config: sql`${integrationConnections.config} #- ARRAY['calendars', ${calendarId}]::text[]`,
+		})
+		.where(eq(integrationConnections.id, connectionId));
+}
+
+export async function patchGmailState(
+	connectionId: string,
+	patch: NonNullable<GoogleConfig["gmail"]>,
+): Promise<void> {
+	const json = JSON.stringify(patch);
+	await db
+		.update(integrationConnections)
+		.set({
+			config: sql`jsonb_set(
+				coalesce(${integrationConnections.config}, '{"provider":"google"}'::jsonb),
+				'{gmail}',
+				coalesce(${integrationConnections.config} -> 'gmail', '{}'::jsonb) || ${json}::jsonb
+			)`,
+		})
+		.where(eq(integrationConnections.id, connectionId));
+}

--- a/packages/trpc/src/router/integration/google/state.ts
+++ b/packages/trpc/src/router/integration/google/state.ts
@@ -55,7 +55,7 @@ export async function patchCalendarState(
 		.set({
 			config: sql`jsonb_set(
 				jsonb_set(
-					coalesce(${integrationConnections.config}, '{"provider":"google"}'::jsonb),
+					coalesce(${integrationConnections.config}, '{}'::jsonb) || '{"provider":"google"}'::jsonb,
 					'{calendars}',
 					coalesce(${integrationConnections.config} -> 'calendars', '{}'::jsonb)
 				),
@@ -87,7 +87,7 @@ export async function patchGmailState(
 		.update(integrationConnections)
 		.set({
 			config: sql`jsonb_set(
-				coalesce(${integrationConnections.config}, '{"provider":"google"}'::jsonb),
+				coalesce(${integrationConnections.config}, '{}'::jsonb) || '{"provider":"google"}'::jsonb,
 				'{gmail}',
 				coalesce(${integrationConnections.config} -> 'gmail', '{}'::jsonb) || ${json}::jsonb
 			)`,

--- a/packages/trpc/src/router/integration/google/state.ts
+++ b/packages/trpc/src/router/integration/google/state.ts
@@ -21,12 +21,19 @@ export function googleConfigOf(config: unknown): GoogleConfig {
 	return { provider: "google" };
 }
 
-/** Active Google connection for an org, or null. */
-export async function findGoogleConnection(organizationId: string) {
+/**
+ * One member's active Google connection in an org, or null. Per user, not per
+ * org: Calendar and Gmail are personal, and each member connects their own.
+ */
+export async function findGoogleConnection(
+	organizationId: string,
+	userId: string,
+) {
 	const connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.organizationId, organizationId),
 			eq(integrationConnections.provider, "google"),
+			eq(integrationConnections.connectedByUserId, userId),
 			isNull(integrationConnections.disconnectedAt),
 		),
 	});

--- a/packages/trpc/src/router/integration/integration.ts
+++ b/packages/trpc/src/router/integration/integration.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
 import { githubRouter } from "./github";
+import { googleRouter } from "./google";
 import { linearRouter } from "./linear";
 import { microsoftTeamsRouter } from "./microsoft-teams";
 import { notionRouter } from "./notion";
@@ -14,6 +15,7 @@ import { verifyOrgMembership } from "./utils";
 
 export const integrationRouter = {
 	github: githubRouter,
+	google: googleRouter,
 	linear: linearRouter,
 	microsoftTeams: microsoftTeamsRouter,
 	notion: notionRouter,


### PR DESCRIPTION
## Summary

One Google connection (`integration_provider = google`, OAuth with `calendar.readonly` + `gmail.readonly`, refresh tokens stored and rotated when Google returns one) and two trigger kinds on top of it.

**Google Calendar (`google_calendar`)** — `event.created`, `event.updated`, `event.cancelled`, `event.starting_soon`, `event.ended`; filters calendar · attendee (anyone / me / people, by address) · title pattern · hasExternalAttendee (created/updated) · minutesBefore (starting_soon).
- Every calendar in the account's list gets an `events.watch` channel. `calendar/push` verifies `X-Goog-Channel-Token` against the stored SHA-256 of the per-channel token (the config column reaches every member's client via `integration.list`, so the token itself is never stored), then runs `events.list` with the stored `syncToken` (410 → full resync, nothing recorded) and records one `automation_events` row per changed item.
- created vs updated: no prior `automation_events` row for `resource_key = google_calendar:<connection>:<calendar>:<eventId>` **and** Google's `created` ≥ the calendar's `watchedSince` → created; otherwise updated. `status: cancelled` → cancelled (title/attendees taken from the previously recorded row, since incremental cancellations are bare).
- starting_soon/ended are ours: `jobs/sweep-schedules` (every 15 min) lists instances due within a 35-minute horizon and publishes QStash `notBefore` fires per distinct `minutesBefore` across enabled triggers; the sync path does the same for changed events inside the horizon. `calendar/scheduled` re-reads the event and skips if it moved or was cancelled. Duplicate deliveries are absorbed by the `automation_events` unique index. All-day events get no fires.
- `jobs/renew-watches` (daily, and once per connection right after connect) renews channels expiring within 2 days, baselines new calendars, stops channels for calendars that left the list.

**Gmail (`gmail`)** — `message.received`; filters from · to (free-form address or domain) · subject pattern · label · hasAttachment.
- `users.watch` → Pub/Sub push → `gmail/push?token=<shared secret>` → `history.list(startHistoryId, messageAdded)` from the *stored* history id → `messages.get` → record. `SENT`/`DRAFT` are excluded so your own outgoing mail never fires it. Only headers, label ids, snippet and an attachment flag are stored — never the body. Watch is renewed by the daily job (7-day cap).

**Shared** — `googleCalendarTriggerConfigSchema` (union on event) + `gmailTriggerConfigSchema`; `describeTriggerProblems` requires a calendar / a sender (or explicit "any"). `automation-matching/google.ts` with `GoogleCalendarMatchableEvent` / `GmailMatchableEvent` (`BaseMatchableEvent & {…}`, `identityProvider: "google"` so both kinds resolve `me` through the one `google` identity), two `case`s in `triggerMatches`, both types in the `MatchableEvent` union. Routes end in the shared `dispatchMatchingTriggers`. `isRegex` stays pinned false.

**Desktop** — `providers/google/` (two `TriggerProvider`s, sentence-as-data grammar, `useGoogleOptions` → `options.google.{calendars,gmailLabels,people}`), registry lines, `ScopeChip` gains an optional `allowCustom` prop (input row for free-form values — used by Gmail from/to; no behaviour change when absent), settings row. **Web** — `/integrations/google` connect page.

`me` on the attendee filter resolves through `user_identities` (provider `google`, `externalId` = the account address, since that is what calendar events name people by; Google's `sub` rides in `metadata`), which the callback upserts. Any member may connect their own account. `hasExternalAttendee` = someone on the event whose domain ≠ the connected account's. Organizer, creator and invitees all count as attendees.

## Known limitations / follow-ups
- **Connections are per member** (Satya: per-user is what calendar/mail should be). Migration `packages/db/drizzle/0084_per_user_google_connections.sql` replaces `integration_connections_unique (organization_id, provider)` with two partial unique indexes — `(organization_id, provider) WHERE provider <> 'google'` for org-scoped providers and `(organization_id, provider, connected_by_user_id) WHERE provider = 'google'` — and the Linear/Slack callbacks name the predicate in their `ON CONFLICT` target so Postgres can infer it (isolated in commit `aa2107aff` in case it should become a base PR). Each member connects, sees and disconnects their own account; an event from a member's account matches only that member's automations (`accountEmail` on the event must be one of the owner's Google identity ids), and `starting_soon`/`ended` fires are planned per owner. Two members connecting the *same* Google account passes the index, but the identity row re-points to the last connector, so only their `me`/ownership resolves — documented, not blocked.
- Per-calendar sync/channel state lives in `integration_connections.config` (`GoogleConfig`, atomic jsonb merges). If it outgrows a jsonb blob (many calendars, more per-calendar state), a `google_calendar_watches` table is the follow-up.
- Fires for triggers created after an event was already synced land on the next sweep (≤15 min).

## Infra needed before this works live
1. OAuth client behind `GOOGLE_CLIENT_ID`: redirect URIs `http://localhost/api/integrations/google/callback` (dev) and `https://<api-host>/api/integrations/google/callback`; enable Google Calendar API + Gmail API; add both scopes to the consent screen (gmail.readonly is restricted → test users until verified); register the API host as an authorized domain (Calendar `events.watch` requires it).
2. Pub/Sub topic with **Pub/Sub Publisher** for `gmail-api-push@system.gserviceaccount.com` and a push subscription to `https://<api-host>/api/integrations/google/gmail/push?token=<secret>`; env `GOOGLE_PUBSUB_TOPIC`, `GOOGLE_PUBSUB_PUSH_TOKEN` (both optional; Gmail watch is skipped when absent).
3. QStash schedules: `POST /api/integrations/google/jobs/renew-watches` daily, `POST /api/integrations/google/jobs/sweep-schedules` every 15 minutes.

## Verification
- Desktop over CDP (this worktree, vite :8905, API :8901): added a Google Calendar "Event starting soon" trigger (30 minutes · Any calendar · Me · titled "standup") and a Gmail trigger (from `acme.com` typed into the free-form ScopeChip · Any recipient · subject "invoice" · Any label · with an attachment), saved ("Triggers saved"), reloaded the renderer, both rows re-render from the server; `automation_triggers` holds the two rows with the expected configs.
- Calendar push route replayed with `X-Goog-*` headers against a seeded connection: wrong token → 401, unknown channel → 404, `state: sync` → 200, `state: exists` → verified token, then `events.list` with the stored syncToken hit Google (401 with the placeholder token, as expected — no real account yet).
- Gmail push route replayed with a Pub/Sub envelope: bad `?token` → 401, malformed data → 200 ack, unknown mailbox → 200 ack, known mailbox → decoded, found the connection, `history.list` from the stored history id hit Google (401 with the placeholder token).
- Record + dispatch layer, fed a captured-shape `events.list` page and a `messages.get` payload through the real `applyCalendarChanges` / `recordMessage`: `automation_events` rows for `event.created` (first sight), `event.updated` (second sight of the same id; a pre-connection event), `event.cancelled`, and `gmail message.received`; the Gmail event matched the saved trigger (`[google/gmail] event … matched triggers 815c4ec3-…`); one `starting_soon` fire scheduled for the standup; a second replay of the same message deduped (null).
- Not verified live: real OAuth consent, Google-originated pushes, `events.watch`/`users.watch` — blocked on the infra above.
- `bun run typecheck` → 0. `bun run lint` → only the pre-existing `main` failure noted above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google integration support for OAuth connection, reconnection, and disconnection.
  * Added Google Calendar and Gmail automation triggers with customizable filters.
  * Added Calendar event and Gmail message synchronization for automation workflows.
  * Added webhook and scheduled processing for near real-time Google updates.
  * Added Google integration settings, searchable configuration, and connected-account details.
* **Bug Fixes**
  * Improved connection handling to support multiple Google accounts within an organization.
  * Added safeguards against duplicate events and stale or invalid notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->