### PR TITLE
Fix Superset terminal CLI auth

### DIFF
--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -94,6 +94,16 @@ the edge.** A sandbox whose preview is ever made public is open to anyone with
 the URL. Treat preview configuration (`public: false`) as the security-
 critical setting it now is.
 
+**Because sandbox hostAuth admits everything, credential-serving routes must
+not exist there.** `/auth/session-jwt` hands the host's cloud bearer to any
+caller hostAuth admits — on a local host that means "holds the PSK", in a
+sandbox it means *everyone in the box plus anyone with a preview token*.
+Today the sandbox's `AUTH_TOKEN` is the placeholder `"sandbox"` so there is
+nothing to steal, but the route's contract would silently become an open token
+dispenser the day a real credential lands in that env. The route is skipped
+entirely in sandbox run mode; any future route that serves a credential needs
+the same guard.
+
 **Model credentials never enter the sandbox.** The provider's egress proxy
 substitutes them at the edge from a `{{SECRET:...}}` routing rule; the sandbox
 env holds only `SANDBOX_CREDENTIAL_PLACEHOLDER`. The placeholder must still be

--- a/packages/agent-setup/src/shell-wrappers.test.ts
+++ b/packages/agent-setup/src/shell-wrappers.test.ts
@@ -485,6 +485,63 @@ precmd_functions+=(_mise_hook_precmd)
 		expect(typeLine).toContain(integrationBinDir);
 	});
 
