### PR TITLE
fix(desktop): tab from the workspace name to the prompt in the new workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -150,6 +150,13 @@ interface MarkdownEditorProps {
 	searchFiles?: FileMentionSearchFn;
 	/** If provided, pasted file items (e.g. clipboard images) are forwarded here. */
 	onPasteFiles?: (files: File[]) => void;
+	/**
+	 * Called when the user presses Tab (forward) or Shift+Tab (backward) while
+	 * the caret sits outside a list, where Tab changes the indent instead. When
+	 * this is set, the editor stays out of the browser's tab order, and the
+	 * parent picks the element that gets the focus.
+	 */
+	onTabOut?: (direction: "forward" | "backward") => void;
 	/** Toggle optional affordances. Each defaults to enabled. */
 	features?: {
 		slashCommand?: boolean;
@@ -213,6 +220,7 @@ export function MarkdownEditor({
 	onEnterSubmit,
 	searchFiles,
 	onPasteFiles,
+	onTabOut,
 	features,
 	editable = true,
 }: MarkdownEditorProps) {
@@ -229,6 +237,8 @@ export function MarkdownEditor({
 	onPasteFilesRef.current = onPasteFiles;
 	const onEnterSubmitRef = useRef(onEnterSubmit);
 	onEnterSubmitRef.current = onEnterSubmit;
+	const onTabOutRef = useRef(onTabOut);
+	onTabOutRef.current = onTabOut;
 	const editorRef = useRef<Editor | null>(null);
 
 	const urlPolicy = useInlineUrlPolicy();
@@ -359,8 +369,20 @@ export function MarkdownEditor({
 		editorProps: {
 			attributes: {
 				class: cn("focus:outline-none min-h-[100px]", editorClassName),
+				...(onTabOut ? { tabindex: "-1" } : {}),
 			},
 			handleKeyDown: (_, event) => {
+				if (event.key === "Tab" && onTabOutRef.current) {
+					const currentEditor = editorRef.current;
+					const changedIndent = event.shiftKey
+						? currentEditor?.commands.liftListItem("listItem") ||
+							currentEditor?.commands.liftListItem("taskItem")
+						: currentEditor?.commands.sinkListItem("listItem") ||
+							currentEditor?.commands.sinkListItem("taskItem");
+					if (changedIndent) return true;
+					onTabOutRef.current(event.shiftKey ? "backward" : "forward");
+					return true;
+				}
 				if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
 					onModEnter?.();
 					return true;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -388,6 +388,19 @@ export function PromptGroup({
 		return () => window.removeEventListener("keydown", handler);
 	}, [isNewWorkspaceModalOpen, handleSubmit]);
 
+	// ── Keyboard focus order ─────────────────────────────────────────
+	// The Tab key goes from the workspace name field to the prompt, and then to
+	// the branch name field. The prompt editor comes last in the markup, so
+	// these three elements pass the focus to each other. The editor also stays
+	// out of the browser's tab order (see the onTabOut prop below), so the Tab
+	// key does not go back into it from the branch name field.
+	const composerRef = useRef<HTMLDivElement | null>(null);
+	const workspaceNameInputRef = useRef<HTMLInputElement | null>(null);
+	const branchNameInputRef = useRef<HTMLInputElement | null>(null);
+	const focusPromptEditor = useCallback(() => {
+		composerRef.current?.querySelector<HTMLElement>(".ProseMirror")?.focus();
+	}, []);
+
 	// ── Linked issues / PR ───────────────────────────────────────────
 	const {
 		addLinkedIssue,
@@ -399,10 +412,11 @@ export function PromptGroup({
 
 	// ── Render ────────────────────────────────────────────────────────
 	return (
-		<div className="p-3 space-y-2">
+		<div ref={composerRef} className="p-3 space-y-2">
 			{/* Workspace name + branch name */}
 			<div className="flex items-center">
 				<Input
+					ref={workspaceNameInputRef}
 					className="border-none bg-transparent dark:bg-transparent shadow-none text-base font-medium px-0 h-auto focus-visible:ring-0 placeholder:text-muted-foreground/40 min-w-0 flex-1"
 					placeholder="Workspace name (optional)"
 					value={workspaceName}
@@ -412,6 +426,11 @@ export function PromptGroup({
 							workspaceNameEdited: true,
 						})
 					}
+					onKeyDown={(e) => {
+						if (e.key !== "Tab" || e.shiftKey) return;
+						e.preventDefault();
+						focusPromptEditor();
+					}}
 					onBlur={() => {
 						if (!workspaceName.trim())
 							updateDraft({ workspaceName: "", workspaceNameEdited: false });
@@ -419,6 +438,7 @@ export function PromptGroup({
 				/>
 				<div className="shrink min-w-0 ml-auto max-w-[50%]">
 					<Input
+						ref={branchNameInputRef}
 						className={cn(
 							"border-none bg-transparent dark:bg-transparent shadow-none text-xs font-mono text-muted-foreground/60 px-0 h-auto focus-visible:ring-0 placeholder:text-muted-foreground/30 focus:text-muted-foreground text-right placeholder:text-right overflow-hidden text-ellipsis",
 						)}
@@ -431,6 +451,11 @@ export function PromptGroup({
 								branchNameFromProvider: false,
 							})
 						}
+						onKeyDown={(e) => {
+							if (e.key !== "Tab" || !e.shiftKey) return;
+							e.preventDefault();
+							focusPromptEditor();
+						}}
 						onBlur={() => {
 							const sanitized = sanitizeUserBranchName(branchName.trim());
 							if (!sanitized)
@@ -550,6 +575,10 @@ export function PromptGroup({
 					content={prompt}
 					onChange={(markdown) => updateDraft({ prompt: markdown })}
 					onPasteFiles={(files) => attachments.add(files)}
+					onTabOut={(direction) => {
+						if (direction === "forward") branchNameInputRef.current?.focus();
+						else workspaceNameInputRef.current?.focus();
+					}}
 					autoFocus={promptSeed > 0 || prompt ? "end" : "start"}
 					placeholder="What do you want to do?"
 					className="flex flex-col min-h-[100px] max-h-[200px] px-3 pt-3"


### PR DESCRIPTION
Fixes keyboard focus in the New Workspace modal. Tab now moves workspace name → prompt → branch name, and Shift+Tab reverses. Previously Tab skipped the prompt and the editor trapped focus, blocking keyboard navigation into and out of the composer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard focus in the New Workspace modal. Tab now moves workspace name → prompt → branch name, and Shift+Tab reverses. Previously Tab skipped the prompt and the editor trapped focus, blocking keyboard navigation into and out of the composer.

**Review notes**
- Adds optional `onTabOut` to `MarkdownEditor`; when set, the editor is removed from the browser tab order and handles Tab: it indents lists when the caret is in a list, otherwise calls `onTabOut("forward" | "backward")`.
- Wires focus in `PromptGroup`: workspace name and branch name inputs intercept Tab/Shift+Tab to focus the prompt; `onTabOut` advances focus to the branch (forward) or back to the name (backward).
- Only the New Workspace modal passes `onTabOut`; all other `MarkdownEditor` instances keep existing behavior.

**QA**
- Open New Workspace modal and press Tab: focus should move name → prompt → branch, then continue to the remaining controls; Shift+Tab should reverse.
- In the prompt: Tab should indent when inside a list; otherwise it should move focus according to the order above.
- Verify other screens using `MarkdownEditor` are unaffected.

<sup>Written for commit 5e564e4c709b58d3f55ec96e53df0de4a79a42b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation in the Markdown editor, including list indentation with Tab and Shift+Tab.
  * Added predictable forward and backward focus movement across workspace name, branch, and prompt fields in the new workspace form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->