### PR TITLE
fix(host-service): name the phase in a worker task's timeout error

### DIFF
--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -5,11 +5,12 @@
 
 import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import type {
-	SerializedWorkerError,
-	WorkerShutdownRequestMessage,
-	WorkerTaskRequestMessage,
-	WorkerTaskResponseMessage,
+import {
+	isWorkerTaskPhaseMessage,
+	type SerializedWorkerError,
+	type WorkerShutdownRequestMessage,
+	type WorkerTaskRequestMessage,
+	type WorkerTaskResponseMessage,
 } from "./worker-task-protocol.ts";
 
 export class WorkerTaskError extends Error {
@@ -81,6 +82,8 @@ interface QueuedTask {
 	timeoutMs: number;
 	timeoutHandle?: NodeJS.Timeout;
 	slotId?: number;
+	/** Last phase the handler reported, if it reports any. */
+	phase?: string;
 }
 
 export const DEFAULT_TIMEOUT_MS = 60_000;
@@ -402,6 +405,13 @@ export class WorkerTaskRunner {
 		const slot = this.workerSlots.get(slotId);
 		if (!slot) return;
 
+		if (isWorkerTaskPhaseMessage(message)) {
+			if (slot.activeTaskId !== message.taskId) return;
+			const active = this.tasks.get(message.taskId);
+			if (active) active.phase = message.phase;
+			return;
+		}
+
 		if (!this.isWorkerResultMessage(message)) {
 			return;
 		}
@@ -476,10 +486,14 @@ export class WorkerTaskRunner {
 		const task = this.tasks.get(taskId);
 		if (!task) return;
 
+		// Name the phase when the handler reported one: the timer knows only
+		// that the budget expired, and the worker is retired right below, so
+		// this is the sole record of what was still running.
+		const phaseSuffix = task.phase ? ` in phase "${task.phase}"` : "";
 		this.rejectTask(
 			taskId,
 			new WorkerTaskError(
-				`[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms`,
+				`[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms${phaseSuffix}`,
 			),
 		);
 

--- a/packages/host-service/src/workers/define-worker-task.ts
+++ b/packages/host-service/src/workers/define-worker-task.ts
@@ -5,10 +5,15 @@
 // clone-safe and free of DB/event-bus/native imports (see
 // no-native-worker-imports.test.ts).
 
+/** Names the step a multi-step handler is about to start. The pool keeps the
+ * last value and names it in the task's timeout error, so a handler that
+ * hangs says where it hung. Single-step handlers ignore it. */
+export type ReportTaskPhase = (phase: string) => void;
+
 export interface WorkerTaskDefinition<TInput, TResult> {
 	/** Namespaced as "<domain>/<task>", e.g. "git/getStatusSnapshot". */
 	type: string;
-	handler: (input: TInput) => Promise<TResult>;
+	handler: (input: TInput, reportPhase?: ReportTaskPhase) => Promise<TResult>;
 }
 
 export function defineWorkerTask<TInput, TResult>(

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -5,7 +5,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { defineWorkerTask } from "./define-worker-task.ts";
 import { HostWorkerPool } from "./host-worker-pool.ts";
-import { gitStatusSnapshotTask } from "./tasks/git.ts";
+import {
+	gitStatusSnapshotTask,
+	gitWorktreeRemoveTask,
+	gitWorktreeStateTask,
+} from "./tasks/git.ts";
 
 const WORKER_ENTRY = path.resolve(import.meta.dirname, "host-worker.ts");
 const CRASH_WORKER = path.resolve(
@@ -68,6 +72,65 @@ function makeFixtureRepo(): string {
 	return dir;
 }
 
+// A `git` shimmed onto the front of PATH that blocks on one subcommand:
+// `gitEnv` is the spawned process's whole environment, so this is how a real
+// task can be stalled in a chosen phase without stalling real git. The rest
+// of PATH stays real — the shim needs `sleep`.
+//
+// It blocks on a sentinel rather than for a fixed duration: a `sleep` long
+// enough to survive a loaded machine is also a `sleep` left running after the
+// test, and one short enough to clean up can expire mid-assertion and let the
+// task succeed. Waiting on its own existence gives an unbounded hang that
+// afterEach's fixture cleanup releases within ~100ms.
+function makeHangingGitShim(hangOn: "remove" | "list" | "status" | "none"): {
+	dir: string;
+	gitEnv: { PATH: string };
+} {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "host-worker-gitshim-"));
+	fixtureDirs.push(dir);
+	const shim = path.join(dir, "git");
+	const hang = `while [ -f "${shim}" ]; do sleep 0.1; done`;
+	fs.writeFileSync(
+		shim,
+		`#!/bin/sh
+case "$*" in
+  *"worktree remove"*) ${hangOn === "remove" ? hang : ""} ;;
+  *"worktree list"*) ${hangOn === "list" ? hang : ""} ;;
+  status*) ${hangOn === "status" ? hang : ""} ;;
+esac
+exit 0
+`,
+		{ mode: 0o755 },
+	);
+	return { dir, gitEnv: { PATH: `${dir}:/usr/bin:/bin` } };
+}
+
+function shimInput(shim: { dir: string; gitEnv: { PATH: string } }) {
+	return {
+		repoPath: shim.dir,
+		worktreePath: path.join(shim.dir, "wt"),
+		gitEnv: shim.gitEnv,
+	};
+}
+
+// Boot the worker before a timed run. A cold worker compiles the whole task
+// module graph first (~300ms idle, more under load), which can burn a short
+// budget before the handler runs at all — the task would then time out having
+// reported nothing and the phase assertions would flake. Warm, the first
+// phase is reported within a message hop of dispatch.
+async function warmPool(pool: HostWorkerPool): Promise<void> {
+	await pool.run(gitWorktreeRemoveTask, shimInput(makeHangingGitShim("none")));
+}
+
+async function rejectionOf(promise: Promise<unknown>): Promise<Error> {
+	const error = await promise.then(
+		() => null,
+		(reason: Error) => reason,
+	);
+	if (!error) throw new Error("expected a rejection, got a resolved value");
+	return error;
+}
+
 describe("HostWorkerPool", () => {
 	test("worker result matches inline handler result (parity)", async () => {
 		const worktreePath = makeFixtureRepo();
@@ -86,6 +149,80 @@ describe("HostWorkerPool", () => {
 		expect(fromWorker.snapshot.staged.map((f) => f.path)).toEqual([
 			"staged.txt",
 		]);
+	});
+
+	// HOST-SERVICE-17 / HOST-SERVICE-47: `git/removeWorktree` blows its budget
+	// in the field and the timeout named only the budget, so the steps that
+	// stall for unrelated reasons were indistinguishable. These drive the real
+	// task through the real pool and worker and assert, on the exact message
+	// the caller sees, that it says which step hung.
+	test("worker timeout names the phase that was running (worktree-remove)", async () => {
+		const shim = makeHangingGitShim("remove");
+		const pool = makePool();
+		await warmPool(pool);
+
+		const error = await rejectionOf(
+			pool.run(gitWorktreeRemoveTask, shimInput(shim), { timeoutMs: 1_000 }),
+		);
+
+		expect(error.message).toBe(
+			'[host-worker] Task "git/removeWorktree" timed out after 1000ms in phase "worktree-remove"',
+		);
+	});
+
+	test("worker timeout names the phase that was running (worktree-list)", async () => {
+		// Same task, same budget, same shim — only the stalling subcommand
+		// differs. A label that tracked the task rather than the step, or one
+		// left over from the step before, fails here.
+		const shim = makeHangingGitShim("list");
+		const pool = makePool();
+		await warmPool(pool);
+
+		const error = await rejectionOf(
+			pool.run(gitWorktreeRemoveTask, shimInput(shim), { timeoutMs: 1_000 }),
+		);
+
+		expect(error.message).toBe(
+			'[host-worker] Task "git/removeWorktree" timed out after 1000ms in phase "worktree-list"',
+		);
+	});
+
+	test("a task that reports no phase keeps its timeout message unchanged", async () => {
+		// The other half of the contract: this adds information to a failure,
+		// it does not change one. `git/worktreeState` reports no phases, so its
+		// timeout must read exactly as it did before.
+		const shim = makeHangingGitShim("status");
+		const pool = makePool();
+		await warmPool(pool);
+
+		const error = await rejectionOf(
+			pool.run(
+				gitWorktreeStateTask,
+				{ worktreePath: shim.dir, gitEnv: shim.gitEnv },
+				{ timeoutMs: 1_000 },
+			),
+		);
+
+		expect(error.message).toBe(
+			'[host-worker] Task "git/worktreeState" timed out after 1000ms',
+		);
+	});
+
+	test("inline timeout names the phase too", async () => {
+		// The pool degrades to inline on a missing bundle or crash-looping
+		// workers; that path enforces the same budget and must stay as
+		// diagnosable as the worker one.
+		const shim = makeHangingGitShim("remove");
+		const pool = makePool({ scriptPathResolver: () => null });
+		expect(pool.getMode()).toBe("inline");
+
+		const error = await rejectionOf(
+			pool.run(gitWorktreeRemoveTask, shimInput(shim), { timeoutMs: 1_000 }),
+		);
+
+		expect(error.message).toBe(
+			'[host-worker] Task "git/removeWorktree" timed out after 1000ms in phase "worktree-remove" (inline)',
+		);
 	});
 
 	test("unknown task type rejects with the worker's error", async () => {

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -164,6 +164,8 @@ export class HostWorkerPool {
 
 		return new Promise<TResult>((resolve, reject) => {
 			let settled = false;
+			// Same phase record as the worker path, minus the message hop.
+			let phase: string | undefined;
 			const settle = (fn: () => void) => {
 				if (settled) return;
 				settled = true;
@@ -178,7 +180,9 @@ export class HostWorkerPool {
 					settle(() =>
 						reject(
 							new WorkerTaskError(
-								`[host-worker] Task "${def.type}" timed out after ${timeoutMs}ms (inline)`,
+								`[host-worker] Task "${def.type}" timed out after ${timeoutMs}ms${
+									phase ? ` in phase "${phase}"` : ""
+								} (inline)`,
 							),
 						),
 					),
@@ -193,7 +197,11 @@ export class HostWorkerPool {
 			// Promise.resolve() wrapper: a synchronously-throwing handler must
 			// route through settle() too, or the timer and abort listener leak.
 			Promise.resolve()
-				.then(() => def.handler(input))
+				.then(() =>
+					def.handler(input, (reported) => {
+						phase = reported;
+					}),
+				)
 				.then((result) => settle(() => resolve(result)))
 				.catch((error) => settle(() => reject(error)));
 		});

--- a/packages/host-service/src/workers/host-worker.ts
+++ b/packages/host-service/src/workers/host-worker.ts
@@ -10,6 +10,7 @@ import { killAndReapTrackedChildren } from "./worker-child-tracker.ts";
 import {
 	isWorkerShutdownRequestMessage,
 	serializeWorkerError,
+	type WorkerTaskPhaseMessage,
 	type WorkerTaskRequestMessage,
 } from "./worker-task-protocol.ts";
 
@@ -56,7 +57,14 @@ parentPort.on("message", async (message: unknown) => {
 		if (!def) {
 			throw new Error(`unknown worker task type: ${task.taskType}`);
 		}
-		const result = await def.handler(task.payload);
+		const result = await def.handler(task.payload, (phase) => {
+			const phaseMessage: WorkerTaskPhaseMessage = {
+				kind: "phase",
+				taskId: task.taskId,
+				phase,
+			};
+			parentPort?.postMessage(phaseMessage);
+		});
 		parentPort?.postMessage({
 			kind: "result",
 			taskId: task.taskId,

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -200,21 +200,32 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 	{ stillRegistered: boolean }
 >({
 	type: "git/removeWorktree",
-	handler: async ({ repoPath, worktreePath, gitEnv }) => {
+	// This task outlives its caller's budget in the field (HOST-SERVICE-17,
+	// HOST-SERVICE-47) and the timeout named only the budget. Its steps stall
+	// for unrelated reasons, so each announces itself before starting and the
+	// pool names the last one in the timeout error.
+	handler: async ({ repoPath, worktreePath, gitEnv }, reportPhase) => {
+		// Labelled from the first statement so every moment of the handler
+		// falls under some phase — an unlabelled timeout would be
+		// indistinguishable from one reported by a build without this.
+		reportPhase?.("resolve-path");
 		const git = createUserSimpleGit(repoPath).env(gitEnv);
 		// Remove against git's canonical path so a symlinked stored path
 		// (macOS `/var` → `/private/var`) still matches its registration.
+		// `realpathSync.native` is a blocking syscall, hence its own phase.
 		const target = normalizeWorktreePath(worktreePath);
 		// Best-effort: the registry read below is authoritative, not the
 		// command's locale- and version-dependent exit text. `--force --force`
 		// also unregisters a worktree whose directory is already gone, so no
 		// separate prune (which would clobber other stale worktrees' metadata)
 		// is needed.
+		reportPhase?.("worktree-remove");
 		await git
 			.raw(["worktree", "remove", "--force", "--force", target])
 			.catch(() => {});
 		// A `worktree list` failure throws out of the task: the post-remove
 		// state is unknown and the caller must not treat it as removed.
+		reportPhase?.("worktree-list");
 		const raw = await git.raw(["worktree", "list", "--porcelain"]);
 		return {
 			stillRegistered: parseWorktreeList(raw).some(

--- a/packages/host-service/src/workers/worker-task-protocol.ts
+++ b/packages/host-service/src/workers/worker-task-protocol.ts
@@ -33,6 +33,31 @@ export function isWorkerShutdownRequestMessage(
 	);
 }
 
+/** Worker → main thread: the handler has entered a named phase.
+ *
+ * The task budget is enforced by a timer in the parent, which otherwise has
+ * no idea which step of a multi-step handler was in flight when it expired —
+ * and the worker is retired straight afterwards, so there is nothing left to
+ * ask. This carries that one fact out ahead of the hang. Best-effort: a phase
+ * that arrives after the timeout is ignored. */
+export interface WorkerTaskPhaseMessage {
+	kind: "phase";
+	taskId: string;
+	phase: string;
+}
+
+export function isWorkerTaskPhaseMessage(
+	message: unknown,
+): message is WorkerTaskPhaseMessage {
+	if (!message || typeof message !== "object") return false;
+	const candidate = message as Partial<WorkerTaskPhaseMessage>;
+	return (
+		candidate.kind === "phase" &&
+		typeof candidate.taskId === "string" &&
+		typeof candidate.phase === "string"
+	);
+}
+
 export type WorkerTaskResponseMessage =
 	| {
 			kind: "result";

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -568,6 +568,40 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 		);
 	});
 
+	test("worktree-removal timeout carries its phase into the reported error", async () => {
+		// The Sentry event for HOST-SERVICE-17 / -47 is this TRPCError, and its
+		// message is the pool's timeout text verbatim — so a phase named there
+		// is a phase named in the report. Without this link the label would
+		// stop at the pool and never reach anyone triaging.
+		const poolTimeout = new WorkerTaskError(
+			'[host-worker] Task "git/removeWorktree" timed out after 120000ms in phase "worktree-remove"',
+		);
+		const ctx = makeCtx({
+			workspace: {
+				id: "ws-1",
+				projectId: "p-1",
+				worktreePath: "/branch/wt",
+				branch: "feature",
+			},
+			project: { id: "p-1", repoPath: "/repo" },
+			removeWorktree: () => Promise.reject(poolTimeout),
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+
+		const error = await caller
+			.destroy({ workspaceId: "ws-1", deleteBranch: false, force: true })
+			.then(() => null)
+			.catch((err: Error) => err);
+
+		// Built from the pool error rather than restated, so the two halves
+		// cannot drift; the pool's exact wording is pinned by the phase tests
+		// in src/workers/host-worker-pool.test.ts.
+		expect(error?.message).toBe(
+			`Failed to verify worktree removal at /branch/wt: ${poolTimeout.message}`,
+		);
+		expect(error?.message).toContain('in phase "worktree-remove"');
+	});
+
 	test("preflight pool timeout fails closed instead of skipping the dirty check", async () => {
 		const ctx = makeCtx({
 			workspace: {


### PR DESCRIPTION
## Problem

Deleting a workspace runs `git worktree remove` as a worker-pool task with a
two-minute budget. On some machines the task never returns, the pool kills it,
the deletion fails, and the user retries into the same two-minute wait. The
error that reaches Sentry says only:

```
Failed to verify worktree removal at <path>: [host-worker] Task "git/removeWorktree" timed out after 120000ms
```

That is the whole report. The task does three things that stall for entirely
unrelated reasons — a blocking `realpathSync.native` on the worktree path, the
`git worktree remove --force --force` subprocess (which recursively deletes the
tree), and the `git worktree list --porcelain` read afterwards — and nothing
distinguishes them. The condition has been raised as needing an owner on four
consecutive triage runs and has never been diagnosable from its own telemetry.

**User-visible harm:** a user deleting a workspace waits two minutes, gets a
failure, and the workspace is still there; retrying costs another two minutes.
HOST-SERVICE-17 has 192 occurrences between 2026-08-10 and today on one machine
(release 1.23.0); HOST-SERVICE-47 is the same condition on a second machine in a
different organization (6 occurrences, release 1.24.1). Both are live released
builds.

**This PR does not fix that hang** — we still do not know what hangs, which is
the point. It makes the next occurrence say which step was in flight.

**Will this reach the reported failure?** Yes, and the path is exact. The Sentry
event *is* the `TRPCError` thrown at `workspace-cleanup.ts:525`, and its message
interpolates the pool's timeout text verbatim (it is also the `trpc_message`
extra). Enriching that text puts the phase in the issue title and in the event
body. The captured events carry no `(inline)` suffix, so they came from the
worker path — which is what this instruments; the inline fallback is covered
too. Sentry groups these by stacktrace, not message (192 events with 192
different worktree paths share one group), so the existing issues keep
collecting rather than fragmenting.

**Why code, versus the alternatives?** Archiving is what already happened to
HOST-SERVICE-47 (`archived_until_escalating`) and the condition simply came back
on another machine. The code path cannot be deleted — it is the core of workspace
deletion. An inbound Sentry filter is forbidden by repo law (#6164) and would
destroy the only signal there is. Fixing at another layer — raising the budget,
retrying, making removal more tolerant — would mask the hang without explaining
it. Doing nothing is what four triage runs already did. The missing fact exists
only inside the worker at the moment it stalls, and nothing but the worker can
observe it.

No classifier or matcher is added here.

## Root cause of the blind spot

The budget is enforced by a `setTimeout` in the parent (`WorkerTaskRunner`),
while the phases run inside the worker thread. When the timer fires, the parent
knows the elapsed time and nothing else — and it immediately retires the worker,
so there is nothing left to interrogate afterwards either.

**Design choice (worker reports outward, not parent reconstructs).** The parent
has no way to reconstruct the phase: it holds one timer and one opaque task
payload, the handler's progress leaves no trace it can read, and the worker is
killed the instant the budget expires. The only shape that reconstructs anything
in the parent would be splitting `git/removeWorktree` into one pool call per
step, which would change the deletion's failure semantics — a partial removal
would become an observable intermediate state the saga has to handle — and that
is out of scope for a capture-enrichment change. So the worker announces each
step as it starts, the parent keeps the last announcement, and the timeout names
it. That is one message kind, one optional callback, and one string; there is no
progress framework here, no percentages, no subscribers, and a task that reports
nothing produces byte-identical output to before.

## Fix

- `worker-task-protocol.ts`: a `{kind: "phase", taskId, phase}` message and its
  type guard.
- `define-worker-task.ts`: handlers get an optional second argument,
  `reportPhase(phase)`. Existing handlers are untouched and ignore it.
- `host-worker.ts`: binds `reportPhase` to the running task's id.
- `WorkerTaskRunner.ts`: records the last phase per task; the timeout error
  appends ` in phase "<phase>"` **when one was reported**, leaving the message
  unchanged otherwise.
- `host-worker-pool.ts`: same for the inline fallback, which enforces the same
  budget and would otherwise stay undiagnosable.
- `tasks/git.ts`: `gitWorktreeRemoveTask` reports `resolve-path`,
  `worktree-remove`, `worktree-list`. The first statement is labelled so no
  moment of the handler is unlabelled — an unlabelled timeout would be
  indistinguishable from one produced by a build without this change.

Nothing else changes: not the 120000ms budget, not retry behaviour, not what the
user sees, not the deletion logic.

A note on the brief: it described the middle step as "delete a leftover
directory directly". That step exists but lives in `runDestroyPhases` in the
parent process, outside the worker budget, so it cannot be the step that
expires. The handler's actual three steps are the ones labelled above.

## Verification

All run on this branch; output pasted verbatim.

`bunx biome check` on the changed files:

```
Checked 8 files in 10ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
TYPECHECK EXIT=0
```

`bun test packages/host-service` — the whole package, including
`test/workspace-cleanup.test.ts`, which #6753 also edits:

```
 1213 pass
 8 todo
 0 fail
Ran 1221 tests across 115 files. [213.91s]
```

### Proof of the outcome, not an assertion of it

Four tests in `host-worker-pool.test.ts` shim a `git` onto the front of `PATH`
that blocks on a chosen subcommand, then drive the **real**
`gitWorktreeRemoveTask` through the **real** pool, worker thread and task
registry — the only fakes are `git` itself and the budget — and assert on the
**exact** message the caller receives:

```
(pass) HostWorkerPool > worker timeout names the phase that was running (worktree-remove)
(pass) HostWorkerPool > worker timeout names the phase that was running (worktree-list)
(pass) HostWorkerPool > a task that reports no phase keeps its timeout message unchanged
(pass) HostWorkerPool > inline timeout names the phase too
```

The two `removeWorktree` cases are the same task with the same budget and the
same shim, differing only in which subcommand stalls — so a label that tracked
the task rather than the step, or one left over from the step before, fails one
of them. The third is the other half of the contract: `git/worktreeState`
reports no phases, so its timeout must read exactly as it did before.

With the three `reportPhase` calls disabled, the three phase tests fail and the
no-phase test still passes — they are not vacuous, and the no-phase test is not
secretly coupled to the machinery:

```
(fail) HostWorkerPool > worker timeout names the phase that was running (worktree-remove)
(fail) HostWorkerPool > worker timeout names the phase that was running (worktree-list)
(fail) HostWorkerPool > inline timeout names the phase too
 11 pass
 3 fail
```

Two determinism notes, because a timing-dependent test that hangs a subprocess
is easy to get subtly wrong:

- **The worker is warmed before each timed run.** A cold worker compiles the
  whole task module graph first — measured at ~305ms against a 1000ms budget on
  an idle machine — which could burn the budget before the handler ran at all,
  timing the task out having reported nothing. Warm, the first phase is reported
  within a message hop of dispatch, so the margin stops depending on machine
  load.
- **The shim blocks on a sentinel, not a `sleep`.** A fixed `sleep` long enough
  to survive a loaded machine is also one left running after the test, and one
  short enough to clean up can expire mid-assertion and let the task *succeed* —
  a false pass. The shim instead spins until its own file is removed, which
  `afterEach`'s existing fixture cleanup does, giving an unbounded hang with
  bounded cleanup.

The suite passes 3/3 under 16-way CPU contention as well as idle.

A fourth test in `test/workspace-cleanup.test.ts` closes the last link — that the
label survives into the error the reporter actually captures. It is a unit test
of the interpolation: it builds its expectation from the injected pool error
rather than restating it, so the two halves cannot drift, and the pool's exact
wording is pinned separately by the tests above.

Repo-wide `bun run lint` was not run — it hangs on cross-worktree bun locks.

Not covered by a test: the `resolve-path` label. Making `realpathSync.native`
block on demand is not something a test can arrange portably, so that one line
rests on inspection.

---

**Stacked on #6753** (`fix/delete-orphan-worktree-fallback`), not `main` — that PR
edits `workers/tasks/git.ts` and `test/workspace-cleanup.test.ts` too, and this
builds on top of it without reverting or restating any of it. Review the single
commit `d4b037b9a`; everything below it belongs to #6753.

Note for whoever merges: #6753 is a fork PR, so its branch did not exist on
`superset-sh/superset` and could not be used as a base ref. The base branch here
is a mirror of #6753's head (`95c5d2112`) pushed to this repo purely to make the
stack expressible — **delete `fix/delete-orphan-worktree-fallback` once #6753
merges**, and retarget this PR at `main`.

Both issues stay **open** as their own trackers. This does not resolve the hang;
it makes the next occurrence say where it hung — hence `Refs`, not `Fixes`.

Refs HOST-SERVICE-47
Refs HOST-SERVICE-17

https://claude.ai/code/session_01BrNKdKTC54LnA9jdpDDtA8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the in-flight phase in worker task timeout errors so triage can see which step hung. Previously the timeout named only elapsed time; now it appends the last reported phase, improving signal for `git/removeWorktree` timeouts (HOST-SERVICE-17, -47).

- Adds a worker→parent `phase` message and guard; `WorkerTaskRunner` records the last phase and appends it to timeout errors; the inline path does the same.
- Extends `define-worker-task` so handlers can accept an optional `reportPhase(phase)`; existing handlers need no changes.
- Instruments `gitWorktreeRemoveTask` to report `resolve-path`, `worktree-remove`, and `worktree-list`.
- Keeps all other behavior unchanged: budgets, retries, deletion logic, and Sentry grouping. Tasks that report no phase keep the exact prior timeout message.

<sup>Written for commit 1216030d1f022de5b29168e9df0403e37e4959f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress phase reporting for background tasks.
  * Timeout errors now identify the task phase that was active when the timeout occurred.
  * Git worktree cleanup reports progress during path resolution, removal, and verification.

* **Bug Fixes**
  * Improved timeout diagnostics for both worker-based and inline task execution.

* **Tests**
  * Added coverage for phase-aware timeout messages and cleanup error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->