### PR TITLE
marketing: tighten About page hero, cut timeline and principles, founder titles

### DIFF
--- a/apps/marketing/content/people/avi.mdx
+++ b/apps/marketing/content/people/avi.mdx
@@ -1,7 +1,7 @@
 ---
 name: Avi Peltz
-role: Cofounder
-order: 1
+role: Cofounder and CPO
+order: 3
 bio: Ex-CTO at <a href="https://adam.new" target="_blank" rel="noopener noreferrer">Adam</a> (YC W25). Previously founded <a href="https://bioglyph.app" target="_blank" rel="noopener noreferrer">BioGlyph</a>, computer vision research. Builds robots.
 avatar: /team/avi.jpg
 twitter: avimakesrobots

--- a/apps/marketing/content/people/kiet.mdx
+++ b/apps/marketing/content/people/kiet.mdx
@@ -1,7 +1,7 @@
 ---
 name: Kiet Ho
-role: Cofounder
-order: 3
+role: Cofounder and CEO
+order: 1
 bio: Ex-CTO at <a href="https://onlook.com" target="_blank" rel="noopener noreferrer">Onlook</a> (YC W25). Previously at <a href="https://amazon.com" target="_blank" rel="noopener noreferrer">Amazon</a> and <a href="https://servicenow.com" target="_blank" rel="noopener noreferrer">ServiceNow</a>. Trains fighting.
 avatar: /team/kiet.jpg
 twitter: kietho_

--- a/apps/marketing/content/people/satya.mdx
+++ b/apps/marketing/content/people/satya.mdx
@@ -1,6 +1,6 @@
 ---
 name: Satya Patel
-role: Cofounder
+role: Cofounder and CTO
 order: 2
 bio: Ex-CTO at <a href="https://www.untetherlabs.com" target="_blank" rel="noopener noreferrer">Untether Labs</a> (YC W23). Previously at <a href="https://scribehow.com" target="_blank" rel="noopener noreferrer">Scribe</a>, <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>, <a href="https://amazon.com" target="_blank" rel="noopener noreferrer">Amazon</a>, and <a href="https://meta.com" target="_blank" rel="noopener noreferrer">Facebook</a>. Lifts heavy.
 avatar: /team/satya.jpeg

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -50,7 +50,8 @@ export default function TeamPage() {
 					</h1>
 					<p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-2xl">
 						Superset is building self-improving software. It starts with giving
-						engineers the best tools that adapt to their needs over time.
+						engineers the best tools that adapt to their needs over time. We're
+						3 ex-YC CTOs building a tool that we love.
 					</p>
 				</section>
 

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -34,35 +34,6 @@ export const metadata: Metadata = {
 	},
 };
 
