### PR TITLE
fix(host-service): drain check and thread pagination before grading a PR

### DIFF
--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -537,6 +537,12 @@ interface GithubGraphqlClient {
  * be seen, and the card would grade a partial pull request as ready. Drains
  * the connection; a handful of round trips at most.
  */
+// GitHub's own flags are trusted but not absolutely: a stuck cursor from a
+// GitHub-side pagination bug must not turn one detail query into an infinite
+// loop that pins the host and burns the token's rate limit. 20 pages is
+// 2,000 nodes — far past any real pull request.
+const MAX_DRAIN_PAGES = 20;
+
 async function drainReviewThreads(
 	octokit: GithubGraphqlClient,
 	input: { owner: string; repo: string; pullNumber: number },
@@ -544,7 +550,14 @@ async function drainReviewThreads(
 ): Promise<(ReviewThreadNode | null)[]> {
 	const nodes: (ReviewThreadNode | null)[] = [];
 	let page = pageInfo ?? null;
+	let pages = 0;
 	while (page?.hasNextPage && page.endCursor) {
+		if (++pages > MAX_DRAIN_PAGES) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `Pull request #${input.pullNumber} did not finish paginating review threads after ${MAX_DRAIN_PAGES} pages.`,
+			});
+		}
 		const data = await octokit.graphql<{
 			repository: {
 				pullRequest: { reviewThreads: ReviewThreadsConnection | null } | null;
@@ -559,9 +572,10 @@ async function drainReviewThreads(
 		// A missing page mid-drain would silently re-create the truncation this
 		// drain exists to remove — fail the query instead of grading on less.
 		if (!connection) {
-			throw new Error(
-				`GitHub returned no reviewThreads page for pull request #${input.pullNumber} while paginating.`,
-			);
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `GitHub returned no reviewThreads page for pull request #${input.pullNumber} while paginating.`,
+			});
 		}
 		nodes.push(...connection.nodes);
 		page = connection.pageInfo;
@@ -576,7 +590,14 @@ async function drainCheckContexts(
 ): Promise<(CheckContextNode | null)[]> {
 	const nodes: (CheckContextNode | null)[] = [];
 	let page = pageInfo ?? null;
+	let pages = 0;
 	while (page?.hasNextPage && page.endCursor) {
+		if (++pages > MAX_DRAIN_PAGES) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `Pull request #${input.pullNumber} did not finish paginating checks after ${MAX_DRAIN_PAGES} pages.`,
+			});
+		}
 		const data = await octokit.graphql<{
 			repository: {
 				pullRequest: {
@@ -594,9 +615,10 @@ async function drainCheckContexts(
 		const connection =
 			data.repository?.pullRequest?.statusCheckRollup?.contexts;
 		if (!connection) {
-			throw new Error(
-				`GitHub returned no check contexts page for pull request #${input.pullNumber} while paginating.`,
-			);
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `GitHub returned no check contexts page for pull request #${input.pullNumber} while paginating.`,
+			});
 		}
 		nodes.push(...connection.nodes);
 		page = connection.pageInfo;

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -556,7 +556,13 @@ async function drainReviewThreads(
 			cursor: page.endCursor,
 		});
 		const connection = data.repository?.pullRequest?.reviewThreads;
-		if (!connection) break;
+		// A missing page mid-drain would silently re-create the truncation this
+		// drain exists to remove — fail the query instead of grading on less.
+		if (!connection) {
+			throw new Error(
+				`GitHub returned no reviewThreads page for pull request #${input.pullNumber} while paginating.`,
+			);
+		}
 		nodes.push(...connection.nodes);
 		page = connection.pageInfo;
 	}
@@ -587,7 +593,11 @@ async function drainCheckContexts(
 		});
 		const connection =
 			data.repository?.pullRequest?.statusCheckRollup?.contexts;
