### PR TITLE
fix(desktop): wire up Quick Create Workspace (Cmd+Shift+N) in v2

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
+++ b/apps/desktop/src/renderer/commandPalette/CommandPaletteHost.tsx
@@ -8,6 +8,7 @@ import { registerAllModules } from "./modules";
 import { CommandPalette } from "./ui/CommandPalette/CommandPalette";
 import { DeleteWorkspaceMount } from "./ui/DeleteWorkspaceMount/DeleteWorkspaceMount";
 import { FolderImportMount } from "./ui/FolderImportMount/FolderImportMount";
+import { QuickCreateWorkspaceMount } from "./ui/QuickCreateWorkspaceMount/QuickCreateWorkspaceMount";
 import { RemoveFromSidebarMount } from "./ui/RemoveFromSidebarMount/RemoveFromSidebarMount";
 import { SetPreferredOpenInAppMount } from "./ui/SetPreferredOpenInAppMount/SetPreferredOpenInAppMount";
 
@@ -25,6 +26,7 @@ export function CommandPaletteHost({ children }: { children?: ReactNode }) {
 			<RemoveFromSidebarMount />
 			<SetPreferredOpenInAppMount />
 			<FolderImportMount />
+			<QuickCreateWorkspaceMount />
 			{children}
 		</CommandContextProvider>
 	);

--- a/apps/desktop/src/renderer/commandPalette/core/ContextProvider.tsx
+++ b/apps/desktop/src/renderer/commandPalette/core/ContextProvider.tsx
@@ -13,6 +13,7 @@ import {
 	useContext,
 	useMemo,
 } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
