### PR TITLE
chore(desktop): bump version to 1.24.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.24.0",
+	"version": "1.24.1",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -809,7 +809,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -905,7 +905,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.24.0",
+	"version": "1.24.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.24.0",
+	"version": "1.24.1",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@superset/desktop`, `@superset/cli`, and `@superset/host-service` to 1.24.1 for the desktop 1.24.1 release. No runtime or API behavior changes.

- Updates version fields in package manifests and syncs `bun.lock`; no dependency versions changed.
- Verify 1.24.1 is consistent across `apps/desktop`, `packages/cli`, `packages/host-service`, and `bun.lock`.
- No migrations or config changes required; proceed with the desktop 1.24.1 build and publish.

<sup>Written for commit 9792fb7413276aefdf585b80eb90a4c1bc091ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 1.24.1.
  * Updated the command-line interface version to 1.24.1.
  * Updated the host service version to 1.24.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->