### PR TITLE
fix(mobile): stop waiting on the workspace destroy the host already committed

### DIFF
--- a/apps/mobile/hooks/useCloudWorkspaceActions/useCloudWorkspaceActions.ts
+++ b/apps/mobile/hooks/useCloudWorkspaceActions/useCloudWorkspaceActions.ts
@@ -1,7 +1,10 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import type { CloudWorkspaceRow } from "@/hooks/useCloudWorkspaces";
 import { clearSandboxAccess } from "@/lib/sandbox-access";
 import { apiClient } from "@/lib/trpc/client";
+
+const LIST_KEY = ["cloud", "cloudWorkspace", "list"];
 
 /**
  * Rename and delete for cloud workspaces go to the API, not the sandbox: the
@@ -13,10 +16,7 @@ export function useCloudWorkspaceActions() {
 	const queryClient = useQueryClient();
 
 	const invalidate = useCallback(
-		() =>
-			queryClient.invalidateQueries({
-				queryKey: ["cloud", "cloudWorkspace", "list"],
-			}),
+		() => queryClient.invalidateQueries({ queryKey: LIST_KEY }),
 		[queryClient],
 	);
 
@@ -30,11 +30,21 @@ export function useCloudWorkspaceActions() {
 
 	const remove = useCallback(
 		async (id: string) => {
-			await apiClient.cloudWorkspace.delete.mutate({ id });
-			clearSandboxAccess(id);
-			await invalidate();
+			// The row goes when the user asks, not when the provider finishes
+			// tearing the sandbox down; the invalidate below is what restores it
+			// if the delete never landed.
+			queryClient.setQueriesData<CloudWorkspaceRow[]>(
+				{ queryKey: LIST_KEY },
+				(rows) => rows?.filter((row) => row.id !== id),
+			);
+			try {
+				await apiClient.cloudWorkspace.delete.mutate({ id });
+				clearSandboxAccess(id);
+			} finally {
+				await invalidate();
+			}
 		},
-		[invalidate],
+		[invalidate, queryClient],
 	);
 
 	return { rename, remove };

--- a/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
+++ b/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
@@ -149,22 +149,9 @@ export function useCloudWorkspaceItems(): CloudWorkspaceItemsValue {
 					},
 				);
 			},
-			removeWorkspace: (hostId, workspaceId) => {
-				const key = keyFor(hostId);
-				if (!key) return;
-				queryClient.setQueryData<HostWorkspaceRow[] | undefined>(key, (rows) =>
-					rows?.filter((row) => row.id !== workspaceId),
-				);
-			},
 			invalidateHost: (hostId) => {
 				const key = keyFor(hostId);
 				if (key) void queryClient.invalidateQueries({ queryKey: key });
-			},
-			refetchHost: async (hostId) => {
-				const key = keyFor(hostId);
-				if (!key) return undefined;
-				await queryClient.refetchQueries({ queryKey: key });
-				return queryClient.getQueryData<HostWorkspaceRow[]>(key);
 			},
 		};
 	}, [queryClient]);

--- a/apps/mobile/hooks/useDeleteWorkspace/index.ts
+++ b/apps/mobile/hooks/useDeleteWorkspace/index.ts
@@ -1,0 +1,4 @@
+export {
+	type DeleteWorkspaceTarget,
+	useDeleteWorkspace,
+} from "./useDeleteWorkspace";

--- a/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
+++ b/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
@@ -1,0 +1,155 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { Alert } from "react-native";
+import { useCloudWorkspaceActions } from "@/hooks/useCloudWorkspaceActions";
+import {
+	getHostWorkspacesQueryKey,
+	type HostWorkspaceRow,
+} from "@/hooks/useHostWorkspaces";
+import { getHostServiceClientByUrl } from "@/lib/host-service/client";
+import { isTrpcErrorWithData } from "@/lib/host-service/errors";
+
+export interface DeleteWorkspaceTarget {
+	id: string;
+	name: string;
+	/** Host owning the worktree. Unused for a cloud workspace. */
+	hostId: string | null;
+	/** Where that host answers — null when it is offline. */
+	hostUrl: string | null;
+	/** Only the API can destroy a cloud workspace; its sandbox cannot. */
+	isCloud: boolean;
+}
+
+/** Codes the relay answers with itself, about its tunnel and not the delete. */
+const RELAY_ERROR_CODES = new Set(["BAD_GATEWAY", "SERVICE_UNAVAILABLE"]);
+
+/**
+ * Confirm, then delete a workspace: the row leaves the list the moment the
+ * user confirms and the destroy runs unattended.
+ *
+ * Waiting on the mutation is what made this feel broken on a phone.
+ * host-service archives the row *before* any slow work, and that archive is
+ * the commit point, so the 10-20s a teardown script and a worktree removal
+ * take are all spent after the delete is already decided. Worse, past the
+ * relay's 30s exchange cap the client is handed `BAD_GATEWAY: Request timed
+ * out` for a delete that committed.
+ *
+ * The confirm is the whole gate. `force` goes out with every destroy rather
+ * than preflighting for uncommitted work first: on a phone the answer to
+ * "this worktree is dirty" is yes anyway — agent work is cheap to redo — and
+ * a second alert after a refused destroy costs more than it protects.
+ * Teardown still runs; `force` is git consent only.
+ *
+ * `onConfirmed` fires at that commit point, so a caller showing the workspace
+ * can leave for the list instead of sitting on a screen whose row is gone.
+ */
+export function useDeleteWorkspace() {
+	const queryClient = useQueryClient();
+	const cloud = useCloudWorkspaceActions();
+
+	return useCallback(
+		(target: DeleteWorkspaceTarget, onConfirmed?: () => void) => {
+			if (target.isCloud) {
+				Alert.alert(
+					"Delete cloud workspace",
+					`Delete "${target.name}"? This shuts down its sandbox and everything in it.`,
+					[
+						{ style: "cancel", text: "Cancel" },
+						{
+							onPress: () => {
+								onConfirmed?.();
+								void cloud
+									.remove(target.id)
+									.catch(() => Alert.alert("Delete failed"));
+							},
+							style: "destructive",
+							text: "Delete",
+						},
+					],
+				);
+				return;
+			}
+
+			const { hostId, hostUrl } = target;
+			if (!hostId || !hostUrl) {
+				Alert.alert("Host is not online");
+				return;
+			}
+			const client = getHostServiceClientByUrl(hostUrl);
+			const listKey = getHostWorkspacesQueryKey(hostId, hostUrl);
+
+			const destroy = async (skipTeardown: boolean): Promise<void> => {
+				try {
+					await client.workspaceCleanup.destroy.mutate({
+						workspaceId: target.id,
+						deleteBranch: false,
+						force: true,
+						skipTeardown,
+					});
+				} catch (error) {
+					if (isTrpcErrorWithData(error)) {
+						// Another destroy already owns this workspace and will
+						// either finish it or un-archive it.
+						if (error.data.deleteInProgress) return;
+						// A failing teardown script shouldn't hold the delete
+						// hostage on a phone: it already ran, so let the workspace
+						// go without it.
+						if (error.data.teardownFailure && !skipTeardown) {
+							await destroy(true);
+							return;
+						}
+					}
+					// The host archives the row before any slow work, so a fresh
+					// list without it means the delete committed and only the
+					// relay gave up waiting (its 30s cap is shorter than a
+					// teardown script's). Ask the host directly: a cache refetch
+					// that fails leaves the optimistic removal behind and would
+					// read as success.
+					const rows = await client.workspace.list.query().catch(() => null);
+					if (rows && !rows.some((row) => row.id === target.id)) return;
+					void queryClient.invalidateQueries({ queryKey: listKey });
+					Alert.alert("Delete failed", failureDetail(error));
+				}
+			};
+
+			Alert.alert(
+				"Delete workspace",
+				`Delete "${target.name}"? This removes its worktree from the host.`,
+				[
+					{ style: "cancel", text: "Cancel" },
+					{
+						onPress: () => {
+							// Drop the row now. The host's archive lands within
+							// milliseconds and every later refetch agrees; a failure
+							// un-archives and the invalidate above brings it back.
+							queryClient.setQueryData<HostWorkspaceRow[]>(listKey, (rows) =>
+								rows?.filter((row) => row.id !== target.id),
+							);
+							onConfirmed?.();
+							void destroy(false);
+						},
+						style: "destructive",
+						text: "Delete",
+					},
+				],
+			);
+		},
+		[cloud, queryClient],
+	);
+}
+
+/**
+ * What to put under "Delete failed". The relay's own messages describe its
+ * tunnel — "Request timed out" at the 30s exchange cap — and the caller only
+ * reaches here once a fresh list has proved the workspace is still on the
+ * host, so they would name the wrong problem.
+ */
+function failureDetail(error: unknown): string | undefined {
+	if (
+		isTrpcErrorWithData(error) &&
+		RELAY_ERROR_CODES.has(error.data.code ?? "")
+	) {
+		return undefined;
+	}
+	return error instanceof Error ? error.message : undefined;
+}

