### PR TITLE
fix(desktop): make shell-PATH env test hold on machines missing common macOS dirs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -277,9 +277,11 @@ describe("Shell Environment", () => {
 	}, 10_000);
 
 	test("getProcessEnvWithShellPath applies shell PATH and preserves string vars", async () => {
-		const { getProcessEnvWithShellPath, getShellEnvironment } = await import(
-			"./shell-env"
-		);
+		const {
+			augmentPathForMacOS,
+			getProcessEnvWithShellPath,
+			getShellEnvironment,
+		} = await import("./shell-env");
 
 		const shellEnv = await getShellEnvironment();
 		const env = await getProcessEnvWithShellPath({
@@ -293,7 +295,13 @@ describe("Shell Environment", () => {
 
 		const shellPath = shellEnv.PATH || shellEnv.Path;
 		if (shellPath) {
-			expect(env.PATH).toBe(shellPath);
+			// getProcessEnvWithShellPath augments the login-shell PATH with common
+			// macOS dirs, so the expectation must apply the same augmentation — a
+			// literal shellPath comparison only holds on machines whose login shell
+			// already has all of them.
+			const expected = { PATH: shellPath };
+			augmentPathForMacOS(expected);
+			expect(env.PATH).toBe(expected.PATH);
 			if (process.platform === "win32" || "Path" in shellEnv) {
 				expect(env.Path).toBe(shellPath);
 			}


### PR DESCRIPTION
## What & why

`Shell Environment > getProcessEnvWithShellPath applies shell PATH and preserves string vars` fails on any Mac whose login shell is missing one of the four common dirs that `augmentPathForMacOS` prepends (`/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`, `/usr/local/sbin`).

The test (from #1758, Feb 2026) asserts `env.PATH` equals the raw login-shell PATH — but since #5574 (Jul 2026), `getProcessEnvWithShellPath` deliberately augments that PATH with the common macOS dirs so git resolves even with a truncated login-shell PATH. On my machine (login shell has three of the four dirs, no `/usr/local/sbin`) the failure is exact and mechanical:

```
Expected: "<login-shell PATH>"
Received: "/usr/local/sbin:<login-shell PATH>"
```

CI never sees this because the augment is a no-op off macOS, and any Mac whose shell config already includes all four dirs passes by luck. The fix asserts the actual contract: the expected value is the shell PATH run through the same exported `augmentPathForMacOS`, which stays byte-identical to the old expectation on machines/platforms where the augment adds nothing.

## How I tested it

- Before: the test fails on this machine (macOS, arm64) with the diff above, on a clean `main` checkout.
- After: `bun test src/lib/trpc/routers/workspaces/utils/git.test.ts` — 39 pass / 0 fail, including this test on the machine that reproduced the failure.
- Test-only change; no production code touched. Biome clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the shell PATH env test on macOS by asserting against the PATH after augmentation with common macOS dirs, matching current `getProcessEnvWithShellPath` behavior. Previously the test compared to the raw login-shell PATH and failed on Macs missing one of those dirs; now it passes consistently.

- Test-only change in apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts; no production code.
- Expected PATH is now computed via `augmentPathForMacOS`; it stays identical where augmentation is a no-op (non-macOS or shells that already include all four dirs).

<sup>Written for commit d1f75d50e6b0f3f083449e5dfaba63d314024618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS shell environment validation to correctly account for PATH augmentation.
  * Prevented false failures when the shell PATH differs from the raw system PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->