### PR TITLE
fix(mobile): make the ⏎ quick key a real Enter, ordered after esc

### DIFF
--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -154,18 +154,6 @@ export const GlassComposer = forwardRef<
 		setHasText(text.trim().length > 0);
 	};
 
-	// Appends to the draft and leaves the caret after it. The field never
-	// reports where its cursor actually is — both onSelectionChange and a
-	// `selection` state read back {0,0} once you've typed — so the end is the
-	// only position an insert can be sure of. Setting the caret does work.
-	const appendToDraft = (insert: string) => {
-		const next = draftRef.current + insert;
-		writeDraft(next);
-		void fieldRef.current
-			?.setText(next)
-			.then(() => fieldRef.current?.setSelection(next.length, next.length));
-	};
-
 	const attachments = showAttachments
 		? controller.attachments.attachments
 		: NO_ATTACHMENTS;
@@ -300,31 +288,6 @@ export const GlassComposer = forwardRef<
 		</Button>
 	);
 
-	// Explicit line break for multi-line messages: expo-ui's TextField exposes
-	// nothing for the soft keyboard's return key, so this is the only way to
-	// put a newline in a draft. Lives in the terminal's quick-key row, shaped
-	// like the keys beside it; the home composer has no such row and no button.
-	const newlineChip = (
-		<Button
-			onPress={() => {
-				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				appendToDraft("\n");
-			}}
-			modifiers={[
-				buttonStyle("bordered"),
-				buttonBorderShape("roundedRectangle", 10),
-				tint(FOREGROUND),
-				accessibilityLabel("New line"),
-			]}
-		>
-			<Image
-				systemName="return"
-				size={13}
-				modifiers={[frame({ width: 24, height: 17 })]}
-			/>
-		</Button>
-	);
-
 	const voiceControl = <VoiceControl dictation={dictation} />;
 
 	// Inserted beside the mic when a draft exists: the animated layout change
@@ -372,7 +335,6 @@ export const GlassComposer = forwardRef<
 				>
 					{above ? (
 						<HStack spacing={8} modifiers={[padding({ horizontal: 2 })]}>
-							{newlineChip}
 							{above}
 						</HStack>
 					) : null}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -236,9 +236,16 @@ export function WorkspaceScreen() {
 		[hostUrl, activeTerminalId, id],
 	);
 
-	const handleQuickKey = useCallback((key: TerminalQuickKey) => {
-		if (key.data) terminalRef.current?.sendInput(key.data);
-	}, []);
+	const handleQuickKey = useCallback(
+		(key: TerminalQuickKey) => {
+			if (key.submits) {
+				void handleSubmit("").catch(() => undefined);
+				return;
+			}
+			if (key.data) terminalRef.current?.sendInput(key.data);
+		},
+		[handleSubmit],
+	);
 
 	const banner = STATE_BANNERS[connectionState];
 	const showComposer = activeTerminalId !== null && routingKey !== null;

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/constants.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/constants.ts
@@ -14,14 +14,17 @@ export interface TerminalQuickKey {
 	label?: string;
 	/** SF Symbol name (e.g. "arrow.up"). */
 	symbol?: SFSymbolName;
-	/** Raw bytes written into the PTY. */
+	/** Raw bytes written into the PTY. Empty for keys that submit instead. */
 	data: string;
+	/** Sent through the host's Enter path rather than as raw bytes, so a TUI never mistakes it for a paste. */
+	submits?: true;
 }
 
 // Escape/tab/arrow keys the soft keyboard doesn't have. The leading expander
 // (`»`) reveals the wider set (ctrl, space, function keys) in a later pass.
 export const QUICK_KEYS: TerminalQuickKey[] = [
 	{ id: "esc", label: "esc", data: "\u001b" },
+	{ id: "enter", symbol: "return", data: "", submits: true },
 	{ id: "tab", label: "tab", data: "\t" },
 	{ id: "shift-tab", label: "⇧tab", data: "\u001b[Z" },
 	{ id: "up", symbol: "arrow.up", data: "\u001b[A" },

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -171,12 +171,16 @@ export const terminalRouter = router({
 	// is framed as a bracketed paste server-side.
 	send: protectedProcedure
 		.input(
-			z.object({
-				terminalId: z.string(),
-				workspaceId: z.string(),
-				text: z.string().min(1),
-				submit: z.boolean().default(true),
-			}),
+			z
+				.object({
+					terminalId: z.string(),
+					workspaceId: z.string(),
+					text: z.string(),
+					submit: z.boolean().default(true),
+				})
+				.refine((input) => input.submit || input.text.length > 0, {
+					message: "Nothing to send",
+				}),
 		)
 		.mutation(async ({ ctx, input }) => {
 			const result = await writeFramedInputToSession({


### PR DESCRIPTION
## What & why

The ⏎ button above the terminal composer looked like Enter but only appended a newline to the draft — it never sent anything to the terminal. So there was no way from the phone to confirm a selection in an agent's questionnaire: the draft is empty, and the button did nothing you could see.

- It is now a real **Enter quick key**, second in the row after **esc** (`esc · ⏎ · tab · ⇧tab · ↑ ↓ ← → · ^C`).
- It sends through the host's `terminal.send` rather than raw `\r` down the attached stream, so it gets the same delayed, paste-aware handling as a typed submit and a TUI never mistakes it for a paste.
- `terminal.send` now accepts empty text when it submits — the bare-Enter path already existed one line below the `min(1)` validator that refused it. Empty text with `submit: false` is still rejected.
- The chip is removed from `GlassComposer` entirely, so the composer owns nothing Enter-shaped. It had been re-added there more than once.

One thing this changes: the old chip was the only way to put a line break in a draft, per its own comment. The field is `axis="vertical"`, where the soft keyboard's return key inserts a newline natively — verified below.

## How I tested it

Local stack against the PR's Neon branch, iPhone 16e simulator, live Claude Code session in a workspace terminal.

- Opened a Claude questionnaire (`AskUserQuestion`), moved the selection with ↓, tapped ⏎ — the answer submitted.
- Typed a draft, pressed the keyboard's return, typed more — two lines in the draft, sent as one message.
- esc / tab / arrows unchanged.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the mobile ⏎ quick key send a real Enter via the host and place it after esc. Before, the ⏎ button only appended a newline to the draft and never submitted, blocking confirmations in terminal questionnaires.

- Add `enter` to `QUICK_KEYS` with `submits: true`; `WorkspaceScreen` routes it to `handleSubmit("")`, which calls `terminal.send` for paste-aware Enter handling.
- Update `terminal.send` to accept empty `text` when `submit` is true; empty text with `submit: false` still fails.
- Remove the newline chip from `GlassComposer`; multi-line drafts still use the soft keyboard return in the vertical field.
- Order the quick keys with Enter second (after `esc`, before `tab`).

<sup>Written for commit 67c544d8c4616982da143f92766e675f6fc201d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

