### PR TITLE
fix(host-service): let destroy complete when the project repo is gone from disk

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { sanitizePromptForPty } from "@superset/shared/agent-prompt-launch";
 import { TRPCError } from "@trpc/server";
@@ -355,6 +355,16 @@ async function runDestroy(
 
 /** "merged" when the linked PR was observed merged; every other delete —
  * open/closed/draft PR or none at all — is a plain "deleted". */
+/** existsSync also answers false for a path that exists but cannot be read;
+ * this answers true only when the path is really absent. */
+function isMissingDirectory(path: string): boolean {
+	try {
+		return statSync(path, { throwIfNoEntry: false }) === undefined;
+	} catch {
+		return false;
+	}
+}
+
 function archiveReasonFor(
 	ctx: HostServiceContext,
 	local: { pullRequestId: string | null },
@@ -448,10 +458,13 @@ async function runDestroyPhases(
 	}
 	if (local && project) {
 		worktreeRemoved = !existsSync(local.worktreePath);
-		if (!worktreeRemoved && !existsSync(project.repoPath)) {
+		if (!worktreeRemoved && isMissingDirectory(project.repoPath)) {
 			// The project repo was moved or deleted outside Superset: there is
 			// no repository to run `git worktree remove` in, and the worktree's
 			// gitdir pointer is already dead, so no retry can ever succeed.
+			// Only a genuine ENOENT takes this branch — a repo this process
+			// merely cannot read (EPERM/EACCES) is not gone, and keeps the
+			// "failed to open" throw below rather than losing its worktree.
 			// Delete the folder directly under the same root guard the
 			// sessions branch uses — anything outside the project's managed
 			// worktrees root is left on disk (warned) while the delete proceeds.

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -21,7 +21,9 @@ import type {
 	TeardownFailureCause,
 } from "../../error-types";
 import { protectedProcedure, router } from "../../index";
+import { getHostWorktreeBaseDir } from "../settings/worktree-location";
 import { isInsideSessionsRoot } from "../workspace-creation/shared/session-paths";
+import { isInsideProjectWorktreesRoot } from "../workspace-creation/shared/worktree-paths";
 import { cleanupGitOps, isIndeterminateGitTaskFailure } from "./git-ops";
 import { isMainWorkspace } from "./is-main-workspace";
 
@@ -446,19 +448,52 @@ async function runDestroyPhases(
 	}
 	if (local && project) {
 		worktreeRemoved = !existsSync(local.worktreePath);
-		try {
-			repoGitEnv = await cleanupGitOps.resolveGitEnv(ctx, project.repoPath);
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			if (!worktreeRemoved) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: `Failed to open project repo at ${project.repoPath}: ${message}`,
-				});
+		if (!worktreeRemoved && !existsSync(project.repoPath)) {
+			// The project repo was moved or deleted outside Superset: there is
+			// no repository to run `git worktree remove` in, and the worktree's
+			// gitdir pointer is already dead, so no retry can ever succeed.
+			// Delete the folder directly under the same root guard the
+			// sessions branch uses — anything outside the project's managed
+			// worktrees root is left on disk (warned) while the delete proceeds.
+			const worktreeBaseDir =
+				project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
+			if (
+				!isInsideProjectWorktreesRoot(
+					local.worktreePath,
+					project.id,
+					worktreeBaseDir,
+				)
+			) {
+				warnings.push(
+					`Skipped worktree removal at ${local.worktreePath}: project repo at ${project.repoPath} is missing and the folder is outside the managed worktrees root`,
+				);
+			} else {
+				try {
+					await rm(local.worktreePath, { recursive: true, force: true });
+					worktreeRemoved = true;
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message: `Failed to remove worktree at ${local.worktreePath}: ${message}`,
+					});
+				}
 			}
-			warnings.push(
-				`Failed to open project repo at ${project.repoPath}: ${message}`,
-			);
+		} else {
+			try {
+				repoGitEnv = await cleanupGitOps.resolveGitEnv(ctx, project.repoPath);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (!worktreeRemoved) {
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message: `Failed to open project repo at ${project.repoPath}: ${message}`,
+					});
+				}
+				warnings.push(
+					`Failed to open project repo at ${project.repoPath}: ${message}`,
+				);
+			}
 		}
 
 		if (repoGitEnv) {

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isInsideProjectWorktreesRoot } from "./worktree-paths";
+
+describe("isInsideProjectWorktreesRoot", () => {
+	const dirs: string[] = [];
+	const tmp = (prefix: string) => {
+		const d = mkdtempSync(join(tmpdir(), prefix));
+		dirs.push(d);
+		return d;
+	};
+	afterEach(() => {
+		for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+	});
+
+	test("accepts a worktree beneath <base>/<projectId>", () => {
+		const base = tmp("wt-base-");
+		mkdirSync(join(base, "proj", "feature"), { recursive: true });
+		expect(
+			isInsideProjectWorktreesRoot(join(base, "proj", "feature"), "proj", base),
+		).toBe(true);
+	});
+
+	test("rejects the project root itself, siblings, and paths outside the base", () => {
+		const base = tmp("wt-base-");
+		mkdirSync(join(base, "proj"), { recursive: true });
+		expect(isInsideProjectWorktreesRoot(join(base, "proj"), "proj", base)).toBe(
+			false,
+		);
+		expect(
+			isInsideProjectWorktreesRoot(join(base, "other", "x"), "proj", base),
+		).toBe(false);
+		expect(
+			isInsideProjectWorktreesRoot(join(tmp("elsewhere-"), "x"), "proj", base),
+		).toBe(false);
+	});
+
+	test("rejects a worktree under a project root that is a symlink out of the base", () => {
+		const base = tmp("wt-base-");
+		const outside = tmp("wt-outside-");
+		mkdirSync(join(outside, "feature"), { recursive: true });
+		symlinkSync(outside, join(base, "proj"));
+		expect(
+			isInsideProjectWorktreesRoot(join(base, "proj", "feature"), "proj", base),
+		).toBe(false);
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { TRPCError } from "@trpc/server";
@@ -36,6 +37,31 @@ export function projectWorktreesRoot(
 	worktreeBaseDir?: string | null,
 ): string {
 	return resolve(worktreeBaseDir ?? defaultWorktreesRoot(), projectId);
+}
+
+/**
+ * True when `path` resolves strictly inside the project's managed worktrees
+ * root. The destroy saga's direct `rm -rf` (taken when the project repo is
+ * gone and there is nothing to run `git worktree remove` in) refuses
+ * anything else, so an adopted or corrupt `worktreePath` can never delete
+ * user data outside the managed folder.
+ */
+export function isInsideProjectWorktreesRoot(
+	path: string,
+	projectId: string,
+	worktreeBaseDir?: string | null,
+): boolean {
+	const root = normalizePath(projectWorktreesRoot(projectId, worktreeBaseDir));
+	const resolved = normalizePath(path);
+	return resolved !== root && resolved.startsWith(root + sep);
+}
+
+function normalizePath(p: string): string {
+	try {
+		return realpathSync(p);
+	} catch {
+		return resolve(p);
+	}
 }
 
 export function safeResolveWorktreePath(

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -51,9 +51,17 @@ export function isInsideProjectWorktreesRoot(
 	projectId: string,
 	worktreeBaseDir?: string | null,
 ): boolean {
+	// Both prefixes are canonicalised: a `<base>/<projectId>` entry that is a
+	// symlink out of the base would otherwise let a path beneath it pass.
+	const base = normalizePath(worktreeBaseDir ?? defaultWorktreesRoot());
 	const root = normalizePath(projectWorktreesRoot(projectId, worktreeBaseDir));
 	const resolved = normalizePath(path);
-	return resolved !== root && resolved.startsWith(root + sep);
+	return (
+		root !== base &&
+		root.startsWith(base + sep) &&
+		resolved !== root &&
+		resolved.startsWith(root + sep)
+	);
 }
 
 function normalizePath(p: string): string {

--- a/packages/host-service/test/helpers/seed.ts
+++ b/packages/host-service/test/helpers/seed.ts
@@ -28,6 +28,7 @@ export interface SeedProjectOptions {
 	repoUrl?: string;
 	repoProvider?: string;
 	remoteName?: string;
+	worktreeBaseDir?: string | null;
 }
 
 export function seedProject(
@@ -45,6 +46,7 @@ export function seedProject(
 			repoUrl: options.repoUrl,
 			repoProvider: options.repoProvider,
 			remoteName: options.remoteName,
+			worktreeBaseDir: options.worktreeBaseDir,
 		})
 		.run();
 	return { id };

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -463,6 +465,57 @@ describe("workspaceCleanup.destroy integration", () => {
 			await host.dispose();
 			repo.dispose();
 			rmSync(outside, { recursive: true, force: true });
+			rmSync(worktreeBaseDir, { recursive: true, force: true });
+		}
+	});
+
+	test("unreadable project repo is not treated as missing: destroy still throws and the worktree stays", async () => {
+		// existsSync says false for EPERM/EACCES too. A repo this process merely
+		// cannot read (macOS privacy protection, a permissions accident) must not
+		// take the direct-delete branch — the worktree may hold uncommitted work
+		// and the repo is intact. The old "failed to open" throw stays.
+		if (process.getuid?.() === 0) return; // root ignores mode bits
+		await scenario.dispose();
+		const host = await createTestHost();
+		const repo = await createGitFixture();
+		const worktreeBaseDir = mkdtempSync(
+			join(tmpdir(), "host-service-worktrees-"),
+		);
+		const lockedParent = mkdtempSync(join(tmpdir(), "host-service-locked-"));
+		const lockedRepo = join(lockedParent, "repo");
+		const { id: projectId } = seedProject(host, {
+			repoPath: lockedRepo,
+			worktreeBaseDir,
+		});
+		const worktreePath = join(worktreeBaseDir, projectId, "feature-locked");
+		mkdirSync(join(worktreeBaseDir, projectId), { recursive: true });
+		await repo.git.raw([
+			"worktree",
+			"add",
+			"-b",
+			"feature/locked",
+			worktreePath,
+		]);
+		const { id: workspaceId } = seedWorkspace(host, {
+			projectId,
+			worktreePath,
+			branch: "feature/locked",
+		});
+		// Park the repo under a parent this process cannot traverse, so
+		// stat(repoPath) fails with EACCES rather than ENOENT.
+		renameSync(repo.repoPath, lockedRepo);
+		chmodSync(lockedParent, 0o000);
+
+		try {
+			await expect(
+				host.trpc.workspaceCleanup.destroy.mutate({ workspaceId, force: true }),
+			).rejects.toThrow(/Failed to open project repo/);
+			expect(existsSync(worktreePath)).toBe(true);
+		} finally {
+			chmodSync(lockedParent, 0o755);
+			await host.dispose();
+			rmSync(lockedParent, { recursive: true, force: true });
+			repo.dispose();
 			rmSync(worktreeBaseDir, { recursive: true, force: true });
 		}
 	});

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -474,7 +474,8 @@ describe("workspaceCleanup.destroy integration", () => {
 		// cannot read (macOS privacy protection, a permissions accident) must not
 		// take the direct-delete branch — the worktree may hold uncommitted work
 		// and the repo is intact. The old "failed to open" throw stays.
-		if (process.getuid?.() === 0) return; // root ignores mode bits
+		// root ignores mode bits; Windows has neither getuid nor POSIX traversal denial
+		if (process.platform === "win32" || process.getuid?.() === 0) return;
 		await scenario.dispose();
 		const host = await createTestHost();
 		const repo = await createGitFixture();

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -371,6 +371,102 @@ describe("workspaceCleanup.destroy integration", () => {
 		expect(branches.all).not.toContain(scenario.branch);
 	});
 
+	test("missing project repo: worktree inside the managed root is deleted directly", async () => {
+		// The project repo was moved or deleted outside Superset. There is no
+		// repository to run `git worktree remove` in, so the saga must delete
+		// the (dangling) worktree folder itself and still complete — every
+		// retry used to 500 on "Failed to open project repo" (HOST-SERVICE-3A).
+		await scenario.dispose();
+		const host = await createTestHost();
+		const repo = await createGitFixture();
+		const worktreeBaseDir = mkdtempSync(
+			join(tmpdir(), "host-service-worktrees-"),
+		);
+		const { id: projectId } = seedProject(host, {
+			repoPath: repo.repoPath,
+			worktreeBaseDir,
+		});
+		const worktreePath = join(worktreeBaseDir, projectId, "feature-gone");
+		mkdirSync(join(worktreeBaseDir, projectId), { recursive: true });
+		await repo.git.raw(["worktree", "add", "-b", "feature/gone", worktreePath]);
+		const { id: workspaceId } = seedWorkspace(host, {
+			projectId,
+			worktreePath,
+			branch: "feature/gone",
+		});
+		rmSync(repo.repoPath, { recursive: true, force: true });
+
+		try {
+			const result = await host.trpc.workspaceCleanup.destroy.mutate({
+				workspaceId,
+				deleteBranch: true,
+			});
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(true);
+			expect(result.branchDeleted).toBe(false);
+			expect(result.warnings).toEqual([]);
+			expect(existsSync(worktreePath)).toBe(false);
+
+			const remaining = host.db
+				.select()
+				.from(workspaces)
+				.where(eq(workspaces.id, workspaceId))
+				.all();
+			expect(remaining[0]?.archivedAt).not.toBeNull();
+		} finally {
+			await host.dispose();
+			repo.dispose();
+			rmSync(worktreeBaseDir, { recursive: true, force: true });
+		}
+	});
+
+	test("missing project repo: worktree outside the managed root is left on disk with a warning", async () => {
+		// An adopted (or corrupt) worktreePath outside the project's managed
+		// worktrees root must never be rm -rf'd — the delete still succeeds,
+		// the folder stays, and the caller is told why.
+		await scenario.dispose();
+		const host = await createTestHost();
+		const repo = await createGitFixture();
+		const outside = mkdtempSync(join(tmpdir(), "host-service-adopted-"));
+		const worktreeBaseDir = mkdtempSync(
+			join(tmpdir(), "host-service-worktrees-"),
+		);
+		const { id: projectId } = seedProject(host, {
+			repoPath: repo.repoPath,
+			worktreeBaseDir,
+		});
+		const worktreePath = join(outside, "feature-adopted");
+		await repo.git.raw([
+			"worktree",
+			"add",
+			"-b",
+			"feature/adopted",
+			worktreePath,
+		]);
+		const { id: workspaceId } = seedWorkspace(host, {
+			projectId,
+			worktreePath,
+			branch: "feature/adopted",
+		});
+		rmSync(repo.repoPath, { recursive: true, force: true });
+
+		try {
+			const result = await host.trpc.workspaceCleanup.destroy.mutate({
+				workspaceId,
+			});
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(false);
+			expect(result.warnings).toHaveLength(1);
+			expect(result.warnings[0]).toMatch(/outside the managed worktrees root/);
+			expect(existsSync(worktreePath)).toBe(true);
+		} finally {
+			await host.dispose();
+			repo.dispose();
+			rmSync(outside, { recursive: true, force: true });
+			rmSync(worktreeBaseDir, { recursive: true, force: true });
+		}
+	});
+
 	test("opted-in branch delete runs after the local commit point", async () => {
 		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
 			workspaceId: scenario.featureWorkspaceId,

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -379,6 +379,9 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 
 	test("worktree removal failure blocks local delete while the path still exists", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		// The repo must exist on disk: a missing repo directory now takes the
+		// direct-removal branch instead of the mocked git layer under test.
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
 		try {
 			const ctx = makeCtx({
 				workspace: {
@@ -387,7 +390,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 					worktreePath: tmp,
 					branch: "feature",
 				},
-				project: { id: "p-1", repoPath: "/repo" },
+				project: { id: "p-1", repoPath: repo },
 				// git still lists the worktree after the remove attempt — the
 				// authoritative signal that cleanup did not succeed.
 				removeWorktree: async () => ({ stillRegistered: true }),
@@ -409,11 +412,15 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			expect(events).toEqual(["deleted", "created"]);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
 		}
 	});
 
 	test("worktree removal task failure blocks local delete (post-remove state unknown)", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		// The repo must exist on disk: a missing repo directory now takes the
+		// direct-removal branch instead of the mocked git layer under test.
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
 		try {
 			const ctx = makeCtx({
 				workspace: {
@@ -422,7 +429,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 					worktreePath: tmp,
 					branch: "feature",
 				},
-				project: { id: "p-1", repoPath: "/repo" },
+				project: { id: "p-1", repoPath: repo },
 				removeWorktree: async () => {
 					throw new Error("worktree list boom");
 				},
@@ -438,11 +445,15 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			).rejects.toThrow(/Failed to verify worktree removal/i);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
 		}
 	});
 
 	test("git env-resolution failure blocks local delete while the worktree path still exists", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		// The repo must exist on disk: a missing repo directory now takes the
+		// direct-removal branch instead of the mocked git layer under test.
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
 		try {
 			const ctx = makeCtx({
 				workspace: {
@@ -451,7 +462,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 					worktreePath: tmp,
 					branch: "feature",
 				},
-				project: { id: "p-1", repoPath: "/repo" },
+				project: { id: "p-1", repoPath: repo },
 				resolveGitEnvThrows: true,
 			});
 			const caller = workspaceCleanupRouter.createCaller(ctx);
@@ -465,6 +476,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			).rejects.toThrow(/Failed to open project repo/i);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
 		}
 	});
 
@@ -500,6 +512,9 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 
 	test("destroy archives the row and broadcasts once", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		// The repo must exist on disk: a missing repo directory now takes the
+		// direct-removal branch instead of the mocked git layer under test.
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
 		try {
 			const ctx = makeCtx({
 				workspace: {
@@ -508,7 +523,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 					worktreePath: tmp,
 					branch: "feature",
 				},
-				project: { id: "p-1", repoPath: "/repo" },
+				project: { id: "p-1", repoPath: repo },
 			});
 			const caller = workspaceCleanupRouter.createCaller(ctx);
 
@@ -521,6 +536,7 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			expect(ctx.__mocks.broadcastWorkspaceChanged).toHaveBeenCalledTimes(1);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Problem

A user deletes a workspace whose **project repository directory no longer exists on disk** (moved or deleted outside Superset) while the workspace's worktree directory still exists. `workspaceCleanup.destroy` fails every time with a 500 (`Failed to open project repo at <repoPath>: Cannot use simple-git on a directory that does not exist`), un-archives the row, and the workspace reappears. There is no way out from the UI: the events on HOST-SERVICE-3A are one user pressing delete on the same workspace ~10 times over 9 hours.

**User-visible harm:** a workspace whose project repo is gone can never be deleted from the UI; every attempt errors and the row comes back.

**Reach:** the events are from host-service 1.22.0; the code path (`runDestroyPhases`, step 3b) is unchanged on `main`, so this ships in the next host-service/desktop release and reaches every desktop user who deletes a workspace after moving or removing the project folder.

**Why code, not archive/filter:** archiving the issue leaves the user stuck; there is no other layer that can decide "the repo is gone" for the saga; the throw is a protective guard against orphaning disk, but the disk it protects is a dangling worktree whose gitdir pointer is already dead, so no retry can ever succeed. No in-flight PR touches this saga (checked #6381, #6605 — different files).

## Root cause

`runDestroyPhases` step 3b (`if (local && project)`) always tries `cleanupGitOps.resolveGitEnv(ctx, project.repoPath)` to run `git worktree remove` in the project repo. When the repo directory is missing, simple-git's constructor throws, and because the worktree directory still exists the saga throws `INTERNAL_SERVER_ERROR` — a genuinely-unknown-state guard that is wrong for this specific, fully-known state.

## Fix

Check the filesystem before opening the repo — no message matching, and only a genuine **ENOENT** counts: `statSync(repoPath, { throwIfNoEntry: false }) === undefined`. `existsSync` also answers false for a repo this process merely cannot read (EPERM under macOS privacy protection, EACCES), and that repo is intact — its worktree may hold uncommitted work — so it must not take this branch (triage-review addition, second commit). When the repo directory is really missing **and** the worktree directory still exists:

- skip the git-based `worktree remove` — there is no repository to run it in;
- delete the worktree folder directly **only** when it resolves strictly inside the project's managed worktrees root — new `isInsideProjectWorktreesRoot(path, projectId, worktreeBaseDir)` in `worktree-paths.ts`, same shape as `isInsideSessionsRoot` (realpath-normalised, strict-prefix). Third commit (from review): the base directory is canonicalised too and `<base>/<projectId>` must itself sit strictly inside it, so a project-root entry that is a symlink out of the base cannot let a path beneath it pass; unit tests in `worktree-paths.test.ts` (the symlink case fails against the previous guard). The root is resolved the same way workspace creation resolves it: `project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx)` → `<base>/<projectId>`;
- anything outside that root is left on disk with a warning (`Skipped worktree removal at …: project repo at … is missing and the folder is outside the managed worktrees root`) and the delete still succeeds — an adopted or corrupt `worktreePath` can never be `rm -rf`'d;
- mark the worktree removed and continue; step 4 (branch delete) is naturally skipped because there is no git env (`branchDeleted: false`).

Every other path is byte-for-byte unchanged: the repo-exists-but-won't-open case (permissions, corrupt `.git`, credential/remote failure) still throws `Failed to open project repo …` as a 500 — that is a genuine unknown state. Also unchanged: repo missing **and** worktree missing (still resolves via the old branch → warning + success, as before).

**Still reports as 500 on this path, deliberately:** `Failed to open project repo …` when the repo directory exists but cannot be opened, including when it exists but is unreadable by this process (EPERM/EACCES — pinned by the third test); `Failed to remove worktree at …` if the direct `rm` of a managed-root worktree fails (EACCES etc.). Both un-archive the row and stay retryable.

**No typed `cause`:** nothing reads one on this branch (no renderer branch, no retry decision), so it stays a plain `TRPCError({ code, message })`.

Not touched (different causes): `Failed to verify worktree removal` on task timeout/EAGAIN (HOST-SERVICE-17, HOST-SERVICE-2X) and `Couldn't verify worktree state` (HOST-SERVICE-28).

## Verification

Both new tests reproduce the production failure against unfixed `src/` (stashed):

```
$ git stash push -- src/ && bun test test/integration/workspace-cleanup.integration.test.ts -t "missing project repo"
  httpStatus: 500,
  stack: "TRPCError: Failed to open project repo at /private/var/folders/…/host-service-test-repo-1AgyuP: Cannot use simple-git on a directory that does not exist
    at runDestroyPhases (…/workspace-cleanup.ts:454:15)
(fail) workspaceCleanup.destroy integration > missing project repo: worktree outside the managed root is left on disk with a warning [748.17ms]
 0 pass
 2 fail
```

With the fix:

```
$ bunx biome check src/trpc/router/workspace-cleanup/workspace-cleanup.ts src/trpc/router/workspace-creation/shared/worktree-paths.ts test/helpers/seed.ts test/integration/workspace-cleanup.integration.test.ts
Checked 4 files. No fixes applied.   (one --write formatting pass on the test file before this)

$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false      (clean)

$ bun test test/integration/workspace-cleanup.integration.test.ts
 16 pass
 0 fail
 64 expect() calls
Ran 16 tests across 1 file. [9.95s]

$ bun test test/integration/workspace-create-delete.integration.test.ts test/integration/session-create-delete.integration.test.ts test/integration/workspace-delete-teardown.integration.test.ts src/trpc/router/workspace-cleanup
 23 pass
 0 fail
 95 expect() calls
Ran 23 tests across 3 files. [11.44s]
```

(`src/trpc/router/workspace-cleanup` has no unit tests; the destroy saga is covered by the integration suites above.)

New tests in `workspace-cleanup.integration.test.ts`:
- **positive** — project with a custom `worktreeBaseDir`, real `git worktree add` under `<base>/<projectId>/…`, repo directory removed, `destroy` → `success`, `worktreeRemoved: true`, `branchDeleted: false`, no warnings, worktree directory gone, row archived.
- **negative** — worktree at a path outside the managed root, repo removed, `destroy` → `success`, `worktreeRemoved: false`, exactly one `outside the managed worktrees root` warning, directory still on disk.
- **negative (unreadable ≠ missing)** — repo parked under a parent with mode 000 so `stat` fails with EACCES; `destroy` still rejects with `Failed to open project repo` and the worktree stays on disk. Fails against the `existsSync` version (the destroy resolved and deleted the worktree), passes with the ENOENT-only check. Skipped when running as root.

Fourth commit: CI caught four cases in `test/workspace-cleanup.test.ts` (mocked git layer, placeholder `/repo` path) that now routed into the direct-removal branch because their repo path did not exist on disk — fixture change only, they get a real empty temp directory. Full `bun run test` in packages/host-service: **1135 pass, 0 fail** across 113 files.

Third-commit verification: `bunx biome check` clean; `bun run typecheck` clean; `bun test` over the four destroy suites + `workspace-creation/shared`: 102 pass, 0 fail.

Second-commit verification: `bunx biome check` clean on both files; `bun run typecheck` clean; `bun test` over workspace-cleanup + workspace-create-delete + session-create-delete + workspace-delete-teardown: 40 pass, 0 fail.

Refs HOST-SERVICE-3A

https://claude.ai/code/session_a9535131-e42d-466f-b011-268a5e960a27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup when project repositories are unavailable.
  * Safely removes missing worktrees only when they are within the managed worktree directory.
  * Preserves external worktrees and provides a warning instead.
  * Distinguishes inaccessible repositories from missing repositories, preserving them and reporting cleanup failures.
* **Reliability**
  * Added path validation to prevent unintended directory deletion.
  * Improved support for custom worktree base directories.
  * Enhanced cleanup behavior for archived and temporary workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

