### PR TITLE
fix(terminal): disarm leaked TUI input modes that corrupt the shell after sleep/wake

### DIFF
--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
@@ -238,12 +238,12 @@ describe("HeadlessEmulator", () => {
 			// The rehydrate preamble is an authoritative resync: an attaching
 			// xterm may have stale modes armed (missed disarm bytes across a
 			// sleep gap), so defaults are asserted too, not just diffs.
-			expect(snapshot.rehydrateSequences).toContain("?1l"); // app cursor off
-			expect(snapshot.rehydrateSequences).toContain("?1003l"); // mouse off
-			expect(snapshot.rehydrateSequences).toContain("?1006l"); // SGR encoding off
-			expect(snapshot.rehydrateSequences).toContain("?1004l"); // focus off
-			expect(snapshot.rehydrateSequences).toContain("?2004l"); // bracketed paste off
-			expect(snapshot.rehydrateSequences).toContain("?25h"); // cursor visible
+			expect(snapshot.rehydrateSequences).toContain(DISABLE_APP_CURSOR);
+			expect(snapshot.rehydrateSequences).toContain(`${CSI}?1003l`); // mouse off
+			expect(snapshot.rehydrateSequences).toContain(DISABLE_MOUSE_SGR);
+			expect(snapshot.rehydrateSequences).toContain(`${CSI}?1004l`); // focus off
+			expect(snapshot.rehydrateSequences).toContain(DISABLE_BRACKETED_PASTE);
+			expect(snapshot.rehydrateSequences).toContain(SHOW_CURSOR);
 		});
 
 		test("should set the active mouse level after every inactive level's reset", async () => {

--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
@@ -229,14 +229,64 @@ describe("HeadlessEmulator", () => {
 			expect(snapshot.rehydrateSequences).toContain("?2004h"); // bracketed paste
 		});
 
-		test("should not generate rehydrate sequences for default modes", async () => {
+		test("should assert default modes in both directions", async () => {
 			// Don't change any modes - use defaults
 			await emulator.writeSync("Some text\r\n");
 
 			const snapshot = emulator.getSnapshot();
 
-			// Should have empty or minimal rehydrate sequences
-			expect(snapshot.rehydrateSequences).toBe("");
+			// The rehydrate preamble is an authoritative resync: an attaching
+			// xterm may have stale modes armed (missed disarm bytes across a
+			// sleep gap), so defaults are asserted too, not just diffs.
+			expect(snapshot.rehydrateSequences).toContain("?1l"); // app cursor off
+			expect(snapshot.rehydrateSequences).toContain("?1003l"); // mouse off
+			expect(snapshot.rehydrateSequences).toContain("?1006l"); // SGR encoding off
+			expect(snapshot.rehydrateSequences).toContain("?1004l"); // focus off
+			expect(snapshot.rehydrateSequences).toContain("?2004l"); // bracketed paste off
+			expect(snapshot.rehydrateSequences).toContain("?25h"); // cursor visible
+		});
+
+		test("should set the active mouse level after every inactive level's reset", async () => {
+			// Mouse tracking levels are one mutually exclusive group in xterm:
+			// any level's reset clears the whole protocol, so a reset emitted
+			// after the active level's set would disarm it again.
+			await emulator.writeSync(`${CSI}?1002h`); // button-event tracking (drag)
+
+			const snapshot = emulator.getSnapshot();
+
+			const setIndex = snapshot.rehydrateSequences.indexOf("?1002h");
+			expect(setIndex).toBeGreaterThan(-1);
+			for (const reset of ["?9l", "?1000l", "?1001l", "?1003l"]) {
+				const resetIndex = snapshot.rehydrateSequences.indexOf(reset);
+				expect(resetIndex).toBeGreaterThan(-1);
+				expect(resetIndex).toBeLessThan(setIndex);
+			}
+			expect(snapshot.rehydrateSequences).not.toContain("?1002l");
+		});
+
+		test("should disarm a diverged target whose modes the source never had", async () => {
+			// Simulates the post-sleep corruption: the renderer xterm (target)
+			// still has TUI input modes armed while the session (source) sits at
+			// a plain shell prompt. Applying the rehydrate preamble must disarm.
+			const target = new HeadlessEmulator({ cols: 80, rows: 24 });
+			try {
+				await target.writeSync(ENABLE_MOUSE_NORMAL);
+				await target.writeSync(ENABLE_MOUSE_SGR);
+				await target.writeSync(ENABLE_APP_CURSOR);
+				await target.writeSync(ENABLE_FOCUS_REPORTING);
+
+				await emulator.writeSync("plain shell prompt $ ");
+				const snapshot = emulator.getSnapshot();
+				await target.writeSync(snapshot.rehydrateSequences);
+
+				const modes = target.getModes();
+				expect(modes.mouseTrackingNormal).toBe(false);
+				expect(modes.mouseSgr).toBe(false);
+				expect(modes.applicationCursorKeys).toBe(false);
+				expect(modes.focusReporting).toBe(false);
+			} finally {
+				target.dispose();
+			}
 		});
 	});
 });

