### PR TITLE
feat(shared,api): identityProvider and automationId scope on the shared dispatcher

### DIFF
--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -35,6 +35,13 @@ export async function dispatchMatchingTriggers(params: {
 	organizationId: string;
 	eventId: string;
 	event: MatchableEvent;
+	/**
+	 * Restrict candidates to one automation. Provider webhooks fan out across
+	 * the org because the provider does not know which automation cares; a
+	 * raw webhook is addressed to one automation by URL, so fanning out to
+	 * every webhook trigger in the org would be wrong.
+	 */
+	automationId?: string;
 }): Promise<{ matched: number; considered: number }> {
 	const { event } = params;
 
@@ -56,6 +63,9 @@ export async function dispatchMatchingTriggers(params: {
 				eq(automationTriggers.kind, event.provider as never),
 				eq(automationTriggers.enabled, true),
 				eq(automations.enabled, true),
+				params.automationId
+					? eq(automations.id, params.automationId)
+					: undefined,
 			),
 		);
 
@@ -73,7 +83,7 @@ export async function dispatchMatchingTriggers(params: {
 		.where(
 			and(
 				eq(userIdentities.organizationId, params.organizationId),
-				eq(userIdentities.provider, event.provider),
+				eq(userIdentities.provider, event.identityProvider ?? event.provider),
 			),
 		);
 	const idsByUser = new Map<string, string[]>();

--- a/packages/shared/src/automation-matching/core.ts
+++ b/packages/shared/src/automation-matching/core.ts
@@ -18,6 +18,13 @@ import type { TriggerActor, TriggerScope } from "../automation-triggers";
  */
 export type BaseMatchableEvent = {
 	provider: string;
+	/**
+	 * Which `user_identities.provider` resolves `me` for this event, when it
+	 * differs from `provider`. Google Calendar and Gmail are two trigger kinds
+	 * behind one Google identity, so both set this to "google". Defaults to
+	 * `provider`; every other provider leaves it unset.
+	 */
+	identityProvider?: string;
 	/** Qualified with its action, e.g. `pull_request.opened`. */
 	eventType: string;
 	/** The provider's id for whoever caused the event; what people filters compare against. */


### PR DESCRIPTION
Two small additions the provider agents needed once #6594 landed. `identityProvider` lets Google's two trigger kinds resolve `me` through one `google` identity. `automationId` lets the raw-webhook route restrict candidates to the automation its URL names instead of fanning out org-wide. Optional, default-off, no behaviour change for existing callers. Typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `identityProvider` on `BaseMatchableEvent` and optional `automationId` scoping in `dispatchMatchingTriggers`. Old behavior resolved "me" against `event.provider` and raw webhooks fanned out org‑wide; new behavior resolves "me" against `identityProvider` when set and allows raw webhooks to restrict dispatch to one automation. Defaults keep existing behavior.

- `packages/shared`: `identityProvider` defaults to `provider`; Google Calendar and Gmail should set `identityProvider: "google"` to unify "me" resolution.
- `apps/api`: dispatcher uses `identityProvider ?? provider` for identity lookups and optionally filters by `automationId`; omit it to keep org‑wide fan‑out. No migrations required.

<sup>Written for commit 9dec333efaaa988acf7894c40768c7f00c4afbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

