### PR TITLE
fix(host-service): classify missing Command Line Tools and unreadable tree objects as typed non-500s

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
@@ -191,6 +191,22 @@ describe("rethrowEnvironmentalGitError", () => {
 		).toBeNull();
 	});
 
+	test("does not claim the refusal sentence when git is not the one refusing", () => {
+		// A hook that shells out to an Xcode tool can print the stub's sentence
+		// into git's stderr while git itself failed for its own reason. Only a
+		// line that *starts* with the stub's prefix means "git cannot run here";
+		// matching the sentence alone would silence the hook failure.
+		expect(
+			capture(
+				new Error(
+					"hint: The '.git/hooks/pre-commit' hook was ignored because it's not set as executable.\n" +
+						"No developer tools were found, requesting install.\n" +
+						"error: cannot run .git/hooks/pre-commit: No such file or directory\n",
+				),
+			),
+		).toBeNull();
+	});
+
 	test("does not claim git's other 'unable to read' failures", () => {
 		// Git says "unable to read" about several object kinds and about plain
 		// files. Only the tree variant names the damage this branch describes;

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
@@ -127,4 +127,116 @@ describe("rethrowEnvironmentalGitError", () => {
 			capture(new Error("Unable to find path to repository in parent tree")),
 		).toBeNull();
 	});
+
+	test("Command Line Tools missing → PRECONDITION_FAILED / GIT_ENVIRONMENT", () => {
+		// Verbatim stub output: on macOS /usr/bin/git forwards to the Command
+		// Line Tools, and prints this instead of running when they are absent.
+		const message =
+			"xcode-select: note: No developer tools were found, requesting install.\n" +
+			"If developer tools are located at a non-default location on disk, use `sudo xcode-select --switch path/to/Xcode.app` to specify the Xcode that you wish to use for command line developer tools, and cancel the installation dialog.\n" +
+			"See `man xcode-select` for more details.\n";
+		const thrown = capture(new Error(message));
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_ENVIRONMENT");
+		expect(thrown?.message).toBe(message);
+	});
+
+	test("unreadable tree object → PRECONDITION_FAILED / GIT_REPO_DAMAGED", () => {
+		const message =
+			"fatal: unable to read tree f3cfda51e445b3c911572cf9ae3dc34d78fc4c35\n";
+		const thrown = capture(new Error(message));
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_REPO_DAMAGED");
+		expect(thrown?.message).toBe(message);
+	});
+
+	test("unreadable tree object behind a truncated packfile", () => {
+		// The same condition with git's own diagnosis of the damage in front of
+		// it, and git's parenthesised phrasing of the sentence.
+		const thrown = capture(
+			new Error(
+				"error: file .git/objects/pack/pack-816a419ea2792b300adb04c1f8bc739065981ebe.pack is far too short to be a packfile\n" +
+					"fatal: unable to read tree (f3cfda51e445b3c911572cf9ae3dc34d78fc4c35)\n",
+			),
+		);
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_REPO_DAMAGED");
+	});
+
+	test("does not claim unrelated Xcode and developer-tools output", () => {
+		// The stub is identified by its own prefix *and* its refusal sentence.
+		// Neither half alone is distinctive: git says "Xcode" whenever a path
+		// contains it, and xcode-select has other, unrelated complaints that are
+		// not "git cannot run here".
+		expect(
+			capture(
+				new Error(
+					"xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"fatal: pathspec 'ios/Runner.xcodeproj/project.pbxproj' did not match any files known to git\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"error: unable to stat 'Library/Developer/Xcode/DerivedData/Runner/info.plist'\n",
+				),
+			),
+		).toBeNull();
+	});
+
+	test("does not claim git's other 'unable to read' failures", () => {
+		// Git says "unable to read" about several object kinds and about plain
+		// files. Only the tree variant names the damage this branch describes;
+		// the rest are ordinary failures that must keep reporting as 500s.
+		expect(
+			capture(
+				new Error(
+					"fatal: unable to read d83d2d027bcd790f397d1ef07c663ca57d44cac2\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"error: unable to read sha1 file of src/index.ts (e69de29bb2d1d6434b8b29ae775ad8c2e48c5391)\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(new Error("error: unable to read asciidoc from stdin\n")),
+		).toBeNull();
+	});
+
+	test("keeps the working-directory branch ahead of the damaged-repo branch", () => {
+		// "unable to read current working directory" is an environment failure,
+		// not object-store damage — the new branch must not reclassify it.
+		const thrown = capture(
+			new Error(
+				"fatal: Unable to read current working directory: Operation not permitted\n",
+			),
+		);
+		expect(causeKind(thrown)).toBe("GIT_ENVIRONMENT");
+	});
+
+	test("genuine failures on the getStatus path still report as 500s", () => {
+		// Real messages seen in this Sentry group that this change deliberately
+		// leaves unclassified: a resource exhaustion bug we would want to hear
+		// about, and a missing third-party filter binary that is a separate
+		// condition from the two named here.
+		expect(capture(new Error("spawn git EAGAIN"))).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"git-lfs filter-process: git-lfs: command not found\nfatal: the remote end hung up unexpectedly\n",
+				),
+			),
+		).toBeNull();
+	});
 });

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
@@ -21,6 +21,22 @@ const NOT_A_WORK_TREE_PATTERN = /this operation must be run in a work tree/i;
 // mistakes too, and those must keep reporting as 500s.
 const SIMPLE_GIT_BASE_DIR_MISSING_PATTERN =
 	/cannot use simple-git on a directory that does not exist/i;
