### PR TITLE
fix(desktop): self-heal host-service queries stuck failed after a restart

### DIFF
--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -1,5 +1,9 @@
 import type { AppRouter } from "@superset/host-service";
-import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
+import {
+	createTRPCClient,
+	httpBatchStreamLink,
+	TRPCClientError,
+} from "@trpc/client";
 import superjson from "superjson";
 import { getHostServiceHeaders } from "./host-service-auth";
 
@@ -36,4 +40,39 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 
 	clientCache.set(hostUrl, client);
 	return client;
+}
+
+const HOST_SERVICE_MAX_RETRIES = 3;
+const HOST_SERVICE_RETRY_DELAY_MS = 700;
+
+/**
+ * True for a failed host-service request that never got a real response —
+ * connection-refused during a restart, a dropped stream, DNS failure. tRPC
+ * only populates `data` from a parsed server error envelope, so its absence
+ * means the failure was transport-level rather than the server rejecting the
+ * request (404, validation, etc.), which should never be retried here.
+ */
+export function isHostServiceConnectionError(error: unknown): boolean {
+	return error instanceof TRPCClientError && error.data == null;
+}
+
+/**
+ * Query-level `retry` for host-service requests: bounded retries with
+ * backoff for connection-level failures only, so a query in flight during a
+ * host-service restart self-heals instead of settling into a permanent
+ * "Failed to fetch" that only a manual "Try again" click clears. Real
+ * application errors (404s, validation) still fail on the first attempt.
+ */
+export function hostServiceQueryRetry(
+	failureCount: number,
+	error: unknown,
+): boolean {
+	return (
+		isHostServiceConnectionError(error) &&
+		failureCount < HOST_SERVICE_MAX_RETRIES
+	);
+}
+
+export function hostServiceQueryRetryDelay(attempt: number): number {
+	return HOST_SERVICE_RETRY_DELAY_MS * (attempt + 1);
 }

--- a/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
+++ b/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
@@ -12,6 +12,10 @@ import {
 	cloudTrpcClient,
 } from "renderer/lib/cloud-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	hostServiceQueryRetry,
+	hostServiceQueryRetryDelay,
+} from "renderer/lib/host-service-client";
 import { electronReactClient } from "../../lib/trpc-client";
 
 // In Electron, blurring the BrowserWindow keeps document.visibilityState
@@ -38,7 +42,11 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			networkMode: "always",
-			retry: false,
+			// Bounded, backoff-delayed retries for connection-level failures only
+			// (e.g. a host-service restart) — see hostServiceQueryRetry. Anything
+			// else, including real application errors, still fails on attempt one.
+			retry: hostServiceQueryRetry,
+			retryDelay: hostServiceQueryRetryDelay,
 		},
 		mutations: {
 			networkMode: "always",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -81,7 +81,6 @@ function PullRequestDetailPage() {
 			});
 		},
 		enabled: !!hostUrl && !!project && !!projectId && prNumber !== null,
-		retry: false,
 		staleTime: 30_000,
 		gcTime: 10 * 60_000,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsContent/PullRequestsContent.tsx
@@ -109,7 +109,6 @@ export function PullRequestsContent({
 			enabled: !!target.hostUrl,
 			staleTime: 30_000,
 			gcTime: 10 * 60_000,
-			retry: false,
 		}),
 		getRows: (data) => data.pullRequests,
 		getRowKey: (pullRequest) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
@@ -101,7 +101,6 @@ export function GitHubIssuesContent({
 			enabled: !!target.hostUrl,
 			staleTime: 30_000,
 			gcTime: 10 * 60_000,
-			retry: false,
 		}),
 		getRows: (data) => data.issues,
 		getRowKey: (issue) => `${issue.projectId}:${issue.issueNumber}`,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/issue/$issueNumber/page.tsx
@@ -78,7 +78,6 @@ function IssueDetailPage() {
 			});
 		},
 		enabled: !!hostUrl && !!project && !!projectId && issueNumber !== null,
-		retry: false,
 		staleTime: 30_000,
 		gcTime: 10 * 60_000,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
