### PR TITLE
Disable autocapitalization in mobile terminal composer

### DIFF
--- a/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/components/GlassComposer/GlassComposer.tsx
@@ -33,6 +33,7 @@ import {
 	padding,
 	resizable,
 	shapes,
+	textInputAutocapitalization,
 	tint,
 	truncationMode,
 } from "@expo/ui/swift-ui/modifiers";
@@ -73,6 +74,10 @@ const GLASS_BLEED = 10;
 /** Stable identity so `showAttachments={false}` doesn't churn effect deps. */
 const NO_ATTACHMENTS: PromptInputAttachmentItem[] = [];
 
+type TextInputAutocapitalization = Parameters<
+	typeof textInputAutocapitalization
+>[0];
+
 export interface GlassComposerHandle {
 	focus: () => void;
 	blur: () => void;
@@ -94,6 +99,8 @@ export interface GlassComposerProps {
 	toolbarLeading?: ReactNode;
 	/** Keeps the composer expanded while the field isn't focused. */
 	keepExpanded?: boolean;
+	/** Overrides the native keyboard's autocapitalization behavior. */
+	textInputAutocapitalization?: TextInputAutocapitalization;
 	/** A submit is in flight: send stays visible but disabled. */
 	isSending?: boolean;
 	/**
@@ -132,6 +139,7 @@ export const GlassComposer = forwardRef<
 		header,
 		toolbarLeading,
 		keepExpanded = false,
+		textInputAutocapitalization: inputAutocapitalization,
 		isSending = false,
 		showAttachments = true,
 		onActiveChange,
@@ -510,6 +518,9 @@ export const GlassComposer = forwardRef<
 									frame({ minHeight: expanded ? 56 : 38 }),
 									lineLimit(expanded ? 12 : 1),
 									truncationMode("tail"),
+									...(inputAutocapitalization
+										? [textInputAutocapitalization(inputAutocapitalization)]
+										: []),
 								]}
 							/>
 							<HStack

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -100,6 +100,7 @@ export const TerminalComposer = forwardRef<
 				above={<QuickKeysRow onKey={onQuickKey} />}
 				isSending={writeAttachments.isPending || isSubmitting}
 				showAttachments={allowAttachments}
+				textInputAutocapitalization="never"
 				onActiveChange={onActiveChange}
 				onSubmit={submit}
 				placeholder={placeholder}


### PR DESCRIPTION
## Summary

- Add an optional SwiftUI `textInputAutocapitalization` override to the shared mobile `GlassComposer`
- Set terminal composers to `never` so mobile terminal prompts do not auto-capitalize by default
- Leave the home composer unchanged so it keeps the platform default capitalization behavior

## Validation

- `bun run --cwd apps/mobile lint`
- `git diff --check`
- `bun run --cwd apps/mobile typecheck` still has existing unrelated mobile/shared type errors; no diagnostics mention `GlassComposer`, `TerminalComposer`, or `textInputAutocapitalization`
- Loaded this branch in the iOS simulator through Metro on port `8092`; terminal journey was blocked by the current org's Pro gate before reaching workspace terminals


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables autocapitalization in the mobile terminal composer to avoid unintended capital letters in commands. Previously terminal input followed the platform default; now terminal uses “never,” while the home composer and others keep platform defaults.

- Adds optional `textInputAutocapitalization` prop to `GlassComposer`, passed to SwiftUI’s `textInputAutocapitalization` modifier from `@expo/ui/swift-ui/modifiers` when provided.
- Sets `textInputAutocapitalization="never"` in `TerminalComposer`.
- No migration required; existing composers are unchanged unless the new prop is set.

<sup>Written for commit c89cac27979a62ebb8edf888428f7555680b1504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable text autocapitalization for composer text fields.
  * Terminal input now keeps capitalization unchanged, improving command entry and preventing unintended uppercase characters.

* **Bug Fixes**
  * Improved text-entry behavior by ensuring terminal commands are entered exactly as typed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->