### PR TITLE
perf(auth): collapse the session lookup from seven round trips to one

### DIFF
--- a/packages/auth/src/lib/cached-jwks.ts
+++ b/packages/auth/src/lib/cached-jwks.ts
@@ -1,0 +1,50 @@
+import type { GenericEndpointContext } from "better-auth";
+import type { Jwk } from "better-auth/plugins/jwt";
+
+/**
+ * The jwt plugin reads the whole `jwks` table every time it mints a token, and
+ * it mints one on every `/get-session` to set the `set-auth-jwt` header. That
+ * is a database round trip on every authenticated request in the product for a
+ * key set that only changes when a key is created.
+ *
+ * Disabling the header instead would be cheaper still, but the desktop and
+ * mobile clients read it opportunistically to refresh their token
+ * (apps/desktop/src/renderer/lib/auth-client.ts, apps/mobile/lib/auth/client.ts),
+ * so the header stays and the read gets cached.
+ *
+ * The TTL is short because the cost of being stale is real but bounded: a key
+ * created by another instance is absent from `/jwks` until the cache expires,
+ * so tokens signed with it fail verification until then. Creations go through
+ * `createJwk` below, which clears this instance's copy immediately.
+ */
+const JWKS_CACHE_TTL_MS = 60 * 1000;
+
+let cache: { keys: Jwk[]; fetchedAt: number } | null = null;
+
+export function jwksAdapter() {
+	return {
+		getJwks: async (ctx: GenericEndpointContext): Promise<Jwk[]> => {
+			if (cache && Date.now() - cache.fetchedAt < JWKS_CACHE_TTL_MS) {
+				return cache.keys;
+			}
+
+			const keys = await ctx.context.adapter.findMany<Jwk>({
+				model: "jwks",
+			});
+			cache = { keys, fetchedAt: Date.now() };
+			return keys;
+		},
+
+		createJwk: async (
+			data: Omit<Jwk, "id">,
+			ctx: GenericEndpointContext,
+		): Promise<Jwk> => {
+			const created = await ctx.context.adapter.create<Omit<Jwk, "id">, Jwk>({
+				model: "jwks",
+				data: { ...data, createdAt: new Date() },
+			});
+			cache = null;
+			return created;
+		},
+	};
+}

