### PR TITLE
feat(desktop): drop Me from the actor picker and let Google Calendar attendees be typed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/components/ActorChip/ActorChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggerSentence/components/ActorChip/ActorChip.tsx
@@ -4,13 +4,17 @@ import {
 	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { Input } from "@superset/ui/input";
+import { useState } from "react";
 import type { ScopeOption } from "../../scopeOption";
 import { ChipButton } from "../ChipButton";
 
 function actorLabel(actor: TriggerActor, people: ScopeOption[]): string {
 	if (actor === "anyone") return "Anyone";
+	// Legacy rows only; the picker no longer offers "me".
 	if (actor === "me") return "Me";
 	if (actor.ids.length === 0) return "Select people";
 	if (actor.ids.length === 1) {
@@ -20,21 +24,49 @@ function actorLabel(actor: TriggerActor, people: ScopeOption[]): string {
 	return `${actor.ids.length} people`;
 }
 
+/**
+ * Multi-select over the provider's own people, plus "Anyone".
+ *
+ * `allowCustom` adds a field for values that are not pickable — an email
+ * address — which then sit in the list like any chosen person.
+ */
 export function ActorChip({
 	actor,
 	onChange,
 	people,
+	allowCustom,
 	disabled,
 	className,
 }: {
 	actor: TriggerActor;
 	onChange: (next: TriggerActor) => void;
 	people: ScopeOption[];
+	allowCustom?: { placeholder: string };
 	disabled?: boolean;
 	className?: string;
 }) {
 	const ids = typeof actor === "string" ? [] : actor.ids;
 	const empty = typeof actor !== "string" && ids.length === 0;
+	const [custom, setCustom] = useState("");
+
+	const toggle = (id: string) => {
+		const next = ids.includes(id) ? ids.filter((p) => p !== id) : [...ids, id];
+		onChange(next.length ? { ids: next } : "anyone");
+	};
+
+	const addCustom = () => {
+		const value = custom.trim();
+		if (!value) return;
+		if (!ids.includes(value)) {
+			onChange({ ids: [...ids, value] });
+		}
+		setCustom("");
+	};
+
+	// Typed values that no person describes still need a row to be unticked.
+	const customSelected = ids.filter(
+		(id) => !people.some((person) => person.id === id),
+	);
 
 	return (
 		<DropdownMenu>
@@ -55,28 +87,50 @@ export function ActorChip({
 				>
 					Anyone
 				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
-					checked={actor === "me"}
-					onCheckedChange={() => onChange("me")}
-				>
-					Me
-				</DropdownMenuCheckboxItem>
 				{people.map((person) => (
 					<DropdownMenuCheckboxItem
 						key={person.id}
 						checked={ids.includes(person.id)}
-						onCheckedChange={() => {
-							const next = ids.includes(person.id)
-								? ids.filter((p) => p !== person.id)
-								: [...ids, person.id];
-							onChange(next.length ? { ids: next } : "anyone");
-						}}
+						onCheckedChange={() => toggle(person.id)}
 					>
 						{person.label}
 					</DropdownMenuCheckboxItem>
 				))}
-				{people.length === 0 && (
-					<DropdownMenuItem disabled>No linked accounts yet</DropdownMenuItem>
+				{allowCustom &&
+					customSelected.map((id) => (
+						<DropdownMenuCheckboxItem
+							key={id}
+							checked
+							onCheckedChange={() => toggle(id)}
+						>
+							{id}
+						</DropdownMenuCheckboxItem>
+					))}
+				{people.length === 0 && !allowCustom && (
+					<DropdownMenuItem disabled>No people to choose yet</DropdownMenuItem>
+				)}
+				{allowCustom && (
+					<>
+						<DropdownMenuSeparator />
+						<div className="p-1">
+							<Input
+								value={custom}
+								placeholder={allowCustom.placeholder}
+								disabled={disabled}
+								onChange={(event) => setCustom(event.target.value)}
+								// The menu owns arrow keys and typeahead; the field keeps
+								// what it types.
+								onKeyDown={(event) => {
+									event.stopPropagation();
+									if (event.key === "Enter") {
+										event.preventDefault();
+										addCustom();
+									}
+								}}
+								className="h-7 text-[13px]"
+							/>
+						</div>
+					</>
 				)}
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/googleCalendar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/google/googleCalendar.tsx
@@ -52,6 +52,7 @@ function renderPart(
 					onChange={(v) => set({ attendee: v })}
 					className={mark("attendee")}
 					people={options.google?.people ?? []}
+					allowCustom={{ placeholder: "Type an email, press Enter" }}
 					disabled={disabled}
 				/>
 			);


### PR DESCRIPTION
## Summary

Part of the people-picker change: nothing links Superset users to provider accounts, so the editor stops offering the "Me" actor filter and instead lets users pick from the provider's own people list. Stored config shape is unchanged (`"anyone" | "me" | { ids }`).

- **ActorChip**: removed the "Me" checkbox item. A stored `"me"` (legacy rows) still renders its label as "Me" but is never offered. Added an optional `allowCustom?: { placeholder }` prop mirroring `ScopeChip`: type a value, press Enter, it is added to `ids`; typed values that no person describes get their own checked row so they can be unticked. Empty-list copy is now "No people to choose yet". Select/deselect semantics unchanged (`{ ids }`, or `"anyone"` when emptied).
- **Google Calendar attendee chip**: passes `allowCustom={{ placeholder: "Type an email, press Enter" }}` while keeping `people={options.google?.people ?? []}` (Google keeps `listLinkedPeople` as suggestions; tRPC untouched).
- **Circleback**: no change needed — attendees are already a free-text `ScopeChip` with `allowCustom`.
- **`describeTriggerProblems`**: wording for an empty `{ ids: [] }` actor is "Specify at least one person, or choose Anyone." — fine as-is, no rules added.

## Test plan

- [x] `bunx biome check` on touched files exit 0
- [x] `bun run typecheck` in apps/desktop exit 0
- [ ] Open a Google Calendar trigger, click the attendee chip: no "Me" entry, linked people are ticked/unticked as before, typing an email + Enter adds it as a checked row, unticking the last one returns to Anyone
- [ ] Open a legacy automation with `attendee: "me"`: chip reads "Me"; picking anything else replaces it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes “Me” from the actor picker and allows typing attendee emails for Google Calendar. This avoids misleading self-selection (no user-to-provider link) and lets users add people not in the linked list.

- Storage shape unchanged (`"anyone" | "me" | { ids }`). Legacy `"me"` still displays as “Me” but is no longer offered; picking anything else replaces it.
- Actor picker: adds optional allow-custom input; typed values are added to `ids` and shown as toggleable rows; clearing all selections returns to “Anyone”; empty-state copy is “No people to choose yet.”
- Google Calendar attendee chip enables the allow-custom input with a placeholder; suggestions from the provider remain unchanged; no validation or tRPC changes.

<sup>Written for commit 0fa6fb69b0b349df202066fb8e4d2e196cf442b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automation actor pickers now support custom values in addition to existing people.
  - Users can enter and select custom email addresses for Google Calendar attendees.
  - Selected custom values remain visible even when they aren’t in the available people list.
  - Updated picker guidance and empty states improve clarity when no people are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->