### PR TITLE
fix(desktop): equalize pane splits actually moves v2 panes

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -63,6 +63,20 @@ function SplitView<TData>({
 		};
 	}, [onSplitResizeDragging, resizeSourceId]);
 
+	// `defaultSize` is only read when the group mounts, so a layout change that
+	// comes from the store (equalize, a preset) has to be pushed through the
+	// imperative handle or the panels stay where the user last dragged them.
+	useEffect(() => {
+		const group = groupRef.current;
+		if (!group) return;
+
+		const layout = group.getLayout();
+		if (layout.length !== 2) return;
+		if (Math.abs((layout[0] ?? 0) - firstSize) < 0.01) return;
+
+		group.setLayout([firstSize, secondSize]);
+	}, [firstSize, secondSize]);
+
 	return (
 		<ResizablePanelGroup
 			ref={groupRef}


### PR DESCRIPTION
## Summary
- ⌘⇧0 (Equalize Pane Splits) and the pane context-menu item of the same name were no-ops in v2 workspaces: the store recomputed every split percentage, but the panels never moved.
- `SplitView` now pushes the store's split percentage into the `ResizablePanelGroup` through its imperative handle whenever the percentage changes.

## Why / Context
`react-resizable-panels` treats `defaultSize` as mount-time-only — after mount, panel sizes live in the group's own layout state and only change via a drag or `setLayout`. `equalizeTab`/`equalizeSplit` rewrite `splitPercentage` in the panes store, which re-rendered `ResizablePanel` with a new `defaultSize` that the library ignores. The v1 workspace uses react-mosaic (fully controlled), which is why only v2 was affected.

Same root cause for both entry points, since both call `equalizeTab` on the store.

## How It Works
An effect keyed on the node's split percentage compares the group's current layout to the store's value and calls `setLayout([first, second])` when they differ (0.01 tolerance). `setLayout` is a no-op when the layout already matches, and it re-emits `onLayout`, so any value the library clamps is written back to the store — no feedback loop, and dragging still owns the layout while the user is dragging.

The sync is general, not equalize-specific: any store-driven size change (e.g. a preset layout) now reaches the DOM.

## Manual QA
Drove the running dev app over CDP (v2 workspace, real key/mouse input), measuring `data-panel-size` plus screenshots before and after:

- **Repro before the fix**: ⌘T, ⌘D, ⌘⇧D, dragged the root divider to 26.5/73.5, pressed ⌘⇧0 → sizes unchanged (26.5/73.5).
- **After the fix**, same journey → 33.3/66.7 (leaf-weighted equal areas), divider visibly moves.
- Equalize pressed twice in a row is stable (no jitter).
- Oscillating drags across the handle with mid-gesture dwells and an induced 120ms/400ms main-thread stall: no feedback loop, `console.error` empty.
- Dragging after an equalize still works (33.3/66.7 → 17.1/82.9), so the sync effect doesn't fight the user.
- Three-level nesting: [6.3/93.7, 38.1/61.9, 50/50] → [25/75, 33.3/66.7, 50/50].
- Context-menu "Equalize Pane Splits": [5.1/94.9, …] → [25/75, …].
- Layout survives leaving the workspace route and coming back, so store and DOM agree.

## Testing
- `bunx turbo test --filter=@superset/panes` — 100 pass
- `bunx turbo test --filter=@superset/desktop` — 2792 pass
- `bunx turbo typecheck --filter=@superset/panes --filter=@superset/desktop`
- `biome check` on the changed file

https://claude.ai/code/session_01Td2NUVeMANb1qfap6xtzxt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Equalizes pane splits in v2 workspaces by pushing store-driven sizes into the `ResizablePanelGroup` layout. Previously, ⌘⇧0 and the “Equalize Pane Splits” menu were no-ops; now panes move to the equalized sizes and any store-driven size change applies.

- Adds a `useEffect` in `SplitView` that reads the group layout and calls `setLayout([firstSize, secondSize])` when it differs (0.01 tolerance).
- Maintains drag behavior: `setLayout` is a no-op when matching and re-emits `onLayout`, so clamped values flow back to the store without feedback loops.
- Scope: v2 (`react-resizable-panels`) only; v1 (`react-mosaic`) was already controlled and unaffected.

<sup>Written for commit d88d7c965d857074ed5577b2b3183b1f687094bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-panel layout synchronization when split sizes change.
  * Prevented unnecessary layout updates when the current arrangement is already within the expected tolerance.
  * Added safeguards for unavailable split groups or unexpected panel configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->