### PR TITLE
feat: tag-bound sidebar groups (smart sections) + section→tag migration

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -107,6 +107,7 @@ export function DashboardSidebarCloudSection({
 					lineageDepth: 0,
 					lineageChildCount: 0,
 					lineageCollapsed: false,
+					tags: [],
 				};
 			});
 	}, [cloudWorkspaces, hostWorkspaces, localStateRows]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -82,7 +82,17 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							className="-ml-1 h-5 w-full min-w-0 px-1 py-0 text-[13px] font-medium bg-transparent border-none outline-none text-muted-foreground"
 						/>
 					) : (
-						<span className="truncate">{section.name}</span>
+						<>
+							<span className="truncate">{section.name}</span>
+							{section.tagBinding && (
+								<span
+									className="ml-1 shrink-0 rounded bg-fill-hover px-1 font-normal text-[10px] text-muted-foreground"
+									title={`Smart group: workspaces tagged "${section.tagBinding}" appear here automatically`}
+								>
+									#{section.tagBinding}
+								</span>
+							)}
+						</>
 					)}
 				</div>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -40,6 +40,7 @@ function makeSection(
 		isCollapsed: false,
 		tabOrder: 1,
 		color: "#abcdef",
+		tagBinding: null,
 		...overrides,
 	};
 }
@@ -64,6 +65,7 @@ function makeWorkspace(
 		pendingTransaction: null,
 		parentWorkspaceId: null,
 		lineageCollapsed: false,
+		tags: [],
 		...overrides,
 	};
 }
@@ -195,6 +197,221 @@ describe("buildDashboardSidebarProjects", () => {
 			"orphan-late",
 			"section:section-1",
 		]);
