### PR TITLE
fix(api,trpc): automation run dedup and failure handling for schedule and event shapes

### DIFF
--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -3,10 +3,9 @@ import { automations } from "@superset/db/schema";
 import { dispatchAutomation } from "@superset/trpc/automation-dispatch";
 import { Receiver } from "@upstash/qstash";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
-
 import { env } from "@/env";
 import { getRelayUrl } from "@/lib/relay-url";
+import { runPayloadSchema } from "../../runPayloadSchema";
 
 export const maxDuration = 60;
 export const dynamic = "force-dynamic";
@@ -15,29 +14,6 @@ const receiver = new Receiver({
 	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
 	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
 });
-
-/**
- * A run comes from a schedule or from an event, never both. Scheduled runs
- * carry the minute they were due, which is also their dedupe key; event runs
- * carry the trigger and the event instead, and have no scheduled time.
- */
-const payloadSchema = z.union([
-	// Strict, so a payload carrying both causes is rejected rather than
-	// silently treated as whichever branch happens to match first.
-	z
-		.object({
-			automationId: z.string().uuid(),
-			scheduledFor: z.string().datetime(),
-		})
-		.strict(),
-	z
-		.object({
-			automationId: z.string().uuid(),
-			triggerId: z.string().uuid(),
-			eventId: z.string().uuid(),
-		})
-		.strict(),
-]);
 
 export async function POST(
 	request: Request,
@@ -59,7 +35,7 @@ export async function POST(
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}
 
-	const parsed = payloadSchema.safeParse(JSON.parse(body));
+	const parsed = runPayloadSchema.safeParse(JSON.parse(body));
 	if (!parsed.success) {
 		console.error("[automations/dispatch] invalid payload", parsed.error);
 		return Response.json({ error: "Invalid payload" }, { status: 400 });
@@ -87,6 +63,7 @@ export async function POST(
 					automation,
 					relayUrl,
 					scheduledFor: new Date(parsed.data.scheduledFor),
+					triggerId: parsed.data.triggerId,
 				}
 			: {
 					automation,

--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -64,6 +64,7 @@ export async function POST(request: Request): Promise<Response> {
 	const rows = await dbWs
 		.select({
 			automationId: automations.id,
+			triggerId: automationTriggers.id,
 			nextRunAt: automationTriggers.nextRunAt,
 			config: automationTriggers.config,
 		})
@@ -91,6 +92,7 @@ export async function POST(request: Request): Promise<Response> {
 	// while its next_run_at stayed put.
 	const planned: Array<{
 		automationId: string;
+		triggerId: string;
 		scheduledFor: Date;
 		next: Date | null;
 	}> = [];
@@ -108,6 +110,7 @@ export async function POST(request: Request): Promise<Response> {
 		try {
 			planned.push({
 				automationId: row.automationId,
+				triggerId: row.triggerId,
 				scheduledFor: bucketToMinute(row.nextRunAt),
 				next: nextOccurrenceAfter({ ...schedule, after: row.nextRunAt }),
 			});
@@ -130,10 +133,11 @@ export async function POST(request: Request): Promise<Response> {
 	}
 
 	await qstash.batchJSON(
-		planned.map(({ automationId, scheduledFor }) => ({
+		planned.map(({ automationId, triggerId, scheduledFor }) => ({
 			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${automationId}`,
 			body: {
 				automationId,
+				triggerId,
 				scheduledFor: scheduledFor.toISOString(),
 			},
 			deduplicationId: `${automationId}_${scheduledFor.getTime()}`,
@@ -143,16 +147,11 @@ export async function POST(request: Request): Promise<Response> {
 	);
 
 	const advanceResults = await Promise.allSettled(
-		planned.map(async ({ automationId, next }) => {
+		planned.map(async ({ triggerId, next }) => {
 			await dbWs
 				.update(automationTriggers)
 				.set(next ? { nextRunAt: next } : { enabled: false })
-				.where(
-					and(
-						eq(automationTriggers.automationId, automationId),
-						eq(automationTriggers.kind, "schedule"),
-					),
-				);
+				.where(eq(automationTriggers.id, triggerId));
 		}),
 	);
 
@@ -162,7 +161,11 @@ export async function POST(request: Request): Promise<Response> {
 	const advanceFailures = advanceResults.flatMap((result, index) => {
 		if (result.status !== "rejected") return [];
 		return [
-			{ automationId: planned[index]?.automationId, reason: result.reason },
+			{
+				automationId: planned[index]?.automationId,
+				triggerId: planned[index]?.triggerId,
+				reason: result.reason,
+			},
 		];
 	});
 	if (advanceFailures.length > 0) {

--- a/apps/api/src/app/api/automations/run-failed/route.ts
+++ b/apps/api/src/app/api/automations/run-failed/route.ts
@@ -6,6 +6,7 @@ import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { env } from "@/env";
+import { runPayloadSchema } from "../runPayloadSchema";
 
 export const dynamic = "force-dynamic";
 
@@ -20,11 +21,6 @@ const failurePayloadSchema = z.object({
 	status: z.number(),
 	error: z.string().optional(),
 	retried: z.number().optional(),
-});
-
-const sourceBodySchema = z.object({
-	automationId: z.string().uuid(),
-	scheduledFor: z.string().datetime(),
 });
 
 export async function POST(request: Request): Promise<Response> {
@@ -66,13 +62,13 @@ export async function POST(request: Request): Promise<Response> {
 		console.error("[automations/run-failed] invalid sourceBody JSON", err);
 		return Response.json({ error: "Invalid sourceBody JSON" }, { status: 400 });
 	}
-	const source = sourceBodySchema.safeParse(decoded);
+	const source = runPayloadSchema.safeParse(decoded);
 	if (!source.success) {
 		console.error("[automations/run-failed] invalid sourceBody", source.error);
 		return Response.json({ error: "Invalid sourceBody" }, { status: 400 });
 	}
 
-	const { automationId, scheduledFor } = source.data;
+	const { automationId } = source.data;
 
 	const [automation] = await dbWs
 		.select({
@@ -88,30 +84,48 @@ export async function POST(request: Request): Promise<Response> {
 	}
 
 	const errorText = `delivery failed after retries (status ${parsed.data.status}): ${parsed.data.error ?? "unknown"}`;
+	const failed = { status: "dispatch_failed", error: errorText } as const;
 
-	await dbWs
-		.insert(automationRuns)
-		.values({
-			automationId,
-			organizationId: automation.organizationId,
-			title: automation.name,
-			scheduledFor: new Date(scheduledFor),
-			status: "dispatch_failed",
-			error: errorText,
-		})
-		.onConflictDoUpdate({
-			target: [automationRuns.automationId, automationRuns.scheduledFor],
-			targetWhere: sql`${automationRuns.scheduledFor} IS NOT NULL`,
-			set: { status: "dispatch_failed", error: errorText },
-		});
+	if ("scheduledFor" in source.data) {
+		await dbWs
+			.insert(automationRuns)
+			.values({
+				automationId,
+				organizationId: automation.organizationId,
+				title: automation.name,
+				scheduledFor: new Date(source.data.scheduledFor),
+				triggerId: source.data.triggerId ?? null,
+				...failed,
+			})
+			.onConflictDoUpdate({
+				target: [automationRuns.automationId, automationRuns.scheduledFor],
+				targetWhere: sql`${automationRuns.scheduledFor} IS NOT NULL`,
+				set: failed,
+			});
+	} else {
+		await dbWs
+			.insert(automationRuns)
+			.values({
+				automationId,
+				organizationId: automation.organizationId,
+				title: automation.name,
+				triggerId: source.data.triggerId,
+				eventId: source.data.eventId,
+				...failed,
+			})
+			.onConflictDoUpdate({
+				target: [automationRuns.triggerId, automationRuns.eventId],
+				targetWhere: sql`${automationRuns.eventId} IS NOT NULL`,
+				set: failed,
+			});
+	}
 
 	Sentry.captureException(
 		new Error(`automation dispatch failed: ${automationId}`),
 		{
 			tags: { feature: "automations" },
 			extra: {
-				automationId,
-				scheduledFor,
+				...source.data,
 				sourceMessageId: parsed.data.sourceMessageId,
 				status: parsed.data.status,
 			},

--- a/apps/api/src/app/api/automations/runPayloadSchema.ts
+++ b/apps/api/src/app/api/automations/runPayloadSchema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * The QStash body a run is enqueued with, and therefore what both the dispatch
+ * route and the failure callback (which echoes the source body) parse.
+ *
+ * A run comes from a schedule or from an event, never both. Scheduled runs
+ * carry the minute they were due, which is also their dedupe key, plus the
+ * trigger that was due when the evaluator knows it; event runs carry the
+ * trigger and the event instead, and have no scheduled time.
+ */
+export const runPayloadSchema = z.union([
+	// Strict, so a payload carrying both causes is rejected rather than
+	// silently treated as whichever branch happens to match first.
+	z
+		.object({
+			automationId: z.string().uuid(),
+			scheduledFor: z.string().datetime(),
+			triggerId: z.string().uuid().optional(),
+		})
+		.strict(),
+	z
+		.object({
+			automationId: z.string().uuid(),
+			triggerId: z.string().uuid(),
+			eventId: z.string().uuid(),
+		})
+		.strict(),
+]);
+
+export type RunPayload = z.infer<typeof runPayloadSchema>;

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -43,10 +43,17 @@ export type DispatchableAutomation = Pick<
 	| "v2WorkspaceId"
 >;
 
-/** What caused this run: a schedule with a due minute, or a matched event. */
+/**
+ * What caused this run: a schedule with a due minute (and the schedule trigger
+ * that was due, when the caller knows it), or a matched event.
+ */
 export type DispatchCause =
-	| { scheduledFor: Date; trigger?: null }
-	| { scheduledFor?: null; trigger: { triggerId: string; eventId: string } };
+	| { scheduledFor: Date; triggerId?: string; trigger?: null }
+	| {
+			scheduledFor?: null;
+			triggerId?: null;
+			trigger: { triggerId: string; eventId: string };
+	  };
 
 export type DispatchOptions = {
 	automation: DispatchableAutomation;
@@ -64,13 +71,12 @@ export async function dispatchAutomation(
 	opts: DispatchOptions,
 ): Promise<DispatchOutcome> {
 	const { automation, relayUrl } = opts;
-	const scheduledFor = opts.scheduledFor ?? null;
-	const trigger = opts.trigger ?? null;
+	const cause = runCause(opts);
 
 	const candidates = await resolveCandidateHosts(automation);
 	if (candidates.length === 0) {
 		const error = "no host available";
-		const inserted = await recordSkipped(automation, scheduledFor, null, error);
+		const inserted = await recordSkipped(automation, cause, null, error);
 		return { status: "skipped_offline", runId: inserted?.id ?? null, error };
 	}
 
@@ -79,7 +85,7 @@ export async function dispatchAutomation(
 		const error = "target host offline";
 		const inserted = await recordSkipped(
 			automation,
-			scheduledFor,
+			cause,
 			candidates[0]?.machineId ?? null,
 			error,
 		);
@@ -92,16 +98,11 @@ export async function dispatchAutomation(
 			automationId: automation.id,
 			organizationId: automation.organizationId,
 			title: automation.name,
-			scheduledFor,
-			triggerId: trigger?.triggerId ?? null,
-			eventId: trigger?.eventId ?? null,
+			...cause,
 			hostId: host.machineId,
 			status: "dispatching",
 		})
-		.onConflictDoNothing({
-			target: [automationRuns.automationId, automationRuns.scheduledFor],
-			where: sql`${automationRuns.scheduledFor} IS NOT NULL`,
-		})
+		.onConflictDoNothing(runDedupTarget(cause))
 		.returning();
 
 	if (!run) return { status: "conflict" };
@@ -289,9 +290,50 @@ async function pickOnlineHost(
 	);
 }
 
+/** The run row columns that identify the cause, in either shape. */
+type RunCause = {
+	scheduledFor: Date | null;
+	triggerId: string | null;
+	eventId: string | null;
+};
+
+function runCause(opts: DispatchCause): RunCause {
+	if (opts.trigger) {
+		return {
+			scheduledFor: null,
+			triggerId: opts.trigger.triggerId,
+			eventId: opts.trigger.eventId,
+		};
+	}
+	return {
+		scheduledFor: opts.scheduledFor,
+		triggerId: opts.triggerId ?? null,
+		eventId: null,
+	};
+}
+
+/**
+ * The partial unique index a run of this shape can collide on:
+ * automation_runs_schedule_dedup_idx for scheduled runs,
+ * automation_runs_event_dedup_idx for event runs. Postgres only matches
+ * ON CONFLICT against an index whose predicate the target clause repeats,
+ * so the two shapes need different targets, not one that names both.
+ */
+function runDedupTarget(cause: RunCause) {
+	return cause.eventId !== null
+		? {
+				target: [automationRuns.triggerId, automationRuns.eventId],
+				where: sql`${automationRuns.eventId} IS NOT NULL`,
+			}
+		: {
+				target: [automationRuns.automationId, automationRuns.scheduledFor],
+				where: sql`${automationRuns.scheduledFor} IS NOT NULL`,
+			};
+}
+
 async function recordSkipped(
 	automation: DispatchableAutomation,
-	scheduledFor: Date | null,
+	cause: RunCause,
 	hostId: string | null,
 	error: string,
 ): Promise<{ id: string } | undefined> {
@@ -301,15 +343,12 @@ async function recordSkipped(
 			automationId: automation.id,
 			organizationId: automation.organizationId,
 			title: automation.name,
-			scheduledFor,
+			...cause,
 			hostId,
 			status: "skipped_offline",
 			error,
 		})
-		.onConflictDoNothing({
-			target: [automationRuns.automationId, automationRuns.scheduledFor],
-			where: sql`${automationRuns.scheduledFor} IS NOT NULL`,
-		})
+		.onConflictDoNothing(runDedupTarget(cause))
 		.returning({ id: automationRuns.id });
 	return row;
 }


### PR DESCRIPTION
## Summary

Three fixes from the event-triggered automations audit.

1. **`/api/automations/run-failed` could not parse event-run failures.** Its source-body schema only accepted `{automationId, scheduledFor}`, but `dispatchMatchingTriggers` sets the same `failureCallback` with `{automationId, triggerId, eventId}`, so every event dispatch that exhausted QStash retries 400'd here and left no trace. The dispatch route's strict schedule-XOR-event union now lives in `apps/api/src/app/api/automations/runPayloadSchema.ts` and both routes import it. The failure handler branches on shape: schedule runs upsert on `automation_runs_schedule_dedup_idx` as before; event runs upsert a `dispatch_failed` row on `automation_runs_event_dedup_idx` with `triggerId`/`eventId` set. The Sentry capture carries whichever cause fields were present.

2. **The schedule evaluator advanced every schedule trigger on the automation.** `evaluate/route.ts` did not select `automation_triggers.id` and updated `WHERE automation_id = ? AND kind = 'schedule'`, so one due row's `next_run_at` (or `enabled = false` when exhausted) was written onto every schedule trigger of that automation. It now selects the trigger id, carries it through `planned`, and updates `WHERE id = ?`. The QStash body for scheduled runs also includes `triggerId` — added as `optional()` on the schedule branch of the shared schema (still `.strict()`, XOR intact) — and `dispatchAutomation` accepts `triggerId` on its schedule cause and records it, so scheduled runs now name the trigger that fired. `deduplicationId` and the `automation_runs` unique indexes are unchanged.

3. **Event-run insert could raise an uncaught unique violation.** `dispatchAutomation`'s `automation_runs` insert only listed the schedule dedup index as its `ON CONFLICT` target, so a redelivered event (or a QStash retry after a partial dispatch) hit `automation_runs_event_dedup_idx` and threw outside the try. The insert (and `recordSkipped`) now pick the conflict target from the run's shape — `(automation_id, scheduled_for) WHERE scheduled_for IS NOT NULL` for schedule runs, `(trigger_id, event_id) WHERE event_id IS NOT NULL` for event runs — so an existing row returns the same `{ status: "conflict" }` outcome the schedule path already returned. `recordSkipped` also now records `triggerId`/`eventId` for skipped event runs, since it shares the same cause plumbing.

Nothing skipped: no schema migration or product decision was needed.

## Test plan

- [x] `bunx tsc --noEmit` in `apps/api` and `packages/trpc` exit 0
- [x] `bunx biome check` on touched files exit 0
- [ ] Deploy preview: POST a QStash failure callback whose base64 `sourceBody` is `{automationId, triggerId, eventId}` and confirm a `dispatch_failed` row appears with those ids (previously 400 "Invalid sourceBody")
- [ ] Automation with two schedule triggers due at different times: after the earlier one fires, only its `next_run_at` advances
- [ ] Re-deliver the same provider event twice: second dispatch returns `outcome: {status: "conflict"}` rather than 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes automation run deduplication and failure handling for both schedule- and event-triggered runs, and ensures the evaluator advances only the due schedule trigger. Previously, event failure callbacks 400’d with no row, schedule evaluation advanced all schedule triggers, and event re-deliveries could throw unique-violation 500s.

- Shared strict XOR schema `runPayloadSchema` for QStash bodies in both dispatch and run-failed routes. The failure handler now upserts a `dispatch_failed` row on the schedule index or the event index based on shape and includes cause fields in Sentry.
- Evaluator selects `triggerId`, updates by trigger id, and enqueues `triggerId` in scheduled dispatches. Scheduled runs now record the trigger that fired; previously, every schedule trigger on the automation was advanced. `deduplicationId` is unchanged.
- `dispatchAutomation` targets the schedule or event dedup index according to the run’s shape for both initial insert and `recordSkipped`, returning `{ status: "conflict" }` on re-delivery instead of a 500. No schema migration required.

<sup>Written for commit 1e57757b265bf1095ac0803a4ac7b8a1a42167d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automation run handling for both scheduled and event-triggered automations.
  - Scheduled runs now retain their specific trigger details.
  - Failed runs support consistent recovery for scheduled and event-triggered executions.
- **Bug Fixes**
  - Prevented duplicate event-triggered runs using trigger and event details.
  - Improved schedule advancement to update the correct trigger.
  - Strengthened validation for automation run data and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->