### PR TITLE
feat(trpc,desktop): directory-backed people pickers for GitHub, Teams and Notion triggers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,7 @@ SLACK_BILLING_WEBHOOK_URL=
 # -----------------------------------------------------------------------------
 # Microsoft Teams Integration (optional; Entra app registration with
 # application permissions ChannelMessage.Read.All, Channel.ReadBasic.All,
-# Team.ReadBasic.All)
+# Team.ReadBasic.All, User.ReadBasic.All)
 # -----------------------------------------------------------------------------
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/useGithubOptions.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import type { ProviderOptions } from "../types";
 
-/** The pickable values a GitHub sentence needs: repositories and linked people. */
+/** The pickable values a GitHub sentence needs: repositories and the installation's people. */
 export function useGithubOptions(organizationId: string): ProviderOptions {
 	// repoId is GitHub's numeric id, which is what the matcher compares against —
 	// a full name would stop matching the moment someone renames the repo.
@@ -10,7 +10,7 @@ export function useGithubOptions(organizationId: string): ProviderOptions {
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);
-	const people = cloudTrpc.integration.github.listLinkedPeople.useQuery(
+	const people = cloudTrpc.integration.github.listPeople.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/microsoftTeams.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/microsoftTeams.tsx
@@ -51,16 +51,13 @@ function renderPart(
 				/>
 			);
 		case "actor":
-			// Anyone or Me only. The shared people list holds GitHub ids, which is
-			// the wrong id space; Teams people are Entra object ids, resolved for
-			// `me` through user_identities at match time.
 			return (
 				<ActorChip
 					key={index}
 					actor={config.actor}
 					onChange={(v) => set({ actor: v })}
 					className={mark("actor")}
-					people={[]}
+					people={options.microsoftTeams?.people ?? []}
 					disabled={disabled}
 				/>
 			);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/useTeamsOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/microsoftTeams/useTeamsOptions.ts
@@ -3,10 +3,10 @@ import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import type { ProviderOptions } from "../types";
 
 /**
- * The pickable values a Teams sentence needs: the tenant's teams, and every
- * channel in them labelled "Team › Channel". Both come from Graph through the
- * connection's app token; without a connection both are empty and the chips
- * say so.
+ * The pickable values a Teams sentence needs: the tenant's teams, every
+ * channel in them labelled "Team › Channel", and the tenant's people as Entra
+ * object ids. All come from Graph through the connection's app token; without
+ * a connection all are empty and the chips say so.
  */
 export function useTeamsOptions(organizationId: string): ProviderOptions {
 	const teams = cloudTrpc.integration.microsoftTeams.listTeams.useQuery(
@@ -14,6 +14,10 @@ export function useTeamsOptions(organizationId: string): ProviderOptions {
 		{ enabled: Boolean(organizationId), staleTime: 5 * 60 * 1000 },
 	);
 	const channels = cloudTrpc.integration.microsoftTeams.listChannels.useQuery(
+		{ organizationId },
+		{ enabled: Boolean(organizationId), staleTime: 5 * 60 * 1000 },
+	);
+	const people = cloudTrpc.integration.microsoftTeams.listPeople.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId), staleTime: 5 * 60 * 1000 },
 	);
@@ -26,8 +30,9 @@ export function useTeamsOptions(organizationId: string): ProviderOptions {
 					id: channel.id,
 					label: channel.label,
 				})),
+				people: people.data ?? [],
 			},
 		}),
-		[teams.data, channels.data],
+		[teams.data, channels.data, people.data],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/notion.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/notion.tsx
@@ -59,7 +59,7 @@ function renderPart(
 					actor={c.actor}
 					onChange={(v) => set({ actor: v })}
 					className={mark("actor")}
-					people={options.notion?.users ?? []}
+					people={options.notion?.people ?? []}
 					disabled={disabled}
 				/>
 			);
@@ -70,7 +70,7 @@ function renderPart(
 					actor={c.mentionedUser}
 					onChange={(v) => set({ mentionedUser: v })}
 					className={mark("mentionedUser")}
-					people={options.notion?.users ?? []}
+					people={options.notion?.people ?? []}
 					disabled={disabled}
 				/>
 			);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/useNotionOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/notion/useNotionOptions.ts
@@ -12,7 +12,7 @@ export function useNotionOptions(organizationId: string): ProviderOptions {
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);
-	const users = cloudTrpc.integration.notion.listUsers.useQuery(
+	const people = cloudTrpc.integration.notion.listPeople.useQuery(
 		{ organizationId },
 		{ enabled: Boolean(organizationId) },
 	);
@@ -21,9 +21,9 @@ export function useNotionOptions(organizationId: string): ProviderOptions {
 		() => ({
 			notion: {
 				dataSources: dataSources.data ?? [],
-				users: users.data ?? [],
+				people: people.data ?? [],
 			},
 		}),
-		[dataSources.data, users.data],
+		[dataSources.data, people.data],
 	);
 }

