### PR TITLE
fix(ci): use the configured QStash base URL in the schedule sync

### DIFF
--- a/.github/workflows/sync-qstash-schedules.yml
+++ b/.github/workflows/sync-qstash-schedules.yml
@@ -17,10 +17,18 @@ jobs:
       - name: Create missing schedules
         env:
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          QSTASH_URL: ${{ secrets.QSTASH_URL }}
           API_URL: https://api.superset.sh
         run: |
           set -euo pipefail
-          existing=$(curl -sf -H "Authorization: Bearer $QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules)
+          base="${QSTASH_URL:-https://qstash.upstash.io}"
+          base="${base%/}"
+          status=$(curl -s -o /tmp/schedules.json -w "%{http_code}" -H "Authorization: Bearer $QSTASH_TOKEN" "$base/v2/schedules")
+          if [ "$status" != "200" ]; then
+            echo "listing schedules failed: HTTP $status from $base"
+            exit 1
+          fi
+          existing=$(cat /tmp/schedules.json)
 
           ensure() {
             local path="$1" cron="$2"
@@ -29,7 +37,7 @@ jobs:
               echo "exists: $path"
               return
             fi
-            curl -sf -X POST "https://qstash.upstash.io/v2/schedules/$destination" \
+            curl -sf -X POST "$base/v2/schedules/$destination" \
               -H "Authorization: Bearer $QSTASH_TOKEN" \
               -H "Upstash-Cron: $cron" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
The list call 4xx'd against qstash.upstash.io — the app's QSTASH_URL secret exists because the endpoint isn't the default. Use it, and print the HTTP status when listing fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the schedule sync to use the configured QStash base URL and fail clearly on list errors. Previously the workflow always called https://qstash.upstash.io and 4xx’d for non-default endpoints; now it respects the `QSTASH_URL` secret.

- Reads `QSTASH_URL` (falls back to https://qstash.upstash.io), trims trailing slash, and uses it for both list and create calls.
- Captures list HTTP status; prints the status and exits non-zero if not 200.
- No product/runtime impact; ensure the `QSTASH_URL` secret is set when using a non-default Upstash endpoint.

<sup>Written for commit 2f6556813856ca9e5504edbf735aaaf773eb38af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

