### PR TITLE
fix(desktop,host-service): stop the Changes pane from hanging on large diffs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -72,7 +72,7 @@
 		"@lezer/highlight": "1.2.3",
 		"@paper-design/shaders-react": "0.0.77",
 		"@parcel/watcher": "2.5.6",
-		"@pierre/diffs": "1.2.12",
+		"@pierre/diffs": "1.3.5",
 		"@pierre/trees": "1.0.0-beta.5",
 		"@radix-ui/react-dialog": "1.1.15",
 		"@radix-ui/react-label": "2.1.8",

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -76,6 +76,11 @@ export function useGitStatus(workspaceId: string, enabled = true) {
 				// picks up the new branch's base.
 				void utils.git.getBaseBranch.invalidate({ workspaceId });
 			}
+			// getDiffBulk queries are keyed by the whole file-path list, not one
+			// path, so they can't be targeted per-path like getDiff above —
+			// invalidate the (small, bounded) set of bulk queries for this
+			// workspace instead.
+			void utils.git.getDiffBulk.invalidate({ workspaceId });
 		},
 		[refreshScheduler, utils, workspaceId],
 	);

--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -34,6 +34,15 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: () => getHostServiceHeaders(hostUrl),
+				// host-service is a local connection with no HTTP cache in front of
+				// it, so there's no upside to GET. Forcing POST puts query inputs in
+				// the request body instead of the URL — without this, a same-tick
+				// batch across many workspaces (terminalAgents.listByWorkspace,
+				// ports.getAll, etc.) can produce a GET URL long enough to blow past
+				// the server's HTTP header-size limit, failing even the CORS
+				// preflight before it reaches the route. See the identical fix on
+				// WorkspaceClientProvider in @superset/workspace-client.
+				methodOverride: "POST",
 			}),
 		],
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
@@ -49,6 +49,9 @@ export function ChangesSection({
 		void utils.git.getDiff.invalidate({
 			workspaceId: stagingActions.workspaceId,
 		});
+		void utils.git.getDiffBulk.invalidate({
+			workspaceId: stagingActions.workspaceId,
+		});
 	};
 
 	const discardAllUnstaged = workspaceTrpc.git.discardAllUnstaged.useMutation({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -282,6 +282,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		onSuccess: () => {
 			void utils.git.getStatus.invalidate({ workspaceId });
 			void utils.git.getDiff.invalidate({ workspaceId });
+			void utils.git.getDiffBulk.invalidate({ workspaceId });
 		},
 		onError: (err) => {
 			toast.error("Couldn't discard changes", { description: err.message });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -87,6 +87,7 @@ export const FileRow = memo(function FileRow({
 		onSuccess: () => {
 			void utils.git.getStatus.invalidate({ workspaceId });
 			void utils.git.getDiff.invalidate({ workspaceId });
+			void utils.git.getDiffBulk.invalidate({ workspaceId });
 		},
 		onError: (err) => {
 			toast.error("Couldn't discard changes", { description: err.message });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -96,6 +96,7 @@ export function useChangesTab({
 			void utils.git.getStatus.invalidate({ workspaceId });
 			void utils.git.listCommits.invalidate({ workspaceId });
 			void utils.git.getDiff.invalidate({ workspaceId });
+			void utils.git.getDiffBulk.invalidate({ workspaceId });
 		},
 		// The picker re-renders from getBaseBranch, so a rejected change
 		// silently snaps back without this.
@@ -154,6 +155,7 @@ export function useChangesTab({
 			await Promise.all([
 				utils.git.getStatus.invalidate({ workspaceId }),
 				utils.git.getDiff.invalidate({ workspaceId }),
+				utils.git.getDiffBulk.invalidate({ workspaceId }),
 				utils.git.listCommits.invalidate({ workspaceId }),
 				utils.git.listBranches.invalidate({ workspaceId }),
 				utils.git.getBaseBranch.invalidate({ workspaceId }),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -71,6 +71,7 @@ export function DiffHeaderMetadata({
 		onSuccess: () => {
 			void utils.git.getStatus.invalidate({ workspaceId });
 			void utils.git.getDiff.invalidate({ workspaceId });
+			void utils.git.getDiffBulk.invalidate({ workspaceId });
 		},
 		onError: (err) => {
 			toast.error("Couldn't discard changes", { description: err.message });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -9,7 +9,7 @@ import type { AppRouter } from "@superset/host-service";
 import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import { useQueries } from "@tanstack/react-query";
 import { getQueryKey } from "@trpc/react-query";
-import type { inferRouterInputs } from "@trpc/server";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { useMemo, useRef } from "react";
 import {
 	type ChangesetFile,
@@ -19,10 +19,10 @@ import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
 
 type GetDiffInput = inferRouterInputs<AppRouter>["git"]["getDiff"];
 type GetDiffBulkInput = inferRouterInputs<AppRouter>["git"]["getDiffBulk"];
-type DiffContent = {
-	oldFile: { name: string; contents: string };
-	newFile: { name: string; contents: string };
-};
+type DiffContent = Omit<
+	inferRouterOutputs<AppRouter>["git"]["getDiffBulk"]["diffs"][number],
+	"path"
+>;
 
 interface UseDiffCodeViewItemsOptions {
 	workspaceId: string;
@@ -131,9 +131,13 @@ export function useDiffCodeViewItems({
 
 	// One lookup per group resolution (not per file, not per render) — keeps
 	// the per-file work below linear in file count instead of the quadratic
-	// rebuild the old per-file `useQueries` produced.
+	// rebuild the old per-file `useQueries` produced. `revision` is a hash of
+	// this file's own contents, not the group's fetch timestamp — a group
+	// query covers every file sharing a category, so keying off
+	// `dataUpdatedAt` would invalidate every other file's parsed-diff and
+	// highlight caches whenever any one file in the group changed.
 	const diffContentByItemId = useMemo(() => {
-		const map = new Map<string, DiffContent & { dataUpdatedAt: number }>();
+		const map = new Map<string, DiffContent & { revision: number }>();
 		diffGroups.forEach((group, index) => {
 			const query = diffGroupQueries[index];
 			if (!query?.data) return;
@@ -144,7 +148,9 @@ export function useDiffCodeViewItems({
 				map.set(member.itemId, {
 					oldFile: entry.oldFile,
 					newFile: entry.newFile,
-					dataUpdatedAt: query.dataUpdatedAt,
+					revision: hashString(
+						`${entry.oldFile.contents}\0${entry.newFile.contents}`,
+					),
 				});
 			}
 		});
@@ -160,11 +166,12 @@ export function useDiffCodeViewItems({
 	}, [files]);
 
 	// Parsing a file's diff (parseDiffFromFile) is the expensive part of
-	// building an item — cache it per item id, keyed by the group's
-	// dataUpdatedAt, so a render triggered by something unrelated (collapsed
-	// state, an annotation on a different file) doesn't re-parse every file.
+	// building an item — cache it per item id, keyed by the file's content
+	// revision, so a render triggered by something unrelated (collapsed
+	// state, an annotation on a different file, another file in the same
+	// group refetching) doesn't re-parse every file.
 	const fileDiffCacheRef = useRef(
-		new Map<string, { dataUpdatedAt: number; fileDiff: FileDiffMetadata }>(),
+		new Map<string, { revision: number; fileDiff: FileDiffMetadata }>(),
 	);
 
 	const items = useMemo<CodeViewItem<DiffAnnotationMetadata>[]>(() => {
@@ -236,7 +243,7 @@ export function useDiffCodeViewItems({
 
 			const cached = cache.get(itemId);
 			const fileDiff =
-				cached && cached.dataUpdatedAt === content.dataUpdatedAt
+				cached && cached.revision === content.revision
 					? cached.fileDiff
 					: parseDiffFromFile(
 							{
@@ -246,18 +253,19 @@ export function useDiffCodeViewItems({
 								// already-highlighted AST across remounts (e.g.
 								// navigating away from a workspace and back), which
 								// this hook's own fileDiffCacheRef can't cover since
-								// it's wiped on unmount. dataUpdatedAt changes
-								// whenever the underlying diff content changes.
-								cacheKey: `${itemId}:${content.dataUpdatedAt}:old`,
+								// it's wiped on unmount. revision changes only when
+								// this file's own contents change, not when a
+								// sibling in the same bulk group refetches.
+								cacheKey: `${itemId}:${content.revision}:old`,
 							},
 							{
 								...content.newFile,
 								name: file.path,
-								cacheKey: `${itemId}:${content.dataUpdatedAt}:new`,
+								cacheKey: `${itemId}:${content.revision}:new`,
 							},
 						);
-			if (!cached || cached.dataUpdatedAt !== content.dataUpdatedAt) {
-				cache.set(itemId, { dataUpdatedAt: content.dataUpdatedAt, fileDiff });
+			if (!cached || cached.revision !== content.revision) {
+				cache.set(itemId, { revision: content.revision, fileDiff });
 			}
 
 			const baseAnnotations = getAnnotationsForFile(annotationsByPath, file);
@@ -268,7 +276,7 @@ export function useDiffCodeViewItems({
 					: (extra ?? baseAnnotations);
 			const version = hashString(
 				[
-					content.dataUpdatedAt,
+					content.revision,
 					file.path,
 					file.oldPath ?? "",
 					file.status,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -242,10 +242,18 @@ export function useDiffCodeViewItems({
 							{
 								...content.oldFile,
 								name: file.oldPath ?? file.path,
+								// Lets @pierre/diffs' WorkerPoolManager reuse an
+								// already-highlighted AST across remounts (e.g.
+								// navigating away from a workspace and back), which
+								// this hook's own fileDiffCacheRef can't cover since
+								// it's wiped on unmount. dataUpdatedAt changes
+								// whenever the underlying diff content changes.
+								cacheKey: `${itemId}:${content.dataUpdatedAt}:old`,
 							},
 							{
 								...content.newFile,
 								name: file.path,
+								cacheKey: `${itemId}:${content.dataUpdatedAt}:new`,
 							},
 						);
 			if (!cached || cached.dataUpdatedAt !== content.dataUpdatedAt) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -1,6 +1,7 @@
 import {
 	type CodeViewItem,
 	type DiffLineAnnotation,
+	type FileDiffMetadata,
 	type LineAnnotation,
 	parseDiffFromFile,
 } from "@pierre/diffs";
@@ -9,7 +10,7 @@ import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import { useQueries } from "@tanstack/react-query";
 import { getQueryKey } from "@trpc/react-query";
 import type { inferRouterInputs } from "@trpc/server";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import {
 	type ChangesetFile,
 	getChangesetFileKey,
@@ -17,6 +18,11 @@ import {
 import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
 
 type GetDiffInput = inferRouterInputs<AppRouter>["git"]["getDiff"];
+type GetDiffBulkInput = inferRouterInputs<AppRouter>["git"]["getDiffBulk"];
+type DiffContent = {
+	oldFile: { name: string; contents: string };
+	newFile: { name: string; contents: string };
+};
 
 interface UseDiffCodeViewItemsOptions {
 	workspaceId: string;
@@ -41,6 +47,26 @@ interface UseDiffCodeViewItemsResult {
 	hasDiffError: boolean;
 }
 
+/** A file's diff request, grouped with every other file that shares the same
+ * (category, baseBranch, commitHash, fromHash) — i.e. the same `getDiffBulk`
+ * call. A DiffPane's file list can mix categories (e.g. staged + unstaged +
+ * against-base all in one "changes" view), so this is usually 1-3 groups,
+ * never one per file. */
+interface DiffGroup {
+	key: string;
+	bulkInput: Omit<GetDiffBulkInput, "workspaceId" | "paths">;
+	members: { file: ChangesetFile; itemId: string; path: string }[];
+}
+
+function groupKeyFor(input: GetDiffInput): string {
+	return [
+		input.category,
+		input.baseBranch ?? "",
+		input.commitHash ?? "",
+		input.fromHash ?? "",
+	].join("\0");
+}
+
 export function useDiffCodeViewItems({
 	workspaceId,
 	files,
@@ -61,13 +87,69 @@ export function useDiffCodeViewItems({
 		[files, workspaceId],
 	);
 
-	const diffQueries = useQueries({
-		queries: diffRequests.map(({ input }) => ({
-			queryKey: getQueryKey(workspaceTrpc.git.getDiff, input, "query"),
-			queryFn: () => trpcClient.git.getDiff.query(input),
-			staleTime: Number.POSITIVE_INFINITY,
-		})),
+	const diffGroups = useMemo<DiffGroup[]>(() => {
+		const groups = new Map<string, DiffGroup>();
+		for (const { file, input } of diffRequests) {
+			const key = groupKeyFor(input);
+			let group = groups.get(key);
+			if (!group) {
+				group = {
+					key,
+					bulkInput: {
+						category: input.category,
+						baseBranch: input.baseBranch,
+						commitHash: input.commitHash,
+						fromHash: input.fromHash,
+					},
+					members: [],
+				};
+				groups.set(key, group);
+			}
+			group.members.push({
+				file,
+				itemId: getDiffItemId(file),
+				path: input.path,
+			});
+		}
+		return [...groups.values()];
+	}, [diffRequests]);
+
+	const diffGroupQueries = useQueries({
+		queries: diffGroups.map((group) => {
+			const input: GetDiffBulkInput = {
+				workspaceId,
+				paths: group.members.map((member) => member.path),
+				...group.bulkInput,
+			};
+			return {
+				queryKey: getQueryKey(workspaceTrpc.git.getDiffBulk, input, "query"),
+				queryFn: () => trpcClient.git.getDiffBulk.query(input),
+				staleTime: Number.POSITIVE_INFINITY,
+			};
+		}),
 	});
+
+	// One lookup per group resolution (not per file, not per render) — keeps
+	// the per-file work below linear in file count instead of the quadratic
+	// rebuild the old per-file `useQueries` produced.
+	const diffContentByItemId = useMemo(() => {
+		const map = new Map<string, DiffContent & { dataUpdatedAt: number }>();
+		diffGroups.forEach((group, index) => {
+			const query = diffGroupQueries[index];
+			if (!query?.data) return;
+			const byPath = new Map(query.data.diffs.map((d) => [d.path, d]));
+			for (const member of group.members) {
+				const entry = byPath.get(member.path);
+				if (!entry) continue;
+				map.set(member.itemId, {
+					oldFile: entry.oldFile,
+					newFile: entry.newFile,
+					dataUpdatedAt: query.dataUpdatedAt,
+				});
+			}
+		});
+		return map;
+	}, [diffGroups, diffGroupQueries]);
 
 	const fileByItemId = useMemo(() => {
 		const map = new Map<string, ChangesetFile>();
@@ -77,17 +159,22 @@ export function useDiffCodeViewItems({
 		return map;
 	}, [files]);
 
+	// Parsing a file's diff (parseDiffFromFile) is the expensive part of
+	// building an item — cache it per item id, keyed by the group's
+	// dataUpdatedAt, so a render triggered by something unrelated (collapsed
+	// state, an annotation on a different file) doesn't re-parse every file.
+	const fileDiffCacheRef = useRef(
+		new Map<string, { dataUpdatedAt: number; fileDiff: FileDiffMetadata }>(),
+	);
+
 	const items = useMemo<CodeViewItem<DiffAnnotationMetadata>[]>(() => {
 		const nextItems: CodeViewItem<DiffAnnotationMetadata>[] = [];
-		const queryByItemId = new Map(
-			diffRequests.map((request, index) => [
-				getDiffItemId(request.file),
-				diffQueries[index],
-			]),
-		);
+		const cache = fileDiffCacheRef.current;
+		const liveItemIds = new Set<string>();
 
 		for (const file of files) {
 			const itemId = getDiffItemId(file);
+			liveItemIds.add(itemId);
 			const collapsed = collapsedSet.has(getChangesetFileKey(file));
 
 			if (file.isBinary) {
@@ -144,8 +231,26 @@ export function useDiffCodeViewItems({
 				continue;
 			}
 
-			const query = queryByItemId.get(itemId);
-			if (!query?.data) continue;
+			const content = diffContentByItemId.get(itemId);
+			if (!content) continue;
+
+			const cached = cache.get(itemId);
+			const fileDiff =
+				cached && cached.dataUpdatedAt === content.dataUpdatedAt
+					? cached.fileDiff
+					: parseDiffFromFile(
+							{
+								...content.oldFile,
+								name: file.oldPath ?? file.path,
+							},
+							{
+								...content.newFile,
+								name: file.path,
+							},
+						);
+			if (!cached || cached.dataUpdatedAt !== content.dataUpdatedAt) {
+				cache.set(itemId, { dataUpdatedAt: content.dataUpdatedAt, fileDiff });
+			}
 
 			const baseAnnotations = getAnnotationsForFile(annotationsByPath, file);
 			const extra = extraAnnotationsByItemId?.get(itemId);
@@ -153,19 +258,9 @@ export function useDiffCodeViewItems({
 				baseAnnotations && extra
 					? [...baseAnnotations, ...extra]
 					: (extra ?? baseAnnotations);
-			const fileDiff = parseDiffFromFile(
-				{
-					...query.data.oldFile,
-					name: file.oldPath ?? file.path,
-				},
-				{
-					...query.data.newFile,
-					name: file.path,
-				},
-			);
 			const version = hashString(
 				[
-					query.dataUpdatedAt,
+					content.dataUpdatedAt,
 					file.path,
 					file.oldPath ?? "",
 					file.status,
@@ -186,11 +281,16 @@ export function useDiffCodeViewItems({
 			});
 		}
 
+		// Drop cache entries for files no longer in the changeset so the map
+		// doesn't grow unbounded as the user navigates between diffs.
+		for (const key of cache.keys()) {
+			if (!liveItemIds.has(key)) cache.delete(key);
+		}
+
 		return nextItems;
 	}, [
 		files,
-		diffRequests,
-		diffQueries,
+		diffContentByItemId,
 		annotationsByPath,
 		collapsedSet,
 		extraAnnotationsByItemId,
@@ -199,8 +299,8 @@ export function useDiffCodeViewItems({
 	return {
 		items,
 		fileByItemId,
-		hasPendingDiff: diffQueries.some((query) => query.isPending),
-		hasDiffError: diffQueries.some((query) => query.isError),
+		hasPendingDiff: diffGroupQueries.some((query) => query.isPending),
+		hasDiffError: diffGroupQueries.some((query) => query.isError),
 	};
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -151,7 +151,7 @@
         "@lezer/highlight": "1.2.3",
         "@paper-design/shaders-react": "0.0.77",
         "@parcel/watcher": "2.5.6",
-        "@pierre/diffs": "1.2.12",
+        "@pierre/diffs": "1.3.5",
         "@pierre/trees": "1.0.0-beta.5",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-label": "2.1.8",
@@ -2464,11 +2464,11 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.5", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw=="],
 
-    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 
-    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+    "@pierre/theming": ["@pierre/theming@1.0.1", "", { "peerDependencies": { "@pierre/theme": "^1.1.0 || ^2.0.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.5", "", { "dependencies": { "@pierre/theming": "0.0.2", "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-IzxkB9qv6GLbeEXObhlAD205LfYHiLeRwJdnaIdX0f5keTZF4X9EfiuEQ3QiyxOxouVVmUX3rX7m6a8zNMo/wA=="],
 
@@ -7146,6 +7146,10 @@
 
     "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
+    "@pierre/diffs/shiki": ["shiki@4.4.3", "", { "dependencies": { "@shikijs/core": "4.4.3", "@shikijs/engine-javascript": "4.4.3", "@shikijs/engine-oniguruma": "4.4.3", "@shikijs/langs": "4.4.3", "@shikijs/themes": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g=="],
+
+    "@pierre/trees/@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+
     "@pierre/trees/preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
 
     "@poppinss/dumper/@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
@@ -8207,6 +8211,20 @@
     "@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.1", "", {}, "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@4.4.3", "", { "dependencies": { "@shikijs/primitive": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w=="],
+
+    "@pierre/diffs/shiki/@shikijs/langs": ["@shikijs/langs@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3" } }, "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A=="],
+
+    "@pierre/diffs/shiki/@shikijs/themes": ["@shikijs/themes@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3" } }, "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw=="],
+
+    "@pierre/diffs/shiki/@shikijs/types": ["@shikijs/types@4.4.3", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g=="],
+
+    "@pierre/trees/@pierre/theming/@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
 
     "@react-email/preview-server/next/@next/env": ["@next/env@16.0.7", "", {}, "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw=="],
 
@@ -9303,6 +9321,8 @@
     "@expo/package-manager/ora/cli-cursor/restore-cursor": ["restore-cursor@2.0.0", "", { "dependencies": { "onetime": "^2.0.0", "signal-exit": "^3.0.2" } }, "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q=="],
 
     "@expo/package-manager/ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
+
+    "@pierre/diffs/shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ=="],
 
     "@react-email/preview-server/next/postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -272,6 +272,14 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		"/trpc/*",
 		trpcServer({
 			router: appRouter,
+			// Renderer clients send every request (including queries) as POST —
+			// see WorkspaceClientProvider/host-service-client's methodOverride —
+			// so a query with a large input (e.g. git.getDiffBulk's file-path
+			// list, or a same-tick batch across many workspaces) doesn't produce
+			// a GET URL long enough to blow past the header-size limit. Without
+			// this flag trpc's default HTTP-method map rejects those POSTs with
+			// METHOD_NOT_SUPPORTED before the query ever runs.
+			allowMethodOverride: true,
 			createContext: async (_opts, c) => {
 				const isAuthenticated = await providers.hostAuth.validate(c.req.raw);
 				return {

--- a/packages/host-service/src/trpc/router/git/get-diff-bulk.test.ts
+++ b/packages/host-service/src/trpc/router/git/get-diff-bulk.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit, { type SimpleGit } from "simple-git";
+import type { HostServiceContext } from "../../../types";
+import { gitRouter } from "./git";
+
+/**
+ * Proves `getDiffBulk` scales to a large changeset in one call: a real repo
+ * with a few hundred added files, diffed in a single request instead of one
+ * `getDiff` call per file. Guards against the N+1/quadratic regression this
+ * endpoint replaced (see DiffPane's useDiffCodeViewItems).
+ */
+
+const FILE_COUNT = 300;
+
+function createCaller(worktreePath: string) {
+	const ctx = {
+		isAuthenticated: true,
+		db: {
+			query: {
+				workspaces: {
+					findFirst: () => ({ sync: () => ({ worktreePath }) }),
+				},
+			},
+		},
+		git: async (path: string) => simpleGit(path),
+		credentials: {
+			getCredentials: async () => ({ env: {} }),
+			getToken: async () => null,
+		},
+	} as unknown as HostServiceContext;
+	return gitRouter.createCaller(ctx);
+}
+
+async function initRepo(path: string): Promise<SimpleGit> {
+	const git = simpleGit(path);
+	await git.init();
+	await git.raw(["config", "user.email", "test@example.com"]);
+	await git.raw(["config", "user.name", "test"]);
+	await git.raw(["config", "commit.gpgsign", "false"]);
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+	return git;
+}
+
+function mkTmp(): string {
+	return mkdtempSync(join(tmpdir(), "superset-diff-bulk-"));
+}
+
+describe("gitRouter.getDiffBulk — large changeset", () => {
+	let repo: string;
+	let git: SimpleGit;
+	let paths: string[];
+
+	beforeEach(async () => {
+		repo = mkTmp();
+		git = await initRepo(repo);
+
+		await writeFile(join(repo, "seed.txt"), "seed\n");
+		await git.raw(["add", "--", "seed.txt"]);
+		await git.raw(["commit", "-m", "seed"]);
+		const baseSha = (await git.revparse(["HEAD"])).trim();
+
+		// origin/main tracks the pre-changeset commit — this is what
+		// "against-base" resolves against via resolveBaseComparison.
+		await git.raw(["update-ref", "refs/remotes/origin/main", baseSha]);
+		await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			"refs/remotes/origin/main",
+		]);
+		await git.raw(["config", "branch.main.remote", "origin"]);
+		await git.raw(["config", "branch.main.merge", "refs/heads/main"]);
+
+		paths = Array.from(
+			{ length: FILE_COUNT },
+			(_, i) => `src/generated/file-${i}.ts`,
+		);
+		await mkdir(join(repo, "src", "generated"), { recursive: true });
+		for (const path of paths) {
+			await writeFile(
+				join(repo, path),
+				`export const value = ${paths.indexOf(path)};\n`,
+			);
+		}
+		await git.raw(["add", "-A"]);
+		await git.raw(["commit", "-m", `add ${FILE_COUNT} files`]);
+	});
+
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	test("returns every file's diff in one call, and stays fast", async () => {
+		const caller = createCaller(repo);
+		const start = performance.now();
+		const result = await caller.getDiffBulk({
+			workspaceId: "ws-1",
+			paths,
+			category: "against-base",
+		});
+		const elapsedMs = performance.now() - start;
+
+		expect(result.diffs).toHaveLength(FILE_COUNT);
+
+		const byPath = new Map(result.diffs.map((d) => [d.path, d]));
+		const first = byPath.get("src/generated/file-0.ts");
+		const last = byPath.get(`src/generated/file-${FILE_COUNT - 1}.ts`);
+		expect(first?.oldFile.contents).toBe("");
+		expect(first?.newFile.contents).toBe("export const value = 0;\n");
+		expect(last?.newFile.contents).toBe(
+			`export const value = ${FILE_COUNT - 1};\n`,
+		);
+
+		// Generous bound for CI/dev-machine variance — the point is proving
+		// this doesn't hang or scale quadratically, not micro-benchmarking.
+		expect(elapsedMs).toBeLessThan(60_000);
+	}, 90_000);
+
+	test("matches per-file getDiff output for every file", async () => {
+		const caller = createCaller(repo);
+		const bulk = await caller.getDiffBulk({
+			workspaceId: "ws-1",
+			paths,
+			category: "against-base",
+		});
+		const byPath = new Map(bulk.diffs.map((d) => [d.path, d]));
+
+		// Spot-check a sample rather than all 300 — this asserts getDiffBulk
+		// didn't diverge from getDiff's per-category logic, not scale.
+		const sample = [
+			paths[0],
+			paths[Math.floor(FILE_COUNT / 2)],
+			paths[FILE_COUNT - 1],
+		].filter((path): path is string => path !== undefined);
+		for (const path of sample) {
+			const single = await caller.getDiff({
+				workspaceId: "ws-1",
+				path,
+				category: "against-base",
+			});
+			const bulkEntry = byPath.get(path);
+			expect({
+				oldFile: bulkEntry?.oldFile,
+				newFile: bulkEntry?.newFile,
+			}).toEqual(single);
+		}
+	}, 30_000);
+});

--- a/packages/host-service/src/trpc/router/git/get-diff-bulk.test.ts
+++ b/packages/host-service/src/trpc/router/git/get-diff-bulk.test.ts
@@ -95,13 +95,11 @@ describe("gitRouter.getDiffBulk — large changeset", () => {
 
 	test("returns every file's diff in one call, and stays fast", async () => {
 		const caller = createCaller(repo);
-		const start = performance.now();
 		const result = await caller.getDiffBulk({
 			workspaceId: "ws-1",
 			paths,
 			category: "against-base",
 		});
-		const elapsedMs = performance.now() - start;
 
 		expect(result.diffs).toHaveLength(FILE_COUNT);
 
@@ -114,9 +112,7 @@ describe("gitRouter.getDiffBulk — large changeset", () => {
 			`export const value = ${FILE_COUNT - 1};\n`,
 		);
 
-		// Generous bound for CI/dev-machine variance — the point is proving
-		// this doesn't hang or scale quadratically, not micro-benchmarking.
-		expect(elapsedMs).toBeLessThan(60_000);
+		// The 90s test timeout is the hang/quadratic-scaling guard.
 	}, 90_000);
 
 	test("matches per-file getDiff output for every file", async () => {
@@ -148,4 +144,25 @@ describe("gitRouter.getDiffBulk — large changeset", () => {
 			}).toEqual(single);
 		}
 	}, 30_000);
+
+	test("rejects a path-traversal path instead of reading outside the worktree", async () => {
+		const caller = createCaller(repo);
+		const traversal = "../../../../../../../../etc/passwd";
+
+		await expect(
+			caller.getDiff({
+				workspaceId: "ws-1",
+				path: traversal,
+				category: "unstaged",
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+		await expect(
+			caller.getDiffBulk({
+				workspaceId: "ws-1",
+				paths: [traversal],
+				category: "unstaged",
+			}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+	});
 });

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -1,8 +1,7 @@
-import { readFile, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { isAbsolute, join, normalize, sep } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import type { SimpleGit } from "simple-git";
 import { z } from "zod";
 import { pullRequests, workspaces } from "../../../db/schema";
 import { createGitEnvResolver } from "../../../runtime/git";
@@ -11,6 +10,7 @@ import type { HostServiceContext } from "../../../types";
 import { getHostWorkerPool } from "../../../workers/host-worker-pool";
 import {
 	gitCommitFilesTask,
+	gitDiffBulkTask,
 	gitFetchBaseRefTask,
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
@@ -33,8 +33,9 @@ import { rethrowEnvironmentalGitError } from "./utils/classify-git-error";
 import { gitConfigWrite } from "./utils/config-write";
 import {
 	getDefaultBranchName,
-	mapWithConcurrency,
+	loadFileDiffContent,
 	resolveBaseComparison,
+	resolveDiffCategoryRefs,
 } from "./utils/git-helpers";
 import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
 import {
@@ -195,8 +196,6 @@ function sumSnapshotDiffStats(snapshot: {
 	return { additions, deletions, fileCount: byPath.size };
 }
 
-type DiffCategory = "against-base" | "staged" | "unstaged" | "commit";
-
 const getDiffInputShape = z.object({
 	workspaceId: z.string(),
 	path: z.string(),
@@ -210,107 +209,6 @@ const getDiffInputShape = z.object({
  * changeset we expect the Changes pane to render, while still bounding a
  * runaway/malicious request. */
 const MAX_DIFF_BULK_PATHS = 2000;
-
-/** How many `git show` pairs run at once for a bulk diff request. Each
- * pair is its own SimpleGit instance so slots genuinely run concurrently
- * (simple-git serializes commands within one instance). */
-const DIFF_BULK_CONCURRENCY = 8;
-
-/** Refs shared by every file in a `getDiff`/`getDiffBulk` request for a given
- * category — resolved once per request rather than once per file. */
-interface DiffCategoryRefs {
-	/** against-base: merge-base(baseRef, HEAD) */
-	originRef?: string;
-	/** commit: the "before" ref (fromHash, or commitHash^) */
-	fromRef?: string;
-	/** commit: the commit itself */
-	toRef?: string;
-}
-
-async function resolveDiffCategoryRefs(
-	git: SimpleGit,
-	category: DiffCategory,
-	opts: { baseBranch?: string; commitHash?: string; fromHash?: string },
-): Promise<DiffCategoryRefs> {
-	if (category === "against-base") {
-		const base = await resolveBaseComparison(git, opts.baseBranch);
-		const baseRef = base?.baseRef ?? "HEAD";
-		// Use the merge base so the diff excludes unrelated changes landed on
-		// the base branch after we forked — matches what the file list
-		// (3-dot diff) is already filtered by.
-		const originRef = await git
-			.raw(["merge-base", baseRef, "HEAD"])
-			.then((s) => s.trim())
-			.catch(() => baseRef);
-		return { originRef };
-	}
-	if (category === "commit") {
-		if (!opts.commitHash) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: "commitHash is required for commit diffs",
-			});
-		}
-		return {
-			fromRef: opts.fromHash ?? `${opts.commitHash}^`,
-			toRef: opts.commitHash,
-		};
-	}
-	return {};
-}
-
-async function loadFileDiffContent(
-	git: SimpleGit,
-	worktreePath: string,
-	category: DiffCategory,
-	path: string,
-	refs: DiffCategoryRefs,
-): Promise<{
-	oldFile: { name: string; contents: string };
-	newFile: { name: string; contents: string };
-}> {
-	let originalContent = "";
-	let modifiedContent = "";
-
-	if (category === "against-base") {
-		try {
-			originalContent = await git.show([`${refs.originRef}:${path}`]);
-		} catch {}
-		try {
-			modifiedContent = await git.show([`HEAD:${path}`]);
-		} catch {}
-	} else if (category === "staged") {
-		try {
-			originalContent = await git.show([`HEAD:${path}`]);
-		} catch {}
-		try {
-			modifiedContent = await git.show([`:0:${path}`]);
-		} catch {}
-	} else if (category === "commit") {
-		try {
-			originalContent = await git.show([`${refs.fromRef}:${path}`]);
-		} catch {}
-		try {
-			modifiedContent = await git.show([`${refs.toRef}:${path}`]);
-		} catch {}
-	} else {
-		// Unstaged: compare index (staged version) against working tree.
-		// If the file isn't in the index (untracked), originalContent stays
-		// empty = "new file".
-		try {
-			originalContent = await git.show([`:0:${path}`]);
-		} catch {}
-		try {
-			modifiedContent = await readFile(`${worktreePath}/${path}`, "utf-8");
-		} catch {}
-	}
-
-	const fileName = path.split("/").pop() ?? path;
-	return {
-		oldFile: { name: fileName, contents: originalContent },
-		newFile: { name: fileName, contents: modifiedContent },
-	};
-}
 
 export const gitRouter = router({
 	listBranches: queryProcedure
@@ -718,29 +616,22 @@ export const gitRouter = router({
 		.query(async ({ ctx, input }) => {
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
-			const refs = await resolveDiffCategoryRefs(
-				createUserSimpleGit(worktreePath).env(gitEnv),
-				input.category,
-				input,
-			);
-
-			const diffs = await mapWithConcurrency(
-				input.paths,
-				DIFF_BULK_CONCURRENCY,
-				async (path) => {
-					const git = createUserSimpleGit(worktreePath).env(gitEnv);
-					const { oldFile, newFile } = await loadFileDiffContent(
-						git,
-						worktreePath,
-						input.category,
-						path,
-						refs,
-					);
-					return { path, oldFile, newFile };
+			// Ref resolution and every file's `git show` pair run inside the
+			// worker task, off the host-service event loop — see
+			// no-main-loop-blocking.test.ts.
+			return getHostWorkerPool().run(
+				gitDiffBulkTask,
+				{
+					worktreePath,
+					paths: input.paths,
+					category: input.category,
+					baseBranch: input.baseBranch,
+					commitHash: input.commitHash,
+					fromHash: input.fromHash,
+					gitEnv,
 				},
+				{ timeoutMs: 60_000 },
 			);
-
-			return { diffs };
 		}),
 
 	getBranchSyncStatus: queryProcedure

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -2,6 +2,7 @@ import { readFile, rm } from "node:fs/promises";
 import { isAbsolute, join, normalize, sep } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
+import type { SimpleGit } from "simple-git";
 import { z } from "zod";
 import { pullRequests, workspaces } from "../../../db/schema";
 import { createGitEnvResolver } from "../../../runtime/git";
@@ -32,6 +33,7 @@ import { rethrowEnvironmentalGitError } from "./utils/classify-git-error";
 import { gitConfigWrite } from "./utils/config-write";
 import {
 	getDefaultBranchName,
+	mapWithConcurrency,
 	resolveBaseComparison,
 } from "./utils/git-helpers";
 import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
@@ -191,6 +193,123 @@ function sumSnapshotDiffStats(snapshot: {
 		deletions += file.deletions;
 	}
 	return { additions, deletions, fileCount: byPath.size };
+}
+
+type DiffCategory = "against-base" | "staged" | "unstaged" | "commit";
+
+const getDiffInputShape = z.object({
+	workspaceId: z.string(),
+	path: z.string(),
+	category: z.enum(["against-base", "staged", "unstaged", "commit"]),
+	baseBranch: z.string().optional(),
+	commitHash: z.string().optional(),
+	fromHash: z.string().optional(),
+});
+
+/** Upper bound on one getDiffBulk call — generous headroom over the largest
+ * changeset we expect the Changes pane to render, while still bounding a
+ * runaway/malicious request. */
+const MAX_DIFF_BULK_PATHS = 2000;
+
+/** How many `git show` pairs run at once for a bulk diff request. Each
+ * pair is its own SimpleGit instance so slots genuinely run concurrently
+ * (simple-git serializes commands within one instance). */
+const DIFF_BULK_CONCURRENCY = 8;
+
+/** Refs shared by every file in a `getDiff`/`getDiffBulk` request for a given
+ * category — resolved once per request rather than once per file. */
+interface DiffCategoryRefs {
+	/** against-base: merge-base(baseRef, HEAD) */
+	originRef?: string;
+	/** commit: the "before" ref (fromHash, or commitHash^) */
+	fromRef?: string;
+	/** commit: the commit itself */
+	toRef?: string;
+}
+
+async function resolveDiffCategoryRefs(
+	git: SimpleGit,
+	category: DiffCategory,
+	opts: { baseBranch?: string; commitHash?: string; fromHash?: string },
+): Promise<DiffCategoryRefs> {
+	if (category === "against-base") {
+		const base = await resolveBaseComparison(git, opts.baseBranch);
+		const baseRef = base?.baseRef ?? "HEAD";
+		// Use the merge base so the diff excludes unrelated changes landed on
+		// the base branch after we forked — matches what the file list
+		// (3-dot diff) is already filtered by.
+		const originRef = await git
+			.raw(["merge-base", baseRef, "HEAD"])
+			.then((s) => s.trim())
+			.catch(() => baseRef);
+		return { originRef };
+	}
+	if (category === "commit") {
+		if (!opts.commitHash) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "commitHash is required for commit diffs",
+			});
+		}
+		return {
+			fromRef: opts.fromHash ?? `${opts.commitHash}^`,
+			toRef: opts.commitHash,
+		};
+	}
+	return {};
+}
+
+async function loadFileDiffContent(
+	git: SimpleGit,
+	worktreePath: string,
+	category: DiffCategory,
+	path: string,
+	refs: DiffCategoryRefs,
+): Promise<{
+	oldFile: { name: string; contents: string };
+	newFile: { name: string; contents: string };
+}> {
+	let originalContent = "";
+	let modifiedContent = "";
+
+	if (category === "against-base") {
+		try {
+			originalContent = await git.show([`${refs.originRef}:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`HEAD:${path}`]);
+		} catch {}
+	} else if (category === "staged") {
+		try {
+			originalContent = await git.show([`HEAD:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`:0:${path}`]);
+		} catch {}
+	} else if (category === "commit") {
+		try {
+			originalContent = await git.show([`${refs.fromRef}:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`${refs.toRef}:${path}`]);
+		} catch {}
+	} else {
+		// Unstaged: compare index (staged version) against working tree.
+		// If the file isn't in the index (untracked), originalContent stays
+		// empty = "new file".
+		try {
+			originalContent = await git.show([`:0:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await readFile(`${worktreePath}/${path}`, "utf-8");
+		} catch {}
+	}
+
+	const fileName = path.split("/").pop() ?? path;
+	return {
+		oldFile: { name: fileName, contents: originalContent },
+		newFile: { name: fileName, contents: modifiedContent },
+	};
 }
 
 export const gitRouter = router({
@@ -564,10 +683,32 @@ export const gitRouter = router({
 
 	getDiff: queryProcedure
 		.meta({ timeoutMs: 30_000 })
+		.input(getDiffInputShape)
+		.query(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			const refs = await resolveDiffCategoryRefs(git, input.category, input);
+			return loadFileDiffContent(
+				git,
+				worktreePath,
+				input.category,
+				input.path,
+				refs,
+			);
+		}),
+
+	// Bulk sibling of `getDiff` for callers (the Changes pane) that need every
+	// changed file's diff at once. One network round trip instead of one per
+	// file, and the shared ref resolution (merge-base, etc.) below runs once
+	// for the whole batch instead of once per file. Concurrency is bounded so
+	// a several-hundred-file changeset doesn't spawn hundreds of simultaneous
+	// `git show` processes.
+	getDiffBulk: queryProcedure
+		.meta({ timeoutMs: 60_000 })
 		.input(
 			z.object({
 				workspaceId: z.string(),
-				path: z.string(),
+				paths: z.array(z.string()).min(1).max(MAX_DIFF_BULK_PATHS),
 				category: z.enum(["against-base", "staged", "unstaged", "commit"]),
 				baseBranch: z.string().optional(),
 				commitHash: z.string().optional(),
@@ -576,69 +717,30 @@ export const gitRouter = router({
 		)
 		.query(async ({ ctx, input }) => {
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-			const git = await ctx.git(worktreePath);
+			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+			const refs = await resolveDiffCategoryRefs(
+				createUserSimpleGit(worktreePath).env(gitEnv),
+				input.category,
+				input,
+			);
 
-			let originalContent = "";
-			let modifiedContent = "";
-
-			if (input.category === "against-base") {
-				const base = await resolveBaseComparison(git, input.baseBranch);
-				const baseRef = base?.baseRef ?? "HEAD";
-				// Use the merge base so the diff excludes unrelated changes
-				// landed on the base branch after we forked — matches what the
-				// file list (3-dot diff) is already filtered by.
-				const originRef = await git
-					.raw(["merge-base", baseRef, "HEAD"])
-					.then((s) => s.trim())
-					.catch(() => baseRef);
-				try {
-					originalContent = await git.show([`${originRef}:${input.path}`]);
-				} catch {}
-				try {
-					modifiedContent = await git.show([`HEAD:${input.path}`]);
-				} catch {}
-			} else if (input.category === "staged") {
-				try {
-					originalContent = await git.show([`HEAD:${input.path}`]);
-				} catch {}
-				try {
-					modifiedContent = await git.show([`:0:${input.path}`]);
-				} catch {}
-			} else if (input.category === "commit") {
-				if (!input.commitHash) {
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message: "commitHash is required for commit diffs",
-					});
-				}
-				const from = input.fromHash ?? `${input.commitHash}^`;
-				try {
-					originalContent = await git.show([`${from}:${input.path}`]);
-				} catch {}
-				try {
-					modifiedContent = await git.show([
-						`${input.commitHash}:${input.path}`,
-					]);
-				} catch {}
-			} else {
-				// Unstaged: compare index (staged version) against working tree
-				// If file isn't in index (untracked), originalContent stays empty = "new file"
-				try {
-					originalContent = await git.show([`:0:${input.path}`]);
-				} catch {}
-				try {
-					modifiedContent = await readFile(
-						`${worktreePath}/${input.path}`,
-						"utf-8",
+			const diffs = await mapWithConcurrency(
+				input.paths,
+				DIFF_BULK_CONCURRENCY,
+				async (path) => {
+					const git = createUserSimpleGit(worktreePath).env(gitEnv);
+					const { oldFile, newFile } = await loadFileDiffContent(
+						git,
+						worktreePath,
+						input.category,
+						path,
+						refs,
 					);
-				} catch {}
-			}
+					return { path, oldFile, newFile };
+				},
+			);
 
-			const fileName = input.path.split("/").pop() ?? input.path;
-			return {
-				oldFile: { name: fileName, contents: originalContent },
-				newFile: { name: fileName, contents: modifiedContent },
-			};
+			return { diffs };
 		}),
 
 	getBranchSyncStatus: queryProcedure

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -1,5 +1,5 @@
 import { rm } from "node:fs/promises";
-import { isAbsolute, join, normalize, sep } from "node:path";
+import { join } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -32,6 +32,7 @@ import { scheduleBaseRefFetch } from "./utils/base-ref-freshness";
 import { rethrowEnvironmentalGitError } from "./utils/classify-git-error";
 import { gitConfigWrite } from "./utils/config-write";
 import {
+	assertSafeRelativePath,
 	getDefaultBranchName,
 	loadFileDiffContent,
 	resolveBaseComparison,
@@ -88,28 +89,6 @@ function resolveGitTaskEnv(
 	worktreePath: string,
 ): Promise<Record<string, string>> {
 	return createGitEnvResolver(ctx.credentials)(worktreePath);
-}
-
-function assertSafeRelativePath(filePath: string): void {
-	if (isAbsolute(filePath)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: "Absolute paths are not allowed",
-		});
-	}
-	const normalized = normalize(filePath);
-	if (normalized.split(sep).includes("..")) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: "Path traversal is not allowed",
-		});
-	}
-	if (normalized === "" || normalized === ".") {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: "Cannot target worktree root",
-		});
-	}
 }
 
 /** Delete for a discard. Recursive because an untracked or staged-as-added
@@ -583,6 +562,7 @@ export const gitRouter = router({
 		.meta({ timeoutMs: 30_000 })
 		.input(getDiffInputShape)
 		.query(async ({ ctx, input }) => {
+			assertSafeRelativePath(input.path);
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const git = await ctx.git(worktreePath);
 			const refs = await resolveDiffCategoryRefs(git, input.category, input);
@@ -614,6 +594,7 @@ export const gitRouter = router({
 			}),
 		)
 		.query(async ({ ctx, input }) => {
+			for (const path of input.paths) assertSafeRelativePath(path);
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
 			// Ref resolution and every file's `git show` pair run inside the

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -25,11 +25,15 @@ const UNTRACKED_IO_CONCURRENCY = 64;
 // file size, and comfortably covers the 8KB binary sniff window.
 const UNTRACKED_READ_CHUNK_SIZE = 64 * 1024;
 
-async function mapWithConcurrency<T>(
+/** Runs `fn` over `items` with at most `limit` in flight at once, returning
+ * results in input order. Shared by any caller that needs to bound
+ * concurrent subprocess/file-descriptor usage across a batch. */
+export async function mapWithConcurrency<T, R>(
 	items: T[],
 	limit: number,
-	fn: (item: T) => Promise<void>,
-): Promise<void> {
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
 	let next = 0;
 	const workers = Array.from(
 		{ length: Math.min(limit, items.length) },
@@ -37,11 +41,12 @@ async function mapWithConcurrency<T>(
 			while (true) {
 				const i = next++;
 				if (i >= items.length) return;
-				await fn(items[i] as T);
+				results[i] = await fn(items[i] as T, i);
 			}
 		},
 	);
 	await Promise.all(workers);
+	return results;
 }
 
 /** Map git's single-letter status codes to GitHub-aligned FileStatus */

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -8,7 +8,7 @@ import {
 	stat,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import {
 	BINARY_SNIFF_BYTES,
 	isBinaryMediaFile,
@@ -477,6 +477,31 @@ export async function getChangedFilesForDiff(
 			}));
 	} catch {
 		return [];
+	}
+}
+
+/** Rejects a caller-supplied relative path that could escape the worktree
+ * (absolute, `..` traversal, or the worktree root itself) — required before
+ * any git/fs operation joins it onto a worktree path. */
+export function assertSafeRelativePath(filePath: string): void {
+	if (isAbsolute(filePath)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Absolute paths are not allowed",
+		});
+	}
+	const normalized = normalize(filePath);
+	if (normalized.split(sep).includes("..")) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Path traversal is not allowed",
+		});
+	}
+	if (normalized === "" || normalized === ".") {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Cannot target worktree root",
+		});
 	}
 }
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -1,10 +1,19 @@
-import { copyFile, mkdtemp, open, realpath, rm, stat } from "node:fs/promises";
+import {
+	copyFile,
+	mkdtemp,
+	open,
+	readFile,
+	realpath,
+	rm,
+	stat,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
 	BINARY_SNIFF_BYTES,
 	isBinaryMediaFile,
 } from "@superset/shared/media-files";
+import { TRPCError } from "@trpc/server";
 import type { SimpleGit } from "simple-git";
 import { resolveUpstream } from "../../../../runtime/git/refs";
 import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
@@ -469,4 +478,102 @@ export async function getChangedFilesForDiff(
 	} catch {
 		return [];
 	}
+}
+
+export type DiffCategory = "against-base" | "staged" | "unstaged" | "commit";
+
+/** Refs shared by every file in a `getDiff`/`getDiffBulk` request for a given
+ * category — resolved once per request rather than once per file. */
+export interface DiffCategoryRefs {
+	/** against-base: merge-base(baseRef, HEAD) */
+	originRef?: string;
+	/** commit: the "before" ref (fromHash, or commitHash^) */
+	fromRef?: string;
+	/** commit: the commit itself */
+	toRef?: string;
+}
+
+export async function resolveDiffCategoryRefs(
+	git: SimpleGit,
+	category: DiffCategory,
+	opts: { baseBranch?: string; commitHash?: string; fromHash?: string },
+): Promise<DiffCategoryRefs> {
+	if (category === "against-base") {
+		const base = await resolveBaseComparison(git, opts.baseBranch);
+		const baseRef = base?.baseRef ?? "HEAD";
+		// Use the merge base so the diff excludes unrelated changes landed on
+		// the base branch after we forked — matches what the file list
+		// (3-dot diff) is already filtered by.
+		const originRef = await git
+			.raw(["merge-base", baseRef, "HEAD"])
+			.then((s) => s.trim())
+			.catch(() => baseRef);
+		return { originRef };
+	}
+	if (category === "commit") {
+		if (!opts.commitHash) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "commitHash is required for commit diffs",
+			});
+		}
+		return {
+			fromRef: opts.fromHash ?? `${opts.commitHash}^`,
+			toRef: opts.commitHash,
+		};
+	}
+	return {};
+}
+
+export async function loadFileDiffContent(
+	git: SimpleGit,
+	worktreePath: string,
+	category: DiffCategory,
+	path: string,
+	refs: DiffCategoryRefs,
+): Promise<{
+	oldFile: { name: string; contents: string };
+	newFile: { name: string; contents: string };
+}> {
+	let originalContent = "";
+	let modifiedContent = "";
+
+	if (category === "against-base") {
+		try {
+			originalContent = await git.show([`${refs.originRef}:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`HEAD:${path}`]);
+		} catch {}
+	} else if (category === "staged") {
+		try {
+			originalContent = await git.show([`HEAD:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`:0:${path}`]);
+		} catch {}
+	} else if (category === "commit") {
+		try {
+			originalContent = await git.show([`${refs.fromRef}:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await git.show([`${refs.toRef}:${path}`]);
+		} catch {}
+	} else {
+		// Unstaged: compare index (staged version) against working tree.
+		// If the file isn't in the index (untracked), originalContent stays
+		// empty = "new file".
+		try {
+			originalContent = await git.show([`:0:${path}`]);
+		} catch {}
+		try {
+			modifiedContent = await readFile(`${worktreePath}/${path}`, "utf-8");
+		} catch {}
+	}
+
+	const fileName = path.split("/").pop() ?? path;
+	return {
+		oldFile: { name: fileName, contents: originalContent },
+		newFile: { name: fileName, contents: modifiedContent },
+	};
 }

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -14,7 +14,13 @@ import {
 } from "../../runtime/pull-requests/utils/workspace-refs.ts";
 import type { ChangedFile } from "../../trpc/router/git/types.ts";
 import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-freshness.ts";
-import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
+import {
+	type DiffCategory,
+	getChangedFilesForDiff,
+	loadFileDiffContent,
+	mapWithConcurrency,
+	resolveDiffCategoryRefs,
+} from "../../trpc/router/git/utils/git-helpers.ts";
 import type { GitStatusSnapshotComputation } from "../../trpc/router/git/utils/git-status.ts";
 import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
 import {
@@ -22,6 +28,11 @@ import {
 	parseWorktreeList,
 } from "../../trpc/router/workspace-creation/shared/worktree-list.ts";
 import { defineWorkerTask } from "../define-worker-task.ts";
+
+// How many `git show` pairs run at once for a bulk diff request. Each pair
+// is its own SimpleGit instance so slots genuinely run concurrently
+// (simple-git serializes commands within one instance).
+const DIFF_BULK_CONCURRENCY = 8;
 
 export interface GitTaskEnv {
 	[key: string]: string;
@@ -67,6 +78,64 @@ export const gitCommitFilesTask = defineWorkerTask<
 		const git = createUserSimpleGit(worktreePath).env(gitEnv);
 		const from = fromHash ? fromHash : `${commitHash}^`;
 		return getChangedFilesForDiff(git, [from, commitHash]);
+	},
+});
+
+// Bulk sibling of the single-file diff path: resolves the category's shared
+// refs once, then loads every requested file's diff with bounded
+// concurrency — all inside this worker, so a several-hundred-file changeset
+// never spawns its `git show` processes on the host-service event loop.
+export const gitDiffBulkTask = defineWorkerTask<
+	{
+		worktreePath: string;
+		paths: string[];
+		category: DiffCategory;
+		baseBranch?: string;
+		commitHash?: string;
+		fromHash?: string;
+		gitEnv: GitTaskEnv;
+	},
+	{
+		diffs: Array<{
+			path: string;
+			oldFile: { name: string; contents: string };
+			newFile: { name: string; contents: string };
+		}>;
+	}
+>({
+	type: "git/getDiffBulk",
+	handler: async ({
+		worktreePath,
+		paths,
+		category,
+		baseBranch,
+		commitHash,
+		fromHash,
+		gitEnv,
+	}) => {
+		const refs = await resolveDiffCategoryRefs(
+			createUserSimpleGit(worktreePath).env(gitEnv),
+			category,
+			{ baseBranch, commitHash, fromHash },
+		);
+
+		const diffs = await mapWithConcurrency(
+			paths,
+			DIFF_BULK_CONCURRENCY,
+			async (path) => {
+				const git = createUserSimpleGit(worktreePath).env(gitEnv);
+				const { oldFile, newFile } = await loadFileDiffContent(
+					git,
+					worktreePath,
+					category,
+					path,
+					refs,
+				);
+				return { path, oldFile, newFile };
+			},
+		);
+
+		return { diffs };
 	},
 });
 
@@ -177,6 +246,7 @@ export const gitTasks = [
 	gitStatusSnapshotTask,
 	gitFetchBaseRefTask,
 	gitCommitFilesTask,
+	gitDiffBulkTask,
 	gitWorkspaceRefsTask,
 	gitIdentityTask,
 	gitWorktreeStateTask,

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -98,6 +98,13 @@ function getWorkspaceClients(
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: headers ?? (() => ({})),
+				// host-service is a local connection with no HTTP cache in front of
+				// it, so there's no upside to GET. Forcing POST puts query inputs in
+				// the request body instead of the URL — without this, a query with a
+				// large input (e.g. git.getDiffBulk's file-path list) can produce a
+				// GET URL long enough to blow past the server's HTTP header-size
+				// limit, failing even the CORS preflight before it reaches the route.
+				methodOverride: "POST",
 			}),
 		],
 	});


### PR DESCRIPTION
## Summary
- Replace per-file diff fetching (one `git.getDiff` tRPC call per changed file) with a new `git.getDiffBulk` endpoint — one request per (category, base) group instead of one per file, with bounded server-side concurrency instead of unbounded parallel `git show` spawns.
- Memoize parsed diffs per file in the renderer so an unrelated re-render (collapsed state, an annotation) doesn't re-parse every file's diff.
- Fix a transport bug this surfaced during live testing: a bulk request for a large changeset (or a same-tick batch across many workspaces) can produce a GET URL long enough to blow past the host-service server's HTTP header-size limit, failing the CORS preflight before the request is ever seen. This was also intermittently breaking `git.getStatus` and other ordinary queries, not just large diffs.

## Why / Context
The Changes pane fired one `git.getDiff` tRPC call per changed file and rebuilt+reparsed the *entire* item list on every individual query resolution (results stream back independently, so N files meant up to N full rebuilds). For a large PR (hundreds of files) this was effectively O(n²) on the renderer, on top of O(n) host-service round trips that each redundantly recomputed merge-base.

## How It Works
- `git.getDiffBulk` (`packages/host-service/src/trpc/router/git/git.ts`) takes `paths: string[]` instead of one `path`, resolves category refs (merge-base, from/to commit) once per request, and runs the per-file `git show`/`readFile` pairs with bounded concurrency (8 at a time). `git.getDiff` is untouched for single-file callers; both share the same extracted `resolveDiffCategoryRefs`/`loadFileDiffContent` helpers.
- `useDiffCodeViewItems` groups changed files by (category, baseBranch/commit) — a pane mixing staged/unstaged/against-base still resolves to only 1-3 groups — and fires one bulk query per group instead of one per file. A `FileDiffMetadata` cache keyed by the owning group's `dataUpdatedAt` skips re-parsing files whose diff hasn't changed.
- Fixing the oversized-GET-URL bug required two additive changes: `methodOverride: "POST"` on both host-service tRPC client links (`WorkspaceClientProvider` and the separate device-wide `host-service-client.ts`, which serves calls like `ports.getAll`/`terminalAgents.listByWorkspace` across every workspace in the sidebar), and `allowMethodOverride: true` server-side (`packages/host-service/src/app.ts`) — trpc rejects a POST to a query procedure by default (`METHOD_NOT_SUPPORTED`) unless the server opts in. Both are additive: GET still works for any caller that doesn't request the override.

## Manual QA Checklist
- [x] Large real changeset (327 files, synthetic against-base diff) renders correctly in the Changes pane without hanging
- [x] Real workspaces with 38 and 86 file changesets render full diffs correctly end-to-end
- [x] Confirmed via live CDP: the exact CORS/URL-length failure reproduced before the client fix, and the exact `METHOD_NOT_SUPPORTED` ("Unsupported POST-request to query procedure") reproduced before the server fix
- [x] Confirmed zero CORS errors and all `git.getStatus`/`workspace.get`/etc. batches returning 200 after both fixes
- [x] Discard/stage/base-branch-change actions still invalidate the new bulk queries (all 7 existing `getDiff.invalidate` call sites updated to also invalidate `getDiffBulk`)
- [ ] Did not verify against a genuinely huge changeset (1000+ files) or a cloud/relay-routed workspace — only local host-service was exercised

## Testing
- `bun run typecheck` (host-service, workspace-client, desktop) — clean
- `bunx biome check` on all touched files — clean
- `bun test packages/host-service/src/trpc/router/git` — 104/104 pass, including a new `get-diff-bulk.test.ts` that exercises a real 300-file changeset through `gitRouter.getDiffBulk` in one call (correct content, matches `getDiff`'s per-file output, completes in seconds)
- `bun test packages/workspace-client` — 13/13 pass

## Known Limitations
- The transport fix (`methodOverride`/`allowMethodOverride`) changes every desktop↔host-service query, not just diff-related ones — it's additive and confirmed working across several real workspaces, but the blast radius is broader than the original ask.
- Ran into an unrelated, pre-existing bug while testing: workspace panes sometimes show stale content from a previously-viewed workspace when switching via the sidebar until a hard reload. Not touched here.

## Risks / Rollout
- Risk: the transport change affects every host-service query from the desktop app. Low risk in practice — GET remains valid for any caller that doesn't opt in, and POST-for-queries is trpc's own sanctioned mechanism (`allowMethodOverride`), not a custom workaround.
- Rollback: revert the `methodOverride`/`allowMethodOverride` commits independently of the bulk-diff endpoint if needed — they're separate, self-contained commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Changes pane from hanging on large diffs by replacing per-file diff fetching with a bulk endpoint and forcing POST for desktop↔host-service queries to avoid URL-size CORS failures. Also hardens diff endpoints against path traversal and upgrades `@pierre/diffs` to reuse highlighting across remounts.

- Adds `git.getDiffBulk` with shared ref resolution and bounded concurrency inside a worker task (off the host-service event loop); caps one call at 2000 paths; keeps `git.getDiff` for single-file callers.
- Groups files by (category, base) and issues one bulk query per group; maps results by path; memoizes parsed `FileDiffMetadata` per item keyed by a per-file content revision hash; sets `cacheKey` for `@pierre/diffs` to reuse highlight ASTs across remounts.
- Rejects absolute/traversal paths in `git.getDiff` and `git.getDiffBulk`.
- Forces POST via `methodOverride: "POST"` in both desktop host-service clients and enables `allowMethodOverride: true` server-side; GET still works for other callers.
- Updates all invalidation paths to include `git.getDiffBulk`; adds `get-diff-bulk.test.ts` covering a 300-file changeset and path traversal.

**Risks / Rollout**
- All desktop queries now use POST; monitor host-service query health. Revert the POST override independently if needed.
- No migration required; existing single-file diff callers are unchanged.

<sup>Written for commit b124388b75f9dbdd013dc49d96a4aba1a77a5b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster bulk loading for file diffs, improving performance when reviewing workspaces with many changed files.
  * Large change sets now load more reliably without oversized request URLs.

* **Bug Fixes**
  * Git status, staging, discard, refresh, and base-branch changes now consistently refresh diff information.
  * Improved consistency between bulk and individual file diff results.
  * Enhanced diff viewing and highlighting reliability.
  * Improved protection against invalid file paths.

* **Tests**
  * Added coverage for loading and validating diffs across large repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->