+	it("zsh moves BIN_DIR to the front when it is already present later in PATH", () => {
+		if (!isZshAvailable()) return;
+
+		const integrationRoot = path.join(TEST_ROOT, "path-shadow-repro");
+		const integrationBinDir = path.join(integrationRoot, "superset-bin");
+		const integrationZshDir = path.join(integrationRoot, "zsh");
+		const integrationBashDir = path.join(integrationRoot, "bash");
+		const homeDir = path.join(integrationRoot, "home");
+		const oldBinDir = path.join(integrationRoot, "old-bin");
+
+		mkdirSync(integrationBinDir, { recursive: true });
+		mkdirSync(integrationZshDir, { recursive: true });
+		mkdirSync(integrationBashDir, { recursive: true });
+		mkdirSync(homeDir, { recursive: true });
+		mkdirSync(oldBinDir, { recursive: true });
+
+		writeFileSync(
+			path.join(oldBinDir, "superset"),
+			"#!/usr/bin/env bash\necho old\n",
+		);
+		chmodSync(path.join(oldBinDir, "superset"), 0o755);
+
+		writeFileSync(
+			path.join(integrationBinDir, "superset"),
+			"#!/usr/bin/env bash\necho managed\n",
+		);
+		chmodSync(path.join(integrationBinDir, "superset"), 0o755);
+
+		createZshWrapper({
+			BIN_DIR: integrationBinDir,
+			ZSH_DIR: integrationZshDir,
+			BASH_DIR: integrationBashDir,
+		});
+
+		const output = execFileSync(
+			"zsh",
+			["-lic", "command -v superset && superset"],
+			{
+				encoding: "utf-8",
+				env: {
+					HOME: homeDir,
+					PATH: `${oldBinDir}:${integrationBinDir}:/usr/bin:/bin`,
+					SUPERSET_ORIG_ZDOTDIR: homeDir,
+					ZDOTDIR: integrationZshDir,
+				},
+			},
+		);
+
+		const lines = output
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean);
+		expect(lines).toContain(`${integrationBinDir}/superset`);
+		expect(lines).toContain("managed");
+		expect(lines).not.toContain("old");
+	});
+
 	it("zsh wrappers treat special characters in generated paths literally", () => {
 		if (!isZshAvailable()) return;
 
@@ -839,6 +896,7 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			expect(args[0]).toBe("-l");
 			expect(args[1]).toBe("--init-command");
 			expect(args[2]).toContain(`set -l _superset_bin "${TEST_BIN_DIR}"`);
+			expect(args[2]).toContain(`test "$PATH[1]" = "$_superset_bin"`);
 			// Both markers are emitted so old v1 daemons (777 scanner) and new
 			// scanners (133;A) both detect readiness without a daemon restart.
 			expect(args[2]).toContain("\\033]777;superset-shell-ready\\007");

--- a/packages/agent-setup/src/shell-wrappers.ts
+++ b/packages/agent-setup/src/shell-wrappers.ts
@@ -94,11 +94,11 @@ ${name}() {
 	).join("\n");
 }
 
-/** Build a shell snippet that idempotently prepends BIN_DIR to PATH. */
+/** Build a shell snippet that keeps BIN_DIR first in PATH. */
 function buildPathPrependFunction(binDir: string): string {
 	return `_superset_prepend_bin() {
-  case ":$PATH:" in
-    *:${quoteShellLiteral(binDir)}:*) ;;
+  case "$PATH:" in
+    ${quoteShellLiteral(`${binDir}:`)}*) ;;
     *) export PATH=${quoteShellLiteral(binDir)}:"$PATH" ;;
   esac
 }
@@ -106,7 +106,7 @@ _superset_prepend_bin`;
 }
 
 /**
- * Build a zsh precmd hook that re-asserts BIN_DIR in PATH.
+ * Build a zsh precmd hook that re-asserts BIN_DIR first in PATH.
  * Tools like mise/asdf register precmd hooks that reconstruct PATH,
  * which can remove our BIN_DIR. This is intentionally best-effort so
  * unusual user zsh configs don't break shell startup.
@@ -114,8 +114,8 @@ _superset_prepend_bin`;
 function buildZshPrecmdHook(binDir: string): string {
 	return `typeset -ga precmd_functions 2>/dev/null || true
 _superset_ensure_path() {
-  case ":$PATH:" in
-    *:${quoteShellLiteral(binDir)}:*) ;;
+  case "$PATH:" in
+    ${quoteShellLiteral(`${binDir}:`)}*) ;;
     *) PATH=${quoteShellLiteral(binDir)}:"$PATH" ;;
   esac
 }
@@ -298,7 +298,8 @@ export function getShellArgs(
 	}
 	if (shellName === "fish") {
 		// Use --init-command to prepend BIN_DIR to PATH after config is loaded.
-		// Use fish list-aware checks to avoid duplicate PATH entries across nested shells.
+		// Check the first list entry so an older standalone superset earlier in
+		// PATH cannot shadow the desktop-managed shim.
 		// Emit both OSC 777 (legacy v1 daemon) and OSC 133;A (current scanner)
 		// on fish_prompt. See zsh wrapper for rationale.
 		const escapedBinDir = escapeFishDoubleQuoted(paths.BIN_DIR);
@@ -307,7 +308,7 @@ export function getShellArgs(
 			"--init-command",
 			[
 				`set -l _superset_bin "${escapedBinDir}"`,
-				`contains -- "$_superset_bin" $PATH`,
+				`test "$PATH[1]" = "$_superset_bin"`,
 				`or set -gx PATH "$_superset_bin" $PATH`,
 				`function _superset_prompt_mark --on-event fish_prompt`,
 				`printf '\\033]777;superset-shell-ready\\007\\033]133;A\\007'`,

--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -6,6 +6,7 @@ import { type ApiClient, createApiClient } from "../../../lib/api-client";
 import { login } from "../../../lib/auth";
 import { command } from "../../../lib/command";
 import { readConfig, writeConfig } from "../../../lib/config";
+import { isSupersetTerminalContext } from "../../../lib/resolve-auth";
 import { copyToClipboard } from "./copyToClipboard";
 import { LoginUI, type LoginUIProps } from "./LoginUI";
 
@@ -154,6 +155,11 @@ export default command({
 		),
 	},
 	run: async (opts) => {
+		if (isSupersetTerminalContext()) {
+			p.log.info(
+				"Superset is managing auth for you in this terminal — logging in is only needed for use outside Superset terminals.",
+			);
+		}
 		const requestedOrganization = opts.options.organization;
 		const apiKeyExplicit = apiKeyFlagInArgv();
 		const apiKeyFromCli = apiKeyExplicit

--- a/packages/cli/src/commands/auth/logout/command.ts
+++ b/packages/cli/src/commands/auth/logout/command.ts
@@ -1,5 +1,6 @@
 import { command } from "../../../lib/command";
 import { readConfig, writeConfig } from "../../../lib/config";
+import { isSupersetTerminalContext } from "../../../lib/resolve-auth";
 
 export default command({
 	description: "Clear stored credentials",
@@ -9,6 +10,12 @@ export default command({
 		delete config.auth;
 		delete config.apiKey;
 		writeConfig(config);
+		if (isSupersetTerminalContext()) {
+			return {
+				message:
+					"Logged out.\nSuperset is managing auth for you in this terminal, so commands here stay signed in. Logout affects the CLI outside Superset terminals.",
+			};
+		}
 		return { message: "Logged out." };
 	},
 });

--- a/packages/cli/src/commands/auth/whoami/command.ts
+++ b/packages/cli/src/commands/auth/whoami/command.ts
@@ -11,6 +11,8 @@ export default command({
 		let authLine: string;
 		if (ctx.authSource === "oauth") {
 			authLine = "Session";
+		} else if (ctx.authSource === "host") {
+			authLine = "Superset-managed session (via local host service)";
 		} else if (ctx.authSource === "override") {
 			authLine = "API key (from --api-key flag or SUPERSET_API_KEY env)";
 		} else {

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -10,11 +10,12 @@ export type ApiClient = TRPCClient<AppRouter>;
 export function createApiClient(opts: {
 	bearer: string;
 	organizationId?: string;
+	apiUrl?: string;
 }): ApiClient {
 	return createTRPCClient<AppRouter>({
 		links: [
 			httpBatchLink({
-				url: `${getApiUrl()}/api/trpc`,
+				url: `${opts.apiUrl ?? getApiUrl()}/api/trpc`,
 				transformer: SuperJSON,
 				headers() {
 					// better-auth's apiKey plugin reads `sk_live_…` from the

--- a/packages/cli/src/lib/resolve-auth.test.ts
+++ b/packages/cli/src/lib/resolve-auth.test.ts
@@ -1,7 +1,5 @@
 import { afterAll, afterEach, describe, expect, it } from "bun:test";
 import fs from "node:fs";
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -76,43 +74,18 @@ afterAll(() => {
 });
 
 async function withHostSessionServer<Result>(
-	handler: (request: Request) => Response,
+	respond: (request: Request) => Response,
 	run: (endpoint: string) => Promise<Result>,
 ): Promise<Result> {
-	const server: Server = createServer(async (req, res) => {
-		const chunks: Buffer[] = [];
-		for await (const chunk of req) chunks.push(Buffer.from(chunk));
-		const headers = new Headers();
-		for (const [key, value] of Object.entries(req.headers)) {
-			if (Array.isArray(value)) {
-				for (const item of value) headers.append(key, item);
-			} else if (value !== undefined) {
-				headers.set(key, value);
-			}
-		}
-		const request = new Request(
-			`http://127.0.0.1:${(server.address() as AddressInfo).port}${req.url}`,
-			{
-				method: req.method,
-				headers,
-				body: chunks.length ? Buffer.concat(chunks) : undefined,
-			},
-		);
-		const response = handler(request);
-		res.writeHead(response.status, Object.fromEntries(response.headers));
-		res.end(await response.text());
-	});
-
-	await new Promise<void>((resolve) => {
-		server.listen(0, "127.0.0.1", () => resolve());
+	const server = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch: respond,
 	});
 	try {
-		const address = server.address() as AddressInfo;
-		return await run(`http://127.0.0.1:${address.port}`);
+		return await run(`http://127.0.0.1:${server.port}`);
 	} finally {
-		await new Promise<void>((resolve, reject) => {
-			server.close((error) => (error ? reject(error) : resolve()));
-		});
+		await server.stop(true);
 	}
 }
 
@@ -218,10 +191,16 @@ describe("resolveAuth", () => {
 			},
 		});
 
+		// Assertions on the request happen after the flow completes — an
+		// expect() throw inside the handler would swallow the response and
+		// surface as an unrelated timeout instead of the real mismatch.
+		const seen: { pathname: string; authorization: string | null }[] = [];
 		await withHostSessionServer(
 			(request) => {
-				expect(new URL(request.url).pathname).toBe("/auth/session-jwt");
-				expect(request.headers.get("authorization")).toBe("Bearer host-secret");
+				seen.push({
+					pathname: new URL(request.url).pathname,
+					authorization: request.headers.get("authorization"),
+				});
 				return Response.json({
 					token: "jwt-from-local-host",
 					apiUrl: "https://api.desktop.test",
@@ -235,6 +214,12 @@ describe("resolveAuth", () => {
 				expect(result.config.organizationId).toBe(organizationId);
 			},
 		);
+		expect(seen).toEqual([
+			{
+				pathname: "/auth/session-jwt",
+				authorization: "Bearer host-secret",
+			},
+		]);
 	});
 
 	it("overrides the stored org with SUPERSET_ORGANIZATION_ID", async () => {

--- a/packages/cli/src/lib/resolve-auth.test.ts
+++ b/packages/cli/src/lib/resolve-auth.test.ts
@@ -12,7 +12,15 @@ const tempHome = fs.mkdtempSync(
 process.env.SUPERSET_HOME_DIR = tempHome;
 
 const { resolveAuth } = await import("./resolve-auth");
-const { readConfig, writeConfig } = await import("./config");
+const { readConfig, writeConfig, SUPERSET_HOME_DIR } = await import("./config");
+
+// Manifest writes must use the config module's own SUPERSET_HOME_DIR rather
+// than tempHome: other test files also set the env var at module top level,
+// and if one of them gets collected during this file's top-level awaits, the
+// const can capture that file's dir instead of tempHome. writeConfig and
+// readManifest both go through the const, so deriving the manifest path from
+// it keeps writer and reader consistent no matter which value won.
+const manifestBaseDir = path.join(SUPERSET_HOME_DIR, "host");
 
 function clearConfig(): void {
 	writeConfig({});
@@ -31,6 +39,10 @@ delete process.env.SUPERSET_WORKSPACE_ID;
 
 afterEach(() => {
 	clearConfig();
+	fs.rmSync(path.join(manifestBaseDir, "org_terminal"), {
+		recursive: true,
+		force: true,
+	});
 	delete process.env.SUPERSET_API_KEY;
 	delete process.env.SUPERSET_ORGANIZATION_ID;
 	delete process.env.SUPERSET_TERMINAL_ID;
@@ -105,7 +117,7 @@ async function withHostSessionServer<Result>(
 }
 
 function writeHostManifest(organizationId: string, endpoint: string): void {
-	const manifestDir = path.join(tempHome, "host", organizationId);
+	const manifestDir = path.join(manifestBaseDir, organizationId);
 	fs.mkdirSync(manifestDir, { recursive: true, mode: 0o700 });
 	fs.writeFileSync(
 		path.join(manifestDir, "manifest.json"),

--- a/packages/cli/src/lib/resolve-auth.test.ts
+++ b/packages/cli/src/lib/resolve-auth.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, afterEach, describe, expect, it } from "bun:test";
 import fs from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -20,13 +22,19 @@ function clearConfig(): void {
 // would leak into every test. Clear it for the suite, restore in afterAll.
 const originalEnvKey = process.env.SUPERSET_API_KEY;
 const originalOrganizationId = process.env.SUPERSET_ORGANIZATION_ID;
+const originalTerminalId = process.env.SUPERSET_TERMINAL_ID;
+const originalWorkspaceId = process.env.SUPERSET_WORKSPACE_ID;
 delete process.env.SUPERSET_API_KEY;
 delete process.env.SUPERSET_ORGANIZATION_ID;
+delete process.env.SUPERSET_TERMINAL_ID;
+delete process.env.SUPERSET_WORKSPACE_ID;
 
 afterEach(() => {
 	clearConfig();
 	delete process.env.SUPERSET_API_KEY;
 	delete process.env.SUPERSET_ORGANIZATION_ID;
+	delete process.env.SUPERSET_TERMINAL_ID;
+	delete process.env.SUPERSET_WORKSPACE_ID;
 });
 
 afterAll(() => {
@@ -43,7 +51,74 @@ afterAll(() => {
 	} else {
 		process.env.SUPERSET_ORGANIZATION_ID = originalOrganizationId;
 	}
+	if (originalTerminalId === undefined) {
+		delete process.env.SUPERSET_TERMINAL_ID;
+	} else {
+		process.env.SUPERSET_TERMINAL_ID = originalTerminalId;
+	}
+	if (originalWorkspaceId === undefined) {
+		delete process.env.SUPERSET_WORKSPACE_ID;
+	} else {
+		process.env.SUPERSET_WORKSPACE_ID = originalWorkspaceId;
+	}
 });
+
+async function withHostSessionServer<Result>(
+	handler: (request: Request) => Response,
+	run: (endpoint: string) => Promise<Result>,
+): Promise<Result> {
+	const server: Server = createServer(async (req, res) => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of req) chunks.push(Buffer.from(chunk));
+		const headers = new Headers();
+		for (const [key, value] of Object.entries(req.headers)) {
+			if (Array.isArray(value)) {
+				for (const item of value) headers.append(key, item);
+			} else if (value !== undefined) {
+				headers.set(key, value);
+			}
+		}
+		const request = new Request(
+			`http://127.0.0.1:${(server.address() as AddressInfo).port}${req.url}`,
+			{
+				method: req.method,
+				headers,
+				body: chunks.length ? Buffer.concat(chunks) : undefined,
+			},
+		);
+		const response = handler(request);
+		res.writeHead(response.status, Object.fromEntries(response.headers));
+		res.end(await response.text());
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	try {
+		const address = server.address() as AddressInfo;
+		return await run(`http://127.0.0.1:${address.port}`);
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	}
+}
+
+function writeHostManifest(organizationId: string, endpoint: string): void {
+	const manifestDir = path.join(tempHome, "host", organizationId);
+	fs.mkdirSync(manifestDir, { recursive: true, mode: 0o700 });
+	fs.writeFileSync(
+		path.join(manifestDir, "manifest.json"),
+		JSON.stringify({
+			pid: process.pid,
+			endpoint,
+			authToken: "host-secret",
+			startedAt: Date.now(),
+			organizationId,
+		}),
+		{ mode: 0o600 },
+	);
+}
 
 describe("resolveAuth", () => {
 	it("throws when no override and no stored credentials", async () => {
@@ -118,6 +193,36 @@ describe("resolveAuth", () => {
 		const result = await resolveAuth(undefined);
 		expect(result.bearer).toBe("sk_live_env");
 		expect(result.authSource).toBe("override");
+	});
+
+	it("uses the local host session in a Superset terminal before stale stored credentials", async () => {
+		const organizationId = "org_terminal";
+		process.env.SUPERSET_TERMINAL_ID = "term_1";
+		process.env.SUPERSET_ORGANIZATION_ID = organizationId;
+		writeConfig({
+			auth: {
+				accessToken: "stale-oauth-token",
+				expiresAt: Date.now() - 1000,
+			},
+		});
+
+		await withHostSessionServer(
+			(request) => {
+				expect(new URL(request.url).pathname).toBe("/auth/session-jwt");
+				expect(request.headers.get("authorization")).toBe("Bearer host-secret");
+				return Response.json({
+					token: "jwt-from-local-host",
+					apiUrl: "https://api.desktop.test",
+				});
+			},
+			async (endpoint) => {
+				writeHostManifest(organizationId, endpoint);
+				const result = await resolveAuth(undefined);
+				expect(result.bearer).toBe("jwt-from-local-host");
+				expect(result.authSource).toBe("host");
+				expect(result.config.organizationId).toBe(organizationId);
+			},
+		);
 	});
 
 	it("overrides the stored org with SUPERSET_ORGANIZATION_ID", async () => {

--- a/packages/cli/src/lib/resolve-auth.ts
+++ b/packages/cli/src/lib/resolve-auth.ts
@@ -2,8 +2,9 @@ import { CLIError } from "@superset/cli-framework";
 import { type ApiClient, createApiClient } from "./api-client";
 import { refreshAccessToken } from "./auth";
 import { readConfig, type SupersetConfig, writeConfig } from "./config";
+import { isProcessAlive, readManifest } from "./host/manifest";
 
-export type AuthSource = "override" | "config" | "oauth";
+export type AuthSource = "override" | "host" | "config" | "oauth";
 
 export type ResolvedAuth = {
 	config: SupersetConfig;
@@ -13,6 +14,53 @@ export type ResolvedAuth = {
 };
 
 const REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+const HOST_SESSION_TIMEOUT_MS = 2_000;
+
+type HostSessionAuth = {
+	token: string;
+	apiUrl?: string;
+};
+
+export function isSupersetTerminalContext(): boolean {
+	return Boolean(
+		process.env.SUPERSET_TERMINAL_ID || process.env.SUPERSET_WORKSPACE_ID,
+	);
+}
+
+async function resolveHostSessionAuth(
+	organizationId: string | undefined,
+): Promise<HostSessionAuth | null> {
+	if (!organizationId || !isSupersetTerminalContext()) return null;
+
+	const manifest = readManifest(organizationId);
+	if (!manifest || !isProcessAlive(manifest.pid)) return null;
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), HOST_SESSION_TIMEOUT_MS);
+	try {
+		const response = await fetch(`${manifest.endpoint}/auth/session-jwt`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${manifest.authToken}` },
+		});
+		if (!response.ok) return null;
+
+		const data = (await response.json()) as {
+			token?: unknown;
+			apiUrl?: unknown;
+		};
+		if (typeof data.token !== "string" || data.token.trim() === "") {
+			return null;
+		}
+		return {
+			token: data.token.trim(),
+			apiUrl: typeof data.apiUrl === "string" ? data.apiUrl : undefined,
+		};
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
 
 export async function resolveAuth(
 	apiKeyOption: string | undefined,
@@ -25,10 +73,26 @@ export async function resolveAuth(
 		apiKeyOption?.trim() || process.env.SUPERSET_API_KEY?.trim();
 	let bearer: string | undefined;
 	let authSource: AuthSource;
+	let apiUrl: string | undefined;
+
+	// SUPERSET_ORGANIZATION_ID overrides the stored org for this invocation
+	// (headless/CI, and dev where the CLI must target a specific local org),
+	// mirroring how SUPERSET_API_KEY overrides the stored credential. Not
+	// persisted to disk.
+	const organizationId =
+		process.env.SUPERSET_ORGANIZATION_ID?.trim() || config.organizationId;
+
+	const hostSessionAuth = overrideKey
+		? null
+		: await resolveHostSessionAuth(organizationId);
 
 	if (overrideKey) {
 		bearer = overrideKey;
 		authSource = "override";
+	} else if (hostSessionAuth) {
+		bearer = hostSessionAuth.token;
+		apiUrl = hostSessionAuth.apiUrl;
+		authSource = "host";
 	} else if (config.apiKey?.trim()) {
 		bearer = config.apiKey.trim();
 		authSource = "config";
@@ -64,14 +128,8 @@ export async function resolveAuth(
 		);
 	}
 
-	// SUPERSET_ORGANIZATION_ID overrides the stored org for this invocation
-	// (headless/CI, and dev where the CLI must target a specific local org),
-	// mirroring how SUPERSET_API_KEY overrides the stored credential. Not
-	// persisted to disk.
-	const organizationId =
-		process.env.SUPERSET_ORGANIZATION_ID?.trim() || config.organizationId;
 	const resolvedConfig: SupersetConfig = { ...config, organizationId };
 
-	const api = createApiClient({ bearer, organizationId });
+	const api = createApiClient({ bearer, organizationId, apiUrl });
 	return { config: resolvedConfig, api, bearer, authSource };
 }

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -254,6 +254,31 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	app.use("/chat-v3/*", wsAuth);
 	app.use("/browser/*", wsAuth);
 
+	// Sandbox hostAuth admits every request (the edge is the only gate), so a
+	// credential-serving route must not exist there at all.
+	if (process.env.SUPERSET_HOST_RUN_MODE !== "sandbox") {
+		app.get("/auth/session-jwt", async (c) => {
+			const isAuthenticated = await providers.hostAuth.validate(c.req.raw);
+			if (!isAuthenticated) return c.json({ error: "Unauthorized" }, 401);
+
+			let headers: Record<string, string>;
+			try {
+				headers = await providers.auth.getHeaders();
+			} catch {
+				return c.json({ error: "No bearer session available" }, 412);
+			}
+			const authorization = headers.Authorization ?? headers.authorization;
+			if (!authorization?.startsWith("Bearer ")) {
+				return c.json({ error: "No bearer session available" }, 412);
+			}
+
+			return c.json({
+				token: authorization.slice("Bearer ".length),
+				apiUrl: config.cloudApiUrl,
+			});
+		});
+	}
+
 	registerEventBusRoute({ app, eventBus, upgradeWebSocket });
 	registerBrowserCdpRoute({
 		app,

--- a/packages/host-service/src/host-manifest.test.ts
+++ b/packages/host-service/src/host-manifest.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	claimManifest,
+	type HostServiceManifest,
+	readManifest,
+} from "./host-manifest";
+
+const ORG = "org_manifest_test";
+
+let tempHome: string;
+const originalHome = process.env.SUPERSET_HOME_DIR;
+
+beforeAll(() => {
+	tempHome = mkdtempSync(join(tmpdir(), "superset-host-manifest-"));
+	process.env.SUPERSET_HOME_DIR = tempHome;
+});
+
+afterEach(() => {
+	rmSync(join(tempHome, "host"), { recursive: true, force: true });
+});
+
+afterAll(() => {
+	rmSync(tempHome, { recursive: true, force: true });
+	if (originalHome === undefined) {
+		delete process.env.SUPERSET_HOME_DIR;
+	} else {
+		process.env.SUPERSET_HOME_DIR = originalHome;
+	}
+});
+
+function manifestFor(pid: number, endpoint: string): HostServiceManifest {
+	return {
+		pid,
+		endpoint,
+		authToken: "secret",
+		startedAt: Date.now(),
+		organizationId: ORG,
+	};
+}
+
+async function withHealthyHost<Result>(
+	run: (endpoint: string) => Promise<Result>,
+): Promise<Result> {
+	const server: Server = createServer((req, res) => {
+		if (req.url?.startsWith("/trpc/health.check")) {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ status: "ok" }));
+			return;
+		}
+		res.writeHead(404).end();
+	});
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	try {
+		const { port } = server.address() as AddressInfo;
+		return await run(`http://127.0.0.1:${port}`);
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	}
+}
+
+describe("claimManifest", () => {
+	it("claims when no manifest exists", async () => {
+		const manifest = manifestFor(process.pid, "http://127.0.0.1:1234");
+		await claimManifest(manifest);
+		expect(readManifest(ORG)).toEqual(manifest);
+	});
+
+	it("steals the claim from a dead holder", async () => {
+		const dead = manifestFor(999_999_999, "http://127.0.0.1:1");
+		await claimManifest(dead);
+		const ours = manifestFor(process.pid, "http://127.0.0.1:1234");
+		await claimManifest(ours);
+		expect(readManifest(ORG)?.pid).toBe(process.pid);
+	});
+
+	it("yields to a live, healthy holder", async () => {
+		await withHealthyHost(async (endpoint) => {
+			// ppid is a live process that isn't us — the health probe against the
+			// fake server is what makes it a valid holder.
+			const holder = manifestFor(process.ppid, endpoint);
+			await claimManifest(holder);
+			const ours = manifestFor(process.pid, "http://127.0.0.1:1234");
+			await claimManifest(ours);
+			expect(readManifest(ORG)?.pid).toBe(process.ppid);
+		});
+	});
+
+	it("readManifest rejects malformed files", async () => {
+		const manifest = manifestFor(process.pid, "http://127.0.0.1:1234");
+		await claimManifest(manifest);
+		const filePath = join(tempHome, "host", ORG, "manifest.json");
+		expect(readFileSync(filePath, "utf-8")).toContain(String(process.pid));
+		await Bun.write(filePath, '{"pid": "not-a-number"}');
+		expect(readManifest(ORG)).toBeNull();
+	});
+});

--- a/packages/host-service/src/host-manifest.ts
+++ b/packages/host-service/src/host-manifest.ts
@@ -1,0 +1,161 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The manifest is the CLI's routing table: ~/.superset/host/<org>/manifest.json
+ * names the live host-service for an organization so the CLI can discover its
+ * endpoint and borrow session auth. Format matches the desktop app's
+ * HostServiceManifest (apps/desktop/src/main/lib/host-service-manifest.ts) and
+ * the CLI's reader (packages/cli/src/lib/host/manifest.ts).
+ *
+ * The desktop's bundled host-service entry claims the manifest itself; this
+ * module gives the standalone entry (serve.ts — CLI-spawned and systemd
+ * launches) the same claim behavior, so terminals under a deployed host can
+ * resolve auth the same way desktop terminals do.
+ */
+export interface HostServiceManifest {
+	pid: number;
+	endpoint: string;
+	authToken: string;
+	startedAt: number;
+	organizationId: string;
+}
+
+const RECLAIM_INTERVAL_MS = 15_000;
+const HOLDER_PROBE_TIMEOUT_MS = 2_500;
+const HOLDER_PROBE_RETRY_MS = 200;
+
+function manifestPath(organizationId: string): string {
+	const home = process.env.SUPERSET_HOME_DIR ?? join(homedir(), ".superset");
+	return join(home, "host", organizationId, "manifest.json");
+}
+
+export function readManifest(
+	organizationId: string,
+): HostServiceManifest | null {
+	const filePath = manifestPath(organizationId);
+	if (!existsSync(filePath)) return null;
+	try {
+		const data = JSON.parse(readFileSync(filePath, "utf-8"));
+		if (
+			typeof data.pid !== "number" ||
+			typeof data.endpoint !== "string" ||
+			typeof data.authToken !== "string" ||
+			typeof data.startedAt !== "number" ||
+			typeof data.organizationId !== "string"
+		) {
+			return null;
+		}
+		return data as HostServiceManifest;
+	} catch {
+		return null;
+	}
+}
+
+function writeManifest(manifest: HostServiceManifest): void {
+	const finalPath = manifestPath(manifest.organizationId);
+	const dir = join(finalPath, "..");
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	// Write-then-rename so concurrent readers (the CLI, other instances'
+	// claim checks) never see a torn file.
+	const tempPath = `${finalPath}.${process.pid}.tmp`;
+	writeFileSync(tempPath, JSON.stringify(manifest), {
+		encoding: "utf-8",
+		mode: 0o600,
+	});
+	renameSync(tempPath, finalPath);
+}
+
+function isProcessAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 1) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// Retrying probe, like the desktop's: a holder that is momentarily slow
+// (mid-GC, DB migration) must not get its claim taken.
+async function probeHealthy(
+	endpoint: string,
+	authToken: string,
+): Promise<boolean> {
+	const deadline = Date.now() + HOLDER_PROBE_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(
+				() => controller.abort(),
+				Math.max(HOLDER_PROBE_RETRY_MS, deadline - Date.now()),
+			);
+			try {
+				const response = await fetch(`${endpoint}/trpc/health.check`, {
+					signal: controller.signal,
+					headers: { Authorization: `Bearer ${authToken}` },
+				});
+				if (response.ok) return true;
+			} finally {
+				clearTimeout(timeout);
+			}
+		} catch {
+			// not reachable yet
+		}
+		await new Promise((r) => setTimeout(r, HOLDER_PROBE_RETRY_MS));
+	}
+	return false;
+}
+
+export async function claimManifest(
+	manifest: HostServiceManifest,
+): Promise<void> {
+	const existing = readManifest(manifest.organizationId);
+	if (
+		existing &&
+		existing.pid !== manifest.pid &&
+		isProcessAlive(existing.pid) &&
+		(await probeHealthy(existing.endpoint, existing.authToken))
+	) {
+		console.warn(
+			`[host-service] manifest for ${manifest.organizationId} held by live pid ${existing.pid} at ${existing.endpoint}; not claiming`,
+		);
+		return;
+	}
+	writeManifest(manifest);
+}
+
+/**
+ * Claim the manifest now and keep re-claiming whenever another holder dies
+ * or quits, so the CLI's routing table always names a live instance.
+ */
+export function startManifestClaim(options: {
+	organizationId: string;
+	port: number;
+	authToken: string;
+}): void {
+	const manifest: HostServiceManifest = {
+		pid: process.pid,
+		endpoint: `http://127.0.0.1:${options.port}`,
+		authToken: options.authToken,
+		startedAt: Date.now(),
+		organizationId: options.organizationId,
+	};
+	void claimManifest(manifest).catch((error) => {
+		console.error("[host-service] Failed to write manifest:", error);
+	});
+	const timer = setInterval(() => {
+		if (readManifest(manifest.organizationId)?.pid === process.pid) return;
+		void claimManifest(manifest).catch(() => {});
+	}, RECLAIM_INTERVAL_MS);
+	timer.unref();
+}

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { getSupervisor, startDaemonBootstrap } from "./daemon";
 import { env } from "./env";
