### PR TITLE
fix(desktop): show session-specific copy in the workspace-creating loader

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -224,7 +224,11 @@ export function DashboardSidebarWorkspaceItem({
 					onClick={handleClick}
 					isCreatePending={isPending}
 					pullRequestState={pullRequest?.state ?? null}
-					aria-label={isPending ? `Creating workspace: ${name}` : undefined}
+					aria-label={
+						isPending
+							? `Creating ${workspace.type === "session" ? "session" : "workspace"}: ${name}`
+							: undefined
+					}
 				/>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
@@ -158,6 +158,7 @@ function V2WorkspaceLayout() {
 					name={workspace.name}
 					branch={workspace.branch}
 					startedAt={new Date(workspace.createdAt).getTime()}
+					isSession={workspace.type === "session"}
 				/>
 			</StateScreenShell>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -14,7 +14,7 @@ interface Step {
 // Mirrors the v1 init step order in shared/types/workspace-init.ts so the
 // labels feel real — v2 workspaces.create runs the same git work server-side
 // without streaming progress events, so timings here are estimates.
-const STEPS: readonly Step[] = [
+const WORKTREE_STEPS: readonly Step[] = [
 	{ id: "preparing", label: "Preparing", doneAt: 1 },
 	{ id: "syncing", label: "Syncing with remote", doneAt: 4 },
 	{ id: "verifying", label: "Verifying base branch", doneAt: 5 },
@@ -24,9 +24,17 @@ const STEPS: readonly Step[] = [
 	{ id: "finalizing", label: "Finalizing setup", doneAt: 23 },
 ] as const;
 
-const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;
+// A session has no worktree work — just a folder + git init — so it skips
+// the remote-sync/worktree steps entirely rather than showing steps that
+// never happen.
+const SESSION_STEPS: readonly Step[] = [
+	{ id: "preparing", label: "Preparing", doneAt: 1 },
+	{ id: "initializing", label: "Initializing session", doneAt: 3 },
+	{ id: "finalizing", label: "Finalizing setup", doneAt: 5 },
+] as const;
+
 // Cap synthetic progress so the bar never claims completion before the real
-// workspaces.create mutation resolves.
+// mutation resolves.
 const PROGRESS_CAP = 0.94;
 // Past the typical budget — offer a window reload as an escape hatch in
 // case the renderer state has drifted from the real workspace row.
@@ -36,16 +44,20 @@ interface WorkspaceCreatingStateProps {
 	name?: string;
 	branch?: string;
 	startedAt?: number;
+	isSession?: boolean;
 }
 
 export function WorkspaceCreatingState({
 	name,
 	branch,
 	startedAt,
+	isSession = false,
 }: WorkspaceCreatingStateProps) {
+	const steps = isSession ? SESSION_STEPS : WORKTREE_STEPS;
+	const totalSeconds = steps[steps.length - 1].doneAt;
 	const elapsed = useElapsedSeconds(startedAt);
-	const activeIndex = getActiveIndex(elapsed);
-	const progress = Math.min(elapsed / TOTAL_SECONDS, PROGRESS_CAP);
+	const activeIndex = getActiveIndex(elapsed, steps);
+	const progress = Math.min(elapsed / totalSeconds, PROGRESS_CAP);
 	const stuck = elapsed >= STUCK_AFTER_SECONDS;
 
 	return (
@@ -59,7 +71,7 @@ export function WorkspaceCreatingState({
 
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
-						Creating workspace
+						{isSession ? "Creating session" : "Creating workspace"}
 					</h1>
 					<p className="truncate text-[13px] leading-relaxed text-muted-foreground">
 						{name || "Untitled workspace"}
@@ -80,7 +92,7 @@ export function WorkspaceCreatingState({
 				)}
 
 				<ul className="flex w-full flex-col gap-2">
-					{STEPS.map((step, i) => {
+					{steps.map((step, i) => {
 						const state: StepState =
 							i < activeIndex
 								? "done"
@@ -103,15 +115,15 @@ export function WorkspaceCreatingState({
 						<span className="font-mono tabular-nums">
 							{formatElapsed(elapsed)}
 						</span>
-						<span>~{TOTAL_SECONDS}s typical</span>
+						<span>~{totalSeconds}s typical</span>
 					</div>
 				</div>
 
 				{stuck && (
 					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4 animate-in fade-in slide-in-from-bottom-1 duration-500">
 						<p className="select-text cursor-text text-[12px] leading-relaxed text-muted-foreground">
-							This is taking longer than usual. The workspace may already be
-							ready — reloading can pick it up.
+							This is taking longer than usual. The {isSession ? "session" : "workspace"} may
+							already be ready — reloading can pick it up.
 						</p>
 						<Button
 							size="sm"
@@ -174,12 +186,12 @@ function StepIcon({ state }: { state: StepState }) {
 	);
 }
 
-function getActiveIndex(elapsed: number): number {
-	for (let i = 0; i < STEPS.length; i++) {
-		if (elapsed < STEPS[i].doneAt) return i;
+function getActiveIndex(elapsed: number, steps: readonly Step[]): number {
+	for (let i = 0; i < steps.length; i++) {
+		if (elapsed < steps[i].doneAt) return i;
 	}
 	// Past the synthetic budget — keep the last step active until real completion.
-	return STEPS.length - 1;
+	return steps.length - 1;
 }
 
 function formatElapsed(seconds: number): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -122,8 +122,9 @@ export function WorkspaceCreatingState({
 				{stuck && (
 					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4 animate-in fade-in slide-in-from-bottom-1 duration-500">
 						<p className="select-text cursor-text text-[12px] leading-relaxed text-muted-foreground">
-							This is taking longer than usual. The {isSession ? "session" : "workspace"} may
-							already be ready — reloading can pick it up.
+							This is taking longer than usual. The{" "}
+							{isSession ? "session" : "workspace"} may already be ready —
+							reloading can pick it up.
 						</p>
 						<Button
 							size="sm"


### PR DESCRIPTION
## Summary
- New sessions don't create a git worktree, but the shared "Creating workspace" loader always showed worktree-specific steps ("Syncing with remote", "Verifying base branch", "Creating git worktree").
- `WorkspaceCreatingState` now branches on `workspace.type === "session"` to render a shorter, session-appropriate title and step list; the sidebar's collapsed-icon `aria-label` follows the same branch.

## Test plan
- [ ] Create a new session (project-less workspace) and confirm the loader shows "Creating session" with the short 3-step list, no worktree-specific steps.
- [ ] Create a new workspace and confirm the loader is unchanged ("Creating workspace", full 7-step list).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows session-specific copy in the workspace-creation loader to avoid misleading worktree steps. Previously all creations showed a 7-step worktree flow; now sessions show a 3-step flow with the correct title, progress timing, and ARIA labels. Non-session workspaces are unchanged.

- `V2WorkspaceLayout` passes `isSession={workspace.type === "session"}` to the creating state.
- `WorkspaceCreatingState` selects `SESSION_STEPS` vs `WORKTREE_STEPS`, updates the title to “Creating session,” computes progress/duration from the selected steps, and adjusts the “taking longer” message noun.
- `DashboardSidebarWorkspaceItem` sets the pending `aria-label` to “Creating session: {name}” or “Creating workspace: {name}.”
- Verify: a new session shows the 3-step flow with no worktree steps; a regular workspace still shows the 7-step flow.

<sup>Written for commit 3013902d47c0c146dff41f3406cd456f8f9d1562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved progress feedback while creating sessions with session-specific steps, timing, titles, and status messages.
  * Pending workspace labels now clearly distinguish session creation from workspace creation.
* **Bug Fixes**
  * Corrected creation-state messaging so it accurately reflects whether a session or workspace is being created.
  * Improved stuck-state guidance and estimated duration details for each creation type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->