### PR TITLE
chore(desktop): bump version to 1.24.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.24.1",
+	"version": "1.24.2",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -810,7 +810,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -906,7 +906,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.24.1",
+	"version": "1.24.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.24.1",
+	"version": "1.24.2",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the Desktop 1.24.2 release by bumping versions across packages. Previously packages reported 1.24.1; now they report 1.24.2. No runtime or dependency changes.

**Review notes**
- Updates only version fields in apps/desktop, `@superset/cli`, `@superset/host-service`, and syncs bun.lock.
- No migration required; verify the release pipeline publishes `1.24.2` for `@superset/desktop`, `@superset/cli`, and `@superset/host-service`.

<sup>Written for commit 7b55401d4c71160ca1923b0a461a42e533e9bdb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app, command-line interface, and host service to version 1.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->