### PR TITLE
chore(desktop): bump version to 1.23.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.22.0",
+	"version": "1.23.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
@@ -50,7 +50,6 @@ function addAccountCommand(provider: Provider, slug: string): string {
 	return `mkdir -p "$HOME/.codex-${slug}" && CODEX_HOME="$HOME/.codex-${slug}" codex login`;
 }
 
-
 /** The sign-in that landed after the dialog opened, if any. */
 function findNewLogin(
 	provider: Provider,

--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -821,7 +821,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -917,7 +917,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
@@ -1073,7 +1073,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.22.0",
+	"version": "1.23.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.22.0",
+	"version": "1.23.0",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns desktop canary to 1.23.0 and syncs internal package versions. Includes a lint-only cleanup in `AddAccountDialog` with no behavior changes.

- Version bumps: `@superset/desktop` 1.22.0 → 1.23.0, `@superset/cli` 1.22.0 → 1.23.0, `@superset/host-service` 1.22.0 → 1.23.0, `@superset/pty-daemon` 0.3.0 → 0.3.1.
- `bun.lock` reflects version field updates only. No migrations or configuration changes.

<sup>Written for commit abf670caa2c26597daed6dc5129a522b46d7a4ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released desktop application version 1.23.0.
  * Released CLI version 1.23.0.
  * Released host service version 1.23.0.
  * Updated the terminal process service to version 0.3.1.
  * These updates align the latest application and command-line tooling releases across the product.
  * Included minor maintenance updates with no changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->