### PR TITLE
fix(billing): keep paid access during Stripe's dunning window

### DIFF
--- a/apps/desktop/src/renderer/components/PaymentFailedBanner/PaymentFailedBanner.tsx
+++ b/apps/desktop/src/renderer/components/PaymentFailedBanner/PaymentFailedBanner.tsx
@@ -1,0 +1,71 @@
+import { isPaymentFailingStatus } from "@superset/shared/billing";
+import { SidebarCard } from "@superset/ui/sidebar-card";
+import { useNavigate } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect } from "react";
+import { track } from "renderer/lib/analytics";
+import { authClient } from "renderer/lib/auth-client";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+
+interface PaymentFailedBannerProps {
+	surface: "v1" | "v2";
+	isCollapsed?: boolean;
+}
+
+/**
+ * Stripe keeps retrying for ~14 days before canceling, and access continues for
+ * that whole window, so a failed charge is otherwise invisible in-app until the
+ * plan abruptly disappears. Not dismissible for that reason.
+ */
+export function PaymentFailedBanner({
+	surface,
+	isCollapsed,
+}: PaymentFailedBannerProps) {
+	const { data: session } = authClient.useSession();
+	const { data: activeOrg } = authClient.useActiveOrganization();
+	const { data: activePlan } = cloudTrpc.billing.activePlan.useQuery(undefined);
+	const navigate = useNavigate();
+
+	const isOwner =
+		activeOrg?.members?.find((m) => m.userId === session?.user?.id)?.role ===
+		"owner";
+	const isPaymentFailing = isPaymentFailingStatus(activePlan?.status);
+	const isVisible = !isCollapsed && isPaymentFailing;
+
+	useEffect(() => {
+		if (!isVisible) return;
+		track("payment_failed_banner_shown", { surface, isOwner });
+	}, [isVisible, surface, isOwner]);
+
+	function handleUpdatePayment() {
+		track("payment_failed_banner_clicked", { surface });
+		navigate({ to: "/settings/billing" });
+	}
+
+	if (!isVisible) return null;
+
+	return (
+		<AnimatePresence>
+			<motion.div
+				initial={{ opacity: 0, y: 8 }}
+				animate={{ opacity: 1, y: 0 }}
+				exit={{ opacity: 0, y: 8 }}
+				transition={{ duration: 0.2 }}
+				className="px-3 pb-2"
+			>
+				<SidebarCard
+					badge="Action needed"
+					title="Payment failed"
+					description={
+						isOwner
+							? "We couldn't charge your payment method. Update it to keep your plan."
+							: "We couldn't charge this organization's payment method. Ask an owner to update it."
+					}
+					actionLabel={isOwner ? "Update payment method" : undefined}
+					onAction={isOwner ? handleUpdatePayment : undefined}
+					className="border-amber-500/50"
+				/>
+			</motion.div>
+		</AnimatePresence>
+	);
+}

--- a/apps/desktop/src/renderer/components/PaymentFailedBanner/index.ts
+++ b/apps/desktop/src/renderer/components/PaymentFailedBanner/index.ts
@@ -1,0 +1,1 @@
+export { PaymentFailedBanner } from "./PaymentFailedBanner";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -11,6 +11,7 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
 import { HiringBanner } from "renderer/components/HiringBanner";
+import { PaymentFailedBanner } from "renderer/components/PaymentFailedBanner";
 import { StarNagCard } from "renderer/components/StarNagCard";
 import { UpdatesPill } from "renderer/components/UpdatesPill";
 import { useHotkeyDisplay } from "renderer/hotkeys";
@@ -318,6 +319,7 @@ export function DashboardSidebar({
 											projectName={activeV2Project.name}
 										/>
 									)}
+									<PaymentFailedBanner surface="v2" isCollapsed={isCollapsed} />
 									<HiringBanner surface="v2" isCollapsed={isCollapsed} />
 									<StarNagCard isCollapsed={isCollapsed} />
 									<div

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -169,6 +169,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 								isRestoring={isRestoring}
 								cancelAt={activePlan?.cancelAt}
 								periodEnd={activePlan?.periodEnd}
