### PR TITLE
fix: repair main CI after #6645

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -259,10 +259,10 @@ export function getOpenCodePluginContent(notifyPath: string): string {
 export function createClaudeWrapper(): void {
 	const script = buildWrapperScript(
 		"claude",
-		buildDefaultAccountResolver(
+		`${buildDefaultAccountResolver(
 			"CLAUDE_CONFIG_DIR",
 			"default-claude-config-dir",
-		) + `exec "$REAL_BIN" "$@"`,
+		)}exec "$REAL_BIN" "$@"`,
 		{ agentId: "claude" },
 	);
 	createWrapper("claude", script);

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -321,7 +321,7 @@ describe("buildTerminalAgentLaunch default account env", () => {
 			prompt: "hi",
 		});
 		expect(launch.fullCommand).toBe(
-			`CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
+			`CLAUDE_CONFIG_DIR='${existingDir}' SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
 		);
 	});
 
@@ -334,8 +334,11 @@ describe("buildTerminalAgentLaunch default account env", () => {
 			agent: "claude",
 			prompt: "hi",
 		});
+		// The per-agent value wins for CLAUDE_CONFIG_DIR; the SUPERSET_DEFAULT_*
+		// twin still carries the host default so the wrapper can re-resolve a
+		// later account switch without overriding the user-pinned value.
 		expect(launch.fullCommand).toBe(
-			"CLAUDE_CONFIG_DIR='/pinned/profile' 'claude' 'hi'",
+			`CLAUDE_CONFIG_DIR='/pinned/profile' SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR='${existingDir}' 'claude' 'hi'`,
 		);
 	});
 


### PR DESCRIPTION
Main CI has been red since #6645 merged (its own CI never went green). Two causes, both from that PR:

- `packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts`: string concat with a template literal trips `lint/style/useTemplate`. scripts/lint.sh fails on any diagnostic, info included. Rewritten as a single template literal, output unchanged.
- `packages/host-service/src/trpc/router/agents/agents.test.ts`: two expectations predate the `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR` twin the launcher now injects (the twin marks the value as Superset-injected so the wrapper can re-resolve account switches without overriding user-set values, per default-account.ts). Expectations updated to the intended behavior.

agents.test.ts 27/27, agent-setup suite 151/151, lint.sh clean on both files. Unblocks CI for every open PR, including #6693.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs main CI broken by #6645. Replaces a lint-violating string concatenation with a single template literal and aligns tests with the launcher’s injected `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR`. No runtime behavior change in this PR.

**Changes to review**
- `packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts`: switch to a single template literal to satisfy `lint/style/useTemplate`; generated wrapper script content is unchanged.
- `packages/host-service/src/trpc/router/agents/agents.test.ts`: expectations now include `SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR` alongside `CLAUDE_CONFIG_DIR`. When a per‑agent profile is pinned, `CLAUDE_CONFIG_DIR` uses the pinned path while the `SUPERSET_DEFAULT_*` twin carries the host default.

<sup>Written for commit 38f207e1538a8e2c8b6c6c0500aaab192b9aa940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude account configuration handling so the default configuration directory is consistently included, including when an agent-specific profile is selected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->