### PR TITLE
fix(desktop): resolve the dev app's workspace title from host.db

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -285,6 +285,9 @@ step_write_env() {
   {
     echo ""
     echo "# Workspace Identity"
+    # Stable folder-derived identity (data dir, protocol scheme, Neon branch).
+    # The dev app reads its display title live from ~/.superset/host/*/host.db,
+    # so a later workspace rename never needs this file rewritten.
     write_env_var "SUPERSET_WORKSPACE_NAME" "${WORKSPACE_NAME:-$(basename "$PWD")}"
     write_env_var "SUPERSET_HOME_DIR" "$PWD/superset-dev-data"
     echo ""

--- a/apps/desktop/scripts/patch-dev-protocol.ts
+++ b/apps/desktop/scripts/patch-dev-protocol.ts
@@ -33,6 +33,7 @@ config({
 	quiet: true,
 });
 
+import { getWorkspaceNameFromHostDbs } from "../src/main/lib/host-db-workspace-name";
 // Import directly — shared/constants.ts would trigger Zod env validation during predev
 import {
 	deriveWorkspaceNameFromWorktreeSegments,
@@ -84,6 +85,16 @@ export function deriveWorktreePathFromSegments(
 	if (endIndex <= 1) return undefined;
 
 	return resolve(worktreeBase, ...segments.slice(0, endIndex));
+}
+
+export function getWorkspaceDisplayNameFromHostDbs(
+	worktreePath: string,
+): string | undefined {
+	return getWorkspaceNameFromHostDbs(
+		worktreePath,
+		(dbPath) =>
+			new BunSqliteDatabase(dbPath, { readonly: true, create: false }),
+	);
 }
 
 export function getWorkspaceDisplayNameFromProdDb(
@@ -180,7 +191,9 @@ export function main() {
 		resolveWorkspaceIdentity({
 			cwd: process.cwd(),
 			envWorkspaceName: getWorkspaceName(),
-			lookupDisplayName: getWorkspaceDisplayNameFromProdDb,
+			lookupDisplayName: (worktreePath) =>
+				getWorkspaceDisplayNameFromHostDbs(worktreePath) ??
+				getWorkspaceDisplayNameFromProdDb(worktreePath),
 		});
 	if (!workspaceName || !bundleDisplayWorkspaceName) {
 		console.log("[patch-dev-protocol] Skipping - workspace name not resolved");

--- a/apps/desktop/src/main/lib/dev-workspace-name.ts
+++ b/apps/desktop/src/main/lib/dev-workspace-name.ts
@@ -6,6 +6,7 @@ import BetterSqlite3 from "better-sqlite3";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { getWorkspaceName as getEnvWorkspaceName } from "shared/env.shared";
 import { deriveWorkspaceNameFromWorktreeSegments } from "shared/worktree-id";
+import { getWorkspaceNameFromHostDbs } from "./host-db-workspace-name";
 import { localDb } from "./local-db";
 
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -108,8 +109,15 @@ export function resolveDevWorkspaceName(
 	const workspaceNameFromPath =
 		deriveWorkspaceNameFromWorktreeSegments(segments);
 	const worktreePath = getWorktreePathFromSegments(segments);
+	// v2 workspaces (and their AI/manual renames) live in host.db; the
+	// local.db lookups below serve worktrees created by the v1 desktop.
 	const workspaceNameFromDb = worktreePath
-		? (getWorkspaceNameForPathFromCurrentDb(worktreePath) ??
+		? (getWorkspaceNameFromHostDbs(
+				worktreePath,
+				(dbPath) =>
+					new BetterSqlite3(dbPath, { readonly: true, fileMustExist: true }),
+			) ??
+			getWorkspaceNameForPathFromCurrentDb(worktreePath) ??
 			getWorkspaceNameForPathFromProdDb(worktreePath))
 		: undefined;
 

--- a/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
@@ -1,12 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import {
-	chmodSync,
-	mkdirSync,
-	mkdtempSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getWorkspaceNameFromHostDbs } from "./host-db-workspace-name";

--- a/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
@@ -1,6 +1,12 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getWorkspaceNameFromHostDbs } from "./host-db-workspace-name";
@@ -57,6 +63,19 @@ describe("getWorkspaceNameFromHostDbs", () => {
 		expect(getWorkspaceNameFromHostDbs(worktreePath, openReadonly, root)).toBe(
 			"Fix setup rename race",
 		);
+	});
+
+	it("returns undefined when the host root cannot be enumerated", () => {
+		const locked = join(root, "locked");
+		mkdirSync(locked);
+		chmodSync(locked, 0o000);
+		try {
+			expect(
+				getWorkspaceNameFromHostDbs(worktreePath, openReadonly, locked),
+			).toBeUndefined();
+		} finally {
+			chmodSync(locked, 0o700);
+		}
 	});
 
 	it("skips unreadable DBs, stray files, and blank names", () => {

--- a/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
@@ -66,16 +66,13 @@ describe("getWorkspaceNameFromHostDbs", () => {
 	});
 
 	it("returns undefined when the host root cannot be enumerated", () => {
-		const locked = join(root, "locked");
-		mkdirSync(locked);
-		chmodSync(locked, 0o000);
-		try {
-			expect(
-				getWorkspaceNameFromHostDbs(worktreePath, openReadonly, locked),
-			).toBeUndefined();
-		} finally {
-			chmodSync(locked, 0o700);
-		}
+		// A regular file exists but is not a directory: readdirSync throws ENOTDIR
+		// regardless of the user's privileges.
+		const notADir = join(root, "not-a-dir");
+		writeFileSync(notADir, "");
+		expect(
+			getWorkspaceNameFromHostDbs(worktreePath, openReadonly, notADir),
+		).toBeUndefined();
 	});
 
 	it("skips unreadable DBs, stray files, and blank names", () => {

--- a/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.test.ts
@@ -1,0 +1,71 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getWorkspaceNameFromHostDbs } from "./host-db-workspace-name";
+
+const openReadonly = (path: string) =>
+	new Database(path, { readonly: true, create: false });
+
+function seedHostDb(
+	root: string,
+	orgId: string,
+	rows: Array<{ worktreePath: string; name: string }>,
+) {
+	mkdirSync(join(root, orgId), { recursive: true });
+	const db = new Database(join(root, orgId, "host.db"));
+	db.run(
+		"CREATE TABLE workspaces (id TEXT PRIMARY KEY, worktree_path TEXT NOT NULL, name TEXT NOT NULL DEFAULT '')",
+	);
+	for (const [i, row] of rows.entries()) {
+		db.run(
+			"INSERT INTO workspaces (id, worktree_path, name) VALUES (?, ?, ?)",
+			[`${orgId}-${i}`, row.worktreePath, row.name],
+		);
+	}
+	db.close();
+}
+
+describe("getWorkspaceNameFromHostDbs", () => {
+	let root: string;
+	const worktreePath =
+		"/Users/me/.superset/worktrees/proj/silky-ophthalmologist";
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "host-db-workspace-name-"));
+	});
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("returns undefined when the host root does not exist", () => {
+		expect(
+			getWorkspaceNameFromHostDbs(
+				worktreePath,
+				openReadonly,
+				join(root, "missing"),
+			),
+		).toBeUndefined();
+	});
+
+	it("returns the renamed title for the worktree path from any org DB", () => {
+		seedHostDb(root, "org-a", [{ worktreePath: "/elsewhere", name: "Other" }]);
+		seedHostDb(root, "org-b", [
+			{ worktreePath, name: "Fix setup rename race" },
+		]);
+		expect(getWorkspaceNameFromHostDbs(worktreePath, openReadonly, root)).toBe(
+			"Fix setup rename race",
+		);
+	});
+
+	it("skips unreadable DBs, stray files, and blank names", () => {
+		mkdirSync(join(root, "broken"));
+		writeFileSync(join(root, "broken", "host.db"), "not a sqlite file");
+		writeFileSync(join(root, "stray-file"), "");
+		seedHostDb(root, "org-a", [{ worktreePath, name: "   " }]);
+		expect(
+			getWorkspaceNameFromHostDbs(worktreePath, openReadonly, root),
+		).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/main/lib/host-db-workspace-name.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.ts
@@ -24,7 +24,18 @@ export function getWorkspaceNameFromHostDbs(
 ): string | undefined {
 	if (!existsSync(hostDbRoot)) return undefined;
 
-	for (const entry of readdirSync(hostDbRoot)) {
+	let entries: string[];
+	try {
+		entries = readdirSync(hostDbRoot);
+	} catch (error) {
+		console.warn(
+			`[host-db-workspace-name] Failed to enumerate ${hostDbRoot}:`,
+			error,
+		);
+		return undefined;
+	}
+
+	for (const entry of entries) {
 		const dbPath = join(hostDbRoot, entry, "host.db");
 		if (!existsSync(dbPath)) continue;
 		try {

--- a/apps/desktop/src/main/lib/host-db-workspace-name.ts
+++ b/apps/desktop/src/main/lib/host-db-workspace-name.ts
@@ -1,0 +1,51 @@
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Minimal readonly handle satisfied by both better-sqlite3 and bun:sqlite. */
+export interface ReadonlySqlite {
+	prepare(sql: string): { get(...params: unknown[]): unknown };
+	close(): void;
+}
+
+export const DEFAULT_HOST_DB_ROOT = join(homedir(), ".superset", "host");
+
+/**
+ * Resolve a workspace's display title from the outer (production) host-service
+ * DBs at `~/.superset/host/<org>/host.db`. That row's `name` is what AI naming
+ * and manual renames update, so reading it when the dev app starts means no
+ * name has to be captured at setup time. Only columns every host-service
+ * version has are referenced (older ones lack `archived_at`).
+ */
+export function getWorkspaceNameFromHostDbs(
+	worktreePath: string,
+	openReadonly: (dbPath: string) => ReadonlySqlite,
+	hostDbRoot = DEFAULT_HOST_DB_ROOT,
+): string | undefined {
+	if (!existsSync(hostDbRoot)) return undefined;
+
+	for (const entry of readdirSync(hostDbRoot)) {
+		const dbPath = join(hostDbRoot, entry, "host.db");
+		if (!existsSync(dbPath)) continue;
+		try {
+			const db = openReadonly(dbPath);
+			try {
+				const row = db
+					.prepare(
+						"SELECT name FROM workspaces WHERE worktree_path = ? LIMIT 1",
+					)
+					.get(worktreePath) as { name?: string } | undefined;
+				const name = row?.name?.trim();
+				if (name) return name;
+			} finally {
+				db.close();
+			}
+		} catch (error) {
+			console.warn(
+				`[host-db-workspace-name] Failed to read workspace name from ${dbPath}:`,
+				error,
+			);
+		}
+	}
+	return undefined;
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -7,13 +7,11 @@ import { app, Notification, nativeTheme } from "electron";
 import log from "electron-log/main";
 import { createWindow } from "lib/electron-app/factories/windows/create";
 import { createAppRouter } from "lib/trpc/routers";
+import { resolveDevWorkspaceName } from "main/lib/dev-workspace-name";
 import { localDb } from "main/lib/local-db";
 import { isExpectedRendererExit } from "main/lib/renderer-exit";
 import { NOTIFICATION_EVENTS, PLATFORM } from "shared/constants";
-import {
-	env,
-	getWorkspaceName as getEnvWorkspaceName,
-} from "shared/env.shared";
+import { env } from "shared/env.shared";
 import type { AgentLifecycleEvent } from "shared/notification-types";
 import { createIPCHandler } from "trpc-electron/main";
 import { productName } from "~/package.json";
@@ -98,7 +96,7 @@ export async function MainWindow() {
 	let persistedZoomLevel = savedWindowState?.zoomLevel;
 
 	const isDev = env.NODE_ENV === "development";
-	const workspaceName = isDev ? getEnvWorkspaceName() : undefined;
+	const workspaceName = isDev ? resolveDevWorkspaceName() : undefined;
 	const windowTitle = workspaceName
 		? `${productName} — ${workspaceName}`
 		: productName;


### PR DESCRIPTION
## Summary
- The dev-only `Superset (<name>)` app label, window title, and predev `CFBundleName` looked the workspace title up in v1 `local.db`, which has had no new workspace rows since May. Every v2-created worktree therefore fell back to its random folder name (`silky-ophthalmologist`) instead of its AI/manual title.
- Read `~/.superset/host/<org>/host.db` first (keyed by `worktree_path`), then the existing v1 lookups. Dev only; no production behavior changes.

## Why / Context
This showed up as "setup.sh captures the name before the AI rename lands". It isn't a race: `workspaces.create` already awaits the AI rename before spawning the setup terminal. The dev app was simply reading the wrong DB. Nothing is captured at setup time now, so a later manual rename is picked up on the next `bun dev`.

## How It Works
- New `apps/desktop/src/main/lib/host-db-workspace-name.ts`: `getWorkspaceNameFromHostDbs(worktreePath, openReadonly)` scans each `host/*/host.db` with `SELECT name FROM workspaces WHERE worktree_path = ? LIMIT 1`, returns the first non-blank name, skips unreadable DBs. Only references columns every host-service version has (live prod host.db lacks `archived_at`). The sqlite opener is injected because main runs on `better-sqlite3` and the predev script on `bun:sqlite`.
- `dev-workspace-name.ts` (app.setName) and `patch-dev-protocol.ts` (CFBundleName) try host.db, then fall through to the unchanged v1 `local.db` lookups, then folder name, then `.env`.
- `windows/main.ts` window title uses `resolveDevWorkspaceName()` instead of the `.env` snapshot so it matches `app.setName`.
- Identity stays folder-based: `SUPERSET_WORKSPACE_NAME` in `.env` (data dir, protocol scheme, bundle id, Neon branch) is untouched; only the display title is read live. `steps.sh` gets a comment saying so.

## Manual QA (CDP, live)
- Launched the dev app from a v2-created worktree (`RENDERER_REMOTE_DEBUG_PORT=9601`, CDP target confirmed on this worktree's `DESKTOP_VITE_PORT`).
- After: System Events window title `Superset — Fix setup script race condition with workspace naming`; `CFBundleName = Superset (Fix setup script race condition with workspace naming)`; bundle id / scheme still `com.superset.desktop.silky-ophthalmologist` / `superset-silky-ophthalmologist`; macOS notification banner names the app by title.
- Before (two other worktrees' running instances on unmodified code): window titles `Superset — feline-cast` / `Superset — super-chamomile` while their host.db rows hold the real titles.
- Host-service children ran with the worktree `SUPERSET_HOME_DIR` (no split-brain with Canary).

## Testing
- `bun test apps/desktop/src/main/lib/host-db-workspace-name.test.ts apps/desktop/scripts/patch-dev-protocol.test.ts` (8 pass)
- `bunx tsc --noEmit` in `apps/desktop`
- `biome check` on changed files

## Design Decisions
- **Why not inject `SUPERSET_WORKSPACE_NAME` (the title) into the v2 PTY env and let setup.sh write it**: the title is mutable and has spaces; this repo's setup keys the `.superset-<name>` data dir, protocol scheme, and Neon branch off that var, so a rename would silently move state. Display and identity are kept separate instead.

## Known Limitations
- Docs (`setup-teardown-scripts.mdx`, `terminal-integration.mdx`) still list `SUPERSET_WORKSPACE_NAME` for v2 terminals, but host-service's v2 PTY env never sets it; scripts get the folder-name fallback. Unchanged here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dev desktop now resolves the workspace display title from the host-service DB at ~/.superset/host/<org>/host.db keyed by worktree_path. Previously it read v1 local.db, so v2 worktrees fell back to the folder name; now dev window titles and predev CFBundleName use the AI/manual title, and resolution tolerates an unreadable host root.

- Resolution order in dev: host.db, then v1 local.db, then folder name; predev checks host.db before the prod v1 DB; the main window now uses resolveDevWorkspaceName so its title matches app.setName.
- Only the display title is read live; `.env` SUPERSET_WORKSPACE_NAME stays folder-derived for data dir, protocol scheme, and Neon branch. No migration or production changes.
- New getWorkspaceNameFromHostDbs scans ~/.superset/host/*/host.db, skips unreadable DBs and blank names; tests cover the unreadable-host-root case and clean up an unused import.

<sup>Written for commit d3c5e77e56c6a6d5fd085468c7974a8116ca4331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Development workspace names now automatically reflect renamed workspaces.
  * Workspace names are resolved from available host-service data before local or fallback values.
  * Renaming a workspace no longer requires updating environment configuration.
* **Bug Fixes**
  * Improved handling of missing, unreadable, or incomplete workspace data during development setup.
  * Development setup now continues smoothly when workspace information is unavailable, invalid, or inaccessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->