### PR TITLE
feat(cli/sdk/mcp): expose per-launch agent models

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -895,6 +895,16 @@ superset agents create --workspace ws_… --agent codex --prompt "Review this di
 superset agents create --workspace ws_… --agent claude --resume-session 0b7c…
 ```
 
+#### Agent models
+
+Model is an explicit override for one launch. If you omit `--model`, Superset
+passes no model flag and the agent uses its own configured default. Ids match
+the desktop model picker: Claude takes a family alias (`fable`, `opus`,
+`sonnet`, `haiku`) that tracks the newest release, or a pinned id such as
+`claude-opus-4-8`. The host rejects an unknown id before launching the agent,
+and the error names every id that agent accepts. Agents without a model
+picker, including Superset chat, reject an explicit model override.
+
 #### Agent effort levels
 
 Effort is an explicit override for one launch. If you omit `--effort`,

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -649,6 +649,7 @@ project id when the host doesn't know the project's name.
 		{ flag: "--local", description: "Target this machine. Mutually exclusive with `--host`; one is required." },
 		{ flag: "--agent <preset|uuid|superset>", description: "Agent to spawn after creation." },
 		{ flag: "--prompt <text>", description: "Initial prompt. Required when `--agent` is set." },
+		{ flag: "--model <id>", description: "Model for the spawned agent. Supported values depend on the agent; omit to use its default." },
 		{ flag: "--effort <level>", description: "Reasoning effort for the spawned agent. Omit to use the agent default." },
 		{ flag: "--command <cmd>", description: "Shell command to run in the new workspace after creation." },
 		{ flag: "--attachment <path>", description: "Local file to upload for the spawned agent. Repeatable." },
@@ -660,8 +661,8 @@ Create a workspace on the target host. With `--project`, specify one of
 `--branch`, `--pr`, or `--task` (`--branch` and `--pr` are mutually
 exclusive). If you pass `--agent`, you must also pass `--prompt`. `--command`
 runs a one-off shell command in the worktree and is independent of
-`--agent`/`--prompt`. Pass either or both. `--effort` requires `--agent`; see
-the [agent effort levels](#agent-effort-levels) below.
+`--agent`/`--prompt`. Pass either or both. `--model` and `--effort` require
+`--agent`; see the [agent effort levels](#agent-effort-levels) below.
 
 Omitting `--project` creates a **session**: a project-less workspace backed
 by a managed folder under `~/.superset/sessions`, initialized as its own git
@@ -872,6 +873,7 @@ superset agents list --host host_…
 		{ flag: "--agent <preset|uuid|superset>", required: true, description: "Agent preset id (e.g. `claude`, `codex`), HostAgentConfig instance UUID, or `superset`." },
 		{ flag: "--prompt <text>", description: "Prompt sent to the agent. Required unless `--resume-session` is set." },
 		{ flag: "--resume-session <id>", description: "Agent session id of a previous run to restore instead of starting fresh (e.g. `claude --resume <id>`). Fails for agents without an id-based resume." },
+		{ flag: "--model <id>", description: "Model for this launch. Supported values depend on the agent; omit to use its default." },
 		{ flag: "--effort <level>", description: "Reasoning effort for this launch. Omit to use the agent default." },
 		{ flag: "--attachment-id <uuid>", description: "Pre-uploaded attachment UUID; pass repeatedly for multiple attachments." },
 		{ flag: "--attachment <path>", description: "Local file path to upload as an attachment. Repeatable." },
@@ -887,7 +889,7 @@ machine): starts the named preset (or HostAgentConfig instance) in a fresh
 terminal session there.
 
 ```bash
-superset agents create --workspace ws_… --agent claude --effort high --prompt "Audit the login flow"
+superset agents create --workspace ws_… --agent claude --model sonnet --effort high --prompt "Audit the login flow"
 superset agents create --workspace ws_… --agent codex --prompt "Review this diff" --attachment ./trace.log
 # Restore a killed agent session by the agent's own session id
 superset agents create --workspace ws_… --agent claude --resume-session 0b7c…

