### PR TITLE
fix(host-service): classify a missing project directory as NOT_FOUND in workspaces.create

### DIFF
--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -42,7 +42,10 @@ import {
 	dispatchSugarAgents,
 } from "../workspace-creation/shared/dispatch-agents";
 import { enablePushAutoSetupRemote } from "../workspace-creation/shared/git-config";
-import { requireLocalProject } from "../workspace-creation/shared/local-project";
+import {
+	requireLocalProject,
+	requireProjectRepoPath,
+} from "../workspace-creation/shared/local-project";
 import { startSetupTerminalIfPresent } from "../workspace-creation/shared/setup-terminal";
 import {
 	addWorktreeWithSparseCheckout,
@@ -524,6 +527,7 @@ export const workspacesRouter = router({
 			}
 
 			const localProject = requireLocalProject(ctx, input.projectId);
+			const repoPath = requireProjectRepoPath(localProject);
 
 			// Kick off AI naming when the user supplied a prompt but no
 			// workspace name. The worktree add and registration run with an
@@ -559,13 +563,10 @@ export const workspacesRouter = router({
 			// rename the git branch.
 			let aiCanRenameBranch = false;
 
-			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
+			await ensureMainWorkspace(ctx, input.projectId, repoPath);
 
-			const git = await ctx.git(localProject.repoPath);
-			const fetchBaseRefOffLoop = createWorkerBaseRefFetcher(
-				ctx,
-				localProject.repoPath,
-			);
+			const git = await ctx.git(repoPath);
+			const fetchBaseRefOffLoop = createWorkerBaseRefFetcher(ctx, repoPath);
 			const worktreeBaseDir =
 				localProject.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
 			// Empty means a full checkout. Only applies to worktrees we create —
@@ -594,7 +595,7 @@ export const workspacesRouter = router({
 				);
 				try {
 					const prMetadata = await fetchPrMetadata({
-						cwd: localProject.repoPath,
+						cwd: repoPath,
 						prNumber: input.pr,
 						execGh: ctx.execGh,
 					});
@@ -857,7 +858,7 @@ export const workspacesRouter = router({
 							input.baseBranch,
 							fetchBaseRefOffLoop,
 						),
-						listBranchNames(ctx, localProject.repoPath),
+						listBranchNames(ctx, repoPath),
 					]);
 					plan = planResult;
 					// plan.branch may carry an existing branch's canonical casing.
@@ -892,7 +893,7 @@ export const workspacesRouter = router({
 							input.baseBranch,
 							fetchBaseRefOffLoop,
 						),
-						listBranchNames(ctx, localProject.repoPath),
+						listBranchNames(ctx, repoPath),
 					]);
 					const prefix = await resolveProjectBranchPrefix({
 						ctx,
@@ -1080,7 +1081,7 @@ export const workspacesRouter = router({
 						const applied = await applyGeneratedWorkspaceNames({
 							ctx,
 							workspaceId: workspaceRow.id,
-							repoPath: localProject.repoPath,
+							repoPath,
 							worktreePath,
 							oldBranchName: resolvedBranch,
 							oldWorkspaceName: workspaceRow.name || resolvedBranch,
@@ -1238,7 +1239,7 @@ export const workspacesRouter = router({
 			for (const launch of input.agents ?? []) {
 				validateAgentLaunchEffort(ctx.db, launch);
 			}
-			requireLocalProject(ctx, input.projectId);
+			requireProjectRepoPath(requireLocalProject(ctx, input.projectId));
 
 			void createWorkspacesCaller(ctx)
 				.create(input)

--- a/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-delete.integration.test.ts
@@ -1,17 +1,27 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	realpathSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
 import { eq } from "drizzle-orm";
 import { workspaces } from "../../src/db/schema";
 import { cloudFlows, cloudOk } from "../helpers/cloud-fakes";
+import { createTestHost } from "../helpers/createTestHost";
+import { createGitFixture } from "../helpers/git-fixture";
 import {
 	createBasicScenario,
 	createFeatureWorktreeScenario,
 	createProjectScenario,
 } from "../helpers/scenarios";
+import { seedProject } from "../helpers/seed";
 
 describe("workspace.create + workspace.delete integration", () => {
 	let dispose: (() => Promise<void>) | undefined;
@@ -378,6 +388,54 @@ describe("workspace.create + workspace.delete integration", () => {
 			.all();
 		expect(rows).toHaveLength(1);
 		expect(existsSync(rows[0]?.worktreePath ?? "")).toBe(true);
+	});
+
+	test("create() classifies a project directory missing from disk as NOT_FOUND", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+		rmSync(scenario.repo.repoPath, { recursive: true, force: true });
+
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				name: "gone repo ws",
+				branch: "feature/gone-repo",
+			}),
+		).rejects.toMatchObject({ data: { code: "NOT_FOUND" } });
+	});
+
+	test("create() does not classify a permission-walled project directory as NOT_FOUND", async () => {
+		// Only a genuine ENOENT means the project is gone. EACCES/EPERM (macOS
+		// privacy protection, a permissions accident) must keep surfacing as an
+		// unexpected error, not get silenced as a routine missing directory.
+		// root ignores mode bits; Windows has neither getuid nor POSIX traversal denial
+		if (process.platform === "win32" || process.getuid?.() === 0) return;
+		const host = await createTestHost({
+			apiOverrides: cloudFlows.workspaceCreateOk(),
+		});
+		const repo = await createGitFixture();
+		const lockedParent = mkdtempSync(join(tmpdir(), "host-service-locked-"));
+		const lockedRepo = join(lockedParent, "repo");
+		const { id: projectId } = seedProject(host, { repoPath: lockedRepo });
+		renameSync(repo.repoPath, lockedRepo);
+		chmodSync(lockedParent, 0o000);
+
+		try {
+			await expect(
+				host.trpc.workspaces.create.mutate({
+					projectId,
+					name: "locked repo ws",
+					branch: "feature/locked-repo",
+				}),
+			).rejects.toMatchObject({ data: { code: "INTERNAL_SERVER_ERROR" } });
+		} finally {
+			chmodSync(lockedParent, 0o755);
+			await host.dispose();
+			rmSync(lockedParent, { recursive: true, force: true });
+			repo.dispose();
+		}
 	});
 
 	test("delete() rejects deleting a main workspace by path equality", async () => {

--- a/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-enqueued.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { eq } from "drizzle-orm";
 import { workspaces } from "../../src/db/schema";
 import type { ServerMessage } from "../../src/events";
@@ -130,6 +130,26 @@ describe("workspaces.createEnqueued integration", () => {
 				branch: "feature/no-id",
 			}),
 		).rejects.toThrow(/requires a client-minted/);
+	});
+
+	test("rejects with NOT_FOUND before enqueueing when the project directory is missing from disk", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+		const settled = captureSettled(scenario.host.eventBus);
+		rmSync(scenario.repo.repoPath, { recursive: true, force: true });
+
+		await expect(
+			scenario.host.trpc.workspaces.createEnqueued.mutate({
+				projectId: scenario.projectId,
+				branch: "feature/gone-repo",
+				id: randomUUID(),
+			}),
+		).rejects.toMatchObject({ data: { code: "NOT_FOUND" } });
+		// Cheap validation rejected the call, so no background create ran and
+		// nothing settles later.
+		expect(settled.length).toBe(0);
 	});
 
 	test("a create that fails after enqueue broadcasts ok:false with the error", async () => {


### PR DESCRIPTION
## Problem

Creating a workspace for a project whose repository folder no longer exists at its registered path (moved or deleted outside the app) fails with simple-git's construct error ("Cannot use simple-git on a directory that does not exist") thrown from the create mutation's `ctx.git(localProject.repoPath)` call. It escapes as INTERNAL_SERVER_ERROR, so the user sees an opaque internal error instead of an actionable "project directory is gone" message, and every retry is a fresh 500 — the latest events show one user retrying repeatedly within minutes against a condition that is deterministic and permanent until they re-point or restore the folder. 13 events in the last 24h, 233 lifetime, regressed on 1.23.0.

**User-visible harm:** a user whose project folder was moved/deleted outside Superset gets a raw internal error on every workspace-create attempt, with no hint that the project path is the problem.

**Reach:** the create path is unchanged on main; this ships in the next host-service/desktop release and reaches every user creating workspaces on it. The condition is a routine lifecycle state, so it will keep firing until classified.

**Why code (vs. archiving / filtering):** this issue already regressed once — #6495 classified the same construct error on the git.getStatus path, and the issue came back through the uncovered create path. Archiving would just repeat that cycle, and Sentry-side suppression is banned by the repo's classification contract (#6164). The classification helper for exactly this state already exists (`requireProjectRepoPath`, added in #6316); the create mutation was simply never given it.

## Root cause

PR #6316 added `requireProjectRepoPath` — an ENOENT-safe `statSync(..., { throwIfNoEntry: false })?.isDirectory()` precheck that throws `TRPCError NOT_FOUND` with `cause: { kind: "PROJECT_DIR_MISSING" }` — and applied it to search-branches, list-project-worktrees and adopt, but not to `workspaces.create` or `createEnqueued`. The reporting middleware reports on INTERNAL_SERVER_ERROR alone, and `createEnqueued` drives the real `create` through a server-side caller whose middleware chain reports the escaping construct error even though the enqueue wrapper catches it afterwards.

## Fix

Structural precheck only — no message matcher, matching the shape #6316 and #6634 established:

- In `workspaces.create`, resolve the path through `requireProjectRepoPath(localProject)` once, immediately after `requireLocalProject`, and use the validated path for everything downstream that consumed `localProject.repoPath` (ensureMainWorkspace, `ctx.git`, the worker base-ref fetcher, fetchPrMetadata, both listBranchNames calls, applyGeneratedWorkspaceNames).
- In `createEnqueued`'s cheap-validation layer, the same one-line guard, so a missing directory rejects synchronously with NOT_FOUND instead of enqueueing a create that is guaranteed to fail and settling with an error event. That layer already throws synchronous non-500s today (BAD_REQUEST for a missing id, PRECONDITION_FAILED for an unregistered project), so this adds no new client contract.

Typed cause: reuses the helper's existing `PROJECT_DIR_MISSING` as-is; nothing new is invented and no new reader is added.

**What still reports, deliberately:**
- A directory deleted between the precheck and the git call still surfaces as a 500 — that race is genuinely unexpected.
- A permission-walled path (EACCES/EPERM) still throws unclassified and keeps reporting: `throwIfNoEntry: false` swallows only ENOENT, and the new negative test pins that a permission error is NOT converted to NOT_FOUND (the over-match #6634's merge gate had to fix).

Adjacent sites left alone: `workspaces.generateBranchName` (and `aiRename`) also touch `project.repoPath` outside the create mutation; they have not appeared in this issue and are out of scope.

## Verification

New tests written first and confirmed failing before the fix: the two NOT_FOUND tests failed (both paths returned 500s), and the EACCES negative pin passed pre-fix (stays INTERNAL_SERVER_ERROR before and after).

`bunx biome check` on the three changed files:
```
Checked 3 files in 17ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
```
(no errors)

Full `bun test test` in packages/host-service:
```
 1158 pass
 8 todo
 0 fail
 2709 expect() calls
Ran 1166 tests across 113 files. [178.84s]
```

Co-located router suites (`bun test src/trpc/router/workspaces src/trpc/router/workspace-creation`):
```
 167 pass
 0 fail
Ran 167 tests across 14 files. [3.37s]
```

Refs HOST-SERVICE-W

https://claude.ai/code/session_01PWSqv5bU8VzRDHP8Z4iWqi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies a missing project repo directory as NOT_FOUND during workspace creation to replace opaque 500s. Previously, `workspaces.create` and `workspaces.createEnqueued` threw INTERNAL_SERVER_ERROR from `simple-git` when the repo path was gone; now both precheck and return NOT_FOUND with cause PROJECT_DIR_MISSING, and the enqueued path rejects before scheduling.

- Validates the repo path once via `requireProjectRepoPath` after `requireLocalProject` in `workspaces.create`, then uses the validated path for all downstream calls (main workspace ensure, git, base-ref fetcher, PR metadata, branch listing, name application).
- Adds the same guard to `createEnqueued` so a missing directory rejects synchronously and is not enqueued.
- Keeps intentional reporting: a directory deleted after the precheck still surfaces as a 500; permission errors (EACCES/EPERM) remain unclassified and report.
- Adds integration tests for NOT_FOUND on missing directories in both create paths and a negative pin that permission-walled paths stay INTERNAL_SERVER_ERROR.
- No API shape or schema changes; clients see deterministic NOT_FOUND instead of 500 on this condition. Addresses the classification gap tracked in HOST-SERVICE-W.

<sup>Written for commit f67582ad96417bb151a6a2347a894ddcf190edba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace creation now validates that the project repository path exists before starting operations.
  * Missing project directories return a clear “not found” error.
  * Permission-related access failures are reported accurately instead of being treated as missing directories.
  * Enqueued workspace creation no longer starts when the project directory is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->