### PR TITLE
feat(host-service): remember every PR a workspace links, and serve it to mobile

### DIFF
--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/index.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/index.ts
@@ -1,4 +1,5 @@
 export {
 	useWorkspacePullRequest,
 	useWorkspacePullRequests,
+	type WorkspacePullRequest,
 } from "./useWorkspacePullRequest";

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
@@ -1,57 +1,91 @@
+import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { useHostProjects } from "@/hooks/useHostProjects";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
 import {
-	type OrgPullRequest,
-	usePullRequests,
-} from "@/screens/(authenticated)/hooks/usePullRequests";
+	getHostServiceClientByUrl,
+	hostServiceUrl,
+} from "@/lib/host-service/client";
 
-const NONE: OrgPullRequest[] = [];
+const HISTORY_REFETCH_MS = 60_000;
 
-/** Every pull request on the workspace's branch, newest first. */
+export interface WorkspacePullRequest {
+	/** Stable row key; the host rows have no client-facing id. */
+	key: string;
+	repoOwner: string;
+	repoName: string;
+	prNumber: number;
+	url: string;
+	title: string;
+	state: "open" | "closed" | "merged";
+	isDraft: boolean;
+	headBranch: string;
+	mergedAt: Date | null;
+	linkedAt: number;
+	/** The PR on the workspace's current branch — what the sidebar calls linked. */
+	isCurrent: boolean;
+}
+
+export function getWorkspacePullRequestsQueryKey(workspaceId: string | null) {
+	return ["workspace-pull-request-history", workspaceId] as const;
+}
+
+/**
+ * Every pull request this workspace has ever been linked to, straight from
+ * the host's append-only history — current one first, then newest link
+ * first. The host is the thing that watches the branch, so this needs no
+ * cloud GitHub integration and no branch reconstruction.
+ */
 export function useWorkspacePullRequests(
 	workspaceId: string | null,
-): OrgPullRequest[] {
-	const { workspace, host } = useWorkspaceHost(workspaceId);
-	const { projects } = useHostProjects(
-		host
-			? {
-					organizationId: host.organizationId,
-					machineId: host.machineId,
-					isOnline: host.isOnline,
-				}
-			: null,
+): WorkspacePullRequest[] {
+	const { host } = useWorkspaceHost(workspaceId);
+	const hostUrl =
+		host?.isOnline === true
+			? hostServiceUrl(host.organizationId, host.machineId)
+			: null;
+
+	const query = useQuery({
+		queryKey: getWorkspacePullRequestsQueryKey(workspaceId),
+		enabled: hostUrl !== null && workspaceId !== null,
+		refetchInterval: HISTORY_REFETCH_MS,
+		staleTime: 30_000,
+		networkMode: "always" as const,
+		queryFn: async () => {
+			if (!hostUrl || !workspaceId) return [];
+			const result = await getHostServiceClientByUrl(
+				hostUrl,
+			).pullRequests.historyByWorkspaces.query({
+				workspaceIds: [workspaceId],
+			});
+			return result.workspaces[0]?.pullRequests ?? [];
+		},
+	});
+
+	return useMemo(
+		() =>
+			(query.data ?? []).map(
+				(entry): WorkspacePullRequest => ({
+					key: `${entry.repoOwner}/${entry.repoName}#${entry.number}`,
+					repoOwner: entry.repoOwner,
+					repoName: entry.repoName,
+					prNumber: entry.number,
+					url: entry.url,
+					title: entry.title,
+					state: entry.state as WorkspacePullRequest["state"],
+					isDraft: entry.isDraft,
+					headBranch: entry.headBranch,
+					mergedAt: entry.mergedAt ? new Date(entry.mergedAt) : null,
+					linkedAt: entry.linkedAt,
+					isCurrent: entry.isCurrent,
+				}),
+			),
+		[query.data],
 	);
-
-	const pullRequests = usePullRequests();
-
-	return useMemo(() => {
-		if (!workspace) return NONE;
-		// Projects are fully local: match PRs by repo coordinates parsed from
-		// the PR URL (the cloud repo UUID isn't known host-side).
-		const project = projects.find((item) => item.id === workspace.projectId);
-		if (!project?.repoOwner || !project.repoName) return NONE;
-		const repoPrefix =
-			`https://github.com/${project.repoOwner}/${project.repoName}/`.toLowerCase();
-		const candidates = pullRequests.filter(
-			(pullRequest) =>
-				pullRequest.url.toLowerCase().startsWith(repoPrefix) &&
-				pullRequest.headBranch === workspace.branch,
-		);
-		// Newest first. With several pull requests on one branch, the recent one
-		// is what is being worked on; ordering by state would bury it behind
-		// whatever merely counts as "most open".
-		candidates.sort(
-			(a, b) =>
-				new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-		);
-		return candidates;
-	}, [workspace, projects, pullRequests]);
 }
 
 /** The one worth showing when there is only room for one. */
 export function useWorkspacePullRequest(
 	workspaceId: string | null,
-): OrgPullRequest | null {
+): WorkspacePullRequest | null {
 	return useWorkspacePullRequests(workspaceId)[0] ?? null;
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
@@ -16,7 +16,7 @@ export interface WorkspacePullRequest {
 	prNumber: number;
 	url: string;
 	title: string;
-	state: "open" | "closed" | "merged";
+	state: "open" | "draft" | "merged" | "closed" | "queued";
 	isDraft: boolean;
 	headBranch: string;
 	mergedAt: Date | null;
@@ -71,7 +71,7 @@ export function useWorkspacePullRequests(
 					prNumber: entry.number,
 					url: entry.url,
 					title: entry.title,
-					state: entry.state as WorkspacePullRequest["state"],
+					state: entry.state,
 					isDraft: entry.isDraft,
 					headBranch: entry.headBranch,
 					mergedAt: entry.mergedAt ? new Date(entry.mergedAt) : null,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
@@ -83,9 +83,16 @@ export function useWorkspacePullRequests(
 	);
 }
 
-/** The one worth showing when there is only room for one. */
+/**
+ * The currently linked pull request only. Surfaces with room for one PR
+ * (Files Changed's share/open actions) must never point at a historical PR
+ * from a branch the workspace has moved past.
+ */
 export function useWorkspacePullRequest(
 	workspaceId: string | null,
 ): WorkspacePullRequest | null {
-	return useWorkspacePullRequests(workspaceId)[0] ?? null;
+	return (
+		useWorkspacePullRequests(workspaceId).find((entry) => entry.isCurrent) ??
+		null
+	);
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/usePullRequestRoute.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/usePullRequestRoute.ts
@@ -22,8 +22,9 @@ export function usePullRequestRoute() {
 	// The history sheet passes the entry's own coordinates: an old entry can
 	// predate a remote rename, and the workspace's current repo would then
 	// resolve the number against the wrong repository.
-	const owner = params.owner ?? workspaceRepo.owner;
-	const repo = params.repo ?? workspaceRepo.repo;
+	const hasExplicitRepo = Boolean(params.owner && params.repo);
+	const owner = hasExplicitRepo ? (params.owner ?? null) : workspaceRepo.owner;
+	const repo = hasExplicitRepo ? (params.repo ?? null) : workspaceRepo.repo;
 	const detail = useWorkspacePullRequestDetail({
 		workspaceId,
 		owner,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/usePullRequestRoute.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/usePullRequestRoute.ts
@@ -8,14 +8,22 @@ import { useWorkspaceRepo } from "../../hooks/useWorkspaceRepo";
  * data — react-query serves them all from one cache entry.
  */
 export function usePullRequestRoute() {
-	const { id, pullRequestId } = useLocalSearchParams<{
+	const params = useLocalSearchParams<{
 		id: string;
 		pullRequestId: string;
+		owner?: string;
+		repo?: string;
 	}>();
+	const { id, pullRequestId } = params;
 	const workspaceId = id ?? null;
 	const parsed = Number.parseInt(pullRequestId ?? "", 10);
 	const pullNumber = Number.isNaN(parsed) ? null : parsed;
-	const { owner, repo } = useWorkspaceRepo(workspaceId);
+	const workspaceRepo = useWorkspaceRepo(workspaceId);
+	// The history sheet passes the entry's own coordinates: an old entry can
+	// predate a remote rename, and the workspace's current repo would then
+	// resolve the number against the wrong repository.
+	const owner = params.owner ?? workspaceRepo.owner;
+	const repo = params.repo ?? workspaceRepo.repo;
 	const detail = useWorkspacePullRequestDetail({
 		workspaceId,
 		owner,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
@@ -1,14 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { ChevronRight } from "lucide-react-native";
 import { Pressable, ScrollView, View } from "react-native";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
-import { useWorkspacePullRequests } from "../hooks/useWorkspacePullRequest";
+import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import {
+	getHostServiceClientByUrl,
+	hostServiceUrl,
+} from "@/lib/host-service/client";
+import {
+	useWorkspacePullRequests,
+	type WorkspacePullRequest,
+} from "../hooks/useWorkspacePullRequest";
 import { PULL_REQUEST_STATUS, pullRequestStatus } from "../utils/pullRequest";
 
 /**
- * Every pull request on this workspace's branch, oldest first, so the list
- * reads as the history of the branch and the newest sits nearest the thumb.
+ * Every pull request this workspace has produced, oldest first, so the list
+ * reads as the history of the workspace and the newest sits nearest the thumb.
  *
  * The state is carried by the leading glyph alone: with the number and title on
  * one line and the diffstat opposite, a status word would be a third thing
@@ -17,8 +26,13 @@ import { PULL_REQUEST_STATUS, pullRequestStatus } from "../utils/pullRequest";
 export function PullRequestsSheet() {
 	const { id } = useLocalSearchParams<{ id: string }>();
 	const router = useRouter();
-	// The hook hands back newest-first, which is what the chip colours itself
-	// from; only the list wants the other direction.
+	const { host } = useWorkspaceHost(id ?? null);
+	const hostUrl =
+		host?.isOnline === true
+			? hostServiceUrl(host.organizationId, host.machineId)
+			: null;
+	// The hook hands back current-then-newest, which is what the chip colours
+	// itself from; only the list wants the other direction.
 	const pullRequests = useWorkspacePullRequests(id ?? null).toReversed();
 
 	return (
@@ -43,7 +57,7 @@ export function PullRequestsSheet() {
 							accessibilityLabel={`Pull request #${pullRequest.prNumber}`}
 							accessibilityRole="button"
 							className="flex-row items-center gap-3 py-3 active:opacity-60"
-							key={pullRequest.id}
+							key={pullRequest.key}
 							onPress={() =>
 								router.replace({
 									pathname: "/workspace/[id]/pull-request/[pullRequestId]",
@@ -62,14 +76,7 @@ export function PullRequestsSheet() {
 							<Text className="flex-1 text-[15px]" numberOfLines={2}>
 								#{pullRequest.prNumber} {pullRequest.title}
 							</Text>
-							<View className="flex-row items-center gap-1">
-								<Text className="text-green-500 text-[13px]">
-									+{pullRequest.additions}
-								</Text>
-								<Text className="text-red-500 text-[13px]">
-									−{pullRequest.deletions}
-								</Text>
-							</View>
+							<RowDiffstat hostUrl={hostUrl} pullRequest={pullRequest} />
 							<Icon
 								as={ChevronRight}
 								className="text-muted-foreground/60 size-4"
@@ -79,5 +86,42 @@ export function PullRequestsSheet() {
 				})}
 			</ScrollView>
 		</>
+	);
+}
+
+/**
+ * The history rows come from the host's sweep, which lists PRs without
+ * per-PR detail; the diffstat is fetched per row on open. Renders nothing
+ * until the numbers exist — a placeholder would be a third thing on the row.
+ */
+function RowDiffstat({
+	hostUrl,
+	pullRequest,
+}: {
+	hostUrl: string | null;
+	pullRequest: WorkspacePullRequest;
+}) {
+	const { data } = useQuery({
+		queryKey: ["pull-request-diffstat", pullRequest.key],
+		enabled: hostUrl !== null,
+		staleTime: 5 * 60_000,
+		networkMode: "always" as const,
+		queryFn: async () => {
+			if (!hostUrl) return null;
+			const pr = await getHostServiceClientByUrl(hostUrl).github.getPR.query({
+				owner: pullRequest.repoOwner,
+				repo: pullRequest.repoName,
+				pullNumber: pullRequest.prNumber,
+			});
+			return { additions: pr.additions, deletions: pr.deletions };
+		},
+	});
+
+	if (!data) return null;
+	return (
+		<View className="flex-row items-center gap-1">
+			<Text className="text-green-500 text-[13px]">+{data.additions}</Text>
+			<Text className="text-red-500 text-[13px]">−{data.deletions}</Text>
+		</View>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
@@ -1,19 +1,17 @@
-import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { ChevronRight } from "lucide-react-native";
-import { Pressable, ScrollView, View } from "react-native";
+import { Pressable, ScrollView } from "react-native";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import {
-	getHostServiceClientByUrl,
-	hostServiceUrl,
-} from "@/lib/host-service/client";
-import {
-	useWorkspacePullRequests,
-	type WorkspacePullRequest,
-} from "../hooks/useWorkspacePullRequest";
+import { hostServiceUrl } from "@/lib/host-service/client";
+import { useWorkspacePullRequests } from "../hooks/useWorkspacePullRequest";
 import { PULL_REQUEST_STATUS, pullRequestStatus } from "../utils/pullRequest";
+import { RowDiffstat } from "./components/RowDiffstat";
+
+// Diffstat is one GitHub call per row; only the newest rows get one, so a
+// long-lived workspace's history cannot fan out unbounded on open.
+const DIFFSTAT_ROW_LIMIT = 20;
 
 /**
  * Every pull request this workspace has produced, oldest first, so the list
@@ -50,7 +48,7 @@ export function PullRequestsSheet() {
 				contentContainerClassName="px-4 pb-10 pt-2"
 				contentInsetAdjustmentBehavior="automatic"
 			>
-				{pullRequests.map((pullRequest) => {
+				{pullRequests.map((pullRequest, index) => {
 					const status = PULL_REQUEST_STATUS[pullRequestStatus(pullRequest)];
 					return (
 						<Pressable
@@ -76,7 +74,11 @@ export function PullRequestsSheet() {
 							<Text className="flex-1 text-[15px]" numberOfLines={2}>
 								#{pullRequest.prNumber} {pullRequest.title}
 							</Text>
-							<RowDiffstat hostUrl={hostUrl} pullRequest={pullRequest} />
+							<RowDiffstat
+								enabled={index >= pullRequests.length - DIFFSTAT_ROW_LIMIT}
+								hostUrl={hostUrl}
+								pullRequest={pullRequest}
+							/>
 							<Icon
 								as={ChevronRight}
 								className="text-muted-foreground/60 size-4"
@@ -86,42 +88,5 @@ export function PullRequestsSheet() {
 				})}
 			</ScrollView>
 		</>
-	);
-}
-
-/**
- * The history rows come from the host's sweep, which lists PRs without
- * per-PR detail; the diffstat is fetched per row on open. Renders nothing
- * until the numbers exist — a placeholder would be a third thing on the row.
- */
-function RowDiffstat({
-	hostUrl,
-	pullRequest,
-}: {
-	hostUrl: string | null;
-	pullRequest: WorkspacePullRequest;
-}) {
-	const { data } = useQuery({
-		queryKey: ["pull-request-diffstat", pullRequest.key],
-		enabled: hostUrl !== null,
-		staleTime: 5 * 60_000,
-		networkMode: "always" as const,
-		queryFn: async () => {
-			if (!hostUrl) return null;
-			const pr = await getHostServiceClientByUrl(hostUrl).github.getPR.query({
-				owner: pullRequest.repoOwner,
-				repo: pullRequest.repoName,
-				pullNumber: pullRequest.prNumber,
-			});
-			return { additions: pr.additions, deletions: pr.deletions };
-		},
-	});
-
-	if (!data) return null;
-	return (
-		<View className="flex-row items-center gap-1">
-			<Text className="text-green-500 text-[13px]">+{data.additions}</Text>
-			<Text className="text-red-500 text-[13px]">−{data.deletions}</Text>
-		</View>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/PullRequestsSheet.tsx
@@ -62,6 +62,8 @@ export function PullRequestsSheet() {
 									params: {
 										id: id ?? "",
 										pullRequestId: String(pullRequest.prNumber),
+										owner: pullRequest.repoOwner,
+										repo: pullRequest.repoName,
 									},
 								})
 							}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/RowDiffstat.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/RowDiffstat.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { getHostServiceClientByUrl } from "@/lib/host-service/client";
+import type { WorkspacePullRequest } from "../../../hooks/useWorkspacePullRequest";
+
+/**
+ * The history rows come from the host's sweep, which lists PRs without
+ * per-PR detail; the diffstat is fetched per row on open. Renders nothing
+ * until the numbers exist — a placeholder would be a third thing on the row.
+ */
+export function RowDiffstat({
+	hostUrl,
+	pullRequest,
+	enabled,
+}: {
+	hostUrl: string | null;
+	pullRequest: WorkspacePullRequest;
+	/** The sheet caps how many rows fetch, so an old long history cannot fan
+	 * out one GitHub call per row the moment the sheet opens. */
+	enabled: boolean;
+}) {
+	const { data } = useQuery({
+		queryKey: ["pull-request-diffstat", pullRequest.key],
+		enabled: enabled && hostUrl !== null,
+		staleTime: 5 * 60_000,
+		networkMode: "always" as const,
+		queryFn: async () => {
+			if (!hostUrl) return null;
+			const pr = await getHostServiceClientByUrl(hostUrl).github.getPR.query({
+				owner: pullRequest.repoOwner,
+				repo: pullRequest.repoName,
+				pullNumber: pullRequest.prNumber,
+			});
+			return { additions: pr.additions, deletions: pr.deletions };
+		},
+	});
+
+	if (!data) return null;
+	return (
+		<View className="flex-row items-center gap-1">
+			<Text className="text-green-500 text-[13px]">+{data.additions}</Text>
+			<Text className="text-red-500 text-[13px]">−{data.deletions}</Text>
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/RowDiffstat.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/RowDiffstat.tsx
@@ -21,7 +21,7 @@ export function RowDiffstat({
 	enabled: boolean;
 }) {
 	const { data } = useQuery({
-		queryKey: ["pull-request-diffstat", pullRequest.key],
+		queryKey: ["pull-request-diffstat", hostUrl, pullRequest.key],
 		enabled: enabled && hostUrl !== null,
 		staleTime: 5 * 60_000,
 		networkMode: "always" as const,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/index.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-requests/components/RowDiffstat/index.ts
@@ -1,0 +1,1 @@
+export { RowDiffstat } from "./RowDiffstat";

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/utils/pullRequest/status.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/utils/pullRequest/status.ts
@@ -58,5 +58,7 @@ export function pullRequestStatus(
 	if (pullRequest.mergedAt || pullRequest.state === "merged") return "merged";
 	if (pullRequest.state === "closed") return "closed";
 	if (pullRequest.isDraft) return "draft";
-	return queued ? "queued" : "open";
+	// The host history rows carry "queued" as a state; the detail path derives
+	// it from mergeability and passes the flag instead.
+	return queued || pullRequest.state === "queued" ? "queued" : "open";
 }

--- a/packages/host-service/drizzle/0025_fuzzy_true_believers.sql
+++ b/packages/host-service/drizzle/0025_fuzzy_true_believers.sql
@@ -9,7 +9,8 @@ CREATE TABLE `workspace_pull_requests` (
 --> statement-breakpoint
 CREATE INDEX `workspace_pull_requests_workspace_idx` ON `workspace_pull_requests` (`workspace_id`);--> statement-breakpoint
 INSERT INTO `workspace_pull_requests` (`workspace_id`, `pull_request_id`, `linked_at`)
-SELECT `id`, `pull_request_id`, CAST(strftime('%s','now') AS INTEGER) * 1000
-FROM `workspaces`
-WHERE `pull_request_id` IS NOT NULL
+SELECT `w`.`id`, `w`.`pull_request_id`, CAST(strftime('%s','now') AS INTEGER) * 1000
+FROM `workspaces` `w`
+JOIN `pull_requests` `p` ON `p`.`id` = `w`.`pull_request_id`
+WHERE `w`.`pull_request_id` IS NOT NULL
 ON CONFLICT DO NOTHING;

--- a/packages/host-service/drizzle/0025_fuzzy_true_believers.sql
+++ b/packages/host-service/drizzle/0025_fuzzy_true_believers.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `workspace_pull_requests` (
+	`workspace_id` text NOT NULL,
+	`pull_request_id` text NOT NULL,
+	`linked_at` integer NOT NULL,
+	PRIMARY KEY(`workspace_id`, `pull_request_id`),
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`pull_request_id`) REFERENCES `pull_requests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `workspace_pull_requests_workspace_idx` ON `workspace_pull_requests` (`workspace_id`);--> statement-breakpoint
+INSERT INTO `workspace_pull_requests` (`workspace_id`, `pull_request_id`, `linked_at`)
+SELECT `id`, `pull_request_id`, CAST(strftime('%s','now') AS INTEGER) * 1000
+FROM `workspaces`
+WHERE `pull_request_id` IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/packages/host-service/drizzle/meta/0025_snapshot.json
+++ b/packages/host-service/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1001 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cabb9da2-eb6f-4a9e-87a0-c465d4faca47",
+  "prevId": "792828a4-edf9-4577-b8c5-6ea21e493743",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_pull_requests": {
+      "name": "workspace_pull_requests",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_pull_requests_workspace_idx": {
+          "name": "workspace_pull_requests_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_pull_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pull_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pull_requests_pull_request_id_pull_requests_id_fk": {
+          "name": "workspace_pull_requests_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_pull_requests_workspace_id_pull_request_id_pk": {
+          "columns": [
+            "workspace_id",
+            "pull_request_id"
+          ],
+          "name": "workspace_pull_requests_workspace_id_pull_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1787007811544,
       "tag": "0024_odd_war_machine",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1787516889350,
+      "tag": "0025_fuzzy_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -7,6 +7,7 @@ import { sql } from "drizzle-orm";
 import {
 	index,
 	integer,
+	primaryKey,
 	sqliteTable,
 	text,
 	uniqueIndex,
@@ -263,5 +264,30 @@ export const workspaces = sqliteTable(
 		uniqueIndex("workspaces_one_main_per_project")
 			.on(table.projectId)
 			.where(sql`type = 'main'`),
+	],
+);
+
+/**
+ * Every pull request a workspace has ever been linked to, append-only.
+ * `workspaces.pullRequestId` stays the single "currently linked" pointer the
+ * sidebar shows (and Remove PR Link clears); this table is the memory that
+ * survives the pointer moving on — a workspace that opens a PR per branch
+ * accumulates one row each. Unlinking hides a PR from the sidebar, never
+ * from here.
+ */
+export const workspacePullRequests = sqliteTable(
+	"workspace_pull_requests",
+	{
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		pullRequestId: text("pull_request_id")
+			.notNull()
+			.references(() => pullRequests.id, { onDelete: "cascade" }),
+		linkedAt: integer("linked_at").notNull(),
+	},
+	(table) => [
+		primaryKey({ columns: [table.workspaceId, table.pullRequestId] }),
+		index("workspace_pull_requests_workspace_idx").on(table.workspaceId),
 	],
 );

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -1264,3 +1264,130 @@ describe("missing-worktree degraded state", () => {
 		}
 	});
 });
+
+describe("PullRequestRuntimeManager workspace PR history", () => {
+	// Serves one open PR per branch through both the per-head query and the
+	// repo-wide sweep, with empty detail endpoints.
+	function historyExecGh(prsByBranch: Map<string, number>) {
+		return async (args: string[]) => {
+			if (args.includes("graphql")) {
+				return {
+					data: { repository: { pullRequest: { mergeQueueEntry: null } } },
+				};
+			}
+			const path = args.find(
+				(arg) => typeof arg === "string" && arg.startsWith("repos/"),
+			);
+			if (path?.endsWith("/reviews")) return [];
+			if (path?.endsWith("/check-runs")) return { check_runs: [] };
+			if (path?.endsWith("/statuses")) return [];
+			const head = args.find(
+				(arg) => typeof arg === "string" && arg.startsWith("head="),
+			);
+			if (head) {
+				const branch = head.slice(`head=${REPO.owner}:`.length);
+				const prNumber = prsByBranch.get(branch);
+				return prNumber
+					? [
+							makePrNode({
+								number: prNumber,
+								headRef: branch,
+								headSha: `sha-${branch}`,
+							}),
+						]
+					: [];
+			}
+			if (path === `repos/${REPO.owner}/${REPO.name}/pulls`) {
+				return [...prsByBranch.entries()].map(([branch, prNumber]) =>
+					makePrNode({
+						number: prNumber,
+						headRef: branch,
+						headSha: `sha-${branch}`,
+					}),
+				);
+			}
+			throw new Error(`unexpected gh call: ${args.join(" ")}`);
+		};
+	}
+
+	test("history accumulates across branch moves; unlink hides the pointer, never the history", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "branch-a",
+			headSha: "sha-branch-a",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "branch-a",
+		});
+		const prsByBranch = new Map([["branch-a", 101]]);
+		const manager = createManager(db, { execGh: historyExecGh(prsByBranch) });
+
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+		const first = await manager.getPullRequestHistoryByWorkspaces(["ws"]);
+		expect(first[0]?.pullRequests.map((pr) => pr.number)).toEqual([101]);
+		expect(first[0]?.pullRequests[0]?.isCurrent).toBe(true);
+
+		// The workspace moves on: new branch, new PR. The pointer follows;
+		// the history keeps both.
+		db.update(workspaces)
+			.set({
+				branch: "branch-b",
+				headSha: "sha-branch-b",
+				upstreamBranch: "branch-b",
+			})
+			.where(eq(workspaces.id, "ws"))
+			.run();
+		prsByBranch.set("branch-b", 102);
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+
+		const both = await manager.getPullRequestHistoryByWorkspaces(["ws"]);
+		expect(both[0]?.pullRequests.map((pr) => pr.number)).toEqual([102, 101]);
+		expect(both[0]?.pullRequests.map((pr) => pr.isCurrent)).toEqual([
+			true,
+			false,
+		]);
+		const current = await manager.getPullRequestsByWorkspaces(["ws"]);
+		expect(current[0]?.pullRequest?.number).toBe(102);
+
+		// Remove PR Link: the sidebar loses the pointer; history keeps 102.
+		manager.unlinkWorkspacePullRequest("ws");
+		const afterUnlink = await manager.getPullRequestsByWorkspaces(["ws"]);
+		expect(afterUnlink[0]?.pullRequest).toBeNull();
+		const history = await manager.getPullRequestHistoryByWorkspaces(["ws"]);
+		expect(history[0]?.pullRequests.map((pr) => pr.number)).toEqual([102, 101]);
+		expect(history[0]?.pullRequests.every((pr) => pr.isCurrent === false)).toBe(
+			true,
+		);
+	});
+
+	test("relinking the same PR after flip-flopping branches stays deduped", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "branch-a",
+			headSha: "sha-branch-a",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "branch-a",
+		});
+		const prsByBranch = new Map([["branch-a", 101]]);
+		const manager = createManager(db, { execGh: historyExecGh(prsByBranch) });
+
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+
+		const history = await manager.getPullRequestHistoryByWorkspaces(["ws"]);
+		expect(history[0]?.pullRequests.map((pr) => pr.number)).toEqual([101]);
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -4,7 +4,12 @@ import type { Octokit } from "@octokit/rest";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { HostDb } from "../../db";
-import { projects, pullRequests, workspaces } from "../../db/schema";
+import {
+	projects,
+	pullRequests,
+	workspacePullRequests,
+	workspaces,
+} from "../../db/schema";
 import type { EventBus } from "../../events/event-bus";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
@@ -98,6 +103,32 @@ export interface PullRequestWorkspaceSnapshot {
 	pullRequest: PullRequestStateSnapshot | null;
 	error: string | null;
 	lastFetchedAt: string | null;
+}
+
+export interface WorkspacePullRequestHistoryEntry {
+	repoOwner: string;
+	repoName: string;
+	number: number;
+	url: string;
+	title: string;
+	state: PullRequestState;
+	isDraft: boolean;
+	headBranch: string;
+	reviewDecision: ReviewDecision;
+	checksStatus: ChecksStatus;
+	/** First observed merged, epoch ms. Never cleared once set. */
+	mergedAt: number | null;
+	/** Row refresh time, epoch ms — ordering, not GitHub's own clock. */
+	updatedAt: number;
+	/** When this workspace first linked to the PR, epoch ms. */
+	linkedAt: number;
+	/** True for the PR the sidebar shows: the one on the current branch. */
+	isCurrent: boolean;
+}
+
+export interface WorkspacePullRequestHistory {
+	workspaceId: string;
+	pullRequests: WorkspacePullRequestHistoryEntry[];
 }
 
 export interface PullRequestRuntimeManagerOptions {
@@ -334,6 +365,80 @@ export class PullRequestRuntimeManager {
 		}));
 	}
 
+	/**
+	 * Every PR each workspace has ever been linked to, currently-linked one
+	 * first and then newest link first. Suppressed ("Remove PR Link") PRs stay
+	 * listed — suppression governs the sidebar pointer, not the history.
+	 */
+	async getPullRequestHistoryByWorkspaces(
+		workspaceIds: string[],
+	): Promise<WorkspacePullRequestHistory[]> {
+		if (workspaceIds.length === 0) return [];
+
+		const rows = this.db
+			.select({
+				workspaceId: workspacePullRequests.workspaceId,
+				linkedAt: workspacePullRequests.linkedAt,
+				currentPullRequestId: workspaces.pullRequestId,
+				pullRequestRowId: pullRequests.id,
+				repoOwner: pullRequests.repoOwner,
+				repoName: pullRequests.repoName,
+				prNumber: pullRequests.prNumber,
+				url: pullRequests.url,
+				title: pullRequests.title,
+				state: pullRequests.state,
+				isDraft: pullRequests.isDraft,
+				headBranch: pullRequests.headBranch,
+				reviewDecision: pullRequests.reviewDecision,
+				checksStatus: pullRequests.checksStatus,
+				mergedAt: pullRequests.mergedAt,
+				updatedAt: pullRequests.updatedAt,
+			})
+			.from(workspacePullRequests)
+			.innerJoin(
+				pullRequests,
+				eq(workspacePullRequests.pullRequestId, pullRequests.id),
+			)
+			.innerJoin(
+				workspaces,
+				eq(workspacePullRequests.workspaceId, workspaces.id),
+			)
+			.where(inArray(workspacePullRequests.workspaceId, workspaceIds))
+			.all();
+
+		const byWorkspace = new Map<string, WorkspacePullRequestHistoryEntry[]>();
+		for (const row of rows) {
+			const entry: WorkspacePullRequestHistoryEntry = {
+				repoOwner: row.repoOwner,
+				repoName: row.repoName,
+				number: row.prNumber,
+				url: row.url,
+				title: row.title,
+				state: coercePullRequestState(row.state),
+				isDraft: row.isDraft,
+				headBranch: row.headBranch,
+				reviewDecision: coerceReviewDecision(row.reviewDecision),
+				checksStatus: coerceChecksStatus(row.checksStatus),
+				mergedAt: row.mergedAt ?? null,
+				updatedAt: row.updatedAt,
+				linkedAt: row.linkedAt,
+				isCurrent: row.pullRequestRowId === row.currentPullRequestId,
+			};
+			const list = byWorkspace.get(row.workspaceId);
+			if (list) list.push(entry);
+			else byWorkspace.set(row.workspaceId, [entry]);
+		}
+
+		return workspaceIds.map((workspaceId) => {
+			const entries = byWorkspace.get(workspaceId) ?? [];
+			entries.sort((a, b) => {
+				if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
+				return b.linkedAt - a.linkedAt;
+			});
+			return { workspaceId, pullRequests: entries };
+		});
+	}
+
 	async refreshPullRequestsByWorkspaces(workspaceIds: string[]): Promise<void> {
 		if (workspaceIds.length === 0) return;
 
@@ -439,8 +544,27 @@ export class PullRequestRuntimeManager {
 			})
 			.where(eq(workspaces.id, workspaceId))
 			.run();
+		this.recordWorkspacePullRequestLink(workspaceId, rowId, now);
 
 		return rowId;
+	}
+
+	/**
+	 * Append-only memory of every PR a workspace has been linked to. The
+	 * current-link pointer moves on when the branch does; this row stays, so
+	 * the workspace's whole PR history remains listable. Unlinking hides a PR
+	 * from the sidebar surfaces, never from here.
+	 */
+	private recordWorkspacePullRequestLink(
+		workspaceId: string,
+		pullRequestId: string,
+		linkedAt: number,
+	): void {
+		this.db
+			.insert(workspacePullRequests)
+			.values({ workspaceId, pullRequestId, linkedAt })
+			.onConflictDoNothing()
+			.run();
 	}
 
 	private async syncWorkspaceBranches(): Promise<void> {
@@ -756,6 +880,9 @@ export class PullRequestRuntimeManager {
 						and(eq(workspaces.id, workspace.id), isNull(workspaces.archivedAt)),
 					)
 					.run();
+				// The sweep re-asserts the link every pass, so this also heals
+				// history rows for links that predate the table.
+				this.recordWorkspacePullRequestLink(workspace.id, match.id, Date.now());
 				continue;
 			}
 

--- a/packages/host-service/src/trpc/router/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/pull-requests.ts
@@ -18,6 +18,24 @@ export const pullRequestsRouter = router({
 				);
 			return { workspaces };
 		}),
+	/**
+	 * Every PR each workspace has ever been linked to, current one first.
+	 * `getByWorkspaces` stays the sidebar's view (the one currently-linked PR,
+	 * honoring Remove PR Link); this is the full record behind it.
+	 */
+	historyByWorkspaces: protectedProcedure
+		.input(
+			z.object({
+				workspaceIds: z.array(z.string()),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const workspaces =
+				await ctx.runtime.pullRequests.getPullRequestHistoryByWorkspaces(
+					input.workspaceIds,
+				);
+			return { workspaces };
+		}),
 	unlinkFromWorkspace: protectedProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
## What & why

Two mobile symptoms, one cause. The chip/picker derived "this workspace's PRs" from the cloud's `integration.github.listPullRequests` — the **100 most-recently-updated PRs org-wide, all states** (in this repo the window reaches back ~35h) — filtered client-side by repo URL and the workspace's **current** branch. So chips read zero once PRs aged out of the window, and multi-PR workspaces never showed more than one because every earlier PR stopped matching the moment the agent re-branched. Meanwhile the host's own model (`workspaces.pullRequestId`) is a single overwritable pointer that forgets each PR when the next one links.

This makes the workspace→PR relationship first-class on the host:

- **`workspace_pull_requests`** — append-only join table (composite PK, cascade deletes), migration `0025` backfills from every current pointer.
- Both link sites (`checkoutPullRequest`, the branch-match sweep) record into it; the sweep re-asserts links every pass, so links that predate the table self-heal.
- **`pullRequests.historyByWorkspaces`** returns each workspace's accumulated set, current-linked first then newest link first. **`getByWorkspaces` is untouched** — desktop's sidebar view and Remove PR Link semantics are exactly as before; unlinking hides the pointer, never the history row.
- Mobile's `useWorkspacePullRequests` reads host history (no cloud GitHub integration needed, no branch reconstruction); the picker fetches diffstat lazily per row via `github.getPR` since the sweep's REST list endpoints carry no additions/deletions.

## How I tested it

- [x] Lifecycle tests against the real migrated schema: link → re-branch → second link keeps both (current-first) → unlink keeps history and survives a sweep without relinking; flip-flop relinks stay deduped
- [x] Full host-service suite green on the combined branch (1,222 tests); mobile tests + typecheck clean
- [x] Live E2E on a dev stack against real GitHub over CDP: migration + backfill on boot, real sweep linked open PRs #6787→#6780 across a real branch move, history accumulated both, desktop board/header badge showed only the current PR with the merge menu intact, and unlink cleared the badge while a real sweep honored suppression and history retained both (screenshots in session)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes workspace→PR links first-class and serves full history to mobile so chips and pickers stay stable. Previously mobile filtered the cloud’s org‑wide top‑100 updated PRs by the current branch; now the host keeps an append‑only history and mobile reads it. “Remove PR Link” hides the pointer but preserves history.

- Host-service
  - Adds `workspace_pull_requests` (composite PK, cascade deletes). Migration `0025` backfills via an inner join to `pull_requests` to skip legacy orphaned pointers. No manual action required.
  - Records links at checkout and during the sweep; the sweep re-asserts links so pre-table links self-heal and duplicates are ignored.
  - Serves `pullRequests.historyByWorkspaces` (current-linked first, then newest link). `getByWorkspaces` stays unchanged. “Remove PR Link” clears the pointer and suppresses relinking but keeps history.

- Mobile
  - `useWorkspacePullRequests` reads host history (polls every 60s). `useWorkspacePullRequest` now returns only the currently linked PR.
  - `PullRequestsSheet` passes each entry’s `owner`/`repo` in the route as a pair to handle repo renames. Diffstat renders via per-row `github.getPR`; only the 20 newest rows fetch to bound fan‑out, and the query key includes the host URL to avoid cross-host cache collisions. No placeholder shows until numbers arrive.
  - History state includes `draft` and `queued`; `pullRequestStatus` treats `queued` from either state or mergeability.

<sup>Written for commit 82142c5a8db65dadba69b9abc0061595e899cdbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace pull request history that persists across branch changes.
  * Shows the currently linked pull request first, followed by recent history.
  * Displays diffstat details, link dates, merge dates, and pull request metadata.
  * Added draft and queued pull request statuses.
  * Supports viewing pull request details from the associated repository.

* **Bug Fixes**
  * Prevents duplicate entries when relinking pull requests.
  * Retains history after pull requests are unlinked.
  * Improves queued status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->