### PR TITLE
fix(trpc,mobile): resolve the default branch server-side, paginate branch listing

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -45,7 +45,9 @@ export function useCreateCloudWorkspace() {
 				organizationId,
 				projectId: target.projectId,
 				prompt: message.text.trim() || undefined,
-				branch: branch ?? "main",
+				// Omitted when unresolved: the server falls back to the repo's
+				// actual default branch, which the client must not guess.
+				branch: branch ?? undefined,
 			});
 		},
 		onSuccess: (row: CloudWorkspaceRow) => {

--- a/packages/trpc/src/lib/blaxel/list-branches.ts
+++ b/packages/trpc/src/lib/blaxel/list-branches.ts
@@ -21,6 +21,8 @@ export interface RemoteBranchPage {
 }
 
 const PER_PAGE = 100;
+/** Enough for a query to reach deep branches without unbounded API walks. */
+const MAX_PAGES = 10;
 
 export async function listRemoteBranches(
 	projectId: string,
@@ -49,11 +51,17 @@ export async function listRemoteBranches(
 	let data: Array<{ name: string }>;
 	try {
 		const octokit = await installationOctokit(installation.installationId);
-		const response = await octokit.request(
-			"GET /repos/{owner}/{repo}/branches",
-			{ owner: repo.owner, repo: repo.name, per_page: PER_PAGE },
-		);
-		data = response.data;
+		// Paginated: a repo easily holds more than one page of branches, and a
+		// single request would make everything past it unfindable.
+		data = [];
+		for (let page = 1; page <= MAX_PAGES; page++) {
+			const response = await octokit.request(
+				"GET /repos/{owner}/{repo}/branches",
+				{ owner: repo.owner, repo: repo.name, per_page: PER_PAGE, page },
+			);
+			data.push(...response.data);
+			if (response.data.length < PER_PAGE) break;
+		}
 	} catch (error) {
 		// An installation that stopped matching the App (uninstalled, or a dev
 		// environment pointed at another App's data) shouldn't break the

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -178,7 +178,9 @@ export const cloudWorkspaceRouter = {
 				/** Omitted when the user didn't type one; then `prompt` names it. */
 				name: z.string().min(1).max(200).optional(),
 				prompt: z.string().max(20000).optional(),
-				branch: z.string().min(1).max(300),
+				/** Omitted = the repo's default branch, resolved here — a client
+				 * whose branch query hadn't answered must not guess "main". */
+				branch: z.string().min(1).max(300).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -198,6 +200,11 @@ export const cloudWorkspaceRouter = {
 				});
 			}
 
+			const branch =
+				input.branch ??
+				(await repoForProject(input.projectId))?.defaultBranch ??
+				"main";
+
 			// The id is generated here rather than by the database so the sandbox
 			// name can be derived before the insert. A placeholder would briefly
 			// leave two rows sharing ("blaxel", ""), which the unique constraint
@@ -211,7 +218,7 @@ export const cloudWorkspaceRouter = {
 					organizationId: input.organizationId,
 					projectId: input.projectId,
 					name: input.name ?? FALLBACK_NAME,
-					branch: input.branch,
+					branch,
 					provider: "blaxel",
 					providerSandboxId,
 					status: "provisioning",


### PR DESCRIPTION
## Summary
- Follow-ups to #6651 from CodeRabbit's review (which landed after merge):
  1. `cloudWorkspace.create`'s `branch` is now optional; when omitted the server resolves the repo's actual default via `repoForProject` instead of a client guessing `"main"`. The mobile create hook now omits the branch when its query hadn't resolved.
  2. `listRemoteBranches` paginates (up to 10 × 100, early exit on a short page) — a single request made everything past the first hundred branches unfindable, and this repo alone exceeds that.

## Testing
- `bunx tsc --noEmit` (trpc, mobile)
- `bun run lint`
- Behavior change is server-side fallback + pagination; exercised the same code paths against the local API in #6651's verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the default branch server-side and paginate branch listing to avoid missing branches. Previously, mobile guessed "main" for `cloudWorkspace.create` when branch was unresolved and the server listed only the first 100 branches; now the client omits `branch`, the server selects the repository default (falling back to "main" if unknown), and `listRemoteBranches` paginates up to 10×100 results.

**Review notes**
- TRPC: `cloudWorkspace.create.branch` is optional; the server resolves via `repoForProject.defaultBranch` or uses "main" if unavailable. If a branch is provided, behavior is unchanged.
- Mobile: `useCreateCloudWorkspace` omits `branch` when the branch query has not resolved.
- Pagination: `packages/trpc` `listRemoteBranches` fetches up to 10 pages (100 per page) and exits early on a short page; no caller changes required.
- Clients should stop guessing default branches; omit `branch` when unknown.

<sup>Written for commit 4f9253f61c73b4b13a7cf689d74272f9c818e384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud workspaces now automatically use the repository’s default branch when no branch is specified.
  * Branch selection supports repositories with more than 100 branches by retrieving results across multiple pages.

* **Bug Fixes**
  * Prevented unresolved branch names from incorrectly defaulting to `main` before the repository’s actual default branch is determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->