### PR TITLE
fix(shared): move MIN_HOST_SERVICE_VERSION onto the unified version line so the gate can actually fire

### DIFF
--- a/packages/shared/src/host-version.test.ts
+++ b/packages/shared/src/host-version.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import semver from "semver";
+import { MIN_HOST_SERVICE_VERSION } from "./host-version";
+
+const hostServiceVersion: string = JSON.parse(
+	readFileSync(
+		new URL("../../host-service/package.json", import.meta.url),
+		"utf-8",
+	),
+).version;
+
+describe("MIN_HOST_SERVICE_VERSION", () => {
+	it("is a valid semver version", () => {
+		expect(semver.valid(MIN_HOST_SERVICE_VERSION)).not.toBeNull();
+	});
+
+	// Host-service left its own 0.x line for the unified product version
+	// (desktop == host-service == cli at every release), and the floor was
+	// never migrated with it, so `>=0.8.0` accepted every 1.x host and the
+	// gate could not reject anything (#6525). Keeping the floor on the same
+	// major line as the shipped host-service makes that drift loud.
+	it("lives on the same major line as the shipped host-service", () => {
+		expect(semver.major(MIN_HOST_SERVICE_VERSION)).toBe(
+			semver.major(hostServiceVersion),
+		);
+	});
+
+	it("never exceeds the version we ship", () => {
+		expect(semver.gte(hostServiceVersion, MIN_HOST_SERVICE_VERSION)).toBe(true);
+	});
+
+	// The incident behind #6525: `terminal.list` shipped in 1.22.0 and every
+	// client calls it unconditionally, so a 1.20.2 host renders a blank
+	// terminal pane. The gate must reject that host.
+	it("rejects a host from before terminal.list existed", () => {
+		expect(semver.satisfies("1.20.2", `>=${MIN_HOST_SERVICE_VERSION}`)).toBe(
+			false,
+		);
+	});
+});

--- a/packages/shared/src/host-version.test.ts
+++ b/packages/shared/src/host-version.test.ts
@@ -38,4 +38,10 @@ describe("MIN_HOST_SERVICE_VERSION", () => {
 			false,
 		);
 	});
+
+	// Rejecting 1.20.2 alone would still pass with a floor of 1.21.0, which
+	// admits hosts without terminal.list. Pin the introduction version.
+	it("is not below the terminal.list introduction version", () => {
+		expect(semver.gte(MIN_HOST_SERVICE_VERSION, "1.22.0")).toBe(true);
+	});
 });

--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -1,25 +1,26 @@
 /**
  * Minimum host-service version a v2 workspace UI can work with against a
  * **remote** host whose binary we don't control (gates renderer mounting
- * via `useRemoteHostStatus`). For the local host-service we bundle, the
- * desktop coordinator pins to the bundled version exactly (read from
- * `@superset/host-service/package.json`) — this floor does not apply.
+ * via `useRemoteHostStatus`, and mobile's `useHostCompatibility`). For the
+ * local host-service we bundle, the desktop coordinator pins to the bundled
+ * version exactly (read from `@superset/host-service/package.json`) — this
+ * floor does not apply.
  *
- * 0.4.0: terminal launch moved from `terminal.ensureSession` to
- * `terminal.launchSession` plus WebSocket attach params.
- * 0.3.0: host-service registers via cloud `host.ensure` (was
- * `device.ensureV2Host`); v2_hosts/v2_users_hosts/v2_workspaces use
- * machineId text instead of uuid surrogates.
- * 0.2.0: `workspaceCreation.adopt` gained optional `worktreePath`.
+ * The floor lives on the unified product version line (desktop ==
+ * host-service == cli at every release, see `scripts/release/README.md`).
+ * It originally tracked host-service's own pre-release `0.x` line
+ * (0.2.0 → 0.8.0) and was never migrated when host-service joined the
+ * unified line, so for the whole 1.x series `>=0.8.0` accepted every host
+ * and the gate could not reject anything (#6525). A test next to this file
+ * pins the floor to the same major line as the shipped host-service so
+ * that drift stays loud.
  *
- * 0.5.0 — pty-daemon supervision migrated into host-service. New
- * `terminal.daemon` tRPC namespace; older 0.4.x host-services don't
- * expose it.
+ * When a release adds a host-service procedure that clients call
+ * unconditionally, raise this to that release, or the mismatch renders as
+ * silent empty states instead of an explicit "host too old" screen.
  *
- * 0.7.0 — canonical `workspaces.create` flow + `settings.hostAgentConfigs`
- * router (PR1, #3893). Older 0.6.x host-services don't expose either.
- *
- * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
- * WebSocket route is attach-only by `terminalId`.
+ * 1.22.0 — `terminal.list` added; every terminal surface (desktop
+ * renderer, CLI, SDK, MCP, mobile) calls it unconditionally. Older hosts
+ * answer NOT_FOUND, which rendered as a blank terminal pane (#6525).
  */
