### PR TITLE
fix(web): surface OAuth consent errors instead of hanging on "Authorizing..."

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,8 +45,11 @@
 		"zod": "4.4.3"
 	},
 	"devDependencies": {
+		"@happy-dom/global-registrator": "20.0.2",
 		"@superset/typescript": "workspace:*",
 		"@tailwindcss/postcss": "4.2.2",
+		"@testing-library/dom": "10.4.1",
+		"@testing-library/react": "16.3.0",
 		"@types/bun": "1.3.14",
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.test.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.test.tsx
@@ -1,0 +1,124 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom's globals are process-wide and bun runs test files sequentially in
+// one process, so unregister in afterAll to avoid leaking readonly DOM globals
+// into other suites.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const consentMock = mock(
+	async (_body: { accept: boolean; scope?: string }) =>
+		({ data: null, error: null }) as {
+			data: { redirect?: boolean; url?: string } | null;
+			error: { message?: string } | null;
+		},
+);
+const setActiveMock = mock(async (_body: { organizationId: string }) => ({
+	data: null,
+	error: null,
+}));
+
+mock.module("@superset/auth/client", () => ({
+	authClient: {
+		oauth2: { consent: consentMock },
+		organization: { setActive: setActiveMock },
+	},
+}));
+
+const { act, cleanup, fireEvent, render, screen } = await import(
+	"@testing-library/react"
+);
+const { ConsentForm } = await import("./ConsentForm");
+
+const baseProps = {
+	clientId: "superset-cli",
+	clientName: "Superset CLI",
+	scopes: ["openid", "profile", "email", "offline_access"],
+	userName: "Test User",
+	organizations: [{ id: "org_1", name: "Acme" }],
+	defaultOrganizationId: "org_1",
+};
+
+function authorizeButton(): HTMLButtonElement {
+	return screen.getByRole("button", { name: "Authorize" });
+}
+
+beforeEach(() => {
+	consentMock.mockClear();
+	setActiveMock.mockClear();
+	// Replace happy-dom's Location with a plain object so the component's
+	// `window.location.href = url` assignment is observable instead of
+	// triggering a simulated navigation.
+	Object.defineProperty(window, "location", {
+		value: {
+			href: "http://localhost:3000/oauth/consent?client_id=superset-cli",
+		},
+		writable: true,
+		configurable: true,
+	});
+});
+
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+describe("ConsentForm", () => {
+	test("navigates to the redirect url when consent succeeds", async () => {
+		const callbackUrl = "http://127.0.0.1:51789/callback?code=abc&state=xyz";
+		consentMock.mockResolvedValue({
+			data: { redirect: true, url: callbackUrl },
+			error: null,
+		});
+
+		render(<ConsentForm {...baseProps} />);
+		await act(async () => {
+			fireEvent.click(authorizeButton());
+		});
+
+		expect(window.location.href).toBe(callbackUrl);
+	});
+
+	test("shows an error and re-enables the button when consent succeeds without a redirect url", async () => {
+		// A 200 response whose body carries no redirect target must not wedge the
+		// page in a disabled "Authorizing..." state with no feedback (GH #6609).
+		consentMock.mockResolvedValue({ data: {}, error: null });
+
+		render(<ConsentForm {...baseProps} />);
+		await act(async () => {
+			fireEvent.click(authorizeButton());
+		});
+
+		expect(screen.getByText(/did not return a redirect URL/i)).toBeTruthy();
+		const button = authorizeButton();
+		expect(button.disabled).toBe(false);
+		expect(window.location.href).toContain("/oauth/consent");
+	});
+
+	test("shows the server error message when consent fails", async () => {
+		consentMock.mockResolvedValue({
+			data: null,
+			error: { message: "invalid_request" },
+		});
+
+		render(<ConsentForm {...baseProps} />);
+		await act(async () => {
+			fireEvent.click(authorizeButton());
+		});
+
+		expect(screen.getByText("invalid_request")).toBeTruthy();
+		expect(authorizeButton().disabled).toBe(false);
+	});
+});

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.test.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.test.tsx
@@ -14,6 +14,9 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 // into other suites.
 const alreadyRegistered = GlobalRegistrator.isRegistered;
 if (!alreadyRegistered) GlobalRegistrator.register();
