### PR TITLE
fix(desktop): stop painting Remove from Sidebar red in sidebar context menus

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectContextMenu/DashboardSidebarProjectContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectContextMenu/DashboardSidebarProjectContextMenu.tsx
@@ -59,11 +59,8 @@ export function DashboardSidebarProjectContextMenu({
 					Import untracked worktrees
 				</ContextMenuItem>
 				<ContextMenuSeparator />
-				<ContextMenuItem
-					onSelect={onRemoveFromSidebar}
-					className="text-destructive focus:text-destructive"
-				>
-					<LuX className="size-4 mr-2 text-destructive" />
+				<ContextMenuItem onSelect={onRemoveFromSidebar}>
+					<LuX className="size-4 mr-2" />
 					Remove from Sidebar
 				</ContextMenuItem>
 			</ContextMenuContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -241,11 +241,8 @@ export function DashboardSidebarWorkspaceContextMenu({
 						Close all ports
 					</ContextMenuItem>
 				)}
-				<ContextMenuItem
-					onSelect={onRemoveFromSidebar}
-					className="text-destructive focus:text-destructive"
-				>
-					<LuX className="size-4 mr-2 text-destructive" />
+				<ContextMenuItem onSelect={onRemoveFromSidebar}>
+					<LuX className="size-4 mr-2" />
 					Remove from Sidebar
 				</ContextMenuItem>
 				{onDelete ? (


### PR DESCRIPTION
## Summary
- "Remove from Sidebar" was styled red alongside "Delete" in the workspace right-click menu (and the project menu), so every menu had two red items competing for attention.
- Removing from the sidebar is non-destructive, so it now uses the default item color. Delete stays red as the single destructive cue.

## Test plan
- [x] biome check on both files
- [ ] Right-click a workspace and a project in the sidebar: only Delete is red

https://claude.ai/code/session_01HA7cEPVFb7BAw9jqimAAcf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops styling “Remove from Sidebar” as destructive in workspace and project sidebar context menus. Previously both “Remove from Sidebar” and “Delete” were red; now only “Delete” is red to signal the destructive action.

- Scope: Desktop sidebar context menus for workspace and project; removed destructive text/icon classes only. No handler, copy, or behavior changes.
- QA: Right‑click a workspace and a project; confirm only “Delete” renders in red and focus states still work. No migrations or rollout steps.

<sup>Written for commit 4532bf75e4b0f2b5dbd650d282c9aa1420de3f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated “Remove from Sidebar” menu items to use standard text and icon styling.
  * Removal actions and labels remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->