### PR TITLE
fix(relay): un-wedgeable tunnel supervision + SDK relay resolution

### DIFF
--- a/packages/host-service/src/sentry.ts
+++ b/packages/host-service/src/sentry.ts
@@ -39,3 +39,31 @@ export async function captureFatalStartupError(error: unknown): Promise<void> {
 		// Best-effort — the process is exiting either way.
 	}
 }
+
+// One rescue event per reason per hour: the point is a countable field signal
+// that a tunnel wedge occurred and was recovered, not a log firehose from a
+// host stuck behind a captive portal all day.
+const RESCUE_REPORT_INTERVAL_MS = 60 * 60_000;
+const lastRescueReport = new Map<string, number>();
+
+/**
+ * Report that tunnel supervision rescued a connection that would previously
+ * have wedged the host until a manual restart. Every one of these in the
+ * field is a support ticket that didn't happen — and the count is how we
+ * confirm the fix works outside the lab.
+ */
+export function reportTunnelRescue(
+	reason: string,
+	detail: Record<string, string | number>,
+): void {
+	if (!initialized) return;
+	const now = Date.now();
+	const last = lastRescueReport.get(reason) ?? 0;
+	if (now - last < RESCUE_REPORT_INTERVAL_MS) return;
+	lastRescueReport.set(reason, now);
+	Sentry.captureMessage(`tunnel rescue: ${reason}`, {
+		level: "warning",
+		tags: { tunnel_rescue: reason },
+		extra: detail,
+	});
+}

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -92,6 +92,7 @@ export async function connectRelay(
 				getAuthToken: () => options.authProvider.getJwt(),
 				localPort: options.localPort,
 				hostServiceSecret: options.hostServiceSecret,
+				resolveRelayUrl: () => resolveRelayUrl(options.api, options.relayUrl),
 			};
 
 			const proto = await detectRelayProto(relayUrl);

