### PR TITLE
feat(trpc): hand the triggering event to the agent as trigger context

### DIFF
--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -1,6 +1,7 @@
 import { mintUserJwt } from "@superset/auth/server";
 import { dbWs } from "@superset/db/client";
 import {
+	automationEvents,
 	automationRuns,
 	automations,
 	type SelectAutomation,
@@ -17,6 +18,7 @@ import {
 import { and, eq, sql } from "drizzle-orm";
 import { fetchRelayPresence } from "../../lib/relay-presence";
 import { RelayDispatchError, relayMutation } from "./relay-client";
+import { promptWithTriggerContext } from "./triggerContext";
 
 type AgentRunResult = { kind: "terminal"; sessionId: string; label: string };
 
@@ -141,6 +143,28 @@ export async function dispatchAutomation(
 			return created.workspaceId;
 		};
 
+		const event = cause.eventId
+			? ((await dbWs.query.automationEvents.findFirst({
+					where: eq(automationEvents.id, cause.eventId),
+					columns: {
+						provider: true,
+						eventType: true,
+						title: true,
+						url: true,
+						actorLogin: true,
+						ref: true,
+						repositoryId: true,
+						payload: true,
+						receivedAt: true,
+					},
+				})) ?? null)
+			: null;
+		const prompt = promptWithTriggerContext(
+			automation.prompt,
+			{ automationId: automation.id, triggerId: cause.triggerId },
+			event,
+		);
+
 		const runAgent = (targetWorkspaceId: string) =>
 			runAgentOnHost({
 				relayUrl,
@@ -148,7 +172,7 @@ export async function dispatchAutomation(
 				jwt,
 				workspaceId: targetWorkspaceId,
 				agent: automation.agent,
-				prompt: automation.prompt,
+				prompt,
 			});
 
 		workspaceId = automation.v2WorkspaceId ?? (await createFreshWorkspace());

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -161,7 +161,11 @@ export async function dispatchAutomation(
 			: null;
 		const prompt = promptWithTriggerContext(
 			automation.prompt,
-			{ automationId: automation.id, triggerId: cause.triggerId },
+			{
+				automationId: automation.id,
+				triggerId: cause.triggerId,
+				scheduledFor: cause.scheduledFor,
+			},
 			event,
 		);
 

--- a/packages/trpc/src/router/automation/triggerContext.ts
+++ b/packages/trpc/src/router/automation/triggerContext.ts
@@ -1,0 +1,81 @@
+import type { SelectAutomationEvent } from "@superset/db/schema";
+
+/**
+ * Keeps a provider payload from swamping the prompt. Teams and Notion store
+ * whole API objects; GitHub payloads run to tens of kilobytes.
+ */
+const MAX_PAYLOAD_CHARS = 24_000;
+
+type TriggerEvent = Pick<
+	SelectAutomationEvent,
+	| "provider"
+	| "eventType"
+	| "title"
+	| "url"
+	| "actorLogin"
+	| "ref"
+	| "repositoryId"
+	| "payload"
+	| "receivedAt"
+>;
+
+/**
+ * The prompt the agent runs is the automation's prompt verbatim, followed by a
+ * machine-readable block describing what fired it. The block, not the prompt,
+ * carries the event: users write "review the PR" and the agent finds which PR
+ * here. Schedule runs have no event and get the prompt alone.
+ */
+export function promptWithTriggerContext(
+	prompt: string,
+	context: { automationId: string; triggerId: string | null },
+	event: TriggerEvent | null,
+): string {
+	if (!event) return prompt;
+
+	const payload = boundedPayload(event.payload);
+	const triggerContext =
+		event.provider === "webhook"
+			? { webhookPayload: payload.value }
+			: {
+					[event.provider]: {
+						eventType: event.eventType,
+						title: event.title,
+						url: event.url,
+						actor: event.actorLogin,
+						ref: event.ref,
+						repositoryId: event.repositoryId,
+						payload: payload.value,
+					},
+				};
+
+	const info = {
+		automationId: context.automationId,
+		triggerId: context.triggerId,
+		receivedAt: event.receivedAt.toISOString(),
+		triggerContext,
+		...(payload.truncated ? { payloadTruncated: true } : {}),
+	};
+
+	return [
+		prompt,
+		"",
+		"<automation_trigger_info>",
+		JSON.stringify(info, null, 2),
+		"</automation_trigger_info>",
+		`<timestamp>${new Date().toUTCString()}</timestamp>`,
+	].join("\n");
+}
+
+function boundedPayload(payload: unknown): {
+	value: unknown;
+	truncated: boolean;
+} {
+	const serialized = JSON.stringify(payload);
+	if (serialized === undefined || serialized.length <= MAX_PAYLOAD_CHARS) {
+		return { value: payload, truncated: false };
+	}
+	return {
+		value: `${serialized.slice(0, MAX_PAYLOAD_CHARS)}…`,
+		truncated: true,
+	};
+}

--- a/packages/trpc/src/router/automation/triggerContext.ts
+++ b/packages/trpc/src/router/automation/triggerContext.ts
@@ -23,19 +23,23 @@ type TriggerEvent = Pick<
  * The prompt the agent runs opens with a machine-readable block describing
  * what fired it, then the automation's prompt verbatim. The block, not the
  * prompt, carries the event: users write "review the PR" and the agent finds
- * which PR here. Schedule runs have no event and get the prompt alone.
+ * which PR here. Every run gets one; a schedule run's block says when it was
+ * due.
  */
 export function promptWithTriggerContext(
 	prompt: string,
-	context: { automationId: string; triggerId: string | null },
+	context: {
+		automationId: string;
+		triggerId: string | null;
+		scheduledFor: Date | null;
+	},
 	event: TriggerEvent | null,
 ): string {
-	if (!event) return prompt;
-
-	const payload = boundedPayload(event.payload);
-	const triggerContext =
-		event.provider === "webhook"
-			? { webhookPayload: payload.value }
+	const payload = event ? boundedPayload(event.payload) : null;
+	const triggerContext = !event
+		? { schedule: { scheduledFor: context.scheduledFor?.toISOString() } }
+		: event.provider === "webhook"
+			? { webhookPayload: payload?.value }
 			: {
 					[event.provider]: {
 						eventType: event.eventType,
@@ -44,16 +48,16 @@ export function promptWithTriggerContext(
 						actor: event.actorLogin,
 						ref: event.ref,
 						repositoryId: event.repositoryId,
-						payload: payload.value,
+						payload: payload?.value,
 					},
 				};
 
 	const info = {
 		automationId: context.automationId,
 		triggerId: context.triggerId,
-		receivedAt: event.receivedAt.toISOString(),
+		...(event ? { receivedAt: event.receivedAt.toISOString() } : {}),
 		triggerContext,
-		...(payload.truncated ? { payloadTruncated: true } : {}),
+		...(payload?.truncated ? { payloadTruncated: true } : {}),
 	};
 
 	return [

--- a/packages/trpc/src/router/automation/triggerContext.ts
+++ b/packages/trpc/src/router/automation/triggerContext.ts
@@ -20,10 +20,10 @@ type TriggerEvent = Pick<
 >;
 
 /**
- * The prompt the agent runs is the automation's prompt verbatim, followed by a
- * machine-readable block describing what fired it. The block, not the prompt,
- * carries the event: users write "review the PR" and the agent finds which PR
- * here. Schedule runs have no event and get the prompt alone.
+ * The prompt the agent runs opens with a machine-readable block describing
+ * what fired it, then the automation's prompt verbatim. The block, not the
+ * prompt, carries the event: users write "review the PR" and the agent finds
+ * which PR here. Schedule runs have no event and get the prompt alone.
  */
 export function promptWithTriggerContext(
 	prompt: string,
@@ -57,12 +57,12 @@ export function promptWithTriggerContext(
 	};
 
 	return [
-		prompt,
-		"",
 		"<automation_trigger_info>",
 		JSON.stringify(info, null, 2),
 		"</automation_trigger_info>",
 		`<timestamp>${new Date().toUTCString()}</timestamp>`,
+		"",
+		prompt,
 	].join("\n");
 }
 


### PR DESCRIPTION
## Summary
Event-triggered runs sent `automation.prompt` verbatim — the `automation_events` row (title, url, actor, payload) was written by every provider and read by nothing at dispatch, so a "review the PR" automation could not know which PR.

Verified against the reference by firing its raw webhook with a probe body and asking the agent to echo its input: the reference leaves the visible prompt untouched and appends a hidden block:
```
<automation_trigger_info>
{ "automationId": "…", "triggerContext": { "webhookPayload": {…}, "headers": {…}, "bodyDigest": "sha256:…" } }
</automation_trigger_info>
<timestamp>Tuesday, Aug 18, 2026, 5:55 PM (UTC)</timestamp>
```

This does the same in `dispatchAutomation`: when the run has an `eventId`, load the event row and prepend
```
<automation_trigger_info>
{ "automationId", "triggerId", "receivedAt", "triggerContext": { "<provider>": { eventType, title, url, actor, ref, repositoryId, payload } } }
</automation_trigger_info>
<timestamp>…</timestamp>
```
(`webhookPayload` for the raw webhook, matching the reference key). Payload is capped at 24k chars with `payloadTruncated: true`. Schedule runs get a `{ schedule: { scheduledFor } }` block, so every run opens the same way.

New co-located `triggerContext.ts`; one call site in `dispatch.ts`. Since our agents are terminal CLIs, the block is visible as part of the typed initial prompt (the reference hides it in the UI) — acceptable for now; hiding it is a renderer concern.

## Test plan
- [x] tsc packages/trpc, biome
- [x] `promptWithTriggerContext` sanity-run for github / webhook / schedule shapes
- [ ] Fire the raw webhook against a local automation and confirm the agent's first message carries the block

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepends a machine-readable trigger context block to the agent prompt so event- and schedule-triggered runs can act on the right resource or due time. Previously we sent `automation.prompt` verbatim; now the prompt begins with the context block. In terminal CLIs the block is visible.

**Details**
- Adds an `<automation_trigger_info>` block with `automationId`, `triggerId`, `triggerContext`, optional `receivedAt`, and a `<timestamp>` line.
- Event-triggered runs: sets `triggerContext.webhookPayload` for raw webhooks; for other providers, sets `triggerContext.<provider>` with `eventType`, `title`, `url`, `actor`, `ref`, `repositoryId`, and `payload`. Caps serialized payload at 24k chars and sets `payloadTruncated: true` when truncated.
- Scheduled runs: sets `triggerContext.schedule.scheduledFor` so every run opens the same way.
- Implements `promptWithTriggerContext` in `packages/trpc/src/router/automation/triggerContext.ts` and uses it in `dispatchAutomation` for all runs to build the prefixed prompt.

<sup>Written for commit 25542fe916a7e225e5ef5fb8502960f69f2da520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

