### PR TITLE
fix(api,shared,trpc): harden Sentry webhook and install callback

### DIFF
--- a/apps/api/src/app/api/integrations/sentry/callback/route.ts
+++ b/apps/api/src/app/api/integrations/sentry/callback/route.ts
@@ -15,8 +15,18 @@ import { env } from "@/env";
 import { verifySignedState } from "@/lib/oauth-state";
 import { SENTRY_STATE_COOKIE } from "../connect/route";
 
-const web = (params: string) =>
-	Response.redirect(`${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry${params}`);
+/**
+ * Redirect back to the web integration page, clearing the one-shot state
+ * cookie on every exit so a failed callback does not leave it live for its TTL.
+ */
+const web = (params = "") =>
+	new Response(null, {
+		status: 302,
+		headers: {
+			Location: `${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry${params}`,
+			"Set-Cookie": `${SENTRY_STATE_COOKIE}=; HttpOnly; SameSite=Lax; Path=/api/integrations/sentry; Max-Age=0`,
+		},
+	});
 
 /**
  * Finishes a Sentry install: exchanges the grant code for a token pair and
@@ -111,14 +121,7 @@ export async function GET(request: Request) {
 	// Verify Install, if the app has it on; best-effort, the token already works.
 	await verifySentryInstall(installationId, token.token);
 
-	// Clear the one-shot state cookie on the way back.
-	return new Response(null, {
-		status: 302,
-		headers: {
-			Location: `${env.NEXT_PUBLIC_WEB_URL}/integrations/sentry`,
-			"Set-Cookie": `${SENTRY_STATE_COOKIE}=; HttpOnly; SameSite=Lax; Path=/api/integrations/sentry; Max-Age=0`,
-		},
-	});
+	return web();
 }
 
 /** One cookie value from a request's Cookie header. */

--- a/apps/api/src/app/api/integrations/sentry/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/sentry/webhook/route.ts
@@ -2,8 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { db } from "@superset/db/client";
 import { integrationConnections } from "@superset/db/schema";
 import { disconnectSentry } from "@superset/trpc/integrations/sentry";
-import { and, eq, isNull, sql } from "drizzle-orm";
-import { z } from "zod";
+import { and, eq, sql } from "drizzle-orm";
 
 import { env } from "@/env";
 import { dispatchMatchingTriggers } from "@/lib/automations/dispatchMatchingTriggers";
