### PR TITLE
fix(mobile): workspace row long-press opens only the menu; delete shows progress and tolerates teardown failures

### DIFF
--- a/apps/mobile/expo-router-context-menu-patch.test.ts
+++ b/apps/mobile/expo-router-context-menu-patch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Guards the bun patch on expo-router (patches/README.md): without
+// cancelReactNativeTouches, long-pressing a Link.Menu trigger opens the
+// context menu and still fires the row's onPress. Reads the installed package
+// so it also passes once an expo-router bump carries the fix upstream.
+const swiftFile = join(
+	dirname(require.resolve("expo-router/package.json")),
+	"ios/LinkPreview/LinkPreviewNativeView.swift",
+);
+
+describe("expo-router context-menu touch cancel", () => {
+	test("the menu interaction cancels react-native's in-flight touch", () => {
+		const source = readFileSync(swiftFile, "utf8");
+		expect(source).toContain(
+			"configurationForMenuAtLocation location: CGPoint",
+		);
+		expect(source).toMatch(
+			/configurationForMenuAtLocation location: CGPoint\s*\) -> UIContextMenuConfiguration\? \{\s*cancelReactNativeTouches\(\)/,
+		);
+		expect(source).toContain('NSClassFromString("RCTSurfaceTouchHandler")');
+	});
+});

--- a/apps/mobile/hooks/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/mobile/hooks/useHostWorkspaces/useHostWorkspaces.ts
@@ -37,6 +37,8 @@ export interface HostWorkspacesCacheOps {
 	removeWorkspace: (hostId: string, workspaceId: string) => void;
 	/** Rollback hammer: refetch the host's list after a failed write. */
 	invalidateHost: (hostId: string) => void;
+	/** Refetch and resolve with the host's fresh list (undefined = unreachable). */
+	refetchHost: (hostId: string) => Promise<HostWorkspaceRow[] | undefined>;
 }
 
 export interface UseHostWorkspacesResult {
@@ -116,6 +118,11 @@ export function useHostWorkspaces(
 			invalidateHost: (hostId) => {
 				if (hostId !== machineId) return;
 				void queryClient.invalidateQueries({ queryKey: key });
+			},
+			refetchHost: async (hostId) => {
+				if (hostId !== machineId) return undefined;
+				await queryClient.refetchQueries({ queryKey: key });
+				return queryClient.getQueryData<HostWorkspaceRow[]>(key);
 			},
 		};
 	}, [machineId, hostUrl, queryClient]);

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
@@ -1,7 +1,7 @@
 import type { SelectGithubPullRequest } from "@superset/db/schema";
 import { useRouter } from "expo-router";
 import { FolderGit2, Plus } from "lucide-react-native";
