### PR TITLE
chore(api): raise desktop minimumVersion gate to 1.24.0

### DIFF
--- a/apps/api/src/app/api/desktop/version/route.ts
+++ b/apps/api/src/app/api/desktop/version/route.ts
@@ -1,7 +1,7 @@
 import { db } from "@superset/db";
 import type { DesktopNotice } from "@superset/shared/desktop-notices";
 
-const MINIMUM_DESKTOP_VERSION = "1.5.0";
+const MINIMUM_DESKTOP_VERSION = "1.21.0";
 
 /**
  * Version gate + server-driven notices for the desktop app.
@@ -43,7 +43,8 @@ export async function GET() {
 
 	return Response.json({
 		minimumVersion: MINIMUM_DESKTOP_VERSION,
-		message: "Please update to the latest version to continue.",
+		message:
+			"Superset needs an update to keep syncing your workspaces. This version relies on a background sync service that is being retired. Updating takes a few seconds, and your workspaces, terminals, and settings are untouched.",
 		notices,
 	});
 }


### PR DESCRIPTION
## Summary
- Raise `MINIMUM_DESKTOP_VERSION` in `/api/desktop/version` from `1.5.0` to `1.24.0`.
- Replace the generic update message with one explaining the sync-service retirement and reassuring users that workspaces, terminals, and settings are untouched.

## Why / Context
Desktop builds <= 1.18.1 end `before-quit` with an unconditional `app.exit(0)`, which skips `will-quit`, so electron-updater's `autoInstallOnAppQuit` never runs and staged updates are discarded on every normal quit (fixed by #6049, first shipped in 1.18.3). ~2,400 weekly-active users are stuck on <= 1.18.1.

A blocking desktop notice for the sync retirement shipped on 2026-08-20 targeting stable <= 1.20.2, but notices only render on 1.18.2+ (DesktopNoticesGate shipped in 1.18.2), so the stuck cohort cannot see it.

The legacy minimumVersion gate IS honored by all old builds: it shows the full-screen UpdateRequiredPage, which drives the explicit check/download/quitAndInstall flow that works on old builds (only the passive install-on-quit path is broken), with a manual download fallback.

**PostHog evidence (2026-08-20):** 42% of notice-reachable users (2,135 of 5,129) updated to 1.21+ within a day of the notice, while only 10% of the stuck cohort did (237 of 2,407, the organic banner-click rate).

Bumping the gate to 1.21.0 aligns it with the notice's cutoff (notice maxVersion 1.20.2) so both levers enforce the same policy.

## Testing
- `bunx turbo run typecheck --filter=@superset/api` — passed

## Risks / Rollout
- Risk: this hard-blocks the ~2,400 stuck weekly actives into the UpdateRequiredPage flow on next boot or version poll. That is the intent, but it is a forced interruption: they cannot use the app until they update (or use the manual download fallback).
- Rollback: revert the constant and redeploy the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the desktop minimum version gate from 1.5.0 to 1.24.0 and replaces the generic update message with sync‑retirement guidance. Previously, builds ≥1.5.0 could run; now builds <1.24.0 are blocked and see UpdateRequiredPage, which drives the explicit check/download/quitAndInstall flow that works even on builds too old to render notices. The bump to 1.24.0 targets the first release carrying the v1/v2 flip lock, so builds below it can no longer keep the old sync path alive after migration, and it also catches builds below 1.19 that cannot self‑update at all.

**Review and rollout**
- `GET /api/desktop/version` now returns minimumVersion 1.24.0 and a sync‑retirement message; response shape is unchanged.
- Users on <1.24.0 are blocked until they update; manual download fallback remains. Roll back by reverting the constant.

<sup>Written for commit 5dadf015150871f1fb6156e01745781ba50cdbe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum supported desktop app version from 1.21.0 to 1.24.0.
  * Added clearer upgrade messaging about background sync retirement and confirmed that workspace data, terminals, and settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update, 13 Sep 2026

Bumped from 1.21.0 to **1.24.0**: that is the first release carrying the v1/v2 flip lock (#6693). As of 12 Sep, 1,202 weekly-active v1 users are on builds below 1.24 where the switch still works after the migration completes, and 889 are below 1.19 and cannot self-update at all. This gate is the only lever that reaches both. Context: https://app.superset.sh/page/v1-v2-migration-where-we-stand-yxfx0w

https://claude.ai/code/session_016NkfQLLDdHvrPS1BRJtfhj