### PR TITLE
fix(desktop,shared): stop calling an already-run schedule invalid

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
@@ -55,23 +55,28 @@ export function TriggersCard({
 		// The zone travels with the date: schedules on one automation can sit in
 		// different timezones, so formatting them all in the automation-level one
 		// would label the tooltip wrongly for every schedule but the soonest.
-		const entries = new Map<string, { at: Date; timezone: string }>();
+		const entries = new Map<
+			string,
+			{ at: Date; timezone: string; exhausted: boolean }
+		>();
 
 		for (const trigger of automation.triggers) {
 			const config = trigger.config as DraftTrigger["config"];
 			if (config.kind !== "schedule") continue;
 
-			// A paused automation keeps a stale nextRunAt, so compute what this
-			// schedule would fire next — the row is previewable before resuming.
-			if (automation.enabled) {
-				if (trigger.nextRunAt) {
-					entries.set(trigger.id, {
-						at: new Date(trigger.nextRunAt),
-						timezone: config.timezone,
-					});
-				}
+			// The evaluator disables a schedule once its last occurrence fires
+			// (COUNT/UNTIL) and leaves nextRunAt at that final time — so a
+			// disabled trigger's nextRunAt is when it last ran, not when it will.
+			if (automation.enabled && trigger.nextRunAt) {
+				entries.set(trigger.id, {
+					at: new Date(trigger.nextRunAt),
+					timezone: config.timezone,
+					exhausted: !trigger.enabled,
+				});
 				continue;
 			}
+			// A paused automation keeps a stale nextRunAt, so compute what this
+			// schedule would fire next — the row is previewable before resuming.
 			try {
 				const next = nextOccurrenceAfter({
 					rrule: config.rrule,
@@ -80,7 +85,11 @@ export function TriggersCard({
 					after: new Date(),
 				});
 				if (next)
-					entries.set(trigger.id, { at: next, timezone: config.timezone });
+					entries.set(trigger.id, {
+						at: next,
+						timezone: config.timezone,
+						exhausted: false,
+					});
 			} catch (error) {
 				console.warn(
 					`[TriggersCard] failed to compute next occurrence for trigger ${trigger.id}`,
@@ -107,7 +116,11 @@ export function TriggersCard({
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<span>
-						{automation.enabled ? "Next run " : "Would run "}
+						{run.exhausted
+							? "Ran "
+							: automation.enabled
+								? "Next run "
+								: "Would run "}
 						{formatDistanceStrict(run.at, new Date(), { addSuffix: true })}
 					</span>
 				</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -1,5 +1,5 @@
 import {
-	isValidRrule,
+	rruleProblem,
 	timezoneAbbreviation,
 	type Weekday,
 } from "@superset/shared/rrule";
@@ -77,10 +77,14 @@ export function ScheduleSentence({
 	};
 
 	const customDraft = state.customRrule.trim();
-	const customValid = useMemo(() => isValidRrule(customDraft), [customDraft]);
+	const customProblem = useMemo(() => rruleProblem(customDraft), [customDraft]);
+	// The saved rule itself can be exhausted (a run-once schedule that already
+	// ran); that is history, not an edit gone wrong, so only a changed draft
+	// gets the complaint.
+	const draftEdited = customDraft !== "" && customDraft !== rrule;
 
 	const commitCustom = () => {
-		if (!customDraft || customDraft === rrule || !customValid) return;
+		if (!draftEdited || customProblem) return;
 		emit(customDraft);
 	};
 
@@ -161,9 +165,11 @@ export function ScheduleSentence({
 							if (event.key === "Enter") commitCustom();
 						}}
 					/>
-					{customDraft && !customValid && (
+					{draftEdited && customProblem && (
 						<span className="select-text cursor-text text-xs text-destructive">
-							Invalid recurrence rule — changes aren't saved
+							{customProblem === "exhausted"
+								? "No upcoming runs — changes aren't saved"
+								: "Invalid recurrence rule — changes aren't saved"}
 						</span>
 					)}
 				</div>

--- a/packages/shared/src/rrule.ts
+++ b/packages/shared/src/rrule.ts
@@ -397,18 +397,29 @@ export function parseRrule(args: {
  * editors can gate saves instead of persisting rules the server will reject.
  */
 export function isValidRrule(rrule: string): boolean {
-	if (!parseRruleParts(rrule)) return false;
+	return rruleProblem(rrule) === null;
+}
+
+/**
+ * Why a rule can't be saved: `unparseable` (not an RRULE at all) or
+ * `exhausted` (well-formed, but COUNT/UNTIL leaves nothing in the future —
+ * a run-once schedule that already ran looks exactly like this). Null when
+ * the rule is fine.
+ */
+export function rruleProblem(
+	rrule: string,
+): "unparseable" | "exhausted" | null {
+	if (!parseRruleParts(rrule)) return "unparseable";
 	try {
-		return (
-			nextOccurrenceAfter({
-				rrule,
-				dtstart: new Date(),
-				timezone: "UTC",
-				after: new Date(),
-			}) !== null
-		);
+		const next = nextOccurrenceAfter({
+			rrule,
+			dtstart: new Date(),
+			timezone: "UTC",
+			after: new Date(),
+		});
+		return next === null ? "exhausted" : null;
 	} catch {
-		return false;
+		return "unparseable";
 	}
 }
 


### PR DESCRIPTION
## Summary
A run-once schedule (`FREQ=DAILY;COUNT=1;DTSTART=…`, typically authored by an agent via CLI/MCP) fires once, then the evaluator disables the trigger and leaves `next_run_at` at that fire time — correct. The editor then rendered it as **"Invalid recurrence rule — changes aren't saved"** and **"Next run 2 days ago"**, both wrong.

- `rruleProblem()` in shared: distinguishes `unparseable` from `exhausted`; `isValidRrule` delegates to it.
- ScheduleSentence: only complains about an *edited* draft (the saved rule being exhausted is history, not an error); wording is "No upcoming runs" vs "Invalid recurrence rule".
- TriggersCard: a disabled (exhausted) trigger's row reads **"Ran 2 days ago"** with the exact time in the tooltip.

Not changed: run-once still shows as **Custom** with the raw rule, since it isn't one of the five preset shapes.

## Test plan
- [x] typecheck desktop + shared, biome, shared rrule tests
- [ ] Open the automation from the screenshot: row says "Ran 2 days ago", no red text
- [ ] Type garbage into Custom → "Invalid recurrence rule…"; type `FREQ=DAILY;COUNT=1;DTSTART=20200101T000000Z` → "No upcoming runs…"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops marking already-run schedules as invalid and fixes misleading “next run” text. Previously, a run-once rule that already fired showed “Invalid recurrence rule — changes aren't saved” and “Next run 2 days ago”; now it’s treated as exhausted, shows “No upcoming runs” when editing, and trigger rows read “Ran … ago”.

- `@superset/shared/rrule`: adds `rruleProblem` to distinguish `unparseable` vs `exhausted`; `isValidRrule` delegates to it.
- Schedule editor: only warns on an edited custom rule; shows “No upcoming runs — changes aren't saved” for exhausted drafts, otherwise “Invalid…”.
- Triggers card: treats disabled schedules with a final `nextRunAt` as last run; label reads “Ran … ago” (tooltip shows exact time); still previews “Would run …” for paused automations.
- Not changed: run-once rules remain “Custom” with the raw RRULE.

<sup>Written for commit 55e673f85f131d771644ba4cb2b81310299f0bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Automation schedules now clearly indicate whether they have already run, are scheduled to run next, or would run if re-enabled.
  - Paused automations continue showing their upcoming occurrence accurately.
  - Exhausted recurring schedules are distinguished from invalid schedule rules.
  - Saved, exhausted schedules no longer show an error unless their recurrence settings are changed.
  - Custom recurrence changes are accepted only when valid and different from the saved schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->