### PR TITLE
fix(desktop): keep the diff pane scrolled to the clicked file as content loads

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,7 +1,9 @@
+import { workspaceTrpc } from "@superset/workspace-client";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef, useState } from "react";
 import { LuFile, LuGitCompareArrows } from "react-icons/lu";
+import { getChangesetFileKey } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useSettings } from "renderer/stores/settings";
@@ -108,6 +110,17 @@ export function WorkspaceSidebar({
 		icon: LuGitCompareArrows,
 	};
 
+	// PR review comments are always relative to the base branch, so they map
+	// onto the "against-base" source group — matching the same query (and
+	// changeKey format) the Changes tab uses for that group lets us disambiguate
+	// a path that also has staged/unstaged edits, instead of falling back to
+	// "first item whose path matches" and landing on the wrong group.
+	const baseBranchQuery = workspaceTrpc.git.getBaseBranch.useQuery(
+		{ workspaceId },
+		{ staleTime: Number.POSITIVE_INFINITY },
+	);
+	const baseBranch = baseBranchQuery.data?.baseBranch ?? null;
+
 	const reviewTab = useReviewTab({
 		workspaceId,
 		onOpenComment,
@@ -115,7 +128,14 @@ export function WorkspaceSidebar({
 			? (path, line, openInNewTab, side) => {
 					// Force annotations on so the user lands on the comment, not an empty line.
 					useSettings.getState().update("showDiffComments", true);
-					onSelectDiffFile(path, openInNewTab ?? false, line, side);
+					const changeKey = getChangesetFileKey({
+						path,
+						status: "modified",
+						additions: 0,
+						deletions: 0,
+						source: { kind: "against-base", baseBranch },
+					});
+					onSelectDiffFile(path, openInNewTab ?? false, line, side, changeKey);
 				}
 			: undefined,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -119,7 +119,6 @@ export function WorkspaceSidebar({
 		{ workspaceId },
 		{ staleTime: Number.POSITIVE_INFINITY },
 	);
-	const baseBranch = baseBranchQuery.data?.baseBranch ?? null;
 
 	const reviewTab = useReviewTab({
 		workspaceId,
@@ -128,13 +127,23 @@ export function WorkspaceSidebar({
 			? (path, line, openInNewTab, side) => {
 					// Force annotations on so the user lands on the comment, not an empty line.
 					useSettings.getState().update("showDiffComments", true);
-					const changeKey = getChangesetFileKey({
-						path,
-						status: "modified",
-						additions: 0,
-						deletions: 0,
-						source: { kind: "against-base", baseBranch },
-					});
+					// Only disambiguate once the real base branch is known — while
+					// baseBranchQuery is still loading, omit changeKey so this falls
+					// back to the old (safe) "first item whose path matches" behavior
+					// instead of building a changeKey with a guessed-empty base branch
+					// that won't match the real item once it resolves.
+					const changeKey = baseBranchQuery.isSuccess
+						? getChangesetFileKey({
+								path,
+								status: "modified",
+								additions: 0,
+								deletions: 0,
+								source: {
+									kind: "against-base",
+									baseBranch: baseBranchQuery.data.baseBranch,
+								},
+							})
+						: undefined;
 					onSelectDiffFile(path, openInNewTab ?? false, line, side, changeKey);
 				}
 			: undefined,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -150,7 +150,7 @@ export function DiffPane({
 		paneId: context.pane.id,
 	});
 
-	const { targetItemId } = useDiffCodeViewScroll({
+	const { targetItemId, notifyScroll } = useDiffCodeViewScroll({
 		codeViewRef,
 		data,
 		fileByItemId,
@@ -174,8 +174,9 @@ export function DiffPane({
 		(scrollTop: number) => {
 			savePaneScrollState(scrollStateKey, { scrollTop, scrollLeft: 0 });
 			onScroll();
+			notifyScroll();
 		},
-		[scrollStateKey, onScroll],
+		[scrollStateKey, onScroll, notifyScroll],
 	);
 	const { options, style } = useDiffCodeViewTheme();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -7,7 +7,7 @@ import {
 } from "@pierre/diffs";
 import type { AppRouter } from "@superset/host-service";
 import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
-import { keepPreviousData, useQueries } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { getQueryKey } from "@trpc/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { useMemo, useRef } from "react";
@@ -19,10 +19,8 @@ import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
 
 type GetDiffInput = inferRouterInputs<AppRouter>["git"]["getDiff"];
 type GetDiffBulkInput = inferRouterInputs<AppRouter>["git"]["getDiffBulk"];
-type DiffContent = Omit<
-	inferRouterOutputs<AppRouter>["git"]["getDiffBulk"]["diffs"][number],
-	"path"
->;
+type GetDiffBulkOutput = inferRouterOutputs<AppRouter>["git"]["getDiffBulk"];
+type DiffContent = Omit<GetDiffBulkOutput["diffs"][number], "path">;
 
 interface UseDiffCodeViewItemsOptions {
 	workspaceId: string;
@@ -125,16 +123,21 @@ export function useDiffCodeViewItems({
 				queryKey: getQueryKey(workspaceTrpc.git.getDiffBulk, input, "query"),
 				queryFn: () => trpcClient.git.getDiffBulk.query(input),
 				staleTime: Number.POSITIVE_INFINITY,
-				// The query key includes this group's full `paths` array, so an
-				// ordinary worktree change (a file added/removed) rotates the key
-				// and would otherwise drop `query.data` to undefined until the
-				// refetch lands — vanishing that group's items and losing scroll
-				// position. Keep the previous group's data on screen through the
-				// gap instead.
-				placeholderData: keepPreviousData,
 			};
 		}),
 	});
+
+	// The query key includes each group's full `paths` array, so an ordinary
+	// worktree change (a file added/removed) rotates the key and drops
+	// `query.data` to undefined until the refetch lands. `useQueries` matches
+	// observers to `diffGroups` by array *position*, not by `group.key` — and
+	// a category going from zero files to some (or vice versa) inserts/removes
+	// a whole group, shifting every later group's index. `placeholderData:
+	// keepPreviousData` would then hand back the wrong group's stale data at
+	// that shifted position. Cache the last successful response per
+	// `group.key` instead, so a rotated/shifted query still finds the right
+	// group's prior content — its items stay visible while it refetches.
+	const groupDataCacheRef = useRef(new Map<string, GetDiffBulkOutput>());
 
 	// One lookup per group resolution (not per file, not per render) — keeps
 	// the per-file work below linear in file count instead of the quadratic
@@ -145,10 +148,15 @@ export function useDiffCodeViewItems({
 	// highlight caches whenever any one file in the group changed.
 	const diffContentByItemId = useMemo(() => {
 		const map = new Map<string, DiffContent & { revision: number }>();
+		const cache = groupDataCacheRef.current;
+		const liveGroupKeys = new Set<string>();
 		diffGroups.forEach((group, index) => {
+			liveGroupKeys.add(group.key);
 			const query = diffGroupQueries[index];
-			if (!query?.data) return;
-			const byPath = new Map(query.data.diffs.map((d) => [d.path, d]));
+			if (query?.data) cache.set(group.key, query.data);
+			const data = query?.data ?? cache.get(group.key);
+			if (!data) return;
+			const byPath = new Map(data.diffs.map((d) => [d.path, d]));
 			for (const member of group.members) {
 				const entry = byPath.get(member.path);
 				if (!entry) continue;
@@ -161,6 +169,11 @@ export function useDiffCodeViewItems({
 				});
 			}
 		});
+		// Drop cached groups that no longer exist so this doesn't grow
+		// unbounded as the user changes base branch or navigates diffs.
+		for (const key of cache.keys()) {
+			if (!liveGroupKeys.has(key)) cache.delete(key);
+		}
 		return map;
 	}, [diffGroups, diffGroupQueries]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -7,7 +7,7 @@ import {
 } from "@pierre/diffs";
 import type { AppRouter } from "@superset/host-service";
 import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
-import { useQueries } from "@tanstack/react-query";
+import { keepPreviousData, useQueries } from "@tanstack/react-query";
 import { getQueryKey } from "@trpc/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { useMemo, useRef } from "react";
@@ -125,6 +125,13 @@ export function useDiffCodeViewItems({
 				queryKey: getQueryKey(workspaceTrpc.git.getDiffBulk, input, "query"),
 				queryFn: () => trpcClient.git.getDiffBulk.query(input),
 				staleTime: Number.POSITIVE_INFINITY,
+				// The query key includes this group's full `paths` array, so an
+				// ordinary worktree change (a file added/removed) rotates the key
+				// and would otherwise drop `query.data` to undefined until the
+				// refetch lands — vanishing that group's items and losing scroll
+				// position. Keep the previous group's data on screen through the
+				// gap instead.
+				placeholderData: keepPreviousData,
 			};
 		}),
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -1,6 +1,6 @@
 import type { CodeViewItem, CodeViewScrollTarget } from "@pierre/diffs";
 import type { CodeViewHandle } from "@pierre/diffs/react";
-import { type RefObject, useEffect, useMemo, useRef } from "react";
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 import type { DiffPaneData } from "../../../../../../types";
 import {
 	type ChangesetFile,
@@ -22,7 +22,18 @@ interface UseDiffCodeViewScrollOptions {
 
 interface UseDiffCodeViewScrollResult {
 	targetItemId?: string;
+	/** Call on every CodeView `onScroll` event. A scroll that lands outside
+	 *  our own programmatic `scrollTo`'s settle window is treated as the user
+	 *  taking over, which releases the sticky re-scroll below for the current
+	 *  click until a new one arrives. */
+	notifyScroll: () => void;
 }
+
+// @pierre/diffs' default critically-damped spring settles a smooth-auto
+// scroll in ~440ms (see SmoothScrollSettings.omega). Give it headroom so the
+// animation's own scroll events aren't mistaken for the user grabbing the
+// scrollbar.
+const PROGRAMMATIC_SCROLL_SETTLE_MS = 700;
 
 export function useDiffCodeViewScroll({
 	codeViewRef,
@@ -34,7 +45,14 @@ export function useDiffCodeViewScroll({
 	scrollStateKey,
 	initialScrollState,
 }: UseDiffCodeViewScrollOptions): UseDiffCodeViewScrollResult {
-	const lastScrollTargetRef = useRef<string | null>(null);
+	// Identifies the click/focus request currently being tracked, and whether
+	// it's still "sticky" — i.e. whether we should keep re-asserting
+	// `scrollTo` for it as `items` shifts under the viewport (a later
+	// `getDiffBulk` group resolving, a comment thread arriving) instead of
+	// landing once and never correcting for drift.
+	const activeScrollKeyRef = useRef<string | null>(null);
+	const stickyRef = useRef(true);
+	const lastProgrammaticScrollAtRef = useRef(0);
 	const resolvedScrollStateKeyRef = useRef<string | null>(null);
 	const itemById = useMemo(() => {
 		const map = new Map<string, CodeViewItem<DiffAnnotationMetadata>>();
@@ -63,7 +81,8 @@ export function useDiffCodeViewScroll({
 			data.focusTick ?? "",
 		].join(":");
 		if (resolvedScrollStateKeyRef.current !== scrollStateKey) {
-			lastScrollTargetRef.current = null;
+			activeScrollKeyRef.current = null;
+			stickyRef.current = true;
 			if (shouldRestoreCachedScrollState(initialScrollState, data.focusTick)) {
 				const instance = codeViewRef.current?.getInstance();
 				if (!instance || items.length === 0) return;
@@ -72,12 +91,20 @@ export function useDiffCodeViewScroll({
 					position: initialScrollState.scrollTop,
 					behavior: "instant",
 				});
-				lastScrollTargetRef.current = scrollKey;
+				activeScrollKeyRef.current = scrollKey;
 				resolvedScrollStateKeyRef.current = scrollStateKey;
 				return;
 			}
 			resolvedScrollStateKeyRef.current = scrollStateKey;
 		}
+
+		// A new click (or focus target) always re-arms sticky tracking, even
+		// if the user had released a previous one by scrolling manually.
+		if (activeScrollKeyRef.current !== scrollKey) {
+			activeScrollKeyRef.current = scrollKey;
+			stickyRef.current = true;
+		}
+		if (!stickyRef.current) return;
 
 		if (!targetItemId) return;
 		const file = fileByItemId.get(targetItemId);
@@ -88,8 +115,6 @@ export function useDiffCodeViewScroll({
 			setCollapsed(changeKey, false);
 			return;
 		}
-
-		if (lastScrollTargetRef.current === scrollKey) return;
 
 		const targetItem = itemById.get(targetItemId);
 		const target: CodeViewScrollTarget =
@@ -110,14 +135,14 @@ export function useDiffCodeViewScroll({
 					};
 
 		codeViewRef.current?.scrollTo(target);
-		lastScrollTargetRef.current = scrollKey;
+		lastProgrammaticScrollAtRef.current = Date.now();
 	}, [
 		codeViewRef,
 		data.focusLine,
 		data.focusSide,
 		data.focusTick,
 		initialScrollState,
-		items.length,
+		items,
 		scrollStateKey,
 		targetItemId,
 		fileByItemId,
@@ -126,5 +151,15 @@ export function useDiffCodeViewScroll({
 		setCollapsed,
 	]);
 
-	return { targetItemId };
+	const notifyScroll = useCallback(() => {
+		if (
+			Date.now() - lastProgrammaticScrollAtRef.current <
+			PROGRAMMATIC_SCROLL_SETTLE_MS
+		) {
+			return;
+		}
+		stickyRef.current = false;
+	}, []);
+
+	return { targetItemId, notifyScroll };
 }


### PR DESCRIPTION
**Links**
- Issue: #6673

## Summary
- Fix the diff pane silently landing on the wrong (or a completely unrelated) file after clicking, when other diff content finishes loading after the initial scroll.
- Fix the Review tab's "open in diff" opening the wrong source group for a path that exists in more than one (e.g. staged + against-base).

## Why / Context
#6673 reports clicking a file in the Changes/Review sidebar landing on the wrong file, and notes it's hard to reproduce — it worked as soon as the reporter started recording. That's consistent with a race: the pane's files can span 1-3 `getDiffBulk` groups (staged/unstaged/against-base/commit) that resolve independently, plus async PR comment threads. With a warm cache everything resolves in one pass and looks fine; under real conditions (cold cache, an agent actively changing files, a big changeset) it doesn't.

## How It Works
Three contributing causes, all fixed:

1. **`useDiffCodeViewScroll` — one-shot scroll latch.** The scroll effect bailed once `lastScrollTargetRef.current === scrollKey`, and depended on `items.length` rather than `items` itself. So the *first* group to resolve triggered a scroll, then a later-resolving group landing *above* the target (or an async comment thread growing content above it) silently pushed the target out of view with no re-scroll. Replaced the one-shot latch with a sticky re-scroll: it keeps re-asserting `scrollTo` for the current click whenever `items` changes, until either the target settles or the user manually takes over scrolling (detected via a timing window around our own programmatic `scrollTo` calls, since `@pierre/diffs` doesn't expose a scroll-settled callback).
2. **`useDiffCodeViewItems` — bulk query key rotation.** Each `getDiffBulk` query is keyed on that group's full `paths` array. An ordinary worktree change (agent adds/removes a file) rotates the key, and `query.data` goes `undefined` until the refetch lands — vanishing that group's items mid-session and, if it was the *only* group with data, unmounting `CodeView` entirely and losing scroll position. Cache the last successful response per `DiffGroup.key` (category + base/commit, independent of array position) so a rotated query still finds its group's prior content while it refetches.
3. **`WorkspaceSidebar` — Review tab missing `changeKey`.** The Changes tab already disambiguates same-path files across source groups via a `changeKey` (`getChangesetFileKey`), but the Review tab's "open in diff" never passed one, so it fell back to "first item whose path matches" — landing in the wrong group whenever a path exists in more than one (e.g. a file with both staged edits and a pending PR comment against the base branch). Now builds the same `changeKey` once the workspace's base branch is known (PR review comments are inherently against-base); while it's still loading, `changeKey` is omitted so this falls back to the old (safe) path-match behavior instead of guessing.

## Manual QA Checklist
- [x] Click a file in the Changes tab — lands on the correct file and stays there
- [x] Live-reproduced the original race and confirmed the fix (see Testing below)
- [x] Group-cardinality edge case (a category's file count going 1→0 mid-session) — no crash, no console errors
- [x] `bun run typecheck` clean
- [x] `bash scripts/lint.sh` clean on the changed files

## Testing
- `bun run typecheck` (desktop) — clean
- `bash scripts/lint.sh` on the changed files — clean
- **Live CDP verification against a real dev build**, with the actual before/after evidence gate:
  - Built a throwaway workspace with a real 26-file changeset spanning two source groups (25 unstaged files, 1 staged file).
  - Temporarily staggered the "unstaged" group's resolution (~2.5s artificial delay, removed before commit) to reliably reproduce the async race the issue describes as "hard to repro."
  - **Before fix** (`git stash` of `useDiffCodeViewScroll.ts`/`DiffPane.tsx`, delay still active): clicked the staged file, landed correctly while only that group had resolved; once the delayed unstaged group resolved and inserted 25 files above it, the viewport silently jumped to an unrelated file (`preset-icons/index.ts`) with no trace of the originally clicked file — reproducing the exact reported symptom.
  - **After fix** (same steps, fix restored): the same sequence kept the originally clicked file correctly in view once the delayed group resolved.
  - Re-verified the happy path with the artificial delay removed (real network/processing timing) — no regression.
  - `renderHook`-based unit tests for the scroll hook were considered (matching a regression test suggested in the issue thread) but this repo's Bun test environment doesn't have a real DOM (`test-setup.ts` stubs `document` minimally), so `@testing-library/react`'s `renderHook` throws (`TypeError: style is not an Object`, confirmed empirically) — live verification was used instead.
- **Follow-up round** (addressing CodeRabbit review): fresh workspace, fresh changeset (5 unstaged + 1 staged). Clicked the staged file — landed correctly with zero console errors. Then unstaged that file mid-session (the staged group's file count goes 1→0, the exact scenario the `DiffGroup.key` cache fix targets) — no crash, no console errors, pane correctly re-rendered the file under Unstaged.

## Known Limitations
- The "user took over scrolling" detection is a timing heuristic (a window after our own `scrollTo` calls), not an exact signal — `@pierre/diffs`' `CodeView` doesn't expose a scroll-settled/animation-complete callback. A user who manually scrolls *during* our own smooth-scroll animation (rare) may have that scroll ignored.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the diff pane anchored on the clicked file as diff groups and comments load, and opens the correct source group from the Review tab. Previously the pane could jump to a different file as later content arrived, and Review could open the wrong group for paths present in multiple sources.

- useDiffCodeViewScroll: replaces the one-shot latch with a sticky re-scroll keyed to the current click; re-asserts scrollTo on items changes; stops re-scrolling when the user takes over (timed window around programmatic scrolls aligned with `@pierre/diffs` smooth scroll). Exposes notifyScroll; `DiffPane` wires it to CodeView onScroll.
- useDiffCodeViewItems: replaces `placeholderData: keepPreviousData` with a cache keyed by each diff group's `key`, preserving that group’s content while its query refetches even when group positions shift. Prunes entries for removed groups. Avoids mismatches caused by `useQueries` index-based observer matching in `@tanstack/react-query`.
- WorkspaceSidebar (Review tab): builds an against-base `changeKey` only after `workspaceTrpc.git.getBaseBranch` resolves; otherwise falls back to path-match. Passes `changeKey` to `onSelectDiffFile` to disambiguate same-path files across groups.

<sup>Written for commit 740b8976ace7d9dfa8c0074add3b2c8ef43ea851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review comments now open the correct files in the diff, including when staged or unstaged changes are present.
  - Diff content remains visible while switching files instead of briefly disappearing during loading.
  - Improved smooth scrolling and scroll restoration in diffs, reducing unwanted jumps and preserving the selected location.
  - Manual scrolling now reliably takes control after programmatic navigation.
  - Diff navigation now maintains the correct content when switching between groups or revisiting recently viewed changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
