### PR TITLE
feat(trpc): emit app.first_opened on first onboarding completion

### DIFF
--- a/packages/trpc/src/lib/activation-events.ts
+++ b/packages/trpc/src/lib/activation-events.ts
@@ -1,0 +1,30 @@
+import { Resend } from "resend";
+import { env } from "../env";
+
+const resend = new Resend(env.RESEND_API_KEY);
+const EVENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// `app.first_opened` lets the Resend activation automation branch
+// installed-but-no-workspace users away from the download nudge. Guarded to
+// recent signups so old accounts don't feed the automation; failures must
+// never fail the calling mutation.
+export async function emitAppFirstOpened(
+	user: { email: string; createdAt: Date },
+	userId: string,
+	source: string,
+) {
+	try {
+		if (Date.now() - user.createdAt.getTime() >= EVENT_WINDOW_MS) return;
+		const { error } = await resend.events.send({
+			event: "app.first_opened",
+			email: user.email,
+			payload: { userId },
+		});
+		if (error) throw new Error(error.message);
+	} catch (error) {
+		console.error(
+			`[${source}] Failed to emit first-open event for ${userId}:`,
+			error,
+		);
+	}
+}

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -16,19 +16,14 @@ import {
 } from "@superset/shared/host-routing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, count, desc, eq, inArray } from "drizzle-orm";
-import { Resend } from "resend";
 import { z } from "zod";
-import { env } from "../../env";
+import { emitAppFirstOpened } from "../../lib/activation-events";
 import { fetchRelayPresence } from "../../lib/relay-presence";
 import { resolveUserRelayUrl } from "../../lib/relay-url";
 import { jwtProcedure } from "../../trpc";
 
-const resend = new Resend(env.RESEND_API_KEY);
-const FIRST_OPEN_EVENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
-
-// Emits `app.first_opened` when a recent signup registers their first host,
-// so the Resend activation automation can branch installed-but-no-workspace
-// users away from the download nudge.
+// Registering a first host means the app is installed and running, so it
+// also marks the user as first-opened for the activation automation.
 async function emitFirstHostEvent(userId: string) {
 	try {
 		const [hostCount] = await db
@@ -41,17 +36,8 @@ async function emitFirstHostEvent(userId: string) {
 			columns: { email: true, createdAt: true },
 			where: eq(users.id, userId),
 		});
-		const isRecentSignup =
-			user &&
-			Date.now() - user.createdAt.getTime() < FIRST_OPEN_EVENT_WINDOW_MS;
-		if (!user || !isRecentSignup) return;
-
-		const { error } = await resend.events.send({
-			event: "app.first_opened",
-			email: user.email,
-			payload: { userId },
-		});
-		if (error) throw new Error(error.message);
+		if (!user) return;
+		await emitAppFirstOpened(user, userId, "host.ensure");
 	} catch (error) {
 		console.error(
 			`[host.ensure] Failed to emit first-open event for ${userId}:`,

--- a/packages/trpc/src/router/user/user.ts
+++ b/packages/trpc/src/router/user/user.ts
@@ -11,6 +11,7 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, count, desc, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 
+import { emitAppFirstOpened } from "../../lib/activation-events";
 import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { protectedProcedure } from "../../trpc";
 
@@ -139,11 +140,22 @@ export const userRouter = {
 	}),
 
 	completeOnboarding: protectedProcedure.mutation(async ({ ctx }) => {
+		const userId = ctx.session.user.id;
+		const existing = await db.query.users.findFirst({
+			columns: { email: true, createdAt: true, onboardedAt: true },
+			where: eq(users.id, userId),
+		});
 		const [updatedUser] = await db
 			.update(users)
 			.set({ onboardedAt: new Date() })
-			.where(eq(users.id, ctx.session.user.id))
+			.where(eq(users.id, userId))
 			.returning();
+		// Onboarding completes inside the installed app, which makes it the
+		// broadest first-opened signal (~84% of signups vs ~5% via v2 host
+		// registration); only the first completion counts.
+		if (existing && !existing.onboardedAt) {
+			await emitAppFirstOpened(existing, userId, "user.completeOnboarding");
+		}
 		return updatedUser;
 	}),
 


### PR DESCRIPTION
## Summary
- Emit the `app.first_opened` Resend event from `user.completeOnboarding` (first completion only), via a shared `emitAppFirstOpened` helper now also used by `host.ensure`.

## Why / Context
#6696 added the event so the activation email automation can branch installed-but-no-workspace users to a paste-able-prompt nudge instead of a download link. But its only emission point was `host.ensure` (host-service relay registration), which only the v2 path reaches — prod data shows ~3-5% of new signups get a v2 host today (down from 80% in the mid-July cohort), so the branch would almost never fire.

Onboarding completion is the broadest "app is installed and running" signal: 84% of the last 30 days' 4,113 signups completed it, 77% within an hour of signup. The live automation (`activation-drip`) already waits on this event; no automation change needed.

## How It Works
- New `packages/trpc/src/lib/activation-events.ts`: `emitAppFirstOpened` with the 30-day signup-recency guard; errors log and never fail the calling mutation.
- `completeOnboarding` reads the previous `onboardedAt` and emits only when it was null, so repeat calls don't re-emit. The unconditional timestamp update is unchanged.
- `host.ensure` keeps emitting (first host only) through the shared helper — a v2 user may emit twice; the automation's `wait_for_event` consumes the first and ignores the rest.

## Manual QA Checklist
- [ ] Fresh user completes onboarding → one `app.first_opened` event visible in Resend, automation run's `wait_install` step goes `event_received`
- [ ] Calling `completeOnboarding` again does not emit a second event
- [ ] Account older than 30 days completing onboarding emits nothing

## Testing
- `bun --filter=@superset/trpc typecheck`
- `bunx biome check packages/trpc/src` clean
- Not exercised against live Resend; the event name and payload match the emission `host.ensure` already ships.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `app.first_opened` on first onboarding completion to broaden activation coverage. Previously we only emitted from `host.ensure` (v2-only path); now we also emit from `user.completeOnboarding` for recent signups. Duplicate events are harmless and do not fail mutations.

- New helper `packages/trpc/src/lib/activation-events.ts::emitAppFirstOpened` centralizes the event, applies a 30‑day recency window, and logs errors without throwing.
- `user.completeOnboarding` emits only when `onboardedAt` was null; it still always updates the timestamp.
- `host.ensure` now calls the shared helper; behavior is preserved. A v2 user may emit twice; the activation flow consumes the first and ignores the rest.
- No automation or client changes required.

<sup>Written for commit e0c911704eec4f0efb17c25d2ece2167915aa90d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-opened activation tracking when users complete onboarding.
  * Added first-opened tracking when users register their first host.
  * Events include the user’s email and identifier when eligible.

* **Bug Fixes**
  * Activation-event failures are logged without interrupting onboarding or host registration.
  * Missing user records continue to be handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->