--- a/apps/mobile/hooks/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/mobile/hooks/useHostWorkspaces/useHostWorkspaces.ts
@@ -33,12 +33,8 @@ export interface HostWorkspacesCacheOps {
 	resolveHostUrl: (hostId: string) => string | null;
 	/** Optimistically upsert a row into the host's cached list. */
 	upsertWorkspace: (row: HostWorkspaceRow) => void;
-	/** Optimistically drop a row from the host's cached list. */
-	removeWorkspace: (hostId: string, workspaceId: string) => void;
 	/** Rollback hammer: refetch the host's list after a failed write. */
 	invalidateHost: (hostId: string) => void;
-	/** Refetch and resolve with the host's fresh list (undefined = unreachable). */
-	refetchHost: (hostId: string) => Promise<HostWorkspaceRow[] | undefined>;
 }
 
 export interface UseHostWorkspacesResult {
@@ -109,20 +105,9 @@ export function useHostWorkspaces(
 					},
 				);
 			},
-			removeWorkspace: (hostId, workspaceId) => {
-				if (hostId !== machineId) return;
-				queryClient.setQueryData<HostWorkspaceRow[] | undefined>(key, (rows) =>
-					rows?.filter((row) => row.id !== workspaceId),
-				);
-			},
 			invalidateHost: (hostId) => {
 				if (hostId !== machineId) return;
 				void queryClient.invalidateQueries({ queryKey: key });
-			},
-			refetchHost: async (hostId) => {
-				if (hostId !== machineId) return undefined;
-				await queryClient.refetchQueries({ queryKey: key });
-				return queryClient.getQueryData<HostWorkspaceRow[]>(key);
 			},
 		};
 	}, [machineId, hostUrl, queryClient]);

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
@@ -1,7 +1,7 @@
 import type { SelectGithubPullRequest } from "@superset/db/schema";
 import { useRouter } from "expo-router";
 import { FolderGit2, Plus } from "lucide-react-native";
