### PR TITLE
fix(mobile): load the attachments sheet's photos off the main thread

### DIFF
--- a/apps/mobile/modules/attachments-sheet/ios/AttachmentsSheetView.swift
+++ b/apps/mobile/modules/attachments-sheet/ios/AttachmentsSheetView.swift
@@ -14,6 +14,7 @@ internal final class SheetModel: ObservableObject {
   @Published var screenshots: [PHAsset] = []
   @Published var selection: [PHAsset] = []
   @Published var isExporting = false
+  @Published var hasLoaded = false
 
   var libraryUsable: Bool { status == .authorized || status == .limited }
   var canAskAgain: Bool { status == .notDetermined }
@@ -32,25 +33,41 @@ internal final class SheetModel: ObservableObject {
     }
   }
 
+  /// The fetches below cross into the photo service, which can take seconds to
+  /// answer; on the main thread that is the whole app hanging until it does.
   func loadIfUsable() {
     guard libraryUsable else { return }
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      guard let self else { return }
+      let fetched = self.fetchLibrary()
+      DispatchQueue.main.async {
+        self.recents = fetched.recents
+        self.screenshots = fetched.screenshots
+        self.hasLoaded = true
+      }
+    }
+  }
+
+  private func fetchLibrary() -> (recents: [PHAsset], screenshots: [PHAsset]) {
     let byNewest = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
     let recentOptions = PHFetchOptions()
     recentOptions.sortDescriptors = byNewest
     recentOptions.fetchLimit = 30
-    recents = assetArray(PHAsset.fetchAssets(with: .image, options: recentOptions))
+    let recents = assetArray(PHAsset.fetchAssets(with: .image, options: recentOptions))
 
     let screenshotsAlbum = PHAssetCollection.fetchAssetCollections(
       with: .smartAlbum,
       subtype: .smartAlbumScreenshots,
       options: nil
     ).firstObject
-    if let screenshotsAlbum {
-      let screenshotOptions = PHFetchOptions()
-      screenshotOptions.sortDescriptors = byNewest
-      screenshots = assetArray(PHAsset.fetchAssets(in: screenshotsAlbum, options: screenshotOptions))
-    }
+    guard let screenshotsAlbum else { return (recents, []) }
+    let screenshotOptions = PHFetchOptions()
+    screenshotOptions.sortDescriptors = byNewest
+    let screenshots = assetArray(
+      PHAsset.fetchAssets(in: screenshotsAlbum, options: screenshotOptions)
+    )
+    return (recents, screenshots)
   }
 
   func selectionIndex(of asset: PHAsset) -> Int? {
@@ -218,7 +235,7 @@ private struct ScreenshotsGridView: View {
             }
             .padding(.horizontal, horizontalPadding)
             .padding(.bottom, 12)
-            if model.screenshots.isEmpty {
+            if model.hasLoaded, model.screenshots.isEmpty {
               Text("No screenshots found")
                 .font(.system(size: 14))
                 .foregroundColor(Color(model.theme.mutedForeground))
@@ -258,7 +275,7 @@ private struct RecentPhotosCarousel: View {
           SelectableThumbnail(model: model, asset: asset, side: 96, badgeSize: 36)
         }
         if model.recents.isEmpty {
-          Text("No photos in your library")
+          Text(model.hasLoaded ? "No photos in your library" : "")
             .font(.system(size: 14))
             .foregroundColor(Color(model.theme.mutedForeground))
             .frame(height: 96)


### PR DESCRIPTION
## Problem

Opening the attachments sheet freezes the entire app for up to ~3.6s. The tap
does nothing, no sheet appears, nothing on screen responds, and then the sheet
animates in fully populated. iOS's hang detector reported one instance on a
real device in production (iPhone17,2, iOS 26.6, `sh.superset.mobile@1.0.0+14`),
but that detector only fires above a threshold — every faster-but-still-janky
opening is the same bug and is invisible in telemetry. It reproduces on any
device where the photo service is slow to answer, on every open.

## Root cause

`SheetModel.init` called `loadIfUsable()` directly, and `loadIfUsable()` did its
work on whatever thread it was called from. `AttachmentsSheetController.present`
constructs the model on the main queue, so the two `PHAsset.fetchAssets` calls
and the `result.objects(at:)` materialization all ran on the main thread, inline
with the sheet presentation. `PHAsset.fetchAssets` is not a local read — it goes
out to the photo service over XPC, and the reported main-thread stack ends in
exactly that:

```
SheetModel.init (AttachmentsSheetView.swift:23)
SheetModel.loadIfUsable (AttachmentsSheetView.swift:42)
+[PHAsset fetchAssetsWithMediaType:options:]
-[PHQuery executeQuery]
-[NSXPCStore sendMessage:fromContext:interrupts:error:]
__semwait_signal
```

The main thread is parked in a semaphore wait for the whole duration.

## Fix

`loadIfUsable()` now hops to a `userInitiated` global queue, runs both fetches
there, and publishes the results back on the main queue, since the view model
drives SwiftUI. The fetch logic itself is unchanged — same media type, same sort
descriptors, same 30-item recents limit, same screenshots smart album — so the
sheet ends up showing exactly what it shows today. All four authorization states
behave as before: the `guard libraryUsable` gate still runs on the caller's
thread, `.limited` still loads, and the `requestAccess` path still calls the same
loader after a grant (now also off the main thread).

One addition, to avoid trading a hang for a new visible defect: because the list
is now empty for the first frames, the sheet would flash "No photos in your
library" on every open. A `hasLoaded` flag gates the two empty-state strings, and
the placeholder keeps its 96pt height so the carousel does not jump when the
thumbnails land. Once loaded, the sheet is pixel-identical to today.

### Triage notes

1. **User-visible harm:** anyone opening the attachments sheet gets a completely
   unresponsive app for up to ~3.6s before the sheet appears, on every open, on
   any device where the photo query is slow.
2. **Reach:** the code path is live on `main` (`bc66ee939`, #6688) and unchanged;
   this ships in the next mobile build and executes on every presentation.
3. **Why code:** archiving hides a reproducible freeze, and the sheet is not
   going away — #6761 (native composer) touches this module only in
   `AttachmentsSheet.podspec` (iOS platform bump) and `src/index.ts` (adds an
   optional `onDismiss`); the Swift sheet is untouched and the new native
   composer still presents it. No inbound-filter or other-layer option removes a
   main-thread block inside a native module.
4. **Scope:** the smallest change that removes the hang — move the fetches off
   main, publish on main, and don't introduce an empty-state flash. No new
   Sentry capture, no re-entrancy machinery, no redesign.
5. **Matcher:** not applicable — no classifier or matcher added.

## Verification

**Not built as an app here, and not run on a device.** `apps/mobile/ios` is not
checked in (Expo prebuild generates it) and there are no pods installed in this
worktree, so there is no iOS target to compile and no `bun test` covering Swift.
No TypeScript or JavaScript changed, so Biome does not apply.

What I did run: a type-check of the changed file against the real iOS SDK. The
module's other file imports `ExpoModulesCore` (needs pods), so `SheetTheme` — a
plain struct of `UIColor`s — was stubbed; `Photos`, `SwiftUI` and `UIKit` are the
real frameworks. The pre-change file was compiled the same way as a control.

```
$ SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
$ xcrun swiftc -typecheck -sdk "$SDK" -target arm64-apple-ios16.0-simulator \
    -swift-version 5 Original.swift SheetThemeShim.swift
control exit: 0

$ xcrun swiftc -typecheck -sdk "$SDK" -target arm64-apple-ios16.0-simulator \
    -swift-version 5 \
    apps/mobile/modules/attachments-sheet/ios/AttachmentsSheetView.swift \
    SheetThemeShim.swift
modified exit: 0

swift: swift-driver version: 1.148.6 Apple Swift version 6.3.2
sdk:   .../iPhoneSimulator26.5.sdk
```

Both clean, no warnings. That proves it compiles; it does not prove runtime
behaviour.

**A reviewer must check on a device or simulator with a populated library:**
the sheet opens immediately and stays interactive while the recents carousel
fills in; recents and the screenshots grid contain the same items as before;
no "No photos in your library" flash and no layout jump when thumbnails arrive;
the not-determined path still shows the permission card, and granting access
populates the sheet; `.limited` access still loads; selection, Add, and the
Photos/Camera/Files rows are unaffected.

Adjacent main-thread work noticed and deliberately left alone:
`PHPhotoLibrary.authorizationStatus(for:)` in the property initializer (a cheap
local check, not in the reported stack), and `AssetExporter.exportOne`'s
`isSynchronous = true` request, which already runs on a global queue.

Refs MOBILE-2

https://claude.ai/code/session_01QgCeuU9hPAGU2q27Jya1UU


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves attachments sheet photo fetches off the main thread to prevent open-time UI freezes. Previously, `loadIfUsable()` ran synchronously during presentation and blocked the app for up to ~3.6s; now fetches run on a background queue and publish results on main, keeping the sheet responsive with identical content and authorization behavior.

**Review notes**
- Fetch logic is unchanged: same media type, sort by newest, 30-item recents cap, and screenshots smart album; only `apps/mobile/modules/attachments-sheet/ios/AttachmentsSheetView.swift` is modified.
- Adds a `hasLoaded` flag to gate empty-state strings and keep a 96pt placeholder so the layout does not jump while thumbnails arrive.
- Verify on device or simulator with photos: the sheet opens immediately and stays interactive while recents/screenshots populate; no empty-state flash; not-determined and limited paths still work; selection and export are unaffected. No migration needed. Addresses Linear MOBILE-2.

<sup>Written for commit 464568eb9ca074e02bc40c4f16b97cfdc02c7148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo-library loading performance by running retrieval in the background.
  * Empty-state messages now appear only after photo-library content has finished loading.
  * Improved handling when screenshot albums are unavailable.
  * Recent photos, screenshots, and loading status now update more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->