-export const MIN_HOST_SERVICE_VERSION = "0.8.0";
+export const MIN_HOST_SERVICE_VERSION = "1.22.0";


### PR DESCRIPTION
Fixes #6525

## What was wrong

`MIN_HOST_SERVICE_VERSION` was still `"0.8.0"`, a number from host-service's own pre-release line. Host-service has since joined the unified product version (desktop == host-service == cli at every release, per `scripts/release/README.md`), so every host on the 1.x line satisfied `>=0.8.0` trivially. The gate has been a no-op for the entire 1.x series; it was not merely un-bumped for `terminal.list`, it was on a numbering line that no longer exists.

`terminal.list` (added in 1.22.0) surfaced it: every terminal surface (desktop renderer, CLI, SDK, MCP, mobile) calls it unconditionally, an older host answers `NOT_FOUND`, and the result is the blank terminal pane with no error described in the issue.

## The fix

- `MIN_HOST_SERVICE_VERSION` is now `"1.22.0"`, the release that introduced `terminal.list`. A 1.20.2 host now hits the explicit "host too old" screen (desktop `useRemoteHostStatus`, mobile `useHostCompatibility`, both of which read this constant) instead of rendering empty.
- The doc block is rewritten: the old `0.2.0 -> 0.8.0` history no longer described the numbers being compared. It now records the migration onto the unified line and what 1.22.0 gates.
- New `host-version.test.ts` pins the invariants so this cannot silently drift again:
  - the floor is valid semver,
  - it lives on the same major line as the shipped `@superset/host-service` version (read from its `package.json`), which is the assertion that would have caught the original drift the day host-service joined the unified line,
  - it never exceeds the version we ship,
  - `1.20.2` does not satisfy it (the concrete incident from the issue).

The first two invariants both fail on main today.

## Deliberately out of scope

The issue's triage also found that the desktop hook falls through to `ready` when `host.info` errors, and that CLI/SDK/MCP have no version preflight at all. I left both alone in this PR: mobile's port explicitly documents failing open as intentional (an unreachable host should hit the host-unreachable handling, not the version screen), so changing the desktop hook's error semantics deserves its own discussion rather than riding along with a constant bump. Same for mapping `NOT_FOUND` on host procedures to a "host too old" error in the shared client, which would help every future additive procedure and might be the better long-term fix.

## Tests

`packages/shared`: 779 pass (4 new), typecheck and Biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the host-service floor to the unified product version and raises it from 0.8.0 to 1.22.0 so the compatibility gate works. Previously every 1.x host passed and 1.22+ clients called `terminal.list` on <1.22 hosts, rendering a blank terminal pane; now those hosts show the “host too old” screen.

- Set `MIN_HOST_SERVICE_VERSION` to "1.22.0" and update docs; desktop (`useRemoteHostStatus`) and mobile (`useHostCompatibility`) block <1.22.0 remote hosts. The local bundled host still pins to the shipped `@superset/host-service` version.
- Add `host-version.test.ts` to pin invariants: valid semver, same major as the shipped `@superset/host-service`, not above it, rejects 1.20.2, and enforces a floor of at least 1.22.0.
- Rollout: upgrade remote hosts to >=1.22.0 to avoid the compatibility block.

<sup>Written for commit e20c3185b29f097a097e878c45d57086b61af8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated host compatibility requirements to support reliable terminal functionality.
  * Older host versions without terminal listing support are now rejected instead of showing a blank terminal pane.

* **Tests**
  * Added checks to verify the minimum supported host version is valid and aligned with the shipped release.
  * Added coverage to ensure unsupported and outdated host versions are correctly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->