### PR TITLE
fix(cli): automations update no longer re-targets the host as a side effect, and --workspace "" clears the pin

### DIFF
--- a/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
@@ -50,3 +50,37 @@ describe("resolveAutomationTarget host preflight", () => {
 		});
 	});
 });
+
+describe("resolveAutomationTarget default host", () => {
+	it("falls back to defaultHostId, not this machine, when --host is omitted", async () => {
+		const target = await resolveAutomationTarget({
+			...BASE,
+			api: apiWithHosts(["host-current"]),
+			defaultHostId: "host-current",
+		});
+		expect(target).toEqual({
+			targetHostId: "host-current",
+			v2ProjectId: null,
+		});
+	});
+
+	it("prefers an explicit --host over defaultHostId", async () => {
+		const target = await resolveAutomationTarget({
+			...BASE,
+			api: apiWithHosts(["host-explicit", "host-current"]),
+			hostId: "host-explicit",
+			defaultHostId: "host-current",
+		});
+		expect(target.targetHostId).toBe("host-explicit");
+	});
+
+	it("reports an unregistered default host without claiming it is this machine", async () => {
+		await expect(
+			resolveAutomationTarget({
+				...BASE,
+				api: apiWithHosts([]),
+				defaultHostId: "host-current",
+			}),
+		).rejects.toThrow(/Host host-current is not registered/);
+	});
+});

