### PR TITLE
fix(marketing): hide decorative GridCross corner marks from screen readers

### DIFF
--- a/apps/marketing/src/app/blog/components/GridCross/GridCross.tsx
+++ b/apps/marketing/src/app/blog/components/GridCross/GridCross.tsx
@@ -1,6 +1,6 @@
 export function GridCross({ className }: { className?: string }) {
 	return (
-		<div className={`absolute overflow-hidden ${className}`}>
+		<div className={`absolute overflow-hidden ${className}`} aria-hidden="true">
 			<div className="absolute -translate-x-1/2 -translate-y-1/2 w-px h-4 bg-border" />
 			<div className="absolute -translate-x-1/2 -translate-y-1/2 w-4 h-px bg-border" />
 		</div>


### PR DESCRIPTION
## Summary
- `GridCross` renders purely decorative corner tick marks (used on blog and starchart pages) with no `aria-hidden`, so screen readers announce empty content for them
- Adds `aria-hidden="true"` to the wrapping div; no visual or behavioral change

## Test plan
- [ ] Visual diff: confirm no rendering change on `/blog` and `/starchart`

https://claude.ai/code/session_01QoayXLUNFTGNYN3BAeL8FS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide decorative `GridCross` corner marks from screen readers to reduce noise. Previously, screen readers announced empty content; now the wrapper has aria-hidden="true" so assistive tech ignores it. No visual or behavioral change.

**Review notes**
- Verify no visual differences on `/blog` and `/starchart`.
- No API or prop changes. No migration required.

<sup>Written for commit d96d8c5d72111221cdedd7c48dfe44605575f032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Marked the decorative grid cross as hidden from screen readers, improving the experience for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->