### PR TITLE
Show skipped PR checks in mobile sheet

### DIFF
--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
@@ -1,11 +1,16 @@
-import type { PullRequestCheck } from "../../../../../../utils/pullRequest";
 import {
+	type EffectiveCheck,
 	effectiveCheckStatus,
 	tallyChecks,
-} from "../../../../../../utils/pullRequest";
-import { CHECK_OUTCOME } from "../../../../utils/checkOutcome";
+} from "../../../../../../utils/pullRequest/checks";
+import type { PullRequestCheck } from "../../../../../../utils/pullRequest/types";
 
-export type ChecksFilterValue = "all" | "running" | "failed" | "passed";
+export type ChecksFilterValue =
+	| "all"
+	| "running"
+	| "failed"
+	| "passed"
+	| "skipped";
 
 const GROUPS: {
 	filter: Exclude<ChecksFilterValue, "all">;
@@ -15,7 +20,19 @@ const GROUPS: {
 	{ filter: "running", title: "In Progress", segment: "Running" },
 	{ filter: "failed", title: "Failed", segment: "Failed" },
 	{ filter: "passed", title: "Passed", segment: "Passed" },
+	{ filter: "skipped", title: "Skipped", segment: "Skipped" },
 ];
+
+const CHECK_FILTER: Record<
+	EffectiveCheck,
+	Exclude<ChecksFilterValue, "all">
+> = {
+	failed: "failed",
+	"needs-action": "failed",
+	running: "running",
+	passed: "passed",
+	ignored: "skipped",
+};
 
 /** Segments to offer and groups to show; "Failed" is offered even at zero. */
 export function checksFilterState(
@@ -28,6 +45,7 @@ export function checksFilterState(
 		running: tally.running,
 		failed: tally.failed + tally.needsAction,
 		passed: tally.passed,
+		skipped: tally.ignored,
 	};
 
 	const options = [
@@ -47,7 +65,7 @@ export function checksFilterState(
 	const groups = GROUPS.map((group) => ({
 		...group,
 		members: checks.filter(
-			(check) => CHECK_OUTCOME[effectiveCheckStatus(check)] === group.filter,
+			(check) => CHECK_FILTER[effectiveCheckStatus(check)] === group.filter,
 		),
 	})).filter(
 		(group) =>

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/utils/checkOutcome/checkOutcome.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/utils/checkOutcome/checkOutcome.ts
@@ -1,15 +1,14 @@
-import { Check, Loader, X } from "lucide-react-native";
+import { Check, Loader, Minus, X } from "lucide-react-native";
 import type { EffectiveCheck } from "../../../../utils/pullRequest";
 
-export type CheckOutcome = "failed" | "running" | "passed";
+export type CheckOutcome = "failed" | "running" | "passed" | "skipped";
 
-/** Skipped runs sit with the passes: they are not news, and not a problem. */
 export const CHECK_OUTCOME: Record<EffectiveCheck, CheckOutcome> = {
 	failed: "failed",
 	"needs-action": "failed",
 	running: "running",
 	passed: "passed",
-	ignored: "passed",
+	ignored: "skipped",
 };
 
 export const CHECK_STYLE: Record<
@@ -19,4 +18,9 @@ export const CHECK_STYLE: Record<
 	failed: { icon: X, surface: "bg-red-500/15", ink: "text-red-500" },
 	running: { icon: Loader, surface: "bg-amber-500/15", ink: "text-amber-500" },
 	passed: { icon: Check, surface: "bg-green-500/15", ink: "text-green-500" },
+	skipped: {
+		icon: Minus,
+		surface: "bg-secondary",
+		ink: "text-muted-foreground",
+	},
 };

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/utils/pullRequest/checks.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/utils/pullRequest/checks.ts
@@ -38,7 +38,7 @@ export interface ChecksTally {
 	needsAction: number;
 	/** Skipped and cancelled runs: they ran to no verdict, so they neither pass nor fail. */
 	ignored: number;
-	/** Counts ignored runs too, so 17 passing of 19 can include a skip. */
+	/** Counts ignored runs too, so the All tab can expose skipped runs separately. */
 	total: number;
 	failing: PullRequestCheck[];
 }


### PR DESCRIPTION
## Summary
- Add a Skipped filter/group to the mobile PR checks sheet.
- Keep skipped/cancelled checks in All while showing them separately from Passed.
- Render ignored checks with a neutral skipped row style.

## Validation
- bun --cwd apps/mobile lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show skipped PR checks in the mobile checks sheet and style them neutrally. Previously, ignored (skipped/cancelled) checks appeared as Passed; now they appear as Skipped and show separately within All.

- Map `ignored` effective checks to `skipped` for both filtering and outcome.
- Add a Skipped filter/group in the sheet; All shows Skipped separate from Passed.
- Use `Minus` from `lucide-react-native` and muted colors for skipped rows.
- No change to failure logic; Failed still includes needs-action.

<sup>Written for commit 792b99da3b37ac05617fe9edbf0a891b98e021e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Skipped** status for pull request checks.
  * Skipped checks now appear separately from passed checks and include their own count.
  * Added distinct visual styling and an icon for skipped checks.

* **Bug Fixes**
  * Ignored checks are no longer incorrectly shown as passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->