### PR TITLE
feat(automations): Circleback trigger provider

### DIFF
--- a/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
+++ b/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
@@ -158,9 +158,10 @@ export async function POST(
 			organizationId: trigger.organizationId,
 			eventId: inserted.id,
 			// Addressed: Circleback was configured with this trigger's URL, so
-			// only its automation is a candidate — the other Circleback
-			// triggers in the organization each have their own URL.
+			// only this trigger is a candidate — every other Circleback trigger
+			// in the organization has its own URL and gets its own delivery.
 			automationId: trigger.automationId,
+			triggerId,
 			event: {
 				provider: "circleback",
 				eventType: EVENT_TYPE,

--- a/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
+++ b/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
@@ -1,0 +1,186 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { dbWs } from "@superset/db/client";
+import { automationEvents, automationTriggers } from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
+import { stripNullChars } from "@/lib/strip-null-chars";
+
+export const dynamic = "force-dynamic";
+
+const EVENT_TYPE = "meeting.completed";
+
+/**
+ * The fields matching and the row need. Everything else — notes, action items,
+ * transcript, insights — rides along in `payload` for the prompt.
+ */
+const meetingSchema = z
+	.object({
+		id: z.union([z.string().min(1), z.number()]).transform(String),
+		name: z.string().default(""),
+		tags: z.array(z.string()).default([]),
+		attendees: z
+			.array(z.object({ email: z.string().nullable().optional() }))
+			.default([]),
+	})
+	.passthrough();
+
+/**
+ * Circleback signs the raw body with the secret it issued for the automation
+ * and puts the hex digest in `x-signature`. Compared in constant time on the
+ * bytes Circleback sent, before anything is parsed.
+ */
+function signatureValid(
+	body: string,
+	signature: string | null,
+	secret: string,
+): boolean {
+	if (!signature) return false;
+	const expected = createHmac("sha256", secret).update(body).digest("hex");
+	const a = Buffer.from(expected, "utf8");
+	const b = Buffer.from(signature.trim().toLowerCase(), "utf8");
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * One meeting, delivered by Circleback to the trigger named in the URL.
+ *
+ * Unlike GitHub, where one delivery is matched against every trigger in the
+ * organization, a Circleback delivery is addressed: the user configured this
+ * URL in Circleback, so only this trigger is evaluated. Two triggers wired to
+ * the same Circleback workspace each get their own delivery of the same
+ * meeting, which is why the dedupe key carries the trigger id.
+ */
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ triggerId: string }> },
+): Promise<Response> {
+	const { triggerId } = await params;
+	if (!z.string().uuid().safeParse(triggerId).success) {
+		return Response.json({ error: "Unknown trigger" }, { status: 404 });
+	}
+
+	const [trigger] = await dbWs
+		.select({
+			organizationId: automationTriggers.organizationId,
+			automationId: automationTriggers.automationId,
+			// For an HMAC provider the column holds the signing key itself — a
+			// hash could not verify a signature.
+			secret: automationTriggers.secretHash,
+		})
+		.from(automationTriggers)
+		.where(
+			and(
+				eq(automationTriggers.id, triggerId),
+				eq(automationTriggers.kind, "circleback"),
+			),
+		)
+		.limit(1);
+
+	if (!trigger) {
+		return Response.json({ error: "Unknown trigger" }, { status: 404 });
+	}
+
+	const body = await request.text();
+
+	// A trigger with no secret yet cannot tell Circleback from anyone who has
+	// seen the URL, so it accepts nothing until one is pasted in.
+	const secret = trigger.secret;
+	if (!secret) {
+		console.warn(
+			"[circleback/webhook] No signing secret configured for trigger:",
+			triggerId,
+		);
+		return Response.json(
+			{ error: "Signing secret not configured" },
+			{ status: 401 },
+		);
+	}
+	if (!signatureValid(body, request.headers.get("x-signature"), secret)) {
+		console.warn(
+			"[circleback/webhook] Invalid signature for trigger:",
+			triggerId,
+		);
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	let json: unknown;
+	try {
+		json = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+	const parsed = meetingSchema.safeParse(json);
+	if (!parsed.success) {
+		console.error(
+			"[circleback/webhook] Unexpected payload shape",
+			parsed.error,
+		);
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+	const meeting = parsed.data;
+
+	const [inserted] = await dbWs
+		.insert(automationEvents)
+		.values({
+			organizationId: trigger.organizationId,
+			integrationConnectionId: null,
+			provider: "circleback",
+			eventType: EVENT_TYPE,
+			// Per trigger: the same meeting legitimately reaches every trigger
+			// whose URL is configured in Circleback, and a redelivery to one of
+			// them is still a duplicate for that one.
+			externalEventId: `${triggerId}:${meeting.id}`,
+			resourceKey: `circleback:${meeting.id}`,
+			title: meeting.name || meeting.id,
+			url: `https://circleback.ai/meetings/${meeting.id}`,
+			payload: stripNullChars(json) as Record<string, unknown>,
+		})
+		.onConflictDoNothing({
+			target: [
+				automationEvents.integrationConnectionId,
+				automationEvents.provider,
+				automationEvents.externalEventId,
+			],
+		})
+		.returning({ id: automationEvents.id });
+
+	if (!inserted) {
+		return Response.json({ ok: true, duplicate: true });
+	}
+
+	// The event is recorded either way; a failure past this point must not
+	// fail the delivery, since a redelivery would dedupe against the row and
+	// never get the run enqueued either. Same stance as the GitHub route.
+	try {
+		const result = await dispatchMatchingTriggers({
+			organizationId: trigger.organizationId,
+			eventId: inserted.id,
+			// Addressed: Circleback was configured with this trigger's URL, so
+			// only its automation is a candidate — the other Circleback
+			// triggers in the organization each have their own URL.
+			automationId: trigger.automationId,
+			event: {
+				provider: "circleback",
+				eventType: EVENT_TYPE,
+				actorId: null,
+				actorLogin: null,
+				body: null,
+				name: meeting.name || null,
+				tags: meeting.tags,
+				attendeeEmails: meeting.attendees.flatMap((a) =>
+					a.email ? [a.email] : [],
+				),
+			},
+		});
+		console.log(
+			`[circleback/webhook] ${result.matched}/${result.considered} triggers matched:`,
+			inserted.id,
+		);
+		return Response.json({ ok: true, matched: result.matched > 0 });
+	} catch (error) {
+		console.error("[circleback/webhook] dispatch failed:", error);
+		return Response.json({ ok: true, dispatched: false });
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/components/ScopeChip/ScopeChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/components/ScopeChip/ScopeChip.tsx
@@ -4,8 +4,11 @@ import {
 	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { Input } from "@superset/ui/input";
+import { useState } from "react";
 import type { ScopeOption } from "../../scopeOption";
 import { ChipButton } from "../ChipButton";
 
@@ -31,6 +34,9 @@ function scopeLabel(
  * "Any" is its own entry rather than the empty state, because an empty
  * selection matches nothing — that asymmetry is what stops a half-built trigger
  * firing on everything, so choosing "any" has to be deliberate.
+ *
+ * `allowCustom` adds a field for values that are not pickable — an email
+ * address, a domain — which then sit in the list like any chosen option.
  */
 export function ScopeChip({
 	scope,
@@ -38,6 +44,7 @@ export function ScopeChip({
 	options,
 	emptyLabel,
 	anyLabel,
+	allowCustom,
 	disabled,
 	className,
 }: {
@@ -46,12 +53,14 @@ export function ScopeChip({
 	options: ScopeOption[];
 	emptyLabel: string;
 	anyLabel: string;
+	allowCustom?: { placeholder: string };
 	disabled?: boolean;
 	className?: string;
 }) {
 	const selected = scope !== null && scope.mode === "list" ? scope.ids : [];
 	const isAny = scope !== null && scope.mode === "any";
 	const empty = scope === null || (scope.mode === "list" && !scope.ids.length);
+	const [custom, setCustom] = useState("");
 
 	const toggle = (id: string) => {
 		const next = selected.includes(id)
@@ -59,6 +68,20 @@ export function ScopeChip({
 			: [...selected, id];
 		onChange(next.length ? { mode: "list", ids: next } : null);
 	};
+
+	const addCustom = () => {
+		const value = custom.trim();
+		if (!value) return;
+		if (!selected.includes(value)) {
+			onChange({ mode: "list", ids: [...selected, value] });
+		}
+		setCustom("");
+	};
+
+	// Typed values that no option describes still need a row to be unticked.
+	const customSelected = selected.filter(
+		(id) => !options.some((option) => option.id === id),
+	);
 
 	return (
 		<DropdownMenu>
@@ -88,8 +111,41 @@ export function ScopeChip({
 						{option.label}
 					</DropdownMenuCheckboxItem>
 				))}
-				{options.length === 0 && (
+				{allowCustom &&
+					customSelected.map((id) => (
+						<DropdownMenuCheckboxItem
+							key={id}
+							checked
+							onCheckedChange={() => toggle(id)}
+						>
+							{id}
+						</DropdownMenuCheckboxItem>
+					))}
+				{options.length === 0 && !allowCustom && (
 					<DropdownMenuItem disabled>Nothing to choose yet</DropdownMenuItem>
+				)}
+				{allowCustom && (
+					<>
+						<DropdownMenuSeparator />
+						<div className="p-1">
+							<Input
+								value={custom}
+								placeholder={allowCustom.placeholder}
+								disabled={disabled}
+								onChange={(event) => setCustom(event.target.value)}
+								// The menu owns arrow keys and typeahead; the field keeps
+								// what it types.
+								onKeyDown={(event) => {
+									event.stopPropagation();
+									if (event.key === "Enter") {
+										event.preventDefault();
+										addCustom();
+									}
+								}}
+								className="h-7 text-[13px]"
+							/>
+						</div>
+					</>
 				)}
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/circleback.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/circleback.tsx
@@ -1,0 +1,101 @@
+import { LuMic } from "react-icons/lu";
+import { env } from "renderer/env.renderer";
+import { EndpointChip } from "../../TriggerSentence/components/EndpointChip";
+import { ScopeChip } from "../../TriggerSentence/components/ScopeChip";
+import { TextFilterChip } from "../../TriggerSentence/components/TextFilterChip";
+import type { SentenceContext, TriggerProvider } from "../types";
+import { SigningSecretChip } from "./components/SigningSecretChip";
+import {
+	CIRCLEBACK_MENU,
+	CIRCLEBACK_SENTENCE,
+	type CirclebackConfig,
+	type SentencePart,
+} from "./grammar";
+
+export function circlebackWebhookUrl(triggerId: string): string {
+	return `${env.NEXT_PUBLIC_API_URL}/api/integrations/circleback/webhook/${triggerId}`;
+}
+
+function renderPart(
+	config: CirclebackConfig,
+	part: SentencePart,
+	index: number,
+	{ set, disabled, triggerId }: SentenceContext,
+) {
+	if ("text" in part) {
+		return (
+			<span key={index} className="text-[13px] text-muted-foreground">
+				{part.text}
+			</span>
+		);
+	}
+	switch (part.slot) {
+		case "tags":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.tags}
+					// Clearing an optional filter means "any", not "none": the chip
+					// says "Any tag" either way, and null would make that a lie.
+					onChange={(v) => set({ tags: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any tag"
+					anyLabel="Any tag"
+					allowCustom={{ placeholder: "Type a tag, press Enter" }}
+					disabled={disabled}
+				/>
+			);
+		case "attendees":
+			return (
+				<ScopeChip
+					key={index}
+					scope={config.attendees}
+					onChange={(v) => set({ attendees: v ?? { mode: "any" } })}
+					options={[]}
+					emptyLabel="Any attendee"
+					anyLabel="Any attendee"
+					allowCustom={{ placeholder: "Type an email, press Enter" }}
+					disabled={disabled}
+				/>
+			);
+		case "nameFilter":
+			return (
+				<TextFilterChip
+					key={index}
+					value={config.nameFilter}
+					onChange={(v) => set({ nameFilter: v })}
+					emptyLabel="Any name"
+					placeholder="Contains this text..."
+					disabled={disabled}
+				/>
+			);
+		case "endpoint":
+			// The URL carries the saved row's id, so a row that has not been
+			// saved yet has nothing to paste into Circleback.
+			return (
+				<EndpointChip
+					key={index}
+					url={triggerId ? circlebackWebhookUrl(triggerId) : null}
+				/>
+			);
+		case "signingSecret":
+			return (
+				<SigningSecretChip
+					key={index}
+					triggerId={triggerId}
+					disabled={disabled}
+				/>
+			);
+	}
+}
+
+export const circlebackProvider: TriggerProvider<CirclebackConfig> = {
+	kind: "circleback",
+	label: "Circleback",
+	icon: LuMic,
+	menu: CIRCLEBACK_MENU,
+	renderSentence: (config, ctx) =>
+		CIRCLEBACK_SENTENCE.map((part, index) =>
+			renderPart(config, part, index, ctx),
+		),
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/components/SigningSecretChip/SigningSecretChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/components/SigningSecretChip/SigningSecretChip.tsx
@@ -1,0 +1,117 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { useMutation } from "@tanstack/react-query";
+import { useParams } from "@tanstack/react-router";
+import { useState } from "react";
+import { LuKeyRound } from "react-icons/lu";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { CHIP, CHIP_EMPTY } from "../../../../TriggerSentence/chipStyles";
+
+/**
+ * Circleback issues the signing secret when the URL is pasted into its
+ * automation editor, so this takes it back rather than revealing one of ours.
+ * The value goes straight to the trigger row's secret column — never through
+ * the config, which every member of the organization can read — and the chip
+ * shows only its prefix afterwards.
+ */
+export function SigningSecretChip({
+	triggerId,
+	disabled,
+}: {
+	triggerId?: string;
+	disabled?: boolean;
+}) {
+	const { automationId } = useParams({ strict: false });
+	const automation = cloudTrpc.automation.get.useQuery(
+		{ id: automationId ?? "" },
+		{ enabled: Boolean(automationId) },
+	);
+	const utils = cloudTrpc.useUtils();
+	const secretPrefix = automation.data?.triggers.find(
+		(t) => t.id === triggerId,
+	)?.secretPrefix;
+
+	const [open, setOpen] = useState(false);
+	const [draft, setDraft] = useState("");
+
+	const save = useMutation({
+		mutationFn: (secret: string) =>
+			apiTrpcClient.automation.setTriggerSecret.mutate({
+				triggerId: triggerId ?? "",
+				secret,
+			}),
+		onSuccess: () => {
+			setDraft("");
+			setOpen(false);
+			toast.success("Signing secret saved");
+			if (automationId) {
+				void utils.automation.get.invalidate({ id: automationId });
+			}
+		},
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to save secret",
+			),
+	});
+
+	const submit = () => {
+		const secret = draft.trim();
+		if (!secret || save.isPending) return;
+		save.mutate(secret);
+	};
+
+	return (
+		<Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
+			<PopoverTrigger asChild>
+				<span>
+					<button
+						type="button"
+						disabled={disabled || !triggerId}
+						title={triggerId ? undefined : "Save triggers first"}
+						className={cn(CHIP, !secretPrefix && CHIP_EMPTY)}
+					>
+						<LuKeyRound className="size-3 shrink-0 opacity-50" />
+						<span className="truncate">
+							{secretPrefix ? `${secretPrefix}…` : "Signing secret"}
+						</span>
+					</button>
+				</span>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-80 p-2">
+				<div className="flex items-center gap-1.5">
+					<Input
+						autoFocus
+						value={draft}
+						placeholder="Paste the whsec_… secret from Circleback"
+						disabled={save.isPending}
+						autoComplete="off"
+						spellCheck={false}
+						onChange={(event) => setDraft(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") submit();
+						}}
+						className="h-8 font-mono text-[13px]"
+					/>
+					<Button
+						type="button"
+						size="sm"
+						onClick={submit}
+						disabled={!draft.trim() || save.isPending}
+						className="h-8 shrink-0 text-[13px]"
+					>
+						{save.isPending ? "Saving..." : "Save"}
+					</Button>
+				</div>
+				<p className="mt-1.5 px-1 text-[12px] text-muted-foreground">
+					{secretPrefix
+						? `${secretPrefix}… is set. Saving a new one replaces it.`
+						: "Circleback shows this when you paste the URL into its automation. Deliveries are rejected until it is set."}
+				</p>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/components/SigningSecretChip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/components/SigningSecretChip/index.ts
@@ -1,0 +1,1 @@
+export { SigningSecretChip } from "./SigningSecretChip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/grammar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/circleback/grammar.ts
@@ -1,0 +1,48 @@
+import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import type { TriggerMenuEntry } from "../types";
+
+export type CirclebackConfig = Extract<
+	TriggerConfigInput,
+	{ kind: "circleback" }
+>;
+
+/**
+ * The one sentence a Circleback trigger reads as. Circleback sends one webhook
+ * per finished meeting, so there is one event and three optional narrowings —
+ * then the two chips Circleback's side needs: where to post, and what it signs
+ * with.
+ */
+export type Slot =
+	| "tags"
+	| "attendees"
+	| "nameFilter"
+	| "endpoint"
+	| "signingSecret";
+
+export type SentencePart = { text: string } | { slot: Slot };
+
+export const CIRCLEBACK_SENTENCE: SentencePart[] = [
+	{ text: "Meeting ended tagged" },
+	{ slot: "tags" },
+	{ text: "with attendee" },
+	{ slot: "attendees" },
+	{ text: "named like" },
+	{ slot: "nameFilter" },
+	{ slot: "endpoint" },
+	{ slot: "signingSecret" },
+];
+
+export const CIRCLEBACK_MENU: TriggerMenuEntry<CirclebackConfig>[] = [
+	{ label: "Meeting ended", create: createCirclebackConfig },
+];
+
+/** A new trigger: every narrowing wide open. */
+export function createCirclebackConfig(): CirclebackConfig {
+	return {
+		kind: "circleback",
+		event: "meeting.completed",
+		tags: { mode: "any" },
+		attendees: { mode: "any" },
+		nameFilter: null,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/index.ts
@@ -1,4 +1,5 @@
 import type { TriggerConfigInput } from "@superset/shared/automation-triggers";
+import { circlebackProvider } from "./circleback/circleback";
 import { githubProvider } from "./github/github";
 import { linearProvider } from "./linear/linear";
 import { notionProvider } from "./notion/notion";
@@ -27,6 +28,7 @@ export const TRIGGER_PROVIDERS: TriggerProvider[] = [
 	notionProvider as TriggerProvider,
 	slackProvider as TriggerProvider,
 	webhookProvider as TriggerProvider,
+	circlebackProvider as TriggerProvider,
 ];
 
 const byKind = new Map(TRIGGER_PROVIDERS.map((p) => [p.kind, p]));

--- a/packages/shared/src/automation-matching/circleback.ts
+++ b/packages/shared/src/automation-matching/circleback.ts
@@ -1,0 +1,56 @@
+import type { TextFilter, TriggerScope } from "../automation-triggers";
+import {
+	type BaseMatchableEvent,
+	bodyMatches,
+	type MatchContext,
+	type MatchResult,
+	scopeAllowsAny,
+} from "./core";
+
+/**
+ * A Circleback meeting, normalized to what Circleback triggers filter on.
+ * Every value here is typed by a person on one side and by Circleback on the
+ * other, so comparison is case-insensitive: "events" and "Events" are the same
+ * tag, and an email is an email whatever its case.
+ */
+export type CirclebackMatchableEvent = BaseMatchableEvent & {
+	provider: "circleback";
+	name: string | null;
+	tags: string[];
+	attendeeEmails: string[];
+};
+
+const no = (reason: string): MatchResult => ({ matches: false, reason });
+
+function lower(values: string[]): string[] {
+	return values.map((v) => v.trim().toLowerCase());
+}
+
+/**
+ * Same null semantics as GitHub's branches and labels: null means the trigger
+ * author never chose to narrow on this, which for an optional filter is "any".
+ */
+function narrows(scope: TriggerScope, values: string[]): boolean {
+	if (scope === null || scope.mode === "any") return true;
+	return scopeAllowsAny({ mode: "list", ids: lower(scope.ids) }, lower(values));
+}
+
+/** Whether a Circleback trigger config accepts this meeting. */
+export function circlebackTriggerMatches(
+	config: {
+		event: string;
+		tags: TriggerScope;
+		attendees: TriggerScope;
+		nameFilter?: TextFilter | null;
+	},
+	event: CirclebackMatchableEvent,
+	_context: MatchContext,
+): MatchResult {
+	if (config.event !== event.eventType) return no("event");
+	if (!narrows(config.tags, event.tags)) return no("tags");
+	if (!narrows(config.attendees, event.attendeeEmails)) return no("attendees");
+	if (!bodyMatches(config.nameFilter ?? null, event.name)) {
+		return no("nameFilter");
+	}
+	return { matches: true };
+}

--- a/packages/shared/src/automation-matching/index.ts
+++ b/packages/shared/src/automation-matching/index.ts
@@ -1,4 +1,8 @@
 import type { TriggerConfigInput } from "../automation-triggers";
+import {
+	type CirclebackMatchableEvent,
+	circlebackTriggerMatches,
+} from "./circleback";
 import type { BaseMatchableEvent, MatchContext, MatchResult } from "./core";
 import { type GithubMatchableEvent, githubTriggerMatches } from "./github";
 import { type LinearMatchableEvent, linearTriggerMatches } from "./linear";
@@ -6,6 +10,7 @@ import { type NotionMatchableEvent, notionTriggerMatches } from "./notion";
 import { type SlackMatchableEvent, slackTriggerMatches } from "./slack";
 import { type WebhookMatchableEvent, webhookTriggerMatches } from "./webhook";
 
+export * from "./circleback";
 export * from "./core";
 export * from "./github";
 export * from "./linear";
@@ -27,7 +32,8 @@ export type MatchableEvent =
 	| WebhookMatchableEvent
 	| NotionMatchableEvent
 	| LinearMatchableEvent
-	| SlackMatchableEvent;
+	| SlackMatchableEvent
+	| CirclebackMatchableEvent;
 
 /**
  * Whether a trigger config accepts an event, whatever provider it belongs to.
@@ -76,6 +82,12 @@ export function triggerMatches(
 		case "slack":
 			return slackTriggerMatches(
 				config as Extract<TriggerConfigInput, { kind: "slack" }>,
+				event,
+				context,
+			);
+		case "circleback":
+			return circlebackTriggerMatches(
+				config as Extract<TriggerConfigInput, { kind: "circleback" }>,
 				event,
 				context,
 			);

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -238,6 +238,22 @@ export const sentryTriggerConfigSchema = z.object({
 	level: triggerScopeSchema,
 });
 
+export const circlebackTriggerEventValues = ["meeting.completed"] as const;
+
+/**
+ * Circleback has no connection: it posts to a per-trigger URL and signs the
+ * body with a secret it generates and shows in its own UI. That secret is
+ * pasted into the trigger row and lives on the trigger row's secret column,
+ * never in this config — the config is returned to every member of the org.
+ */
+export const circlebackTriggerConfigSchema = z.object({
+	kind: z.literal("circleback"),
+	event: z.enum(circlebackTriggerEventValues),
+	tags: triggerScopeSchema,
+	attendees: triggerScopeSchema,
+	nameFilter: textFilterSchema.nullable().default(null),
+});
+
 /**
  * Notion. `comment.mentioned` is not a Notion event: it is `comment.created`
  * narrowed to comments whose rich text mentions a user, which the webhook
@@ -304,6 +320,7 @@ export const draftTriggerSchema = z.object({
 		linearTriggerConfigSchema,
 		sentryTriggerConfigSchema,
 		notionTriggerConfigSchema,
+		circlebackTriggerConfigSchema,
 	]),
 });
 export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
@@ -402,6 +419,7 @@ export function describeTriggerProblems(
 				break;
 			}
 			case "sentry":
+			case "circleback":
 				break;
 			case "schedule":
 			case "webhook":


### PR DESCRIPTION
## Summary

Adds the **Circleback** trigger provider (kind `circleback`, tier 0 — no connection, no `integration_provider`).

- **Event:** `meeting.completed` (Circleback sends one webhook per finished meeting). Sentence: *Meeting ended tagged [tags] with attendee [email] named like ["…"]* + URL chip + signing-secret chip.
- **Filters:** `tags` / `attendees` (ScopeChip with free-form entry, case-insensitive match, `{mode:"any"}` default like GitHub's branches/labels), `nameFilter` (TextFilterChip, substring, `isRegex` pinned false).
- **Route:** `POST /api/integrations/circleback/webhook/[triggerId]` — verifies `x-signature` (HMAC-SHA256 hex over the raw body, timing-safe) **before** parsing, records `automation_events` (`provider="circleback"`, full body in `payload`, `title=name`, `url=https://circleback.ai/meetings/{id}`), evaluates the addressed trigger via `triggerMatches`, enqueues a run through QStash.
- **Shared:** `circlebackTriggerConfigSchema` in `automation-triggers.ts`; `automation-matching/circleback.ts` + one `case` in `triggerMatches` (`MatchContext.circleback`).

### Two brief-vs-reality deviations (facts, agreed with the coordinator)
1. **Circleback issues the signing secret** (`whsec_…`, shown in its automation editor) and uses it as the HMAC key — so we can't generate-and-show-once, and can't verify from a hash. The row shows the per-trigger URL; the user pastes Circleback's secret into the "Signing secret" chip → `automation.setTriggerSecret` stores it **raw** in `automation_triggers.secret_hash` (never in `config`, which every org member can read; the API never returns the column, only `secret_prefix`). The route 401s until it's set.
2. **`externalEventId = ${triggerId}:${meeting.id}`**, not the bare id: the dedup unique is `(integration_connection_id NULLS NOT DISTINCT, provider, external_event_id)`, and the same meeting legitimately reaches every trigger whose URL is configured in Circleback — a bare id would make the second automation never fire.

### Shared bits carried byte-identically (first commit) — whichever PR lands first, the other rebases as a no-op
- From #6586 (trigger-provider-webhook): `automation.setTriggerSecret` + `rotateWebhookSecret` + `webhookSecret.ts` + `EndpointChip` + `secret_hash` schema comment.
- From trigger-provider-google: `ScopeChip.allowCustom`.
- `SentenceContext.triggerId` (+ 1 line in `TriggerSentence.tsx`) — same text as #6586; the coordinator is landing a consolidated seam on main, I'll rebase onto it.

## Verification (CDP against the running dev app, workspace API on :8761, workspace Neon branch)
- Added the trigger from **Add Trigger › Circleback**, typed a custom tag `Sales`, attendee `Alice@Example.com`, name filter `Venue`, **Save triggers** → URL chip appears with the saved trigger id; pasted a `whsec_…` secret → chip shows `whsec_verify…`; navigated away and back → all persisted. DB row: `config = {"kind":"circleback","tags":{"ids":["Sales"],"mode":"list"},"event":"meeting.completed","attendees":{"ids":["Alice@Example.com"],"mode":"list"},"nameFilter":{"isRegex":false,"pattern":"Venue"}}`, `secret_prefix = whsec_verify`, `secret_hash` set.
- Replayed Circleback's documented example payload at the route:
  - bad / missing `x-signature` → **401**
  - valid signature, meeting tagged `Sales`, attendee `alice@example.com`, name "Event Venue Review" → **200 matched** — log: `[circleback/webhook] trigger d79600c1-… matched, enqueuing run for automation 747434f5-…: 80663d01-…`; `automation_events` row `provider=circleback, event_type=meeting.completed, external_event_id=d79600c1-…:WRweb12iCBimU6Vo8cD7z, title=Event Venue Review`.
  - same delivery again → **200 duplicate** (no second row)
  - valid signature, tag `Internal` → **200 matched:false reason:tags**
  - QStash publish itself fails locally (`invalid destination url: endpoint resolves to a loopback address`) — known local-only limitation, handled like the GitHub route (logged, delivery acknowledged).
- `bun run typecheck` in shared/db/trpc/api/desktop: all exit 0. `biome check` on every touched dir: exit 0. Root `bun run lint` exits 1 only on the pre-existing `TerminalAgentAutoResume.tsx` a11y error on main.

## Not in this PR
- No migration (enum values already on main). No new packages.
- Nothing prevents pasting a non-`whsec_` string — Circleback's format isn't enforced by the general mutation; the chip's placeholder says what to paste.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Circleback trigger provider for meeting-completed webhooks. Requests are HMAC-verified, deduped per trigger, and only the addressed trigger dispatches runs; deliveries 401 until a signing secret is set.

- API: POST /api/integrations/circleback/webhook/[triggerId] verifies x-signature (HMAC‑SHA256 over the raw body) before parsing. Records automation_events with provider="circleback", event_type="meeting.completed", external_event_id="${triggerId}:${meeting.id}" (per-trigger dedupe), then dispatches only to the addressed trigger; duplicate deliveries ack without re‑enqueue and dispatch failures do not fail the delivery.
- Matching: Adds `circleback` matcher in `@superset/shared/automation-matching` and `circlebackTriggerConfigSchema` in `@superset/shared/automation-triggers`. Optional filters tags and attendees are case‑insensitive with “any” semantics; nameFilter is a substring match.
- Desktop: New Circleback provider with sentence UI, `EndpointChip` (per‑trigger URL), `SigningSecretChip` (stores Circleback’s whsec_… and shows its prefix), and `ScopeChip.allowCustom` for free‑form tags/emails.

**Rollout**
- Create a Circleback trigger, save, copy the URL into Circleback, then paste the whsec_… into Signing secret. Deliveries return 401 until the secret is set.
- Deploy API and Desktop together; no DB migration. Ensure QStash configuration is present.

<sup>Written for commit e0c9ee4ca9c7c004a9db51913fc29875d2d4619c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Circleback meeting-completed automation triggers with filters for tags, attendees, and meeting names.
  * Added configurable webhook endpoints and signing-secret management.
  * Added secure webhook token creation, rotation, and signature validation.
  * Added support for custom scope values in automation settings.
  * Added endpoint display with HTTP method details, copy action, and notifications.

* **Bug Fixes**
  * Prevented duplicate meeting events from triggering automations more than once.
  * Improved handling and feedback for invalid requests and dispatch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->