### PR TITLE
feat(workspaces): start work in the project folder without a worktree

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
@@ -67,6 +67,7 @@ export function useDashboardNewWorkspaceDraft() {
 			branchNameFromProvider: store.branchNameFromProvider,
 			linkedIssues: store.linkedIssues,
 			linkedPR: store.linkedPR,
+			noWorktree: store.noWorktree,
 			selectedAgentId: store.selectedAgentId,
 			attachments: store.attachments,
 		})),

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -711,13 +711,16 @@ export function PromptGroup({
 						)}
 					</AnimatePresence>
 					{/* A pull request is checked out into a worktree of its own,
-					    so the folder is not a choice there. */}
-					{!draft.isSession && !linkedPR && (
-						<WorkspaceFolderPicker
-							noWorktree={draft.noWorktree}
-							onChange={(noWorktree) => updateDraft({ noWorktree })}
-						/>
-					)}
+					    and a cloud workspace runs on a machine that has no
+					    project folder, so neither offers the choice. */}
+					{!draft.isSession &&
+						!linkedPR &&
+						(draft.hostId ?? machineId) !== CLOUD_HOST_ID && (
+							<WorkspaceFolderPicker
+								noWorktree={draft.noWorktree}
+								onChange={(noWorktree) => updateDraft({ noWorktree })}
+							/>
+						)}
 				</div>
 				<div className="flex items-center gap-1.5">
 					{needsSetup ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -56,6 +56,7 @@ import { PRLinkCommand } from "./components/PRLinkCommand";
 import { ProjectPickerPill } from "./components/ProjectPickerPill";
 import { PromptHistoryCommand } from "./components/PromptHistoryCommand";
 import { UploadingAttachmentPill } from "./components/UploadingAttachmentPill";
+import { WorkspaceFolderPicker } from "./components/WorkspaceFolderPicker";
 import { useBranchPickerController } from "./hooks/useBranchPickerController";
 import { useLinkedContext } from "./hooks/useLinkedContext";
 import { useSubmitWorkspace } from "./hooks/useSubmitWorkspace";
@@ -709,6 +710,14 @@ export function PromptGroup({
 							</motion.div>
 						)}
 					</AnimatePresence>
+					{/* A pull request is checked out into a worktree of its own,
+					    so the folder is not a choice there. */}
+					{!draft.isSession && !linkedPR && (
+						<WorkspaceFolderPicker
+							noWorktree={draft.noWorktree}
+							onChange={(noWorktree) => updateDraft({ noWorktree })}
+						/>
+					)}
 				</div>
 				<div className="flex items-center gap-1.5">
 					{needsSetup ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceFolderPicker/WorkspaceFolderPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceFolderPicker/WorkspaceFolderPicker.tsx
@@ -1,0 +1,89 @@
+import { Command, CommandItem, CommandList } from "@superset/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { useState } from "react";
+import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
+import { LuFolderGit2, LuFolderOpen } from "react-icons/lu";
+import { FormPickerTrigger } from "../FormPickerTrigger";
+
+interface WorkspaceFolderPickerProps {
+	/** True while the workspace is set to run in the project's own folder. */
+	noWorktree: boolean;
+	onChange: (noWorktree: boolean) => void;
+}
+
+/**
+ * Picks the folder the new workspace runs in: a git worktree of its own, or
+ * the folder the project itself lives in.
+ *
+ * The project folder is the same one the user has open in their editor, and
+ * a project has exactly one workspace for it, so picking it opens that
+ * workspace instead of creating another one.
+ */
+export function WorkspaceFolderPicker({
+	noWorktree,
+	onChange,
+}: WorkspaceFolderPickerProps) {
+	const [open, setOpen] = useState(false);
+
+	const options = [
+		{
+			value: false,
+			label: "New worktree",
+			description: "A folder of its own, so the project folder is untouched.",
+			icon: LuFolderGit2,
+		},
+		{
+			value: true,
+			label: "Project folder",
+			description: "Work where the project already is. No worktree is added.",
+			icon: LuFolderOpen,
+		},
+	];
+	const selected = options.find((option) => option.value === noWorktree);
+	const SelectedIcon = selected?.icon ?? LuFolderGit2;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<FormPickerTrigger className="max-w-full">
+					<SelectedIcon className="size-3 shrink-0" />
+					<span className="truncate">{selected?.label}</span>
+					<HiChevronUpDown className="size-3 shrink-0" />
+				</FormPickerTrigger>
+			</PopoverTrigger>
+			<PopoverContent className="w-[320px] p-0" align="start">
+				<Command>
+					<CommandList>
+						{options.map((option) => {
+							const OptionIcon = option.icon;
+							return (
+								<CommandItem
+									key={option.label}
+									value={option.label}
+									onSelect={() => {
+										onChange(option.value);
+										setOpen(false);
+									}}
+									className="group items-start gap-3 rounded-md px-2.5 py-2"
+								>
+									<OptionIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+									<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+										<span className="truncate text-sm leading-snug">
+											{option.label}
+										</span>
+										<span className="text-xs leading-snug text-muted-foreground">
+											{option.description}
+										</span>
+									</div>
+									{option.value === noWorktree && (
+										<HiCheck className="mt-0.5 size-4 shrink-0" />
+									)}
+								</CommandItem>
+							);
+						})}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceFolderPicker/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/WorkspaceFolderPicker/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceFolderPicker } from "./WorkspaceFolderPicker";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -183,7 +183,14 @@ export function useSubmitWorkspace(
 			: {
 					id: workspaceId,
 					projectId: projectId as string,
-					name: isPrCheckout ? prName : (workspaceName ?? undefined),
+					// A workspace in the project folder is that project's one
+					// main workspace, which is named after the branch the
+					// folder is on, so a typed name has nowhere to go.
+					name: isPrCheckout
+						? prName
+						: draft.noWorktree
+							? undefined
+							: (workspaceName ?? undefined),
 					branch: isPrCheckout ? undefined : (branchName ?? undefined),
 					skipBranchPrefix:
 						!isPrCheckout && branchName !== null && draft.branchNameFromProvider
@@ -192,6 +199,7 @@ export function useSubmitWorkspace(
 					pr: isPrCheckout ? draft.linkedPR?.prNumber : undefined,
 					baseBranch: draft.baseBranch ?? undefined,
 					taskId: linkedTaskId,
+					noWorktree: draft.noWorktree || undefined,
 					agents,
 					namingPrompt:
 						!isPrCheckout && !wantAgent && trimmedPrompt

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -199,7 +199,9 @@ export function useSubmitWorkspace(
 					pr: isPrCheckout ? draft.linkedPR?.prNumber : undefined,
 					baseBranch: draft.baseBranch ?? undefined,
 					taskId: linkedTaskId,
-					noWorktree: draft.noWorktree || undefined,
+					// A pull request is checked out into a worktree of its own,
+					// and the server rejects the two together.
+					noWorktree: !isPrCheckout && draft.noWorktree ? true : undefined,
 					agents,
 					namingPrompt:
 						!isPrCheckout && !wantAgent && trimmedPrompt

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -49,6 +49,12 @@ export interface NewWorkspaceDraft {
 	branchNameFromProvider: boolean;
 	linkedIssues: LinkedIssue[];
 	linkedPR: LinkedPR | null;
+	/**
+	 * True to work in the project's own folder instead of adding a git
+	 * worktree for this workspace. The create then resolves to the
+	 * project's one main workspace.
+	 */
+	noWorktree: boolean;
 	selectedAgentId: string | null;
 	attachments: DraftAttachment[];
 }
@@ -79,6 +85,7 @@ function buildInitialDraft(): NewWorkspaceDraft {
 		branchNameFromProvider: false,
 		linkedIssues: [],
 		linkedPR: null,
+		noWorktree: false,
 		selectedAgentId: null,
 		attachments: [],
 	};
@@ -95,7 +102,8 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 		selectProject: (projectId) =>
 			set({ selectedProjectId: projectId, isSession: false }),
 		// Sessions can't check out a PR or fork a branch — clear the
-		// repo-scoped inputs instead of failing at submit.
+		// repo-scoped inputs instead of failing at submit. A session has no
+		// project folder to work in either, so it drops noWorktree too.
 		selectSession: () =>
 			set({
 				selectedProjectId: null,
@@ -103,6 +111,7 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 				linkedPR: null,
 				baseBranch: null,
 				baseBranchSource: null,
+				noWorktree: false,
 			}),
 		addAttachment: (attachment) =>
 			set((state) => ({

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -23,6 +23,9 @@ export default command({
 		skipBranchPrefix: boolean().desc(
 			"Use --branch exactly as given instead of namespacing it under the project branch prefix",
 		),
+		noWorktree: boolean().desc(
+			"Work in the project folder itself instead of adding a git worktree. Without --branch the folder keeps the branch it is on; with --branch it is checked out to that branch, which fails when the folder has uncommitted changes. That workspace is named after the branch, so --name is ignored",
+		),
 		agent: string().desc(
 			"Agent to spawn after creation. Preset id (`claude`, `codex`, …), HostAgentConfig instance UUID, or `superset`",
 		),
@@ -56,6 +59,7 @@ export default command({
 				["--base-branch", options.baseBranch],
 				["--task", options.task],
 				["--skip-branch-prefix", options.skipBranchPrefix || undefined],
+				["--no-worktree", options.noWorktree || undefined],
 			] as const) {
 				if (value !== undefined) {
 					throw new CLIError(
@@ -71,10 +75,23 @@ export default command({
 					"Use --branch <name> or --pr <number>",
 				);
 			}
-			if (!options.branch && !options.pr && !options.task) {
+			if (options.noWorktree && options.pr) {
+				throw new CLIError(
+					"Specify only one of --no-worktree or --pr",
+					"Checking out a pull request needs its own worktree",
+				);
+			}
+			// --no-worktree keeps the branch the project folder is already
+			// on, so it is the one case that needs no branch at all.
+			if (
+				!options.noWorktree &&
+				!options.branch &&
+				!options.pr &&
+				!options.task
+			) {
 				throw new CLIError(
 					"Specify --branch, --pr, or --task",
-					"Use --branch <name>, --pr <number>, or --task <id>",
+					"Use --branch <name>, --pr <number>, --task <id>, or --no-worktree",
 				);
 			}
 		}
@@ -116,7 +133,7 @@ export default command({
 			api: ctx.api,
 		});
 
-		if (!isSession && !options.name) {
+		if (!isSession && !options.name && !options.noWorktree) {
 			throw new CLIError("--name is required when --project is set");
 		}
 
@@ -148,9 +165,6 @@ export default command({
 			};
 		}
 
-		if (!options.name) {
-			throw new CLIError("--name is required when --project is set");
-		}
 		const result = await target.client.workspaces.create.mutate({
 			projectId,
 			name: options.name,
@@ -159,6 +173,7 @@ export default command({
 			taskId: options.task,
 			baseBranch: options.baseBranch,
 			skipBranchPrefix: options.skipBranchPrefix ?? undefined,
+			noWorktree: options.noWorktree ?? undefined,
 			agents,
 			command: options.command ?? undefined,
 		});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/in-place-checkout.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/in-place-checkout.ts
@@ -11,8 +11,8 @@ import { normalizeWorktreePath } from "./worktree-list";
  *
  * A workspace normally gets its own directory from `git worktree add`, so a
  * checkout there cannot disturb anything. These helpers run against the
- * project's own clone, where the user may have edits open, so every one of
- * them refuses rather than moves files it did not create.
+ * project's own clone, where the user may have edits open, so they refuse
+ * rather than move a file the user did not ask them to move.
  */
 
 /** The branch name checked out in the repo, or null when HEAD is detached. */
@@ -25,11 +25,38 @@ async function readCheckedOutBranch(git: GitClient): Promise<string | null> {
 	}
 }
 
+/** The commit a ref points at, or null when the ref does not resolve. */
+async function readCommit(git: GitClient, ref: string): Promise<string | null> {
+	try {
+		const out = await git.raw(["rev-parse", "--verify", `${ref}^{commit}`]);
+		const trimmed = out.trim();
+		return /^[0-9a-f]{40,}/.test(trimmed) ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
 /**
- * Refuse when the repo has edits to files git already tracks. Such edits
- * follow the checkout onto the other branch, which is a surprise nobody
- * asked for. Files git does not track stay put during a checkout, so they
- * do not block it — build output and local scratch files are normal.
+ * True when the checkout writes no file: a branch this call creates, whose
+ * start point is the commit the folder is already on. `git checkout -b` at
+ * the same commit only writes a new ref, and edits in progress stay exactly
+ * where they are, on the new branch.
+ */
+async function movesNoFiles(
+	git: GitClient,
+	plan: BranchSourcePlan,
+): Promise<boolean> {
+	if (plan.usedExistingBranch) return false;
+	if (plan.startPoint.kind === "head") return true;
+	const target = await readCommit(git, startPointArg(plan));
+	const head = await readCommit(git, "HEAD");
+	return target !== null && target === head;
+}
+
+/**
+ * Refuse when the repo has edits to files git already tracks. A checkout
+ * that changes which commit the folder holds carries those edits onto the
+ * other branch, which is a surprise nobody asked for.
  */
 async function assertNoUncommittedChanges(
 	git: GitClient,
@@ -92,7 +119,9 @@ export async function checkoutBranchInProjectRepo(args: {
 	const { git, repoPath, plan } = args;
 
 	await assertBranchNotCheckedOutElsewhere(git, repoPath, plan.branch);
-	await assertNoUncommittedChanges(git, repoPath, plan.branch);
+	if (!(await movesNoFiles(git, plan))) {
+		await assertNoUncommittedChanges(git, repoPath, plan.branch);
+	}
 
 	const checkoutArgs = plan.usedExistingBranch
 		? plan.startPoint.kind === "remote-tracking"
@@ -111,11 +140,24 @@ export async function checkoutBranchInProjectRepo(args: {
 			// first push sets one.
 			["checkout", "--no-track", "-b", plan.branch, startPointArg(plan)];
 
-	await runWithPostCheckoutHookTolerance({
-		run: async () => {
-			await git.raw(checkoutArgs);
-		},
-		didSucceed: async () => (await readCheckedOutBranch(git)) === plan.branch,
-		context: `${repoPath} checked out ${plan.branch}`,
-	});
+	try {
+		await runWithPostCheckoutHookTolerance({
+			run: async () => {
+				await git.raw(checkoutArgs);
+			},
+			didSucceed: async () => (await readCheckedOutBranch(git)) === plan.branch,
+			context: `${repoPath} checked out ${plan.branch}`,
+		});
+	} catch (err) {
+		// Git refuses a checkout that would write over a file it does not
+		// track, so a folder holding build output or a local scratch file
+		// can fail here even though the two guards above passed. The folder
+		// is left on the branch it started on either way.
+		throw new TRPCError({
+			code: "CONFLICT",
+			message: `Could not check out "${plan.branch}" in ${repoPath}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		});
+	}
 }

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/in-place-checkout.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/in-place-checkout.ts
@@ -1,0 +1,121 @@
+import { runWithPostCheckoutHookTolerance } from "@superset/shared/git-hook-tolerance";
+import { TRPCError } from "@trpc/server";
+import type { BranchSourcePlan } from "../../workspaces/workspaces";
+import { listWorktreeBranches } from "./branch-search";
+import type { GitClient } from "./types";
+import { normalizeWorktreePath } from "./worktree-list";
+
+/**
+ * Checking out a branch in the folder the user works in themselves, instead
+ * of adding a git worktree for it.
+ *
+ * A workspace normally gets its own directory from `git worktree add`, so a
+ * checkout there cannot disturb anything. These helpers run against the
+ * project's own clone, where the user may have edits open, so every one of
+ * them refuses rather than moves files it did not create.
+ */
+
+/** The branch name checked out in the repo, or null when HEAD is detached. */
+async function readCheckedOutBranch(git: GitClient): Promise<string | null> {
+	try {
+		const branch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
+		return branch.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Refuse when the repo has edits to files git already tracks. Such edits
+ * follow the checkout onto the other branch, which is a surprise nobody
+ * asked for. Files git does not track stay put during a checkout, so they
+ * do not block it — build output and local scratch files are normal.
+ */
+async function assertNoUncommittedChanges(
+	git: GitClient,
+	repoPath: string,
+	branch: string,
+): Promise<void> {
+	const status = await git.raw([
+		"status",
+		"--porcelain",
+		"--untracked-files=no",
+	]);
+	if (!status.trim()) return;
+	throw new TRPCError({
+		code: "CONFLICT",
+		message: `${repoPath} has uncommitted changes, so switching it to "${branch}" would carry them onto that branch. Commit or stash them first, or create this workspace with a worktree instead.`,
+	});
+}
+
+/**
+ * Refuse when another worktree already has the branch checked out. Git
+ * allows one checkout of a branch at a time and would fail the command
+ * anyway; this says where the other checkout is.
+ */
+async function assertBranchNotCheckedOutElsewhere(
+	git: GitClient,
+	repoPath: string,
+	branch: string,
+): Promise<void> {
+	const { worktreeMap } = await listWorktreeBranches(git);
+	const holder = worktreeMap.get(branch);
+	if (!holder) return;
+	if (normalizeWorktreePath(holder) === normalizeWorktreePath(repoPath)) return;
+	throw new TRPCError({
+		code: "CONFLICT",
+		message: `Branch "${branch}" is already checked out at ${holder}. Open that workspace, or pick another branch.`,
+	});
+}
+
+/** The ref `git checkout` starts a new branch from. */
+function startPointArg(plan: BranchSourcePlan): string {
+	if (plan.startPoint.kind === "head") return "HEAD";
+	if (plan.startPoint.kind === "remote-tracking") {
+		return plan.startPoint.remoteShortName;
+	}
+	return plan.startPoint.shortName;
+}
+
+/**
+ * Check `plan.branch` out in the project's own clone, creating the branch
+ * first when it does not exist yet.
+ *
+ * The caller must have established that the repo is on a different branch;
+ * this does not compare.
+ */
+export async function checkoutBranchInProjectRepo(args: {
+	git: GitClient;
+	repoPath: string;
+	plan: BranchSourcePlan;
+}): Promise<void> {
+	const { git, repoPath, plan } = args;
+
+	await assertBranchNotCheckedOutElsewhere(git, repoPath, plan.branch);
+	await assertNoUncommittedChanges(git, repoPath, plan.branch);
+
+	const checkoutArgs = plan.usedExistingBranch
+		? plan.startPoint.kind === "remote-tracking"
+			? // A branch that only exists on the remote needs --track -b to
+				// become a local branch; plain checkout would detach HEAD.
+				[
+					"checkout",
+					"--track",
+					"-b",
+					plan.branch,
+					plan.startPoint.remoteShortName,
+				]
+			: ["checkout", plan.branch]
+		: // --no-track matches the worktree path: `git pull` and the
+			// ahead/behind counts follow this branch's own upstream once the
+			// first push sets one.
+			["checkout", "--no-track", "-b", plan.branch, startPointArg(plan)];
+
+	await runWithPostCheckoutHookTolerance({
+		run: async () => {
+			await git.raw(checkoutArgs);
+		},
+		didSucceed: async () => (await readCheckedOutBranch(git)) === plan.branch,
+		context: `${repoPath} checked out ${plan.branch}`,
+	});
+}

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -134,7 +134,7 @@ const createInputSchema = z
 	})
 	.refine((value) => !(value.noWorktree && value.pr), {
 		message:
-			"`noWorktree` and `pr` cannot both be set — checking out a pull request needs its own worktree",
+			"`noWorktree` and `pr` cannot both be set. Checking out a pull request needs its own worktree",
 	})
 	.refine((value) => !(value.noWorktree && value.worktreePath), {
 		message: "`noWorktree` and `worktreePath` cannot both be set",
@@ -484,10 +484,33 @@ async function fetchLinkedTaskBranch(
 }
 
 /**
+ * Refuse to start an agent or a shell command in the project folder unless
+ * the caller asked to work there.
+ *
+ * A branch that the project folder itself has checked out resolves to that
+ * project's main workspace, whose directory is the folder the user edits
+ * in. Handing it back is fine on its own; launching work inside it when the
+ * caller expected a worktree of its own is not.
+ */
+function assertNotStartingWorkInProjectFolder(args: {
+	input: z.infer<typeof createInputSchema>;
+	existing: CloudWorkspace;
+	repoPath: string;
+}): void {
+	const { input, existing, repoPath } = args;
+	if (existing.type !== "main") return;
+	if (!input.agents?.length && !input.command) return;
+	throw new TRPCError({
+		code: "CONFLICT",
+		message: `Branch "${existing.branch}" is checked out in the project folder (${repoPath}), so this workspace is that folder. Set noWorktree to work there, or pick another branch.`,
+	});
+}
+
+/**
  * `noWorktree` create: the workspace is the project folder itself.
  *
  * Every project already has exactly one `type='main'` workspace whose path
- * is the project folder, so nothing is inserted — this returns that row.
+ * is the project folder, so nothing is inserted. This returns that row.
  * When the caller named a branch, the project folder is checked out to it
  * first, and the row follows the checkout.
  */
@@ -502,6 +525,9 @@ async function useProjectRepoAsWorkspace(args: {
 	const { ctx, input, git, localProject, repoPath, fetchBaseRef } = args;
 
 	const main = await ensureMainWorkspaceStrict(ctx, localProject.id, repoPath);
+	// Both worktree paths set this on every create. An agent that commits
+	// on a branch with no upstream needs it just as much here.
+	await enablePushAutoSetupRemote(git, repoPath, "[workspaces.create]");
 	const readRow = () => {
 		const row = getLocalWorkspace(ctx.db, main.id);
 		if (!row) {
@@ -528,7 +554,7 @@ async function useProjectRepoAsWorkspace(args: {
 		]);
 		let plan = planned;
 		// Namespace a branch this call would create, and leave one that
-		// already exists alone — same rule as the worktree path.
+		// already exists alone. Same rule as the worktree path.
 		if (!plan.usedExistingBranch && !(input.skipBranchPrefix || taskBranch)) {
 			const prefix = await resolveProjectBranchPrefix({
 				ctx,
@@ -549,16 +575,13 @@ async function useProjectRepoAsWorkspace(args: {
 
 		if (plan.branch !== readRow().branch) {
 			await checkoutBranchInProjectRepo({ git, repoPath, plan });
-			if (!plan.usedExistingBranch) {
-				await enablePushAutoSetupRemote(git, repoPath, "[workspaces.create]");
-				if (plan.startPoint.kind !== "head") {
-					await recordBaseBranchConfig({
-						git,
-						worktreePath: repoPath,
-						branch: plan.branch,
-						baseBranch: plan.startPoint.shortName,
-					});
-				}
+			if (!plan.usedExistingBranch && plan.startPoint.kind !== "head") {
+				await recordBaseBranchConfig({
+					git,
+					worktreePath: repoPath,
+					branch: plan.branch,
+					baseBranch: plan.startPoint.shortName,
+				});
 			}
 			// Reads HEAD again, so the row's branch (and its name, while the
 			// name is just the branch) follow the checkout.
@@ -704,14 +727,24 @@ export const workspacesRouter = router({
 			let workspaceRow: CloudWorkspace;
 
 			if (input.noWorktree) {
-				workspaceRow = await useProjectRepoAsWorkspace({
-					ctx,
-					input,
-					git,
-					localProject,
-					repoPath,
-					fetchBaseRef: fetchBaseRefOffLoop,
-				});
+				// One shared working tree, so two of these creates cannot run
+				// their checkouts at the same time. The worktree paths need no
+				// such lock: each one writes a directory only it owns.
+				const releaseCreateLock = await acquireWorkspaceCreateLock(
+					`repo:${input.projectId}`,
+				);
+				try {
+					workspaceRow = await useProjectRepoAsWorkspace({
+						ctx,
+						input,
+						git,
+						localProject,
+						repoPath,
+						fetchBaseRef: fetchBaseRefOffLoop,
+					});
+				} finally {
+					releaseCreateLock();
+				}
 				resolvedBranch = workspaceRow.branch;
 				worktreePath = repoPath;
 				// The project folder is not a folder this call created, and its
@@ -737,6 +770,11 @@ export const workspacesRouter = router({
 						resolvedBranch,
 					);
 					if (existing) {
+						assertNotStartingWorkInProjectFolder({
+							input,
+							existing,
+							repoPath,
+						});
 						workspaceRow = existing;
 						alreadyExists = true;
 					} else {
@@ -1050,6 +1088,11 @@ export const workspacesRouter = router({
 					resolvedBranch,
 				);
 				if (existing) {
+					assertNotStartingWorkInProjectFolder({
+						input,
+						existing,
+						repoPath,
+					});
 					workspaceRow = existing;
 					alreadyExists = true;
 				} else {

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -18,6 +18,7 @@ import {
 	getLocalWorkspace,
 	insertLocalWorkspace,
 	toCloudShape,
+	updateLocalWorkspace,
 } from "../../../workspaces/local-workspace-store";
 import {
 	createCallerFactory,
@@ -26,7 +27,10 @@ import {
 	router,
 } from "../../index";
 import { buildTerminalAgentLaunch, validateAgentLaunchEffort } from "../agents";
-import { ensureMainWorkspace } from "../project/utils/ensure-main-workspace";
+import {
+	ensureMainWorkspace,
+	ensureMainWorkspaceStrict,
+} from "../project/utils/ensure-main-workspace";
 import { getHostWorktreeBaseDir } from "../settings/worktree-location";
 import { createSession } from "../workspace-creation/procedures/create-session";
 import { adoptExistingWorktree } from "../workspace-creation/shared/adopt-existing-worktree";
@@ -42,7 +46,9 @@ import {
 	dispatchSugarAgents,
 } from "../workspace-creation/shared/dispatch-agents";
 import { enablePushAutoSetupRemote } from "../workspace-creation/shared/git-config";
+import { checkoutBranchInProjectRepo } from "../workspace-creation/shared/in-place-checkout";
 import {
+	type LocalProject,
 	requireLocalProject,
 	requireProjectRepoPath,
 } from "../workspace-creation/shared/local-project";
@@ -113,12 +119,25 @@ const createInputSchema = z
 		// When false, skip the setup terminal. Used by worktree import,
 		// where the worktree is usually already set up.
 		runSetup: z.boolean().optional(),
+		// Work in the folder the project itself lives in, with no
+		// `git worktree add`. The call resolves to the project's one
+		// `type='main'` workspace. Without `branch` the repo keeps the
+		// branch it already has; with one, the repo is checked out to that
+		// branch, which fails when it has uncommitted changes.
+		noWorktree: z.boolean().optional(),
 	})
 	.refine((value) => !(value.branch && value.pr), {
 		message: "`branch` and `pr` cannot both be set",
 	})
 	.refine((value) => !(value.worktreePath && value.pr), {
 		message: "`worktreePath` and `pr` cannot both be set",
+	})
+	.refine((value) => !(value.noWorktree && value.pr), {
+		message:
+			"`noWorktree` and `pr` cannot both be set — checking out a pull request needs its own worktree",
+	})
+	.refine((value) => !(value.noWorktree && value.worktreePath), {
+		message: "`noWorktree` and `worktreePath` cannot both be set",
 	});
 
 const workspaceCreateLocks = new Map<string, Promise<void>>();
@@ -465,6 +484,97 @@ async function fetchLinkedTaskBranch(
 }
 
 /**
+ * `noWorktree` create: the workspace is the project folder itself.
+ *
+ * Every project already has exactly one `type='main'` workspace whose path
+ * is the project folder, so nothing is inserted — this returns that row.
+ * When the caller named a branch, the project folder is checked out to it
+ * first, and the row follows the checkout.
+ */
+async function useProjectRepoAsWorkspace(args: {
+	ctx: HostServiceContext;
+	input: z.infer<typeof createInputSchema>;
+	git: GitClient;
+	localProject: LocalProject;
+	repoPath: string;
+	fetchBaseRef: BaseRefFetcher;
+}): Promise<CloudWorkspace> {
+	const { ctx, input, git, localProject, repoPath, fetchBaseRef } = args;
+
+	const main = await ensureMainWorkspaceStrict(ctx, localProject.id, repoPath);
+	const readRow = () => {
+		const row = getLocalWorkspace(ctx.db, main.id);
+		if (!row) {
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: `Workspace ${main.id} disappeared during creation`,
+			});
+		}
+		return row;
+	};
+
+	// A linked task can name the branch when the caller didn't, exactly as
+	// on the worktree path.
+	const taskBranch =
+		!input.branch && input.taskId
+			? await fetchLinkedTaskBranch(ctx, input.taskId)
+			: undefined;
+	const requestedBranch = input.branch?.trim() || taskBranch;
+
+	if (requestedBranch) {
+		const [planned, existingBranches] = await Promise.all([
+			planBranchSource(git, requestedBranch, input.baseBranch, fetchBaseRef),
+			listBranchNames(ctx, repoPath),
+		]);
+		let plan = planned;
+		// Namespace a branch this call would create, and leave one that
+		// already exists alone — same rule as the worktree path.
+		if (!plan.usedExistingBranch && !(input.skipBranchPrefix || taskBranch)) {
+			const prefix = await resolveProjectBranchPrefix({
+				ctx,
+				project: localProject,
+				git,
+				existingBranches,
+			});
+			if (prefix) {
+				plan = {
+					...plan,
+					branch: deduplicateBranchName(
+						`${prefix}/${plan.branch}`,
+						existingBranches,
+					),
+				};
+			}
+		}
+
+		if (plan.branch !== readRow().branch) {
+			await checkoutBranchInProjectRepo({ git, repoPath, plan });
+			if (!plan.usedExistingBranch) {
+				await enablePushAutoSetupRemote(git, repoPath, "[workspaces.create]");
+				if (plan.startPoint.kind !== "head") {
+					await recordBaseBranchConfig({
+						git,
+						worktreePath: repoPath,
+						branch: plan.branch,
+						baseBranch: plan.startPoint.shortName,
+					});
+				}
+			}
+			// Reads HEAD again, so the row's branch (and its name, while the
+			// name is just the branch) follow the checkout.
+			await ensureMainWorkspaceStrict(ctx, localProject.id, repoPath);
+		}
+	}
+
+	// The main workspace outlives any one task, so the newest link wins.
+	if (input.taskId && readRow().taskId !== input.taskId) {
+		updateLocalWorkspace(ctx, main.id, { taskId: input.taskId });
+	}
+
+	return toCloudShape(readRow(), ctx.organizationId);
+}
+
+/**
  * Fully local registration: the host mints the id and commits the local
  * row — the authoritative and only record; workspaces have no cloud mirror.
  */
@@ -539,9 +649,13 @@ export const workspacesRouter = router({
 			// their names are already meaningful.
 			const composerPrompt =
 				input.agents?.[0]?.prompt?.trim() || input.namingPrompt?.trim() || "";
+			// The `main` workspace is named after the branch the project
+			// folder is on, and renaming it would fight that, so noWorktree
+			// skips naming too.
 			const wantAi =
 				input.pr === undefined &&
 				input.worktreePath === undefined &&
+				input.noWorktree !== true &&
 				input.name === undefined &&
 				!!composerPrompt;
 			const namingAgent = input.agents?.[0]?.agent;
@@ -589,7 +703,23 @@ export const workspacesRouter = router({
 			let alreadyExists = false;
 			let workspaceRow: CloudWorkspace;
 
-			if (input.pr !== undefined) {
+			if (input.noWorktree) {
+				workspaceRow = await useProjectRepoAsWorkspace({
+					ctx,
+					input,
+					git,
+					localProject,
+					repoPath,
+					fetchBaseRef: fetchBaseRefOffLoop,
+				});
+				resolvedBranch = workspaceRow.branch;
+				worktreePath = repoPath;
+				// The project folder is not a folder this call created, and its
+				// `main` workspace already existed. Setup scripts belong to a
+				// fresh worktree, so they stay out of it; the agents and the
+				// command below still run.
+				alreadyExists = true;
+			} else if (input.pr !== undefined) {
 				const releaseCreateLock = await acquireWorkspaceCreateLock(
 					`pr:${input.projectId}:${input.pr}`,
 				);

--- a/packages/host-service/test/integration/workspace-create-no-worktree.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-no-worktree.integration.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { workspaces } from "../../src/db/schema";
+import { cloudFlows } from "../helpers/cloud-fakes";
+import { createProjectScenario } from "../helpers/scenarios";
+
+/**
+ * `workspaces.create({ noWorktree: true })` — the workspace is the project
+ * folder itself. These tests assert against the real repo on disk: which
+ * branch it ends up on, and that no worktree was added for it.
+ */
+describe("workspaces.create with noWorktree", () => {
+	let dispose: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		if (dispose) {
+			await dispose();
+			dispose = undefined;
+		}
+	});
+
+	test("returns the project's main workspace and leaves the branch alone", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			noWorktree: true,
+		});
+
+		expect(result.workspace.branch).toBe("main");
+		expect(result.alreadyExists).toBe(true);
+
+		const persisted = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, result.workspace.id))
+			.get();
+		expect(persisted?.type).toBe("main");
+		expect(persisted?.worktreePath).toBe(scenario.repo.repoPath);
+
+		// One worktree in the list means the repo itself and nothing else.
+		const worktrees = await scenario.repo.git.raw([
+			"worktree",
+			"list",
+			"--porcelain",
+		]);
+		expect(worktrees.match(/^worktree /gm)?.length).toBe(1);
+	});
+
+	test("a second create with noWorktree returns the same workspace", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		const first = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			noWorktree: true,
+		});
+		const second = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			noWorktree: true,
+		});
+
+		expect(second.workspace.id).toBe(first.workspace.id);
+	});
+
+	test("a branch is created in the project folder, not in a worktree", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		const result = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			branch: "in-place",
+			skipBranchPrefix: true,
+			noWorktree: true,
+		});
+
+		expect(result.workspace.branch).toBe("in-place");
+
+		const head = await scenario.repo.git.raw([
+			"symbolic-ref",
+			"--short",
+			"HEAD",
+		]);
+		expect(head.trim()).toBe("in-place");
+		expect(existsSync(join(scenario.repo.repoPath, ".worktrees"))).toBe(false);
+
+		// The row follows the checkout, so the sidebar and every terminal
+		// opened later report the branch the folder is really on.
+		const persisted = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, result.workspace.id))
+			.get();
+		expect(persisted?.branch).toBe("in-place");
+	});
+
+	test("an existing branch is checked out rather than re-created", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		await scenario.repo.git.raw(["branch", "already-here"]);
+
+		const result = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			branch: "already-here",
+			noWorktree: true,
+		});
+
+		expect(result.workspace.branch).toBe("already-here");
+		const head = await scenario.repo.git.raw([
+			"symbolic-ref",
+			"--short",
+			"HEAD",
+		]);
+		expect(head.trim()).toBe("already-here");
+	});
+
+	test("refuses to switch a folder that has uncommitted changes", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		writeFileSync(
+			join(scenario.repo.repoPath, "README.md"),
+			"edited but not committed",
+		);
+
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				branch: "in-place",
+				skipBranchPrefix: true,
+				noWorktree: true,
+			}),
+		).rejects.toThrow(/uncommitted changes/i);
+
+		const head = await scenario.repo.git.raw([
+			"symbolic-ref",
+			"--short",
+			"HEAD",
+		]);
+		expect(head.trim()).toBe("main");
+	});
+
+	test("refuses a branch another worktree already has checked out", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		const elsewhere = join(scenario.repo.repoPath, ".worktrees", "taken");
+		await scenario.repo.git.raw(["worktree", "add", "-b", "taken", elsewhere]);
+
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				branch: "taken",
+				noWorktree: true,
+			}),
+		).rejects.toThrow(/already checked out/i);
+	});
+
+	test("rejects noWorktree together with pr", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				pr: 1,
+				noWorktree: true,
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/host-service/test/integration/workspace-create-no-worktree.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-no-worktree.integration.test.ts
@@ -1,13 +1,21 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { workspaces } from "../../src/db/schema";
 import { cloudFlows } from "../helpers/cloud-fakes";
 import { createProjectScenario } from "../helpers/scenarios";
 
+/** How many worktrees git itself reports, the repo folder included. */
+async function countWorktrees(git: {
+	raw: (args: string[]) => Promise<string>;
+}): Promise<number> {
+	const listed = await git.raw(["worktree", "list", "--porcelain"]);
+	return listed.match(/^worktree /gm)?.length ?? 0;
+}
+
 /**
- * `workspaces.create({ noWorktree: true })` — the workspace is the project
+ * `workspaces.create({ noWorktree: true })`: the workspace is the project
  * folder itself. These tests assert against the real repo on disk: which
  * branch it ends up on, and that no worktree was added for it.
  */
@@ -44,12 +52,7 @@ describe("workspaces.create with noWorktree", () => {
 		expect(persisted?.worktreePath).toBe(scenario.repo.repoPath);
 
 		// One worktree in the list means the repo itself and nothing else.
-		const worktrees = await scenario.repo.git.raw([
-			"worktree",
-			"list",
-			"--porcelain",
-		]);
-		expect(worktrees.match(/^worktree /gm)?.length).toBe(1);
+		expect(await countWorktrees(scenario.repo.git)).toBe(1);
 	});
 
 	test("a second create with noWorktree returns the same workspace", async () => {
@@ -91,7 +94,7 @@ describe("workspaces.create with noWorktree", () => {
 			"HEAD",
 		]);
 		expect(head.trim()).toBe("in-place");
-		expect(existsSync(join(scenario.repo.repoPath, ".worktrees"))).toBe(false);
+		expect(await countWorktrees(scenario.repo.git)).toBe(1);
 
 		// The row follows the checkout, so the sidebar and every terminal
 		// opened later report the branch the folder is really on.
@@ -126,11 +129,16 @@ describe("workspaces.create with noWorktree", () => {
 		expect(head.trim()).toBe("already-here");
 	});
 
-	test("refuses to switch a folder that has uncommitted changes", async () => {
+	test("refuses to move a folder that has uncommitted changes", async () => {
 		const scenario = await createProjectScenario({
 			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
 		});
 		dispose = scenario.dispose;
+
+		// A branch one commit ahead, so checking it out rewrites files.
+		await scenario.repo.git.raw(["checkout", "-b", "ahead"]);
+		await scenario.repo.commit("second commit");
+		await scenario.repo.git.raw(["checkout", "main"]);
 
 		writeFileSync(
 			join(scenario.repo.repoPath, "README.md"),
@@ -140,8 +148,7 @@ describe("workspaces.create with noWorktree", () => {
 		await expect(
 			scenario.host.trpc.workspaces.create.mutate({
 				projectId: scenario.projectId,
-				branch: "in-place",
-				skipBranchPrefix: true,
+				branch: "ahead",
 				noWorktree: true,
 			}),
 		).rejects.toThrow(/uncommitted changes/i);
@@ -152,6 +159,75 @@ describe("workspaces.create with noWorktree", () => {
 			"HEAD",
 		]);
 		expect(head.trim()).toBe("main");
+	});
+
+	test("keeps uncommitted work when the new branch starts at HEAD", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		// `git checkout -b` at the commit the folder is already on writes a
+		// ref and nothing else, so work in progress is safe.
+		writeFileSync(join(scenario.repo.repoPath, "README.md"), "still working");
+
+		const result = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			branch: "carry-on",
+			skipBranchPrefix: true,
+			noWorktree: true,
+		});
+
+		expect(result.workspace.branch).toBe("carry-on");
+		expect(
+			readFileSync(join(scenario.repo.repoPath, "README.md"), "utf8"),
+		).toBe("still working");
+	});
+
+	test("reports an untracked file in the way as a conflict", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		// git refuses to write over a file it does not track, and
+		// `status --untracked-files=no` cannot see it coming.
+		await scenario.repo.git.raw(["checkout", "-b", "has-dist"]);
+		await scenario.repo.commit("add dist", { "dist.js": "built" });
+		await scenario.repo.git.raw(["checkout", "main"]);
+		writeFileSync(join(scenario.repo.repoPath, "dist.js"), "local build");
+
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				branch: "has-dist",
+				noWorktree: true,
+			}),
+		).rejects.toThrow(/Could not check out "has-dist"/);
+
+		const head = await scenario.repo.git.raw([
+			"symbolic-ref",
+			"--short",
+			"HEAD",
+		]);
+		expect(head.trim()).toBe("main");
+	});
+
+	test("refuses to start an agent in the project folder unasked", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		dispose = scenario.dispose;
+
+		// The project folder is on `main`, so an ordinary create for `main`
+		// resolves to it. Launching work there needs noWorktree.
+		await expect(
+			scenario.host.trpc.workspaces.create.mutate({
+				projectId: scenario.projectId,
+				branch: "main",
+				command: "echo hi",
+			}),
+		).rejects.toThrow(/checked out in the project folder/);
 	});
 
 	test("refuses a branch another worktree already has checked out", async () => {

--- a/packages/mcp/src/tools/workspaces/create.ts
+++ b/packages/mcp/src/tools/workspaces/create.ts
@@ -24,7 +24,7 @@ export function register(server: McpServer): void {
 		name: "workspaces_create",
 		annotations: { destructiveHint: false },
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. When `projectId` is set, provide exactly one of `branch` or `pr`. Omit `projectId` (and `branch`/`pr`/`baseBranch`/`taskId`) to create a project-less session instead — a managed scratch folder (its own git repo, no branch/PR semantics). Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_create` against the new workspace), and/or pass `command` to run a one-off shell command in the worktree. Use projects_list and hosts_list first to get the projectId and hostId.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. When `projectId` is set, provide exactly one of `branch` or `pr`, or set `noWorktree` to work in the project folder itself. Omit `projectId` (and `branch`/`pr`/`baseBranch`/`taskId`) to create a project-less session instead — a managed scratch folder (its own git repo, no branch/PR semantics). Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_create` against the new workspace), and/or pass `command` to run a one-off shell command in the worktree. Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {
 			projectId: z
 				.string()
@@ -75,6 +75,12 @@ export function register(server: McpServer): void {
 				.min(1)
 				.optional()
 				.describe("Shell command to run in the new worktree after creation."),
+			noWorktree: z
+				.boolean()
+				.optional()
+				.describe(
+					"Work in the project folder itself instead of adding a git worktree, which resolves to the project's one main workspace. Without `branch` that folder keeps the branch it is on; with `branch` it is checked out to that branch, which fails when the folder has uncommitted changes. That workspace is named after the branch, so `name` is ignored. Cannot be combined with `pr`.",
+				),
 		},
 		handler: async (input, ctx) => {
 			if (input.projectId === undefined) {
@@ -83,6 +89,7 @@ export function register(server: McpServer): void {
 					["pr", input.pr],
 					["baseBranch", input.baseBranch],
 					["taskId", input.taskId],
+					["noWorktree", input.noWorktree || undefined],
 				] as const) {
 					if (value !== undefined) {
 						throw new Error(
@@ -149,6 +156,7 @@ export function register(server: McpServer): void {
 					taskId: input.taskId,
 					agents: input.agents,
 					command: input.command,
+					noWorktree: input.noWorktree,
 				},
 			);
 		},

--- a/packages/mcp/src/tools/workspaces/create.ts
+++ b/packages/mcp/src/tools/workspaces/create.ts
@@ -33,7 +33,13 @@ export function register(server: McpServer): void {
 				.describe(
 					"Project UUID. Omit to create a project-less session (managed scratch folder).",
 				),
-			name: z.string().min(1).describe("Workspace name (display)."),
+			name: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Workspace name (display). Optional: the host names the workspace after its branch when this is omitted, and `noWorktree` ignores it entirely.",
+				),
 			branch: z
 				.string()
 				.min(1)
@@ -83,6 +89,11 @@ export function register(server: McpServer): void {
 				),
 		},
 		handler: async (input, ctx) => {
+			if (input.noWorktree && input.pr !== undefined) {
+				throw new Error(
+					"`noWorktree` and `pr` cannot both be set. Checking out a pull request needs its own worktree",
+				);
+			}
 			if (input.projectId === undefined) {
 				for (const [field, value] of [
 					["branch", input.branch],


### PR DESCRIPTION
A workspace for a project always got a git worktree. Some repositories do not work well in a worktree. Sometimes the work belongs in the folder that the editor already shows. `workspaces.create` now accepts `noWorktree`. The call returns the project's one main workspace, which points at the project folder.

If the caller gives no branch, the folder keeps the branch it is on. If the caller gives a branch, the host checks the folder out to that branch. The host applies the project branch prefix to a new branch. The host creates the branch from the base branch when the branch does not exist yet.

Two guards protect the files in that folder. The host refuses the checkout when the folder holds uncommitted changes to tracked files. The host also refuses when another worktree holds the branch. A new branch that starts at the current commit moves no file, so the host keeps the uncommitted work and skips the first guard. Git refuses to overwrite an untracked file, and the host reports that failure as a conflict. A create that starts an agent or a command in the project folder needs the flag, and the host refuses it otherwise.

The desktop composer shows a folder picker beside the branch picker. The picker stays hidden for sessions, for pull request checkouts, and for cloud hosts. The CLI adds `superset ws create --no-worktree`, the one case that needs no `--branch`, `--pr`, or `--task`. The MCP tool `workspaces_create` takes the same field.

Ten integration tests drive the real procedure against a real git repository. They assert the branch on disk, the count that `git worktree list` reports, and every guard above. The host-service suite reports 1222 pass and 0 fail. The CLI suite reports 101 pass and 0 fail. Typecheck and biome are clean.

I did not run the desktop picker in the app, because this worktree has no `.env` file and a dev stack needs a Neon branch. The SDK and the automation dispatcher still do not pass `noWorktree`. Three review findings stay open, and each one needs a product decision: an in-place checkout can swap files under a terminal that already runs in that folder, a detached HEAD fails before the checkout that would repair it, and the board column plus the sidebar placement rules still special case the main workspace.

https://claude.ai/code/session_017wzc7Uie1ZF7bCVAcJaUbR
