### PR TITLE
fix(host-service): resolve default-account.ts imports under node --test

### DIFF
--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -6,9 +6,9 @@
  */
 
 import { existsSync } from "node:fs";
-import type { HostDb } from "../../../db";
-import { hostSettings } from "../../../db/schema";
-import type { UsageProvider } from "./types";
+import type { HostDb } from "../../../db/index.ts";
+import { hostSettings } from "../../../db/schema.ts";
+import type { UsageProvider } from "./types.ts";
 
 export interface DefaultAccountSelections {
 	/** CLAUDE_CONFIG_DIR to inject, or null for the system-default login. */


### PR DESCRIPTION
## Summary
- Fix `ERR_MODULE_NOT_FOUND` failures in the `Terminal node-tests` CI job by adding explicit `.ts` extensions to `default-account.ts`'s imports.

## Why / Context
#6585 added `packages/host-service/src/trpc/router/usage/default-account.ts` and wired `resolveDefaultAccountTerminalEnv` into `terminal.ts`, which is transitively imported by the `test:integration:terminal` node-tests. Those tests run via plain `node --experimental-strip-types --test` (no bundler/loader), which requires explicit file extensions on relative imports — unlike the bun/tsc bundler resolution used elsewhere in the app. `default-account.ts` used the ordinary extensionless import style, so `node --test` couldn't resolve `../../../db/schema`, failing all 4 terminal node-tests on `main`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/host-service/src/db/schema'
imported from .../packages/host-service/src/trpc/router/usage/default-account.ts
```

## How It Works
Matches the `.ts`-extension import convention already used throughout the module cluster reachable from the raw-Node test suites (`terminal.ts`, `db/index.ts`, `daemon/index.ts`, etc.) — no behavior change, just import specifiers.

## Testing
- `node --experimental-strip-types --test src/terminal/terminal.initial-command.node-test.ts src/terminal/terminal.ungated-launch.node-test.ts src/terminal/terminal.shell-ready-learning.node-test.ts src/terminal/terminal.fish-prompt-transport.node-test.ts` — 12 pass / 2 skipped / 0 fail (previously 4/4 files failing)
- `bunx tsc --noEmit -p packages/host-service/tsconfig.json` — clean
- `bunx @biomejs/biome@2.4.2 check packages/host-service/src/trpc/router/usage/default-account.ts` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ERR_MODULE_NOT_FOUND in terminal node-tests by adding explicit .ts extensions to three imports in packages/host-service/src/trpc/router/usage/default-account.ts. Previously, extensionless imports failed under plain Node ESM in node --experimental-strip-types --test; now Node resolves them and the tests pass.

**Notes for reviewers**
- Only import specifiers changed; no runtime behavior changes.
- Aligns with the .ts-extension convention already used in the Node-executed path (e.g., terminal.ts, db modules).
- Please spot-check for any remaining extensionless imports in files executed by node --test; no migration or build changes required.

<sup>Written for commit 9b25e87fae8271a06677e13af7e572507c9deb79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal import references for improved module resolution.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->