### PR TITLE
fix(api): keep the webhook body out of a failed ingest write's error

### DIFF
--- a/apps/api/src/lib/ingest/recordWebhookDelivery.test.ts
+++ b/apps/api/src/lib/ingest/recordWebhookDelivery.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, mock, test } from "bun:test";
+import { DrizzleQueryError } from "drizzle-orm";
+
+const execute = mock(
+	async (_query: unknown): Promise<{ rows: unknown[] }> => ({
+		rows: [],
+	}),
+);
+
+mock.module("@superset/db/client", () => ({
+	db: { execute },
+	dbWs: { execute },
+}));
+
+const { recordWebhookDelivery } = await import("./recordWebhookDelivery");
+
+/** Invented, not captured: stands in for a third party's webhook body. */
+const WEBHOOK_BODY = {
+	action: "opened",
+	repository: { full_name: "example-org/example-repo", private: true },
+	pull_request: {
+		number: 7,
+		head: { ref: "example/topic-branch" },
+		title: "Example pull request",
+		body: "free text authored by someone who is not our user: leaked-body-marker",
+	},
+};
+const BODY_MARKER = "leaked-body-marker";
+
+/**
+ * Everything the error tracker reads off a thrown error: the message, the
+ * stack, every own property, and the same again for each link of the `cause`
+ * chain, which Sentry's linkedErrors integration follows by default.
+ */
+function whatTheReporterSees(error: unknown): string {
+	const parts: string[] = [];
+	let current: unknown = error;
+	for (let depth = 0; depth < 5 && current instanceof Error; depth++) {
+		parts.push(
+			current.name,
+			current.message,
+			current.stack ?? "",
+			JSON.stringify(current, Object.getOwnPropertyNames(current)) ?? "",
+		);
+		current = current.cause;
+	}
+	return parts.join("\n");
+}
+
+function drizzleFailure(): DrizzleQueryError {
+	return new DrizzleQueryError(
+		"WITH event AS (INSERT INTO ingest.webhook_events ... VALUES ($1, $2, $3, 'pending') ...), body AS (INSERT INTO ingest.webhook_payloads ... $4::jsonb ...) SELECT id, status, retry_count, received_at FROM event",
+		["github", "delivery-1", "pull_request", JSON.stringify(WEBHOOK_BODY)],
+		new Error("Error connecting to database: TypeError: fetch failed"),
+	);
+}
+
+describe("recordWebhookDelivery", () => {
+	test("a failed write does not report the webhook body", async () => {
+		execute.mockImplementationOnce(() => Promise.reject(drizzleFailure()));
+
+		const thrown = await recordWebhookDelivery({
+			provider: "github",
+			eventId: "delivery-1",
+			eventType: "pull_request",
+			payload: WEBHOOK_BODY,
+		}).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect(whatTheReporterSees(thrown)).not.toContain(BODY_MARKER);
+		expect(whatTheReporterSees(thrown)).not.toContain("example-org");
+	});
+
+	test("a failed write still names the operation, provider and reason", async () => {
+		execute.mockImplementationOnce(() => Promise.reject(drizzleFailure()));
+
+		const thrown = await recordWebhookDelivery({
+			provider: "github",
+			eventId: "delivery-1",
+			eventType: "pull_request",
+			payload: WEBHOOK_BODY,
+		}).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		const message = (thrown as Error).message;
+		expect(message).toContain("recordWebhookDelivery");
+		expect(message).toContain("ingest.webhook_events");
+		expect(message).toContain("github");
+		expect(message).toContain(
+			"Error connecting to database: TypeError: fetch failed",
+		);
+	});
+
+	// Guards the matcher: only the wrapper that carries bind parameters is
+	// rewritten. Anything else propagates exactly as it did before.
+	test("an error that carries no bind parameters propagates untouched", async () => {
+		const original = new Error("boom");
+		execute.mockImplementationOnce(() => Promise.reject(original));
+
+		const thrown = await recordWebhookDelivery({
+			provider: "linear",
+			eventId: "delivery-2",
+			eventType: "Issue",
+			payload: WEBHOOK_BODY,
+		}).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		expect(thrown).toBe(original);
+		expect((thrown as Error).message).toBe("boom");
+	});
+
+	test("a successful write still returns the recorded delivery", async () => {
+		execute.mockImplementationOnce(() =>
+			Promise.resolve({
+				rows: [
+					{
+						id: "event-1",
+						status: "pending",
+						retry_count: 0,
+						received_at: "2026-08-22 12:00:00",
+					},
+				],
+			}),
+		);
+
+		const recorded = await recordWebhookDelivery({
+			provider: "github",
+			eventId: "delivery-3",
+			eventType: "push",
+			payload: WEBHOOK_BODY,
+		});
+
+		expect(recorded).toEqual({
+			id: "event-1",
+			status: "pending",
+			retryCount: 0,
+			receivedAt: new Date("2026-08-22T12:00:00Z"),
+		});
+	});
+});