--- a/packages/auth/src/lib/load-custom-session-data.ts
+++ b/packages/auth/src/lib/load-custom-session-data.ts
@@ -1,0 +1,132 @@
+import { db } from "@superset/db/client";
+import type { SelectMember } from "@superset/db/schema/auth";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
+import { sql } from "drizzle-orm";
+
+/**
+ * Everything `customSession` needs, in one round trip.
+ *
+ * These were three sequential drizzle calls — memberships, then the active
+ * organization's subscription, then the user's own row. Neon speaks HTTP, so
+ * each call is its own request, and with the database in a different region to
+ * the functions that was ~220ms on every authenticated request in the product.
+ * Only the active-organization fallback made the order matter, and that is
+ * expressible in SQL, so the three collapse into one statement.
+ *
+ * Raw SQL rather than drizzle's query builder because the point is the single
+ * statement; expressing the fallback across three builder calls is what we are
+ * replacing.
+ */
+export interface CustomSessionData {
+	memberships: SelectMember[];
+	/**
+	 * The organization the plan below belongs to. A concurrent request can move
+	 * the session's active organization between this query and the caller
+	 * settling on one, so the caller compares before trusting `plan`.
+	 */
+	planOrganizationId: string | null;
+	plan: string | null;
+	onboardedAt: Date | null;
+	deletionRequestedAt: Date | null;
+}
+
+interface CustomSessionRow extends Record<string, unknown> {
+	memberships: Array<{
+		id: string;
+		organizationId: string;
+		userId: string;
+		role: string;
+		createdAt: string;
+	}> | null;
+	active_organization_id: string | null;
+	plan: string | null;
+	onboarded_at: string | Date | null;
+	deletion_requested_at: string | Date | null;
+}
+
+/**
+ * These are `timestamp` columns, so Postgres hands back a naive string with no
+ * zone. `new Date()` reads that as local time, which silently shifts every
+ * value by the server's offset; drizzle's own mapping treats it as UTC, so
+ * match that or the onboarding gate moves by hours depending on where the
+ * function ran.
+ */
+function toDate(value: string | Date | null): Date | null {
+	if (value === null) return null;
+	if (value instanceof Date) return value;
+	const normalized = value.replace(" ", "T");
+	const hasZone = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/.test(normalized);
+	return new Date(hasZone ? normalized : `${normalized}Z`);
+}
+
+export async function loadCustomSessionData({
+	userId,
+	activeOrganizationId,
+}: {
+	userId: string;
+	activeOrganizationId: string | null;
+}): Promise<CustomSessionData> {
+	const statuses = sql.join(
+		ACTIVE_SUBSCRIPTION_STATUSES.map((status) => sql`${status}`),
+		sql`, `,
+	);
+
+	const result = await db.execute<CustomSessionRow>(sql`
+		WITH memberships AS (
+			SELECT id, organization_id, user_id, role, created_at
+			FROM auth.members
+			WHERE user_id = ${userId}::uuid
+		),
+		active AS (
+			SELECT COALESCE(
+				(SELECT organization_id FROM memberships
+				 WHERE organization_id = ${activeOrganizationId}::uuid LIMIT 1),
+				(SELECT organization_id FROM memberships
+				 ORDER BY created_at DESC LIMIT 1)
+			) AS organization_id
+		)
+		SELECT
+			(SELECT COALESCE(json_agg(json_build_object(
+					'id', id,
+					'organizationId', organization_id,
+					'userId', user_id,
+					'role', role,
+					'createdAt', created_at
+				) ORDER BY created_at DESC), '[]'::json)
+			 FROM memberships) AS memberships,
+			(SELECT organization_id FROM active) AS active_organization_id,
+			(SELECT s.plan FROM subscriptions s, active a
+			 WHERE s.reference_id = a.organization_id
+			   AND s.status IN (${statuses})
+			 LIMIT 1) AS plan,
+			u.onboarded_at,
+			u.deletion_requested_at
+		FROM auth.users u
+		WHERE u.id = ${userId}::uuid
+	`);
+
+	const row = result.rows[0];
+	if (!row) {
+		return {
+			memberships: [],
+			planOrganizationId: null,
+			plan: null,
+			onboardedAt: null,
+			deletionRequestedAt: null,
+		};
+	}
+
+	return {
+		memberships: (row.memberships ?? []).map((member) => ({
+			id: member.id,
+			organizationId: member.organizationId,
+			userId: member.userId,
+			role: member.role,
+			createdAt: toDate(member.createdAt) ?? new Date(0),
+		})),
+		planOrganizationId: row.active_organization_id,
+		plan: row.plan,
+		onboardedAt: toDate(row.onboarded_at),
+		deletionRequestedAt: toDate(row.deletion_requested_at),
+	};
+}

--- a/packages/auth/src/lib/resolve-session-organization-state.ts
+++ b/packages/auth/src/lib/resolve-session-organization-state.ts
@@ -64,8 +64,9 @@ export async function resolveSessionOrganizationState(
 		userId?: string | null;
 		session?: SessionOrganizationContext | null;
 	},
