### PR TITLE
fix(cli): await the stdout flush so large --json output isn't truncated at exit

### DIFF
--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -400,6 +400,19 @@ async function execute(
 			json: isJson,
 			quiet: isQuiet,
 		});
-		if (output) console.log(output);
+		if (output) await writeStdout(`${output}\n`);
 	}
+}
+
+/**
+ * console.log queues pipe writes asynchronously; when the process exits while
+ * the reader is slow, Bun drops the still-queued tail, truncating output
+ * beyond ~64KB (seen with `superset tasks list --json | jq` and `$(...)`
+ * capture). Awaiting the write callback keeps the process alive until the
+ * whole payload reaches the pipe.
+ */
+function writeStdout(text: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		process.stdout.write(text, (error) => (error ? reject(error) : resolve()));
+	});
 }

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -41,7 +41,7 @@ export async function run(opts: RunOptions): Promise<void> {
 	try {
 		await execute(opts, opts.tree, ac.signal);
 	} catch (error) {
-		await handleError(error, opts.name);
+		await handleError(error, opts.name, ac.signal);
 	} finally {
 		process.off("SIGINT", onSignal);
 		process.off("SIGTERM", onSignal);
@@ -108,14 +108,22 @@ export function formatError(
 	return { message: String(error) };
 }
 
-async function handleError(error: unknown, cliName: string): Promise<never> {
+async function handleError(
+	error: unknown,
+	cliName: string,
+	signal?: AbortSignal,
+): Promise<never> {
 	const { message, hint } = formatError(error, cliName);
 	// Same drain rule as stdout (see writeStream): exiting before the pipe
 	// reader catches up would drop the message. Best effort; a failed stderr
 	// write must not mask the exit code.
-	await writeStream(process.stderr, `Error: ${message}\n`).catch(() => {});
+	await writeStream(process.stderr, `Error: ${message}\n`, signal).catch(
+		() => {},
+	);
 	if (hint) {
-		await writeStream(process.stderr, `Hint: ${hint}\n`).catch(() => {});
+		await writeStream(process.stderr, `Hint: ${hint}\n`, signal).catch(
+			() => {},
+		);
 	}
 	process.exit(1);
 }
@@ -407,7 +415,7 @@ async function execute(
 		});
 		// All command output must leave through writeStream; a bare console.log
 		// here reintroduces truncation for any payload past the pipe buffer.
-		if (output) await writeStream(process.stdout, `${output}\n`);
+		if (output) await writeStream(process.stdout, `${output}\n`, signal);
 	}
 }
 
@@ -418,8 +426,29 @@ async function execute(
  * capture). Awaiting the write callback keeps the process alive until the
  * whole payload reaches the pipe.
  */
-function writeStream(stream: NodeJS.WriteStream, text: string): Promise<void> {
+function writeStream(
+	stream: NodeJS.WriteStream,
+	text: string,
+	signal?: AbortSignal,
+): Promise<void> {
 	return new Promise((resolve, reject) => {
-		stream.write(text, (error) => (error ? reject(error) : resolve()));
+		let settled = false;
+		const settle = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			fn();
+		};
+		stream.write(text, (error) =>
+			settle(() => (error ? reject(error) : resolve())),
+		);
+		// A full pipe whose reader never drains would otherwise wait forever
+		// and swallow SIGINT/SIGTERM (run() replaces their default exit). On
+		// abort, stop waiting and let the exit path proceed; losing the tail
+		// is the right trade once the user asked to stop.
+		if (signal?.aborted) settle(resolve);
+		else
+			signal?.addEventListener("abort", () => settle(resolve), {
+				once: true,
+			});
 	});
 }

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -41,7 +41,7 @@ export async function run(opts: RunOptions): Promise<void> {
 	try {
 		await execute(opts, opts.tree, ac.signal);
 	} catch (error) {
-		handleError(error, opts.name);
+		await handleError(error, opts.name);
 	} finally {
 		process.off("SIGINT", onSignal);
 		process.off("SIGTERM", onSignal);
@@ -108,10 +108,15 @@ export function formatError(
 	return { message: String(error) };
 }
 
-function handleError(error: unknown, cliName: string): never {
+async function handleError(error: unknown, cliName: string): Promise<never> {
 	const { message, hint } = formatError(error, cliName);
-	process.stderr.write(`Error: ${message}\n`);
-	if (hint) process.stderr.write(`Hint: ${hint}\n`);
+	// Same drain rule as stdout (see writeStream): exiting before the pipe
+	// reader catches up would drop the message. Best effort; a failed stderr
+	// write must not mask the exit code.
+	await writeStream(process.stderr, `Error: ${message}\n`).catch(() => {});
+	if (hint) {
+		await writeStream(process.stderr, `Hint: ${hint}\n`).catch(() => {});
+	}
 	process.exit(1);
 }
 
@@ -400,7 +405,9 @@ async function execute(
 			json: isJson,
 			quiet: isQuiet,
 		});
-		if (output) await writeStdout(`${output}\n`);
+		// All command output must leave through writeStream; a bare console.log
+		// here reintroduces truncation for any payload past the pipe buffer.
+		if (output) await writeStream(process.stdout, `${output}\n`);
 	}
 }
 
