### PR TITLE
feat(email): redesign lifecycle emails and branch activation nudges on install

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -255,9 +255,11 @@ export const auth = betterAuth({
 					// diluted intent-to-treat effect would need years to resolve.
 					// Kill switch for the nudges is the Resend automation toggle.
 					try {
+						// The email says "just reply"; a visible noreply@ sender
+						// contradicts that even with replyTo set, so send from the
+						// monitored founders@ address directly.
 						const { error } = await resend.emails.send({
-							from: "Superset <noreply@superset.sh>",
-							replyTo: "founders@superset.sh",
+							from: "Superset <founders@superset.sh>",
 							to: user.email,
 							subject: "Welcome to Superset",
 							react: WelcomeEmail({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -255,11 +255,9 @@ export const auth = betterAuth({
 					// diluted intent-to-treat effect would need years to resolve.
 					// Kill switch for the nudges is the Resend automation toggle.
 					try {
-						// The email says "just reply"; a visible noreply@ sender
-						// contradicts that even with replyTo set, so send from the
-						// monitored founders@ address directly.
 						const { error } = await resend.emails.send({
-							from: "Superset <founders@superset.sh>",
+							from: "Superset <noreply@superset.sh>",
+							replyTo: "founders@superset.sh",
 							to: user.email,
 							subject: "Welcome to Superset",
 							react: WelcomeEmail({

--- a/packages/email/src/components/index.ts
+++ b/packages/email/src/components/index.ts
@@ -1,3 +1,4 @@
 export { EmailLayout, emailTheme } from "./layout/EmailLayout";
 export { PersonalLayout } from "./layout/PersonalLayout";
 export { Button } from "./ui/Button";
+export { DetailRow } from "./ui/DetailRow";

--- a/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
+++ b/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
@@ -1,6 +1,5 @@
 import {
 	Body,
-	Column,
 	Container,
 	Head,
 	Hr,
@@ -8,7 +7,6 @@ import {
 	Img,
 	Link,
 	Preview,
-	Row,
 	Section,
 	Text,
 } from "@react-email/components";
@@ -20,19 +18,17 @@ export const emailTheme = {
 	colors: {
 		background: "#FFFFFF",
 		foreground: "#242424",
-		muted: "#515759",
+		muted: "#51575A",
+		faint: "#A3A39E",
 		border: "#EBEBEB",
 		surface: "#F7F7F7",
-		primary: "#343434",
-		footer: "#000000",
-		footerText: "#FFFFFF",
-		footerMuted: "#A3A3A3",
+		primary: "#242424",
 	},
 	fonts: {
 		sans: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
 		mono: "'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace",
 	},
-	width: 640,
+	width: 560,
 } as const;
 
 interface EmailLayoutProps {
@@ -44,10 +40,9 @@ interface EmailLayoutProps {
 
 const footerText = {
 	margin: 0,
-	fontFamily: emailTheme.fonts.sans,
 	fontSize: "12px",
-	lineHeight: "16px",
-	color: emailTheme.colors.footerMuted,
+	lineHeight: "20px",
+	color: emailTheme.colors.faint,
 } as const;
 
 export function EmailLayout({
@@ -70,6 +65,7 @@ export function EmailLayout({
 								foreground: emailTheme.colors.foreground,
 								primary: emailTheme.colors.primary,
 								muted: emailTheme.colors.muted,
+								faint: emailTheme.colors.faint,
 								border: emailTheme.colors.border,
 								surface: emailTheme.colors.surface,
 							},
@@ -89,135 +85,50 @@ export function EmailLayout({
 						style={{
 							margin: "0 auto",
 							maxWidth: `${emailTheme.width}px`,
-							backgroundColor: emailTheme.colors.background,
+							padding: "40px 24px 48px",
 						}}
 					>
-						<Section
-							style={{
-								backgroundColor: emailTheme.colors.footer,
-								padding: "26px 0",
-								textAlign: "center",
-							}}
-						>
-							<Img
-								src={`${assets}/logo-full-white.png`}
-								alt="Superset"
-								width="150"
-								style={{ margin: "0 auto" }}
-							/>
-						</Section>
+						<Img src={`${assets}/logo-full.png`} alt="Superset" width="116" />
 
-						<Section className="px-9 py-8">{children}</Section>
+						<Section style={{ paddingTop: "32px" }}>{children}</Section>
 
-						<Section
+						<Hr
 							style={{
-								backgroundColor: emailTheme.colors.footer,
-								padding: "48px 40px 56px 40px",
+								borderTop: `1px solid ${emailTheme.colors.border}`,
+								borderBottom: "none",
+								margin: "40px 0 20px",
 							}}
-						>
-							<Row>
-								<Column style={{ width: "50%", verticalAlign: "top" }}>
-									<Img
-										src={`${assets}/logo-full-white.png`}
-										alt="Superset"
-										width="232"
-									/>
-								</Column>
-								<Column style={{ width: "50%", verticalAlign: "top" }}>
-									<Section style={{ width: "248px", margin: "0 auto" }}>
-										<Row>
-											<Column style={{ width: "25%", textAlign: "center" }}>
-												<Link href="https://instagram.com/superset">
-													<Img
-														src={`${assets}/icon-instagram-white.png`}
-														alt="Instagram"
-														width="32"
-														height="32"
-														style={{ display: "inline-block" }}
-													/>
-												</Link>
-											</Column>
-											<Column style={{ width: "25%", textAlign: "center" }}>
-												<Link href="https://www.linkedin.com/company/superset-sh">
-													<Img
-														src={`${assets}/icon-linkedin-white.png`}
-														alt="LinkedIn"
-														width="32"
-														height="32"
-														style={{ display: "inline-block" }}
-													/>
-												</Link>
-											</Column>
-											<Column style={{ width: "25%", textAlign: "center" }}>
-												<Link href="https://x.com/superset_sh">
-													<Img
-														src={`${assets}/icon-x-white.png`}
-														alt="X"
-														width="32"
-														height="32"
-														style={{ display: "inline-block" }}
-													/>
-												</Link>
-											</Column>
-											<Column style={{ width: "25%", textAlign: "center" }}>
-												<Link href="https://www.youtube.com/@superset-sh">
-													<Img
-														src={`${assets}/icon-youtube-white.png`}
-														alt="YouTube"
-														width="32"
-														height="32"
-														style={{ display: "inline-block" }}
-													/>
-												</Link>
-											</Column>
-										</Row>
-										<Hr
-											style={{
-												borderTop: "solid 1px #C2C0B6",
-												borderBottom: "none",
-												width: "100%",
-												margin: "34px 0 18px 0",
-											}}
-										/>
-										<Text style={{ ...footerText, marginBottom: "8px" }}>
-											Superset, Inc., San Francisco, CA
-										</Text>
-										<Text style={footerText}>
-											{recipientEmail ? (
-												<>
-													This email was sent to{" "}
-													<Link
-														href={`mailto:${recipientEmail}`}
-														style={{
-															color: "#8CA6DE",
-															textDecoration: "underline",
-														}}
-													>
-														{recipientEmail}
-													</Link>
-													.{" "}
-												</>
-											) : null}
-											{unsubscribeUrl ? (
-												<>
-													To opt out of future emails, click{" "}
-													<Link
-														href={unsubscribeUrl}
-														style={{
-															color: emailTheme.colors.footerMuted,
-															textDecoration: "underline",
-														}}
-													>
-														unsubscribe
-													</Link>
-													.
-												</>
-											) : null}
-										</Text>
-									</Section>
-								</Column>
-							</Row>
-						</Section>
+						/>
+						<Text style={footerText}>
+							<Link
+								href="https://superset.sh"
+								style={{
+									color: emailTheme.colors.faint,
+									textDecoration: "none",
+								}}
+							>
+								Superset
+							</Link>
+							, Inc., San Francisco, CA
+						</Text>
+						{recipientEmail || unsubscribeUrl ? (
+							<Text style={footerText}>
+								{recipientEmail ? (
+									<>This email was sent to {recipientEmail}. </>
+								) : null}
+								{unsubscribeUrl ? (
+									<Link
+										href={unsubscribeUrl}
+										style={{
+											color: emailTheme.colors.faint,
+											textDecoration: "underline",
+										}}
+									>
+										Unsubscribe
+									</Link>
+								) : null}
+							</Text>
+						) : null}
 					</Container>
 				</Body>
 			</Tailwind>

--- a/packages/email/src/components/ui/Button/Button.tsx
+++ b/packages/email/src/components/ui/Button/Button.tsx
@@ -10,8 +10,8 @@ interface ButtonProps {
 export function Button({ href, children, variant = "primary" }: ButtonProps) {
 	const className =
 		variant === "primary"
-			? "inline-block rounded-lg bg-primary text-white px-6 py-3 text-base font-semibold no-underline text-center"
-			: "inline-block rounded-lg bg-white border border-border text-foreground px-6 py-3 text-base font-semibold no-underline text-center";
+			? "inline-block rounded-md bg-primary text-white px-5 py-3 text-[14px] font-medium no-underline text-center"
+			: "inline-block rounded-md bg-white border border-solid border-border text-foreground px-5 py-3 text-[14px] font-medium no-underline text-center";
 
 	return (
 		<ReactEmailButton href={href} className={className}>

--- a/packages/email/src/components/ui/DetailRow/DetailRow.tsx
+++ b/packages/email/src/components/ui/DetailRow/DetailRow.tsx
@@ -1,0 +1,21 @@
+import { Column, Row, Text } from "@react-email/components";
+
+interface DetailRowProps {
+	label: string;
+	value: string;
+}
+
+export function DetailRow({ label, value }: DetailRowProps) {
+	return (
+		<Row>
+			<Column>
+				<Text className="text-[13px] leading-7 text-muted m-0">{label}</Text>
+			</Column>
+			<Column align="right">
+				<Text className="text-[14px] leading-7 text-foreground m-0">
+					{value}
+				</Text>
+			</Column>
+		</Row>
+	);
+}

--- a/packages/email/src/components/ui/DetailRow/index.ts
+++ b/packages/email/src/components/ui/DetailRow/index.ts
@@ -1,0 +1,1 @@
+export { DetailRow } from "./DetailRow";

--- a/packages/email/src/emails/activation/00-welcome.tsx
+++ b/packages/email/src/emails/activation/00-welcome.tsx
@@ -20,30 +20,27 @@ export function WelcomeEmail({ userEmail }: WelcomeEmailProps = {}) {
 			preview="They do the work. You review the diffs."
 			recipientEmail={userEmail}
 		>
-			<Heading className="text-[28px] font-semibold leading-9 text-foreground text-center mt-2 mb-2">
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-3">
 				Welcome to Superset
 			</Heading>
-			<Text className="text-base leading-6 text-muted text-center m-0 mb-8">
-				Run coding agents in parallel, each in an isolated copy of your repo.
-				<br />
-				They do the work. You review the diffs.
+			<Text className="text-[15px] leading-6 text-muted m-0 mb-6">
+				Run Claude Code, Codex, or any CLI agent in parallel, each in an
+				isolated copy of your repo. They do the work. You review the diffs.
 			</Text>
 
-			<Section className="bg-surface border border-solid border-border rounded-2xl p-4 mb-8">
-				<a href={`${DOWNLOAD}${utm("hero-image")}`}>
-					<Img
-						src={`${assets}/welcome-hero.png`}
-						alt="Superset running coding agents across parallel workspaces"
-						width="536"
-						className="w-full rounded-lg"
-					/>
-				</a>
-			</Section>
+			<a href={`${DOWNLOAD}${utm("hero-image")}`}>
+				<Img
+					src={`${assets}/welcome-hero.png`}
+					alt="Superset running coding agents across parallel workspaces"
+					width="512"
+					className="w-full rounded-lg mb-6"
+				/>
+			</a>
 
-			<Text className="text-base leading-6 text-foreground m-0 mb-2 font-semibold">
+			<Text className="text-[15px] leading-6 text-foreground font-medium m-0 mb-2">
 				Two minutes to your first agent:
 			</Text>
-			<Text className="text-base leading-[26px] text-foreground m-0 mb-8">
+			<Text className="text-[15px] leading-7 text-foreground m-0 mb-6">
 				1. Get the desktop app
 				<br />
 				2. Open a repo you&apos;re working on
@@ -51,14 +48,14 @@ export function WelcomeEmail({ userEmail }: WelcomeEmailProps = {}) {
 				3. Type the thing you were going to do anyway
 			</Text>
 
-			<Section className="text-center mb-8">
+			<Section className="mb-8">
 				<Button href={`${DOWNLOAD}${utm("hero-cta")}`}>
 					Download Superset
 				</Button>
 			</Section>
 
-			<Text className="text-base leading-6 text-muted text-center m-0">
-				Questions? Just reply — a founder reads every message.
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				Questions? Just reply. A founder reads every message.
 			</Text>
 		</EmailLayout>
 	);

--- a/packages/email/src/emails/activation/01-first-agent.tsx
+++ b/packages/email/src/emails/activation/01-first-agent.tsx
@@ -19,36 +19,37 @@ export function ActivationNudge1({
 			recipientEmail={userEmail}
 			unsubscribeUrl={unsubscribeUrl}
 		>
-			<Heading className="text-[28px] font-semibold leading-9 text-foreground text-center mt-2 mb-2">
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-3">
 				Your first agent, safely
 			</Heading>
-			<Text className="text-base leading-6 text-muted text-center m-0 mb-8">
+			<Text className="text-[15px] leading-6 text-muted m-0 mb-6">
 				The part most people don&apos;t realize: the agent never touches your
 				working tree.
 			</Text>
 
-			<Section className="bg-surface border border-solid border-border rounded-2xl p-6 mb-8">
-				<Text className="text-base leading-[26px] text-foreground m-0 mb-3">
+			<Section className="bg-surface border border-solid border-border rounded-lg p-5 mb-6">
+				<Text className="text-[15px] leading-6 text-foreground m-0 mb-3">
 					<strong>Every workspace is an isolated copy of your repo</strong> on
 					its own branch. Your checkout, your uncommitted changes, your local
-					state — untouched.
+					state all stay untouched.
 				</Text>
-				<Text className="text-base leading-[26px] text-foreground m-0">
-					If the result is garbage, delete the workspace.
-					<br />
-					Nothing happened.
+				<Text className="text-[15px] leading-6 text-foreground m-0">
+					If the result is garbage, delete the workspace. Nothing happened.
 				</Text>
 			</Section>
 
-			<Text className="text-base leading-6 text-foreground m-0 mb-2 font-semibold">
-				So take the first swing on something small:
-			</Text>
-			<Text className="text-base leading-[26px] text-foreground m-0 mb-8">
-				A flaky test. A TODO. The rename you&apos;ve been putting off. Something
-				you were going to do anyway this week.
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				And it&apos;s all local. Your code never leaves your machine unless you
+				say so.
 			</Text>
 
-			<Section className="text-center mb-2">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				So take the first swing on something small: a flaky test, or the rename
+				you&apos;ve been putting off. Something you were going to do anyway this
+				week.
+			</Text>
+
+			<Section>
 				<Button href={`https://superset.sh/download${utm}`}>
 					Get the desktop app
 				</Button>

--- a/packages/email/src/emails/activation/01b-first-prompt.tsx
+++ b/packages/email/src/emails/activation/01b-first-prompt.tsx
@@ -1,0 +1,56 @@
+import { Heading, Section, Text } from "@react-email/components";
+import { EmailLayout, emailTheme } from "../../components";
+
+// Sent instead of 01-first-agent when the Resend automation has seen
+// `app.first_opened`: the user installed the app but hasn't created a
+// workspace, so the nudge is a paste-able first prompt, not a download link.
+
+interface ActivationNudge1InstalledProps {
+	userEmail?: string;
+	unsubscribeUrl?: string;
+}
+
+export function ActivationNudge1Installed({
+	userEmail,
+	unsubscribeUrl,
+}: ActivationNudge1InstalledProps = {}) {
+	return (
+		<EmailLayout
+			preview="Open a repo and paste this."
+			recipientEmail={userEmail}
+			unsubscribeUrl={unsubscribeUrl}
+		>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-3">
+				Your first agent is one prompt away
+			</Heading>
+			<Text className="text-[15px] leading-6 text-muted m-0 mb-6">
+				You&apos;ve got the app. The next step takes two minutes.
+			</Text>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+				Open a repo you&apos;re working on, create a workspace, and paste this:
+			</Text>
+
+			<Section className="bg-surface border border-solid border-border rounded-lg p-5 mb-6">
+				<Text
+					className="text-[13px] leading-6 text-foreground m-0"
+					style={{ fontFamily: emailTheme.fonts.mono }}
+				>
+					Find a small bug in this repo and fix it. Explain the bug and the fix
+					in your final message.
+				</Text>
+			</Section>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				The agent works in an isolated copy of your repo, so your checkout stays
+				untouched. If the result is garbage, delete the workspace.
+			</Text>
+
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				Stuck on anything? Just reply. A founder reads every message.
+			</Text>
+		</EmailLayout>
+	);
+}
+
+export default ActivationNudge1Installed;

--- a/packages/email/src/emails/activation/02-parallel.tsx
+++ b/packages/email/src/emails/activation/02-parallel.tsx
@@ -1,0 +1,63 @@
+import { Heading, Link, Section, Text } from "@react-email/components";
+import { EmailLayout } from "../../components";
+
+// Sent after the first workspace exists. The isolation nudge removes fear;
+// this one escalates to the actual habit: several agents running at once.
+
+interface ActivationNudge2ParallelProps {
+	userEmail?: string;
+	unsubscribeUrl?: string;
+}
+
+export function ActivationNudge2Parallel({
+	userEmail,
+	unsubscribeUrl,
+}: ActivationNudge2ParallelProps = {}) {
+	return (
+		<EmailLayout
+			preview="Queue three tasks before your next meeting."
+			recipientEmail={userEmail}
+			unsubscribeUrl={unsubscribeUrl}
+		>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-3">
+				The day it clicks
+			</Heading>
+			<Text className="text-[15px] leading-6 text-muted m-0 mb-6">
+				Superset gets good the day you stop watching one agent work.
+			</Text>
+
+			<Section className="bg-surface border border-solid border-border rounded-lg p-5 mb-6">
+				<Text className="text-[15px] leading-6 text-foreground m-0 mb-3">
+					<strong>Before your next meeting, kick off three workspaces:</strong>{" "}
+					the bug you were assigned, the rename you&apos;ve been avoiding, and
+					the doc nobody updated.
+				</Text>
+				<Text className="text-[15px] leading-6 text-foreground m-0">
+					Each runs in its own copy of your repo. Review the diffs when
+					you&apos;re back.
+				</Text>
+			</Section>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				Agents do the work in parallel. You review the diffs and spend your time
+				shipping, not waiting.
+			</Text>
+
+			<Text className="text-[13px] leading-5 text-muted m-0 mb-2">
+				Prefer a guided run? The{" "}
+				<Link
+					href="https://docs.superset.sh/first-workspace"
+					className="text-muted underline"
+				>
+					ten-minute tutorial
+				</Link>{" "}
+				races three agents on one prompt and ships the winner.
+			</Text>
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				Questions? Just reply. A founder reads every message.
+			</Text>
+		</EmailLayout>
+	);
+}
+
+export default ActivationNudge2Parallel;

--- a/packages/email/src/emails/activation/03-founder-note.tsx
+++ b/packages/email/src/emails/activation/03-founder-note.tsx
@@ -27,13 +27,14 @@ export function ActivationNudge2({
 					running yet.
 				</Text>
 				<Text style={paragraph}>
-					No worries at all — I&apos;m just trying to understand where people
-					get stuck. Was it the download? Setup? Not wanting to point an agent
-					at your repo yet? Just busy?
+					No worries at all, I&apos;m just trying to understand where people get
+					stuck. Was it the download? Setup? Not wanting to point an agent at
+					your repo yet? Just busy?
 				</Text>
 				<Text style={paragraph}>
-					Even a one-line reply helps us a lot. And if you hit something broken,
-					tell me and I&apos;ll get it fixed this week.
+					Even a one-word reply helps: download, setup, trust, or busy. And if
+					you hit something broken, tell me and I&apos;ll get it fixed this
+					week.
 				</Text>
 				<Text style={{ ...paragraph, margin: 0 }}>Kiet</Text>
 			</Body>

--- a/packages/email/src/emails/activation/04-automations.tsx
+++ b/packages/email/src/emails/activation/04-automations.tsx
@@ -1,0 +1,52 @@
+import { Heading, Section, Text } from "@react-email/components";
+import { Button, EmailLayout } from "../../components";
+
+// Week-2 habit email in the post-activation automation: the most
+// differentiated retention hook, scheduled agents that produce a reviewable
+// workspace while you're away.
+
+interface ActivationNudge3AutomationsProps {
+	userEmail?: string;
+	unsubscribeUrl?: string;
+}
+
+export function ActivationNudge3Automations({
+	userEmail,
+	unsubscribeUrl,
+}: ActivationNudge3AutomationsProps = {}) {
+	return (
+		<EmailLayout
+			preview="Wake up to a reviewable workspace."
+			recipientEmail={userEmail}
+			unsubscribeUrl={unsubscribeUrl}
+		>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-3">
+				Put a chore on a schedule
+			</Heading>
+			<Text className="text-[15px] leading-6 text-muted m-0 mb-6">
+				Agents don&apos;t need you awake.
+			</Text>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-3">
+				<strong>Pick something recurring:</strong> issue triage, changelog
+				drafts, dependency bumps. Create an automation and Superset runs an
+				agent on schedule, each run in its own workspace.
+			</Text>
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				You wake up to a diff to review, not a task to start.
+			</Text>
+
+			<Section className="mb-8">
+				<Button href="https://docs.superset.sh/automations">
+					See how automations work
+				</Button>
+			</Section>
+
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				Questions? Just reply. A founder reads every message.
+			</Text>
+		</EmailLayout>
+	);
+}
+
+export default ActivationNudge3Automations;

--- a/packages/email/src/emails/billing/member-added.tsx
+++ b/packages/email/src/emails/billing/member-added.tsx
@@ -1,5 +1,5 @@
-import { Heading, Section, Text } from "@react-email/components";
-import { EmailLayout } from "../../components";
+import { Heading, Hr, Text } from "@react-email/components";
+import { DetailRow, EmailLayout } from "../../components";
 
 interface MemberAddedBillingEmailProps {
 	ownerName?: string | null;
@@ -24,45 +24,30 @@ export function MemberAddedBillingEmail({
 		<EmailLayout
 			preview={`Billing update: ${newMemberName} was added to ${organizationName}`}
 		>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				New member added to <strong>{organizationName}</strong>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				New member added to {organizationName}
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {ownerName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				{addedByName} added a new member to <strong>{organizationName}</strong>:
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+				{addedByName} added <strong>{newMemberName}</strong> ({newMemberEmail})
+				to <strong>{organizationName}</strong>. Your subscription has been
+				updated:
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>{newMemberName}</strong>
-				</Text>
-				<Text className="text-sm leading-5 text-muted m-0">
-					{newMemberEmail}
-				</Text>
-			</Section>
+			<Hr className="border-border my-4" />
+			<DetailRow label="Seats" value={String(newSeatCount)} />
+			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			<Hr className="border-border my-4" />
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				Your subscription has been updated:
+			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
+				Your next invoice will include the prorated amount.
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Seats:</strong> {newSeatCount}
-				</Text>
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>New monthly total:</strong> {newMonthlyTotal}
-				</Text>
-			</Section>
-
-			<Text className="text-sm leading-5 text-muted mb-4">
-				The prorated amount will be reflected in your next invoice.
-			</Text>
-
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				You're receiving this because you're an owner of {organizationName}.
 			</Text>
 		</EmailLayout>

--- a/packages/email/src/emails/billing/member-removed.tsx
+++ b/packages/email/src/emails/billing/member-removed.tsx
@@ -1,5 +1,5 @@
-import { Heading, Section, Text } from "@react-email/components";
-import { EmailLayout } from "../../components";
+import { Heading, Hr, Text } from "@react-email/components";
+import { DetailRow, EmailLayout } from "../../components";
 
 interface MemberRemovedBillingEmailProps {
 	ownerName?: string | null;
@@ -24,46 +24,30 @@ export function MemberRemovedBillingEmail({
 		<EmailLayout
 			preview={`Billing update: ${removedMemberName} was removed from ${organizationName}`}
 		>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				Member removed from <strong>{organizationName}</strong>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				Member removed from {organizationName}
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {ownerName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				{removedByName} removed a member from{" "}
-				<strong>{organizationName}</strong>:
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+				{removedByName} removed <strong>{removedMemberName}</strong> (
+				{removedMemberEmail}) from <strong>{organizationName}</strong>. Your
+				subscription has been updated:
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>{removedMemberName}</strong>
-				</Text>
-				<Text className="text-sm leading-5 text-muted m-0">
-					{removedMemberEmail}
-				</Text>
-			</Section>
+			<Hr className="border-border my-4" />
+			<DetailRow label="Seats" value={String(newSeatCount)} />
+			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			<Hr className="border-border my-4" />
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				Your subscription has been updated:
+			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
+				Your next invoice will include a credit for the unused time.
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Seats:</strong> {newSeatCount}
-				</Text>
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>New monthly total:</strong> {newMonthlyTotal}
-				</Text>
-			</Section>
-
-			<Text className="text-sm leading-5 text-muted mb-4">
-				A credit will be applied to your next invoice for the unused time.
-			</Text>
-
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				You're receiving this because you're an owner of {organizationName}.
 			</Text>
 		</EmailLayout>

--- a/packages/email/src/emails/billing/payment-failed.tsx
+++ b/packages/email/src/emails/billing/payment-failed.tsx
@@ -20,62 +20,55 @@ export function PaymentFailedEmail({
 }: PaymentFailedEmailProps) {
 	return (
 		<EmailLayout preview={`Payment failed for ${organizationName}`}>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
 				Payment failed
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {ownerName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				We were unable to process the payment of <strong>{amount}</strong> for{" "}
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+				We couldn't process the <strong>{amount}</strong> payment for{" "}
 				<strong>{organizationName}</strong>'s <strong>{planName}</strong>{" "}
 				subscription.
 			</Text>
 
-			<Section className="bg-[#fef2f2] border border-[#fecaca] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-[#991b1b] m-0">
-					<strong>Action required:</strong> Please update your payment method to
-					avoid service interruption.
+			<Section className="bg-[#fef2f2] border border-solid border-[#fecaca] rounded-lg p-4 mb-4">
+				<Text className="text-[14px] leading-5 text-[#991b1b] m-0">
+					<strong>Action required:</strong> Update your payment method so your
+					team doesn't lose {planName} access.
 				</Text>
 			</Section>
 
 			{nextRetryDate && (
-				<Text className="text-base leading-[26px] text-foreground mb-4">
-					We'll automatically retry the payment in a few days. To avoid any
-					disruption, please update your payment method now.
+				<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+					We'll automatically retry the payment in a few days.
 				</Text>
 			)}
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
 				Common reasons for payment failure:
 			</Text>
 
-			<Text className="text-sm leading-6 text-muted mb-1">
+			<Text className="text-[13px] leading-6 text-muted m-0 mb-6">
 				• Card expired or about to expire
-			</Text>
-			<Text className="text-sm leading-6 text-muted mb-1">
-				• Insufficient funds
-			</Text>
-			<Text className="text-sm leading-6 text-muted mb-1">
-				• Card blocked by your bank
-			</Text>
-			<Text className="text-sm leading-6 text-muted mb-4">
-				• Incorrect billing information
+				<br />• Insufficient funds
+				<br />• Card blocked by your bank
+				<br />• Incorrect billing information
 			</Text>
 
 			{billingPortalUrl && (
-				<Section className="mt-6 mb-6">
+				<Section className="mb-6">
 					<Button href={billingPortalUrl}>Update Payment Method</Button>
 				</Section>
 			)}
 
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				Need help?{" "}
 				<Link
 					href="mailto:support@superset.sh"
-					className="text-primary no-underline"
+					className="text-muted underline"
 				>
 					Contact our support team
 				</Link>{" "}

--- a/packages/email/src/emails/billing/subscription-cancelled.tsx
+++ b/packages/email/src/emails/billing/subscription-cancelled.tsx
@@ -1,6 +1,6 @@
-import { Heading, Link, Section, Text } from "@react-email/components";
+import { Heading, Hr, Link, Section, Text } from "@react-email/components";
 import { format } from "date-fns";
-import { Button, EmailLayout } from "../../components";
+import { Button, DetailRow, EmailLayout } from "../../components";
 
 interface SubscriptionCancelledEmailProps {
 	ownerName?: string | null;
@@ -21,50 +21,48 @@ export function SubscriptionCancelledEmail({
 
 	return (
 		<EmailLayout preview={`Your ${planName} subscription has been cancelled`}>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
 				Subscription cancelled
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {ownerName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
 				Your <strong>{planName}</strong> subscription for{" "}
 				<strong>{organizationName}</strong> has been cancelled.
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Access until:</strong> {formattedEndDate}
-				</Text>
-			</Section>
+			<Hr className="border-border my-4" />
+			<DetailRow label="Access until" value={formattedEndDate} />
+			<Hr className="border-border my-4" />
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				You'll continue to have access to all {planName} features until{" "}
-				{formattedEndDate}. After that, your organization will be moved to the
-				free plan.
+				{formattedEndDate}. After that, your organization moves to the free
+				plan.
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
 				Changed your mind? You can resubscribe anytime before your access ends.
 			</Text>
 
 			{billingPortalUrl && (
-				<Section className="mt-6 mb-6">
+				<Section className="mb-6">
 					<Button href={billingPortalUrl}>Resubscribe</Button>
 				</Section>
 			)}
 
-			<Text className="text-xs leading-5 text-muted">
-				We'd love to hear your feedback.{" "}
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				Something not working?{" "}
 				<Link
 					href="mailto:support@superset.sh"
-					className="text-primary no-underline"
+					className="text-muted underline"
 				>
-					Let us know
+					Tell us
 				</Link>{" "}
-				why you cancelled so we can improve.
+				and we'll fix it.
 			</Text>
 		</EmailLayout>
 	);

--- a/packages/email/src/emails/billing/subscription-started.tsx
+++ b/packages/email/src/emails/billing/subscription-started.tsx
@@ -1,5 +1,5 @@
-import { Heading, Section, Text } from "@react-email/components";
-import { EmailLayout } from "../../components";
+import { Heading, Hr, Text } from "@react-email/components";
+import { DetailRow, EmailLayout } from "../../components";
 
 interface SubscriptionStartedEmailProps {
 	ownerName?: string | null;
@@ -22,49 +22,36 @@ export function SubscriptionStartedEmail({
 
 	return (
 		<EmailLayout preview={`Welcome to Superset ${planName}!`}>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				Welcome to <strong>Superset {planName}</strong>! 🎉
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				Welcome to Superset {planName}
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {ownerName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
 				Thanks for upgrading <strong>{organizationName}</strong> to the{" "}
 				<strong>{planName}</strong> plan. Your subscription is now active.
 			</Text>
 
-			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Plan:</strong> {planName}
-				</Text>
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Billing:</strong> {amount}/{intervalText}
-				</Text>
-				<Text className="text-sm leading-5 text-foreground m-0">
-					<strong>Seats:</strong> {seatCount}
-				</Text>
-			</Section>
+			<Hr className="border-border my-4" />
+			<DetailRow label="Plan" value={planName} />
+			<DetailRow label="Billing" value={`${amount}/${intervalText}`} />
+			<DetailRow label="Seats" value={String(seatCount)} />
+			<Hr className="border-border my-4" />
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				With {planName}, you now have access to:
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+				{planName} includes:
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-1">
+			<Text className="text-[15px] leading-7 text-foreground m-0 mb-6">
 				✓ Unlimited team members
-			</Text>
-			<Text className="text-base leading-[26px] text-foreground mb-1">
-				✓ Advanced workflow automation
-			</Text>
-			<Text className="text-base leading-[26px] text-foreground mb-1">
-				✓ Priority support
-			</Text>
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				✓ And much more...
+				<br />✓ Remote workspaces
+				<br />✓ Linear and Slack integrations
 			</Text>
 
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				You're receiving this because you're an owner of {organizationName}.
 			</Text>
 		</EmailLayout>

--- a/packages/email/src/emails/team/invitation.tsx
+++ b/packages/email/src/emails/team/invitation.tsx
@@ -23,7 +23,6 @@ export function OrganizationInvitationEmail({
 }: OrganizationInvitationEmailProps) {
 	const roleDisplay = role === "member" ? "Member" : "Admin";
 
-	// Calculate days until expiration
 	const daysUntilExpiration = differenceInDays(expiresAt, new Date());
 	const expirationText =
 		daysUntilExpiration === 1 ? "1 day" : `${daysUntilExpiration} days`;
@@ -32,42 +31,42 @@ export function OrganizationInvitationEmail({
 		<EmailLayout
 			preview={`${inviterName} invited you to join ${organizationName}`}
 		>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				Join <strong>{organizationName}</strong> on <strong>Superset</strong>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				Join {organizationName} on Superset
 			</Heading>
 
 			{inviteeName && (
-				<Text className="text-base leading-[26px] mb-4 text-foreground">
+				<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 					Hi {inviteeName},
 				</Text>
 			)}
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				{inviterName} ({inviterEmail}) has invited you to join{" "}
 				<strong>{organizationName}</strong> on Superset as a{" "}
 				<strong>{roleDisplay}</strong>.
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				Superset helps teams automate workflows, manage tasks, and collaborate
-				effectively. Accept this invitation to get started.
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				Superset runs coding agents in parallel, each in an isolated copy of
+				your repo. Accept the invite to work alongside your team.
 			</Text>
 
-			<Section className="mt-6 mb-6">
+			<Section className="mb-6">
 				<Button href={inviteLink}>Accept Invitation</Button>
 			</Section>
 
-			<Text className="text-xs leading-5 text-muted mt-4 mb-2">
+			<Text className="text-[13px] leading-5 text-muted m-0 mb-1">
 				Or copy and paste this URL into your browser:
 			</Text>
 			<Link
 				href={inviteLink}
-				className="text-sm leading-6 text-primary break-all block mb-6 no-underline"
+				className="text-[13px] leading-5 text-muted underline break-all block mb-6"
 			>
 				{inviteLink}
 			</Link>
 
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				This invitation expires in {expirationText}. If you didn't expect this
 				invitation, you can safely ignore this email.
 			</Text>

--- a/packages/email/src/emails/team/member-added.tsx
+++ b/packages/email/src/emails/team/member-added.tsx
@@ -21,29 +21,29 @@ export function MemberAddedEmail({
 
 	return (
 		<EmailLayout preview={`You've been added to ${organizationName}`}>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				You're now part of <strong>{organizationName}</strong>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				You're now part of {organizationName}
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {memberName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				{addedByName} has added you to <strong>{organizationName}</strong> on
 				Superset as a <strong>{roleDisplay}</strong>.
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				You now have access to the team's workspaces, tasks, and workflows. Head
-				over to your dashboard to get started.
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				You now have access to the team's projects and workspaces. Open Superset
+				to get started.
 			</Text>
 
-			<Section className="mt-6 mb-6">
-				<Button href={dashboardLink}>Go to Dashboard</Button>
+			<Section className="mb-6">
+				<Button href={dashboardLink}>Open Superset</Button>
 			</Section>
 
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				If you have any questions, reach out to {addedByName} or your team
 				administrator.
 			</Text>

--- a/packages/email/src/emails/team/member-removed.tsx
+++ b/packages/email/src/emails/team/member-removed.tsx
@@ -14,25 +14,24 @@ export function MemberRemovedEmail({
 }: MemberRemovedEmailProps) {
 	return (
 		<EmailLayout preview={`You've been removed from ${organizationName}`}>
-			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
-				You've been removed from <strong>{organizationName}</strong>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				You've been removed from {organizationName}
 			</Heading>
 
-			<Text className="text-base leading-[26px] mb-4 text-foreground">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {memberName ?? "there"},
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				{removedByName} has removed you from <strong>{organizationName}</strong>{" "}
 				on Superset.
 			</Text>
 
-			<Text className="text-base leading-[26px] text-foreground mb-4">
-				You no longer have access to this organization's workspaces, tasks, or
-				workflows.
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+				You no longer have access to this organization's projects or workspaces.
 			</Text>
 
-			<Text className="text-xs leading-5 text-muted">
+			<Text className="text-[13px] leading-5 text-muted m-0">
 				If you believe this was a mistake, please contact {removedByName} or
 				your team administrator.
 			</Text>

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -1,5 +1,10 @@
 import { db, dbWs } from "@superset/db/client";
-import { subscriptions, v2Hosts, v2UsersHosts } from "@superset/db/schema";
+import {
+	subscriptions,
+	users,
+	v2Hosts,
+	v2UsersHosts,
+} from "@superset/db/schema";
 import {
 	ACTIVE_SUBSCRIPTION_STATUSES,
 	isActiveSubscriptionStatus,
@@ -10,11 +15,50 @@ import {
 	parseHostRoutingKey,
 } from "@superset/shared/host-routing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, count, desc, eq, inArray } from "drizzle-orm";
+import { Resend } from "resend";
 import { z } from "zod";
+import { env } from "../../env";
 import { fetchRelayPresence } from "../../lib/relay-presence";
 import { resolveUserRelayUrl } from "../../lib/relay-url";
 import { jwtProcedure } from "../../trpc";
+
+const resend = new Resend(env.RESEND_API_KEY);
+const FIRST_OPEN_EVENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Emits `app.first_opened` when a recent signup registers their first host,
+// so the Resend activation automation can branch installed-but-no-workspace
+// users away from the download nudge.
+async function emitFirstHostEvent(userId: string) {
+	try {
+		const [hostCount] = await db
+			.select({ value: count() })
+			.from(v2Hosts)
+			.where(eq(v2Hosts.createdByUserId, userId));
+		if (hostCount?.value !== 1) return;
+
+		const user = await db.query.users.findFirst({
+			columns: { email: true, createdAt: true },
+			where: eq(users.id, userId),
+		});
+		const isRecentSignup =
+			user &&
+			Date.now() - user.createdAt.getTime() < FIRST_OPEN_EVENT_WINDOW_MS;
+		if (!user || !isRecentSignup) return;
+
+		const { error } = await resend.events.send({
+			event: "app.first_opened",
+			email: user.email,
+			payload: { userId },
+		});
+		if (error) throw new Error(error.message);
+	} catch (error) {
+		console.error(
+			`[host.ensure] Failed to emit first-open event for ${userId}:`,
+			error,
+		);
+	}
+}
 
 export const hostRouter = {
 	/**
@@ -146,6 +190,10 @@ export const hostRouter = {
 							v2UsersHosts.hostId,
 						],
 					});
+			}
+
+			if (inserted) {
+				await emitFirstHostEvent(ctx.userId);
 			}
 
 			return host;


### PR DESCRIPTION
## Summary
- Full pass on the Resend email templates: voice-guide copy edits, three new lifecycle templates, and a design restructure of the shared layout onto the Linear/Stripe transactional skeleton.
- New `app.first_opened` Resend event from `host.ensure` so the activation automation can branch installed-but-no-workspace users to a paste-able-prompt nudge instead of a download link.

## Why / Context
The templates had placeholder SaaS copy ("advanced workflow automation"), a 2015-newsletter layout (black header/footer bands, social icon farm, centered everything), and the activation sequence was blind between signup and first workspace. Copy is now grounded in the Notion voice guide + Vale house rules, YC/Bookface guidance, and activation research (behavior-triggered sends outperform time-based 2-4x); the layout follows the react.email recreations of Linear/Stripe and Resend's Matte set.

Rendered previews of every template: https://claude.ai/code/artifact/6b019c25-aa8b-4967-ba92-18144ccaf036

## How It Works
- `EmailLayout` rebuilt: white ground, 560px, left-aligned, small dark wordmark header, one-line faint footer (address, sent-to, unsubscribe). Social icons and black bands removed.
- Type scale: 22px medium headings / 15px body / 14px data+buttons+alert / 13px supporting / 12px footer.
- New `DetailRow` component replaces stacked gray boxes in billing with hairline label/value rows.
- Activation sequence: welcome (code-sent) → day-1 nudge branched on `app.first_opened` (`01-first-agent` not-installed / `01b-first-prompt` installed) → day-7 founder note (`03-`); post-activation habit emails `02-parallel` and `04-automations`.
- `emitFirstHostEvent` in `host.ts` fires once per user (first host row, 30-day signup window), mirroring `exitActivationEmailCampaign`; failures log and never fail the mutation.

## Manual QA Checklist
- [ ] `bun --filter=@superset/email dev` renders all templates (activation, team, billing) with the new layout
- [ ] Welcome hero image and wordmark load (both exist in `apps/marketing/public/assets/emails/`)
- [ ] Billing DetailRow rows render label-left / value-right in Gmail + Apple Mail
- [ ] `host.ensure` on a fresh user's first host emits `app.first_opened` once; second host or old account emits nothing

## Testing
- `bun --filter=@superset/email typecheck`, `bun --filter=@superset/trpc typecheck`
- `bunx biome check` clean on both packages
- Vale (marketing config, Superset house rules) run over all email copy: 0 errors
- Not yet sent through a real email client; automation nudges only take effect after re-export into Resend

## Rollout
- Deploy API before desktop releases (deploy ordering) so `app.first_opened` flows.
- The nudge templates (`01`, `01b`, `02`, `03`, `04`) live in the Resend automations: after merge, run `bun --filter=@superset/email export`, add the day-1 branch on `app.first_opened`, and create the second automation entered on `user.activated`. Code-sent templates (welcome, team, billing) go live on API deploy.
- Rollback: revert the commit; the Resend event is additive and ignored if no automation consumes it.

## Follow-ups
- Unsubscribe-URL generation (layout supports it; nothing generates one)
- Welcome CTA data check: if most signups happen post-download, "Download Superset" should become "open a repo"
- Fold the V1→V2 migration plain-text report into the feedback template
- Restore `apps/marketing/docs/copywriting-references.md` (three Vale rules cite it; file doesn't exist)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns lifecycle, team, and billing emails and lets activation automation branch on install state. Previously automations only saw `user.signed_up`/`user.activated` and always sent a download nudge; now `host.ensure` emits `app.first_opened` on a recent signup’s first host so installed‑but‑no‑workspace users get a paste‑able first prompt.

- Email: `EmailLayout` moves to a 560px, left‑aligned white layout with a small wordmark and a single‑line footer; type scale 22/15/14/13/12. `Button` styles updated; new `DetailRow` replaces boxed billing summaries. New templates: `activation/01b-first-prompt`, `activation/02-parallel`, `activation/04-automations`; founder note renamed to `activation/03-founder-note`; copy updates across activation, team, and billing.
- API: `host.ensure` adds a best‑effort `emitFirstHostEvent` that fires `app.first_opened` once per user (only on the very first host, within 30 days of signup) via Resend.
- Note: No change to the welcome email sender; an earlier sender change was reverted.

- Rollout
  - Set `RESEND_API_KEY`. Deploy the API before desktop releases so `app.first_opened` events flow.
  - After merge: run `bun --filter=@superset/email export`, branch the day‑1 nudge on `app.first_opened` in Resend, and create a post‑activation automation entered on `user.activated`. Code‑sent templates go live on API deploy.
  - Rollback: revert; the extra Resend event is harmless if no automation consumes it.

<sup>Written for commit 538a9b8cea08599731295dec250fcccb46cc248e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activation emails covering setup, parallel workspaces, and scheduled automations.
  * Added reusable detail rows for clearer billing information.
* **Improvements**
  * Refreshed email layouts, typography, spacing, colors, buttons, and calls to action.
  * Updated welcome, invitation, team, billing, and founder messages for greater clarity.
  * Improved activation messaging based on initial app activity.
  * Updated welcome email delivery details and support messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->