### PR TITLE
fix(host-service): remove a git-unregistered-but-left-on-disk worktree on delete

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -536,6 +536,40 @@ async function runDestroyPhases(
 					message: `Failed to remove worktree at ${local.worktreePath}`,
 				});
 			}
+			// `git worktree remove --force` is not atomic: it can fully
+			// unregister the worktree (so it no longer appears in
+			// `git worktree list`) while still failing to delete the working
+			// directory when a nested file is undeletable (#6730). Trusting
+			// `stillRegistered` alone then leaves an orphaned folder on disk
+			// and archives the row over it. Mirror the repo-missing branch
+			// above: when git no longer tracks it but the directory survives,
+			// remove it directly under the same root guard.
+			if (existsSync(local.worktreePath)) {
+				const worktreeBaseDir =
+					project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
+				if (
+					!isInsideProjectWorktreesRoot(
+						local.worktreePath,
+						project.id,
+						worktreeBaseDir,
+					)
+				) {
+					warnings.push(
+						`Skipped orphaned worktree removal at ${local.worktreePath}: folder is outside the managed worktrees root`,
+					);
+				} else {
+					try {
+						await rm(local.worktreePath, { recursive: true, force: true });
+					} catch (err) {
+						const message =
+							err instanceof Error ? err.message : String(err);
+						throw new TRPCError({
+							code: "INTERNAL_SERVER_ERROR",
+							message: `Failed to remove orphaned worktree at ${local.worktreePath}: ${message}`,
+						});
+					}
+				}
+			}
 			worktreeRemoved = true;
 		}
 	}

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -567,9 +567,9 @@ async function runDestroyPhases(
 							message: `Failed to remove orphaned worktree at ${local.worktreePath}: ${message}`,
 						});
 					}
+					worktreeRemoved = true;
 				}
 			}
