### PR TITLE
fix(desktop): stop entity-escaping typed angle brackets in prompt composers

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -338,7 +338,12 @@ export function MarkdownEditor({
 					"first:before:text-muted-foreground first:before:float-left first:before:h-0 first:before:pointer-events-none first:before:content-[attr(data-placeholder)]",
 			}),
 			Markdown.configure({
-				html: true,
+				// Prompts and descriptions are plain-text payloads, not HTML
+				// documents. With html:true, reloading `content` re-parses
+				// serialized text as markup, so a typed `Array<string>` comes
+				// back as `Array` and `<b>x</b>` as `x`. Parsing angle brackets
+				// as text is what keeps a remount lossless.
+				html: false,
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -24,7 +24,6 @@ import { Strike } from "@tiptap/extension-strike";
 import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
-import { Text } from "@tiptap/extension-text";
 import { Underline } from "@tiptap/extension-underline";
 import {
 	type Editor,
@@ -38,6 +37,7 @@ import { useEffect, useRef } from "react";
 import { BubbleMenuToolbar } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/BubbleMenuToolbar";
 import { env } from "renderer/env.renderer";
 import { useInlineUrlPolicy } from "renderer/lib/clickPolicy";
+import { TextWithoutHtmlEscape } from "renderer/lib/tiptap/text-without-html-escape";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { Markdown } from "tiptap-markdown";
 import { CodeBlockView } from "./components/CodeBlockView";
@@ -238,7 +238,7 @@ export function MarkdownEditor({
 		autofocus: autoFocus === true ? "end" : autoFocus || false,
 		extensions: [
 			Document,
-			Text,
+			TextWithoutHtmlEscape,
 			Paragraph.configure({
 				HTMLAttributes: { class: "my-0 leading-relaxed" },
 			}),

--- a/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.test.ts
+++ b/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.test.ts
@@ -17,29 +17,39 @@ afterAll(async () => {
 	if (!alreadyRegistered) await GlobalRegistrator.unregister();
 });
 
-/** Serializes a document holding exactly the text a user typed. */
-function serializeTyped(text: string): string {
-	const editor = new Editor({
+/** Mirrors MarkdownEditor's markdown-relevant extension set. */
+function buildEditor() {
+	return new Editor({
 		extensions: [
 			Document,
 			Paragraph,
 			TextWithoutHtmlEscape,
 			Markdown.configure({
-				html: true,
+				html: false,
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),
 		],
-		content: {
-			type: "doc",
-			content: [{ type: "paragraph", content: [{ type: "text", text }] }],
-		},
+		content: "",
 	});
+}
+
+function getMarkdown(editor: ReturnType<typeof buildEditor>): string {
 	const storage = editor.storage as unknown as Record<
 		string,
 		{ getMarkdown?: () => string }
 	>;
 	return storage.markdown?.getMarkdown?.() ?? "";
+}
+
+/** Serializes a document holding exactly the text a user typed. */
+function serializeTyped(text: string): string {
+	const editor = buildEditor();
+	editor.commands.setContent({
+		type: "doc",
+		content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+	});
+	return getMarkdown(editor);
 }
 
 describe("TextWithoutHtmlEscape", () => {
@@ -62,5 +72,57 @@ describe("TextWithoutHtmlEscape", () => {
 
 	it("still escapes real markdown syntax", () => {
 		expect(serializeTyped("a * b")).toBe("a \\* b");
+	});
+});
+
+/**
+ * MarkdownEditor is uncontrolled after mount but re-parses `content` whenever
+ * its key changes (the new-workspace composer remounts on prompt seeding and
+ * reset). Serializing without the HTML escape is only safe because the editor
+ * also parses with html:false — otherwise the reload reads angle brackets as
+ * markup and drops them. These cover that pair together.
+ */
+function reload(typed: string): { markdown: string; afterReload: string } {
+	const write = buildEditor();
+	write.commands.setContent({
+		type: "doc",
+		content: [{ type: "paragraph", content: [{ type: "text", text: typed }] }],
+	});
+	const markdown = getMarkdown(write);
+
+	const read = buildEditor();
+	read.commands.setContent(markdown);
+	return { markdown, afterReload: read.state.doc.textContent };
+}
+
+describe("MarkdownEditor reload round trip", () => {
+	it("keeps a generic type through a remount", () => {
+		// With html:true this reloaded as "returns Array" — <string> was markup.
+		expect(reload("returns Array<string>")).toEqual({
+			markdown: "returns Array<string>",
+			afterReload: "returns Array<string>",
+		});
+	});
+
+	it("keeps HTML-looking text through a remount", () => {
+		// With html:true this reloaded as "text".
+		expect(reload("<b>text</b>")).toEqual({
+			markdown: "<b>text</b>",
+			afterReload: "<b>text</b>",
+		});
+	});
+
+	it("keeps a shell redirect through a remount", () => {
+		expect(reload("run build > out.log")).toEqual({
+			markdown: "run build > out.log",
+			afterReload: "run build > out.log",
+		});
+	});
+
+	it("decodes a typed entity on reload, which markdown-it always does", () => {
+		// Documented, not endorsed: markdown-it's entity rule runs regardless of
+		// the html option, so `&gt;` cannot survive the parser as its spelling.
+		// It reached the agent as `&gt;` before this change either way.
+		expect(reload("&gt;")).toEqual({ markdown: "&gt;", afterReload: ">" });
 	});
 });

--- a/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.test.ts
+++ b/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.test.ts
@@ -1,0 +1,66 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom over the preloaded plain-object document — TipTap's Editor needs
+// real DOM APIs. bun runs test files sequentially in one process and
+// happy-dom's globals are process-wide, so register once and unregister after.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+
+const { afterAll, describe, expect, it } = await import("bun:test");
+const { Editor } = await import("@tiptap/core");
+const { Document } = await import("@tiptap/extension-document");
+const { Paragraph } = await import("@tiptap/extension-paragraph");
+const { Markdown } = await import("tiptap-markdown");
+const { TextWithoutHtmlEscape } = await import("./text-without-html-escape");
+
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+/** Serializes a document holding exactly the text a user typed. */
+function serializeTyped(text: string): string {
+	const editor = new Editor({
+		extensions: [
+			Document,
+			Paragraph,
+			TextWithoutHtmlEscape,
+			Markdown.configure({
+				html: true,
+				transformPastedText: true,
+				transformCopiedText: true,
+			}),
+		],
+		content: {
+			type: "doc",
+			content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+		},
+	});
+	const storage = editor.storage as unknown as Record<
+		string,
+		{ getMarkdown?: () => string }
+	>;
+	return storage.markdown?.getMarkdown?.() ?? "";
+}
+
+describe("TextWithoutHtmlEscape", () => {
+	it("keeps angle brackets as typed", () => {
+		// Stock tiptap-markdown emits "2 &gt; 1 and a &lt; b", which reaches
+		// agent CLIs verbatim over the launch heredoc.
+		expect(serializeTyped("2 > 1 and a < b")).toBe("2 > 1 and a < b");
+	});
+
+	it("keeps shell redirects and generics intact", () => {
+		expect(serializeTyped("run build > out.log")).toBe("run build > out.log");
+		expect(serializeTyped("returns Array<string>")).toBe(
+			"returns Array<string>",
+		);
+	});
+
+	it("does not rewrite a literal entity the user typed", () => {
+		expect(serializeTyped("&gt;")).toBe("&gt;");
+	});
+
+	it("still escapes real markdown syntax", () => {
+		expect(serializeTyped("a * b")).toBe("a \\* b");
+	});
+});

--- a/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.ts
+++ b/apps/desktop/src/renderer/lib/tiptap/text-without-html-escape.ts
@@ -1,0 +1,26 @@
+import { Text } from "@tiptap/extension-text";
+import type { MarkdownNodeSpec } from "tiptap-markdown";
+
+/**
+ * tiptap-markdown escapes `<` and `>` to entities on every text node
+ * (extensions/nodes/text.js), so a typed `2 > 1` serializes as `2 &gt; 1`.
+ * That protects its own round trip, which re-parses output as
+ * markdown-with-HTML. Ours isn't one: this markdown reaches agent CLIs over
+ * argv/stdin and lands in stored task and automation prompts, where nothing
+ * decodes it again.
+ *
+ * Emit text as typed. prosemirror-markdown still escapes real markdown
+ * syntax, so only the HTML entity layer goes away.
+ */
+export const TextWithoutHtmlEscape = Text.extend({
+	addStorage() {
+		return {
+			markdown: {
+				serialize(state, node) {
+					state.text(node.text ?? "");
+				},
+				parse: {},
+			} satisfies MarkdownNodeSpec,
+		};
+	},
+});


### PR DESCRIPTION
## Problem

Typing `>` in the new-workspace composer reaches the agent as `&gt;`. It shows up in the terminal the moment a new workspace starts its agent session.

The cause is in the composer, not the terminal. `tiptap-markdown`'s text-node serializer escapes `<` and `>` on every text node, unconditionally:

```js
// tiptap-markdown/src/extensions/nodes/text.js
serialize(state, node) { state.text(escapeHTML(node.text)); }
```

So `onChange` hands `2 &gt; 1` to the draft store, `buildPromptCommandString` wraps that in the launch heredoc verbatim, and the CLI receives the entity. Nothing downstream decodes it.

Notes on the library's behaviour, since it looks arbitrary:

- The escape guards *its own* round trip — it re-parses output as markdown-with-HTML, where unescaped `<b>hi</b>` would come back as markup and destroy the text. Reasonable for that use.
- It ignores its own `html` option: `html: false` still escapes.
- It doesn't escape `&`, so it's non-injective — a literal `&gt;` typed by a user re-parses to `>`.

## Fix

Override the text node's markdown serializer for `MarkdownEditor` only. `prosemirror-markdown` still escapes real markdown syntax; only the HTML entity layer goes away.

One line in the extension list covers every affected surface: the new-workspace screen, the dashboard modal's `PromptGroup`, `CreateTaskDialog`, and `AutomationBody`. The latter two persist their text, so this stops writing entities into stored task descriptions and automation instructions too.

## Scope

`createMarkdownExtensions` (markdown **file** editing and preview — `FileViewerPane`, `MarkdownPreviewView`) deliberately keeps the escape. Those files really are re-parsed as markdown-with-HTML, so unescaping could turn a typed literal `<b>` or `<!-- -->` into real markup. `mergeMarkdownEdits.roundtrip.test.ts` encodes that lossiness on purpose, and it still passes untouched.

Rows already written with `&gt;` are not backfilled.

## Verification

- New test: angle brackets, shell redirects, `Array<string>`, a literal `&gt;` staying literal, and markdown escaping still working.
- Full desktop suite: 2796 pass / 0 fail.
- biome and tsc clean on touched files.

https://claude.ai/code/session_01TbJoL3qT5SX1bjXc6kK6zN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves typed angle brackets in prompt composers and stops remounts from stripping them. Previously, prompts serialized `>` as `&gt;` and re-parsed angle brackets as markup on reload (e.g., `Array<string>` became `Array`).

- Replace `@tiptap/extension-text` with `TextWithoutHtmlEscape` in `MarkdownEditor` used by the new workspace composer, dashboard `PromptGroup` modal, `CreateTaskDialog`, and `AutomationBody`.
- Configure `Markdown` from `tiptap-markdown` with `html: false` so serialized prompt text round-trips on remount; only the HTML-entity layer is removed—`prosemirror-markdown` still escapes real markdown syntax.
- Markdown file editing (`createMarkdownExtensions`) is unchanged to keep markdown-with-HTML round-trip safety.
- No migration required; existing stored entities remain as-is.
- Adds focused tests, including reload round trips; full desktop suite passes.

<sup>Written for commit c547b4c4b2373732dce040e4e0129f580d65ce62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown text now preserves literal angle brackets, shell redirects, generic type syntax, and entities when exported.
  * Content remains unchanged when the editor is remounted or reloaded.
  * Markdown syntax continues to be escaped correctly during serialization.

* **Tests**
  * Added coverage for preserving special characters across editor reloads.
  * Verified that typed entities reload as their intended characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->