--- a/packages/cli/src/commands/automations/resolveAutomationTarget.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.ts
@@ -16,10 +16,17 @@ export async function resolveAutomationTarget(args: {
 	userJwt: string;
 	api: ApiClient;
 	hostId?: string;
+	/**
+	 * Host to fall back to when `hostId` (--host) is omitted. Create leaves
+	 * this unset and targets this machine; update passes the automation's
+	 * current host so that omitting --host never moves the automation as a
+	 * side effect (#6522).
+	 */
+	defaultHostId?: string;
 	workspaceId?: string;
 	projectId?: string;
 }): Promise<{ targetHostId: string; v2ProjectId: string | null }> {
-	const targetHostId = args.hostId ?? getHostId();
+	const targetHostId = args.hostId ?? args.defaultHostId ?? getHostId();
 
 	// The cloud rejects automations whose target host has no v2Hosts row
 	// (the host-service registers one at startup, and that registration can
@@ -30,13 +37,16 @@ export async function resolveAutomationTarget(args: {
 		organizationId: args.organizationId,
 	});
 	if (!hosts.some((host) => host.id === targetHostId)) {
+		// Key the wording on which host is actually failing, not on how it
+		// was chosen: a defaulted host may be a remote machine.
+		const isThisMachine = targetHostId === getHostId();
 		throw new CLIError(
-			args.hostId
-				? `Host ${targetHostId} is not registered in this organization`
-				: `This machine (host ${targetHostId}) isn't registered with the cloud`,
-			args.hostId
-				? "Run: superset hosts list"
-				: "Restart the host service (superset stop && superset start), then check: superset hosts list",
+			isThisMachine
+				? `This machine (host ${targetHostId}) isn't registered with the cloud`
+				: `Host ${targetHostId} is not registered in this organization`,
+			isThisMachine
+				? "Restart the host service (superset stop && superset start), then check: superset hosts list"
+				: "Run: superset hosts list",
 		);
 	}
 

--- a/packages/cli/src/commands/automations/update/command.test.ts
+++ b/packages/cli/src/commands/automations/update/command.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture what the command hands to the target resolver and to the update
+// mutation. The command imports the resolver from the parent directory, so
+// mock that module before importing the SUT.
+type ResolverArgs = Record<string, unknown>;
+let resolverCalls: ResolverArgs[] = [];
+let resolverResult: { targetHostId: string; v2ProjectId: string | null } = {
+	targetHostId: "host-current",
+	v2ProjectId: "project-1",
+};
+mock.module("../resolveAutomationTarget", () => ({
+	resolveAutomationTarget: async (args: ResolverArgs) => {
+		resolverCalls.push(args);
+		return resolverResult;
+	},
+}));
+
+const { default: updateCommand } = await import("./command");
+
+const AUTOMATION_ID = "0b8f4a92-01c4-4c8e-9f31-b1a5b2f9d001";
+const WORKSPACE_ID = "b502bf30-8693-4815-be65-795035e0ce5f";
+
+let updateCalls: Record<string, unknown>[] = [];
+let getCalls: Record<string, unknown>[] = [];
+let existingAutomation: Record<string, unknown>;
+
+function makeCtx() {
+	return {
+		api: {
+			automation: {
+				get: {
+					query: async (input: Record<string, unknown>) => {
+						getCalls.push(input);
+						return existingAutomation;
+					},
+				},
+				update: {
+					mutate: async (input: Record<string, unknown>) => {
+						updateCalls.push(input);
+						return { ...existingAutomation, ...input };
+					},
+				},
+				setEnabled: { mutate: async () => ({}) },
+			},
+		},
+		config: { organizationId: "org-1" },
+		bearer: "jwt",
+		authSource: "oauth",
+	} as never;
+}
+
+function invoke(options: Record<string, unknown>) {
+	return updateCommand.run({
+		ctx: makeCtx(),
+		args: { id: AUTOMATION_ID } as never,
+		options: options as never,
+		signal: new AbortController().signal,
+	});
+}
+
+beforeEach(() => {
+	resolverCalls = [];
+	updateCalls = [];
+	getCalls = [];
+	resolverResult = { targetHostId: "host-current", v2ProjectId: "project-1" };
+	existingAutomation = {
+		id: AUTOMATION_ID,
+		name: "nightly",
+		targetHostId: "host-current",
+		v2ProjectId: "project-1",
+		v2WorkspaceId: null,
+	};
+});
+
+describe("automations update host targeting (#6522)", () => {
+	test("a metadata-only update never resolves a target or sends a host", async () => {
+		await invoke({ name: "renamed" });
+		expect(resolverCalls).toHaveLength(0);
+		expect(getCalls).toHaveLength(0);
+		expect(updateCalls).toHaveLength(1);
+		expect("targetHostId" in (updateCalls[0] ?? {})).toBe(false);
+	});
+
+	test("--project without --host validates against the automation's current host and does not move it", async () => {
+		resolverResult = { targetHostId: "host-current", v2ProjectId: "project-2" };
+		await invoke({ project: "project-2" });
+		expect(resolverCalls).toHaveLength(1);
+		expect(resolverCalls[0]?.hostId).toBeUndefined();
+		expect(resolverCalls[0]?.defaultHostId).toBe("host-current");
+		expect("targetHostId" in (updateCalls[0] ?? {})).toBe(false);
+		expect(updateCalls[0]?.v2ProjectId).toBe("project-2");
+	});
+
+	test("--host moves the automation explicitly", async () => {
+		resolverResult = { targetHostId: "host-b", v2ProjectId: "project-2" };
+		await invoke({ project: "project-2", host: "host-b" });
+		expect(resolverCalls[0]?.hostId).toBe("host-b");
+		expect(updateCalls[0]?.targetHostId).toBe("host-b");
+	});
+
+	test("--workspace pins with the automation's current host when --host is omitted", async () => {
+		await invoke({ workspace: WORKSPACE_ID });
+		expect(resolverCalls[0]?.defaultHostId).toBe("host-current");
+		// The pin is stored denormalized, so its host must ride along even
+		// though --host was omitted; it is the current host, not this machine.
+		expect(updateCalls[0]?.targetHostId).toBe("host-current");
+		expect(updateCalls[0]?.v2WorkspaceId).toBe(WORKSPACE_ID);
+		expect(updateCalls[0]?.v2ProjectId).toBe("project-1");
+	});
+});
+
+describe("automations update pin clearing (#6523)", () => {
+	test('--workspace "" clears the pin without resolving or moving anything', async () => {
+		await invoke({ workspace: "" });
+		expect(resolverCalls).toHaveLength(0);
+		expect(updateCalls[0]?.v2WorkspaceId).toBeNull();
+		expect("targetHostId" in (updateCalls[0] ?? {})).toBe(false);
+	});
+
+	test('--workspace "" combined with --project keeps the project and clears the pin', async () => {
+		resolverResult = { targetHostId: "host-current", v2ProjectId: "project-2" };
+		await invoke({ workspace: "", project: "project-2" });
+		expect(resolverCalls).toHaveLength(1);
+		expect(resolverCalls[0]?.workspaceId).toBeUndefined();
+		expect(updateCalls[0]?.v2WorkspaceId).toBeNull();
+		expect(updateCalls[0]?.v2ProjectId).toBe("project-2");
+		expect("targetHostId" in (updateCalls[0] ?? {})).toBe(false);
+	});
+});

--- a/packages/cli/src/commands/automations/update/command.ts
+++ b/packages/cli/src/commands/automations/update/command.ts
@@ -13,9 +13,13 @@ export default command({
 		agent: string().desc(
 			"New host agent instance id or presetId (e.g. claude, codex, superset).",
 		),
-		host: string().desc("New target host id"),
+		host: string().desc(
+			"New target host id — moves the automation. Omitting it keeps the current host",
+		),
 		project: string().desc("New v2 project id"),
-		workspace: string().desc("New v2 workspace id"),
+		workspace: string().desc(
+			'New v2 workspace id to reuse every run. Pass "" to clear the pin so each run creates a fresh workspace',
+		),
 		session: boolean().desc(
 			"Switch to session mode: no project, each run creates a project-less session workspace",
 		),
@@ -39,8 +43,10 @@ export default command({
 			});
 		}
 
-		// Retargeting (--workspace or --project) re-derives targetHostId +
-		// v2ProjectId; the resource must exist on the target host.
+		// Retargeting (--workspace or --project) re-derives v2ProjectId
+		// against a concrete host; the resource must exist there. That host
+		// defaults to the automation's current one, not this machine, so an
+		// update that omits --host never moves the automation (#6522).
 		let target:
 			| { targetHostId: string; v2ProjectId: string | null }
 			| undefined;
@@ -52,12 +58,14 @@ export default command({
 					"Run: superset auth login",
 				);
 			}
+			const existing = await ctx.api.automation.get.query({ id });
 			target = await resolveAutomationTarget({
 				organizationId,
 				userJwt: ctx.bearer,
 				api: ctx.api,
 				hostId: options.host ?? undefined,
-				workspaceId: options.workspace ?? undefined,
+				defaultHostId: existing.targetHostId ?? undefined,
+				workspaceId: options.workspace || undefined,
 				projectId: options.project ?? undefined,
 			});
 		}
@@ -73,12 +81,25 @@ export default command({
 			...(options.project !== undefined
 				? { v2ProjectId: options.project }
 				: {}),
+			// An empty --workspace is an explicit null: it clears the pin so
+			// each run creates a fresh workspace again (#6523).
 			...(options.workspace !== undefined
-				? { v2WorkspaceId: options.workspace }
+				? { v2WorkspaceId: options.workspace || null }
 				: {}),
 			// Session mode clears both the project and any workspace pin.
 			...(options.session ? { v2ProjectId: null, v2WorkspaceId: null } : {}),
-			...target,
+			...(target
+				? {
+						v2ProjectId: target.v2ProjectId,
+						// A workspace pin is stored denormalized, so the pin's
+						// host must ride along even without --host; it is the
+						// automation's current host. A plain --project update
+						// sends a host only when --host names one.
+						...(options.workspace || options.host !== undefined
+							? { targetHostId: target.targetHostId }
+							: {}),
+					}
+				: {}),
 		});
 
 		return {


### PR DESCRIPTION
Fixes #6522
Fixes #6523

## What was wrong

**#6522**: `superset automations update <id> --project <p>` (or `--workspace <w>`) without `--host` re-resolved the target host through `resolveAutomationTarget`, which defaulted to `getHostId()`, the machine running the command. Updating an automation from any machine other than its target host silently moved it there. Nothing about the invocation said "move this", and the run keeps succeeding on the wrong machine, so there is no error to notice.

(As the triage on the issue found, plain metadata updates like `--name` were already safe; the bug was scoped to `--project` and `--workspace` updates, which are exactly the ones people run when grooming automations from a second machine.)

**#6523**: there was no way to remove a workspace pin. `--workspace ""` was rejected by the server schema (`Invalid UUID`), and the only workaround was the undocumented same-project trick, which risked the host side effect above.

## The fix

- `resolveAutomationTarget` now takes an explicit `defaultHostId` instead of always reaching for `getHostId()`. Create keeps the old behavior (defaults to this machine). Update first fetches the automation and passes its current `targetHostId`, so validation of `--project`/`--workspace` runs against the host the automation actually lives on, and only an explicit `--host` moves it.
- The update payload only carries `targetHostId` when it has to: when `--host` was named, or when pinning a workspace (the pin is stored denormalized server-side, so the pin's host must ride along; it is now the automation's current host, not the local machine).
- `--workspace ""` is treated as an explicit `null` and clears the pin, which the server already accepts (`v2WorkspaceId: z.string().uuid().nullish()`). No resolver call, no host change.
- The unregistered-host error now picks its wording ("This machine ..." vs "Host X is not registered ...") from which host actually failed, since a defaulted host can now be a remote machine.
- Help text for `--host` and `--workspace` documents both behaviors.

## Tests

- New `update/command.test.ts` covers: metadata-only updates send no host and never resolve a target; `--project` without `--host` validates against the automation's current host and omits `targetHostId` from the payload; `--host` moves explicitly; `--workspace <id>` pins with the automation's current host; `--workspace ""` clears the pin with no resolver call and no host key, alone and combined with `--project`.
- `resolveAutomationTarget.test.ts` gains cases for the default-host fallback, explicit `--host` precedence, and the error wording for an unregistered non-local default host.

All 6 new tests fail on main and pass here. Full package suite: 110 pass, typecheck and Biome clean.

## Notes for review

The server side already did the right thing on both counts (an omitted `targetHostId` keeps the existing host, and an explicit `v2WorkspaceId: null` clears the pin), so this is a CLI-only change. Clearing the pin via `--workspace ""` follows the first option suggested in #6523; happy to switch to a `--no-workspace` flag instead if that is preferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `superset automations update` from moving an automation to the invoking machine when `--project` or `--workspace` is used without `--host`. Also allows clearing a workspace pin with `--workspace ""`.

- The target resolver now accepts a `defaultHostId`. Create keeps defaulting to this machine; update fetches the automation and defaults to its current host. Only an explicit `--host` moves the automation.
- Update payload includes `targetHostId` only when needed: when `--host` is set or when pinning a workspace (pin is denormalized and must carry its host). Metadata-only and `--project`-only updates omit `targetHostId` unless moving.
- `--workspace ""` sends `null` to clear the pin. No resolver call. No host change.
- Unregistered-host errors choose wording based on the actual failing host (“This machine …” vs “Host X …”).
- Help text for `--host` and `--workspace` documents these behaviors.
- Tests cover: no-host movement on metadata updates, host defaulting on project updates, explicit host moves, pinning uses current host, and clearing the pin with `--workspace ""`.

<sup>Written for commit fef9e41ddba0887315038c3533f8a721637cb8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation updates now retain the current host when no host is specified.
  * You can move an automation to another host using the host option.
  * Workspace pins can be cleared by providing an empty workspace value.
* **Bug Fixes**
  * Improved host registration errors with clearer guidance based on the resolved target.
  * Project and workspace targeting now remain consistent when updating automations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->