### PR TITLE
feat(trpc,desktop): Slack and Linear people pickers from provider directories

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/linear/useLinearOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/linear/useLinearOptions.ts
@@ -4,14 +4,14 @@ import type { ProviderOptions } from "../types";
 
 /**
  * The pickable values a Linear sentence needs: teams, projects, labels and
- * workflow states from Linear, plus the people who have linked a Linear account.
+ * workflow states and members, all from Linear.
  */
 export function useLinearOptions(organizationId: string): ProviderOptions {
 	const options = cloudTrpc.integration.linear.getTriggerOptions.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);
-	const people = cloudTrpc.integration.linear.listLinkedPeople.useQuery(
+	const people = cloudTrpc.integration.linear.listPeople.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/useSlackOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/slack/useSlackOptions.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import type { ProviderOptions } from "../types";
 
-/** The pickable values a Slack sentence needs: channels and linked people. */
+/** The pickable values a Slack sentence needs: channels and workspace members. */
 export function useSlackOptions(organizationId: string): ProviderOptions {
 	// Channel ids, not names — a channel can be renamed and the trigger must
 	// keep matching it afterwards. Same for people: Slack user ids.
@@ -10,7 +10,7 @@ export function useSlackOptions(organizationId: string): ProviderOptions {
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);
-	const people = cloudTrpc.integration.slack.listLinkedPeople.useQuery(
+	const people = cloudTrpc.integration.slack.listPeople.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);

--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -5,8 +5,6 @@ import {
 	type LinearConfig,
 	taskStatuses,
 	tasks,
-	userIdentities,
-	users,
 } from "@superset/db/schema";
 import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import type { TRPCRouterRecord } from "@trpc/server";
@@ -70,6 +68,27 @@ async function fetchAllTriggerOptions(
 		}
 	}
 	return result;
+}
+
+const MAX_PEOPLE = 1000;
+
+async function fetchAllPeople(
+	client: LinearClient,
+): Promise<Array<{ id: string; label: string }>> {
+	const people: Array<{ id: string; label: string }> = [];
+	let page = await client.users({
+		first: 250,
+		filter: { active: { eq: true } },
+	});
+	while (true) {
+		for (const user of page.nodes) {
+			if (user.active === false) continue;
+			people.push({ id: user.id, label: user.displayName || user.name });
+		}
+		if (!page.pageInfo.hasNextPage || people.length >= MAX_PEOPLE) break;
+		page = await page.fetchNext();
+	}
+	return people;
 }
 
 export const linearRouter = {
@@ -236,30 +255,17 @@ export const linearRouter = {
 			};
 		}),
 
