### PR TITLE
fix(relay2): pin workers_dev so deploys can't disable the workers.dev URL

### DIFF
--- a/apps/relay2/wrangler.jsonc
+++ b/apps/relay2/wrangler.jsonc
@@ -2,6 +2,10 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "superset-relay2",
 	"main": "src/index.ts",
+	// The workers.dev URL is load-bearing: it is the flag payload every shipped
+	// build's CSP allows. Adding routes below silently disables it on deploy
+	// unless pinned on — that took the fleet down on 2026-08-21.
+	"workers_dev": true,
 	// Also reachable at the workers.dev URL; both serve the same Durable
 	// Objects, so hosts and clients may mix hostnames during migration.
 	"routes": [{ "pattern": "relay2.superset.sh", "custom_domain": true }],


### PR DESCRIPTION
One line, incident follow-up: the routes entry added in #6719 without `workers_dev: true` caused the next `deploy-relay2` CI run to silently disable the workers.dev subdomain — the URL in the relay flag payload — giving reconnecting hosts CF error 1042 for ~55 minutes tonight. The pin is already live via manual deploy; this makes main's config match so the next merge doesn't kill it again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `workers_dev: true` in `apps/relay2/wrangler.jsonc` so deploys keep the workers.dev URL enabled even with routes configured. Previously, adding routes without this pin disabled the workers.dev subdomain used in the relay flag payload, causing CF 1042 errors for reconnecting hosts; now deploys preserve it. No traffic change—both the custom domain and workers.dev continue to serve the same Durable Objects.

- Confirm `workers_dev: true` is set and routes are unchanged.
- No migration required; this matches the manual fix already live.
- After deploy, verify the workers.dev subdomain remains enabled and serves normally.

<sup>Written for commit e4e7ccd2bfe6575eda2c68c1394376c7c07b4d36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved access to the workers.dev deployment URL alongside the existing custom-domain route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->