### PR TITLE
fix(host-service): classify a missing git filter helper as a typed non-500

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
@@ -242,15 +242,95 @@ describe("rethrowEnvironmentalGitError", () => {
 	});
 
 	test("genuine failures on the getStatus path still report as 500s", () => {
-		// Real messages seen in this Sentry group that this change deliberately
-		// leaves unclassified: a resource exhaustion bug we would want to hear
-		// about, and a missing third-party filter binary that is a separate
-		// condition from the two named here.
+		// A resource exhaustion bug we would want to hear about.
 		expect(capture(new Error("spawn git EAGAIN"))).toBeNull();
+	});
+
+	test("missing filter helper → PRECONDITION_FAILED / GIT_ENVIRONMENT", () => {
+		// Verbatim from the Sentry group: a repository configured for git-lfs on
+		// a machine without the helper installed. Git runs the filter through the
+		// shell, which cannot find the helper, and git then reports the filter
+		// pipe dying. Polled status re-reports it indefinitely.
+		const message =
+			"git-lfs filter-process: git-lfs: command not found\n" +
+			"fatal: the remote end hung up unexpectedly\n";
+		const thrown = capture(new Error(message));
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_ENVIRONMENT");
+		expect(thrown?.message).toBe(message);
+	});
+
+	test("missing filter helper is not specific to git-lfs", () => {
+		// The branch names the shape git produces for any filter helper it cannot
+		// execute, not one vendor's binary. Reproduced against a repository whose
+		// `filter.<name>.process` points at a program that is not installed.
+		const thrown = capture(
+			new Error(
+				"fake-lfs-helper filter-process: fake-lfs-helper: command not found\n" +
+					"fatal: the remote end hung up unexpectedly\n",
+			),
+		);
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_ENVIRONMENT");
+	});
+
+	test("keeps installed filters that fail for their own reasons as 500s", () => {
+		// Git emits a family of similar-looking filter failures that are not a
+		// missing helper. The helper ran and refused, so nothing about the
+		// machine's setup is wrong in the way this branch names — these must keep
+		// reporting as 500s. Both messages are real traffic from the same group.
 		expect(
 			capture(
 				new Error(
-					"git-lfs filter-process: git-lfs: command not found\nfatal: the remote end hung up unexpectedly\n",
+					"git-secret-protector: AES key for filter 'secrets-dev' is not cached locally. Run: git-secret-protector pull-aes-key secrets-dev\n" +
+						"error: external filter 'git-secret-protector encrypt %f' failed 1\n" +
+						"error: external filter 'git-secret-protector encrypt %f' failed\n" +
+						"fatal: infra/secrets.tfvars: clean filter 'secrets-dev' failed\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					'unknown command ""\n' +
+						"error: external filter 'git-lfs filter-process' failed\n" +
+						"fatal: assets/img/hash.png: clean filter 'lfs' failed\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error("fatal: assets/img/hash.png: clean filter 'lfs' failed\n"),
+			),
+		).toBeNull();
+	});
+
+	test("does not claim either half of the missing-helper pair alone", () => {
+		// Neither sentence is distinctive by itself. Git reports the remote end
+		// hanging up for ordinary network failures, and the shell says "command
+		// not found" for hooks and other programs that are not filters — matching
+		// on one half would silence a broken clone or a broken hook.
+		expect(
+			capture(
+				new Error(
+					"fatal: the remote end hung up unexpectedly\n" +
+						"fatal: early EOF\n" +
+						"fatal: index-pack failed\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					".git/hooks/pre-commit: line 2: definitely-not-installed-linter: command not found\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"error: cannot run definitely-not-a-real-ssh: No such file or directory\n" +
+						"fatal: unable to fork\n",
 				),
 			),
 		).toBeNull();

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
@@ -305,6 +305,29 @@ describe("rethrowEnvironmentalGitError", () => {
 		).toBeNull();
 	});
 
+	test("does not claim the same pair from a non-filter source", () => {
+		// A remote host without git, and a failing hook followed by a network
+		// drop, both print "command not found" and then the remote hanging up.
+		// Neither is a missing filter helper, and the filter's own invocation on
+		// the command-not-found line is what separates them.
+		expect(
+			capture(
+				new Error(
+					"bash: git-receive-pack: command not found\n" +
+						"fatal: The remote end hung up unexpectedly\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					".git/hooks/post-checkout: line 3: some-linter: command not found\n" +
+						"fatal: the remote end hung up unexpectedly\n",
+				),
+			),
+		).toBeNull();
+	});
+
 	test("does not claim either half of the missing-helper pair alone", () => {
 		// Neither sentence is distinctive by itself. Git reports the remote end
 		// hanging up for ordinary network failures, and the shell says "command

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
@@ -30,6 +30,20 @@ const SIMPLE_GIT_BASE_DIR_MISSING_PATTERN =
 // ordinary failures all the time.
 const XCODE_SELECT_NO_TOOLS_PATTERN =
 	/^xcode-select: .*no developer tools were found/im;
+// A content filter's helper program is not installed on this machine. Git runs
+// `filter.<name>.process`/`.clean` through the shell with the configured
+// command as the shell's $0, so an absent helper fails as
+// `<filter command>: <helper>: command not found`, and git then reports the
+// filter pipe dying as "the remote end hung up unexpectedly". A required
+// filter aborts the whole command, so everything touching a filtered path —
+// including the status snapshot we poll — fails until the helper is installed.
+// Both halves are required, in the order git emits them: git reports the
+// remote end hanging up for ordinary network failures too, and the shell says
+// "command not found" for hooks and other programs that are not filters.
+// Filters that are installed and then fail — refusing a file, missing a key —
+// say "external filter ... failed" instead and stay unclassified.
+const FILTER_HELPER_MISSING_PATTERN =
+	/: command not found$[\s\S]*?^fatal: the remote end hung up unexpectedly/im;
 // Git cannot read a tree object its own refs point at — a damaged or
 // incompletely fetched object store (a truncated packfile, most often). Every
 // command that walks a commit fails until the repository is repaired.
@@ -82,6 +96,13 @@ export function rethrowEnvironmentalGitError(error: unknown): void {
 		});
 	}
 	if (XCODE_SELECT_NO_TOOLS_PATTERN.test(error.message)) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message: error.message,
+			cause: { kind: "GIT_ENVIRONMENT" },
+		});
+	}
+	if (FILTER_HELPER_MISSING_PATTERN.test(error.message)) {
 		throw new TRPCError({
 			code: "PRECONDITION_FAILED",
 			message: error.message,

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
@@ -37,13 +37,17 @@ const XCODE_SELECT_NO_TOOLS_PATTERN =
 // filter pipe dying as "the remote end hung up unexpectedly". A required
 // filter aborts the whole command, so everything touching a filtered path —
 // including the status snapshot we poll — fails until the helper is installed.
-// Both halves are required, in the order git emits them: git reports the
-// remote end hanging up for ordinary network failures too, and the shell says
-// "command not found" for hooks and other programs that are not filters.
+// All three parts are required, in the order git emits them. The filter's own
+// invocation must appear on the command-not-found line: without it this would
+// also claim a remote host that lacks git-receive-pack, and a failing hook that
+// happens to precede a network drop — both of which print the same pair. Only
+// `filter.<name>.process` speaks the packet protocol whose pipe dying produces
+// "the remote end hung up unexpectedly", so requiring it costs no real case;
+// `.clean`/`.smudge` failures say "external filter ... failed" instead.
 // Filters that are installed and then fail — refusing a file, missing a key —
 // say "external filter ... failed" instead and stay unclassified.
 const FILTER_HELPER_MISSING_PATTERN =
-	/: command not found$[\s\S]*?^fatal: the remote end hung up unexpectedly/im;
+	/filter-process.*: command not found$[\s\S]*?^fatal: the remote end hung up unexpectedly/im;
 // Git cannot read a tree object its own refs point at — a damaged or
 // incompletely fetched object store (a truncated packfile, most often). Every
 // command that walks a commit fails until the repository is repaired.


### PR DESCRIPTION
## Problem

A repository configured to use a git content filter (git-lfs, in the observed
traffic) on a machine where the filter's helper program is not installed. Git
invokes the filter on ordinary operations, including the status snapshot the app
polls continuously, and the whole command aborts:

```
git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
```

Nothing the user does against that repository can succeed until they install the
helper, and the app reported it as an internal server error rather than a
typed "your machine can't do this" failure. Because status is polled, one such
repository re-reports indefinitely: **621 events over seven days**, the largest
single contributor to host-service's error volume.

**Reality check (asked before writing this):**

1. **User-visible harm.** A user with a filter-configured repository and no
   helper installed gets an opaque internal-server-error on every status poll of
   that workspace, instead of a typed failure the client can recognise as an
   environment precondition. I want to be precise about the size of this: the
   condition is concentrated on **exactly one machine and one release** (verified
   in Sentry, not taken on faith — grouping by `server_name` over 7d returns a
   single row, 621 events, release 1.23.0). So this is one user's broken
   workspace, plus a large, permanent stream of false bug signal. On the v2
   surface this diff does not by itself change rendered copy — no v2 consumer
   reads the cause kind yet, and the client retry predicate keys on timeout and
   connection errors rather than the code. What it changes is the contract: the
   error stops being labelled "our server has a bug".
2. **Reach.** The events carry release 1.23.0+ and culprit
   `gitRouter.getStatus`. That is `packages/host-service/.../git.ts:245`, whose
   catch block already calls `rethrowEnvironmentalGitError`. The change is inside
   that classifier, so it executes on the exact path the events come from, and
   ships to the affected user in the next host-service release.
3. **Why code, and why here.** Archiving is wrong: `HOST-SERVICE-3Q` is a
   grouping bucket holding ~1,360 events across at least a dozen unrelated
   causes (every git failure arrives with an identical library-only stack), so
   archiving it would also silence real bugs in it, such as `spawn git EAGAIN`.
   An inbound Sentry filter is forbidden by repo law (#6164) — classify at the
   throw site, never suppress Sentry-side. A different layer is not available:
   the producer is the git CLI, the error crosses a worker boundary that strips
   prototypes, and there is no errno or structured code, so the message is the
   only signal there is. The code path is not being deleted or restructured by
   in-flight work. That leaves exactly the instrument the two conditions merged
   earlier today (#6737) used, in the same file, in the same shape.

## Root cause

Git runs `filter.<name>.process` / `.clean` through the shell with the
configured command as the shell's `$0`, so a helper that is not on `PATH` fails
as `<filter command>: <helper>: command not found`. Git is waiting on the filter
protocol handshake, sees the pipe close, and dies with `fatal: the remote end
hung up unexpectedly`. When the filter is `required`, that aborts the command,
so `getStatus` throws and the classifier had no branch for it.

I reproduced this locally rather than inferring it — a scratch repo with
`filter.<name>.process` pointing at a program that does not exist reproduces the
message byte-for-byte with the vendor name substituted, which is what tells us
the shape is git's, not git-lfs's:

```
fake-lfs-helper filter-process: fake-lfs-helper: command not found
fatal: the remote end hung up unexpectedly
```

## Fix

One named module-level regex plus one branch in `rethrowEnvironmentalGitError`,
classified `PRECONDITION_FAILED` with `cause: { kind: "GIT_ENVIRONMENT" }`.

**Typed causes: I reused `GIT_ENVIRONMENT` and did not invent a new kind.** It
already means "this machine's git environment cannot serve this workspace",
which is exactly this condition, and it is already in the renderer's
`GitChangesErrorCause` union and copy switch. A new kind would have had no
reader.

**The pattern requires both halves of the pair, in the order git emits them.**
This is the deliberate part of the change, because git emits a family of
similar-looking filter failures that are *not* a missing helper, and neither
sentence is distinctive alone:

| Naive anchor | What it would have wrongly silenced |
| --- | --- |
| `the remote end hung up unexpectedly` | any failed clone/fetch/push over the network |
| `command not found` | a hook shelling out to a missing binary |
| `external filter .* failed` | an installed filter that refuses a file, or is missing a key |
| `clean filter .* failed` | same, plus the bare per-path failure line |

### Failures on this path that still report as 500s

Deliberately unclassified, and pinned by tests so a later widening breaks them:

- **An installed filter that fails for its own reasons.** Real traffic in this
  same bucket: a filter whose key is not cached locally (`external filter ...
  failed` → `clean filter '<name>' failed`, 104 events), and a filter that
  rejects one specific path (`unknown command ""` → `external filter ... failed`).
  The helper ran and refused — nothing about the machine's setup is wrong in the
  way this branch names.
- **A bare `clean filter '<name>' failed`** with no indication the helper is
  absent.
- **A network failure reporting `the remote end hung up unexpectedly`** (the
  classic `early EOF` / `index-pack failed` clone failure).
- **A hook shelling out to a missing binary** (`command not found` with no
  filter involved).
- **A missing `GIT_SSH_COMMAND`** — different text entirely (`error: cannot run
  ...: No such file or directory` / `fatal: unable to fork`), pinned anyway.
- `spawn git EAGAIN`, and every other cause sharing this bucket.

### An existing assertion changed on purpose

`classify-git-error.test.ts` previously asserted that this exact message keeps
reporting as a 500:

```ts
// ...and a missing third-party filter binary that is a separate
// condition from the two named here.
expect(capture(new Error("git-lfs filter-process: git-lfs: command not found\n..."))).toBeNull();
```

That was a deliberate scope boundary when #6737 landed, not a finding. **This PR
inverts it**, which is the point of the change: that message is now a positive
test. The `spawn git EAGAIN` half of that test is untouched and still asserts a
500.

Not done, per scope: no fingerprinting or grouping work (raised separately), no
classification of the other conditions in this bucket, no detection or install
prompt for the missing helper, and no new Sentry capture.

## Verification

Negative tests were written **before** the source change. Since the classifier
matched nothing here beforehand, "these pass before" is vacuous on its own — so
I separately checked each negative against the naive anchors above to prove the
discrimination is real:

```
POSITIVES (candidate must match):
  MATCH   lfs helper absent (621 events, verbatim)
  MATCH   locally reproduced, non-lfs filter helper

NEGATIVES (candidate must NOT match; naive anchors that would have):
  no match filter installed, key not cached (86 events)
      miscaught by: NAIVE_CLEAN_FILTER, NAIVE_EXTERNAL_FILTER
  no match filter installed, rejects one path (1 event)
      miscaught by: NAIVE_CLEAN_FILTER, NAIVE_EXTERNAL_FILTER
  no match bare clean filter failed
      miscaught by: NAIVE_CLEAN_FILTER
  no match network clone, remote hung up
      miscaught by: NAIVE_HUNG_UP
  no match hook shells out to a missing binary (reproduced)
      miscaught by: NAIVE_NOT_FOUND
  no match missing GIT_SSH_COMMAND (reproduced)
      miscaught by: (none)
```

**Before the source change** (tests in place, classifier untouched) — only the
two new positives fail, every negative already holds:

```
19 pass
 2 fail
51 expect() calls
Ran 21 tests across 1 file. [57.00ms]
```

**`bunx biome check` on both changed files:**

```
Checked 2 files in 16ms. No fixes applied.
```

**`cd packages/host-service && bun run typecheck`:**

```
$ tsc --noEmit --emitDeclarationOnly false
```

(no diagnostics; clean exit)

**`bun test packages/host-service/src/trpc/router/git`:**

```
bun test v1.3.14 (0d9b296a)

packages/host-service/src/trpc/router/git/get-diff-bulk.test.ts:
[host-worker-pool] host-worker bundle not found — running worker tasks inline on the main thread

 117 pass
 0 fail
 258 expect() calls
Ran 117 tests across 10 files. [41.39s]
```

Repo-wide `bun run lint` was not run, per instruction (it hangs on cross-worktree
bun locks).

Refs HOST-SERVICE-3Q

https://claude.ai/code/session_01DfTPsnbbiBeZbNRpAkuZKN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies a missing git content-filter helper as a typed non-500 so clients can treat it as an environment precondition. Previously these returned 500 Internal Server Error; now they throw PRECONDITION_FAILED with cause kind GIT_ENVIRONMENT, reducing noisy 500s.

- Adds `FILTER_HELPER_MISSING_PATTERN` and a branch in `packages/host-service/src/trpc/router/git/utils/classify-git-error.ts` to match the ordered two-line shape, and now requires the filter’s own invocation on the “command not found” line before “fatal: the remote end hung up unexpectedly” to avoid misclassifying remote or hook failures.
- Keeps installed-filter failures (`external filter ... failed` / `clean filter '<name>' failed`), network “hung up” errors, hook “command not found”, and resource exhaustion as 500s; tests add and pin negative cases.
- Message is preserved; no API or copy changes. Changes limited to `classify-git-error.ts` and its test.

<sup>Written for commit e1db7c40f676c25a314f3a546c6bb1d8612eb2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git errors caused by missing content-filter helper programs.
  * These environment issues now provide a clearer precondition failure classification.
  * Preserved existing handling for resource exhaustion, installed filter failures, and unrelated Git or SSH errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->