### PR TITLE
fix(desktop): keep submit prompt dialog open

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/components/SubmitPromptDialog/SubmitPromptDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/components/SubmitPromptDialog/SubmitPromptDialog.tsx
@@ -65,7 +65,7 @@ export function SubmitPromptDialog({
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange} modal>
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>
 					<DialogTitle>Submit a prompt</DialogTitle>


### PR DESCRIPTION
## Summary
- Make the Submit Prompt dialog modal when opened from the Help submenu.
- Prevent dropdown focus restoration from immediately dismissing the dialog.

## Testing
- Manually verified `Help > Submit a prompt` remains open and closes normally.
- `bun run lint` (passes)
- `bun run test` (2,755 pass; 1 pre-existing desktop shell PATH failure tracked in #6653)
- `bun run typecheck` (blocked by pre-existing duplicate `mermaid` and `@types/hast` dependency type errors outside this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the submit prompt dialog to behave consistently as a modal, ensuring proper focus and interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Submit Prompt dialog open by making it modal. Previously, opening it from Help > Submit a prompt closed immediately when the Organization dropdown restored focus; now it stays open until the user closes it.

- Adds the `modal` prop to the `Dialog`, trapping focus and preventing the underlying dropdown from regaining focus.
- Scope limited to the Submit Prompt dialog; no other dialogs or APIs change.

<sup>Written for commit b0ae88a263a396940b35aa933b8db5e1a92b6ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

