### PR TITLE
fix(port-scanner): use absolute macOS system paths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1292,6 +1292,7 @@
     "@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
     "metro@0.84.4": "patches/metro@0.84.4.patch",
     "node-pty@1.2.0-beta.14": "patches/node-pty@1.2.0-beta.14.patch",
+    "pidtree@0.6.0": "patches/pidtree@0.6.0.patch",
   },
   "overrides": {
     "@tiptap/extension-dropcursor": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"@xterm/addon-webgl@0.20.0-beta.297": "patches/@xterm%2Faddon-webgl@0.20.0-beta.297.patch",
 		"metro@0.84.4": "patches/metro@0.84.4.patch",
 		"expo-router@56.2.18": "patches/expo-router@56.2.18.patch",
-		"node-pty@1.2.0-beta.14": "patches/node-pty@1.2.0-beta.14.patch"
+		"node-pty@1.2.0-beta.14": "patches/node-pty@1.2.0-beta.14.patch",
+		"pidtree@0.6.0": "patches/pidtree@0.6.0.patch"
 	}
 }

--- a/packages/port-scanner/src/pidtree-patch.test.ts
+++ b/packages/port-scanner/src/pidtree-patch.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const psFile = join(
+	dirname(require.resolve("pidtree/package.json")),
+	"lib/ps.js",
+);
+
+test("pidtree uses the absolute macOS ps path", () => {
+	const source = readFileSync(psFile, "utf8");
+	expect(source).toContain("os.platform() === 'darwin' ? '/bin/ps' : 'ps'");
+});

--- a/packages/port-scanner/src/scanner.test.ts
+++ b/packages/port-scanner/src/scanner.test.ts
@@ -115,6 +115,21 @@ describe("getProcessTreesForPids (real process table)", () => {
 		expect(trees.has(99_999_999)).toBe(false);
 		expect(trees.has(process.pid)).toBe(true);
 	});
