### PR TITLE
fix(desktop): quarantine host rows the app cannot key, instead of crashing

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type HostProjectRow,
+	type HostProjectsQueryTarget,
+	mergeHostProjects,
+} from "./useHostProjects.utils";
+
+const PROJECT_A = "3d4e5f6a-7b8c-4d9e-8f0a-1b2c3d4e5f6a";
+const PROJECT_B = "5f6a7b8c-9d0e-4f1a-8b2c-3d4e5f6a7b8c";
+
+const target: HostProjectsQueryTarget = {
+	machineId: "machine-1",
+	organizationId: "org-1",
+	hostUrl: "http://127.0.0.1:1234",
+	isLocal: true,
+};
+
+function projectRow(id: string, name: string): HostProjectRow {
+	return {
+		id,
+		name,
+		repoPath: `/tmp/${name}`,
+		repoOwner: null,
+		repoName: null,
+		repoUrl: null,
+		worktreeBaseDir: null,
+		icon: null,
+		color: null,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+describe("mergeHostProjects", () => {
+	it("drops a project whose id the sidebar collection cannot key, keeping the rest", () => {
+		const merged = mergeHostProjects({
+			hostResults: [
+				{
+					target,
+					rows: [
+						projectRow(PROJECT_A, "keeps-syncing"),
+						projectRow("not-a-uuid", "quarantined"),
+						projectRow(PROJECT_B, "also-syncs"),
+					],
+					reachable: true,
+				},
+			],
+		});
+
+		expect(merged.map((row) => row.name)).toEqual([
+			"keeps-syncing",
+			"also-syncs",
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-projects/useHostProjects/useHostProjects.utils.ts
@@ -1,6 +1,7 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { ProjectSnapshotPayload } from "@superset/workspace-client";
 import { del as idbDel, get as idbGet, set as idbSet } from "idb-keyval";
+import { filterRepresentableHostRows } from "renderer/lib/hostRowContract";
 
 /** A project row as served by a host (`project.list`). */
 export interface HostProjectRow {
@@ -275,7 +276,13 @@ export function mergeHostProjects({
 
 	for (const result of hostResults) {
 		if (!result.rows) continue;
-		for (const row of result.rows) {
+		// Same identity contract as workspaces: a project id the app cannot
+		// represent would crash the sidebar's project collection on insert.
+		for (const row of filterRepresentableHostRows(
+			result.rows,
+			"project",
+			(candidate) => ({ id: candidate.id }),
+		)) {
 			const key = row.id;
 			const existing = byKey.get(key);
 			if (!existing) {

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/hostWorkspaceQuarantine.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/hostWorkspaceQuarantine.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import {
+	type DashboardSidebarSectionRow,
+	dashboardSidebarSectionSchema,
+	type WorkspaceLocalStateRow,
+	workspaceLocalStateSchema,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { writeWorkspacePaneLayout } from "renderer/stores/workspace-creates/writeWorkspacePaneLayout";
+import {
+	type HostWorkspaceRow,
+	type HostWorkspacesQueryTarget,
+	mergeHostWorkspaces,
+} from "./useHostWorkspaces.utils";
+
+/**
+ * A host serving one unrepresentable row used to take the whole dashboard
+ * down: the sidebar reconciler inserted it into `v2WorkspaceLocalState`,
+ * TanStack DB threw `SchemaValidationError` synchronously out of the effect,
+ * and the root error boundary ("Something went wrong") swallowed the app.
+ */
+
+const WORKSPACE_A = "8f6bf4e6-0f8a-4d4a-9f0b-9c1d2e3f4a5b";
+const WORKSPACE_B = "1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f";
+const WORKSPACE_C = "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c9d0e";
+const WORKSPACE_D = "9d0e1f2a-3b4c-4d5e-8f6a-7b8c9d0e1f2a";
+const PROJECT = "3d4e5f6a-7b8c-4d9e-8f0a-1b2c3d4e5f6a";
+
+const target: HostWorkspacesQueryTarget = {
+	machineId: "machine-1",
+	organizationId: "org-1",
+	hostUrl: "http://127.0.0.1:1234",
+	isLocal: true,
+};
+
+function hostRow(
+	id: string,
+	projectId: string | null,
+	name: string,
+): HostWorkspaceRow {
+	return {
+		id,
+		organizationId: target.organizationId,
+		projectId,
+		hostId: target.machineId,
+		name,
+		branch: `branch/${name}`,
+		type: projectId === null ? "session" : "worktree",
+		createdByUserId: null,
+		taskId: null,
+		createdAt: new Date(0),
+		updatedAt: new Date(0),
+		worktreePath: `/tmp/${name}`,
+		worktreeExists: true,
+	};
+}
+
+function makeMapStorage() {
+	const map = new Map<string, string>();
+	return {
+		getItem: (key: string) => map.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			map.set(key, value);
+		},
+		removeItem: (key: string) => {
+			map.delete(key);
+		},
+	};
+}
+
+const noopEvents = {
+	addEventListener: () => {},
+	removeEventListener: () => {},
+};
+
+/** The two real collections `writeWorkspacePaneLayout` touches. */
+function makeCollections(storageKeyPrefix: string): AppCollections {
+	const storage = makeMapStorage();
+	const v2WorkspaceLocalState = createCollection(
+		localStorageCollectionOptions({
+			id: `${storageKeyPrefix}-local-state`,
+			storageKey: `${storageKeyPrefix}-local-state`,
+			schema: workspaceLocalStateSchema,
+			getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
+			storage,
+			storageEventApi: noopEvents,
+			startSync: true,
+			gcTime: 0,
+		}),
+	);
+	const v2SidebarSections = createCollection(
+		localStorageCollectionOptions({
+			id: `${storageKeyPrefix}-sections`,
+			storageKey: `${storageKeyPrefix}-sections`,
+			schema: dashboardSidebarSectionSchema,
+			getKey: (item: DashboardSidebarSectionRow) => item.sectionId,
+			storage,
+			storageEventApi: noopEvents,
+			startSync: true,
+			gcTime: 0,
+		}),
+	);
+	return { v2WorkspaceLocalState, v2SidebarSections } as AppCollections;
+}
+
+describe("host workspace ingest quarantine", () => {
+	it("hides every unrepresentable row and still syncs the rest of the host's list", () => {
+		const rows: HostWorkspaceRow[] = [
+			hostRow(WORKSPACE_A, PROJECT, "good-one"),
+			hostRow("not-a-uuid", PROJECT, "bad-id"),
+			hostRow(WORKSPACE_D, "also-not-a-uuid", "bad-project"),
+			// A project-less session: a null projectId is an absence, not a
+			// violation, so this row has to survive.
+			hostRow(WORKSPACE_B, null, "session"),
+			// `workspace.list` is cast, never parsed, so the row type lies about
+			// the wire — a missing id must be dropped, not thrown on.
+			{
+				...hostRow(WORKSPACE_C, PROJECT, "no-id"),
+				id: undefined as unknown as string,
+			},
+			hostRow(WORKSPACE_C, PROJECT, "good-two"),
+		];
+
+		const merged = mergeHostWorkspaces({
+			hostResults: [{ target, rows, reachable: true }],
+		});
+		expect(merged.map((row) => row.name)).toEqual([
+			"good-one",
+			"session",
+			"good-two",
+		]);
+
+		const collections = makeCollections("quarantine-sync");
+		// The write the sidebar reconciler performs for each ingested row. It
+		// throwing here is exactly what reached the root error boundary.
+		for (const workspace of merged) {
+			writeWorkspacePaneLayout(
+				collections,
+				{ id: workspace.id, projectId: workspace.projectId },
+				[],
+				[],
+			);
+		}
+
+		expect([...collections.v2WorkspaceLocalState.state.keys()].sort()).toEqual(
+			[WORKSPACE_A, WORKSPACE_B, WORKSPACE_C].sort(),
+		);
+	});
+
+	it("still rejects the malformed row at the collection, so validation is not silenced", () => {
+		const collections = makeCollections("quarantine-strict");
+		expect(() =>
+			writeWorkspacePaneLayout(
+				collections,
+				{ id: "not-a-uuid", projectId: PROJECT },
+				[],
+				[],
+			),
+		).toThrow();
+		expect(collections.v2WorkspaceLocalState.size).toBe(0);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -13,6 +13,7 @@ import {
 	type HostWorkspaceItem,
 	type HostWorkspaceRow,
 	isEventBusReopen,
+	keepRepresentableHostWorkspaces,
 	loadHostWorkspacesSnapshot,
 	mergeHostWorkspaces,
 	saveHostWorkspacesSnapshot,
@@ -336,7 +337,9 @@ export function useHostWorkspacesSource(
 		const liveIds = new Set(merged.map((row) => row.id));
 		const archived: HostWorkspaceItem[] = targets.flatMap((_target, index) => {
 			const query = archivedQueries[index];
-			const rows = query?.data ?? [];
+			// Tombstones skip mergeHostWorkspaces, so they get the same
+			// identity filter here rather than an exemption from it.
+			const rows = keepRepresentableHostWorkspaces(query?.data ?? []);
 			return rows
 				.filter((row) => !liveIds.has(row.id))
 				.map((row) => ({

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -5,6 +5,7 @@ import type {
 	WorkspaceSnapshotPayload,
 } from "@superset/workspace-client";
 import { get as idbGet, set as idbSet } from "idb-keyval";
+import { filterRepresentableHostRows } from "renderer/lib/hostRowContract";
 
 /**
  * The frozen cloud row shape, widened for host-only capabilities the cloud
@@ -243,6 +244,22 @@ export function applyWorkspaceChangedEvent(
 }
 
 /**
+ * Drop rows whose workspace or project id this app cannot represent. Every
+ * source a host row can arrive from — the live `workspace.list` answer, an
+ * IndexedDB snapshot, a `workspace:changed` patch — passes through here, so
+ * this is the one place the identity contract has to hold for downstream
+ * consumers (see `filterRepresentableHostRows`).
+ */
+export function keepRepresentableHostWorkspaces(
+	rows: readonly HostWorkspaceRow[],
+): readonly HostWorkspaceRow[] {
+	return filterRepresentableHostRows(rows, "workspace", (row) => ({
+		id: row.id,
+		projectId: row.projectId,
+	}));
+}
+
+/**
  * Merge per-host results. A host that answered is authoritative for its
  * rows — a deleted row must not resurrect.
  */
@@ -260,7 +277,7 @@ export function mergeHostWorkspaces({
 
 	for (const result of hostResults) {
 		if (!result.rows) continue;
-		for (const row of result.rows) {
+		for (const row of keepRepresentableHostWorkspaces(result.rows)) {
 			if (seenIds.has(row.id)) continue;
 			seenIds.add(row.id);
 			items.push({

--- a/apps/desktop/src/renderer/lib/hostRowContract/hostRowContract.ts
+++ b/apps/desktop/src/renderer/lib/hostRowContract/hostRowContract.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+/**
+ * The identity contract for every id a host authors and this app persists.
+ * Hosts mint these with `randomUUID()`, but their SQLite columns are plain
+ * `text` and callers may supply their own id, so nothing host-side enforces
+ * the shape.
+ *
+ * The local collections that key rows on these ids validate them as UUIDs, as
+ * do the cloud procedures that still accept a workspace or project id. Both
+ * sides share this one schema so the ingest filter below can never become more
+ * lenient than the collections it protects.
+ */
+export const hostAuthoredIdSchema = z.string().uuid();
+
+export function isHostAuthoredId(value: unknown): value is string {
+	return hostAuthoredIdSchema.safeParse(value).success;
+}
+
+/**
+ * Warn once per offending value — feeds re-merge on every host refetch. The
+ * warning is also the Sentry breadcrumb: `breadcrumbsIntegration` is on by
+ * default with `console: true`, so this lands on the scope of whatever the app
+ * reports next without a second, duplicate `addBreadcrumb` call.
+ */
+const reportedIds = new Set<string>();
+
+function reportQuarantinedRow(
+	kind: string,
+	field: string,
+	value: unknown,
+): void {
+	const reportKey = `${kind}:${field}:${String(value)}`;
+	if (reportedIds.has(reportKey)) return;
+	reportedIds.add(reportKey);
+
+	console.warn(
+		`[host-rows] Quarantined ${kind} row: ${field} is not a valid id (${JSON.stringify(value)})`,
+	);
+}
+
+/**
+ * Drop host-served rows carrying an id this app cannot represent, so one bad
+ * row degrades to a hidden row instead of taking the app down.
+ *
+ * TanStack DB enforces the id contract by throwing `SchemaValidationError` out
+ * of `insert`/`update` — synchronously, inside the effect that places host
+ * workspaces in the sidebar, where nothing catches it and the root error
+ * boundary swallows the whole dashboard. Rejecting the row where host data
+ * enters keeps that invariant true for every consumer downstream, instead of
+ * loosening the schema or wrapping the writes in a catch.
+ */
+export function filterRepresentableHostRows<TRow>(
+	rows: readonly TRow[],
+	kind: string,
+	getIds: (row: TRow) => Record<string, unknown>,
+): readonly TRow[] {
+	return rows.filter((row) =>
+		Object.entries(getIds(row)).every(([field, value]) => {
+			// An explicit null is an absence (a project-less session), not a
+			// violation. Undefined is not: the row is missing the field, and
+			// letting that through would pass a row with no id at all.
+			if (value === null) return true;
+			if (isHostAuthoredId(value)) return true;
+			reportQuarantinedRow(kind, field, value);
+			return false;
+		}),
+	);
+}

--- a/apps/desktop/src/renderer/lib/hostRowContract/index.ts
+++ b/apps/desktop/src/renderer/lib/hostRowContract/index.ts
@@ -1,0 +1,5 @@
+export {
+	filterRepresentableHostRows,
+	hostAuthoredIdSchema,
+	isHostAuthoredId,
+} from "./hostRowContract";

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -1,6 +1,7 @@
 import type { AppRouter } from "@superset/host-service";
 import type { LayoutNode, Tab, WorkspaceState } from "@superset/panes";
 import type { inferRouterInputs } from "@trpc/server";
+import { hostAuthoredIdSchema } from "renderer/lib/hostRowContract";
 import { z } from "zod";
 
 const persistedDateSchema = z
@@ -8,7 +9,7 @@ const persistedDateSchema = z
 	.transform((value) => (typeof value === "string" ? new Date(value) : value));
 
 export const dashboardSidebarProjectSchema = z.object({
-	projectId: z.string().uuid(),
+	projectId: hostAuthoredIdSchema,
 	createdAt: persistedDateSchema,
 	isCollapsed: z.boolean().default(false),
 	tabOrder: z.number().int().default(0),
@@ -107,7 +108,7 @@ const workspaceRunStateSchema = z.enum([
 
 export const workspaceRunTerminalStateSchema = z.object({
 	terminalId: z.string(),
-	workspaceId: z.string().uuid(),
+	workspaceId: hostAuthoredIdSchema,
 	state: workspaceRunStateSchema,
 	command: z.string(),
 	definitionSource: z.enum(["project-config", "terminal-preset"]),
@@ -120,7 +121,7 @@ export const workspaceRunTerminalStateSchema = z.object({
 });
 
 export const workspaceLocalStateSchema = z.object({
-	workspaceId: z.string().uuid(),
+	workspaceId: hostAuthoredIdSchema,
 	createdAt: persistedDateSchema,
 	sidebarState: z.object({
 		// Null = project-less "session" workspace (renders in the Sessions
@@ -128,7 +129,7 @@ export const workspaceLocalStateSchema = z.object({
 		// keeps every pre-existing persisted row parsing unchanged, and heal
 		// must never synthesize null (that would silently reparent a corrupt
 		// project workspace into Sessions).
-		projectId: z.string().uuid().nullable(),
+		projectId: hostAuthoredIdSchema.nullable(),
 		tabOrder: z.number().int().default(0),
 		sectionId: z.string().uuid().nullable().default(null),
 		changesFilter: changesFilterSchema.default({ kind: "all" }),
@@ -207,7 +208,7 @@ const WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS = {
  */
 export const dashboardSidebarSectionSchema = z.object({
 	sectionId: z.string().uuid(),
-	projectId: z.string().uuid(),
+	projectId: hostAuthoredIdSchema,
 	name: z.string().trim().min(1),
 	createdAt: persistedDateSchema,
 	tabOrder: z.number().int().default(0),


### PR DESCRIPTION
## The bug

A host serving a workspace row whose `id` is not a UUID hard-crashes the desktop app to its root error boundary ("Something went wrong"). `usePlaceLocalWorktreesInSidebar` inserts the row into `v2WorkspaceLocalState`, TanStack DB's `validateData` throws `SchemaValidationError` ("Invalid UUID — path: workspaceId") synchronously out of the effect, and nothing catches it. One malformed row from one host takes down the entire dashboard, and the user can't recover without finding and deleting a row in a SQLite file.

Reproduced 2026-08-23 by inserting a workspace row with a non-UUID id into a host DB.

## Why it can happen

Nothing upstream enforces the shape the app relies on:

- `packages/host-service/src/db/schema.ts` declares `id: text().primaryKey()` for both `workspaces` and `projects`.
- `insertLocalWorkspace` takes `values.id ?? randomUUID()` — the CLI, automations, and `adopt-existing-worktree` can all supply an id the host stores verbatim.
- The renderer casts `client.workspace.list.query() as HostWorkspaceRow[]` without parsing it.

So the row type lies about the wire, and the first thing that actually checks is a collection insert deep inside a React effect.

## The fix

Reject host rows carrying an id the app cannot represent **where host data enters the app**, so the invariant holds for every consumer downstream instead of being discovered as a crash.

`mergeHostWorkspaces` is the one funnel every workspace row passes through — the live `workspace.list` answer, an IndexedDB snapshot, a `workspace:changed` patch. Archived tombstones and `mergeHostProjects` are the two paths that bypass it, so they get the same filter. A dropped row is warned about once per offending value.

This covers the class, not the field: a workspace's `projectId` crashes `v2SidebarProjects` the same way its `id` crashes `v2WorkspaceLocalState`, and host projects reach the same collection.

## Decisions worth reviewing

**The UUID contract stays, and still throws.** The collections key rows on these ids, and the `packages/trpc` v2-workspace and cloud-workspace procedures that accept a workspace or project id declare `z.string().uuid()` — so a non-UUID row isn't something the app can represent, and relaxing the schema to `z.string().min(1)` would trade a loud crash for silent half-broken behaviour. Those five host-authored fields now reference one shared `hostAuthoredIdSchema` so the ingest filter cannot drift more lenient than the collections it protects. Locally-minted ids (section ids, preset ids) keep their own `z.string().uuid()` — a violation there is our bug and should still surface.

**No blanket write guard.** Wrapping collection `insert`/`update` in a catch would contain the class at the collection layer too, but it would equally hide our own bugs, which is the thing the brief ruled out. Validation is untouched; it's just no longer reached by untrusted data.

**No manual Sentry breadcrumb.** The brief asked for one, but it's already there: `initSentry` doesn't override `integrations`, `@sentry/electron`'s renderer `getDefaultIntegrations` keeps `breadcrumbsIntegration()`, and that defaults to `console: true`. The `console.warn` *is* the breadcrumb. A manual `addBreadcrumb` would have been a duplicate.

## Tests

Two files, three tests, all through the real production path:

- `hostWorkspaceQuarantine.test.ts` — real host rows through the real `mergeHostWorkspaces` into a real collection built from the real `workspaceLocalStateSchema`, written by the real `writeWorkspacePaneLayout`. Asserts the malformed rows are hidden, the valid rows still sync, a project-less session (`projectId: null`) survives, and no throw escapes. A second test asserts the collection **still throws** on the same row, so a future change can't quietly silence the validation instead.
- `useHostProjects.utils.test.ts` — the same for the projects feed.

The session/undefined cases in the first test caught a real defect in the first draft of this patch: an `id` of `undefined` was being treated as an absence and passed through. Only an explicit `null` is an absence now.

Full desktop suite: 2802 pass, 0 fail. Typecheck and `lint:fix` clean.

https://claude.ai/code/session_013qmzGzpB7PiusbMeCub4tW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quarantines host workspace and project rows with non-UUID ids at ingest to prevent desktop crashes. Previously, a non-UUID id crashed the dashboard via TanStack DB validation; now these rows are dropped and a warning is logged once, while validation remains strict.

- Introduces `renderer/lib/hostRowContract` with `hostAuthoredIdSchema` and `filterRepresentableHostRows`; sidebar schemas now reference the shared `hostAuthoredIdSchema`.
- Applies the filter in `mergeHostWorkspaces`, in archived tombstones via `keepRepresentableHostWorkspaces`, and in projects via `mergeHostProjects`.
- Keeps collection validation unchanged; no try/catch around inserts. Invalid local writes still throw.
- Logs a single `console.warn` per offending value; `@sentry/electron` captures this as a breadcrumb.
- Treats `projectId: null` as a valid session; filters out missing or non-UUID ids.
- Adds tests that verify quarantine behavior and that collections still reject invalid ids.
- No migration required.

<sup>Written for commit bffd1210ffde79937c292ec7b824e3125d59e258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

