### PR TITLE
fix(mobile): move home search in-page — iOS 26 header search bar swallows all touches

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -2,12 +2,13 @@ import { LegendList } from "@legendapp/list/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import { isAfter } from "date-fns";
 import * as Haptics from "expo-haptics";
-import { Stack, useFocusEffect, useRouter } from "expo-router";
-import { Cloud } from "lucide-react-native";
+import { useFocusEffect, useRouter } from "expo-router";
+import { Cloud, Search } from "lucide-react-native";
 import { useCallback, useMemo, useState } from "react";
 import { RefreshControl, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import {
 	type CloudWorkspaceStatus,
@@ -18,7 +19,6 @@ import {
 	type HostWorkspaceItem,
 	useHostWorkspaces,
 } from "@/hooks/useHostWorkspaces";
-import { THEME } from "@/lib/theme";
 import { useSelectedHost } from "@/screens/(authenticated)/(home)/hooks/useSelectedHost";
 import { useOrganizations } from "@/screens/(authenticated)/hooks/useOrganizations";
 import {
@@ -577,6 +577,37 @@ export function HomeScreen() {
 		/>
 	);
 
+	// Search lives in the page, not the native header: activating a
+	// UISearchController on iOS 26 lays an invisible view over the screen's
+	// content that swallows every touch — results can't be tapped and search
+	// won't dismiss (unfixed through rns 4.27 / iOS 26.5).
+	const listHeader = (
+		<>
+			<View className="px-4 pb-1 pt-1">
+				<View className="relative justify-center">
+					<View className="absolute left-3 z-10">
+						<Icon
+							as={Search}
+							className="text-muted-foreground size-4"
+							strokeWidth={2}
+						/>
+					</View>
+					<Input
+						autoCapitalize="none"
+						autoCorrect={false}
+						className="rounded-full pl-9"
+						clearButtonMode="always"
+						returnKeyType="search"
+						onChangeText={setSearchQuery}
+						placeholder="Search workspaces"
+						value={searchQuery}
+					/>
+				</View>
+			</View>
+			{scopeBar}
+		</>
+	);
+
 	return (
 		<>
 			<OrganizationHeaderButton
@@ -587,21 +618,6 @@ export function HomeScreen() {
 					void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 					setSheetOpen(true);
 				}}
-			/>
-			{/* placement="integratedButton" + allowToolbarIntegration={false}
-			    evicts the custom left toolbar view (org switcher) a few seconds
-			    after mount on iOS 26 — "stacked" is the only placement that
-			    coexists with it. */}
-			<Stack.SearchBar
-				placeholder="Search workspaces"
-				placement="stacked"
-				hideWhenScrolling={false}
-				hideNavigationBar={false}
-				textColor={THEME.dark.foreground}
-				hintTextColor={THEME.dark.mutedForeground}
-				tintColor={THEME.dark.foreground}
-				onChangeText={(event) => setSearchQuery(event.nativeEvent.text)}
-				onCancelButtonPress={() => setSearchQuery("")}
 			/>
 			{selectedHost &&
 			!selectedHost.isOnline &&
@@ -621,6 +637,8 @@ export function HomeScreen() {
 				<LegendList
 					className="flex-1 bg-background"
 					contentInsetAdjustmentBehavior="automatic"
+					keyboardDismissMode="on-drag"
+					keyboardShouldPersistTaps="handled"
 					contentContainerStyle={{
 						minHeight:
 							windowHeight - insets.top - NAVIGATION_BAR_HEIGHT - insets.bottom,
@@ -631,7 +649,7 @@ export function HomeScreen() {
 					extraData={renderItem}
 					keyExtractor={homeListItemKey}
 					renderItem={renderItem}
-					ListHeaderComponent={scopeBar}
+					ListHeaderComponent={listHeader}
 					viewabilityConfig={VIEWABILITY_CONFIG}
 					onViewableItemsChanged={onViewableItemsChanged}
 					refreshControl={


### PR DESCRIPTION
## What

Search results on mobile home couldn't be tapped, and active search couldn't be dismissed. This replaces the native header `Stack.SearchBar` with an in-page search field (the BranchPickerScreen pattern) in the home list header. Filtering logic is unchanged.

## Why

Reproduced end-to-end on an iOS 26.0 simulator against a local stack: while the `UISearchController` is active, an invisible native view covers the screen content and eats **every** touch — instrumented `onTouchStart` on the list never fired during search, and fired normally once dismissed. Nothing reaches RN, so rows are dead and search feels stuck (only the tiny X escapes).

Tried and failed: `obscureBackground={false}`, `hideNavigationBar` both ways, placement variants. No upstream fix through react-native-screens 4.27 / iOS 26.5; adjacent known iOS 26 search regressions: [rns #3270](https://github.com/software-mansion/react-native-screens/issues/3270) (back nav breaks after search), [Apple FB17888632](https://developer.apple.com/forums/thread/797701) (stacked search steals touches), [rns #3621](https://github.com/software-mansion/react-native-screens/issues/3621) (zoom transition blocks touches). The native header search bar is not shippable on iOS 26.

## How

- In-page `Input` + magnifier glyph as the LegendList header above the scope chips (visually near-identical to the native bar), `clearButtonMode="always"`, `returnKeyType="search"`, autocapitalize/autocorrect off
- `keyboardShouldPersistTaps="handled"` + `keyboardDismissMode="on-drag"` on the list
- Removed the now-unused `Stack`/`THEME` imports

## Verified

On-device (iPhone Air sim, iOS 26.0, local API/relay/host-service + seeded workspaces): type → list filters live with result count; tap result → workspace opens; back → query retained; clear (x) → full list restores; scroll drops the keyboard.

Known wrinkle (pre-existing, unchanged): with the keyboard up, the first tap on a row dismisses the keyboard and the second opens it — the rows' native `Link.Trigger` context-menu wrapper takes the first touch outside RN's control.

Checks: lint:fix clean, typecheck clean, sherif clean. `bun test`: 175 local failures on this branch vs 178 on clean HEAD — identical failure set (zero unique to this change), all pre-existing local-env noise (pty/git/relay suites).

https://claude.ai/code/session_01JMrgzD2hPpB89caKAxR7ux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves home search from the native header to an in-page field to restore tap interactions on iOS 26. Old: `Stack.SearchBar` (`UISearchController`) swallowed all touches while active; results couldn’t be tapped and search couldn’t dismiss. New: an in-page `Input` in the list header; taps work, keyboard dismisses on drag, and filtering logic is unchanged.

- Review notes
  - `HomeScreen.tsx`: remove header `Stack.SearchBar`; add `listHeader` with `Input` + `Search` icon above scope chips; set `keyboardShouldPersistTaps="handled"` and `keyboardDismissMode="on-drag"`.
  - Visual parity with the native bar; clear button always visible. Known pre-existing quirk remains: first tap with keyboard up dismisses it; second opens the row.

- Rollout
  - No migration required. Focus testing on iOS 26 tap-through and keyboard behavior; quick smoke on Android/earlier iOS.

<sup>Written for commit 3e32874d576689151f06e3dcd741deccff0c7a06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-page search field to the home screen.
  * Added a scope bar alongside the search field for easier browsing.

* **Improvements**
  * Improved touch handling and keyboard dismissal while interacting with the home list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->