### PR TITLE
feat(desktop): add OMP model and plan controls

### DIFF
--- a/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
@@ -22,6 +22,8 @@ export interface AgentSelectAgent {
 	iconId?: string;
 	/** Host preset slug ("claude", "custom", …) — stable across hosts and DB re-seeds, unlike `id`. */
 	presetId?: string;
+	/** Executable-aware launch capability id; differs from presetId for OMP. */
+	launchPresetId?: string;
 }
 
 interface AgentSelectProps<T extends string> {

--- a/apps/desktop/src/renderer/hooks/useAgentModePreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModePreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentModePreference } from "./useAgentModePreference";

--- a/apps/desktop/src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts
@@ -1,0 +1,72 @@
+import { getAgentModeSupport } from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(storageKey);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+			return {};
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredMode(
+	storageKey: string,
+	presetId: string | null,
+): string | null {
+	if (!presetId) return null;
+	const stored = readStoredMap(storageKey)[presetId];
+	if (!stored) return null;
+	// Drop ids that fell out of the curated registry. No override is safer than
+	// forwarding a launch mode the CLI no longer accepts.
+	const support = getAgentModeSupport(presetId);
+	return support?.modes.some((mode) => mode.id === stored) ? stored : null;
+}
+
+/**
+ * Last-selected launch mode per agent preset, persisted as a bounded JSON map
+ * in localStorage. `null` means the CLI default and removes the preset entry.
+ */
+export function useAgentModePreference(
+	storageKey: string,
+	presetId: string | null,
+) {
+	const [selectedMode, setSelectedModeState] = useState<string | null>(() =>
+		readStoredMode(storageKey, presetId),
+	);
+
+	useEffect(() => {
+		setSelectedModeState(readStoredMode(storageKey, presetId));
+	}, [storageKey, presetId]);
+
+	const setSelectedMode = useCallback(
+		(mode: string | null) => {
+			setSelectedModeState(mode);
+			if (typeof window === "undefined" || !presetId) return;
+			const map = readStoredMap(storageKey);
+			if (mode) {
+				map[presetId] = mode;
+			} else {
+				delete map[presetId];
+			}
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// Quota/security errors only cost persistence of the preference;
+				// the in-memory selection above still applies to this dialog.
+			}
+		},
+		[storageKey, presetId],
+	);
+
+	return { selectedMode, setSelectedMode };
+}

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
@@ -1,3 +1,4 @@
+import { resolveAgentLaunchPresetId } from "@superset/shared/agent-models";
 import { useMemo } from "react";
 import type { AgentSelectAgent } from "renderer/components/AgentSelect";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
@@ -29,6 +30,10 @@ export function useV2AgentChoices(
 				// URI); fall back to the preset-implied icon.
 				iconId: config.iconId ?? config.presetId,
 				presetId: config.presetId,
+				launchPresetId: resolveAgentLaunchPresetId(
+					config.presetId,
+					config.command,
+				),
 			}),
 		);
 		return [...terminalAgents, SUPERSET_AGENT];