@@ -411,8 +418,8 @@ async function execute(
  * capture). Awaiting the write callback keeps the process alive until the
  * whole payload reaches the pipe.
  */
-function writeStdout(text: string): Promise<void> {
+function writeStream(stream: NodeJS.WriteStream, text: string): Promise<void> {
 	return new Promise((resolve, reject) => {
-		process.stdout.write(text, (error) => (error ? reject(error) : resolve()));
+		stream.write(text, (error) => (error ? reject(error) : resolve()));
 	});
 }

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -114,17 +114,11 @@ async function handleError(
 	signal?: AbortSignal,
 ): Promise<never> {
 	const { message, hint } = formatError(error, cliName);
+	const text = `Error: ${message}\n${hint ? `Hint: ${hint}\n` : ""}`;
 	// Same drain rule as stdout (see writeStream): exiting before the pipe
 	// reader catches up would drop the message. Best effort; a failed stderr
 	// write must not mask the exit code.
-	await writeStream(process.stderr, `Error: ${message}\n`, signal).catch(
-		() => {},
-	);
-	if (hint) {
-		await writeStream(process.stderr, `Hint: ${hint}\n`, signal).catch(
-			() => {},
-		);
-	}
+	await writeStream(process.stderr, text, signal).catch(() => {});
 	process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

`superset <cmd> --json` silently truncates large output when stdout is a pipe whose reader is momentarily slow (command substitution, `| jq` under load). `superset tasks list --json` (~157KB) reliably comes back cut at a 16KB multiple (81920, 114688, ...), so `$(...)` capture and jq see unparseable JSON. Redirecting to a file never truncates.

Root cause: the runner prints the result with `console.log` and returns; nothing awaits the write. Bun queues pipe writes it can't complete immediately, and when the process exits with the reader still catching up, the queued tail is dropped.

Fix: `execute()` now writes the formatted output via `process.stdout.write` and awaits its completion callback, keeping the process alive until the whole payload has reached the pipe. One-line call-site change plus a small helper.

## Verification

Repro: `tasks list --json | (sleep 0.5; cat) | wc -c` against a workspace with a full task list (~157KB expected).

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| dev CLI, before | 81920 | 114688 | — |
| dev CLI, after | 157612 | 157612 | 157612 |
| compiled darwin-arm64, after | 157612 | 157612 | 157612 |

`out=$(superset tasks list --json)` with the fixed binary parses cleanly (`jq length` = 50); the currently installed CLI truncates on the same machine.

No regression test is included: a hermetic fixture CLI (300KB payload through `run()`, slow shell reader, with and without a keep-alive fetch) does not reproduce the truncation — the trigger needs something about the full CLI's process state I couldn't isolate. Verified behaviorally as above instead; existing `runner.test.ts` still passes and `tsc --noEmit` is clean.

## Context

Found while shipping #6762: the standup/10x skill scripts hit this and now capture CLI stdout via a temp file. With this fix that workaround is belt-and-suspenders rather than load-bearing.

https://claude.ai/code/session_01SudpHaYT4rQ1msxeVpWwC1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents truncation of large `--json` output and error messages on slow pipes and ensures prompt exit on interrupt. Previously we returned after unawaited writes and dropped queued bytes; we now await stdout/stderr writes and abort a stuck drain on SIGINT/SIGTERM.

- Replace `console.log(output)` with an awaited `writeStream(process.stdout, ...)`.
- Errors use the same helper and are awaited in `run()`, draining the message and hint in one `stderr` write and preserving a non-zero exit even if the write fails.
- SIGINT/SIGTERM abort a drain-write stuck on a full pipe so Ctrl-C exits promptly.
- Side effect: under backpressure the process may exit slightly later; interrupted runs may drop the tail by design. File redirects behave the same.
- No migration required; consumers of `--json` and error output now receive complete payloads when runs complete.

<sup>Written for commit 3b93326a9c32f33a7686e3e884dfc124d474797a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of command output when writing to slow or buffered streams.
  * Commands now respond promptly to cancellation, even when output streams do not drain.
  * Improved handling of standard output and error messages during shutdown.
  * Error output failures are handled gracefully without interrupting command termination.
  * Commands continue to preserve exit code `1` when error output cannot be written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->