### PR TITLE
feat(discord-triage): bridge Discord reports into Plain over email, rebrand the bot

### DIFF
--- a/apps/discord-triage/README.md
+++ b/apps/discord-triage/README.md
@@ -1,6 +1,9 @@
 # discord-triage
 
-Gateway bot that auto-ingests Discord support messages into Linear Triage. Every new top-level message in a watched text channel (and every new post in a watched forum channel) becomes a Linear issue labeled `Source: Discord`; the bot opens a thread on the message with a link to the issue. Thread replies are not synced (future work).
+Gateway bot that turns Discord support posts into tickets. Every new top-level message in a watched text channel (and every new post in a watched forum channel) is picked up, the bot opens a thread on it, and two optional sinks run:
+
+- **Linear** (`LINEAR_FILING_ENABLED`): files a Triage issue labeled `Source: Discord` and links it from the thread; issue close archives the thread via the Linear webhook.
+- **Plain bridge** (`PLAIN_BRIDGE_ENABLED`): mirrors the post into Plain over email so the support team (and the Parahelp agent) can work it like any other ticket. Each Discord user is a synthetic Plain customer `discord-<userId>@<BRIDGE_EMAIL_DOMAIN>`; the post is emailed to Plain's inbound address, follow-ups in the Discord thread are emailed as replies (threaded with `In-Reply-To`), and support replies are sent by Plain to the synthetic address, received by Resend, delivered to `/resend-webhook`, and posted into the Discord thread as "Superset Support". The thread <-> email map lives in SQLite on a Fly volume.
 
 After filing, an async enhancement pass mirrors message attachments to Linear uploads (Discord CDN URLs expire) and — when `ANTHROPIC_API_KEY` is set — has Claude Sonnet rewrite the ticket into the standard format (improved title, Context, Artifacts, References, original report preserved as a quote). Screenshots are passed to the model as vision input. Enhancement failures leave the raw issue untouched.
 
@@ -15,6 +18,14 @@ After filing, an async enhancement pass mirrors message attachments to Linear up
 | `LINEAR_TEAM_KEY` | Team key, default `SUPER` |
 | `LINEAR_SOURCE_LABEL` | Label name, default `Discord`; must exist on the team (boot fails otherwise) |
 | `LINEAR_WEBHOOK_SECRET` | Signing secret of the Linear webhook; `/linear-webhook` (issue close → archive Discord thread) stays disabled when unset |
+| `LINEAR_FILING_ENABLED` | `true` (default) files every report into Linear Triage; set `false` once the Parahelp agent files issues itself |
+| `DISCORD_BOT_NAME` / `DISCORD_BOT_AVATAR_URL` | Bot profile, applied at boot when it differs from the current one |
+| `PLAIN_BRIDGE_ENABLED` | `true` mirrors reports into Plain over email and relays replies back; needs the four vars below |
+| `PLAIN_INBOUND_ADDRESS` | Plain's inbound address for the support email channel (Settings → Channels → Email) |
+| `RESEND_API_KEY` | Resend key with sending + receiving access |
+| `BRIDGE_EMAIL_DOMAIN` | Resend domain with receiving enabled, e.g. `discord.superset.sh` |
+| `RESEND_WEBHOOK_SECRET` | Signing secret of the Resend `email.received` webhook pointed at `/resend-webhook`; inbound relay stays disabled when unset |
+| `BRIDGE_DB_PATH` | SQLite path for the thread map (`/data/bridge.sqlite` on the Fly volume); in-memory when unset |
 
 ## One-time setup
 
@@ -33,3 +44,11 @@ After filing, an async enhancement pass mirrors message attachments to Linear up
    The bot MUST run as a single machine (`--ha=false`) — two machines file every issue twice. Watched channel IDs live in `fly.toml` `[env]`, not secrets.
 
 Issues land in Triage because API-created issues default to the Triage state — the bot never sets a state explicitly.
+
+## Plain bridge setup
+
+1. Resend: add the bridge domain (e.g. `discord.superset.sh`), add its DKIM/SPF records plus the receiving `MX 10 inbound-smtp.us-east-1.amazonaws.com`, and enable receiving.
+2. Resend → Webhooks: add `https://superset-discord-triage.fly.dev/resend-webhook` for `email.received`; store its signing secret as `RESEND_WEBHOOK_SECRET`.
+3. `fly secrets set RESEND_API_KEY=... RESEND_WEBHOOK_SECRET=... PLAIN_INBOUND_ADDRESS=...@inbound.postmarkapp.com`, then deploy (the deploy script creates the `bridge_data` volume on first run).
+
+Plain threads replies only on `In-Reply-To`/`References`, never on subject, which is why the bot records every Message-ID it sends or receives.

--- a/apps/discord-triage/fly.toml
+++ b/apps/discord-triage/fly.toml
@@ -10,6 +10,17 @@ kill_timeout = "10s"
   PORT = "8080"
   # 1456374121494478869 = #bugs (forum), 1466502145825050759 = #feature-request (text)
   DISCORD_CHANNEL_IDS = "1456374121494478869,1466502145825050759"
+  DISCORD_BOT_NAME = "Superset"
+  DISCORD_BOT_AVATAR_URL = "https://superset.sh/apple-touch-icon.png"
+  LINEAR_FILING_ENABLED = "true"
+  PLAIN_BRIDGE_ENABLED = "true"
+  BRIDGE_EMAIL_DOMAIN = "discord.superset.sh"
+  BRIDGE_DB_PATH = "/data/bridge.sqlite"
+
+# SQLite map of Discord threads <-> email conversations; survives deploys.
+[mounts]
+  source = "bridge_data"
+  destination = "/data"
 
 [http_service]
   internal_port = 8080

--- a/apps/discord-triage/package.json
+++ b/apps/discord-triage/package.json
@@ -7,7 +7,8 @@
 		"dev": "bun run --env-file=../../.env --hot src/index.ts",
 		"start": "bun run src/index.ts",
 		"deploy": "./scripts/deploy.sh",
-		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
+		"test": "bun test"
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "0.78.0",

--- a/apps/discord-triage/scripts/deploy.sh
+++ b/apps/discord-triage/scripts/deploy.sh
@@ -5,6 +5,12 @@ APP=superset-discord-triage
 
 cd "$(git rev-parse --show-toplevel)"
 
