### PR TITLE
fix(mobile): theme markdown table body rows in the PR description

### DIFF
--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/PullRequestDescription/constants.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/PullRequestDescription/constants.ts
@@ -50,5 +50,7 @@ export const DESCRIPTION_MARKDOWN_STYLE: MarkdownStyle = {
 		borderColor: THEME.dark.border,
 		headerBackgroundColor: THEME.dark.secondary,
 		headerTextColor: THEME.dark.foreground,
+		rowEvenBackgroundColor: THEME.dark.background,
+		rowOddBackgroundColor: THEME.dark.background,
 	},
 };


### PR DESCRIPTION
## Problem
Markdown tables in the mobile PR description rendered with white body rows and near-white text on the dark theme — every other row looked empty, the rest barely legible.

`DESCRIPTION_MARKDOWN_STYLE` themed the table header, border and text but never set the body row backgrounds, so `react-native-enriched-markdown`'s defaults leaked through (even rows `#FFFFFF`, odd rows `#F9FAFB`).

## Fix
Set `rowEvenBackgroundColor` / `rowOddBackgroundColor` to `THEME.dark.background` — the same flat-row treatment the chat markdown table (`MESSAGE_MARKDOWN_STYLE`) already uses. Border width, radius and cell padding stay at the library defaults, which already match the chat style.

## Verified
Rendered `PullRequestDescription` with PR #6635's body on the iPhone 16e simulator via a temporary Storybook story: all nine provider rows readable on dark, `secondary` header, 1px border. Before/after: https://claude.ai/code/artifact/d8799837-7ab8-4e3b-9964-0d65ce8c29cb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable markdown table body rows in the mobile PR description on dark theme by theming the body backgrounds. Previously `react-native-enriched-markdown` defaults set even rows to #FFFFFF and odd to #F9FAFB against near-white text; now both use `THEME.dark.background`, matching chat table styling.

**Review/QA**
- Change: set `rowEvenBackgroundColor` and `rowOddBackgroundColor` in `DESCRIPTION_MARKDOWN_STYLE`; header/border/text remain as before.
- Scope: affects PR description tables in dark theme only; no API or prop changes; border radius/width and cell padding remain library defaults.
- Verify: open a PR description with a markdown table in dark mode; body rows sit on the app background, header uses secondary, 1px border, and text is readable.

<sup>Written for commit b9b399365f21635bdac8bda01089605e996946a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved pull request description tables with consistent dark-theme background colors for alternating rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->