--- a/apps/docs/content/docs/mcp-server.mdx
+++ b/apps/docs/content/docs/mcp-server.mdx
@@ -305,7 +305,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `workspaces_list` | List workspaces on a host (get the hostId from `hosts_list`) |
-| `workspaces_create` | Create a workspace on a host (branch-scoped git worktree) |
+| `workspaces_create` | Create a workspace on a host, optionally launching agents with per-launch model and effort overrides |
 | `workspaces_update` | Update fields on a workspace on its host |
 | `workspaces_delete` | Delete a workspace by UUID on its host |
 
@@ -314,7 +314,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `agents_list` | List agents configured on a host |
-| `agents_create` | Create (launch) an agent session in an existing workspace |
+| `agents_create` | Create (launch) an agent session with optional per-launch model and effort overrides |
 
 ### Terminals
 

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -236,8 +236,8 @@ Create (launch) an agent session in an existing workspace on its host.
 
 `agent` accepts either a preset id (e.g. `"claude"`) or a `HostAgentConfig`
 instance UUID. `model` and `effort` are agent-specific launch overrides; omit
-them to use the agent's own configured defaults. Unsupported effort values fail
-before launch.
+them to use the agent's own configured defaults. Unsupported values for either
+fail before launch with a message naming the supported ids.
 Returns `{ kind, sessionId, label }`.
 
 ```ts

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -137,7 +137,7 @@ host, so don't assume it's always present).
 
 Create a worktree on a specific host. Provide exactly one of `branch` or `pr` (a pull request number; the host checks out the verified PR head and derives the branch). `baseBranch` picks the fork point when `branch` doesn't exist yet, and `taskId` links the new workspace to a task. Optionally spawn one or more agents inside it as soon as the worktree is ready, and/or run a one-off shell `command` in the worktree. Goes through the relay tunnel: the host must be online.
 
-Each entry in `agents` takes a preset id (e.g. `"claude"`) or a `HostAgentConfig` instance UUID: the host service resolves it against its configured rows and copies their stored `command`, `args`, and `env`. Set `effort` to override the agent's reasoning effort for that launch, or omit it to use the agent's own default. Use [`agents.list({ hostId })`](#agentslist-hostid-) to enumerate what's installed. `command` is independent of `agents`. Pass either or both.
+Each entry in `agents` takes a preset id (e.g. `"claude"`) or a `HostAgentConfig` instance UUID: the host service resolves it against its configured rows and copies their stored `command`, `args`, and `env`. Set `model` or `effort` to override the agent's model or reasoning effort for that launch, or omit them to use the agent's own defaults. Use [`agents.list({ hostId })`](#agentslist-hostid-) to enumerate what's installed. `command` is independent of `agents`. Pass either or both.
 
 ```ts
 const result = await client.workspaces.create({
@@ -146,7 +146,7 @@ const result = await client.workspaces.create({
   name: 'wire-up-auth',
   branch: 'feat/auth',
   agents: [                  // optional: spawn agents on creation
-    { agent: 'claude', effort: 'high', prompt: 'Implement the auth flow described in SUPER-100.' },
+    { agent: 'claude', model: 'sonnet', effort: 'high', prompt: 'Implement the auth flow described in SUPER-100.' },
     { agent: 'claude', prompt: 'Write integration tests for the new auth flow.' },
   ],
 });
@@ -230,13 +230,14 @@ prompt-transport fields used to launch the agent.
 const agents = await client.agents.list({ hostId: '<machineId>' });
 ```
 
-### `agents.create({ hostId, workspaceId, agent, prompt, effort?, attachmentIds? })`
+### `agents.create({ hostId, workspaceId, agent, prompt, model?, effort?, attachmentIds? })`
 
 Create (launch) an agent session in an existing workspace on its host.
 
 `agent` accepts either a preset id (e.g. `"claude"`) or a `HostAgentConfig`
-instance UUID. `effort` is an agent-specific reasoning override; omit it to
-use the agent's own configured default. Unsupported values fail before launch.
+instance UUID. `model` and `effort` are agent-specific launch overrides; omit
+them to use the agent's own configured defaults. Unsupported effort values fail
+before launch.
 Returns `{ kind, sessionId, label }`.
 
 ```ts
@@ -244,6 +245,7 @@ const { sessionId } = await client.agents.create({
   hostId: '<machineId>',
   workspaceId: '<uuid>',
   agent: 'claude',
+  model: 'sonnet',
   effort: 'high',
   prompt: 'Audit the login flow for race conditions.',
 });

--- a/packages/cli/src/commands/agents/create/command.test.ts
+++ b/packages/cli/src/commands/agents/create/command.test.ts
@@ -91,6 +91,22 @@ afterEach(() => {
 });
 
 describe("agents create", () => {
+	test("forwards an explicit model to the host", async () => {
+		await invoke(undefined, {
+			prompt: "Review this diff",
+			model: "gpt-5.6-sol",
+		});
+
+		expect(runInput).toEqual({
+			workspaceId: "00000000-0000-4000-8000-000000000001",
+			agent: "codex",
+			prompt: "Review this diff",
+			model: "gpt-5.6-sol",
+			effort: undefined,
+			attachmentIds: undefined,
+		});
+	});
+
 	test("forwards an explicit reasoning effort to the host", async () => {
 		await invoke("xhigh");
 
@@ -98,6 +114,7 @@ describe("agents create", () => {
 			workspaceId: "00000000-0000-4000-8000-000000000001",
 			agent: "codex",
 			prompt: "Review this diff",
+			model: undefined,
 			effort: "xhigh",
 			attachmentIds: undefined,
 		});
@@ -110,6 +127,7 @@ describe("agents create", () => {
 			workspaceId: "00000000-0000-4000-8000-000000000001",
 			agent: "codex",
 			prompt: "Review this diff",
+			model: undefined,
 			effort: undefined,
 			attachmentIds: undefined,
 		});
@@ -123,6 +141,7 @@ describe("agents create", () => {
 			agent: "codex",
 			prompt: "",
 			resumeSessionId: "abc-123",
+			model: undefined,
 			effort: undefined,
 			attachmentIds: undefined,
 		});

--- a/packages/cli/src/commands/agents/create/command.ts
+++ b/packages/cli/src/commands/agents/create/command.ts
@@ -36,6 +36,9 @@ export default command({
 			.desc(
 				`Cap the handed-over context, 1-${TERMINAL_HANDOFF_MAX_CHARS} characters (default ${TERMINAL_HANDOFF_MAX_CHARS}, roughly 9-12k tokens)`,
 			),
+		model: string().desc(
+			"Model for this launch (agent-specific; omit to use the agent default)",
+		),
 		effort: string().desc(
 			"Reasoning effort for this launch (agent-specific; omit to use the agent default)",
 		),
@@ -123,6 +126,7 @@ export default command({
 			prompt,
 			resumeSessionId: options.resumeSession,
 			forkSessionId: options.forkSession,
+			model: options.model,
 			effort: options.effort,
 			attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
 		});

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -36,6 +36,7 @@ function invoke(
 		tag?: string[];
 		project?: string | undefined;
 		branch?: string | undefined;
+		model?: string;
 	} = {},
 ) {
 	return createWorkspaceCommand.run({
@@ -60,6 +61,24 @@ afterEach(() => {
 });
 
 describe("workspaces create", () => {
+	test("forwards model to the agent launched with the workspace", async () => {
+		await invoke({
+			agent: "claude",
+			prompt: "Implement the feature",
+			model: "sonnet",
+		});
+
+		expect(createInput).toMatchObject({
+			agents: [
+				{
+					agent: "claude",
+					prompt: "Implement the feature",
+					model: "sonnet",
+				},
+			],
+		});
+	});
+
 	test("forwards effort to the agent launched with the workspace", async () => {
 		await invoke({
 			agent: "claude",
@@ -99,6 +118,13 @@ describe("workspaces create", () => {
 		await expect(
 			invoke({ project: undefined, branch: undefined, tag: ["perf"] }),
 		).rejects.toThrow(/--tag requires --project/);
+		expect(createInput).toBeUndefined();
+	});
+
+	test("rejects model when no agent is selected", async () => {
+		await expect(invoke({ model: "sonnet" })).rejects.toThrow(
+			/--model requires --agent/,
+		);
 		expect(createInput).toBeUndefined();
 	});
 });

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -29,6 +29,9 @@ export default command({
 		prompt: string().desc(
 			"Initial prompt the agent starts with. Required when --agent is set",
 		),
+		model: string().desc(
+			"Model for the spawned agent (agent-specific; omit to use the agent default)",
+		),
 		effort: string().desc(
 			"Reasoning effort for the spawned agent (agent-specific; omit to use the agent default)",
 		),
@@ -103,6 +106,12 @@ export default command({
 				"Pass --agent <id> alongside --effort",
 			);
 		}
+		if (options.model && !options.agent) {
+			throw new CLIError(
+				"--model requires --agent",
+				"Pass --agent <id> alongside --model",
+			);
+		}
 		if (options.attachment && options.attachment.length > 0 && !options.agent) {
 			throw new CLIError(
 				"--attachment requires --agent",
@@ -136,6 +145,7 @@ export default command({
 						{
 							agent: options.agent,
 							prompt: options.prompt,
+							model: options.model,
 							effort: options.effort,
 							...(attachmentIds.length > 0 ? { attachmentIds } : {}),
 						},

--- a/packages/mcp/src/tools/agents/create.ts
+++ b/packages/mcp/src/tools/agents/create.ts
@@ -30,6 +30,20 @@ export function register(server: McpServer): void {
 				.describe(
 					"Prompt sent to the agent. Required unless resumeSessionId is provided.",
 				),
+			model: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Model for this launch. Supported values depend on the agent; omit to use its default.",
+				),
+			effort: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Reasoning effort for this launch. Supported values depend on the agent; omit to use its default.",
+				),
 			resumeSessionId: z
 				.string()
 				.min(1)
@@ -62,6 +76,8 @@ export function register(server: McpServer): void {
 					workspaceId: input.workspaceId,
 					agent: input.agent,
 					prompt: input.prompt,
+					model: input.model,
+					effort: input.effort,
 					resumeSessionId: input.resumeSessionId,
 					attachmentIds: input.attachmentIds,
 				},

--- a/packages/mcp/src/tools/workspaces/create.ts
+++ b/packages/mcp/src/tools/workspaces/create.ts
@@ -11,6 +11,20 @@ const agentLaunchSchema = z.object({
 			"Agent preset id (e.g. `claude`, `codex`, `superset`) or HostAgentConfig instance UUID.",
 		),
 	prompt: z.string().min(1).describe("Initial prompt the agent starts with."),
+	model: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			"Model for this launch. Supported values depend on the agent; omit to use its default.",
+		),
+	effort: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			"Reasoning effort for this launch. Supported values depend on the agent; omit to use its default.",
+		),
 	attachmentIds: z
 		.array(z.string().uuid())
 		.optional()

--- a/packages/sdk/api.md
+++ b/packages/sdk/api.md
@@ -88,7 +88,7 @@ Types:
 Methods:
 
 - <code title="host get /api/trpc/settings.agentConfigs.list">client.agents.<a href="./src/resources/agents.ts">list</a>({ hostId }) -> AgentListResponse</code>
-- <code title="host post /api/trpc/agents.run">client.agents.<a href="./src/resources/agents.ts">create</a>({ hostId, workspaceId, agent, prompt?, resumeSessionId?, effort?, attachmentIds? }) -> AgentCreateResult</code>
+- <code title="host post /api/trpc/agents.run">client.agents.<a href="./src/resources/agents.ts">create</a>({ hostId, workspaceId, agent, prompt?, resumeSessionId?, model?, effort?, attachmentIds? }) -> AgentCreateResult</code>
 
 # Terminals
 

--- a/packages/sdk/src/resources/agents.ts
+++ b/packages/sdk/src/resources/agents.ts
@@ -46,6 +46,7 @@ export class Agents extends APIResource {
 				agent: params.agent,
 				prompt: params.prompt,
 				resumeSessionId: params.resumeSessionId,
+				model: params.model,
 				effort: params.effort,
 				attachmentIds: params.attachmentIds,
 			},
@@ -97,6 +98,8 @@ export interface AgentCreateParams {
 	prompt?: string;
 	/** Session id of a previous run of this agent to restore instead of starting fresh (e.g. `claude --resume <id>`). */
 	resumeSessionId?: string;
+	/** Model for this launch. Supported values depend on the agent; omit to use its default. */
+	model?: string;
 	/** Reasoning effort for this launch. Supported values depend on the agent; omit to use its default. */
 	effort?: string;
 	/** Host-scoped attachment ids; host resolves to absolute paths in the prompt. */

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -208,6 +208,8 @@ export interface WorkspaceAgentLaunch {
 	agent: string;
 	/** What to tell the agent. */
 	prompt: string;
+	/** Model for this launch. Supported values depend on the agent; omit to use its default. */
+	model?: string;
 	/** Reasoning effort for this launch. Supported values depend on the agent; omit to use its default. */
 	effort?: string;
 	/** Host-scoped attachment ids; host resolves to absolute paths in the prompt. */


### PR DESCRIPTION
## Summary

- add `--model <id>` to `superset agents create` and `superset workspaces create`
- forward per-launch model selection through the TypeScript SDK
- expose the host's existing `model` and `effort` inputs in MCP agent and workspace launch tools
- document the new CLI, SDK, and MCP surface

## Why

The host service has supported per-launch model selection since #5248, using
the shared per-agent model registry to translate a model ID into the correct
flag or environment variable. Desktop can already use that path, but CLI, SDK,
and MCP callers cannot.

This change exposes the existing host behavior without duplicating model maps
or changing launch semantics. Omitting `model` still delegates to the agent's
configured default.

Since #6920, the host validates the id before launch: an unknown model fails
with a `BAD_REQUEST` naming every id the agent accepts, and an agent without a
model picker rejects the override. Nothing here re-implements that; the CLI,
SDK, and MCP surfaces just get the same error a desktop caller would.

This is a focused first slice of #5202. Agent-config CRUD and arbitrary
command/environment overrides remain out of scope.

## CLI surface

```text
$ superset agents create --help
  --model <string>  Model for this launch (agent-specific; omit to use the agent default)

$ superset workspaces create --help
  --model <string>  Model for the spawned agent (agent-specific; omit to use the agent default)
```

`workspaces create --model` requires `--agent`, matching the existing
`--effort` contract.

## Testing

Rebased onto `main` on 2026-09-04 (conflicts with #6962 and #6990 were
additive neighbours). On the rebased branch:

- `bun test` for `agents create` and `workspaces create` in `packages/cli` — 20 pass
- `tsc --noEmit` clean for `packages/cli`, `packages/mcp`, `packages/sdk`
- `biome check` clean on touched directories

## Related issue

Progresses #5202.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose per-launch agent model selection in `@superset/cli`, `@superset/sdk`, and `@superset/mcp` so callers can choose a model per run. Previously only the host/Desktop path supported per-launch models; other surfaces always used the agent default. Omitting model still uses the agent’s default. Progresses #5202.

- CLI: Add `--model` to `superset agents create` and `superset workspaces create`; require `--agent` when using `--model`; forward to host; tests and help updated.
- SDK: Add optional `model` to `agents.create` and `WorkspaceAgentLaunch`; forward to host; `api.md` updated; no breaking changes.
- MCP: Add optional `model` (and expose `effort`) in `agents_create` and `workspaces_create` tools; schema updated.
- Docs: Document that model ids match the desktop picker, unknown ids are rejected before launch, and agents without a model picker reject explicit overrides.

<sup>Written for commit ac612fbf9b08ae598d473319e29f01a78ca184c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional per-launch model selection for agent sessions.
  - Added `--model` support to agent and workspace creation commands.
  - Added model override support to SDK and MCP interfaces.
  - Model values may use supported aliases or pinned IDs; omitted values use the agent default.
  - Added validation for unsupported models and overrides without an agent.

- **Documentation**
  - Updated CLI, SDK, and MCP documentation with model and effort launch options, examples, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->