### PR TITLE
feat(desktop): redesign the PR detail page header

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -7,6 +7,7 @@ import {
 	AlertDialogTitle,
 	EnterEnabledAlertDialogContent,
 } from "@superset/ui/alert-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import {
@@ -414,11 +415,15 @@ function PullRequestDetailPage() {
 					</Badge>
 					{data.author && (
 						<span className="flex min-w-0 items-center gap-1.5">
-							<img
-								alt=""
-								src={`https://github.com/${data.author}.png?size=32`}
-								className="size-4 shrink-0 rounded"
-							/>
+							<Avatar className="size-4 rounded-sm">
+								<AvatarImage
+									src={`https://github.com/${data.author}.png?size=32`}
+									alt={data.author}
+								/>
+								<AvatarFallback className="rounded-sm text-[8px]">
+									{data.author.slice(0, 1).toUpperCase()}
+								</AvatarFallback>
+							</Avatar>
 							<span className="min-w-0 break-words">{data.author}</span>
 						</span>
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -66,25 +66,26 @@ const MERGE_METHOD_LABELS: Record<MergeMethod, string> = {
 
 type PendingAction = { kind: "close" } | { kind: "merge"; method: MergeMethod };
 
+// Mirrors PRStatusGroup's state-tinted badge language, so a PR reads the
+// same way here as it does in the v2 workspace sidebar.
 const PR_STATE_BADGE_STYLES: Record<PRState, string> = {
-	open: "bg-[#dcfae8] text-[#00a558] border-transparent dark:bg-emerald-500/15 dark:text-emerald-400",
+	open: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
 	merged:
-		"bg-violet-500/10 text-violet-600 border-transparent dark:text-violet-400",
-	closed:
-		"bg-[#fde5e5] text-[#f43b3a] border-transparent dark:bg-red-500/15 dark:text-red-400",
-	draft: "bg-muted text-muted-foreground border-transparent",
+		"border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-400",
+	closed: "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+	draft: "border-border bg-muted/40 text-muted-foreground",
 	queued:
-		"bg-[#fef3c6] text-[#a15c07] border-transparent dark:bg-amber-500/15 dark:text-amber-400",
+		"border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
 };
 
 // Just the text-color half of PR_STATE_BADGE_STYLES, so the icon inside the
 // badge reads as one color with its label instead of PRIcon's own palette.
 const PR_BADGE_ICON_COLOR: Record<PRState, string> = {
-	open: "text-[#00a558] dark:text-emerald-400",
+	open: "text-emerald-600 dark:text-emerald-400",
 	merged: "text-violet-600 dark:text-violet-400",
-	closed: "text-[#f43b3a] dark:text-red-400",
+	closed: "text-rose-600 dark:text-rose-400",
 	draft: "text-muted-foreground",
-	queued: "text-[#a15c07] dark:text-amber-400",
+	queued: "text-amber-600 dark:text-amber-400",
 };
 
 function PullRequestDetailPage() {
@@ -294,9 +295,11 @@ function PullRequestDetailPage() {
 
 	return (
 		<div className="@container flex min-h-0 flex-1 flex-col">
-			<div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 pb-4 pt-3 @md:px-6">
-				<div className="flex min-w-0 items-start gap-2">
+			<div className="flex shrink-0 flex-col border-b border-border px-4 pb-4 pt-2 @md:px-6">
+				<div className="mb-2 flex items-center">
 					<PullRequestListToggle />
+				</div>
+				<div className="mb-3 flex min-w-0 items-center gap-2">
 					<h1 className="min-w-0 flex-1 break-words text-2xl font-semibold leading-tight text-wrap-pretty">
 						{data.title}
 					</h1>
@@ -317,9 +320,8 @@ function PullRequestDetailPage() {
 								<DropdownMenuTrigger asChild>
 									<Button
 										variant="outline"
-										size="sm"
+										size="xs"
 										className={cn(
-											"h-7 gap-1.5 px-2 text-xs",
 											canMerge &&
 												"border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400",
 										)}
@@ -385,8 +387,7 @@ function PullRequestDetailPage() {
 						)}
 						<Button
 							variant="outline"
-							size="sm"
-							className="h-7 gap-1.5 px-2 text-xs"
+							size="xs"
 							onClick={handleAddToWorkspace}
 							aria-label="Add to workspace"
 							title="Add to workspace"
@@ -401,13 +402,13 @@ function PullRequestDetailPage() {
 					<Badge
 						variant="outline"
 						className={cn(
-							"gap-1 rounded-full border-0 font-medium capitalize",
+							"h-6 gap-1 rounded-full font-medium capitalize",
 							PR_STATE_BADGE_STYLES[state],
 						)}
 					>
 						<PRIcon
 							state={state}
-							className={cn("size-3.5 shrink-0", PR_BADGE_ICON_COLOR[state])}
+							className={cn("size-3 shrink-0", PR_BADGE_ICON_COLOR[state])}
 						/>
 						{stateLabel}
 					</Badge>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -7,6 +7,7 @@ import {
 	AlertDialogTitle,
 	EnterEnabledAlertDialogContent,
 } from "@superset/ui/alert-dialog";
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -31,6 +32,7 @@ import {
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { WorkItemDetailState } from "renderer/routes/_authenticated/_dashboard/components/WorkItemDetailState";
 import { useProjectHost } from "renderer/routes/_authenticated/_dashboard/hooks/useProjectHost";
@@ -64,16 +66,25 @@ const MERGE_METHOD_LABELS: Record<MergeMethod, string> = {
 
 type PendingAction = { kind: "close" } | { kind: "merge"; method: MergeMethod };
 
-// Mirrors PRStatusGroup's state-tinted badge language, so a PR reads the
-// same way here as it does in the v2 workspace sidebar.
-const STATE_BADGE_STYLES: Record<PRState, string> = {
-	open: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+const PR_STATE_BADGE_STYLES: Record<PRState, string> = {
+	open: "bg-[#dcfae8] text-[#00a558] border-transparent dark:bg-emerald-500/15 dark:text-emerald-400",
 	merged:
-		"border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-400",
-	closed: "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
-	draft: "border-border bg-muted/40 text-muted-foreground",
+		"bg-violet-500/10 text-violet-600 border-transparent dark:text-violet-400",
+	closed:
+		"bg-[#fde5e5] text-[#f43b3a] border-transparent dark:bg-red-500/15 dark:text-red-400",
+	draft: "bg-muted text-muted-foreground border-transparent",
 	queued:
-		"border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+		"bg-[#fef3c6] text-[#a15c07] border-transparent dark:bg-amber-500/15 dark:text-amber-400",
+};
+
+// Just the text-color half of PR_STATE_BADGE_STYLES, so the icon inside the
+// badge reads as one color with its label instead of PRIcon's own palette.
+const PR_BADGE_ICON_COLOR: Record<PRState, string> = {
+	open: "text-[#00a558] dark:text-emerald-400",
+	merged: "text-violet-600 dark:text-violet-400",
+	closed: "text-[#f43b3a] dark:text-red-400",
+	draft: "text-muted-foreground",
+	queued: "text-[#a15c07] dark:text-amber-400",
 };
 
 function PullRequestDetailPage() {
@@ -189,130 +200,14 @@ function PullRequestDetailPage() {
 		openModal(projectId);
 	};
 
-	const defaultState = normalizePRState("open", false);
-	const state = data
-		? normalizePRState(data.state, data.isDraft)
-		: defaultState;
-	const canMerge = data?.state === "open" && !data.isDraft;
 	// The list pane is always visible in the split view (or reachable via the
 	// list-collapse toggle in the shared layout), so there's no "back"
-	// affordance here — just the PR identity and its actions.
-	const itemNumber = data?.number ?? prNumber;
+	// affordance here — just the toggle, kept reachable while the PR is
+	// loading or failed to load. The full title/actions/metadata header only
+	// renders once `data` is available, further down.
 	const header = (
-		<div className="@container flex shrink-0 items-center gap-2 border-b border-border px-4 pb-9 pt-3 @md:gap-3 @md:px-6">
+		<div className="@container flex shrink-0 items-center gap-2 border-b border-border px-4 py-2 @md:px-6">
 			<PullRequestListToggle />
-			<PRIcon state={state} className="size-4 shrink-0" />
-			<span className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
-				{itemNumber === null ? "#—" : `#${itemNumber}`}
-			</span>
-			{data && (
-				<span
-					className={cn(
-						"shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium capitalize",
-						STATE_BADGE_STYLES[state],
-					)}
-				>
-					{data.isDraft ? "Draft" : data.state}
-				</span>
-			)}
-			<div className="min-w-0 flex-1" />
-			<div className="ml-auto flex shrink-0 items-center gap-1">
-				{data?.url && (
-					<Button variant="ghost" size="icon" className="size-8" asChild>
-						<a
-							href={data.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							aria-label="Open pull request in GitHub"
-							title="Open pull request in GitHub"
-						>
-							<LuExternalLink className="size-4" />
-						</a>
-					</Button>
-				)}
-				{data && data.state !== "merged" && (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								variant="outline"
-								size="sm"
-								className={cn(
-									"h-8 gap-1.5 px-2 @md:px-3",
-									canMerge &&
-										"border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400",
-								)}
-								disabled={isActionPending}
-								aria-label="Pull request actions"
-							>
-								{canMerge ? (
-									<VscGitMerge className="size-4" />
-								) : data.state === "closed" ? (
-									<LuRotateCcw className="size-4" />
-								) : (
-									<LuGitPullRequestClosed className="size-4" />
-								)}
-								<span className="hidden @md:inline">
-									{data.state === "closed"
-										? "Reopen"
-										: canMerge
-											? "Merge"
-											: "Close"}
-								</span>
-								<VscChevronDown className="size-3" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="w-56">
-							{canMerge && (
-								<>
-									<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-										Merge
-									</DropdownMenuLabel>
-									{(["squash", "merge", "rebase"] as const).map((method) => (
-										<DropdownMenuItem
-											key={method}
-											onClick={() =>
-												setPendingAction({ kind: "merge", method })
-											}
-										>
-											<VscGitMerge className="size-3.5" />
-											{MERGE_METHOD_LABELS[method]}
-										</DropdownMenuItem>
-									))}
-									<DropdownMenuSeparator />
-								</>
-							)}
-							{data.state === "open" && (
-								<DropdownMenuItem
-									variant="destructive"
-									onClick={() => setPendingAction({ kind: "close" })}
-								>
-									<LuGitPullRequestClosed className="size-3.5" />
-									Close pull request
-								</DropdownMenuItem>
-							)}
-							{data.state === "closed" && (
-								<DropdownMenuItem onClick={handleReopen}>
-									<LuRotateCcw className="size-3.5" />
-									Reopen pull request
-								</DropdownMenuItem>
-							)}
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
-				{data && (
-					<Button
-						variant="outline"
-						size="sm"
-						className="h-8 gap-1.5 px-2 @md:px-3"
-						onClick={handleAddToWorkspace}
-						aria-label="Add to workspace"
-						title="Add to workspace"
-					>
-						<LuPlus className="size-4" />
-						<span className="hidden @md:inline">Add to workspace</span>
-					</Button>
-				)}
-			</div>
 		</div>
 	);
 
@@ -390,6 +285,8 @@ function PullRequestDetailPage() {
 		);
 	}
 
+	const state = normalizePRState(data.state, data.isDraft);
+	const canMerge = data.state === "open" && !data.isDraft;
 	const stateLabel = data.isDraft ? "Draft" : data.state;
 	const branchSummary = data.branch
 		? `${data.headRepositoryOwner && data.isCrossRepository ? `${data.headRepositoryOwner}:${data.branch}` : data.branch} → ${data.baseBranch}`
@@ -397,7 +294,153 @@ function PullRequestDetailPage() {
 
 	return (
 		<div className="@container flex min-h-0 flex-1 flex-col">
-			{header}
+			<div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 pb-4 pt-3 @md:px-6">
+				<div className="flex min-w-0 items-start gap-2">
+					<PullRequestListToggle />
+					<h1 className="min-w-0 flex-1 break-words text-2xl font-semibold leading-tight text-wrap-pretty">
+						{data.title}
+					</h1>
+					<div className="flex shrink-0 items-center gap-1">
+						<Button variant="ghost" size="icon-xs" asChild>
+							<a
+								href={data.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label="Open pull request in GitHub"
+								title="Open pull request in GitHub"
+							>
+								<LuExternalLink className="size-3.5" />
+							</a>
+						</Button>
+						{data.state !== "merged" && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="outline"
+										size="sm"
+										className={cn(
+											"h-7 gap-1.5 px-2 text-xs",
+											canMerge &&
+												"border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400",
+										)}
+										disabled={isActionPending}
+										aria-label="Pull request actions"
+									>
+										{canMerge ? (
+											<VscGitMerge className="size-3.5" />
+										) : data.state === "closed" ? (
+											<LuRotateCcw className="size-3.5" />
+										) : (
+											<LuGitPullRequestClosed className="size-3.5" />
+										)}
+										<span className="hidden @md:inline">
+											{data.state === "closed"
+												? "Reopen"
+												: canMerge
+													? "Merge"
+													: "Close"}
+										</span>
+										<VscChevronDown className="size-3" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end" className="w-56">
+									{canMerge && (
+										<>
+											<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+												Merge
+											</DropdownMenuLabel>
+											{(["squash", "merge", "rebase"] as const).map(
+												(method) => (
+													<DropdownMenuItem
+														key={method}
+														onClick={() =>
+															setPendingAction({ kind: "merge", method })
+														}
+													>
+														<VscGitMerge className="size-3.5" />
+														{MERGE_METHOD_LABELS[method]}
+													</DropdownMenuItem>
+												),
+											)}
+											<DropdownMenuSeparator />
+										</>
+									)}
+									{data.state === "open" && (
+										<DropdownMenuItem
+											variant="destructive"
+											onClick={() => setPendingAction({ kind: "close" })}
+										>
+											<LuGitPullRequestClosed className="size-3.5" />
+											Close pull request
+										</DropdownMenuItem>
+									)}
+									{data.state === "closed" && (
+										<DropdownMenuItem onClick={handleReopen}>
+											<LuRotateCcw className="size-3.5" />
+											Reopen pull request
+										</DropdownMenuItem>
+									)}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						)}
+						<Button
+							variant="outline"
+							size="sm"
+							className="h-7 gap-1.5 px-2 text-xs"
+							onClick={handleAddToWorkspace}
+							aria-label="Add to workspace"
+							title="Add to workspace"
+						>
+							<LuPlus className="size-3.5" />
+							<span className="hidden @md:inline">Add to workspace</span>
+						</Button>
+					</div>
+				</div>
+
+				<div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+					<Badge
+						variant="outline"
+						className={cn(
+							"gap-1 rounded-full border-0 font-medium capitalize",
+							PR_STATE_BADGE_STYLES[state],
+						)}
+					>
+						<PRIcon
+							state={state}
+							className={cn("size-3.5 shrink-0", PR_BADGE_ICON_COLOR[state])}
+						/>
+						{stateLabel}
+					</Badge>
+					{data.author && (
+						<span className="flex min-w-0 items-center gap-1.5">
+							<img
+								alt=""
+								src={`https://github.com/${data.author}.png?size=32`}
+								className="size-4 shrink-0 rounded"
+							/>
+							<span className="min-w-0 break-words">{data.author}</span>
+						</span>
+					)}
+					<span aria-hidden>·</span>
+					<span>#{data.number}</span>
+					{data.createdAt && (
+						<>
+							<span aria-hidden>·</span>
+							<span>
+								{formatRelativeTime(new Date(data.createdAt).getTime())} ago
+							</span>
+						</>
+					)}
+					{branchSummary && (
+						<>
+							<span aria-hidden>·</span>
+							<span className="min-w-0 break-all font-mono">
+								{branchSummary}
+							</span>
+						</>
+					)}
+				</div>
+			</div>
 			<AlertDialog
 				open={pendingAction !== null}
 				onOpenChange={(open) => {
@@ -448,33 +491,6 @@ function PullRequestDetailPage() {
 			<ScrollArea className="min-h-0 flex-1">
 				<div className="grid w-full gap-8 px-4 py-6 @md:px-6 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:py-8">
 					<article className="min-w-0">
-						<div className="mb-4 flex min-w-0 items-start gap-3">
-							<PRIcon state={state} className="mt-1 size-5 shrink-0" />
-							<h1 className="min-w-0 break-words text-2xl font-semibold leading-tight text-wrap-pretty">
-								{data.title}
-							</h1>
-						</div>
-
-						<div className="mb-7 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-							<span>{project.name}</span>
-							<span aria-hidden>·</span>
-							<span className="capitalize">{stateLabel}</span>
-							{data.author && (
-								<>
-									<span aria-hidden>·</span>
-									<span className="min-w-0 break-words">by {data.author}</span>
-								</>
-							)}
-							{branchSummary && (
-								<>
-									<span aria-hidden>·</span>
-									<span className="min-w-0 break-all font-mono">
-										{branchSummary}
-									</span>
-								</>
-							)}
-						</div>
-
 						{data.body.trim() ? (
 							<MarkdownRenderer content={data.body} />
 						) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -93,6 +93,36 @@ const PR_BADGE_ICON_COLOR: Record<PRState, string> = {
 	queued: "text-amber-600 dark:text-amber-400",
 };
 
+// Mount one instance per PR (parent passes `key={prNumber}`) so switching PRs
+// in the split view resets the copied state instead of leaking a stale
+// checkmark from whatever branch was last copied — the route component
+// itself isn't remounted on a $prNumber change alone.
+function CopyBranchButton({ branchRef }: { branchRef: string }) {
+	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={() => copyToClipboard(branchRef)}
+					aria-label={copied ? "Branch name copied" : "Copy branch name"}
+					className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				>
+					{copied ? (
+						<LuCheck className="size-3 text-emerald-500" />
+					) : (
+						<LuCopy className="size-3" />
+					)}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				{copied ? "Copied!" : "Copy branch name"}
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 function PullRequestDetailPage() {
 	const { prNumber: prNumberRaw } = Route.useParams();
 	const prNumber = parsePositiveIntegerParam(prNumberRaw);
@@ -114,7 +144,6 @@ function PullRequestDetailPage() {
 	const [pendingAction, setPendingAction] = useState<PendingAction | null>(
 		null,
 	);
-	const { copyToClipboard, copied: branchNameCopied } = useCopyToClipboard();
 
 	const { data, isLoading, error, refetch } = useQuery({
 		queryKey: ["pull-request-detail", projectId, hostUrl, prNumber],
@@ -302,6 +331,13 @@ function PullRequestDetailPage() {
 	const branchSummary = data.branch
 		? `${headBranchRef} → ${data.baseBranch}`
 		: null;
+	const createdAtMs = data.createdAt
+		? new Date(data.createdAt).getTime()
+		: null;
+	const relativeCreatedAt =
+		createdAtMs !== null && !Number.isNaN(createdAtMs)
+			? formatRelativeTime(createdAtMs)
+			: null;
 
 	return (
 		<div className="@container flex min-h-0 flex-1 flex-col">
@@ -314,17 +350,19 @@ function PullRequestDetailPage() {
 						{data.title}
 					</h1>
 					<div className="flex shrink-0 items-center gap-1">
-						<Button variant="ghost" size="icon-xs" asChild>
-							<a
-								href={data.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								aria-label="Open pull request in GitHub"
-								title="Open pull request in GitHub"
-							>
-								<LuExternalLink className="size-3.5" />
-							</a>
-						</Button>
+						{data.url && (
+							<Button variant="ghost" size="icon-xs" asChild>
+								<a
+									href={data.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									aria-label="Open pull request in GitHub"
+									title="Open pull request in GitHub"
+								>
+									<LuExternalLink className="size-3.5" />
+								</a>
+							</Button>
+						)}
 						{data.state !== "merged" && (
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
@@ -438,11 +476,13 @@ function PullRequestDetailPage() {
 					)}
 					<span aria-hidden>·</span>
 					<span>#{data.number}</span>
-					{data.createdAt && (
+					{relativeCreatedAt && (
 						<>
 							<span aria-hidden>·</span>
 							<span>
-								{formatRelativeTime(new Date(data.createdAt).getTime())} ago
+								{relativeCreatedAt === "now"
+									? relativeCreatedAt
+									: `${relativeCreatedAt} ago`}
 							</span>
 						</>
 					)}
@@ -452,25 +492,7 @@ function PullRequestDetailPage() {
 							<span className="min-w-0 break-all font-mono">
 								{branchSummary}
 							</span>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<button
-										type="button"
-										onClick={() => copyToClipboard(headBranchRef)}
-										aria-label="Copy branch name"
-										className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
-									>
-										{branchNameCopied ? (
-											<LuCheck className="size-3 text-emerald-500" />
-										) : (
-											<LuCopy className="size-3" />
-										)}
-									</button>
-								</TooltipTrigger>
-								<TooltipContent side="bottom">
-									{branchNameCopied ? "Copied!" : "Copy branch name"}
-								</TooltipContent>
-							</Tooltip>
+							<CopyBranchButton key={data.number} branchRef={headBranchRef} />
 						</>
 					)}
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -20,11 +20,14 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import {
+	LuCheck,
+	LuCopy,
 	LuExternalLink,
 	LuGitPullRequestClosed,
 	LuPlus,
@@ -33,6 +36,7 @@ import {
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { WorkItemDetailState } from "renderer/routes/_authenticated/_dashboard/components/WorkItemDetailState";
@@ -110,6 +114,7 @@ function PullRequestDetailPage() {
 	const [pendingAction, setPendingAction] = useState<PendingAction | null>(
 		null,
 	);
+	const { copyToClipboard, copied: branchNameCopied } = useCopyToClipboard();
 
 	const { data, isLoading, error, refetch } = useQuery({
 		queryKey: ["pull-request-detail", projectId, hostUrl, prNumber],
@@ -290,8 +295,12 @@ function PullRequestDetailPage() {
 	const state = normalizePRState(data.state, data.isDraft);
 	const canMerge = data.state === "open" && !data.isDraft;
 	const stateLabel = data.isDraft ? "Draft" : data.state;
+	const headBranchRef =
+		data.headRepositoryOwner && data.isCrossRepository
+			? `${data.headRepositoryOwner}:${data.branch}`
+			: data.branch;
 	const branchSummary = data.branch
-		? `${data.headRepositoryOwner && data.isCrossRepository ? `${data.headRepositoryOwner}:${data.branch}` : data.branch} → ${data.baseBranch}`
+		? `${headBranchRef} → ${data.baseBranch}`
 		: null;
 
 	return (
@@ -443,6 +452,25 @@ function PullRequestDetailPage() {
 							<span className="min-w-0 break-all font-mono">
 								{branchSummary}
 							</span>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										onClick={() => copyToClipboard(headBranchRef)}
+										aria-label="Copy branch name"
+										className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+									>
+										{branchNameCopied ? (
+											<LuCheck className="size-3 text-emerald-500" />
+										) : (
+											<LuCopy className="size-3" />
+										)}
+									</button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									{branchNameCopied ? "Copied!" : "Copy branch name"}
+								</TooltipContent>
+							</Tooltip>
 						</>
 					)}
 				</div>


### PR DESCRIPTION
**Links**
- Reference: #6689 (source of the title/badge/metadata-row layout pattern)

## Summary
- Redesign the PR detail header: the title now renders as a large heading with a compact, muted metadata row below it (state pill, author avatar, `#number`, relative time, branch summary + copy button) instead of the old single dense icon+badge+actions row.
- Move the external-GitHub-link, Merge/Close/Reopen dropdown, and "Add to workspace" actions into a small icon-row beside the title.
- Keep the list-collapse toggle reachable via its own thin top row (matching the current Figma spec for this page), rather than inline with the title where it visually floated above the text.
- Avatar falls back to initials when the GitHub avatar image 404s (e.g. bot/app-authored PRs like `app/warp-agent-staging`).

## Why / Context
Follows the header pattern introduced in the reference PR #6689 ("PR review experience: split view, Code tab, comments"), applied here as a standalone, header-only change on top of the split-view foundation branch — the tab bar (Review/Summary/Code/Checks) from that reference isn't part of this PR.

## How It Works
- The header is three stacked rows inside one bordered container: (1) list-toggle strip, (2) title + icon-row actions, (3) muted metadata row.
- State pill colors use this codebase's existing opacity-tinted Tailwind token system (`bg-emerald-500/10 border-emerald-500/30 text-emerald-600 dark:text-emerald-400`, etc.) rather than hardcoded Figma hex values, so it adapts correctly between light and dark instead of swapping to a different palette per theme.
- Icon-row buttons standardized on the Button `xs` size token (28px); the state badge is an explicit `h-6` (24px) — everything in the header now shares one consistent sizing scale.
- The branch-name copy button reuses the existing `useCopyToClipboard` hook and the icon-swap/tooltip pattern from `FileDiffHeader`'s copy-path button; it copies the head branch ref (not the full "head → base" display string), since that's the value someone would actually check out.
- A minimal header (list-toggle only) still renders during loading/error/not-found states so the toggle stays reachable, mirroring the prior behavior.

## Manual QA Checklist
- [x] Header renders correctly for Draft, Open (mergeable), Closed, and Merged PR states — pill color and dropdown contents (Merge/Close/Reopen, or hidden for merged) match state
- [x] External-GitHub-link button present and correctly linked
- [x] Merge/Close/Reopen dropdown opens; the confirm dialog opens and **Cancel** closes it without executing (never triggered an actual merge/close against a real PR)
- [x] "Add to workspace" button present and wired to the existing handler
- [x] List-collapse toggle stays reachable in a minimal header during loading/error states, and in its own row once the PR loads
- [x] Avatar falls back to initials when the GitHub avatar 404s
- [x] Branch-name copy button copies the head branch ref to the clipboard and shows a checkmark + "Copied!" tooltip
- [x] Verified in both light and dark theme
- [x] No console errors during any of the above interactions

## Testing
- `bunx tsc --noEmit -p apps/desktop`
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/\$prNumber/page.tsx`
- Manual: live CDP verification against the running dev app (real clicks/screenshots, not synthetic) — see Manual QA Checklist above

## Design Decisions
- Kept the existing `<a>`-tag external-link button instead of the reference PR's `onClick={() => window.open(...)}` pattern, to preserve standard middle-click/ctrl-click-to-open-in-new-tab behavior.
- Reverted the state-badge palette from the reference PR's raw Figma hex values back to this codebase's existing opacity-tinted tokens after review feedback that the hardcoded colors looked washed out in light mode and didn't adapt well between themes.

## Known Limitations
- The tab bar (Review/Summary/Code/Checks) shown in the current Figma spec isn't implemented here — intentionally out of scope for this header-only change.

## Follow-ups
- Wire up the tab bar once Code/Checks/Review tabs land, and move the list-toggle top strip into that tab bar row per the Figma spec.

https://claude.ai/code/session_01UBriMdtL1Kpp67g1aQMTBH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the PR detail header to a three-row layout for clarity and split-view consistency. The old single dense row becomes: a thin list toggle strip, a large title with a compact action row, and a muted metadata row. Toggle remains reachable while loading; merge/close/reopen behavior is unchanged, only repositioned.

- Moves the GitHub link, Merge/Close/Reopen dropdown, and Add to workspace into a compact icon row beside the title; standardizes button sizing to the xs token.
- Adds a metadata row: state pill with theme-aware tokens, author avatar with initials fallback, PR number, relative created time (handles “now” without “ago”), and a branch summary with a copy button that copies the head branch ref (owner:branch for cross-repo).
- Fixes: copy button state no longer leaks when switching PRs (extracted `CopyBranchButton` keyed by PR number); tooltip and aria-label reflect copied state; guards NaN createdAt and empty PR URL.
- Minimal header (toggle only) still renders during loading/error/not-found.
- Out of scope: the Review/Summary/Code/Checks tab bar; this PR is header-only.

<sup>Written for commit 62fc72c9a5b4b6c8aab2ba65e2d07334cf26e588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

