### PR TITLE
feat(skills): add computer control with Cua Driver

### DIFF
--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -1,0 +1,83 @@
+---
+title: Computer Control
+description: Let agents operate native desktop applications with Cua Driver
+---
+
+## Overview
+
+Superset includes a `computer` skill that teaches agents to operate native
+desktop applications through [Cua Driver](https://cua.ai/docs/cua-driver). It
+can inspect windows, read accessibility state and screenshots, click, type,
+scroll, use native menus, and verify the resulting UI state on macOS, Windows,
+and Linux.
+
+The agent works in the actual app window you can see. Cua Driver targets a
+specific process and window and uses background interaction when the platform
+supports it, so routine automation does not need to take over your mouse or
+bring the target app to the front.
+
+## Install Cua Driver
+
+The skill is bundled with Superset, but the `cua-driver` runtime is installed
+separately.
+
+**macOS and Linux**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://cua.ai/driver/install.ps1 | iex
+cua-driver autostart kick
+```
+
+Then verify the host:
+
+```bash
+cua-driver --version
+cua-driver doctor
+```
+
+macOS also requires Accessibility and Screen Recording permission for the
+CuaDriver app. Run `cua-driver permissions grant` and follow the System
+Settings prompts. See the complete [installation and permissions
+guide](https://cua.ai/docs/how-to-guides/driver/install).
+
+## Hand an app to your agent
+
+Ask naturally, or invoke `/superset:computer` in Claude Code and
+`/superset/computer` in Superset's in-app chat:
+
+```text
+Open Calculator, compute 27 × 14, and tell me the displayed result.
+```
+
+```text
+Use the open design app to export the current canvas as a PNG, then verify the
+file appeared in the chosen folder.
+```
+
+The skill makes the agent declare a task-scoped session, identify the exact app
+and window, take a fresh state snapshot before every action, and verify the UI
+afterward. It starts with accessibility targets, uses pixels only when needed,
+and escalates to foreground or full-desktop control only after observed failure.
+
+## Computer or browser?
+
+Use [`browser`](/browser) for a page open in Superset's in-app browser pane. It
+provides direct DOM, console, screenshot, and Chrome DevTools Protocol access.
+
+Use `computer` for native applications, the Superset desktop UI itself, browser
+chrome, or a browser engine that is not available through the in-app browser
+skill.
+
+## Safety
+
+The agent sees the real state of the targeted application. The skill tells it
+to avoid unrelated private data, preserve your other windows, and ask before
+consequential actions such as sending a message, submitting a form that creates
+an external commitment, publishing, purchasing, deleting data, or changing
+account settings.

--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -1,25 +1,29 @@
 ---
 title: Computer Control
-description: Let agents operate native desktop applications with Cua Driver
+description: Let agents operate native desktop applications through an accessibility-first driver
 ---
 
 ## Overview
 
 Superset includes a `computer` skill that teaches agents to operate native
-desktop applications through [Cua Driver](https://cua.ai/docs/cua-driver). It
-can inspect windows, read accessibility state and screenshots, click, type,
-scroll, use native menus, and verify the resulting UI state on macOS, Windows,
-and Linux.
+desktop applications through an accessibility-first driver. It can inspect
+windows, read accessibility state and screenshots, click, type, scroll, use
+native menus, and verify the resulting UI state on macOS, Windows, and Linux.
+
+The skill's workflow is driver-agnostic; [Cua
+Driver](https://cua.ai/docs/cua-driver) is the default. On macOS,
+[Peekaboo](https://peekaboo.sh) works as an alternative — agents use whichever
+supported driver you have installed, and ask before installing one.
 
 The agent works in the actual app window you can see. Cua Driver targets a
 specific process and window and uses background interaction when the platform
 supports it, so routine automation does not need to take over your mouse or
 bring the target app to the front.
 
-## Install Cua Driver
+## Install a driver
 
-The skill is bundled with Superset, but the `cua-driver` runtime is installed
-separately.
+The skill is bundled with Superset, but the driver runtime is installed
+separately. Cua Driver is the default:
 
 **macOS and Linux**
 
@@ -46,6 +50,19 @@ macOS also requires Accessibility and Screen Recording permission for the
 CuaDriver app. Run `cua-driver permissions grant` and follow the System
 Settings prompts. See the complete [installation and permissions
 guide](https://cua.ai/docs/how-to-guides/driver/install).
+
+Cua Driver enables anonymous telemetry by default; turn it off with
+`cua-driver telemetry disable`.
+
+**Prefer Peekaboo? (macOS only)**
+
+```bash
+brew install steipete/tap/peekaboo
+```
+
+[Peekaboo](https://peekaboo.sh) needs the same Accessibility and Screen
+Recording permissions. Agents use whichever supported driver is installed, so
+installing Peekaboo instead of Cua Driver selects it.
 
 ## Hand an app to your agent
 

--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -22,6 +22,16 @@ bring the target app to the front.
 
 ## Install a driver
 
+<Callout type="info" title="Optional third-party software">
+	Drivers are not built or maintained by Superset — Cua Driver comes from
+	[Cua](https://cua.ai) and Peekaboo from [its open-source
+	project](https://peekaboo.sh) — and nothing in Superset requires one:
+	without a driver installed, this skill simply isn't used. Installing a
+	driver and granting it Accessibility and Screen Recording gives it, and
+	agents driving it, deep control of your machine — extend it the same trust
+	as any system-level tool.
+</Callout>
+
 The skill is bundled with Superset, but the driver runtime is installed
 separately. Cua Driver is the default:
 

--- a/apps/docs/content/docs/computer.mdx
+++ b/apps/docs/content/docs/computer.mdx
@@ -31,6 +31,7 @@ separately.
 
 ```powershell
 irm https://cua.ai/driver/install.ps1 | iex
+cua-driver autostart enable
 cua-driver autostart kick
 ```
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -22,6 +22,7 @@
 		"terminal-integration",
 		"ports",
 		"browser",
+		"computer",
 		"agent-integration",
 		"agent-status",
 		"tasks",

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -31,7 +31,7 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
 | `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
-| `superset:computer` | Drives [native desktop apps](/computer) with Cua Driver — inspect windows, click, type, use menus, and verify results without taking over your mouse |
+| `superset:computer` | Drives [native desktop apps](/computer) with Cua Driver — inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
 | `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -31,7 +31,7 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
 | `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
-| `superset:computer` | Drives [native desktop apps](/computer) with Cua Driver — inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
+| `superset:computer` | Drives [native desktop apps](/computer) through an accessibility-first driver (Cua Driver by default) — inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
 | `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -31,7 +31,7 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
 | `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
-| `superset:computer` | Drives native desktop apps and system browser windows with [Cua Driver](https://cua.ai/docs/cua-driver) using a snapshot, act, and verify loop |
+| `superset:computer` | Drives [native desktop apps](/computer) with Cua Driver — inspect windows, click, type, use menus, and verify results without taking over your mouse |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
 | `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -31,6 +31,7 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
 | `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
+| `superset:computer` | Drives native desktop apps and system browser windows with [Cua Driver](https://cua.ai/docs/cua-driver) using a snapshot, act, and verify loop |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |
 | `superset:doctor` | Diagnoses Superset problems (expired auth, offline hosts, stale versions) and fixes them one step at a time |
 | `superset:feedback` | Files a bug report or feature request: privately to the Superset team (from your account, so we can reply) or as a public GitHub issue |
@@ -45,6 +46,7 @@ You usually don't invoke them; agents pick the right skill from context:
 - "what did my agents do overnight?" → `superset:standup`
 - "run these three refactors in parallel" → `superset:orchestrate`
 - "open localhost:3000 and click through the signup flow" → `superset:browser`
+- "open the desktop app and change its settings" → `superset:computer`
 
 To invoke one explicitly: `/superset:feedback` in Claude Code, or `/superset/feedback` in the in-app chat. Other agents that read skills (Codex, Kimi, Vibe, Grok) see the same skills with a `superset-` prefix.
 

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -18,10 +18,12 @@ targeted input without making the agent guess at stale screen coordinates.
 
 ## Set up Cua Driver
 
-1. Require `command -v cua-driver` and inspect `cua-driver --version`. Do not
-   silently install or upgrade it. If it is missing, ask the user to authorize
-   an installer from the [Cua Driver installation guide](https://cua.ai/docs/how-to-guides/driver/install).
-   On macOS or Linux, use:
+1. Confirm the installed executable with `command -v cua-driver` on macOS or
+   Linux, or `Get-Command cua-driver` in Windows PowerShell, then inspect
+   `cua-driver --version`. Do not silently install or upgrade it. If it is
+   missing, ask the user to authorize an installer from the [Cua Driver
+   installation guide](https://cua.ai/docs/how-to-guides/driver/install). On
+   macOS or Linux, use:
 
    ```bash
    /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
@@ -31,6 +33,7 @@ targeted input without making the agent guess at stale screen coordinates.
 
    ```powershell
    irm https://cua.ai/driver/install.ps1 | iex
+   cua-driver autostart enable
    cua-driver autostart kick
    ```
 
@@ -99,12 +102,18 @@ the same window, navigation, modal transition, or substantial repaint.
 - Use `set_value` or `type_text` for accessible fields and `press_key` or
   `hotkey` for non-text keys.
 - Use `set_window_frame` for window geometry and verify it with `list_windows`.
-- For Chromium or Electron page content, bind the exact native window with
-  `get_browser_state`, then use `browser_click`, `browser_type`,
-  `browser_navigate`, and `browser_pointer` with fresh page refs.
-- Use pixel coordinates only for canvas, video, WebGL, or custom-drawn controls
-  absent from the accessibility tree. Coordinates must come from the same fresh
-  window snapshot used by the action.
+- For Chromium or Electron page content, discover the exact browser PID and
+  window ID, then call `get_browser_state`. If it reports
+  `browser_requires_setup`, call `browser_prepare` under its approval rules.
+  After preparation, use its returned PID to rediscover the window and call
+  `get_browser_state` again. Use the returned `target_id` and `tab_id` with
+  `browser_click`, `browser_type`, `browser_navigate`, and `browser_pointer`,
+  refreshing the page snapshot before each later browser action.
+- For browser pixel actions, `browser_click` and `browser_pointer` coordinates
+  must be viewport CSS pixels from the latest `get_browser_state` page
+  snapshot. For native pixel actions, use coordinates only for canvas, video,
+  WebGL, or custom-drawn controls absent from the accessibility tree, and take
+  them from the same fresh `get_window_state` snapshot used by the action.
 
 ## Handle failures conservatively
 

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: computer
+description: "Drive native desktop apps and system browser windows on macOS, Windows, or Linux with Cua Driver. Use when asked to open or operate a real app, click or type in a desktop UI, inspect a window, use a signed-in system-browser session, or verify an end-to-end GUI flow. Not for Superset's in-app browser pane, headless scraping, or tasks an API or CLI can complete directly."
+---
+
+# Superset Computer Control
+
+Operate the user's real desktop with the `cua-driver` CLI. Cua Driver exposes
+accessibility snapshots, exact window screenshots, native menu operations, and
+targeted input without making the agent guess at stale screen coordinates.
+
+## Choose the right surface
+
+- Use this skill for native apps, OS UI, and browser windows outside Superset.
+- Use `superset:browser` for Superset's in-app browser pane.
+- Prefer an application API, purpose-built CLI, or direct filesystem operation
+  when the requested result does not require GUI interaction.
+
+## Set up Cua Driver
+
+1. Require `command -v cua-driver` and inspect `cua-driver --version`. Do not
+   silently install or upgrade it. If it is missing, ask the user to authorize
+   an installer from the [Cua Driver installation guide](https://cua.ai/docs/how-to-guides/driver/install).
+   On macOS or Linux, use:
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
+   ```
+
+   On Windows, use PowerShell:
+
+   ```powershell
+   irm https://cua.ai/driver/install.ps1 | iex
+   cua-driver autostart kick
+   ```
+
+2. Run `cua-driver doctor` and `cua-driver status`. On macOS, also run
+   `cua-driver permissions status`. If Accessibility or Screen Recording is
+   missing, ask the user to run `cua-driver permissions grant` and complete the
+   OS prompts. Never work around missing OS permissions with AppleScript,
+   synthetic shell input, or another GUI driver.
+3. If the daemon is not running, start `cua-driver serve` in a long-lived
+   terminal. Preserve an already-running daemon's permission mode; do not
+   restart it merely to broaden permissions.
+4. Inspect the installed tool surface instead of assuming a version-specific
+   schema:
+
+   ```bash
+   cua-driver list-tools
+   cua-driver describe get_window_state
+   cua-driver describe click
+   ```
+
+Invoke tools with `cua-driver call <tool> '<json>'`. Use `describe` whenever an
+argument is uncertain.
+
+## Snapshot, act, verify
+
+Follow this loop for every GUI action:
+
+1. State the exact postcondition, such as "Settings shows Dark mode selected."
+2. Discover the target with `get_accessibility_tree` or another semantic tool,
+   then take a fresh `get_window_state` snapshot for the exact PID and window.
+3. Prefer the snapshot's `element_token` over `element_index`, and prefer both
+   over pixel coordinates. Tokens identify the control and fail closed when the
+   snapshot becomes stale.
+4. Perform one action. Default to background delivery; use foreground delivery
+   only when fresh evidence shows the background action did not land.
+5. Take a new snapshot and verify the postcondition before continuing. A
+   successful tool response proves delivery, not the resulting UI state.
+
+Minimal shape:
+
+```bash
+cua-driver call get_accessibility_tree '{}'
+cua-driver call get_window_state '{"pid":844,"window_id":10725}'
+cua-driver call click '{"pid":844,"element_token":"s0000002a:14"}'
+cua-driver call verify_state '{"pid":844,"window_id":10725,"expect":[{"element":{"selector":{"label_contains":"Saved"},"exists":true}}]}'
+```
+
+Re-snapshot before every later action. Never reuse a token after a snapshot of
+the same window, navigation, modal transition, or substantial repaint.
+
+## Use semantic operations first
+
+- Use `invoke_menu` for native application-menu paths.
+- Use `set_value` or `type_text` for accessible fields and `press_key` or
+  `hotkey` for non-text keys.
+- Use `set_window_frame` for window geometry and verify it with `list_windows`.
+- For Chromium or Electron page content, bind the exact native window with
+  `get_browser_state`, then use `browser_click`, `browser_type`,
+  `browser_navigate`, and `browser_pointer` with fresh page refs.
+- Use pixel coordinates only for canvas, video, WebGL, or custom-drawn controls
+  absent from the accessibility tree. Coordinates must come from the same fresh
+  window snapshot used by the action.
+
+## Handle failures conservatively
+
+- If a control is absent, refresh the snapshot and inspect dialogs, sheets, and
+  application menus before escalating.
+- If an action has no verified effect, retry only the narrowest failed step:
+  background accessibility, then background pixel input, then foreground input.
+- If the target or resulting state is ambiguous, stop and report what is
+  visible. Do not click through unknown dialogs or retry destructive actions.
+- Leave the user's windows, focus, tabs, and clipboard as you found them unless
+  changing them is part of the request.
+
+## Safety
+
+This skill reaches real apps and signed-in sessions. Limit inspection and
+actions to the user's request; never extract credentials, cookies, tokens, or
+unrelated private data. Obtain confirmation immediately before sending a
+message, submitting a form that creates an external commitment, publishing,
+purchasing, deleting data, changing an account, accepting legal terms, or
+taking another consequential external action. Authentication prompts,
+passkeys, passwords, and MFA stay with the user.

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: computer
-description: "Drive native desktop apps and system browser windows on macOS, Windows, or Linux with Cua Driver. Use when asked to open or operate a real app, click or type in a desktop UI, inspect a window, use a signed-in system-browser session, or verify an end-to-end GUI flow. Not for Superset's in-app browser pane, headless scraping, or tasks an API or CLI can complete directly."
+description: "Drive native desktop apps and system browser windows on macOS, Windows, or Linux through an accessibility-first driver (Cua Driver by default; Peekaboo supported on macOS). Use when asked to open or operate a real app, click or type in a desktop UI, inspect a window, use a signed-in system-browser session, or verify an end-to-end GUI flow. Not for Superset's in-app browser pane, headless scraping, or tasks an API or CLI can complete directly."
 ---
 
 # Superset Computer Control
 
-Operate the user's real desktop with the `cua-driver` CLI. Cua Driver exposes
-accessibility snapshots, exact window screenshots, native menu operations, and
-targeted input without making the agent guess at stale screen coordinates.
+Operate the user's real desktop through an accessibility-first driver: a local
+CLI that exposes accessibility snapshots, exact window screenshots, native menu
+operations, and targeted input without making the agent guess at stale screen
+coordinates. The contract in this skill — preflight, task-scoped session,
+snapshot → act → verify, semantic operations first, conservative failure
+handling, clean teardown — is driver-agnostic. The command reference below is
+for Cua Driver, the default.
 
 ## Choose the right surface
 
@@ -16,7 +20,21 @@ targeted input without making the agent guess at stale screen coordinates.
 - Prefer an application API, purpose-built CLI, or direct filesystem operation
   when the requested result does not require GUI interaction.
 
-## Set up Cua Driver
+## Choose a driver
+
+- If the user names a driver, use that one.
+- Otherwise use whichever supported driver is already installed:
+  [Cua Driver](https://cua.ai/docs/cua-driver) (`cua-driver`, cross-platform,
+  the default) or [Peekaboo](https://peekaboo.sh) (`peekaboo`, macOS only). If
+  both are installed, use Cua Driver and mention the alternative once.
+- If neither is installed, ask the user which to install before installing
+  anything; recommend Cua Driver unless the user is macOS-only and prefers
+  Peekaboo.
+- With a driver other than Cua Driver, apply this skill's contract through that
+  driver's own command surface — discover it with the driver's help output and
+  documentation rather than assuming the Cua command shapes below.
+
+## Set up Cua Driver (default)
 
 1. Confirm the installed executable with `command -v cua-driver` on macOS or
    Linux, or `Get-Command cua-driver` in Windows PowerShell, then inspect

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -39,9 +39,9 @@ targeted input without making the agent guess at stale screen coordinates.
    missing, ask the user to run `cua-driver permissions grant` and complete the
    OS prompts. Never work around missing OS permissions with AppleScript,
    synthetic shell input, or another GUI driver.
-3. If the daemon is not running, start `cua-driver serve` in a long-lived
-   terminal. Preserve an already-running daemon's permission mode; do not
-   restart it merely to broaden permissions.
+3. Preserve an already-running daemon's permission mode; do not restart it
+   merely to broaden permissions. If the environment needs explicit service
+   setup, follow the platform-specific guidance reported by `doctor`.
 4. Inspect the installed tool surface instead of assuming a version-specific
    schema:
 
@@ -53,6 +53,18 @@ targeted input without making the agent guess at stale screen coordinates.
 
 Invoke tools with `cua-driver call <tool> '<json>'`. Use `describe` whenever an
 argument is uncertain.
+
+## Declare a task session
+
+Create a unique session before the first GUI observation:
+
+```bash
+cua-driver call start_session '{"session":"superset-computer-<unique>"}'
+```
+
+Pass the same `session` to every tool that accepts it. It owns this run's agent
+cursor and lifecycle cleanup. It does not select the capture mode or grant
+access beyond the daemon's fixed permission mode.
 
 ## Snapshot, act, verify
 
@@ -73,9 +85,9 @@ Minimal shape:
 
 ```bash
 cua-driver call get_accessibility_tree '{}'
-cua-driver call get_window_state '{"pid":844,"window_id":10725}'
-cua-driver call click '{"pid":844,"element_token":"s0000002a:14"}'
-cua-driver call verify_state '{"pid":844,"window_id":10725,"expect":[{"element":{"selector":{"label_contains":"Saved"},"exists":true}}]}'
+cua-driver call get_window_state '{"pid":844,"window_id":10725,"session":"superset-computer-<unique>"}'
+cua-driver call click '{"pid":844,"element_token":"s0000002a:14","session":"superset-computer-<unique>"}'
+cua-driver call verify_state '{"pid":844,"window_id":10725,"session":"superset-computer-<unique>","expect":[{"element":{"selector":{"label_contains":"Saved"},"exists":true}}]}'
 ```
 
 Re-snapshot before every later action. Never reuse a token after a snapshot of
@@ -100,10 +112,25 @@ the same window, navigation, modal transition, or substantial repaint.
   application menus before escalating.
 - If an action has no verified effect, retry only the narrowest failed step:
   background accessibility, then background pixel input, then foreground input.
+- Escalate to full-desktop control only after semantic, accessibility, pixel,
+  and foreground-window routes are exhausted, and only through the mechanism
+  advertised by the installed driver version.
 - If the target or resulting state is ambiguous, stop and report what is
   visible. Do not click through unknown dialogs or retry destructive actions.
 - Leave the user's windows, focus, tabs, and clipboard as you found them unless
   changing them is part of the request.
+
+## Finish cleanly
+
+Take a final fresh snapshot or semantic readback, report the observable result,
+and end only the session created for this task:
+
+```bash
+cua-driver call end_session '{"session":"superset-computer-<unique>"}'
+```
+
+Do not stop a shared driver daemon or close unrelated windows when the task
+ends.
 
 ## Safety
 


### PR DESCRIPTION

<img width="500" height="800" alt="superset-computer-docs-narrow" src="https://github.com/user-attachments/assets/3abc1107-24a1-4509-855b-8f4d9cbf7c42" />
## What & why

Adds a `superset:computer` skill alongside `superset:browser` so agents can operate native desktop apps and system browser windows through Cua Driver.

The skill:

- routes Superset in-app panes to `superset:browser` and host desktop UI to `superset:computer`;
- preflights the installed Cua Driver, daemon, and OS permissions without silently installing or widening access;
- creates a task-scoped Cua Driver session and cleans it up without stopping a shared daemon;
- requires a fresh snapshot → targeted action → fresh verification loop;
- prefers semantic and accessibility operations before pixel, foreground, or desktop escalation;
- preserves confirmation boundaries for consequential actions and authentication.

Also adds a responsive `/computer` docs page with current macOS, Linux, and Windows installation commands, invocation examples, browser-versus-computer routing, and safety guidance.

Refs #6643

## How I tested it

- Skill Creator `quick_validate.py` (pass)
- Real Cua Driver smoke: `start_session` → `get_accessibility_tree` → `end_session` (pass)
- `bun run lint` (pass)
- `bun run typecheck` (38/38 tasks pass)
- `bun run --cwd apps/docs build` (150 static pages pass)
- Visual QA in standalone Chrome at 1200×917 and 500×800; restored the original window geometry and removed only the task-created tab afterward
- `bun run test` reached unrelated `@superset/agent-setup` shell-wrapper tests; 2/121 failed because the real host `claude` binary was selected as the system fallback and rejected a no-input invocation. CI runs the suite in an isolated environment and passes.
- External-readiness scan for placeholders, private paths, credentials, and drafting residue (pass)

## Checklist

- [x] PR title follows conventional commits
- [x] `bun run lint` and `bun run typecheck` pass
- [x] Allow edits from maintainers is enabled on the fork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `computer` skill for accessibility-first control of desktop applications and system browsers.
  * Added support for Cua Driver and macOS Peekaboo, with driver selection and installation guidance.
  * Added Windows driver autostart configuration and cross-platform setup guidance.
* **Documentation**
  * Added the skill to documentation navigation and the skills reference.
  * Included setup, permissions, telemetry opt-out, invocation, session management, verification, browser interaction, and safety guidance.
  * Added examples for opening desktop apps and modifying settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->