### PR TITLE
fix(mobile): drop the newline button from the home composer's bottom row

### DIFF
--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -302,30 +302,8 @@ export const GlassComposer = forwardRef<
 
 	// Explicit line break for multi-line messages: expo-ui's TextField exposes
 	// nothing for the soft keyboard's return key, so this is the only way to
-	// put a newline in a draft.
-	const newlineButton = (
-		<Button
-			onPress={() => {
-				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				appendToDraft("\n");
-			}}
-			modifiers={[
-				buttonStyle("bordered"),
-				buttonBorderShape("circle"),
-				tint(FOREGROUND),
-				accessibilityLabel("New line"),
-			]}
-		>
-			<Image
-				systemName="return"
-				size={16}
-				modifiers={[frame({ width: 16, height: 16 })]}
-			/>
-		</Button>
-	);
-
-	// Same chip shape as the quick keys it sits beside, rather than the circular
-	// bottom-row buttons — it belongs to that row visually, not to send/mic.
+	// put a newline in a draft. Lives in the terminal's quick-key row, shaped
+	// like the keys beside it; the home composer has no such row and no button.
 	const newlineChip = (
 		<Button
 			onPress={() => {
@@ -564,7 +542,6 @@ export const GlassComposer = forwardRef<
 							>
 								{plusButton}
 							</HStack>
-							{above ? null : newlineButton}
 							{toolbarLeading}
 							<Spacer />
 							{/* Bordered buttons carry ~6pt of invisible tap-target inset


### PR DESCRIPTION
## Summary
- #6543 moved the newline button into the terminal's quick-key row but left a fallback copy in the composer's bottom toolbar for surfaces without that row, so the home composer still showed a `↵` button next to `+`.
- Removes that fallback (`newlineButton`) and its slot. The terminal's `newlineChip` in the quick-key row is unchanged.

## Test plan
- Biome clean; mobile typecheck has the same 135 pre-existing errors with and without this change, none in `GlassComposer`.
- Home composer: expand it — bottom row is `+`, agent picker, mic/send. No `↵`.
- Terminal composer: `↵` chip still pinned left of the quick keys and still appends a newline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the fallback newline button from the home composer’s bottom row in `GlassComposer` so only the terminal’s quick-key newline chip remains. Previously, the home composer showed a ↵ button beside +; now it does not. The terminal composer is unchanged.

- Home composer: bottom row shows +, agent picker, mic/send; no ↵; no API changes.
- Terminal composer: `newlineChip` in the quick-key row still inserts a newline.

<sup>Written for commit 73b4c2ceea1b0111564b64c8feda528594f82bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

