### PR TITLE
fix(api): automation pruner passed its provider list as one bind parameter

### DIFF
--- a/apps/api/src/app/api/automations/jobs/prune-payloads/route.ts
+++ b/apps/api/src/app/api/automations/jobs/prune-payloads/route.ts
@@ -36,6 +36,16 @@ const TIME_BUDGET_MS = 20_000;
  */
 const PAYLOAD_READBACK_PROVIDERS = ["google_calendar"];
 
+/**
+ * Built as an explicit list rather than passing the array as one bind
+ * parameter: drizzle sends a JS array as a record, and Postgres will not cast
+ * that to text[], so `<> ALL($1)` fails on every run.
+ */
+const excludedProviders = sql.join(
+	PAYLOAD_READBACK_PROVIDERS.map((provider) => sql`${provider}`),
+	sql`, `,
+);
+
 export async function POST(request: Request): Promise<Response> {
 	const body = await request.text();
 	const rejected = await verifyQstashRequest(
@@ -59,7 +69,7 @@ export async function POST(request: Request): Promise<Response> {
 				FROM automation_events
 				WHERE payload IS NOT NULL
 				  AND received_at < now() - ${`${RETAIN_DAYS} days`}::interval
-				  AND provider <> ALL(${PAYLOAD_READBACK_PROVIDERS})
+				  AND provider NOT IN (${excludedProviders})
 				  -- A row still awaiting its handoff is re-dispatched from
 				  -- dispatch_input rather than payload, but leaving it whole
 				  -- keeps the sweep's inputs untouched for the cost of a few rows.


### PR DESCRIPTION
The automation payload pruner has failed on **every run since it deployed** — 811 errors in 24h, last one two minutes before I opened this. It has never pruned a row.

```
Failed query: WITH batch AS ( SELECT id, received_at FROM automation_events
WHERE payload IS NOT NULL AND received_at < now() - $1::interval
AND provider <> ALL(($2)) ...
```

`provider <> ALL(${PAYLOAD_READBACK_PROVIDERS})` sends the JS array as a single bind parameter. Postgres receives it as a record and won't cast it to `text[]`.

Fixed by building an explicit list with `sql.join`, the same way `ACTIVE_SUBSCRIPTION_STATUSES` is handled in `load-custom-session-data.ts`.

## Verified against a copy of production

- Plans as `Index Scan using automation_events_prunable_idx`, no sort
- One batch executes in **50ms**

It prunes **0 rows today**, which is correct rather than broken: `automation_events` was created on 2026-08-15 by migration `0071`, so nothing is older than the 7-day window yet. It has work from tomorrow.

## Related correction

I previously described `automation_events` as having been accumulating unpruned for a long time. It's **7 days old**. That makes the growth rate worse than I said, not better — **35 GB in 7 days, ~5 GB/day**, with nothing deleting it. The 4.55M rows currently in it are all within the retention window.

## Why this reached production

I hit the identical array-binding failure in a throwaway script earlier the same day and fixed it there, then shipped this route without ever executing it against a database. The partitioning work beside it was validated end-to-end against a real production copy; this route was not. The check that would have caught it is the one I ran today: execute the actual statement against a real branch before merging.

https://claude.ai/code/session_014D6wif8HDRCXEFf5Ku4w7V

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the automation payload pruner by replacing `provider <> ALL($1)` with an explicit `NOT IN (...)` list built via `sql.join`. The old query bound the provider array as one parameter, which Postgres rejected, so every run failed; the new query runs successfully.

- Review notes:
  - Filter semantics are unchanged; we still exclude `["google_calendar"]`.
  - We build the exclusion list with `sql.join`, emitting parameterized values to avoid the array-binding bug.

- Operational notes:
  - On a production copy, the query plans as an index scan on `automation_events_prunable_idx` and completes in ~50 ms per batch.
  - No rows prune today: `automation_events` is 7 days old and the retention window is 7 days. Expect first deletions starting tomorrow.

<sup>Written for commit c5d614c2fb91b2c2b0a97877cf128f15d98e4782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation payload cleanup by correctly excluding configured providers during pruning.
  * Ensured eligible payloads are identified more reliably for removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->