### PR TITLE
fix(api): harden Linear webhook dedupe, verification, and failure isolation

### DIFF
--- a/apps/api/src/app/api/integrations/linear/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.ts
@@ -1,4 +1,7 @@
-import type { EntityWebhookPayloadWithIssueData } from "@linear/sdk/webhooks";
+import type {
+	EntityWebhookPayloadWithIssueData,
+	LinearWebhookPayload,
+} from "@linear/sdk/webhooks";
 import {
 	LINEAR_WEBHOOK_SIGNATURE_HEADER,
 	LinearWebhookClient,
@@ -38,7 +41,16 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Missing signature" }, { status: 401 });
 	}
 
-	const payload = webhookClient.parseData(Buffer.from(body), signature);
+	let payload: LinearWebhookPayload;
+	try {
+		payload = parseVerifiedPayload(body, signature);
+	} catch (error) {
+		console.warn(
+			"[linear/webhook] rejected delivery:",
+			error instanceof Error ? error.message : error,
+		);
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
 	const deliveryId = request.headers.get("linear-delivery");
 
 	const connections = await db.query.integrationConnections.findMany({
@@ -86,8 +98,24 @@ export async function POST(request: Request) {
 	);
 }
 
+// The SDK only enforces Linear's ±60s replay window when handed the
+// timestamp, and the timestamp lives inside the body being verified.
+function parseVerifiedPayload(
+	body: string,
+	signature: string,
+): LinearWebhookPayload {
+	const { webhookTimestamp } = JSON.parse(body) as {
+		webhookTimestamp?: unknown;
+	};
+	return webhookClient.parseData(
+		Buffer.from(body),
+		signature,
+		typeof webhookTimestamp === "number" ? webhookTimestamp : undefined,
+	);
+}
+
 async function processForConnection(
-	payload: ReturnType<LinearWebhookClient["parseData"]>,
+	payload: LinearWebhookPayload,
 	deliveryId: string | null,
 	connection: SelectIntegrationConnection,
 ): Promise<{
@@ -96,8 +124,13 @@ async function processForConnection(
 	error?: string;
 }> {
 	// One webhookEvents row per (Linear event × Superset connection) so each
-	// tenant's processing status is independently retryable.
-	const eventId = `${connection.id}-${payload.organizationId}-${payload.webhookTimestamp}`;
+	// tenant's processing status is independently retryable. Linear's delivery
+	// id is stable across its retries; without the header, the timestamp alone
+	// collides for bulk edits landing in the same millisecond.
+	const entityId = (payload as { data?: { id?: unknown } }).data?.id;
+	const eventId = deliveryId
+		? `${connection.id}-${deliveryId}`
+		: `${connection.id}-${payload.organizationId}-${payload.webhookTimestamp}-${payload.type}-${entityId ?? payload.action}`;
 
 	const [webhookEvent] = await db
 		.insert(webhookEvents)
@@ -133,39 +166,36 @@ async function processForConnection(
 		return { connectionId: connection.id, outcome: "skipped" };
 	}
 
-	try {
-		let outcome: "processed" | "skipped" = "processed";
+	// The task mirror and the automation event run independently so a failure
+	// in one never suppresses the other. Either failing marks the row `failed`
+	// so a redelivery re-runs both: the task upsert is idempotent and the
+	// automation event dedupes on delivery id.
+	let outcome: "processed" | "skipped" = "processed";
+	const failures: string[] = [];
 
-		if (payload.type === "Issue") {
+	if (payload.type === "Issue") {
+		try {
 			outcome = await processIssueEvent(
 				payload as EntityWebhookPayloadWithIssueData,
 				connection,
 			);
+		} catch (error) {
+			console.error("[linear/webhook] task sync failed:", error);
+			failures.push(errorMessage(error));
 		}
+	}
 
-		// Deliberately not allowed to fail the delivery: a bad automation row
-		// must not make Linear retry the task sync above.
-		if (isEntityDelivery(payload)) {
-			try {
-				await recordAndDispatch(
-					payload,
-					deliveryId,
-					connection,
-					webhookEvent.id,
-				);
-			} catch (error) {
-				console.error("[linear/webhook] recordAndDispatch failed:", error);
-			}
+	if (isEntityDelivery(payload)) {
+		try {
+			await recordAndDispatch(payload, deliveryId, connection, webhookEvent.id);
+		} catch (error) {
+			console.error("[linear/webhook] recordAndDispatch failed:", error);
+			failures.push(errorMessage(error));
 		}
+	}
 
-		await db
-			.update(webhookEvents)
-			.set({ status: outcome, processedAt: new Date() })
-			.where(eq(webhookEvents.id, webhookEvent.id));
-
-		return { connectionId: connection.id, outcome };
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
+	if (failures.length > 0) {
+		const message = failures.join("; ");
 		await db
 			.update(webhookEvents)
 			.set({
@@ -174,9 +204,19 @@ async function processForConnection(
 				retryCount: webhookEvent.retryCount + 1,
 			})
 			.where(eq(webhookEvents.id, webhookEvent.id));
-
 		return { connectionId: connection.id, outcome: "failed", error: message };
 	}
+
+	await db
+		.update(webhookEvents)
+		.set({ status: outcome, processedAt: new Date() })
+		.where(eq(webhookEvents.id, webhookEvent.id));
+
+	return { connectionId: connection.id, outcome };
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : "Unknown error";
 }
 
 /** Entity deliveries carry `data`; OAuth and notification payloads do not. */


### PR DESCRIPTION
## Summary

Fixes from the event-triggered automations audit for `apps/api/src/app/api/integrations/linear/webhook/route.ts`:

1. **`webhook_events.event_id` used a millisecond timestamp.** Same-millisecond deliveries (bulk status changes) collided on `${connection.id}-${organizationId}-${webhookTimestamp}`; the second returned early as processed and its automation event was lost. The row is now keyed on `${connection.id}-${linear-delivery header}` when the header is present, falling back to `${connection.id}-${organizationId}-${webhookTimestamp}-${type}-${data.id}` (action when there is no entity) only when it is absent.
2. **Invalid signature returned 500.** `parseData` throws on a mismatch; that throw is now caught and answered with 401. The existing 401 for a missing header is unchanged.
3. **Replay window was skipped.** The installed `@linear/sdk` (68.1.1) only checks the ±60s window when the timestamp is passed, and its `parseVerifiedPayload` is private. The body is parsed once to read `webhookTimestamp`, which is then passed as the third argument to `parseData`, so stale replays are rejected with 401.
4. **Task-sync failure suppressed the automation event.** `processIssueEvent` and `recordAndDispatch` now each run in their own try/catch; a failure in either is logged and collected, the other still runs, and the `webhook_events` row is marked `failed` (retry count incremented, both messages in `error`) so a redelivery re-runs both. The task upsert is idempotent and the automation event dedupes on delivery id, so the retry is safe. On success the row is marked `processed`/`skipped` as before.

Skipped by decision (not in scope): identity link route, null=any semantics, actor filter, cycle verification.

## Test plan

- [x] `bunx biome check apps/api/src/app/api/integrations/linear/webhook/route.ts` exit 0
- [x] `bunx tsc --noEmit -p apps/api/tsconfig.json` exit 0
- [ ] Deliver two Issue updates from Linear with the same `webhookTimestamp` and distinct `linear-delivery` ids; expect two `webhook_events` rows and two `automation_events` rows
- [ ] POST with a wrong `linear-signature`; expect 401, not 500
- [ ] Replay a captured delivery more than 60s later; expect 401
- [ ] Make the task mirror throw (for example an unknown Linear state is fine, but a thrown error such as a DB failure); expect the automation event still recorded and the `webhook_events` row `failed`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Linear webhook processing to prevent dropped automation events and bad responses. Old behavior deduped by millisecond timestamp, returned 500 on bad signatures, skipped the ±60s replay window, and let task-sync failures suppress automation events; new behavior keys by delivery id, returns 401 on verification errors, enforces the replay window, and isolates failures while keeping retries safe.

- Deduplication: Use `linear-delivery` for `webhook_events.event_id`; fallback to `${connection.id}-${organizationId}-${webhookTimestamp}-${type}-${data.id|action}` when absent to avoid same-millisecond collisions and keep redeliveries idempotent.
- Signature handling: Catch verification errors and return 401 "Invalid signature"; the 401 for a missing signature header is unchanged.
- Replay protection: Parse `webhookTimestamp` and pass it to `parseData` in `@linear/sdk` so stale replays outside ±60s are rejected with 401.
- Failure isolation: Run task mirror and automation recording independently; any failure marks the row `failed` with incremented `retryCount` and aggregated errors so a redelivery re-runs both. Success still marks `processed`/`skipped`.

<sup>Written for commit e5029554a43059cf700c8698996c2898517a706c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

