### PR TITLE
fix(host-service,trpc): dead-relay protocol negotiation + never-seen presence fallback (stacked on tunnel-wedge-supervision)

### DIFF
--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -93,6 +93,7 @@ export async function connectRelay(
 	// cloud-invisible (issue #6415) — so retry with backoff until it lands,
 	// and record the outcome where health.check can report it.
 	for (let attempt = 0; ; attempt++) {
+		let registered = false;
 		try {
 			const host = await options.api.host.ensure.mutate({
 				organizationId: options.organizationId,
@@ -100,6 +101,15 @@ export async function connectRelay(
 				name: getHostName(),
 			});
 			recordRegistrationSuccess();
+			registered = true;
+			// Registration is the slow-moving failure this backoff was built
+			// for. Once it lands, the remaining steps fail in relay-outage
+			// shapes that resolve on the relay's schedule, not ours — without
+			// the reset, a sustained outage walks the delay up to
+			// REGISTER_RETRY_MAX_MS and the host can lag almost five minutes
+			// behind the relay coming back, versus the tunnel clients'
+			// seconds-scale reconnects.
+			attempt = 0;
 			console.log(`[host-service] registered as host ${host.machineId}`);
 
 			const relayUrl = await resolveRelayUrl(options.api, options.relayUrl);
@@ -123,7 +133,12 @@ export async function connectRelay(
 			void tunnel.connect();
 			return tunnel;
 		} catch (error) {
-			recordRegistrationFailure(error);
+			// A failure past this point is a relay problem, not a registration
+			// problem: the host is registered, and overwriting that state
+			// would make health.check and superset status warn that the host
+			// is missing from the fleet when it isn't. The console.error
+			// below keeps the relay failure observable.
+			if (!registered) recordRegistrationFailure(error);
 			const delay = Math.min(
 				REGISTER_RETRY_BASE_MS * 2 ** attempt,
 				REGISTER_RETRY_MAX_MS,

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -41,25 +41,44 @@ async function resolveRelayUrl(
 	return fallback;
 }
 
-// The relay advertises its protocol on /health ({proto: 2} for tunnel v2);
-// anything else — including the v1 relay's {ok, region} and any probe
-// failure — selects the v1 client. Negotiating here keeps protocol choice
-// between host and relay instead of adding config plumbing through every
-// spawner (desktop, CLI, env).
+// The relay advertises its protocol on /health ({proto: 2} for tunnel v2;
+// the v1 relay answers {ok, region} with no proto). Negotiating here keeps
+// protocol choice between host and relay instead of adding config plumbing
+// through every spawner (desktop, CLI, env).
+//
+// Only a healthy 200 gets to decide. An unreachable or erroring relay must
+// not be mistaken for a v1 relay: during the relay2 cutover the deleted
+// scratch worker answered every probe with an error page, and the old
+// v1-on-failure fallback wedged hosts in a silent v1 reconnect loop against
+// an endpoint that spoke neither protocol — and once a protocol is picked it
+// sticks for the client's lifetime, so per-reconnect URL re-resolution alone
+// can't recover it. Throwing instead sends the caller back through
+// registration, which re-resolves the relay URL and re-negotiates, so a
+// relay that moved is picked up on the next attempt.
 async function detectRelayProto(relayUrl: string): Promise<1 | 2> {
+	let lastFailure: unknown;
 	for (let attempt = 0; attempt < 3; attempt++) {
+		if (attempt > 0) {
+			await new Promise((r) => setTimeout(r, 1_000 * attempt).unref());
+		}
 		try {
 			const res = await fetch(new URL("/health", relayUrl), {
 				signal: AbortSignal.timeout(5_000),
 			});
-			if (!res.ok) return 1;
-			const data = (await res.json()) as { proto?: number };
-			return data.proto === 2 ? 2 : 1;
-		} catch {
-			await new Promise((r) => setTimeout(r, 1_000 * (attempt + 1)));
+			if (res.ok) {
+				const data = (await res.json()) as { proto?: number };
+				return data.proto === 2 ? 2 : 1;
+			}
+			lastFailure = new Error(`/health responded ${res.status}`);
+		} catch (error) {
+			lastFailure = error;
 		}
 	}
-	return 1;
+	throw new Error(
+		`relay ${relayUrl} health probe failed: ${
+			lastFailure instanceof Error ? lastFailure.message : lastFailure
+		}`,
+	);
 }
 
 const REGISTER_RETRY_BASE_MS = 30_000;

--- a/packages/trpc/src/lib/relay-presence.test.ts
+++ b/packages/trpc/src/lib/relay-presence.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { mergeHostPresence } from "./relay-presence";
+
+describe("mergeHostPresence", () => {
+	test("no presence entry falls back to the DB flag", () => {
+		expect(mergeHostPresence(undefined, true)).toBe(true);
+		expect(mergeHostPresence(undefined, false)).toBe(false);
+	});
+
+	test("a relay sighting is authoritative in both directions", () => {
+		expect(
+			mergeHostPresence({ online: true, lastSeenAt: 1_755_700_000_000 }, false),
+		).toBe(true);
+		expect(
+			mergeHostPresence({ online: false, lastSeenAt: 1_755_700_000_000 }, true),
+		).toBe(false);
+	});
+
+	test("online with no lastSeenAt still counts as online", () => {
+		expect(mergeHostPresence({ online: true, lastSeenAt: null }, false)).toBe(
+			true,
+		);
+	});
+
+	test("never-seen hosts fall back to the DB flag", () => {
+		// The migration case: the new relay's DO has never seen a host that is
+		// still tunneled to the previous relay, which keeps the DB flag current.
+		expect(mergeHostPresence({ online: false, lastSeenAt: null }, true)).toBe(
+			true,
+		);
+		expect(mergeHostPresence({ online: false, lastSeenAt: null }, false)).toBe(
+			false,
+		);
+	});
+});

--- a/packages/trpc/src/lib/relay-presence.ts
+++ b/packages/trpc/src/lib/relay-presence.ts
@@ -1,6 +1,27 @@
-interface PresenceInfo {
+export interface PresenceInfo {
 	online: boolean;
 	lastSeenAt: number | null;
+}
+
+/**
+ * Merges one host's relay presence with the legacy `v2_hosts.is_online` flag.
+ *
+ * The relay's answer wins only where the relay has actually seen the host.
+ * `{online: false, lastSeenAt: null}` is the Durable Object's answer for a
+ * host it has *never* seen — during a relay migration that describes every
+ * host still tunneled to the previous relay, and taking it at face value
+ * rendered the whole fleet offline while the v1 relay kept the DB flag
+ * current. No entry at all means the same thing via a different path (the
+ * batch omits denied hosts). Both fall back to the DB flag; an explicit
+ * sighting (`lastSeenAt` set) makes the relay authoritative either way.
+ */
+export function mergeHostPresence(
+	info: PresenceInfo | undefined,
+	dbIsOnline: boolean,
+): boolean {
+	if (!info) return dbIsOnline;
+	if (info.online) return true;
+	return info.lastSeenAt === null ? dbIsOnline : false;
 }
 
 const HEALTH_TTL_MS = 5 * 60_000;

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -16,10 +16,7 @@ import {
 	slugifyForBranch,
 } from "@superset/shared/workspace-launch";
 import { and, eq, sql } from "drizzle-orm";
-import {
-	fetchRelayPresence,
-	mergeHostPresence,
-} from "../../lib/relay-presence";
+import { fetchRelayPresence } from "../../lib/relay-presence";
 import { RelayDispatchError, relayMutation } from "./relay-client";
 import { promptWithTriggerContext } from "./triggerContext";
 
@@ -335,12 +332,18 @@ async function pickOnlineHost(
 		),
 	);
 	return (
-		candidates.find((host) =>
-			mergeHostPresence(
-				presence?.[buildHostRoutingKey(host.organizationId, host.machineId)],
-				host.isOnline,
-			),
-		) ?? null
+		candidates.find((host) => {
+			const info =
+				presence?.[buildHostRoutingKey(host.organizationId, host.machineId)];
+			// Deliberately NOT host.list's mergeHostPresence: dispatch acts over
+			// `relayUrl`, so a host this relay has never seen is unreachable
+			// through it no matter what the DB flag says — selecting one fails
+			// the dispatch and shadows a later candidate genuinely online here.
+			// Where the relay answered, it is authoritative; the DB flag only
+			// decides when presence is unavailable (v1 relay / fetch failure),
+			// in which case dispatch reaches hosts the v1 way.
+			return info ? info.online : host.isOnline;
+		}) ?? null
 	);
 }
 

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -16,7 +16,10 @@ import {
 	slugifyForBranch,
 } from "@superset/shared/workspace-launch";
 import { and, eq, sql } from "drizzle-orm";
-import { fetchRelayPresence } from "../../lib/relay-presence";
+import {
+	fetchRelayPresence,
+	mergeHostPresence,
+} from "../../lib/relay-presence";
 import { RelayDispatchError, relayMutation } from "./relay-client";
 import { promptWithTriggerContext } from "./triggerContext";
 
@@ -332,11 +335,12 @@ async function pickOnlineHost(
 		),
 	);
 	return (
-		candidates.find((host) => {
-			const info =
-				presence?.[buildHostRoutingKey(host.organizationId, host.machineId)];
-			return info ? info.online : host.isOnline;
-		}) ?? null
+		candidates.find((host) =>
+			mergeHostPresence(
+				presence?.[buildHostRoutingKey(host.organizationId, host.machineId)],
+				host.isOnline,
+			),
+		) ?? null
 	);
 }
 

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -18,7 +18,10 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, count, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { emitAppFirstOpened } from "../../lib/activation-events";
-import { fetchRelayPresence } from "../../lib/relay-presence";
+import {
+	fetchRelayPresence,
+	mergeHostPresence,
+} from "../../lib/relay-presence";
 import { resolveUserRelayUrl } from "../../lib/relay-url";
 import { jwtProcedure } from "../../trpc";
 
@@ -107,9 +110,10 @@ export const hostRouter = {
 			return rows.map((row) => ({
 				id: row.machineId,
 				name: row.name,
-				online:
-					presence?.[buildHostRoutingKey(row.organizationId, row.machineId)]
-						?.online ?? row.isOnline,
+				online: mergeHostPresence(
+					presence?.[buildHostRoutingKey(row.organizationId, row.machineId)],
+					row.isOnline,
+				),
 				wakeCommand: row.wakeCommand,
 				organizationId: row.organizationId,
 			}));


### PR DESCRIPTION
**Now stacked on `fix/tunnel-wedge-supervision`** — rebased down to the two pieces that branch doesn't cover, per [the earlier comment](https://github.com/superset-sh/superset/pull/6723#issuecomment-5365690251). The supervisor loop and v1 watchdog from the original version of this PR are dropped in favor of that branch's per-reconnect re-resolution and any-state watchdog.

## 1. `detectRelayProto`: don't mistake a dead relay for a v1 relay

An unreachable or erroring `/health` selected the v1 client. During the 2026-08-20 cutover the deleted scratch worker answered every probe with an error page, so a host that (re)started against the stale flag URL ran the v1 client in a silent reconnect loop against an endpoint speaking neither protocol.

This composes badly with the base branch: protocol is chosen once at establish, so per-reconnect URL re-resolution converges on the URL but never on the protocol — the wedged host keeps dialing `/tunnel` on a v2-only relay forever. Only a healthy 200 decides now; anything else throws back into the registration/resolve retry loop, which re-resolves the URL, re-negotiates the protocol, and records the failure where `health.check` and `superset status` can report it instead of claiming healthy while the tunnel is dark.

## 2. `mergeHostPresence`: never-seen ≠ offline

relay2's `/presence` answers `{online: false, lastSeenAt: null}` for any access-granted host its Durable Object has never seen. `host.list` and automation dispatch's `pickOnlineHost` merged with `?? row.isOnline`, so the explicit `false` shadowed the DB flag the v1 relay still maintains — during the cutover every host still tunneled to the v1 relay rendered offline (and would be skipped by dispatch) the moment a user's relay flag flipped, regardless of actual health.

`lastSeenAt === null` discriminates never-seen from seen-and-gone: a relay sighting is authoritative in both directions; never-seen and absent entries fall back to the DB flag. Truth-table test co-located.

## Testing

- `packages/trpc`: new `relay-presence.test.ts` (4 pass); `tsc --noEmit` clean.
- `packages/host-service`: full `bun test` on top of the base branch — 1170 pass / 0 fail; `tsc --noEmit` clean.
- `biome check` clean on all touched files.

Incident timeline and full diagnosis in the feedback report submitted 2026-08-20 ~22:00 PT.
