### PR TITLE
fix(desktop): use a skip-forward glyph for skipped CI checks

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/utils/checkStatusIcons/checkStatusIcons.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/utils/checkStatusIcons/checkStatusIcons.ts
@@ -1,4 +1,10 @@
-import { LuCheck, LuLoaderCircle, LuMinus, LuX } from "react-icons/lu";
+import {
+	LuCheck,
+	LuLoaderCircle,
+	LuMinus,
+	LuSkipForward,
+	LuX,
+} from "react-icons/lu";
 
 /** One icon/color pair per CI check status, shared by every checks surface. */
 export const CHECK_STATUS_ICONS = {
@@ -11,6 +17,6 @@ export const CHECK_STATUS_ICONS = {
 		Icon: LuLoaderCircle,
 		className: "text-amber-600 dark:text-amber-400",
 	},
-	skipped: { Icon: LuMinus, className: "text-muted-foreground" },
+	skipped: { Icon: LuSkipForward, className: "text-muted-foreground" },
 	cancelled: { Icon: LuMinus, className: "text-muted-foreground" },
 } as const;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/utils.ts
@@ -1,5 +1,11 @@
 import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
-import { LuCheck, LuLoaderCircle, LuMinus, LuX } from "react-icons/lu";
+import {
+	LuCheck,
+	LuLoaderCircle,
+	LuMinus,
+	LuSkipForward,
+	LuX,
+} from "react-icons/lu";
 
 export type PullRequestCheck = NonNullable<
 	GitHubStatus["pr"]
@@ -42,7 +48,7 @@ export const checkIconConfig = {
 		label: "Pending",
 	},
 	skipped: {
-		icon: LuMinus,
+		icon: LuSkipForward,
 		className: "text-muted-foreground",
 		label: "Skipped",
 	},


### PR DESCRIPTION
## Summary
- Swap the "skipped" CI check icon from `LuMinus` to `LuSkipForward`.

## Why / Context
The "skipped" status used the exact same icon and color (`LuMinus`, muted gray dash) as "cancelled" and "no checks" — all three rendered identically, making skipped checks indistinguishable from a run that never produced a real verdict at all. `LuSkipForward` reads unambiguously as "skipped" while staying in the same Lucide icon family every other check status already uses (`LuCheck`, `LuX`, `LuLoaderCircle`).

## How It Works
Same icon/color config shape in both places, just the glyph swapped:
- `checkStatusIcons.ts` (the dashboard's shared checks-icon config)
- `ReviewPanel/utils.ts` (a separate, independent icon config for the workspace sidebar's Review panel — this codebase currently has several duplicated checks-icon implementations; this PR touches the two most visible ones without attempting to consolidate them)

## Testing
- `bun run typecheck` (desktop) — clean
- Manual: rendered both icon variants at actual size (16px) against the app's real dark-theme `muted-foreground` color to compare before picking the final glyph.

## Known Limitations
- Other duplicated checks-icon implementations elsewhere in the codebase (e.g. the v2 workspace sidebar's `PRActionHeader`) still use their own icon config and aren't touched by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the “skipped” CI check icon from `LuMinus` to `LuSkipForward` so skipped checks are visually distinct from “cancelled” and “no checks,” which still use `LuMinus`. UI-only change; no behavior or data impact.

**Review notes**
- Updates icon maps in two places: `checkStatusIcons.ts` (dashboard) and `ReviewPanel/utils.ts` (workspace sidebar).
- Keeps existing colors and labels; stays within the Lucide set via `react-icons/lu`.
- No API or config changes; no migrations required.
- Other duplicated icon configs remain unchanged and may still show the old glyph.

<sup>Written for commit 2e6f50908e0520057ad82a2877ef5501e0f9cd1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the skipped check status indicator to a dedicated skip-forward icon for clearer visual distinction.
  * Applied the updated icon consistently across the dashboard and review panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->