### PR TITLE
chore(desktop): drop stray blank line failing biome format on main

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/components/AddAccountDialog/AddAccountDialog.tsx
@@ -50,7 +50,6 @@ function addAccountCommand(provider: Provider, slug: string): string {
 	return `mkdir -p "$HOME/.codex-${slug}" && CODEX_HOME="$HOME/.codex-${slug}" codex login`;
 }
 
-
 /** The sign-in that landed after the dialog opened, if any. */
 function findNewLogin(
 	provider: Provider,


### PR DESCRIPTION
main's Lint job has been red since #6628 — biome's formatter flags one extra blank line in `AddAccountDialog.tsx` ("Found 1 error"), which then shows as a failed Lint check on every PR (e.g. #6639). This is the `biome format --write` output for that file, nothing else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a stray blank line in `AddAccountDialog.tsx` so `biome` format passes and the Lint job on `main` goes green. Previously the file failed `biome format` with 1 error, causing red Lint checks across PRs; now it matches `biome` output.

**Review notes**
- One-line formatting change in `apps/desktop/src/renderer/.../AddAccountDialog/AddAccountDialog.tsx`; no behavior or runtime impact.
- No action required; merging will unblock CI on `main`.

<sup>Written for commit 9d25e57a7f77e04851b034946e63202cebc47c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed unnecessary whitespace for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->