### PR TITLE
fix(email): stop habit-drip triggering on a per-workspace event

### DIFF
--- a/packages/email/scripts/sync-automations.ts
+++ b/packages/email/scripts/sync-automations.ts
@@ -4,9 +4,17 @@
  * Resend dashboard.
  *
  * Usage (dry-run by default, pass --apply to mutate):
- *   RESEND_API_KEY=... bun scripts/sync-automations.ts [--apply]
+ *   RESEND_API_KEY=... bun scripts/sync-automations.ts [--apply] [--force]
  *
- * Two hard-won rules this script encodes:
+ * Three hard-won rules this script encodes:
+ * - ONLY `user.signed_up` is safe as a trigger: it fires once per user, from
+ *   better-auth's `user.create.after` hook. `user.activated` fires on every
+ *   workspace create and `app.first_opened` on every first-host/onboarding
+ *   path, so triggering on either enrols a user once per occurrence. Pointing
+ *   habit-drip's trigger at `user.activated` sent 1,487 copies of one email to
+ *   230 people on 2026-08-21. Repeating events belong in `wait_for_event`,
+ *   which absorbs duplicates. Events fan out to every matching consumer, so
+ *   any number of automations can wait on the same one.
  * - NEVER update an enabled automation's steps: despite the API's wording,
  *   doing so cancelled every in-flight run (2026-08-20, ~324 users dropped
  *   mid-drip). Migration is create-new-enabled, then stop (not edit) the old
