### PR TITLE
feat(api): triggerId narrowing on the shared dispatcher

### DIFF
--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -36,12 +36,16 @@ export async function dispatchMatchingTriggers(params: {
 	eventId: string;
 	event: MatchableEvent;
 	/**
-	 * Restrict candidates to one automation. Provider webhooks fan out across
-	 * the org because the provider does not know which automation cares; a
-	 * raw webhook is addressed to one automation by URL, so fanning out to
-	 * every webhook trigger in the org would be wrong.
+	 * Restrict candidates. Provider webhooks fan out across the org because
+	 * the provider does not know which automation cares. Two kinds of inbound
+	 * URL are narrower than that and must not fan out:
+	 * - a raw webhook is addressed to one AUTOMATION by URL → `automationId`
+	 * - a Circleback webhook is addressed to one TRIGGER by URL → `triggerId`
+	 * Without the narrowing, one automation holding two triggers of that kind
+	 * with overlapping filters would run once per URL.
 	 */
 	automationId?: string;
+	triggerId?: string;
 }): Promise<{ matched: number; considered: number }> {
 	const { event } = params;
 
@@ -65,6 +69,9 @@ export async function dispatchMatchingTriggers(params: {
 				eq(automations.enabled, true),
 				params.automationId
 					? eq(automations.id, params.automationId)
+					: undefined,
+				params.triggerId
+					? eq(automationTriggers.id, params.triggerId)
 					: undefined,
 			),
 		);

--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -74,6 +74,14 @@ export async function dispatchMatchingTriggers(params: {
 	// Every identity linked in this org for this provider, so `me` can resolve
 	// to the automation owner. A person may link more than one account — work
 	// and personal — so this is a set per user, not a value.
+	//
+	// Not scoped by external_scope_id. That is safe only because
+	// integration_connections is unique on (organization_id, provider): one
+	// Slack workspace per org means every Slack identity here shares one scope,
+	// so ids cannot collide across workspaces. The day a provider allows more
+	// than one connection per org — per-user Google is the first candidate —
+	// this must also filter by the connection's scope, or a Slack user id from
+	// workspace A will match `me` for workspace B.
 	const identities = await dbWs
 		.select({
 			userId: userIdentities.userId,


### PR DESCRIPTION
Circleback's inbound URL is per-trigger, not per-automation, so `automationId` alone lets one automation with two overlapping Circleback triggers run once per URL. Adds optional `triggerId`. Also documents why the identity lookup's lack of external_scope_id is safe today (integration_connections unique on org+provider) and what loosening that must carry. Additive, no behaviour change for existing callers. Typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional triggerId narrowing to the shared trigger dispatcher so inbound URLs that target a specific trigger do not fan out within the same automation. Previously only automationId narrowing existed; Circleback URLs are per-trigger, so one automation with overlapping triggers could run once per URL.

**Review and rollout**
- The dispatcher now accepts optional triggerId and adds an id predicate when present; leaving it unset preserves previous behavior.
- No migration required. Circleback webhook callers can now pass triggerId to prevent duplicate executions within a single automation.
- Documents identity lookup scope: we do not filter by external_scope_id today because provider connections are unique per (org, provider). If we allow multiple connections per org, add scope filtering to keep “me” resolution correct across workspaces.

<sup>Written for commit e9ec0a5ea2cdafad4a28cad65f7375d8e0423404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation trigger matching by allowing processing to be limited to a specific trigger.
  * Clarified webhook behavior and identity lookup limitations in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->