### PR TITLE
fix(desktop): allow relay2.superset.sh in the renderer CSP

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -11,14 +11,14 @@
       - default-src 'self': Only allow resources from same origin
       - script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com: Allow scripts from same origin + WebAssembly (for xterm ImageAddon) + PostHog
       - style-src 'self' 'unsafe-inline': Allow styles from same origin + inline (needed for CSS-in-JS)
-      - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh https://superset-relay2.avi-6ac.workers.dev %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: https://*.preview.bl.run: Allow WebSocket + API + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + local host-service (127.0.0.1) + relay + relay override target (for staging/failover via PostHog flag) + cloud workspace sandboxes, which a browser reaches directly at the provider's preview domain (this entry goes away once that traffic moves behind the relay)
+      - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh https://relay2.superset.sh https://superset-relay2.avi-6ac.workers.dev %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: https://*.preview.bl.run: Allow WebSocket + API + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + local host-service (127.0.0.1) + relay + relay override target (for staging/failover via PostHog flag) + cloud workspace sandboxes, which a browser reaches directly at the provider's preview domain (this entry goes away once that traffic moves behind the relay)
       - img-src 'self' data: blob: https: http:: Allow images from any source (needed for favicons, browser pane webview content, and file attachment previews)
       - media-src 'self' data: blob:: Allow <video>/<audio> from blob + data URIs (file preview); without this, media falls back to default-src 'self' and blob video won't play
       - font-src 'self': Allow fonts from same origin
       - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
       - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh https://superset-relay2.avi-6ac.workers.dev %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: https://*.preview.bl.run; img-src 'self' data: blob: https: http:; media-src 'self' data: blob:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh https://relay2.superset.sh https://superset-relay2.avi-6ac.workers.dev %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: https://*.preview.bl.run; img-src 'self' data: blob: https: http:; media-src 'self' data: blob:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
   </head>
 
   <body>

--- a/apps/relay2/wrangler.jsonc
+++ b/apps/relay2/wrangler.jsonc
@@ -2,6 +2,9 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "superset-relay2",
 	"main": "src/index.ts",
+	// Also reachable at the workers.dev URL; both serve the same Durable
+	// Objects, so hosts and clients may mix hostnames during migration.
+	"routes": [{ "pattern": "relay2.superset.sh", "custom_domain": true }],
 	"compatibility_date": "2026-07-01",
 	"compatibility_flags": ["nodejs_als"],
 	"vars": {


### PR DESCRIPTION
## What

- Adds `https://relay2.superset.sh` to the renderer CSP `connect-src` (comment + meta tag)
- Declares the already-attached `relay2.superset.sh` Workers custom domain in `apps/relay2/wrangler.jsonc`

## Why

The relay-url-override flag pointed clients at the relay's new custom domain on 2026-08-20/21 and every shipped build silently broke HTTPS-via-relay: `connect-src` only allowlists the baked `%RELAY_URL%`, `relay-backup.superset.sh`, and the workers.dev override target. Bare `wss:` let terminal websockets through, so the failure was partial — hosts reported unavailable (workspace tRPC/presence blocked) while terminals still connected. Found by Satya; flag payload has been reverted to the allowlisted workers.dev URL (v32) and must stay there until a release carrying this CSP is out.

No behavior change for current traffic — this is forward capacity for the relay.superset.sh/relay2.superset.sh cutover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the desktop renderer to use the relay’s new custom domain by adding https://relay2.superset.sh to CSP connect-src and declares that domain in the relay’s `wrangler` config. Previously only the baked %RELAY_URL%, relay-backup.superset.sh, and the workers.dev override were allowlisted; when the flag pointed at relay2.superset.sh, HTTPS-via-relay (workspace tRPC/presence) was blocked while terminals still worked over wss.

- Rollout: No behavior change now; keep the override flag on the workers.dev URL until this ships, then switch it to https://relay2.superset.sh. Verify desktop reaches workspace APIs/presence via relay2; terminals remain unaffected.

<sup>Written for commit 8ed885814861e3e6778a404b85e2c35ce73a4332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the desktop app to connect to the Relay 2 service at its custom domain.
  * Added custom domain routing for Relay 2, while retaining compatibility with its existing endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->