### PR TITLE
fix(desktop): remove paywall gate on Pull Requests sidebar nav

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -178,18 +178,16 @@ export function DashboardSidebarHeader({
 	};
 
 	const handlePullRequestsClick = () => {
-		gateFeature(GATED_FEATURES.TASKS, () => {
-			navigate({
-				to: "/pull-requests",
-				search: pullRequestsSearchFromFilters({
-					search: lastPullRequestsSearch,
-					projectFilters: lastPullRequestsProjectFilters,
-					authorFilter: lastPullRequestsAuthorFilter,
-					reviewFilter: lastPullRequestsReviewFilter,
-					includeClosed: lastPullRequestsIncludeClosed,
-					mergedOnly: lastPullRequestsMergedOnly,
-				}),
-			});
+		navigate({
+			to: "/pull-requests",
+			search: pullRequestsSearchFromFilters({
+				search: lastPullRequestsSearch,
+				projectFilters: lastPullRequestsProjectFilters,
+				authorFilter: lastPullRequestsAuthorFilter,
+				reviewFilter: lastPullRequestsReviewFilter,
+				includeClosed: lastPullRequestsIncludeClosed,
+				mergedOnly: lastPullRequestsMergedOnly,
+			}),
 		});
 	};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -79,18 +79,16 @@ export function WorkspaceSidebarHeader({
 	};
 
 	const handlePullRequestsClick = () => {
-		gateFeature(GATED_FEATURES.TASKS, () => {
-			navigate({
-				to: "/pull-requests",
-				search: pullRequestsSearchFromFilters({
-					search: lastPullRequestsSearch,
-					projectFilters: lastPullRequestsProjectFilters,
-					authorFilter: lastPullRequestsAuthorFilter,
-					reviewFilter: lastPullRequestsReviewFilter,
-					includeClosed: lastPullRequestsIncludeClosed,
-					mergedOnly: lastPullRequestsMergedOnly,
-				}),
-			});
+		navigate({
+			to: "/pull-requests",
+			search: pullRequestsSearchFromFilters({
+				search: lastPullRequestsSearch,
+				projectFilters: lastPullRequestsProjectFilters,
+				authorFilter: lastPullRequestsAuthorFilter,
+				reviewFilter: lastPullRequestsReviewFilter,
+				includeClosed: lastPullRequestsIncludeClosed,
+				mergedOnly: lastPullRequestsMergedOnly,
+			}),
 		});
 	};
 


### PR DESCRIPTION
## Summary
- Removed the `gateFeature(GATED_FEATURES.TASKS, ...)` wrapper from `handlePullRequestsClick` in both sidebar headers (`DashboardSidebarHeader.tsx`, `WorkspaceSidebarHeader.tsx`), so clicking Pull Requests navigates directly instead of hitting the paywall dialog.
- The `/pull-requests` route itself had no gate to begin with (no `beforeLoad` check), and was already reachable ungated via direct URL, deep link, or the legacy `/tasks?type=prs` redirect — this just makes the sidebar entry points consistent with that.
- Tasks navigation is untouched and remains gated.

## Test plan
- [x] `tsc --noEmit` passes for both changed files
- [ ] Manually verify clicking "Pull requests" in both the dashboard and workspace sidebars (collapsed and expanded) navigates straight to `/pull-requests` on a free-tier account, with no upgrade dialog

https://claude.ai/code/session_01Tr469nj8DGqiwrCXyVNU3N

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Tasks paywall gate from the Pull requests sidebar action so clicks navigate directly to /pull-requests. Previously, sidebar clicks showed an upgrade dialog on free plans; now they go straight to the already-ungated route, aligning sidebar behavior with direct links.

**Review notes**
- Updated `DashboardSidebarHeader.tsx` and `WorkspaceSidebarHeader.tsx` to replace `gateFeature(GATED_FEATURES.TASKS, ...)` with a direct `navigate` that preserves existing filters via `pullRequestsSearchFromFilters`.
- Verify on a free plan: clicking Pull requests in both sidebars (collapsed and expanded) routes to `/pull-requests` without a paywall; filter state persists.
- Tasks navigation remains gated; no route guards or feature flags changed.

<sup>Written for commit 72ab73826ecbed5762e525ac74561bed8373e3f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull Requests navigation is now available directly from the dashboard and workspace sidebars without requiring the Tasks feature.
  - Existing pull-request filters, including search, project, author, review status, closed items, and merged items, continue to be restored when opening the Pull Requests view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->