### PR TITLE
fix(desktop): close host-service reconnection gap after a restart

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -161,6 +161,22 @@ export function LocalHostServiceProvider({
 			},
 		);
 
+	// The coordinator only emits "running" after its health check passes, so
+	// this closes the gap the 5s/1s polls above leave open: without it, a
+	// dev-mode restart (or any respawn) can land the renderer on a dead port
+	// for up to a full poll interval, and anything that queries host-service
+	// in that window fails with a connection-refused.
+	electronTrpc.hostServiceCoordinator.onStatusChange.useSubscription(
+		undefined,
+		{
+			onData: (event) => {
+				if (event.organizationId !== activeOrganizationId) return;
+				utils.hostServiceCoordinator.getConnection.invalidate();
+				utils.hostServiceCoordinator.getProcessStatus.invalidate();
+			},
+		},
+	);
+
 	const waitForHostReady = useCallback(
 		async (timeoutMs = 20_000): Promise<string | null> => {
 			const orgId = activeOrganizationId;


### PR DESCRIPTION
## Summary
- Wire the renderer up to the host-service coordinator's existing `onStatusChange` push event, so it learns about a new host-service port immediately instead of waiting on a 5s/1s poll.

## Why / Context
The renderer only discovers host-service's live port via `getConnection` (5s poll) and `getProcessStatus` (1s poll, while not yet connected). Whenever host-service restarts — a crash respawn, an explicit restart/reset from settings, or (constantly, in dev) electron-vite's watch-mode reload — the renderer keeps issuing requests against the dead port until the next poll tick. Any background query that fires in that window fails with `ERR_CONNECTION_REFUSED`. This isn't scoped to any one screen — it hit `ports.getAll`, `pullRequests.getByWorkspaces`, `project.list`, and `terminalAgents.listByWorkspace` alike, since they're all sidebar-owned background polls sharing the same host-service client.

## How It Works
`HostServiceCoordinator` already emits a `status-changed` event over an existing tRPC subscription (`onStatusChange`) — critically, `"running"` is only emitted *after* the new instance passes its health check (`host-service-coordinator.ts:790-819`), so this isn't a partial mitigation; by the time the renderer reacts, the new port is already accepting connections. `LocalHostServiceProvider` now subscribes to it and invalidates the connection/process-status queries the instant it fires. The existing polls stay in place as a fallback (e.g. if the subscription's IPC channel drops).

## Manual QA Checklist
- [x] Ran the dev stack (`bun dev`), confirmed the change hot-reloads cleanly with no console errors
- [x] Confirmed via source that `onStatusChange`'s `"running"` event only fires post-health-check, not on bare process spawn
- [ ] Have not yet forced a live host-service restart end-to-end to watch the reconnection with a network trace (didn't want to kill/respawn host-service unprompted mid-session — happy to do this as a follow-up if wanted)

## Testing
- `bun run typecheck` (apps/desktop) — clean

## Known Limitations
- No retry/backoff added to the affected background queries themselves (global React Query config is `retry: false`). The push fix closes the reconnection gap almost entirely on its own; retry-with-backoff would be a smaller, separate improvement if the residual (sub-second) window is still worth covering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the renderer’s host-service reconnection gap by subscribing to the coordinator’s `onStatusChange` push event. Before: the renderer waited on 5s/1s polls and kept calling a dead port after a restart, causing transient `ERR_CONNECTION_REFUSED`. Now: on `"running"` (emitted post-health-check), it invalidates `getConnection` and `getProcessStatus` to reconnect immediately; polls remain as a fallback.

- Subscribes in `LocalHostServiceProvider` via `electronTrpc.hostServiceCoordinator.onStatusChange.useSubscription`.
- Filters events by `activeOrganizationId` to avoid cross-org churn.
- Reduces transient failures across background polls (ports, PRs, projects, terminal agents); no API or migration changes.

<sup>Written for commit 2123720970f4babff971be650b3c1756ba50298b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection and process status now refresh promptly when the host service restarts, respawns, or otherwise changes status.
  * Improved accuracy of displayed service availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->