### PR TITLE
fix(mobile): handle the OS refusing to open sign-in legal links

### DIFF
--- a/apps/mobile/lib/open-url.ts
+++ b/apps/mobile/lib/open-url.ts
@@ -1,0 +1,12 @@
+import { Alert, Linking } from "react-native";
+
+/**
+ * Opens an external URL. The OS can refuse — web browsing is blockable by
+ * parental controls or a management profile — so surface that instead of
+ * leaving an unhandled rejection and a tap that looks dead.
+ */
+export function openUrl(url: string) {
+	Linking.openURL(url).catch(() => {
+		Alert.alert("Could not open link", url);
+	});
+}

--- a/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
@@ -1,11 +1,12 @@
 import * as AppleAuthentication from "expo-apple-authentication";
 import * as Crypto from "expo-crypto";
 import { useState } from "react";
-import { Image, Linking, View } from "react-native";
+import { Image, View } from "react-native";
 
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
 import { env } from "@/lib/env";
+import { openUrl } from "@/lib/open-url";
 
 import { DevSignInOptions } from "./components/DevSignInOptions";
 import { EmailSignInLink } from "./components/EmailSignInLink";
@@ -128,14 +129,14 @@ export function SignInScreen() {
 				By signing in, you agree to our{"\n"}
 				<Text
 					className="text-xs text-muted-foreground underline"
-					onPress={() => Linking.openURL(TERMS_URL)}
+					onPress={() => openUrl(TERMS_URL)}
 				>
 					Terms of Service
 				</Text>{" "}
 				and{" "}
 				<Text
 					className="text-xs text-muted-foreground underline"
-					onPress={() => Linking.openURL(PRIVACY_URL)}
+					onPress={() => openUrl(PRIVACY_URL)}
 				>
 					Privacy Policy
 				</Text>

--- a/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
@@ -5,7 +5,7 @@ import {
 } from "@superset/shared/constants";
 import * as Application from "expo-application";
 import { useRouter } from "expo-router";
-import { Alert, Linking, ScrollView, View } from "react-native";
+import { Alert, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/ui/text";
 import { useDeleteAccount } from "@/hooks/useDeleteAccount";
@@ -13,6 +13,7 @@ import { useSignOut } from "@/hooks/useSignOut";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "@/lib/auth/client";
 import { env } from "@/lib/env";
+import { openUrl } from "@/lib/open-url";
 import { ListRow } from "@/screens/(authenticated)/components/ListRow";
 import { ListRowValue } from "@/screens/(authenticated)/components/ListRowValue";
 import { OrganizationAvatar } from "@/screens/(authenticated)/components/OrganizationAvatar";
@@ -22,12 +23,6 @@ import { UserAvatar } from "./components/UserAvatar";
 
 const BILLING_URL = `${env.EXPO_PUBLIC_WEB_URL ?? COMPANY.MARKETING_URL}/settings/billing`;
 const WRITE_REVIEW_URL = `${COMPANY.APP_STORE_URL}?action=write-review`;
-
-function openUrl(url: string) {
-	Linking.openURL(url).catch(() => {
-		Alert.alert("Could not open link", url);
-	});
-}
 
 function ExternalIcon({ color }: { color: string }) {
 	return <Ionicons name="open-outline" size={16} color={color} />;


### PR DESCRIPTION
## Problem

On the sign-in screen, tapping **Terms of Service** or **Privacy Policy** does nothing at all on affected devices — no browser, no alert, no indication the tap registered. The OS refuses to open the URL, and the call site doesn't handle the refusal.

The telemetry shows what a dead control looks like from the user's side: 22 events from exactly **2 users, 11 apiece**. Nobody taps a legal link eleven times unless nothing is happening. Both are real devices in production (`simulator: false`, iOS 26.6.1), and it is still occurring.

The refusal itself is not our bug — the most likely cause by far is a device where web browsing is restricted by parental controls or a management profile, which we cannot override. Doing nothing visible in response to it is.

**Why code is the right instrument here:** the alternatives don't remove the harm. Archiving the issue or filtering it inbound leaves the user with the same dead tap and just hides it from us. Deleting the code path isn't available — these are the legal links a user must be able to read before agreeing to them on the sign-in screen. Fixing at a different layer doesn't apply: `Linking.openURL` rejecting is the OS's answer, and the only place that answer can become a user-visible response is the call site. The fix is three lines of already-shipping behaviour.

**Reach:** the events are on `sh.superset.mobile@1.0.0+14`. The app has no OTA updates enabled (`ota_updates.is_enabled: false`), so this ships in the next native `production` EAS build (`autoIncrement`, so `1.0.0+15` or later) and reaches users through TestFlight/App Store. Users who stay on `+14` keep hitting it until they update — this is a next-build fix, not a hotfix.

## Root cause

`SignInScreen.tsx` called `Linking.openURL(...)` directly in both legal-link `onPress` handlers with no `.catch()`. On refusal the promise rejects, nothing renders, and the rejection surfaces via `onunhandledrejection`.

The rest of the app already handles this correctly — `SettingsScreen` wrapped the same call in a local `openUrl` helper that catches and alerts. The sign-in screen simply never got it.

## Fix

Promote `SettingsScreen`'s existing `openUrl` helper to `apps/mobile/lib/open-url.ts` and use it for both legal links.

**Shared rather than duplicated**, deliberately: `AGENTS.md`'s co-location rule says a thing used 2+ times is promoted to the highest shared parent, and these two screens sit in different route groups, so `lib/` is that parent. It already holds small single-purpose modules of exactly this shape (`web-links.ts`, `navigation.ts`). It also keeps the user-facing alert copy in one place instead of letting two copies drift.

The function body is byte-identical to what `SettingsScreen` already shipped, so settings behaviour is unchanged — the diff there is an import replacing a local definition. Both links are covered, not just the one in the issue title; the Privacy Policy link is the same defect and is only absent from the report because nobody happened to tap it. The footer's copy and layout are untouched.

Net diff: +18 / −10.

## Verification

`bunx biome check` on the three changed files:

```
Checked 3 files in 9ms. No fixes applied.
```

`cd apps/mobile && bun run typecheck` — the mobile app has 139 pre-existing errors on this branch point (all in `workspace/[id]/…`, `ChangesetFile` property drift, unrelated to this change). I captured the error set before and after the change and diffed them:

```
baseline errors:      139
total errors:         139
$ diff tc_before.txt tc_after.txt
IDENTICAL: typecheck error set unchanged (139 pre-existing, none in touched files)

$ grep -E "open-url|SignInScreen|SettingsScreen" tc_after.txt
(none)
```

`bun test apps/mobile`:

```
bun test v1.3.14 (0d9b296a)

 33 pass
 0 fail
 60 expect() calls
Ran 33 tests across 6 files. [164.00ms]
```

**No tests exist for either touched screen** (`SignInScreen`, `SettingsScreen`) or for the new helper — the only tests under `screens/` cover pull-request utilities. I ran the suite to confirm no regression rather than to claim coverage, and did not invent one.

**Not verified on device or simulator** — running a simulator was out of scope for this task. Verified by reading the code against the sibling implementation this is extracted from, whose behaviour it reproduces exactly. The user-visible path (a refusal now producing a "Could not open link" alert) is unexercised by any automated check here.

Refs MOBILE-1

https://claude.ai/code/session_015bzRPkpsHpatq8h24h36jj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle OS refusal to open sign-in legal links so taps are no longer dead. Previously, tapping Terms or Privacy on sign-in did nothing and left an unhandled rejection; now it shows "Could not open link" and handles the error, matching Settings behavior.

- Promote `openUrl` to `apps/mobile/lib/open-url.ts` and import where used; function body unchanged.
- Replace `SignInScreen` direct `Linking.openURL(...)` with `openUrl(...)`; `SettingsScreen` switches from local helper to import (behavior unchanged).
- Behavior change limited to sign-in: OS refusal now alerts instead of no-op.
- Rollout: next native production build only (no OTA). Refs MOBILE-1.

<sup>Written for commit e9bf8e8024575a22385cf37ed8c190b79d87f8c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Terms of Service, Privacy Policy, or other external links cannot be opened.
  * Displays a clear alert with the affected link instead of allowing the failure to go unnoticed.
  * Applied consistent link-opening behavior across sign-in and settings screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->