+
+	it.skipIf(process.platform !== "darwin")(
+		"reads the process table when PATH cannot resolve ps",
+		async () => {
+			const originalPath = process.env.PATH;
+			process.env.PATH = "/definitely-missing";
+			try {
+				const trees = await getProcessTreesForPids([process.pid]);
+				expect(trees.get(process.pid)).toContain(process.pid);
+			} finally {
+				if (originalPath === undefined) delete process.env.PATH;
+				else process.env.PATH = originalPath;
+			}
+		},
+	);
 });
 
 describe("getListeningPortsForPids (real sockets)", () => {
@@ -135,6 +150,28 @@ describe("getListeningPortsForPids (real sockets)", () => {
 		const ports = await getListeningPortsForPids([99_999_999]);
 		expect(ports).toHaveLength(0);
 	});
+
+	it.skipIf(process.platform !== "darwin")(
+		"finds listening ports when PATH cannot resolve lsof",
+		async () => {
+			const originalPath = process.env.PATH;
+			const server = Bun.serve({
+				port: 0,
+				fetch: () => new Response("ok"),
+			});
+			try {
+				process.env.PATH = "/definitely-missing";
+				const listeningPort = server.port;
+				if (listeningPort === undefined) throw new Error("server has no port");
+				const ports = await getListeningPortsForPids([process.pid]);
+				expect(ports.map((info) => info.port)).toContain(listeningPort);
+			} finally {
+				if (originalPath === undefined) delete process.env.PATH;
+				else process.env.PATH = originalPath;
+				server.stop(true);
+			}
+		},
+	);
 });
 
 describe("port-scanner", () => {

--- a/packages/port-scanner/src/scanner.test.ts
+++ b/packages/port-scanner/src/scanner.test.ts
@@ -168,7 +168,7 @@ describe("getListeningPortsForPids (real sockets)", () => {
 			} finally {
 				if (originalPath === undefined) delete process.env.PATH;
 				else process.env.PATH = originalPath;
-				server.stop(true);
+				await server.stop(true);
 			}
 		},
 	);

--- a/packages/port-scanner/src/scanner.ts
+++ b/packages/port-scanner/src/scanner.ts
@@ -145,7 +145,7 @@ async function getListeningPortsLsof(
 		// -P: don't convert port numbers to names
 		// -n: don't resolve hostnames
 		const output = await runTolerant(
-			"lsof",
+			"/usr/sbin/lsof",
 			["-a", "-p", pidArg, "-iTCP", "-sTCP:LISTEN", "-P", "-n"],
 			{ maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS, signal },
 		);

--- a/patches/README.md
+++ b/patches/README.md
@@ -175,3 +175,21 @@ bun test apps/desktop/src/pty-crash-ports-patch.test.ts
 ports on the spawn attributes it already builds in `pty_posix_spawn`
 (`posix_spawnattr_setexceptionports_np`). If node-pty ships that, drop the patch
 and the `patchedDependencies` entry.
+
+## pidtree (`pidtree@<version>.patch`)
+
+**Why:** issue #6717. On macOS, `pidtree` launches bare `ps`, so libuv probes
+every earlier `PATH` entry with `posix_spawn` before reaching `/bin/ps`. The
+port scanner runs this every 2.5 seconds, producing bursts of failed process
+launches attributed to Superset.
+
+**What it changes** (`lib/ps.js`): use `/bin/ps` on macOS while preserving the
+existing `ps` lookup on other platforms.
+
+**Guard test:** `packages/port-scanner/src/pidtree-patch.test.ts`. The scanner's
+Darwin regression tests also verify that process and port discovery work when
+`PATH` cannot resolve `ps` or `lsof`.
+
+**Removing:** when `pidtree` supports an absolute macOS `ps` path upstream,
+delete the patch and `patchedDependencies` entry, then update the guard test to
+accept the upstream implementation.

--- a/patches/pidtree@0.6.0.patch
+++ b/patches/pidtree@0.6.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/ps.js b/lib/ps.js
+index 6d9bb5fb8162c3c7c06099723f1dbadfdc6da025..53e99af3ca14342b6125769abf810a650cbd0ce5 100644
+--- a/lib/ps.js
++++ b/lib/ps.js
+@@ -10,7 +10,7 @@ var bin = require('./bin');
+ function ps(callback) {
+   var args = ['-A', '-o', 'ppid,pid'];
+ 
+-  bin('ps', args, function(err, stdout, code) {
++  bin(os.platform() === 'darwin' ? '/bin/ps' : 'ps', args, function(err, stdout, code) {
+     if (err) return callback(err);
+     if (code !== 0) {
+       return callback(new Error('pidtree ps command exited with code ' + code));


### PR DESCRIPTION
## What & why

Fixes #6717.

The port scanner runs a process-table and listening-port scan every 2.5 seconds. On macOS, bare `ps` and `lsof` commands make libuv probe each preceding `PATH` entry with `posix_spawn`; macOS attributes every failed probe to the Superset app, producing the reported bursts of short-lived processes.

This change:

- patches `pidtree` to use `/bin/ps` on macOS while preserving its existing lookup on other platforms
- invokes `/usr/sbin/lsof` directly from the macOS port scanner
- adds real-process and real-socket regression tests that run with a `PATH` unable to resolve either command
- adds a platform-independent guard for the installed `pidtree` patch

## How I tested it

- Confirmed the two Darwin regression tests failed before the fix (`ps` executable not found and no listening port detected)
- `bun run --cwd packages/port-scanner test` — 70 passed
- `bun run lint`
- `bun run typecheck` — 37 tasks passed
- `bun install --frozen-lockfile --ignore-scripts`
- Captured child-process calls after the fix and verified the exact executables were `/bin/ps` and `/usr/sbin/lsof`

No screenshots: this fixes background process spawning and has no visible UI change.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop macOS PATH probing in the port scanner by invoking absolute system binaries. Previously bare ps/lsof made libuv probe each PATH entry and spawn short‑lived processes; now we call `/bin/ps` and `/usr/sbin/lsof` to prevent those bursts. No behavior change on other platforms.

- Patch `pidtree@0.6.0` to use `/bin/ps` on Darwin; add a guard test and register the patch in `package.json` and `bun.lock`.
- Use `/usr/sbin/lsof` in the macOS scanner; add Darwin-only regression tests that pass with a PATH that cannot resolve ps/lsof, and await server shutdown in tests.

<sup>Written for commit 1df888bca104a58bccc3419cb03e4ea936c6134f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process and listening-port detection on macOS when `ps` or `lsof` is unavailable through the system `PATH`.
  - macOS process discovery now uses the system’s absolute `ps` path for more reliable results.
  - macOS port scanning now uses the system’s absolute `lsof` path.
  - Added validation to help ensure these improvements remain reliable across supported environments.

- **Documentation**
  - Added documentation covering the macOS compatibility updates and related validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->