--- a/packages/trpc/src/router/integration/github/github.ts
+++ b/packages/trpc/src/router/integration/github/github.ts
@@ -3,8 +3,6 @@ import {
 	githubInstallations,
 	githubPullRequests,
 	githubRepositories,
-	userIdentities,
-	users,
 } from "@superset/db/schema";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
@@ -14,6 +12,7 @@ import { z } from "zod";
 import { env } from "../../../env";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
+import { listGithubPeople } from "./people";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN });
 
@@ -98,42 +97,11 @@ export const githubRouter = {
 			return { success: true };
 		}),
 
-	/**
-	 * People a GitHub trigger can filter on, as GitHub identities.
-	 *
-	 * The ids are GitHub's, not Superset's, because that is what an event
-	 * carries and what matching compares — a login can be renamed, an id
-	 * cannot. Today this is org members who have linked GitHub; it widens to
-	 * repository collaborators when those are synced, and the shape does not
-	 * change when it does.
-	 */
-	listLinkedPeople: protectedProcedure
+	listPeople: protectedProcedure
 		.input(z.object({ organizationId: z.string().uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
-
-			const rows = await db
-				.select({
-					githubUserId: userIdentities.externalId,
-					handle: userIdentities.handle,
-					name: users.name,
-					email: users.email,
-				})
-				.from(userIdentities)
-				.innerJoin(users, eq(users.id, userIdentities.userId))
-				.where(
-					and(
-						eq(userIdentities.organizationId, input.organizationId),
-						eq(userIdentities.provider, "github"),
-					),
-				);
-
-			return rows.map((row) => ({
-				id: row.githubUserId,
-				// The handle is not always known — a sign-in gives the id without it
-				// — so fall back to the person we do know.
-				label: row.handle ?? row.name ?? row.email,
-			}));
+			return listGithubPeople(input.organizationId);
 		}),
 
 	listRepositories: protectedProcedure

--- a/packages/trpc/src/router/integration/github/people.ts
+++ b/packages/trpc/src/router/integration/github/people.ts
@@ -1,0 +1,87 @@
+import { db } from "@superset/db/client";
+import { githubInstallations, githubRepositories } from "@superset/db/schema";
+import { eq } from "drizzle-orm";
+import { installationOctokit } from "../../../lib/blaxel/clone-token";
+
+const PER_PAGE = 100;
+const MAX_PEOPLE = 1000;
+
+type GithubAccount = { id: number | bigint; login: string };
+type Page = (page: number) => Promise<{ data: GithubAccount[] }>;
+
+async function collect(seen: Map<string, string>, fetchPage: Page) {
+	for (let page = 1; seen.size < MAX_PEOPLE; page++) {
+		const { data } = await fetchPage(page);
+		for (const account of data) seen.set(String(account.id), account.login);
+		if (data.length < PER_PAGE) return;
+	}
+}
+
+function isPermissionError(error: unknown): boolean {
+	const status = (error as { status?: unknown }).status;
+	return status === 403 || status === 404;
+}
+
+/**
+ * The accounts a GitHub trigger can filter on, keyed by GitHub's numeric id —
+ * the same value a delivery's `sender.id` carries, so a login rename cannot
+ * break a saved filter. Organization installations list the organization's
+ * members; user installations list the collaborators of the synced
+ * repositories, deduplicated.
+ */
+export async function listGithubPeople(
+	organizationId: string,
+): Promise<Array<{ id: string; label: string }>> {
+	const installation = await db.query.githubInstallations.findFirst({
+		where: eq(githubInstallations.organizationId, organizationId),
+		columns: {
+			id: true,
+			installationId: true,
+			accountLogin: true,
+			accountType: true,
+		},
+	});
+	if (!installation) return [];
+
+	const octokit = await installationOctokit(installation.installationId);
+	const seen = new Map<string, string>();
+	try {
+		if (installation.accountType === "Organization") {
+			await collect(seen, (page) =>
+				octokit.request("GET /orgs/{org}/members", {
+					org: installation.accountLogin,
+					per_page: PER_PAGE,
+					page,
+				}),
+			);
+		} else {
+			const repositories = await db.query.githubRepositories.findMany({
+				where: eq(githubRepositories.installationId, installation.id),
+				columns: { owner: true, name: true },
+			});
+			for (const repository of repositories) {
+				if (seen.size >= MAX_PEOPLE) break;
+				await collect(seen, (page) =>
+					octokit.request("GET /repos/{owner}/{repo}/collaborators", {
+						owner: repository.owner,
+						repo: repository.name,
+						per_page: PER_PAGE,
+						page,
+					}),
+				);
+			}
+		}
+	} catch (error) {
+		// The App was installed without the members permission (or the
+		// repository is gone): an empty picker, not a red editor.
+		if (isPermissionError(error)) {
+			console.warn("[integration.github] listPeople refused:", error);
+			return [];
+		}
+		throw error;
+	}
+
+	return [...seen]
+		.map(([id, login]) => ({ id, label: login }))
+		.sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/packages/trpc/src/router/integration/microsoft-teams/graph.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/graph.ts
@@ -231,14 +231,15 @@ export async function graphRequest<T>(
 	return json as T;
 }
 
-/** A collection, following `@odata.nextLink` up to a page cap. */
+/** A collection, following `@odata.nextLink` up to a page cap or `limit` items. */
 export async function graphList<T>(
 	accessToken: string,
 	path: string,
+	limit = Number.POSITIVE_INFINITY,
 ): Promise<T[]> {
 	const items: T[] = [];
 	let next: string | undefined = path;
-	for (let page = 0; next && page < MAX_PAGES; page++) {
+	for (let page = 0; next && page < MAX_PAGES && items.length < limit; page++) {
 		const body: { value?: T[]; "@odata.nextLink"?: string } =
 			await graphRequest(accessToken, next);
 		items.push(...(body.value ?? []));

--- a/packages/trpc/src/router/integration/microsoft-teams/microsoft-teams.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/microsoft-teams.ts
@@ -5,8 +5,12 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
-import { findTeamsConnection, getGraphAccessToken } from "./graph";
-import { listChannels, listTeams } from "./resources";
+import {
+	findTeamsConnection,
+	getGraphAccessToken,
+	isGraphAuthError,
+} from "./graph";
+import { listChannels, listTeams, listUsers } from "./resources";
 import { deleteTeamsSubscriptions } from "./subscriptions";
 
 /** How many teams' channel lists are fetched at once when building the
@@ -103,6 +107,34 @@ export const microsoftTeamsRouter = {
 			return teams
 				.map((team) => ({ id: team.id, label: team.displayName ?? team.id }))
 				.sort((a, b) => a.label.localeCompare(b.label));
+		}),
+
+	listPeople: protectedProcedure
+		.input(z.object({ organizationId: z.uuid() }))
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			const auth = await requireAccessToken(input.organizationId);
+			if (!auth) return [];
+
+			try {
+				const users = await listUsers(auth.accessToken);
+				return users
+					.map((user) => ({
+						id: user.id,
+						label:
+							user.displayName ??
+							user.mail ??
+							user.userPrincipalName ??
+							user.id,
+					}))
+					.sort((a, b) => a.label.localeCompare(b.label));
+			} catch (error) {
+				// The tenant consented before User.ReadBasic.All was asked for: an
+				// empty picker, not a red editor.
+				if (!isGraphAuthError(error)) throw error;
+				console.warn("[microsoft-teams] listPeople refused:", error);
+				return [];
+			}
 		}),
 
 	listChannels: protectedProcedure

--- a/packages/trpc/src/router/integration/microsoft-teams/resources.ts
+++ b/packages/trpc/src/router/integration/microsoft-teams/resources.ts
@@ -37,6 +37,27 @@ export function listTeams(accessToken: string): Promise<GraphTeam[]> {
 	return graphList<GraphTeam>(accessToken, "/teams?$select=id,displayName");
 }
 
+const MAX_PEOPLE = 1000;
+
+export type GraphUser = {
+	id: string;
+	displayName: string | null;
+	mail?: string | null;
+	userPrincipalName?: string | null;
+};
+
+/**
+ * The tenant's people, as Entra object ids — what a channel message's
+ * `from.user.id` carries. Needs the User.ReadBasic.All application permission.
+ */
+export function listUsers(accessToken: string): Promise<GraphUser[]> {
+	return graphList<GraphUser>(
+		accessToken,
+		"/users?$select=id,displayName,mail,userPrincipalName&$top=999",
+		MAX_PEOPLE,
+	);
+}
+
 export function listChannels(
 	accessToken: string,
 	teamId: string,

--- a/packages/trpc/src/router/integration/notion/notion.ts
+++ b/packages/trpc/src/router/integration/notion/notion.ts
@@ -111,7 +111,7 @@ export const notionRouter = {
 	 * The people in the connected workspace, for the actor and mention chips.
 	 * Notion user ids, since that is what a comment's author and mentions carry.
 	 */
-	listUsers: protectedProcedure
+	listPeople: protectedProcedure
 		.input(z.object({ organizationId: z.uuid() }))
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
@@ -120,9 +120,11 @@ export const notionRouter = {
 			if (!connection) return [];
 
 			const users = await listOrEmpty(() => listUsers(connection.accessToken));
-			return users.map((user) => ({
-				id: user.id,
-				label: user.name || user.person?.email || user.id,
-			}));
+			return users
+				.map((user) => ({
+					id: user.id,
+					label: user.name || user.person?.email || user.id,
+				}))
+				.sort((a, b) => a.label.localeCompare(b.label));
 		}),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary

Part of the people-picker change: the actor filter is sourced from each provider's own directory instead of Superset's `user_identities`, so users pick themselves. Config shape (`triggerActorSchema`) is unchanged.

**GitHub** — `integration.github.listPeople` (new, replaces `listLinkedPeople`, which is deleted). Uses the installation Octokit (`installationOctokit` from `lib/blaxel/clone-token.ts`). Organization installations page `GET /orgs/{login}/members`; user installations collect `GET /repos/{owner}/{repo}/collaborators` for the synced repositories and dedupe. `per_page` 100, capped at 1000. `id` is `String(user.id)` — the same value `dispatchMatchingTriggers.ts` puts in `actorId` from `sender.id` — `label` is the login, sorted by label. On 403/404 (App installed without the members permission) it logs and returns `[]`. `useGithubOptions` now calls `listPeople`; `github.tsx` already read `options.github.people`.

**Microsoft Teams** — `integration.microsoftTeams.listPeople` (new). Graph `GET /users?$select=id,displayName,mail,userPrincipalName&$top=999` through the app-only token, following `@odata.nextLink`, capped at 1000 (`graphList` gained an optional item `limit`). `id` is the Entra object id (what `from.user.id` carries in `handleNotification.ts`), `label` is displayName (falls back to mail / UPN / id). On a Graph 401/403 it logs and returns `[]`. `useTeamsOptions` exposes `people`; `microsoftTeams.tsx` actor chip now uses `options.microsoftTeams.people` instead of `[]`.

  **Requires a new application permission: `User.ReadBasic.All`** on the Entra app registration. Added to the permission list documented in `.env.example` (the only place scopes are listed). Tenants that consented before it was granted get an empty picker, not an error, until they re-consent.

**Notion** — `listUsers` renamed to `listPeople` (still filters to `type === "person"`, now sorted by label); `useNotionOptions` key `users` -> `people`; `notion.tsx` updated.

## Test plan

- [x] `bunx biome check` on touched files exit 0
- [x] `bunx tsc --noEmit` in packages/trpc exit 0
- [x] `bun run typecheck` in apps/desktop exit 0
- [ ] With a GitHub org installation, open a GitHub trigger's actor chip: org members listed by login; picking one and firing an event from that account matches
- [ ] With a Teams connection whose app has `User.ReadBasic.All`: actor chip lists tenant users; without it the chip is empty and the server logs `listPeople refused`
- [ ] Notion actor chip unchanged in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Directory-backed people pickers for GitHub, Microsoft Teams, and Notion replace the Superset `user_identities` source so actor filters match provider IDs. The actor config shape (`triggerActorSchema`) is unchanged.

- GitHub: new `integration.github.listPeople` replaces and deletes `listLinkedPeople`. Org installations list org members; user installations list collaborators of synced repositories. Items are keyed by stringified GitHub numeric IDs (`sender.id`) with login labels, sorted; capped at 1000. On missing members permission (403/404), returns [] and logs; `useGithubOptions` now calls `listPeople`.
- Microsoft Teams: new `integration.microsoftTeams.listPeople` reads Graph `/users` via the app-only token. Items are Entra object IDs with display name/mail/UPN fallback labels, sorted; capped at 1000. On Graph 401/403, returns [] and logs; the actor chip now uses `options.microsoftTeams.people`.
- Notion: `listUsers` renamed to `listPeople`; `useNotionOptions` key `users` -> `people`; UI reads `options.notion.people`. Behavior is otherwise unchanged; labels are sorted.

**Rollout and migration**
- Microsoft Teams: grant the Entra app permission `User.ReadBasic.All` and re-consent tenants. Until re-consent, the picker is empty.
- Update client calls: replace `cloudTrpc.integration.github.listLinkedPeople` with `listPeople`; update Notion consumers to `people` instead of `users`.

<sup>Written for commit 53508c398909cd282d537fb46f0e2fef060167b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

