### PR TITLE
fix(host): recreating a destroyed workspace's branch silently no-ops

### DIFF
--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -5,7 +5,7 @@ import {
 	sanitizeUserBranchName,
 } from "@superset/shared/workspace-launch";
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
 import { createGitEnvResolver } from "../../../runtime/git";
@@ -164,6 +164,11 @@ function findExistingWorkspaceByBranch(
 			where: and(
 				eq(workspaces.projectId, projectId),
 				eq(workspaces.branch, branch),
+				// Tombstones must not satisfy idempotency: matching one returns
+				// an invisible archived row and silently skips the create, so
+				// re-creating a previously-destroyed workspace's branch no-ops.
+				// The adopt path already filters these.
+				isNull(workspaces.archivedAt),
 			),
 		})
 		.sync();


### PR DESCRIPTION
## Summary
- `workspaces.create`'s idempotency lookup (`findExistingWorkspaceByBranch`) matched archived tombstones, so creating a workspace on a branch whose previous workspace was destroyed returned the invisible archived row with `alreadyExists: true` — no worktree created, nothing appears in the sidebar. One-line filter, matching what the adopt path already does.

## Why / Context
Since tombstones (#6296), destroyed workspaces keep their row forever with `archived_at` set. The create-path idempotency lookup predates that and never learned to skip them. Any user who deletes a workspace and later recreates the same branch hits a silent no-op.

Found while re-running lineage e2e scenes (#6562) that reuse branch names; reproduced directly against a dev host: create → `workspaceCleanup.destroy` → create returned the archived row's id with `alreadyExists: true`.

## Testing
- `bunx tsc --noEmit` on host-service — clean
- Manual repro before the fix (create-after-destroy returns tombstone id); host-service dev verification of the fixed path pending a host restart — the archived-row repro is deterministic
- Not run locally: host-service `*.node-test.ts` (ABI seesaw; relying on CI)

## Notes
- Independent of #6562/#6564 — based on main; those branches will pick it up on their next rebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recreating a destroyed workspace’s branch now creates a new workspace and worktree. Previously, `workspaces.create` matched archived tombstones in its idempotency check, returned alreadyExists=true, and silently no-oped.

**Review notes**
- Add `archivedAt IS NULL` filter to `findExistingWorkspaceByBranch` to ignore tombstones (parity with the adopt path).
- Scope: only affects branch-based creation idempotency; active workspaces still de-dup correctly.
- No API or schema changes; no migration required.

<sup>Written for commit 51b764387853fd6af5ac46d8b22421f9438cdbca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented archived workspaces from being incorrectly returned during workspace creation or lookup.
  * Improved handling of workspace records that have been archived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->