### PR TITLE
fix(desktop): collapse the Cloud sidebar section's rows like every other section

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSectionHeader";
 import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
@@ -29,6 +30,9 @@ export function DashboardSidebarCloudSection({
 }) {
 	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const isSectionCollapsed = useSidebarSectionsCollapseStore(
+		(s) => s.collapsed.cloud,
+	);
 
 	// Row visibility, pinning and order all live in the same local-state
 	// collection every other sidebar row reads. Rendering straight off the
@@ -131,13 +135,14 @@ export function DashboardSidebarCloudSection({
 	return (
 		<div className="mb-1">
 			<DashboardSidebarSectionHeader label="Cloud" section="cloud" />
-			{rows.map((workspace) => (
-				<DashboardSidebarWorkspaceItem
-					key={workspace.id}
-					workspace={workspace}
-					onHoverCardOpen={onWorkspaceHover}
-				/>
-			))}
+			{!isSectionCollapsed &&
+				rows.map((workspace) => (
+					<DashboardSidebarWorkspaceItem
+						key={workspace.id}
+						workspace={workspace}
+						onHoverCardOpen={onWorkspaceHover}
+					/>
+				))}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Clicking the **Cloud** section header in the dashboard sidebar now hides its rows, the same way Pinned / Sessions / Projects do.

## Why / Context
The Cloud header was already wired to the shared `sidebar-sections-collapse` store (it has a `cloud` key and the header toggled it), but `DashboardSidebarCloudSection` never read the flag back. So the chevron rotated and the state persisted while the five cloud rows stayed put.

## How It Works
`DashboardSidebarCloudSection` subscribes to `collapsed.cloud` and skips rendering the rows while it's set, the exact gate `DashboardSidebarPinnedSection` and `DashboardSidebarSessionsSection` use. The collapsed-rail mode is untouched; no section has chrome there.

## Manual QA (CDP, real dev app on this worktree, 5 cloud workspaces in the sidebar)
Before (pre-fix file checked out): click Cloud header → store `cloud: true`, chevron turned, **5 rows still in DOM, section 192px**.

After:
- [x] Click Cloud header → **0 rows in DOM, section 32px** (header only), chevron points right
- [x] Reload → stays collapsed (persisted store)
- [x] Click again → 5 rows back, 192px
- [x] 6 rapid toggles → ends expanded, `console.error` hook stayed empty

## Testing
- `bun run typecheck` (desktop)
- `biome check` on the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the Cloud sidebar section’s rows when its header is toggled, matching Pinned/Sessions/Projects. Previously the chevron rotated and the collapse state persisted, but the rows stayed visible; now they hide and restore on toggle.

- Subscribes to `useSidebarSectionsCollapseStore` and gates rendering on `collapsed.cloud`, mirroring other sections.
- No changes to collapsed-rail mode; only affects the expanded sidebar.

<sup>Written for commit 7d757220b0f57fcb70c3a126a0a1118aafaaf3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud workspace entries in the dashboard sidebar now correctly hide when the cloud section is collapsed.
  * Existing workspace data and filtering behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->