### PR TITLE
fix(host-service): green main — account-env test expectations + lint info from #6645

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -259,10 +259,10 @@ export function getOpenCodePluginContent(notifyPath: string): string {
 export function createClaudeWrapper(): void {
 	const script = buildWrapperScript(
 		"claude",
-		buildDefaultAccountResolver(
+		`${buildDefaultAccountResolver(
 			"CLAUDE_CONFIG_DIR",
 			"default-claude-config-dir",
-		) + `exec "$REAL_BIN" "$@"`,
+		)}exec "$REAL_BIN" "$@"`,
 		{ agentId: "claude" },
 	);
 	createWrapper("claude", script);

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -321,7 +321,7 @@ describe("buildTerminalAgentLaunch default account env", () => {
 			prompt: "hi",
 		});
 		expect(launch.fullCommand).toBe(
-			`CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
+			`CLAUDE_CONFIG_DIR='${existingDir}' SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
 		);
 	});
 
@@ -335,7 +335,7 @@ describe("buildTerminalAgentLaunch default account env", () => {
 			prompt: "hi",
 		});
 		expect(launch.fullCommand).toBe(
-			"CLAUDE_CONFIG_DIR='/pinned/profile' 'claude' 'hi'",
+			`CLAUDE_CONFIG_DIR='/pinned/profile' SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
 		);
 	});
 


### PR DESCRIPTION
Main is currently red for every PR's Test and Lint jobs — both from #6645 as it landed (merge skew; its own CI predated the final shape).

## What
1. **Test**: `resolveDefaultAccountEnv` injects a `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR` twin alongside `CLAUDE_CONFIG_DIR` (so the wrapper can re-resolve a later account switch without clobbering a user-exported value), but the two `buildTerminalAgentLaunch default account env` expectations in `agents.test.ts` still expect the pre-twin command. Updated both — including the pin-beats-default case, where the twin is still expected to point at the host default while the user's pinned `CLAUDE_CONFIG_DIR` wins.
2. **Lint**: the same merge left a FIXABLE `useTemplate` info in `agent-wrappers-claude-codex-opencode.ts`, and `scripts/lint.sh` fails on any diagnostic. Applied biome's fix.

## Verified
- `bun test src/trpc/router/agents/agents.test.ts` — 27 pass, 0 fail (was 25/2 on pristine `22691eadc`)
- `bash scripts/lint.sh .` — clean (was `Found 1 info` → exit 1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks red CI by aligning test expectations with `resolveDefaultAccountEnv` now injecting `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR` alongside `CLAUDE_CONFIG_DIR`, and by applying a lint fix in the Claude wrapper. Previously tests expected only `CLAUDE_CONFIG_DIR`; now they expect both, with a pinned `CLAUDE_CONFIG_DIR` still winning while the twin points to the host default.

- In `packages/host-service/src/trpc/router/agents/agents.test.ts`, update the two default account env expectations to include `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR`; in the pinned case, the twin still references the host default.
- In `packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts`, replace string concatenation with a template literal per biome’s `useTemplate` rule; behavior is unchanged.

<sup>Written for commit 1b710ee9b9d84485097796d96804eed88bdb2e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude agent terminal launches by preserving the default configuration directory alongside any selected agent-specific configuration.
  * Ensured Claude wrapper command behavior remains consistent across supported launch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->