@@ -75,7 +75,7 @@ function TerminalRichInputInner({
 	// mention popover uses to shorten paths.
 	const { data: workspaceStatus } = workspaceTrpc.workspace.get.useQuery(
 		{ id: workspaceId },
-		{ refetchOnWindowFocus: false, retry: false },
+		{ refetchOnWindowFocus: false },
 	);
 	const cwd = workspaceStatus?.worktreePath ?? "";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -115,7 +115,6 @@ export function useV2PresetExecution({
 		{ id: workspaceId },
 		{
 			refetchOnWindowFocus: false,
-			retry: false,
 		},
 	);
 	const writeInput = workspaceTrpc.terminal.writeInput.useMutation();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -94,7 +94,6 @@ function V2WorkspacePage() {
 		{ id: workspace.id },
 		{
 			refetchOnWindowFocus: true,
-			retry: false,
 		},
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -56,7 +56,6 @@ export function useRemoteHostStatus(
 		queryFn: () => getHostServiceClientByUrl(hostUrl).host.info.query(),
 		enabled: workspace != null && !isLocal,
 		staleTime: HOST_INFO_STALE_MS,
-		retry: false,
 	});
 
 	if (!workspace) return { status: "loading" };

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
@@ -79,7 +79,6 @@ export function GitHubIssueLinkCommand({
 			});
 		},
 		enabled: !!projectId && !!hostUrl && open,
-		retry: false,
 	});
 
 	const lastToastedError = useRef<string | null>(null);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
@@ -79,7 +79,6 @@ export function PRLinkCommand({
 			});
 		},
 		enabled: !!projectId && !!hostUrl && open,
-		retry: false,
 	});
 
 	// One toast per error transition — without this, the dropdown's

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -89,7 +89,6 @@ export function ImportProjectsPage({
 		queries: projects.map((project) => ({
 			queryKey: projectFindByPathQueryKey(project, activeHostUrl),
 			queryFn: projectFindByPathQueryFn(project, activeHostUrl),
-			retry: false as const,
 		})),
 	});
 
@@ -301,7 +300,6 @@ function fetchProjectFindByPath(
 	return queryClient.fetchQuery({
 		queryKey: projectFindByPathQueryKey(project, activeHostUrl),
 		queryFn: projectFindByPathQueryFn(project, activeHostUrl),
-		retry: false,
 	});
 }
 
@@ -376,7 +374,6 @@ function ProjectRow({
 	const findByPathQuery = useQuery({
 		queryKey: projectFindByPathQueryKey(project, activeHostUrl),
 		queryFn: projectFindByPathQueryFn(project, activeHostUrl),
-		retry: false,
 	});
 
 	const runImport = async (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -46,7 +46,6 @@ export function ImportWorkspacesPage({
 			const client = getHostServiceClientByUrl(activeHostUrl);
 			return client.project.list.query();
 		},
-		retry: false,
 	});
 
 	// Host-local list (host.db is the authority post-local-first; the old
@@ -57,7 +56,6 @@ export function ImportWorkspacesPage({
 			const client = getHostServiceClientByUrl(activeHostUrl);
 			return client.workspace.list.query();
 		},
-		retry: false,
 	});
 
 	const v2ProjectIdByV1Id = useMemo(() => {
@@ -98,7 +96,6 @@ export function ImportWorkspacesPage({
 					});
 				return result.worktrees;
 			},
-			retry: false,
 		})),
 	});
 

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -8,9 +8,22 @@ const STALE_TIME_MS = 5_000;
 const GC_TIME_MS = 30 * 60 * 1_000;
 const MAX_TIMEOUT_RETRIES = 2;
 const TIMEOUT_RETRY_BASE_DELAY_MS = 300;