-	/** People in the org who have linked a Linear account, as assignee options. */
-	listLinkedPeople: protectedProcedure
+	/**
+	 * The workspace's active members, keyed by Linear user id — what a
+	 * webhook's `assigneeId` and actor id carry.
+	 */
+	listPeople: protectedProcedure
 		.input(z.object({ organizationId: z.uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
-			const rows = await db
-				.select({
-					linearUserId: userIdentities.externalId,
-					displayName: userIdentities.displayName,
-					name: users.name,
-					email: users.email,
-				})
-				.from(userIdentities)
-				.innerJoin(users, eq(users.id, userIdentities.userId))
-				.where(
-					and(
-						eq(userIdentities.organizationId, input.organizationId),
-						eq(userIdentities.provider, "linear"),
-					),
-				);
-			return rows.map((row) => ({
-				id: row.linearUserId,
-				label: row.displayName ?? row.name ?? row.email,
-			}));
+			const people = await callLinear(input.organizationId, fetchAllPeople);
+			if (!people) return [];
+			return people.sort((a, b) => a.label.localeCompare(b.label));
 		}),
 
 	updateConfig: protectedProcedure

--- a/packages/trpc/src/router/integration/slack/list-people.ts
+++ b/packages/trpc/src/router/integration/slack/list-people.ts
@@ -1,0 +1,64 @@
+/**
+ * The workspace's human members, for the trigger editor's people picker. Keyed
+ * by Slack user id — what an event's `user` carries and the matcher compares
+ * against. Same direct-fetch shape as `listSlackChannels`.
+ */
+
+type UsersListResponse = {
+	ok: boolean;
+	error?: string;
+	members?: Array<{
+		id?: string;
+		name?: string;
+		real_name?: string;
+		deleted?: boolean;
+		is_bot?: boolean;
+	}>;
+	response_metadata?: { next_cursor?: string };
+};
+
+const PAGE_SIZE = 200;
+const MAX_PEOPLE = 1000;
+
+export async function listSlackPeople(
+	accessToken: string,
+): Promise<Array<{ id: string; label: string }>> {
+	const people: Array<{ id: string; label: string }> = [];
+	let cursor: string | undefined;
+
+	while (people.length < MAX_PEOPLE) {
+		const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+		if (cursor) params.set("cursor", cursor);
+
+		let data: UsersListResponse;
+		try {
+			const response = await fetch(
+				`https://slack.com/api/users.list?${params.toString()}`,
+				{
+					headers: { Authorization: `Bearer ${accessToken}` },
+					signal: AbortSignal.timeout(5_000),
+				},
+			);
+			data = (await response.json()) as UsersListResponse;
+		} catch (error) {
+			console.error("[slack/listPeople] users.list failed:", error);
+			break;
+		}
+		if (!data.ok) {
+			// `missing_scope` until the app is reinstalled with users:read; an empty
+			// picker is the honest state, not an error the editor can act on.
+			console.error("[slack/listPeople] users.list failed:", data.error);
+			break;
+		}
+		for (const member of data.members ?? []) {
+			if (!member.id || member.deleted || member.is_bot) continue;
+			if (member.id === "USLACKBOT") continue;
+			const label = member.real_name || member.name;
+			if (label) people.push({ id: member.id, label });
+		}
+		cursor = data.response_metadata?.next_cursor || undefined;
+		if (!cursor) break;
+	}
+
+	return people.sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/packages/trpc/src/router/integration/slack/slack.ts
+++ b/packages/trpc/src/router/integration/slack/slack.ts
@@ -1,15 +1,12 @@
 import { db } from "@superset/db/client";
-import {
-	integrationConnections,
-	userIdentities,
-	users,
-} from "@superset/db/schema";
+import { integrationConnections } from "@superset/db/schema";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
 import { listSlackChannels } from "./list-channels";
+import { listSlackPeople } from "./list-people";
 
 export const slackRouter = {
 	getConnection: protectedProcedure
@@ -58,48 +55,25 @@ export const slackRouter = {
 		}),
 
 	/**
-	 * People in this organization who have linked a Slack account, keyed by
-	 * Slack user id — what the matcher compares an event's `user` against.
+	 * The connected workspace's members, keyed by Slack user id — what the
+	 * matcher compares an event's `user` against.
 	 */
-	listLinkedPeople: protectedProcedure
+	listPeople: protectedProcedure
 		.input(z.object({ organizationId: z.uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
 
-			// A Slack user id is only unique within a workspace, so only identities
-			// from the connected workspace can ever match an event from it.
 			const connection = await db.query.integrationConnections.findFirst({
 				where: and(
 					eq(integrationConnections.organizationId, input.organizationId),
 					eq(integrationConnections.provider, "slack"),
 					isNull(integrationConnections.disconnectedAt),
 				),
-				columns: { externalOrgId: true },
+				columns: { accessToken: true },
 			});
-			if (!connection?.externalOrgId) return [];
+			if (!connection) return [];
 
-			const rows = await db
-				.select({
-					slackUserId: userIdentities.externalId,
-					handle: userIdentities.handle,
-					displayName: userIdentities.displayName,
-					name: users.name,
-					email: users.email,
-				})
-				.from(userIdentities)
-				.innerJoin(users, eq(users.id, userIdentities.userId))
-				.where(
-					and(
-						eq(userIdentities.organizationId, input.organizationId),
-						eq(userIdentities.provider, "slack"),
-						eq(userIdentities.externalScopeId, connection.externalOrgId),
-					),
-				);
-
-			return rows.map((row) => ({
-				id: row.slackUserId,
-				label: row.displayName ?? row.handle ?? row.name ?? row.email,
-			}));
+			return listSlackPeople(connection.accessToken);
 		}),
 
 	disconnect: protectedProcedure


### PR DESCRIPTION
## Summary

Part of the people-picker rework (the "Me" actor filter is dropped; every provider offers a picker sourced from its own directory).

- **Slack**: `integration.slack.listPeople` replaces `listLinkedPeople`. New `list-people.ts` calls `users.list` with the org connection's bot token (`limit=200`, cursor pagination, capped at 1000), skips `deleted`, `is_bot` and `USLACKBOT`, returns `{ id: <Slack user id>, label: real_name || name }` sorted by label. On auth/scope error or network failure it logs and returns what it has (empty on first page) rather than throwing into the editor. `id` matches what `normalize.ts` puts in `actorId` (`event.user`). `users:read` was already in both the connect scope list and the manifest, so `apps/api` is untouched.
- **Linear**: `integration.linear.listPeople` replaces `listLinkedPeople`. Pages `client.users({ first: 250, filter: { active: { eq: true } } })` via `fetchNext()`, capped at 1000, drops `active === false`, returns `{ id: <Linear user id>, label: displayName || name }` sorted by label. Goes through `callLinear`, so token refresh / auth failure yields `[]`. `id` matches `assigneeId` / `actor.id` in `recordLinearEvent.ts`.
- Removed both `user_identities` queries and the now-unused `userIdentities`/`users` imports.
- `useSlackOptions` / `useLinearOptions` call the new procedures; both already exposed `people`, and `slack.tsx` / `linear.tsx` already read `options.<kind>?.people`.

## Test plan

- [x] `bunx biome check` on touched files exits 0
- [x] `bunx tsc --noEmit` in `packages/trpc` exits 0
- [x] `bun run typecheck` in `apps/desktop` exits 0
- [ ] In the trigger editor with Slack/Linear connected, the actor/assignee chip lists workspace members; picking one and firing an event from that person matches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sources Slack and Linear people pickers from provider directories instead of linked identities, so triggers can target any workspace member. Previously `listLinkedPeople` returned only users who linked accounts; now `listPeople` returns active members by provider user id, with graceful handling of auth/network issues.

- Replaces `integration.slack.listLinkedPeople` and `integration.linear.listLinkedPeople` with `listPeople`; `apps/desktop` hooks now call the new procedures. Update any remaining callers to use `listPeople` (same return shape: `{ id, label }`), and expect lists capped at 1000 and sorted by label.
- Slack: `listPeople` calls `users.list` with the org bot token, skips `deleted`, `is_bot`, and `USLACKBOT`, paginates (`limit=200`), and logs on scope/network errors, returning the collected page(s) or `[]`. `users:read` is already in the app’s scopes.
- Linear: `listPeople` pages `client.users({ first: 250, filter: { active: { eq: true } } })` via `callLinear`, returns active members only, capped at 1000; auth/refresh failures yield `[]`.
- IDs match event payloads used by matchers: Slack `event.user`; Linear `assigneeId`/actor id.
- Removes `user_identities`-based queries and related imports; no DB migration required.

<sup>Written for commit f85246c7e974032f36c16e43bf6c7748551eff69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation options now include active members directly from connected Linear and Slack workspaces.
  * Member lists support pagination, sorting, and up to 1,000 entries for broader coverage.

* **Bug Fixes**
  * Removed reliance on linked local identities when loading Linear and Slack members.
  * Excludes inactive, deleted, bot, and unnamed Slack accounts from member options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->