### PR TITLE
chore(api): sync the Slack manifest with the live app

### DIFF
--- a/apps/api/src/app/api/integrations/slack/manifest.json
+++ b/apps/api/src/app/api/integrations/slack/manifest.json
@@ -37,32 +37,33 @@
 		"scopes": {
 			"bot": [
 				"app_mentions:read",
-				"chat:write",
-				"reactions:read",
-				"reactions:write",
+				"assistant:write",
 				"channels:history",
 				"channels:read",
+				"chat:write",
+				"files:read",
 				"groups:history",
 				"groups:read",
 				"im:history",
 				"im:read",
 				"im:write",
-				"mpim:history",
-				"users:read",
-				"files:read",
-				"assistant:write",
+				"incoming-webhook",
 				"links:read",
 				"links:write",
-				"incoming-webhook"
+				"mpim:history",
+				"reactions:read",
+				"reactions:write",
+				"users:read"
 			]
-		}
+		},
+		"pkce_enabled": false
 	},
 	"settings": {
 		"event_subscriptions": {
 			"request_url": "https://api.superset.sh/api/integrations/slack/events",
 			"bot_events": [
-				"app_mention",
 				"app_home_opened",
+				"app_mention",
 				"assistant_thread_context_changed",
 				"assistant_thread_started",
 				"channel_created",
@@ -80,6 +81,7 @@
 		},
 		"org_deploy_enabled": false,
 		"socket_mode_enabled": false,
-		"token_rotation_enabled": false
+		"token_rotation_enabled": false,
+		"is_mcp_enabled": false
 	}
 }


### PR DESCRIPTION
The live Slack app (A0ABFSH6SMS) had drifted ahead of the repo manifest — assistant view, rich previews, unfurl domains, and several scopes existed only in the dashboard. Today the trigger scopes (`channels:read`, `groups:read`, `reactions:read`) and bot events (`message.channels`, `message.groups`, `reaction_added`, `channel_created`) were applied to the live app; this commits the exact manifest now live so the repo copy is authoritative again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Slack app manifest in the repo to match the live app so the repo is authoritative again. The live app already had these scopes and events; this commit records them and sets explicit flags without changing runtime behavior.

**Review notes**
- Bot scopes match the live app, including trigger scopes (channels:read, groups:read, reactions:read) and `incoming-webhook`; reactions and files scopes remain.
- Bot events list matches the live app, including message.channels, message.groups, reaction_added, and channel_created.
- Adds explicit flags: `pkce_enabled: false` and `is_mcp_enabled: false`.

**Rollout**
- No action for production. For any dev/staging Slack apps created from this manifest, reinstall the app to apply scopes and events.

<sup>Written for commit 8e36732a06ee773a08e5bf5b6bebb3005a2df1e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Slack integration configuration for improved compatibility.
  * Preserved existing permissions and event destinations while adjusting their ordering and integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->