### PR TITLE
feat(sidebar): file-tree rendering for nested workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -110,6 +110,10 @@ export function DashboardSidebarCloudSection({
 					lineageDepth: 0,
 					lineageChildCount: 0,
 					lineageCollapsed: false,
+					lineageGuides: [],
+					lineageGutter: false,
+					lineageDescendantIds: [],
+					lineageAncestorIds: [],
 				};
 			});
 	}, [cloudWorkspaces, hostWorkspaces, localStateRows]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -1,3 +1,4 @@
+import { useMatchRoute } from "@tanstack/react-router";
 import {
 	type KeyboardEvent,
 	type MouseEvent,
@@ -9,12 +10,16 @@ import {
 } from "react";
 import { useOptimisticActions } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
+import { useLineageThreadHover } from "renderer/stores/lineage-thread-hover";
 import {
 	useDashboardSidebarHoverActions,
 	useDashboardSidebarIsHovered,
 } from "../../providers/DashboardSidebarHoverProvider";
 import type { WorkspaceSelectionEvent } from "../../providers/DashboardSidebarSelectionProvider";
-import { useSidebarWorkspaceStatus } from "../../providers/DashboardSidebarWorkspaceStatusProvider";
+import {
+	useSidebarWorkspaceStatus,
+	useSidebarWorkspacesHighestStatus,
+} from "../../providers/DashboardSidebarWorkspaceStatusProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
 import { DashboardSidebarExpandedWorkspaceRow } from "./components/DashboardSidebarExpandedWorkspaceRow";
@@ -24,6 +29,8 @@ import {
 } from "./components/DashboardSidebarWorkspaceBulkContextMenu";
 import { DashboardSidebarWorkspaceContextMenu } from "./components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu";
 import { useDashboardSidebarWorkspaceItemActions } from "./hooks/useDashboardSidebarWorkspaceItemActions";
+
+const EMPTY_IDS: string[] = [];
 
 interface DashboardSidebarWorkspaceItemProps {
 	workspace: DashboardSidebarWorkspace;
@@ -64,6 +71,34 @@ export function DashboardSidebarWorkspaceItem({
 	} = workspace;
 	const isMainWorkspace = workspace.type === "main";
 	const { status: workspaceStatus, diffStats } = useSidebarWorkspaceStatus(id);
+	// Lineage thread state: keep a parent lit while a descendant is the
+	// active workspace, roll hidden children's status up onto a collapsed
+	// parent, and brighten a whole thread's rails while the pointer is in it.
+	const matchRoute = useMatchRoute();
+	const activeMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+		fuzzy: true,
+	});
+	const activeWorkspaceId = activeMatch ? activeMatch.workspaceId : null;
+	const isThreadActive =
+		activeWorkspaceId !== null &&
+		workspace.lineageDescendantIds.includes(activeWorkspaceId);
+	const collapsedStatus = useSidebarWorkspacesHighestStatus(
+		workspace.lineageCollapsed ? workspace.lineageDescendantIds : EMPTY_IDS,
+	);
+	const threadRootId =
+		workspace.lineageAncestorIds[0] ??
+		(workspace.lineageChildCount > 0 ? workspace.id : null);
+	const isThreadHovered = useLineageThreadHover(
+		(state) =>
+			threadRootId !== null && state.hoveredThreadRootId === threadRootId,
+	);
+	const setHoveredThreadRoot = useLineageThreadHover(
+		(state) => state.setHoveredThreadRoot,
+	);
+	const clearHoveredThreadRoot = useLineageThreadHover(
+		(state) => state.clearHoveredThreadRoot,
+	);
 	const {
 		cancelRename,
 		pendingName,
@@ -128,20 +163,35 @@ export function DashboardSidebarWorkspaceItem({
 
 	const handleMouseEnter = useCallback(
 		(event: React.MouseEvent) => {
+			if (threadRootId !== null) setHoveredThreadRoot(threadRootId);
 			if (!hoverEligible || !rowRef.current) return;
 			hoverRequestOpen(id, rowRef.current, hoverPayload, {
 				x: event.clientX,
 				y: event.clientY,
 			});
 		},
-		[hoverEligible, hoverRequestOpen, id, hoverPayload],
+		[
+			hoverEligible,
+			hoverRequestOpen,
+			id,
+			hoverPayload,
+			threadRootId,
+			setHoveredThreadRoot,
+		],
 	);
 	const handleMouseLeave = useCallback(
 		(event: React.MouseEvent) => {
+			if (threadRootId !== null) clearHoveredThreadRoot(threadRootId);
 			if (!hoverEligible) return;
 			hoverRequestClose(id, { x: event.clientX, y: event.clientY });
 		},
-		[hoverEligible, hoverRequestClose, id],
+		[
+			hoverEligible,
+			hoverRequestClose,
+			id,
+			threadRootId,
+			clearHoveredThreadRoot,
+		],
 	);
 
 	const isHovered = useDashboardSidebarIsHovered(id);
@@ -305,6 +355,9 @@ export function DashboardSidebarWorkspaceItem({
 				diffStats={isPending ? null : diffStats}
 				workspaceStatus={workspaceStatus}
 				isInSection={isInSection}
+				collapsedStatus={collapsedStatus}
+				isThreadActive={isThreadActive}
+				isThreadHovered={isThreadHovered}
 				isBulkSelectable={onSelectionClick != null}
 				isSelected={isSelected}
 				onClick={handleExpandedClick}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -2,6 +2,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import {
 	type ComponentPropsWithoutRef,
+	Fragment,
 	forwardRef,
 	type KeyboardEventHandler,
 	type MouseEventHandler,
@@ -18,6 +19,7 @@ import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import type {
@@ -27,6 +29,16 @@ import type {
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
 import { DashboardSidebarWorkspaceChips } from "./components/DashboardSidebarWorkspaceChips";
+
+/** Horizontal step per lineage level (px); matches common file trees. */
+const LINEAGE_STEP = 20;
+/** Rows are a fixed 32px tall with the icon centred, so the elbow sits at 16px
+ *  from the card top regardless of the chips strip below the row. */
+const LINEAGE_ICON_CENTER_PX = 16;
+/** The chevron gutter is a size-4 slot (+2px gap) ahead of the icon; rails
+ *  hang from the chevron's centre, and a parent's rail leaves just below it. */
+const LINEAGE_GUTTER_CENTER_PX = 8;
+const LINEAGE_CHEVRON_BOTTOM_PX = 25;
 
 const PR_STATE_LABEL: Record<
 	DashboardSidebarWorkspacePullRequest["state"],
@@ -49,6 +61,12 @@ interface DashboardSidebarExpandedWorkspaceRowProps
 	diffStats: DiffStats | null;
 	workspaceStatus?: ActivePaneStatus | null;
 	isInSection?: boolean;
+	/** Rolled-up status of the children a collapsed parent hides. */
+	collapsedStatus?: ActivePaneStatus | null;
+	/** A descendant is the active workspace: keep the thread's parent lit. */
+	isThreadActive?: boolean;
+	/** The pointer is somewhere in this row's thread: brighten its rails. */
+	isThreadHovered?: boolean;
 	isBulkSelectable?: boolean;
 	isSelected?: boolean;
 	/** Present when rendered in the Pinned section: shows the project avatar. */
@@ -80,6 +98,9 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			diffStats,
 			workspaceStatus = null,
 			isInSection = false,
+			collapsedStatus = null,
+			isThreadActive = false,
+			isThreadHovered = false,
 			isBulkSelectable = false,
 			isSelected = false,
 			pinnedContext,
@@ -110,6 +131,10 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		const localRef = useRef<HTMLDivElement>(null);
 		const openUrl = electronTrpc.external.openUrl.useMutation();
 		const isLineageParent = workspace.lineageChildCount > 0;
+		const railColor = isThreadHovered
+			? "bg-muted-foreground/80"
+			: "bg-muted-foreground/40";
+		const lineageBase = isInSection ? 32 : 12;
 		const handleLineageChevronClick: MouseEventHandler<HTMLButtonElement> = (
 			event,
 		) => {
@@ -148,6 +173,10 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				}}
 				className={cn(
 					"relative mx-2 rounded-md text-left text-sm transition-colors",
+					isThreadActive &&
+						!isActive &&
+						!isSelected &&
+						"ring-1 ring-inset ring-foreground/15",
 					isActive && "bg-fill-selected",
 					isSelected && "bg-fill-selected",
 					onClick &&
@@ -161,19 +190,71 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				data-selected={isSelected || undefined}
 				{...props}
 			>
-				{/* Lineage guide rails: one thin vertical line per ancestor level,
-				    aligned under that ancestor's icon column (file-tree styling).
-				    Per-row segments join into continuous lines across siblings. */}
+				{/* Lineage connectors, file-tree style: one rail column per ancestor
+				    level, hanging from that ancestor's chevron gutter. The row's own
+				    column draws ├ (rail continues to a later sibling) or └ (last
+				    child) plus an elbow tick into this row; outer columns only draw
+				    while that ancestor still has siblings below. z-10 keeps the
+				    lines on top of the selected/hover card fill. */}
 				{workspace.lineageDepth > 0 &&
-					Array.from({ length: workspace.lineageDepth }, (_, level) => (
-						<span
-							// biome-ignore lint/suspicious/noArrayIndexKey: the index IS the identity — one rail per fixed ancestor level
-							key={level}
-							aria-hidden
-							className="pointer-events-none absolute inset-y-0 w-px bg-border"
-							style={{ left: (isInSection ? 32 : 12) + level * 16 + 9 }}
-						/>
-					))}
+					Array.from({ length: workspace.lineageDepth }, (_, level) => {
+						const x =
+							lineageBase + level * LINEAGE_STEP + LINEAGE_GUTTER_CENTER_PX;
+						const isOwnColumn = level === workspace.lineageDepth - 1;
+						const continues = workspace.lineageGuides[level] ?? false;
+						if (!isOwnColumn && !continues) return null;
+						return (
+							// biome-ignore lint/suspicious/noArrayIndexKey: the index IS the identity — one column per fixed ancestor level
+							<Fragment key={level}>
+								<span
+									aria-hidden
+									className={cn(
+										"pointer-events-none absolute z-10 w-px transition-colors",
+										railColor,
+										continues ? "inset-y-0" : "top-0",
+									)}
+									style={{
+										left: x,
+										height: continues ? undefined : LINEAGE_ICON_CENTER_PX,
+									}}
+								/>
+								{isOwnColumn && (
+									<span
+										aria-hidden
+										className={cn(
+											"pointer-events-none absolute z-10 h-px transition-colors",
+											railColor,
+										)}
+										style={{
+											left: x,
+											top: LINEAGE_ICON_CENTER_PX,
+											// Into this row's own chevron when it is a parent,
+											// else all the way to its icon past the empty gutter.
+											width: isLineageParent ? 9 : 27,
+										}}
+									/>
+								)}
+							</Fragment>
+						);
+					})}
+				{/* Expanded parent: the rail leaves its chevron, through the chips
+				    strip and the selected fill, into the children below. */}
+				{isLineageParent && !workspace.lineageCollapsed && !isPending && (
+					<span
+						aria-hidden
+						className={cn(
+							"pointer-events-none absolute bottom-0 z-10 w-px transition-colors",
+							railColor,
+						)}
+						style={{
+							left:
+								lineageBase +
+								workspace.lineageDepth * LINEAGE_STEP +
+								LINEAGE_GUTTER_CENTER_PX,
+							top: LINEAGE_CHEVRON_BOTTOM_PX,
+						}}
+					/>
+				)}
 				{/* biome-ignore lint/a11y/useSemanticElements: The row contains nested action buttons, so it cannot be a native button. */}
 				<div
 					role="button"
@@ -200,11 +281,40 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						workspace.lineageDepth > 0
 							? {
 									paddingLeft:
-										(isInSection ? 32 : 12) + workspace.lineageDepth * 16,
+										lineageBase + workspace.lineageDepth * LINEAGE_STEP,
 								}
 							: undefined
 					}
 				>
+					{workspace.lineageGutter &&
+						(isLineageParent && !isPending ? (
+							<button
+								type="button"
+								aria-expanded={!workspace.lineageCollapsed}
+								aria-label={
+									workspace.lineageCollapsed
+										? `Expand ${workspace.lineageChildCount} child workspaces`
+										: "Collapse child workspaces"
+								}
+								onClick={handleLineageChevronClick}
+								onKeyDown={(event) => {
+									if (event.key === "Enter" || event.key === " ") {
+										event.stopPropagation();
+									}
+								}}
+								className="mr-0.5 flex size-4 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+							>
+								<HiChevronRight
+									className={cn(
+										"size-3.5 transition-transform",
+										!workspace.lineageCollapsed && "rotate-90",
+									)}
+								/>
+							</button>
+						) : (
+							// Leaves keep the slot so icons line up with parents.
+							<span aria-hidden className="mr-0.5 size-4 shrink-0" />
+						))}
 					{isSelected ? (
 						<span className="mr-2.5 flex size-5 shrink-0 items-center justify-center text-foreground">
 							<HiCheck className="size-3.5" />
@@ -240,63 +350,16 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 									</button>
 								) : (
 									<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
-										{isLineageParent && !isPending ? (
-											// Expanded: same affordance as the project header — the
-											// status icon swaps to a collapse chevron on row hover.
-											// Collapsed: the chevron is persistent (file-tree
-											// closed-folder convention), so hidden children stay
-											// discoverable at rest.
-											<button
-												type="button"
-												aria-expanded={!workspace.lineageCollapsed}
-												aria-label={
-													workspace.lineageCollapsed
-														? `Expand ${workspace.lineageChildCount} child workspaces`
-														: "Collapse child workspaces"
-												}
-												onClick={handleLineageChevronClick}
-												onKeyDown={(event) => {
-													if (event.key === "Enter" || event.key === " ") {
-														event.stopPropagation();
-													}
-												}}
-												className="flex size-5 cursor-pointer items-center justify-center rounded hover:bg-foreground/10"
-											>
-												{!workspace.lineageCollapsed && (
-													<span className="contents group-hover:hidden group-focus-within:hidden">
-														<DashboardSidebarWorkspaceIcon
-															hostType={hostType}
-															workspaceType={workspace.type}
-															hostIsOnline={hostIsOnline}
-															isActive={isActive}
-															variant="expanded"
-															workspaceStatus={workspaceStatus}
-															isCreatePending={isPending}
-															pullRequestState={null}
-														/>
-													</span>
-												)}
-												<HiChevronRight
-													className={cn(
-														"size-4 text-muted-foreground transition-transform",
-														workspace.lineageCollapsed
-															? "block"
-															: "hidden rotate-90 group-hover:block group-focus-within:block",
-													)}
-												/>
-											</button>
-										) : (
-											<DashboardSidebarWorkspaceIcon
-												hostType={hostType}
-												workspaceType={workspace.type}
-												hostIsOnline={hostIsOnline}
-												isActive={isActive}
-												variant="expanded"
-												workspaceStatus={workspaceStatus}
-												isCreatePending={isPending}
-												pullRequestState={null}
-											/>
-										)}
+										<DashboardSidebarWorkspaceIcon
+											hostType={hostType}
+											workspaceType={workspace.type}
+											hostIsOnline={hostIsOnline}
+											isActive={isActive}
+											variant="expanded"
+											workspaceStatus={workspaceStatus}
+											isCreatePending={isPending}
+											pullRequestState={null}
+										/>
 									</div>
 								)}
 							</TooltipTrigger>
@@ -372,20 +435,25 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						) : (
 							<span
 								className={cn(
-									"truncate text-[13px] leading-tight transition-colors",
+									"flex min-w-0 items-center text-[13px] leading-tight transition-colors",
 									isActive || isSelected
 										? "text-foreground"
 										: "text-foreground/80",
 								)}
 							>
-								{name || branch}
+								<span className="truncate">{name || branch}</span>
 								{isLineageParent && workspace.lineageCollapsed && (
-									// aria-hidden: the chevron button already announces
-									// "Expand N child workspaces" — this is its visual twin.
+									// aria-hidden: the gutter chevron already announces
+									// "Expand N child workspaces" — this is its visual twin,
+									// plus the worst status among the hidden children so a
+									// child waiting on input can't disappear into a fold.
 									<span
 										aria-hidden
-										className="ml-1.5 text-[10px] tabular-nums text-muted-foreground"
+										className="ml-1.5 flex shrink-0 items-center gap-1 text-[10px] tabular-nums text-muted-foreground"
 									>
+										{collapsedStatus && (
+											<StatusIndicator status={collapsedStatus} />
+										)}
 										+{workspace.lineageChildCount}
 									</span>
 								)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/DashboardSidebarWorkspaceChips.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/DashboardSidebarWorkspaceChips.tsx
@@ -56,7 +56,7 @@ export function DashboardSidebarWorkspaceChips({
 			// Matches the row's lineage indent (16px per level).
 			style={
 				lineageDepth > 0
-					? { paddingLeft: (isInSection ? 50 : 42) + lineageDepth * 16 }
+					? { paddingLeft: (isInSection ? 50 : 42) + lineageDepth * 20 }
 					: undefined
 			}
 			onMouseDown={(event) => event.stopPropagation()}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -247,6 +247,58 @@ describe("lineage nesting", () => {
 		expect(rendered).toEqual(["root:0", "kid-a:1", "grandkid:2", "kid-b:1"]);
 	});
 
+	it("marks which rail columns continue past each row (├ vs └)", () => {
+		const [project] = build({
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "root", tabOrder: 1 }),
+				makeWorkspace({ id: "kid-a", tabOrder: 2, parentWorkspaceId: "root" }),
+				makeWorkspace({ id: "kid-b", tabOrder: 4, parentWorkspaceId: "root" }),
+				makeWorkspace({
+					id: "grandkid",
+					tabOrder: 3,
+					parentWorkspaceId: "kid-a",
+				}),
+			],
+		});
+
+		const rendered = renderedWorkspaces(project, (w) =>
+			w.lineageGuides.map((g) => (g ? "|" : ".")).join(""),
+		);
+		// kid-a has a later sibling, so its column continues through the
+		// grandkid's row; the grandkid is last under kid-a (└).
+		expect(rendered).toEqual(["root:", "kid-a:|", "grandkid:|.", "kid-b:."]);
+	});
+
+	it("exposes thread membership: gutter, descendants, ancestors", () => {
+		const [project] = build({
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "root", tabOrder: 1 }),
+				makeWorkspace({ id: "kid", tabOrder: 2, parentWorkspaceId: "root" }),
+				makeWorkspace({
+					id: "grandkid",
+					tabOrder: 3,
+					parentWorkspaceId: "kid",
+				}),
+				makeWorkspace({ id: "loner", tabOrder: 4 }),
+			],
+		});
+
+		const byId = new Map(
+			project.children.flatMap((child) =>
+				child.type === "workspace"
+					? [[child.workspace.id, child.workspace]]
+					: [],
+			),
+		);
+		// Every row in a nested container reserves the chevron gutter.
+		expect([...byId.values()].every((w) => w.lineageGutter)).toBe(true);
+		expect(byId.get("root")?.lineageDescendantIds).toEqual(["kid", "grandkid"]);
+		expect(byId.get("kid")?.lineageDescendantIds).toEqual(["grandkid"]);
+		expect(byId.get("loner")?.lineageDescendantIds).toEqual([]);
+		expect(byId.get("grandkid")?.lineageAncestorIds).toEqual(["root", "kid"]);
+		expect(byId.get("loner")?.lineageAncestorIds).toEqual([]);
+	});
+
 	it("re-roots a child whose parent is not rendered in the same container", () => {
 		const [project] = build({
 			sidebarSections: [makeSection({ id: "section-1", tabOrder: 1 })],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -114,6 +114,10 @@ function decorateSidebarWorkspace(
 		lineageDepth: 0,
 		lineageChildCount: 0,
 		lineageCollapsed: workspace.lineageCollapsed,
+		lineageGuides: [],
+		lineageGutter: false,
+		lineageDescendantIds: [],
+		lineageAncestorIds: [],
 	};
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/nestSidebarWorkspaceLineage.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/nestSidebarWorkspaceLineage.ts
@@ -36,7 +36,22 @@ export function nestSidebarWorkspaceLineage(
 
 	const result: DashboardSidebarWorkspace[] = [];
 	const emitted = new Set<string>();
-	const emit = (workspace: DashboardSidebarWorkspace, depth: number) => {
+	// Every id below a node, collapsed or not, cycle-guarded by `seen`.
+	const collectDescendantIds = (id: string, seen: Set<string>): string[] => {
+		const ids: string[] = [];
+		for (const child of childrenByParentId.get(id) ?? []) {
+			if (seen.has(child.id)) continue;
+			seen.add(child.id);
+			ids.push(child.id, ...collectDescendantIds(child.id, seen));
+		}
+		return ids;
+	};
+	const emit = (
+		workspace: DashboardSidebarWorkspace,
+		depth: number,
+		guides: boolean[],
+		ancestors: string[],
+	) => {
 		if (emitted.has(workspace.id)) return;
 		emitted.add(workspace.id);
 		const children = childrenByParentId.get(workspace.id) ?? [];
@@ -44,6 +59,13 @@ export function nestSidebarWorkspaceLineage(
 			...workspace,
 			lineageDepth: depth,
 			lineageChildCount: children.length,
+			lineageGuides: guides,
+			lineageGutter: true,
+			lineageDescendantIds: collectDescendantIds(
+				workspace.id,
+				new Set([workspace.id]),
+			),
+			lineageAncestorIds: ancestors,
 		});
 		if (workspace.lineageCollapsed) {
 			// Hidden, not orphaned: mark the subtree emitted so descendants
@@ -58,15 +80,22 @@ export function nestSidebarWorkspaceLineage(
 			markHidden(workspace);
 			return;
 		}
-		for (const child of children) {
-			emit(child, depth + 1);
-		}
+		children.forEach((child, index) => {
+			// The rail under this row's chevron continues past the child only
+			// while later siblings remain below it.
+			emit(
+				child,
+				depth + 1,
+				[...guides, index < children.length - 1],
+				[...ancestors, workspace.id],
+			);
+		});
 	};
-	for (const root of roots) emit(root, 0);
+	for (const root of roots) emit(root, 0, [], []);
 	// Members of a cycle are reachable from no root; re-promote them so
 	// malformed lineage can never hide a row.
 	for (const workspace of workspaces) {
-		if (!emitted.has(workspace.id)) emit(workspace, 0);
+		if (!emitted.has(workspace.id)) emit(workspace, 0, [], []);
 	}
 	return result;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -279,6 +279,10 @@ export function useDashboardSidebarData() {
 					isHidden: sidebarWorkspaces.sidebarState.isHidden,
 					pinnedAt: sidebarWorkspaces.sidebarState.pinnedAt,
 					lineageCollapsed: sidebarWorkspaces.sidebarState.lineageCollapsed,
+					lineageGuides: [],
+					lineageGutter: false,
+					lineageDescendantIds: [],
+					lineageAncestorIds: [],
 				})),
 		[collections],
 	);
@@ -304,6 +308,10 @@ export function useDashboardSidebarData() {
 						pinnedAt: localState.pinnedAt,
 						parentWorkspaceId: workspace.parentWorkspaceId ?? null,
 						lineageCollapsed: localState.lineageCollapsed ?? false,
+						lineageGuides: [],
+						lineageGutter: false,
+						lineageDescendantIds: [],
+						lineageAncestorIds: [],
 					},
 				];
 			}),
@@ -357,6 +365,10 @@ export function useDashboardSidebarData() {
 					parentWorkspaceId: workspace.parentWorkspaceId ?? null,
 					// Auto-included mains have no local-state row to collapse with.
 					lineageCollapsed: false,
+					lineageGuides: [],
+					lineageGutter: false,
+					lineageDescendantIds: [],
+					lineageAncestorIds: [],
 				})),
 		[hostWorkspaces],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
@@ -367,6 +367,38 @@ export function useSidebarWorkspaceStatus(
 }
 
 /**
+ * Highest-priority status across several workspaces — what a collapsed
+ * lineage parent shows for the children it hides. Subscribes to each id and
+ * snapshots a primitive, so it re-renders only when the rolled-up answer
+ * changes.
+ */
+export function useSidebarWorkspacesHighestStatus(
+	workspaceIds: readonly string[],
+): ActivePaneStatus | null {
+	const store = useSidebarWorkspaceStatusStore();
+	const key = workspaceIds.join("\u0000");
+	const ids = useMemo(() => (key ? key.split("\u0000") : []), [key]);
+	return useSyncExternalStore(
+		useCallback(
+			(listener) => {
+				const unsubscribes = ids.map((id) => store.subscribe(id, listener));
+				return () => {
+					for (const unsubscribe of unsubscribes) unsubscribe();
+				};
+			},
+			[store, ids],
+		),
+		useCallback(
+			() =>
+				getHighestPriorityStatus(
+					ids.map((id) => store.get(id).status ?? undefined),
+				),
+			[store, ids],
+		),
+	);
+}
+
+/**
  * Marks every terminal with a live agent binding in the workspace as seen,
  * clearing derived `review` statuses. Reads bindings from the store at call
  * time, so callers don't subscribe to binding updates just to hold this.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/index.ts
@@ -4,4 +4,5 @@ export {
 	type SidebarWorkspaceStatusEntry,
 	useMarkSidebarWorkspaceTerminalsSeen,
 	useSidebarWorkspaceStatus,
+	useSidebarWorkspacesHighestStatus,
 } from "./DashboardSidebarWorkspaceStatusProvider";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -59,6 +59,17 @@ export interface DashboardSidebarWorkspace {
 	lineageChildCount: number;
 	/** True when this row's child subtree is collapsed in the sidebar. */
 	lineageCollapsed: boolean;
+	/** One flag per ancestor rail column (index = depth level): true when
+	 *  that rail continues past this row, i.e. the ancestor at that level
+	 *  has later siblings. Drives ├ vs └ connectors. Empty for roots. */
+	lineageGuides: boolean[];
+	/** True for every row of a container that has any nesting: rows reserve a
+	 *  leading chevron gutter so icons stay aligned between parents and leaves. */
+	lineageGutter: boolean;
+	/** Every descendant id (rendered or collapsed); empty for leaves. */
+	lineageDescendantIds: string[];
+	/** Ancestor ids from the thread root down to the direct parent. */
+	lineageAncestorIds: string[];
 }
 
 /**

--- a/apps/desktop/src/renderer/stores/lineage-thread-hover.ts
+++ b/apps/desktop/src/renderer/stores/lineage-thread-hover.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+/**
+ * Which lineage thread (keyed by its root workspace id) the pointer is over,
+ * so every row in that thread can brighten its rails together — rows of one
+ * thread are DOM siblings, not descendants, so CSS group-hover can't do it.
+ */
+interface LineageThreadHoverState {
+	hoveredThreadRootId: string | null;
+	setHoveredThreadRoot: (rootId: string | null) => void;
+	clearHoveredThreadRoot: (rootId: string) => void;
+}
+
+export const useLineageThreadHover = create<LineageThreadHoverState>((set) => ({
+	hoveredThreadRootId: null,
+	setHoveredThreadRoot: (rootId) => set({ hoveredThreadRootId: rootId }),
+	// Only the thread that set it clears it, so a leave racing a
+	// neighbour's enter can't wipe the neighbour's highlight.
+	clearHoveredThreadRoot: (rootId) =>
+		set((state) =>
+			state.hoveredThreadRootId === rootId
+				? { hoveredThreadRootId: null }
+				: state,
+		),
+}));


### PR DESCRIPTION
Stacked on #6562. Replaces the hover-only icon-swap chevron with the file-tree model the competitor/design research converged on (VS Code explorer, Devin's tree connector, Notion's chevron gutter), and adds the cues that keep a thread legible when its parent is selected.

Three commits, reviewable separately:
1. **Tree model** — `nestSidebarWorkspaceLineage` emits `lineageGuides` (├ vs └ per rail column), `lineageGutter`, `lineageDescendantIds`, `lineageAncestorIds`. Rendering unchanged; unit-tested.
2. **Gutter chevron + connectors** — every row in a nested container reserves a 16px chevron gutter so icons stay aligned; parents get a persistent `›`/`⌄`; rails hang from the chevron into elbow ticks at each child and draw above the selected fill. 20px per level. Also fixes parents with a PR icon never having had a collapse control.
3. **Thread cues** — collapsed parent shows the worst status of its hidden children next to `+N`; parent keeps a hollow ring while a descendant is active; hovering any row brightens its whole thread's rails (store keyed by thread root, since thread rows are DOM siblings).

## Why
Selected parent + agent chip + one child read as unrelated rows (user screenshot in the thread). Devin/Factory both shipped fixes for exactly "children vs. selected parent"; Linear keeps hierarchy as a single parent edge with rollups on the parent — same model.

## Verified
- 85 sidebar tests pass; desktop typecheck + repo lint clean.
- Live CDP on the real state (selected parent with agents + PR, nested child): rest / hover / collapsed / child-active captures in the design thread.
- Live CDP battery on fresh self-staged fixtures (demo repo → project → coordinator ▸ auth ▸ flaky chain + root sibling), **10/10 pass**: depths + gutter chevrons only on parents, connectors on children only, collapse cycle (+N badge, route stable), drag semantics (descendants disabled), thread hover brightens rails + parent ring while a descendant is active, pin mid-parent re-roots subtree / unpin re-nests, hide root re-roots / unhide restores, "Move to top level" context menu re-roots with subtree then API re-nests, fresh spawn nests live and destroy clears, cycle rejected by the API.

## Not in this PR
Collapse-by-default above N children, "+ spawn child" on hover, sticky ancestors, children panel on the parent workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render nested workspaces in the sidebar as a file-tree to improve hierarchy legibility. Old: a hover-only icon swap controlled collapse and some parents lacked a control; children and a selected parent read as separate rows. New: a persistent chevron gutter with rails (├/└), 20px per level, plus thread cues for collapsed status, active descendants, and hover.

- Data model: `nestSidebarWorkspaceLineage` now emits `lineageGuides`, `lineageGutter`, `lineageDescendantIds`, and `lineageAncestorIds` for each row; defaults added where workspaces are constructed; tests cover rail continuation and thread membership.
- UI: every row reserves a 16px chevron gutter; parents get a persistent chevron; rails hang from the gutter and draw above selected fill; chips indent matches the tree; parents with PR icons now have collapse controls.
- Thread cues: collapsed parents show the highest-priority status of hidden children next to +N via `useSidebarWorkspacesHighestStatus`; parents keep a subtle ring when a descendant is active; a zustand store brightens an entire thread’s rails on hover.
- Required action if you construct `DashboardSidebarWorkspace` manually: initialize `lineageGuides: []`, `lineageGutter: false`, `lineageDescendantIds: []`, and `lineageAncestorIds: []` (or use existing decorators).

<sup>Written for commit d5e559fe1cb16b255f1295b083c325dfcdb237eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