@@ -19,10 +18,20 @@ import {
  * Every delivery is signed with the app's one client secret, an env var, so the
  * signature is verified before anything is looked up. The payload names no
  * Superset org, only the installation's uuid — and that uuid is what the
- * install callback stored on the connection, so it is how a delivery finds the
- * org it belongs to. (`?organization=` stays a fallback for a delivery that
- * somehow carries no installation.)
+ * install callback stored on the connection, so it is the only way a delivery
+ * finds the org it belongs to.
  */
+
+/** How far a delivery's `sentry-hook-timestamp` may sit from our clock. */
+const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+
+/** Sentry sends unix seconds; a stale or future timestamp is a replay. */
+function timestampFresh(header: string | null): boolean {
+	if (!header) return false;
+	const seconds = Number(header);
+	if (!Number.isFinite(seconds)) return false;
+	return Math.abs(Date.now() - seconds * 1000) <= TIMESTAMP_TOLERANCE_MS;
+}
 
 /** Constant-time compare of Sentry's hex HMAC-SHA256 against ours. */
 function signatureMatches(
@@ -51,12 +60,16 @@ async function connectionByInstallation(installationUuid: string) {
 export async function POST(request: Request) {
 	const body = await request.text();
 	const signature = request.headers.get("sentry-hook-signature");
+	const timestamp = request.headers.get("sentry-hook-timestamp");
 	const resource = request.headers.get("sentry-hook-resource");
 	const requestId = request.headers.get("request-id");
 
 	const secret = env.SENTRY_CLIENT_SECRET;
 	if (!secret || !signature || !signatureMatches(body, signature, secret)) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+	if (!timestampFresh(timestamp)) {
+		return Response.json({ error: "Stale timestamp" }, { status: 401 });
 	}
 
 	let payload: SentryIssuePayload;
@@ -87,22 +100,12 @@ export async function POST(request: Request) {
 		return Response.json({ success: true, message: "Ignored" });
 	}
 
-	// The install uuid picks the connection; the URL param is only a fallback.
-	const urlOrg = new URL(request.url).searchParams.get("organization");
 	const connection = installationUuid
 		? await connectionByInstallation(installationUuid)
-		: urlOrg && z.uuid().safeParse(urlOrg).success
-			? await db.query.integrationConnections.findFirst({
-					where: and(
-						eq(integrationConnections.organizationId, urlOrg),
-						eq(integrationConnections.provider, "sentry"),
-						isNull(integrationConnections.disconnectedAt),
-					),
-					columns: { id: true, organizationId: true, disconnectedAt: true },
-				})
-			: null;
+		: null;
 
 	// No active connection for this install: nothing to attribute the event to.
+	// 200 so Sentry does not retry what can never resolve.
 	if (!connection || connection.disconnectedAt) {
 		return Response.json({ success: true, message: "No connection" });
 	}
@@ -127,6 +130,10 @@ export async function POST(request: Request) {
 
 	// Nothing in the product names this action, so there is nothing to match.
 	if (event.names.length === 0) {
+		console.log(
+			`[sentry/webhook] Unhandled action ${resource}.${payload.action}, recorded only:`,
+			deliveryId,
+		);
 		return Response.json({ success: true, message: "Recorded" });
 	}
 

--- a/packages/shared/src/automation-matching/sentry.ts
+++ b/packages/shared/src/automation-matching/sentry.ts
@@ -31,6 +31,9 @@ export function sentryEventNames(eventType: string): SentryTriggerEvent[] {
 		case "issue.archived":
 		case "issue.unresolved":
 			return [eventType, "issue.any"];
+		// Sentry's older wire name for Archive; both spellings still arrive.
+		case "issue.ignored":
+			return ["issue.archived", "issue.any"];
 		default:
 			return [];
 	}

--- a/packages/trpc/src/router/integration/sentry/utils.ts
+++ b/packages/trpc/src/router/integration/sentry/utils.ts
@@ -100,20 +100,41 @@ export async function verifySentryInstall(
 	installationUuid: string,
 	token: string,
 ) {
-	await fetch(
-		`${SENTRY_URL}/api/0/sentry-app-installations/${installationUuid}/`,
-		{
-			method: "PUT",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${token}`,
+	// Best-effort: the token already works, and a failure here only leaves the
+	// install in "pending" on Sentry's side.
+	try {
+		const response = await fetch(
+			`${SENTRY_URL}/api/0/sentry-app-installations/${installationUuid}/`,
+			{
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({ status: "installed" }),
 			},
-			body: JSON.stringify({ status: "installed" }),
-		},
-	).catch(() => {
-		// Verify Install is best-effort: the token already works, and a failure
-		// here only leaves the install in "pending" on Sentry's side.
-	});
+		);
+		if (!response.ok) {
+			console.warn(
+				`[sentry] Verify Install returned ${response.status} for ${installationUuid}`,
+			);
+		}
+	} catch (error) {
+		console.warn(
+			`[sentry] Verify Install failed for ${installationUuid}:`,
+			error,
+		);
+	}
+}
+
+/** A revoked or already-used refresh token comes back as 400 invalid_grant. */
+async function isInvalidGrant(response: Response): Promise<boolean> {
+	try {
+		const body = (await response.json()) as { error?: unknown };
+		return body?.error === "invalid_grant";
+	} catch {
+		return false;
+	}
 }
 
 type TokenResult =
@@ -172,7 +193,11 @@ export async function getSentryAccessToken(
 			}),
 		});
 		if (!response.ok) {
-			if (response.status === 401 || response.status === 403) {
+			if (
+				response.status === 401 ||
+				response.status === 403 ||
+				(response.status === 400 && (await isInvalidGrant(response)))
+			) {
 				await tx
 					.update(integrationConnections)
 					.set({


### PR DESCRIPTION
## Summary

Fixes from the event-triggered automations audit, Sentry provider. Each item and how it was fixed:

1. **`?organization=<uuid>` fallback deleted** (`apps/api/.../sentry/webhook/route.ts`). Connections resolve by installation uuid only. A delivery with no installation uuid returns 200 "No connection" so Sentry does not retry.
2. **`sentry-hook-timestamp` replay check** (same file). Missing, non-numeric, or more than 5 minutes off our clock in either direction returns 401 "Stale timestamp". The HMAC check is unchanged and runs first.
3. **`issue.ignored` handled as archived** (`packages/shared/src/automation-matching/sentry.ts`). `sentryEventNames("issue.ignored")` returns `["issue.archived", "issue.any"]`, so Sentry's older wire name for Archive fires "Issue archived" and "Any" alongside `issue.archived`.
4. **Empty-names drop logged** (webhook route). When a delivery is recorded but maps to no product event, the route now logs `Unhandled action <resource>.<action>` with the delivery id before returning "Recorded".
5. **Refresh-failure classification** (`packages/trpc/.../sentry/utils.ts` `getSentryAccessToken`). A 400 whose JSON body has `error === "invalid_grant"` marks the connection disconnected with `invalid_grant`, same as 401/403, instead of throwing as transient.
6. **OAuth state cookie cleared on every callback exit** (`apps/api/.../sentry/callback/route.ts`). The `web()` redirect helper now always appends the `Max-Age=0` clear-cookie header, so the error paths no longer leave the cookie live for its TTL. Success path uses the same helper.
7. **`verifySentryInstall` no longer swallows failure** (`utils.ts`). Still best-effort, but a non-2xx response or a thrown fetch logs `console.warn` with the status / error.

Skipped per brief (product decisions or schema): identity writer, assignee filter, regression event, disconnect semantics, jsonb index, level null convention.

## Test plan

- [x] `bunx biome check` on the four touched files, exit 0
- [x] `bunx tsc --noEmit` in `packages/shared`, `packages/trpc`, `apps/api`, exit 0
- [ ] Replay a signed Sentry `issue.ignored` delivery with a current `sentry-hook-timestamp` against a connected org: expect an "Issue archived" trigger to match
- [ ] Replay the same delivery with the timestamp header removed or 10 minutes old: expect 401 "Stale timestamp"
- [ ] Hit `/api/integrations/sentry/callback?error=access_denied` after starting an install: expect the redirect response to carry `Set-Cookie: sentry_oauth_state=; ...; Max-Age=0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Sentry webhook and OAuth callback to prevent replays, resolve connections only by installation uuid, and improve failure handling. This stops unresolvable retries, reduces misattribution, and makes token and install issues visible.

- Webhook resolution: Drops the `?organization=<uuid>` fallback. Deliveries resolve by installation uuid only; missing uuids return 200 "No connection" so Sentry does not retry.
- Replay protection: Requires `sentry-hook-timestamp` within ±5 minutes of our clock; missing/non-numeric/stale returns 401 "Stale timestamp". HMAC check still runs first.
- Event mapping: Maps `issue.ignored` to `issue.archived` so Archive and Any triggers fire for both spellings.
- Observability: Logs `Unhandled action <resource>.<action>` with the recorded delivery id when no product event maps.
- Token refresh: Treats a 400 with `error: "invalid_grant"` like 401/403 and marks the connection disconnected with `invalid_grant`.
- Callback: Always clears the OAuth state cookie on every exit (success and error).
- Verify Install: Logs a warning on non-2xx or thrown fetch instead of swallowing failures.

**Rollout/Migration**
- Stop using `?organization` in any manual webhook tests or replay scripts; rely on the installation uuid.
- Include a current `sentry-hook-timestamp` header when replaying deliveries manually. No action needed for real Sentry deliveries.

<sup>Written for commit e24ec2e193d7aa0445a7d11d5721193ab2a93426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry integration security by rejecting stale or invalid webhook requests.
  * Improved handling of disconnected integrations and expired authorization, including automatic cleanup when access is revoked.
  * Fixed callback flows so temporary connection state is consistently cleared and users are returned to the integration page when needed.
  * Added support for legacy Sentry “issue ignored” events.
  * Improved reporting for unrecognized Sentry events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->