-		if (!connection) break;
+		if (!connection) {
+			throw new Error(
+				`GitHub returned no check contexts page for pull request #${input.pullNumber} while paginating.`,
+			);
+		}
 		nodes.push(...connection.nodes);
 		page = connection.pageInfo;
 	}

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -551,7 +551,15 @@ async function drainReviewThreads(
 	const nodes: (ReviewThreadNode | null)[] = [];
 	let page = pageInfo ?? null;
 	let pages = 0;
-	while (page?.hasNextPage && page.endCursor) {
+	while (page?.hasNextPage) {
+		// hasNextPage with no cursor would end the loop on a partial set —
+		// the silent truncation this drain exists to remove.
+		if (!page.endCursor) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `GitHub reported more review threads but no cursor for pull request #${input.pullNumber}.`,
+			});
+		}
 		if (++pages > MAX_DRAIN_PAGES) {
 			throw new TRPCError({
 				code: "CONFLICT",
@@ -591,7 +599,13 @@ async function drainCheckContexts(
 	const nodes: (CheckContextNode | null)[] = [];
 	let page = pageInfo ?? null;
 	let pages = 0;
-	while (page?.hasNextPage && page.endCursor) {
+	while (page?.hasNextPage) {
+		if (!page.endCursor) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: `GitHub reported more checks but no cursor for pull request #${input.pullNumber}.`,
+			});
+		}
 		if (++pages > MAX_DRAIN_PAGES) {
 			throw new TRPCError({
 				code: "CONFLICT",

--- a/packages/host-service/src/trpc/router/github/github.ts
+++ b/packages/host-service/src/trpc/router/github/github.ts
@@ -195,43 +195,56 @@ export const githubRouter = router({
 				});
 			}
 
-			const checks = (pr.statusCheckRollup?.contexts?.nodes ?? []).flatMap(
-				(node) => {
-					if (!node) return [];
-					if (node.__typename === "CheckRun") {
-						return [
-							{
-								name: node.name ?? "Check",
-								status: node.status ?? "COMPLETED",
-								conclusion: node.conclusion ?? null,
-								isRequired: node.isRequired ?? false,
-								startedAt: node.startedAt ?? null,
-								completedAt: node.completedAt ?? null,
-								detailsUrl: node.detailsUrl ?? null,
-							},
-						];
-					}
-					// A commit status has no runtime of its own, only a verdict.
-					return [
-						{
-							name: node.context ?? "Status",
-							status: "COMPLETED",
-							conclusion:
-								node.state === "SUCCESS"
-									? "SUCCESS"
-									: node.state === "PENDING"
-										? null
-										: "FAILURE",
-							isRequired: node.isRequired ?? false,
-							startedAt: null,
-							completedAt: node.createdAt ?? null,
-							detailsUrl: node.targetUrl ?? null,
-						},
-					];
-				},
+			// Both connections page at 100; anything past the first page must be
+			// fetched before grading, or a failing check or open thread there is
+			// silently invisible.
+			const [restThreads, restContexts] = await Promise.all([
+				drainReviewThreads(octokit, input, pr.reviewThreads?.pageInfo),
+				drainCheckContexts(
+					octokit,
+					input,
+					pr.statusCheckRollup?.contexts?.pageInfo,
+				),
+			]);
+			const contextNodes = (pr.statusCheckRollup?.contexts?.nodes ?? []).concat(
+				restContexts,
 			);
 
-			const threads = pr.reviewThreads?.nodes ?? [];
+			const checks = contextNodes.flatMap((node) => {
+				if (!node) return [];
+				if (node.__typename === "CheckRun") {
+					return [
+						{
+							name: node.name ?? "Check",
+							status: node.status ?? "COMPLETED",
+							conclusion: node.conclusion ?? null,
+							isRequired: node.isRequired ?? false,
+							startedAt: node.startedAt ?? null,
+							completedAt: node.completedAt ?? null,
+							detailsUrl: node.detailsUrl ?? null,
+						},
+					];
+				}
+				// A commit status has no runtime of its own, only a verdict.
+				return [
+					{
+						name: node.context ?? "Status",
+						status: "COMPLETED",
+						conclusion:
+							node.state === "SUCCESS"
+								? "SUCCESS"
+								: node.state === "PENDING"
+									? null
+									: "FAILURE",
+						isRequired: node.isRequired ?? false,
+						startedAt: null,
+						completedAt: node.createdAt ?? null,
+						detailsUrl: node.targetUrl ?? null,
+					},
+				];
+			});
+
+			const threads = (pr.reviewThreads?.nodes ?? []).concat(restThreads);
 			const allowed: string[] = [];
 			if (data.repository?.squashMergeAllowed) allowed.push("squash");
 			if (data.repository?.mergeCommitAllowed) allowed.push("merge");
@@ -363,9 +376,49 @@ query($owner: String!, $name: String!, $number: Int!) {
 					}
 				}
 			}
-			reviewThreads(first: 100) { nodes { isResolved isOutdated } }
+			reviewThreads(first: 100) {
+				pageInfo { hasNextPage endCursor }
+				nodes { isResolved isOutdated }
+			}
 			statusCheckRollup {
 				contexts(first: 100) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						__typename
+						... on CheckRun {
+							name status conclusion detailsUrl startedAt completedAt
+							isRequired(pullRequestNumber: $number)
+						}
+						... on StatusContext {
+							context state targetUrl createdAt
+							isRequired(pullRequestNumber: $number)
+						}
+					}
+				}
+			}
+		}
+	}
+}`;
+
+const REVIEW_THREADS_PAGE_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
+	repository(owner: $owner, name: $name) {
+		pullRequest(number: $number) {
+			reviewThreads(first: 100, after: $cursor) {
+				pageInfo { hasNextPage endCursor }
+				nodes { isResolved isOutdated }
+			}
+		}
+	}
+}`;
+
+const CHECK_CONTEXTS_PAGE_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
+	repository(owner: $owner, name: $name) {
+		pullRequest(number: $number) {
+			statusCheckRollup {
+				contexts(first: 100, after: $cursor) {
+					pageInfo { hasNextPage endCursor }
 					nodes {
 						__typename
 						... on CheckRun {
@@ -431,29 +484,114 @@ interface PullRequestDetailQuery {
 					} | null;
 				} | null)[];
 			} | null;
-			reviewThreads: {
-				nodes: ({ isResolved: boolean; isOutdated: boolean } | null)[];
-			} | null;
+			reviewThreads: ReviewThreadsConnection | null;
 			statusCheckRollup: {
-				contexts: {
-					nodes: ({
-						__typename: string;
-						name?: string;
-						status?: string;
-						conclusion?: string | null;
-						detailsUrl?: string | null;
-						startedAt?: string | null;
-						completedAt?: string | null;
-						context?: string;
-						state?: string;
-						targetUrl?: string | null;
-						createdAt?: string | null;
-						isRequired?: boolean;
-					} | null)[];
-				} | null;
+				contexts: CheckContextsConnection | null;
 			} | null;
 		} | null;
 	} | null;
+}
+
+interface ConnectionPageInfo {
+	hasNextPage: boolean;
+	endCursor: string | null;
+}
+
+interface ReviewThreadNode {
+	isResolved: boolean;
+	isOutdated: boolean;
+}
+
+interface ReviewThreadsConnection {
+	pageInfo: ConnectionPageInfo;
+	nodes: (ReviewThreadNode | null)[];
+}
+
+interface CheckContextNode {
+	__typename: string;
+	name?: string;
+	status?: string;
+	conclusion?: string | null;
+	detailsUrl?: string | null;
+	startedAt?: string | null;
+	completedAt?: string | null;
+	context?: string;
+	state?: string;
+	targetUrl?: string | null;
+	createdAt?: string | null;
+	isRequired?: boolean;
+}
+
+interface CheckContextsConnection {
+	pageInfo: ConnectionPageInfo;
+	nodes: (CheckContextNode | null)[];
+}
+
+interface GithubGraphqlClient {
+	graphql: <T>(query: string, variables: Record<string, unknown>) => Promise<T>;
+}
+
+/**
+ * 100 nodes is GitHub's page cap, not a promise of completeness — a failing
+ * required check or an open thread past the first page would otherwise never
+ * be seen, and the card would grade a partial pull request as ready. Drains
+ * the connection; a handful of round trips at most.
+ */
+async function drainReviewThreads(
+	octokit: GithubGraphqlClient,
+	input: { owner: string; repo: string; pullNumber: number },
+	pageInfo: ConnectionPageInfo | undefined,
+): Promise<(ReviewThreadNode | null)[]> {
+	const nodes: (ReviewThreadNode | null)[] = [];
+	let page = pageInfo ?? null;
+	while (page?.hasNextPage && page.endCursor) {
+		const data = await octokit.graphql<{
+			repository: {
+				pullRequest: { reviewThreads: ReviewThreadsConnection | null } | null;
+			} | null;
+		}>(REVIEW_THREADS_PAGE_QUERY, {
+			owner: input.owner,
+			name: input.repo,
+			number: input.pullNumber,
+			cursor: page.endCursor,
+		});
+		const connection = data.repository?.pullRequest?.reviewThreads;
+		if (!connection) break;
+		nodes.push(...connection.nodes);
+		page = connection.pageInfo;
+	}
+	return nodes;
+}
+
+async function drainCheckContexts(
+	octokit: GithubGraphqlClient,
+	input: { owner: string; repo: string; pullNumber: number },
+	pageInfo: ConnectionPageInfo | undefined,
+): Promise<(CheckContextNode | null)[]> {
+	const nodes: (CheckContextNode | null)[] = [];
+	let page = pageInfo ?? null;
+	while (page?.hasNextPage && page.endCursor) {
+		const data = await octokit.graphql<{
+			repository: {
+				pullRequest: {
+					statusCheckRollup: {
+						contexts: CheckContextsConnection | null;
+					} | null;
+				} | null;
+			} | null;
+		}>(CHECK_CONTEXTS_PAGE_QUERY, {
+			owner: input.owner,
+			name: input.repo,
+			number: input.pullNumber,
+			cursor: page.endCursor,
+		});
+		const connection =
+			data.repository?.pullRequest?.statusCheckRollup?.contexts;
+		if (!connection) break;
+		nodes.push(...connection.nodes);
+		page = connection.pageInfo;
+	}
+	return nodes;
 }
 
 /**


### PR DESCRIPTION
## What & why

`getPullRequestDetail` fetched `reviewThreads(first: 100)` and `statusCheckRollup.contexts(first: 100)` with no cursor. A PR with more than 100 checks or threads got a partial page, so a failing required check or an open thread past the first page was never seen — the mobile PR card could read "Ready to Merge" and offer the button on incomplete data (SUPER-1914, from CodeRabbit's review of #6491).

Both connections now request `pageInfo { hasNextPage endCursor }` and are drained to exhaustion (`drainReviewThreads` / `drainCheckContexts`, run concurrently) before checks are graded or unresolved threads counted. Nothing changes for PRs within one page — no extra requests. The 20-node caps on reviews/review-requests stay, per the ticket's accepted-risk note.

Closes SUPER-1914.

## How I tested it

- [x] host-service typecheck clean; full host-service suite green on the combined branch (1,222 tests)
- [x] Response shape unchanged — no client changes needed (desktop and mobile consume the same fields)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains GitHub review thread and status-check pagination in `host-service` before grading PR readiness. Old behavior: only the first 100 items were considered; new behavior: drains all pages (capped at 20) and fails with CONFLICT if a page is missing, the cap is hit, or GitHub reports a next page without a cursor. Addresses SUPER-1914.

- Adds pageInfo to the base query and drains via drainReviewThreads and drainCheckContexts, run concurrently in getPullRequestDetail.
- Response shape unchanged; no client changes required.
- Keeps the 20-node caps on latestOpinionatedReviews and reviewRequests.

<sup>Written for commit a5919a5a5e8787f19e94cef17629466b687abe9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Pull request details continue to include review threads and status checks beyond the first 100 results.
  - Pagination is now handled more reliably for large pull requests, helping prevent incomplete review and verification information.
  - Pull request details clearly report when available review or check data cannot be fully loaded.
  - Combined review and check results remain consistently available in the pull request details view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->