### PR TITLE
fix(api): harden inbound automation webhook routes

### DIFF
--- a/apps/api/src/app/api/automations/webhook/[automationId]/route.ts
+++ b/apps/api/src/app/api/automations/webhook/[automationId]/route.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { db } from "@superset/db/client";
 import {
 	automationEvents,
@@ -66,9 +66,18 @@ export async function POST(
 		return Response.json({ error: "Invalid bearer token" }, { status: 401 });
 	}
 
-	const { success: withinLimit } = await rateLimit.limit(automationId);
+	// Keyed on the presented token, not the public automation id, so someone
+	// who only knows the URL cannot spend the real producer's budget.
+	const { success: withinLimit } = await rateLimit.limit(
+		createHash("sha256").update(token).digest("hex"),
+	);
 	if (!withinLimit) {
 		return Response.json({ error: "Rate limit exceeded" }, { status: 429 });
+	}
+
+	const contentLength = Number(request.headers.get("content-length"));
+	if (contentLength > MAX_BODY_BYTES) {
+		return Response.json({ error: "Body too large" }, { status: 413 });
 	}
 
 	const triggers = await db

--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -10,6 +10,8 @@ import {
 } from "./recordAutomationEvent";
 import { webhooks } from "./webhooks";
 
+export const maxDuration = 60;
+
 export async function POST(request: Request) {
 	const body = await request.text();
 	const signature = request.headers.get("x-hub-signature-256");

--- a/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
+++ b/apps/api/src/app/api/integrations/circleback/webhook/[triggerId]/route.ts
@@ -1,15 +1,32 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { dbWs } from "@superset/db/client";
-import { automationEvents, automationTriggers } from "@superset/db/schema";
+import {
+	automationEvents,
+	automations,
+	automationTriggers,
+} from "@superset/db/schema";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { env } from "@/env";
 import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
 import { stripNullChars } from "@/lib/strip-null-chars";
 
 export const dynamic = "force-dynamic";
 
+const rateLimit = new Ratelimit({
+	redis: new Redis({
+		url: env.KV_REST_API_URL,
+		token: env.KV_REST_API_TOKEN,
+	}),
+	limiter: Ratelimit.slidingWindow(300, "1 m"),
+	prefix: "ratelimit:integrations:circleback:webhook",
+});
+
 const EVENT_TYPE = "meeting.completed";
+const MAX_BODY_BYTES = 1024 * 1024;
 
 /**
  * The fields matching and the row need. Everything else — notes, action items,
@@ -61,6 +78,16 @@ export async function POST(
 		return Response.json({ error: "Unknown trigger" }, { status: 404 });
 	}
 
+	const { success: withinLimit } = await rateLimit.limit(triggerId);
+	if (!withinLimit) {
+		return Response.json({ error: "Rate limit exceeded" }, { status: 429 });
+	}
+
+	const contentLength = Number(request.headers.get("content-length"));
+	if (contentLength > MAX_BODY_BYTES) {
+		return Response.json({ error: "Body too large" }, { status: 413 });
+	}
+
 	const [trigger] = await dbWs
 		.select({
 			organizationId: automationTriggers.organizationId,
@@ -68,8 +95,11 @@ export async function POST(
 			// For an HMAC provider the column holds the signing key itself — a
 			// hash could not verify a signature.
 			secret: automationTriggers.secretHash,
+			triggerEnabled: automationTriggers.enabled,
+			automationEnabled: automations.enabled,
 		})
 		.from(automationTriggers)
+		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))
 		.where(
 			and(
 				eq(automationTriggers.id, triggerId),
@@ -83,6 +113,9 @@ export async function POST(
 	}
 
 	const body = await request.text();
+	if (Buffer.byteLength(body) > MAX_BODY_BYTES) {
+		return Response.json({ error: "Body too large" }, { status: 413 });
+	}
 
 	// A trigger with no secret yet cannot tell Circleback from anyone who has
 	// seen the URL, so it accepts nothing until one is pasted in.
@@ -103,6 +136,15 @@ export async function POST(
 			triggerId,
 		);
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	// Refused before the event row exists: the dedupe key is permanent, so a
+	// delivery recorded during a pause would swallow the redelivery too.
+	if (!trigger.automationEnabled) {
+		return Response.json({ error: "Automation is disabled" }, { status: 400 });
+	}
+	if (!trigger.triggerEnabled) {
+		return Response.json({ error: "Trigger is disabled" }, { status: 409 });
 	}
 
 	let json: unknown;
@@ -150,11 +192,11 @@ export async function POST(
 		return Response.json({ ok: true, duplicate: true });
 	}
 
-	// The event is recorded either way; a failure past this point must not
-	// fail the delivery, since a redelivery would dedupe against the row and
-	// never get the run enqueued either. Same stance as the GitHub route.
+	// A dispatch failure removes the row so Circleback's retry is not deduped
+	// against a delivery that never got its run enqueued.
+	let result: { matched: number; considered: number };
 	try {
-		const result = await dispatchMatchingTriggers({
+		result = await dispatchMatchingTriggers({
 			organizationId: trigger.organizationId,
 			eventId: inserted.id,
 			// Addressed: Circleback was configured with this trigger's URL, so
@@ -175,13 +217,20 @@ export async function POST(
 				),
 			},
 		});
-		console.log(
-			`[circleback/webhook] ${result.matched}/${result.considered} triggers matched:`,
-			inserted.id,
-		);
-		return Response.json({ ok: true, matched: result.matched > 0 });
 	} catch (error) {
-		console.error("[circleback/webhook] dispatch failed:", error);
-		return Response.json({ ok: true, dispatched: false });
+		console.error(
+			`[circleback/webhook] dispatch failed for event ${inserted.id}:`,
+			error,
+		);
+		await dbWs
+			.delete(automationEvents)
+			.where(eq(automationEvents.id, inserted.id));
+		return Response.json({ error: "Dispatch failed" }, { status: 500 });
 	}
+
+	console.log(
+		`[circleback/webhook] ${result.matched}/${result.considered} triggers matched:`,
+		inserted.id,
+	);
+	return Response.json({ ok: true, matched: result.matched > 0 });
 }

--- a/apps/api/src/app/api/integrations/notion/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/notion/webhook/route.ts
@@ -21,6 +21,8 @@ import {
 	notionWebhookEventSchema,
 } from "./fetchNotionEvent";
 
+export const maxDuration = 60;
+
 /**
  * Notion signs every delivery with the verification token it sent when the
  * subscription was created: `sha256=` + HMAC-SHA256(token, raw body).


### PR DESCRIPTION
## Summary

Fixes from the event-triggered automations audit, inbound-route items:

1. **Circleback: paused automation permanently consumed the delivery.** The route wrote the `automation_events` row (permanent dedupe key `triggerId:meeting.id`) before checking `automations.enabled` / `automation_triggers.enabled`, so a delivery during a pause was dropped forever and a redelivery deduped. The trigger lookup now joins `automations` and, after the signature check, returns 400 `Automation is disabled` / 409 `Trigger is disabled` before any row is written. On the dispatch-throw path the row is deleted and the route returns 500 (mirrors the raw-webhook route) so Circleback retries instead of the old swallow-and-200.
2. **Circleback: no body cap, no rate limit.** Added the same 1 MiB cap (early `Content-Length` reject, then enforced after `text()`) and the same Upstash sliding-window limiter (300/min) as the raw-webhook route, keyed on `triggerId`.
3. **Raw webhook: rate limit keyed on a public id before auth.** The limiter is now keyed on `sha256(bearer token)` so someone who only knows the URL cannot exhaust the legitimate producer's budget. Also rejects oversized `Content-Length` before `request.text()`.
4. **Notion webhook: no `maxDuration`.** Added `export const maxDuration = 60;` (matches `google/gmail/push`).
5. **GitHub webhook: no `maxDuration`.** Same single export line; nothing else in that file touched.

Skipped (need a decision, per brief): Circleback `secretPrefix` exposure, Notion verification-token logging.

## Test plan

- [x] `bunx biome check` on the four files: exit 0
- [x] `bunx tsc --noEmit` in `apps/api`: exit 0
- [ ] Circleback: POST a signed delivery to a trigger whose automation is paused → 400, no `automation_events` row; unpause and redeliver → 200 with a run
- [ ] Circleback: > 1 MiB body → 413; > 300 deliveries/min to one trigger → 429
- [ ] Raw webhook: 301 requests with a bogus `sk_...` token → 429 for that token only; a valid token still succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens inbound automation webhooks to prevent lost events and limit abuse. Circleback deliveries no longer get permanently consumed during pauses; routes add body caps, fairer rate limits, and consistent execution timeouts.

- Circleback webhook:
  - Old: wrote `automation_events` before enable checks, so a delivery during a pause permanently deduped redeliveries. New: after signature, refuse 400 (automation disabled) or 409 (trigger disabled) before writing any row; on dispatch error, delete the row and return 500 so Circleback retries.
  - Adds a 1 MiB body cap (early `Content-Length` 413 + post-read check) and an Upstash sliding-window limit (300/min) keyed by `triggerId`.
- Automation raw webhook:
  - Rate limit is now keyed on `sha256(bearer token)` instead of the public `automationId`, protecting producer budgets; rejects oversized `Content-Length` with 413 before reading.
- GitHub and Notion webhooks:
  - Export `maxDuration = 60` for consistent execution limits.
- Rollout:
  - No schema changes. Circleback senders will see 400/409 while paused and should retry on 500. Ensure Upstash env vars (`KV_REST_API_URL`, `KV_REST_API_TOKEN`) are configured (uses `@upstash/ratelimit`/`@upstash/redis`).

<sup>Written for commit e5ff60b9275adba48b8405a48f61a3219976b954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

