### PR TITLE
fix(desktop): keep image alt/src/title strings so markdown preview can't crash on numeric alt text

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.test.ts
@@ -1,0 +1,87 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom over the preloaded plain-object document — TipTap's Editor needs
+// real DOM APIs. bun runs test files sequentially in one process and
+// happy-dom's globals are process-wide, so register once and unregister after.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+
+const { afterAll, describe, expect, it } = await import("bun:test");
+const { Editor } = await import("@tiptap/core");
+const { createMarkdownExtensions } = await import("./createMarkdownExtensions");
+
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+function getMarkdown(editor: InstanceType<typeof Editor>): string {
+	const storage = editor.storage as unknown as Record<
+		string,
+		{ getMarkdown?: () => string }
+	>;
+	return storage.markdown?.getMarkdown?.() ?? "";
+}
+
+function createEditor(content: string) {
+	return new Editor({
+		editable: true,
+		extensions: createMarkdownExtensions({
+			editable: true,
+			onSaveRef: { current: undefined },
+		}),
+		content,
+	});
+}
+
+function roundTrip(markdown: string): string {
+	const editor = createEditor(markdown);
+	try {
+		return getMarkdown(editor);
+	} finally {
+		editor.destroy();
+	}
+}
+
+describe("image attribute parsing", () => {
+	// @tiptap/core's default attribute parser (fromString) coerces
+	// numeric/boolean-looking strings, so ![123](x.png) used to load as
+	// alt: 123 (number) and the markdown serializer threw
+	// "str.replace is not a function" on every render (DESKTOP-100).
+	it("keeps a numeric alt as a string and serializes it", () => {
+		const editor = createEditor("![123](https://example.com/img.png)");
+		try {
+			const image = editor.state.doc.firstChild;
+			expect(image?.type.name).toBe("image");
+			expect(image?.attrs.alt).toBe("123");
+			expect(getMarkdown(editor)).toBe("![123](https://example.com/img.png)");
+		} finally {
+			editor.destroy();
+		}
+	});
+
+	it("keeps a boolean-looking alt as a string", () => {
+		const editor = createEditor("![true](https://example.com/img.png)");
+		try {
+			expect(editor.state.doc.firstChild?.attrs.alt).toBe("true");
+			expect(getMarkdown(editor)).toBe("![true](https://example.com/img.png)");
+		} finally {
+			editor.destroy();
+		}
+	});
+
+	it("keeps a numeric title as a string and serializes it", () => {
+		expect(roundTrip('![photo](https://example.com/img.png "2024")')).toBe(
+			'![photo](https://example.com/img.png "2024")',
+		);
+	});
+
+	it("keeps a numeric src as a string and serializes it", () => {
+		expect(roundTrip("![photo](123)")).toBe("![photo](123)");
+	});
+
+	it("round-trips an ordinary image unchanged", () => {
+		expect(roundTrip("![photo](https://example.com/img.png)")).toBe(
+			"![photo](https://example.com/img.png)",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -70,6 +70,26 @@ const TaskListTightness = Extension.create({
 });
 
 const SafeImage = Image.extend({
+	// @tiptap/core's default attribute parser coerces numeric/boolean-looking
+	// strings (fromString), so ![123](x.png) loads alt: 123 and the markdown
+	// serializer throws on .replace. Read these verbatim instead.
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			src: {
+				default: null,
+				parseHTML: (element) => element.getAttribute("src"),
+			},
+			alt: {
+				default: null,
+				parseHTML: (element) => element.getAttribute("alt"),
+			},
+			title: {
+				default: null,
+				parseHTML: (element) => element.getAttribute("title"),
+			},
+		};
+	},
 	addNodeView() {
 		return ReactNodeViewRenderer(ReadOnlySafeImageView);
 	},


### PR DESCRIPTION
## Problem

Opening a markdown document whose image alt text (or src/title) is a purely numeric or boolean-looking string — e.g. `![123](screenshot.png)` — crashes the rendered markdown view on every render. On the affected machine it threw 8 times in five minutes as the component remounted; the preview/editor is unusable for any document with that shape, and it hits any user whose content matches. The same throw was captured twice: once escaping via TipTap's deferred `onCreate` timer (DESKTOP-100) and once from the value-sync effect (DESKTOP-ZZ).

## Root cause

`@tiptap/core`'s default attribute parser (used for any attribute without an explicit `parseHTML`) is `fromString(element.getAttribute(name))`, which coerces `"123"` → number `123` and `"true"`/`"false"` → booleans. `@tiptap/extension-image@3.21.0` declares `src`/`alt`/`title` with no `parseHTML`, so tiptap-markdown's markdown→HTML→DOM parse of `![123](x.png)` loads an image node with `alt: 123` (a number).

Serializing back to markdown — `getEditorMarkdown`, called from `createSourceTracking` in `onCreate` and from the value-sync effect's equality check — reaches prosemirror-markdown 1.13.5's image serializer:

```js
state.write("![" + state.esc(node.attrs.alt || "") + "](" + node.attrs.src.replace(...) +
    (node.attrs.title ? ' "' + node.attrs.title.replace(...) + '"' : "") + ")")
```

`esc` calls `.replace` on the non-string and throws `TypeError: str.replace is not a function` (bundled: `str2.replace`). Numeric `src` (`![a](123)`) and numeric `title` (`![a](x "2024")`) throw on the same serializer line the same way — all reproduced in the new tests, failing before the fix.

Deliberately **not** fixed at the serializer or by swallowing errors: `getEditorMarkdown`'s output is the merge baseline for format-preserving saves, so the document must simply never hold a non-string. Archiving instead of fixing would leave every affected document permanently broken, and Sentry-side suppression is off the table per repo policy.

## Fix

Give `SafeImage` explicit verbatim `parseHTML` for `src`/`alt`/`title` (`element.getAttribute(...)`), bypassing the `fromString` coercion, so those attributes stay exactly what the document said. `width`/`height` keep the coerced default — numbers are fine there and the markdown serializer never touches them. As a bonus, `![123](x.png)` now round-trips with its alt intact instead of crashing.

Reaches the failure: the events came from release 1.22.0 with `@tiptap/core@3.21.0` / `tiptap-markdown@0.9.0` / `prosemirror-markdown@1.13.5` — the exact versions on main today, and `createMarkdownExtensions.ts` is unchanged since #6406. The fix ships in the next desktop release and executes on the same path that threw (initial content parse feeding both capture sites).

No typed cause added — nothing reads one; no error construction is involved at all, the fix removes the throw at its source.

Out of scope, same latent defect (naming, not fixing here): `MarkdownEditor.tsx`'s `LinearImage` (`apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx:71`) extends the same `Image` extension and serializes via tiptap-markdown, so a numeric alt there would throw identically. No Sentry events point at it; it can get the same three-line treatment in a follow-up.

## Verification

- `bunx biome check` on both changed files — `Checked 2 files in 11ms. No fixes applied.`
- `cd apps/desktop && bun run typecheck` — `tsc --noEmit` clean.
- `bun test apps/desktop/src/renderer/components/MarkdownRenderer` — `49 pass, 0 fail` (before the fix, the 4 new coercion tests failed: numeric alt reproduced the exact `esc` throw from the issue, numeric src/title threw on `node.attrs.src.replace` / `node.attrs.title.replace`; the ordinary-image round-trip control passed both before and after).

Refs DESKTOP-100
Refs DESKTOP-ZZ

https://claude.ai/code/session_01DDjpii9beJCCCn5Z2cfG73

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents markdown preview crashes when an image’s alt/src/title are numeric or boolean-looking strings by preserving them as strings. Old behavior coerced these values via `@tiptap/core`, causing `prosemirror-markdown` to throw during serialization; new behavior reads attributes verbatim so the document round-trips safely.

- Extends image as SafeImage and overrides `parseHTML` for `src`/`alt`/`title` to return `element.getAttribute(...)` verbatim; leaves `width`/`height` default coercion intact.
- Adds tests that cover numeric/boolean-like `alt`/`src`/`title` and a normal image round-trip.
- Fix applies on the same path reported in DESKTOP-100 and DESKTOP-ZZ; no migration or config changes required.
- Known follow-up: `LinearImage` in `MarkdownEditor.tsx` shares the defect and will get the same treatment separately.

<sup>Written for commit 1eab1e2aaed2b74783e330fc79fa7048d6047a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown images with numeric or boolean-looking `src`, `alt`, and `title` values being incorrectly converted.
  * Ensured image attributes remain intact when Markdown is parsed and converted back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->