-			worktreeRemoved = true;
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -561,8 +561,7 @@ async function runDestroyPhases(
 					try {
 						await rm(local.worktreePath, { recursive: true, force: true });
 					} catch (err) {
-						const message =
-							err instanceof Error ? err.message : String(err);
+						const message = err instanceof Error ? err.message : String(err);
 						throw new TRPCError({
 							code: "INTERNAL_SERVER_ERROR",
 							message: `Failed to remove orphaned worktree at ${local.worktreePath}: ${message}`,

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -209,10 +209,25 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 		// command's locale- and version-dependent exit text. `--force --force`
 		// also unregisters a worktree whose directory is already gone, so no
 		// separate prune (which would clobber other stale worktrees' metadata)
-		// is needed.
+		// is needed. Log the real git error though — `--force --force` can
+		// unregister while still failing to delete the folder (undeletable
+		// nested file, #6730), and without this the underlying cause is
+		// invisible to anyone debugging an orphan.
 		await git
 			.raw(["worktree", "remove", "--force", "--force", target])
-			.catch(() => {});
+			.catch((err) => {
+				const message =
+					typeof err === "object" && err !== null && "message" in err
+						? String((err as { message: unknown }).message)
+						: String(err);
+				console.warn(
+					`[host-service] git worktree remove --force failed but may still unregister`,
+					{
+						error: message,
+						target,
+					},
+				);
+			});
 		// A `worktree list` failure throws out of the task: the post-remove
 		// state is unknown and the caller must not treat it as removed.
 		const raw = await git.raw(["worktree", "list", "--porcelain"]);

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -218,11 +218,26 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 		// command's locale- and version-dependent exit text. `--force --force`
 		// also unregisters a worktree whose directory is already gone, so no
 		// separate prune (which would clobber other stale worktrees' metadata)
-		// is needed.
+		// is needed. Log the real git error though — `--force --force` can
+		// unregister while still failing to delete the folder (undeletable
+		// nested file, #6730), and without this the underlying cause is
+		// invisible to anyone debugging an orphan.
 		reportPhase?.("worktree-remove");
 		await git
 			.raw(["worktree", "remove", "--force", "--force", target])
-			.catch(() => {});
+			.catch((err) => {
+				const message =
+					typeof err === "object" && err !== null && "message" in err
+						? String((err as { message: unknown }).message)
+						: String(err);
+				console.warn(
+					`[host-service] git worktree remove --force failed but may still unregister`,
+					{
+						error: message,
+						target,
+					},
+				);
+			});
 		// A `worktree list` failure throws out of the task: the post-remove
 		// state is unknown and the caller must not treat it as removed.
 		reportPhase?.("worktree-list");

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
@@ -26,7 +27,7 @@ type WorkspaceRow = {
 	pullRequestId?: string | null;
 	archivedAt?: number | null;
 };
-type ProjectRow = { id: string; repoPath: string };
+type ProjectRow = { id: string; repoPath: string; worktreeBaseDir?: string };
 
 type WorktreeState = { hasChanges: boolean; hasUnpushedCommits: boolean };
 
@@ -42,6 +43,10 @@ interface ContextSpec {
 	resolveGitEnvThrows?: boolean;
 	removeWorktree?: () => Promise<{ stillRegistered: boolean }>;
 	deleteBranch?: () => Promise<{ deleted: boolean }>;
+	// Value returned by the host-settings lookup (`getHostWorktreeBaseDir`).
+	// When set, the worktree-removal root guard resolves against this base dir
+	// instead of the (absent) live settings row.
+	hostWorktreeBaseDir?: string;
 	// Simulates sqlite failure at the archive UPDATE — the commit point.
 	dbUpdateThrows?: boolean | "once";
 }
@@ -118,7 +123,14 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 			},
 			select: () => ({
 				from: () => ({
-					where: () => ({ all: terminalSelectAll }),
+					where: () => ({
+						all: terminalSelectAll,
+						// `getHostWorktreeBaseDir` reads the host-settings row.
+						get: () =>
+							spec.hostWorktreeBaseDir !== undefined
+								? { worktreeBaseDir: spec.hostWorktreeBaseDir }
+								: null,
+					}),
 				}),
 			}),
 			update: () => ({
@@ -476,6 +488,57 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			).rejects.toThrow(/Failed to open project repo/i);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("git-unregistered-but-left-on-disk worktree is removed, not orphaned", async () => {
+		// Regression for #6730: `git worktree remove --force` is not atomic —
+		// it can fully unregister the worktree (so it's absent from `git worktree
+		// list`, hence stillRegistered=false) while the working directory stays
+		// on disk when a nested file is undeletable. The destroy saga must then
+		// delete the leftover folder directly instead of trusting stillRegistered
+		// and archiving the row over an orphan.
+		const base = mkdtempSync(join(tmpdir(), "worktree-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		// Worktree must sit under <base>/<projectId>/ so the managed-root guard
+		// passes and the direct rm is allowed.
+		const projectRoot = join(base, "p-1");
+		mkdirSync(projectRoot, { recursive: true });
+		const worktree = join(projectRoot, "ws-1");
+		mkdirSync(worktree, { recursive: true });
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				// `runDestroyPhases` resolves the managed base dir via the
+				// host-settings lookup; surface it so the root guard treats the
+				// leftover worktree as inside the managed root.
+				hostWorktreeBaseDir: base,
+				// git says the worktree is no longer registered, but the folder
+				// still exists on disk (the undeletable-file case).
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			// The leftover folder must be gone now, not silently orphaned.
+			expect(existsSync(worktree)).toBe(false);
+			// No warning naming it as skipped (it was inside the managed root).
+			expect(
+				result.warnings.some((w: string) => w.includes("Skipped orphaned")),
+			).toBe(false);
+		} finally {
+			rmSync(base, { recursive: true, force: true });
 			rmSync(repo, { recursive: true, force: true });
 		}
 	});

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -543,6 +543,51 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 		}
 	});
 
+	test("orphaned worktree outside the managed root is skipped with worktreeRemoved=false", async () => {
+		// Regression for reviewer #6753: when the root guard skips orphaned
+		// removal, `worktreeRemoved` must stay false — the folder was NOT
+		// removed, so reporting it removed would be a lie in the response.
+		const base = mkdtempSync(join(tmpdir(), "worktree-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		// Worktree sits OUTSIDE <base>/<projectId>/ so the guard skips removal.
+		const safePath = mkdtempSync(join(tmpdir(), "worktree-outside-root-"));
+		const worktree = join(safePath, "ws-1");
+		mkdirSync(worktree, { recursive: true });
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				hostWorktreeBaseDir: base,
+				// git says no longer registered, but the folder exists on disk —
+				// and it is outside the managed root, so the direct rm is skipped.
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			// Folder survives (guard skipped the direct rm)...
+			expect(existsSync(worktree)).toBe(true);
+			// ...and we must NOT claim it was removed.
+			expect(result.worktreeRemoved).toBe(false);
+			// The skip is surfaced as a warning, not silent.
+			expect(
+				result.warnings.some((w: string) => w.includes("Skipped orphaned")),
+			).toBe(true);
+		} finally {
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
 	test("missing project metadata warns but still deletes local state", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
 		try {


### PR DESCRIPTION
Fixes #6730

## What & why

Two fixes for the workspace-delete saga in #6730:

**1. Orphaned-worktree cleanup (`workspace-cleanup.ts`).**
`git worktree remove --force` is not atomic: it can fully **unregister** a
worktree (so it no longer appears in `git worktree list` → `stillRegistered =
false`) while still failing to delete the working directory when a nested file
is undeletable (`Operation not permitted`, e.g. `chflags uchg`). The destroy
saga trusted `stillRegistered` alone and set `worktreeRemoved = true`, then
archived the row — leaving a silently **orphaned folder** on disk with no git
record of it. The repo-missing and session branches in the same saga already do
an `existsSync` → `rm` fallback under the managed-worktrees root guard; this
wires that same fallback into the common "project + repo present" path.

**2. Logging the underlying git error (`workers/tasks/git.ts`).**
The real git failure was swallowed by `.catch(() => {})`, so the toast text was
the only diagnostic and nothing reached host-service.log. It's now captured and
logged via `console.warn` (the existing host-service pattern) with the target
path, so the cause is discoverable when a folder is left orphaned.

## How I tested it

- New unit test in `packages/host-service/test/workspace-cleanup.test.ts`:
  `removeWorktree` returns `{ stillRegistered: false }` while the worktree's
  directory exists on disk → asserts the directory is gone after destroy.
- `bun test packages/host-service/test/` → **308 pass, 0 fail** (workspace-cleanup
  suite 26/26).
- `bun x tsc --noEmit` clean on the changed files.
- Also threaded a `hostWorktreeBaseDir` option through `makeCtx` so
  `getHostWorktreeBaseDir` returns a value in the test harness (the live
  host-settings lookup was previously untestable there).

Note: #6730's point 1 (git's non-atomic unregister/delete) is a git behavior we
cannot change in-repo; this PR covers points 2 and 3.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup for directories that remain after Git unregisters a worktree.
  * Safely removes leftover directories within the managed workspace area.
  * Preserves directories outside the managed area and warns when cleanup is skipped.
  * Cleanup status now accurately reflects whether removal succeeded.
  * Reports cleanup failures appropriately instead of indicating successful removal.
  * Added clearer warnings when forced worktree removal fails, including the affected location and error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->