--- a/apps/api/src/lib/ingest/recordWebhookDelivery.test.ts
+++ b/apps/api/src/lib/ingest/recordWebhookDelivery.test.ts
@@ -75,7 +75,8 @@ describe("recordWebhookDelivery", () => {
 	});
 
 	test("a failed write still names the operation, provider and reason", async () => {
-		execute.mockImplementationOnce(() => Promise.reject(drizzleFailure()));
+		const failure = drizzleFailure();
+		execute.mockImplementationOnce(() => Promise.reject(failure));
 
 		const thrown = await recordWebhookDelivery({
 			provider: "github",
@@ -94,6 +95,10 @@ describe("recordWebhookDelivery", () => {
 		expect(message).toContain(
 			"Error connecting to database: TypeError: fetch failed",
 		);
+		// The driver error must survive as `cause`: it carries the code and
+		// stack the report needs, and the message assertions above would still
+		// pass if a later change dropped it.
+		expect((thrown as Error).cause).toBe(failure.cause);
 	});
 
 	// Guards the matcher: only the wrapper that carries bind parameters is

--- a/apps/api/src/lib/ingest/recordWebhookDelivery.ts
+++ b/apps/api/src/lib/ingest/recordWebhookDelivery.ts
@@ -1,6 +1,6 @@
 import { db } from "@superset/db/client";
 import type { integrationProvider } from "@superset/db/schema";
-import { sql } from "drizzle-orm";
+import { DrizzleQueryError, sql } from "drizzle-orm";
 
 type Provider = (typeof integrationProvider.enumValues)[number];
 
@@ -9,6 +9,26 @@ export interface RecordedDelivery {
 	status: string;
 	retryCount: number;
 	receivedAt: Date;
+}
+
+/**
+ * Drizzle wraps a failed query in a DrizzleQueryError whose message, and own
+ * `query`/`params` properties, are the statement text followed by every bind
+ * parameter. One of ours is the entire webhook body, so reporting that error
+ * unmodified publishes a third party's payload into the error tracker.
+ *
+ * Rethrow with the operation, the provider and the driver's own message, and
+ * the driver error as the cause so its code and stack still reach the report:
+ * a failure says what broke and why, without the body. Anything that is not
+ * the wrapper carries no bind parameters and is left exactly as it was.
+ */
+function withoutBoundParameters(provider: Provider, error: unknown): unknown {
+	if (!(error instanceof DrizzleQueryError)) return error;
+	const cause = error.cause;
+	return new Error(
+		`recordWebhookDelivery failed for ${provider} writing ingest.webhook_events and ingest.webhook_payloads: ${cause?.message ?? "unknown database error"}`,
+		{ cause },
+	);
 }
 
 /**
@@ -37,12 +57,13 @@ export async function recordWebhookDelivery({
 	eventType: string;
 	payload: unknown;
 }): Promise<RecordedDelivery | null> {
-	const result = await db.execute<{
-		id: string;
-		status: string;
-		retry_count: number;
-		received_at: string | Date;
-	}>(sql`
+	const result = await db
+		.execute<{
+			id: string;
+			status: string;
+			retry_count: number;
+			received_at: string | Date;
+		}>(sql`
 		WITH event AS (
 			INSERT INTO ingest.webhook_events (provider, event_id, event_type, status)
 			VALUES (${provider}, ${eventId}, ${eventType}, 'pending')
@@ -64,7 +85,10 @@ export async function recordWebhookDelivery({
 			RETURNING webhook_event_id
 		)
 		SELECT id, status, retry_count, received_at FROM event
-	`);
+	`)
+		.catch((error: unknown) => {
+			throw withoutBoundParameters(provider, error);
+		});
 
 	const row = result.rows[0];
 	if (!row) return null;


### PR DESCRIPTION
## Problem

`recordWebhookDelivery` records an inbound provider delivery — identity row plus body — in one `db.execute`. The body is a bind parameter of that statement.

Drizzle wraps any failed query in a `DrizzleQueryError`:

```js
super(`Failed query: ${query}\nparams: ${params}`)
```

with `query` and `params` also set as own properties. So when that statement failed (in API-1Z the database was refusing new connections during a deploy), the error that propagated out of `recordWebhookDelivery` carried the complete serialized webhook body — in its message, in its stack, and in its own `params` array — and Sentry recorded all of it in the issue title and message. That is a third party's payload (private repository identifiers, branch and pull-request metadata, free text authored by people who are not our users) published into our error tracker.

The connection refusal was transient and is not what this fixes. The leak is not specific to it: any future failure of that statement, on any of the three routes that call it (github, linear, notion webhooks), publishes the same thing.

**1. User-visible harm.** Content belonging to our customers and to third parties who never contracted with us is copied verbatim into a third-party SaaS, readable by everyone with Sentry access and retained there, every time the ingest write fails on the product's hottest write path. The harm is the disclosure, not the presence of an error entry.

**2. Does the change reach the reported failure?** Yes. The events came from `6af8f122d`; `recordWebhookDelivery.ts` is unchanged since `75c641f14` (#6749) and is byte-identical on `main` today, so the leaking line is live. The fix is at the only place the statement is issued, and ships in the next `@superset/api` deploy, which serves all three webhook routes.

**3. Why code, and why here?** Archiving leaves the leak armed for the next failure. A `beforeSend` filter or inbound Sentry filter is forbidden by repo law (#6164) and would suppress the whole event, losing the signal along with the body. The code path cannot be deleted — it is the ingest write. Fixing it in the db client would change error text for every query in the monorepo for a leak that only this statement actually has, so it is a much larger blast radius for no extra coverage here. Nothing in flight restructures this file. That leaves the throw site.

## Root cause

`db.execute(...)` binds `JSON.stringify(payload)` as a parameter, and drizzle's failure wrapper renders every bind parameter into the error it throws.

## Fix

One `.catch` on the existing `db.execute`. When — and only when — the rejection is a `DrizzleQueryError` (the wrapper that carries bind parameters), rethrow an error that names the operation, the provider and the driver's own message, with the driver error attached as `cause` so its stack and code still reach the report. Anything else propagates untouched.

Unchanged: the statement, the single round trip, the fact that a failure throws, and what all three callers do with it. This is a change to what the error carries, nothing else.

No typed `cause: { kind: ... }` — nothing reads one. The three callers let the error propagate to Next.js. `cause` here is the ordinary `Error` chain, which *is* read: Sentry's default `linkedErrors` integration walks it, which is how the driver's own reason still shows up.

Before:

```
Failed query: WITH event AS (INSERT INTO ingest.webhook_events ...
params: github,delivery-1,pull_request,{"action":"opened","repository":{...entire body...}}
```

After (real output, printed from the test's cause-chain walk):

```
Error
recordWebhookDelivery failed for github writing ingest.webhook_events and ingest.webhook_payloads: Error connecting to database: TypeError: fetch failed
Error: recordWebhookDelivery failed for github writing ingest.webhook_events and ingest.webhook_payloads: Error connecting to database: TypeError: fetch failed
Error
Error connecting to database: TypeError: fetch failed
Error: Error connecting to database: TypeError: fetch failed
```

**4. Smallest change.** 21 lines: one import symbol, one helper, one `.catch`. The formatter re-indented the `db.execute` generic when the call became chained; that is the whole rest of the diff.

**5. The matcher.** `error instanceof DrizzleQueryError`. What it must **not** match: any other rejection from `db.execute` — a plain `Error`, an `AbortError`, anything a future driver throws before drizzle wraps it. None of those carry bind parameters, so rewriting them would silence real messages for nothing. `recordWebhookDelivery.test.ts` pins that with `expect(thrown).toBe(original)` on a plain `Error("boom")` — identity, not just message. That test passes before and after the change (there was no matcher before to over-match); the two tests that fail before and pass after are the leak proof and the still-diagnosable proof.

## Verification

`bunx @biomejs/biome@2.4.2 check apps/api/src/lib/ingest/recordWebhookDelivery.ts apps/api/src/lib/ingest/recordWebhookDelivery.test.ts` — first run reported 2 formatting errors; `--write` fixed them; re-check:

```
Checked 2 files in 10ms. No fixes applied.
```

`cd apps/api && bun run typecheck`:

```
$ tsc --noEmit
```

`bun test apps/api` — before this change: `11 pass, 1 fail, 1 error`. After:

```
 15 pass
 1 fail
 1 error
 36 expect() calls
Ran 16 tests across 4 files. [106.00ms]
```

The one failure and one error are pre-existing on `main`, both in `apps/api/src/app/api/integrations/slack/interactions/route.test.ts` (`SyntaxError: Export named 'integrationConnections' not found` — a partial `mock.module` of the db schema leaking across files). Untouched by this change; the counts are identical before and after.

**Proof of the outcome, not an assertion of it.** `recordWebhookDelivery.test.ts` drives the real `recordWebhookDelivery`, rejects its `db.execute` with a genuine `DrizzleQueryError` whose params include an invented webhook body, and inspects what the reporter would see: message, stack, every own property via `JSON.stringify(err, Object.getOwnPropertyNames(err))`, repeated across five levels of the `cause` chain — the same chain `linkedErrors` follows. Against the unmodified source that check fails with the full body in the received string, plus the second test failing because the message is `Failed query: ...` rather than naming the operation:

```
(fail) recordWebhookDelivery > a failed write does not report the webhook body
(fail) recordWebhookDelivery > a failed write still names the operation, provider and reason
 2 pass
 2 fail
```

After the change:

```
 4 pass
 0 fail
 10 expect() calls
```

The fixture body is invented, not the captured payload.

## Adjacent, deliberately left alone

`recordAutomationEvent` (`apps/api/src/lib/automations/recordAutomationEvent.ts`) binds a payload through drizzle's insert builder and has the same wrapper shape, and in principle so does every other `db.execute` in the repo. Out of scope here, and none of them are the statement API-1Z reports.

Refs API-1Z

https://claude.ai/code/session_01FnF1gNfEwKxo6G9abY9DPe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking webhook payloads in error reports when `recordWebhookDelivery` fails. Previously `drizzle-orm`’s `DrizzleQueryError` included bound params (the full webhook body); now we catch that error and rethrow a sanitized message that names the operation and provider while preserving the driver’s message via `cause`.

- Review notes
  - Change is limited to a `.catch` and helper; SQL, single round trip, and all callers are unchanged.
  - Sanitizes only `DrizzleQueryError`; other errors propagate unchanged.
  - Tests assert no payload leak, that the driver error survives as `cause`, and that successful writes are unaffected.

<sup>Written for commit 51c54e83868f8d2a093eb37cc530661b599d119a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sensitive webhook payload data from appearing in reported database errors.
  - Preserved useful operation, provider, and database details when webhook delivery writes fail.
  - Retained the underlying database error for troubleshooting while leaving unrelated errors unchanged.

- **Tests**
  - Added coverage for sanitized failures, preserved error details, unchanged unrelated errors, and successful delivery recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->