-	deps: ResolveSessionOrganizationDeps = defaultResolveSessionOrganizationDeps,
+	overrides: Partial<ResolveSessionOrganizationDeps> = {},
 ) {
+	const deps = { ...defaultResolveSessionOrganizationDeps, ...overrides };
 	const previousActiveOrganizationId = session?.activeOrganizationId ?? null;
 	let activeOrganizationId = previousActiveOrganizationId;
 	if (!userId) {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -33,7 +33,9 @@ import { and, asc, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
+import { jwksAdapter } from "./lib/cached-jwks";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
+import { loadCustomSessionData } from "./lib/load-custom-session-data";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
 import {
@@ -305,6 +307,7 @@ export const auth = betterAuth({
 			jwks: {
 				keyPairConfig: { alg: "RS256" },
 			},
+			adapter: jwksAdapter(),
 			jwt: {
 				issuer: env.NEXT_PUBLIC_API_URL,
 				audience: env.NEXT_PUBLIC_API_URL,
@@ -872,22 +875,39 @@ export const auth = betterAuth({
 		customSession(
 			async ({ user, session: baseSession }) => {
 				const session = baseSession as typeof sessions.$inferSelect;
+				const userId = session.userId ?? user.id;
+
+				// Memberships, the active organization's plan and the user's own
+				// flags in one statement. This runs on every authenticated request
+				// in the product, so each extra round trip here is a region-crossing
+				// hop the whole fleet pays for.
+				const data = await loadCustomSessionData({
+					userId,
+					activeOrganizationId: session.activeOrganizationId ?? null,
+				});
+
 				const { activeOrganizationId, allMemberships, membership } =
-					await resolveSessionOrganizationState({
-						userId: session.userId ?? user.id,
-						session,
-					});
+					await resolveSessionOrganizationState(
+						{ userId, session },
+						{ listMemberships: async () => data.memberships },
+					);
 
 				const organizationIds = [
 					...new Set(allMemberships.map((m) => m.organizationId)),
 				];
 
+				// Same statuses the rest of the app gates on — this is the value
+				// the paywall falls back to when the activePlan query can't be
+				// reached, so an "active"-only read here would strand trialing
+				// and past_due organizations on a cold start.
 				let plan: string | null = null;
-				if (activeOrganizationId) {
-					// Same statuses the rest of the app gates on — this is the value
-					// the paywall falls back to when the activePlan query can't be
-					// reached, so an "active"-only read here would strand trialing
-					// and past_due orgs on a cold start.
+				if (activeOrganizationId === data.planOrganizationId) {
+					plan = data.plan;
+				} else if (activeOrganizationId) {
+					// A concurrent request moved the session's active organization
+					// after the query above ran, so the plan it found belongs to the
+					// wrong one. Rare enough to be worth a second read rather than
+					// serialising the common path behind it.
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, activeOrganizationId),
@@ -897,19 +917,11 @@ export const auth = betterAuth({
 					plan = subscription?.plan ?? null;
 				}
 
-				// additionalFields declares onboardedAt for client typing, but the
-				// drizzle adapter doesn't surface it on the passed-in user — read it
-				// explicitly so the onboarding gate is deterministic.
-				const userRow = await db.query.users.findFirst({
-					where: eq(authSchema.users.id, user.id),
-					columns: { onboardedAt: true, deletionRequestedAt: true },
-				});
-
 				return {
 					user: {
 						...user,
-						onboardedAt: userRow?.onboardedAt ?? null,
-						deletionRequestedAt: userRow?.deletionRequestedAt ?? null,
+						onboardedAt: data.onboardedAt,
+						deletionRequestedAt: data.deletionRequestedAt,
 					},
 					session: {
 						...session,


### PR DESCRIPTION
> **Not a candidate for admin-merge.** This touches the auth path for every authenticated request across desktop, web, mobile, CLI and MCP. It's the biggest win available, but it wants a human read — see *What to look at* below.

## The problem

Every authenticated request resolves a session, and each resolution was **seven** HTTP round trips to Neon. The database is in `us-west-2`; every Vercel function is in `iad1`. So one query costs **73-100ms**, not a few.

Scale: `api`'s `GET /api/trpc/[trpc]` alone has **360M** Neon spans at 73ms average.

| # | query | |
|---|---|---|
| 1 | `findOne sessions` | covered by cookieCache ~2/3 of the time |
| 2 | `findOne users` | ditto |
| 3 | `update sessions` | `updateAge` refresh |
| 4 | `findMany jwkss` | **every call**, 136ms |
| 5 | `members.findMany` | customSession |
| 6 | `subscriptions.findFirst` | customSession |
| 7 | `users.findFirst` | **the same row as #2** |

`cookieCache` was already hitting on 40 of 60 sampled requests — but `customSession` re-ran its callback regardless, so 4-7 were paid even on a cache hit.

## The changes

**#5, #6, #7 → one statement.** They were sequential only because the active-organization fallback made the order matter, and that fallback is expressible in SQL. #7 was reading a row better-auth had already handed us; the old comment blamed `additionalFields` not surfacing on the passed-in user.

**#4 cached**, not disabled. `disableSettingJwtHeader` would remove the round trip outright, but desktop (`auth-client.ts:142`) and mobile (`client.ts:45`) both read `set-auth-jwt` off response headers to refresh opportunistically. So the read is cached behind the plugin's `adapter.getJwks` hook instead, with `createJwk` writing through and invalidating.

Net: **7 → 1** on a cookie-cache hit, **7 → 3** on a miss.

## Verification

A differential harness ran old vs. new against a real database branch across **64 cases** — multi-membership users at every active-organization permutation, paid and unpaid, stale organization ids, no active organization, and a user with no memberships.

**0 mismatches. 104ms → 36ms per call.**

## What to look at

The harness caught a genuine bug, which is the best argument for reviewing this carefully:

`onboardedAt` came back **8 hours off** on every user. These are `timestamp` (not `timestamptz`) columns, so Postgres returns a naive string with no zone — `new Date()` reads that as *local* time, while drizzle's mapping treats it as UTC. Silent, and it would have shifted the onboarding gate by the function's offset. Fixed in `toDate()`, re-verified.

Specific things worth a second opinion:

1. **`toDate()` in `load-custom-session-data.ts`** — the fix above. If it's wrong, onboarding and pending-deletion gates move.
2. **The raw SQL.** It's the only `db.execute` in `packages/auth`, deliberately: the single statement *is* the point. Worth checking the active-org CTE matches `resolveSessionOrganizationState`'s TS fallback exactly (it takes memberships ordered `created_at DESC` and picks the session's org if present, else the first).
3. **The concurrent-move path.** If another request changes the session's active organization between the query and `resolveSessionOrganizationState` settling, the plan fetched belongs to the wrong org. Handled by comparing `planOrganizationId` and re-reading — rare, but confirm the fallback is right.
4. **JWKS cache TTL (60s).** A key created on another instance is absent from `/jwks` until expiry, so tokens signed with it would fail verification for up to a minute. `createJwk` invalidates locally. Keys effectively never rotate here (no expiry configured), but the window is real.

## Testing

- 64-case differential harness against a live branch, 0 mismatches
- JWKS cache: 3 calls → 1 read; `createJwk` invalidates
- better-auth instance constructs cleanly with the `adapter` option (106 endpoints)
- Lint, typecheck, full suite green

https://claude.ai/code/session_014D6wif8HDRCXEFf5Ku4w7V

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses session resolution from seven DB round trips per request to one on a cookie-cache hit (three on a miss) by combining membership/subscription/user reads into a single SQL statement and caching JWKS reads. This reduces per-request latency and fixes timestamp parsing that could shift onboarding/deletion gates.

**Review and rollout**
- Verify the raw SQL active-org fallback matches the TypeScript logic: prefer the session’s org if present, else the most-recent membership (`created_at DESC`).
- Confirm `toDate()` treats Postgres `timestamp` (no tz) as UTC; a mismatch moves onboarding/deletion gates by the server offset.
- Check the concurrent move path: if `planOrganizationId` differs from the resolved active org, we re-read the subscription; this avoids serializing the common path.
- JWKS caching: 60s per-instance TTL. Keys created on another instance may fail verification until expiry; `createJwk` invalidates locally. We keep the `set-auth-jwt` header for desktop/mobile refresh behavior.
- Expected impact: 7→1 round trip on cache hit (7→3 on miss); ~104ms→36ms per call over 64 cases. No migrations required.

<sup>Written for commit e5167e6bd5e8ec686e13c2046bfec9941044aece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session loading with memberships, active organization details, subscription plans, onboarding status, and deletion-request status.
  * Added caching for authentication keys to improve repeated sign-in and session checks.
  * Session data now stays accurate when the active organization changes.

* **Bug Fixes**
  * Improved fallback behavior when an active organization is unavailable.
  * Ensured session timestamps are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->