@@ -27,6 +28,7 @@ export function CommandContextProvider({ children }: { children: ReactNode }) {
 	const matchRoute = useMatchRoute();
 	const navigate = useNavigate();
 	const collections = useCollections();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const {
 		activeHostUrl,
 		activeOrganizationId,
@@ -94,6 +96,7 @@ export function CommandContextProvider({ children }: { children: ReactNode }) {
 			hostServiceStatus,
 			localMachineId: machineId ?? null,
 			notificationSoundsMuted,
+			isV2CloudEnabled,
 			navigate: navigateTo,
 		}),
 		[
@@ -106,6 +109,7 @@ export function CommandContextProvider({ children }: { children: ReactNode }) {
 			hostServiceStatus,
 			machineId,
 			notificationSoundsMuted,
+			isV2CloudEnabled,
 			navigateTo,
 		],
 	);

--- a/apps/desktop/src/renderer/commandPalette/core/types.ts
+++ b/apps/desktop/src/renderer/commandPalette/core/types.ts
@@ -29,6 +29,7 @@ export interface CommandContext {
 	hostServiceStatus: HostServiceAvailabilityStatus;
 	localMachineId: string | null;
 	notificationSoundsMuted: boolean;
+	isV2CloudEnabled: boolean;
 	navigate: (path: string) => void;
 	focusedView?: "editor" | "terminal" | "git" | "issues" | "files" | "chat";
 }

--- a/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
@@ -4,10 +4,12 @@ import {
 	LinkIcon,
 	PlusIcon,
 	Trash2Icon,
+	ZapIcon,
 } from "lucide-react";
 import { useQuickOpenStore } from "renderer/commandPalette/ui/QuickOpen/quickOpenStore";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { useNewWorkspaceModalStore } from "renderer/stores/new-workspace-modal";
+import { useQuickCreateWorkspaceIntent } from "renderer/stores/quick-create-workspace-intent";
 import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import type { Command, CommandProvider } from "../../core/types";
 import { LinkTaskFrame } from "../../ui/LinkTask/LinkTaskFrame";
@@ -15,11 +17,29 @@ import { LinkTaskFrame } from "../../ui/LinkTask/LinkTaskFrame";
 export const workspaceProvider: CommandProvider = {
 	id: "workspace",
 	provide: (context) => {
-		if (!context.workspace) return [];
+		// Not gated on context.workspace — quick-create should work from any
+		// v2 dashboard view (e.g. the workspaces list), not just an open one.
+		const commands: Command[] = [
+			{
+				id: "workspace.quickCreate",
+				title: "Quick create workspace",
+				section: "workspace",
+				icon: ZapIcon,
+				hotkeyId: "QUICK_CREATE_WORKSPACE",
+				keywords: ["new", "fast"],
+				when: (ctx) => ctx.isV2CloudEnabled,
+				run: (ctx) =>
+					useQuickCreateWorkspaceIntent
+						.getState()
+						.request(ctx.workspace?.projectId ?? null),
+			},
+		];
+
+		if (!context.workspace) return commands;
 		const workspace = context.workspace;
 		const isMain = workspace.workspaceType === "main";
 
-		const commands: Command[] = [
+		commands.push(
 			{
 				id: "workspace.new",
 				title: "New workspace",
@@ -49,7 +69,7 @@ export const workspaceProvider: CommandProvider = {
 				keywords: ["issue", "linear"],
 				renderFrame: () => <LinkTaskFrame workspaceId={workspace.id} />,
 			},
-		];
+		);
 
 		if (workspace.projectId) {
 			commands.push({

--- a/apps/desktop/src/renderer/commandPalette/ui/QuickCreateWorkspaceMount/QuickCreateWorkspaceMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/QuickCreateWorkspaceMount/QuickCreateWorkspaceMount.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+import { useQuickCreateWorkspace } from "renderer/hooks/useQuickCreateWorkspace";
+import { useQuickCreateWorkspaceIntent } from "renderer/stores/quick-create-workspace-intent";
+
+/**
+ * No visible UI. `useQuickCreateWorkspace` needs full hook access (host
+ * service, host projects, workspace-creates), which `Command.run` doesn't
+ * have — the command palette requests through the intent store instead, and
+ * this globally-mounted component performs the create.
+ */
+export function QuickCreateWorkspaceMount() {
+	const quickCreateWorkspace = useQuickCreateWorkspace();
+	const target = useQuickCreateWorkspaceIntent((state) => state.target);
+	const clear = useQuickCreateWorkspaceIntent((state) => state.clear);
+	const lastTickRef = useRef(0);
+
+	useEffect(() => {
+		if (!target || target.tick === lastTickRef.current) return;
+		lastTickRef.current = target.tick;
+		quickCreateWorkspace(target.projectId);
+		clear();
+	}, [target, quickCreateWorkspace, clear]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/hooks/useQuickCreateWorkspace/index.ts
+++ b/apps/desktop/src/renderer/hooks/useQuickCreateWorkspace/index.ts
@@ -1,0 +1,1 @@
+export { useQuickCreateWorkspace } from "./useQuickCreateWorkspace";

--- a/apps/desktop/src/renderer/hooks/useQuickCreateWorkspace/useQuickCreateWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/useQuickCreateWorkspace/useQuickCreateWorkspace.ts
@@ -1,0 +1,64 @@
+import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+
+/**
+ * Creates a v2 workspace immediately, skipping the new-workspace modal.
+ * `projectIdHint` is the caller's best guess at "current project" (e.g. the
+ * open v2 workspace route); when absent it falls back to the last-used
+ * project, then the first known project. With no project to infer at all,
+ * falls back to opening the modal so the user can add or pick one.
+ */
+export function useQuickCreateWorkspace() {
+	const navigate = useNavigate();
+	const { machineId } = useLocalHostService();
+	const { projects: hostProjects } = useHostProjects();
+	const { submit } = useWorkspaceCreates();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+
+	return useCallback(
+		(projectIdHint?: string | null) => {
+			const projectId =
+				projectIdHint ??
+				useV2WorkspaceCreateDefaultsStore.getState().lastProjectId ??
+				hostProjects[0]?.id ??
+				null;
+
+			if (!projectId || !machineId) {
+				openNewWorkspaceModal();
+				return;
+			}
+
+			const workspaceId = crypto.randomUUID();
+			const { completed } = submit({
+				hostId: machineId,
+				snapshot: { id: workspaceId, projectId },
+			});
+			void navigate({
+				to: "/v2-workspace/$workspaceId",
+				params: { workspaceId },
+			}).catch((error) => {
+				console.error("[QuickCreateWorkspace] failed to open workspace", error);
+			});
+			toast.promise(
+				completed.then((outcome) => {
+					if (!outcome.ok) throw new Error(outcome.error);
+				}),
+				{
+					loading: "Creating workspace...",
+					success: "Workspace created",
+					error: (error) =>
+						error instanceof Error
+							? error.message
+							: "Failed to create workspace",
+				},
+			);
+		},
+		[hostProjects, machineId, navigate, openNewWorkspaceModal, submit],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@superset/ui/sonner";
 import {
 	CatchBoundary,
 	createFileRoute,
@@ -9,6 +10,7 @@ import {
 import { useMemo, useState } from "react";
 import { CommandPaletteHost } from "renderer/commandPalette";
 import { Redirect } from "renderer/components/Redirect";
+import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -16,12 +18,15 @@ import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/comp
 import { DashboardSidebarPortsProvider } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarPortsProvider";
 import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { usePortsDisplayMode } from "renderer/stores/inline-workspace-ports";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
 	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
@@ -52,6 +57,9 @@ function DashboardLayout() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const portsDisplayMode = usePortsDisplayMode();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const { machineId } = useLocalHostService();
+	const { projects: hostProjects } = useHostProjects();
+	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
 	useDevSeedV2Sidebar();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
@@ -120,6 +128,50 @@ function DashboardLayout() {
 		openNewWorkspaceModal(
 			currentWorkspace?.projectId ?? currentV2Workspace?.projectId ?? undefined,
 		),
+	);
+	useHotkey(
+		"QUICK_CREATE_WORKSPACE",
+		() => {
+			const projectId =
+				currentV2Workspace?.projectId ??
+				useV2WorkspaceCreateDefaultsStore.getState().lastProjectId ??
+				hostProjects[0]?.id ??
+				null;
+
+			// Nothing to quick-create into yet — fall back to the modal so the
+			// user can add or pick a project, same as v1 falling back to "Open
+			// Project" when it had no current project to infer.
+			if (!projectId || !machineId) {
+				openNewWorkspaceModal();
+				return;
+			}
+
+			const workspaceId = crypto.randomUUID();
+			const { completed } = submitWorkspaceCreate({
+				hostId: machineId,
+				snapshot: { id: workspaceId, projectId },
+			});
+			void navigate({
+				to: "/v2-workspace/$workspaceId",
+				params: { workspaceId },
+			}).catch((error) => {
+				console.error("[QuickCreateWorkspace] failed to open workspace", error);
+			});
+			toast.promise(
+				completed.then((outcome) => {
+					if (!outcome.ok) throw new Error(outcome.error);
+				}),
+				{
+					loading: "Creating workspace...",
+					success: "Workspace created",
+					error: (error) =>
+						error instanceof Error
+							? error.message
+							: "Failed to create workspace",
+				},
+			);
+		},
+		{ enabled: isV2CloudEnabled },
 	);
 
 	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,4 +1,3 @@
-import { toast } from "@superset/ui/sonner";
 import {
 	CatchBoundary,
 	createFileRoute,
@@ -10,23 +9,20 @@ import {
 import { useMemo, useState } from "react";
 import { CommandPaletteHost } from "renderer/commandPalette";
 import { Redirect } from "renderer/components/Redirect";
-import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { useQuickCreateWorkspace } from "renderer/hooks/useQuickCreateWorkspace";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
 import { DashboardSidebarPortsProvider } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarPortsProvider";
 import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
-import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { usePortsDisplayMode } from "renderer/stores/inline-workspace-ports";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
-import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
-import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
 	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
@@ -57,9 +53,7 @@ function DashboardLayout() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const portsDisplayMode = usePortsDisplayMode();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
-	const { machineId } = useLocalHostService();
-	const { projects: hostProjects } = useHostProjects();
-	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
+	const quickCreateWorkspace = useQuickCreateWorkspace();
 	useDevSeedV2Sidebar();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
@@ -131,46 +125,7 @@ function DashboardLayout() {
 	);
 	useHotkey(
 		"QUICK_CREATE_WORKSPACE",
-		() => {
-			const projectId =
-				currentV2Workspace?.projectId ??
-				useV2WorkspaceCreateDefaultsStore.getState().lastProjectId ??
-				hostProjects[0]?.id ??
-				null;
-
-			// Nothing to quick-create into yet — fall back to the modal so the
-			// user can add or pick a project, same as v1 falling back to "Open
-			// Project" when it had no current project to infer.
-			if (!projectId || !machineId) {
-				openNewWorkspaceModal();
-				return;
-			}
-
-			const workspaceId = crypto.randomUUID();
-			const { completed } = submitWorkspaceCreate({
-				hostId: machineId,
-				snapshot: { id: workspaceId, projectId },
-			});
-			void navigate({
-				to: "/v2-workspace/$workspaceId",
-				params: { workspaceId },
-			}).catch((error) => {
-				console.error("[QuickCreateWorkspace] failed to open workspace", error);
-			});
-			toast.promise(
-				completed.then((outcome) => {
-					if (!outcome.ok) throw new Error(outcome.error);
-				}),
-				{
-					loading: "Creating workspace...",
-					success: "Workspace created",
-					error: (error) =>
-						error instanceof Error
-							? error.message
-							: "Failed to create workspace",
-				},
-			);
-		},
+		() => quickCreateWorkspace(currentV2Workspace?.projectId ?? null),
 		{ enabled: isV2CloudEnabled },
 	);
 

--- a/apps/desktop/src/renderer/stores/quick-create-workspace-intent.ts
+++ b/apps/desktop/src/renderer/stores/quick-create-workspace-intent.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+export interface QuickCreateWorkspaceTarget {
+	projectId: string | null;
+	tick: number;
+}
+
+interface QuickCreateWorkspaceIntentState {
+	target: QuickCreateWorkspaceTarget | null;
+	request: (projectId: string | null) => void;
+	clear: () => void;
+}
+
+/**
+ * Drives the globally-mounted QuickCreateWorkspaceMount: the command
+ * palette's `Command.run` has no hook access, so it requests through this
+ * store instead of calling `useQuickCreateWorkspace` directly.
+ */
+export const useQuickCreateWorkspaceIntent =
+	create<QuickCreateWorkspaceIntentState>((set, get) => ({
+		target: null,
+		request: (projectId) => {
+			const prevTick = get().target?.tick ?? 0;
+			set({ target: { projectId, tick: prevTick + 1 } });
+		},
+		clear: () => set({ target: null }),
+	}));


### PR DESCRIPTION
## Summary
- `QUICK_CREATE_WORKSPACE` (⌘⇧N) has been in the hotkey registry with no bound handler since `CreateWorkspaceButton` — the component that used to own it — was deleted in #586 (Workbench/Review mode rewrite), before v2 existed. Confirmed via `git log -S` that no handler has referenced it since.
- Wires it into `apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx`, gated to v2 (`isV2CloudEnabled`). On trigger it skips the new-workspace modal and creates directly via `useWorkspaceCreates().submit(...)` against the local host, in the current project.
- "Current project" fallback chain: current v2 workspace route (`currentV2Workspace.projectId`) → last-used project (`useV2WorkspaceCreateDefaultsStore`) → first known project (`useHostProjects`). If none resolve (or no local host), falls back to opening the new-workspace modal so the user can add/pick a project — mirroring v1's old `handleQuickCreate` → `handleOpenNewProject` fallback.

## Context
Reported in #6041 ("Quick Create Workspace is not working in v2"). Investigation showed this was never actually v1-vs-v2 behavior — the one-shot quick-create flow has been dead code in both versions since #586; it just happened to be noticed now by a v2 user. The issue's second complaint (new-workspace modal preselecting the wrong project) is a separate, still-open gap and not addressed by this PR.

## Test plan
- [x] `bun run typecheck` passes for `apps/desktop`
- [x] `bunx biome check` passes on the changed file
- [ ] Manually verify in the running desktop app: with v2 enabled, open a v2 workspace, hit ⌘⇧N elsewhere in a different project's view, confirm a new workspace is created in the expected project without the modal appearing
- [ ] Verify the modal-fallback path when no project can be inferred (fresh profile, no projects added yet)

https://claude.ai/code/session_01NDYjeZY5haNbjmg5gv94Xu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the Quick Create Workspace hotkey (Cmd+Shift+N) in v2 and adds a command palette entry so users can create a workspace immediately in the inferred project. Previously the hotkey did nothing; now it creates instantly when v2 is enabled and falls back to the modal if no project or local host can be inferred.

- Hotkey: handled in the v2 dashboard layout; creates via `useWorkspaceCreates().submit` on the local host (`machineId`), navigates to `/v2-workspace/$workspaceId`, and shows progress/success/error toasts via `@superset/ui/sonner`.
- Command palette: new “Quick create workspace” command (shows ⌘⇧N), available from any v2 dashboard view; gated by `isV2CloudEnabled`; triggers via a `quick-create-workspace-intent` store and a globally mounted `QuickCreateWorkspaceMount` that performs the create.
- Project inference order: current v2 workspace route → last-used from `useV2WorkspaceCreateDefaultsStore` → first from `useHostProjects`; otherwise opens the new-workspace modal.
- Extracts shared logic into `useQuickCreateWorkspace()`. No change to v1 behavior; no migrations or config changes.

<sup>Written for commit 9eeb037d22f9510310602737f619cab882d96323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut and command palette action for quickly creating a workspace.
  * Automatically selects an available project and opens the newly created workspace.
  * Provides a new-workspace prompt when no suitable project or machine is available.
  * Displays notifications for workspace creation status.
  * Quick workspace creation is available for supported cloud workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->