### PR TITLE
fix(desktop): hide star-repo button unless GitHub confirms unstarred

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/github-star/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/github-star/index.ts
@@ -3,8 +3,6 @@ import { execWithShellEnv } from "../workspaces/utils/shell-env";
 
 export type GithubStarState = "starred" | "not_starred" | "unknown";
 
-// Matches COMPANY.GITHUB_URL ("https://github.com/superset-sh/superset") in
-// packages/shared/src/constants.ts, used by the renderer for the browser fallback.
 const STARRED_REPO_PATH = "user/starred/superset-sh/superset";
 // A hung `gh` process must not leave the query/mutation pending forever —
 // both callers already treat any failure as a safe "unknown"/false outcome.
@@ -17,8 +15,9 @@ const GH_CALL_TIMEOUT_MS = 10_000;
  * Checks whether the signed-in `gh` CLI user has starred superset-sh/superset.
  * GitHub returns 204 for "starred", 404 for "not starred". Every other
  * outcome (gh missing/unauthenticated, network error, rate limit) collapses
- * to "unknown" so callers always have a safe web-fallback state instead of
- * an error to handle.
+ * to "unknown" so callers always have a safe fallback value instead of an
+ * error to handle — renderer surfaces treat "unknown" as "not actionable"
+ * and hide/disable their star button rather than offering a distinct CTA.
  */
 export async function checkGithubStarred(): Promise<GithubStarState> {
 	try {

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -98,7 +98,7 @@ export function AnimatedStarButton({
 		<button
 			type="button"
 			onClick={onActivate}
-			disabled={busy || state === "loading"}
+			disabled={busy || (state !== "not_starred" && state !== "starred")}
 			className={cn(
 				"star-button group",
 				compact && "star-button--compact",

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -92,13 +92,7 @@ export function AnimatedStarButton({
 	}, [state, prefersReducedMotion]);
 
 	const isStarred = state === "starred";
-	const label = isStarred
-		? "Starred"
-		: busy
-			? "Starring…"
-			: state === "unknown"
-				? "Open GitHub"
-				: "Star on GitHub";
+	const label = isStarred ? "Starred" : busy ? "Starring…" : "Star on GitHub";
 
 	return (
 		<button

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -76,7 +76,14 @@ export function AnimatedStarButton({
 	useEffect(() => {
 		const prevState = prevStateRef.current;
 		prevStateRef.current = state;
-		if (prevState !== "starred" && state === "starred") {
+		// Matches useJustStarredWindow's transition condition (not just "wasn't
+		// starred before") — a cold mount that resolves straight from "loading"
+		// to "starred" (the repo was already starred before this session) isn't
+		// a fresh star and shouldn't burst confetti for it.
+		if (
+			(prevState === "not_starred" || prevState === "unknown") &&
+			state === "starred"
+		) {
 			setJustStarred(true);
 			if (!prefersReducedMotion) setParticles(createBurst());
 			const clearTimer = setTimeout(() => {

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/AnimatedStarButton.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Star } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
+import { STAR_SUCCESS_ANIMATION_MS } from "renderer/hooks/useGithubStarAction";
 import "./AnimatedStarButton.css";
 import { PlusMark } from "./components/PlusMark";
 
@@ -20,11 +21,6 @@ const CORNERS = ["top-left", "top-right", "bottom-right", "bottom-left"];
 // here would collide with that meaning.
 const CONFETTI_COLORS = ["#fbbf24", "#34d399", "#fbbf24"];
 const PARTICLE_COUNT = 8;
-
-// How long the post-star celebration (icon pop + confetti) stays visible.
-// Shared with GitHubStarPill and StarNagCard so they keep rendering the
-// button — instead of unmounting it — for exactly as long as this plays.
-export const STAR_SUCCESS_ANIMATION_MS = 1700;
 
 interface Particle {
 	id: number;

--- a/apps/desktop/src/renderer/components/AnimatedStarButton/index.ts
+++ b/apps/desktop/src/renderer/components/AnimatedStarButton/index.ts
@@ -1,4 +1,1 @@
-export {
-	AnimatedStarButton,
-	STAR_SUCCESS_ANIMATION_MS,
-} from "./AnimatedStarButton";
+export { AnimatedStarButton } from "./AnimatedStarButton";

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -61,7 +61,10 @@ export function GitHubStarPill({
 	const isVisible = canActivateStarAction(state) || celebrating;
 
 	const handleClick = () => {
-		track("star_nag_starred", { surface });
+		// A click during the post-star celebration window (state === "starred")
+		// reaches this handler but activate() no-ops for it — don't record a
+		// "starred" event for a click that didn't actually do anything.
+		if (canActivateStarAction(state)) track("star_nag_starred", { surface });
 		activate();
 	};
 

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -1,14 +1,11 @@
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
-import {
-	AnimatedStarButton,
-	STAR_SUCCESS_ANIMATION_MS,
-} from "renderer/components/AnimatedStarButton";
-import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
+import { AnimatedStarButton } from "renderer/components/AnimatedStarButton";
 import {
 	canActivateStarAction,
 	useGithubStarAction,
+	useJustStarredWindow,
+	useTrackShownOnce,
 } from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 
@@ -47,72 +44,21 @@ export function GitHubStarPill({
 	reserveSpace = false,
 }: GitHubStarPillProps) {
 	const { state, activate, isBusy } = useGithubStarAction();
-	const prevStateRef = useRef<GithubStarActionState | null>(null);
+	const celebrating = useJustStarredWindow(state);
 
-	// Computed synchronously during render (not inside the effect below) so
-	// the hide check further down can't lag a render behind the state flip.
-	// That lag used to unmount this component's child AnimatedStarButton for
-	// exactly one render right as `state` became "starred" — before
-	// staysVisibleForAnimation had a chance to flip true — which reset
-	// AnimatedStarButton's own "was I just starred" ref on remount and
-	// silently dropped its confetti/pop celebration.
-	const prevState = prevStateRef.current;
-	prevStateRef.current = state;
-	const justStarred =
-		(prevState === "not_starred" || prevState === "unknown") &&
-		state === "starred";
-
-	// Separate ref + effect from the render-time justStarred above, and keyed
-	// on `state` rather than `justStarred`: `justStarred` itself flips back to
-	// false on the very next render (setStaysVisibleForAnimation(true) causes
-	// a re-render, and prevStateRef has already advanced to "starred" by
-	// then) — if this effect depended on `justStarred` directly, that flip
-	// would re-run it, firing the cleanup that cancels the just-started timer
-	// before it ever fires, and no replacement timer gets scheduled since
-	// justStarred is false by then. Keying on `state` (which only changes
-	// once) keeps the timer alive for its full duration instead.
-	const [staysVisibleForAnimation, setStaysVisibleForAnimation] =
-		useState(false);
-	const prevStateForTimerRef = useRef<GithubStarActionState | null>(null);
-	useEffect(() => {
-		const prev = prevStateForTimerRef.current;
-		prevStateForTimerRef.current = state;
-		const justStarredForTimer =
-			(prev === "not_starred" || prev === "unknown") && state === "starred";
-		if (justStarredForTimer) {
-			setStaysVisibleForAnimation(true);
-			const timer = setTimeout(
-				() => setStaysVisibleForAnimation(false),
-				STAR_SUCCESS_ANIMATION_MS,
-			);
-			return () => clearTimeout(timer);
-		}
-	}, [state]);
-
-	// Fire at most once per showing per surface — reset once starred so a
-	// later unstar re-shows the pill and tracks a fresh "shown" impression,
-	// and reset again if `surface` itself changes so a re-purposed mounted
-	// instance still gets its own impression instead of inheriting the prior
-	// surface's guard.
-	const trackedShownSurfaceRef = useRef<NonNullable<
-		GitHubStarPillProps["surface"]
-	> | null>(null);
-	useEffect(() => {
-		if (state === "starred") {
-			trackedShownSurfaceRef.current = null;
-			return;
-		}
-		if (trackedShownSurfaceRef.current === surface) return;
-		if (!canActivateStarAction(state)) return;
-		trackedShownSurfaceRef.current = surface;
-		track("star_nag_shown", { surface });
-	}, [state, surface]);
+	// Fire at most once per showing per surface — reset once hidden (unknown,
+	// loading, or the post-celebration hide) so a later re-show, or a
+	// re-purposed instance with a different `surface`, gets its own fresh
+	// impression instead of inheriting a stale guard.
+	useTrackShownOnce(
+		canActivateStarAction(state),
+		() => track("star_nag_shown", { surface }),
+		surface,
+	);
 
 	if (state === "loading" && !reserveSpace) return null;
 
-	const isVisible =
-		canActivateStarAction(state) ||
-		(state === "starred" && (justStarred || staysVisibleForAnimation));
+	const isVisible = canActivateStarAction(state) || celebrating;
 
 	const handleClick = () => {
 		track("star_nag_starred", { surface });

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -30,11 +30,13 @@ interface GitHubStarPillProps {
  * the new-workspace screen. Renders straight from live `state`, with no
  * nag-suppression layer — unlike the sidebar card/toast, this is a low-key
  * status indicator, not an interruptive campaign, so it's allowed to be
- * fully truthful: it hides the instant `state` is "starred" and reappears
- * the instant a later unstar is confirmed, without waiting on any mute
- * grace window. It briefly stays mounted past that point so the
- * confetti/label animation on a fresh star has time to play, then
- * dissolves out (fade + soft blur) instead of vanishing instantly.
+ * fully truthful: it only shows while `state` is confirmed "not_starred"
+ * (a "loading" or "unknown" read isn't trustworthy enough to act on), hides
+ * the instant `state` is "starred", and reappears the instant a later
+ * unstar is confirmed, without waiting on any mute grace window. It briefly
+ * stays mounted past that point so the confetti/label animation on a fresh
+ * star has time to play, then dissolves out (fade + soft blur) instead of
+ * vanishing instantly.
  */
 export function GitHubStarPill({
 	className,
@@ -98,7 +100,7 @@ export function GitHubStarPill({
 			return;
 		}
 		if (trackedShownSurfaceRef.current === surface) return;
-		if (state !== "not_starred" && state !== "unknown") return;
+		if (state !== "not_starred") return;
 		trackedShownSurfaceRef.current = surface;
 		track("star_nag_shown", { surface });
 	}, [state, surface]);
@@ -106,13 +108,11 @@ export function GitHubStarPill({
 	if (state === "loading" && !reserveSpace) return null;
 
 	const isVisible =
-		state !== "loading" &&
-		!(state === "starred" && !justStarred && !staysVisibleForAnimation);
+		state === "not_starred" ||
+		(state === "starred" && (justStarred || staysVisibleForAnimation));
 
 	const handleClick = () => {
-		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
-			surface,
-		});
+		track("star_nag_starred", { surface });
 		activate();
 	};
 

--- a/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
+++ b/apps/desktop/src/renderer/components/GitHubStarPill/GitHubStarPill.tsx
@@ -6,7 +6,10 @@ import {
 	STAR_SUCCESS_ANIMATION_MS,
 } from "renderer/components/AnimatedStarButton";
 import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
-import { useGithubStarAction } from "renderer/hooks/useGithubStarAction";
+import {
+	canActivateStarAction,
+	useGithubStarAction,
+} from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 
 interface GitHubStarPillProps {
@@ -100,7 +103,7 @@ export function GitHubStarPill({
 			return;
 		}
 		if (trackedShownSurfaceRef.current === surface) return;
-		if (state !== "not_starred") return;
+		if (!canActivateStarAction(state)) return;
 		trackedShownSurfaceRef.current = surface;
 		track("star_nag_shown", { surface });
 	}, [state, surface]);
@@ -108,7 +111,7 @@ export function GitHubStarPill({
 	if (state === "loading" && !reserveSpace) return null;
 
 	const isVisible =
-		state === "not_starred" ||
+		canActivateStarAction(state) ||
 		(state === "starred" && (justStarred || staysVisibleForAnimation));
 
 	const handleClick = () => {

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -8,7 +8,10 @@ import {
 	STAR_SUCCESS_ANIMATION_MS,
 } from "renderer/components/AnimatedStarButton";
 import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
-import { useGithubStarAction } from "renderer/hooks/useGithubStarAction";
+import {
+	canActivateStarAction,
+	useGithubStarAction,
+} from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 import { useStarNagStore } from "renderer/stores/star-nag";
 
@@ -74,13 +77,8 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 		}
 	}, [state]);
 
-	// A "loading" or "unknown" read isn't trustworthy enough to act on, so the
-	// card only shows its button once `state` is confirmed "not_starred" —
-	// same rule as every other star-nag surface.
-	const renderVisible =
-		(shouldShow && state === "not_starred") || staysVisibleForAnimation;
-	const isVisible =
-		!isCollapsed && isEnabled && shouldShow && state === "not_starred";
+	const renderVisible = shouldShow || staysVisibleForAnimation;
+	const isVisible = !isCollapsed && isEnabled && shouldShow;
 
 	// Fire at most once per visible showing — without the reset, every
 	// sidebar collapse/expand cycle re-triggers this effect and inflates
@@ -123,12 +121,18 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 						description="Superset is open source. If it's helped you today, a GitHub star helps other developers find it."
 						onDismiss={handleDismiss}
 					>
-						<AnimatedStarButton
-							state={state}
-							busy={isBusy}
-							onActivate={handleAction}
-							className="mt-3 w-full justify-center"
-						/>
+						{/* A "loading" or "unknown" read isn't trustworthy enough to act
+						on, so the button doesn't render for those — the card chrome
+						(title, description, dismiss) stays up regardless, same pattern
+						as StarNagToast. */}
+						{(canActivateStarAction(state) || state === "starred") && (
+							<AnimatedStarButton
+								state={state}
+								busy={isBusy}
+								onActivate={handleAction}
+								className="mt-3 w-full justify-center"
+							/>
+						)}
 					</SidebarCard>
 				</motion.div>
 			)}

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -2,15 +2,13 @@ import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { SidebarCard } from "@superset/ui/sidebar-card";
 import { AnimatePresence, motion } from "framer-motion";
 import { useFeatureFlagEnabled } from "posthog-js/react";
-import { useEffect, useReducer, useRef, useState } from "react";
-import {
-	AnimatedStarButton,
-	STAR_SUCCESS_ANIMATION_MS,
-} from "renderer/components/AnimatedStarButton";
-import type { GithubStarActionState } from "renderer/hooks/useGithubStarAction";
+import { useEffect, useReducer } from "react";
+import { AnimatedStarButton } from "renderer/components/AnimatedStarButton";
 import {
 	canActivateStarAction,
 	useGithubStarAction,
+	useJustStarredWindow,
+	useTrackShownOnce,
 } from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 import { useStarNagStore } from "renderer/stores/star-nag";
@@ -58,41 +56,17 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	// Starring calls markCompleted() internally, which flips shouldShow to
 	// false immediately — without this, the card would unmount before the
 	// AnimatedStarButton's confetti/label animation gets a chance to play.
-	const [staysVisibleForAnimation, setStaysVisibleForAnimation] =
-		useState(false);
-	const prevStateRef = useRef<GithubStarActionState | null>(null);
+	const celebrating = useJustStarredWindow(state);
 
-	useEffect(() => {
-		const prev = prevStateRef.current;
-		prevStateRef.current = state;
-		const justStarred =
-			(prev === "not_starred" || prev === "unknown") && state === "starred";
-		if (justStarred) {
-			setStaysVisibleForAnimation(true);
-			const timer = setTimeout(
-				() => setStaysVisibleForAnimation(false),
-				STAR_SUCCESS_ANIMATION_MS,
-			);
-			return () => clearTimeout(timer);
-		}
-	}, [state]);
-
-	const renderVisible = shouldShow || staysVisibleForAnimation;
-	const isVisible = !isCollapsed && isEnabled && shouldShow;
+	const renderVisible = shouldShow || celebrating;
+	const isVisible = Boolean(!isCollapsed && isEnabled && shouldShow);
 
 	// Fire at most once per visible showing — without the reset, every
-	// sidebar collapse/expand cycle re-triggers this effect and inflates
-	// impressions relative to the other surfaces' once-per-showing trackers.
-	const trackedShownRef = useRef(false);
-	useEffect(() => {
-		if (!isVisible) {
-			trackedShownRef.current = false;
-			return;
-		}
-		if (trackedShownRef.current) return;
-		trackedShownRef.current = true;
-		track("star_nag_shown", { surface: "card" });
-	}, [isVisible]);
+	// sidebar collapse/expand cycle would inflate impressions relative to the
+	// other surfaces' once-per-showing trackers.
+	useTrackShownOnce(isVisible, () =>
+		track("star_nag_shown", { surface: "card" }),
+	);
 
 	function handleAction() {
 		track("star_nag_starred", { surface: "card" });
@@ -125,7 +99,7 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 						on, so the button doesn't render for those — the card chrome
 						(title, description, dismiss) stays up regardless, same pattern
 						as StarNagToast. */}
-						{(canActivateStarAction(state) || state === "starred") && (
+						{(canActivateStarAction(state) || celebrating) && (
 							<AnimatedStarButton
 								state={state}
 								busy={isBusy}

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -74,8 +74,13 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 		}
 	}, [state]);
 
-	const renderVisible = shouldShow || staysVisibleForAnimation;
-	const isVisible = !isCollapsed && isEnabled && shouldShow;
+	// A "loading" or "unknown" read isn't trustworthy enough to act on, so the
+	// card only shows its button once `state` is confirmed "not_starred" —
+	// same rule as every other star-nag surface.
+	const renderVisible =
+		(shouldShow && state === "not_starred") || staysVisibleForAnimation;
+	const isVisible =
+		!isCollapsed && isEnabled && shouldShow && state === "not_starred";
 
 	// Fire at most once per visible showing — without the reset, every
 	// sidebar collapse/expand cycle re-triggers this effect and inflates
@@ -92,9 +97,7 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	}, [isVisible]);
 
 	function handleAction() {
-		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
-			surface: "card",
-		});
+		track("star_nag_starred", { surface: "card" });
 		activate();
 	}
 

--- a/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
+++ b/apps/desktop/src/renderer/components/StarNagCard/StarNagCard.tsx
@@ -59,17 +59,23 @@ export function StarNagCard({ isCollapsed }: StarNagCardProps) {
 	const celebrating = useJustStarredWindow(state);
 
 	const renderVisible = shouldShow || celebrating;
-	const isVisible = Boolean(!isCollapsed && isEnabled && shouldShow);
+	const cardVisible = Boolean(!isCollapsed && isEnabled && shouldShow);
 
-	// Fire at most once per visible showing — without the reset, every
-	// sidebar collapse/expand cycle would inflate impressions relative to the
-	// other surfaces' once-per-showing trackers.
-	useTrackShownOnce(isVisible, () =>
+	// Fire at most once per visible showing of the *button* specifically
+	// (not just the card) — the card can be visible with its title/
+	// description/dismiss while the button itself is hidden (loading/
+	// unknown), and that's not a "shown" impression of the star ask.
+	useTrackShownOnce(cardVisible && canActivateStarAction(state), () =>
 		track("star_nag_shown", { surface: "card" }),
 	);
 
 	function handleAction() {
-		track("star_nag_starred", { surface: "card" });
+		// A click during the post-star celebration window (state === "starred")
+		// reaches this handler but activate() no-ops for it — don't record a
+		// "starred" event for a click that didn't actually do anything.
+		if (canActivateStarAction(state)) {
+			track("star_nag_starred", { surface: "card" });
+		}
 		activate();
 	}
 

--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -17,9 +17,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 	}, [state, toastId]);
 
 	function handleAction() {
-		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
-			surface: "toast",
-		});
+		track("star_nag_starred", { surface: "toast" });
 		activate();
 	}
 
@@ -48,13 +46,18 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 				If you're enjoying Superset so far, a GitHub star helps other developers
 				discover it.
 			</p>
-			<AnimatedStarButton
-				state={state}
-				busy={isBusy}
-				onActivate={handleAction}
-				className="mt-3 w-full justify-center"
-				compact
-			/>
+			{/* A "loading" or "unknown" read isn't trustworthy enough to act on —
+			same rule as every other star-nag surface — so the button just doesn't
+			render for those; the toast itself still auto-dismisses/closes normally. */}
+			{(state === "not_starred" || state === "starred") && (
+				<AnimatedStarButton
+					state={state}
+					busy={isBusy}
+					onActivate={handleAction}
+					className="mt-3 w-full justify-center"
+					compact
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -2,7 +2,10 @@ import { toast } from "@superset/ui/sonner";
 import { X } from "lucide-react";
 import { useEffect } from "react";
 import { AnimatedStarButton } from "renderer/components/AnimatedStarButton";
-import { useGithubStarAction } from "renderer/hooks/useGithubStarAction";
+import {
+	canActivateStarAction,
+	useGithubStarAction,
+} from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 import { useStarNagStore } from "renderer/stores/star-nag";
 
@@ -49,7 +52,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 			{/* A "loading" or "unknown" read isn't trustworthy enough to act on —
 			same rule as every other star-nag surface — so the button just doesn't
 			render for those; the toast itself still auto-dismisses/closes normally. */}
-			{(state === "not_starred" || state === "starred") && (
+			{(canActivateStarAction(state) || state === "starred") && (
 				<AnimatedStarButton
 					state={state}
 					busy={isBusy}

--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -20,7 +20,12 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 	}, [state, toastId]);
 
 	function handleAction() {
-		track("star_nag_starred", { surface: "toast" });
+		// A click during the post-star celebration window (state === "starred")
+		// reaches this handler but activate() no-ops for it — don't record a
+		// "starred" event for a click that didn't actually do anything.
+		if (canActivateStarAction(state)) {
+			track("star_nag_starred", { surface: "toast" });
+		}
 		activate();
 	}
 
@@ -51,7 +56,11 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 			</p>
 			{/* A "loading" or "unknown" read isn't trustworthy enough to act on —
 			same rule as every other star-nag surface — so the button just doesn't
-			render for those; the toast itself still auto-dismisses/closes normally. */}
+			render for those; the toast itself still auto-dismisses/closes normally.
+			Unlike GitHubStarPill/StarNagCard, "starred" isn't time-boxed via
+			useJustStarredWindow here — the effect above already dismisses the
+			whole toast 2s after a real star, so there's no separate window to
+			bound. */}
 			{(canActivateStarAction(state) || state === "starred") && (
 				<AnimatedStarButton
 					state={state}

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
@@ -3,7 +3,10 @@ export {
 	CHECK_STARRED_STALE_TIME_MS,
 	canActivateStarAction,
 	msUntilUnstarGraceWindowCloses,
+	STAR_SUCCESS_ANIMATION_MS,
 	shouldUnmuteOnUnstarredRead,
 	UNSTAR_CONFIRM_DELAY_MS,
 	useGithubStarAction,
+	useJustStarredWindow,
+	useTrackShownOnce,
 } from "./useGithubStarAction";

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/index.ts
@@ -1,6 +1,7 @@
 export type { GithubStarActionState } from "./useGithubStarAction";
 export {
 	CHECK_STARRED_STALE_TIME_MS,
+	canActivateStarAction,
 	msUntilUnstarGraceWindowCloses,
 	shouldUnmuteOnUnstarredRead,
 	UNSTAR_CONFIRM_DELAY_MS,

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.test.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
+	canActivateStarAction,
 	msUntilUnstarGraceWindowCloses,
 	shouldUnmuteOnUnstarredRead,
 	UNSTAR_CONFIRM_DELAY_MS,
 } from "./useGithubStarAction";
+
+describe("canActivateStarAction", () => {
+	test("only true for a confirmed not_starred read", () => {
+		expect(canActivateStarAction("not_starred")).toBe(true);
+		expect(canActivateStarAction("loading")).toBe(false);
+		expect(canActivateStarAction("unknown")).toBe(false);
+		expect(canActivateStarAction("starred")).toBe(false);
+	});
+});
 
 describe("shouldUnmuteOnUnstarredRead", () => {
 	test("ignores reads other than not_starred", () => {

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -72,14 +72,16 @@ export function useJustStarredWindow(state: GithubStarActionState): boolean {
  * resets so it fires again the next time `active` goes true -> false ->
  * true (or `key` changes while still active) — for once-per-showing "shown"
  * impression tracking. `onShow` doesn't need to be memoized; only its latest
- * value is ever called.
+ * value is ever called. `key` must be a primitive — the dedupe guard relies
+ * on `===` equality, so a fresh object/array reference every render would
+ * never match and defeat the "once" guarantee entirely.
  */
 export function useTrackShownOnce(
 	active: boolean,
 	onShow: () => void,
-	key: unknown = true,
+	key: string | number | boolean | null | undefined = true,
 ) {
-	const trackedKeyRef = useRef<unknown>(null);
+	const trackedKeyRef = useRef<typeof key>(null);
 	const onShowRef = useRef(onShow);
 	onShowRef.current = onShow;
 	useEffect(() => {
@@ -178,10 +180,14 @@ interface UseGithubStarActionOptions {
  * hook's concern — StarNagCard and StarNagToast derive that straight from
  * useStarNagStore (shouldShowThresholdCard()/isEligible()), and the pill and
  * Settings row are deliberately always-truthful with no suppression at all.
- * Every surface additionally only renders its button while `state ===
- * "not_starred"` (see each surface's visibility gate) — a "loading" or
- * "unknown" read isn't trustworthy enough to act on, so the button simply
- * doesn't show rather than offering a fallback for an unconfirmed state.
+ * A "loading" or "unknown" read isn't trustworthy enough to act on, so
+ * canActivateStarAction() gates clicking to `state === "not_starred"` only
+ * — but that's not the same as each surface's *visibility* gate. Three of
+ * the four (GitHubStarPill, StarNagCard, StarNagToast) also keep showing
+ * their button through the brief "starred" celebration window right after
+ * a fresh star (see useJustStarredWindow), and GithubStarRow always shows
+ * its button, just disabled when not actionable. Read each surface's own
+ * gate rather than assuming "not_starred-only" from here.
  *
  * checkResult -> store side effects (markCompleted/markUnstarred) are NOT
  * handled here — StarNagObserver owns that, once, so the four independently

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -1,4 +1,3 @@
-import { COMPANY } from "@superset/shared/constants";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 export type GithubStarActionState =
@@ -82,16 +81,20 @@ interface UseGithubStarActionOptions {
 }
 
 /**
- * Shared check-star-repo/star-repo/open-web-fallback flow, reused by every
- * "Star Superset on GitHub" surface (settings row, empty-state pill,
- * threshold card, onboarding toast). `state` is the live, truthful star
- * status — backed by the shared query cache, so a confirmed star from any
- * one surface is reflected on every other mounted surface immediately.
+ * Shared check-star-repo/star-repo flow, reused by every "Star Superset on
+ * GitHub" surface (settings row, empty-state pill, threshold card, onboarding
+ * toast). `state` is the live, truthful star status — backed by the shared
+ * query cache, so a confirmed star from any one surface is reflected on
+ * every other mounted surface immediately.
  *
  * Suppression (whether a nag surface should show itself at all) is NOT this
  * hook's concern — StarNagCard and StarNagToast derive that straight from
  * useStarNagStore (shouldShowThresholdCard()/isEligible()), and the pill and
  * Settings row are deliberately always-truthful with no suppression at all.
+ * Every surface additionally only renders its button while `state ===
+ * "not_starred"` (see each surface's visibility gate) — a "loading" or
+ * "unknown" read isn't trustworthy enough to act on, so the button simply
+ * doesn't show rather than offering a fallback for an unconfirmed state.
  *
  * checkResult -> store side effects (markCompleted/markUnstarred) are NOT
  * handled here — StarNagObserver owns that, once, so the four independently
@@ -108,15 +111,10 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 			refetchOnMount: options?.alwaysFreshOnMount ? "always" : true,
 		});
 	const starMutation = electronTrpc.githubStar.star.useMutation();
-	const openUrlMutation = electronTrpc.external.openUrl.useMutation();
 
 	const state: GithubStarActionState = isSuccess ? checkResult : "loading";
 
 	const activate = () => {
-		if (state === "unknown") {
-			openUrlMutation.mutate(COMPANY.GITHUB_URL);
-			return;
-		}
 		if (state !== "not_starred") return;
 		// Deliberately NOT optimistic: writing "starred" into the cache before
 		// the mutation resolves would make StarNagObserver's checkResult effect
@@ -157,17 +155,18 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 	return {
 		state,
 		activate,
-		isBusy: starMutation.isPending || openUrlMutation.isPending,
+		isBusy: starMutation.isPending,
 	};
 }
 
 /**
- * A failed/declined star attempt still writes "unknown" into the cache for
- * immediate UI feedback (the web-fallback state), but unlike a real
+ * A failed/declined star attempt still writes "unknown" into the cache —
+ * every surface's visibility gate hides the button for that state, so this
+ * is what makes it disappear immediately on failure — but unlike a real
  * "starred"/"not_starred" confirmation it shouldn't count as a fresh,
  * settled-for-10-minutes read — mark it stale (with no eager refetch of its
  * own) so the next mount naturally rechecks instead of every surface being
- * stuck on the failure fallback for up to staleTime.
+ * stuck hidden for up to staleTime.
  */
 function markStaleWithoutRefetch(
 	utils: ReturnType<typeof electronTrpc.useUtils>,

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -6,6 +6,16 @@ export type GithubStarActionState =
 	| "unknown"
 	| "starred";
 
+/**
+ * Whether a surface should let the user act on the star button right now.
+ * A "loading" or "unknown" read isn't trustworthy enough to treat as either
+ * confirmation — every surface (and activate() itself) gates on this same
+ * check rather than re-deriving `state === "not_starred"` independently.
+ */
+export function canActivateStarAction(state: GithubStarActionState): boolean {
+	return state === "not_starred";
+}
+
 // GitHub's starred-check API has been observed to flap between 204 and 404 on
 // rapid successive calls (see the "flaky checkStarred" fix) — so a
 // "not_starred" read moments after we mark the repo starred is more likely
@@ -115,7 +125,7 @@ export function useGithubStarAction(options?: UseGithubStarActionOptions) {
 	const state: GithubStarActionState = isSuccess ? checkResult : "loading";
 
 	const activate = () => {
-		if (state !== "not_starred") return;
+		if (!canActivateStarAction(state)) return;
 		// Deliberately NOT optimistic: writing "starred" into the cache before
 		// the mutation resolves would make StarNagObserver's checkResult effect
 		// treat the optimistic value as confirmation and mark completed — even

--- a/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
+++ b/apps/desktop/src/renderer/hooks/useGithubStarAction/useGithubStarAction.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 export type GithubStarActionState =
@@ -14,6 +15,82 @@ export type GithubStarActionState =
  */
 export function canActivateStarAction(state: GithubStarActionState): boolean {
 	return state === "not_starred";
+}
+
+// How long a fresh star confirmation still counts as "just happened" for
+// useJustStarredWindow — long enough for AnimatedStarButton's confetti/label
+// celebration to finish before a surface that normally hides on "starred"
+// (GitHubStarPill, StarNagCard) unmounts it mid-animation.
+export const STAR_SUCCESS_ANIMATION_MS = 1700;
+
+/**
+ * Whether `state` is "starred" as a direct result of an action taken in this
+ * session — true for STAR_SUCCESS_ANIMATION_MS after the transition, so a
+ * surface that normally hides once starred can instead keep showing the
+ * button (with its confetti/label celebration) for that window before
+ * hiding. Not true for a repo that was *already* starred on mount — only a
+ * live not_starred/unknown -> starred transition counts.
+ *
+ * Centralizes a subtlety two call sites (GitHubStarPill, StarNagCard) used
+ * to reimplement by hand, with a real risk of drifting: the "just
+ * transitioned" value has to be computed twice — once synchronously during
+ * render (so a caller's visibility check can't lag a render behind the state
+ * flip) and once inside an effect keyed on `state` rather than on the
+ * render-time value itself (an effect keyed on the render-time value would
+ * see it flip back to false on the very next render and cancel its own
+ * just-started timer before it ever fires).
+ */
+export function useJustStarredWindow(state: GithubStarActionState): boolean {
+	const prevStateRef = useRef(state);
+	const prevState = prevStateRef.current;
+	prevStateRef.current = state;
+	const justTransitioned =
+		(prevState === "not_starred" || prevState === "unknown") &&
+		state === "starred";
+
+	const [staysVisible, setStaysVisible] = useState(false);
+	const prevStateForTimerRef = useRef(state);
+	useEffect(() => {
+		const prev = prevStateForTimerRef.current;
+		prevStateForTimerRef.current = state;
+		const justTransitionedForTimer =
+			(prev === "not_starred" || prev === "unknown") && state === "starred";
+		if (!justTransitionedForTimer) return;
+		setStaysVisible(true);
+		const timer = setTimeout(
+			() => setStaysVisible(false),
+			STAR_SUCCESS_ANIMATION_MS,
+		);
+		return () => clearTimeout(timer);
+	}, [state]);
+
+	return state === "starred" && (justTransitioned || staysVisible);
+}
+
+/**
+ * Fires `onShow` the first time `active` becomes true for a given `key`, and
+ * resets so it fires again the next time `active` goes true -> false ->
+ * true (or `key` changes while still active) — for once-per-showing "shown"
+ * impression tracking. `onShow` doesn't need to be memoized; only its latest
+ * value is ever called.
+ */
+export function useTrackShownOnce(
+	active: boolean,
+	onShow: () => void,
+	key: unknown = true,
+) {
+	const trackedKeyRef = useRef<unknown>(null);
+	const onShowRef = useRef(onShow);
+	onShowRef.current = onShow;
+	useEffect(() => {
+		if (!active) {
+			trackedKeyRef.current = null;
+			return;
+		}
+		if (trackedKeyRef.current === key) return;
+		trackedKeyRef.current = key;
+		onShowRef.current();
+	}, [active, key]);
 }
 
 // GitHub's starred-check API has been observed to flap between 204 and 404 on

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
@@ -1,7 +1,10 @@
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
 import { Star } from "lucide-react";
-import { useGithubStarAction } from "renderer/hooks/useGithubStarAction";
+import {
+	canActivateStarAction,
+	useGithubStarAction,
+} from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 
@@ -41,7 +44,12 @@ export function GithubStarRow({ searchQuery }: GithubStarRowProps) {
 					variant="outline"
 					size="sm"
 					onClick={handleClick}
-					disabled={state !== "not_starred" || isBusy}
+					disabled={!canActivateStarAction(state) || isBusy}
+					title={
+						state === "unknown"
+							? "Couldn't confirm star status from the GitHub CLI — check that `gh` is installed and signed in"
+							: undefined
+					}
 				>
 					<Star className="size-3.5" />
 					Star

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
-import { ExternalLink, Star } from "lucide-react";
+import { Star } from "lucide-react";
 import { useGithubStarAction } from "renderer/hooks/useGithubStarAction";
 import { track } from "renderer/lib/analytics";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
@@ -18,9 +18,7 @@ export function GithubStarRow({ searchQuery }: GithubStarRowProps) {
 	});
 
 	function handleClick() {
-		track(state === "unknown" ? "star_nag_opened_web" : "star_nag_starred", {
-			surface: "settings",
-		});
+		track("star_nag_starred", { surface: "settings" });
 		activate();
 	}
 
@@ -43,14 +41,10 @@ export function GithubStarRow({ searchQuery }: GithubStarRowProps) {
 					variant="outline"
 					size="sm"
 					onClick={handleClick}
-					disabled={state === "loading" || isBusy}
+					disabled={state !== "not_starred" || isBusy}
 				>
-					{state === "unknown" ? (
-						<ExternalLink className="size-3.5" />
-					) : (
-						<Star className="size-3.5" />
-					)}
-					{state === "unknown" ? "Open GitHub" : "Star"}
+					<Star className="size-3.5" />
+					Star
 				</Button>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/components/GithubStarRow/GithubStarRow.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { Star } from "lucide-react";
 import {
 	canActivateStarAction,
@@ -39,17 +40,32 @@ export function GithubStarRow({ searchQuery }: GithubStarRowProps) {
 				<span className="text-xs text-muted-foreground">
 					Starred — thank you!
 				</span>
+			) : state === "unknown" ? (
+				// A disabled shadcn Button has pointer-events-none baked into its
+				// base classes, so a `title` attribute on the button itself would
+				// never receive the hover needed to show it — wrap it (same pattern
+				// as DeleteProjectSection) so the tooltip trigger sits outside the
+				// disabled element.
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span>
+							<Button variant="outline" size="sm" disabled>
+								<Star className="size-3.5" />
+								Star
+							</Button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="left">
+						Couldn't confirm star status — check that the GitHub CLI (`gh`) is
+						installed, signed in, and that you have a network connection
+					</TooltipContent>
+				</Tooltip>
 			) : (
 				<Button
 					variant="outline"
 					size="sm"
 					onClick={handleClick}
 					disabled={!canActivateStarAction(state) || isBusy}
-					title={
-						state === "unknown"
-							? "Couldn't confirm star status from the GitHub CLI — check that `gh` is installed and signed in"
-							: undefined
-					}
 				>
 					<Star className="size-3.5" />
 					Star


### PR DESCRIPTION
## Summary
- The "Star Superset on GitHub" button (empty-state pill, sidebar card, onboarding toast, Settings row) no longer shows an "Open GitHub" fallback when the local `gh` CLI can't confirm star status — it now only shows while the check has confirmed the repo is **not** starred.

## Why / Context
`checkGithubStarred()` (`apps/desktop/src/lib/trpc/routers/github-star/index.ts`) collapses every ambiguous outcome — `gh` not installed/authenticated, network error, rate limit — into `"unknown"`. Every star-nag surface rendered that as a distinct "Open GitHub" CTA, so a user who had already starred the repo (e.g. via browser) but whose local `gh` check failed to confirm it kept seeing "Open GitHub" instead of "Starred".

## How It Works
- `useGithubStarAction.activate()` dropped its `state === "unknown"` branch (which opened `COMPANY.GITHUB_URL` in the browser) — it now only acts when `state === "not_starred"`.
- `AnimatedStarButton` dropped the "Open GitHub" label branch.
- Each surface's visibility/enabled gate (`GitHubStarPill`, `StarNagCard`, `StarNagToast`, `GithubStarRow`) now requires `state === "not_starred"` (plus the existing brief post-star celebration window), instead of showing for anything other than `"loading"`.
- Click-tracking calls collapsed to always fire `star_nag_starred` (the `star_nag_opened_web` event path no longer exists).
- Untouched: the backend still returns `"unknown"` from `checkGithubStarred()` (a legitimate signal), and `StarNagObserver`'s grace-window/flap-protection logic, since neither depended on a visible "unknown" UI state.

## Manual QA Checklist
- [ ] Settings → Behavior: with `gh` confirming "not starred", Star button is enabled; after starring, row shows "Starred — thank you!"
- [ ] Simulate a `gh` failure (e.g. rename/remove `gh` from PATH or revoke its auth) with the repo actually starred — confirm no "Open GitHub" button appears anywhere (pill, sidebar card, toast, Settings row)
- [ ] Empty-state pill / sidebar card / onboarding toast: button only appears once state resolves to "not_starred"; clicking still stars via the `gh` CLI and plays the confetti/label animation

## Testing
- `bun test src/renderer/hooks/useGithubStarAction/useGithubStarAction.test.ts` (existing grace-window unit tests, unaffected by this change)
- `bunx tsc --noEmit` scoped to the touched files (desktop)
- `bunx biome check` on the touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the “Star on GitHub” button unless GitHub confirms the repo is not starred. Previously “unknown” showed an “Open GitHub” fallback; now “loading”/“unknown” hide or disable the button, preventing nags and no‑op clicks.

- UI: `GitHubStarPill`, `StarNagCard`, `StarNagToast`, and `GithubStarRow` gate clicks with `canActivateStarAction(state)` (“not_starred” only). `StarNagCard` keeps its chrome visible and hides only the button when not actionable. `AnimatedStarButton` disables on “unknown” and aligns its celebration trigger with the shared hook. Settings row wraps the disabled button in a Tooltip explaining why status can’t be confirmed.
- Action: `useGithubStarAction.activate()` only runs when actionable; the browser fallback is removed. `isBusy` reflects only the star mutation. Extracted `canActivateStarAction` for consistent gating.
- Analytics: remove `star_nag_opened_web`. Track `star_nag_starred` only for actionable clicks. “Shown” impressions fire once per showing via `useTrackShownOnce`, and the card now tracks only when the button is visible.
- Refactor: centralize celebration and impression logic into `useJustStarredWindow` and `useTrackShownOnce`; move `STAR_SUCCESS_ANIMATION_MS` next to those hooks to keep timing consistent across surfaces.
- Tests/unchanged: add a unit test for `canActivateStarAction`. Backend `checkGithubStarred()` can still return “unknown”, and `StarNagObserver` grace-window/flap protection is unchanged.

<sup>Written for commit 242060ad00f0ee5d08ac9298f2646ab9accfd8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub star actions so buttons appear and activate only when the status is actionable.
  * Added clearer troubleshooting guidance when the star status cannot be verified.
  * Kept star prompts visible briefly after a successful star while hiding unavailable actions.
  * Standardized star behavior and impression tracking across settings, cards, pills, and notifications.
  * Refined success animations to trigger only after a confirmed star action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->