### PR TITLE
fix(desktop): make image paste work in remote and cloud workspace terminals

### DIFF
--- a/apps/desktop/src/renderer/lib/agent-session-orchestrator/adapters/terminal-adapter.ts
+++ b/apps/desktop/src/renderer/lib/agent-session-orchestrator/adapters/terminal-adapter.ts
@@ -1,4 +1,8 @@
 import type { AgentLaunchRequest } from "@superset/shared/agent-launch";
+import {
+	assignAttachmentFileName,
+	WORKSPACE_ATTACHMENTS_DIR,
+} from "@superset/shared/workspace-attachments";
 import { launchCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { AgentSessionLaunchContext, LaunchResultPayload } from "../types";
 
@@ -112,7 +116,7 @@ async function writeAttachmentFiles(
 	// recursive — a plain mkdir ENOENTs and kills the whole agent launch.
 	const attachmentsDirectory = joinAbsolutePath(
 		workspace.worktreePath,
-		".superset/attachments",
+		WORKSPACE_ATTACHMENTS_DIR,
 	);
 	await electronTrpcClient.filesystem.createDirectory.mutate({
 		workspaceId,
@@ -120,7 +124,6 @@ async function writeAttachmentFiles(
 		recursive: true,
 	});
 
-	// Track all used filenames to prevent collisions (includes user and generated names)
 	const usedFilenames = new Set<string>();
 	const writtenPaths: string[] = [];
 
@@ -128,46 +131,13 @@ async function writeAttachmentFiles(
 		const { file, base64Data } = parsedFiles[i];
 		if (!file) continue;
 
-		// Generate unique filename
-		let fileName: string;
-
-		if (!file.filename) {
-			// Generated names: find next available attachment_N
-			let index = i + 1;
-			do {
-				fileName = `attachment_${index}`;
-				index++;
-			} while (usedFilenames.has(fileName));
-		} else {
-			// Sanitize filename
-			const sanitized = file.filename.replace(/[^a-zA-Z0-9._-]/g, "_");
-
-			// Handle empty sanitized filename (e.g., "!!!" becomes "")
-			if (!sanitized.trim()) {
-				let index = i + 1;
-				do {
-					fileName = `attachment_${index}`;
-					index++;
-				} while (usedFilenames.has(fileName));
-			} else if (usedFilenames.has(sanitized)) {
-				// Find unique name by appending _1, _2, etc. if needed
-				const parts = sanitized.split(".");
-				const ext = parts.length > 1 ? parts.pop() : undefined;
-				const base = parts.join(".");
-
-				let counter = 1;
-				do {
-					fileName = ext
-						? `${base}_${counter}.${ext}`
-						: `${sanitized}_${counter}`;
-					counter++;
-				} while (usedFilenames.has(fileName));
-			} else {
-				fileName = sanitized;
-			}
-		}
-
-		usedFilenames.add(fileName);
+		// Must assign identically to the prompt renderer
+		// (agent-launch-request.ts), which runs over the same list.
+		const fileName = assignAttachmentFileName({
+			rawName: file.filename,
+			index: i,
+			used: usedFilenames,
+		});
 
 		const absolutePath = joinAbsolutePath(attachmentsDirectory, fileName);
 		await electronTrpcClient.filesystem.writeFile.mutate({
@@ -177,7 +147,7 @@ async function writeAttachmentFiles(
 		});
 
 		// Return relative path from workspace root
-		writtenPaths.push(`.superset/attachments/${fileName}`);
+		writtenPaths.push(`${WORKSPACE_ATTACHMENTS_DIR}/${fileName}`);
 	}
 
 	return writtenPaths;

--- a/apps/desktop/src/renderer/lib/file-to-base64.ts
+++ b/apps/desktop/src/renderer/lib/file-to-base64.ts
@@ -1,0 +1,19 @@
+/** Read a File into base64 (handles binary + large files via the reader). */
+export function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result;
+			if (typeof result !== "string") {
+				reject(new Error("Unexpected file reader result"));
+				return;
+			}
+			// Strip the "data:<mime>;base64," prefix.
+			const comma = result.indexOf(",");
+			resolve(comma >= 0 ? result.slice(comma + 1) : result);
+		};
+		reader.onerror = () =>
+			reject(reader.error ?? new Error("Failed to read file"));
+		reader.readAsDataURL(file);
+	});
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
@@ -144,6 +144,60 @@ describe("handleImagePasteFallback", () => {
 		expect(flags.defaultPrevented).toBe(false);
 		expect(flags.immediateStopped).toBe(false);
 	});
+
+	it("routes the clipboard files to the override instead of forwarding ^V", () => {
+		// Remote workspaces: the TUI's machine has no access to the local
+		// clipboard, so the override ships the bytes over and pastes a path.
+		const fileA = { name: "image.png" };
+		const fileB = { name: "notes.pdf" };
+		const { event, flags } = clipboardEvent({
+			types: ["Files"],
+			getData: () => "",
+			files: { length: 2, 0: fileA, 1: fileB } as unknown as {
+				length: number;
+			},
+		});
+		const { terminal, input } = makeFakeTerminal();
+		const override = mock((_files: File[]) => {});
+
+		handleImagePasteFallback(event, terminal, () => override);
+
+		expect(input).not.toHaveBeenCalled();
+		expect(override).toHaveBeenCalledTimes(1);
+		expect(override.mock.calls[0]?.[0]).toEqual([
+			fileA,
+			fileB,
+		] as unknown as File[]);
+		expect(flags.defaultPrevented).toBe(true);
+		expect(flags.immediateStopped).toBe(true);
+	});
+
+	it("forwards ^V when the override getter returns null", () => {
+		const { event } = clipboardEvent({
+			types: ["Files"],
+			getData: () => "",
+			files: { length: 1 },
+		});
+		const { terminal, input } = makeFakeTerminal();
+
+		handleImagePasteFallback(event, terminal, () => null);
+
+		expect(input).toHaveBeenCalledWith("\x16", true);
+	});
+
+	it("does not consult the override for text paste", () => {
+		const { event } = clipboardEvent({
+			types: ["text/plain"],
+			getData: (t) => (t === "text/plain" ? "hello" : ""),
+		});
+		const { terminal, input } = makeFakeTerminal();
+		const override = mock((_files: File[]) => {});
+
+		handleImagePasteFallback(event, terminal, () => override);
+
+		expect(override).not.toHaveBeenCalled();
+		expect(input).not.toHaveBeenCalled();
+	});
 });
 
 describe("installImagePasteFallback", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
@@ -20,6 +20,15 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 // listeners, so `stopImmediatePropagation` cleanly preempts the bracketed-paste
 // wrap.
 
+/**
+ * Replaces the Ctrl+V forward for terminals whose PTY runs on another machine
+ * (relay-reached host, cloud sandbox): the TUI over there reads *its own* OS
+ * clipboard, which never holds the user's local screenshot. The override
+ * receives the clipboard's File entries so the caller can ship the bytes to
+ * the workspace and paste a path instead.
+ */
+export type ImagePasteOverride = (files: File[]) => void;
+
 export function isNonTextPaste(event: ClipboardEvent): boolean {
 	const data = event.clipboardData;
 	if (!data) return false;
@@ -30,19 +39,27 @@ export function isNonTextPaste(event: ClipboardEvent): boolean {
 export function handleImagePasteFallback(
 	event: ClipboardEvent,
 	terminal: XTerm,
+	getOverride?: () => ImagePasteOverride | null,
 ): void {
 	if (!isNonTextPaste(event)) return;
 	event.preventDefault();
 	event.stopImmediatePropagation();
+	const override = getOverride?.() ?? null;
+	if (override) {
+		// File handles stay readable after dispatch; the list itself doesn't.
+		override(Array.from(event.clipboardData?.files ?? []));
+		return;
+	}
 	terminal.input("\x16", true);
 }
 
 export function installImagePasteFallback(
 	terminal: XTerm,
 	wrapper: HTMLElement,
+	getOverride?: () => ImagePasteOverride | null,
 ): () => void {
 	const handler = (event: ClipboardEvent) => {
-		handleImagePasteFallback(event, terminal);
+		handleImagePasteFallback(event, terminal, getOverride);
 	};
 
 	wrapper.addEventListener("paste", handler, { capture: true });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -3,6 +3,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { DEFAULT_TERMINAL_PARKED_RUNTIME_CAP } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { runWhenParserIdle } from "./parser-idle-gate";
+import type { ImagePasteOverride } from "./terminal-image-paste-fallback";
 import {
 	type LinkHoverInfo,
 	type TerminalLinkHandlers,
@@ -50,6 +51,8 @@ interface RegistryEntry {
 	linkManager: TerminalLinkManager | null;
 	/** Stored until linkManager is created (mount called after setLinkHandlers). */
 	pendingLinkHandlers: TerminalLinkHandlers | null;
+	/** Survives runtime eviction/rebuild (the override outlives any one xterm). */
+	imagePasteOverride: ImagePasteOverride | null;
 	/** Stops the alternate/normal buffer observer installed with the runtime. */
 	disposeBufferChangeListener: (() => void) | null;
 	/** Monotonic use counter; bumped on mount/detach, drives parked-LRU eviction. */
@@ -101,6 +104,7 @@ class TerminalRuntimeRegistryImpl {
 			}),
 			linkManager: null,
 			pendingLinkHandlers: null,
+			imagePasteOverride: null,
 			disposeBufferChangeListener: null,
 			lastUsedAt: 0,
 		};
@@ -206,6 +210,7 @@ class TerminalRuntimeRegistryImpl {
 					entry.transport.seqAnchor = loadPersistedSeqAnchor(terminalId);
 				}
 			}
+			entry.runtime.imagePasteOverride = entry.imagePasteOverride;
 			this.observeBufferChanges(entry);
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
 			if (entry.pendingLinkHandlers) {
@@ -301,6 +306,22 @@ class TerminalRuntimeRegistryImpl {
 			entry.linkManager.setHandlers(handlers);
 		} else {
 			entry.pendingLinkHandlers = handlers;
+		}
+	}
+
+	/**
+	 * Set (or clear, with null) the image-paste override for a terminal. Safe
+	 * to call before or after mount(); survives runtime eviction/rebuild.
+	 */
+	setImagePasteOverride(
+		terminalId: string,
+		override: ImagePasteOverride | null,
+		instanceId = terminalId,
+	) {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
+		entry.imagePasteOverride = override;
+		if (entry.runtime) {
+			entry.runtime.imagePasteOverride = override;
 		}
 	}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -25,7 +25,10 @@ import {
 	TERMINAL_DIMS_KEY_PREFIX,
 	touchTerminalStatePersistedAt,
 } from "./terminal-buffer-gc";
-import { installImagePasteFallback } from "./terminal-image-paste-fallback";
+import {
+	type ImagePasteOverride,
+	installImagePasteFallback,
+} from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
 import { persistSeqAnchor } from "./terminal-seq-anchor";
@@ -56,6 +59,12 @@ export interface TerminalRuntime {
 	_setLigaturesEnabled: ((enabled: boolean) => void) | null;
 	ligaturesEnabled: boolean;
 	_disposeImagePasteFallback: (() => void) | null;
+	/**
+	 * When set, image/file pastes call this with the clipboard files instead
+	 * of forwarding Ctrl+V — used for workspaces whose PTY runs on another
+	 * machine, where the TUI can't see the local clipboard.
+	 */
+	imagePasteOverride: ImagePasteOverride | null;
 	/**
 	 * How this runtime's xterm was seeded: from the persisted localStorage
 	 * snapshot (its seq anchor pairs with it), from a sibling instance's
@@ -336,12 +345,7 @@ export function createRuntime(
 		terminal.write(FRESH_SHELL_INPUT_MODE_RESET);
 	}
 
-	const disposeImagePasteFallback = installImagePasteFallback(
-		terminal,
-		wrapper,
-	);
-
-	return {
+	const runtime: TerminalRuntime = {
 		terminalId,
 		terminal,
 		fitAddon,
@@ -358,9 +362,17 @@ export function createRuntime(
 		_disposeAddons: addonsResult.dispose,
 		_setLigaturesEnabled: addonsResult.setLigaturesEnabled,
 		ligaturesEnabled: appearance.ligatures,
-		_disposeImagePasteFallback: disposeImagePasteFallback,
+		_disposeImagePasteFallback: null,
+		imagePasteOverride: null,
 		initialContent,
 	};
+	runtime._disposeImagePasteFallback = installImagePasteFallback(
+		terminal,
+		wrapper,
+		() => runtime.imagePasteOverride,
+	);
+
+	return runtime;
 }
 
 export function attachToContainer(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -3,6 +3,7 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useEffect, useState } from "react";
+import { fileToBase64 } from "renderer/lib/file-to-base64";
 import {
 	asDirectoryHandle,
 	basename,
@@ -232,26 +233,6 @@ async function flattenEntries(
 		files: trees.flatMap((t) => t.files),
 		dirs: trees.flatMap((t) => t.dirs),
 	};
-}
-
-/** Read a File into base64 (handles binary + large files via the reader). */
-function fileToBase64(file: File): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => {
-			const result = reader.result;
-			if (typeof result !== "string") {
-				reject(new Error("Unexpected file reader result"));
-				return;
-			}
-			// Strip the "data:<mime>;base64," prefix.
-			const comma = result.indexOf(",");
-			resolve(comma >= 0 ? result.slice(comma + 1) : result);
-		};
-		reader.onerror = () =>
-			reject(reader.error ?? new Error("Failed to read file"));
-		reader.readAsDataURL(file);
-	});
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -51,7 +51,7 @@ import {
 	terminalRichInputOpenStore,
 	useTerminalRichInputOpen,
 } from "./richInputOpenStore";
-import { uploadPastedFiles } from "./uploadPastedFiles";
+import { PasteUploadLimitError, uploadPastedFiles } from "./uploadPastedFiles";
 import { shellEscapePaths } from "./utils";
 
 interface TerminalPaneProps {
@@ -402,9 +402,11 @@ export function TerminalPane({
 				} catch (error) {
 					console.error("[v2 Terminal] remote file upload failed", error);
 					toast.error(
-						files.length === 1
-							? "Failed to send the file to the remote workspace"
-							: "Failed to send the files to the remote workspace",
+						error instanceof PasteUploadLimitError
+							? error.message
+							: files.length === 1
+								? "Failed to send the file to the remote workspace"
+								: "Failed to send the files to the remote workspace",
 					);
 				}
 			})();
@@ -541,7 +543,9 @@ export function TerminalPane({
 				items.length > 0 &&
 				items.every(
 					(item) =>
-						item.kind === "file" && item.webkitGetAsEntry()?.isFile === true,
+						item.kind === "file" &&
+						typeof item.webkitGetAsEntry === "function" &&
+						item.webkitGetAsEntry()?.isFile === true,
 				);
 			const files = Array.from(event.dataTransfer.files);
 			if (allPlainFiles && files.length > 0) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import type { RendererContext } from "@superset/panes";
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
@@ -33,6 +34,8 @@ import type {
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { openUrlInV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openUrlInV2Workspace";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
 import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalSearch";
 import { useTheme } from "renderer/stores/theme";
@@ -48,6 +51,7 @@ import {
 	terminalRichInputOpenStore,
 	useTerminalRichInputOpen,
 } from "./richInputOpenStore";
+import { uploadPastedFiles } from "./uploadPastedFiles";
 import { shellEscapePaths } from "./utils";
 
 interface TerminalPaneProps {
@@ -348,6 +352,89 @@ export function TerminalPane({
 		folderPolicy,
 	]);
 
+	// --- Remote image paste ---
+	// The default paste path forwards Ctrl+V and lets the TUI read the OS
+	// clipboard — which only exists on the machine the PTY runs on. When the
+	// workspace lives on another host (relay-reached machine, cloud sandbox),
+	// ship the clipboard bytes there via filesystem.writeFile and paste the
+	// resulting paths instead. Local workspaces keep the Ctrl+V forward, which
+	// lets TUIs attach the image natively.
+	const { machineId } = useLocalHostService();
+	const hostWorkspaces = useHostWorkspaces();
+	const workspaceHostId = hostWorkspaces.workspaces.find(
+		(w) => w.id === workspaceId,
+	)?.hostId;
+	// A cloud sandbox workspace has no host row, so "known list is ready and
+	// the workspace isn't in it" also means remote. Until the list is ready
+	// the override stays unset and paste falls back to the local behavior.
+	const isRemoteHost =
+		hostWorkspaces.isReady &&
+		Boolean(machineId) &&
+		workspaceHostId !== machineId;
+
+	const writeFileMutation = workspaceTrpc.filesystem.writeFile.useMutation();
+	const createDirectoryMutation =
+		workspaceTrpc.filesystem.createDirectory.useMutation();
+	const writeFileRef = useRef(writeFileMutation.mutateAsync);
+	writeFileRef.current = writeFileMutation.mutateAsync;
+	const createDirectoryRef = useRef(createDirectoryMutation.mutateAsync);
+	createDirectoryRef.current = createDirectoryMutation.mutateAsync;
+
+	// Fire-and-forget: ship files to the workspace, then paste the paths.
+	const uploadAndPasteFiles = useCallback(
+		(files: File[], worktree: string) => {
+			void (async () => {
+				try {
+					const paths = await uploadPastedFiles({
+						deps: {
+							createDirectory: (input) => createDirectoryRef.current(input),
+							writeFile: (input) => writeFileRef.current(input),
+						},
+						workspaceId,
+						worktreePath: worktree,
+						files,
+					});
+					terminalRuntimeRegistry.paste(
+						terminalId,
+						shellEscapePaths(paths),
+						terminalInstanceId,
+					);
+				} catch (error) {
+					console.error("[v2 Terminal] remote file upload failed", error);
+					toast.error(
+						files.length === 1
+							? "Failed to send the file to the remote workspace"
+							: "Failed to send the files to the remote workspace",
+					);
+				}
+			})();
+		},
+		[terminalId, terminalInstanceId, workspaceId],
+	);
+
+	useEffect(() => {
+		if (!isRemoteHost || !worktreePath) return;
+
+		terminalRuntimeRegistry.setImagePasteOverride(
+			terminalId,
+			(files) => uploadAndPasteFiles(files, worktreePath),
+			terminalInstanceId,
+		);
+		return () => {
+			terminalRuntimeRegistry.setImagePasteOverride(
+				terminalId,
+				null,
+				terminalInstanceId,
+			);
+		};
+	}, [
+		terminalId,
+		terminalInstanceId,
+		worktreePath,
+		isRemoteHost,
+		uploadAndPasteFiles,
+	]);
+
 	useTerminalInterruptClear({
 		terminalId,
 		terminalInstanceId,
@@ -443,6 +530,29 @@ export function TerminalPane({
 		dragCounterRef.current = 0;
 		setIsDropActive(false);
 		if (connectionState === "closed") return;
+
+		// Dropped OS paths are local paths — meaningless on the machine a
+		// remote workspace's PTY runs on. When every dropped entry is a plain
+		// file, ship the bytes instead. Folders keep the path flow (their File
+		// entries carry no content), which at least preserves today's behavior.
+		if (isRemoteHost && worktreePath) {
+			const items = Array.from(event.dataTransfer.items);
+			const allPlainFiles =
+				items.length > 0 &&
+				items.every(
+					(item) =>
+						item.kind === "file" && item.webkitGetAsEntry()?.isFile === true,
+				);
+			const files = Array.from(event.dataTransfer.files);
+			if (allPlainFiles && files.length > 0) {
+				terminalRuntimeRegistry
+					.getTerminal(terminalId, terminalInstanceId)
+					?.focus();
+				uploadAndPasteFiles(files, worktreePath);
+				return;
+			}
+		}
+
 		const text = resolveDroppedText(event.dataTransfer);
 		if (!text) return;
 		terminalRuntimeRegistry

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { WORKSPACE_ATTACHMENTS_DIR } from "@superset/shared/workspace-attachments";
+import {
+	type UploadPastedFilesDeps,
+	uploadPastedFiles,
+} from "./uploadPastedFiles";
+
+// fileToBase64 goes through FileReader.readAsDataURL, which the renderer has
+// but Bun's test runtime may not — pin a minimal implementation over
+// Blob.arrayBuffer so the tests exercise the real base64 pipeline.
+class TestFileReader {
+	result: string | null = null;
+	error: Error | null = null;
+	onload: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+
+	readAsDataURL(file: File) {
+		file
+			.arrayBuffer()
+			.then((buffer) => {
+				const base64 = Buffer.from(buffer).toString("base64");
+				this.result = `data:${file.type};base64,${base64}`;
+				this.onload?.();
+			})
+			.catch((error) => {
+				this.error = error;
+				this.onerror?.();
+			});
+	}
+}
+
+const originalFileReader = (globalThis as { FileReader?: unknown }).FileReader;
+
+beforeAll(() => {
+	(globalThis as { FileReader?: unknown }).FileReader = TestFileReader;
+});
+
+afterAll(() => {
+	(globalThis as { FileReader?: unknown }).FileReader = originalFileReader;
+});
+
+interface RecordedWrite {
+	absolutePath: string;
+	content: string | { kind: "base64"; data: string };
+	options: { create: boolean; overwrite: boolean };
+}
+
+/**
+ * Fake deps backed by a real "directory": create-only writes report "exists"
+ * on a name collision exactly like the host does, so the collision-probing
+ * naming is exercised for real.
+ */
+function makeDeps(options: { existing?: string[]; failWrites?: boolean } = {}) {
+	const createdDirs: string[] = [];
+	const writes: RecordedWrite[] = [];
+	const existing = new Set(options.existing ?? []);
+	const deps: UploadPastedFilesDeps = {
+		async createDirectory(input) {
+			createdDirs.push(input.absolutePath);
+		},
+		async writeFile(input) {
+			const write: RecordedWrite = {
+				absolutePath: input.absolutePath,
+				content: input.content,
+				options: input.options,
+			};
+			writes.push(write);
+			if (options.failWrites && !input.absolutePath.endsWith(".gitignore")) {
+				return { ok: false, reason: "conflict" };
+			}
+			if (existing.has(input.absolutePath) && !input.options.overwrite) {
+				return { ok: false, reason: "exists" };
+			}
+			existing.add(input.absolutePath);
+			return { ok: true };
+		},
+	};
+	return { deps, createdDirs, writes };
+}
+
+const WORKTREE = "/home/user/.superset/worktrees/demo";
+const DIR_ABS = `${WORKTREE}/${WORKSPACE_ATTACHMENTS_DIR}`;
+
+describe("uploadPastedFiles", () => {
+	it("creates the attachments dir, self-ignores it, writes each file, returns relative paths", async () => {
+		const { deps, createdDirs, writes } = makeDeps();
+		const files = [
+			new File([new Uint8Array([1, 2, 3])], "image.png", {
+				type: "image/png",
+			}),
+			new File([new Uint8Array([4, 5])], "notes.pdf", {
+				type: "application/pdf",
+			}),
+		];
+
+		const paths = await uploadPastedFiles({
+			deps,
+			workspaceId: "ws-1",
+			worktreePath: WORKTREE,
+			files,
+		});
+
+		expect(createdDirs).toEqual([DIR_ABS]);
+		expect(writes[0]).toEqual({
+			absolutePath: `${DIR_ABS}/.gitignore`,
+			content: "*\n",
+			// create-only: a user's own .gitignore edit is never clobbered.
+			options: { create: true, overwrite: false },
+		});
+		// Worktree-relative, matching the agent-launch and mobile convention.
+		expect(paths).toEqual([
+			`${WORKSPACE_ATTACHMENTS_DIR}/image.png`,
+			`${WORKSPACE_ATTACHMENTS_DIR}/notes.pdf`,
+		]);
+		expect(writes[1]?.options).toEqual({ create: true, overwrite: false });
+		expect(writes[1]?.content).toEqual({
+			kind: "base64",
+			data: Buffer.from([1, 2, 3]).toString("base64"),
+		});
+	});
+
+	it("never overwrites an earlier paste — collisions probe to a fresh _N name", async () => {
+		const { deps, writes } = makeDeps({
+			existing: [`${DIR_ABS}/image.png`, `${DIR_ABS}/image_1.png`],
+		});
+
+		const paths = await uploadPastedFiles({
+			deps,
+			workspaceId: "ws-1",
+			worktreePath: WORKTREE,
+			files: [new File(["x"], "image.png", { type: "image/png" })],
+		});
+
+		expect(paths).toEqual([`${WORKSPACE_ATTACHMENTS_DIR}/image_2.png`]);
+		// Every probe was create-only; nothing was written over.
+		expect(writes.every((w) => w.options.overwrite === false)).toBe(true);
+	});
+
+	it("tolerates a .gitignore that already exists from an earlier paste", async () => {
+		const { deps } = makeDeps({ existing: [`${DIR_ABS}/.gitignore`] });
+
+		const paths = await uploadPastedFiles({
+			deps,
+			workspaceId: "ws-1",
+			worktreePath: WORKTREE,
+			files: [new File(["x"], "image.png", { type: "image/png" })],
+		});
+
+		expect(paths).toEqual([`${WORKSPACE_ATTACHMENTS_DIR}/image.png`]);
+	});
+
+	it("throws when a file write is refused", async () => {
+		const { deps } = makeDeps({ failWrites: true });
+
+		await expect(
+			uploadPastedFiles({
+				deps,
+				workspaceId: "ws-1",
+				worktreePath: WORKTREE,
+				files: [new File(["x"], "image.png", { type: "image/png" })],
+			}),
+		).rejects.toThrow("conflict");
+	});
+
+	it("sanitizes path-hostile clipboard names and falls back to attachment_N", async () => {
+		const { deps } = makeDeps();
+
+		const paths = await uploadPastedFiles({
+			deps,
+			workspaceId: "ws-1",
+			worktreePath: WORKTREE,
+			files: [
+				new File(["x"], "../shot: 1/final.png", { type: "image/png" }),
+				new File(["y"], "", { type: "image/png" }),
+				new File(["z"], "", { type: "application/x-thing" }),
+			],
+		});
+
+		expect(paths).toEqual([
+			`${WORKSPACE_ATTACHMENTS_DIR}/.._shot__1_final.png`,
+			`${WORKSPACE_ATTACHMENTS_DIR}/attachment_2.png`,
+			`${WORKSPACE_ATTACHMENTS_DIR}/attachment_3`,
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
@@ -9,6 +9,8 @@ import {
 // fileToBase64 goes through FileReader.readAsDataURL, which the renderer has
 // but Bun's test runtime may not — pin a minimal implementation over
 // Blob.arrayBuffer so the tests exercise the real base64 pipeline.
+let fileReads = 0;
+
 class TestFileReader {
 	result: string | null = null;
 	error: Error | null = null;
@@ -16,6 +18,7 @@ class TestFileReader {
 	onerror: (() => void) | null = null;
 
 	readAsDataURL(file: File) {
+		fileReads += 1;
 		file
 			.arrayBuffer()
 			.then((buffer) => {
@@ -164,7 +167,8 @@ describe("uploadPastedFiles", () => {
 	});
 
 	it("refuses oversized files before reading any bytes", async () => {
-		const { deps, writes } = makeDeps();
+		const { deps, createdDirs, writes } = makeDeps();
+		fileReads = 0;
 		const big = new File([new Uint8Array(1)], "video.mov", {
 			type: "video/quicktime",
 		});
@@ -180,12 +184,15 @@ describe("uploadPastedFiles", () => {
 				files: [big],
 			}),
 		).rejects.toThrow(PasteUploadLimitError);
-		// Failed fast: no directory created, no bytes shipped.
+		// Failed fast: nothing read, no directory created, no bytes shipped.
+		expect(fileReads).toBe(0);
+		expect(createdDirs).toHaveLength(0);
 		expect(writes).toHaveLength(0);
 	});
 
 	it("refuses batches over the total budget", async () => {
-		const { deps, writes } = makeDeps();
+		const { deps, createdDirs, writes } = makeDeps();
+		fileReads = 0;
 		const files = Array.from({ length: 5 }, (_, i) => {
 			const f = new File([new Uint8Array(1)], `part${i}.bin`, {
 				type: "application/octet-stream",
@@ -202,6 +209,8 @@ describe("uploadPastedFiles", () => {
 				files,
 			}),
 		).rejects.toThrow(PasteUploadLimitError);
+		expect(fileReads).toBe(0);
+		expect(createdDirs).toHaveLength(0);
 		expect(writes).toHaveLength(0);
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { WORKSPACE_ATTACHMENTS_DIR } from "@superset/shared/workspace-attachments";
 import {
+	PasteUploadLimitError,
 	type UploadPastedFilesDeps,
 	uploadPastedFiles,
 } from "./uploadPastedFiles";
@@ -160,6 +161,48 @@ describe("uploadPastedFiles", () => {
 				files: [new File(["x"], "image.png", { type: "image/png" })],
 			}),
 		).rejects.toThrow("conflict");
+	});
+
+	it("refuses oversized files before reading any bytes", async () => {
+		const { deps, writes } = makeDeps();
+		const big = new File([new Uint8Array(1)], "video.mov", {
+			type: "video/quicktime",
+		});
+		// A 2GB Blob in the test would be real memory; fake the size instead —
+		// the check reads file.size only.
+		Object.defineProperty(big, "size", { value: 2 * 1024 * 1024 * 1024 });
+
+		await expect(
+			uploadPastedFiles({
+				deps,
+				workspaceId: "ws-1",
+				worktreePath: WORKTREE,
+				files: [big],
+			}),
+		).rejects.toThrow(PasteUploadLimitError);
+		// Failed fast: no directory created, no bytes shipped.
+		expect(writes).toHaveLength(0);
+	});
+
+	it("refuses batches over the total budget", async () => {
+		const { deps, writes } = makeDeps();
+		const files = Array.from({ length: 5 }, (_, i) => {
+			const f = new File([new Uint8Array(1)], `part${i}.bin`, {
+				type: "application/octet-stream",
+			});
+			Object.defineProperty(f, "size", { value: 45 * 1024 * 1024 });
+			return f;
+		});
+
+		await expect(
+			uploadPastedFiles({
+				deps,
+				workspaceId: "ws-1",
+				worktreePath: WORKTREE,
+				files,
+			}),
+		).rejects.toThrow(PasteUploadLimitError);
+		expect(writes).toHaveLength(0);
 	});
 
 	it("sanitizes path-hostile clipboard names and falls back to attachment_N", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.ts
@@ -1,0 +1,136 @@
+import {
+	attachmentFallbackName,
+	attachmentNameWithSuffix,
+	sanitizeAttachmentFileName,
+	WORKSPACE_ATTACHMENTS_DIR,
+} from "@superset/shared/workspace-attachments";
+import { fileToBase64 } from "renderer/lib/file-to-base64";
+
+// Pastes follow the shared workspace-attachments convention (same directory
+// and naming as agent-launch and the mobile composer): worktree-relative
+// paths, since `filesystem.writeFile` refuses paths outside the worktree.
+// The directory self-ignores (see the `.gitignore` write below) so
+// attachments never dirty git status.
+
+/** Collision-probe cap; matches the spirit of createUniqueEntry's bound. */
+const MAX_NAME_ATTEMPTS = 50;
+
+interface FsWriteOutcome {
+	ok: boolean;
+	reason?: string;
+}
+
+export interface UploadPastedFilesDeps {
+	createDirectory(input: {
+		workspaceId: string;
+		absolutePath: string;
+		recursive: boolean;
+	}): Promise<unknown>;
+	writeFile(input: {
+		workspaceId: string;
+		absolutePath: string;
+		content: string | { kind: "base64"; data: string };
+		options: { create: boolean; overwrite: boolean };
+	}): Promise<FsWriteOutcome>;
+}
+
+const MIME_EXTENSIONS: Record<string, string> = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/gif": "gif",
+	"image/webp": "webp",
+	"image/svg+xml": "svg",
+	"image/tiff": "tiff",
+	"image/bmp": "bmp",
+};
+
+/**
+ * Clipboard names (Chromium synthesizes "image.png" for screenshots; Finder
+ * copies keep their real name) go through the shared sanitizer; generated
+ * fallbacks take their extension from the mime type, the only signal a
+ * clipboard file carries.
+ */
+function baseFileName(file: File, index: number): string {
+	const sanitized = sanitizeAttachmentFileName(file.name);
+	if (sanitized) return sanitized;
+	const extension = MIME_EXTENSIONS[file.type];
+	return attachmentFallbackName(index, extension ? `.${extension}` : "");
+}
+
+/**
+ * Write one file under a collision-free name. The batch conventions dedupe
+ * against an in-memory set; pastes arrive one at a time across a session, so
+ * probe the real directory instead (create-only writes report "exists") —
+ * a second screenshot must never overwrite a path an earlier prompt already
+ * references.
+ */
+async function writeUnique(
+	deps: UploadPastedFilesDeps,
+	workspaceId: string,
+	dirAbs: string,
+	base: string,
+	data: string,
+): Promise<string> {
+	for (let attempt = 0; attempt < MAX_NAME_ATTEMPTS; attempt++) {
+		const fileName = attachmentNameWithSuffix(base, attempt);
+		const outcome = await deps.writeFile({
+			workspaceId,
+			absolutePath: `${dirAbs}/${fileName}`,
+			content: { kind: "base64", data },
+			options: { create: true, overwrite: false },
+		});
+		if (outcome.ok !== false) return fileName;
+		if (outcome.reason !== "exists") {
+			throw new Error(outcome.reason ?? "write failed");
+		}
+	}
+	throw new Error(`Could not find a free name for ${base}`);
+}
+
+/**
+ * Ship clipboard files to a workspace whose PTY runs on another machine and
+ * return the worktree-relative paths written, ready to paste into the
+ * terminal. Throws on the first failed write — the caller owns the error
+ * surface.
+ */
+export async function uploadPastedFiles(options: {
+	deps: UploadPastedFilesDeps;
+	workspaceId: string;
+	worktreePath: string;
+	files: File[];
+}): Promise<string[]> {
+	const { deps, workspaceId, worktreePath, files } = options;
+	const dirAbs = `${worktreePath}/${WORKSPACE_ATTACHMENTS_DIR}`;
+
+	await deps.createDirectory({
+		workspaceId,
+		absolutePath: dirAbs,
+		recursive: true,
+	});
+
+	// `*` ignores every attachment and the .gitignore itself, so agents never
+	// see attachments as untracked changes. create-only: a user's own edit wins.
+	const ignoreOutcome = await deps.writeFile({
+		workspaceId,
+		absolutePath: `${dirAbs}/.gitignore`,
+		content: "*\n",
+		options: { create: true, overwrite: false },
+	});
+	if (ignoreOutcome.ok === false && ignoreOutcome.reason !== "exists") {
+		throw new Error(ignoreOutcome.reason ?? "write failed");
+	}
+
+	const paths: string[] = [];
+	for (const [index, file] of files.entries()) {
+		const data = await fileToBase64(file);
+		const fileName = await writeUnique(
+			deps,
+			workspaceId,
+			dirAbs,
+			baseFileName(file, index),
+			data,
+		);
+		paths.push(`${WORKSPACE_ATTACHMENTS_DIR}/${fileName}`);
+	}
+	return paths;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/uploadPastedFiles.ts
@@ -15,6 +15,20 @@ import { fileToBase64 } from "renderer/lib/file-to-base64";
 /** Collision-probe cap; matches the spirit of createUniqueEntry's bound. */
 const MAX_NAME_ATTEMPTS = 50;
 
+// Same caps as the agent-launch adapter's attachment writer. The bytes are
+// FileReader-read and base64'd (~1.33x) in renderer memory, then travel as
+// one JSON body — an accidentally pasted multi-GB Finder file must fail
+// fast instead of stalling the renderer and the host.
+const MAX_SINGLE_FILE_BYTES = 50 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 200 * 1024 * 1024;
+
+/** Thrown for limits the user can act on; the message is toast-ready. */
+export class PasteUploadLimitError extends Error {}
+
+function formatMb(bytes: number): string {
+	return `${Math.round(bytes / 1024 / 1024)}MB`;
+}
+
 interface FsWriteOutcome {
 	ok: boolean;
 	reason?: string;
@@ -101,6 +115,21 @@ export async function uploadPastedFiles(options: {
 }): Promise<string[]> {
 	const { deps, workspaceId, worktreePath, files } = options;
 	const dirAbs = `${worktreePath}/${WORKSPACE_ATTACHMENTS_DIR}`;
+
+	let totalBytes = 0;
+	for (const file of files) {
+		if (file.size > MAX_SINGLE_FILE_BYTES) {
+			throw new PasteUploadLimitError(
+				`"${file.name || "pasted file"}" is ${formatMb(file.size)} — files over ${formatMb(MAX_SINGLE_FILE_BYTES)} can't be sent to a remote workspace`,
+			);
+		}
+		totalBytes += file.size;
+	}
+	if (totalBytes > MAX_TOTAL_BYTES) {
+		throw new PasteUploadLimitError(
+			`Pasted files total ${formatMb(totalBytes)} — more than the ${formatMb(MAX_TOTAL_BYTES)} limit for a remote workspace`,
+		);
+	}
 
 	await deps.createDirectory({
 		workspaceId,

--- a/apps/desktop/src/shared/context/buildLaunchSpec.ts
+++ b/apps/desktop/src/shared/context/buildLaunchSpec.ts
@@ -1,5 +1,6 @@
 import { renderPromptTemplate } from "@superset/shared/agent-prompt-template";
 import type { ResolvedAgentConfig } from "@superset/shared/agent-settings";
+import { WORKSPACE_ATTACHMENTS_DIR } from "@superset/shared/workspace-attachments";
 import type {
 	AgentLaunchSpec,
 	ContentPart,
@@ -191,13 +192,15 @@ function renderKindBlock(sections: ContextSection[]): string {
 function renderAttachmentsList(sections: ContextSection[]): string {
 	const refs: string[] = [];
 	for (const section of sectionsOfKind(sections, "attachment")) {
-		refs.push(`- .superset/attachments/${section.label}`);
+		refs.push(`- ${WORKSPACE_ATTACHMENTS_DIR}/${section.label}`);
 	}
 	for (const section of sectionsOfKind(sections, "user-prompt")) {
 		for (const part of section.content) {
 			if (part.type === "text") continue;
 			const label = part.type === "file" ? part.filename : undefined;
-			refs.push(`- .superset/attachments/${label ?? "inline-attachment"}`);
+			refs.push(
+				`- ${WORKSPACE_ATTACHMENTS_DIR}/${label ?? "inline-attachment"}`,
+			);
 		}
 	}
 	if (refs.length === 0) return "";
@@ -205,7 +208,7 @@ function renderAttachmentsList(sections: ContextSection[]): string {
 		"# Attached files",
 		"",
 		"The user attached these files alongside the prompt. They've been",
-		"written into the worktree at `.superset/attachments/`. Read them",
+		`written into the worktree at \`${WORKSPACE_ATTACHMENTS_DIR}/\`. Read them`,
 		"to understand the request — they're part of the task, not",
 		"optional reference.",
 		"",

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
@@ -1,11 +1,12 @@
+import {
+	assignAttachmentFileName,
+	WORKSPACE_ATTACHMENTS_DIR,
+} from "@superset/shared/workspace-attachments";
 import { useMutation } from "@tanstack/react-query";
 import { File } from "expo-file-system";
 import { Alert } from "react-native";
 import type { PromptInputAttachmentItem } from "@/components/ai-elements/prompt-input";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
-
-/** Worktree-relative, so the paths read the same to the agent as to the user. */
-const ATTACHMENTS_DIRECTORY = ".superset/attachments";
 
 export interface TerminalAttachmentTarget {
 	workspaceId: string;
@@ -18,41 +19,14 @@ interface WriteArgs {
 	attachments: PromptInputAttachmentItem[];
 }
 
+/**
+ * Generated names keep the uri's extension when the picker gave us no
+ * filename — an extensionless image is one an agent has to guess at.
+ */
 function extensionOf(value: string): string {
 	const name = value.split("?")[0]?.split("/").pop() ?? "";
 	const dot = name.lastIndexOf(".");
 	return dot > 0 ? name.slice(dot) : "";
-}
-
-/**
- * Unique, shell-safe name for one attachment. Falls back to the uri's
- * extension when the picker gave us no filename — an extensionless image is
- * one an agent has to guess at.
- */
-function fileNameFor(
-	attachment: PromptInputAttachmentItem,
-	index: number,
-	used: Set<string>,
-): string {
-	const sanitized = (attachment.name ?? "").replace(/[^a-zA-Z0-9._-]/g, "_");
-	const base = sanitized.trim()
-		? sanitized
-		: `attachment_${index + 1}${extensionOf(attachment.uri)}`;
-
-	if (!used.has(base)) {
-		used.add(base);
-		return base;
-	}
-	const extension = extensionOf(base);
-	const stem = extension ? base.slice(0, -extension.length) : base;
-	let counter = 1;
-	let candidate = `${stem}_${counter}${extension}`;
-	while (used.has(candidate)) {
-		counter += 1;
-		candidate = `${stem}_${counter}${extension}`;
-	}
-	used.add(candidate);
-	return candidate;
 }
 
 /**
@@ -66,7 +40,7 @@ export function useWriteTerminalAttachments() {
 		mutationFn: async ({ target, attachments }: WriteArgs) => {
 			if (attachments.length === 0) return [];
 			const client = getHostServiceClientByUrl(target.hostUrl);
-			const directory = `${target.worktreePath}/${ATTACHMENTS_DIRECTORY}`;
+			const directory = `${target.worktreePath}/${WORKSPACE_ATTACHMENTS_DIR}`;
 			await client.filesystem.createDirectory.mutate({
 				workspaceId: target.workspaceId,
 				absolutePath: directory,
@@ -76,7 +50,12 @@ export function useWriteTerminalAttachments() {
 			const used = new Set<string>();
 			const paths: string[] = [];
 			for (const [index, attachment] of attachments.entries()) {
-				const fileName = fileNameFor(attachment, index, used);
+				const fileName = assignAttachmentFileName({
+					rawName: attachment.name,
+					index,
+					used,
+					fallbackExtension: extensionOf(attachment.uri),
+				});
 				await client.filesystem.writeFile.mutate({
 					workspaceId: target.workspaceId,
 					absolutePath: `${directory}/${fileName}`,
@@ -85,7 +64,7 @@ export function useWriteTerminalAttachments() {
 						data: await new File(attachment.uri).base64(),
 					},
 				});
-				paths.push(`${ATTACHMENTS_DIRECTORY}/${fileName}`);
+				paths.push(`${WORKSPACE_ATTACHMENTS_DIR}/${fileName}`);
 			}
 			return paths;
 		},

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -139,6 +139,19 @@ rebuilt.
 creation — anything assuming a worktree can be created or discarded next to a
 main checkout has nothing to work with.
 
+**There is no clipboard where the PTY runs.** Pasting an image into a terminal
+forwards Ctrl+V and lets the TUI (Claude Code, Codex) read the image from the
+OS clipboard — of the machine the PTY runs on. A sandbox (or any
+relay-reached host) never holds the user's local screenshot, so the paste
+silently did nothing or surfaced "Failed to paste image". Fixed renderer-side:
+for non-local hosts the desktop ships the clipboard bytes over
+`filesystem.writeFile` into the shared `.superset/attachments/` worktree dir
+(the same convention the agent-launch terminal adapter and the mobile
+composer use — mobile proved the pattern) and pastes the worktree-relative
+path instead (`setImagePasteOverride` in the terminal runtime registry).
+Chosen over a new host endpoint because deployed sandboxes never update
+their baked host-service.
+
 ## Lifecycle
 
 **Delete is not wired.** The generic delete routes to the owning host, which

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -136,6 +136,10 @@
 			"types": "./src/agent-launch-request.ts",
 			"default": "./src/agent-launch-request.ts"
 		},
+		"./workspace-attachments": {
+			"types": "./src/workspace-attachments.ts",
+			"default": "./src/workspace-attachments.ts"
+		},
 		"./agent-permissions-migration": {
 			"types": "./src/agent-permissions-migration.ts",
 			"default": "./src/agent-permissions-migration.ts"

--- a/packages/shared/src/agent-launch-request.ts
+++ b/packages/shared/src/agent-launch-request.ts
@@ -9,6 +9,10 @@ import {
 	renderTaskPromptTemplate,
 	type TerminalResolvedAgentConfig,
 } from "./agent-settings";
+import {
+	assignAttachmentFileName,
+	WORKSPACE_ATTACHMENTS_DIR,
+} from "./workspace-attachments";
 
 function getRequiredAgentConfig(
 	configsById: ReadonlyMap<AgentDefinitionId, ResolvedAgentConfig>,
@@ -57,55 +61,21 @@ export function buildPromptAgentLaunchRequest({
 
 	const config = getRequiredAgentConfig(configsById, selectedAgent);
 
-	// For terminal agents with files, append file information to the prompt
-	// Use the same filename sanitization logic as terminal-adapter.ts to ensure paths match
+	// For terminal agents with files, append file information to the prompt.
+	// The writer (terminal-adapter.ts) runs the same assignment over the same
+	// list, so the rendered paths match the files on disk.
 	let enhancedPrompt = prompt;
 	if (initialFiles?.length) {
-		// Track all used filenames to prevent collisions (same logic as terminal-adapter.ts)
 		const usedFilenames = new Set<string>();
 
 		const fileList = initialFiles
 			.map((file, index) => {
-				let filename: string;
-
-				if (!file.filename) {
-					// Generated names: find next available attachment_N
-					let counter = index + 1;
-					do {
-						filename = `attachment_${counter}`;
-						counter++;
-					} while (usedFilenames.has(filename));
-				} else {
-					// Sanitize filename
-					const sanitized = file.filename.replace(/[^a-zA-Z0-9._-]/g, "_");
-
-					// Handle empty sanitized filename (e.g., "!!!" becomes "")
-					if (!sanitized.trim()) {
-						let counter = index + 1;
-						do {
-							filename = `attachment_${counter}`;
-							counter++;
-						} while (usedFilenames.has(filename));
-					} else if (usedFilenames.has(sanitized)) {
-						// Find unique name by appending _1, _2, etc. if needed
-						const parts = sanitized.split(".");
-						const ext = parts.length > 1 ? parts.pop() : undefined;
-						const base = parts.join(".");
-
-						let counter = 1;
-						do {
-							filename = ext
-								? `${base}_${counter}.${ext}`
-								: `${sanitized}_${counter}`;
-							counter++;
-						} while (usedFilenames.has(filename));
-					} else {
-						filename = sanitized;
-					}
-				}
-
-				usedFilenames.add(filename);
-				return `- .superset/attachments/${filename}`;
+				const filename = assignAttachmentFileName({
+					rawName: file.filename,
+					index,
+					used: usedFilenames,
+				});
+				return `- ${WORKSPACE_ATTACHMENTS_DIR}/${filename}`;
 			})
 			.join("\n");
 		// If prompt exists, prepend it; otherwise just use file list

--- a/packages/shared/src/workspace-attachments.test.ts
+++ b/packages/shared/src/workspace-attachments.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import {
+	assignAttachmentFileName,
+	attachmentFallbackName,
+	attachmentNameWithSuffix,
+	sanitizeAttachmentFileName,
+} from "./workspace-attachments";
+
+describe("sanitizeAttachmentFileName", () => {
+	it("keeps safe names and replaces hostile characters", () => {
+		expect(sanitizeAttachmentFileName("image.png")).toBe("image.png");
+		expect(sanitizeAttachmentFileName("../shot: 1/final.png")).toBe(
+			".._shot__1_final.png",
+		);
+	});
+
+	it("returns null when nothing usable survives", () => {
+		expect(sanitizeAttachmentFileName("!!!")).toBe("___");
+		expect(sanitizeAttachmentFileName("   ")).toBe("___");
+		expect(sanitizeAttachmentFileName("")).toBeNull();
+		expect(sanitizeAttachmentFileName(undefined)).toBeNull();
+		expect(sanitizeAttachmentFileName(null)).toBeNull();
+	});
+});
+
+describe("attachmentNameWithSuffix", () => {
+	it("returns the base unchanged for attempt 0", () => {
+		expect(attachmentNameWithSuffix("image.png", 0)).toBe("image.png");
+	});
+
+	it("suffixes before the last extension", () => {
+		expect(attachmentNameWithSuffix("image.png", 1)).toBe("image_1.png");
+		expect(attachmentNameWithSuffix("a.b.png", 2)).toBe("a.b_2.png");
+	});
+
+	it("appends for extensionless and dotfile names", () => {
+		expect(attachmentNameWithSuffix("Makefile", 1)).toBe("Makefile_1");
+		expect(attachmentNameWithSuffix(".bashrc", 1)).toBe(".bashrc_1");
+	});
+});
+
+describe("attachmentFallbackName", () => {
+	it("is 1-based and takes an optional dotted extension", () => {
+		expect(attachmentFallbackName(0)).toBe("attachment_1");
+		expect(attachmentFallbackName(2, ".png")).toBe("attachment_3.png");
+	});
+});
+
+describe("assignAttachmentFileName", () => {
+	it("is deterministic across two independent passes over the same list", () => {
+		// The load-bearing property: the file writer and the prompt renderer
+		// run this separately and must agree on every name.
+		const list = [
+			{ rawName: "image.png" },
+			{ rawName: "image.png" },
+			{ rawName: undefined },
+			{ rawName: "!!!" },
+			{ rawName: "notes.pdf" },
+		];
+		const assign = () => {
+			const used = new Set<string>();
+			return list.map((item, index) =>
+				assignAttachmentFileName({ ...item, index, used }),
+			);
+		};
+		const first = assign();
+		expect(first).toEqual([
+			"image.png",
+			"image_1.png",
+			"attachment_3",
+			"___",
+			"notes.pdf",
+		]);
+		expect(assign()).toEqual(first);
+	});
+
+	it("uses the fallback extension for generated names", () => {
+		const used = new Set<string>();
+		expect(
+			assignAttachmentFileName({
+				rawName: "",
+				index: 0,
+				used,
+				fallbackExtension: ".png",
+			}),
+		).toBe("attachment_1.png");
+	});
+
+	it("dedupes generated names that collide with real ones", () => {
+		const used = new Set<string>();
+		expect(
+			assignAttachmentFileName({ rawName: "attachment_2", index: 0, used }),
+		).toBe("attachment_2");
+		expect(
+			assignAttachmentFileName({ rawName: undefined, index: 1, used }),
+		).toBe("attachment_2_1");
+	});
+});

--- a/packages/shared/src/workspace-attachments.test.ts
+++ b/packages/shared/src/workspace-attachments.test.ts
@@ -21,6 +21,13 @@ describe("sanitizeAttachmentFileName", () => {
 		expect(sanitizeAttachmentFileName(undefined)).toBeNull();
 		expect(sanitizeAttachmentFileName(null)).toBeNull();
 	});
+
+	it("rejects names that resolve to the directory or its parent", () => {
+		expect(sanitizeAttachmentFileName(".")).toBeNull();
+		expect(sanitizeAttachmentFileName("..")).toBeNull();
+		// "..." is a legal (if odd) filename — only the two specials are out.
+		expect(sanitizeAttachmentFileName("...")).toBe("...");
+	});
 });
 
 describe("attachmentNameWithSuffix", () => {
@@ -84,6 +91,16 @@ describe("assignAttachmentFileName", () => {
 				fallbackExtension: ".png",
 			}),
 		).toBe("attachment_1.png");
+	});
+
+	it("dedupes case-insensitively — one path on APFS/NTFS", () => {
+		const used = new Set<string>();
+		expect(
+			assignAttachmentFileName({ rawName: "image.png", index: 0, used }),
+		).toBe("image.png");
+		expect(
+			assignAttachmentFileName({ rawName: "Image.png", index: 1, used }),
+		).toBe("Image_1.png");
 	});
 
 	it("dedupes generated names that collide with real ones", () => {

--- a/packages/shared/src/workspace-attachments.ts
+++ b/packages/shared/src/workspace-attachments.ts
@@ -24,7 +24,11 @@ export function sanitizeAttachmentFileName(
 	raw: string | null | undefined,
 ): string | null {
 	const sanitized = (raw ?? "").replace(/[^a-zA-Z0-9._-]/g, "_");
-	return sanitized.trim() ? sanitized : null;
+	if (!sanitized.trim()) return null;
+	// "." and ".." survive the charset but name the directory itself or its
+	// parent, not a file — send those to the generated-name fallback.
+	if (sanitized === "." || sanitized === "..") return null;
+	return sanitized;
 }
 
 /** Generated name for an attachment with no usable filename (1-based). */
@@ -69,8 +73,12 @@ export function assignAttachmentFileName(input: {
 		attachmentFallbackName(input.index, input.fallbackExtension ?? "");
 	for (let attempt = 0; ; attempt++) {
 		const candidate = attachmentNameWithSuffix(base, attempt);
-		if (!input.used.has(candidate)) {
-			input.used.add(candidate);
+		// Case-insensitive: on APFS/NTFS "image.png" and "Image.png" are the
+		// same path, and a same-batch collision would silently overwrite while
+		// the prompt lists two names.
+		const key = candidate.toLowerCase();
+		if (!input.used.has(key)) {
+			input.used.add(key);
 			return candidate;
 		}
 	}

--- a/packages/shared/src/workspace-attachments.ts
+++ b/packages/shared/src/workspace-attachments.ts
@@ -1,0 +1,77 @@
+/**
+ * The workspace attachments convention: files a prompt references (launch
+ * attachments, mobile composer picks, desktop terminal pastes/drops) are
+ * written into this directory inside the worktree, and agents receive
+ * worktree-relative paths — so the paths read the same to the agent as to
+ * the user.
+ *
+ * The naming here is a correctness coupling, not a style choice: the writer
+ * (e.g. the desktop terminal adapter) and the prompt renderer (e.g.
+ * `agent-launch-request.ts`) must produce byte-identical names for the same
+ * input list, or the prompt points at files that don't exist. Every surface
+ * must go through these helpers rather than reimplementing them.
+ */
+
+/** Worktree-relative directory attachments are written into. */
+export const WORKSPACE_ATTACHMENTS_DIR = ".superset/attachments";
+
+/**
+ * Reduce an untrusted filename (clipboard, picker, upload) to a shell- and
+ * path-safe charset. Returns null when nothing usable survives (e.g. "!!!"),
+ * so callers fall back to a generated name.
+ */
+export function sanitizeAttachmentFileName(
+	raw: string | null | undefined,
+): string | null {
+	const sanitized = (raw ?? "").replace(/[^a-zA-Z0-9._-]/g, "_");
+	return sanitized.trim() ? sanitized : null;
+}
+
+/** Generated name for an attachment with no usable filename (1-based). */
+export function attachmentFallbackName(index: number, extension = ""): string {
+	return `attachment_${index + 1}${extension}`;
+}
+
+/**
+ * The nth candidate name for a base: the base itself, then `stem_n.ext`.
+ * The extension splits on the last dot only when it isn't leading, so
+ * ".bashrc" suffixes to ".bashrc_1", not "_1.bashrc".
+ */
+export function attachmentNameWithSuffix(
+	base: string,
+	attempt: number,
+): string {
+	if (attempt === 0) return base;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return `${base}_${attempt}`;
+	return `${base.slice(0, dot)}_${attempt}${base.slice(dot)}`;
+}
+
+/**
+ * Assign a collision-free name within one batch, recording it in `used`.
+ * Deterministic for a given input list — writers and prompt renderers call
+ * this with the same list and get the same names.
+ *
+ * Batch-local only: it cannot see files already on disk. Surfaces where a
+ * later batch must not overwrite an earlier one (terminal paste) probe the
+ * real directory with `attachmentNameWithSuffix` and create-only writes
+ * instead.
+ */
+export function assignAttachmentFileName(input: {
+	rawName: string | null | undefined;
+	index: number;
+	used: Set<string>;
+	/** Appended to generated names, dot included (e.g. ".png"). */
+	fallbackExtension?: string;
+}): string {
+	const base =
+		sanitizeAttachmentFileName(input.rawName) ??
+		attachmentFallbackName(input.index, input.fallbackExtension ?? "");
+	for (let attempt = 0; ; attempt++) {
+		const candidate = attachmentNameWithSuffix(base, attempt);
+		if (!input.used.has(candidate)) {
+			input.used.add(candidate);
+			return candidate;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Pasting an image (or dropping files) into a terminal whose PTY runs on another machine — a relay-reached host or a cloud sandbox — now uploads the bytes into the workspace and pastes a worktree-relative path, instead of forwarding a Ctrl+V the remote TUI can't do anything with.
- Extracts the `.superset/attachments` naming convention into `@superset/shared/workspace-attachments`, replacing three hand-rolled copies (agent-launch adapter, its prompt renderer, mobile composer) that had to stay byte-identical but were kept in sync only by a comment.

## Why / Context
Image paste forwards `\x16` and lets the TUI (Claude Code, Codex) read the OS clipboard — of the machine the PTY runs on. A remote host or sandbox never holds the user's local screenshot, so the paste silently did nothing (Codex shows "Failed to paste image"). Users hit this on every remote/cloud workspace.

## How It Works
- `TerminalPane` registers a per-terminal `imagePasteOverride` through the runtime registry (same pattern as link handlers; survives runtime eviction) when the workspace's `hostId` isn't this machine's — a cloud sandbox has no host row at all, so "list ready and no row" also counts as remote.
- The override reads the clipboard `File`s, writes them via the existing `filesystem.writeFile` (base64) into `<worktree>/.superset/attachments/` — the same directory agent-launch attachments and mobile composer attachments use — and pastes the shell-escaped worktree-relative paths.
- The directory self-ignores (`.gitignore` containing `*`, create-only) so attachments never dirty git status; this also covers launch/mobile attachments, which previously showed as untracked.
- Uploads are create-only and probe `_1`/`_2` suffixes against the real directory, so a repeat paste never overwrites a file an earlier prompt referenced (the batch-scoped dedupe in launch/mobile can't see prior batches).
- Drag-drop of plain files onto a remote terminal reroutes through the same upload (dropped local paths point at nothing on the remote machine); folder drops and all local-workspace behavior are unchanged.

## Manual QA (done — verified over CDP against the real app)
Stood up a genuinely remote target in dev: a second standalone host-service with a distinct machine identity, registered against the dev API and local relay, and a session workspace created on it through the actual new-workspace UI (Blaxel keys in dev are placeholders, so a real sandbox wasn't reachable; `kind: "sandbox"` takes the same code path as `kind: "remote"` in this change).

- [x] Baseline with the fix disabled: real Cmd+V (image on OS clipboard) pastes nothing, no `.superset` dir created — bug reproduced
- [x] Fix enabled, same gesture: `.superset/attachments/image.png` pasted as bracketed paste; `cksum` on the remote side identical to the clipboard bytes
- [x] `.gitignore` contains `*`; `git status --porcelain` empty; Changes panel shows "No changes"
- [x] Second paste of the same image lands as `image_1.png` (no overwrite), live over the relay
- [x] Local workspace terminal: paste still forwards Ctrl+V, nothing uploaded, no dir created

## Testing
- `bun run typecheck` (desktop, packages/shared)
- `bunx biome check` on all touched files
- `bun test` — desktop full suite (2694 pass), packages/shared (773 pass, includes new `workspace-attachments` determinism tests), mobile (33 pass)
- New unit tests: paste-override routing in the fallback, upload helper (relative paths, gitignore create-only, collision probing, sanitization), shared naming (two independent passes over the same list produce identical names — the writer/renderer contract)
- Mutation-checked the new tests fail when the logic is broken

## Design Decisions
- **Renderer-only instead of a new host endpoint**: deployed sandboxes bake host-service into their image and never update, so a server-side change wouldn't reach the affected users. `filesystem.writeFile` base64 has shipped since March.
- **Worktree dir instead of host temp dir**: `writeFile` is confined to the worktree root by design; the self-ignoring `.gitignore` removes the git-dirt downside.
- **`machineId` + host-workspaces list instead of `useWorkspaceHostTarget`**: that hook mints sandbox access credentials in an effect per consumer; long-lived terminal panes would multiply the broker loop.
- **Directory-probing dedupe instead of the convention's batch-scoped set**: pastes accumulate across a session; overwriting would silently swap an image an earlier prompt referenced.

## Known Limitations
- Not exercised against a real Blaxel sandbox (no real API key in dev); the detection and transport are identical for `kind: "sandbox"`.
- Naming edge changes from the refactor (writer and prompt renderer move in lockstep): dotfiles dedupe as `.bashrc_1` instead of `_1.bashrc`; a generated name colliding with a real `attachment_N` file suffixes instead of incrementing N.

## Follow-ups
- Agent-launch and mobile attachments still overwrite across batches (a second launch attaching another `image.png` clobbers the first one's file). Adopting the paste path's directory probing there is a deliberate behavior change per surface — worth its own ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables image/file paste in remote and cloud workspace terminals by uploading clipboard files into the workspace and pasting worktree‑relative paths. Previously we forwarded Ctrl+V, which remote TUIs could not use.

- Remote terminals: intercept image/file paste and plain-file drag/drop, write via filesystem.writeFile to `WORKSPACE_ATTACHMENTS_DIR` (`.superset/attachments/`), then paste shell‑escaped relative paths; create‑only writes probe `_N` to avoid overwrites; `.gitignore` (`*`) keeps git clean; drop handler guards `webkitGetAsEntry`.
- Runtime/Terminal: add per‑terminal `imagePasteOverride` in the runtime registry; `TerminalPane` enables it only when the workspace host differs from this machine; local terminals keep forwarding Ctrl+V.
- Shared convention: new `@superset/shared/workspace-attachments` exports `WORKSPACE_ATTACHMENTS_DIR` and deterministic filename helpers; desktop agent launch adapter, prompt renderer, mobile composer, and `buildLaunchSpec` updated so writers and renderers produce identical paths.
- Naming and safety: reject `"."`/`".."`; case‑insensitive same‑batch dedupe; dotfiles dedupe as `.bashrc_1`; generated names colliding with a real `attachment_N` now suffix (e.g., `attachment_2_1`); refuse files >50MB and batches >200MB before reading; errors surface as toasts.
- Tests/docs: add override routing and upload coverage (including fast‑fail that does no reads or directory creation); extract `fileToBase64`; document sandbox clipboard mismatch; renderer‑only, no host‑service changes.

<sup>Written for commit cc5d87e0d07dcf51afc87b9943012d0299693667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste images and files into terminals in remote workspaces; uploads are inserted as workspace-relative paths.
  * File drops and clipboard uploads now provide consistent attachment handling across desktop and mobile.
  * Attachment filenames are sanitized and collision-resistant.
  * Uploads are limited to 50 MB per file and 200 MB per batch.
* **Bug Fixes**
  * Improved handling of unsupported clipboard content and upload failures with fallback behavior and error notifications.
* **Documentation**
  * Documented clipboard limitations and attachment handling for remote hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->