### PR TITLE
fix(host-service): agents.run treats archived workspaces as gone, so automation pins self-heal

### DIFF
--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -11,7 +11,7 @@ import {
 	sanitizePromptForPty,
 } from "@superset/shared/agent-prompt-launch";
 import { TRPCError } from "@trpc/server";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import type { HostDb } from "../../../db";
 import { hostAgentConfigs, workspaces } from "../../../db/schema";
@@ -346,7 +346,16 @@ export async function runAgentInWorkspace(
 	input: AgentRunInput,
 ): Promise<AgentRunResult> {
 	const workspace = ctx.db.query.workspaces
-		.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+		.findFirst({
+			// A tombstoned (archived) row is gone for agent launches: without
+			// the filter an archived workspace still resolves, and the failure
+			// surfaces one layer deeper as a worktree-path error that carries
+			// no workspace id (#6521).
+			where: and(
+				eq(workspaces.id, input.workspaceId),
+				isNull(workspaces.archivedAt),
+			),
+		})
 		.sync();
 	if (!workspace) {
 		// NOT_FOUND (not a 500) so callers like automation dispatch can tell a

--- a/packages/host-service/test/integration/agents.integration.test.ts
+++ b/packages/host-service/test/integration/agents.integration.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { archiveLocalWorkspace } from "../../src/workspaces/local-workspace-store";
+import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
+
+describe("agents router integration", () => {
+	let scenario: BasicScenario;
+
+	beforeEach(async () => {
+		scenario = await createBasicScenario();
+	});
+
+	afterEach(async () => {
+		await scenario?.dispose();
+	});
+
+	// An archived workspace keeps its row (tombstone) but is semantically
+	// gone. agents.run must answer with the id-bearing NOT_FOUND that
+	// automation dispatch matches to clear a stale workspace pin and fall
+	// back to a fresh workspace (#6521). Without the archived filter the
+	// tombstone still resolved, and the failure surfaced one layer deeper
+	// as a worktree-path error dispatch cannot match, so pinned automations
+	// failed every run once their workspace was archived.
+	test("run rejects an archived workspace with a NOT_FOUND naming the id", async () => {
+		archiveLocalWorkspace(
+			{
+				db: scenario.host.db,
+				eventBus: { broadcastWorkspaceChanged: () => {} } as never,
+			},
+			scenario.workspaceId,
+			"merged",
+		);
+
+		await expect(
+			scenario.host.trpc.agents.run.mutate({
+				workspaceId: scenario.workspaceId,
+				agent: "claude",
+				prompt: "",
+			}),
+		).rejects.toMatchObject({
+			data: { code: "NOT_FOUND" },
+			message: expect.stringContaining(scenario.workspaceId),
+		});
+	});
+});


### PR DESCRIPTION
Fixes #6521

## What was wrong

When a pinned workspace is archived (which the routine merged-PR path guarantees for any automation that does its job and gets its PR merged), the pin is left pointing at the tombstone. There is a self-heal in automation dispatch that clears a dead pin and falls back to creating a fresh workspace, but it is gated on the host answering `NOT_FOUND` with a message naming the pinned workspace id (`dispatch.ts`, the `pinGone` check).

That signal never fired for archived workspaces: `runAgentInWorkspace` looked the workspace up with `eq(workspaces.id, ...)` and no archived filter, and archiving keeps the row. So the tombstone resolved, and the failure surfaced one layer deeper as `Workspace worktree no longer exists: <path>`, a message that carries the worktree path but not the workspace id. `pinGone` stayed false, the run was recorded `dispatch_failed`, and the pin survived, so every subsequent run failed the same way.

## The fix

Add `isNull(workspaces.archivedAt)` to the lookup in `runAgentInWorkspace`. A tombstoned row is semantically gone for agent launches, so the existing id-bearing `NOT_FOUND` (whose comment already says it exists precisely so dispatch can tell a dead pin from a host-side failure) now fires, and the existing dispatch fallback clears the pin and creates a fresh workspace with no cloud-side change at all.

This also closes the nastier variant from the issue triage: an archived workspace whose worktree teardown was interrupted still had its directory on disk, so an agent could launch inside an archived workspace that no list shows.

## Test

New `test/integration/agents.integration.test.ts` on the real host harness: seed a workspace, archive it via `archiveLocalWorkspace` (the same tombstone path production uses), call `agents.run`, and assert the client sees `NOT_FOUND` with the workspace id in the message. On main this fails because the tombstone resolves and the error comes from a later stage without the id.

Full host-service suite: 1213 pass, 0 fail. Typecheck and Biome clean.

## Deliberately out of scope

The issue triage also suggests gating the dispatch fallback on a structured error kind instead of a message substring, and writing a run-level warning when a pin is silently cleared. Both are worthwhile observability improvements but touch the cloud dispatch path and the host error formatter; this PR is the minimal host-side change that makes the existing machinery work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats archived workspaces as not found in `agents.run`, so automation dispatch clears stale pins and recreates a workspace. Previously, archived workspaces resolved and failed later without the workspace id; now the lookup skips archived rows and returns NOT_FOUND naming the id. This also blocks agent launches in archived workspace remnants.

- Add `isNull(workspaces.archivedAt)` to the workspace query so tombstones are treated as gone and the id-bearing NOT_FOUND fires (#6521).
- Add an integration test that archives a workspace and asserts NOT_FOUND includes the workspace id.
- No API or schema changes; no migration required.

<sup>Written for commit 96b68282ce5736a1acfb896978d72d109a4b9f43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived workspaces are now correctly treated as unavailable when running agents.
  * Error messages now clearly identify the archived workspace that could not be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->