+# The bridge DB lives on a volume; create it once in the app's region.
+if ! fly volumes list --app "$APP" | grep -q bridge_data; then
+  echo "==> creating bridge_data volume"
+  fly volumes create bridge_data --app "$APP" --region sjc --size 1 --yes
+fi
+
 # --ha=false: gateway bot must be a single machine or every message files duplicate issues
 echo "==> fly deploy"
 fly deploy \

--- a/apps/discord-triage/src/branding.ts
+++ b/apps/discord-triage/src/branding.ts
@@ -1,0 +1,29 @@
+import { type Client, EmbedBuilder } from "discord.js";
+import { env } from "./env";
+import { store } from "./store";
+
+export const BRAND_COLOR = 0x5b5bd6;
+export const SUPPORT_NAME = "Superset Support";
+
+export function brandedEmbed(): EmbedBuilder {
+	return new EmbedBuilder()
+		.setColor(BRAND_COLOR)
+		.setFooter({ text: "Superset · superset.sh" });
+}
+
+// Username edits are rate limited to a couple per hour, so only touch the
+// profile when it drifts from the configured brand.
+export async function applyBranding(client: Client<true>) {
+	if (env.DISCORD_BOT_NAME && client.user.username !== env.DISCORD_BOT_NAME) {
+		await client.user.setUsername(env.DISCORD_BOT_NAME);
+		console.log(`renamed bot to ${env.DISCORD_BOT_NAME}`);
+	}
+	if (
+		env.DISCORD_BOT_AVATAR_URL &&
+		store.getSetting("avatar_url") !== env.DISCORD_BOT_AVATAR_URL
+	) {
+		await client.user.setAvatar(env.DISCORD_BOT_AVATAR_URL);
+		store.setSetting("avatar_url", env.DISCORD_BOT_AVATAR_URL);
+		console.log("updated bot avatar");
+	}
+}

--- a/apps/discord-triage/src/bridge.test.ts
+++ b/apps/discord-triage/src/bridge.test.ts
@@ -78,10 +78,9 @@ describe("store", () => {
 			store.findThreadByMessageIds(["<unknown>", "<plain-reply@mtasv.net>"])
 				?.discordThreadId,
 		).toBe("t1");
-		expect(
-			store.findThreadBySubject("u1", "App crashes on launch")?.discordThreadId,
-		).toBe("t1");
 		expect(store.markInboundProcessed("e1")).toBe(true);
 		expect(store.markInboundProcessed("e1")).toBe(false);
+		store.unmarkInboundProcessed("e1");
+		expect(store.markInboundProcessed("e1")).toBe(true);
 	});
 });

--- a/apps/discord-triage/src/bridge.test.ts
+++ b/apps/discord-triage/src/bridge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+process.env.DISCORD_BOT_TOKEN ??= "test";
+process.env.DISCORD_CHANNEL_IDS ??= "1";
+process.env.LINEAR_FILING_ENABLED = "false";
+
+const { replyText } = await import("./bridge");
+const { verifyWebhook } = await import("./resend");
+const { store } = await import("./store");
+
+describe("replyText", () => {
+	test("drops the quoted history under an 'On ... wrote:' line", () => {
+		const text =
+			"Thanks, try restarting the host.\n\nOn Sat, 22 Aug 2026 at 17:38, Discord Bridge Test <x@y> wrote:\n\n> original report\n";
+		expect(replyText(text)).toBe("Thanks, try restarting the host.");
+	});
+
+	test("drops a trailing block of quoted lines", () => {
+		expect(replyText("Reply here\n\n> quoted\n> more\n")).toBe("Reply here");
+	});
+
+	test("keeps a quote that is followed by more reply text", () => {
+		const text = "> you said X\n\nYes, and also Y.";
+		expect(replyText(text)).toBe(text);
+	});
+});
+
+describe("verifyWebhook", () => {
+	const secret = `whsec_${Buffer.from("topsecret").toString("base64")}`;
+	const body = '{"type":"email.received"}';
+	const sign = (id: string, ts: string) =>
+		new Bun.CryptoHasher("sha256", Buffer.from("topsecret"))
+			.update(`${id}.${ts}.${body}`)
+			.digest("base64");
+
+	test("accepts a valid svix signature", () => {
+		const ts = String(Math.floor(Date.now() / 1000));
+		const headers = new Headers({
+			"svix-id": "msg_1",
+			"svix-timestamp": ts,
+			"svix-signature": `v1,${sign("msg_1", ts)}`,
+		});
+		expect(verifyWebhook(headers, body, secret)).toBe(true);
+	});
+
+	test("rejects a tampered body and a stale timestamp", () => {
+		const ts = String(Math.floor(Date.now() / 1000));
+		const headers = new Headers({
+			"svix-id": "msg_1",
+			"svix-timestamp": ts,
+			"svix-signature": `v1,${sign("msg_1", ts)}`,
+		});
+		expect(verifyWebhook(headers, `${body} `, secret)).toBe(false);
+		const old = String(Math.floor(Date.now() / 1000) - 3600);
+		const stale = new Headers({
+			"svix-id": "msg_1",
+			"svix-timestamp": old,
+			"svix-signature": `v1,${sign("msg_1", old)}`,
+		});
+		expect(verifyWebhook(stale, body, secret)).toBe(false);
+	});
+});
+
+describe("store", () => {
+	test("maps every known Message-ID back to its Discord thread", () => {
+		store.createThread({
+			discordThreadId: "t1",
+			discordUserId: "u1",
+			subject: "App crashes on launch",
+			rootMessageId: "<root@ses>",
+			lastMessageId: "<root@ses>",
+		});
+		store.rememberMessageId("<plain-reply@mtasv.net>", "t1");
+		expect(store.getThread("t1")?.lastMessageId).toBe(
+			"<plain-reply@mtasv.net>",
+		);
+		expect(
+			store.findThreadByMessageIds(["<unknown>", "<plain-reply@mtasv.net>"])
+				?.discordThreadId,
+		).toBe("t1");
+		expect(
+			store.findThreadBySubject("u1", "App crashes on launch")?.discordThreadId,
+		).toBe("t1");
+		expect(store.markInboundProcessed("e1")).toBe(true);
+		expect(store.markInboundProcessed("e1")).toBe(false);
+	});
+});

