### PR TITLE
fix(api): reject GitHub webhook deliveries whose signature does not match

### DIFF
--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -24,11 +24,16 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
 	}
 
-	// Verify signature BEFORE storing to prevent spam from unverified requests
+	// Verify signature BEFORE storing to prevent spam from unverified requests.
+	// `verify` returns false on a mismatch and only throws when the signature is
+	// missing, so both outcomes have to be checked.
+	let signatureValid = false;
 	try {
-		await webhooks.verify(body, signature ?? "");
+		signatureValid = await webhooks.verify(body, signature ?? "");
 	} catch (error) {
 		console.error("[github/webhook] Signature verification failed:", error);
+	}
+	if (!signatureValid) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}
 


### PR DESCRIPTION
## Summary
`webhooks.verify(body, signature)` from `@octokit/webhooks` **returns `false`** on an HMAC mismatch and only *throws* when the signature is empty. The route awaited it inside a `try/catch` and discarded the boolean, so any request carrying a well-formed `x-hub-signature-256: sha256=<64 hex>` header was accepted and fully processed (webhook_events → PR mirror → automation_events → dispatch). Pre-existing since 99920ed1a; surfaced by the trigger-provider audit.

Fix: capture the result and 401 when it is not `true`.

## Test plan
- [x] typecheck + biome
- [ ] Deliver a real GitHub ping → 200; same body with the last hex digit changed → 401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects GitHub webhook deliveries when the HMAC signature does not match, preventing unverified events from entering the pipeline. Previously, the route awaited `@octokit/webhooks` `verify()` inside a try/catch and ignored its boolean result, so any well-formed `x-hub-signature-256` header was accepted; now we check the return value and return 401 on mismatch.

- Behavior change: mismatched or missing signatures now return 401 and the event is not stored, mirrored, or dispatched.
- Required: ensure the GitHub webhook secret matches the server’s configured secret; validate with a GitHub “ping” delivery.
- Rollout: monitor 401s on the GitHub webhook endpoint after deploy.

<sup>Written for commit 98e4acde74d031ea9497c7d220a7db07683b3c61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature validation to consistently reject requests with invalid signatures.
  * Requests are now rejected whether verification fails explicitly or encounters an error, helping prevent unauthorized webhook processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->