--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
@@ -509,53 +509,69 @@ export class HeadlessEmulator {
 	}
 
 	/**
-	 * Generate escape sequences to restore current mode state
-	 * These sequences should be written to a fresh xterm instance before
-	 * writing the snapshot to ensure input behavior matches.
+	 * Generate escape sequences to bring an attaching xterm to this emulator's
+	 * mode state.
+	 *
+	 * This is an authoritative resync, not a diff against xterm defaults: the
+	 * attaching xterm is not always fresh. A cached renderer xterm that missed
+	 * a TUI's mode-restore bytes (laptop sleep, dropped stream, replayed stale
+	 * scrollback) can have mouse tracking or app-cursor mode still armed while
+	 * the PTY sits at a plain shell prompt — every scroll then sprays SGR mouse
+	 * reports into the shell. So input-affecting modes are asserted in BOTH
+	 * directions, the way tmux resyncs a client tty on attach.
+	 *
+	 * Origin mode (?6) is the exception: both DECSET and DECRST home the
+	 * cursor, so it is only asserted when set.
 	 */
 	private generateRehydrateSequences(): string {
 		const sequences: string[] = [];
 
-		// Helper to add DECSET/DECRST sequence
-		const addModeSequence = (
-			modeNum: number,
-			enabled: boolean,
-			defaultEnabled: boolean,
-		) => {
-			// Only add sequence if different from default
-			if (enabled !== defaultEnabled) {
-				sequences.push(`${ESC}[?${modeNum}${enabled ? "h" : "l"}`);
-			}
+		const assertMode = (modeNum: number, enabled: boolean) => {
+			sequences.push(`${ESC}[?${modeNum}${enabled ? "h" : "l"}`);
 		};
 
 		// Application cursor keys (mode 1)
-		addModeSequence(1, this.modes.applicationCursorKeys, false);
+		assertMode(1, this.modes.applicationCursorKeys);
 
-		// Origin mode (mode 6)
-		addModeSequence(6, this.modes.originMode, false);
+		// Origin mode (mode 6): set-only — DECSET/DECRST both home the cursor,
+		// so an unconditional ?6l would teleport the cursor on every attach.
+		if (this.modes.originMode) {
+			assertMode(6, true);
+		}
 
 		// Auto-wrap mode (mode 7)
-		addModeSequence(7, this.modes.autoWrap, true);
+		assertMode(7, this.modes.autoWrap);
 
 		// Cursor visibility (mode 25)
-		addModeSequence(25, this.modes.cursorVisible, true);
+		assertMode(25, this.modes.cursorVisible);
 
-		// Mouse tracking modes (mutually exclusive typically, but we track all)
-		addModeSequence(9, this.modes.mouseTrackingX10, false);
-		addModeSequence(1000, this.modes.mouseTrackingNormal, false);
-		addModeSequence(1001, this.modes.mouseTrackingHighlight, false);
-		addModeSequence(1002, this.modes.mouseTrackingButtonEvent, false);
-		addModeSequence(1003, this.modes.mouseTrackingAnyEvent, false);
+		// Mouse tracking protocol: the levels are one mutually exclusive group
+		// in xterm (any level's reset clears the whole protocol). Reset every
+		// inactive level first and set the active one last — a reset emitted
+		// after the set would immediately disarm it again.
+		const mouseLevels: Array<[number, boolean]> = [
+			[9, this.modes.mouseTrackingX10],
+			[1000, this.modes.mouseTrackingNormal],
+			[1001, this.modes.mouseTrackingHighlight],
+			[1002, this.modes.mouseTrackingButtonEvent],
+			[1003, this.modes.mouseTrackingAnyEvent],
+		];
+		for (const [modeNum, active] of mouseLevels) {
+			if (!active) assertMode(modeNum, false);
+		}
+		for (const [modeNum, active] of mouseLevels) {
+			if (active) assertMode(modeNum, true);
+		}
 
 		// Mouse encoding modes
-		addModeSequence(1005, this.modes.mouseUtf8, false);
-		addModeSequence(1006, this.modes.mouseSgr, false);
+		assertMode(1005, this.modes.mouseUtf8);
+		assertMode(1006, this.modes.mouseSgr);
 
 		// Focus reporting (mode 1004)
-		addModeSequence(1004, this.modes.focusReporting, false);
+		assertMode(1004, this.modes.focusReporting);
 
 		// Bracketed paste (mode 2004)
-		addModeSequence(2004, this.modes.bracketedPaste, false);
+		assertMode(2004, this.modes.bracketedPaste);
 
 		// Note: We don't restore alternate screen mode (1049/47) here because
 		// the serialized snapshot already contains the correct screen buffer.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,3 +1,4 @@
+import { FRESH_SHELL_INPUT_MODE_RESET } from "@superset/shared/leaked-input-mode-reclaim";
 import { installTerminalWheelEventHandler } from "@superset/shared/terminal-wheel-handler";
 import { FitAddon } from "@xterm/addon-fit";
 import type { ProgressAddon } from "@xterm/addon-progress";
@@ -323,6 +324,16 @@ export function createRuntime(
 		if (options.initialBuffer.length > 0) initialContent = "seeded";
 	} else if (restoreBuffer(terminalId, terminal)) {
 		initialContent = "restored";
+	}
+	if (initialContent !== "none") {
+		// SerializeAddon snapshots bake in whatever input-reporting modes were
+		// active at capture (?1002/?1003 mouse tracking, ?1h app cursor, …).
+		// Replaying them arms this fresh xterm before it has seen a single
+		// prompt marker, so the reclaimer above brands them shell-owned and can
+		// never reclaim them if the TUI turns out to be dead. Reset them now:
+		// the attach preamble re-asserts the session's real modes moments
+		// later, so a live TUI loses nothing.
+		terminal.write(FRESH_SHELL_INPUT_MODE_RESET);
 	}
 
 	const disposeImagePasteFallback = installImagePasteFallback(

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { Terminal as XTerm } from "@xterm/xterm";
 import {
 	createLeakedInputModeReclaimer,
 	KITTY_KEYBOARD_DISARM_SEQUENCE,
-} from "shared/leaked-input-mode-reclaim";
+} from "@superset/shared/leaked-input-mode-reclaim";
+import type { Terminal as XTerm } from "@xterm/xterm";
 import { installInputModeReclaimer } from "./terminalInputModeReclaimer";
 
 // The transport-agnostic decision core (shared). The renderer, and any future

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
@@ -29,6 +29,9 @@ export function installInputModeReclaimer(terminal: Terminal): IDisposable {
 	const parser = terminal.parser;
 	const disposables: IDisposable[] = [];
 	let scheduled = false;
+	// The deferred flush must not write into a terminal whose lifecycle ended
+	// between the marker and the microtask.
+	let disposed = false;
 
 	// Kitty keyboard protocol: `CSI > flags u` push/arm, `CSI = flags ; mode u`
 	// set (0 disarms), `CSI < n u` pop/disarm. Return false so xterm still applies.
@@ -89,6 +92,7 @@ export function installInputModeReclaimer(terminal: Terminal): IDisposable {
 				scheduled = true;
 				queueMicrotask(() => {
 					scheduled = false;
+					if (disposed) return;
 					const disarm = reclaimer.collectDisarm();
 					if (disarm) terminal.write(disarm);
 				});
@@ -99,6 +103,7 @@ export function installInputModeReclaimer(terminal: Terminal): IDisposable {
 
 	return {
 		dispose(): void {
+			disposed = true;
 			for (const d of disposables) d.dispose();
 		},
 	};

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
@@ -1,9 +1,9 @@
-import type { IDisposable, Terminal } from "@xterm/xterm";
 import {
 	createLeakedInputModeReclaimer,
 	SHELL_READY_MARKER_PAYLOAD,
 	SHELL_READY_OSC_ID,
-} from "shared/leaked-input-mode-reclaim";
+} from "@superset/shared/leaked-input-mode-reclaim";
+import type { IDisposable, Terminal } from "@xterm/xterm";
 
 /**
  * Renderer adapter that wires xterm's parser to the shared leaked-input-mode

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -22,6 +22,7 @@ import {
 	wrapWrite,
 } from "renderer/lib/terminal/parser-idle-gate";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
+import { installInputModeReclaimer } from "renderer/lib/terminal/terminalInputModeReclaimer";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
 import {
@@ -168,6 +169,10 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 	const uninstallWheelHandler = installTerminalWheelEventHandler(xterm);
+	// Disarm TUI-only input modes (kitty keyboard / mouse / focus) leaked into a
+	// live shell prompt by a TUI killed while attached (#4949) — keyed on the
+	// OSC 777 shell-ready marker, same as v2's terminal-runtime.
+	const inputModeReclaimer = installInputModeReclaimer(xterm);
 
 	const linkManager = new TerminalLinkManager(xterm);
 	linkManager.setHandlers({
@@ -234,6 +239,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			cancelAnimationFrame(rafId);
 			cleanupQuerySuppression();
 			uninstallWheelHandler();
+			inputModeReclaimer.dispose();
 			linkManager.dispose();
 			try {
 				webglAddon?.dispose();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -1,3 +1,4 @@
+import { FRESH_SHELL_INPUT_MODE_RESET } from "@superset/shared/leaked-input-mode-reclaim";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef, useState } from "react";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -179,6 +180,12 @@ export function useTerminalColdRestore({
 				error: error instanceof Error ? error.message : String(error),
 			});
 		});
+
+		// The replayed scrollback can contain the dead session's TUI arming
+		// sequences (mouse tracking, kitty keyboard, …); the brand-new shell
+		// knows nothing about them, so scrolling would spray mouse reports into
+		// the prompt as garbage text. Disarm before handing the pane over.
+		xterm.write(FRESH_SHELL_INPUT_MODE_RESET);
 
 		// Add visual separator
 		xterm.write("\r\n\x1b[90m─── Session Contents Restored ───\x1b[0m\r\n\r\n");

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -1,3 +1,4 @@
+import { FRESH_SHELL_INPUT_MODE_RESET } from "@superset/shared/leaked-input-mode-reclaim";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable, ITheme, Terminal as XTerm } from "@xterm/xterm";
@@ -363,6 +364,10 @@ export function useTerminalLifecycle({
 				wasKilledByUserRef.current = false;
 				setExitStatus(null);
 				resetModes();
+				// clear() drops the buffer but not parser input modes — a TUI that
+				// died with mouse/kitty reporting armed would spray reports into
+				// the replacement shell. Disarm before attaching it.
+				xterm.write(FRESH_SHELL_INPUT_MODE_RESET);
 				xterm.clear();
 				const attach = () => {
 					const requestId = nextAttachRequestId();

--- a/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.test.ts
@@ -18,7 +18,7 @@ function preambleString(tracker: ReturnType<typeof createModeTracker>): string {
  */
 const DEFAULT_SYNC =
 	"\x1b[?1l\x1b[?66l\x1b[?2004l\x1b[4l\x1b[?45l\x1b[?1004l" +
-	"\x1b[?25h\x1b[?7h\x1b[?2026l\x1b[?1003l\x1b[=0;1u";
+	"\x1b[?25h\x1b[?7h\x1b[?2026l\x1b[?1003l\x1b[?1006l\x1b[=0;1u";
 
 describe("createModeTracker", () => {
 	test("default state emits the full both-directions sync", () => {
@@ -74,11 +74,6 @@ describe("createModeTracker", () => {
 	});
 
 	test("focus reporting and mouse tracking are captured", () => {
-		// `?1002h` is button-tracking, NOT SGR encoding (`?1006h`). xterm.js's
-		// public IModes doesn't expose mouse encoding format, so the preamble
-		// can't restore it — clients reattaching mid-session keep the default
-		// X10 encoding. Acceptable today; revisit if a TUI relying on SGR
-		// breaks on reattach.
 		const t = createModeTracker(120, 32);
 		t.feed(enc.encode("\x1b[?1004h\x1b[?1002h"));
 		const preamble = preambleString(t);
@@ -86,6 +81,19 @@ describe("createModeTracker", () => {
 		expect(preamble).toContain("\x1b[?1002h");
 		expect(preamble).not.toContain("\x1b[?1004l");
 		expect(preamble).not.toContain("\x1b[?1003l");
+		t.dispose();
+	});
+
+	test("SGR mouse encoding is asserted in both directions", () => {
+		// A rebuilt renderer (persisted SerializeAddon snapshots don't capture
+		// ?1006) falls back to legacy X10 reports for a live TUI without this —
+		// and the full-fidelity wheel handler refuses to synthesize non-SGR
+		// reports.
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode("\x1b[?1002h\x1b[?1006h"));
+		expect(preambleString(t)).toContain("\x1b[?1006h");
+		t.feed(enc.encode("\x1b[?1006l"));
+		expect(preambleString(t)).toContain("\x1b[?1006l");
 		t.dispose();
 	});
 
@@ -174,6 +182,94 @@ describe("createModeTracker", () => {
 		t.feed(enc.encode(">7"));
 		t.feed(enc.encode("u"));
 		expect(preambleString(t)).toContain("\x1b[=7;1u");
+		t.dispose();
+	});
+});
+
+describe("host-side leaked-input-mode reclaim", () => {
+	const MARKER = "\x1b]777;superset-shell-ready\x07";
+	const flush = () => new Promise<void>((r) => queueMicrotask(r));
+
+	function makeTracker() {
+		const disarms: string[] = [];
+		const t = createModeTracker(120, 32, {
+			onLeakedInputModeDisarm(bytes) {
+				disarms.push(dec.decode(bytes));
+				// Mirror terminal.ts: deliverOutput feeds the disarm back in.
+				t.feed(bytes);
+			},
+		});
+		return { t, disarms };
+	}
+
+	test("disarms a dead TUI's modes at the reclaiming shell's prompt", async () => {
+		const { t, disarms } = makeTracker();
+		t.feed(enc.encode(MARKER)); // session's first prompt
+		t.feed(enc.encode("\x1b[?1003h\x1b[?1006h\x1b[?1004h\x1b[>7u")); // TUI arms
+		t.feed(enc.encode(MARKER)); // shell reprompts after an unclean kill
+		await flush();
+		const out = disarms.join("");
+		expect(out).toContain("\x1b[?1003l");
+		expect(out).toContain("\x1b[?1004l");
+		expect(out).toContain("\x1b[=0;1u");
+		// The fed-back disarm converges the tracker: the next attach preamble
+		// no longer re-arms fresh renderers.
+		const preamble = preambleString(t);
+		expect(preamble).toContain("\x1b[?1003l");
+		expect(preamble).toContain("\x1b[=0;1u");
+		t.dispose();
+	});
+
+	test("leaves modes armed before the first marker alone (shell-owned)", async () => {
+		const { t, disarms } = makeTracker();
+		t.feed(enc.encode("\x1b[?1003h")); // armed before any prompt marker
+		t.feed(enc.encode(MARKER));
+		await flush();
+		expect(disarms).toHaveLength(0);
+		t.dispose();
+	});
+
+	test("does not disarm modes a TUI restored on clean exit", async () => {
+		const { t, disarms } = makeTracker();
+		t.feed(enc.encode(MARKER));
+		t.feed(enc.encode("\x1b[?1003h\x1b[>7u"));
+		t.feed(enc.encode("\x1b[?1003l\x1b[<u")); // clean restore
+		t.feed(enc.encode(MARKER));
+		await flush();
+		expect(disarms).toHaveLength(0);
+		t.dispose();
+	});
+
+	test("a TUI re-arming right after the marker keeps its modes", async () => {
+		const { t, disarms } = makeTracker();
+		t.feed(enc.encode(MARKER));
+		t.feed(enc.encode("\x1b[?1003h"));
+		// Marker and re-arm land in the same chunk (fg after ^Z): the deferred
+		// flush must see the re-arm and stand down.
+		t.feed(enc.encode(`${MARKER}\x1b[?1003h`));
+		await flush();
+		expect(disarms).toHaveLength(0);
+		t.dispose();
+	});
+
+	test("ignores urxvt-style OSC 777 payloads", async () => {
+		const { t, disarms } = makeTracker();
+		t.feed(enc.encode(MARKER));
+		t.feed(enc.encode("\x1b[?1003h"));
+		t.feed(enc.encode("\x1b]777;notify;title;body\x07"));
+		await flush();
+		expect(disarms).toHaveLength(0);
+		t.dispose();
+	});
+
+	test("no callback wiring means no reclaim side effects", async () => {
+		const t = createModeTracker(120, 32);
+		t.feed(enc.encode(MARKER));
+		t.feed(enc.encode("\x1b[?1003h"));
+		t.feed(enc.encode(MARKER));
+		await flush();
+		// Tracker still reports the armed state untouched.
+		expect(preambleString(t)).toContain("\x1b[?1003h");
 		t.dispose();
 	});
 });

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -110,6 +110,8 @@ export function createModeTracker(
 	// no-op. Set it on rawOptions directly.
 	optionsRaw.vtExtensions = { kittyKeyboard: true };
 
+	let disposed = false;
+
 	// Host-side leaked-input-mode reclaim (#4949): observe mode arming and the
 	// OSC 777 shell-ready marker through this mirror's parser — the same
 	// adapter shape as the renderer's terminalInputModeReclaimer, but acting at
@@ -178,7 +180,6 @@ export function createModeTracker(
 			return false;
 		});
 	}
-	let disposed = false;
 
 	// `Terminal.write` is async-buffered, so `term.modes` lags behind feeds.
 	// Pump synchronously through the internal WriteBuffer so the preamble can

--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -15,6 +15,11 @@
 // (src/vs/platform/terminal/node/ptyService.ts).
 
 import { createRequire } from "node:module";
+import {
+	createLeakedInputModeReclaimer,
+	SHELL_READY_MARKER_PAYLOAD,
+	SHELL_READY_OSC_ID,
+} from "@superset/shared/leaked-input-mode-reclaim";
 
 const require = createRequire(import.meta.url);
 const { Terminal: HeadlessTerminal } =
@@ -32,6 +37,20 @@ export interface ModeTracker {
 	dispose(): void;
 }
 
+export interface ModeTrackerOptions {
+	/**
+	 * Called with disarm bytes when a shell prompt marker (OSC 777) flows
+	 * through the stream while TUI-only input-reporting modes (kitty keyboard,
+	 * mouse tracking, focus reporting) are still armed — the signature of a TUI
+	 * killed uncleanly (#4949's host-side surface). Without this, the tracker
+	 * believes the dead TUI's modes are live forever, so every attach preamble
+	 * re-arms fresh renderers and each scroll/keypress sprays reports into the
+	 * shell prompt as garbage. The callback should deliver the bytes into the
+	 * session's output stream (which also feeds them back to this tracker).
+	 */
+	onLeakedInputModeDisarm?: (bytes: Uint8Array) => void;
+}
+
 export interface TerminalSnapshot {
 	cols: number;
 	rows: number;
@@ -47,13 +66,20 @@ type HeadlessInternals = {
 	_core?: {
 		_writeBuffer?: { writeSync(data: string | Uint8Array): void };
 		coreService?: { kittyKeyboard?: { flags: number } };
+		mouseStateService?: { activeEncoding?: string };
+		// Pre-rename alias of mouseStateService in older engine builds.
+		coreMouseService?: { activeEncoding?: string };
 		optionsService?: {
 			rawOptions: { vtExtensions?: { kittyKeyboard?: boolean } };
 		};
 	};
 };
 
-export function createModeTracker(cols: number, rows: number): ModeTracker {
+export function createModeTracker(
+	cols: number,
+	rows: number,
+	options: ModeTrackerOptions = {},
+): ModeTracker {
 	const term = new HeadlessTerminal({
 		cols,
 		rows,
@@ -83,6 +109,76 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 	// key). Without this, kitty handlers early-return and `\x1b[>7u` is a
 	// no-op. Set it on rawOptions directly.
 	optionsRaw.vtExtensions = { kittyKeyboard: true };
+
+	// Host-side leaked-input-mode reclaim (#4949): observe mode arming and the
+	// OSC 777 shell-ready marker through this mirror's parser — the same
+	// adapter shape as the renderer's terminalInputModeReclaimer, but acting at
+	// the source. A TUI killed uncleanly (SIGKILL, sleep/wake casualty) never
+	// writes its mode restores; when the reclaiming shell's prompt marker flows
+	// while those modes are still armed, hand disarm bytes to the session so
+	// every attached renderer AND this tracker converge on the truth. The
+	// microtask defer lets a TUI that re-arms right after the marker (fg after
+	// ^Z) keep its modes — same mark-then-recheck as the renderer surface.
+	if (options.onLeakedInputModeDisarm) {
+		const onDisarm = options.onLeakedInputModeDisarm;
+		const reclaimer = createLeakedInputModeReclaimer();
+		const parser = term.parser;
+		let flushScheduled = false;
+
+		parser.registerCsiHandler({ prefix: ">", final: "u" }, () => {
+			reclaimer.noteArm("kitty", true);
+			return false;
+		});
+		parser.registerCsiHandler({ prefix: "=", final: "u" }, (params) => {
+			const raw = params[0];
+			const flags = typeof raw === "number" ? raw : (raw?.[0] ?? 0);
+			reclaimer.noteArm("kitty", flags !== 0);
+			return false;
+		});
+		parser.registerCsiHandler({ prefix: "<", final: "u" }, () => {
+			reclaimer.noteArm("kitty", false);
+			return false;
+		});
+
+		const applyDecMode = (
+			params: (number | number[])[],
+			armed: boolean,
+		): void => {
+			for (const param of params) {
+				const primary = typeof param === "number" ? param : param[0];
+				if (primary === 1000 || primary === 1002 || primary === 1003) {
+					reclaimer.noteArm("mouse", armed);
+				} else if (primary === 1004) {
+					reclaimer.noteArm("focus", armed);
+				}
+			}
+		};
+		parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+			applyDecMode(params, true);
+			return false;
+		});
+		parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+			applyDecMode(params, false);
+			return false;
+		});
+
+		parser.registerOscHandler(SHELL_READY_OSC_ID, (data) => {
+			// Exact match: OSC 777 is also urxvt's notification channel.
+			if (data !== SHELL_READY_MARKER_PAYLOAD) return false;
+			reclaimer.noteShellReady();
+			if (!flushScheduled) {
+				flushScheduled = true;
+				queueMicrotask(() => {
+					flushScheduled = false;
+					if (disposed) return;
+					const disarm = reclaimer.collectDisarm();
+					if (disarm) onDisarm(new TextEncoder().encode(disarm));
+				});
+			}
+			return false;
+		});
+	}
+	let disposed = false;
 
 	// `Terminal.write` is async-buffered, so `term.modes` lags behind feeds.
 	// Pump synchronously through the internal WriteBuffer so the preamble can
@@ -140,6 +236,19 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 				break;
 		}
 
+		// Mouse report encoding (?1006 SGR). Not on the public modes API, so
+		// read the engine's mouse service directly (same private-surface bet as
+		// kitty below). Asserted both ways: a rebuilt renderer (persisted
+		// SerializeAddon snapshots don't capture ?1006) would otherwise fall
+		// back to legacy X10 reports for a live TUI — and the full-fidelity
+		// wheel handler refuses to synthesize non-SGR reports.
+		const mouseService =
+			internals._core?.mouseStateService ?? internals._core?.coreMouseService;
+		const encoding = mouseService?.activeEncoding;
+		if (typeof encoding === "string") {
+			parts.push(encoding === "SGR" ? "\x1b[?1006h" : "\x1b[?1006l");
+		}
+
 		const kittyFlags = internals._core?.coreService?.kittyKeyboard?.flags ?? 0;
 		// `=N;1u` sets flags directly — restoring effective state to the
 		// peer, not modeling the program's push/pop stack. `=0;1u` likewise
@@ -183,6 +292,7 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		},
 		snapshot,
 		dispose() {
+			disposed = true;
 			term.dispose();
 		},
 	};

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -2607,6 +2607,20 @@ export async function createTerminalSessionInternal({
 			})
 		: Promise.resolve();
 
+	// The tracker's leaked-mode reclaim needs the session to broadcast disarm
+	// bytes, but the session literal below needs the tracker — close over a
+	// ref assigned right after construction.
+	let reclaimSession: TerminalSession | null = null;
+	const modeTracker = createModeTracker(cols, rows, {
+		onLeakedInputModeDisarm(bytes) {
+			const s = reclaimSession;
+			if (!s || !isCurrentLiveSession(s)) return;
+			// deliverOutput feeds the tracker too, so its modes (and the next
+			// attach preamble) converge with what clients were just told.
+			deliverOutput(s, bytes);
+		},
+	});
+
 	const session: TerminalSession = {
 		terminalId,
 		workspaceId,
@@ -2646,7 +2660,7 @@ export async function createTerminalSessionInternal({
 		initialCommandQueued: isAdopted,
 		launchShellName: basename(shell),
 		portHintDecoder: new StringDecoder("utf8"),
-		modeTracker: createModeTracker(cols, rows),
+		modeTracker,
 		adoptionReplaySettled: Promise.resolve(),
 		epoch: randomBytes(8).toString("hex"),
 		outputSeq: 0,
@@ -2657,6 +2671,7 @@ export async function createTerminalSessionInternal({
 		resizeGeneration: 0,
 		focusedSockets: new Set(),
 	};
+	reclaimSession = session;
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -184,6 +184,10 @@
 			"types": "./src/shell-ready-scanner.ts",
 			"default": "./src/shell-ready-scanner.ts"
 		},
+		"./leaked-input-mode-reclaim": {
+			"types": "./src/leaked-input-mode-reclaim.ts",
+			"default": "./src/leaked-input-mode-reclaim.ts"
+		},
 		"./terminal-title-scanner": {
 			"types": "./src/terminal-title-scanner.ts",
 			"default": "./src/terminal-title-scanner.ts"

--- a/packages/shared/src/leaked-input-mode-reclaim.ts
+++ b/packages/shared/src/leaked-input-mode-reclaim.ts
@@ -37,6 +37,24 @@ export const SHELL_READY_MARKER_PAYLOAD = "superset-shell-ready";
  */
 export const KITTY_KEYBOARD_DISARM_SEQUENCE = `${ESC}[<255u${ESC}[=0;1u`;
 
+/**
+ * Full input-mode reset for an xterm that is about to host a brand-new shell
+ * over stale content (cold-restore "Start shell", terminal restart). The
+ * replayed scrollback of the old session can contain a TUI's arming sequences
+ * (mouse tracking, kitty keyboard, app cursor, bracketed paste), and the fresh
+ * PTY knows nothing about them — every scroll would spray SGR mouse reports
+ * and every keypress CSI-u codes into the new shell as garbage text. Unlike
+ * the marker-based reclaimer below, this is unconditional: at this moment the
+ * shell is known to be new, so any armed input mode is stale by definition.
+ */
+export const FRESH_SHELL_INPUT_MODE_RESET =
+	KITTY_KEYBOARD_DISARM_SEQUENCE +
+	`${ESC}[?1003l` + // mouse tracking (any level's reset clears the protocol)
+	`${ESC}[?1006l` + // SGR mouse encoding
+	`${ESC}[?1004l` + // focus reporting
+	`${ESC}[?2004l` + // bracketed paste
+	`${ESC}[?1l`; // application cursor keys
+
 /** TUI-only input-reporting modes a killed TUI can leak into a shell prompt. */
 export type LeakableInputMode = "kitty" | "mouse" | "focus";
 


### PR DESCRIPTION
## Summary

After a laptop sleep (or app update/relaunch) kills a TUI like Claude Code uncleanly, the terminal could get stuck spraying garbage — scrolling dumped SGR mouse reports (`35;89;34M…`) and keypresses dumped kitty CSI-u fragments into the shell prompt, forcing users to abandon the session.

Root cause: the dead TUI never wrote its mode-restore sequences, so its input-reporting modes (mouse tracking, kitty keyboard, focus reporting) stayed armed. Two protections both missed this path:

- host-service's mode tracker never saw disarm bytes, so it believed the modes were live forever and every attach preamble **re-armed** fresh renderers;
- the renderer reclaimer brands modes armed before the first prompt marker as "shell-owned" — after an app relaunch, snapshot replay and the attach preamble both arm modes pre-marker, making them permanently un-reclaimable.

## Changes

- **Host-side leaked-mode reclaimer** (the definitive fix): the mode tracker now observes mode arming and the OSC 777 shell-ready marker through its own headless parser; when a prompt marker flows while TUI-only input modes are still armed, it injects disarm bytes into the output stream — every attached renderer *and* the tracker converge, and the pane self-heals at the next prompt with no session restart.
- Moved the shared reclaim decision logic from `apps/desktop/src/shared` to `@superset/shared/leaked-input-mode-reclaim` so host-service and both renderer stacks use one module.
- Attach preamble now asserts **SGR mouse encoding** (`?1006`) in both directions — previously a relaunched renderer dropped a live TUI to legacy X10 reports (persisted snapshots don't capture `?1006`).
- v2 renderer resets snapshot-baked input modes after replaying a persisted buffer (the preamble re-asserts the real state moments later).
- v1 stack hardening (legacy surface, same bug class): install the input-mode reclaimer in v1 terminals, unconditional input-mode reset on cold-restore "Start shell" and terminal restart, and the v1 HeadlessEmulator rehydrate preamble is now an authoritative both-directions resync (mouse levels reset-then-set; origin mode stays set-only).

Overhead is negligible: parser handlers fire only on rare mode-changing escapes; everything else is a few bytes at attach time.

## Verification

- Reproduced end-to-end in the real dev app over CDP, before and after: armed a fake TUI (same modes Claude Code arms), simulated relaunch + unclean TUI kill. Pre-fix the renderer stayed armed (`mouse: any`, kitty flags 7) over a plain prompt with visible input mangling (`echo hello;1:3A`); post-fix it auto-disarms within seconds of the kill and input is clean. SGR encoding now survives relaunch for live TUIs.
- Deterministic parser-level repro (headless xterm + real mouse-report encoder) confirmed before/after for the cold-restore path.
- New unit tests: host-side reclaimer (dead-TUI disarm, shell-owned epoch, clean-exit and re-arm suppression), SGR preamble assertion, both-directions rehydrate incl. diverged-target resync.

## Test plan

- [ ] `bun test` in `packages/host-service` (1136 pass), `apps/desktop` (2603 pass), `packages/shared` (760 pass)
- [ ] Typecheck desktop + host-service
- [ ] Manual: run claude in a workspace terminal, `kill -9` it, confirm scrolling/typing at the returned prompt stays clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents post-sleep terminal corruption by reclaiming TUI-only input modes. Before: a killed TUI left mouse/kitty/focus reporting armed and attach preambles re-armed them, so scroll/keys injected SGR/CSI-u garbage into the shell. Now the host detects a shell-ready marker with modes still armed and injects disarms so panes self-heal at the next prompt.

- Host-side leaked-mode reclaimer in `packages/host-service`: tracks kitty/mouse/focus arming and OSC 777 via a headless parser, defers flush to let a foregrounded TUI re-arm, and feeds disarms back through session output so the tracker and all clients converge; it guards against flushing after dispose.
- Shared logic is centralized in `@superset/shared/leaked-input-mode-reclaim`; it exports `FRESH_SHELL_INPUT_MODE_RESET` for unconditional disarm when starting a brand-new shell over restored content.
- Attach/rehydrate is an authoritative both-direction resync: `HeadlessEmulator` and the host tracker assert SGR mouse encoding (`?1006`) on set and reset, order mouse-level resets before the active set, and treat origin mode (`?6`) as set-only to avoid homing on attach.
- Renderer hardening: v2 resets snapshot-baked input modes after replay using `FRESH_SHELL_INPUT_MODE_RESET`; v1 installs the reclaimer, resets modes on cold-restore and terminal restart, and disarms on dispose to avoid late flushes.
- Tests cover host-side reclaim paths (dead TUI, shell-owned epoch, clean exit, same-chunk re-arm), SGR assertion in both directions, mouse reset ordering, diverged-target disarm on rehydrate, and disposal guards.

<sup>Written for commit fe758ff6cbbede8a8fa0c4fcca4cc83aa67915e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session restoration so cursor visibility and input modes are restored reliably.
  * Prevented stale mouse, keyboard, focus, paste, and cursor modes from leaking into shell prompts.
  * Improved recovery after terminal restarts, cold restores, and TUI exits.
  * Enhanced mouse-reporting synchronization during terminal rehydration.
* **Tests**
  * Added coverage for mode resets, restoration behavior, leaked input-mode recovery, mouse tracking, and cleanup after terminal disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->