### PR TITLE
fix(desktop): keep cloud workspaces visible when Cloud dropdown is collapsed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSectionHeader";
 import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
@@ -29,6 +30,9 @@ export function DashboardSidebarCloudSection({
 }) {
 	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const isSectionCollapsed = useSidebarSectionsCollapseStore(
+		(s) => s.collapsed.cloud,
+	);
 
 	// Row visibility, pinning and order all live in the same local-state
 	// collection every other sidebar row reads. Rendering straight off the
@@ -112,9 +116,15 @@ export function DashboardSidebarCloudSection({
 
 	if (rows.length === 0) return null;
 
-	if (isCollapsed) {
+	// Cloud workspaces are never fully hidden — the sidebar rail collapsing
+	// and the section's own chevron both switch to this compact icon form
+	// instead of hiding rows, so a workspace never looks like it disappeared.
+	if (isCollapsed || isSectionCollapsed) {
 		return (
 			<div className="flex flex-col gap-0.5 py-1">
+				{!isCollapsed && (
+					<DashboardSidebarSectionHeader label="Cloud" section="cloud" />
+				)}
 				{rows.map((workspace) => (
 					<DashboardSidebarWorkspaceItem
 						key={workspace.id}
@@ -123,7 +133,7 @@ export function DashboardSidebarCloudSection({
 						onHoverCardOpen={onWorkspaceHover}
 					/>
 				))}
-				<div className="mx-3 mt-1 border-b border-border" />
+				{isCollapsed && <div className="mx-3 mt-1 border-b border-border" />}
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
-import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSectionHeader";
 import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
@@ -30,9 +29,6 @@ export function DashboardSidebarCloudSection({
 }) {
 	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
-	const isSectionCollapsed = useSidebarSectionsCollapseStore(
-		(s) => s.collapsed.cloud,
-	);
 
 	// Row visibility, pinning and order all live in the same local-state
 	// collection every other sidebar row reads. Rendering straight off the
@@ -135,14 +131,13 @@ export function DashboardSidebarCloudSection({
 	return (
 		<div className="mb-1">
 			<DashboardSidebarSectionHeader label="Cloud" section="cloud" />
-			{!isSectionCollapsed &&
-				rows.map((workspace) => (
-					<DashboardSidebarWorkspaceItem
-						key={workspace.id}
-						workspace={workspace}
-						onHoverCardOpen={onWorkspaceHover}
-					/>
-				))}
+			{rows.map((workspace) => (
+				<DashboardSidebarWorkspaceItem
+					key={workspace.id}
+					workspace={workspace}
+					onHoverCardOpen={onWorkspaceHover}
+				/>
+			))}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -116,15 +116,12 @@ export function DashboardSidebarCloudSection({
 
 	if (rows.length === 0) return null;
 
-	// Cloud workspaces are never fully hidden — the sidebar rail collapsing
-	// and the section's own chevron both switch to this compact icon form
-	// instead of hiding rows, so a workspace never looks like it disappeared.
-	if (isCollapsed || isSectionCollapsed) {
+	// Only the sidebar rail collapsing forces cloud workspaces into the
+	// compact icon form; the section's own chevron hides them entirely, same
+	// as every other collapsible section (Pinned, Sessions).
+	if (isCollapsed) {
 		return (
 			<div className="flex flex-col gap-0.5 py-1">
-				{!isCollapsed && (
-					<DashboardSidebarSectionHeader label="Cloud" section="cloud" />
-				)}
 				{rows.map((workspace) => (
 					<DashboardSidebarWorkspaceItem
 						key={workspace.id}
@@ -133,7 +130,7 @@ export function DashboardSidebarCloudSection({
 						onHoverCardOpen={onWorkspaceHover}
 					/>
 				))}
-				{isCollapsed && <div className="mx-3 mt-1 border-b border-border" />}
+				<div className="mx-3 mt-1 border-b border-border" />
 			</div>
 		);
 	}
@@ -141,13 +138,14 @@ export function DashboardSidebarCloudSection({
 	return (
 		<div className="mb-1">
 			<DashboardSidebarSectionHeader label="Cloud" section="cloud" />
-			{rows.map((workspace) => (
-				<DashboardSidebarWorkspaceItem
-					key={workspace.id}
-					workspace={workspace}
-					onHoverCardOpen={onWorkspaceHover}
-				/>
-			))}
+			{!isSectionCollapsed &&
+				rows.map((workspace) => (
+					<DashboardSidebarWorkspaceItem
+						key={workspace.id}
+						workspace={workspace}
+						onHoverCardOpen={onWorkspaceHover}
+					/>
+				))}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Collapsing the "Cloud" section's dropdown header used to hide the entire cloud workspace list. Now the workspace rows always stay visible; only the header's chevron reflects the collapsed/expanded state.

## Test plan
- [x] `biome check` on the changed file
- [x] `tsc --noEmit` shows no new errors from this file
- [ ] Manually collapse the Cloud section header in the desktop app and confirm workspace rows stay visible

https://claude.ai/code/session_01Env8JHRqvfTtPtQjFt5TBT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores standard collapse behavior for the Cloud section. Collapsing the Cloud dropdown now hides its workspace rows; only a collapsed sidebar rail forces the compact icon layout. This removes the half-working states from prior changes and aligns Cloud with Pinned and Sessions.

- Sidebar rail collapsed: show compact icon rows. Rail expanded: show full rows unless the Cloud section is collapsed.
- Cloud section collapsed: hide rows. Expanded: show rows in the current rail mode.
- No changes to ordering, pinning, or hover.

<sup>Written for commit e351031910b6bf69bd6d77a4102679105fb6a602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud workspace entries remain visible when the sidebar is expanded.
  * Collapsing the Cloud section hides its workspace entries while keeping the Cloud header visible.
  * Workspace rows use compact icons when the sidebar is collapsed.
  * The divider now appears only when the sidebar is in rail mode.
  * Improved consistency across sidebar and Cloud section collapse states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->