### PR TITLE
fix(desktop): key workspace model picker off presetId, not icon override

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
@@ -11,6 +11,7 @@ const SUPERSET_AGENT: AgentSelectAgent = {
 	id: "superset",
 	label: "Superset",
 	iconId: "superset",
+	presetId: "superset",
 };
 
 // Superset chat isn't in the host's `host_agent_configs` table — it's

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -189,9 +189,11 @@ export function PromptGroup({
 		});
 
 	// ── Model picker (per agent preset) ──────────────────────────────
-	// `iconId` carries the presetId for v2 agents ("superset" for chat).
+	// Keyed off `presetId` ("superset" for chat) — `iconId` is display-only
+	// and diverges from the preset when the user overrides the agent icon.
 	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
+		() =>
+			v2Agents.find((agent) => agent.id === selectedAgent)?.presetId ?? null,
 		[v2Agents, selectedAgent],
 	);
 	const modelSupport = selectedPresetId

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -461,7 +461,8 @@ export function NewWorkspaceScreen({
 	}, [v2AgentsFetched, selectableAgentIds, selectedAgent, setSelectedAgent]);
 
 	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
+		() =>
+			v2Agents.find((agent) => agent.id === selectedAgent)?.presetId ?? null,
 		[v2Agents, selectedAgent],
 	);
 	const modelSupport = selectedPresetId


### PR DESCRIPTION
## Problem

Setting a custom icon on an agent in Settings → Agents silently removes that agent's model and effort pickers in the new-workspace modal.

`useV2AgentChoices` maps `iconId: config.iconId ?? config.presetId`, where `config.iconId` is the user's icon override — a built-in icon key or an uploaded `data:` URI. Both workspace-create surfaces (`NewWorkspaceScreen`, `PromptGroup`) then derive `selectedPresetId` from that `iconId` and feed it to `getAgentModelSupport()` / `getAgentEffortSupport()`, whose catalogs are keyed by preset id. As soon as the icon override diverges from the preset id, the lookup misses and the pickers vanish — an uploaded image icon can never match.

It can also show the wrong catalog, not just none: give a Claude agent the Codex *built-in* icon and the modal offers Codex's model list; the host then silently drops the out-of-catalog model id at launch (`buildAgentModelArgs` returns `[]`), so the selection looks accepted but never applies. Keying off `presetId` also re-aligns the renderer with the host, which already validates model/effort against `config.presetId`, and with `useAgentModelPreference`'s own documented contract ("keyed by presetId").

## Repro

1. Settings → Agents → Claude → set any icon override (different built-in icon or uploaded image)
2. Open the new-workspace modal and select Claude
3. Model and effort pickers are gone (before) / present (after)

## Fix

Key `selectedPresetId` off `presetId` in both surfaces, and give the hard-coded `SUPERSET_AGENT` an explicit `presetId: "superset"` so chat behavior is unchanged. `iconId` stays display-only (icon rendering in `AgentSelect` is untouched).

## Checks

- `apps/desktop` `bun run typecheck` clean
- `biome check` clean on changed files
- Manually traced every `selectedPresetId` consumer in both components (model support, effort support, preference-storage keys, submit hook) — semantics unchanged for agents without icon overrides and for Superset chat

<!-- SCREENSHOTS: before/after of the modal with a custom-iconed Claude -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model and effort pickers in the new-workspace modal now key off agent `presetId` instead of the icon override. Previously, deriving from `iconId` hid or mis-mapped pickers when users changed an agent icon; now catalogs and selections match the chosen preset.

- Use `presetId` for `selectedPresetId` in `NewWorkspaceScreen` and `PromptGroup`; `iconId` stays display-only.
- Add `presetId: "superset"` to `SUPERSET_AGENT` to keep Superset chat behavior unchanged.
- Aligns renderer with host validation and preference keys, preventing out-of-catalog model selections from being silently dropped at launch.

<sup>Written for commit 0cf418d952ec7f8efe9a5ecafb52e37583c57098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

