### PR TITLE
fix(api): run the api test suite in CI and repair the slack interactions test

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
 		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'",
 		"start": "next start --port 3001",
+		"test": "bun test src",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/apps/api/src/app/api/integrations/slack/interactions/route.test.ts
+++ b/apps/api/src/app/api/integrations/slack/interactions/route.test.ts
@@ -14,18 +14,17 @@ mock.module("@/lib/analytics", () => ({
 
 mock.module("@superset/db/client", () => ({
 	db: {
-		query: { userIdentities: { findFirst: findSlackUser } },
+		query: {
+			userIdentities: { findFirst: findSlackUser },
+			// The route resolves the Slack workspace to an organization before it
+			// looks at any action. Returning a connection is what lets the tests
+			// below reach the action handling at all.
+			integrationConnections: {
+				findFirst: async () => ({ organizationId: "org-1" }),
+			},
+		},
 		update: () => ({ set: () => ({ where: async () => undefined }) }),
 		delete: () => ({ where: async () => undefined }),
-	},
-}));
-
-mock.module("@superset/db/schema", () => ({
-	userIdentities: {
-		provider: "provider",
-		externalId: "externalId",
-		externalScopeId: "externalScopeId",
-		id: "id",
 	},
 }));
 


### PR DESCRIPTION
## Problem

`apps/api` has four test files and **CI has never run any of them**. `turbo test` runs the `test` script per workspace, and `apps/api/package.json` did not define one — it was the only app with test files and no test script.

The consequence was invisible rot: `slack/interactions/route.test.ts` has been failing on `main` with nobody notified.

## Root cause

Mock drift, and specifically *not* a cross-file `mock.module` leak — the test fails in isolation too.

The test mocked `@superset/db/schema` with a single export:

```ts
mock.module("@superset/db/schema", () => ({
  userIdentities: { provider, externalId, externalScopeId, id },
}));
```

but `interactions/route.ts` line 2 imports **two** things from it:

```ts
import { integrationConnections, userIdentities } from "@superset/db/schema";
```

so the route module could not load at all — `SyntaxError: Export named 'integrationConnections' not found`. The mock also omitted `userIdentities.organizationId`, which the route uses in every one of its queries. The mock froze at one shape while the route grew past it.

## Fix

**Drop the schema mock rather than extend it.** `@superset/db/schema` is pure table definitions — its index is re-exports only, with no connection, no `process.env`, no `DATABASE_URL`. The db *client* is already mocked separately, so the schema mock was protecting against nothing and could only drift again. Using the real schema means the next table the route imports needs no test change.

That exposed the same drift one layer down: the db mock had no `query.integrationConnections`, which the route reads to resolve the Slack workspace to an organization *before* it inspects any action. Returning a connection matters for correctness of the tests, not just to stop the throw — without it the route returns early at `if (!connection)` and the action-handling assertions would pass having never executed the code they name.

Then add `"test": "bun test src"` to `apps/api/package.json`, matching `apps/web`.

## Verification

`cd apps/api && bun run test` — was: module would not load, `1 fail`, `1 error`.

```
 21 pass
 0 fail
 46 expect() calls
Ran 21 tests across 4 files. [52.00ms]
```

`bunx turbo test --filter=@superset/api` — turbo skipped this package entirely before; it now runs it:

```
@superset/api:test:  21 pass
@superset/api:test:  0 fail
 Tasks:    1 successful, 1 total
```

The `WARNING no output files found for task @superset/api#test` that turbo prints is pre-existing and not introduced here — the `test` task declares `outputs: ["coverage/**"]` and no package emits coverage. Confirmed identical on `@superset/port-scanner --force`.

**The repaired tests are not vacuous.** Removing the value-type check from `isSlackInteractionAction`:

```
(fail) slack interactions route > ignores model select actions with malformed selected option values
 5 pass
 1 fail
```

It fails that test and only that test. Before this change it could not have caught anything, because the module never loaded.

`cd apps/api && bun run typecheck` — clean. `bunx biome check` on both changed files — clean.

## Side effect worth noting

This also puts #6764's `recordWebhookDelivery` webhook-payload-leak test under CI. That test was correct and load-bearing when run by hand, but inert until now.

Found by the Sentry triage automation while gating #6764.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the `apps/api` test suite in CI and repairs the Slack interactions route test. CI previously skipped `apps/api` due to no `test` script, and the test failed from schema mock drift that prevented the module from loading.

- Add `"test": "bun test src"` to `apps/api/package.json` so `turbo test` runs `@superset/api`.
- Remove the mock of `@superset/db/schema`; use the real schema to prevent future drift.
- Update the `@superset/db/client` mock to include `query.integrationConnections.findFirst`, allowing the route to resolve the Slack workspace and reach action handling.
- CI now runs all `apps/api` tests, including the `recordWebhookDelivery` payload leak test.

<sup>Written for commit b3f92b798d36f1ef946b787acf7347ff5376d034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Slack interaction testing by providing the required connection context for action-handling scenarios.
  * Removed an unused test mock to streamline test setup.

* **Chores**
  * Added a command for running API tests with Bun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->