### PR TITLE
feat(desktop): collapsible per-workspace groups in top-bar ports dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/TopBarPortsDropdown/TopBarPortsDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/TopBarPortsDropdown/TopBarPortsDropdown.tsx
@@ -50,7 +50,7 @@ export function TopBarPortsDropdown({
 						<button
 							type="button"
 							aria-label={`Ports — ${totalPortCount} live`}
-							className="flex items-center gap-1.5 rounded px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-fill-hover hover:text-foreground data-[state=open]:bg-fill-hover data-[state=open]:text-foreground"
+							className="flex items-center gap-1.5 rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-fill-hover hover:text-foreground data-[state=open]:bg-fill-hover data-[state=open]:text-foreground"
 						>
 							<LuRadioTower className="size-3.5" strokeWidth={STROKE_WIDTH} />
 							<span className="font-medium tabular-nums">{totalPortCount}</span>
@@ -66,7 +66,14 @@ export function TopBarPortsDropdown({
 					</p>
 				</TooltipContent>
 			</Tooltip>
-			<PopoverContent align={align} sideOffset={6} className="w-72 p-0">
+			<PopoverContent align={align} sideOffset={6} className="w-80 p-0">
+				<div className="flex items-center gap-1.5 border-border border-b px-3 py-2">
+					<LuRadioTower
+						className="size-3 text-muted-foreground"
+						strokeWidth={STROKE_WIDTH}
+					/>
+					<span className="font-medium text-foreground text-xs">Ports</span>
+				</div>
 				<div className="max-h-80 overflow-y-auto p-1">
 					{workspacePortGroups.map((group) => (
 						<TopBarPortsGroup

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/TopBarPortsDropdown/components/TopBarPortsGroup/TopBarPortsGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/TopBarPortsDropdown/components/TopBarPortsGroup/TopBarPortsGroup.tsx
@@ -1,11 +1,18 @@
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { LuLoaderCircle, LuX } from "react-icons/lu";
+import { LuChevronRight, LuLoaderCircle, LuX } from "react-icons/lu";
 import { useDashboardSidebarPortKill } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortKill";
 import type { DashboardSidebarPortGroup } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarPortsData";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import { usePortsStore } from "renderer/stores/ports";
 import { TopBarPortRow } from "../TopBarPortRow";
 
 interface TopBarPortsGroupProps {
@@ -14,13 +21,18 @@ interface TopBarPortsGroupProps {
 }
 
 /**
- * One workspace's ports in the top-bar dropdown: a header that navigates to
- * the workspace (with a hover-revealed close-all for the group), then a row
- * per port.
+ * One workspace's ports in the top-bar dropdown: a collapsible header that
+ * navigates to the workspace (with a hover-revealed close-all for the
+ * group), then a row per port. Collapse state is keyed per workspace and
+ * persists across sessions via `usePortsStore`.
  */
 export function TopBarPortsGroup({ group, onNavigate }: TopBarPortsGroupProps) {
 	const navigate = useNavigate();
 	const { isPending, killPorts } = useDashboardSidebarPortKill();
+	const isCollapsed = usePortsStore(
+		(s) => !!s.collapsedWorkspaceIds[group.workspaceId],
+	);
+	const toggleCollapsed = usePortsStore((s) => s.toggleWorkspaceCollapsed);
 
 	const handleWorkspaceClick = () => {
 		void navigateToV2Workspace(group.workspaceId, navigate);
@@ -39,8 +51,31 @@ export function TopBarPortsGroup({ group, onNavigate }: TopBarPortsGroupProps) {
 	};
 
 	return (
-		<div className="pb-1">
-			<div className="group/wsheader flex items-center gap-1.5 px-2 pt-1.5 pb-0.5">
+		<Collapsible
+			open={!isCollapsed}
+			onOpenChange={() => toggleCollapsed(group.workspaceId)}
+			className="border-border/60 border-t pb-1 first:border-t-0 first:pt-0"
+		>
+			<div className="group/wsheader flex items-center gap-1 px-1 pt-1.5 pb-0.5">
+				<CollapsibleTrigger asChild>
+					<button
+						type="button"
+						aria-label={
+							isCollapsed
+								? `Expand ${group.workspaceName}`
+								: `Collapse ${group.workspaceName}`
+						}
+						className="shrink-0 rounded p-0.5 text-muted-foreground/70 transition-colors hover:bg-fill-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					>
+						<LuChevronRight
+							className={cn(
+								"size-3 transition-transform duration-150",
+								!isCollapsed && "rotate-90",
+							)}
+							strokeWidth={STROKE_WIDTH}
+						/>
+					</button>
+				</CollapsibleTrigger>
 				<button
 					type="button"
 					onClick={handleWorkspaceClick}
@@ -53,6 +88,9 @@ export function TopBarPortsGroup({ group, onNavigate }: TopBarPortsGroupProps) {
 						remote
 					</span>
 				)}
+				<span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums">
+					{group.ports.length}
+				</span>
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
 						<button
@@ -78,13 +116,17 @@ export function TopBarPortsGroup({ group, onNavigate }: TopBarPortsGroupProps) {
 					</TooltipContent>
 				</Tooltip>
 			</div>
-			{group.ports.map((port) => (
-				<TopBarPortRow
-					key={`${port.hostId}:${port.terminalId}:${port.port}`}
-					port={port}
-					onNavigate={onNavigate}
-				/>
-			))}
-		</div>
+			<CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+				<div className="pl-3">
+					{group.ports.map((port) => (
+						<TopBarPortRow
+							key={`${port.hostId}:${port.terminalId}:${port.port}`}
+							port={port}
+							onNavigate={onNavigate}
+						/>
+					))}
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
 	);
 }

--- a/apps/desktop/src/renderer/stores/ports/store.ts
+++ b/apps/desktop/src/renderer/stores/ports/store.ts
@@ -3,9 +3,11 @@ import { devtools, persist } from "zustand/middleware";
 
 interface PortsState {
 	isListCollapsed: boolean;
+	collapsedWorkspaceIds: Record<string, boolean>;
 
 	setListCollapsed: (collapsed: boolean) => void;
 	toggleListCollapsed: () => void;
+	toggleWorkspaceCollapsed: (workspaceId: string) => void;
 }
 
 export const usePortsStore = create<PortsState>()(
@@ -13,16 +15,26 @@ export const usePortsStore = create<PortsState>()(
 		persist(
 			(set, get) => ({
 				isListCollapsed: false,
+				collapsedWorkspaceIds: {},
 
 				setListCollapsed: (collapsed) => set({ isListCollapsed: collapsed }),
 
 				toggleListCollapsed: () =>
 					set({ isListCollapsed: !get().isListCollapsed }),
+
+				toggleWorkspaceCollapsed: (workspaceId) =>
+					set((state) => ({
+						collapsedWorkspaceIds: {
+							...state.collapsedWorkspaceIds,
+							[workspaceId]: !state.collapsedWorkspaceIds[workspaceId],
+						},
+					})),
 			}),
 			{
 				name: "ports-store",
 				partialize: (state) => ({
 					isListCollapsed: state.isListCollapsed,
+					collapsedWorkspaceIds: state.collapsedWorkspaceIds,
 				}),
 			},
 		),


### PR DESCRIPTION
## Summary
- Each workspace's ports in the top-bar dropdown (`TopBarPortsDropdown`) can now be collapsed/expanded independently, via a chevron toggle on the workspace header row. Collapse state persists per workspace across sessions (extends the existing `ports-store`).
- Added a small "Ports" title header to the dropdown and a port-count badge per workspace group.
- Minor polish: aligned the trigger pill's corner radius with sibling top-bar buttons, added dividers between workspace groups, indented port rows under their workspace header.

Reuses the same `Collapsible`/`CollapsibleTrigger`/`CollapsibleContent` pattern already used in `CategorySection.tsx` for consistency with the rest of the codebase.

## Test plan
- [x] `tsc --noEmit` and `biome check` pass on the changed files
- [x] Verified live in the dev app: enabled the "Ports in top bar dropdown" experimental setting, started a real local server in a real workspace, confirmed the dropdown groups ports per workspace, and that clicking the chevron collapses/expands the port list correctly with the count badge and close-all action still working
- [x] Repeated collapse/expand toggling (6x) produced zero console errors
- [x] Confirmed the dropdown correctly stays hidden when there are zero live ports (unchanged gating behavior)

https://claude.ai/code/session_01CNABZEhYe2zBdT4WFXYAuc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make each workspace’s port group in the top-bar Ports dropdown collapsible with per-workspace persisted state. Previously all groups were always expanded; now users can collapse/expand via a chevron, with a count badge and minor UI polish.

- Persist collapse state per workspace in `ports-store` via `collapsedWorkspaceIds` and `toggleWorkspaceCollapsed` (backward compatible).
- Reuse the existing collapsible pattern to animate open/close; “close all” and zero-ports gating remain unchanged.
- UI tweaks: add a “Ports” header, widen popover to `w-80`, align trigger radius, add dividers, and indent port rows.

<sup>Written for commit c3af6a94f8e22302eb61d1cf4062d0c43735420c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible port lists for each workspace.
  * Port list collapse states are preserved between sessions.
  * Added workspace port counts and accessible expand/collapse controls.
  * Updated the ports dropdown with a clearer header, icon, and expanded layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->