### PR TITLE
fix(api): read the DEFAULT partition count before maintenance, not after

### DIFF
--- a/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
+++ b/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
@@ -33,13 +33,24 @@ export async function POST(request: Request): Promise<Response> {
 	// a day with no partition, and creating that day's partition then fails with
 	// "would be violated by some row" — so reading this afterwards would skip
 	// the one diagnostic that explains the failure.
-	const [defaultPartition] = (
-		await dbWs.execute(sql`
-			SELECT count(*)::int AS n FROM ingest.webhook_payloads_default
-		`)
-	).rows as Array<{ n: number }>;
-	const defaultRows = defaultPartition?.n ?? 0;
-	if (defaultRows > 0) {
+	//
+	// null means the count itself failed. Reporting 0 there would read as "the
+	// default partition is empty", which is the opposite of what is known.
+	let defaultRows: number | null = null;
+	try {
+		const [row] = (
+			await dbWs.execute(sql`
+				SELECT count(*)::int AS n FROM ingest.webhook_payloads_default
+			`)
+		).rows as Array<{ n: number }>;
+		defaultRows = row?.n ?? 0;
+	} catch (error) {
+		console.error(
+			"[ingest/maintain-partitions] could not read the default partition:",
+			error,
+		);
+	}
+	if (defaultRows !== null && defaultRows > 0) {
 		console.error(
 			`[ingest/maintain-partitions] webhook_payloads_default holds ${defaultRows} rows; partition creation for those days will fail until they are drained`,
 		);

--- a/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
+++ b/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
@@ -29,19 +29,10 @@ export async function POST(request: Request): Promise<Response> {
 	);
 	if (rejected) return rejected;
 
-	const result = await dbWs.execute(sql`
-		SELECT action, partition_name
-		FROM ingest.maintain_webhook_payload_partitions(${DAYS_AHEAD}, ${RETAIN_DAYS})
-	`);
-	const changes = result.rows as Array<{
-		action: string;
-		partition_name: string;
-	}>;
-
-	// Rows here mean a delivery landed on a day with no partition, which only
-	// happens if this job has been failing. They block the partition for that
-	// range from being created until drained, so surface it loudly rather than
-	// letting it accumulate quietly.
+	// Counted before maintenance, not after. Rows here mean a delivery landed on
+	// a day with no partition, and creating that day's partition then fails with
+	// "would be violated by some row" — so reading this afterwards would skip
+	// the one diagnostic that explains the failure.
 	const [defaultPartition] = (
 		await dbWs.execute(sql`
 			SELECT count(*)::int AS n FROM ingest.webhook_payloads_default
@@ -51,6 +42,25 @@ export async function POST(request: Request): Promise<Response> {
 	if (defaultRows > 0) {
 		console.error(
 			`[ingest/maintain-partitions] webhook_payloads_default holds ${defaultRows} rows; partition creation for those days will fail until they are drained`,
+		);
+	}
+
+	let changes: Array<{ action: string; partition_name: string }>;
+	try {
+		const result = await dbWs.execute(sql`
+			SELECT action, partition_name
+			FROM ingest.maintain_webhook_payload_partitions(${DAYS_AHEAD}, ${RETAIN_DAYS})
+		`);
+		changes = result.rows as Array<{ action: string; partition_name: string }>;
+	} catch (error) {
+		console.error("[ingest/maintain-partitions] maintenance failed:", error);
+		return Response.json(
+			{
+				error: "Partition maintenance failed",
+				// The likely cause, and the thing to act on.
+				defaultRows,
+			},
+			{ status: 500 },
 		);
 	}
 


### PR DESCRIPTION
Follow-up to #6749, from a CodeRabbit comment I merged before reading.

`maintain_webhook_payload_partitions()` throws when `webhook_payloads_default` holds rows for a day it's trying to create. My route counted the DEFAULT partition *after* calling it — so in the one case that count exists to explain, it never ran, and the operator got an opaque 500.

Counted first now, logged if non-empty, and returned alongside the error so a failing run still says what to drain.

## Reproduced on a copy of production

```
DROP TABLE ingest.webhook_payloads_20260827;
INSERT ... received_at '2026-08-27'   -- lands in DEFAULT
SELECT * FROM ingest.maintain_webhook_payload_partitions();

ERROR: updated partition constraint for default partition
       "webhook_payloads_default" would be violated by some row
CONTEXT: SQL statement "CREATE TABLE ingest.webhook_payloads_20260827 ..."
```

Then the documented recovery — drain, recreate, reinsert, in one transaction:

```
default_now_empty: 0
maintenance_ok:    runs clean
```

## Testing

Lint and typecheck pass; the failure and the recovery both executed against a real production copy rather than a fixture.

https://claude.ai/code/session_014D6wif8HDRCXEFf5Ku4w7V

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads the default-partition row count before partition maintenance and returns it with failures. Previously we counted after calling maintain, so failures returned an opaque 500; now we guard the count and include defaultRows (number or null) in the error, while successful runs still report created/dropped counts.

**Operational notes**
- On failure, the JSON response includes defaultRows. Drain ingest.webhook_payloads_default and rerun the job.
- No schema or function changes; only call order and error handling.

<sup>Written for commit 11bc7fcae8f7f43a15f3d815ab34da839adf6714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition maintenance error handling and reporting.
  * Maintenance failures now return a clear error response with relevant row-count details.
  * Added visibility into the number of rows in the default partition before maintenance runs.
  * Maintenance results now consistently include partition changes and default-partition row information, including when the row count cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->