+	});
+});
+
+describe("tag-derived section membership", () => {
+	it("places a tagged workspace into the matching tag-bound section", () => {
+		const [project] = build({
+			sidebarSections: [
+				makeSection({ id: "smart", tagBinding: "perf", tabOrder: 1 }),
+			],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "tagged", tags: ["perf"], sectionId: null }),
+				makeWorkspace({ id: "untagged", sectionId: null, tabOrder: 2 }),
+			],
+		});
+
+		const section = project.children.find((child) => child.type === "section");
+		if (section?.type !== "section") throw new Error("expected section");
+		expect(section.section.workspaces.map((workspace) => workspace.id)).toEqual(
+			["tagged"],
+		);
+		const topLevel = project.children.flatMap((child) =>
+			child.type === "workspace" ? [child.workspace.id] : [],
+		);
+		expect(topLevel).toEqual(["untagged"]);
+	});
+
+	it("lets explicit sectionId beat tag membership", () => {
+		const [project] = build({
+			sidebarSections: [
+				makeSection({ id: "manual", tagBinding: null, tabOrder: 1 }),
+				makeSection({ id: "smart", tagBinding: "perf", tabOrder: 2 }),
+			],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "ws", tags: ["perf"], sectionId: "manual" }),
+			],
+		});
+
+		const bySection = Object.fromEntries(
+			project.children.flatMap((child) =>
+				child.type === "section"
+					? [
+							[
+								child.section.id,
+								child.section.workspaces.map((workspace) => workspace.id),
+							],
+						]
+					: [],
+			),
+		);
+		expect(bySection).toEqual({ manual: ["ws"], smart: [] });
+	});
+
+	it("renders a multi-tag workspace in exactly one section (first by tab order)", () => {
+		const [project] = build({
+			sidebarSections: [
+				makeSection({ id: "second", tagBinding: "b", tabOrder: 2 }),
+				makeSection({ id: "first", tagBinding: "a", tabOrder: 1 }),
+			],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "ws", tags: ["b", "a"], sectionId: null }),
+			],
+		});
+
+		const bySection = Object.fromEntries(
+			project.children.flatMap((child) =>
+				child.type === "section"
+					? [
+							[
+								child.section.id,
+								child.section.workspaces.map((workspace) => workspace.id),
+							],
+						]
+					: [],
+			),
+		);
+		expect(bySection).toEqual({ first: ["ws"], second: [] });
+	});
+
+	it("resolves two sections bound to the same tag to the lower tab order", () => {
+		const [project] = build({
+			sidebarSections: [
+				makeSection({ id: "late", tagBinding: "perf", tabOrder: 5 }),
+				makeSection({ id: "early", tagBinding: "perf", tabOrder: 1 }),
+			],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "ws", tags: ["perf"], sectionId: null }),
+			],
+		});
+
+		const bySection = Object.fromEntries(
+			project.children.flatMap((child) =>
+				child.type === "section"
+					? [
+							[
+								child.section.id,
+								child.section.workspaces.map((workspace) => workspace.id),
+							],
+						]
+					: [],
+			),
+		);
+		expect(bySection).toEqual({ early: ["ws"], late: [] });
+	});
+
+	it("never leaks a tagged workspace into another project's tag-bound section", () => {
+		const projects = buildDashboardSidebarProjects({
+			sidebarProjects: [
+				makeProject({ id: "p-with-section" }),
+				makeProject({ id: "p-of-workspace" }),
+			],
+			sidebarSections: [
+				makeSection({
+					id: "smart",
+					projectId: "p-with-section",
+					tagBinding: "perf",
+				}),
+			],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({
+					id: "ws",
+					projectId: "p-of-workspace",
+					tags: ["perf"],
+					sectionId: null,
+				}),
+			],
+			machineId: MACHINE_ID,
+			pullRequestsByWorkspaceId: new Map(),
+		});
+
+		const home = projects.find((project) => project.id === "p-of-workspace");
+		expect(
+			home?.children.flatMap((child) =>
+				child.type === "workspace" ? [child.workspace.id] : [],
+			),
+		).toEqual(["ws"]);
+		const other = projects.find((project) => project.id === "p-with-section");
+		const smart = other?.children.find((child) => child.type === "section");
+		if (smart?.type !== "section") throw new Error("expected section");
+		expect(smart.section.workspaces).toEqual([]);
+	});
+
+	it("keeps a pinned workspace out of tag-bound sections", () => {
+		const { pinned, unpinned } = partitionSidebarWorkspacesByPinned([
+			makeWorkspace({ id: "ws", tags: ["perf"], pinnedAt: 1000 }),
+		]);
+		expect(pinned.map((workspace) => workspace.id)).toEqual(["ws"]);
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "smart", tagBinding: "perf" })],
+			visibleSidebarWorkspaces: unpinned,
+		});
+		const smart = project.children.find((child) => child.type === "section");
+		if (smart?.type !== "section") throw new Error("expected section");
+		expect(smart.section.workspaces).toEqual([]);
+	});
+
+	it("re-roots an untagged child whose parent moved into a tag-bound section", () => {
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "smart", tagBinding: "perf" })],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "parent", tags: ["perf"], tabOrder: 1 }),
+				makeWorkspace({
+					id: "child",
+					parentWorkspaceId: "parent",
+					tabOrder: 2,
+				}),
+			],
+		});
+
+		const topLevel = project.children.flatMap((child) =>
+			child.type === "workspace"
+				? [`${child.workspace.id}:${child.workspace.lineageDepth}`]
+				: [],
+		);
+		expect(topLevel).toEqual(["child:0"]);
+		const smart = project.children.find((child) => child.type === "section");
+		if (smart?.type !== "section") throw new Error("expected section");
+		expect(
+			smart.section.workspaces.map(
+				(workspace) => `${workspace.id}:${workspace.lineageDepth}`,
+			),
+		).toEqual(["parent:0"]);
+	});
+
+	it("nests lineage inside a tag-derived section and re-roots cross-container children", () => {
+		const [project] = build({
+			sidebarSections: [
+				makeSection({ id: "smart", tagBinding: "perf", tabOrder: 1 }),
+			],
+			visibleSidebarWorkspaces: [
+				// Parent stays top-level; both children land in the tag section
+				// and nest against each other there, re-rooting off the absent
+				// parent.
+				makeWorkspace({ id: "parent", tabOrder: 1 }),
+				makeWorkspace({
+					id: "child",
+					tags: ["perf"],
+					parentWorkspaceId: "parent",
+					tabOrder: 2,
+				}),
+				makeWorkspace({
+					id: "grandchild",
+					tags: ["perf"],
+					parentWorkspaceId: "child",
+					tabOrder: 3,
+				}),
+			],
+		});
+
+		const section = project.children.find((child) => child.type === "section");
+		if (section?.type !== "section") throw new Error("expected section");
+		expect(
+			section.section.workspaces.map(
+				(workspace) => `${workspace.id}:${workspace.lineageDepth}`,
+			),
+		).toEqual(["child:0", "grandchild:1"]);
 	});
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -33,6 +33,8 @@ export interface SidebarSectionInput {
 	isCollapsed: boolean;
 	tabOrder: number;
 	color: string | null;
+	/** Non-null = smart section: membership also derives from this tag. */
+	tagBinding: string | null;
 }
 
 export interface SidebarWorkspaceInput {
@@ -55,6 +57,8 @@ export interface SidebarWorkspaceInput {
 	parentWorkspaceId: string | null;
 	/** True when the user collapsed this workspace's child subtree. */
 	lineageCollapsed: boolean;
+	/** Normalized host-side labels. */
+	tags: string[];
 }
 
 /**
@@ -114,6 +118,7 @@ function decorateSidebarWorkspace(
 		lineageDepth: 0,
 		lineageChildCount: 0,
 		lineageCollapsed: workspace.lineageCollapsed,
+		tags: workspace.tags,
 	};
 }
 
@@ -286,6 +291,30 @@ export function buildDashboardSidebarProjects({
 			project.orphanedWorkspaces.push({
 				tabOrder: workspace.tabOrder,
 				workspace: sidebarWorkspace,
+			});
+			continue;
+		}
+
+		// Tag-derived membership: an unsectioned workspace joins the matching
+		// tag-bound section with the lowest tab order. Explicit sectionId
+		// always wins above, and single-match keeps the "a workspace renders
+		// in exactly one container" invariant that ordering, DnD, and
+		// selection assume. Sorted here rather than trusting input order so
+		// the rule holds for any caller.
+		const tagSection =
+			workspace.tags.length > 0
+				? [...project.sectionMap.values()]
+						.filter(
+							(section) =>
+								section.tagBinding !== null &&
+								workspace.tags.includes(section.tagBinding),
+						)
+						.sort((left, right) => left.tabOrder - right.tabOrder)[0]
+				: undefined;
+		if (tagSection) {
+			tagSection.workspaces.push({
+				...sidebarWorkspace,
+				accentColor: tagSection.color,
 			});
 			continue;
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/planSectionTagMigrations.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/planSectionTagMigrations.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+	deriveTagFromSectionName,
+	planSectionTagMigrations,
+} from "./planSectionTagMigrations";
+
+describe("deriveTagFromSectionName", () => {
+	it("slugs names into CLI-typeable tags", () => {
+		expect(deriveTagFromSectionName("Test Fleet")).toBe("test-fleet");
+		expect(deriveTagFromSectionName("  API_v2 (staging) ")).toBe(
+			"api-v2-staging",
+		);
+		expect(deriveTagFromSectionName("perf")).toBe("perf");
+	});
+
+	it("falls back for names that slug to nothing", () => {
+		expect(deriveTagFromSectionName("🚀🚀")).toBe("group");
+		expect(deriveTagFromSectionName("   ")).toBe("group");
+	});
+
+	it("caps at the host's 64-char tag limit", () => {
+		expect(deriveTagFromSectionName("x".repeat(200)).length).toBe(64);
+	});
+});
+
+describe("planSectionTagMigrations", () => {
+	const section = (over: Record<string, unknown> = {}) => ({
+		id: "s1",
+		projectId: "p1",
+		name: "Backend",
+		tagBinding: null as string | null,
+		...over,
+	});
+	const workspace = (over: Record<string, unknown> = {}) => ({
+		id: "w1",
+		sectionId: "s1" as string | null,
+		tags: [] as string[],
+		...over,
+	});
+
+	it("tags every explicit member with the derived tag, merging existing tags", () => {
+		const [step] = planSectionTagMigrations({
+			sections: [section()],
+			workspaces: [
+				workspace({ id: "w1" }),
+				workspace({ id: "w2", tags: ["perf"] }),
+				workspace({ id: "elsewhere", sectionId: null }),
+			],
+		});
+		expect(step.tag).toBe("backend");
+		expect(step.members).toEqual([
+			{ workspaceId: "w1", nextTags: ["backend"] },
+			{ workspaceId: "w2", nextTags: ["backend", "perf"] },
+		]);
+	});
+
+	it("skips already-bound sections, making reruns idempotent", () => {
+		const steps = planSectionTagMigrations({
+			sections: [section({ tagBinding: "backend" })],
+			workspaces: [workspace()],
+		});
+		expect(steps).toEqual([]);
+	});
+
+	it("dedupes colliding names within a project but not across projects", () => {
+		const steps = planSectionTagMigrations({
+			sections: [
+				section({ id: "s1", name: "Backend" }),
+				section({ id: "s2", name: "backend" }),
+				section({ id: "s3", name: "Backend", projectId: "p2" }),
+			],
+			workspaces: [],
+		});
+		expect(steps.map((step) => step.tag)).toEqual([
+			"backend",
+			"backend-2",
+			"backend",
+		]);
+	});
+
+	it("avoids tags already claimed by existing smart sections in the project", () => {
+		const steps = planSectionTagMigrations({
+			sections: [
+				section({ id: "bound", tagBinding: "backend" }),
+				section({ id: "manual", name: "Backend" }),
+			],
+			workspaces: [],
+		});
+		expect(steps).toHaveLength(1);
+		expect(steps[0].tag).toBe("backend-2");
+	});
+
+	it("keeps a member that already carries the tag unchanged", () => {
+		const [step] = planSectionTagMigrations({
+			sections: [section()],
+			workspaces: [workspace({ tags: ["backend"] })],
+		});
+		expect(step.members).toEqual([
+			{ workspaceId: "w1", nextTags: ["backend"] },
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/planSectionTagMigrations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/planSectionTagMigrations.ts
@@ -1,0 +1,111 @@
+/**
+ * Plans the conversion of manual sections into tag-bound ("smart") sections:
+ * each section gets a tag derived from its name, every explicit member is
+ * tagged host-side, and membership becomes derived. Pure so the same plan
+ * can back a per-section "Convert to smart group" action or a bulk migration.
+ *
+ * Execution order matters for a seamless switch: write the members' tags
+ * first (explicit sectionId still holds them in place), then set the
+ * section's tagBinding, then clear the members' sectionId — at no point
+ * does a member visually leave its group.
+ *
+ * One deliberate consequence of merging (never replacing) tags: a member
+ * that already carries a tag bound by an earlier-ordered smart section
+ * lands there after migration, per the multi-tag lowest-tab-order rule —
+ * membership becomes honest to the model rather than to the old manual
+ * placement. A migration UI should surface those members before running.
+ */
+
+export interface SectionForTagMigration {
+	id: string;
+	projectId: string;
+	name: string;
+	tagBinding: string | null;
+}
+
+export interface WorkspaceForTagMigration {
+	id: string;
+	sectionId: string | null;
+	tags: string[];
+}
+
+export interface SectionTagMigrationStep {
+	sectionId: string;
+	projectId: string;
+	tag: string;
+	/** Explicit members: tag each host-side, then clear its sectionId. */
+	members: Array<{ workspaceId: string; nextTags: string[] }>;
+}
+
+/**
+ * Section name → tag in the host's normalized form, made CLI-ergonomic:
+ * spaces/underscores collapse to hyphens and anything outside [a-z0-9-]
+ * drops, so "Test Fleet" becomes `test-fleet` (typeable as `--tag test-fleet`).
+ */
+export function deriveTagFromSectionName(name: string): string {
+	const slug = name
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_]+/g, "-")
+		.replace(/[^a-z0-9-]/g, "")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, 64);
+	return slug || "group";
+}
+
+export function planSectionTagMigrations(args: {
+	sections: SectionForTagMigration[];
+	/** Every local-state row with a sectionId — including hidden rows, so
+	 * they stay grouped when unhidden. */
+	workspaces: WorkspaceForTagMigration[];
+}): SectionTagMigrationStep[] {
+	// Uniqueness is per project: bindings already in use plus tags this plan
+	// is about to claim. Two sections named "Backend" in one project become
+	// backend and backend-2 rather than silently merging their membership.
+	const claimedByProject = new Map<string, Set<string>>();
+	for (const section of args.sections) {
+		if (!section.tagBinding) continue;
+		const claimed = claimedByProject.get(section.projectId) ?? new Set();
+		claimed.add(section.tagBinding);
+		claimedByProject.set(section.projectId, claimed);
+	}
+
+	const membersBySectionId = new Map<string, WorkspaceForTagMigration[]>();
+	for (const workspace of args.workspaces) {
+		if (!workspace.sectionId) continue;
+		const members = membersBySectionId.get(workspace.sectionId) ?? [];
+		members.push(workspace);
+		membersBySectionId.set(workspace.sectionId, members);
+	}
+
+	const steps: SectionTagMigrationStep[] = [];
+	for (const section of args.sections) {
+		// Already smart — nothing to migrate; rerunning the plan is a no-op
+		// for it, which is what makes the migration idempotent.
+		if (section.tagBinding) continue;
+
+		const claimed = claimedByProject.get(section.projectId) ?? new Set();
+		claimedByProject.set(section.projectId, claimed);
+		const base = deriveTagFromSectionName(section.name);
+		let tag = base;
+		for (let suffix = 2; claimed.has(tag); suffix++) {
+			tag = `${base.slice(0, 60)}-${suffix}`;
+		}
+		claimed.add(tag);
+
+		steps.push({
+			sectionId: section.id,
+			projectId: section.projectId,
+			tag,
+			members: (membersBySectionId.get(section.id) ?? []).map((workspace) => ({
+				workspaceId: workspace.id,
+				// Merge, never replace: a member keeps the tags it already has.
+				nextTags: workspace.tags.includes(tag)
+					? workspace.tags
+					: [...workspace.tags, tag].sort(),
+			})),
+		});
+	}
+	return steps;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -247,6 +247,7 @@ export function useDashboardSidebarData() {
 					isCollapsed: sidebarSections.isCollapsed,
 					tabOrder: sidebarSections.tabOrder,
 					color: sidebarSections.color,
+					tagBinding: sidebarSections.tagBinding,
 				})),
 		[collections],
 	);
