### PR TITLE
feat(mobile,trpc): create cloud workspaces from the phone

### DIFF
--- a/apps/mobile/hooks/useCloudProjects/index.ts
+++ b/apps/mobile/hooks/useCloudProjects/index.ts
@@ -1,0 +1,4 @@
+export {
+	type CloudProjectRow,
+	useCloudProjects,
+} from "./useCloudProjects";

--- a/apps/mobile/hooks/useCloudProjects/useCloudProjects.ts
+++ b/apps/mobile/hooks/useCloudProjects/useCloudProjects.ts
@@ -1,0 +1,55 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import type { RouterOutputs } from "@superset/trpc";
+import { useQuery } from "@tanstack/react-query";
+import { TRPCClientError } from "@trpc/client";
+import { useFeatureFlag } from "posthog-react-native";
+import { useSession } from "@/lib/auth/client";
+import { apiClient } from "@/lib/trpc/client";
+
+export type CloudProjectRow =
+	RouterOutputs["cloudWorkspace"]["listProjects"][number];
+
+const NO_PROJECTS: CloudProjectRow[] = [];
+
+/**
+ * Projects a cloud workspace can be created from, straight from the API — the
+ * one create source that works with zero machines online. Gated like the
+ * cloud list: the flag decides whether to ask, and a FORBIDDEN answer means
+ * "none", not an error.
+ */
+export function useCloudProjects(): {
+	projects: CloudProjectRow[];
+	organizationId: string | null;
+} {
+	const enabledByFlag = Boolean(useFeatureFlag(FEATURE_FLAGS.CLOUD_WORKSPACES));
+	const { data: session } = useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? null;
+
+	const query = useQuery({
+		queryKey: ["cloud", "cloudWorkspace", "listProjects", organizationId],
+		enabled: enabledByFlag && organizationId !== null,
+		staleTime: 60_000,
+		networkMode: "always" as const,
+		retry: (count, error) =>
+			!(error instanceof TRPCClientError && error.data?.code === "FORBIDDEN") &&
+			count < 2,
+		queryFn: async (): Promise<CloudProjectRow[]> => {
+			if (!organizationId) return NO_PROJECTS;
+			try {
+				return await apiClient.cloudWorkspace.listProjects.query({
+					organizationId,
+				});
+			} catch (error) {
+				if (
+					error instanceof TRPCClientError &&
+					error.data?.code === "FORBIDDEN"
+				) {
+					return NO_PROJECTS;
+				}
+				throw error;
+			}
+		},
+	});
+
+	return { projects: query.data ?? NO_PROJECTS, organizationId };
+}

--- a/apps/mobile/plans/20260817-cloud-workspaces.md
+++ b/apps/mobile/plans/20260817-cloud-workspaces.md
@@ -123,3 +123,19 @@ code path is `ensureSandboxAccess` at dial + invalidate on `AppState` active).
 Setup traps hit: Metro `.worklets` ENOENT in a fresh worktree; local API's
 GitHub App doesn't match the branch DB's installation, so create fails at the
 token step here (that is what produced the failed row).
