### PR TITLE
fix(mobile): make the branch / line-count separator on the home list legible

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
@@ -121,7 +121,7 @@ export function WorkspaceRow({
 					<Text className="font-medium text-[15px]" numberOfLines={1}>
 						{workspace.name}
 					</Text>
-					<View className="flex-row items-center gap-2">
+					<View className="flex-row items-center gap-1">
 						{/* A workspace named after its branch says it twice otherwise —
 						    common now that every project shows its `main`. */}
 						{workspace.branch === workspace.name ? null : (
@@ -136,7 +136,7 @@ export function WorkspaceRow({
 						(diffStats.additions > 0 || diffStats.deletions > 0) ? (
 							<>
 								{workspace.branch === workspace.name ? null : (
-									<Text className="text-muted-foreground text-xs">·</Text>
+									<Text className="text-muted-foreground text-xs">•</Text>
 								)}
 								<Text className="text-muted-foreground font-mono text-xs">
 									+{diffStats.additions} −{diffStats.deletions}


### PR DESCRIPTION
## Summary
- The `·` between the branch name and the `+N −M` counts on the mobile home list is a 12px text glyph, so it renders about a pixel and a half wide.
- Swap it for a bullet (`•`, U+2022) and tighten the subtitle row from `gap-2` to `gap-1` so the separator sits 4px from each neighbour instead of 8px.

Considered a lucide icon, but lucide `Dot` is a radius-1 circle in a 24-unit box — at text height it renders smaller than the `·` it would replace, plus dead space either side. Comparison of the candidates: https://claude.ai/code/artifact/3a4f8612-52b7-4810-9bb1-dc1701309ae0

## Test plan
- [ ] Home list, dark and light: bullet reads clearly between branch and counts
- [ ] Rows where the workspace is named after its branch still show only the counts (no stray bullet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the branch/count separator on the mobile home list legible by replacing the tiny middle dot with a bullet and tightening spacing. Previously a 12px “·” with 8px gaps rendered ~1.5px wide; now a “•” sits 4px from its neighbors. Rows where the branch equals the workspace name still omit the separator.

**Review notes**
- Change is scoped to `WorkspaceRow.tsx`; no new icons or dependencies.
- Verify light and dark themes: bullet reads clearly.
- Verify workspaces named after their branch show only counts (no stray bullet).

<sup>Written for commit b851d4d8ab2f69275bb37ee54c069a2a5855805e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced spacing between workspace branch and diff details.
  * Updated the metadata separator for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->