### PR TITLE
fix(host-service): keep pull-request search results when one chunk fails

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -19,6 +19,7 @@ import { githubSearchInputSchema } from "../schemas";
 import {
 	buildSearchQuery,
 	chunkProjectRepos,
+	collectChunkResults,
 	formatRepoList,
 	githubRateLimitError,
 	isGithubNotFoundError,
@@ -1181,11 +1182,22 @@ export const searchPullRequests = protectedProcedure
 			}
 
 			const chunks = chunkProjectRepos(projectRepos, qualifiers);
-			const chunkResults = await Promise.all(
-				chunks.map((chunk) =>
-					octokitSearchPullRequests(octokit, chunk, qualifiers, page, limit),
+			// One chunk failing (a repo this token cannot see, a timed-out
+			// request) must not blank the repos that answered — this is the
+			// last resort, so throwing here empties the whole list.
+			const { results: chunkResults, failures } = collectChunkResults(
+				await Promise.allSettled(
+					chunks.map((chunk) =>
+						octokitSearchPullRequests(octokit, chunk, qualifiers, page, limit),
+					),
 				),
 			);
+			if (failures.length > 0) {
+				console.warn(
+					`[workspaceCreation.searchPullRequests] ${failures.length} of ${chunks.length} search chunks failed; returning the rest`,
+					failures,
+				);
+			}
 			const merged = mergeByUpdatedAtDesc(
 				chunkResults.map((result) => result.items),
 			);

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildSearchQuery,
 	chunkProjectRepos,
+	collectChunkResults,
 	GITHUB_SEARCH_QUERY_MAX_LENGTH,
 	githubRateLimitError,
 	isGithubNotFoundError,
@@ -217,6 +218,42 @@ describe("resolveProjectRepos", () => {
 		expect(resolveProjectRepos(["no-remote"], false, resolve)).rejects.toThrow(
 			"no GitHub remote",
 		);
+	});
+});
+
+describe("collectChunkResults", () => {
+	const rateLimited = () =>
+		Object.assign(new Error("API rate limit exceeded for user"), {
+			status: 403,
+		});
+
+	test("keeps the chunks that answered and reports the failures", async () => {
+		const settled = await Promise.allSettled([
+			Promise.resolve("web"),
+			Promise.reject(
+				new Error("Validation Failed: repositories cannot be searched"),
+			),
+			Promise.resolve("api"),
+		]);
+		const { results, failures } = collectChunkResults(settled);
+		expect(results).toEqual(["web", "api"]);
+		expect(failures).toHaveLength(1);
+	});
+
+	test("surfaces the failure when every chunk failed", async () => {
+		const settled = await Promise.allSettled([
+			Promise.reject(new Error("Connect Timeout Error")),
+			Promise.reject(new Error("Bad credentials")),
+		]);
+		expect(() => collectChunkResults(settled)).toThrow("Connect Timeout Error");
+	});
+
+	test("surfaces a rate limit even when other chunks answered", async () => {
+		const settled = await Promise.allSettled([
+			Promise.resolve("web"),
+			Promise.reject(rateLimited()),
+		]);
+		expect(() => collectChunkResults(settled)).toThrow("rate limit exceeded");
 	});
 });
 

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.ts
@@ -93,6 +93,32 @@ export function chunkProjectRepos(
 	return chunks;
 }
 
+/**
+ * Keep the chunks that answered. A chunk fails on its own terms — GitHub
+ * rejects the whole query when it names a repo the token cannot see, a
+ * request times out — and one such failure must not blank the repos that
+ * did answer. The failure only surfaces when every chunk failed, so a total
+ * outage still reports rather than returning a silently empty page.
+ */
+export function collectChunkResults<T>(settled: PromiseSettledResult<T>[]): {
+	results: T[];
+	failures: unknown[];
+} {
+	const results = settled.flatMap((result) =>
+		result.status === "fulfilled" ? [result.value] : [],
+	);
+	const failures = settled.flatMap((result) =>
+		result.status === "rejected" ? [result.reason] : [],
+	);
+	for (const failure of failures) {
+		// A rate limit is account-wide, not per-chunk: keeping a partial page
+		// would hide why the rest is missing and would flap between polls.
+		if (isGithubRateLimitError(failure)) throw failure;
+	}
+	if (results.length === 0 && failures.length > 0) throw failures[0];
+	return { results, failures };
+}
+
 // REST search items carry `repository_url` like
 // https://api.github.com/repos/<owner>/<name>.
 const REPOSITORY_URL_RE = /\/repos\/([^/]+)\/([^/]+)\/?$/;


### PR DESCRIPTION
## Problem

Searching pull requests across several configured projects returns an internal
error and **zero** pull requests when one repository in the set fails — the PR
list renders the raw GitHub error in red with a "Try again" button, and none of
the repos that answered are shown.

Two triggers hit this in the reported window: GitHub rejecting a search query
outright (`Validation Failed` — the query named a repo the token cannot see,
which is permanent for that install) and a connect timeout to `api.github.com`
(transient, same total effect).

