### PR TITLE
fix(mobile): honest agent-picker states, and a checks filter with room to breathe

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -264,9 +264,6 @@ export function NewChatWidget({
 			}}
 			onModelPress={() => {
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				// Hand the picker the machine resolved here. It has no workspace
-				// list of its own, so left to re-derive one it picks a different
-				// target than this composer is about to create on.
 				router.push({
 					pathname: "/(authenticated)/(home)/new-session/agent",
 					params: { machineId: selectedTarget?.machineId ?? "" },
@@ -278,10 +275,19 @@ export function NewChatWidget({
 					dismiss();
 				} else if (id === "project") {
 					if (targets.length > 0) {
-						router.push("/(authenticated)/(home)/new-session/project");
+						router.push({
+							pathname: "/(authenticated)/(home)/new-session/project",
+							params: { selectedKey: selectedTarget?.key ?? "" },
+						});
 					}
 				} else if (selectedTarget) {
-					router.push("/(authenticated)/(home)/new-session/branch");
+					router.push({
+						pathname: "/(authenticated)/(home)/new-session/branch",
+						params: {
+							projectId: selectedTarget.projectId,
+							machineId: selectedTarget.machineId,
+						},
+					});
 				}
 			}}
 		/>

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -264,7 +264,13 @@ export function NewChatWidget({
 			}}
 			onModelPress={() => {
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-				router.push("/(authenticated)/(home)/new-session/agent");
+				// Hand the picker the machine resolved here. It has no workspace
+				// list of its own, so left to re-derive one it picks a different
+				// target than this composer is about to create on.
+				router.push({
+					pathname: "/(authenticated)/(home)/new-session/agent",
+					params: { machineId: selectedTarget?.machineId ?? "" },
+				});
 			}}
 			onChipPress={(id) => {
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
@@ -38,12 +38,6 @@ export function AgentMark({
  * Picks which host agent preset the next session launches with — the target
  * host's agent configs (Claude Code, Codex, …), fetched live so the list
  * matches what the host can actually run.
- *
- * The machine arrives as a route param because the composer already resolved
- * it. Re-deriving it here landed somewhere else: the composer weighs the
- * recent workspace list this screen never sees, so the fallback picked the
- * first target alphabetically — usually a cloud one, which has no host to
- * list agents from and left the screen loading forever.
  */
 export function AgentPickerScreen() {
 	const router = useRouter();
@@ -70,8 +64,6 @@ export function AgentPickerScreen() {
 	});
 	const configs = configsQuery.data ?? [];
 
-	// Every way this can come up empty, told apart. A spinner is for a fetch
-	// that is genuinely in flight and nothing else.
 	let notice: string | null = null;
 	let isLoading = false;
 	let canRetry = false;

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
@@ -124,40 +124,41 @@ export function AgentPickerScreen() {
 					) : null}
 				</View>
 			) : null}
-			{configs.map((config) => {
-				// Persist the presetId, not the row id: config ids are per-host
-				// UUIDs, presetIds resolve on any host (agents.run accepts both).
-				const isSelected = config.presetId === agentId;
-				return (
-					<Pressable
-						key={config.id}
-						onPress={() => {
-							setAgentId(config.presetId);
-							router.back();
-						}}
-						className="flex-row items-center gap-2.5 py-2.5"
-					>
-						<AgentMark
-							agentId={config.iconId ?? config.presetId}
-							size={18}
-							color={theme.mutedForeground}
-						/>
-						<Text
-							className="flex-1 text-sm font-medium"
-							style={{ color: theme.foreground }}
+			{notice === null &&
+				configs.map((config) => {
+					// Persist the presetId, not the row id: config ids are per-host
+					// UUIDs, presetIds resolve on any host (agents.run accepts both).
+					const isSelected = config.presetId === agentId;
+					return (
+						<Pressable
+							key={config.id}
+							onPress={() => {
+								setAgentId(config.presetId);
+								router.back();
+							}}
+							className="flex-row items-center gap-2.5 py-2.5"
 						>
-							{config.label}
-						</Text>
-						{isSelected ? (
-							<Ionicons
-								name="checkmark-circle"
+							<AgentMark
+								agentId={config.iconId ?? config.presetId}
 								size={18}
-								color={theme.primary}
+								color={theme.mutedForeground}
 							/>
-						) : null}
-					</Pressable>
-				);
-			})}
+							<Text
+								className="flex-1 text-sm font-medium"
+								style={{ color: theme.foreground }}
+							>
+								{config.label}
+							</Text>
+							{isSelected ? (
+								<Ionicons
+									name="checkmark-circle"
+									size={18}
+									color={theme.primary}
+								/>
+							) : null}
+						</Pressable>
+					);
+				})}
 		</ScrollView>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
@@ -1,11 +1,17 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { Stack, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SquareTerminal } from "lucide-react-native";
-import { Image, Pressable, ScrollView } from "react-native";
+import { useMemo } from "react";
+import { Image, Pressable, ScrollView, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
+import { useHostsPresence } from "@/hooks/useHostsPresence";
+import { useOrgHostsQuery } from "@/hooks/useOrgHosts";
 import { useTheme } from "@/hooks/useTheme";
 import { agentIconSource } from "@/lib/agent-icons";
-import { useNewChatTargets } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
+import { hostServiceUrl } from "@/lib/host-service/client";
+import { CLOUD_TARGET_ID } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 import { useHostAgentConfigs } from "@/screens/(authenticated)/hooks/useHostAgentConfigs";
 
@@ -32,22 +38,62 @@ export function AgentMark({
  * Picks which host agent preset the next session launches with — the target
  * host's agent configs (Claude Code, Codex, …), fetched live so the list
  * matches what the host can actually run.
+ *
+ * The machine arrives as a route param because the composer already resolved
+ * it. Re-deriving it here landed somewhere else: the composer weighs the
+ * recent workspace list this screen never sees, so the fallback picked the
+ * first target alphabetically — usually a cloud one, which has no host to
+ * list agents from and left the screen loading forever.
  */
 export function AgentPickerScreen() {
 	const router = useRouter();
 	const theme = useTheme();
 	const agentId = useNewSessionPreferencesStore((state) => state.agentId);
 	const setAgentId = useNewSessionPreferencesStore((state) => state.setAgentId);
-	const targetKey = useNewSessionPreferencesStore((state) => state.targetKey);
-	const { targets, defaultTarget } = useNewChatTargets();
-	const selectedTarget =
-		targets.find((target) => target.key === targetKey) ?? defaultTarget;
+	const { machineId } = useLocalSearchParams<{ machineId?: string }>();
+
+	const hostsQuery = useOrgHostsQuery();
+	const host =
+		machineId && machineId !== CLOUD_TARGET_ID
+			? (hostsQuery.data?.find((entry) => entry.machineId === machineId) ??
+				null)
+			: null;
+	const presenceTargets = useMemo(() => (host ? [host] : []), [host]);
+	const presence = useHostsPresence(presenceTargets);
+	const isOnline = host
+		? (presence?.get(host.machineId) ?? host.isOnline)
+		: false;
 
 	const configsQuery = useHostAgentConfigs({
-		machineId: selectedTarget?.machineId ?? null,
-		hostUrl: selectedTarget?.hostUrl ?? null,
+		machineId: host?.machineId ?? null,
+		hostUrl: host ? hostServiceUrl(host.organizationId, host.machineId) : null,
 	});
 	const configs = configsQuery.data ?? [];
+
+	// Every way this can come up empty, told apart. A spinner is for a fetch
+	// that is genuinely in flight and nothing else.
+	let notice: string | null = null;
+	let isLoading = false;
+	let canRetry = false;
+	if (!machineId) {
+		notice = "No project selected";
+	} else if (machineId === CLOUD_TARGET_ID) {
+		notice = "Cloud workspaces don't run an agent yet";
+	} else if (!host) {
+		if (hostsQuery.isPending) isLoading = true;
+		else notice = "That machine is no longer available";
+	} else if (configs.length === 0) {
+		if (configsQuery.isError) {
+			notice = isOnline
+				? `Could not load agents from ${host.name}`
+				: `${host.name} is offline`;
+			canRetry = true;
+		} else if (configsQuery.isPending) {
+			isLoading = true;
+		} else {
+			notice = `No agents configured on ${host.name}`;
+		}
+	}
 
 	return (
 		<ScrollView
@@ -57,13 +103,29 @@ export function AgentPickerScreen() {
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button icon="xmark" onPress={() => router.back()} />
 			</Stack.Toolbar>
-			{configs.length === 0 ? (
-				<Text
-					className="py-6 text-center text-sm"
-					style={{ color: theme.mutedForeground }}
-				>
-					{selectedTarget ? "Loading agents…" : "No projects on an online host"}
-				</Text>
+			{isLoading ? (
+				<View className="items-center py-8">
+					<Spinner />
+				</View>
+			) : null}
+			{notice ? (
+				<View className="items-center gap-3 py-6">
+					<Text
+						className="text-center text-sm"
+						style={{ color: theme.mutedForeground }}
+					>
+						{notice}
+					</Text>
+					{canRetry ? (
+						<Button
+							size="sm"
+							variant="secondary"
+							onPress={() => void configsQuery.refetch()}
+						>
+							<Text>Try again</Text>
+						</Button>
+					) : null}
+				</View>
 			) : null}
 			{configs.map((config) => {
 				// Persist the presetId, not the row id: config ids are per-host

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
@@ -60,26 +60,35 @@ export function AgentPickerScreen() {
 
 	const configsQuery = useHostAgentConfigs({
 		machineId: host?.machineId ?? null,
-		hostUrl: host ? hostServiceUrl(host.organizationId, host.machineId) : null,
+		hostUrl:
+			host && isOnline
+				? hostServiceUrl(host.organizationId, host.machineId)
+				: null,
 	});
 	const configs = configsQuery.data ?? [];
 
 	let notice: string | null = null;
 	let isLoading = false;
-	let canRetry = false;
+	let retry: (() => void) | null = null;
 	if (!machineId) {
 		notice = "No project selected";
 	} else if (machineId === CLOUD_TARGET_ID) {
 		notice = "Cloud workspaces don't run an agent yet";
 	} else if (!host) {
-		if (hostsQuery.isPending) isLoading = true;
-		else notice = "That machine is no longer available";
+		if (hostsQuery.isPending) {
+			isLoading = true;
+		} else if (hostsQuery.isError) {
+			notice = "Could not load your machines";
+			retry = () => void hostsQuery.refetch();
+		} else {
+			notice = "That machine is no longer available";
+		}
+	} else if (!isOnline) {
+		notice = `${host.name} is offline`;
 	} else if (configs.length === 0) {
 		if (configsQuery.isError) {
-			notice = isOnline
-				? `Could not load agents from ${host.name}`
-				: `${host.name} is offline`;
-			canRetry = true;
+			notice = `Could not load agents from ${host.name}`;
+			retry = () => void configsQuery.refetch();
 		} else if (configsQuery.isPending) {
 			isLoading = true;
 		} else {
@@ -108,12 +117,8 @@ export function AgentPickerScreen() {
 					>
 						{notice}
 					</Text>
-					{canRetry ? (
-						<Button
-							size="sm"
-							variant="secondary"
-							onPress={() => void configsQuery.refetch()}
-						>
+					{retry ? (
+						<Button size="sm" variant="secondary" onPress={retry}>
 							<Text>Try again</Text>
 						</Button>
 					) : null}

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
@@ -1,16 +1,20 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useQuery } from "@tanstack/react-query";
-import { Stack, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, View } from "react-native";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
+import { useOrgHostsQuery } from "@/hooks/useOrgHosts";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "@/lib/auth/client";
-import { getHostServiceClientByUrl } from "@/lib/host-service/client";
+import {
+	getHostServiceClientByUrl,
+	hostServiceUrl,
+} from "@/lib/host-service/client";
 import { apiClient } from "@/lib/trpc/client";
-import { useNewChatTargets } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
+import { CLOUD_TARGET_ID } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets";
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 
 function BranchRow({
@@ -43,18 +47,27 @@ export function BranchPickerScreen() {
 	const router = useRouter();
 	const theme = useTheme();
 	const [query, setQuery] = useState("");
-	const { targets, defaultTarget } = useNewChatTargets();
-	const targetKey = useNewSessionPreferencesStore((state) => state.targetKey);
+	const params = useLocalSearchParams<{
+		projectId?: string;
+		machineId?: string;
+	}>();
 	const baseBranch = useNewSessionPreferencesStore((state) => state.baseBranch);
 	const setBaseBranch = useNewSessionPreferencesStore(
 		(state) => state.setBaseBranch,
 	);
 
-	const selectedTarget =
-		targets.find((target) => target.key === targetKey) ?? defaultTarget;
-	const isCloud = selectedTarget?.kind === "cloud";
-	const hostUrl = selectedTarget?.hostUrl ?? null;
-	const projectId = selectedTarget?.projectId ?? null;
+	const isCloud = params.machineId === CLOUD_TARGET_ID;
+	const hostsQuery = useOrgHostsQuery();
+	const host =
+		!isCloud && params.machineId
+			? (hostsQuery.data?.find(
+					(entry) => entry.machineId === params.machineId,
+				) ?? null)
+			: null;
+	const hostUrl = host
+		? hostServiceUrl(host.organizationId, host.machineId)
+		: null;
+	const projectId = params.projectId || null;
 	const { data: session } = useSession();
 	const organizationId = session?.session?.activeOrganizationId ?? null;
 

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
@@ -110,6 +110,7 @@ export function BranchPickerScreen() {
 		},
 	});
 
+	const resolvingHost = !isCloud && !host && hostsQuery.isPending;
 	const defaultBranch = data?.defaultBranch ?? null;
 	const branches = useMemo(
 		() => (data?.items ?? []).filter((branch) => branch.name !== defaultBranch),
@@ -183,12 +184,15 @@ export function BranchPickerScreen() {
 						onPress={() => selectAndClose(branch.name)}
 					/>
 				))}
-				{isLoading && !data ? (
+				{(isLoading || resolvingHost) && !data ? (
 					<View className="items-center py-6">
 						<Spinner size="small" />
 					</View>
 				) : null}
-				{!isLoading && !defaultBranch && branches.length === 0 ? (
+				{!isLoading &&
+				!resolvingHost &&
+				!defaultBranch &&
+				branches.length === 0 ? (
 					<Text
 						className="py-6 text-center text-sm"
 						style={{ color: theme.mutedForeground }}

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
@@ -1,5 +1,5 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { Stack, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { Cloud } from "lucide-react-native";
 import { useMemo } from "react";
 import { Pressable, ScrollView, View } from "react-native";
@@ -20,6 +20,7 @@ import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/
  */
 export function ProjectPickerScreen() {
 	const router = useRouter();
+	const routeParams = useLocalSearchParams<{ selectedKey?: string }>();
 	const theme = useTheme();
 	const { targets, defaultTarget } = useNewChatTargets();
 	const targetKey = useNewSessionPreferencesStore((state) => state.targetKey);
@@ -28,9 +29,10 @@ export function ProjectPickerScreen() {
 	);
 
 	const selectedKey =
-		targets.find((target) => target.key === targetKey)?.key ??
-		defaultTarget?.key ??
-		null;
+		routeParams.selectedKey ||
+		(targets.find((target) => target.key === targetKey)?.key ??
+			defaultTarget?.key ??
+			null);
 
 	const sections = useMemo(() => {
 		const cloud = targets.filter((target) => target.kind === "cloud");

--- a/apps/mobile/screens/(authenticated)/hooks/useHostAgentConfigs/useHostAgentConfigs.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useHostAgentConfigs/useHostAgentConfigs.ts
@@ -10,6 +10,10 @@ export function getHostAgentConfigsQueryKey(machineId: string | null) {
  * the host can actually run. Edits usually happen on the desktop while this
  * app is backgrounded, so focus refetches unconditionally — returning to the
  * app is the earliest moment the fresh list can matter.
+ *
+ * An empty `hostUrl` disables the query the way null does: a cloud target
+ * carries `""`, and treating that as addressable used to resolve the query
+ * to an empty list, which callers cannot tell from a host with no agents.
  */
 export function useHostAgentConfigs({
 	machineId,
@@ -22,12 +26,12 @@ export function useHostAgentConfigs({
 }) {
 	return useQuery({
 		queryKey: getHostAgentConfigsQueryKey(machineId),
-		enabled: enabled && hostUrl !== null,
+		enabled: enabled && Boolean(hostUrl),
 		staleTime: 60_000,
 		refetchOnWindowFocus: "always" as const,
 		networkMode: "always" as const,
 		queryFn: async () => {
-			if (!hostUrl) return [];
+			if (!hostUrl) throw new Error("no host to list agents from");
 			return getHostServiceClientByUrl(
 				hostUrl,
 			).settings.agentConfigs.list.query();

--- a/apps/mobile/screens/(authenticated)/hooks/useHostAgentConfigs/useHostAgentConfigs.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useHostAgentConfigs/useHostAgentConfigs.ts
@@ -11,9 +11,7 @@ export function getHostAgentConfigsQueryKey(machineId: string | null) {
  * app is backgrounded, so focus refetches unconditionally — returning to the
  * app is the earliest moment the fresh list can matter.
  *
- * An empty `hostUrl` disables the query the way null does: a cloud target
- * carries `""`, and treating that as addressable used to resolve the query
- * to an empty list, which callers cannot tell from a host with no agents.
+ * A cloud target's hostUrl is "" — unaddressable, same as null.
  */
 export function useHostAgentConfigs({
 	machineId,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
@@ -40,8 +40,6 @@ export function NewSessionSheet() {
 	// resolves so a double-tap can't start two sessions.
 	const [launchingKey, setLaunchingKey] = useState<string | null>(null);
 
-	// Told apart rather than conflated: a spinner used to stand for a failed
-	// fetch, an unresolved host and a host with nothing configured alike.
 	let notice: string | null = null;
 	let isLoading = false;
 	let canRetry = false;

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
@@ -3,6 +3,7 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SquareTerminal } from "lucide-react-native";
 import { useState } from "react";
 import { ActivityIndicator, Alert, ScrollView, View } from "react-native";
+import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
@@ -24,7 +25,7 @@ export function NewSessionSheet() {
 	const router = useRouter();
 	const theme = useTheme();
 	const queryClient = useQueryClient();
-	const { workspace, host } = useWorkspaceHost(id ?? null);
+	const { workspace, host, isResolving } = useWorkspaceHost(id ?? null);
 	const hostUrl = host
 		? hostServiceUrl(host.organizationId, host.machineId)
 		: null;
@@ -38,6 +39,25 @@ export function NewSessionSheet() {
 	// The launching row shows a spinner; every row locks until the launch
 	// resolves so a double-tap can't start two sessions.
 	const [launchingKey, setLaunchingKey] = useState<string | null>(null);
+
+	// Told apart rather than conflated: a spinner used to stand for a failed
+	// fetch, an unresolved host and a host with nothing configured alike.
+	let notice: string | null = null;
+	let isLoading = false;
+	let canRetry = false;
+	if (!host) {
+		if (isResolving) isLoading = true;
+		else notice = "Could not reach this workspace's machine";
+	} else if (presets.length === 0) {
+		if (presetsQuery.isError) {
+			notice = "Could not load presets from the host";
+			canRetry = true;
+		} else if (presetsQuery.isPending) {
+			isLoading = true;
+		} else {
+			notice = "No agents configured on this machine";
+		}
+	}
 
 	const launch = async (agentId: string | null) => {
 		if (!workspace || !hostUrl || launchingKey !== null) return;
@@ -93,15 +113,19 @@ export function NewSessionSheet() {
 					onPress={() => router.back()}
 				/>
 			</Stack.Toolbar>
-			{presets.length === 0 ? (
-				<View className="items-center py-8">
-					{presetsQuery.isError ? (
-						<Text className="text-muted-foreground text-sm">
-							Could not load presets from the host.
-						</Text>
-					) : (
-						spinner
-					)}
+			{isLoading ? <View className="items-center py-8">{spinner}</View> : null}
+			{notice ? (
+				<View className="items-center gap-3 py-8">
+					<Text className="text-muted-foreground text-sm">{notice}</Text>
+					{canRetry ? (
+						<Button
+							size="sm"
+							variant="secondary"
+							onPress={() => void presetsQuery.refetch()}
+						>
+							<Text>Try again</Text>
+						</Button>
+					) : null}
 				</View>
 			) : null}
 			{presets.map((preset) => (

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.stories.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.stories.tsx
@@ -32,5 +32,5 @@ export const SettledWithOneFailure: Story = {
 	args: { name: "openTwoChecksOneFailed" },
 };
 export const TwoFailures: Story = { args: { name: "openTwoChecksFailed" } };
-/** All green: no Failed tab at all, since a "Failed 0" segment is just noise. */
+/** All green: no Failed tab. */
 export const AllGreen: Story = { args: { name: "openWaitingForReview" } };

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.stories.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.stories.tsx
@@ -27,9 +27,10 @@ type Story = StoryObj<typeof meta>;
 export const MidRunWithInProgress: Story = {
 	args: { name: "draftChecksRunning" },
 };
-/** Settled, so there is no In Progress tab — but Failed still shows at zero. */
+/** Settled with a failure, so All / Failed / Passed and no In Progress tab. */
 export const SettledWithOneFailure: Story = {
 	args: { name: "openTwoChecksOneFailed" },
 };
 export const TwoFailures: Story = { args: { name: "openTwoChecksFailed" } };
+/** All green: no Failed tab at all, since a "Failed 0" segment is just noise. */
 export const AllGreen: Story = { args: { name: "openWaitingForReview" } };

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.tsx
@@ -11,8 +11,8 @@ import {
 } from "./utils/checksFilter";
 
 /**
- * Every check, filterable. The filter leads the list rather than sharing the
- * header's title slot with the ✕ and Fix All, which left it squeezed.
+ * Every check, filterable. The filter cannot share the header title slot
+ * with the ✕ and Fix All — there is not enough width for four segments.
  */
 export function ChecksSheet({
 	checks,
@@ -25,8 +25,6 @@ export function ChecksSheet({
 }) {
 	const router = useRouter();
 	const [filter, setFilter] = useState<ChecksFilterValue>("all");
-	// `active` is `filter` unless its tab has stopped existing, so the row and
-	// the groups below can never disagree about what is selected.
 	const {
 		counts,
 		options,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/ChecksSheet.tsx
@@ -11,8 +11,8 @@ import {
 } from "./utils/checksFilter";
 
 /**
- * Every check, filterable. The filter is the sheet's title rather than a row in
- * the list, so it stays put while the checks scroll under it.
+ * Every check, filterable. The filter leads the list rather than sharing the
+ * header's title slot with the ✕ and Fix All, which left it squeezed.
  */
 export function ChecksSheet({
 	checks,
@@ -25,21 +25,18 @@ export function ChecksSheet({
 }) {
 	const router = useRouter();
 	const [filter, setFilter] = useState<ChecksFilterValue>("all");
-	const { counts, options, groups } = checksFilterState(checks, filter);
+	// `active` is `filter` unless its tab has stopped existing, so the row and
+	// the groups below can never disagree about what is selected.
+	const {
+		counts,
+		options,
+		groups,
+		filter: active,
+	} = checksFilterState(checks, filter);
 
 	return (
 		<>
-			<Stack.Screen
-				options={{
-					headerTitle: () => (
-						<ChecksFilter
-							onChange={setFilter}
-							options={options}
-							value={filter}
-						/>
-					),
-				}}
-			/>
+			<Stack.Screen options={{ headerTitle: "Checks" }} />
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button
 					accessibilityLabel="Close"
@@ -58,11 +55,12 @@ export function ChecksSheet({
 			) : null}
 			<ScrollView
 				className="bg-background flex-1"
-				contentContainerClassName="gap-6 px-4 pb-10 pt-2"
+				contentContainerClassName="gap-6 pb-10 pt-2"
 				contentInsetAdjustmentBehavior="automatic"
 			>
+				<ChecksFilter onChange={setFilter} options={options} value={active} />
 				{groups.map((group) => (
-					<View className="gap-3" key={group.filter}>
+					<View className="gap-3 px-4" key={group.filter}>
 						<Text className="text-muted-foreground text-[15px]">
 							{group.title}{" "}
 							<Text className="text-muted-foreground/60 text-[15px]">

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/components/ChecksFilter/ChecksFilter.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/components/ChecksFilter/ChecksFilter.tsx
@@ -1,8 +1,16 @@
-import { Host, Picker, Text } from "@expo/ui/swift-ui";
-import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
+import { Pressable, ScrollView } from "react-native";
+import { Text } from "@/components/ui/text";
 import type { ChecksFilterValue } from "../../utils/checksFilter";
 
-/** Segmented filter in the sheet's title; a form sheet paints its header over content, so it cannot live in the list. */
+/**
+ * The sheet's filter row, under the header rather than in its title: the
+ * title slot is shared with the ✕ and the Fix All action, and four segments
+ * competing for what is left of it squeezed the first one to nothing. Its own
+ * row is also what the reference set shows.
+ *
+ * Scrolls horizontally so a narrow screen or a fifth segment pushes off the
+ * edge instead of compressing every tab.
+ */
 export function ChecksFilter({
 	value,
 	onChange,
@@ -13,20 +21,37 @@ export function ChecksFilter({
 	options: { value: ChecksFilterValue; label: string; count: number }[];
 }) {
 	return (
-		<Host matchContents style={{ minWidth: 300 }}>
-			<Picker
-				modifiers={[pickerStyle("segmented")]}
-				onSelectionChange={(selection) =>
-					onChange(selection as ChecksFilterValue)
-				}
-				selection={value}
-			>
-				{options.map((option) => (
-					<Text key={option.value} modifiers={[tag(option.value)]}>
-						{`${option.label} ${option.count}`}
-					</Text>
-				))}
-			</Picker>
-		</Host>
+		<ScrollView
+			horizontal
+			showsHorizontalScrollIndicator={false}
+			// pl-1 + the pill's px-3 lands the first tab's text on the same
+			// 16px gutter as the rows below it.
+			contentContainerClassName="flex-row items-center gap-1 pl-1 pr-4"
+		>
+			{options.map((option) => {
+				const isSelected = option.value === value;
+				return (
+					<Pressable
+						accessibilityLabel={`${option.label} ${option.count}`}
+						accessibilityRole="tab"
+						accessibilityState={{ selected: isSelected }}
+						className={`rounded-full px-3 py-1.5 ${isSelected ? "bg-secondary" : ""}`}
+						key={option.value}
+						onPress={() => onChange(option.value)}
+					>
+						<Text
+							className={`text-[15px] ${isSelected ? "text-foreground" : "text-muted-foreground"}`}
+						>
+							{option.label}{" "}
+							<Text
+								className={`text-[15px] ${isSelected ? "text-foreground/50" : "text-muted-foreground/60"}`}
+							>
+								{option.count}
+							</Text>
+						</Text>
+					</Pressable>
+				);
+			})}
+		</ScrollView>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/components/ChecksFilter/ChecksFilter.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/components/ChecksFilter/ChecksFilter.tsx
@@ -2,15 +2,7 @@ import { Pressable, ScrollView } from "react-native";
 import { Text } from "@/components/ui/text";
 import type { ChecksFilterValue } from "../../utils/checksFilter";
 
-/**
- * The sheet's filter row, under the header rather than in its title: the
- * title slot is shared with the ✕ and the Fix All action, and four segments
- * competing for what is left of it squeezed the first one to nothing. Its own
- * row is also what the reference set shows.
- *
- * Scrolls horizontally so a narrow screen or a fifth segment pushes off the
- * edge instead of compressing every tab.
- */
+/** The sheet's filter row; segments scroll rather than compress. */
 export function ChecksFilter({
 	value,
 	onChange,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.test.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import type { PullRequestCheck } from "../../../../../../utils/pullRequest/types";
+import { checksFilterState } from "./checksFilter";
+
+function check(
+	name: string,
+	status: PullRequestCheck["status"],
+	conclusion: PullRequestCheck["conclusion"],
+): PullRequestCheck {
+	return {
+		name,
+		status,
+		conclusion,
+		isRequired: false,
+		startedAt: null,
+		completedAt: null,
+		detailsUrl: null,
+	};
+}
+
+const passed = (name: string) => check(name, "COMPLETED", "SUCCESS");
+const failed = (name: string) => check(name, "COMPLETED", "FAILURE");
+const running = (name: string) => check(name, "IN_PROGRESS", null);
+const skipped = (name: string) => check(name, "COMPLETED", "SKIPPED");
+const needsAction = (name: string) =>
+	check(name, "COMPLETED", "ACTION_REQUIRED");
+
+const labels = (checks: PullRequestCheck[]) =>
+	checksFilterState(checks, "all").options.map((option) => option.label);
+
+describe("checksFilterState options", () => {
+	it("drops Failed when nothing failed", () => {
+		expect(labels([passed("CI / Lint"), passed("CI / Test")])).toEqual([
+			"All",
+			"Passed",
+		]);
+	});
+
+	it("keeps Failed when something failed", () => {
+		expect(labels([passed("CI / Lint"), failed("CI / Test")])).toEqual([
+			"All",
+			"Failed",
+			"Passed",
+		]);
+	});
+
+	it("counts a needs-action check as failed", () => {
+		const state = checksFilterState([needsAction("Deploy / Approve")], "all");
+		expect(state.options.map((option) => option.label)).toEqual([
+			"All",
+			"Failed",
+		]);
+		expect(state.counts.failed).toBe(1);
+	});
+
+	it("offers only All when there are no checks at all", () => {
+		expect(labels([])).toEqual(["All"]);
+	});
+
+	it("offers every populated segment, in run order", () => {
+		expect(
+			labels([
+				running("CI / Build"),
+				failed("CI / Test"),
+				passed("CI / Lint"),
+				skipped("Deploy / Docs"),
+			]),
+		).toEqual(["All", "Running", "Failed", "Passed", "Skipped"]);
+	});
+
+	it("counts every segment", () => {
+		const { counts } = checksFilterState(
+			[
+				running("CI / Build"),
+				failed("CI / Test"),
+				needsAction("Deploy / Approve"),
+				passed("CI / Lint"),
+				skipped("Deploy / Docs"),
+			],
+			"all",
+		);
+		expect(counts).toEqual({
+			all: 5,
+			running: 1,
+			failed: 2,
+			passed: 1,
+			skipped: 1,
+		});
+	});
+});
+
+describe("checksFilterState active filter", () => {
+	it("keeps a filter whose segment still exists", () => {
+		const state = checksFilterState(
+			[failed("CI / Test"), passed("CI / Lint")],
+			"failed",
+		);
+		expect(state.filter).toBe("failed");
+		expect(state.groups.map((group) => group.filter)).toEqual(["failed"]);
+	});
+
+	it("falls back to All when the selected segment disappears", () => {
+		// The Failed tab the user selected is gone now that the run went green.
+		const state = checksFilterState([passed("CI / Test")], "failed");
+		expect(state.filter).toBe("all");
+		expect(state.options.map((option) => option.value)).toEqual([
+			"all",
+			"passed",
+		]);
+		expect(state.groups.map((group) => group.filter)).toEqual(["passed"]);
+	});
+
+	it("shows every non-empty group under All", () => {
+		const state = checksFilterState(
+			[running("CI / Build"), failed("CI / Test"), passed("CI / Lint")],
+			"all",
+		);
+		expect(state.groups.map((group) => group.filter)).toEqual([
+			"running",
+			"failed",
+			"passed",
+		]);
+	});
+});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.test.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.test.ts
@@ -100,7 +100,6 @@ describe("checksFilterState active filter", () => {
 	});
 
 	it("falls back to All when the selected segment disappears", () => {
-		// The Failed tab the user selected is gone now that the run went green.
 		const state = checksFilterState([passed("CI / Test")], "failed");
 		expect(state.filter).toBe("all");
 		expect(state.options.map((option) => option.value)).toEqual([

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
@@ -34,7 +34,10 @@ const CHECK_FILTER: Record<
 	ignored: "skipped",
 };
 
-/** Segments to offer and groups to show; "Failed" is offered even at zero. */
+/**
+ * Segments to offer and groups to show. Only "All" is unconditional — a tab
+ * whose count is zero is noise, "Failed 0" included.
+ */
 export function checksFilterState(
 	checks: PullRequestCheck[],
 	filter: ChecksFilterValue,
@@ -55,12 +58,13 @@ export function checksFilterState(
 			label: group.segment,
 			count: counts[group.filter],
 		})),
-	].filter(
-		(option) =>
-			option.value === "all" ||
-			option.value === "failed" ||
-			counts[option.value] > 0,
-	);
+	].filter((option) => option.value === "all" || counts[option.value] > 0);
+
+	// Checks settle while the sheet is open, so the selected tab can stop
+	// existing under the user. All is the one segment that never leaves.
+	const active = options.some((option) => option.value === filter)
+		? filter
+		: ("all" as ChecksFilterValue);
 
 	const groups = GROUPS.map((group) => ({
 		...group,
@@ -69,8 +73,8 @@ export function checksFilterState(
 		),
 	})).filter(
 		(group) =>
-			group.members.length > 0 && (filter === "all" || filter === group.filter),
+			group.members.length > 0 && (active === "all" || active === group.filter),
 	);
 
-	return { counts, options, groups, tally };
+	return { counts, options, groups, tally, filter: active };
 }

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/components/ChecksSheet/utils/checksFilter/checksFilter.ts
@@ -34,10 +34,7 @@ const CHECK_FILTER: Record<
 	ignored: "skipped",
 };
 
-/**
- * Segments to offer and groups to show. Only "All" is unconditional — a tab
- * whose count is zero is noise, "Failed 0" included.
- */
+/** Segments to offer and groups to show; zero-count tabs are dropped, All never. */
 export function checksFilterState(
 	checks: PullRequestCheck[],
 	filter: ChecksFilterValue,
@@ -60,8 +57,7 @@ export function checksFilterState(
 		})),
 	].filter((option) => option.value === "all" || counts[option.value] > 0);
 
-	// Checks settle while the sheet is open, so the selected tab can stop
-	// existing under the user. All is the one segment that never leaves.
+	// Checks settle while the sheet is open; the selected tab can stop existing.
 	const active = options.some((option) => option.value === filter)
 		? filter
 		: ("all" as ChecksFilterValue);


### PR DESCRIPTION
## What & why

**Agent picker hung on "Loading agents…" forever** (reproduced on TestFlight build 19, on device over cellular — and reproduced against production on the simulator before fixing). Three compounding causes: the screen rendered "Loading agents…" for every non-success state (error, disabled query, cloud target alike); cloud targets carry `hostUrl: ""` which passed the `?? null` check so the query ran "enabled" and its guard returned an empty list forever; and the picker re-derived targets via `useNewChatTargets()` *without* the composer's workspace list, so its fallback resolved a different target than the composer — usually a cloud one.

Fixes, no patchwork: the composer passes its resolved `machineId` to the picker as a route param (single source of target truth); `useHostAgentConfigs` treats an empty `hostUrl` as disabled and its guard now throws instead of minting an empty success; and the picker + workspace `NewSessionSheet` distinguish their states — spinner only while genuinely fetching, error with a retry button, host-offline and no-agents-configured named explicitly, cloud targets told "no agents" instead of an eternal spinner.

**Checks sheet filter was smushed and showed "Failed 0".** Root cause of the smush: the segmented filter lived in the header's *title slot*, competing with the ✕ and Fix All for leftover width. It now gets its own horizontally scrolling pill row under the header (matching the reference mocks), and the Failed tab is dropped when its count is zero, with selection falling back to All so the row and the groups can never disagree (`checksFilterState` returns the effective filter).

Extended in-review: the branch and project pickers shared the same re-derivation root cause — the composer now passes `projectId`/`machineId` to the branch picker (host resolved from org hosts, cloud sentinel handled) and its selected key to the project picker highlight. Pre-existing and untouched: `PullRequestChecksScreen` never passes `onFixAll`, so the Fix All toolbar action is currently dead code.

## How I tested it

- [x] Reproduced the hang against production on the simulator before the fix; verified all three fixes on the simulator after
- [x] bun test apps/mobile: 47 pass (new checksFilter suite included)
- [x] lint clean; typecheck has zero app-code errors (only the known shared-package leaks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent picker’s endless “Loading agents…” and gives the checks filter its own row. Pickers now use the composer’s chosen target to avoid mismatches and never fetch from an offline host.

- Agent, branch, project, and session pickers
  - Composer passes `machineId` (and `projectId`/`selectedKey` where needed); host resolves from org hosts and presence. No fetch from an offline or unaddressable host; host-list failure is distinct from a missing machine.
  - Spinner shows only while fetching; explicit notices for cloud/no selection/host offline/no agents, with “Try again” on errors. Avoids empty-state flashes while the host list resolves and hides stale lists when a notice is shown.
  - `useHostAgentConfigs` treats empty `hostUrl` as disabled and throws when no host is addressable. Migration: if you relied on an empty list meaning “no host,” handle the error state instead.

- Checks filter
  - Moves out of the header title into a horizontally scrolling pill row; header title is now “Checks.”
  - Drops zero-count tabs and falls back to All if the selected segment disappears to keep UI and groups in sync.
  - Replaces `@expo/ui/swift-ui` segmented picker with native components; adds unit tests and updates stories.

<sup>Written for commit 9655ea36054c94199ef4f390e7f26fb7b46738b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual navigation for new agent, project, and branch sessions.
  * Improved agent and project selection with clearer loading, offline, unavailable, and error states.
  * Added retry options for failed agent and preset configuration loading.
  * Added a scrollable checks filter with accessible tabs and result counts.

* **Bug Fixes**
  * Removed empty check-status tabs and preserved valid filters as results update.
  * Improved handling of unavailable hosts and missing agents.

* **Documentation**
  * Updated checks display examples to reflect current filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->