+// The macOS Command Line Tools stub. /usr/bin/git is a shim that forwards to
+// the active developer directory; with no tools installed it prints this and
+// exits non-zero instead of running git, so every git command fails the same
+// way until the user installs them. Anchored on the stub's own prefix at the
+// start of a line together with its refusal sentence: `xcode-select` has other
+// complaints that are not "git cannot run here", and git names Xcode paths in
+// ordinary failures all the time.
+const XCODE_SELECT_NO_TOOLS_PATTERN =
+	/^xcode-select: .*no developer tools were found/im;
+// Git cannot read a tree object its own refs point at — a damaged or
+// incompletely fetched object store (a truncated packfile, most often). Every
+// command that walks a commit fails until the repository is repaired.
+// Requiring the object id keeps this off git's other "unable to read"
+// failures, which name blobs, loose files and stdin rather than this damage.
+const UNREADABLE_TREE_OBJECT_PATTERN =
+	/unable to read tree \(?[0-9a-f]{7,64}\)?/i;
 
 /**
  * Rethrows environmental git failures as typed non-500 TRPCErrors — the same
@@ -63,6 +79,20 @@ export function rethrowEnvironmentalGitError(error: unknown): void {
 			code: "PRECONDITION_FAILED",
 			message: error.message,
 			cause: { kind: "GIT_ENVIRONMENT" },
+		});
+	}
+	if (XCODE_SELECT_NO_TOOLS_PATTERN.test(error.message)) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: error.message,
+			cause: { kind: "GIT_ENVIRONMENT" },
+		});
+	}
+	if (UNREADABLE_TREE_OBJECT_PATTERN.test(error.message)) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: error.message,
+			cause: { kind: "GIT_REPO_DAMAGED" },
 		});
 	}
 }


### PR DESCRIPTION
## Problem

Two environmental git-CLI failures reached the `getStatus` catch block unrecognised and became `INTERNAL_SERVER_ERROR`s. Because status is polled continuously while the app is open, a machine stuck in either state re-reported the same failure indefinitely.

1. **macOS Command Line Tools absent.** `/usr/bin/git` is a stub that forwards to the active developer directory. With no tools installed it prints its refusal and exits non-zero instead of running git, so every git command the app runs fails identically until the user installs them. (`HOST-SERVICE-42`, 173 events in 8 hours from one machine, release 1.24.1.)
2. **Unreadable tree object.** Git cannot supply a tree object that the repository's own refs point at. The same object hash recurs on every event across two days, and a subset of events carry git's own diagnosis in front of it — a packfile "far too short to be a packfile" — so this is a stable damaged or incompletely fetched object store, not a transient race. (~540 events inside `HOST-SERVICE-3Q`, release 1.23.0.)

### Reality check

**1. User-visible harm.** None on the reported path, and this change does not claim any. On the v2 host path nothing branches on the error code or cause: `useGitStatus` has no error backoff, and `WorkspaceClientProvider`'s retry policy keys only on TIMEOUT. A user on either machine sees the same broken Changes tab before and after. The cost is to our telemetry's signal quality, and it is a real one — see (3).

**2. Reach.** The classifier already runs at this throw site (`git.ts`, `getStatus` catch block), so no wiring is needed; this only adds branches to `rethrowEnvironmentalGitError`. It ships in the next desktop/host-service release and reaches users on that build onward. It cannot retroactively affect the 1.23.0 and 1.24.1 events already reported.

**3. Why code, and not archiving.** `HOST-SERVICE-3Q` is not one root cause — it is a **grouping bucket**. Sentry grouped it on simple-git's error-plugin frames (`PluginStore.exec` → `Object.action` → `new GitError`), so every git-CLI failure surfacing through simple-git lands in it regardless of message. Over 30 days it holds at least eight distinct conditions, including `spawn git EAGAIN`, `index.lock` contention, and `mmap failed: Operation timed out`. Archiving it would silence those and every future regression that routes through the same frames. Classifying the two non-bugs at the throw site is what keeps the bucket usable. A Sentry-side filter is forbidden by repo law (PR #6164) and would have the same blinding effect.

**4. Smallest change.** Two module-level regexes and two branches, matching the four patterns already in this file. No new capture, no recovery or retry machinery, no repair of the user's repository, no new call sites.

**5. What the matchers could wrongly claim.** Both are anchored on the distinctive part of git's own sentence, and each over-match is pinned by a negative test:
- Bare `xcode`/`developer tools` would catch `xcode-select: error: tool 'xcodebuild' requires Xcode…` (a different complaint), any pathspec naming an `.xcodeproj`, and any path under `Library/Developer/Xcode`. The pattern requires the stub's `xcode-select:` prefix **at the start of a line** together with its refusal sentence.
- Bare `unable to read` would catch git's whole family of similarly-worded failures. The pattern requires `unable to read tree` **plus an object id**, so `unable to read <oid>` (also present in this Sentry group), `unable to read sha1 file of …`, and `unable to read asciidoc from stdin` are untouched. It also does not match `unable to read worktree` or the existing `Unable to find path to repository in parent tree` negative test.

## Root cause

Neither condition is produced by our code. Verified independently rather than assumed:

- Nothing in the repo mutates a `.git` object store. The only pruning is `git worktree prune` (worktree admin records, never objects) and `git reset HEAD -- <paths>` (index only). There is no `gc`, `prune`, `repack`, or `fsck` call, and nothing writes into `.git/objects`.
- The only shallow clone is `cloneTemplateInto`'s `--depth=1`, whose `.git` is deleted and re-`init`ed immediately after — it cannot leave a user's repository unable to read its own trees. Nothing performs a treeless or blobless partial clone; the one `promisor` reference in `git-remote.ts` *detects* a user's partial clone in order to avoid parsing `git remote -v` output, it does not create one.
- An interrupted `scheduleBaseRefFetch` cannot cause this either: git indexes a pack to a temp file and renames it atomically, and updates refs only afterwards, so a killed fetch leaves refs pointing at objects that were already present. The reported failure has refs pointing at a tree that is missing, stably, across two days.

## Fix

Two named patterns in `classify-git-error.ts`, following the file's existing shape (module-level regex, comment naming the exact git condition, matched in `rethrowEnvironmentalGitError`):

- `XCODE_SELECT_NO_TOOLS_PATTERN` → `PRECONDITION_FAILED` with `cause: { kind: "GIT_ENVIRONMENT" }`, reusing the existing kind. This is precisely the existing "the git environment cannot answer" case.
- `UNREADABLE_TREE_OBJECT_PATTERN` → `PRECONDITION_FAILED` with a new `cause: { kind: "GIT_REPO_DAMAGED" }`.

Both are appended after the existing branches, so no existing precedence changes. A test pins that `unable to read current working directory` still resolves to `GIT_ENVIRONMENT` rather than being reclassified as damage.

**Nothing reads `GIT_REPO_DAMAGED` today.** It is carried because this file attaches a kind to every branch, and the tests assert it. The renderer's only cause-kind consumer (`gitChangesUnavailableCopy` in `useGitChangesStatus`) is fed by the v1 `changes.*` router, which has its own separate classifier; the v2 `git.getStatus` consumers do not read `cause` at all. `GIT_ENVIRONMENT` is reused rather than introduced, so the first consumer to branch on it gets the Command Line Tools case for free.

### What still reports as a 500 on this path

Deliberately unchanged, and pinned by tests where they are real messages from this group:

- `git-lfs filter-process: git-lfs: command not found` / `the remote end hung up unexpectedly` — **the largest sub-population in `HOST-SERVICE-3Q` (~616 events)**. A missing third-party filter binary is a separate condition from the two named here, so `HOST-SERVICE-3Q` will keep receiving events and will **not** go quiet from this change.
- `git-secret-protector: AES key … is not cached locally` (~90 events) — likewise a third-party clean-filter failure.
- `spawn git EAGAIN`, `spawn EBADF` — resource exhaustion we want to hear about.
- `Unable to create '…/index.lock': File exists` — concurrent git process.
- `mmap failed: Operation timed out`, `read error while indexing …: Operation timed out`.
- `fatal: unable to read <oid>` (no object kind named), `unable to read sha1 file of …`.
- `A branch named '…' already exists` (the string `HOST-SERVICE-3Q` is currently titled after, from `git.renameBranch`).
- Every other unrecognised git failure, unchanged.

### Sibling call sites left alone

`rethrowEnvironmentalGitError` is called only from `getStatus`. Other git procedures in this router (`listBranches`, `listCommits`, `getBaseBranch`) swallow their errors with bare `catch {}` and never reach a classifier; `getCommitFiles` and the mutation procedures do not call it. Adding call sites is not part of this change. Worth noting separately: the `xcode-select` stub message also appears on `POST /trpc/project.create` (8 events), which is a different router with its own error handling and is not touched here.

## Verification

`bunx biome check` on both changed files:

```
Checked 2 files in 10ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck` — 48 errors, all pre-existing. Verified by reverting both files to `origin/main` and re-running: the clean tree produces the same 48. None are in `src/trpc/router/git/`; they are missing optional integration deps (`@microsoft/microsoft-graph-client`, `@notionhq/client`, `@slack/web-api`) in `packages/trpc` and unrelated files elsewhere in `src/`.

`bun test packages/host-service/src/trpc/router/git`:

```
 112 pass
 0 fail
 247 expect() calls
Ran 112 tests across 10 files. [39.32s]
```

### Negative tests were written first and shown to have teeth

Before the change (3 new positive tests fail, all negatives pass vacuously):

```
 13 pass
 3 fail
Ran 16 tests across 1 file. [116.00ms]
```

Then, as a deliberate check that the negative tests are not vacuous, the branches were implemented with the naive over-broad patterns `/xcode|developer tools/i` and `/unable to read/i`. Both negative tests fail, confirming they pin real over-matches:

```
(fail) rethrowEnvironmentalGitError > does not claim unrelated Xcode and developer-tools output
(fail) rethrowEnvironmentalGitError > does not claim git's other 'unable to read' failures
 14 pass
 2 fail
Ran 16 tests across 1 file. [174.00ms]
```

With the anchored patterns actually shipped:

```
 16 pass
 0 fail
Ran 16 tests across 1 file. [107.00ms]
```

Repo-wide `bun run lint` was not run, per the task instruction that it hangs on cross-worktree bun locks.

Refs HOST-SERVICE-3Q
Refs HOST-SERVICE-42

https://claude.ai/code/session_019rnm3JosPzi3DuhTACTp7z

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies two recurring git-CLI environment failures as typed non-500s to improve signal quality. Previously `getStatus` returned `INTERNAL_SERVER_ERROR`; now it returns `PRECONDITION_FAILED` with explicit causes.

- Missing macOS Command Line Tools (`xcode-select` stub refusal) → `PRECONDITION_FAILED` with `cause: { kind: "GIT_ENVIRONMENT" }`.
- Unreadable tree object (damaged/incomplete object store) → `PRECONDITION_FAILED` with `cause: { kind: "GIT_REPO_DAMAGED" }`.
- Other failures on this path remain 500s; no user-visible behavior change. Adds `GIT_REPO_DAMAGED`; no current consumers.

**Review notes**
- Scope: `packages/host-service/src/trpc/router/git/utils/classify-git-error.ts` and its tests only; two anchored regexes appended after existing branches. Ordering keeps the working-directory environment case ahead of the new repo-damage check.
- Tests cover positive cases and nearby negatives to prevent over-matching, including a new negative that pins the `xcode-select` line-prefix anchor so hook output does not get misclassified.
- No new call sites; classifier still only used by `getStatus`. No migration required.

<sup>Written for commit 39a8f03b4f2ce16e072faf1ade385c299e5b8cdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git errors caused by missing macOS Command Line Tools.
  * Added clearer classification for damaged or incomplete Git repositories.
  * Preserved existing handling for working-directory errors and unrelated Git failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->