--- a/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
+++ b/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
@@ -147,6 +147,10 @@ export const PERSISTED_KEY_REGISTRY: ReadonlyArray<
 		["lastSelectedV2WorkspaceCreateEffortByPreset"],
 	],
 	[
+		"src/renderer/hooks/useAgentModePreference/useAgentModePreference.ts",
+		["lastSelectedV2WorkspaceCreateModeByPreset"],
+	],
+	[
 		"src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts",
 		[
 			"lastSelectedV2WorkspaceCreateAgent",

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -1,6 +1,7 @@
 import {
 	getAgentEffortSupport,
 	getAgentModelSupport,
+	getAgentModeSupport,
 } from "@superset/shared/agent-models";
 import { sanitizeUserBranchName } from "@superset/shared/workspace-launch";
 import {
@@ -35,6 +36,7 @@ import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId"
 import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
 import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
+import { useAgentModePreference } from "renderer/hooks/useAgentModePreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { PLATFORM } from "renderer/hotkeys";
@@ -66,6 +68,7 @@ import {
 import {
 	AGENT_STORAGE_KEY,
 	EFFORT_STORAGE_KEY,
+	MODE_STORAGE_KEY,
 	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
 	type ProjectOption,
@@ -189,11 +192,12 @@ export function PromptGroup({
 		});
 
 	// ── Model picker (per agent preset) ──────────────────────────────
-	// `iconId` carries the presetId for v2 agents ("superset" for chat).
-	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
-		[v2Agents, selectedAgent],
-	);
+	// `launchPresetId` carries executable-aware capability metadata; Superset
+	// chat has no host config and falls back to its icon id.
+	const selectedPresetId = useMemo(() => {
+		const agent = v2Agents.find((candidate) => candidate.id === selectedAgent);
+		return agent?.launchPresetId ?? agent?.presetId ?? agent?.iconId ?? null;
+	}, [v2Agents, selectedAgent]);
 	const modelSupport = selectedPresetId
 		? getAgentModelSupport(selectedPresetId)
 		: undefined;
@@ -207,6 +211,13 @@ export function PromptGroup({
 	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
+	);
+	const modeSupport = selectedPresetId
+		? getAgentModeSupport(selectedPresetId)
+		: undefined;
+	const { selectedMode, setSelectedMode } = useAgentModePreference(
+		MODE_STORAGE_KEY,
+		modeSupport ? selectedPresetId : null,
 	);
 
 	// Promote the placeholder "none" → first configured agent whenever the
@@ -346,6 +357,7 @@ export function PromptGroup({
 		selectedAgent,
 		modelSupport ? selectedModel : null,
 		effortSupport ? selectedEffort : null,
+		modeSupport ? selectedMode : null,
 		uploadAttachments,
 		promptContext,
 	);
@@ -590,6 +602,15 @@ export function PromptGroup({
 								value={selectedEffort}
 								onValueChange={setSelectedEffort}
 								defaultLabel="Default effort"
+								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+							/>
+						)}
+						{modeSupport && (
+							<AgentModelSelect
+								models={modeSupport.modes}
+								value={selectedMode}
+								onValueChange={setSelectedMode}
+								defaultLabel="Direct mode"
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -24,6 +24,7 @@ export function useSubmitWorkspace(
 	selectedAgent: WorkspaceCreateAgent,
 	selectedModel: string | null,
 	selectedEffort: string | null,
+	selectedMode: string | null,
 	uploadAttachments: UseUploadAttachmentsApi,
 	promptContext: NewWorkspacePromptContextApi,
 ) {
@@ -157,6 +158,7 @@ export function useSubmitWorkspace(
 						attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
 						model: selectedModel ?? undefined,
 						effort: selectedEffort ?? undefined,
+						mode: selectedMode ?? undefined,
 					},
 				]
 			: undefined;
@@ -253,6 +255,7 @@ export function useSubmitWorkspace(
 		selectedAgent,
 		selectedModel,
 		selectedEffort,
+		selectedMode,
 		submit,
 		uploadAttachments,
 		utils,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -11,6 +11,9 @@ export const MODEL_STORAGE_KEY = "lastSelectedV2WorkspaceCreateModelByPreset";
 // JSON map of presetId → effort id; same contract as MODEL_STORAGE_KEY.
 export const EFFORT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateEffortByPreset";
 
+// JSON map of presetId → launch mode id; same contract as MODEL_STORAGE_KEY.
+export const MODE_STORAGE_KEY = "lastSelectedV2WorkspaceCreateModeByPreset";
+
 export const PILL_BUTTON_CLASS =
 	"!h-[22px] min-h-0 rounded-md border-[0.5px] border-border bg-foreground/[0.04] shadow-none text-[11px]";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -1,6 +1,7 @@
 import {
 	getAgentEffortSupport,
 	getAgentModelSupport,
+	getAgentModeSupport,
 } from "@superset/shared/agent-models";
 import {
 	PromptInput,
@@ -39,6 +40,7 @@ import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId"
 import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
 import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
+import { useAgentModePreference } from "renderer/hooks/useAgentModePreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { track } from "renderer/lib/analytics";
@@ -81,6 +83,7 @@ import {
 import {
 	AGENT_STORAGE_KEY,
 	EFFORT_STORAGE_KEY,
+	MODE_STORAGE_KEY,
 	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
 	type WorkspaceCreateAgent,
@@ -460,10 +463,10 @@ export function NewWorkspaceScreen({
 		if (first) setSelectedAgent(first);
 	}, [v2AgentsFetched, selectableAgentIds, selectedAgent, setSelectedAgent]);
 
-	const selectedPresetId = useMemo(
-		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
-		[v2Agents, selectedAgent],
-	);
+	const selectedPresetId = useMemo(() => {
+		const agent = v2Agents.find((candidate) => candidate.id === selectedAgent);
+		return agent?.launchPresetId ?? agent?.presetId ?? agent?.iconId ?? null;
+	}, [v2Agents, selectedAgent]);
 	const modelSupport = selectedPresetId
 		? getAgentModelSupport(selectedPresetId)
 		: undefined;
@@ -477,6 +480,13 @@ export function NewWorkspaceScreen({
 	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
+	);
+	const modeSupport = selectedPresetId
+		? getAgentModeSupport(selectedPresetId)
+		: undefined;
+	const { selectedMode, setSelectedMode } = useAgentModePreference(
+		MODE_STORAGE_KEY,
+		modeSupport ? selectedPresetId : null,
 	);
 
 	// ── Base branch ──────────────────────────────────────────────────
@@ -519,6 +529,7 @@ export function NewWorkspaceScreen({
 		selectedAgent,
 		modelSupport ? selectedModel : null,
 		effortSupport ? selectedEffort : null,
+		modeSupport ? selectedMode : null,
 		uploadAttachments,
 		promptContext,
 	);
@@ -833,6 +844,15 @@ export function NewWorkspaceScreen({
 										value={selectedEffort}
 										onValueChange={setSelectedEffort}
 										defaultLabel="Default effort"
+										triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+									/>
+								)}
+								{modeSupport && (
+									<AgentModelSelect
+										models={modeSupport.modes}
+										value={selectedMode}
+										onValueChange={setSelectedMode}
+										defaultLabel="Direct mode"
 										triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 									/>
 								)}

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -12,6 +12,7 @@ import {
 	buildAgentCommandString,
 	buildTerminalAgentLaunch,
 	validateAgentEffortSelection,
+	validateAgentModeSelection,
 	validateAgentResumeSelection,
 } from "./agents";
 
@@ -279,6 +280,37 @@ describe("buildTerminalAgentLaunch", () => {
 		).toThrow(/does not support resuming a session by id/);
 	});
 
+	it("builds OMP model, effort, and plan-mode arguments", () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: "00000000-0000-0000-0000-00000000000c",
+				presetId: "pi",
+				label: "Oh My Pi",
+				command: "omp",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: JSON.stringify(["--resume"]),
+				envJson: "{}",
+				displayOrder: 2,
+			})
+			.run();
+
+		const launch = buildTerminalAgentLaunch(db, {
+			workspaceId: "11111111-1111-1111-1111-111111111111",
+			agent: "pi",
+			prompt: "do the thing",
+			model: "@plan",
+			effort: "high",
+			mode: "plan",
+		});
+
+		expect(launch.fullCommand).toBe(
+			"'omp' '--model' '@plan' '--thinking' 'high' '--plan-yolo' 'do the thing'",
+		);
+	});
+
 	it("throws NOT_FOUND for an unknown agent", () => {
 		const db = createTestDb();
 		expect(() =>
@@ -430,5 +462,31 @@ describe("validateAgentEffortSelection", () => {
 				"Superset does not support a reasoning effort override. Omit effort to use the agent default.",
 			);
 		}
+	});
+});
+
+describe("validateAgentModeSelection", () => {
+	it("leaves the mode unset so the agent can use its own default", () => {
+		expect(() =>
+			validateAgentModeSelection("omp", "Oh My Pi", undefined),
+		).not.toThrow();
+	});
+
+	it("accepts OMP plan mode", () => {
+		expect(() =>
+			validateAgentModeSelection("omp", "Oh My Pi", "plan"),
+		).not.toThrow();
+	});
+
+	it("rejects unsupported launch modes", () => {
+		expect(() =>
+			validateAgentModeSelection("omp", "Oh My Pi", "review"),
+		).toThrow('Unsupported launch mode "review" for Oh My Pi');
+		expect(() => validateAgentModeSelection("pi", "Pi", "plan")).toThrow(
+			"Pi does not support a launch mode override",
+		);
+		expect(() =>
+			validateAgentModeSelection("claude", "Claude", "plan"),
+		).toThrow("Claude does not support a launch mode override");
 	});
 });

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,8 +1,11 @@
 import {
 	buildAgentEffortArgs,
+	buildAgentModeArgs,
 	buildAgentModelArgs,
 	buildAgentModelEnv,
 	getAgentEffortSupport,
+	getAgentModeSupport,
+	resolveAgentLaunchPresetId,
 } from "@superset/shared/agent-models";
 import {
 	buildArgvCommand,
@@ -177,6 +180,7 @@ export interface AgentRunInput {
 	attachmentIds?: string[];
 	model?: string;
 	effort?: string;
+	mode?: string;
 	/** Session id of a previous run of this agent to restore (e.g. a killed
 	 * session's `agentSessionId`). The prompt may be empty when resuming. */
 	resumeSessionId?: string;
@@ -216,6 +220,33 @@ export function validateAgentEffortSelection(
 }
 
 /**
+ * Validate an explicit launch mode before launch. Omitting mode delegates to
+ * the underlying agent's default behaviour.
+ */
+export function validateAgentModeSelection(
+	presetId: string,
+	label: string,
+	mode: string | undefined,
+): void {
+	if (!mode) return;
+
+	const support = getAgentModeSupport(presetId);
+	if (!support) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `${label} does not support a launch mode override. Omit mode to use the agent default.`,
+		});
+	}
+
+	if (!support.modes.some((option) => option.id === mode)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Unsupported launch mode "${mode}" for ${label}. Choose one of: ${support.modes.map((option) => option.id).join(", ")}.`,
+		});
+	}
+}
+
+/**
  * Validate an explicit resume request before launch. Resumability is a
  * per-config capability: configs without `resumeArgs` have no id-based
  * resume form to splice the session id into.
@@ -245,11 +276,11 @@ export function validateAgentResumeSelection(
  * Preflight a host-scoped launch before any larger workflow (such as
  * workspace creation) performs side effects.
  */
-export function validateAgentLaunchEffort(
+export function validateAgentLaunchOptions(
 	db: HostDb,
-	input: Pick<AgentRunInput, "agent" | "effort">,
+	input: Pick<AgentRunInput, "agent" | "effort" | "mode">,
 ): void {
-	if (!input.effort) return;
+	if (!input.effort && !input.mode) return;
 
 	const config = resolveHostAgentConfig(db, input.agent);
 	if (!config) {
@@ -258,7 +289,12 @@ export function validateAgentLaunchEffort(
 			message: `No host agent config matching '${input.agent}' (tried instance id then preset id).`,
 		});
 	}
-	validateAgentEffortSelection(config.presetId, config.label, input.effort);
+	const launchPresetId = resolveAgentLaunchPresetId(
+		config.presetId,
+		config.command,
+	);
+	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
+	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 }
 
 /**
@@ -281,7 +317,12 @@ export function buildTerminalAgentLaunch(
 			message: `No host agent config matching '${input.agent}' — the agent may have been removed or this host's agents were reset. Re-select an agent (or use a preset id like "claude").`,
 		});
 	}
-	validateAgentEffortSelection(config.presetId, config.label, input.effort);
+	const launchPresetId = resolveAgentLaunchPresetId(
+		config.presetId,
+		config.command,
+	);
+	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
+	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 	validateAgentResumeSelection(config, input.resumeSessionId);
 
 	const resolvedAttachments: Array<{ attachmentId: string; path: string }> = [];
@@ -297,15 +338,16 @@ export function buildTerminalAgentLaunch(
 	}
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
-	const modelArgs = buildAgentModelArgs(config.presetId, input.model);
-	const effortArgs = buildAgentEffortArgs(config.presetId, input.effort);
+	const modelArgs = buildAgentModelArgs(launchPresetId, input.model);
+	const effortArgs = buildAgentEffortArgs(launchPresetId, input.effort);
+	const modeArgs = buildAgentModeArgs(launchPresetId, input.mode);
 	const command = buildAgentCommandString(
 		config,
 		prompt,
-		[...modelArgs, ...effortArgs],
+		[...modelArgs, ...effortArgs, ...modeArgs],
 		{ resumeSessionId: input.resumeSessionId },
 	);
-	const modelEnv = buildAgentModelEnv(config.presetId, input.model);
+	const modelEnv = buildAgentModelEnv(launchPresetId, input.model);
 	// Host-default provider account (Usage tab switcher). Per-agent env wins,
 	// so a "Claude (work)" agent with its own CLAUDE_CONFIG_DIR stays pinned.
 	const accountEnv = resolveDefaultAccountEnv(db, config.presetId);
@@ -371,6 +413,7 @@ export const agentsRouter = router({
 				attachmentIds: z.array(z.string().uuid()).optional(),
 				model: z.string().min(1).optional(),
 				effort: z.string().min(1).optional(),
+				mode: z.string().min(1).optional(),
 				resumeSessionId: z.string().min(1).optional(),
 			}),
 		)

--- a/packages/host-service/src/trpc/router/agents/index.ts
+++ b/packages/host-service/src/trpc/router/agents/index.ts
@@ -4,5 +4,5 @@ export {
 	agentsRouter,
 	buildTerminalAgentLaunch,
 	runAgentInWorkspace,
-	validateAgentLaunchEffort,
+	validateAgentLaunchOptions,
 } from "./agents";

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create-session.ts
@@ -14,7 +14,7 @@ import {
 	updateLocalWorkspace,
 } from "../../../../workspaces/local-workspace-store";
 import { protectedProcedure } from "../../../index";
-import { validateAgentLaunchEffort } from "../../agents";
+import { validateAgentLaunchOptions } from "../../agents";
 import { initEmptyRepo } from "../../project/utils/resolve-repo";
 import { startCommandTerminal } from "../shared/command-terminal";
 import {
@@ -68,7 +68,7 @@ export const createSession = protectedProcedure
 	.input(createSessionInputSchema)
 	.mutation(async ({ ctx, input }) => {
 		for (const launch of input.agents ?? []) {
-			validateAgentLaunchEffort(ctx.db, launch);
+			validateAgentLaunchOptions(ctx.db, launch);
 		}
 
 		// Idempotency: a retry carrying the same optimistic id must return the

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/dispatch-agents.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/dispatch-agents.ts
@@ -9,6 +9,7 @@ export const agentLaunchSchema = z
 		attachmentIds: z.array(z.string().uuid()).optional(),
 		model: z.string().optional(),
 		effort: z.string().optional(),
+		mode: z.string().optional(),
 	})
 	.refine(
 		(value) =>
@@ -36,6 +37,7 @@ export async function dispatchSugarAgents(
 					attachmentIds: entry.attachmentIds,
 					model: entry.model,
 					effort: entry.effort,
+					mode: entry.mode,
 				});
 				return { ok: true as const, ...result };
 			} catch (err) {

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -25,7 +25,10 @@ import {
 	protectedProcedure,
 	router,
 } from "../../index";
-import { buildTerminalAgentLaunch, validateAgentLaunchEffort } from "../agents";
+import {
+	buildTerminalAgentLaunch,
+	validateAgentLaunchOptions,
+} from "../agents";
 import { ensureMainWorkspace } from "../project/utils/ensure-main-workspace";
 import { getHostWorktreeBaseDir } from "../settings/worktree-location";
 import { createSession } from "../workspace-creation/procedures/create-session";
@@ -523,7 +526,7 @@ export const workspacesRouter = router({
 		.input(createInputSchema)
 		.mutation(async ({ ctx, input }) => {
 			for (const launch of input.agents ?? []) {
-				validateAgentLaunchEffort(ctx.db, launch);
+				validateAgentLaunchOptions(ctx.db, launch);
 			}
 
 			const localProject = requireLocalProject(ctx, input.projectId);
@@ -1125,6 +1128,7 @@ export const workspacesRouter = router({
 						attachmentIds: soleLaunch.attachmentIds,
 						model: soleLaunch.model,
 						effort: soleLaunch.effort,
+						mode: soleLaunch.mode,
 					});
 				} catch (err) {
 					console.warn(
@@ -1237,7 +1241,7 @@ export const workspacesRouter = router({
 				});
 			}
 			for (const launch of input.agents ?? []) {
-				validateAgentLaunchEffort(ctx.db, launch);
+				validateAgentLaunchOptions(ctx.db, launch);
 			}
 			requireProjectRepoPath(requireLocalProject(ctx, input.projectId));
 

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import {
 	AGENT_EFFORT_SUPPORT,
+	AGENT_MODE_SUPPORT,
 	AGENT_MODEL_SUPPORT,
 	buildAgentEffortArgs,
+	buildAgentModeArgs,
 	buildAgentModelArgs,
 	buildAgentModelEnv,
 	getAgentEffortSupport,
 	getAgentModelSupport,
+	getAgentModeSupport,
+	resolveAgentLaunchPresetId,
 	SUPERSET_CHAT_MODELS,
 } from "./agent-models";
 import { BUILTIN_TERMINAL_AGENT_TYPES } from "./builtin-terminal-agents";
@@ -16,6 +20,7 @@ describe("AGENT_MODEL_SUPPORT", () => {
 		const validIds = new Set<string>([
 			...BUILTIN_TERMINAL_AGENT_TYPES,
 			"superset",
+			"omp",
 		]);
 		for (const entry of AGENT_MODEL_SUPPORT) {
 			expect(validIds.has(entry.presetId)).toBe(true);
@@ -168,11 +173,19 @@ describe("buildAgentModelArgs", () => {
 		expect(buildAgentModelArgs("polygraph", "")).toEqual([]);
 		expect(buildAgentModelArgs("polygraph", "gemini")).toEqual([]);
 	});
+
+	it("builds OMP model args for configured roles and exact models", () => {
+		expect(buildAgentModelArgs("omp", "@plan")).toEqual(["--model", "@plan"]);
+		expect(buildAgentModelArgs("omp", "openai-codex/gpt-5.6-sol")).toEqual([
+			"--model",
+			"openai-codex/gpt-5.6-sol",
+		]);
+	});
 });
 
 describe("AGENT_EFFORT_SUPPORT", () => {
 	it("only references builtin presets", () => {
-		const validIds = new Set<string>(BUILTIN_TERMINAL_AGENT_TYPES);
+		const validIds = new Set<string>([...BUILTIN_TERMINAL_AGENT_TYPES, "omp"]);
 		for (const entry of AGENT_EFFORT_SUPPORT) {
 			expect(validIds.has(entry.presetId)).toBe(true);
 		}
@@ -182,6 +195,45 @@ describe("AGENT_EFFORT_SUPPORT", () => {
 		for (const entry of AGENT_EFFORT_SUPPORT) {
 			expect(entry.efforts.length).toBeGreaterThan(0);
 		}
+	});
+});
+
+describe("AGENT_MODE_SUPPORT", () => {
+	it("only references builtin presets", () => {
+		const validIds = new Set<string>([...BUILTIN_TERMINAL_AGENT_TYPES, "omp"]);
+		for (const entry of AGENT_MODE_SUPPORT) {
+			expect(validIds.has(entry.presetId)).toBe(true);
+		}
+	});
+
+	it("lists at least one mode per entry", () => {
+		for (const entry of AGENT_MODE_SUPPORT) {
+			expect(entry.modes.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("getAgentModeSupport", () => {
+	it("returns OMP plan-mode support", () => {
+		expect(getAgentModeSupport("omp")?.modes.map((mode) => mode.id)).toEqual([
+			"plan",
+		]);
+	});
+
+	it("returns undefined for presets without launch modes", () => {
+		expect(getAgentModeSupport("claude")).toBeUndefined();
+	});
+});
+
+describe("resolveAgentLaunchPresetId", () => {
+	it("recognizes OMP without reclassifying legacy Pi", () => {
+		expect(resolveAgentLaunchPresetId("pi", "omp")).toBe("omp");
+		expect(
+			resolveAgentLaunchPresetId("custom:omp", "/opt/homebrew/bin/omp"),
+		).toBe("omp");
+		expect(resolveAgentLaunchPresetId("pi", "C:\\Tools\\OMP.EXE")).toBe("omp");
+		expect(resolveAgentLaunchPresetId("pi", "pi")).toBe("pi");
+		expect(resolveAgentLaunchPresetId("custom", "")).toBe("custom");
 	});
 });
 
@@ -223,6 +275,19 @@ describe("buildAgentEffortArgs", () => {
 	it("returns [] for effort ids outside the preset's curated list", () => {
 		expect(buildAgentEffortArgs("claude", "bogus")).toEqual([]);
 		expect(buildAgentEffortArgs("copilot", "max")).toEqual([]);
+	});
+});
+
+describe("buildAgentModeArgs", () => {
+	it("starts OMP in plan-first mode", () => {
+		expect(buildAgentModeArgs("omp", "plan")).toEqual(["--plan-yolo"]);
+	});
+
+	it("degrades unset and unsupported modes to the CLI default", () => {
+		expect(buildAgentModeArgs("omp", undefined)).toEqual([]);
+		expect(buildAgentModeArgs("omp", "bogus")).toEqual([]);
+		expect(buildAgentModeArgs("pi", "plan")).toEqual([]);
+		expect(buildAgentModeArgs("claude", "plan")).toEqual([]);
 	});
 });
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -1,12 +1,14 @@
 /**
- * Curated per-agent model and effort catalogs for the workspace-create
- * pickers.
+ * Curated per-agent model, effort, and launch-mode catalogs for the
+ * workspace-create pickers.
  *
  * Entries are keyed by terminal-agent presetId (see
  * `builtin-terminal-agents.ts`). Agents absent from this list don't support
  * model selection and render no picker. Model ids are the exact values the CLI
  * accepts after `modelFlag` (opencode requires `provider/model`, so the
  * provider is baked into the id).
+ * The virtual `omp` preset is resolved from the configured executable so OMP
+ * options never leak onto the legacy `pi` CLI.
  *
  * The lists are hand-maintained and expected to drift with CLI releases —
  * update them here when a tool adds or retires models.
@@ -146,6 +148,27 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		],
 	},
 	{
+		presetId: "omp",
+		modelFlag: "--model",
+		models: [
+			// OMP accepts configured role aliases as well as exact
+			// provider/model selectors. Exact ids verified against
+			// `omp models --json` in OMP 18.0.1.
+			{ id: "@smol", label: "Configured fast model" },
+			{ id: "@slow", label: "Configured slow model" },
+			{ id: "@plan", label: "Configured plan model" },
+			{ id: "anthropic/claude-opus-5", label: "Claude Opus 5" },
+			{ id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
+			{
+				id: "anthropic/claude-sonnet-4-6",
+				label: "Claude Sonnet 4.6",
+			},
+			{ id: "openai-codex/gpt-5.6-sol", label: "GPT-5.6 Sol" },
+			{ id: "openai-codex/gpt-5.6-terra", label: "GPT-5.6 Terra" },
+			{ id: "openai-codex/gpt-5.6-luna", label: "GPT-5.6 Luna" },
+		],
+	},
+	{
 		presetId: "vibe",
 		modelFlag: null,
 		modelEnv: "VIBE_ACTIVE_MODEL",
@@ -181,6 +204,25 @@ export interface AgentEffortSupport {
 	effortValuePrefix?: string;
 	efforts: AgentModelOption[];
 }
+
+export interface AgentModeOption extends AgentModelOption {
+	/** Exact argv tokens appended when this mode is selected. */
+	args: string[];
+}
+
+export interface AgentModeSupport {
+	presetId: string;
+	modes: AgentModeOption[];
+}
+
+const PI_THINKING_LEVELS: AgentModelOption[] = [
+	{ id: "off", label: "Off" },
+	{ id: "minimal", label: "Minimal" },
+	{ id: "low", label: "Low" },
+	{ id: "medium", label: "Medium" },
+	{ id: "high", label: "High" },
+	{ id: "xhigh", label: "xHigh" },
+];
 
 /**
  * Curated per-agent reasoning-effort catalogs, mirroring
@@ -239,14 +281,12 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 	{
 		presetId: "pi",
 		effortFlag: "--thinking",
-		efforts: [
-			{ id: "off", label: "Off" },
-			{ id: "minimal", label: "Minimal" },
-			{ id: "low", label: "Low" },
-			{ id: "medium", label: "Medium" },
-			{ id: "high", label: "High" },
-			{ id: "xhigh", label: "xHigh" },
-		],
+		efforts: [...PI_THINKING_LEVELS],
+	},
+	{
+		presetId: "omp",
+		effortFlag: "--thinking",
+		efforts: [...PI_THINKING_LEVELS],
 	},
 	{
 		presetId: "copilot",
@@ -260,6 +300,33 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 	},
 ];
 
+/**
+ * Optional launch modes that change how an agent starts. An unset mode always
+ * delegates to the CLI default.
+ */
+export const AGENT_MODE_SUPPORT: readonly AgentModeSupport[] = [
+	{
+		presetId: "omp",
+		modes: [{ id: "plan", label: "Plan first", args: ["--plan-yolo"] }],
+	},
+];
+
+/**
+ * Existing Superset profiles can use Pi's preset/icon with an overridden OMP
+ * executable. Resolve capabilities from that executable so legacy Pi keeps its
+ * own launch surface while `omp` and absolute OMP paths get OMP controls.
+ */
+export function resolveAgentLaunchPresetId(
+	presetId: string,
+	command: string,
+): string {
+	const commandParts = command.trim().split(/[\\/]/);
+	const executable = (
+		commandParts[commandParts.length - 1] ?? ""
+	).toLowerCase();
+	return executable === "omp" || executable === "omp.exe" ? "omp" : presetId;
+}
+
 export function getAgentModelSupport(
 	presetId: string,
 ): AgentModelSupport | undefined {
@@ -270,6 +337,12 @@ export function getAgentEffortSupport(
 	presetId: string,
 ): AgentEffortSupport | undefined {
 	return AGENT_EFFORT_SUPPORT.find((entry) => entry.presetId === presetId);
+}
+
+export function getAgentModeSupport(
+	presetId: string,
+): AgentModeSupport | undefined {
+	return AGENT_MODE_SUPPORT.find((entry) => entry.presetId === presetId);
 }
 
 /**
@@ -287,6 +360,20 @@ export function buildAgentEffortArgs(
 	if (!support) return [];
 	if (!support.efforts.some((option) => option.id === effort)) return [];
 	return [support.effortFlag, `${support.effortValuePrefix ?? ""}${effort}`];
+}
+
+/**
+ * Argv tokens that select a launch mode for the given preset. Unknown presets,
+ * unset modes, and stale mode ids degrade to the CLI default.
+ */
+export function buildAgentModeArgs(
+	presetId: string,
+	mode: string | undefined,
+): string[] {
+	if (!mode) return [];
+	const support = getAgentModeSupport(presetId);
+	const option = support?.modes.find((candidate) => candidate.id === mode);
+	return option ? [...option.args] : [];
 }
 
 /**


### PR DESCRIPTION
## What & why

Fixes #6801.

Superset only exposed OMP's reasoning effort in the new-workspace flow. This adds executable-aware OMP launch capabilities without applying OMP-only flags to the legacy `pi` CLI:

- model choices for configured OMP roles and current Anthropic/OpenAI Codex selectors;
- a persisted `Direct mode` / `Plan first` picker;
- end-to-end `mode` propagation through workspace/session creation and direct agent launches;
- host-side validation and argv construction for `--model`, `--thinking`, and `--plan-yolo`;
- per-capability local preference persistence for both new-workspace surfaces.

Existing configs that retain the Pi preset/icon but override the executable to `omp` are detected from the command. A true `pi` executable keeps the legacy Pi capability surface.

## How I tested it

- `bun run lint`
- `bun run typecheck` — 37/37 tasks passed
- `bun test packages/shared/src/agent-models.test.ts packages/host-service/src/trpc/router/agents/agents.test.ts` — 72 pass, 0 fail
- Desktop CDP flow against the local dev app:
  1. configured the Pi preset to execute `omp`;
  2. selected **Oh My Pi** in New Workspace;
  3. confirmed configured-role and exact-model choices, including GPT-5.6 Sol;
  4. selected **Configured plan model** and **Plan first**;
  5. closed and reopened the modal and confirmed both preferences persisted;
  6. captured the rendered modal and confirmed all four selectors fit without clipping.

`bun run test` was also attempted. It finished with 3 failures in `packages/host-service/test/integration/terminal.integration.test.ts` (real-daemon session disposal/reaper/restart timeouts); the changed focused suites above passed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] Allow edits from maintainers is enabled on this fork PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds executable-aware Oh My Pi (OMP) model selection and a Plan-first mode across desktop workspace creation and direct agent launches. Previously only reasoning effort was exposed; now model, effort, and mode propagate end-to-end with safe defaults, while a true Pi executable keeps the legacy Pi surface.

- UI: adds a mode picker backed by `useAgentModePreference` (per-preset, localStorage); renders when `getAgentModeSupport` exists. Agent selection now exposes a `launchPresetId` so OMP controls appear when the preset runs `omp`.
- Shared (`@superset/shared/agent-models`): introduces `AGENT_MODE_SUPPORT`, `getAgentModeSupport`, `buildAgentModeArgs`, and `resolveAgentLaunchPresetId`; adds OMP model catalog and reuses Pi thinking levels for OMP.
- Host: validates mode via `validateAgentModeSelection` and consolidates checks in `validateAgentLaunchOptions`; TRPC inputs accept `mode`; argv construction includes `--model`, `--thinking`, and `--plan-yolo` for OMP.
- Rollout: existing Pi presets that point to an `omp` executable automatically gain OMP controls; real `pi` keeps Pi behavior. Stale stored mode ids are ignored; no migrations required.

<sup>Written for commit 32fdaef5f9d5dae1891670afe62dcbf6a4b63ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added launch-mode selection when creating a workspace, including Direct and Plan modes where supported.
  * Remembers the last selected mode for each agent preset.
  * Added Open Model Protocol (OMP) support with model, effort, and plan-mode options.
  * Applies selected modes when launching agents and supports executable-based preset detection.

* **Bug Fixes**
  * Validates unsupported launch modes before starting agents and ensures consistent handling across workspace creation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->