--- a/apps/discord-triage/src/bridge.ts
+++ b/apps/discord-triage/src/bridge.ts
@@ -1,0 +1,251 @@
+import {
+	type Attachment,
+	AttachmentBuilder,
+	type Client,
+	type Message,
+	type ThreadChannel,
+	type User,
+} from "discord.js";
+import { brandedEmbed, SUPPORT_NAME } from "./branding";
+import { env } from "./env";
+import {
+	getReceivedAttachment,
+	getReceivedEmail,
+	type OutboundAttachment,
+	type ReceivedEmail,
+	sendEmail,
+	verifyWebhook,
+	waitForMessageId,
+} from "./resend";
+import { store } from "./store";
+
+// Resend rejects larger uploads; bigger files stay as (expiring) Discord links.
+const MAX_EMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const MAX_DISCORD_UPLOAD_BYTES = 8 * 1024 * 1024;
+const MAX_EMBED_CHARS = 4000;
+
+const domain = env.BRIDGE_EMAIL_DOMAIN ?? "";
+const inbound = env.PLAIN_INBOUND_ADDRESS ?? "";
+
+function customerAddress(user: User): string {
+	const name = (user.globalName ?? user.username).replace(/[<>"\r\n]/g, "");
+	return `${name} <discord-${user.id}@${domain}>`;
+}
+
+function userIdFromAddress(address: string): string | undefined {
+	const m = address.match(/discord-(\d+)@/);
+	return m?.[1];
+}
+
+function splitAttachments(attachments: Attachment[]): {
+	attached: OutboundAttachment[];
+	linked: Attachment[];
+} {
+	const attached: OutboundAttachment[] = [];
+	const linked: Attachment[] = [];
+	let budget = 40 * 1024 * 1024;
+	for (const a of attachments) {
+		if (a.size <= MAX_EMAIL_ATTACHMENT_BYTES && a.size <= budget) {
+			attached.push({ filename: a.name, path: a.url });
+			budget -= a.size;
+		} else {
+			linked.push(a);
+		}
+	}
+	return { attached, linked };
+}
+
+function emailBody(opts: {
+	content: string;
+	author: User;
+	url: string;
+	linked: Attachment[];
+	intro?: string;
+}): string {
+	const parts = [opts.intro, opts.content || "(no text, see attachments)"];
+	if (opts.linked.length > 0) {
+		parts.push(
+			`Large attachments (Discord links expire):\n${opts.linked.map((a) => `- ${a.name}: ${a.url}`).join("\n")}`,
+		);
+	}
+	parts.push(`--\nDiscord: ${opts.url}\nFrom: @${opts.author.username}`);
+	return parts.filter(Boolean).join("\n\n");
+}
+
+/** Opens the email conversation for a new Discord report. */
+export async function openBridgeThread(opts: {
+	thread: ThreadChannel;
+	author: User;
+	title: string;
+	content: string;
+	url: string;
+	attachments: Attachment[];
+}): Promise<void> {
+	const { attached, linked } = splitAttachments(opts.attachments);
+	const sent = await sendEmail({
+		from: customerAddress(opts.author),
+		to: inbound,
+		subject: opts.title,
+		text: emailBody({
+			content: opts.content,
+			author: opts.author,
+			url: opts.url,
+			linked,
+			intro: `New report from the Superset Discord #${opts.thread.parent?.name ?? "support"} channel.`,
+		}),
+		attachments: attached,
+	});
+	const rootMessageId = await waitForMessageId(sent.id);
+	store.createThread({
+		discordThreadId: opts.thread.id,
+		discordUserId: opts.author.id,
+		subject: opts.title,
+		rootMessageId,
+		lastMessageId: rootMessageId,
+	});
+	console.log(`bridged thread ${opts.thread.id} -> email ${sent.id}`);
+}
+
+/** Forwards a follow-up Discord message into its email conversation. */
+export async function relayFollowUp(message: Message): Promise<void> {
+	if (!message.channel.isThread()) return;
+	const thread = store.getThread(message.channel.id);
+	if (!thread) return;
+	const { attached, linked } = splitAttachments([
+		...message.attachments.values(),
+	]);
+	const sent = await sendEmail({
+		from: customerAddress(message.author),
+		to: inbound,
+		subject: `Re: ${thread.subject}`,
+		text: emailBody({
+			content: message.content,
+			author: message.author,
+			url: message.url,
+			linked,
+		}),
+		inReplyTo: thread.lastMessageId,
+		references: [thread.rootMessageId, thread.lastMessageId].filter(
+			(id, i, all) => all.indexOf(id) === i,
+		),
+		attachments: attached,
+	});
+	const messageId = await waitForMessageId(sent.id);
+	store.rememberMessageId(messageId, thread.discordThreadId);
+}
+
+function referencedIds(email: ReceivedEmail): string[] {
+	const raw = `${email.headers["in-reply-to"] ?? ""} ${email.headers.references ?? ""}`;
+	return raw.match(/<[^>]+>/g) ?? [];
+}
+
+function normalizeSubject(subject: string): string {
+	return subject.replace(/^(\s*(re|fwd?)\s*:\s*)+/i, "").trim();
+}
+
+// Keep the fresh reply; drop the quoted history mail clients append.
+export function replyText(text: string): string {
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	const cut = lines.findIndex(
+		(line, i) =>
+			/^On .+ wrote:\s*$/.test(line.trim()) ||
+			(line.startsWith(">") &&
+				lines.slice(i).every((l) => l.startsWith(">") || l.trim() === "")),
+	);
+	const kept = cut === -1 ? lines : lines.slice(0, cut);
+	return kept.join("\n").trim();
+}
+
+function isAutomatic(email: ReceivedEmail): boolean {
+	const auto = email.headers["auto-submitted"];
+	return (
+		(!!auto && auto !== "no") ||
+		/^(automatic reply|out of office)/i.test(email.subject ?? "")
+	);
+}
+
+async function discordFiles(
+	email: ReceivedEmail,
+): Promise<AttachmentBuilder[]> {
+	const files: AttachmentBuilder[] = [];
+	for (const a of email.attachments) {
+		try {
+			const meta = await getReceivedAttachment(email.id, a.id);
+			if (meta.size > MAX_DISCORD_UPLOAD_BYTES) continue;
+			const res = await fetch(meta.download_url, {
+				signal: AbortSignal.timeout(20_000),
+			});
+			if (!res.ok) continue;
+			files.push(
+				new AttachmentBuilder(Buffer.from(await res.arrayBuffer()), {
+					name: meta.filename || a.filename,
+				}),
+			);
+		} catch (err) {
+			console.error(`attachment ${a.id} from email ${email.id} failed`, err);
+		}
+	}
+	return files;
+}
+
+async function deliverReply(discord: Client, email: ReceivedEmail) {
+	const userId = email.to.map(userIdFromAddress).find(Boolean);
+	const thread =
+		store.findThreadByMessageIds(referencedIds(email)) ??
+		(userId && email.subject
+			? store.findThreadBySubject(userId, normalizeSubject(email.subject))
+			: undefined);
+	if (!thread) {
+		console.warn(
+			`inbound email ${email.id} matches no bridged thread (to ${email.to.join(",")}, subject ${email.subject})`,
+		);
+		return;
+	}
+	if (email.message_id) {
+		store.rememberMessageId(email.message_id, thread.discordThreadId);
+	}
+	const channel = await discord.channels.fetch(thread.discordThreadId);
+	if (!channel?.isThread()) return;
+	const body = replyText(email.text ?? "") || "(empty reply)";
+	const embed = brandedEmbed()
+		.setAuthor({ name: SUPPORT_NAME })
+		.setDescription(
+			body.length > MAX_EMBED_CHARS
+				? `${body.slice(0, MAX_EMBED_CHARS - 1)}…`
+				: body,
+		);
+	await channel.send({ embeds: [embed], files: await discordFiles(email) });
+	if (channel.archived) await channel.setArchived(false).catch(() => {});
+	console.log(`relayed email ${email.id} to thread ${thread.discordThreadId}`);
+}
+
+type ResendWebhook = { type?: string; data?: { email_id?: string } };
+
+export async function handleResendWebhook(
+	discord: Client,
+	req: Request,
+): Promise<Response> {
+	if (!env.RESEND_WEBHOOK_SECRET) {
+		return new Response("webhook not configured", { status: 503 });
+	}
+	const raw = await req.text();
+	if (!verifyWebhook(req.headers, raw, env.RESEND_WEBHOOK_SECRET)) {
+		console.warn("resend webhook rejected: bad signature");
+		return new Response("bad signature", { status: 401 });
+	}
+	const payload = JSON.parse(raw) as ResendWebhook;
+	const emailId = payload.data?.email_id;
+	if (payload.type !== "email.received" || !emailId) {
+		return new Response("ignored");
+	}
+	// At-least-once delivery: acknowledge duplicates without reposting.
+	if (!store.markInboundProcessed(emailId)) return new Response("duplicate");
+	try {
+		const email = await getReceivedEmail(emailId);
+		if (!isAutomatic(email)) await deliverReply(discord, email);
+	} catch (err) {
+		console.error(`resend webhook handling failed for ${emailId}`, err);
+		return new Response("handling failed", { status: 500 });
+	}
+	return new Response("ok");
+}

--- a/apps/discord-triage/src/bridge.ts
+++ b/apps/discord-triage/src/bridge.ts
@@ -32,11 +32,6 @@ function customerAddress(user: User): string {
 	return `${name} <discord-${user.id}@${domain}>`;
 }
 
-function userIdFromAddress(address: string): string | undefined {
-	const m = address.match(/discord-(\d+)@/);
-	return m?.[1];
-}
-
 function splitAttachments(attachments: Attachment[]): {
 	attached: OutboundAttachment[];
 	linked: Attachment[];
@@ -139,10 +134,6 @@ function referencedIds(email: ReceivedEmail): string[] {
 	return raw.match(/<[^>]+>/g) ?? [];
 }
 
-function normalizeSubject(subject: string): string {
-	return subject.replace(/^(\s*(re|fwd?)\s*:\s*)+/i, "").trim();
-}
-
 // Keep the fresh reply; drop the quoted history mail clients append.
 export function replyText(text: string): string {
 	const lines = text.replace(/\r\n/g, "\n").split("\n");
@@ -189,16 +180,11 @@ async function discordFiles(
 }
 
 async function deliverReply(discord: Client, email: ReceivedEmail) {
-	const userId = email.to.map(userIdFromAddress).find(Boolean);
-	const thread =
-		store.findThreadByMessageIds(referencedIds(email)) ??
-		(userId && email.subject
-			? store.findThreadBySubject(userId, normalizeSubject(email.subject))
-			: undefined);
+	// Message-ID correlation only: anyone can email a synthetic address, so a
+	// subject or recipient match must never be enough to speak in a thread.
+	const thread = store.findThreadByMessageIds(referencedIds(email));
 	if (!thread) {
-		console.warn(
-			`inbound email ${email.id} matches no bridged thread (to ${email.to.join(",")}, subject ${email.subject})`,
-		);
+		console.warn(`inbound email ${email.id} matches no bridged thread`);
 		return;
 	}
 	if (email.message_id) {
@@ -238,12 +224,15 @@ export async function handleResendWebhook(
 	if (payload.type !== "email.received" || !emailId) {
 		return new Response("ignored");
 	}
-	// At-least-once delivery: acknowledge duplicates without reposting.
+	// At-least-once delivery: acknowledge duplicates without reposting. The
+	// claim is released on failure so Resend's retry is not treated as a
+	// duplicate of a delivery that never happened.
 	if (!store.markInboundProcessed(emailId)) return new Response("duplicate");
 	try {
 		const email = await getReceivedEmail(emailId);
 		if (!isAutomatic(email)) await deliverReply(discord, email);
 	} catch (err) {
+		store.unmarkInboundProcessed(emailId);
 		console.error(`resend webhook handling failed for ${emailId}`, err);
 		return new Response("handling failed", { status: 500 });
 	}

--- a/apps/discord-triage/src/env.ts
+++ b/apps/discord-triage/src/env.ts
@@ -1,29 +1,67 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const csv = z
+	.string()
+	.min(1)
+	.transform((v) =>
+		v
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean),
+	);
+
+const bool = z.enum(["true", "false"]).transform((v) => v === "true");
+
 export const env = createEnv({
 	server: {
 		DISCORD_BOT_TOKEN: z.string().min(1),
 		/** Comma-separated channel IDs to watch (text and/or forum channels). */
-		DISCORD_CHANNEL_IDS: z
-			.string()
-			.min(1)
-			.transform((v) =>
-				v
-					.split(",")
-					.map((s) => s.trim())
-					.filter(Boolean),
-			),
+		DISCORD_CHANNEL_IDS: csv,
+		/** Bot display name; applied at boot when it differs from the current one. */
+		DISCORD_BOT_NAME: z.string().min(1).optional(),
+		/** PNG/JPEG URL for the bot avatar; applied once per URL. */
+		DISCORD_BOT_AVATAR_URL: z.string().url().optional(),
 		/** Enables Claude summarization/enhancement of tickets; skipped when unset. */
 		ANTHROPIC_API_KEY: z.string().min(1).optional(),
-		LINEAR_API_KEY: z.string().min(1),
+		/** File every new report into Linear Triage (the original behavior). */
+		LINEAR_FILING_ENABLED: bool.default(true),
+		LINEAR_API_KEY: z.string().min(1).optional(),
 		LINEAR_TEAM_KEY: z.string().min(1).default("SUPER"),
 		/** Label applied to every ingested issue. Must exist on the team. */
 		LINEAR_SOURCE_LABEL: z.string().min(1).default("Discord"),
 		/** Signing secret for the Linear webhook; endpoint is disabled when unset. */
 		LINEAR_WEBHOOK_SECRET: z.string().min(1).optional(),
+		/** Mirror reports into Plain over email and relay support replies back. */
+		PLAIN_BRIDGE_ENABLED: bool.default(false),
+		/** Plain's inbound email address for the support@ channel. */
+		PLAIN_INBOUND_ADDRESS: z.string().email().optional(),
+		RESEND_API_KEY: z.string().min(1).optional(),
+		/** Resend domain with receiving enabled; synthetic customer addresses live here. */
+		BRIDGE_EMAIL_DOMAIN: z.string().min(1).optional(),
+		/** Signing secret of the Resend `email.received` webhook (whsec_...). */
+		RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
+		/** SQLite file for the Discord thread <-> email thread map. In-memory when unset. */
+		BRIDGE_DB_PATH: z.string().min(1).optional(),
 		PORT: z.coerce.number().default(8080),
 	},
 	runtimeEnv: process.env,
 	emptyStringAsUndefined: true,
 });
+
+export const linearEnabled = env.LINEAR_FILING_ENABLED && !!env.LINEAR_API_KEY;
+
+export const bridgeEnabled =
+	env.PLAIN_BRIDGE_ENABLED &&
+	!!env.PLAIN_INBOUND_ADDRESS &&
+	!!env.RESEND_API_KEY &&
+	!!env.BRIDGE_EMAIL_DOMAIN;
+
+if (env.PLAIN_BRIDGE_ENABLED && !bridgeEnabled) {
+	throw new Error(
+		"PLAIN_BRIDGE_ENABLED needs PLAIN_INBOUND_ADDRESS, RESEND_API_KEY and BRIDGE_EMAIL_DOMAIN",
+	);
+}
+if (env.LINEAR_FILING_ENABLED && !env.LINEAR_API_KEY) {
+	throw new Error("LINEAR_FILING_ENABLED needs LINEAR_API_KEY");
+}

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -8,16 +8,22 @@ import {
 	GatewayIntentBits,
 	type Message,
 	type ThreadChannel,
+	type User,
 } from "discord.js";
+import { applyBranding, brandedEmbed } from "./branding";
+import { handleResendWebhook, openBridgeThread, relayFollowUp } from "./bridge";
 import { enhanceIssue, mdEscape } from "./enhance";
-import { env } from "./env";
+import { bridgeEnabled, env, linearEnabled } from "./env";
 
-const linear = new LinearClient({ apiKey: env.LINEAR_API_KEY });
+const linear = linearEnabled
+	? new LinearClient({ apiKey: env.LINEAR_API_KEY })
+	: undefined;
 
 let teamId: string;
 let sourceLabelId: string | undefined;
 
 async function resolveLinearIds() {
+	if (!linear) return;
 	const teams = await linear.teams({
 		filter: { key: { eq: env.LINEAR_TEAM_KEY } },
 	});
@@ -62,6 +68,7 @@ async function fileIssue(opts: {
 			? `\n\nAttachments:\n${opts.attachments.map((a) => `- [${mdEscape(a.name)}](${a.url})`).join("\n")}`
 			: "";
 	const description = `${opts.content}${attachmentList}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`;
+	if (!linear) return undefined;
 	// No stateId: API-created issues default into Triage.
 	const payload = await linear.createIssue({
 		teamId,
@@ -89,39 +96,94 @@ const discord = new Client({
 	],
 });
 
+type Report = {
+	thread: ThreadChannel;
+	author: User;
+	title: string;
+	content: string;
+	messageUrl: string;
+	attachments: Attachment[];
+	channelName: string;
+};
+
+// Shared intake: file to Linear (when enabled), mirror to Plain (when enabled),
+// then acknowledge in the Discord thread.
+async function intake(report: Report) {
+	const issue = await fileIssue({
+		title: report.title,
+		content: report.content,
+		authorTag: report.author.tag,
+		messageUrl: report.messageUrl,
+		attachments: report.attachments,
+	}).catch((err) => {
+		console.error("linear filing failed", err);
+		return undefined;
+	});
+	let bridged = false;
+	if (bridgeEnabled) {
+		bridged = await openBridgeThread({
+			thread: report.thread,
+			author: report.author,
+			title: report.title,
+			content: report.content,
+			url: report.messageUrl,
+			attachments: report.attachments,
+		})
+			.then(() => true)
+			.catch((err) => {
+				console.error("plain bridge failed", err);
+				return false;
+			});
+	}
+	if (!issue && !bridged) return;
+
+	const embed = brandedEmbed().setTitle("Thanks, we're on it");
+	const lines: string[] = [];
+	if (bridged) {
+		lines.push(
+			"Your report reached the Superset support team. Replies show up right here in this thread, and you can add details by posting below.",
+		);
+	}
+	if (issue) {
+		lines.push(`Tracked in Linear as [${issue.identifier}](${issue.url}).`);
+	}
+	embed.setDescription(lines.join("\n\n"));
+	await report.thread.send({ embeds: [embed] });
+
+	if (issue && linear) {
+		enhanceIssue(linear, {
+			issueId: issue.id,
+			channelName: report.channelName,
+			title: report.title,
+			content: report.content,
+			authorTag: report.author.tag,
+			messageUrl: report.messageUrl,
+			attachments: report.attachments,
+			initialDescription: issue.description,
+		}).catch((err) =>
+			console.error(`enhance failed for ${issue.identifier}`, err),
+		);
+	}
+}
+
 async function handleChannelMessage(message: Message) {
-	const attachments = [...message.attachments.values()];
 	const title = issueTitle(
 		message.content,
 		`Discord report from ${message.author.tag}`,
 	);
-	const issue = await fileIssue({
+	const thread = await message.startThread({ name: title.slice(0, 100) });
+	await intake({
+		thread,
+		author: message.author,
 		title,
 		content: message.content,
-		authorTag: message.author.tag,
 		messageUrl: message.url,
-		attachments,
-	});
-	if (!issue) return;
-	const thread = await message.startThread({ name: issue.identifier });
-	await thread.send(
-		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
-	);
-	enhanceIssue(linear, {
-		issueId: issue.id,
+		attachments: [...message.attachments.values()],
 		channelName:
 			"name" in message.channel && message.channel.name
 				? message.channel.name
 				: "support",
-		title,
-		content: message.content,
-		authorTag: message.author.tag,
-		messageUrl: message.url,
-		attachments,
-		initialDescription: issue.description,
-	}).catch((err) =>
-		console.error(`enhance failed for ${issue.identifier}`, err),
-	);
+	});
 }
 
 // Forum posts arrive as new threads; the starter message may lag thread creation.
@@ -131,38 +193,32 @@ async function handleForumPost(thread: ThreadChannel) {
 		await new Promise((r) => setTimeout(r, 2000));
 		starter = await thread.fetchStarterMessage().catch(() => null);
 	}
-	const content = starter?.content ?? "";
-	const attachments = starter ? [...starter.attachments.values()] : [];
-	const title = thread.name || issueTitle(content, "Discord forum post");
-	const authorTag = starter?.author.tag ?? "unknown";
-	const messageUrl = starter?.url ?? thread.url;
-	const issue = await fileIssue({
-		title,
+	if (!starter) {
+		console.warn(`no starter message for forum thread ${thread.id}`);
+		return;
+	}
+	const content = starter.content;
+	await intake({
+		thread,
+		author: starter.author,
+		title: thread.name || issueTitle(content, "Discord forum post"),
 		content,
-		authorTag,
-		messageUrl,
-		attachments,
-	});
-	if (!issue) return;
-	await thread.send(
-		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
-	);
-	enhanceIssue(linear, {
-		issueId: issue.id,
+		messageUrl: starter.url,
+		attachments: [...starter.attachments.values()],
 		channelName: thread.parent?.name ?? "forum",
-		title,
-		content,
-		authorTag,
-		messageUrl,
-		attachments,
-		initialDescription: issue.description,
-	}).catch((err) =>
-		console.error(`enhance failed for ${issue.identifier}`, err),
-	);
+	});
 }
 
 discord.on(Events.MessageCreate, (message) => {
 	if (message.author.bot) return;
+	if (message.channel.isThread()) {
+		// The forum starter shares the thread's ID and is handled on ThreadCreate.
+		if (!bridgeEnabled || message.id === message.channel.id) return;
+		relayFollowUp(message).catch((err) =>
+			console.error("failed to relay follow-up", err),
+		);
+		return;
+	}
 	if (!env.DISCORD_CHANNEL_IDS.includes(message.channelId)) return;
 	if (message.channel.type !== ChannelType.GuildText) return;
 	// Replies are follow-up discussion, not new reports.
@@ -183,7 +239,10 @@ discord.on(Events.ThreadCreate, (thread) => {
 
 discord.once(Events.ClientReady, (client) => {
 	console.log(
-		`discord-triage ready as ${client.user.tag}, watching ${env.DISCORD_CHANNEL_IDS.join(", ")}`,
+		`discord-triage ready as ${client.user.tag}, watching ${env.DISCORD_CHANNEL_IDS.join(", ")} (linear: ${linearEnabled}, plain bridge: ${bridgeEnabled})`,
+	);
+	applyBranding(client).catch((err) =>
+		console.error("branding update failed", err),
 	);
 });
 
@@ -235,9 +294,12 @@ async function handleIssueClosed(payload: LinearWebhookPayload) {
 	}
 	if (candidateIds.size === 0) return;
 	const done = issue.state?.type === "completed";
-	const message = done
-		? `✅ Fixed — closed in Linear as **${issue.identifier}** (${issue.state?.name}).`
-		: `Closed in Linear as **${issue.identifier}** (${issue.state?.name}).`;
+	const embed = brandedEmbed()
+		.setTitle(done ? "Fixed" : "Closed")
+		.setDescription(
+			`Closed in Linear as **${issue.identifier}** (${issue.state?.name}).`,
+		)
+		.toJSON();
 	for (const threadId of candidateIds) {
 		const t = await discordRest(`/channels/${threadId}`);
 		if (!t.ok) continue;
@@ -251,7 +313,7 @@ async function handleIssueClosed(payload: LinearWebhookPayload) {
 		if (thread.thread_metadata?.archived) continue;
 		const post = await discordRest(`/channels/${threadId}/messages`, {
 			method: "POST",
-			body: JSON.stringify({ content: message }),
+			body: JSON.stringify({ embeds: [embed] }),
 		});
 		if (!post.ok) {
 			throw new Error(`post to thread ${threadId} failed: ${post.status}`);
@@ -324,6 +386,9 @@ Bun.serve({
 		}
 		if (path === "/linear-webhook" && req.method === "POST") {
 			return handleLinearWebhook(req);
+		}
+		if (path === "/resend-webhook" && req.method === "POST") {
+			return handleResendWebhook(discord, req);
 		}
 		return new Response("not found", { status: 404 });
 	},

--- a/apps/discord-triage/src/resend.ts
+++ b/apps/discord-triage/src/resend.ts
@@ -1,0 +1,108 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { env } from "./env";
+
+const API = "https://api.resend.com";
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+	const res = await fetch(`${API}${path}`, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${env.RESEND_API_KEY}`,
+			"Content-Type": "application/json",
+			...init?.headers,
+		},
+	});
+	if (!res.ok) {
+		throw new Error(
+			`Resend ${init?.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return (await res.json()) as T;
+}
+
+export type OutboundAttachment = { filename: string; path: string };
+
+export async function sendEmail(opts: {
+	from: string;
+	to: string;
+	subject: string;
+	text: string;
+	inReplyTo?: string;
+	references?: string[];
+	attachments?: OutboundAttachment[];
+}): Promise<{ id: string }> {
+	const headers: Record<string, string> = {};
+	if (opts.inReplyTo) headers["In-Reply-To"] = opts.inReplyTo;
+	if (opts.references?.length) headers.References = opts.references.join(" ");
+	return api<{ id: string }>("/emails", {
+		method: "POST",
+		body: JSON.stringify({
+			from: opts.from,
+			to: [opts.to],
+			subject: opts.subject,
+			text: opts.text,
+			headers,
+			attachments: opts.attachments,
+		}),
+	});
+}
+
+// The RFC Message-ID is assigned on delivery, so it can lag the send call.
+export async function waitForMessageId(emailId: string): Promise<string> {
+	for (let i = 0; i < 10; i++) {
+		const email = await api<{ message_id?: string | null }>(
+			`/emails/${emailId}`,
+		);
+		if (email.message_id) return email.message_id;
+		await new Promise((r) => setTimeout(r, 1500));
+	}
+	throw new Error(`no Message-ID for Resend email ${emailId}`);
+}
+
+export type ReceivedEmail = {
+	id: string;
+	from: string;
+	to: string[];
+	subject: string | null;
+	text: string | null;
+	html: string | null;
+	message_id: string | null;
+	headers: Record<string, string>;
+	attachments: { id: string; filename: string; content_type: string }[];
+};
+
+export function getReceivedEmail(id: string): Promise<ReceivedEmail> {
+	return api<ReceivedEmail>(`/emails/receiving/${id}`);
+}
+
+export function getReceivedAttachment(
+	emailId: string,
+	attachmentId: string,
+): Promise<{ download_url: string; filename: string; size: number }> {
+	return api(`/emails/receiving/${emailId}/attachments/${attachmentId}`);
+}
+
+// Resend webhooks are Svix-signed: HMAC-SHA256 over `${id}.${timestamp}.${body}`
+// with the base64 secret after the `whsec_` prefix; the header may carry
+// several space-separated `v1,<base64>` signatures.
+export function verifyWebhook(
+	headers: Headers,
+	rawBody: string,
+	secret: string,
+): boolean {
+	const id = headers.get("svix-id");
+	const timestamp = headers.get("svix-timestamp");
+	const signatures = headers.get("svix-signature");
+	if (!id || !timestamp || !signatures) return false;
+	if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) return false;
+	const key = Buffer.from(secret.replace(/^whsec_/, ""), "base64");
+	const expected = createHmac("sha256", key)
+		.update(`${id}.${timestamp}.${rawBody}`)
+		.digest();
+	return signatures.split(" ").some((entry) => {
+		const [version, sig] = entry.split(",");
+		if (version !== "v1" || !sig) return false;
+		const given = Buffer.from(sig, "base64");
+		return given.length === expected.length && timingSafeEqual(given, expected);
+	});
+}

--- a/apps/discord-triage/src/store.ts
+++ b/apps/discord-triage/src/store.ts
@@ -84,20 +84,6 @@ export const store = {
 		return undefined;
 	},
 
-	// Last resort when every reference is unknown: the customer's most recent
-	// thread with the same subject.
-	findThreadBySubject(
-		discordUserId: string,
-		subject: string,
-	): BridgeThread | undefined {
-		const row = db
-			.query<Row, [string, string]>(
-				`SELECT * FROM threads WHERE discord_user_id = ? AND subject = ? ORDER BY created_at DESC LIMIT 1`,
-			)
-			.get(discordUserId, subject);
-		return row ? toThread(row) : undefined;
-	},
-
 	rememberMessageId(messageId: string, discordThreadId: string) {
 		db.run(`INSERT OR IGNORE INTO message_ids VALUES (?, ?)`, [
 			messageId,

--- a/apps/discord-triage/src/store.ts
+++ b/apps/discord-triage/src/store.ts
@@ -104,6 +104,11 @@ export const store = {
 		return res.changes === 1;
 	},
 
+	/** Failed delivery: release the id so the webhook retry gets to run it. */
+	unmarkInboundProcessed(emailId: string) {
+		db.run(`DELETE FROM processed_inbound WHERE email_id = ?`, [emailId]);
+	},
+
 	getSetting(key: string): string | undefined {
 		return db
 			.query<{ value: string }, [string]>(

--- a/apps/discord-triage/src/store.ts
+++ b/apps/discord-triage/src/store.ts
@@ -1,0 +1,132 @@
+import { Database } from "bun:sqlite";
+import { env } from "./env";
+
+export type BridgeThread = {
+	discordThreadId: string;
+	discordUserId: string;
+	subject: string;
+	/** Message-ID of the first email we sent; every follow-up references it. */
+	rootMessageId: string;
+	/** Most recent Message-ID in the conversation, ours or Plain's. */
+	lastMessageId: string;
+};
+
+const db = new Database(env.BRIDGE_DB_PATH ?? ":memory:", { create: true });
+db.run("PRAGMA journal_mode = WAL");
+db.run(`CREATE TABLE IF NOT EXISTS threads (
+	discord_thread_id TEXT PRIMARY KEY,
+	discord_user_id TEXT NOT NULL,
+	subject TEXT NOT NULL,
+	root_message_id TEXT NOT NULL,
+	last_message_id TEXT NOT NULL,
+	created_at INTEGER NOT NULL
+)`);
+db.run(`CREATE TABLE IF NOT EXISTS message_ids (
+	message_id TEXT PRIMARY KEY,
+	discord_thread_id TEXT NOT NULL
+)`);
+db.run(`CREATE TABLE IF NOT EXISTS processed_inbound (
+	email_id TEXT PRIMARY KEY,
+	processed_at INTEGER NOT NULL
+)`);
+db.run(`CREATE TABLE IF NOT EXISTS settings (
+	key TEXT PRIMARY KEY,
+	value TEXT NOT NULL
+)`);
+
+type Row = {
+	discord_thread_id: string;
+	discord_user_id: string;
+	subject: string;
+	root_message_id: string;
+	last_message_id: string;
+};
+
+function toThread(row: Row): BridgeThread {
+	return {
+		discordThreadId: row.discord_thread_id,
+		discordUserId: row.discord_user_id,
+		subject: row.subject,
+		rootMessageId: row.root_message_id,
+		lastMessageId: row.last_message_id,
+	};
+}
+
+export const store = {
+	createThread(thread: BridgeThread) {
+		db.run(`INSERT OR REPLACE INTO threads VALUES (?, ?, ?, ?, ?, ?)`, [
+			thread.discordThreadId,
+			thread.discordUserId,
+			thread.subject,
+			thread.rootMessageId,
+			thread.lastMessageId,
+			Date.now(),
+		]);
+		store.rememberMessageId(thread.rootMessageId, thread.discordThreadId);
+	},
+
+	getThread(discordThreadId: string): BridgeThread | undefined {
+		const row = db
+			.query<Row, [string]>(`SELECT * FROM threads WHERE discord_thread_id = ?`)
+			.get(discordThreadId);
+		return row ? toThread(row) : undefined;
+	},
+
+	findThreadByMessageIds(messageIds: string[]): BridgeThread | undefined {
+		for (const id of messageIds) {
+			const row = db
+				.query<Row, [string]>(
+					`SELECT t.* FROM message_ids m JOIN threads t ON t.discord_thread_id = m.discord_thread_id WHERE m.message_id = ?`,
+				)
+				.get(id);
+			if (row) return toThread(row);
+		}
+		return undefined;
+	},
+
+	// Last resort when every reference is unknown: the customer's most recent
+	// thread with the same subject.
+	findThreadBySubject(
+		discordUserId: string,
+		subject: string,
+	): BridgeThread | undefined {
+		const row = db
+			.query<Row, [string, string]>(
+				`SELECT * FROM threads WHERE discord_user_id = ? AND subject = ? ORDER BY created_at DESC LIMIT 1`,
+			)
+			.get(discordUserId, subject);
+		return row ? toThread(row) : undefined;
+	},
+
+	rememberMessageId(messageId: string, discordThreadId: string) {
+		db.run(`INSERT OR IGNORE INTO message_ids VALUES (?, ?)`, [
+			messageId,
+			discordThreadId,
+		]);
+		db.run(
+			`UPDATE threads SET last_message_id = ? WHERE discord_thread_id = ?`,
+			[messageId, discordThreadId],
+		);
+	},
+
+	/** Returns false when the inbound email was already handled (webhook retry). */
+	markInboundProcessed(emailId: string): boolean {
+		const res = db.run(
+			`INSERT OR IGNORE INTO processed_inbound VALUES (?, ?)`,
+			[emailId, Date.now()],
+		);
+		return res.changes === 1;
+	},
+
+	getSetting(key: string): string | undefined {
+		return db
+			.query<{ value: string }, [string]>(
+				`SELECT value FROM settings WHERE key = ?`,
+			)
+			.get(key)?.value;
+	},
+
+	setSetting(key: string, value: string) {
+		db.run(`INSERT OR REPLACE INTO settings VALUES (?, ?)`, [key, value]);
+	},
+};


### PR DESCRIPTION
## What

`apps/discord-triage` now mirrors every watched Discord post (#bugs forum, #feature-request) into Plain so the support team and the Parahelp agent can work Discord tickets without the Plain Horizon plan ($299 + $99/seat/mo).

- Each Discord user becomes a synthetic Plain customer `discord-<userId>@discord.superset.sh`; the post is emailed to Plain's inbound address with attachments.
- Follow-ups in the Discord thread are emailed as replies. Plain threads only on `In-Reply-To`/`References` (verified: subject-only and custom Message-IDs both create new threads), so the bot records the SES Message-ID of everything it sends and everything Plain sends back.
- Support replies: Plain emails the synthetic address, Resend receives on `discord.superset.sh`, `email.received` hits `/resend-webhook` (svix-verified, idempotent), and the reply lands in the Discord thread as a "Superset Support" embed with attachments.
- Linear filing stays on behind `LINEAR_FILING_ENABLED` so Triage doesn't regress before the Parahelp agent files issues itself; `PLAIN_BRIDGE_ENABLED` gates the bridge.
- Bot branding: name/avatar from env, embeds instead of bare messages.
- Thread <-> email map in SQLite on a Fly volume (`bridge_data`), created by the deploy script.

## Verified against Plain

Sent from `hey.superset.sh` (receiving-enabled) straight to Plain's Postmark inbound address: accepted (T-101); subject-only follow-up made a new thread (T-102); In-Reply-To a Plain-sent Message-ID threaded (T-102); In-Reply-To our own SES Message-ID threaded (T-105).

## Rollout (needs Fly login)

1. `discord.superset.sh` is added to Resend with receiving enabled; DNS records are in Vercel, verification pending.
2. Create the Resend `email.received` webhook → `https://superset-discord-triage.fly.dev/resend-webhook`.
3. `fly secrets set RESEND_API_KEY RESEND_WEBHOOK_SECRET PLAIN_INBOUND_ADDRESS` then `bun run deploy`.

## Tests

`bun test` in the app: reply-quote stripping, svix signature verification, SQLite thread map.

https://claude.ai/code/session_01PddrtYWVXGsjodhLmzQyiH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridges Discord reports into Plain over email and applies configurable bot branding. Previously we only filed to Linear; now, with `PLAIN_BRIDGE_ENABLED`, we mirror new reports to Plain, forward Discord thread follow-ups via email, and post Plain replies back into the Discord thread, while Linear filing remains behind `LINEAR_FILING_ENABLED`.

- Mirrors each report to Plain using a synthetic customer address `discord-<userId>@<BRIDGE_EMAIL_DOMAIN>`; threads via `In-Reply-To`/`References` using stored Message-IDs; large attachments are kept as Discord links.
- Forwards Discord thread replies as email replies referencing the root and last Message-IDs; posts support replies as a branded embed with small attachments reuploaded to Discord.
- Adds `/resend-webhook` for `email.received` with Svix signature verification; correlates inbound by referenced Message-IDs only; idempotent with duplicate suppression and retry-safe claim release on failure.
- Stores the Discord thread ↔ email conversation map in SQLite at `BRIDGE_DB_PATH` on the Fly volume `bridge_data`.
- Gated config: `PLAIN_BRIDGE_ENABLED` requires `PLAIN_INBOUND_ADDRESS`, `RESEND_API_KEY`, and `BRIDGE_EMAIL_DOMAIN`; inbound relay requires `RESEND_WEBHOOK_SECRET`. `LINEAR_FILING_ENABLED` (default true) requires `LINEAR_API_KEY`. Bot name/avatar come from `DISCORD_BOT_NAME` and `DISCORD_BOT_AVATAR_URL`.

**Rollout**
- Enable receiving for `BRIDGE_EMAIL_DOMAIN` in Resend and add the inbound MX record.
- Create a Resend `email.received` webhook to `/resend-webhook`; store its secret in `RESEND_WEBHOOK_SECRET`.
- Set `RESEND_API_KEY`, `PLAIN_INBOUND_ADDRESS`, and deploy; the `bridge_data` volume is created on first deploy.

<sup>Written for commit fa067c5d61e1dfe2008b7ae982d906ae0deed1f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Linear issue filing for Discord reports.
  * Added two-way email bridging between Discord support threads and Plain/Resend, including attachments and synchronized replies.
  * Added customizable Discord bot branding and branded notifications.
  * Added persistent bridge storage and automatic deployment volume setup.
* **Documentation**
  * Added setup and configuration guidance for Linear and email integrations.
* **Tests**
  * Added coverage for webhook validation, reply handling, message mapping, and duplicate event prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->