-import { ActivityIndicator, Pressable, View } from "react-native";
+import { Pressable, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
@@ -63,13 +63,8 @@ export function WorkspaceRow({
 		workspace.hostReachable &&
 		workspace.worktreeExists !== false &&
 		(cloudStatus === undefined || cloudStatus === "ready");
-	const {
-		isDeleting,
-		renameWorkspace,
-		deleteWorkspace,
-		copyId,
-		shareWorkspace,
-	} = useWorkspaceRowActions(workspace, cache, cloudStatus);
+	const { renameWorkspace, deleteWorkspace, copyId, shareWorkspace } =
+		useWorkspaceRowActions(workspace, cache, cloudStatus);
 
 	return (
 		<WorkspaceRowMenu
@@ -94,22 +89,15 @@ export function WorkspaceRow({
 				className={cn(
 					"flex-row items-center gap-3 rounded-xl py-2 pl-10 pr-3",
 					targeted ? "bg-foreground/5" : "bg-background",
-					isDeleting && "opacity-40",
 				)}
-				disabled={isDeleting}
 				onPress={() =>
 					router.push(`/(authenticated)/workspace/${workspace.id}`)
 				}
 			>
 				{/* Desktop WorkspaceIcon semantics: working replaces the icon with
 				    the braille spinner; other statuses overlay a corner ping on the
-				    base icon (PR state when one exists, else the workspace mark).
-				    A delete in flight takes the slot over everything else. */}
-				{isDeleting ? (
-					<View className="size-6 items-center justify-center">
-						<ActivityIndicator size="small" color={theme.mutedForeground} />
-					</View>
-				) : attention === "working" || cloudStatus === "provisioning" ? (
+				    base icon (PR state when one exists, else the workspace mark). */}
+				{attention === "working" || cloudStatus === "provisioning" ? (
 					<View className="size-6 items-center justify-center">
 						<AsciiSpinner />
 					</View>
@@ -212,7 +200,7 @@ export function WorkspaceRow({
 					accessibilityLabel={`New agent in ${workspace.name}`}
 					variant="ghost"
 					size="icon"
-					disabled={!canChat || isDeleting}
+					disabled={!canChat}
 					onPress={() =>
 						setTarget({
 							workspaceId: workspace.id,

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
@@ -1,23 +1,15 @@
 import { prompt } from "@superset/alert-prompt";
 import * as Clipboard from "expo-clipboard";
-import { useState } from "react";
 import { Alert, Share } from "react-native";
 import { useCloudWorkspaceActions } from "@/hooks/useCloudWorkspaceActions";
 import type { CloudWorkspaceStatus } from "@/hooks/useCloudWorkspaceItems";
+import { useDeleteWorkspace } from "@/hooks/useDeleteWorkspace";
 import type {
 	HostWorkspaceItem,
 	HostWorkspacesCacheOps,
 } from "@/hooks/useHostWorkspaces";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
-import { isTrpcErrorWithData } from "@/lib/host-service/errors";
 import { workspaceShareUrl } from "@/lib/web-links";
-
-interface DestroyOptions {
-	/** Git-destructive consent only: skips the dirty-worktree preflight. */
-	force: boolean;
-	/** Consent to abandon the teardown script — set once it has already failed. */
-	skipTeardown: boolean;
-}
 
 export function useWorkspaceRowActions(
 	workspace: HostWorkspaceItem,
@@ -25,8 +17,8 @@ export function useWorkspaceRowActions(
 	/** Set for a cloud workspace, whose name and lifetime the API owns. */
 	cloudStatus?: CloudWorkspaceStatus,
 ) {
-	const [isDeleting, setIsDeleting] = useState(false);
 	const cloud = useCloudWorkspaceActions();
+	const remove = useDeleteWorkspace();
 	const isCloud = cloudStatus !== undefined;
 
 	const renameWorkspace = async () => {
@@ -61,107 +53,14 @@ export function useWorkspaceRowActions(
 		cache.invalidateHost(workspace.hostId);
 	};
 
-	const deleteCloudWorkspace = () => {
-		Alert.alert(
-			"Delete cloud workspace",
-			`Delete "${workspace.name}"? This shuts down its sandbox and everything in it.`,
-			[
-				{ style: "cancel", text: "Cancel" },
-				{
-					onPress: () => {
-						setIsDeleting(true);
-						void cloud
-							.remove(workspace.id)
-							.catch(() => Alert.alert("Delete failed"))
-							.finally(() => setIsDeleting(false));
-					},
-					style: "destructive",
-					text: "Delete",
-				},
-			],
-		);
-	};
-
-	const destroyWorkspace = async ({ force, skipTeardown }: DestroyOptions) => {
-		const hostUrl = cache.resolveHostUrl(workspace.hostId);
-		if (!hostUrl) {
-			Alert.alert("Host is not online");
-			return;
-		}
-		setIsDeleting(true);
-		try {
-			await getHostServiceClientByUrl(hostUrl).workspaceCleanup.destroy.mutate({
-				workspaceId: workspace.id,
-				deleteBranch: false,
-				force,
-				skipTeardown,
-			});
-			cache.removeWorkspace(workspace.hostId, workspace.id);
-		} catch (error) {
-			if (isTrpcErrorWithData(error)) {
-				if (error.data.deleteInProgress) {
-					Alert.alert("Delete already in progress");
-					return;
-				}
-				// A failing teardown script shouldn't hold the delete hostage on a
-				// phone: it already ran, so let the workspace go without it.
-				if (error.data.teardownFailure && !skipTeardown) {
-					await destroyWorkspace({ force: true, skipTeardown: true });
-					return;
-				}
-				if (error.data.code === "CONFLICT") {
-					Alert.alert("Worktree has uncommitted changes", undefined, [
-						{ style: "cancel", text: "Cancel" },
-						{
-							onPress: () =>
-								void destroyWorkspace({ force: true, skipTeardown }),
-							style: "destructive",
-							text: "Delete anyway",
-						},
-					]);
-					return;
-				}
-			}
-			// The host archives the row before any slow work, so if it is gone
-			// from a fresh list the delete committed and only the relay gave up
-			// waiting (its 30s cap is shorter than a teardown script's).
-			const rows = await cache.refetchHost(workspace.hostId);
-			if (rows && !rows.some((row) => row.id === workspace.id)) return;
-			Alert.alert(
-				"Delete failed",
-				error instanceof Error ? error.message : undefined,
-			);
-		} finally {
-			setIsDeleting(false);
-		}
-	};
-
-	const deleteWorkspace = () => {
-		if (isDeleting) return;
-		if (isCloud) {
-			// Deleting through the sandbox would remove the row inside it and
-			// leave the sandbox running — and billing. Only the API can destroy.
-			deleteCloudWorkspace();
-			return;
-		}
-		if (!cache.resolveHostUrl(workspace.hostId)) {
-			Alert.alert("Host is not online");
-			return;
-		}
-		Alert.alert(
-			"Delete workspace",
-			`Delete "${workspace.name}"? This removes its worktree from the host.`,
-			[
-				{ style: "cancel", text: "Cancel" },
-				{
-					onPress: () =>
-						void destroyWorkspace({ force: false, skipTeardown: false }),
-					style: "destructive",
-					text: "Delete",
-				},
-			],
-		);
-	};
+	const deleteWorkspace = () =>
+		remove({
+			id: workspace.id,
+			name: workspace.name,
+			hostId: workspace.hostId,
+			hostUrl: cache.resolveHostUrl(workspace.hostId),
+			isCloud,
+		});
 
 	const copyId = () => void Clipboard.setStringAsync(workspace.id);
 
@@ -169,7 +68,6 @@ export function useWorkspaceRowActions(
 		void Share.share({ url: workspaceShareUrl(workspace.id) });
 
 	return {
-		isDeleting,
 		renameWorkspace,
 		deleteWorkspace,
 		copyId,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspaceHeaderActions/useWorkspaceHeaderActions.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspaceHeaderActions/useWorkspaceHeaderActions.ts
@@ -4,13 +4,13 @@ import * as Clipboard from "expo-clipboard";
 import { useRouter } from "expo-router";
 import { Alert, Share } from "react-native";
 import { useCloudWorkspaceActions } from "@/hooks/useCloudWorkspaceActions";
+import { useDeleteWorkspace } from "@/hooks/useDeleteWorkspace";
 import type { HostWorkspaceRow } from "@/hooks/useHostWorkspaces";
 import type { OrgHost } from "@/hooks/useOrgHosts";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
 } from "@/lib/host-service/client";
-import { isTrpcErrorWithData } from "@/lib/host-service/errors";
 import { isSandboxHost } from "@/lib/sandbox-access";
 import { workspaceShareUrl } from "@/lib/web-links";
 
@@ -21,6 +21,7 @@ export function useWorkspaceHeaderActions(
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const cloud = useCloudWorkspaceActions();
+	const remove = useDeleteWorkspace();
 	// A sandbox is its own host, keyed by the workspace's id; its name and its
 	// lifetime belong to the cloud row, not to anything the sandbox serves.
 	const isCloud = host !== null && isSandboxHost(host.machineId);
@@ -57,97 +58,25 @@ export function useWorkspaceHeaderActions(
 		});
 	};
 
-	const destroyWorkspace = async ({
-		force,
-		skipTeardown,
-	}: {
-		/** Git-destructive consent only: skips the dirty-worktree preflight. */
-		force: boolean;
-		/** Consent to abandon the teardown script — set once it has already failed. */
-		skipTeardown: boolean;
-	}) => {
-		if (!workspace || !host) return;
-		const hostUrl = hostServiceUrl(host.organizationId, host.machineId);
-		try {
-			await getHostServiceClientByUrl(hostUrl).workspaceCleanup.destroy.mutate({
-				workspaceId: workspace.id,
-				deleteBranch: false,
-				force,
-				skipTeardown,
-			});
-			void queryClient.invalidateQueries({
-				queryKey: ["host-service", "workspaces", "list"],
-			});
-			router.back();
-		} catch (error) {
-			if (isTrpcErrorWithData(error)) {
-				if (error.data.deleteInProgress) {
-					Alert.alert("Delete already in progress");
-					return;
-				}
-				// A failing teardown script shouldn't hold the delete hostage on a
-				// phone: it already ran, so let the workspace go without it.
-				if (error.data.teardownFailure && !skipTeardown) {
-					await destroyWorkspace({ force: true, skipTeardown: true });
-					return;
-				}
-				if (error.data.code === "CONFLICT") {
-					Alert.alert("Worktree has uncommitted changes", undefined, [
-						{ style: "cancel", text: "Cancel" },
-						{
-							onPress: () =>
-								void destroyWorkspace({ force: true, skipTeardown }),
-							style: "destructive",
-							text: "Delete anyway",
-						},
-					]);
-					return;
-				}
-			}
-			Alert.alert(
-				"Delete failed",
-				error instanceof Error ? error.message : undefined,
-			);
-		}
-	};
-
 	const deleteWorkspace = () => {
 		if (!workspace) return;
 		if (!host) {
 			Alert.alert("Host is not online");
 			return;
 		}
-		if (isCloud) {
-			Alert.alert(
-				"Delete cloud workspace",
-				`Delete "${workspace.name}"? This shuts down its sandbox and everything in it.`,
-				[
-					{ style: "cancel", text: "Cancel" },
-					{
-						onPress: () =>
-							void cloud
-								.remove(workspace.id)
-								.then(() => router.back())
-								.catch(() => Alert.alert("Delete failed")),
-						style: "destructive",
-						text: "Delete",
-					},
-				],
-			);
-			return;
-		}
-		Alert.alert(
-			"Delete workspace",
-			`Delete "${workspace.name}"? This removes its worktree from the host.`,
-			[
-				{ style: "cancel", text: "Cancel" },
-				{
-					onPress: () =>
-						void destroyWorkspace({ force: false, skipTeardown: false }),
-					style: "destructive",
-					text: "Delete",
-				},
-			],
+		remove(
+			{
+				id: workspace.id,
+				name: workspace.name,
+				hostId: host.machineId,
+				hostUrl: hostServiceUrl(host.organizationId, host.machineId),
+				isCloud,
+			},
+			// Nothing on this screen outlives the workspace: every panel below
+			// reads a row that is now gone, and the host placeholder it falls
+			// back to describes a machine that is perfectly fine. Leave for the
+			// list the moment the delete is decided.
+			() => router.dismissTo("/(authenticated)/(home)"),
 		);
 	};
 


### PR DESCRIPTION
Deleting a workspace on a phone took 10-20 seconds staring at the screen you deleted from, then usually said **"Delete failed: Request timed out"** about a delete that had gone through, and left you on the workspace with **"This workspace's host is offline"** — the placeholder for a machine that was fine and still serving every other row.

## Why the wait bought nothing

`host-service` archives the workspace row **before** the dirty-worktree preflight, the teardown script and the worktree removal — step 0, commented in `workspace-cleanup.ts` as "the commit point" — and that archive is what drops the workspace from every list. Everything the mutation was still awaiting happens after the delete is already decided.

Worse, both relays cap a tRPC exchange at 30s and answer `BAD_GATEWAY: "Request timed out"`. A teardown script routinely outlives that, so the message the phone showed was the relay describing its own tunnel, for a delete that had committed.

## What changes

The row goes and the screen is handed back the moment the user confirms; the destroy runs unattended.

- **The workspace screen leaves for the list on confirm** (`dismissTo`) instead of sitting on a placeholder whose row is gone. The home row just vanishes.
- **The confirm is the whole gate.** Every destroy goes out with `force` rather than preflighting for uncommitted work first: on a phone the answer to "this worktree is dirty" is yes anyway — agent work is cheap to redo — and a second alert after a refused destroy costs more than it protects. `force` carries git consent only; the teardown script still runs.
- **A failed destroy asks the host directly whether the workspace is still there.** Gone means it committed and only the relay gave up waiting; still there is a real failure, reported without the relay's timeout wording pinned to it.
- Teardown-script failure keeps the existing behaviour — retry without it rather than prompt, since there is nobody at a phone to fix a script.

Both call sites (home row menu, workspace actions sheet) share one `useDeleteWorkspace` hook; cloud workspaces drop their row optimistically the same way, since `cloudWorkspace.delete` awaits the provider tearing the sandbox down.

The delete-in-flight spinner on the home row goes with this — the row leaves on confirm now, so there is nothing left to spin. `removeWorkspace` / `refetchHost` on the cache-ops interface were its only callers.

## Verified on device, against production

Before/after traces with screenshots and timings: https://claude.ai/code/artifact/6ea54b44-560f-446c-b86d-f3feaf839545

Both runs used a throwaway workspace whose `.superset/teardown.sh` sleeps 35s, so the destroy outlives the relay's 30s cap — the condition that produced the report.

| | on `main` | on this branch |
|---|---|---|
| back on the list | ~30s (via an error alert) | **0.6s** |
| "host is offline" placeholder | at +25s | never |
| "Request timed out" alert | at +30.5s | never |

Host-side the destroy ran to completion in the background in both runs (worktree gone at +37s / +39.6s).

`bun test`, `biome check` and `tsc --noEmit` are clean for `@superset/mobile`.

Not exercised: cloud (sandbox) workspaces — shared code path, but no sandbox was driven — and a genuinely failing destroy, where the row returns and the alert *should* fire.

https://claude.ai/code/session_01A935A7SxB3U9wKtjjAi3pZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified workspace deletion flow for cloud and connected workspaces.
  * Workspace removal now updates lists immediately and refreshes them after completion.
  * Added clearer handling for offline connections, cleanup failures, and deletion errors.

* **Bug Fixes**
  * Cloud access is cleared only after successful workspace deletion.
  * Workspace rows remain usable while deletion is in progress, preventing unnecessary navigation blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->