-const FACTS = [
-	{
-		term: "Founded",
-		definition: "November 2025, San Francisco",
-	},
-	{
-		term: "License",
-		definition: "Source-available on GitHub under Elastic License 2.0",
-	},
-	{
-		term: "Platforms",
-		definition:
-			"macOS desktop app, experimental Linux AppImage, plus a CLI, TypeScript SDK, and MCP server",
-	},
-	{
-		term: "Agents",
-		definition:
-			"Any CLI agent: Claude Code, Codex, OpenCode, Gemini, Copilot, and more",
-	},
-	{
-		term: "Pricing",
-		definition: "Free tier plus paid seats; your API keys, never proxied",
-	},
-	{
-		term: "Not to be confused with",
-		definition: "Apache Superset, the unrelated business-intelligence tool",
-	},
-];
-
 export default function TeamPage() {
 	const people = getAllPeople();
 
@@ -231,23 +202,6 @@ export default function TeamPage() {
 							<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
 						</Link>
 					</div>
-				</section>
-
-				{/* Superset at a Glance */}
-				<section>
-					<h2 className="text-2xl md:text-3xl font-normal text-foreground mb-8">
-						Superset at a glance
-					</h2>
-					<dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-10 gap-y-6 max-w-2xl text-sm">
-						{FACTS.map((fact) => (
-							<div key={fact.term}>
-								<dt className="text-foreground font-medium mb-1">
-									{fact.term}
-								</dt>
-								<dd className="text-muted-foreground">{fact.definition}</dd>
-							</div>
-						))}
-					</dl>
 				</section>
 			</div>
 

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -1,6 +1,5 @@
 import { ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
-import { Micro_5 } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -11,14 +10,6 @@ import {
 import { getAllPeople } from "@/lib/people";
 import { CTASection } from "../components/CTASection";
 import { TeamBio } from "./components/TeamBio";
-
-// Loaded here instead of the root layout so other pages don't preload it
-const micro5 = Micro_5({
-	weight: "400",
-	subsets: ["latin"],
-	variable: "--font-micro5",
-	display: "swap",
-});
 
 export const metadata: Metadata = {
 	title: "About",
@@ -42,52 +33,6 @@ export const metadata: Metadata = {
 		images: ["/opengraph-image"],
 	},
 };
-
-const MILESTONES = [
-	{
-		date: "Nov 2025",
-		title: "The hackathon",
-		description:
-			"Superset starts as a hackathon project at YC HQ: a simple desktop app for managing worktrees.",
-	},
-	{
-		date: "May 2026",
-		title: "Public launch",
-		description:
-			"Superset launches publicly. Engineers running parallel agents finally have one place to run them.",
-	},
-	{
-		date: "Jul 2026",
-		title: "$11M seed",
-		description:
-			"Raised from the best investors in Silicon Valley to build the platform for software factories.",
-	},
-	{
-		date: "Next",
-		title: "100 agents",
-		description:
-			"The goal for 2026: one developer, 100 agents running in parallel.",
-		href: "/blog/roadmap-to-100-agents",
-	},
-];
-
-const PRINCIPLES = [
-	{
-		title: "Built in Superset",
-		description:
-			"We're our own #1 users. Every feature ships through the same worktrees, agents, and automations we ask you to trust, so we feel our own bugs before you do.",
-	},
-	{
-		title: "Small and in person",
-		description:
-			"A flat, talent-dense team in one room in San Francisco. No managers, no handoffs, no waiting for a meeting to decide.",
-	},
-	{
-		title: "Fun is the strategy",
-		description:
-			"We want to create the best team that has fun working together. Success will be a lagging indicator.",
-	},
-];
 
 const FACTS = [
 	{
@@ -122,7 +67,7 @@ export default function TeamPage() {
 	const people = getAllPeople();
 
 	return (
-		<main className={`relative min-h-screen bg-background ${micro5.variable}`}>
+		<main className="relative min-h-screen bg-background">
 			<div className="max-w-5xl mx-auto px-6 py-24 md:py-32">
 				{/* Hero */}
 				<section className="mb-24 md:mb-32">
@@ -131,16 +76,10 @@ export default function TeamPage() {
 					</p>
 					<h1 className="text-4xl sm:text-5xl md:text-6xl font-normal leading-[1.05] text-foreground max-w-4xl mb-8">
 						Building the last piece of software.
-						<br />
-						<span className="text-muted-foreground">
-							Give teams the tools to build software that improves itself.
-						</span>
 					</h1>
 					<p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-2xl">
-						Superset is the workspace for parallel coding agents: Claude Code,
-						Codex, or any CLI agent, each in its own isolated worktree. It's
-						built by three ex-YC CTOs in San Francisco, for the way we work
-						ourselves.
+						Superset is building self-improving software. It starts with giving
+						engineers the best tools that adapt to their needs over time.
 					</p>
 				</section>
 
@@ -149,7 +88,7 @@ export default function TeamPage() {
 					<div className="grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-16 items-start">
 						<div>
 							<h2 className="text-2xl md:text-3xl font-normal text-foreground mb-6">
-								From worktree manager to software factories
+								So how did we get here?
 							</h2>
 							<div className="space-y-4 text-muted-foreground leading-relaxed">
 								<p>
@@ -188,56 +127,6 @@ export default function TeamPage() {
 								November 2025
 							</figcaption>
 						</figure>
-					</div>
-				</section>
-
-				{/* Timeline */}
-				<section className="mb-24 md:mb-32">
-					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-10">
-						{MILESTONES.map((milestone) => (
-							<div key={milestone.date} className="border-t border-border pt-5">
-								<p
-									className="text-2xl md:text-3xl text-foreground mb-3 tracking-wide uppercase"
-									style={{ fontFamily: "var(--font-micro5)" }}
-								>
-									{milestone.date}
-								</p>
-								<h3 className="text-base font-medium text-foreground mb-2">
-									{milestone.title}
-								</h3>
-								<p className="text-sm text-muted-foreground leading-relaxed">
-									{milestone.description}
-								</p>
-								{milestone.href && (
-									<Link
-										href={milestone.href}
-										className="mt-3 inline-flex items-center gap-1.5 text-sm text-foreground hover:text-foreground/80 transition-colors group"
-									>
-										Read the plan
-										<ArrowRight className="size-3.5 transition-transform group-hover:translate-x-1" />
-									</Link>
-								)}
-							</div>
-						))}
-					</div>
-				</section>
-
-				{/* How We Work */}
-				<section className="mb-24 md:mb-32">
-					<h2 className="text-2xl md:text-3xl font-normal text-foreground mb-10">
-						How we work
-					</h2>
-					<div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-10">
-						{PRINCIPLES.map((principle) => (
-							<div key={principle.title}>
-								<h3 className="text-base font-medium text-foreground mb-2">
-									{principle.title}
-								</h3>
-								<p className="text-sm text-muted-foreground leading-relaxed">
-									{principle.description}
-								</p>
-							</div>
-						))}
 					</div>
 				</section>
 


### PR DESCRIPTION
## Summary
- Hero: single H1 "Building the last piece of software." with the join-us self-improving-software lead as the subtitle; drops the invented second line and the parallel-agents descriptor.
- Story heading goes PostHog-style: "So how did we get here?" (re-applies the tweak that missed the #6607 squash).
- Cuts the milestone timeline and "How we work" sections; removes the now-unused Micro5 font import.
- Founder cards: Kiet first with titles Cofounder and CEO / Satya CTO / Avi CPO (via people frontmatter).

## Testing
- `bunx tsc --noEmit`, `bunx biome check`
- Manual: verified full-page render at 1440px (headless Chrome); founder order and titles correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the About page to focus on the self‑improving software narrative. Old page used a multi‑part hero, timeline, “How we work,” and “Superset at a glance”; new page uses a single H1, a conversational story heading, and removes the extra sections.

- Hero: H1 is “Building the last piece of software.”; drops the second line and parallel‑agents descriptor; supporting paragraph reframed to self‑improving software and now notes “We’re 3 ex‑YC CTOs.”
- Cuts: timeline, “How we work,” and “Superset at a glance”; removes unused `Micro_5` font import and `--font-micro5` variable.
- Founders: Kiet (Cofounder and CEO), Satya (Cofounder and CTO), Avi (Cofounder and CPO).
- No migrations or config changes. Verify copy, founder order/titles, and that no references to removed sections or the `Micro_5` font remain.

<sup>Written for commit c4fcdc8c37dc667864246d22f30b6a47fdd19f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated team member titles for greater accuracy.
  - Reordered team members on the team page.

- **Page Updates**
  - Simplified the team page layout and messaging.
  - Removed milestones, work principles, and company overview sections.
  - Updated the hero content and renamed the story section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->