### PR TITLE
feat(desktop): gate trigger providers behind a payload-driven feature flag

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -3,6 +3,7 @@ import {
 	describeTriggerProblems,
 	summarizeTriggerProblems,
 } from "@superset/shared/automation-triggers";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -12,6 +13,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Input } from "@superset/ui/input";
 import { Separator } from "@superset/ui/separator";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { type ReactNode, useMemo, useState } from "react";
 import { LuCirclePlus, LuTriangleAlert } from "react-icons/lu";
 import { type ProviderOptions, TRIGGER_PROVIDERS } from "../providers";
@@ -74,8 +76,19 @@ export function TriggersEditor({
 	const shownProblems = submitted ? problems : [];
 	const banner = submitted ? summarizeTriggerProblems(problems) : null;
 
+	const eventTriggersEnabled = useFeatureFlagEnabled(
+		FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
+	);
+	const providers = useMemo(
+		() =>
+			eventTriggersEnabled
+				? TRIGGER_PROVIDERS
+				: TRIGGER_PROVIDERS.filter((provider) => provider.kind === "schedule"),
+		[eventTriggersEnabled],
+	);
+
 	const [query, setQuery] = useState("");
-	const leaves = useMemo(() => flattenTriggerMenu(), []);
+	const leaves = useMemo(() => flattenTriggerMenu(providers), [providers]);
 	const results = query
 		? leaves.filter((leaf) => matchesQuery(leaf, query))
 		: [];
@@ -202,18 +215,20 @@ export function TriggersEditor({
 						{/* Radix runs a typeahead on printable keys and would swallow what
 					    is being typed here; Escape and the arrows still need to reach
 					    the menu, so only the characters are stopped. */}
-						<Input
-							autoFocus
-							value={query}
-							placeholder="Search triggers..."
-							onChange={(event) => setQuery(event.target.value)}
-							onKeyDown={(event) => {
-								if (event.key.length === 1 || event.key === "Backspace") {
-									event.stopPropagation();
-								}
-							}}
-							className="mb-1 h-8 border-none bg-transparent px-2 text-[13px] shadow-none focus-visible:ring-0 dark:bg-transparent"
-						/>
+						{leaves.length > 1 && (
+							<Input
+								autoFocus
+								value={query}
+								placeholder="Search triggers..."
+								onChange={(event) => setQuery(event.target.value)}
+								onKeyDown={(event) => {
+									if (event.key.length === 1 || event.key === "Backspace") {
+										event.stopPropagation();
+									}
+								}}
+								className="mb-1 h-8 border-none bg-transparent px-2 text-[13px] shadow-none focus-visible:ring-0 dark:bg-transparent"
+							/>
+						)}
 
 						{query ? (
 							<>
@@ -245,7 +260,7 @@ export function TriggersEditor({
 								)}
 							</>
 						) : (
-							<TriggerMenuItems providers={TRIGGER_PROVIDERS} onPick={add} />
+							<TriggerMenuItems providers={providers} onPick={add} />
 						)}
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -13,7 +13,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Input } from "@superset/ui/input";
 import { Separator } from "@superset/ui/separator";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useFeatureFlagPayload } from "posthog-js/react";
 import { type ReactNode, useMemo, useState } from "react";
 import { LuCirclePlus, LuTriangleAlert } from "react-icons/lu";
 import { type ProviderOptions, TRIGGER_PROVIDERS } from "../providers";
@@ -76,16 +76,19 @@ export function TriggersEditor({
 	const shownProblems = submitted ? problems : [];
 	const banner = submitted ? summarizeTriggerProblems(problems) : null;
 
-	const eventTriggersEnabled = useFeatureFlagEnabled(
+	const enabledKinds = useFeatureFlagPayload(
 		FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
 	);
-	const providers = useMemo(
-		() =>
-			eventTriggersEnabled
-				? TRIGGER_PROVIDERS
-				: TRIGGER_PROVIDERS.filter((provider) => provider.kind === "schedule"),
-		[eventTriggersEnabled],
-	);
+	const providers = useMemo(() => {
+		const kinds = new Set(
+			Array.isArray(enabledKinds)
+				? enabledKinds.filter((kind) => typeof kind === "string")
+				: [],
+		);
+		return TRIGGER_PROVIDERS.filter(
+			(provider) => provider.kind === "schedule" || kinds.has(provider.kind),
+		);
+	}, [enabledKinds]);
 
 	const [query, setQuery] = useState("");
 	const leaves = useMemo(() => flattenTriggerMenu(providers), [providers]);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -138,6 +138,12 @@ export const FEATURE_FLAGS = {
 	/** Shows the "Star Superset on GitHub" sidebar card once a user crosses the workspace-count threshold. Lets us kill the nag instantly without a release if it reads as annoying. */
 	STAR_NAG_CARD: "star-nag-card",
 	/**
+	 * Shows every trigger provider in the Add Trigger menu. Off, unloaded, or
+	 * offline all mean Scheduled only — the event providers exist on main
+	 * ahead of their credentials being provisioned.
+	 */
+	AUTOMATION_EVENT_TRIGGERS: "automation-event-triggers",
+	/**
 	 * Experiment flag (control/test): renders the new-workspace surface as a
 	 * full-screen view with sample prompts instead of the dense modal.
 	 * Eligibility (new accounts only) is a release condition on the flag —

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -138,9 +138,11 @@ export const FEATURE_FLAGS = {
 	/** Shows the "Star Superset on GitHub" sidebar card once a user crosses the workspace-count threshold. Lets us kill the nag instantly without a release if it reads as annoying. */
 	STAR_NAG_CARD: "star-nag-card",
 	/**
-	 * Shows every trigger provider in the Add Trigger menu. Off, unloaded, or
-	 * offline all mean Scheduled only — the event providers exist on main
-	 * ahead of their credentials being provisioned.
+	 * Which trigger providers the Add Trigger menu offers. Payload is a JSON
+	 * array of provider kinds, e.g. `["github", "slack"]`; Scheduled is always
+	 * offered. Off, unloaded, offline, or a payload that isn't an array all
+	 * mean Scheduled only — the event providers exist on main ahead of their
+	 * credentials being provisioned, and each is exposed by adding its kind.
 	 */
 	AUTOMATION_EVENT_TRIGGERS: "automation-event-triggers",
 	/**


### PR DESCRIPTION
## Summary
- New \`FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS\` (\`automation-event-triggers\`). Its **payload is a JSON array of provider kinds** — the Add Trigger menu offers Scheduled plus whatever's listed. Off, unloaded, offline, or a non-array payload ⇒ Scheduled only (search box hidden since there's one leaf).
- Existing trigger rows of any kind still render/edit; only *adding* is gated.
- Flag created in PostHog prod (id 829320): \`@superset.sh\` emails get the full list; everyone else gets Scheduled. Rollout per provider = add its kind to a group's payload.

Why: every event provider is on main ahead of its credentials/infra being provisioned; users shouldn't see triggers that can't fire yet, and providers will become ready one at a time.

## Test plan
- [x] typecheck + biome clean
- [ ] Not matched by flag: Add Trigger opens straight to "Scheduled"
- [ ] superset.sh account: full menu + search as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to control access to event-based automation triggers.
  * When event triggers are unavailable, the Add Trigger menu shows scheduled triggers only.
  * Simplified the trigger menu by hiding search when fewer than two options are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->