### PR TITLE
fix(host-service): workspace delete re-checks the disk after git unregisters the worktree

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
@@ -61,7 +61,7 @@ export const cleanupGitOps = {
 		repoPath: string;
 		worktreePath: string;
 		gitEnv: GitTaskEnv;
-	}): Promise<{ stillRegistered: boolean }> {
+	}): Promise<{ stillRegistered: boolean; removeError?: string }> {
 		// Generous timeout: removal recursively deletes the worktree
 		// directory, which can take a while for large trees (node_modules
 		// etc.).

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -539,7 +539,7 @@ async function runDestroyPhases(
 					}`,
 				});
 			}
-			if (existsSync(local.worktreePath)) {
+			if (!isMissingDirectory(local.worktreePath)) {
 				// Unregistered is not removed: git's unregistration and its
 				// recursive delete are not atomic, so `remove --force --force`
 				// can drop the registration and still fail partway through
@@ -576,8 +576,10 @@ async function runDestroyPhases(
 			}
 			// The outside-root branch above leaves the folder in place, so
 			// report removal from the final disk state rather than assuming
-			// this path always cleared it (#6785 review).
-			worktreeRemoved = !existsSync(local.worktreePath);
+			// this path always cleared it (#6785 review). `isMissingDirectory`
+			// rather than `existsSync`: a leftover this process cannot read
+			// still exists, and must not be reported as removed.
+			worktreeRemoved = isMissingDirectory(local.worktreePath);
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -567,12 +567,17 @@ async function runDestroyPhases(
 						const message = err instanceof Error ? err.message : String(err);
 						throw new TRPCError({
 							code: "INTERNAL_SERVER_ERROR",
-							message: `Worktree at ${local.worktreePath} is no longer registered with git, but its folder could not be removed: ${removeError ?? message}`,
+							message: `Worktree at ${local.worktreePath} is no longer registered with git, but its folder could not be removed: ${message}${
+								removeError ? ` (git worktree remove: ${removeError})` : ""
+							}`,
 						});
 					}
 				}
 			}
-			worktreeRemoved = true;
+			// The outside-root branch above leaves the folder in place, so
+			// report removal from the final disk state rather than assuming
+			// this path always cleared it (#6785 review).
+			worktreeRemoved = !existsSync(local.worktreePath);
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -514,8 +514,9 @@ async function runDestroyPhases(
 			// treat that like "still registered" and block rather than risk
 			// orphaning disk past the archive commit point.
 			let stillRegistered = true;
+			let removeError: string | undefined;
 			try {
-				({ stillRegistered } = await cleanupGitOps.removeWorktree({
+				({ stillRegistered, removeError } = await cleanupGitOps.removeWorktree({
 					repoPath: project.repoPath,
 					worktreePath: local.worktreePath,
 					gitEnv: repoGitEnv,
@@ -533,8 +534,43 @@ async function runDestroyPhases(
 				// retryable instead of orphaning disk past the commit point.
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
-					message: `Failed to remove worktree at ${local.worktreePath}`,
+					message: `Failed to remove worktree at ${local.worktreePath}${
+						removeError ? `: ${removeError}` : ""
+					}`,
 				});
+			}
+			if (existsSync(local.worktreePath)) {
+				// Unregistered is not removed: git's unregistration and its
+				// recursive delete are not atomic, so `remove --force --force`
+				// can drop the registration and still fail partway through
+				// deleting files (locked file, live writer). Trusting the
+				// registry alone silently orphaned the folder — no list shows
+				// it, and a retry reports success without touching it (#6730).
+				// Fall back to the same guarded direct removal the other
+				// branches use.
+				const worktreeBaseDir =
+					project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
+				if (
+					!isInsideProjectWorktreesRoot(
+						local.worktreePath,
+						project.id,
+						worktreeBaseDir,
+					)
+				) {
+					warnings.push(
+						`Worktree at ${local.worktreePath} is no longer registered with git, but its folder is outside the managed worktrees root and was left on disk`,
+					);
+				} else {
+					try {
+						await rm(local.worktreePath, { recursive: true, force: true });
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						throw new TRPCError({
+							code: "INTERNAL_SERVER_ERROR",
+							message: `Worktree at ${local.worktreePath} is no longer registered with git, but its folder could not be removed: ${removeError ?? message}`,
+						});
+					}
+				}
 			}
 			worktreeRemoved = true;
 		}

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, lstatSync, statSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { sanitizePromptForPty } from "@superset/shared/agent-prompt-launch";
 import { TRPCError } from "@trpc/server";
@@ -365,6 +365,16 @@ function isMissingDirectory(path: string): boolean {
 	}
 }
 
+/** Like isMissingDirectory, but does not follow a final symlink: a dangling
+ * link at the worktree path is still an entry to remove, not an absence. */
+function isMissingPath(path: string): boolean {
+	try {
+		return lstatSync(path, { throwIfNoEntry: false }) === undefined;
+	} catch {
+		return false;
+	}
+}
+
 function archiveReasonFor(
 	ctx: HostServiceContext,
 	local: { pullRequestId: string | null },
@@ -539,7 +549,7 @@ async function runDestroyPhases(
 					}`,
 				});
 			}
