### PR TITLE
fix(host-service,relay2): pin tunnel v2 dial-back to loopback; bind standalone host to 127.0.0.1

### DIFF
--- a/apps/relay2/src/index.ts
+++ b/apps/relay2/src/index.ts
@@ -244,6 +244,7 @@ app.get("/hosts/:hostId/*", async (c) => {
 	const hostId = c.get("hostId");
 	const url = new URL(c.req.url);
 	const path = pathAfterHost(c) || "/";
+	if (path.startsWith("//")) return c.json({ error: "Invalid path" }, 400);
 	const query = url.search.slice(1);
 	const ticket = crypto.randomUUID();
 

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -121,9 +121,10 @@ async function main(): Promise<void> {
 		// Install only after the server is listening so startup throws still
 		// reach `main().catch(...)` and exit with a non-zero code.
 		installProcessSafetyNet();
-		console.log(
-			`[host-service] listening on http://${hostname ?? "0.0.0.0"}:${info.port}`,
-		);
+		const address = info.address.includes(":")
+			? `[${info.address}]`
+			: info.address;
+		console.log(`[host-service] listening on http://${address}:${info.port}`);
 
 		startTerminalReaper(db);
 

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -114,11 +114,16 @@ async function main(): Promise<void> {
 		process.on("SIGTERM", () => void devShutdown("SIGTERM"));
 	}
 
-	const server = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
+	const hostname =
+		env.SUPERSET_HOST_RUN_MODE === "sandbox" ? undefined : "127.0.0.1";
+	const listen = { fetch: app.fetch, port: env.PORT, hostname };
+	const server = serve(listen, (info) => {
 		// Install only after the server is listening so startup throws still
 		// reach `main().catch(...)` and exit with a non-zero code.
 		installProcessSafetyNet();
-		console.log(`[host-service] listening on http://localhost:${info.port}`);
+		console.log(
+			`[host-service] listening on http://${hostname ?? "0.0.0.0"}:${info.port}`,
+		);
 
 		startTerminalReaper(db);
 

--- a/packages/host-service/src/tunnel/tunnel-client-v2.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-v2.ts
@@ -139,10 +139,8 @@ export class TunnelClientV2 {
 		const relayWs = new WebSocket(this.dialUrl(dial.ticket));
 		relayWs.binaryType = "arraybuffer";
 
-		const localUrl = new URL(
-			dial.path,
-			`ws://127.0.0.1:${this.options.localPort}`,
-		);
+		const localUrl = new URL(`ws://127.0.0.1:${this.options.localPort}`);
+		localUrl.pathname = dial.path;
 		localUrl.searchParams.set("token", this.options.hostServiceSecret);
 		if (dial.query) {
 			for (const [key, value] of new URLSearchParams(dial.query)) {


### PR DESCRIPTION
## Summary
- Tunnel v2 host client: build the local dial-back URL by assigning `url.pathname` on a fixed `ws://127.0.0.1:<port>` base instead of resolving `dial.path` as a URL reference. `//evil/x`, `/\evil/x` and `ws://evil/x` now stay on loopback.
- relay2: reject WS upgrade paths that start with `//` with 400 before dialing the host.
- Standalone `serve.ts` (CLI `superset start` / daemon): bind `127.0.0.1` outside sandbox mode, matching the desktop entry; the log line prints the real bind address.

## Why
`new URL(dial.path, "ws://127.0.0.1:<port>")` treats a leading `//` as an authority, so a crafted dial path made the host open its dial-back socket — which carries the host-service token in `?token=` — to a non-loopback origin. Hono routes `GET /hosts/<id>//x` to the WS handler with `path="//x"` and relay2 forwarded it verbatim in `stream:dial`. The host-side pin is the fix and holds regardless of what the relay sends; the relay-side 400 is defence in depth.

Desktop hosts already bind loopback; CLI/daemon hosts listened on all interfaces with no way to change it. Sandboxes keep the unspecified bind because the provider edge is the caller.

## Manual QA
- Verified with Bun's URL implementation that the `pathname` setter keeps `host === 127.0.0.1:<port>` for `//evil.example/x`, `/\evil.example/x`, `ws://evil.example/x`, `/a?b#c`, and empty string.
- Verified in-process with Hono that `/hosts/<id>//evil.example/x` matched `/hosts/:hostId/*` with `path="//evil.example/x"` before the guard.
- `bunx tsc --noEmit` clean in `packages/host-service` and `apps/relay2`; pinned biome check clean on the three files.
- Not exercised end to end against a running relay2 — the change is two lines on each side and the URL/route behaviour was reproduced in isolation.

## Risks / Rollout
- HTTP dial (`forwardHttp`) was already safe by construction (string concat on a fixed origin); unchanged.
- The tunnel client and the CLI health poll already dial `127.0.0.1`, so the loopback bind changes nothing for normal CLI hosts. Anyone reaching a CLI host directly from another machine (not through the relay) will lose that; nothing in the repo does.
- The host-side half only protects hosts once they run a build that includes it; the relay half protects unpatched hosts against the through-the-relay path as soon as relay2 deploys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins tunnel v2 dial-back to 127.0.0.1 and binds the standalone host to loopback outside sandbox to prevent origin spoofing and unintended network exposure. Previously, `//`-prefixed paths could override the loopback authority and expose the host-service token; now the client always dials loopback and the relay rejects double-slash paths.

- Tunnel client (`packages/host-service/src/tunnel/tunnel-client-v2.ts`): builds the local WS URL on `ws://127.0.0.1:<port>` and sets `pathname`; relay-supplied `//...` or `ws://...` cannot change the authority. Only affects WS tunnel; HTTP dial unchanged.
- Relay (`apps/relay2`): returns 400 for WS upgrade paths that start with `//` before dialing the host (defense in depth).
- Standalone host (`packages/host-service/src/serve.ts`): binds to `127.0.0.1` unless `SUPERSET_HOST_RUN_MODE === "sandbox"` and logs the actual listener address. Required: reach CLI/daemon hosts through the relay; direct cross-machine access is no longer available.

<sup>Written for commit cb87ffed4e18c15ac0cbbed8734850b3bffe9a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed WebSocket paths by returning a clear 400 response.
  * Fixed local WebSocket URL construction for more reliable connections.

* **Improvements**
  * Host services now bind to the appropriate network interface based on the runtime environment.
  * Startup logs accurately report the active hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->