### PR TITLE
feat(email): remove app store badges from the footer for now

### DIFF
--- a/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
+++ b/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
@@ -122,22 +122,6 @@ export function EmailLayout({
 										alt="Superset"
 										width="232"
 									/>
-									<Text style={{ margin: "40px 0 0 0" }}>
-										<Img
-											src={`${assets}/badge-appstore.png`}
-											alt="App Store"
-											width="108"
-											height="32"
-											style={{ display: "inline-block", marginRight: "16px" }}
-										/>
-										<Img
-											src={`${assets}/badge-googleplay.png`}
-											alt="Google Play"
-											width="108"
-											height="32"
-											style={{ display: "inline-block" }}
-										/>
-									</Text>
 								</Column>
 								<Column style={{ width: "50%", verticalAlign: "top" }}>
 									<Section style={{ width: "248px", margin: "0 auto" }}>


### PR DESCRIPTION
## Summary

Removes the App Store / Google Play badge images from the shared email footer (`EmailLayout`), the single place they were rendered, so no email shows them for now. They were plain images with no store links attached.

A one-time Superset automation (`eb4fd908`, fires 2026-09-19 9:00 AM PT) will open a follow-up PR restoring the badges — as real store links if the listings are live by then.

## Test Plan

- [x] `turbo run typecheck --filter=@superset/email`
- [x] `biome check` on the edited file

https://claude.ai/code/session_01QJFRaCqJ2W5XCdc7dGRRn9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes App Store and Google Play badge images from the shared email footer to avoid implying live store availability. Previously all emails showed non-clickable badge images; now no badges render in the footer, slightly reducing footer height.

- Centralized change in `packages/email` `EmailLayout`; affects all emails using this layout.
- Visual-only change; no links or tracking behavior removed.
- A scheduled automation will open a follow-up PR on 2026-09-19 9:00 AM PT to restore badges as real store links if listings are live.

<sup>Written for commit aefb40373d5b939f9500053bc44d2a042fe72e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

