### PR TITLE
fix(desktop): don't abort the login import on a cookie row that isn't a buffer

### DIFF
--- a/apps/desktop/src/main/lib/browser/chrome-cookie-import.test.ts
+++ b/apps/desktop/src/main/lib/browser/chrome-cookie-import.test.ts
@@ -64,6 +64,13 @@ describe("decryptCookieValue", () => {
 		expect(decryptCookieValue(v20, KEY)).toBeNull();
 	});
 
+	it("returns null when the stored value is text rather than a buffer", () => {
+		// SQLite is dynamically typed: a row that stored encrypted_value as TEXT
+		// comes back from better-sqlite3 as a string, which has no .subarray.
+		const text = "GS1:some-plain-text-value" as unknown as Buffer;
+		expect(decryptCookieValue(text, KEY)).toBeNull();
+	});
+
 	it("returns null when decrypted with the wrong key", () => {
 		const enc = encryptV10("secret", KEY, { withHostPrefix: true });
 		expect(
@@ -119,6 +126,14 @@ describe("mapCookieRow", () => {
 		const row = {
 			...base,
 			encrypted_value: Buffer.concat([Buffer.from("v20"), Buffer.alloc(48, 7)]),
+		};
+		expect(mapCookieRow(row, KEY)).toBeNull();
+	});
+
+	it("drops a row whose stored value is text rather than a buffer", () => {
+		const row = {
+			...base,
+			encrypted_value: "GS1:some-plain-text-value" as unknown as Buffer,
 		};
 		expect(mapCookieRow(row, KEY)).toBeNull();
 	});

--- a/apps/desktop/src/main/lib/browser/chrome-cookie-import.ts
+++ b/apps/desktop/src/main/lib/browser/chrome-cookie-import.ts
@@ -110,13 +110,15 @@ export function decryptCookieValue(
 	encryptedValue: Buffer,
 	key: Buffer,
 ): string | null {
-	if (
-		encryptedValue.length < 3 ||
-		encryptedValue.subarray(0, 3).toString() !== "v10"
-	) {
-		return null;
-	}
 	try {
+		// Inside the guard: SQLite is dynamically typed, so a row that stored
+		// encrypted_value as TEXT arrives as a string, which has no .subarray.
+		if (
+			encryptedValue.length < 3 ||
+			encryptedValue.subarray(0, 3).toString() !== "v10"
+		) {
+			return null;
+		}
 		const decipher = createDecipheriv("aes-128-cbc", key, AES_IV);
 		decipher.setAutoPadding(false);
 		const padded = Buffer.concat([


### PR DESCRIPTION
## Problem

Someone opens **Import settings from another browser**, ticks *logins*, and presses Import. The mutation throws and they get a red `Could not import from browser — Could not import browser cookies: encryptedValue.subarray is not a function` toast. Nothing is imported, and retrying is futile: the same profile row fails every time. The reporting person pressed the button 6 times in 33 seconds and got nowhere. If they also ticked *history*, the history import runs first and succeeds, but the cookie throw happens before the success toast — so a partly-successful import is still reported to them as a total failure.

## Root cause

`decryptCookieValue` documents that it "returns null for values in any other scheme", and has a `try`/`catch` implementing exactly that. But the "v10" scheme check sat *above* that `try`:

```ts
if (
  encryptedValue.length < 3 ||
  encryptedValue.subarray(0, 3).toString() !== "v10"
) return null;
try { /* decrypt */ } catch { return null; }
```

`.length` succeeds for anything with a length; `.subarray` only exists on a Buffer. The rows come from a raw `better-sqlite3` `.all()` cast straight to `ChromeCookieRow[]`, so `encrypted_value: Buffer` is an assumption about the profile database, not a guarantee — SQLite is dynamically typed, and a value stored in that column as TEXT comes back as a JavaScript string. On such a row the `TypeError` escaped `decryptCookieValue`, escaped `mapCookieRow`, aborted the `for` loop in `readCookiesFromProfile`, and surfaced as a 500 from the tRPC mutation.

## Fix

Move the scheme check inside the existing `try`. One row that isn't a decryptable buffer is now skipped like any other undecryptable row — which is what the function already promised. Nothing else changes: the `try` body is untouched, and a successfully decrypted cookie produces exactly what it did before.

The only behaviour that changes is for input that previously *threw*. No row-shape validation, no per-field error handling, no new capture.

### What still fails loudly

Deliberately unchanged, because these mean "we imported nothing", not "we skipped one cookie":

- **Profile database can't be opened** (`new Database(..., { fileMustExist: true })`) — throws, reaches the tRPC catch, error toast.
- **Profile can't be copied** (permissions / no Full Disk Access on the `copyFileSync`) — same.
- **The `cookies` table/columns aren't what we expect** (SELECT fails) — same.
- **Profile no longer on disk** — `NOT_FOUND`, "That browser profile is no longer available."

One correction on the framing worth stating plainly: **a denied Keychain key never threw**, before or after this change. `readSafeStorageKey` returns null on denial, `readCookiesFromProfile` returns `[]`, and `importCookiesIntoSession` reports `keyUnavailable: true`, which the dialog renders as "logins skipped (Keychain access denied)". That's a distinct, visible signal rather than an error toast, and it is preserved untouched — it is not swallowed by this fix.

### Typed causes

None added. Nothing reads a `cause.kind` on this path — the renderer branches on the `keyUnavailable` field, not on error shape — so the existing plain `new TRPCError({ code, message })` at the router stays as it is.

## Verification

`bunx biome check` on both changed files:

```
Checked 2 files in 15ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ tsr generate
$ tsc --noEmit
EXIT=0
```

Two tests added, using the shape the failure actually arrives in (a string where a Buffer was declared). **Before** the change, both fail with the exact error from the issue:

```
114 | 		encryptedValue.length < 3 ||
115 | 		encryptedValue.subarray(0, 3).toString() !== "v10"
                   ^
TypeError: encryptedValue.subarray is not a function.
  at decryptCookieValue (.../chrome-cookie-import.ts:115:18)
(fail) decryptCookieValue > returns null when the stored value is text rather than a buffer
  at decryptCookieValue (.../chrome-cookie-import.ts:115:18)
  at mapCookieRow (.../chrome-cookie-import.ts:193:5)
(fail) mapCookieRow > drops a row whose stored value is text rather than a buffer

 9 pass
 2 fail
Ran 11 tests across 1 file.
```

**After**, the file passes, and so does the whole `src/main/lib/browser/` directory — including the pre-existing tests that assert real v10 buffers still decrypt, so the skip has not widened into swallowing valid cookies:

```
bun test src/main/lib/browser/chrome-cookie-import.test.ts
 11 pass
 0 fail
 22 expect() calls

bun test src/main/lib/browser/
 68 pass
 0 fail
 148 expect() calls
Ran 68 tests across 8 files.
```

Repo-wide `bun run lint` was not run (it hangs on cross-worktree bun locks); `biome check` on the changed files stands in for it.

Refs DESKTOP-11J

https://claude.ai/code/session_b1c13bee-c201-4c37-bf2a-d43d29438086


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips non-buffer cookie rows during login import to prevent a hard failure. Previously, `decryptCookieValue` checked the "v10" scheme before its try/catch and threw on string rows, aborting the import; now the check runs inside the guard, so undecryptable or non-buffer rows return null and are skipped.

- **Notes for review**
  - Only change: move the scheme guard inside the existing try/catch in `decryptCookieValue`. Valid "v10" buffers still decrypt unchanged.
  - Expected loud failures remain loud (profile open/copy/SELECT issues). Keychain denial still sets `keyUnavailable: true`.
  - Tests added for string-backed `encrypted_value` from `better-sqlite3`.
  - Addresses DESKTOP-11J by ensuring mixed-type cookie rows don’t abort login import.

<sup>Written for commit 8aa0bc42237c6523a7df6631905d3579586b5c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser cookie import handling for invalid encrypted cookie values.
  - Invalid text-based cookie data is now safely rejected instead of causing errors or being processed incorrectly.

- **Tests**
  - Added coverage confirming invalid cookie values return no result during decryption and import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->