### PR TITLE
fix(desktop): don't kill the main process when a CDP command hits a destroyed pane

### DIFF
--- a/apps/desktop/src/main/lib/browser/browser-manager.test.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.test.ts
@@ -260,6 +260,93 @@ describe("forced CDP detach", () => {
 		session.detach();
 	});
 
+	test("a live session forwards commands to the guest debugger", async () => {
+		const wc = register("pane-live");
+		const messages: Array<{ id?: number; result?: unknown }> = [];
+		const session = browserManager.attachCdp(
+			"pane-live",
+			"ws-1",
+			(payload) => messages.push(JSON.parse(payload)),
+			() => {},
+		);
+		const sendCommand = mock(async () => ({ value: 1 }));
+		wc.debugger.sendCommand = sendCommand;
+
+		session.send(
+			JSON.stringify({
+				id: 3,
+				method: "Runtime.evaluate",
+				params: { expression: "1" },
+			}),
+		);
+		for (let i = 0; i < 50 && messages.length === 0; i++) {
+			await new Promise((r) => setTimeout(r, 10));
+		}
+		session.detach();
+
+		expect(sendCommand).toHaveBeenCalledWith(
+			"Runtime.evaluate",
+			{ expression: "1" },
+			undefined,
+		);
+		expect(messages).toEqual([{ id: 3, result: { value: 1 } }]);
+	});
+
+	test("a send after the guest is destroyed detaches instead of throwing", () => {
+		const wc = register("pane-destroyed");
+		const onDetach = mock((_reason: string) => {});
+		const session = browserManager.attachCdp(
+			"pane-destroyed",
+			"ws-1",
+			() => {},
+			onDetach,
+		);
+		// Guest teardown mid-session: every wc.debugger touch now throws the way
+		// Electron's destroyed-WebContents binding does.
+		wc.isDestroyed = () => true;
+		const destroyedThrow = () => {
+			throw new TypeError("Object has been destroyed");
+		};
+		wc.debugger.off = destroyedThrow;
+		wc.debugger.detach = destroyedThrow;
+		wc.debugger.sendCommand = mock(destroyedThrow);
+
+		expect(() =>
+			session.send(JSON.stringify({ id: 1, method: "Runtime.enable" })),
+		).not.toThrow();
+		expect(onDetach).toHaveBeenCalledWith("pane closed");
+		expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+		expect(browserManager.getAgentActivePaneIds()).toEqual([]);
+
+		// The session is closed now — a second late message is a no-op.
+		expect(() =>
+			session.send(JSON.stringify({ id: 2, method: "Runtime.enable" })),
+		).not.toThrow();
+		expect(onDetach).toHaveBeenCalledTimes(1);
+	});
+
+	test("forced detach after the guest is destroyed does not throw", () => {
+		const wc = register("pane-destroyed-force");
+		const onDetach = mock((_reason: string) => {});
+		browserManager.attachCdp(
+			"pane-destroyed-force",
+			"ws-1",
+			() => {},
+			onDetach,
+		);
+		wc.isDestroyed = () => true;
+		const destroyedThrow = () => {
+			throw new TypeError("Object has been destroyed");
+		};
+		wc.debugger.off = destroyedThrow;
+		wc.debugger.detach = destroyedThrow;
+
+		expect(() =>
+			browserManager.unregister("pane-destroyed-force"),
+		).not.toThrow();
+		expect(onDetach).toHaveBeenCalledWith("pane closed");
+	});
+
 	test("agent-active events track attach and detach", () => {
 		register("pane-state");
 		const states: string[][] = [];

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -392,11 +392,16 @@ class BrowserManager extends EventEmitter {
 			cleanup();
 			onDetach(reason);
 		};
+		// Once the webContents is destroyed, any wc.debugger touch throws
+		// synchronously ("Object has been destroyed") — so every path below
+		// checks isDestroyed() before reaching for it.
 		const cleanup = () => {
 			if (closed) return;
 			closed = true;
-			wc.debugger.off("message", handleMessage);
-			wc.debugger.off("detach", handleDetach);
+			if (!wc.isDestroyed()) {
+				wc.debugger.off("message", handleMessage);
+				wc.debugger.off("detach", handleDetach);
+			}
 			this.cdpDetachers.delete(paneId);
 			releaseWake();
 		};
@@ -405,10 +410,11 @@ class BrowserManager extends EventEmitter {
 
 		const detach = () => {
 			cleanup();
+			if (wc.isDestroyed()) return;
 			try {
 				wc.debugger.detach();
 			} catch {
-				// webContents may be destroyed
+				// debugger may already be detached
 			}
 		};
 		// The forced path (pane unregistered while a client is attached) must
@@ -422,6 +428,17 @@ class BrowserManager extends EventEmitter {
 
 		return {
 			send: (rawMessage: string) => {
+				if (closed) return;
+				// A bridge message can arrive after the guest was torn down (pane
+				// closed while an agent's CDP client was mid-session). Close the
+				// session the way the forced-detach path does instead of letting
+				// the synchronous destroyed-webContents throw escape the ws
+				// message handler and take down the main process (DESKTOP-ZS).
+				if (wc.isDestroyed()) {
+					detach();
+					onDetach("pane closed");
+					return;
+				}
 				let parsed: {
 					id?: number;
 					method?: string;


### PR DESCRIPTION
## Problem

`DESKTOP-ZS` (FATAL, `handled:no`, 2 events on 1.23.0): the desktop app quits entirely — an uncaught `TypeError: Object has been destroyed` in the Electron main process. The user-visible harm is losing the whole app mid-work: it fires when an agent-driven CDP client (browser-use, Playwright, the CLI's browser commands) sends a command to a browser pane the user closed while the session was live.

## Root cause

The browser-bridge ws `message` handler calls the CDP session's `send()` synchronously with no try/catch. `send()` had no closed/destroyed guard at entry, so a message arriving after the guest webContents was destroyed reached `wc.debugger.sendCommand(...)`, which throws **synchronously** on a destroyed webContents — the existing `closed` checks only live inside the async `.then`/`.catch` callbacks, so they never saw it. The escape route was uncaught → main process death.

Two more paths in the same session had the same defect: `cleanup()` called `wc.debugger.off(...)` unguarded (so even the forced-detach path could throw after destruction), and the `Target.createTarget` shim branch issued a `Page.navigate` whose synchronous throw its `.catch` couldn't catch.

## Fix

Guards at the owner (`browser-manager.ts`, `attachCdp`), not a broad try/catch in the bridge — a swallow-everything catch there would hide genuinely new bugs in this path:

- `send()` entry: return if the session is `closed`; if `wc.isDestroyed()`, close the session through the existing detach behaviour — the client gets the same `"pane closed"` detach (ws close 1011) the forced path already produces — instead of throwing.
- `cleanup()`: only remove the debugger listeners while the webContents is live.
- `detach()`: skip `wc.debugger.detach()` once destroyed (the try/catch stays for a live-but-already-detached debugger).

Once `closed` or destroyed, no path in the session touches `wc.debugger`. No typed `cause` was added: no error is thrown at all on this path anymore, and nothing would read one.

Reality check: this ships in the next desktop release off main, where the vulnerable code is unchanged from 1.23.0 (verified line-by-line), so it reaches exactly the reported failure. Code beats archiving because this is a process-killing crash in an actively used feature (in-app browser + agent CDP), and no in-flight work deletes this path. Scope is the three `wc.debugger` touchpoints plus tests — no lifecycle refactor, no bridge changes, and DESKTOP-ZV (native teardown crash on the same machine) is intentionally untouched.

## Verification

Negative test written first and confirmed failing pre-fix with the exact crash signature:

```
error: expect(received).not.toThrow()
Error name: "TypeError"
Error message: "Object has been destroyed"
```

After the fix:

- `bunx biome check` on both changed files → `Checked 2 files in 13ms. No fixes applied.` (after one `--write` formatting pass)
- `cd apps/desktop && bun run typecheck` → `tsc --noEmit` passed (`Tasks: 38 successful, 38 total`)
- `bun test src/main/lib/browser/` → `27 pass, 0 fail, 62 expect() calls` — including the new tests: a send after guest destruction detaches cleanly instead of throwing (and a second late send is a no-op), forced detach after destruction doesn't throw, and the inverse pin that a live session still forwards commands and replies.

Refs DESKTOP-ZS

https://claude.ai/code/session_01NoAV3rfHFdQxS86UMdJqPh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a main-process crash when a CDP command targets a destroyed browser pane (DESKTOP-ZS). Previously, `wc.debugger.sendCommand(...)` threw synchronously and killed the app; now the session detects destruction, detaches with "pane closed", and ignores later messages.

- Review notes
  - `browser-manager.ts`: Guard all `wc.debugger` touches behind `closed`/`wc.isDestroyed()` — at `send()` entry, in `cleanup()` (only remove listeners if live), and in `detach()` (skip `debugger.detach()` once destroyed; still catch already-detached).
  - Behavior: A late message after pane teardown triggers the same clean detach as the forced path; no error is thrown; no bridge changes.
  - Tests: Added coverage for live forwarding, post-destroy detach, and forced detach after destruction.

<sup>Written for commit c410cee201f0873b5813c56ea674c1e2d1d2161c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when closing panes or browser content while developer tools are connected.
  - Prevented errors during cleanup of closed browser sessions.
  - Added clearer handling when commands are sent to a pane that has already been closed.
  - Ensured browser debugging sessions detach cleanly without repeated notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->