-			if (!isMissingDirectory(local.worktreePath)) {
+			if (!isMissingPath(local.worktreePath)) {
 				// Unregistered is not removed: git's unregistration and its
 				// recursive delete are not atomic, so `remove --force --force`
 				// can drop the registration and still fail partway through
@@ -576,10 +586,11 @@ async function runDestroyPhases(
 			}
 			// The outside-root branch above leaves the folder in place, so
 			// report removal from the final disk state rather than assuming
-			// this path always cleared it (#6785 review). `isMissingDirectory`
-			// rather than `existsSync`: a leftover this process cannot read
-			// still exists, and must not be reported as removed.
-			worktreeRemoved = isMissingDirectory(local.worktreePath);
+			// this path always cleared it (#6785 review). `isMissingPath`
+			// rather than `existsSync`: a leftover this process cannot read,
+			// or a dangling symlink, still exists and must not be reported
+			// as removed.
+			worktreeRemoved = isMissingPath(local.worktreePath);
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
@@ -37,6 +37,28 @@ describe("isInsideProjectWorktreesRoot", () => {
 		).toBe(false);
 	});
 
+	test("accepts a dangling symlink leaf under a base that itself sits behind a symlink", () => {
+		// tmpdir() on macOS is /var/..., a symlink to /private/var/...: the
+		// base canonicalises to /private/var while an unresolvable leaf used
+		// to fall back to its /var/... spelling and never share the prefix.
+		const base = tmp("wt-base-");
+		mkdirSync(join(base, "proj"), { recursive: true });
+		symlinkSync(join(base, "gone"), join(base, "proj", "feature"));
+		expect(
+			isInsideProjectWorktreesRoot(join(base, "proj", "feature"), "proj", base),
+		).toBe(true);
+	});
+
+	test("rejects a leaf symlink that points out of the base", () => {
+		const base = tmp("wt-base-");
+		const outside = tmp("wt-outside-");
+		mkdirSync(join(base, "proj"), { recursive: true });
+		symlinkSync(outside, join(base, "proj", "feature"));
+		expect(
+			isInsideProjectWorktreesRoot(join(base, "proj", "feature"), "proj", base),
+		).toBe(false);
+	});
+
 	test("rejects a worktree under a project root that is a symlink out of the base", () => {
 		const base = tmp("wt-base-");
 		const outside = tmp("wt-outside-");

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -1,6 +1,14 @@
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join, normalize, resolve, sep } from "node:path";
+import {
+	basename,
+	dirname,
+	isAbsolute,
+	join,
+	normalize,
+	resolve,
+	sep,
+} from "node:path";
 import { TRPCError } from "@trpc/server";
 
 // Kept outside the primary checkout so editors, file watchers, and
@@ -68,7 +76,15 @@ function normalizePath(p: string): string {
 	try {
 		return realpathSync(p);
 	} catch {
-		return resolve(p);
+		// A dangling or unreadable leaf still has a real parent. Canonicalise
+		// that so the leaf compares against the same prefix as a base that
+		// sits behind a symlink (macOS `/var` → `/private/var`).
+		const abs = resolve(p);
+		try {
+			return join(realpathSync(dirname(abs)), basename(abs));
+		} catch {
+			return abs;
+		}
 	}
 }
 

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -227,7 +227,11 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 		await git
 			.raw(["worktree", "remove", "--force", "--force", target])
 			.catch((err: unknown) => {
-				removeError = err instanceof Error ? err.message : String(err);
+				removeError = (err instanceof Error ? err.message : String(err)).trim();
+				console.warn("[git/removeWorktree] git worktree remove failed", {
+					target,
+					error: removeError,
+				});
 			});
 		// A `worktree list` failure throws out of the task: the post-remove
 		// state is unknown and the caller must not treat it as removed.

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -197,7 +197,7 @@ export const gitWorktreeStateTask = defineWorkerTask<
 
 export const gitWorktreeRemoveTask = defineWorkerTask<
 	{ repoPath: string; worktreePath: string; gitEnv: GitTaskEnv },
-	{ stillRegistered: boolean }
+	{ stillRegistered: boolean; removeError?: string }
 >({
 	type: "git/removeWorktree",
 	// This task outlives its caller's budget in the field (HOST-SERVICE-17,
@@ -214,15 +214,21 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 		// (macOS `/var` → `/private/var`) still matches its registration.
 		// `realpathSync.native` is a blocking syscall, hence its own phase.
 		const target = normalizeWorktreePath(worktreePath);
-		// Best-effort: the registry read below is authoritative, not the
-		// command's locale- and version-dependent exit text. `--force --force`
-		// also unregisters a worktree whose directory is already gone, so no
-		// separate prune (which would clobber other stale worktrees' metadata)
-		// is needed.
+		// The registry read below decides "registered or not" (the command's
+		// exit text is locale- and version-dependent), but registration is
+		// not the whole story: git can unregister the worktree and still fail
+		// partway through its recursive delete (#6730). Keep the error — it
+		// is the only record of why files were left behind — and let the
+		// caller re-check the disk. `--force --force` also unregisters a
+		// worktree whose directory is already gone, so no separate prune
+		// (which would clobber other stale worktrees' metadata) is needed.
 		reportPhase?.("worktree-remove");
+		let removeError: string | undefined;
 		await git
 			.raw(["worktree", "remove", "--force", "--force", target])
-			.catch(() => {});
+			.catch((err: unknown) => {
+				removeError = err instanceof Error ? err.message : String(err);
+			});
 		// A `worktree list` failure throws out of the task: the post-remove
 		// state is unknown and the caller must not treat it as removed.
 		reportPhase?.("worktree-list");
@@ -231,6 +237,7 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 			stillRegistered: parseWorktreeList(raw).some(
 				(w) => normalizeWorktreePath(w.path) === target,
 			),
+			removeError,
 		};
 	},
 });

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -489,6 +489,9 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			});
 			expect(result.success).toBe(true);
 			expect(existsSync(tmp)).toBe(true);