--- a/packages/host-service/src/tunnel/tunnel-client-OLD-test.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-OLD-test.ts
@@ -1,4 +1,3 @@
-import { reportTunnelRescue } from "../sentry";
 import type {
 	TunnelHttpRequest,
 	TunnelRequest,
@@ -8,12 +7,6 @@ import type {
 	TunnelWsOpen,
 } from "./types";
 
-// How long a socket may sit outside OPEN before the watchdog abandons it.
-// CONNECTING is normally bounded by the connect deadline and CLOSING by the
-// peer's close reply — a dead peer honors neither (undici has no close
-// timeout), which left sockets in CLOSING forever with the reconnect chain
-// waiting on an onclose that never fired.
-const STUCK_SOCKET_GRACE_MS = 30_000;
 const RECONNECT_BASE_MS = 1_000;
 // 5s ceiling rather than 30s. Under a sustained outage this means slightly
 // more retry traffic, but under transient relay restarts (the common case)
@@ -29,10 +22,6 @@ export interface TunnelClientOptions {
 	getAuthToken: () => Promise<string | null>;
 	localPort: number;
 	hostServiceSecret: string;
-	/** Re-asked on every connect attempt so a server-side relay move is picked
-	 * up by the next reconnect instead of waiting for a process restart. On
-	 * failure the last known URL is reused. */
-	resolveRelayUrl?: () => Promise<string>;
 }
 
 interface LocalChannel {
@@ -41,8 +30,7 @@ interface LocalChannel {
 }
 
 export class TunnelClient {
-	private relayUrl: string;
-	private readonly resolveRelayUrl?: () => Promise<string>;
+	private readonly relayUrl: string;
 	private readonly hostId: string;
 	private readonly getAuthToken: () => Promise<string | null>;
 	private readonly localPort: number;
@@ -53,13 +41,11 @@ export class TunnelClient {
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
 	private lastInboundAt = 0;
-	private notOpenSince: number | null = null;
 	private closed = false;
 	private connecting = false;
 
 	constructor(options: TunnelClientOptions) {
 		this.relayUrl = options.relayUrl;
-		this.resolveRelayUrl = options.resolveRelayUrl;
 		this.hostId = options.hostId;
 		this.getAuthToken = options.getAuthToken;
 		this.localPort = options.localPort;
@@ -76,7 +62,6 @@ export class TunnelClient {
 			return;
 		}
 		this.connecting = true;
-		this.startWatchdog();
 
 		let timedOut = false;
 		const deadline = setTimeout(() => {
@@ -96,13 +81,6 @@ export class TunnelClient {
 		// An unhandled rejection here (e.g. DNS failure inside getAuthToken on
 		// wake from sleep) crashes host-service and orphans every PTY.
 		try {
-			if (this.resolveRelayUrl) {
-				try {
-					this.relayUrl = await this.resolveRelayUrl();
-				} catch {
-					// keep the last known URL
-				}
-			}
 			const token = await this.getAuthToken();
 			if (timedOut || this.closed) {
 				clearTimeout(deadline);
@@ -131,6 +109,7 @@ export class TunnelClient {
 				this.reconnectAttempts = 0;
 				this.connecting = false;
 				this.lastInboundAt = Date.now();
+				this.startWatchdog();
 				console.log(
 					`[host-service:tunnel] connected to relay for host ${this.hostId}`,
 				);
@@ -147,6 +126,7 @@ export class TunnelClient {
 				try {
 					this.socket = null;
 					this.connecting = false;
+					this.stopWatchdog();
 					this.cleanupChannels();
 					if (event.code === 1008) {
 						console.warn(
@@ -393,59 +373,21 @@ export class TunnelClient {
 	}
 
 	private startWatchdog(): void {
-		if (this.watchdogTimer) return;
+		this.stopWatchdog();
 		this.watchdogTimer = setInterval(() => {
-			if (this.closed) return;
-			const socket = this.socket;
-			if (!socket) {
-				this.notOpenSince = null;
-				// No socket and nothing pending means the reconnect chain died
-				// (e.g. an exception between detach and reschedule).
-				if (!this.connecting && !this.reconnectTimer) {
-					reportTunnelRescue("v1_dead_reconnect_chain", {});
-					this.scheduleReconnect();
-				}
-				return;
-			}
-			if (socket.readyState === WebSocket.OPEN) {
-				this.notOpenSince = null;
-				const silentFor = Date.now() - this.lastInboundAt;
-				if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
-					console.warn(
-						`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
-					);
-					this.abandonSocket("Inbound silence timeout");
-				}
-				return;
-			}
-			this.notOpenSince ??= Date.now();
-			if (Date.now() - this.notOpenSince > STUCK_SOCKET_GRACE_MS) {
-				this.notOpenSince = null;
+			if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+			const silentFor = Date.now() - this.lastInboundAt;
+			if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
 				console.warn(
-					`[host-service:tunnel] socket stuck in readyState ${socket.readyState}, abandoning`,
+					`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
 				);
-				reportTunnelRescue("v1_stuck_socket", {
-					readyState: socket.readyState,
-				});
-				this.abandonSocket("Stuck socket");
+				try {
+					this.socket.close(4002, "Inbound silence timeout");
+				} catch {
+					// already closed
+				}
 			}
 		}, WATCHDOG_INTERVAL_MS);
-	}
-
-	/** Detach the socket and reconnect now, without waiting for the peer to
-	 * complete a close handshake it may never answer. The onclose guard makes
-	 * any late events from the abandoned socket no-ops. */
-	private abandonSocket(reason: string): void {
-		const socket = this.socket;
-		this.socket = null;
-		this.connecting = false;
-		this.cleanupChannels();
-		try {
-			socket?.close(4002, reason);
-		} catch {
-			// already closing
-		}
-		this.scheduleReconnect();
 	}
 
 	private stopWatchdog(): void {

--- a/packages/host-service/src/tunnel/tunnel-client-v2.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-v2.ts
@@ -5,6 +5,8 @@ import {
 } from "@superset/shared/tunnel-v2-protocol";
 import ReconnectingWebSocket from "partysocket/ws";
 
+import { reportTunnelRescue } from "../sentry";
+
 const PING_INTERVAL_MS = 30_000;
 const INBOUND_SILENCE_TIMEOUT_MS = 75_000;
 const WATCHDOG_INTERVAL_MS = 10_000;
@@ -23,7 +25,10 @@ function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
 	return Promise.race([
 		promise,
 		new Promise<T>((resolve) => {
-			setTimeout(() => resolve(fallback), URL_PROVIDER_STEP_TIMEOUT_MS).unref?.();
+			setTimeout(
+				() => resolve(fallback),
+				URL_PROVIDER_STEP_TIMEOUT_MS,
+			).unref?.();
 		}),
 	]);
 }
@@ -98,6 +103,9 @@ export class TunnelClientV2 {
 					"[host-service:tunnel-v2] token fetch failed; connecting unauthenticated so the retry cycle survives:",
 					error instanceof Error ? error.message : error,
 				);
+				reportTunnelRescue("v2_token_fetch_failed", {
+					message: error instanceof Error ? error.message.slice(0, 200) : "",
+				});
 			}
 			const url = new URL("/v2/control", toWs(this.relayUrl));
 			url.searchParams.set("hostId", this.options.hostId);
@@ -168,6 +176,7 @@ export class TunnelClientV2 {
 				console.warn(
 					`[host-service:tunnel-v2] control not open for ${stuckFor}ms, kicking reconnect`,
 				);
+				reportTunnelRescue("v2_control_stuck", { stuckForMs: stuckFor });
 				control.reconnect();
 			}
 		}, WATCHDOG_INTERVAL_MS);

--- a/packages/host-service/src/tunnel/tunnel-client-v2.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-v2.ts
@@ -8,6 +8,25 @@ import ReconnectingWebSocket from "partysocket/ws";
 const PING_INTERVAL_MS = 30_000;
 const INBOUND_SILENCE_TIMEOUT_MS = 75_000;
 const WATCHDOG_INTERVAL_MS = 10_000;
+// How long the control socket may sit outside OPEN before the watchdog kicks
+// partysocket. Generous: covers its 5s max backoff plus 20s connect timeout.
+// Partysocket owns retries, but a rejected url provider or a close handshake
+// that never lands can kill its cycle with nothing left to revive it.
+const STUCK_CONTROL_GRACE_MS = 60_000;
+// Bound on the url provider's async work. Partysocket awaits the provider
+// before it creates a socket, so its connectionTimeout cannot cover a hang
+// here — an auth or resolve call that never settles stalls the reconnect
+// cycle forever with no timer left running.
+const URL_PROVIDER_STEP_TIMEOUT_MS = 15_000;
+
+function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((resolve) => {
+			setTimeout(() => resolve(fallback), URL_PROVIDER_STEP_TIMEOUT_MS).unref?.();
+		}),
+	]);
+}
 const MAX_BUFFERED_FRAMES = 256;
 // Bodies are chunked below the Durable Object's per-message ceiling; large
 // tRPC payloads (file contents, diffs) would otherwise fail outright.
@@ -26,6 +45,10 @@ export interface TunnelClientV2Options {
 	getAuthToken: () => Promise<string | null>;
 	localPort: number;
 	hostServiceSecret: string;
+	/** Re-asked on every reconnect attempt so a server-side relay move is
+	 * picked up without a process restart. On failure the last known URL is
+	 * reused. */
+	resolveRelayUrl?: () => Promise<string>;
 }
 
 function toWs(url: string): string {
@@ -41,19 +64,42 @@ export class TunnelClientV2 {
 	private pingTimer: ReturnType<typeof setInterval> | null = null;
 	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
 	private lastInboundAt = 0;
+	private notOpenSince: number | null = null;
+	private relayUrl: string;
 	private closed = false;
 
 	constructor(options: TunnelClientV2Options) {
 		this.options = options;
+		this.relayUrl = options.relayUrl;
 	}
 
 	async connect(): Promise<void> {
 		if (this.closed || this.control) return;
 
-		// Re-invoked on every reconnect, picking up rotated tokens.
+		// Re-invoked on every reconnect, picking up rotated tokens and relay
+		// moves. It must never reject: a rejection kills partysocket's retry
+		// cycle permanently, wedging the host until a process restart.
 		const urlProvider = async (): Promise<string> => {
-			const token = await this.options.getAuthToken();
-			const url = new URL("/v2/control", toWs(this.options.relayUrl));
+			if (this.options.resolveRelayUrl) {
+				try {
+					this.relayUrl = await withTimeout(
+						this.options.resolveRelayUrl(),
+						this.relayUrl,
+					);
+				} catch {
+					// keep the last known URL
+				}
+			}
+			let token: string | null = null;
+			try {
+				token = await withTimeout(this.options.getAuthToken(), null);
+			} catch (error) {
+				console.warn(
+					"[host-service:tunnel-v2] token fetch failed; connecting unauthenticated so the retry cycle survives:",
+					error instanceof Error ? error.message : error,
+				);
+			}
+			const url = new URL("/v2/control", toWs(this.relayUrl));
 			url.searchParams.set("hostId", this.options.hostId);
 			url.searchParams.set("token", token ?? "");
 			return url.toString();
@@ -102,11 +148,25 @@ export class TunnelClientV2 {
 		}, PING_INTERVAL_MS);
 
 		this.watchdogTimer = setInterval(() => {
-			if (control.readyState !== WebSocket.OPEN) return;
-			const silentFor = Date.now() - this.lastInboundAt;
-			if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
+			if (control.readyState === WebSocket.OPEN) {
+				this.notOpenSince = null;
+				const silentFor = Date.now() - this.lastInboundAt;
+				if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
+					console.warn(
+						`[host-service:tunnel-v2] no inbound traffic for ${silentFor}ms, forcing reconnect`,
+					);
+					control.reconnect();
+				}
+				return;
+			}
+			this.notOpenSince ??= Date.now();
+			const stuckFor = Date.now() - this.notOpenSince;
+			if (stuckFor > STUCK_CONTROL_GRACE_MS) {
+				// Reset the clock so a dead cycle gets kicked once per grace
+				// window for as long as it stays down.
+				this.notOpenSince = Date.now();
 				console.warn(
-					`[host-service:tunnel-v2] no inbound traffic for ${silentFor}ms, forcing reconnect`,
+					`[host-service:tunnel-v2] control not open for ${stuckFor}ms, kicking reconnect`,
 				);
 				control.reconnect();
 			}
@@ -124,7 +184,7 @@ export class TunnelClientV2 {
 	}
 
 	private dialUrl(ticket: string): string {
-		const url = new URL("/v2/dial", toWs(this.options.relayUrl));
+		const url = new URL("/v2/dial", toWs(this.relayUrl));
 		url.searchParams.set("hostId", this.options.hostId);
 		url.searchParams.set("ticket", ticket);
 		return url.toString();

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -7,6 +7,12 @@ import type {
 	TunnelWsOpen,
 } from "./types";
 
+// How long a socket may sit outside OPEN before the watchdog abandons it.
+// CONNECTING is normally bounded by the connect deadline and CLOSING by the
+// peer's close reply — a dead peer honors neither (undici has no close
+// timeout), which left sockets in CLOSING forever with the reconnect chain
+// waiting on an onclose that never fired.
+const STUCK_SOCKET_GRACE_MS = 30_000;
 const RECONNECT_BASE_MS = 1_000;
 // 5s ceiling rather than 30s. Under a sustained outage this means slightly
 // more retry traffic, but under transient relay restarts (the common case)
@@ -22,6 +28,10 @@ export interface TunnelClientOptions {
 	getAuthToken: () => Promise<string | null>;
 	localPort: number;
 	hostServiceSecret: string;
+	/** Re-asked on every connect attempt so a server-side relay move is picked
+	 * up by the next reconnect instead of waiting for a process restart. On
+	 * failure the last known URL is reused. */
+	resolveRelayUrl?: () => Promise<string>;
 }
 
 interface LocalChannel {
@@ -30,7 +40,8 @@ interface LocalChannel {
 }
 
 export class TunnelClient {
-	private readonly relayUrl: string;
+	private relayUrl: string;
+	private readonly resolveRelayUrl?: () => Promise<string>;
 	private readonly hostId: string;
 	private readonly getAuthToken: () => Promise<string | null>;
 	private readonly localPort: number;
@@ -41,11 +52,13 @@ export class TunnelClient {
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
 	private lastInboundAt = 0;
+	private notOpenSince: number | null = null;
 	private closed = false;
 	private connecting = false;
 
 	constructor(options: TunnelClientOptions) {
 		this.relayUrl = options.relayUrl;
+		this.resolveRelayUrl = options.resolveRelayUrl;
 		this.hostId = options.hostId;
 		this.getAuthToken = options.getAuthToken;
 		this.localPort = options.localPort;
@@ -62,6 +75,7 @@ export class TunnelClient {
 			return;
 		}
 		this.connecting = true;
+		this.startWatchdog();
 
 		let timedOut = false;
 		const deadline = setTimeout(() => {
@@ -81,6 +95,13 @@ export class TunnelClient {
 		// An unhandled rejection here (e.g. DNS failure inside getAuthToken on
 		// wake from sleep) crashes host-service and orphans every PTY.
 		try {
+			if (this.resolveRelayUrl) {
+				try {
+					this.relayUrl = await this.resolveRelayUrl();
+				} catch {
+					// keep the last known URL
+				}
+			}
 			const token = await this.getAuthToken();
 			if (timedOut || this.closed) {
 				clearTimeout(deadline);
@@ -109,7 +130,6 @@ export class TunnelClient {
 				this.reconnectAttempts = 0;
 				this.connecting = false;
 				this.lastInboundAt = Date.now();
-				this.startWatchdog();
 				console.log(
 					`[host-service:tunnel] connected to relay for host ${this.hostId}`,
 				);
@@ -126,7 +146,6 @@ export class TunnelClient {
 				try {
 					this.socket = null;
 					this.connecting = false;
-					this.stopWatchdog();
 					this.cleanupChannels();
 					if (event.code === 1008) {
 						console.warn(
@@ -373,21 +392,53 @@ export class TunnelClient {
 	}
 
 	private startWatchdog(): void {
-		this.stopWatchdog();
+		if (this.watchdogTimer) return;
 		this.watchdogTimer = setInterval(() => {
-			if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
-			const silentFor = Date.now() - this.lastInboundAt;
-			if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
-				console.warn(
-					`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
-				);
-				try {
-					this.socket.close(4002, "Inbound silence timeout");
-				} catch {
-					// already closed
+			if (this.closed) return;
+			const socket = this.socket;
+			if (!socket) {
+				this.notOpenSince = null;
+				// No socket and nothing pending means the reconnect chain died
+				// (e.g. an exception between detach and reschedule).
+				if (!this.connecting && !this.reconnectTimer) this.scheduleReconnect();
+				return;
+			}
+			if (socket.readyState === WebSocket.OPEN) {
+				this.notOpenSince = null;
+				const silentFor = Date.now() - this.lastInboundAt;
+				if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
+					console.warn(
+						`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
+					);
+					this.abandonSocket("Inbound silence timeout");
 				}
+				return;
+			}
+			this.notOpenSince ??= Date.now();
+			if (Date.now() - this.notOpenSince > STUCK_SOCKET_GRACE_MS) {
+				this.notOpenSince = null;
+				console.warn(
+					`[host-service:tunnel] socket stuck in readyState ${socket.readyState}, abandoning`,
+				);
+				this.abandonSocket("Stuck socket");
 			}
 		}, WATCHDOG_INTERVAL_MS);
+	}
+
+	/** Detach the socket and reconnect now, without waiting for the peer to
+	 * complete a close handshake it may never answer. The onclose guard makes
+	 * any late events from the abandoned socket no-ops. */
+	private abandonSocket(reason: string): void {
+		const socket = this.socket;
+		this.socket = null;
+		this.connecting = false;
+		this.cleanupChannels();
+		try {
+			socket?.close(4002, reason);
+		} catch {
+			// already closing
+		}
+		this.scheduleReconnect();
 	}
 
 	private stopWatchdog(): void {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -150,7 +150,11 @@ export interface ClientOptions {
 	 * Relay base URL for host-routed operations (e.g. workspace create/delete,
 	 * which physically run on the developer's machine via the relay tunnel).
 	 *
-	 * Defaults to process.env['SUPERSET_RELAY_URL'] or `https://relay.superset.sh`.
+	 * When set (or via process.env['SUPERSET_RELAY_URL']) it is used as-is.
+	 * When omitted, the client asks the API which relay this account's hosts
+	 * are on before each host-routed call (cached briefly), falling back to
+	 * `https://relay.superset.sh` if the API is unreachable — a hardcoded
+	 * default silently misses hosts after a server-side relay move.
 	 */
 	relayURL?: string | null | undefined;
 
@@ -246,6 +250,9 @@ export class Superset {
 	private _options: ClientOptions;
 	private _jwtCache: { token: string; expiresAt: number } | null = null;
 	private _jwtInflight: Promise<string> | null = null;
+	private _relayUrlExplicit = false;
+	private _relayUrlCache: { url: string; expiresAt: number } | null = null;
+	private _relayUrlInflight: Promise<string> | null = null;
 
 	/**
 	 * API Client for interfacing with the Superset API.
@@ -316,6 +323,7 @@ export class Superset {
 
 		this.apiKey = apiKey;
 		this.organizationId = organizationId ?? null;
+		this._relayUrlExplicit = Boolean(relayURL);
 		this.relayURL = relayURL || "https://relay.superset.sh";
 	}
 
@@ -530,20 +538,23 @@ export class Superset {
 			);
 		}
 		const routingKey = `${this.organizationId}:${hostId}`;
-		const url = `${this.relayURL}/hosts/${routingKey}/trpc/${procedurePath}`;
-		const optsPromise = this._getJwt().then((jwt) => ({
-			// Caller options first (timeout, retries, signal, etc.) — body and
-			// auth headers are then forced so per-call options can't strip the
-			// JWT or replace the tRPC envelope.
-			...options,
-			body: { json: input ?? null },
-			headers: buildHeaders([
-				options?.headers,
-				// Drop API-key auth (relay only verifies JWTs) and assert the JWT.
-				{ "x-api-key": null, Authorization: `Bearer ${jwt}` },
-			]),
-		}));
-		return this.post<TRPCEnvelope<Rsp>>(url, optsPromise)._thenUnwrap(
+		const optsPromise = Promise.all([this._getJwt(), this._getRelayUrl()]).then(
+			([jwt, relayUrl]) => ({
+				// Caller options first (timeout, retries, signal, etc.) — body and
+				// auth headers are then forced so per-call options can't strip the
+				// JWT or replace the tRPC envelope.
+				...options,
+				method: "post" as const,
+				path: `${relayUrl}/hosts/${routingKey}/trpc/${procedurePath}`,
+				body: { json: input ?? null },
+				headers: buildHeaders([
+					options?.headers,
+					// Drop API-key auth (relay only verifies JWTs) and assert the JWT.
+					{ "x-api-key": null, Authorization: `Bearer ${jwt}` },
+				]),
+			}),
+		);
+		return this.request<TRPCEnvelope<Rsp>>(optsPromise)._thenUnwrap(
 			(r) => r.result.data.json,
 		);
 	}
@@ -567,16 +578,19 @@ export class Superset {
 		if (input !== undefined) {
 			queryParams.input = JSON.stringify({ json: input });
 		}
-		const url = `${this.relayURL}/hosts/${routingKey}/trpc/${procedurePath}`;
-		const optsPromise = this._getJwt().then((jwt) => ({
-			...options,
-			query: queryParams,
-			headers: buildHeaders([
-				options?.headers,
-				{ "x-api-key": null, Authorization: `Bearer ${jwt}` },
-			]),
-		}));
-		return this.get<TRPCEnvelope<Rsp>>(url, optsPromise)._thenUnwrap(
+		const optsPromise = Promise.all([this._getJwt(), this._getRelayUrl()]).then(
+			([jwt, relayUrl]) => ({
+				...options,
+				method: "get" as const,
+				path: `${relayUrl}/hosts/${routingKey}/trpc/${procedurePath}`,
+				query: queryParams,
+				headers: buildHeaders([
+					options?.headers,
+					{ "x-api-key": null, Authorization: `Bearer ${jwt}` },
+				]),
+			}),
+		);
+		return this.request<TRPCEnvelope<Rsp>>(optsPromise)._thenUnwrap(
 			(r) => r.result.data.json,
 		);
 	}
@@ -587,6 +601,53 @@ export class Superset {
 	 * skew. Concurrent host calls share a single in-flight exchange so we
 	 * don't fan out N token requests on a cold cache.
 	 */
+	/**
+	 * The relay this account's hosts are actually on, asked of the API and
+	 * cached for a minute. Hosts resolve their relay through the API, so a
+	 * client that hardcodes one diverges after any server-side relay move —
+	 * the workspace tools then ping a relay the host left. An explicitly
+	 * configured relayURL (option or env) always wins; the API answer only
+	 * replaces the built-in default. Falls back to the last configured URL
+	 * when the API can't answer.
+	 */
+	private async _getRelayUrl(): Promise<string> {
+		if (this._relayUrlExplicit) return this.relayURL;
+		const now = Date.now();
+		if (this._relayUrlCache && this._relayUrlCache.expiresAt > now) {
+			return this._relayUrlCache.url;
+		}
+		if (this._relayUrlInflight) return this._relayUrlInflight;
+		this._relayUrlInflight = (async () => {
+			try {
+				const jwt = await this._getJwt();
+				const envelope = await this.get<TRPCEnvelope<{ url?: string }>>(
+					"/api/trpc/host.relayEndpoint",
+					{
+						timeout: 10_000,
+						headers: buildHeaders([
+							{ "x-api-key": null, Authorization: `Bearer ${jwt}` },
+						]),
+					},
+				);
+				const url = envelope.result.data.json?.url;
+				if (url) {
+					this._relayUrlCache = { url, expiresAt: Date.now() + 60_000 };
+					return url;
+				}
+			} catch {
+				// fall through to the configured URL
+			}
+			this._relayUrlCache = {
+				url: this.relayURL,
+				expiresAt: Date.now() + 60_000,
+			};
+			return this.relayURL;
+		})().finally(() => {
+			this._relayUrlInflight = null;
+		});
+		return this._relayUrlInflight;
+	}
+
 	private async _getJwt(): Promise<string> {
 		const now = Date.now();
 		if (this._jwtCache && this._jwtCache.expiresAt - 5 * 60_000 > now) {


### PR DESCRIPTION
## The bug class

Three field incidents this week (two user reports + one detailed feedback doc) shared one signature: **host process alive and API-reachable, relay tunnel connected to no relay, zero reconnect attempts anywhere, fixed only by manually restarting the host service.** One reporter's watchdog log showed a 4.4-hour rescue on a 75-second timeout.

## Reproduced mechanism (v2, the current fleet)

Partysocket awaits the async `urlProvider` **before creating a socket**, so its `connectionTimeout` cannot cover it. A `getAuthToken()` that hangs (network call to an unreachable API, no timeout) stalls the provider forever — the retry cycle dies with no timer running anywhere. Reproduced against the live relay: **old client makes 1 attempt then goes silent permanently; fixed client keeps cycling indefinitely.** (A *throwing* provider was already survivable — the hang is the killer.)

The v1 client has the sibling defect: its watchdog early-returns unless the socket is OPEN, and its silence recovery calls `close()` and waits for `onclose` — which a dead peer never delivers (undici has no close-handshake timeout), leaving `CLOSING` sockets supervised by nothing.

## The fix — one invariant

*At every moment, some timer is armed that leads back to a healthy socket.*

- **v2**: 15s timeout on each url-provider step (hang → fallback, cycle moves on); provider never rejects; watchdog kicks `control.reconnect()` when the control socket sits outside OPEN past 60s.
- **v1**: watchdog supervises every state (OPEN silence; sockets stuck non-OPEN past 30s; a dead reconnect chain) and abandons sockets by detaching immediately — the onclose guard makes late events no-ops.
- **Both**: relay URL re-resolved via the API on every reconnect attempt (fallback: last known). A server-side relay move now converges on the next reconnect, not the next process restart — previously the URL was pinned once per process lifetime, which is why the relay migration only moved hosts when machines rebooted.

## Verification

- Live-relay harness, hanging provider: old 1 attempt/45s (wedge), new 3 attempts/45s and ongoing
- Live-relay harness, throwing providers (both): 10 attempts/30s, cycle survives
- `@superset/host-service` typecheck + test suite green

Ships on the desktop release cadence — candidate for the next patch release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the tunnel from wedging and ensures host-routed SDK calls use the active relay. Previously v2 could stall on a hanging URL provider and v1 could sit in CONNECTING/CLOSING waiting for a peer; now both always progress back to a healthy socket, and we emit limited Sentry signals that the supervision worked.

- v2: 15s timeout on each url-provider step with fallback; provider never rejects; watchdog kicks `partysocket` if control isn’t OPEN for >60s.
- v1: Watchdog supervises every state; abandons stuck sockets immediately (no close-handshake wait); restarts dead reconnect chains.
- Hosts + SDK: Re-resolve the relay URL via the API (hosts: every reconnect; SDK: before host-routed calls with 60s cache and single-flight), falling back to the last known/configured URL; explicit `relayURL` or `SUPERSET_RELAY_URL` still wins.
- Observability: Report one Sentry “tunnel rescue” per reason per hour (`v1_stuck_socket`, `v1_dead_reconnect_chain`, `v2_token_fetch_failed`, `v2_control_stuck`) to verify field impact.
- Rollout: No config changes. Expect slightly more retry traffic under sustained outages.

<sup>Written for commit 00eab86f1e703000e247b1655e62848988724d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel reliability by refreshing relay connections when needed.
  * Added safeguards for delayed or failed relay URL and authentication lookups.
  * Reuses the last known relay when resolution fails.
  * Automatically recovers connections that become unresponsive or remain stuck during setup.
  * Preserves reconnection behavior when sockets close or stop receiving data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->