@@ -304,6 +305,7 @@ export function useDashboardSidebarData() {
 						pinnedAt: localState.pinnedAt,
 						parentWorkspaceId: workspace.parentWorkspaceId ?? null,
 						lineageCollapsed: localState.lineageCollapsed ?? false,
+						tags: workspace.tags ?? [],
 					},
 				];
 			}),
@@ -357,6 +359,7 @@ export function useDashboardSidebarData() {
 					parentWorkspaceId: workspace.parentWorkspaceId ?? null,
 					// Auto-included mains have no local-state row to collapse with.
 					lineageCollapsed: false,
+					tags: workspace.tags ?? [],
 				})),
 		[hostWorkspaces],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -59,6 +59,8 @@ export interface DashboardSidebarWorkspace {
 	lineageChildCount: number;
 	/** True when this row's child subtree is collapsed in the sidebar. */
 	lineageCollapsed: boolean;
+	/** Normalized host-side labels; tag-bound sections derive membership. */
+	tags: string[];
 }
 
 /**
@@ -80,6 +82,8 @@ export interface DashboardSidebarSection {
 	isCollapsed: boolean;
 	tabOrder: number;
 	color: string | null;
+	/** Non-null = smart section: membership also derives from this tag. */
+	tagBinding: string | null;
 	workspaces: DashboardSidebarWorkspace[];
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -392,6 +392,7 @@ export function useDashboardSidebarState() {
 				tabOrder,
 				isCollapsed: false,
 				color: randomColor,
+				tagBinding: null,
 			});
 
 			return sectionId;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -216,6 +216,11 @@ export const dashboardSidebarSectionSchema = z.object({
 	tabOrder: z.number().int().default(0),
 	isCollapsed: z.boolean().default(false),
 	color: z.string().nullable().default(null),
+	// Non-null = a "smart" section: membership derives from workspaces
+	// carrying this (normalized) tag, in addition to explicit sectionId
+	// members. Tags live host-side, so agents/CLI/automations can move
+	// workspaces into the group by tagging them.
+	tagBinding: z.string().nullable().default(null),
 });
 
 const v2ExecutionModeSchema = z.enum([


### PR DESCRIPTION
> **Stacked on #6564** (which now carries only the tag data layer) — this PR holds the tag-bound section rendering that was extracted from it, and is the starting point for the section/group rework. **Blocked on a binding UI**: today the `tagBinding` can only be set programmatically, which is exactly why it was pulled out of #6564.

## Summary
- Sections gain a nullable `tagBinding`: membership then derives from workspaces carrying that tag (explicit `sectionId` wins; a multi-tag workspace renders in exactly one group, lowest tab order). Tag-bound headers show a `#tag` chip.
- `planSectionTagMigrations`: converts manual sections to tag-bound ones — slugged tag from the section name with per-project collision suffixes, merge-not-replace member tags, idempotent, executed in an order where no member visually leaves its group mid-switch.

## What this needs before review
- Binding UI: create/edit a tag binding from the section context menu or settings (and surface cross-captured members before running a migration — a member already carrying an earlier-ordered smart group's tag lands there, by design).
- Decide the endgame: keep manual sections alongside smart ones, or converge on auto-materialized tag groups (every in-use tag renders as a group; CLI creates groups by tagging).

## Evidence (from when this rode in #6564)
- 16 unit tests (membership precedence, same-tag twins, cross-project isolation, pinned/hidden precedence, lineage-in-group, migration planner ×6)
- Live-verified end-to-end: CLI tag writes moved rows in/out of a bound group with zero renderer writes; 14-scenario edge battery ALL PASS; migration executed live with before/after captures — see the verification dossier linked from #6562.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tag-bound sidebar groups (“smart sections”) and a planner to migrate manual sections. Previously, sections only used explicit sectionId; now, sections with tagBinding auto-include workspaces carrying that tag, with explicit sectionId winning.

- Member resolution: explicit sectionId > tag match; multi-tag workspaces render in the first matching tag-bound section by tabOrder; duplicate tag-bound sections resolve to the lowest tabOrder; membership does not cross projects; pinned/hidden precedence is unchanged; lineage nests inside sections (untagged children re-root if a tagged parent moves).
- UI: section headers display a “#tag” chip with a tooltip when tagBinding is set.
- Data model: adds tagBinding to the local section schema (default null) and threads tags into workspace/sidebar types; no migration required.
- Migration planner: planSectionTagMigrations derives a tag from the section name, dedupes within a project with numeric suffixes, merges (does not replace) existing workspace tags, and is idempotent. Recommended execution order per section: tag members → set tagBinding → clear sectionId.

<sup>Written for commit f1f5f340573dca1019bd6c109f5eabd8e84be077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