+import { startManifestClaim } from "./host-manifest";
 import {
 	ConfigFileSessionTokenSource,
 	JwtApiAuthProvider,
@@ -127,6 +128,17 @@ async function main(): Promise<void> {
 		console.log(`[host-service] listening on http://${address}:${info.port}`);
 
 		startTerminalReaper(db);
+
+		// CLI-spawned hosts get a manifest from spawn.ts, but systemd/direct
+		// launches previously had none — terminals under a deployed host
+		// couldn't discover it for session auth.
+		if (env.SUPERSET_HOST_RUN_MODE !== "sandbox" && env.ORGANIZATION_ID) {
+			startManifestClaim({
+				organizationId: env.ORGANIZATION_ID,
+				port: info.port,
+				authToken: env.HOST_SERVICE_SECRET,
+			});
+		}
 
 		if (env.RELAY_URL && env.SUPERSET_HOST_RUN_MODE !== "sandbox") {
 			void connectRelay({

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -273,6 +273,7 @@ describe("getShellLaunchArgs", () => {
 		expect(args[0]).toBe("-l");
 		expect(args[1]).toBe("--init-command");
 		expect(args[2]).toContain("_superset_bin");
+		expect(args[2]).toContain(`test "$PATH[1]" = "$_superset_bin"`);
 		expect(args[2]).toContain("133;A");
 	});
 

--- a/packages/host-service/src/terminal/shell-launch.ts
+++ b/packages/host-service/src/terminal/shell-launch.ts
@@ -50,7 +50,7 @@ function fileContainsShellReadyMarker(filePath: string): boolean {
 }
 
 /**
- * Matches desktop shell-wrappers.ts fish init: idempotent PATH prepend +
+ * Matches desktop shell-wrappers.ts fish init: keep BIN_DIR first in PATH +
  * OSC 133;A prompt marker (FinalTerm standard) for shell readiness.
  *
  * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
@@ -62,7 +62,7 @@ function buildFishInitCommand(binDir: string): string {
 		.replaceAll("$", "\\$");
 	return [
 		`set -l _superset_bin "${escaped}"`,
-		`contains -- "$_superset_bin" $PATH`,
+		`test "$PATH[1]" = "$_superset_bin"`,
 		`or set -gx PATH "$_superset_bin" $PATH`,
 		`function _superset_prompt_mark --on-event fish_prompt`,
 		`printf '\\033]133;A\\007'`,

--- a/packages/host-service/test/helpers/createTestHost.ts
+++ b/packages/host-service/test/helpers/createTestHost.ts
@@ -30,6 +30,8 @@ export interface TestHostOptions {
 	allowedOrigins?: string[];
 	psk?: string;
 	apiOverrides?: FakeApiOverrides;
+	apiAuthHeaders?: Record<string, string>;
+	apiAuthError?: Error;
 	githubToken?: string | null;
 	/**
 	 * Fake-runtime overrides typed as `unknown` so tests only need to
@@ -110,7 +112,10 @@ export async function createTestHost(
 			allowedOrigins: options.allowedOrigins ?? ["http://localhost:5173"],
 		},
 		providers: {
-			auth: new FakeApiAuthProvider(),
+			auth: new FakeApiAuthProvider(
+				options.apiAuthHeaders,
+				options.apiAuthError,
+			),
 			hostAuth: new FakeHostAuthProvider(psk),
 			credentials: new MemoryGitCredentialProvider(options.githubToken ?? null),
 		},

--- a/packages/host-service/test/helpers/fakes.ts
+++ b/packages/host-service/test/helpers/fakes.ts
@@ -4,8 +4,12 @@ import type { GitCredentialProvider } from "../../src/runtime/git/types";
 import type { ApiClient } from "../../src/types";
 
 export class FakeApiAuthProvider implements ApiAuthProvider {
-	constructor(private readonly headers: Record<string, string> = {}) {}
+	constructor(
+		private readonly headers: Record<string, string> = {},
+		private readonly error?: Error,
+	) {}
 	async getHeaders(): Promise<Record<string, string>> {
+		if (this.error) throw this.error;
 		return { ...this.headers };
 	}
 }

--- a/packages/host-service/test/integration/smoke.integration.test.ts
+++ b/packages/host-service/test/integration/smoke.integration.test.ts
@@ -62,6 +62,68 @@ describe("host-service smoke", () => {
 		);
 	});
 
+	test("session-jwt returns the current bearer token for local host-auth clients", async () => {
+		host = await replaceHost(host, {
+			cloudApiUrl: "https://api.example.test",
+			apiAuthHeaders: { Authorization: "Bearer jwt-from-desktop-session" },
+		});
+
+		const response = await host.fetch(
+			"http://host-service.test/auth/session-jwt",
+			{
+				headers: { authorization: `Bearer ${host.psk}` },
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			token: "jwt-from-desktop-session",
+			apiUrl: "https://api.example.test",
+		});
+	});
+
+	test("session-jwt rejects unauthenticated requests", async () => {
+		const response = await host.fetch(
+			"http://host-service.test/auth/session-jwt",
+		);
+		expect(response.status).toBe(401);
+	});
+
+	test("session-jwt returns 412 when no session credential can be minted", async () => {
+		host = await replaceHost(host, {
+			apiAuthError: new Error("Failed to mint JWT: 401"),
+		});
+
+		const response = await host.fetch(
+			"http://host-service.test/auth/session-jwt",
+			{
+				headers: { authorization: `Bearer ${host.psk}` },
+			},
+		);
+
+		expect(response.status).toBe(412);
+	});
+
+	test("session-jwt does not exist in sandbox run mode", async () => {
+		process.env.SUPERSET_HOST_RUN_MODE = "sandbox";
+		try {
+			host = await replaceHost(host, {
+				apiAuthHeaders: { Authorization: "Bearer jwt-from-desktop-session" },
+			});
+
+			const response = await host.fetch(
+				"http://host-service.test/auth/session-jwt",
+				{
+					headers: { authorization: `Bearer ${host.psk}` },
+				},
+			);
+
+			expect(response.status).toBe(404);
+		} finally {
+			delete process.env.SUPERSET_HOST_RUN_MODE;
+		}
+	});
+
 	test("CORS preflight allows configured origin and rejects others", async () => {
 		const allowed = await host.fetch(
 			"http://host-service.test/trpc/health.check",


### PR DESCRIPTION
## Summary

The CLI's OAuth credential was fully independent of the desktop session, so it expired on its own even while the desktop stayed signed in — and an older standalone `superset` earlier in PATH could shadow the desktop-managed CLI entirely. This makes CLI auth inside any Superset terminal ride the host's session, so it stays fresh as long as the host is signed in.

- **CLI**: inside Superset terminals (detected via `SUPERSET_TERMINAL_ID`/`SUPERSET_WORKSPACE_ID`), resolve auth from the local host service first — manifest discovery, then `GET /auth/session-jwt` for a short-lived JWT plus the host's `apiUrl`. Falls back silently to stored credentials on any failure; `--api-key`/`SUPERSET_API_KEY` still override everything.
- **Shell wrappers**: keep `BIN_DIR` first in PATH instead of merely present, so a stale standalone binary can't shadow the managed CLI (zsh/bash/fish + zsh precmd re-assert).
- **Host service**: `/auth/session-jwt` is PSK-gated, returns 412 when no session can be minted (instead of an unhandled 500), and is not registered in sandbox run mode — sandbox hostAuth admits every request, so credential-serving routes must not exist there (documented in `docs/cloud-sandbox-mismatches.md`).
- **Host service**: the standalone entry (systemd/direct launches) now claims the discovery manifest with the same yield-to-healthy-holder semantics as the desktop, so terminals under deployed hosts resolve auth the same way desktop terminals do.
- **CLI UX**: `auth login`/`logout`/`whoami` now say when Superset is managing auth for the terminal, since logout no longer signs you out inside one.

## Test Plan

- [x] `packages/cli` full suite (102 pass) — includes host-session resolution against a live fake host + manifest
- [x] `packages/host-service` full suite (1163 pass) — includes session-jwt happy path/401/412/absent-in-sandbox, and manifest claim/steal/yield
- [x] `packages/agent-setup` suite (26 pass) — includes PATH-shadowing repro under real zsh
- [x] Typecheck + root lint clean

https://claude.ai/code/session_015FW2TfpCftGyTPjhzVZVv4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI authentication now works with Superset-managed terminal sessions.
  - Added clear login, logout, and session-status messages for managed terminals.
  - Host sessions can automatically provide authentication and API connection details.

- **Bug Fixes**
  - Managed command-line tools now take precedence over older installations across supported shells.
  - Improved handling of multiple host services and stale sessions.

- **Documentation**
  - Documented sandbox authentication behavior and credential-protection safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->