### PR TITLE
fix(api,shared): infer GitHub trigger events from the payload, not the wire event

### DIFF
--- a/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
+++ b/apps/api/src/app/api/github/webhook/dispatchMatchingTriggers.ts
@@ -23,9 +23,10 @@ function matchableFrom(
 		names: githubEventNames({
 			eventType,
 			isDraft: payload.pull_request?.draft === true,
+			isMerged: payload.pull_request?.merged === true,
+			isPullRequestComment: payload.issue?.pull_request !== undefined,
 			reviewState: payload.review?.state ?? null,
 			runConclusion: payload.workflow_run?.conclusion ?? null,
-			threadResolved: null,
 		}),
 		repositoryId,
 		ref,
@@ -37,6 +38,8 @@ function matchableFrom(
 			.map((l) => l?.name)
 			.filter((n): n is string => typeof n === "string"),
 		body: payload.comment?.body ?? payload.review?.body ?? null,
+		// Only PR-shaped payloads carry the head repo; an issue_comment on a fork
+		// PR cannot be told apart and is treated as not a fork.
 		isFork: payload.pull_request?.head?.repo?.fork === true,
 		// Who opened the thing being commented on, which is a different person
 		// from whoever wrote the comment.

--- a/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
+++ b/apps/api/src/app/api/github/webhook/recordAutomationEvent.ts
@@ -33,6 +33,7 @@ export type GithubPayload = {
 		head?: { ref?: string; repo?: { fork?: boolean } };
 		user?: { id?: number | string; login?: string };
 		draft?: boolean;
+		merged?: boolean;
 		author_association?: string;
 	};
 	issue?: {
@@ -41,6 +42,8 @@ export type GithubPayload = {
 		title?: string;
 		html_url?: string;
 		user?: { id?: number | string; login?: string };
+		// Present when the "issue" is a pull request.
+		pull_request?: { url?: string };
 	};
 	comment?: {
 		body?: string;

--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -16,17 +16,9 @@ export async function POST(request: Request) {
 	const eventType = request.headers.get("x-github-event");
 	const deliveryId = request.headers.get("x-github-delivery");
 
-	let payload: unknown;
-	try {
-		payload = JSON.parse(body);
-	} catch {
-		console.error("[github/webhook] Invalid JSON payload");
-		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
-	}
-
-	// Verify signature BEFORE storing to prevent spam from unverified requests.
-	// `verify` returns false on a mismatch and only throws when the signature is
-	// missing, so both outcomes have to be checked.
+	// Verify signature BEFORE parsing or storing so unauthenticated bodies get
+	// no further. `verify` returns false on a mismatch and only throws when the
+	// signature is missing, so both outcomes have to be checked.
 	let signatureValid = false;
 	try {
 		signatureValid = await webhooks.verify(body, signature ?? "");
@@ -35,6 +27,14 @@ export async function POST(request: Request) {
 	}
 	if (!signatureValid) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	let payload: unknown;
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		console.error("[github/webhook] Invalid JSON payload");
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
 	}
 
 	// Store verified event with idempotent handling

--- a/packages/shared/src/automation-matching/github.test.ts
+++ b/packages/shared/src/automation-matching/github.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { githubEventNames } from "./github";
+
+const names = (
+	eventType: string,
+	overrides: Partial<Parameters<typeof githubEventNames>[0]> = {},
+) =>
+	githubEventNames({
+		eventType,
+		isDraft: false,
+		isMerged: false,
+		isPullRequestComment: false,
+		reviewState: null,
+		runConclusion: null,
+		...overrides,
+	});
+
+describe("githubEventNames", () => {
+	it("names a closed pull request merged only when it was merged", () => {
+		expect(names("pull_request.closed", { isMerged: true })).toEqual([
+			"pull_request.merged",
+		]);
+		expect(names("pull_request.closed")).toEqual([]);
+	});
+
+	it("keeps issue comments and pull request comments apart", () => {
+		expect(names("issue_comment.created")).toEqual(["issue_comment"]);
+		expect(
+			names("issue_comment.created", { isPullRequestComment: true }),
+		).toEqual(["comment_added"]);
+	});
+
+	it("counts a review comment as a pull request comment", () => {
+		expect(names("pull_request_review_comment.created")).toEqual([
+			"pr_review_comment",
+			"comment_added",
+		]);
+	});
+});

--- a/packages/shared/src/automation-matching/github.ts
+++ b/packages/shared/src/automation-matching/github.ts
@@ -38,9 +38,11 @@ const no = (reason: string): MatchResult => ({ matches: false, reason });
 export function githubEventNames(event: {
 	eventType: string;
 	isDraft: boolean;
+	isMerged: boolean;
+	/** `issue_comment` fires for PR comments too; GitHub marks those on the issue. */
+	isPullRequestComment: boolean;
 	reviewState: string | null;
 	runConclusion: string | null;
-	threadResolved: boolean | null;
 }): GithubTriggerEvent[] {
 	const t = event.eventType;
 	switch (t) {
@@ -51,7 +53,8 @@ export function githubEventNames(event: {
 		case "pull_request.synchronize":
 			return ["pull_request.pushed"];
 		case "pull_request.closed":
-			return ["pull_request.merged"];
+			// Closed without merging names nothing; there is no closed trigger.
+			return event.isMerged ? ["pull_request.merged"] : [];
 		case "pull_request.labeled":
 		case "pull_request.unlabeled":
 			return ["label_change"];
@@ -60,7 +63,7 @@ export function githubEventNames(event: {
 		case "check_suite.completed":
 			return ["checks_completed"];
 		case "issue_comment.created":
-			return ["comment_added", "issue_comment"];
+			return event.isPullRequestComment ? ["comment_added"] : ["issue_comment"];
 		case "pull_request_review_comment.created":
 			return ["pr_review_comment", "comment_added"];
 		case "pull_request_review.submitted": {


### PR DESCRIPTION
## Summary

Fixes from the event-triggered automations audit, GitHub provider:

1. **`pull_request.merged` fired on every `pull_request.closed`.** `githubEventNames` now takes `isMerged` (from `payload.pull_request.merged`, added to `GithubPayload`) and only names `pull_request.merged` when it is true. Closed-without-merge names no product event; there is no closed trigger and none was added.
2. **`issue_comment` and `comment_added` did not discriminate issues from PRs.** `githubEventNames` takes `isPullRequestComment` (from `payload.issue.pull_request` being present, added to `GithubPayload`). `issue_comment.created` on a plain issue is `issue_comment` only; on a PR it is `comment_added` only. `pull_request_review_comment.created` stays `pr_review_comment` + `comment_added`. This matches the grammar sentences ("on a PR by" / "on an issue by"), which are unchanged.
3. **Removed the unused `threadResolved` parameter** from `githubEventNames` and its always-null call-site argument.
4. **Fork guard** left as-is (only PR-shaped payloads carry `head.repo.fork`); added a one-line comment naming that an `issue_comment` on a fork PR is not detectable from the payload.
5. **Route** now verifies the signature before `JSON.parse`, so unauthenticated bodies are never parsed. Same 400 on invalid JSON, same 401 on bad signature.

Files: `packages/shared/src/automation-matching/github.ts` (+ new `github.test.ts`), `apps/api/src/app/api/github/webhook/{dispatchMatchingTriggers,recordAutomationEvent,route}.ts`.

## Test plan

- [x] `bun test packages/shared/src/automation-matching/github.test.ts` — closed+merged → merged, closed+unmerged → [], issue_comment on issue → [issue_comment], on PR → [comment_added], review comment → [pr_review_comment, comment_added]
- [x] `bunx tsc --noEmit` in `packages/shared` and `apps/api`
- [x] `bunx biome check` on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infer GitHub automation trigger events from webhook payload fields instead of only the wire event, fixing incorrect merges and comment classification. Previously, every `pull_request.closed` emitted `pull_request.merged` and `issue_comment.created` was treated as both a PR and issue comment.

- Map `pull_request.closed` to `pull_request.merged` only when `payload.pull_request.merged === true`; closed-without-merge emits no product event.
- Disambiguate comments: `issue_comment.created` on an issue emits `issue_comment`; on a PR emits `comment_added`. `pull_request_review_comment.created` still emits `pr_review_comment` and `comment_added`.
- Remove the unused `threadResolved` parameter from `githubEventNames`; call sites pass `isMerged` and `isPullRequestComment` derived from the payload.
- Update `GithubPayload` to include `pull_request.merged` and `issue.pull_request`.
- In `apps/api` GitHub webhook route, verify the signature before `JSON.parse`; status codes unchanged (400 for bad JSON, 401 for bad/missing signature).
- Add focused tests for `githubEventNames` in `packages/shared`.

<sup>Written for commit 1350454dc5d70e4b71f3ebfb56bb2901f048512e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub automation triggers now distinguish merged and unmerged pull requests when they are closed.
  * Comments on pull requests and regular issues now generate the appropriate event type without duplicate triggers.
  * Webhook requests with invalid signatures are rejected before their contents are processed.
  * Malformed webhook payloads continue to return a clear client error.

* **Tests**
  * Added coverage for merged pull requests, issue comments, pull-request comments, and review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->