### PR TITLE
fix(ci): read the QStash token from the production environment

### DIFF
--- a/.github/workflows/sync-qstash-schedules.yml
+++ b/.github/workflows/sync-qstash-schedules.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Create missing schedules
         env:


### PR DESCRIPTION
sync-qstash-schedules failed with 401 — QSTASH_TOKEN is an environment secret (production), not a repo secret. Same as deploy-production's jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read the QStash token from the GitHub Actions production environment to fix 401s in the sync job. Previously the workflow expected a repo secret; now it runs in the `production` environment and uses its environment secret, matching deploy-production.

- Ensure the `production` environment defines QSTASH_TOKEN.
- If the `production` environment requires approvals, runs will pause until approved.

<sup>Written for commit 061e8094745adc6668ea5a18b4b51bc8a4a1608f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated schedule synchronization to run within the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->