+const MAX_CONNECTION_RETRIES = 3;
+const CONNECTION_RETRY_BASE_DELAY_MS = 700;
 
 function isTimeoutError(error: unknown): boolean {
 	return error instanceof TRPCClientError && error.data?.code === "TIMEOUT";
+}
+
+// True for a request that never got a real response — connection-refused
+// during a host-service restart, a dropped stream, DNS failure. tRPC only
+// populates `data` from a parsed server error envelope, so its absence means
+// the failure was transport-level, not the server rejecting the request.
+// Without retrying these, a query in flight during a restart settles into a
+// permanent error that only a manual refetch clears, even though
+// host-service is back within a second or two.
+function isConnectionError(error: unknown): boolean {
+	return error instanceof TRPCClientError && error.data == null;
 }
 
 export interface WorkspaceClientContextValue {
@@ -57,16 +70,22 @@ function getWorkspaceClients(
 				refetchOnWindowFocus: false,
 				// Retry server-side TIMEOUT errors a couple of times — these come
 				// from `queryProcedure`'s middleware when a host-service query
-				// (filesystem, git) takes longer than its budget. Other errors
-				// fall back to a single retry as before.
+				// (filesystem, git) takes longer than its budget. Connection-level
+				// failures (host-service restarting) get their own bounded retry.
+				// Other errors fall back to a single retry as before.
 				retry: (failureCount, error) => {
 					if (isTimeoutError(error)) return failureCount < MAX_TIMEOUT_RETRIES;
+					if (isConnectionError(error))
+						return failureCount < MAX_CONNECTION_RETRIES;
 					return failureCount < 1;
 				},
-				retryDelay: (attempt, error) =>
-					isTimeoutError(error)
-						? TIMEOUT_RETRY_BASE_DELAY_MS * (attempt + 1)
-						: Math.min(1000 * 2 ** attempt, 30_000),
+				retryDelay: (attempt, error) => {
+					if (isTimeoutError(error))
+						return TIMEOUT_RETRY_BASE_DELAY_MS * (attempt + 1);
+					if (isConnectionError(error))
+						return CONNECTION_RETRY_BASE_DELAY_MS * (attempt + 1);
+					return Math.min(1000 * 2 ** attempt, 30_000);
+				},
 				staleTime: STALE_TIME_MS,
 				gcTime: GC_TIME_MS,
 			},


### PR DESCRIPTION
## Summary
- PR #6604 closed the reconnection gap for `hostServiceCoordinator`'s own `getConnection`/`getProcessStatus` queries, but every downstream feature query that hits host-service directly (PR list/detail, GitHub issues, v1 import, remote host info, workspace status) still had `retry: false`. A query that fired during a restart's dead window settled into a permanent "Failed to fetch" that only a manual "Try again" click could clear, even though host-service recovers within a second or two.
- Added a shared retry predicate (`hostServiceQueryRetry`/`hostServiceQueryRetryDelay` in `host-service-client.ts`) that retries only transport-level failures — a `TRPCClientError` with no parsed server error envelope, i.e. connection-refused or a dropped stream — up to 3 times with linear backoff, while still failing immediately on real application errors (404s, validation).
- Wired it in as the desktop `QueryClient`'s default so every host-service query benefits without each call site opting in, and dropped the now-redundant local `retry: false` overrides that were shadowing it (PR list/detail, GitHub issues list/link commands, remote host status, v1 import pages).
- The workspace-scoped `QueryClient` (`packages/workspace-client`) already had a predicate-based retry for server-side `TIMEOUT`s; extended it with the same connection-error detection so `workspace.get` and friends self-heal too, and removed the `retry: false` overrides on the v2 workspace status queries that were shadowing that default.

## Test plan
- [x] `bun run typecheck` clean in `apps/desktop` and `packages/workspace-client`
- [x] `bunx biome check` clean on all touched files
- [x] Verified live via CDP against the running dev app: killed host-service mid-fetch to force a connection-refused, then compared the reverted vs. fixed code against the identical repro. Reverted code left a permanent "Some repositories could not be loaded: Failed to fetch" banner requiring a manual Retry, 13+ seconds after host-service had already recovered. Fixed code recovered automatically within ~8-10s of the kill, with no manual click — confirmed across multiple runs.

https://claude.ai/code/session_01UAw5Njrx8u7xT138CuGNbo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically retries host-service queries that fail during a host-service restart, preventing permanent “Failed to fetch” states. Previously, queries during the restart window stayed failed until a manual “Try again”; now transport-level failures retry up to 3 times with linear backoff while real application errors still fail immediately.

- Adds `hostServiceQueryRetry` and `hostServiceQueryRetryDelay` in `apps/desktop/src/renderer/lib/host-service-client.ts` to detect connection errors via `TRPCClientError` from `@trpc/client` (no `data` => transport failure).
- Sets the desktop `QueryClient` default `retry`/`retryDelay` to these helpers; removes local `retry: false` overrides in PR list/detail, GitHub issues, remote host info, and v1 import pages.
- Extends the `packages/workspace-client` `QueryClient` to also retry connection errors (max 3, 700ms base delay) alongside existing `TIMEOUT` handling; removes `retry: false` on v2 workspace status queries.
- No API changes; no migration required.

<sup>Written for commit 5ea1c26d868fc6a278024e60581ac522ea319fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading workspace, project, issue, and pull-request data during temporary connection problems.
  * Queries now retry eligible connection failures up to three times with increasing delays, reducing interruptions from brief service disruptions.
  * Server-side application errors continue to appear promptly without unnecessary retries.
  * Restored consistent retry behavior across dashboard views, workspace tools, imports, and search flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->