+			// The folder is still on disk, so the result must not claim the
+			// worktree was removed (#6785 review).
+			expect(result.worktreeRemoved).toBe(false);
 			expect(
 				result.warnings.some((warning) => warning.includes("left on disk")),
 			).toBe(true);

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
@@ -26,7 +27,7 @@ type WorkspaceRow = {
 	pullRequestId?: string | null;
 	archivedAt?: number | null;
 };
-type ProjectRow = { id: string; repoPath: string };
+type ProjectRow = { id: string; repoPath: string; worktreeBaseDir?: string };
 
 type WorktreeState = { hasChanges: boolean; hasUnpushedCommits: boolean };
 
@@ -40,7 +41,10 @@ interface ContextSpec {
 	worktreeState?: WorktreeState | (() => Promise<WorktreeState>);
 	// Simulates ctx.git()/env-resolution failure ("failed to open repo").
 	resolveGitEnvThrows?: boolean;
-	removeWorktree?: () => Promise<{ stillRegistered: boolean }>;
+	removeWorktree?: () => Promise<{
+		stillRegistered: boolean;
+		removeError?: string;
+	}>;
 	deleteBranch?: () => Promise<{ deleted: boolean }>;
 	// Simulates sqlite failure at the archive UPDATE — the commit point.
 	dbUpdateThrows?: boolean | "once";
@@ -118,7 +122,10 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 			},
 			select: () => ({
 				from: () => ({
-					where: () => ({ all: terminalSelectAll }),
+					// `.all` serves the terminal-session sweep; `.get` serves
+					// getHostWorktreeBaseDir when a spec sets no per-project
+					// worktreeBaseDir ("no host settings row" shape).
+					where: () => ({ all: terminalSelectAll, get: () => undefined }),
 				}),
 			}),
 			update: () => ({
@@ -410,6 +417,113 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				(call) => (call[0] as { eventType: string }).eventType,
 			);
 			expect(events).toEqual(["deleted", "created"]);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("git unregisters the worktree but the folder survives: destroy removes it", async () => {
+		// git's `worktree remove --force --force` is not atomic: it can drop
+		// the registration and then fail partway through its recursive delete
+		// (locked file, live writer). The registry read then says "removed"
+		// while the directory is still on disk (#6730).
+		const base = mkdtempSync(join(tmpdir(), "worktrees-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		const worktree = join(base, "p-1", "wt-partial");
+		mkdirSync(worktree, { recursive: true });
+		writeFileSync(join(worktree, "leftover.txt"), "still here");
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				removeWorktree: async () => ({
+					stillRegistered: false,
+					removeError:
+						"error: failed to delete 'wt-partial': Operation not permitted",
+				}),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(true);
+			expect(existsSync(worktree)).toBe(false);
+		} finally {
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("unregistered leftover outside the managed root is left on disk with a warning", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: tmp,
+					branch: "feature",
+				},
+				// No worktreeBaseDir: the default root is under the home dir,
+				// so this tmp path falls outside it and must not be rm'd.
+				project: { id: "p-1", repoPath: repo },
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			expect(result.success).toBe(true);
+			expect(existsSync(tmp)).toBe(true);
+			expect(
+				result.warnings.some((warning) => warning.includes("left on disk")),
+			).toBe(true);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("still-registered failure surfaces git's own error", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: tmp,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo },
+				removeWorktree: async () => ({
+					stillRegistered: true,
+					removeError: "Operation not permitted",
+				}),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			await expect(
+				caller.destroy({
+					workspaceId: "ws-1",
+					deleteBranch: false,
+					force: true,
+				}),
+			).rejects.toThrow(/Operation not permitted/);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 			rmSync(repo, { recursive: true, force: true });

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
@@ -461,6 +462,85 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 		} finally {
 			rmSync(base, { recursive: true, force: true });
 			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("git unregisters the worktree and leaves a dangling symlink: destroy removes the link", async () => {
+		// A dangling link is not an absence: a stat-based recheck follows the
+		// link, sees nothing, and reports the worktree removed while the entry
+		// is still in the managed root.
+		const base = mkdtempSync(join(tmpdir(), "worktrees-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		const worktree = join(base, "p-1", "wt-dangling");
+		mkdirSync(join(base, "p-1"), { recursive: true });
+		symlinkSync(join(base, "gone-target"), worktree);
+		try {
+			expect(existsSync(worktree)).toBe(false);
+			expect(lstatSync(worktree, { throwIfNoEntry: false })).toBeDefined();
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(true);
+			expect(lstatSync(worktree, { throwIfNoEntry: false })).toBeUndefined();
+		} finally {
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("worktree path is a symlink into the managed root: destroy removes the link, not through it", async () => {
+		const base = mkdtempSync(join(tmpdir(), "worktrees-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		const outside = mkdtempSync(join(tmpdir(), "workspace-delete-outside-"));
+		const worktree = join(base, "p-1", "wt-link");
+		mkdirSync(join(base, "p-1"), { recursive: true });
+		writeFileSync(join(outside, "user-data.txt"), "keep me");
+		symlinkSync(outside, worktree);
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			expect(result.success).toBe(true);
+			// The link resolves outside the managed root, so the root guard
+			// refuses it and the target's contents are untouched.
+			expect(result.worktreeRemoved).toBe(false);
+			expect(existsSync(join(outside, "user-data.txt"))).toBe(true);
+			expect(
+				result.warnings.some((warning) => warning.includes("left on disk")),
+			).toBe(true);
+		} finally {
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+			rmSync(outside, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
Fixes #6730

## What was wrong

`git worktree remove --force --force` is not atomic: git can unregister the worktree from the repo's admin area and then fail partway through the recursive directory delete (locked file, permission issue, a live process still writing). Git exits non-zero, but `git worktree list --porcelain` no longer shows the worktree.

The delete saga leaned on exactly the wrong side of that split, three ways:

1. `gitWorktreeRemoveTask` discarded the git error (`.catch(() => {})`) and derived its verdict solely from the registry read, whose comment declared it "authoritative". Unregistration is authoritative for "registered or not", but it says nothing about the files.
2. The destroy saga took `stillRegistered: false` as "removed" and never looked at the disk, even though the two sibling branches in the same function (session delete, missing project repo) already do the `existsSync` plus guarded `rm` dance. The folder was orphaned in a state nothing can see: git does not list it, the row is archived, and clicking Delete again reports success without touching it.
3. When removal did fail visibly (`stillRegistered: true`), the thrown message was just `Failed to remove worktree at <path>`, because the real git error was already gone. That bare toast was the entire diagnostic record for the incident in the issue.

As the issue triage points out, the startup reconciler (`archived-workspace-reconcile`) walks the same faulty path, so it would "resume" the same interrupted delete on every host-service start, report success, and never clear the orphan.

## The fix

- `gitWorktreeRemoveTask` keeps the git error and returns it as `removeError` alongside `stillRegistered`. The registry read still decides registration; the error is no longer thrown away.
- After an unregistered verdict, the saga re-checks `existsSync(worktreePath)`. A surviving folder inside the managed worktrees root is removed with the same `isInsideProjectWorktreesRoot`-guarded `rm` the other two branches use, so a corrupt path can never aim a recursive delete at user data. A folder outside the root is left on disk with an explicit warning instead of being silently forgotten.
- Both failure throws (`still registered`, and the new `unregistered but could not remove`) now carry git's actual error, so the toast names the real cause (for the incident in the issue, the `Operation not permitted` on the locked file).

Retrying a delete that previously orphaned a folder now takes the fallback and actually clears it, which also un-wedges the reconciler loop.

## Tests

Three new cases in `workspace-cleanup.test.ts`, next to the existing removal-ordering tests and against real temp directories:

- git unregisters but the folder survives inside the managed root: destroy succeeds and the folder is gone (fails on main: destroy succeeds and the folder is orphaned),
- the same shape outside the managed root: destroy succeeds, folder is left, and a warning says so,
- `stillRegistered: true` with a captured git error: the thrown message contains that error.

The harness's mocked `removeWorktree` gained the optional `removeError` field, and the db `select` mock now answers `.get()` for `getHostWorktreeBaseDir` (reached when a spec sets no per-project base dir).

Full host-service suite: 1215 pass, 0 fail. Typecheck and Biome clean.

## Deliberately out of scope

The issue also suggests gating worktree removal on terminal disposal (retry when PTY kills fail) and logging the `warnings` array server-side. Both are reasonable follow-ups; this PR is the disk-recheck and error-capture core that makes the delete correct and diagnosable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-checks the worktree directory on disk after `git worktree remove --force --force` and preserves Git's error, so interrupted removals no longer orphan folders or report success without touching them.

- `gitWorktreeRemoveTask` now returns `{ stillRegistered, removeError }` with trimmed Git error text; callers propagate it.
- After an unregistered verdict, the destroy path re-checks the path with a no-follow `lstatSync` check: a dangling symlink is treated as a leftover to remove, not an absence.
- Leftovers inside the managed worktrees root are removed with a guarded `rm`; outside the root they're left on disk with a warning.
- The root guard canonicalizes the parent of an unresolvable leaf, so a base behind a symlink (macOS `/var` → `/private/var`) still matches.
- If the fallback `rm` fails, the error includes both the local remove error and the original Git error.
- `worktreeRemoved` reflects the final disk state; outside-root leftovers set it to `false`.
- Scope: touches `packages/host-service` delete path only; no DB/schema/config changes or migrations.

<sup>Written for commit 010b5a54cc5b352660274ea58f142dc7027a8f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup when Git worktrees are only partially removed.
  * Automatically removes leftover worktree directories within managed locations.
  * Prevents unsafe deletion outside approved worktree locations and reports clear cleanup errors.
  * Surfaces Git removal failures while continuing to verify worktree registration status.
  * Reports whether a worktree was fully removed based on its final directory state.

* **Tests**
  * Added coverage for incomplete removals, safe cleanup, warnings, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->