### PR TITLE
fix(desktop): one 1px border between the panes and the sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/PRActionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/PRActionHeader.tsx
@@ -22,7 +22,7 @@ export function PRActionHeader({
 	const action = selectActionButton(state);
 
 	return (
-		<div className="@container flex h-12 shrink-0 items-center gap-2 bg-muted/45 px-2 dark:bg-muted/35">
+		<div className="@container flex h-10 shrink-0 items-center gap-2 bg-muted/45 px-2 dark:bg-muted/35">
 			<div className="drag h-full min-w-0 flex-1" />
 			<div className="flex items-center gap-2">
 				<V2WorkspaceOpenInButton workspaceId={workspaceId} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -19,7 +19,7 @@ export function SidebarHeader({
 	const actions = tabs.find((t) => t.id === activeTab)?.actions;
 
 	return (
-		<div className="flex h-10 shrink-0 items-stretch">
+		<div className="-mt-px flex h-10 shrink-0 items-stretch">
 			<div className="flex min-w-0 flex-1 items-center h-full overflow-hidden">
 				{tabs.map((tab, index) => {
 					const isActive = activeTab === tab.id;

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -29,6 +29,7 @@ interface PaneComponentProps<TData> {
 	pane: PaneType<TData>;
 	isActive: boolean;
 	registry: PaneRegistry<TData>;
+	// null only for a solo pane (the layout root)
 	parentDirection?: "horizontal" | "vertical" | null;
 	paneActions?:
 		| PaneActionConfig<TData>[]
@@ -245,13 +246,7 @@ export function Pane<TData>({
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
-				// parentDirection is null only for a solo pane (layout root), which
-				// needs no focus outline.
-				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden border-2 transition-colors duration-150 ${
-					isActive && parentDirection !== null
-						? "border-primary/15"
-						: "border-transparent"
-				}`}
+				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden`}
 				onMouseDown={context.actions.focus}
 			>
 				<PaneHeader


### PR DESCRIPTION
Opening a file leads to some "double" borders. It leads to a lot of variance in the different border styles used in the app. There is also a misalignment (shown below) that is fixed. 

### Top strip alignment

![alignment](https://raw.githubusercontent.com/0x962/superset/pr-assets/double-border/pr-assets/double-border/cmp-alignment.png)

### Pane seams

![seams](https://raw.githubusercontent.com/0x962/superset/pr-assets/double-border/pr-assets/double-border/cmp-seams.png)

### Full window

Before:

![before](https://raw.githubusercontent.com/0x962/superset/pr-assets/double-border/pr-assets/double-border/full-before.png)

After:

![after](https://raw.githubusercontent.com/0x962/superset/pr-assets/double-border/pr-assets/double-border/full-after.png)

https://claude.ai/code/session_01AWpYhSNQVyCQWUfuJ4X5bP



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure a single 1px seam between panes and the right sidebar, and align the sidebar header with the pane tab bar. Old: focused panes drew a 2px border beside a 1px divider (3px seam) and the sidebar header sat lower; New: panes draw no box border, seams are 1px, headers align at 40px; focus is indicated by header opacity.

- Remove the pane’s 2px focus border in `packages/panes` Pane; rely on `PaneHeader` dimming inactive panes.
- Keep the single 1px seam from the split ResizableHandle and the sidebar ResizablePanel; no adjacent double lines.
- Set `PRActionHeader` to `h-10` to match the TabBar height in `packages/panes`.
- Apply `-mt-px` to `SidebarHeader` so its top border shares a row with the tab bar’s bottom border.
- Scope: v2 workspace only; the v1 route using `mosaic-theme.css` is unchanged.
- Review: open two panes next to the right sidebar; seams should be 1px and the two horizontal borders should meet; confirm focus readability without a box outline.

<sup>Written for commit fb96411389554349b1db733c7cc28eeca9d2539b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted workspace sidebar and pull request header spacing for a more compact layout.
  * Simplified pane borders by removing the active-pane border highlight and transition effect.
  * Preserved existing layout and behavior across workspace navigation and panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->