### PR TITLE
fix(host-service,cli): repair workspaces whose worktree moved (#6791)

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -708,6 +708,7 @@ superset workspaces get --field branch   # inside a workspace
 		{ flag: "--name <name>", description: "New workspace name." },
 		{ flag: "--task-id <id>", description: "Link the workspace to a task by id." },
 		{ flag: "--clear-task", description: "Unlink the workspace from its current task. Mutually exclusive with --task-id." },
+		{ flag: "--worktree-path <path>", description: "Re-point the workspace at a worktree that was moved on disk. The path must be a worktree of the project on the workspace's branch." },
 	]}
 	output="Workspace"
 >
@@ -717,7 +718,12 @@ Update a workspace on its host (default: this machine).
 superset workspaces update ws_… --name "better-name"
 superset workspaces update ws_… --task-id tsk_…
 superset workspaces update ws_… --clear-task
+superset workspaces update ws_… --worktree-path ~/repo/.worktrees/feature
 ```
+
+A workspace whose worktree was relocated with `git worktree move` is also repaired
+automatically the next time it is opened or fetched with `workspaces get`, as long as
+the branch still appears in `git worktree list` for the project.
 </Command>
 
 <Command

--- a/packages/cli/src/commands/workspaces/update/command.ts
+++ b/packages/cli/src/commands/workspaces/update/command.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { boolean, CLIError, positional, string } from "@superset/cli-framework";
 import { getHostId } from "@superset/shared/host-info";
 import { command } from "../../../lib/command";
@@ -11,6 +12,9 @@ export default command({
 		name: string().desc("Workspace name"),
 		taskId: string().desc("Link the workspace to a task by id"),
 		clearTask: boolean().desc("Unlink the workspace from its current task"),
+		worktreePath: string().desc(
+			"Re-point the workspace at a worktree that was moved on disk",
+		),
 	},
 	run: async ({ ctx, args, options }) => {
 		const id = args.id as string;
@@ -32,10 +36,14 @@ export default command({
 				? options.taskId
 				: undefined;
 
-		if (options.name === undefined && taskId === undefined) {
+		if (
+			options.name === undefined &&
+			taskId === undefined &&
+			options.worktreePath === undefined
+		) {
 			throw new CLIError(
 				"No fields to update",
-				"Pass --name, --task-id, or --clear-task",
+				"Pass --name, --task-id, --clear-task, or --worktree-path",
 			);
 		}
 
@@ -49,6 +57,9 @@ export default command({
 			id,
 			...(options.name !== undefined ? { name: options.name } : {}),
 			...(taskId !== undefined ? { taskId } : {}),
+			...(options.worktreePath !== undefined
+				? { worktreePath: resolve(options.worktreePath) }
+				: {}),
 		});
 
 		return {

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -8,6 +8,10 @@ import {
 	toCloudShape,
 	updateLocalWorkspace,
 } from "../../../workspaces/local-workspace-store";
+import {
+	repairMovedWorktree,
+	validateWorktreePathUpdate,
+} from "../../../workspaces/moved-worktree";
 import { protectedProcedure, router } from "../../index";
 import { resolveWorktreePath } from "../git/utils/resolve-worktree";
 import { destroyWorkspace } from "../workspace-cleanup";
@@ -15,18 +19,19 @@ import { destroyWorkspace } from "../workspace-cleanup";
 export const workspaceRouter = router({
 	get: protectedProcedure
 		.input(z.object({ id: z.string() }))
-		.query(({ ctx, input }) => {
-			const localWorkspace = ctx.db.query.workspaces
+		.query(async ({ ctx, input }) => {
+			const stored = ctx.db.query.workspaces
 				.findFirst({ where: eq(workspaces.id, input.id) })
 				.sync();
 
-			if (!localWorkspace) {
+			if (!stored) {
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Workspace not found",
 				});
 			}
 
+			const localWorkspace = await repairMovedWorktree(ctx, stored);
 			return {
 				...localWorkspace,
 				worktreeExists: existsSync(localWorkspace.worktreePath),
@@ -84,6 +89,8 @@ export const workspaceRouter = router({
 	 * row commits and broadcasts immediately; the cloud mirror push is
 	 * best-effort (the reconciler retries when unreachable). `branch` only
 	 * re-points the record — callers rename the git branch themselves.
+	 * `worktreePath` re-points a workspace whose worktree was moved on disk;
+	 * the path must be a worktree of the project on the workspace's branch.
 	 */
 	update: protectedProcedure
 		.input(
@@ -92,6 +99,7 @@ export const workspaceRouter = router({
 				name: z.string().min(1).optional(),
 				branch: z.string().min(1).optional(),
 				taskId: z.string().uuid().nullable().optional(),
+				worktreePath: z.string().min(1).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -111,11 +119,29 @@ export const workspaceRouter = router({
 						'The local workspace cannot be renamed — it always displays as "local".',
 				});
 			}
-			const patch: { name?: string; branch?: string; taskId?: string | null } =
-				{};
+			const patch: {
+				name?: string;
+				branch?: string;
+				taskId?: string | null;
+				worktreePath?: string;
+			} = {};
 			if (input.name !== undefined) patch.name = input.name;
 			if (input.branch !== undefined) patch.branch = input.branch;
 			if (input.taskId !== undefined) patch.taskId = input.taskId;
+			if (input.worktreePath !== undefined) {
+				const validated = await validateWorktreePathUpdate(
+					ctx,
+					current,
+					input.worktreePath,
+				);
+				if (!validated.ok) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: validated.message,
+					});
+				}
+				patch.worktreePath = validated.worktreePath;
+			}
 			if (Object.keys(patch).length === 0) {
 				return toCloudShape(current, ctx.organizationId);
 			}

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -26,6 +26,7 @@ import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts"
 import {
 	normalizeWorktreePath,
 	parseWorktreeList,
+	type WorktreeRecord,
 } from "../../trpc/router/workspace-creation/shared/worktree-list.ts";
 import { defineWorkerTask } from "../define-worker-task.ts";
 
@@ -224,6 +225,19 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 	},
 });
 
+export const gitWorktreeListTask = defineWorkerTask<
+	{ repoPath: string; gitEnv: GitTaskEnv },
+	WorktreeRecord[]
+>({
+	type: "git/listWorktrees",
+	handler: async ({ repoPath, gitEnv }) => {
+		const git = createUserSimpleGit(repoPath).env(gitEnv);
+		return parseWorktreeList(
+			await git.raw(["worktree", "list", "--porcelain"]),
+		);
+	},
+});
+
 export const gitDeleteBranchTask = defineWorkerTask<
 	{ repoPath: string; branch: string; gitEnv: GitTaskEnv },
 	{ deleted: boolean }
@@ -251,5 +265,6 @@ export const gitTasks = [
 	gitIdentityTask,
 	gitWorktreeStateTask,
 	gitWorktreeRemoveTask,
+	gitWorktreeListTask,
 	gitDeleteBranchTask,
 ];

--- a/packages/host-service/src/workspaces/moved-worktree.test.ts
+++ b/packages/host-service/src/workspaces/moved-worktree.test.ts
@@ -1,0 +1,219 @@
+import { Database } from "bun:sqlite";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../db";
+import * as schema from "../db/schema";
+import { projects } from "../db/schema";
+import type { EventBus } from "../events";
+import type { GitCredentialProvider } from "../runtime/git";
+import { createUserSimpleGit } from "../runtime/git/simple-git";
+import { listGitWorktrees } from "../trpc/router/workspace-creation/shared/worktree-list";
+import {
+	getLocalWorkspace,
+	insertLocalWorkspace,
+} from "./local-workspace-store";
+import {
+	type MovedWorktreeContext,
+	movedWorktreeGitOps,
+	repairMovedWorktree,
+	validateWorktreePathUpdate,
+} from "./moved-worktree";
+
+const originalListWorktrees = movedWorktreeGitOps.listWorktrees;
+movedWorktreeGitOps.listWorktrees = (_ctx, repoPath) =>
+	listGitWorktrees(createUserSimpleGit(repoPath));
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../drizzle");
+const TEST_DIR = join(
+	realpathSync(tmpdir()),
+	`superset-hs-moved-worktree-${process.pid}`,
+);
+const PROJECT_ID = "00000000-0000-0000-0000-00000000aa01";
+
+function git(cwd: string, cmd: string): void {
+	execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function createTestRepo(): string {
+	const repoPath = join(TEST_DIR, "repo");
+	mkdirSync(repoPath, { recursive: true });
+	git(repoPath, "init -b main");
+	git(repoPath, "config user.email test@test.com");
+	git(repoPath, "config user.name Test");
+	git(repoPath, "commit --allow-empty -m init");
+	return repoPath;
+}
+
+function createContext(repoPath: string): MovedWorktreeContext {
+	const db = drizzle(new Database(":memory:"), { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	db.insert(projects).values({ id: PROJECT_ID, repoPath, name: "repo" }).run();
+	const events: string[] = [];
+	return {
+		db: db as unknown as HostDb,
+		eventBus: {
+			broadcastWorkspaceChanged: (type: string) => {
+				events.push(type);
+			},
+		} as unknown as EventBus,
+		credentials: {} as GitCredentialProvider,
+	};
+}
+
+afterAll(() => {
+	movedWorktreeGitOps.listWorktrees = originalListWorktrees;
+});
+
+describe("repairMovedWorktree", () => {
+	let repoPath: string;
+	let ctx: MovedWorktreeContext;
+	let oldPath: string;
+	let newPath: string;
+
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+		repoPath = createTestRepo();
+		ctx = createContext(repoPath);
+		oldPath = join(TEST_DIR, "worktrees", "feature");
+		newPath = join(TEST_DIR, "moved", "feature");
+		git(repoPath, `worktree add -b feature "${oldPath}"`);
+	});
+
+	afterEach(() => {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	});
+
+	test("re-points the row after `git worktree move`", async () => {
+		const row = insertLocalWorkspace(ctx, {
+			projectId: PROJECT_ID,
+			worktreePath: oldPath,
+			branch: "feature",
+			name: "feature",
+		});
+		mkdirSync(join(TEST_DIR, "moved"), { recursive: true });
+		git(repoPath, `worktree move "${oldPath}" "${newPath}"`);
+		expect(existsSync(oldPath)).toBe(false);
+
+		const repaired = await repairMovedWorktree(ctx, row);
+
+		expect(repaired.worktreePath).toBe(newPath);
+		expect(getLocalWorkspace(ctx.db, row.id)?.worktreePath).toBe(newPath);
+	});
+
+	test("leaves the row alone when the worktree still exists", async () => {
+		const row = insertLocalWorkspace(ctx, {
+			projectId: PROJECT_ID,
+			worktreePath: oldPath,
+			branch: "feature",
+			name: "feature",
+		});
+		const result = await repairMovedWorktree(ctx, row);
+		expect(result.worktreePath).toBe(oldPath);
+	});
+
+	test("leaves the row alone when the worktree was removed, not moved", async () => {
+		const row = insertLocalWorkspace(ctx, {
+			projectId: PROJECT_ID,
+			worktreePath: oldPath,
+			branch: "feature",
+			name: "feature",
+		});
+		git(repoPath, `worktree remove --force "${oldPath}"`);
+		const result = await repairMovedWorktree(ctx, row);
+		expect(result.worktreePath).toBe(oldPath);
+		expect(getLocalWorkspace(ctx.db, row.id)?.worktreePath).toBe(oldPath);
+	});
+
+	test("never touches main workspaces", async () => {
+		const row = insertLocalWorkspace(ctx, {
+			projectId: PROJECT_ID,
+			worktreePath: join(TEST_DIR, "gone"),
+			branch: "feature",
+			name: "local",
+			type: "main",
+		});
+		const result = await repairMovedWorktree(ctx, row);
+		expect(result.worktreePath).toBe(join(TEST_DIR, "gone"));
+	});
+});
+
+describe("validateWorktreePathUpdate", () => {
+	let repoPath: string;
+	let ctx: MovedWorktreeContext;
+	let worktreePath: string;
+
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+		repoPath = createTestRepo();
+		ctx = createContext(repoPath);
+		worktreePath = join(TEST_DIR, "worktrees", "feature");
+		git(repoPath, `worktree add -b feature "${worktreePath}"`);
+	});
+
+	afterEach(() => {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	});
+
+	function row(overrides: Partial<Parameters<typeof insertLocalWorkspace>[1]>) {
+		return insertLocalWorkspace(ctx, {
+			projectId: PROJECT_ID,
+			worktreePath: join(TEST_DIR, "stale"),
+			branch: "feature",
+			name: "feature",
+			...overrides,
+		});
+	}
+
+	test("accepts a worktree of the project on the workspace branch", async () => {
+		const result = await validateWorktreePathUpdate(ctx, row({}), worktreePath);
+		expect(result).toEqual({ ok: true, worktreePath });
+	});
+
+	test("rejects a path that does not exist", async () => {
+		const result = await validateWorktreePathUpdate(
+			ctx,
+			row({}),
+			join(TEST_DIR, "nope"),
+		);
+		expect(result.ok).toBe(false);
+	});
+
+	test("rejects a directory that is not a worktree of the project", async () => {
+		const stray = join(TEST_DIR, "stray");
+		mkdirSync(stray);
+		const result = await validateWorktreePathUpdate(ctx, row({}), stray);
+		expect(result).toMatchObject({ ok: false });
+		if (!result.ok) expect(result.message).toContain("not a worktree");
+	});
+
+	test("rejects a worktree on a different branch", async () => {
+		const result = await validateWorktreePathUpdate(
+			ctx,
+			row({ branch: "other" }),
+			worktreePath,
+		);
+		expect(result).toMatchObject({ ok: false });
+		if (!result.ok) expect(result.message).toContain("branch feature");
+	});
+
+	test("rejects main workspaces", async () => {
+		const result = await validateWorktreePathUpdate(
+			ctx,
+			row({ type: "main", worktreePath: repoPath }),
+			worktreePath,
+		);
+		expect(result).toMatchObject({ ok: false });
+	});
+});

--- a/packages/host-service/src/workspaces/moved-worktree.ts
+++ b/packages/host-service/src/workspaces/moved-worktree.ts
@@ -1,0 +1,136 @@
+import { existsSync } from "node:fs";
+import { eq } from "drizzle-orm";
+import { projects } from "../db/schema";
+import { createGitEnvResolver } from "../runtime/git/git";
+import {
+	normalizeWorktreePath,
+	type WorktreeRecord,
+} from "../trpc/router/workspace-creation/shared/worktree-list";
+import type { HostServiceContext } from "../types";
+import { getHostWorkerPool } from "../workers/host-worker-pool";
+import { gitWorktreeListTask } from "../workers/tasks/git";
+import {
+	type HostWorkspaceRow,
+	updateLocalWorkspace,
+	type WorkspaceStoreContext,
+} from "./local-workspace-store";
+
+export type MovedWorktreeContext = WorkspaceStoreContext &
+	Pick<HostServiceContext, "credentials">;
+
+// Exported as a mutable object so tests can drive it with an in-process git
+// client instead of the worker pool.
+export const movedWorktreeGitOps = {
+	async listWorktrees(
+		ctx: MovedWorktreeContext,
+		repoPath: string,
+	): Promise<WorktreeRecord[]> {
+		const gitEnv = await createGitEnvResolver(ctx.credentials)(repoPath);
+		return getHostWorkerPool().run(
+			gitWorktreeListTask,
+			{ repoPath, gitEnv },
+			{ timeoutMs: 15_000 },
+		);
+	},
+};
+
+function getProjectRepoPath(
+	ctx: MovedWorktreeContext,
+	workspace: HostWorkspaceRow,
+): string | null {
+	if (!workspace.projectId) return null;
+	const project = ctx.db.query.projects
+		.findFirst({ where: eq(projects.id, workspace.projectId) })
+		.sync();
+	if (!project || !existsSync(project.repoPath)) return null;
+	return project.repoPath;
+}
+
+async function listWorktreesSafe(
+	ctx: MovedWorktreeContext,
+	repoPath: string,
+): Promise<WorktreeRecord[]> {
+	try {
+		return await movedWorktreeGitOps.listWorktrees(ctx, repoPath);
+	} catch (err) {
+		console.warn(`[workspace] git worktree list failed for ${repoPath}:`, err);
+		return [];
+	}
+}
+
+/**
+ * A workspace whose worktree was relocated with `git worktree move` keeps a
+ * stale `worktreePath` while git itself stays healthy. When the recorded
+ * path is gone, look the branch up in `git worktree list` for the project
+ * and re-point the row. Returns the (possibly repaired) row, or the original
+ * row when nothing could be repaired.
+ */
+export async function repairMovedWorktree(
+	ctx: MovedWorktreeContext,
+	workspace: HostWorkspaceRow,
+): Promise<HostWorkspaceRow> {
+	if (existsSync(workspace.worktreePath)) return workspace;
+	if (workspace.type !== "worktree" || !workspace.branch) return workspace;
+	const repoPath = getProjectRepoPath(ctx, workspace);
+	if (!repoPath) return workspace;
+
+	const stalePath = normalizeWorktreePath(workspace.worktreePath);
+	const match = (await listWorktreesSafe(ctx, repoPath)).find(
+		(wt) =>
+			!wt.bare &&
+			wt.branch === workspace.branch &&
+			normalizeWorktreePath(wt.path) !== stalePath &&
+			existsSync(wt.path),
+	);
+	if (!match) return workspace;
+
+	console.warn(
+		`[workspace] worktree for ${workspace.id} (${workspace.branch}) moved: ${workspace.worktreePath} -> ${match.path}; repairing stored path`,
+	);
+	return (
+		updateLocalWorkspace(ctx, workspace.id, { worktreePath: match.path }) ??
+		workspace
+	);
+}
+
+export type WorktreePathValidation =
+	| { ok: true; worktreePath: string }
+	| { ok: false; message: string };
+
+/** Validate a caller-supplied path before re-pointing a workspace at it. */
+export async function validateWorktreePathUpdate(
+	ctx: MovedWorktreeContext,
+	workspace: HostWorkspaceRow,
+	requestedPath: string,
+): Promise<WorktreePathValidation> {
+	if (workspace.type !== "worktree") {
+		return {
+			ok: false,
+			message: "Only worktree workspaces can be re-pointed",
+		};
+	}
+	const worktreePath = normalizeWorktreePath(requestedPath);
+	if (!existsSync(worktreePath)) {
+		return { ok: false, message: `Path does not exist: ${worktreePath}` };
+	}
+	const repoPath = getProjectRepoPath(ctx, workspace);
+	if (!repoPath) {
+		return { ok: false, message: "Workspace project repository not found" };
+	}
+	const record = (await listWorktreesSafe(ctx, repoPath)).find(
+		(wt) => normalizeWorktreePath(wt.path) === worktreePath,
+	);
+	if (!record) {
+		return {
+			ok: false,
+			message: `${worktreePath} is not a worktree of ${repoPath}`,
+		};
+	}
+	if (record.branch !== workspace.branch) {
+		return {
+			ok: false,
+			message: `${worktreePath} is on branch ${record.branch ?? "(detached)"}, but the workspace is on ${workspace.branch}`,
+		};
+	}
+	return { ok: true, worktreePath };
+}

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -259,6 +259,11 @@ export interface WorkspaceUpdateParams {
 	name?: string;
 	/** Link the workspace to a task by id, or pass `null` to unlink. */
 	taskId?: string | null;
+	/**
+	 * Re-point the workspace at a worktree that was moved on disk. Must be a
+	 * worktree of the project on the workspace's branch.
+	 */
+	worktreePath?: string;
 }
 
 export interface WorkspaceUpdateResult {


### PR DESCRIPTION
## Problem

A workspace record pins its worktree by absolute path. After `git worktree move` (a supported git operation) git stays healthy but Superset's copy of the path goes stale: `workspaces get` reports `worktreeExists: false`, terminals fail with `WORKTREE_GONE`, and nothing in `workspaces update` could re-point it. The only recoveries were moving the worktree back or deleting and recreating the workspace (losing task links and terminal history).

## Fix

- **Auto repair on open.** `workspace.get` (what the desktop workspace page and `workspaces get` hit) now calls `repairMovedWorktree`: when the stored path no longer exists and the row is a `worktree` workspace, it lists the project's worktrees via a new off-loop `git/listWorktrees` worker task (built on the shared `parseWorktreeList`), finds the one on the workspace's branch, updates the row, and logs a warning.
- **Explicit repair.** `workspace.update` accepts `worktreePath`; the path must exist, be a worktree of the project's repo, and be on the workspace's branch (main workspaces are rejected). Surfaced as `superset workspaces update <id> --worktree-path <path>`, in the SDK `WorkspaceUpdateParams`, and in the CLI reference docs.

## Verified

- `packages/host-service/src/workspaces/moved-worktree.test.ts`: real temp repo + `git worktree add` / `move` / `remove`; 9 cases covering repair, no-op when present, no-op when removed, main workspaces untouched, and each validation rejection. The repair case fails when the repair is disabled.
- `bun run typecheck` in host-service, cli, sdk.
- `no-main-loop-blocking.test.ts` passes (git runs in the worker pool, no new `ctx.git` sites).
- `bun test src/workers`, `src/commands/workspaces` pass.

Not in this PR: the terminal-create path still checks `existsSync` directly (it repairs once the workspace has been fetched), and the two secondary findings in the issue thread (cleanup skipping `git worktree remove` on a stale path; recreate hard-deleting the old row) are left for follow-ups.

Fixes #6791

https://claude.ai/code/session_011XQusXtWEwq2nxN4jfMUpv


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs workspaces whose Git worktree was moved so they open normally and terminals stop failing. Previously, moving a worktree left the workspace pinned to a stale absolute path; now we auto-repair on fetch/open and allow explicit re-pointing.

- Auto repair on fetch/open: `workspace.get` in `host-service` lists project worktrees via the off-loop `git/listWorktrees` task, finds the matching branch, and updates the stored `worktreePath` (logs a warning; main workspaces are untouched).
- Explicit repair: `workspace.update` accepts `worktreePath`; surfaced as `superset workspaces update <id> --worktree-path <path>` in `cli` and `WorkspaceUpdateParams.worktreePath` in `sdk`. Validates that the path exists, is a worktree of the project, and matches the workspace branch.
- Docs/tests: CLI reference updated; added `moved-worktree.test.ts` covering repair, no-ops, and all validation rejections. Git runs in the worker pool, avoiding main-loop blocking.

<sup>Written for commit 0006665df11b0f78112687b0833aa7fb476c36b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--worktree-path` option to update a workspace’s project worktree location.
  * Automatically repairs workspace paths after a Git worktree is moved, when the branch can be matched.
  * Validates that the specified path exists, belongs to the project, and matches the workspace branch.

* **Bug Fixes**
  * Improved workspace retrieval to recover from relocated worktrees while preserving valid workspace records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->