+								status={activePlan?.status}
 							/>
 							{plan === "free" && (
 								<UpgradeCard

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -1,4 +1,6 @@
+import { isPaymentFailingStatus } from "@superset/shared/billing";
 import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
 import { PLANS, type PlanTier } from "../../../../constants";
 
@@ -10,6 +12,7 @@ interface CurrentPlanCardProps {
 	isRestoring?: boolean;
 	cancelAt?: Date | null;
 	periodEnd?: Date | null;
+	status?: string | null;
 }
 
 export function CurrentPlanCard({
@@ -20,14 +23,17 @@ export function CurrentPlanCard({
 	isRestoring,
 	cancelAt,
 	periodEnd,
+	status,
 }: CurrentPlanCardProps) {
 	const plan = PLANS[currentPlan];
 	const isPaidPlan = currentPlan !== "free";
 	const isEnterprise = currentPlan === "enterprise";
 	const isCancelingAtPeriodEnd = isPaidPlan && !isEnterprise && !!cancelAt;
+	const isPaymentFailing = isPaidPlan && isPaymentFailingStatus(status);
 
-	const hint =
-		isCancelingAtPeriodEnd && cancelAt
+	const hint = isPaymentFailing
+		? "Payment failed — update your payment method to keep this plan."
+		: isCancelingAtPeriodEnd && cancelAt
 			? `Cancels ${format(new Date(cancelAt), "MMMM d, yyyy")} — downgrades to Free at the end of the billing period.`
 			: isEnterprise
 				? "Managed by your organization admin."
@@ -45,8 +51,20 @@ export function CurrentPlanCard({
 							{plan.name}
 						</span>
 					)}
+					{isPaymentFailing && (
+						<span className="inline-flex items-center rounded-md bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
+							Payment failed
+						</span>
+					)}
 				</div>
-				<div className="text-xs text-muted-foreground mt-0.5">{hint}</div>
+				<div
+					className={cn(
+						"text-xs mt-0.5",
+						isPaymentFailing ? "text-amber-500" : "text-muted-foreground",
+					)}
+				>
+					{hint}
+				</div>
 			</div>
 			{isPaidPlan && !isEnterprise && (
 				<div className="shrink-0">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { HiringBanner } from "renderer/components/HiringBanner";
+import { PaymentFailedBanner } from "renderer/components/PaymentFailedBanner";
 import { StarNagCard } from "renderer/components/StarNagCard";
 import { useWorkspaceShortcuts } from "renderer/hooks/useWorkspaceShortcuts";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
@@ -117,6 +118,7 @@ export function WorkspaceSidebar({
 				projectName={activeProjectName}
 			/>
 
+			<PaymentFailedBanner surface="v1" isCollapsed={isCollapsed} />
 			<HiringBanner surface="v1" isCollapsed={isCollapsed} />
 			<StarNagCard isCollapsed={isCollapsed} />
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -17,6 +17,7 @@ import { OrganizationInvitationEmail } from "@superset/email/emails/team/invitat
 import { MemberAddedEmail } from "@superset/email/emails/team/member-added";
 import { MemberRemovedEmail } from "@superset/email/emails/team/member-removed";
 import { canInvite, type OrganizationRole } from "@superset/shared/auth";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { getTrustedVercelPreviewOrigins } from "@superset/shared/vercel-preview-origins";
 import { Client } from "@upstash/qstash";
 import { betterAuth } from "better-auth";
@@ -883,10 +884,14 @@ export const auth = betterAuth({
 
 				let plan: string | null = null;
 				if (activeOrganizationId) {
+					// Same statuses the rest of the app gates on — this is the value
+					// the paywall falls back to when the activePlan query can't be
+					// reached, so an "active"-only read here would strand trialing
+					// and past_due orgs on a cold start.
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, activeOrganizationId),
-							eq(subscriptions.status, "active"),
+							inArray(subscriptions.status, ACTIVE_SUBSCRIPTION_STATUSES),
 						),
 					});
 					plan = subscription?.plan ?? null;

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -1,8 +1,20 @@
 export const PLAN_TIERS = ["free", "pro", "enterprise"] as const;
 export type PlanTier = (typeof PLAN_TIERS)[number];
 
-/** Subscription.status values considered "paying" for gating purposes. */
-export const ACTIVE_SUBSCRIPTION_STATUSES = ["active", "trialing"] as const;
+/**
+ * Subscription.status values considered "paying" for gating purposes.
+ *
+ * `past_due` counts. Stripe retries a failed payment for ~14 days before giving
+ * up, and duplicating that window here would mean two sources of truth that
+ * drift the moment anyone edits the retry schedule in the dashboard. When Stripe
+ * does give up it cancels the subscription, `customer.subscription.deleted`
+ * lands, and the row moves to `canceled` — dropping out of this list on its own.
+ */
+export const ACTIVE_SUBSCRIPTION_STATUSES = [
+	"active",
+	"trialing",
+	"past_due",
+] as const;
 export type ActiveSubscriptionStatus =
 	(typeof ACTIVE_SUBSCRIPTION_STATUSES)[number];
 
@@ -13,5 +25,15 @@ export function isPaidPlan(plan: string | null | undefined): boolean {
 export function isActiveSubscriptionStatus(
 	status: string | null | undefined,
 ): status is ActiveSubscriptionStatus {
-	return status === "active" || status === "trialing";
+	return ACTIVE_SUBSCRIPTION_STATUSES.some((candidate) => candidate === status);
+}
+
+/**
+ * Access continues, but collection is failing and the subscription will be
+ * canceled if it keeps failing. Surface this — never gate on it.
+ */
+export function isPaymentFailingStatus(
+	status: string | null | undefined,
+): boolean {
+	return status === "past_due";
 }

--- a/packages/trpc/src/router/support/support.ts
+++ b/packages/trpc/src/router/support/support.ts
@@ -6,6 +6,7 @@ import {
 	users,
 } from "@superset/db/schema";
 import { FeedbackReportEmail } from "@superset/email/emails/feedback-report";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { COMPANY } from "@superset/shared/constants";
 import { TRPCError } from "@trpc/server";
 import { Ratelimit } from "@upstash/ratelimit";
@@ -230,7 +231,7 @@ export const supportRouter = createTRPCRouter({
 					? db.query.subscriptions.findFirst({
 							where: and(
 								eq(subscriptions.referenceId, organizationId),
-								inArray(subscriptions.status, ["active", "trialing"]),
+								inArray(subscriptions.status, ACTIVE_SUBSCRIPTION_STATUSES),
 							),
 							columns: { plan: true, status: true },
 						})


### PR DESCRIPTION
## Problem

A failed charge dropped an organization to free-tier gating on the **first decline**. Stripe keeps retrying for ~14 days before giving up, so orgs that were still being actively collected from — and that mostly recover on a later retry — lost the product they were being billed for, with no in-app explanation.

`ACTIVE_SUBSCRIPTION_STATUSES = ["active", "trialing"]` came verbatim from the Better Auth Stripe plugin docs, which show that snippet to demonstrate how to read the field. It was never a billing policy decision. Better Auth itself has no opinion here — the plugin mirrors `stripeSubscription.status` into the row unchanged and has no grace-period concept anywhere in the package.

## Measured on our own Stripe account

- **104** subscriptions have been auto-canceled by dunning (`cancellation_details.reason == "payment_failed"`), most recently the day before this branch.
- Time from first failed invoice to cancellation, sampled over 25 of them: **min 11.8d, median 14.0d, max 15.0d**, at 9 retry attempts.
- **8 orgs were past_due at the time of writing**, aged 0–12 days, every one of them still inside Stripe's retry window and every one of them gated to free.

## Change

`past_due` now counts as paying. Stripe owns the window — duplicating it here would mean two sources of truth that drift the moment anyone edits the retry schedule in the dashboard. When Stripe gives up it cancels the subscription, `customer.subscription.deleted` lands, the row moves to `canceled`, and access ends on its own. There is no timer of ours to maintain and no way to leak indefinite free access.

This also makes gating agree with analytics, which already counted `past_due` as revenue in `analytics/business.ts`. Today we bill them, count them as customers, and lock them out.

Because access now continues where it previously stopped, the failure is surfaced instead of silent:

- **`PaymentFailedBanner`** — non-dismissible `SidebarCard`, mounted on both the v1 `WorkspaceSidebar` and v2 `DashboardSidebar` next to `HiringBanner`. Owners get "Update payment method" → billing settings; non-owners are told to ask an owner, since `requireBillingOwner` would reject them at the portal anyway.
- **`CurrentPlanCard`** — amber "Payment failed" badge and hint replacing the "Renews …" line.
- **Support reports** now read `pro (past_due)` instead of `free (no active subscription)` — `support.ts` had its own hardcoded copy of the status list, now using the shared constant.

## Trade-off

An org with a permanently dead card gets up to 14 days of unpaid access. That is what a dunning window is, it is bounded by Stripe, and it is cheaper than churning customers whose bank threw a soft decline. Explicitly accepted.

## Testing

- `bun run lint:fix`, `bun run typecheck` (37/37), `bunx turbo test` for the touched packages — 2757 pass, 0 fail.
- Swept the repo for other hardcoded status lists: `support.ts` was the only one, and it is now the shared constant. `seed-dev.ts` writes `"active"` explicitly and is unaffected.

## Note for review

`unpaid` is deliberately still gated. If anyone ever flips the Stripe setting from "cancel subscription" to "mark unpaid" after retries, subscriptions would sit in `unpaid` forever and never cancel — that coupling is worth knowing about before touching that dropdown.

https://claude.ai/code/session_01EgMCm1jQySDYReCGzBBsg2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep paid access during Stripe’s dunning window and surface failed payments in-app. Previously a first decline gated orgs to Free; now `past_due` remains active, while `unpaid` stays gated.

- `@superset/shared/billing`: expand `ACTIVE_SUBSCRIPTION_STATUSES` to include `past_due`; add `isPaymentFailingStatus`. Gate checks, support, and `@superset/auth` session.plan all use the shared constant (covers offline cold start fallback).
- UI: add non-dismissible PaymentFailedBanner to v1 and v2 sidebars; owners get “Update payment method.” CurrentPlanCard shows an amber “Payment failed” badge and hint when status is `past_due`.
- Behavior: access continues until Stripe cancels; no local timers. Gating now matches analytics, which already counted `past_due` as revenue.
- Rollout/ops: keep Stripe’s “after final payment attempt” action set to Cancel subscription. If switched to Mark unpaid, subscriptions may sit in `unpaid` indefinitely (still gated) and never auto-cancel.

<sup>Written for commit 0b0f3c69c76ffc8dd4b0349670092b3806dde377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment-failure banners to dashboard and workspace sidebars.
  * Account owners can update payment details directly through billing settings.
  * Added payment-failure messaging and status badges to the current plan card.
* **Bug Fixes**
  * Subscription access and account status checks now correctly recognize past-due subscriptions.
  * Support reporting uses consistent subscription-status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->