-import { Pressable, View } from "react-native";
+import { ActivityIndicator, Pressable, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
@@ -25,6 +25,7 @@ import type {
 import type { DiffStats } from "../../hooks/useVisibleDiffStats";
 import { useChatTargetStore } from "../../stores/chatTargetStore";
 import { WorkspaceRowMenu } from "./components/WorkspaceRowMenu";
+import { useWorkspaceRowActions } from "./hooks/useWorkspaceRowActions";
 
 // PR state replaces the host icon in the icon slot — same treatment as
 // desktop's DashboardSidebarWorkspaceIcon.
@@ -55,24 +56,44 @@ export function WorkspaceRow({
 		(state) => state.target?.workspaceId === workspace.id,
 	);
 	const canChat = workspace.hostReachable && workspace.worktreeExists !== false;
+	const {
+		isDeleting,
+		renameWorkspace,
+		deleteWorkspace,
+		copyId,
+		shareWorkspace,
+	} = useWorkspaceRowActions(workspace, cache);
 
 	return (
-		<WorkspaceRowMenu workspace={workspace} cache={cache}>
+		<WorkspaceRowMenu
+			canDelete={workspace.type !== "main"}
+			onRename={() => void renameWorkspace()}
+			onDelete={deleteWorkspace}
+			onCopyId={copyId}
+			onShare={shareWorkspace}
+		>
 			{/* Default press behavior on purpose: the system context-menu lift
 			    owns the hold animation, and custom press feedback fights it. */}
 			<Pressable
 				className={cn(
 					"flex-row items-center gap-3 rounded-xl py-2 pl-10 pr-3",
 					targeted ? "bg-foreground/5" : "bg-background",
+					isDeleting && "opacity-40",
 				)}
+				disabled={isDeleting}
 				onPress={() =>
 					router.push(`/(authenticated)/workspace/${workspace.id}`)
 				}
 			>
 				{/* Desktop WorkspaceIcon semantics: working replaces the icon with
 				    the braille spinner; other statuses overlay a corner ping on the
-				    base icon (PR state when one exists, else the workspace mark). */}
-				{attention === "working" ? (
+				    base icon (PR state when one exists, else the workspace mark).
+				    A delete in flight takes the slot over everything else. */}
+				{isDeleting ? (
+					<View className="size-6 items-center justify-center">
+						<ActivityIndicator size="small" color={theme.mutedForeground} />
+					</View>
+				) : attention === "working" ? (
 					<View className="size-6 items-center justify-center">
 						<AsciiSpinner />
 					</View>
@@ -175,7 +196,7 @@ export function WorkspaceRow({
 					accessibilityLabel={`New agent in ${workspace.name}`}
 					variant="ghost"
 					size="icon"
-					disabled={!canChat}
+					disabled={!canChat || isDeleting}
 					onPress={() =>
 						setTarget({
 							workspaceId: workspace.id,

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/components/WorkspaceRowMenu/WorkspaceRowMenu.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/components/WorkspaceRowMenu/WorkspaceRowMenu.tsx
@@ -1,110 +1,21 @@
-import { prompt } from "@superset/alert-prompt";
-import * as Clipboard from "expo-clipboard";
 import { Link } from "expo-router";
 import type { ReactNode } from "react";
-import { Alert, Share } from "react-native";
-import type {
-	HostWorkspaceItem,
-	HostWorkspacesCacheOps,
-} from "@/hooks/useHostWorkspaces";
-import { getHostServiceClientByUrl } from "@/lib/host-service/client";
-import { isTrpcErrorWithData } from "@/lib/host-service/errors";
-import { workspaceShareUrl } from "@/lib/web-links";
 
 export function WorkspaceRowMenu({
-	workspace,
-	cache,
+	canDelete,
+	onRename,
+	onDelete,
+	onCopyId,
+	onShare,
 	children,
 }: {
-	workspace: HostWorkspaceItem;
-	cache: HostWorkspacesCacheOps;
+	canDelete: boolean;
+	onRename: () => void;
+	onDelete: () => void;
+	onCopyId: () => void;
+	onShare: () => void;
 	children: ReactNode;
 }) {
-	const renameWorkspace = async () => {
-		const hostUrl = cache.resolveHostUrl(workspace.hostId);
-		if (!hostUrl) {
-			Alert.alert("Host is not online");
-			return;
-		}
-		const name = await prompt({
-			title: "Rename workspace",
-			defaultValue: workspace.name,
-			confirmText: "Rename",
-			selectText: true,
-		});
-		const trimmed = name?.trim();
-		if (!trimmed || trimmed === workspace.name) return;
-		try {
-			await getHostServiceClientByUrl(hostUrl).workspace.update.mutate({
-				id: workspace.id,
-				name: trimmed,
-			});
-		} catch {
-			Alert.alert("Rename failed");
-		}
-		cache.invalidateHost(workspace.hostId);
-	};
-
-	const destroyWorkspace = async (force: boolean) => {
-		const hostUrl = cache.resolveHostUrl(workspace.hostId);
-		if (!hostUrl) {
-			Alert.alert("Host is not online");
-			return;
-		}
-		try {
-			await getHostServiceClientByUrl(hostUrl).workspaceCleanup.destroy.mutate({
-				workspaceId: workspace.id,
-				deleteBranch: false,
-				force,
-			});
-			cache.removeWorkspace(workspace.hostId, workspace.id);
-		} catch (error) {
-			if (isTrpcErrorWithData(error)) {
-				if (error.data.deleteInProgress) {
-					Alert.alert("Delete already in progress");
-					return;
-				}
-				if (error.data.code === "CONFLICT" || error.data.teardownFailure) {
-					Alert.alert(
-						error.data.teardownFailure
-							? "Teardown script failed"
-							: "Worktree has uncommitted changes",
-						undefined,
-						[
-							{ style: "cancel", text: "Cancel" },
-							{
-								onPress: () => void destroyWorkspace(true),
-								style: "destructive",
-								text: "Force delete",
-							},
-						],
-					);
-					return;
-				}
-			}
-			Alert.alert("Delete failed");
-		}
-	};
-
-	const deleteWorkspace = () => {
-		if (!cache.resolveHostUrl(workspace.hostId)) {
-			Alert.alert("Host is not online");
-			return;
-		}
-		Alert.alert(
-			"Delete workspace",
-			`Delete "${workspace.name}"? This removes its worktree from the host.`,
-			[
-				{ style: "cancel", text: "Cancel" },
-				{
-					onPress: () => void destroyWorkspace(false),
-					style: "destructive",
-					text: "Delete",
-				},
-			],
-		);
-	};
-
 	// Tap navigation lives on the row itself; the Link exists solely because
 	// Link.Menu must be a direct child of Link, so tap is a no-op here.
 	return (
@@ -115,29 +26,19 @@ export function WorkspaceRowMenu({
 		>
 			<Link.Trigger>{children}</Link.Trigger>
 			<Link.Menu>
-				<Link.MenuAction icon="pencil" onPress={() => void renameWorkspace()}>
+				<Link.MenuAction icon="pencil" onPress={onRename}>
 					Rename
 				</Link.MenuAction>
-				{workspace.type !== "main" ? (
-					<Link.MenuAction icon="trash" onPress={deleteWorkspace}>
+				{canDelete ? (
+					<Link.MenuAction icon="trash" destructive onPress={onDelete}>
 						Delete
 					</Link.MenuAction>
 				) : null}
 				<Link.Menu inline>
-					<Link.MenuAction
-						icon="doc.on.doc"
-						onPress={() => void Clipboard.setStringAsync(workspace.id)}
-					>
+					<Link.MenuAction icon="doc.on.doc" onPress={onCopyId}>
 						Copy ID
 					</Link.MenuAction>
-					<Link.MenuAction
-						icon="square.and.arrow.up"
-						onPress={() =>
-							void Share.share({
-								url: workspaceShareUrl(workspace.id),
-							})
-						}
-					>
+					<Link.MenuAction icon="square.and.arrow.up" onPress={onShare}>
 						Share
 					</Link.MenuAction>
 				</Link.Menu>

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceRowActions } from "./useWorkspaceRowActions";

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
@@ -1,26 +1,31 @@
 import { prompt } from "@superset/alert-prompt";
-import { useQueryClient } from "@tanstack/react-query";
 import * as Clipboard from "expo-clipboard";
-import { useRouter } from "expo-router";
+import { useState } from "react";
 import { Alert, Share } from "react-native";
-import type { HostWorkspaceRow } from "@/hooks/useHostWorkspaces";
-import type { OrgHost } from "@/hooks/useOrgHosts";
-import {
-	buildRelayHostUrl,
-	getHostServiceClientByUrl,
-} from "@/lib/host-service/client";
+import type {
+	HostWorkspaceItem,
+	HostWorkspacesCacheOps,
+} from "@/hooks/useHostWorkspaces";
+import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { isTrpcErrorWithData } from "@/lib/host-service/errors";
 import { workspaceShareUrl } from "@/lib/web-links";
 
-export function useWorkspaceHeaderActions(
-	workspace: HostWorkspaceRow | null,
-	host: OrgHost | null,
+interface DestroyOptions {
+	/** Git-destructive consent only: skips the dirty-worktree preflight. */
+	force: boolean;
+	/** Consent to abandon the teardown script — set once it has already failed. */
+	skipTeardown: boolean;
+}
+
+export function useWorkspaceRowActions(
+	workspace: HostWorkspaceItem,
+	cache: HostWorkspacesCacheOps,
 ) {
-	const router = useRouter();
-	const queryClient = useQueryClient();
+	const [isDeleting, setIsDeleting] = useState(false);
+
 	const renameWorkspace = async () => {
-		if (!workspace) return;
-		if (!host) {
+		const hostUrl = cache.resolveHostUrl(workspace.hostId);
+		if (!hostUrl) {
 			Alert.alert("Host is not online");
 			return;
 		}
@@ -33,7 +38,6 @@ export function useWorkspaceHeaderActions(
 		const trimmed = name?.trim();
 		if (!trimmed || trimmed === workspace.name) return;
 		try {
-			const hostUrl = buildRelayHostUrl(host.organizationId, host.machineId);
 			await getHostServiceClientByUrl(hostUrl).workspace.update.mutate({
 				id: workspace.id,
 				name: trimmed,
@@ -41,22 +45,16 @@ export function useWorkspaceHeaderActions(
 		} catch {
 			Alert.alert("Rename failed");
 		}
-		void queryClient.invalidateQueries({
-			queryKey: ["host-service", "workspaces", "list"],
-		});
+		cache.invalidateHost(workspace.hostId);
 	};
 
-	const destroyWorkspace = async ({
-		force,
-		skipTeardown,
-	}: {
-		/** Git-destructive consent only: skips the dirty-worktree preflight. */
-		force: boolean;
-		/** Consent to abandon the teardown script — set once it has already failed. */
-		skipTeardown: boolean;
-	}) => {
-		if (!workspace || !host) return;
-		const hostUrl = buildRelayHostUrl(host.organizationId, host.machineId);
+	const destroyWorkspace = async ({ force, skipTeardown }: DestroyOptions) => {
+		const hostUrl = cache.resolveHostUrl(workspace.hostId);
+		if (!hostUrl) {
+			Alert.alert("Host is not online");
+			return;
+		}
+		setIsDeleting(true);
 		try {
 			await getHostServiceClientByUrl(hostUrl).workspaceCleanup.destroy.mutate({
 				workspaceId: workspace.id,
@@ -64,10 +62,7 @@ export function useWorkspaceHeaderActions(
 				force,
 				skipTeardown,
 			});
-			void queryClient.invalidateQueries({
-				queryKey: ["host-service", "workspaces", "list"],
-			});
-			router.back();
+			cache.removeWorkspace(workspace.hostId, workspace.id);
 		} catch (error) {
 			if (isTrpcErrorWithData(error)) {
 				if (error.data.deleteInProgress) {
@@ -93,16 +88,23 @@ export function useWorkspaceHeaderActions(
 					return;
 				}
 			}
+			// The host archives the row before any slow work, so if it is gone
+			// from a fresh list the delete committed and only the relay gave up
+			// waiting (its 30s cap is shorter than a teardown script's).
+			const rows = await cache.refetchHost(workspace.hostId);
+			if (rows && !rows.some((row) => row.id === workspace.id)) return;
 			Alert.alert(
 				"Delete failed",
 				error instanceof Error ? error.message : undefined,
 			);
+		} finally {
+			setIsDeleting(false);
 		}
 	};
 
 	const deleteWorkspace = () => {
-		if (!workspace) return;
-		if (!host) {
+		if (isDeleting) return;
+		if (!cache.resolveHostUrl(workspace.hostId)) {
 			Alert.alert("Host is not online");
 			return;
 		}
@@ -121,18 +123,13 @@ export function useWorkspaceHeaderActions(
 		);
 	};
 
-	const copyId = () => {
-		if (workspace) void Clipboard.setStringAsync(workspace.id);
-	};
+	const copyId = () => void Clipboard.setStringAsync(workspace.id);
 
-	const shareWorkspace = () => {
-		if (!workspace) return;
-		void Share.share({
-			url: workspaceShareUrl(workspace.id),
-		});
-	};
+	const shareWorkspace = () =>
+		void Share.share({ url: workspaceShareUrl(workspace.id) });
 
 	return {
+		isDeleting,
 		renameWorkspace,
 		deleteWorkspace,
 		copyId,

--- a/bun.lock
+++ b/bun.lock
@@ -1290,6 +1290,7 @@
     "workerd",
   ],
   "patchedDependencies": {
+    "expo-router@56.2.18": "patches/expo-router@56.2.18.patch",
     "@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
     "metro@0.84.4": "patches/metro@0.84.4.patch",
   },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 	],
 	"patchedDependencies": {
 		"@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
-		"metro@0.84.4": "patches/metro@0.84.4.patch"
+		"metro@0.84.4": "patches/metro@0.84.4.patch",
+		"expo-router@56.2.18": "patches/expo-router@56.2.18.patch"
 	}
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -95,3 +95,25 @@ upstream already absorbed the render-loop page-count clamp and `_evictAllPages`
 from the SUPER-1793 report into 0.20.0-beta.297, and hunks 1–3 are candidates
 for upstreaming. If upstream ships them, delete the patch, the
 `patchedDependencies` entry, and update (not delete) the guard test.
+
+## expo-router (`expo-router@<version>.patch`)
+
+**Why:** on iOS, `Link.Menu` adds a `UIContextMenuInteraction` to the trigger
+view, but nothing cancels react-native's in-flight touch when the menu opens.
+Pressability keeps tracking the finger, so lifting it after the menu presents
+still delivers `onPress` — long-pressing a home workspace row opened the menu
+*and* navigated into the workspace.
+
+**What it changes** (`ios/LinkPreview/LinkPreviewNativeView.swift`): when the
+interaction asks for a menu configuration, find the nearest
+`RCTSurfaceTouchHandler` up the view chain and toggle it off/on, which makes
+UIKit deliver `touchesCancelled` for the press. Taken verbatim from upstream
+expo-router 56.2.19 (`cancelReactNativeTouches`, released 2026-08-17). It is a
+native change: a dev client needs a fresh native build to pick it up.
+
+**Guard test:** `apps/mobile/expo-router-context-menu-patch.test.ts`.
+
+**Removing:** the next Expo SDK 56 batch bump (expo-router ≥ 56.2.19, paired
+with its same-day expo-modules-core) carries the fix upstream. Delete the patch
+and the `patchedDependencies` entry then; the guard test reads the installed
+Swift file, so it keeps passing on its own.

--- a/patches/expo-router@56.2.18.patch
+++ b/patches/expo-router@56.2.18.patch
@@ -1,0 +1,41 @@
+diff --git a/ios/LinkPreview/LinkPreviewNativeView.swift b/ios/LinkPreview/LinkPreviewNativeView.swift
+index 254bc4d11147f9fb6eb22888676f0bd266eb2b0a..562d1b907a9b5b858259eb0135541772cc8299c9 100644
+--- a/ios/LinkPreview/LinkPreviewNativeView.swift
++++ b/ios/LinkPreview/LinkPreviewNativeView.swift
+@@ -116,6 +116,7 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
+     _ interaction: UIContextMenuInteraction,
+     configurationForMenuAtLocation location: CGPoint
+   ) -> UIContextMenuConfiguration? {
++    cancelReactNativeTouches()
+     onWillPreviewOpen()
+     return UIContextMenuConfiguration(
+       identifier: nil,
+@@ -185,6 +186,28 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
+     }
+   }
+ 
++  // A press released before the menu fully presents is still recognized as a tap by
++  // react-native, so cancel in-flight touches on the nearest surface when the interaction
++  // starts. Unlike rnscreens_cancelTouches, `reset` is omitted deliberately: the press is
++  // still active and UIKit delivers touchesCancelled after this returns — resetting first
++  // desyncs the touch registry (NSAssert in -[RCTSurfaceTouchHandler _updateTouches:]).
++  private func cancelReactNativeTouches() {
++    guard let touchHandlerClass = NSClassFromString("RCTSurfaceTouchHandler") else {
++      return
++    }
++    var view: UIView? = self
++    while let current = view {
++      if let recognizer = current.gestureRecognizers?.first(where: { $0.isKind(of: touchHandlerClass) }) {
++        if recognizer.isEnabled {
++          recognizer.isEnabled = false
++          recognizer.isEnabled = true
++        }
++        return
++      }
++      view = current.superview
++    }
++  }
++
+   // MARK: - Context Menu Helpers
+ 
+   private func createPreviewViewController() -> UIViewController? {


### PR DESCRIPTION
## Summary
- Long-pressing a home workspace row on iOS opened the native context menu **and** navigated into the workspace. Root cause is in expo-router ≤ 56.2.18 (it never cancels react-native's in-flight touch when the menu opens); upstream's 56.2.19 Swift fix is carried here as a bun patch of our pinned version.
- The delete flow gets a visible in-flight state (dimmed row, spinner, disabled tap/"+"), a real error message on failure, and stops letting a failing teardown script block or loop the delete. Same teardown fix applied to the workspace-screen sheet.

## Why / Context
Reported: "pressing and holding does the normal click (navigates)" and "the delete flow has no signal and then it fails". Three distinct defects were under that:
1. expo-router's `Link.Menu` puts a `UIContextMenuInteraction` on the trigger, but RN's `RCTSurfaceTouchHandler` can't be prevented by a descendant's gesture, so lifting the finger after the menu presents still delivers `onPress`. Upstream fixed it in 56.2.19 (`cancelReactNativeTouches`) — released 2026-08-17, blocked by bun's 3-day `minimumReleaseAge` and paired with a new expo-modules-core (bumping one module alone risks a launch crash, see `patches/README.md`).
2. The teardown-failed retry sent `force` but not `skipTeardown`, so the script ran and failed again — an endless "Force delete" prompt.
3. Relay caps a request at 30s while a teardown may run 60s; slow deletes surfaced as "Delete failed" while the host was still deleting.

## How It Works
- `patches/expo-router@56.2.18.patch`: verbatim upstream Swift — when UIKit asks for the menu configuration, find the nearest `RCTSurfaceTouchHandler` and toggle `isEnabled` so the press is delivered as `touchesCancelled`. Native change: **dev clients need a rebuild** to pick it up. Guard test reads the installed Swift file, so it keeps passing after the eventual bump; drop the patch then.
- `useWorkspaceRowActions` (new, under `WorkspaceRow/hooks/`) owns rename/delete/copy/share + `isDeleting`; `WorkspaceRowMenu` is now purely the native `Link.Menu` (Delete marked `destructive`).
- Delete: dirty worktree → "Delete anyway" (force, teardown still runs); teardown failed → retried once with `skipTeardown` automatically, no prompt (per Satya: the toast was annoying, and the script already ran); other errors alert with the host's message; on any other failure the host list is refetched and, because the host archives the row before slow work, a missing row means the delete committed (covers the relay timeout).
- `useHostWorkspaces` cache ops gain `refetchHost` for that.

## Manual QA Checklist
Verified on the iPhone 16e simulator with a native build of this branch, against a live host over the relay (standalone host-service, scratch project with two worktrees, one with a 6s teardown, one dirty with a teardown that exits 1). Screenshots + notes: https://claude.ai/code/artifact/eb182eda-203d-4622-8520-506ac8f09208
- [x] Long-press a row → native menu (Rename / Delete in red / Copy ID / Share); dismiss → still on home, no navigation
- [x] Delete a clean workspace → confirm alert → row dims with spinner, "+" disabled, for the whole teardown → row gone
- [x] Delete a dirty workspace with a failing teardown → "Worktree has uncommitted changes → Delete anyway" → deleted (filmed before the teardown prompt was removed; the retry now runs without asking — JS-only change, typechecked)
- [ ] Not exercised: a >30s teardown (relay timeout path); code path is refetch-and-decide

## Testing
- `bun run typecheck` (mobile, after `build:types`)
- `bun run lint`
- `bun test` in `apps/mobile` (incl. the new patch guard)
- Native build with the patch compiles (`xcodebuild`, Debug simulator)

## Known Limitations
- Old dev clients keep the old long-press behaviour until rebuilt (JS reload isn't enough).
- The "before" claim rests on the mechanism + upstream's changelog; I did not re-film an unpatched binary side by side.

## Follow-ups
- Next Expo SDK 56 batch bump (expo-router ≥ 56.2.19 with its same-day expo-modules-core): delete the patch and its `patchedDependencies` entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS long-press on a workspace row so it opens only the native context menu (no navigation), and makes delete show progress while tolerating teardown failures and relay timeouts. Previously, long-press also fired the row’s onPress; delete had no in-flight UI and could loop or misreport failures.

Carries upstream Swift fix as a bun patch to `expo-router@56.2.18` so the menu cancels the in-flight touch. While delete runs the row dims, a spinner replaces the icon, and tap and the "+" button are disabled. A teardown failure is retried once with `skipTeardown`; dirty worktrees prompt “Delete anyway”; other errors show the host’s message; after a relay timeout the host list is refetched and a missing row counts as committed.

- Workspace header actions adopt the same delete retry/teardown and timeout handling.
- `useHostWorkspaces` adds `refetchHost` to confirm commits after relay timeouts.

**Rollout notes**
- Rebuild mobile dev clients to pick up the native `expo-router` patch.
- When bumping to `expo-router` ≥ 56.2.19, remove `patches/expo-router@56.2.18.patch` and its `patchedDependencies` entry; the guard test continues to pass.

**Reviewer notes**
- Adds the Swift patch and a guard test; updates `package.json`/`bun.lock`.
- `WorkspaceRowMenu` is now a thin `Link.Menu`; actions moved into `useWorkspaceRowActions` with `isDeleting` wired into `WorkspaceRow`.

<sup>Written for commit daad5c8f77de7c0b7fb91f22ca2c51e28728cfcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