**Will this reach the reported failure?** The events came from a released build
(1.24.1 and a canary) on the Octokit branch of this procedure, which is
unchanged on `main`; this ships in the next host-service/desktop release and
reaches everyone who updates. Honest scope limit: partial tolerance only helps
when there is a surviving chunk, i.e. when the failing repo is not in the same
chunk as everything else. Chunks hold roughly 8–10 repos (GitHub's 256-char
search-query cap), so an install with fewer repos than one chunk still sees the
error — there is nothing partial to keep. Removing *that* case would mean
retrying a failed chunk repo-by-repo, which multiplies search-API calls on every
poll for a permanently-inaccessible repo and risks converting "no PRs" into
"rate-limited, no PRs". Declined as speculative.

**Why code, not triage?** Archiving leaves the PR screen unusable for affected
installs. A Sentry-side filter is forbidden by the contract and would not change
what the user sees. The renderer cannot rebuild results the server discarded.
The layer directly above already does exactly this: `resolveProjectRepos` skips
projects that fail to resolve "so one misconfigured repo cannot blank every
other repository's results" — the chunk fan-out is the one hop that did not.

## Root cause

`searchPullRequests` chunks repos and awaits the per-chunk searches with
`Promise.all`, which rejects on the first failure and discards every fulfilled
chunk. The direct-lookup branch immediately above it already uses
`Promise.allSettled` and keeps what succeeded; the chunked search did not.

## Fix

`collectChunkResults` in `shared/github-search.ts` splits settled results into
what answered and what failed, throwing only when nothing answered. The Octokit
chunked search — the branch both events came from — now settles through it.

- **Total count / paging:** `totalCount` and `hasNextPage` are now summed over
  the chunks that answered, so with a missing chunk the total is a strict
  undercount that matches the rows actually returned (it can no longer be exact,
  and an over-count would be worse: it would advertise pages that never fill).
  Unchanged when all chunks answer.
- **Rate limits still surface.** A rate limit is account-wide, not per-chunk, so
  a partial page would hide why the rest is missing and flap between polls. The
  helper rethrows the raw rejection and the procedure's existing `catch`
  classifies it as `TOO_MANY_REQUESTS` exactly as before — no new classifier,
  and classification stays at the one site that already owns it.
- **No typed `cause`.** Nothing reads a `kind` on this path, so the all-failed
  case rethrows the original error unchanged, preserving today's message.
- **The `gh` chunk fan-out above is deliberately left as-is.** Its all-or-nothing
  behaviour is not a user-visible failure: it is caught and falls back to Octokit
  under a different credential, which may see repos `gh` cannot. Making it
  tolerant would return a partial page instead of taking that fallback.

Stays clear of the hunks #6682 and #6689 touch in this file (result fields and
checks plumbing); neither goes near the fan-out.

## Verification

Negative test first — it pins the one thing this tolerance must **not** swallow.
Against the helper without its rate-limit guard:

```
Expected substring: "rate limit exceeded"
Received function did not throw
Received value: { results: [ "web" ], failures: [ error: API rate limit exceeded for user ] }
(fail) collectChunkResults > surfaces a rate limit even when other chunks answered [0.44ms]
 21 pass
 1 fail
Ran 22 tests across 1 file. [101.00ms]
```

With the guard added, and the full suite:

```
$ bunx biome check <changed files>
Checked 3 files in 15ms. No fixes applied.

$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false

$ bun test packages/host-service/src/trpc/router/workspace-creation
 167 pass
 0 fail
 318 expect() calls
Ran 167 tests across 13 files. [1.79s]
```

Not verified in the running app: reproducing needs a token that cannot see one
of several configured repos.

## Note for triage — this will not zero out HOST-SERVICE-44

Of that issue's 16 events, only 3 are the `Validation Failed` search rejection.
The other 13 are `Bad credentials` (HTTP 401, invalid or expired token) from the
same frame. Every chunk fails in that case, so this change correctly still
throws and those events keep arriving. That is a separate classification gap —
an invalid token is an expected user state, not an internal error, and the
existing auth classification (#6389) covers only the *missing*-token case. Out
of scope here, since this task is explicitly not a classification change.

Adjacent unprotected fan-out, left alone: `search-github-issues.ts` has the same
all-or-nothing chunked search twice (issue search, not on this reported path).

Refs HOST-SERVICE-44
Refs HOST-SERVICE-40

https://claude.ai/code/session_01AgzLgojN5VszeP6LSfDu8g


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps pull‑request search results when one chunk fails. Previously the Octokit chunked search rejected the entire request on any chunk error; now it returns successful chunks and only fails when every chunk fails.

- Introduces `collectChunkResults` in `shared/github-search.ts` and uses it in `searchPullRequests`.
- Sums `totalCount` and `hasNextPage` over successful chunks; totals undercount when a chunk fails.
- Continues to surface account‑wide rate limits by rethrowing; no new error types or schema changes.
- Logs a warning with the failed chunk count; preserves existing messages when all chunks fail.
- Leaves the `gh` fan‑out path unchanged (still falls back to Octokit on failure).
- Tests cover partial success, all‑failed, and rate‑limit cases.
- Impact on Linear: partially addresses HOST-SERVICE-44 (avoids zero results on single‑chunk failures); 401 “Bad credentials” remains unchanged. Related to HOST-SERVICE-40.

<sup>Written for commit d79008c15f7e6ca03d94b02ea0e08bd98162e3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request search reliability when processing multiple result batches.
  - Search results are now displayed even if some batches fail, instead of failing the entire search.
  - Added clearer handling for scenarios where all batches fail, including preserving rate-limit errors.
  - Existing result merging, enrichment, pagination, and rate-limit behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->