+
+## PR B + image rebuild (2026-08-19)
+
+- Sandbox image `superset-hostsvc` rebuilt from main and deployed. Verified
+  end to end with a throwaway sandbox: `settings.agentConfigs.list` (which
+  lazily seeds the builtin agents — anything calling `agents.run` cold must
+  call it first) then `agents.run` with Claude boots the TUI under root with
+  "bypass permissions on" and no dialogs. Probe sandbox deleted after.
+- PR B implemented per the decisions: interim `cloudWorkspace.listProjects` +
+  App-token `listBranches` (degrades to the default branch when the
+  installation can't be authenticated — which is also the local-dev state,
+  where the .env App doesn't match the branch DB's installations), sectioned
+  project sheet, cloud branch source, agent chip hidden for cloud targets,
+  one-call create → seed list → navigate.
+- Verified locally over curl: listProjects returns the org's repo-bearing
+  projects; listBranches returns `main` + degradation path.

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -28,7 +28,9 @@ import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
+import { useSession } from "@/lib/auth/client";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
+import { apiClient } from "@/lib/trpc/client";
 import {
 	FOREGROUND,
 	GlassComposer,
@@ -40,6 +42,7 @@ import {
 	useChatTargetStore,
 } from "../../stores/chatTargetStore";
 import { useAgentIconUri } from "./hooks/useAgentIconUri";
+import { useCreateCloudWorkspace } from "./hooks/useCreateCloudWorkspace";
 import { useCreateTerminalWorkspace } from "./hooks/useCreateTerminalWorkspace";
 import { useNewChatTargets } from "./hooks/useNewChatTargets";
 import { useStartWorkspaceTerminal } from "./hooks/useStartWorkspaceTerminal";
@@ -77,19 +80,29 @@ export function NewChatWidget({
 	const { targets, defaultTarget } = useNewChatTargets(workspaces);
 	const selectedTarget =
 		targets.find((target) => target.key === targetKey) ?? defaultTarget;
+	const isCloudTarget = selectedTarget?.kind === "cloud";
 
+	const { data: session } = useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? null;
 	const { data: branchData } = useQuery({
 		queryKey: [
-			"host-service",
+			isCloudTarget ? "cloud-branches" : "host-service",
 			"branches",
 			selectedTarget?.hostUrl ?? null,
 			selectedTarget?.projectId ?? null,
 			"",
 		],
-		enabled: selectedTarget !== null,
+		enabled: selectedTarget !== null && (!isCloudTarget || !!organizationId),
 		networkMode: "always" as const,
 		queryFn: async () => {
 			if (!selectedTarget) return null;
+			if (selectedTarget.kind === "cloud") {
+				if (!organizationId) return null;
+				return apiClient.cloudWorkspace.listBranches.query({
+					organizationId,
+					projectId: selectedTarget.projectId,
+				});
+			}
 			return getHostServiceClientByUrl(
 				selectedTarget.hostUrl,
 			).workspaceCreation.searchBranches.query({
@@ -101,9 +114,12 @@ export function NewChatWidget({
 	});
 
 	const createTerminalWorkspace = useCreateTerminalWorkspace();
+	const createCloudWorkspace = useCreateCloudWorkspace();
 	const { data: agentConfigs } = useQuery({
 		queryKey: ["host-agent-configs", selectedTarget?.machineId ?? null],
-		enabled: selectedTarget !== null,
+		// A cloud target has no host to list agents from, and create doesn't
+		// launch one (the prompt only feeds the auto-name).
+		enabled: selectedTarget !== null && !isCloudTarget,
 		staleTime: 60_000,
 		networkMode: "always" as const,
 		queryFn: async () => {
@@ -129,7 +145,9 @@ export function NewChatWidget({
 	}, [storeTarget]);
 
 	const isSending =
-		createTerminalWorkspace.isPending || startWorkspaceTerminal.isPending;
+		createTerminalWorkspace.isPending ||
+		createCloudWorkspace.isPending ||
+		startWorkspaceTerminal.isPending;
 
 	const dismiss = () => {
 		clearChatTarget();
@@ -148,7 +166,21 @@ export function NewChatWidget({
 			return;
 		}
 		if (!selectedTarget) {
-			Alert.alert("No project on an online host");
+			Alert.alert("No project available");
+			return;
+		}
+		if (selectedTarget.kind === "cloud") {
+			createCloudWorkspace
+				.mutateAsync({
+					target: selectedTarget,
+					branch: baseBranch ?? branchData?.defaultBranch ?? null,
+					message,
+				})
+				.then(() => {
+					setBaseBranch(null);
+					composerRef.current?.clear();
+				})
+				.catch(() => {});
 			return;
 		}
 		createTerminalWorkspace
@@ -207,7 +239,13 @@ export function NewChatWidget({
 				]}
 			>
 				<Button
-					label={selectedTarget?.projectName ?? "No project"}
+					label={
+						selectedTarget
+							? isCloudTarget
+								? `${selectedTarget.projectName} · Cloud`
+								: selectedTarget.projectName
+							: "No project"
+					}
 					onPress={() => {
 						void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 						router.push("/(authenticated)/(home)/new-session/project");
@@ -238,30 +276,33 @@ export function NewChatWidget({
 		</>
 	);
 
-	const agentPicker = fixedTarget ? undefined : (
-		<Button
-			onPress={() => {
-				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				router.push("/(authenticated)/(home)/new-session/agent");
-			}}
-			modifiers={[buttonStyle("borderless"), tint(FOREGROUND)]}
-		>
-			<HStack spacing={5}>
-				{agentIconUri ? (
-					<Image
-						uiImage={agentIconUri}
-						modifiers={[
-							resizable(),
-							aspectRatio({ contentMode: "fit" }),
-							frame({ width: 15, height: 15 }),
-						]}
-					/>
-				) : null}
-				<Text>{selectedAgent?.label ?? "Claude"}</Text>
-				<Image systemName="chevron.down" size={11} />
-			</HStack>
-		</Button>
-	);
+	// No agent chip for a cloud target: nothing launches on create (parity
+	// with desktop; the sandbox-side launch is a follow-up).
+	const agentPicker =
+		fixedTarget || isCloudTarget ? undefined : (
+			<Button
+				onPress={() => {
+					void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+					router.push("/(authenticated)/(home)/new-session/agent");
+				}}
+				modifiers={[buttonStyle("borderless"), tint(FOREGROUND)]}
+			>
+				<HStack spacing={5}>
+					{agentIconUri ? (
+						<Image
+							uiImage={agentIconUri}
+							modifiers={[
+								resizable(),
+								aspectRatio({ contentMode: "fit" }),
+								frame({ width: 15, height: 15 }),
+							]}
+						/>
+					) : null}
+					<Text>{selectedAgent?.label ?? "Claude"}</Text>
+					<Image systemName="chevron.down" size={11} />
+				</HStack>
+			</Button>
+		);
 
 	return (
 		<View

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/index.ts
@@ -1,0 +1,1 @@
+export { useCreateCloudWorkspace } from "./useCreateCloudWorkspace";

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Alert } from "react-native";
+import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
+import type { CloudWorkspaceRow } from "@/hooks/useCloudWorkspaces";
+import { getCloudWorkspacesQueryKey } from "@/hooks/useCloudWorkspaces";
+import { useSession } from "@/lib/auth/client";
+import { apiClient } from "@/lib/trpc/client";
+import type { NewChatTarget } from "../useNewChatTargets";
+
+interface CreateCloudWorkspaceArgs {
+	target: NewChatTarget;
+	/** Null means the repo's default branch, resolved by the branch query. */
+	branch: string | null;
+	message: PromptInputMessage;
+}
+
+/**
+ * One API call, then navigate: create returns as soon as the row exists and
+ * the workspace screen renders the provisioning state itself. The prompt only
+ * feeds the server-side auto-name today — the sandbox launching the agent
+ * from it is a follow-up that belongs server-side, not choreographed here.
+ */
+export function useCreateCloudWorkspace() {
+	const router = useRouter();
+	const queryClient = useQueryClient();
+	const { data: session } = useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? null;
+
+	return useMutation({
+		mutationFn: async ({
+			target,
+			branch,
+			message,
+		}: CreateCloudWorkspaceArgs) => {
+			if (!organizationId) throw new Error("No active organization");
+			if (message.attachments.length > 0) {
+				// Attachments today are written to a host, and this workspace's
+				// host doesn't exist yet — blob-backed attachments are the fix.
+				throw new Error(
+					"Attachments are not supported for cloud workspaces yet",
+				);
+			}
+			return apiClient.cloudWorkspace.create.mutate({
+				organizationId,
+				projectId: target.projectId,
+				prompt: message.text.trim() || undefined,
+				branch: branch ?? "main",
+			});
+		},
+		onSuccess: (row: CloudWorkspaceRow) => {
+			// Seed the list before navigating: the workspace screen decides
+			// between "provisioning" and "not found" off this cache, and even
+			// one refetch round trip is long enough to flash the wrong one.
+			const key = getCloudWorkspacesQueryKey(organizationId);
+			queryClient.setQueryData<CloudWorkspaceRow[] | undefined>(key, (rows) =>
+				rows ? [row, ...rows] : [row],
+			);
+			void queryClient.invalidateQueries({ queryKey: key });
+			router.push(`/(authenticated)/workspace/${row.id}`);
+		},
+		onError: (error) => {
+			Alert.alert(
+				"Could not create cloud workspace",
+				error instanceof Error ? error.message : String(error),
+			);
+		},
+	});
+}

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/index.ts
@@ -1,4 +1,5 @@
 export {
+	CLOUD_TARGET_ID,
 	type NewChatTarget,
 	targetKeyFor,
 	useNewChatTargets,

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query";
 import { compareDesc } from "date-fns";
 import { useMemo } from "react";
+import { useCloudProjects } from "@/hooks/useCloudProjects";
 import { toHostProjectItem } from "@/hooks/useHostProjects";
 import { useHostsPresence } from "@/hooks/useHostsPresence";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
@@ -14,23 +15,31 @@ import { useNewSessionPreferencesStore } from "../../stores/newSessionPreference
 
 export interface NewChatTarget {
 	key: string;
+	/** A machine's project, or a project a cloud sandbox can be created for. */
+	kind: "host" | "cloud";
 	projectId: string;
 	projectName: string;
 	projectIconUrl: string | null;
+	/** `CLOUD_TARGET_ID` for cloud targets — a sentinel, not a machine. */
 	machineId: string;
 	hostName: string;
+	/** Empty for cloud targets: there is nothing to address until create. */
 	hostUrl: string;
 }
+
+/** Sentinel host id for "create this in a cloud sandbox" (desktop's CLOUD_HOST_ID). */
+export const CLOUD_TARGET_ID = "cloud";
 
 export function targetKeyFor(projectId: string, machineId: string) {
 	return `${projectId}:${machineId}`;
 }
 
 /**
- * All (project, online host) pairs a new chat workspace can be created on,
- * from fanning out `project.list` to every online host, plus the default
- * pick: last used target, else the filtered project, else the most recently
- * updated workspace's target.
+ * Everywhere a new chat workspace can be created: all (project, online host)
+ * pairs from fanning out `project.list` to every online host, plus a cloud
+ * target per API-listed project — available with zero machines online. The
+ * default pick: last used target, else the filtered project, else the most
+ * recently updated workspace's target.
  */
 export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 	targets: NewChatTarget[];
@@ -71,6 +80,8 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 		})),
 	});
 
+	const { projects: cloudProjects } = useCloudProjects();
+
 	const targets = useMemo<NewChatTarget[]>(() => {
 		const result: NewChatTarget[] = [];
 		onlineHosts.forEach((host, index) => {
@@ -78,6 +89,7 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 				const project = toHostProjectItem(row);
 				result.push({
 					key: targetKeyFor(project.id, host.machineId),
+					kind: "host",
 					projectId: project.id,
 					projectName: project.name,
 					projectIconUrl: project.iconUrl,
@@ -87,8 +99,20 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 				});
 			}
 		});
+		for (const project of cloudProjects) {
+			result.push({
+				key: targetKeyFor(project.id, CLOUD_TARGET_ID),
+				kind: "cloud",
+				projectId: project.id,
+				projectName: project.name,
+				projectIconUrl: project.iconUrl,
+				machineId: CLOUD_TARGET_ID,
+				hostName: "Cloud",
+				hostUrl: "",
+			});
+		}
 		return result.sort((a, b) => a.projectName.localeCompare(b.projectName));
-	}, [onlineHosts, projectListQueries]);
+	}, [onlineHosts, projectListQueries, cloudProjects]);
 
 	const defaultTarget = useMemo<NewChatTarget | null>(() => {
 		if (targets.length === 0) return null;

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
@@ -7,7 +7,9 @@ import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
+import { useSession } from "@/lib/auth/client";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
+import { apiClient } from "@/lib/trpc/client";
 import { useNewChatTargets } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 
@@ -50,17 +52,40 @@ export function BranchPickerScreen() {
 
 	const selectedTarget =
 		targets.find((target) => target.key === targetKey) ?? defaultTarget;
+	const isCloud = selectedTarget?.kind === "cloud";
 	const hostUrl = selectedTarget?.hostUrl ?? null;
 	const projectId = selectedTarget?.projectId ?? null;
+	const { data: session } = useSession();
+	const organizationId = session?.session?.activeOrganizationId ?? null;
 
 	const trimmedQuery = query.trim();
 	const { data, isLoading } = useQuery({
-		queryKey: ["host-service", "branches", hostUrl, projectId, trimmedQuery],
-		enabled: hostUrl !== null && projectId !== null,
+		queryKey: [
+			isCloud ? "cloud-branches" : "host-service",
+			"branches",
+			hostUrl,
+			projectId,
+			trimmedQuery,
+		],
+		enabled: projectId !== null && (isCloud ? !!organizationId : !!hostUrl),
 		placeholderData: (previous) => previous,
 		networkMode: "always" as const,
-		queryFn: async () => {
-			if (!hostUrl || !projectId) return null;
+		queryFn: async (): Promise<{
+			defaultBranch: string | null;
+			items: Array<{ name: string }>;
+		} | null> => {
+			if (!projectId) return null;
+			// A cloud target has no host holding a checkout; branches come from
+			// the GitHub remote through the API's App installation instead.
+			if (isCloud) {
+				if (!organizationId) return null;
+				return apiClient.cloudWorkspace.listBranches.query({
+					organizationId,
+					projectId,
+					query: trimmedQuery || undefined,
+				});
+			}
+			if (!hostUrl) return null;
 			return getHostServiceClientByUrl(
 				hostUrl,
 			).workspaceCreation.searchBranches.query({

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
@@ -1,12 +1,23 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { Stack, useRouter } from "expo-router";
-import { Pressable, ScrollView } from "react-native";
+import { Cloud } from "lucide-react-native";
+import { useMemo } from "react";
+import { Pressable, ScrollView, View } from "react-native";
+import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
 import { ProjectAvatar } from "@/screens/(authenticated)/(home)/filter/components/ProjectAvatar";
-import { useNewChatTargets } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
+import {
+	type NewChatTarget,
+	useNewChatTargets,
+} from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 
+/**
+ * One sheet, sectioned by where the workspace would run: Cloud first — it is
+ * never offline — then each online machine. A tap picks both the place and
+ * the project.
+ */
 export function ProjectPickerScreen() {
 	const router = useRouter();
 	const theme = useTheme();
@@ -21,6 +32,50 @@ export function ProjectPickerScreen() {
 		defaultTarget?.key ??
 		null;
 
+	const sections = useMemo(() => {
+		const cloud = targets.filter((target) => target.kind === "cloud");
+		const byHost = new Map<string, { name: string; rows: NewChatTarget[] }>();
+		for (const target of targets) {
+			if (target.kind !== "host") continue;
+			const group = byHost.get(target.machineId);
+			if (group) group.rows.push(target);
+			else
+				byHost.set(target.machineId, {
+					name: target.hostName,
+					rows: [target],
+				});
+		}
+		return { cloud, hosts: [...byHost.values()] };
+	}, [targets]);
+
+	const select = (key: string) => {
+		setTargetKey(key);
+		router.back();
+	};
+
+	const renderRow = (target: NewChatTarget) => (
+		<Pressable
+			key={target.key}
+			onPress={() => select(target.key)}
+			className="flex-row items-center gap-2.5 py-2.5"
+		>
+			<ProjectAvatar
+				name={target.projectName}
+				iconUrl={target.projectIconUrl}
+				size={32}
+			/>
+			<Text
+				className="flex-1 text-sm font-medium"
+				style={{ color: theme.foreground }}
+			>
+				{target.projectName}
+			</Text>
+			{target.key === selectedKey ? (
+				<Ionicons name="checkmark-circle" size={18} color={theme.primary} />
+			) : null}
+		</Pressable>
+	);
+
 	return (
 		<ScrollView
 			className="bg-background flex-1 px-6"
@@ -34,41 +89,39 @@ export function ProjectPickerScreen() {
 					className="py-6 text-center text-sm"
 					style={{ color: theme.mutedForeground }}
 				>
-					No projects on an online host
+					No projects available
 				</Text>
 			) : null}
-			{targets.map((target) => {
-				const isSelected = target.key === selectedKey;
-				return (
-					<Pressable
-						key={target.key}
-						onPress={() => {
-							setTargetKey(target.key);
-							router.back();
-						}}
-						className="flex-row items-center gap-2.5 py-2.5"
-					>
-						<ProjectAvatar
-							name={target.projectName}
-							iconUrl={target.projectIconUrl}
-							size={32}
+			{sections.cloud.length > 0 ? (
+				<>
+					<View className="flex-row items-center gap-2 pb-1 pt-2">
+						<Icon
+							as={Cloud}
+							className="text-muted-foreground size-4"
+							strokeWidth={1.75}
 						/>
-						<Text
-							className="flex-1 text-sm font-medium"
-							style={{ color: theme.foreground }}
-						>
-							{target.projectName}
+						<Text className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+							Cloud
 						</Text>
-						{isSelected ? (
-							<Ionicons
-								name="checkmark-circle"
-								size={18}
-								color={theme.primary}
-							/>
-						) : null}
-					</Pressable>
-				);
-			})}
+					</View>
+					{sections.cloud.map(renderRow)}
+				</>
+			) : null}
+			{sections.hosts.map((host, index) => (
+				<View
+					key={host.name + String(index)}
+					className={
+						sections.cloud.length > 0 || index > 0
+							? "border-border/60 mt-3 border-t pt-3"
+							: undefined
+					}
+				>
+					<Text className="text-muted-foreground pb-1 text-xs font-semibold uppercase tracking-wide">
+						{host.name}
+					</Text>
+					{host.rows.map(renderRow)}
+				</View>
+			))}
 		</ScrollView>
 	);
 }

--- a/packages/trpc/src/lib/blaxel/index.ts
+++ b/packages/trpc/src/lib/blaxel/index.ts
@@ -5,4 +5,9 @@ export {
 	type ProvisionedSandbox,
 	provisionSandbox,
 } from "./blaxel";
+export {
+	listRemoteBranches,
+	type RemoteBranch,
+	type RemoteBranchPage,
+} from "./list-branches";
 export { type ProjectRepo, repoForProject } from "./repo-for-project";

--- a/packages/trpc/src/lib/blaxel/list-branches.ts
+++ b/packages/trpc/src/lib/blaxel/list-branches.ts
@@ -1,0 +1,85 @@
+/**
+ * Branches for a cloud workspace, read from the GitHub remote with the App
+ * installation token. Desktop lists them through the local host's `gh`
+ * instead (the user's own auth); a phone has no host to ask, so this is the
+ * only source that works with zero machines online.
+ */
+import { db } from "@superset/db/client";
+import { githubInstallations, githubRepositories } from "@superset/db/schema";
+import { eq } from "drizzle-orm";
+import { installationOctokit } from "./clone-token";
+import { repoForProject } from "./repo-for-project";
+
+export interface RemoteBranch {
+	name: string;
+	isDefault: boolean;
+}
+
+export interface RemoteBranchPage {
+	defaultBranch: string | null;
+	items: RemoteBranch[];
+}
+
+const PER_PAGE = 100;
+
+export async function listRemoteBranches(
+	projectId: string,
+	query?: string,
+): Promise<RemoteBranchPage> {
+	const repo = await repoForProject(projectId);
+	if (!repo) return { defaultBranch: null, items: [] };
+	// No installation to authenticate with — the default branch alone still
+	// lets a picker offer something create will accept.
+	if (!repo.repositoryId) {
+		return { defaultBranch: repo.defaultBranch, items: [] };
+	}
+
+	const row = await db.query.githubRepositories.findFirst({
+		where: eq(githubRepositories.id, repo.repositoryId),
+	});
+	const installation = row
+		? await db.query.githubInstallations.findFirst({
+				where: eq(githubInstallations.id, row.installationId),
+			})
+		: undefined;
+	if (!installation) {
+		return { defaultBranch: repo.defaultBranch, items: [] };
+	}
+
+	let data: Array<{ name: string }>;
+	try {
+		const octokit = await installationOctokit(installation.installationId);
+		const response = await octokit.request(
+			"GET /repos/{owner}/{repo}/branches",
+			{ owner: repo.owner, repo: repo.name, per_page: PER_PAGE },
+		);
+		data = response.data;
+	} catch (error) {
+		// An installation that stopped matching the App (uninstalled, or a dev
+		// environment pointed at another App's data) shouldn't break the
+		// picker: the default branch is still enough for create to proceed.
+		console.warn(
+			`[cloud-workspace] branch listing failed for ${repo.owner}/${repo.name}`,
+			error instanceof Error ? error.message : error,
+		);
+		return { defaultBranch: repo.defaultBranch, items: [] };
+	}
+
+	const needle = query?.trim().toLowerCase();
+	const items = data
+		.map((branch: { name: string }) => ({
+			name: branch.name,
+			isDefault: branch.name === repo.defaultBranch,
+		}))
+		.filter((branch) =>
+			needle ? branch.name.toLowerCase().includes(needle) : true,
+		)
+		// Default first, then alphabetical — the API returns them unordered and
+		// the picker's first entry is what a user accepts without reading.
+		.sort((a, b) => {
+			if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+			return a.name.localeCompare(b.name);
+		});
+
+	return { defaultBranch: repo.defaultBranch, items };
+}

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -3,11 +3,12 @@ import { cloudWorkspaces, v2Projects } from "@superset/db/schema";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { Client } from "@upstash/qstash";
-import { and, desc, eq, ne } from "drizzle-orm";
+import { and, desc, eq, isNotNull, ne, or } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
 import {
 	deleteSandbox,
+	listRemoteBranches,
 	mintPreviewAccess,
 	repoForProject,
 } from "../../lib/blaxel";
@@ -75,6 +76,69 @@ export const cloudWorkspaceRouter = {
 					),
 				)
 				.orderBy(desc(cloudWorkspaces.createdAt));
+		}),
+
+	/**
+	 * INTERIM until the environments entity replaces `project_id` — see
+	 * docs/cloud-sandbox-considerations.md ("Model"). The projects a cloud
+	 * workspace can be created from: the `v2_projects` rows that still carry
+	 * a repo to clone. Desktop reads projects from the local host instead;
+	 * a phone has no host, and this is its only source.
+	 */
+	listProjects: jwtProcedure
+		.input(z.object({ organizationId: z.string().uuid() }))
+		.query(async ({ ctx, input }) => {
+			assertInternal(ctx.email);
+			assertMember(ctx.organizationIds, input.organizationId);
+			return db
+				.select({
+					id: v2Projects.id,
+					name: v2Projects.name,
+					iconUrl: v2Projects.iconUrl,
+				})
+				.from(v2Projects)
+				.where(
+					and(
+						eq(v2Projects.organizationId, input.organizationId),
+						// Without either there is no repo to resolve and create
+						// would refuse the project anyway.
+						or(
+							isNotNull(v2Projects.githubRepositoryId),
+							isNotNull(v2Projects.repoCloneUrl),
+						),
+					),
+				)
+				.orderBy(v2Projects.name);
+		}),
+
+	/**
+	 * Branches from the GitHub remote via the App installation — the hostless
+	 * counterpart of the desktop's local-`gh` listing.
+	 */
+	listBranches: jwtProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				projectId: z.string().uuid(),
+				query: z.string().max(200).optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			assertInternal(ctx.email);
+			assertMember(ctx.organizationIds, input.organizationId);
+			const project = await db.query.v2Projects.findFirst({
+				where: and(
+					eq(v2Projects.id, input.projectId),
+					eq(v2Projects.organizationId, input.organizationId),
+				),
+			});
+			if (!project) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Project not found in this organization",
+				});
+			}
+			return listRemoteBranches(input.projectId, input.query);
 		}),
 
 	/**


### PR DESCRIPTION
**Links**
- Decision log: `apps/mobile/plans/20260817-cloud-workspaces.md` (PR B section)
- Predecessor: #6596 (list/open/terminal/actions)

## Summary
- Create a cloud workspace from the mobile composer: the project sheet gains a **Cloud** section (API-listed projects, available with zero machines online), branches come from the GitHub remote via the App installation, and submit is one call — `cloudWorkspace.create` returns the provisioning row, the cloud list is seeded, and the app navigates straight into the provisioning screen.
- Two interim API procedures, fenced until the environments entity: `cloudWorkspace.listProjects` (the `v2_projects` rows that still resolve to a repo) and `cloudWorkspace.listBranches` (App-token branch listing that degrades to the default branch when the installation can't be authenticated, instead of breaking the picker).

## How It Works
- `NewChatTarget` gains `kind: "host" | "cloud"`; cloud targets come from `useCloudProjects` under the same flag + FORBIDDEN gating as the cloud list, keyed by the `CLOUD_TARGET_ID` sentinel (desktop's `CLOUD_HOST_ID`).
- The project sheet is sectioned: Cloud first (it is never offline), then each online machine. The composer chip reads "Project · Cloud"; the agent chip is hidden for cloud targets (create launches nothing — the prompt feeds the server-side auto-name; the sandbox-side launch is a follow-up).
- The branch chip and branch sheet read `listBranches` for cloud targets; host targets are unchanged.
- Submit routes cloud targets to `useCreateCloudWorkspace`: one mutation, seed `cloudWorkspace.list`, `router.push` — same shape as desktop's #6566. Attachments are refused with a clear error (host-bound today; blob-backed attachments are the follow-up).

## Manual QA (on the iPhone 16e simulator against the local API and real Blaxel sandboxes)
- [x] Composer defaults to "Superset · Cloud" with branch `main` when no machine is online; agent chip hidden
- [x] Project sheet: CLOUD section header + API projects; picking one updates the chip
- [x] Send → row created (`provisioning`), server auto-named it from the prompt ("Mobile Flow Test"), immediate navigation to the provisioning screen → flipped to `ready` → workspace opened
- [x] In the phone-created sandbox (fresh `superset-hostsvc` image): Start a session → Claude boots with "bypass permissions on", no root refusal; composer prompt answered (`mobile-e2e-ok`)
- [x] Test workspace deleted after; branch listing verified to degrade (local App/installation mismatch) rather than 500

## Testing
- `bunx tsc --noEmit` (mobile, trpc)
- `bun run lint`

## Known Limitations
- `listProjects` reads retired `v2_projects` (fenced; replaced by the environments entity). Projects created since the sync era won't appear until then.
- Cloud attachments unsupported (SUPER-1915 / blob follow-up).
- The project sheet's checkmark falls back to the alphabetical first target when preferences haven't hydrated — pre-existing sheet behavior, chip is authoritative.

## Also in this PR
- Sandbox image `superset-hostsvc` was rebuilt from main and deployed (operational, no code): new sandboxes now run the merged host-service, which is what activated the Claude-as-root fix verified above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create cloud workspaces from the mobile composer. Previously mobile could only create on an online host; now users can choose a cloud project, pick a branch from GitHub, and submit one call that creates the provisioning row and navigates to the workspace. Agent picker is hidden for cloud targets; attachments are rejected.

- New cloud target in the composer: project sheet is sectioned (Cloud first, then each online machine). The project chip shows “Project · Cloud”.
- Branch picker uses `cloudWorkspace.listBranches` for cloud targets. It lists from the GitHub App installation and falls back to the default branch if the installation can’t be authenticated. Host targets are unchanged.
- Create uses `useCreateCloudWorkspace`: calls `cloudWorkspace.create`, seeds the cloud list cache to avoid a provisioning/not-found flash, and routes to the workspace.
- Feature flag `FEATURE_FLAGS.CLOUD_WORKSPACES` gates cloud data. A `FORBIDDEN` response is treated as “no projects,” not an error. Cloud projects load via `useCloudProjects`.
- TRPC: adds `cloudWorkspace.listProjects` (interim, `v2_projects` with a repo) and `cloudWorkspace.listBranches`; server implements `listRemoteBranches`.

- Review and rollout
  - No migrations. Cloud attachments are not supported yet; the create path blocks them with a clear error.
  - Known interim: `listProjects` only returns `v2_projects` that still resolve to a repo; newer projects arrive with the environments entity.

<sup>Written for commit e3acadd48db507ed8420c25f1c936466f4b3d73c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cloud workspace targets to New Chat.
  - Browse Cloud projects and Git branches, with Cloud projects grouped separately from host projects.
  - Create a Cloud workspace directly from New Chat and continue in the new workspace.
  - Added branch search with default branches prioritized.
  - Added clearer empty states and Cloud-specific progress and error handling.
- **Bug Fixes**
  - Improved handling when Cloud access or project data is unavailable.
- **Documentation**
  - Documented Cloud workspace verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->