### PR TITLE
fix(workspace-fs): stop reporting an un-stattable path as a file

### DIFF
--- a/packages/workspace-fs/src/types.ts
+++ b/packages/workspace-fs/src/types.ts
@@ -63,5 +63,12 @@ export type FsWatchEvent = {
 	kind: "create" | "update" | "delete" | "rename" | "overflow";
 	absolutePath: string;
 	oldAbsolutePath?: string;
+	/**
+	 * Absent when the watcher could not determine the path's type — its stat
+	 * lost a race with whatever changed the path again. `false` is a positive
+	 * assertion that the path is not a directory; absent is "no answer", and
+	 * consumers that need one should fall back to what they already know
+	 * about the path rather than reading it as a file.
+	 */
 	isDirectory?: boolean;
 };

--- a/packages/workspace-fs/src/watch-event-coalescing.test.ts
+++ b/packages/workspace-fs/src/watch-event-coalescing.test.ts
@@ -106,6 +106,50 @@ describe("reconcileRenameEvents", () => {
 		});
 	});
 
+	it("carries an undeterminable type through the pair", () => {
+		const events = reconcileRenameEvents([
+			createInternalEvent({
+				kind: "delete",
+				absolutePath: "/workspace/src/old",
+				isDirectory: false,
+			}),
+			createInternalEvent({
+				// The watcher couldn't stat the new path — it must not be
+				// coerced to "file" here, or the consumer loses its chance to
+				// fall back to the type it already holds for the old path.
+				kind: "create",
+				absolutePath: "/workspace/src/new",
+			}),
+		]);
+
+		expect(events).toEqual([
+			{
+				kind: "rename",
+				oldAbsolutePath: "/workspace/src/old",
+				absolutePath: "/workspace/src/new",
+				isDirectory: undefined,
+			},
+		]);
+	});
+
+	it("still refuses to pair a directory with a file", () => {
+		const events = reconcileRenameEvents([
+			createInternalEvent({
+				kind: "delete",
+				absolutePath: "/workspace/src/old-dir",
+				isDirectory: true,
+			}),
+			createInternalEvent({
+				kind: "create",
+				absolutePath: "/workspace/src/new-file.ts",
+				isDirectory: false,
+			}),
+		]);
+
+		expect(events).toHaveLength(2);
+		expect(events.every((event) => event.kind !== "rename")).toEqual(true);
+	});
+
 	it("leaves ambiguous churn as separate events", () => {
 		const events = reconcileRenameEvents([
 			createInternalEvent({

--- a/packages/workspace-fs/src/watch-event-coalescing.ts
+++ b/packages/workspace-fs/src/watch-event-coalescing.ts
@@ -12,7 +12,8 @@ export interface InternalWatchEvent {
 	kind: "create" | "update" | "delete" | "rename" | "overflow";
 	absolutePath: string;
 	oldAbsolutePath?: string;
-	isDirectory: boolean;
+	/** Absent when the watcher could not determine the type — see FsWatchEvent. */
+	isDirectory?: boolean;
 }
 
 function coalesceWatchEvent(
@@ -84,7 +85,7 @@ function getBaseName(absolutePath: string): string {
 interface RenameCandidate {
 	kind: "create" | "delete";
 	absolutePath: string;
-	isDirectory: boolean;
+	isDirectory?: boolean;
 	index: number;
 }
 
@@ -178,7 +179,8 @@ function pairRenameCandidates(
 		remainingCreates.length === 1 &&
 		remainingDelete &&
 		remainingCreate &&
-		remainingDelete.isDirectory === remainingCreate.isDirectory
+		Boolean(remainingDelete.isDirectory) ===
+			Boolean(remainingCreate.isDirectory)
 	) {
 		pairs.push({
 			deleteCandidate: remainingDelete,

--- a/packages/workspace-fs/src/watch-unknown-type.test.ts
+++ b/packages/workspace-fs/src/watch-unknown-type.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { FsWatchEvent } from "./types";
+import { FsWatcherManager } from "./watch";
+
+/**
+ * INTEGRATION: what the watcher reports for a path whose type it could not
+ * measure.
+ *
+ * `normalizeEvent` stats every non-delete event to decide `isDirectory`, and
+ * that stat runs a debounce window after @parcel/watcher classified the
+ * event. These tests reproduce the losing side of that race deterministically:
+ * a symlink to a target outside the watch root, whose target is removed after
+ * parcel has reported the create but before the batch flushes. Parcel saw a
+ * path; our stat sees ENOENT. The target lives outside the root so removing
+ * it doesn't add an event of its own.
+ */
+
+interface WatcherStateView {
+	directoryPaths: Set<string>;
+}
+
+interface FsWatcherManagerInternal {
+	watchers: Map<string, WatcherStateView>;
+}
+
+// Long enough that the symlink's create event is still sitting in
+// `pendingEvents` when the test removes the link target.
+const RACE_DEBOUNCE_MS = 800;
+
+const tempRoots: string[] = [];
+const managers: FsWatcherManager[] = [];
+
+afterEach(async () => {
+	await Promise.all(managers.splice(0).map((m) => m.close()));
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((rootPath) => fs.rm(rootPath, { recursive: true, force: true })),
+	);
+});
+
+async function createTempDir(): Promise<string> {
+	const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "watch-unknown-"));
+	tempRoots.push(tempPath);
+	// macOS puts the temp dir behind /var → /private/var; resolve it so the
+	// paths we compare against match the ones the watcher emits.
+	return fs.realpath(tempPath);
+}
+
+async function watchRoot(
+	rootPath: string,
+	debounceMs: number,
+): Promise<{ manager: FsWatcherManager; events: FsWatchEvent[] }> {
+	const manager = new FsWatcherManager({ debounceMs });
+	managers.push(manager);
+	const events: FsWatchEvent[] = [];
+	await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+		events.push(...batch.events);
+	});
+	// FSEvents can be deaf for a moment after subscribe() resolves, and it
+	// delivers a spurious create for the root itself — let that batch drain.
+	await new Promise((resolve) => setTimeout(resolve, debounceMs + 400));
+	return { manager, events };
+}
+
+async function waitForEvent(
+	events: FsWatchEvent[],
+	absolutePath: string,
+	timeoutMs = 8_000,
+): Promise<FsWatchEvent> {
+	const match = () =>
+		events.find(
+			(event) => event.absolutePath === absolutePath && event.kind !== "delete",
+		);
+	const deadline = Date.now() + timeoutMs;
+	let found = match();
+	while (!found) {
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Timed out waiting for ${absolutePath}\nseen: ${events
+					.map((event) => `${event.kind}:${event.absolutePath}`)
+					.join(", ")}`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		found = match();
+	}
+	return found;
+}
+
+/**
+ * Creates `<root>/<name>` as a symlink parcel reports while it still resolves,
+ * then breaks it so the watcher's own stat fails when the batch flushes.
+ */
+async function createPathThatVanishesBeforeFlush(
+	rootPath: string,
+	name: string,
+): Promise<string> {
+	const targetDir = await createTempDir();
+	const targetPath = path.join(targetDir, "target");
+	await fs.writeFile(targetPath, "x");
+
+	const linkPath = path.join(rootPath, name);
+	await fs.symlink(targetPath, linkPath);
+	// Let parcel classify and deliver the create while the link still resolves.
+	await new Promise((resolve) => setTimeout(resolve, 400));
+	await fs.rm(targetPath);
+	return linkPath;
+}
+
+describe("FsWatcherManager event typing", () => {
+	it("reports a real file as a file", async () => {
+		const rootPath = await createTempDir();
+		const { events } = await watchRoot(rootPath, 50);
+
+		const filePath = path.join(rootPath, "real.ts");
+		await fs.writeFile(filePath, "x");
+
+		const event = await waitForEvent(events, filePath);
+		expect(event.isDirectory).toEqual(false);
+	}, 20_000);
+
+	it("reports a real directory as a directory", async () => {
+		const rootPath = await createTempDir();
+		const { events } = await watchRoot(rootPath, 50);
+
+		const dirPath = path.join(rootPath, "real-dir");
+		await fs.mkdir(dirPath);
+
+		const event = await waitForEvent(events, dirPath);
+		expect(event.isDirectory).toEqual(true);
+	}, 20_000);
+
+	it("reports no type for a path it could not stat", async () => {
+		const rootPath = await createTempDir();
+		const { events } = await watchRoot(rootPath, RACE_DEBOUNCE_MS);
+
+		const linkPath = await createPathThatVanishesBeforeFlush(
+			rootPath,
+			"unmeasurable",
+		);
+
+		const event = await waitForEvent(events, linkPath);
+		// Not `false`. The watcher has never seen this path, so "file" is a
+		// guess, and consumers read `false` as a positive assertion: a
+		// directory that lands in the Files tab as a file node can't be
+		// expanded and poisons every lookup beneath it (DESKTOP-11E).
+		expect(event.isDirectory).toBeUndefined();
+	}, 20_000);
+
+	it("keeps a remembered directory type when the stat fails", async () => {
+		const rootPath = await createTempDir();
+		const { manager, events } = await watchRoot(rootPath, RACE_DEBOUNCE_MS);
+
+		const linkPath = path.join(rootPath, "remembered");
+		const internal = manager as unknown as FsWatcherManagerInternal;
+		const state = internal.watchers.get(rootPath);
+		if (!state) throw new Error(`No WatcherState for ${rootPath}`);
+		state.directoryPaths.add(linkPath);
+
+		await createPathThatVanishesBeforeFlush(rootPath, "remembered");
+
+		const event = await waitForEvent(events, linkPath);
+		expect(event.isDirectory).toEqual(true);
+	}, 20_000);
+});

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -205,11 +205,15 @@ function internalToSearchPatchEvent(
 	if (event.kind === "overflow") {
 		return null;
 	}
+	// The search index only ever holds files, so an undeterminable type is
+	// worth no more than "not a directory" here. Treating it as a directory
+	// instead would invalidate the whole index for every build temp file that
+	// vanishes mid-batch.
 	return {
 		kind: event.kind,
 		absolutePath: event.absolutePath,
 		oldAbsolutePath: event.oldAbsolutePath,
-		isDirectory: event.isDirectory,
+		isDirectory: event.isDirectory ?? false,
 	};
 }
 
@@ -1122,7 +1126,8 @@ export class FsWatcherManager {
 		event: ParcelWatcherEvent,
 	): Promise<InternalWatchEvent> {
 		const absolutePath = normalizeAbsolutePath(event.path);
-		let isDirectory = state.directoryPaths.has(absolutePath);
+		let isDirectory: boolean | undefined =
+			state.directoryPaths.has(absolutePath);
 
 		if (event.type === "delete") {
 			state.filePaths.delete(absolutePath);
@@ -1147,7 +1152,19 @@ export class FsWatcherManager {
 					state.directoryPaths.delete(absolutePath);
 				}
 			} catch {
-				isDirectory = state.directoryPaths.has(absolutePath);
+				// The stat lost a race with whatever changed the path again (the
+				// ordinary case for the rename that produced this event), so all
+				// we have left is what we already recorded. With no record, say
+				// nothing: reporting "file" for a directory we couldn't inspect
+				// puts it in consumers' trees as a file node, where it can't be
+				// expanded and poisons every lookup beneath it (DESKTOP-11E).
+				if (state.directoryPaths.has(absolutePath)) {
+					isDirectory = true;
+				} else if (state.filePaths.has(absolutePath)) {
+					isDirectory = false;
+				} else {
+					isDirectory = undefined;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Rename a folder in a workspace and it can land in the Files tab as a **file**: no
disclosure triangle, can't be expanded, and it stays that way until you leave and
re-enter the workspace. Every later watcher event for anything beneath that path
then resolves against a file node — the poisoning that produced DESKTOP-11E's 22
reports before #6789 contained the throw. #6789 stopped the crash and deliberately
left the bad state; this is the bad state.

No Sentry issue of its own. The harm is established from the code path plus
#6789's own test, which documents the mis-typing as the cause of the throw it
contains.

## Root cause

`WorkspaceWatcher.normalizeEvent` decides `isDirectory` by stat'ing the path,
a debounce window after `@parcel/watcher` reported the event:

```ts
try {
	const stats = await stat(absolutePath);
	isDirectory = stats.isDirectory();
	…
} catch {
	isDirectory = state.directoryPaths.has(absolutePath);
}
```

The stat fails when the path changed again in that window — the ordinary case
for the rename that produced the event. The fallback then asks a set of
directories the watcher has seen before, and for a directory it has never seen
that set answers `false`. `false` is not "don't know", it is a positive
assertion that the path is not a directory, and that is what gets emitted.

Downstream, `useFilesTabBridge`'s rename branch reads it as fact
(`event.isDirectory ?? oldKey?.endsWith("/") ?? false` — with `false` the `??`
never fires) and re-keys the folder to a file key.

## Fix

Contained to the watcher's fallback: report what is on record, and nothing when
there is no record.

```ts
if (state.directoryPaths.has(absolutePath)) isDirectory = true;
else if (state.filePaths.has(absolutePath)) isDirectory = false;
else isDirectory = undefined;
```

`FsWatchEvent.isDirectory` has always been `?: boolean`, so no consumer type
widens and nothing breaks: every other consumer already reads it through
`Boolean(event.isDirectory)` or a truthiness test, where absent behaves exactly
as `false` did. The one consumer that already had a better answer written down —
the Files tab's rename branch — now reaches it, and a renamed folder keeps the
type the tree already holds. `InternalWatchEvent`/`RenameCandidate` are widened
to match so the rename algebra carries "unknown" through instead of flattening
it; the last-resort pairing rule compares `Boolean(…) === Boolean(…)` so
pairing behaviour is bit-for-bit what it was. The search-index patch coerces
`?? false` at its own boundary, because the index holds only files.

**Why decline to assert, rather than retry the stat.** A bounded retry only
helps if the path comes back, and in the case that actually causes this it does
not: the stat failed because the path is no longer there, so retrying re-reads
the same ENOENT while stalling the whole batch (the flush loop is sequential).
It also cannot help the other way stat fails on a path that *is* there —
EACCES, EMFILE under load — where the answer stays unavailable for as long as
the condition lasts. Retrying trades a guaranteed wrong answer for a slower
usually-wrong answer; declining to answer is correct in every one of those
cases, and it is the only shape that doesn't touch batch timing. Flipping the
fallback to assume *directory* was never on the table — that is the same defect
pointing the other way, and it would render every vanished temp file as an
expandable folder.

**Residual, deliberately not fixed here.** A `create` for a never-seen path
whose stat fails still lands as a file, because the bridge's create branch has
no prior knowledge to fall back on (`?? false`) — there is nothing the watcher
can honestly offer it. Likewise, a rename whose *delete* side was a known
directory doesn't pair (mismatched types), so it stays a delete + create pair.
Both are consumer-side changes with a wider blast radius than the reported
failure warrants.

## Verification

`bunx biome check` on the five changed files:

```
Checked 5 files in 19ms. Fixed 1 file.      # --write
Checked 5 files in 11ms. No fixes applied.  # re-check
```

`cd packages/workspace-fs && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
EXIT=0
```

`bun test packages/workspace-fs/` — **before:** `95 pass, 0 fail, 230 expect() calls,
15 files`. **After:** `101 pass, 0 fail, 237 expect() calls, 16 files`.

The new test drives the real race deterministically against a real
`@parcel/watcher`: a symlink to a target outside the watch root, whose target is
removed after parcel has classified the create but before the batch flushes.
Parcel saw a path; our stat sees ENOENT. Run against the unfixed watcher it
reproduces the defect:

```
152 |         expect(event.isDirectory).toBeUndefined();
error: expect(received).toBeUndefined()
Received: false
(fail) FsWatcherManager event typing > reports no type for a path it could not stat
 3 pass
 1 fail
```

The other three assertions in that file are the pins, and they pass before and
after: a real file reports `false`, a real directory reports `true`, and a path
the watcher already has on record as a directory still reports `true` when the
stat fails. Two more pins in `watch-event-coalescing.test.ts` cover the algebra:
an unknown type survives rename reconciliation instead of being coerced, and a
directory delete still refuses to pair with a file create.

One full-suite run out of sixteen showed `100 pass / 1 fail`; I could not
attribute it — it did not recur in the fifteen full-suite runs or the eight
isolated runs of the new file that followed. The real-fs watcher tests in this
package wait on FSEvents with 8s deadlines, and the new file adds four more live
watchers to the same process, so it is plausibly load on those deadlines rather
than a behaviour change.

Not run: repo-wide `bun run lint` (hangs on cross-worktree bun locks).

Refs DESKTOP-11E

https://claude.ai/code/session_01LZ4rtC7vJCrUYNTaUxqdR3


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops mis-typing renamed directories as files when the watcher can’t stat the path. Previously, an un-stattable, never-seen path was emitted with isDirectory=false; now the watcher emits isDirectory only when known, otherwise undefined, so consumers fall back to their own state.

- Uses recorded path sets on stat failure: true if known directory, false if known file, otherwise undefined; fixes the Files tab rename case behind Linear DESKTOP-11E.
- Widens InternalWatchEvent/RenameCandidate isDirectory to optional and keeps rename pairing by comparing Boolean values; unknown type carries through instead of being coerced.
- Search index path coerces undefined to false at its boundary; no timing changes in the batch loop.
- No migration required; `FsWatchEvent.isDirectory` was already optional.
- Tests added, including an integration that reproduces the stat race with real `@parcel/watcher`.

<sup>Written for commit 0f88f9df46fae5694454f2c98af64b2966af25ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-system change detection when a path’s type cannot be determined.
  * Preserved known file or directory information when metadata lookup fails.
  * Improved rename handling for events with incomplete type information.
  * Prevented files and directories from being incorrectly paired during rename detection.

* **Documentation**
  * Clarified how unavailable and explicitly known path-type information is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->