@@ -37,6 +45,7 @@ type DesiredAutomation = {
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 const apply = process.argv.includes("--apply");
+const force = process.argv.includes("--force");
 
 const aliasIds = new Map<string, string>();
 const templates = await resend.templates.list({ limit: 100 });
@@ -119,13 +128,21 @@ const desired: DesiredAutomation[] = [
 		],
 	},
 	{
-		// Post-activation habit drip.
+		// Post-activation habit drip. Triggered by signup and *gated* on
+		// activation rather than triggered by it — see the trigger-cardinality
+		// rule above. On timeout the run simply ends: a user who never
+		// activates should not get habit mail.
 		name: "habit-drip",
 		steps: [
 			{
 				key: "start",
 				type: "trigger",
-				config: { eventName: "user.activated" },
+				config: { eventName: "user.signed_up" },
+			},
+			{
+				key: "wait_activation",
+				type: "wait_for_event",
+				config: { eventName: "user.activated", timeout: "30 days" },
 			},
 			{ key: "delay_1", type: "delay", config: { duration: "1 day" } },
 			{
@@ -141,7 +158,8 @@ const desired: DesiredAutomation[] = [
 			},
 		],
 		connections: [
-			{ from: "start", to: "delay_1", type: "default" },
+			{ from: "start", to: "wait_activation", type: "default" },
+			{ from: "wait_activation", to: "delay_1", type: "event_received" },
 			{ from: "delay_1", to: "send_parallel", type: "default" },
 			{ from: "send_parallel", to: "delay_2", type: "default" },
 			{ from: "delay_2", to: "send_automations", type: "default" },
@@ -195,9 +213,8 @@ const existing = (listed.data?.data ?? []) as Array<{
 }>;
 
 for (const want of desired) {
-	const live = existing.filter(
-		(a) => a.name === want.name && a.status === "enabled",
-	);
+	const sameName = existing.filter((a) => a.name === want.name);
+	const live = sameName.filter((a) => a.status === "enabled");
 	const wantCanon = canonGraph(want.steps, want.connections);
 	const matching = [];
 	for (const a of live) {
@@ -214,6 +231,17 @@ for (const want of desired) {
 	if (matching.length > 0) {
 		console.log(`${want.name}: up to date (${matching[0]?.id})`);
 		continue;
+	}
+
+	// A same-named automation sitting disabled means someone stopped it on
+	// purpose, usually mid-incident. Recreating it here would silently re-arm
+	// the thing they turned off, so make that an explicit choice.
+	const stopped = sameName.filter((a) => a.status !== "enabled");
+	if (live.length === 0 && stopped.length > 0 && !force) {
+		const ids = stopped.map((a) => a.id).join(", ");
+		throw new Error(
+			`${want.name}: ${stopped.length} disabled automation(s) exist (${ids}). Creating would re-arm what someone stopped. Re-run with --force if that is intended.`,
+		);
 	}
 
 	console.log(


### PR DESCRIPTION
## What happened

`habit-drip` was triggered by `user.activated`. That event is emitted from `v2Workspace.trackCreated`, which host-service calls on **every workspace create** — so each workspace enrolled the user in another run of the drip, and each run sent its own copy of the email a day later.

On 2026-08-21 that delivered **1,487 copies of "The day it clicks" to 230 recipients**; the worst-hit user got 113. The automation has been disabled and its in-flight runs cancelled (roughly 3,500–5,000 further duplicates never sent). Apologies went out to the 96 people who received 4 or more copies.

The event itself was fine. It was built on 2026-08-10 as an *exit condition* consumed by a `wait_for_event` step, where repeats are absorbed for free — the emitter is even named `exitActivationEmailCampaign`. Pointing a **trigger** at it ten days later silently changed the contract from "at-least-once is fine" to "exactly-once required", without touching a line of the emitter.

## The fix

Give habit-drip the shape activation-drip already had:

```
trigger:        user.signed_up    ← once per user, from better-auth user.create.after
wait_for_event: user.activated    ← absorbs duplicates, 30d timeout
delay 1 day → habit-01-parallel → delay 12 days → habit-02-automations
```

On timeout the run ends, so a user who never activates gets no habit mail.

I verified empirically that **Resend fans an event out to every matching consumer** — one `events/send` advanced `wait_for_event` steps in two separate automations *and* started a run in a third that triggered on it, all within 40ms. So habit-drip and activation-drip can both wait on `user.activated` without racing. (Run creation lags the 202 by a few seconds; poll before concluding an automation missed an event.)

An earlier draft of this fix added a `users.activated_at` column with an atomic claim in front of the emitter. That was insurance against a single-consumer event race which the test showed doesn't exist, so it was dropped — no schema change here.

## Guard

`--apply` only ever compared against **enabled** automations. With habit-drip now disabled, running it would have created a brand new enabled one from the old graph and restarted the flood. It now refuses to create a name that already exists in a disabled state unless you pass `--force`, since a disabled automation usually means somebody stopped it on purpose.

## Note for @kiet-ho — production drift

The live `activation-drip` does not match this file, and hasn't since before #6705 merged:

| | live | this file |
|---|---|---|
| first wait | `user.activated`, 1 day | `app.first_opened`, 1 day |
| second wait | `app.first_opened`, 6 hours | `user.activated`, 23 hours |
| step key | `wait_activation_1` | `wait_activation_installed` |

The live graph was written at 06:43 UTC on 08-20; #6705 merged at 07:39. So production is running a draft that predates the committed version by an hour.

I've left the file as committed rather than codifying live, because the live ordering looks like a bug: `app.first_opened` is guarded to fire once per user and lands within an hour of signup, but live doesn't start waiting for it until a full day later, after `wait_activation_1` times out. Since `wait_for_event` only matches events arriving during the wait, that event is always already gone — so installed-but-not-activated users fall through to `send_first_agent`, the "get the desktop app" nudge. Exactly what the docstring warns about.

**Consequence:** the next `--apply` will replace activation-drip with this file's graph. In-flight runs finish on the old graph so nobody gets dropped, but confirm that's what you want. If the inversion was deliberate, say so and I'll codify live instead.

## Not included

- Moving `--apply` into CI on merge. It ran from a laptop here, which is how habit-drip went live 56 minutes before its PR merged.
- Send-rate alerting. Baseline is ~73 emails/day; we did 1,487 in 7.5 hours with nothing firing. This is the gate that would have caught it.

## Merging this does not turn the drip back on

`habit-drip` stays disabled until someone runs `sync-automations.ts --apply --force` deliberately.

https://claude.ai/code/session_01R8EsvT521h8m2bHHyGMc2p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops habit-drip from enrolling per workspace and adds a guard against re-arming disabled automations. Previously it triggered on `user.activated` (emitted on every workspace create) and sent duplicates; now it triggers on `user.signed_up` and waits for `user.activated` with a 30-day timeout.

- Review and rollout
  - `habit-drip` remains disabled. Re-enable by running: RESEND_API_KEY=... bun `packages/email/scripts/sync-automations.ts` --apply --force.
  - The script refuses to create an automation when a disabled one with the same name exists; pass `--force` to override.

<sup>Written for commit 295d757a9a3a8003b05a2735cb058e9fb9ee657d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