+// beforeEach replaces window.location; keep the original descriptor so
+// afterAll can restore it even when this suite doesn't own the registration.
+const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
 (
 	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -72,6 +75,11 @@ beforeEach(() => {
 
 afterEach(cleanup);
 afterAll(async () => {
+	if (originalLocation) {
+		Object.defineProperty(window, "location", originalLocation);
+	} else {
+		Reflect.deleteProperty(window, "location");
+	}
 	if (!alreadyRegistered) await GlobalRegistrator.unregister();
 });
 

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -108,7 +108,7 @@ export function ConsentForm({
 			// instead of leaving the page stuck on "Authorizing..." (GH #6609).
 			if (!data?.url) {
 				throw new Error(
-					"The authorization server did not return a redirect URL. Return to your terminal and try again.",
+					"The authorization server did not return a redirect URL. Return to the application that started authorization and try again.",
 				);
 			}
 			window.location.href = data.url;

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -103,9 +103,15 @@ export function ConsentForm({
 				throw new Error(consentError.message ?? "Failed to process consent");
 			}
 
-			if (data?.url) {
-				window.location.href = data.url;
+			// @better-auth/oauth-provider responds { redirect, url } on both accept
+			// and deny; a 2xx without `url` can never proceed, so fail loudly
+			// instead of leaving the page stuck on "Authorizing..." (GH #6609).
+			if (!data?.url) {
+				throw new Error(
+					"The authorization server did not return a redirect URL. Return to your terminal and try again.",
+				);
 			}
+			window.location.href = data.url;
 		} catch (err) {
 			console.error("[oauth/consent] Error:", err);
 			setError(err instanceof Error ? err.message : "An error occurred");

--- a/bun.lock
+++ b/bun.lock
@@ -695,8 +695,11 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.2",
         "@superset/typescript": "workspace:*",
         "@tailwindcss/postcss": "4.2.2",
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.0",
         "@types/bun": "1.3.14",
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",


### PR DESCRIPTION
## What & why

Fixes #6609.

`superset auth login` can wedge permanently: after clicking **Authorize** on `/oauth/consent`, the button stays disabled on "Authorizing..." with no error, the browser never navigates, so the OAuth code never reaches the CLI's loopback callback and every command keeps saying `Not logged in`.

The client-side mechanism is unconditional once triggered: in `ConsentForm.handleConsent`, navigation is gated on `data?.url` with no `else`, and the only `setIsLoading(false)` lives in the `catch`. So any consent response that has no `error` **and** no `url` completes the `try` block normally and leaves the page loading forever. The paste fallback can't save the user either — `/cli/auth/code` is itself a redirect target that reads the code from its own query params, so if consent never yields a redirect, no code is ever delivered anywhere.

The triage-bot analysis on the issue flagged the right code path but left its `redirectURI` field-name hypothesis unconfirmed (it had no `node_modules`). I verified against the actual installed `@better-auth/oauth-provider@1.6.22` source (byte-identical to the registry tarball):

- **The field is `url`.** Every 2xx consent response goes through `handleRedirect`, which returns `{ redirect: true, url }` for browser-fetch/JSON callers — accept path via `redirectWithAuthorizationCode`, deny path directly in `consentEndpoint`. The endpoint's declared TS return type is `{ redirect: boolean; url: string }`, so `data?.url` is the typed, correct read — there is no field mismatch on this version. Same shape in 1.6.13, the previously pinned version, so no deploy-skew mismatch either.
- The plugin's own OpenAPI metadata claims the response key is `redirect_uri`, which the implementation contradicts — likely where the `redirectURI` guess came from.

That means the production failure wasn't the client reading the wrong key; it was a 2xx whose parsed body carried no `url` (empty/mangled body is the plausible class — better-fetch surfaces any non-2xx as `error`, which this page already renders). I couldn't determine which server-side condition produced it from the outside, but the client bug is that this entire class of response had **no handling at all**: not an error, not a retry, just a dead button.

The fix keeps the page's single error path and routes "2xx without a redirect URL" through it: the user sees an actionable message ("…return to your terminal and try again"), the button re-enables, and any future response-shape regression fails loudly instead of hanging every CLI login silently.

Also adds the first component-test setup to `apps/web` — same bun-test + happy-dom + testing-library pattern `apps/desktop` already uses, pinned to the identical versions (sherif green).

## How I tested it

New co-located `ConsentForm.test.tsx` (written failing-first):

1. **success → navigates to `data.url`** — passes before and after the fix; empirically pins that `url` is the right key for the 1.6.22 response shape.
2. **2xx without `url` → error rendered + button re-enabled** — the bug: failed before the fix (page wedged with no error), passes after.
3. **error response → server message rendered + button re-enabled** — pins the existing catch path.

`bun run lint`, `bun run typecheck`, and `bunx sherif` pass locally. `bun run test`: the new web suite passes; the one failing test in the monorepo run (a desktop `getProcessEnvWithShellPath` shell-PATH assertion) fails identically on a clean `main` checkout on my machine — pre-existing and unrelated.

No new visual surface: the error state reuses the exact `text-destructive` paragraph this form already renders for every other consent failure.

**Deliberately out of scope** (worth follow-up issues/PRs, flagged in the triage analysis): the CLI swallows the 5-minute loopback timeout with no message (`packages/cli/src/lib/auth.ts:365`), stuck logins hold one of the five loopback ports indefinitely, and `login()` has no overall deadline. Kept out to keep this PR one reviewable change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces OAuth consent errors so the page no longer hangs on “Authorizing…” when the server returns 2xx without a redirect URL. Previously, a 2xx without `url` left the button disabled and never navigated; now the form shows a neutral error, re-enables the button, and still navigates when `data.url` is present.

**Review notes**
- `ConsentForm.tsx`: treat missing `data.url` as an error with neutral copy; re-enable the button; navigate when `data.url` is present.
- Tests: new `ConsentForm.test.tsx` covers success, 2xx-without-URL, and error; uses `@happy-dom/global-registrator`, restores `window.location` in teardown, and adds `@testing-library/dom` and `@testing-library/react`.
- Dev-only changes in `apps/web/package.json` and `bun.lock`; no new UI elements and no runtime behavior beyond the error handling.

<sup>Written for commit 8634fd60f3e0ec6fb8114b7246d9c83653263a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth consent handling when a redirect URL is missing, showing an error instead of continuing authorization.
  * Ensured consent controls become available again after authorization errors.

* **Tests**
  * Added coverage for successful redirects, missing redirect URLs, and server errors during consent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->