### PR TITLE
fix(billing): surface what a failed payment costs, and stop offering annual to monthly subscribers

### DIFF
--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -3,7 +3,15 @@ import { useNavigate } from "@tanstack/react-router";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { SidebarCardEntry } from "../../types";
+
+function formatAmount(amount: number, currency: string) {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: currency.toUpperCase(),
+	}).format(amount / 100);
+}
 
 /**
  * Stripe keeps retrying for ~14 days before canceling, and access continues
@@ -26,6 +34,13 @@ export function usePaymentFailedCard({
 		{ includeDeactivated: false },
 		{ enabled: isFailing },
 	);
+	// The amount is the whole point of the card: "a payment failed" without it
+	// sends people hunting for a number the app never shows them.
+	const { data: outstandingInvoice } =
+		cloudTrpc.billing.outstandingInvoice.useQuery(undefined, {
+			enabled: isFailing,
+		});
+	const openUrl = electronTrpc.external.openUrl.useMutation();
 	const navigate = useNavigate();
 
 	if (!isFailing) return null;
@@ -35,17 +50,37 @@ export function usePaymentFailedCard({
 	const isOwner =
 		members?.find((m) => m.userId === session?.user?.id)?.role === "owner";
 
+	const amount = outstandingInvoice
+		? formatAmount(outstandingInvoice.amountDue, outstandingInvoice.currency)
+		: null;
+	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
+
+	const ownerDescription = amount
+		? `We couldn't charge your payment method for ${amount}. Pay it to keep your plan.`
+		: "We couldn't charge your payment method. Update it to keep your plan.";
+	const memberDescription = amount
+		? `We couldn't charge this organization's payment method for ${amount}. Ask an owner to update it.`
+		: "We couldn't charge this organization's payment method. Ask an owner to update it.";
+
 	return {
 		id: "payment-failed",
 		badge: "Action needed",
-		title: "Payment failed",
-		description: isOwner
-			? "We couldn't charge your payment method. Update it to keep your plan."
-			: "We couldn't charge this organization's payment method. Ask an owner to update it.",
-		actionLabel: isOwner ? "Update payment method" : undefined,
+		title: amount ? `Payment failed — ${amount} due` : "Payment failed",
+		description: isOwner ? ownerDescription : memberDescription,
+		actionLabel: isOwner
+			? hostedInvoiceUrl
+				? "Pay now"
+				: "Update payment method"
+			: undefined,
 		onAction: isOwner
 			? () => {
 					track("payment_failed_banner_clicked", { surface });
+					// Straight to the invoice when we have one — the billing portal
+					// is several clicks from the same place.
+					if (hostedInvoiceUrl) {
+						openUrl.mutate(hostedInvoiceUrl);
+						return;
+					}
 					navigate({ to: "/settings/billing" });
 				}
 			: undefined,

--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -84,7 +84,7 @@ export function usePaymentFailedCard({
 					navigate({ to: "/settings/billing" });
 				}
 			: undefined,
-		className: "border-destructive/50",
+		className: "border-warning/50",
 		onShown: () => track("payment_failed_banner_shown", { surface, isOwner }),
 	};
 }

--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -56,7 +56,7 @@ export function usePaymentFailedCard({
 	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
 
 	const ownerDescription = amount
-		? `We couldn't charge your payment method for ${amount}. Pay it to keep your plan.`
+		? `We couldn't charge ${amount}. Update your payment method to keep your plan.`
 		: "We couldn't charge your payment method. Update it to keep your plan.";
 	const memberDescription = amount
 		? `We couldn't charge this organization's payment method for ${amount}. Ask an owner to update it.`
@@ -84,7 +84,7 @@ export function usePaymentFailedCard({
 					navigate({ to: "/settings/billing" });
 				}
 			: undefined,
-		className: "border-amber-500/50",
+		className: "border-destructive/50",
 		onShown: () => track("payment_failed_banner_shown", { surface, isOwner }),
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -1,3 +1,4 @@
+import { isPaymentFailingStatus } from "@superset/shared/billing";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Link } from "@tanstack/react-router";
@@ -8,6 +9,7 @@ import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId"
 import { resolveCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import {
@@ -60,12 +62,18 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 		subscriptionsLoaded: activePlan !== undefined,
 	});
 
-	const { data: membersData } =
-		cloudTrpc.organization.listMembers.useQuery(undefined);
 	// Seats are billed from this — never derive it from an unresolved query.
-	// undefined (not 0) keeps the upgrade action disabled until it loads.
+	// undefined (not 0) keeps the upgrade action disabled until it loads. It is
+	// the same list rendered above, which excludes members pending deletion, so
+	// checkout bills exactly the seats the organization can see.
 	const memberCount =
-		membersData && membersData.length > 0 ? membersData.length : undefined;
+		members && members.length > 0 ? members.length : undefined;
+
+	const { data: outstandingInvoice } =
+		cloudTrpc.billing.outstandingInvoice.useQuery(undefined, {
+			enabled: isPaymentFailingStatus(activePlan?.status),
+		});
+	const openUrl = electronTrpc.external.openUrl.useMutation();
 
 	const showOverview = isItemVisible(
 		SETTING_ITEM_ID.BILLING_OVERVIEW,
@@ -178,6 +186,8 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 								cancelAt={activePlan?.cancelAt}
 								periodEnd={activePlan?.periodEnd}
 								status={activePlan?.status}
+								outstandingInvoice={outstandingInvoice}
+								onPayInvoice={(url) => openUrl.mutate(url)}
 							/>
 							{plan === "free" && (
 								<UpgradeCard

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -185,6 +185,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 					<PaymentFailedBanner
 						amountDue={amountDue}
 						hostedInvoiceUrl={outstandingInvoice?.hostedInvoiceUrl ?? null}
+						isOwner={isOwner}
 						onPayInvoice={(url) => openUrl.mutate(url)}
 					/>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -20,6 +20,7 @@ import {
 import type { PlanTier } from "../../constants";
 import { BillingDetails } from "./components/BillingDetails";
 import { CurrentPlanCard } from "./components/CurrentPlanCard";
+import { PaymentFailedBanner } from "./components/PaymentFailedBanner";
 import { RecentInvoices } from "./components/RecentInvoices";
 import { UpgradeCard } from "./components/UpgradeCard";
 
@@ -69,11 +70,18 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 	const memberCount =
 		members && members.length > 0 ? members.length : undefined;
 
+	const isPaymentFailing = isPaymentFailingStatus(activePlan?.status);
 	const { data: outstandingInvoice } =
 		cloudTrpc.billing.outstandingInvoice.useQuery(undefined, {
-			enabled: isPaymentFailingStatus(activePlan?.status),
+			enabled: isPaymentFailing,
 		});
 	const openUrl = electronTrpc.external.openUrl.useMutation();
+	const amountDue = outstandingInvoice
+		? new Intl.NumberFormat("en-US", {
+				style: "currency",
+				currency: outstandingInvoice.currency.toUpperCase(),
+			}).format(outstandingInvoice.amountDue / 100)
+		: null;
 
 	const showOverview = isItemVisible(
 		SETTING_ITEM_ID.BILLING_OVERVIEW,
@@ -173,6 +181,13 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 			</div>
 
 			<div className="space-y-6">
+				{isPaymentFailing && (
+					<PaymentFailedBanner
+						amountDue={amountDue}
+						hostedInvoiceUrl={outstandingInvoice?.hostedInvoiceUrl ?? null}
+						onPayInvoice={(url) => openUrl.mutate(url)}
+					/>
+				)}
 				{showOverview && (
 					<div>
 						<h3 className="text-sm font-medium mb-2">Plan</h3>
@@ -186,8 +201,6 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 								cancelAt={activePlan?.cancelAt}
 								periodEnd={activePlan?.periodEnd}
 								status={activePlan?.status}
-								outstandingInvoice={outstandingInvoice}
-								onPayInvoice={(url) => openUrl.mutate(url)}
 							/>
 							{plan === "free" && (
 								<UpgradeCard

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -4,6 +4,12 @@ import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
 import { PLANS, type PlanTier } from "../../../../constants";
 
+interface OutstandingInvoice {
+	amountDue: number;
+	currency: string;
+	hostedInvoiceUrl: string | null | undefined;
+}
+
 interface CurrentPlanCardProps {
 	currentPlan: PlanTier;
 	onCancel?: () => void;
@@ -13,6 +19,15 @@ interface CurrentPlanCardProps {
 	cancelAt?: Date | null;
 	periodEnd?: Date | null;
 	status?: string | null;
+	outstandingInvoice?: OutstandingInvoice | null;
+	onPayInvoice?: (hostedInvoiceUrl: string) => void;
+}
+
+function formatAmount(amount: number, currency: string) {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: currency.toUpperCase(),
+	}).format(amount / 100);
 }
 
 export function CurrentPlanCard({
@@ -24,6 +39,8 @@ export function CurrentPlanCard({
 	cancelAt,
 	periodEnd,
 	status,
+	outstandingInvoice,
+	onPayInvoice,
 }: CurrentPlanCardProps) {
 	const plan = PLANS[currentPlan];
 	const isPaidPlan = currentPlan !== "free";
@@ -31,8 +48,17 @@ export function CurrentPlanCard({
 	const isCancelingAtPeriodEnd = isPaidPlan && !isEnterprise && !!cancelAt;
 	const isPaymentFailing = isPaidPlan && isPaymentFailingStatus(status);
 
+	const amountDue = outstandingInvoice
+		? formatAmount(outstandingInvoice.amountDue, outstandingInvoice.currency)
+		: null;
+	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
+
+	const paymentFailedHint = amountDue
+		? `Payment failed — ${amountDue} is due. Pay it to keep this plan.`
+		: "Payment failed — update your payment method to keep this plan.";
+
 	const hint = isPaymentFailing
-		? "Payment failed — update your payment method to keep this plan."
+		? paymentFailedHint
 		: isCancelingAtPeriodEnd && cancelAt
 			? `Cancels ${format(new Date(cancelAt), "MMMM d, yyyy")} — downgrades to Free at the end of the billing period.`
 			: isEnterprise
@@ -53,7 +79,7 @@ export function CurrentPlanCard({
 					)}
 					{isPaymentFailing && (
 						<span className="inline-flex items-center rounded-md bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
-							Payment failed
+							{amountDue ? `Payment failed — ${amountDue}` : "Payment failed"}
 						</span>
 					)}
 				</div>
@@ -67,7 +93,17 @@ export function CurrentPlanCard({
 				</div>
 			</div>
 			{isPaidPlan && !isEnterprise && (
-				<div className="shrink-0">
+				<div className="flex shrink-0 items-center gap-1">
+					{isPaymentFailing && hostedInvoiceUrl && onPayInvoice && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onPayInvoice(hostedInvoiceUrl)}
+							className="text-amber-500 hover:text-amber-500"
+						>
+							Pay now
+						</Button>
+					)}
 					{isCancelingAtPeriodEnd ? (
 						<Button
 							variant="ghost"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -1,4 +1,5 @@
 import { isPaymentFailingStatus } from "@superset/shared/billing";
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
@@ -53,9 +54,11 @@ export function CurrentPlanCard({
 		: null;
 	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
 
+	// The badge already says "Payment failed"; the hint adds the amount and the
+	// consequence, and leaves the action to the button next to it.
 	const paymentFailedHint = amountDue
-		? `Payment failed — ${amountDue} is due. Pay it to keep this plan.`
-		: "Payment failed — update your payment method to keep this plan.";
+		? `We couldn't charge ${amountDue}. Update your payment method to keep this plan.`
+		: "Update your payment method to keep this plan.";
 
 	const hint = isPaymentFailing
 		? paymentFailedHint
@@ -78,15 +81,18 @@ export function CurrentPlanCard({
 						</span>
 					)}
 					{isPaymentFailing && (
-						<span className="inline-flex items-center rounded-md bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
-							{amountDue ? `Payment failed — ${amountDue}` : "Payment failed"}
-						</span>
+						<Badge
+							variant="outline"
+							className="border-destructive/30 bg-destructive/10 text-destructive"
+						>
+							Payment failed
+						</Badge>
 					)}
 				</div>
 				<div
 					className={cn(
 						"text-xs mt-0.5",
-						isPaymentFailing ? "text-amber-500" : "text-muted-foreground",
+						isPaymentFailing ? "text-destructive" : "text-muted-foreground",
 					)}
 				>
 					{hint}
@@ -99,7 +105,7 @@ export function CurrentPlanCard({
 							variant="ghost"
 							size="sm"
 							onClick={() => onPayInvoice(hostedInvoiceUrl)}
-							className="text-amber-500 hover:text-amber-500"
+							className="text-destructive hover:bg-destructive/10 hover:text-destructive"
 						>
 							Pay now
 						</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -1,15 +1,7 @@
 import { isPaymentFailingStatus } from "@superset/shared/billing";
-import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
-import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
 import { PLANS, type PlanTier } from "../../../../constants";
-
-interface OutstandingInvoice {
-	amountDue: number;
-	currency: string;
-	hostedInvoiceUrl: string | null | undefined;
-}
 
 interface CurrentPlanCardProps {
 	currentPlan: PlanTier;
@@ -20,15 +12,6 @@ interface CurrentPlanCardProps {
 	cancelAt?: Date | null;
 	periodEnd?: Date | null;
 	status?: string | null;
-	outstandingInvoice?: OutstandingInvoice | null;
-	onPayInvoice?: (hostedInvoiceUrl: string) => void;
-}
-
-function formatAmount(amount: number, currency: string) {
-	return new Intl.NumberFormat("en-US", {
-		style: "currency",
-		currency: currency.toUpperCase(),
-	}).format(amount / 100);
 }
 
 export function CurrentPlanCard({
@@ -40,8 +23,6 @@ export function CurrentPlanCard({
 	cancelAt,
 	periodEnd,
 	status,
-	outstandingInvoice,
-	onPayInvoice,
 }: CurrentPlanCardProps) {
 	const plan = PLANS[currentPlan];
 	const isPaidPlan = currentPlan !== "free";
@@ -49,19 +30,10 @@ export function CurrentPlanCard({
 	const isCancelingAtPeriodEnd = isPaidPlan && !isEnterprise && !!cancelAt;
 	const isPaymentFailing = isPaidPlan && isPaymentFailingStatus(status);
 
-	const amountDue = outstandingInvoice
-		? formatAmount(outstandingInvoice.amountDue, outstandingInvoice.currency)
-		: null;
-	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
-
-	// The badge already says "Payment failed"; the hint adds the amount and the
-	// consequence, and leaves the action to the button next to it.
-	const paymentFailedHint = amountDue
-		? `We couldn't charge ${amountDue}. Update your payment method to keep this plan.`
-		: "Update your payment method to keep this plan.";
-
+	// While collection is failing, the period end is not a renewal we can
+	// promise, so this row says nothing about it — the banner above covers it.
 	const hint = isPaymentFailing
-		? paymentFailedHint
+		? null
 		: isCancelingAtPeriodEnd && cancelAt
 			? `Cancels ${format(new Date(cancelAt), "MMMM d, yyyy")} — downgrades to Free at the end of the billing period.`
 			: isEnterprise
@@ -80,36 +52,13 @@ export function CurrentPlanCard({
 							{plan.name}
 						</span>
 					)}
-					{isPaymentFailing && (
-						<Badge
-							variant="outline"
-							className="border-warning/30 bg-warning/10 text-warning"
-						>
-							Payment failed
-						</Badge>
-					)}
 				</div>
-				<div
-					className={cn(
-						"text-xs mt-0.5",
-						isPaymentFailing ? "text-warning" : "text-muted-foreground",
-					)}
-				>
-					{hint}
-				</div>
+				{hint && (
+					<div className="text-xs mt-0.5 text-muted-foreground">{hint}</div>
+				)}
 			</div>
 			{isPaidPlan && !isEnterprise && (
-				<div className="flex shrink-0 items-center gap-1">
-					{isPaymentFailing && hostedInvoiceUrl && onPayInvoice && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onPayInvoice(hostedInvoiceUrl)}
-							className="text-warning hover:bg-warning/10 hover:text-warning"
-						>
-							Pay now
-						</Button>
-					)}
+				<div className="shrink-0">
 					{isCancelingAtPeriodEnd ? (
 						<Button
 							variant="ghost"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -83,7 +83,7 @@ export function CurrentPlanCard({
 					{isPaymentFailing && (
 						<Badge
 							variant="outline"
-							className="border-destructive/30 bg-destructive/10 text-destructive"
+							className="border-warning/30 bg-warning/10 text-warning"
 						>
 							Payment failed
 						</Badge>
@@ -92,7 +92,7 @@ export function CurrentPlanCard({
 				<div
 					className={cn(
 						"text-xs mt-0.5",
-						isPaymentFailing ? "text-destructive" : "text-muted-foreground",
+						isPaymentFailing ? "text-warning" : "text-muted-foreground",
 					)}
 				>
 					{hint}
@@ -105,7 +105,7 @@ export function CurrentPlanCard({
 							variant="ghost"
 							size="sm"
 							onClick={() => onPayInvoice(hostedInvoiceUrl)}
-							className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+							className="text-warning hover:bg-warning/10 hover:text-warning"
 						>
 							Pay now
 						</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -30,17 +30,20 @@ export function CurrentPlanCard({
 	const isCancelingAtPeriodEnd = isPaidPlan && !isEnterprise && !!cancelAt;
 	const isPaymentFailing = isPaidPlan && isPaymentFailingStatus(status);
 
-	// While collection is failing, the period end is not a renewal we can
-	// promise, so this row says nothing about it — the banner above covers it.
-	const hint = isPaymentFailing
-		? null
-		: isCancelingAtPeriodEnd && cancelAt
-			? `Cancels ${format(new Date(cancelAt), "MMMM d, yyyy")} — downgrades to Free at the end of the billing period.`
-			: isEnterprise
-				? "Managed by your organization admin."
-				: isPaidPlan && periodEnd
-					? `Renews ${format(new Date(periodEnd), "MMMM d, yyyy")}.`
-					: `${plan.description}.`;
+	// While collection is failing the period end is not a renewal we can
+	// promise, so this row drops that line — the banner above covers it. A
+	// scheduled cancellation still shows: the banner never mentions it, and it
+	// is the date the organization actually loses access.
+	const hint =
+		isPaymentFailing && !isCancelingAtPeriodEnd
+			? null
+			: isCancelingAtPeriodEnd && cancelAt
+				? `Cancels ${format(new Date(cancelAt), "MMMM d, yyyy")} — downgrades to Free at the end of the billing period.`
+				: isEnterprise
+					? "Managed by your organization admin."
+					: isPaidPlan && periodEnd
+						? `Renews ${format(new Date(periodEnd), "MMMM d, yyyy")}.`
+						: `${plan.description}.`;
 
 	return (
 		<div className="flex items-center justify-between gap-8 py-3">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/PaymentFailedBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/PaymentFailedBanner.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { LuTriangleAlert } from "react-icons/lu";
+
+interface PaymentFailedBannerProps {
+	amountDue: string | null;
+	hostedInvoiceUrl: string | null;
+	onPayInvoice?: (hostedInvoiceUrl: string) => void;
+	className?: string;
+}
+
+/**
+ * A failed charge is a problem with the account, not with any one row, so it
+ * gets the page's alert slot rather than a chip beside the plan name. Matches
+ * RelayOfflineNotice, the established banner in the app.
+ */
+export function PaymentFailedBanner({
+	amountDue,
+	hostedInvoiceUrl,
+	onPayInvoice,
+	className,
+}: PaymentFailedBannerProps) {
+	return (
+		<div
+			className={cn(
+				"flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs leading-relaxed text-foreground/85 select-text cursor-text",
+				className,
+			)}
+		>
+			<div className="flex min-w-[240px] flex-1 items-start gap-2">
+				<LuTriangleAlert
+					className="mt-0.5 size-3.5 shrink-0 text-warning"
+					aria-hidden="true"
+				/>
+				<span>
+					<span className="font-medium">Payment failed.</span>{" "}
+					{amountDue
+						? `We couldn't charge ${amountDue}. Update your payment method to keep this plan.`
+						: "We couldn't charge your payment method. Update it to keep this plan."}
+				</span>
+			</div>
+			{hostedInvoiceUrl && onPayInvoice && (
+				<Button
+					variant="outline"
+					size="sm"
+					className="ml-auto h-7 shrink-0 border-warning/40 bg-warning/10 px-2.5 text-xs text-warning hover:bg-warning/20"
+					onClick={() => onPayInvoice(hostedInvoiceUrl)}
+				>
+					Pay now
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/PaymentFailedBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/PaymentFailedBanner.tsx
@@ -5,6 +5,7 @@ import { LuTriangleAlert } from "react-icons/lu";
 interface PaymentFailedBannerProps {
 	amountDue: string | null;
 	hostedInvoiceUrl: string | null;
+	isOwner: boolean;
 	onPayInvoice?: (hostedInvoiceUrl: string) => void;
 	className?: string;
 }
@@ -17,9 +18,19 @@ interface PaymentFailedBannerProps {
 export function PaymentFailedBanner({
 	amountDue,
 	hostedInvoiceUrl,
+	isOwner,
 	onPayInvoice,
 	className,
 }: PaymentFailedBannerProps) {
+	// Same split as the sidebar card: only owners can act, so only owners are
+	// told to. Non-owners get the amount without a dead-end button.
+	const message = isOwner
+		? amountDue
+			? `We couldn't charge ${amountDue}. Update your payment method to keep this plan.`
+			: "We couldn't charge your payment method. Update it to keep this plan."
+		: amountDue
+			? `We couldn't charge this organization's payment method for ${amountDue}. Ask an owner to update it.`
+			: "We couldn't charge this organization's payment method. Ask an owner to update it.";
 	return (
 		<div
 			className={cn(
@@ -33,13 +44,10 @@ export function PaymentFailedBanner({
 					aria-hidden="true"
 				/>
 				<span>
-					<span className="font-medium">Payment failed.</span>{" "}
-					{amountDue
-						? `We couldn't charge ${amountDue}. Update your payment method to keep this plan.`
-						: "We couldn't charge your payment method. Update it to keep this plan."}
+					<span className="font-medium">Payment failed.</span> {message}
 				</span>
 			</div>
-			{hostedInvoiceUrl && onPayInvoice && (
+			{isOwner && hostedInvoiceUrl && onPayInvoice && (
 				<Button
 					variant="outline"
 					size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/PaymentFailedBanner/index.ts
@@ -1,0 +1,1 @@
+export { PaymentFailedBanner } from "./PaymentFailedBanner";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
@@ -1,16 +1,9 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
-import { useEffect, useState } from "react";
 import { HiArrowTopRightOnSquare } from "react-icons/hi2";
-import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-
-interface Invoice {
-	id: string;
-	date: number;
-	amount: number;
-	currency: string;
-	hostedInvoiceUrl: string | null | undefined;
-}
 
 function formatAmount(amount: number, currency: string) {
 	return new Intl.NumberFormat("en-US", {
@@ -23,20 +16,18 @@ function formatDate(timestamp: number) {
 	return format(new Date(timestamp * 1000), "MMM d, yyyy");
 }
 
+const UNPAID_LABEL: Record<string, string> = {
+	open: "Unpaid",
+	uncollectible: "Unpaid",
+};
+
 export function RecentInvoices() {
-	const [invoices, setInvoices] = useState<Invoice[]>([]);
+	// cloudTrpc, not the imperative client: it sends this window's organization
+	// header, so the list belongs to the organization on screen.
+	const { data: invoices } = cloudTrpc.billing.invoices.useQuery(undefined);
 	const openUrl = electronTrpc.external.openUrl.useMutation();
 
-	useEffect(() => {
-		apiTrpcClient.billing.invoices
-			.query()
-			.then(setInvoices)
-			.catch(() => {
-				// Silently handle errors — invoices are non-critical
-			});
-	}, []);
-
-	if (invoices.length === 0) {
+	if (!invoices || invoices.length === 0) {
 		return null;
 	}
 
@@ -53,21 +44,48 @@ export function RecentInvoices() {
 							<span className="text-muted-foreground tabular-nums">
 								{formatDate(invoice.date)}
 							</span>
-							<span className="tabular-nums">
-								{formatAmount(invoice.amount, invoice.currency)}
+							<span
+								className={cn(
+									"tabular-nums",
+									invoice.isUnpaid && "text-amber-500 font-medium",
+								)}
+							>
+								{formatAmount(
+									invoice.isUnpaid ? invoice.amountDue : invoice.amountPaid,
+									invoice.currency,
+								)}
 							</span>
+							{invoice.isUnpaid && (
+								<span className="inline-flex items-center rounded-md bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
+									{UNPAID_LABEL[invoice.status ?? ""] ?? "Unpaid"}
+								</span>
+							)}
 						</div>
 						{invoice.hostedInvoiceUrl ? (
-							<button
-								type="button"
-								onClick={() =>
-									openUrl.mutate(invoice.hostedInvoiceUrl as string)
-								}
-								className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-							>
-								View
-								<HiArrowTopRightOnSquare className="h-3 w-3" />
-							</button>
+							invoice.isUnpaid ? (
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() =>
+										openUrl.mutate(invoice.hostedInvoiceUrl as string)
+									}
+									className="text-amber-500 hover:text-amber-500"
+								>
+									Pay now
+									<HiArrowTopRightOnSquare className="h-3 w-3" />
+								</Button>
+							) : (
+								<button
+									type="button"
+									onClick={() =>
+										openUrl.mutate(invoice.hostedInvoiceUrl as string)
+									}
+									className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+								>
+									View
+									<HiArrowTopRightOnSquare className="h-3 w-3" />
+								</button>
+							)
 						) : null}
 					</div>
 				))}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@superset/ui/button";
+import { Badge } from "@superset/ui/badge";
 import { cn } from "@superset/ui/utils";
 import { format } from "date-fns";
 import { HiArrowTopRightOnSquare } from "react-icons/hi2";
@@ -18,7 +18,7 @@ function formatDate(timestamp: number) {
 
 const UNPAID_LABEL: Record<string, string> = {
 	open: "Unpaid",
-	uncollectible: "Unpaid",
+	uncollectible: "Uncollectible",
 };
 
 export function RecentInvoices() {
@@ -47,7 +47,7 @@ export function RecentInvoices() {
 							<span
 								className={cn(
 									"tabular-nums",
-									invoice.isUnpaid && "text-amber-500 font-medium",
+									invoice.isUnpaid && "font-medium",
 								)}
 							>
 								{formatAmount(
@@ -56,36 +56,30 @@ export function RecentInvoices() {
 								)}
 							</span>
 							{invoice.isUnpaid && (
-								<span className="inline-flex items-center rounded-md bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
+								<Badge
+									variant="outline"
+									className="border-destructive/30 bg-destructive/10 text-destructive"
+								>
 									{UNPAID_LABEL[invoice.status ?? ""] ?? "Unpaid"}
-								</span>
+								</Badge>
 							)}
 						</div>
 						{invoice.hostedInvoiceUrl ? (
-							invoice.isUnpaid ? (
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() =>
-										openUrl.mutate(invoice.hostedInvoiceUrl as string)
-									}
-									className="text-amber-500 hover:text-amber-500"
-								>
-									Pay now
-									<HiArrowTopRightOnSquare className="h-3 w-3" />
-								</Button>
-							) : (
-								<button
-									type="button"
-									onClick={() =>
-										openUrl.mutate(invoice.hostedInvoiceUrl as string)
-									}
-									className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-								>
-									View
-									<HiArrowTopRightOnSquare className="h-3 w-3" />
-								</button>
-							)
+							<button
+								type="button"
+								onClick={() =>
+									openUrl.mutate(invoice.hostedInvoiceUrl as string)
+								}
+								className={cn(
+									"flex items-center gap-1 text-xs",
+									invoice.isUnpaid
+										? "text-destructive hover:text-destructive/80"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+							>
+								{invoice.isUnpaid ? "Pay now" : "View"}
+								<HiArrowTopRightOnSquare className="h-3 w-3" />
+							</button>
 						) : null}
 					</div>
 				))}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
@@ -58,7 +58,7 @@ export function RecentInvoices() {
 							{invoice.isUnpaid && (
 								<Badge
 									variant="outline"
-									className="border-destructive/30 bg-destructive/10 text-destructive"
+									className="border-warning/30 bg-warning/10 text-warning"
 								>
 									{UNPAID_LABEL[invoice.status ?? ""] ?? "Unpaid"}
 								</Badge>
@@ -73,7 +73,7 @@ export function RecentInvoices() {
 								className={cn(
 									"flex items-center gap-1 text-xs",
 									invoice.isUnpaid
-										? "text-destructive hover:text-destructive/80"
+										? "text-warning hover:text-warning/80"
 										: "text-muted-foreground hover:text-foreground",
 								)}
 							>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -208,8 +208,39 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 	},
 ];
 
+/**
+ * Whether the subscription bills yearly, or null when there is nothing to read
+ * it from — no subscription yet, or a row predating `billingInterval`, where
+ * the period length is the only signal.
+ */
+function resolveSubscriptionIsYearly(activePlan: {
+	billingInterval?: string | null;
+	periodStart?: Date | null;
+	periodEnd?: Date | null;
+}): boolean | null {
+	const interval = activePlan.billingInterval;
+	if (interval === "year" || interval === "yearly") return true;
+	if (interval === "month" || interval === "monthly") return false;
+
+	if (activePlan.periodStart && activePlan.periodEnd) {
+		return (
+			differenceInDays(
+				new Date(activePlan.periodEnd),
+				new Date(activePlan.periodStart),
+			) > 60
+		);
+	}
+
+	return null;
+}
+
 function PlansPage() {
-	const [isYearly, setIsYearly] = useState(true);
+	// Seeded from the subscription, not hardcoded: showing Annual to a monthly
+	// subscriber turned the Pro column's "Current plan" into a live
+	// "Change to Annual" that bills a year up front. A manual toggle wins from
+	// then on, and Annual stays the default for free and enterprise, which have
+	// no interval to read.
+	const [manualIsYearly, setManualIsYearly] = useState<boolean | null>(null);
 	const [isUpgrading, setIsUpgrading] = useState(false);
 	const [isCanceling, setIsCanceling] = useState(false);
 	const [isRestoring, setIsRestoring] = useState(false);
@@ -234,15 +265,17 @@ function PlansPage() {
 	});
 	const cancelAt = activePlan?.cancelAt;
 
-	const isCurrentlyYearly =
-		activePlan?.periodStart &&
-		activePlan?.periodEnd &&
-		differenceInDays(
-			new Date(activePlan.periodEnd),
-			new Date(activePlan.periodStart),
-		) > 60;
+	const subscriptionIsYearly = activePlan
+		? resolveSubscriptionIsYearly(activePlan)
+		: null;
+	const isYearly = manualIsYearly ?? subscriptionIsYearly ?? true;
+	const setIsYearly = setManualIsYearly;
 
-	const { data: membersData } = cloudTrpc.organization.listMembers.useQuery(undefined);
+	// Explicit, not defaulted: this list is what checkout bills, and it must be
+	// the same definition of a seat the subscription hooks use.
+	const { data: membersData } = cloudTrpc.organization.listMembers.useQuery({
+		includeDeactivated: false,
+	});
 	// Seats are billed from this — never derive it from an unresolved query.
 	const memberCount =
 		membersData && membersData.length > 0 ? membersData.length : undefined;
@@ -447,8 +480,10 @@ function PlansPage() {
 									} else if (isCurrent && plan.id === "pro") {
 										// Before the plan resolves the billing interval is unknown,
 										// so an interval-change action here would be a guess the
-										// user can act on. Hold at "Current plan" until it lands.
-										const intervalMatches = isYearly === !!isCurrentlyYearly;
+										// user can act on. Hold at "Current plan" until it lands — and
+										// equally when the row carries no readable interval.
+										const intervalMatches =
+											subscriptionIsYearly === null || isYearly === subscriptionIsYearly;
 										if (!planResolved || intervalMatches) {
 											planActions = [
 												{

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -43,7 +43,13 @@ import {
 	type SessionOrganizationContext,
 } from "./lib/resolve-session-organization-state";
 import { stripeClient } from "./stripe";
-import { formatPrice, getOrganizationOwners } from "./utils";
+import {
+	countBillableSeats,
+	formatPrice,
+	getOrganizationBillingRecipients,
+	getOrganizationOwners,
+} from "./utils";
+import { previewNextInvoice } from "./utils/invoice-preview";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN });
 
@@ -641,12 +647,7 @@ export const auth = betterAuth({
 
 					if (subscription) return;
 
-					const memberCount = await db
-						.select({ count: count() })
-						.from(members)
-						.where(eq(members.organizationId, organization.id));
-
-					const currentCount = memberCount[0]?.count ?? 0;
+					const currentCount = await countBillableSeats(organization.id);
 
 					if (currentCount >= 1) {
 						throw new Error(
@@ -714,12 +715,10 @@ export const auth = betterAuth({
 					if (!subscription?.stripeSubscriptionId) return;
 					if (subscription.plan === "enterprise") return;
 
-					const memberCount = await db
-						.select({ count: count() })
-						.from(members)
-						.where(eq(members.organizationId, organization.id));
-
-					const quantity = memberCount[0]?.count ?? 1;
+					const quantity = Math.max(
+						1,
+						await countBillableSeats(organization.id),
+					);
 
 					const stripeSub = await stripeClient.subscriptions.retrieve(
 						subscription.stripeSubscriptionId,
@@ -736,7 +735,9 @@ export const auth = betterAuth({
 						);
 					}
 
-					const owners = await getOrganizationOwners(organization.id);
+					const recipients = await getOrganizationBillingRecipients(
+						organization.id,
+					);
 					const pricePerSeat = stripeSub.items.data[0]?.price?.unit_amount ?? 0;
 					const currency = stripeSub.items.data[0]?.price?.currency ?? "usd";
 					const newMonthlyTotal = formatPrice(
@@ -744,13 +745,26 @@ export const auth = betterAuth({
 						currency,
 					);
 
+					// The base total above is not what gets charged: the mid-cycle
+					// catch-up rides on the same invoice. Quote both or quote neither.
+					const customerId =
+						typeof stripeSub.customer === "string"
+							? stripeSub.customer
+							: stripeSub.customer.id;
+					const preview = await previewNextInvoice(
+						customerId,
+						subscription.stripeSubscriptionId,
+					);
+
 					await resend.batch.send(
-						owners.map((owner) => ({
+						recipients.map((recipient) => ({
 							from: "Superset <noreply@superset.sh>",
-							to: owner.email,
+							to: recipient.email,
 							subject: `Billing update: New member added to ${organization.name}`,
 							react: MemberAddedBillingEmail({
-								ownerName: owner.name,
+								recipientName: recipient.name,
+								prorationAmount: preview?.prorationAmount ?? null,
+								nextInvoiceTotal: preview?.nextInvoiceTotal ?? null,
 								organizationName: organization.name,
 								newMemberName: user.name ?? "New member",
 								newMemberEmail: user.email,
@@ -803,12 +817,10 @@ export const auth = betterAuth({
 					if (!subscription?.stripeSubscriptionId) return;
 					if (subscription.plan === "enterprise") return;
 
-					const memberCount = await db
-						.select({ count: count() })
-						.from(members)
-						.where(eq(members.organizationId, organization.id));
-
-					const quantity = Math.max(1, memberCount[0]?.count ?? 1);
+					const quantity = Math.max(
+						1,
+						await countBillableSeats(organization.id),
+					);
 
 					const stripeSub = await stripeClient.subscriptions.retrieve(
 						subscription.stripeSubscriptionId,
@@ -825,7 +837,9 @@ export const auth = betterAuth({
 						);
 					}
 
-					const owners = await getOrganizationOwners(organization.id);
+					const recipients = await getOrganizationBillingRecipients(
+						organization.id,
+					);
 					const pricePerSeat = stripeSub.items.data[0]?.price?.unit_amount ?? 0;
 					const currency = stripeSub.items.data[0]?.price?.currency ?? "usd";
 					const newMonthlyTotal = formatPrice(
@@ -833,13 +847,24 @@ export const auth = betterAuth({
 						currency,
 					);
 
+					const customerId =
+						typeof stripeSub.customer === "string"
+							? stripeSub.customer
+							: stripeSub.customer.id;
+					const preview = await previewNextInvoice(
+						customerId,
+						subscription.stripeSubscriptionId,
+					);
+
 					await resend.batch.send(
-						owners.map((owner) => ({
+						recipients.map((recipient) => ({
 							from: "Superset <noreply@superset.sh>",
-							to: owner.email,
+							to: recipient.email,
 							subject: `Billing update: Member removed from ${organization.name}`,
 							react: MemberRemovedBillingEmail({
-								ownerName: owner.name,
+								recipientName: recipient.name,
+								prorationAmount: preview?.prorationAmount ?? null,
+								nextInvoiceTotal: preview?.nextInvoiceTotal ?? null,
 								organizationName: organization.name,
 								removedMemberName: user.name ?? "Former member",
 								removedMemberEmail: user.email,
@@ -1093,7 +1118,9 @@ export const auth = betterAuth({
 
 					if (!org?.stripeCustomerId) return;
 
-					const owners = await getOrganizationOwners(subscription.referenceId);
+					const recipients = await getOrganizationBillingRecipients(
+						subscription.referenceId,
+					);
 					const accessEndsAt = subscription.periodEnd ?? new Date();
 
 					const portalSession =
@@ -1103,12 +1130,12 @@ export const auth = betterAuth({
 						});
 
 					await resend.batch.send(
-						owners.map((owner) => ({
+						recipients.map((recipient) => ({
 							from: "Superset <noreply@superset.sh>",
-							to: owner.email,
+							to: recipient.email,
 							subject: `Your ${subscription.plan} subscription has been cancelled`,
 							react: SubscriptionCancelledEmail({
-								ownerName: owner.name,
+								recipientName: recipient.name,
 								organizationName: org.name,
 								planName: subscription.plan,
 								accessEndsAt,
@@ -1161,7 +1188,7 @@ export const auth = betterAuth({
 							where: eq(subscriptions.referenceId, org.id),
 						});
 
-						const owners = await getOrganizationOwners(org.id);
+						const recipients = await getOrganizationBillingRecipients(org.id);
 						const amount = formatPrice(invoice.amount_due, invoice.currency);
 
 						const portalSession =
@@ -1171,12 +1198,12 @@ export const auth = betterAuth({
 							});
 
 						await resend.batch.send(
-							owners.map((owner) => ({
+							recipients.map((recipient) => ({
 								from: "Superset <noreply@superset.sh>",
-								to: owner.email,
+								to: recipient.email,
 								subject: `Payment failed for ${org.name}`,
 								react: PaymentFailedEmail({
-									ownerName: owner.name,
+									recipientName: recipient.name,
 									organizationName: org.name,
 									planName: subscription?.plan ?? "Pro",
 									amount,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -744,6 +744,12 @@ export const auth = betterAuth({
 						pricePerSeat * quantity,
 						currency,
 					);
+					// unit_amount is per billing period: on an annual price the total
+					// above is yearly, and calling it monthly understates it 12x.
+					const billingInterval =
+						stripeSub.items.data[0]?.price?.recurring?.interval === "year"
+							? ("yearly" as const)
+							: ("monthly" as const);
 
 					// The base total above is not what gets charged: the mid-cycle
 					// catch-up rides on the same invoice. Quote both or quote neither.
@@ -771,6 +777,7 @@ export const auth = betterAuth({
 								addedByName: "A team admin",
 								newSeatCount: quantity,
 								newMonthlyTotal,
+								billingInterval,
 							}),
 						})),
 					);
@@ -846,6 +853,12 @@ export const auth = betterAuth({
 						pricePerSeat * quantity,
 						currency,
 					);
+					// unit_amount is per billing period: on an annual price the total
+					// above is yearly, and calling it monthly understates it 12x.
+					const billingInterval =
+						stripeSub.items.data[0]?.price?.recurring?.interval === "year"
+							? ("yearly" as const)
+							: ("monthly" as const);
 
 					const customerId =
 						typeof stripeSub.customer === "string"
@@ -871,6 +884,7 @@ export const auth = betterAuth({
 								removedByName: "A team admin",
 								newSeatCount: quantity,
 								newMonthlyTotal,
+								billingInterval,
 							}),
 						})),
 					);

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -647,7 +647,15 @@ export const auth = betterAuth({
 
 					if (subscription) return;
 
-					const currentCount = await countBillableSeats(organization.id);
+					// Not countBillableSeats: the free-plan limit is about how many
+					// people are in the organization, not how many seats we bill,
+					// so a member pending deletion still occupies the one slot.
+					const memberCount = await db
+						.select({ count: count() })
+						.from(members)
+						.where(eq(members.organizationId, organization.id));
+
+					const currentCount = memberCount[0]?.count ?? 0;
 
 					if (currentCount >= 1) {
 						throw new Error(
@@ -757,10 +765,14 @@ export const auth = betterAuth({
 						typeof stripeSub.customer === "string"
 							? stripeSub.customer
 							: stripeSub.customer.id;
-					const preview = await previewNextInvoice(
-						customerId,
-						subscription.stripeSubscriptionId,
-					);
+					const preview = itemId
+						? await previewNextInvoice(
+								customerId,
+								subscription.stripeSubscriptionId,
+								itemId,
+								"charge",
+							)
+						: null;
 
 					await resend.batch.send(
 						recipients.map((recipient) => ({
@@ -864,10 +876,14 @@ export const auth = betterAuth({
 						typeof stripeSub.customer === "string"
 							? stripeSub.customer
 							: stripeSub.customer.id;
-					const preview = await previewNextInvoice(
-						customerId,
-						subscription.stripeSubscriptionId,
-					);
+					const preview = itemId
+						? await previewNextInvoice(
+								customerId,
+								subscription.stripeSubscriptionId,
+								itemId,
+								"credit",
+							)
+						: null;
 
 					await resend.batch.send(
 						recipients.map((recipient) => ({
@@ -1153,7 +1169,8 @@ export const auth = betterAuth({
 								organizationName: org.name,
 								planName: subscription.plan,
 								accessEndsAt,
-								billingPortalUrl: portalSession.url,
+								billingPortalUrl:
+									recipient.role === "owner" ? portalSession.url : undefined,
 							}),
 						})),
 					);
@@ -1221,7 +1238,8 @@ export const auth = betterAuth({
 									organizationName: org.name,
 									planName: subscription?.plan ?? "Pro",
 									amount,
-									billingPortalUrl: portalSession.url,
+									billingPortalUrl:
+										recipient.role === "owner" ? portalSession.url : undefined,
 								}),
 							})),
 						);

--- a/packages/auth/src/utils/billing.ts
+++ b/packages/auth/src/utils/billing.ts
@@ -1,7 +1,14 @@
 import { db } from "@superset/db/client";
 import { members } from "@superset/db/schema";
 import * as authSchema from "@superset/db/schema/auth";
-import { and, eq } from "drizzle-orm";
+import { and, count, eq, inArray, isNull } from "drizzle-orm";
+
+/**
+ * Roles that can act on a billing problem. Owners alone is too narrow: the
+ * person holding the card is often an admin, and a payment-failure notice that
+ * never reaches them is a notice nobody can act on.
+ */
+const BILLING_ROLES = ["owner", "admin"];
 
 export async function getOrganizationOwners(organizationId: string) {
 	return db
@@ -18,6 +25,49 @@ export async function getOrganizationOwners(organizationId: string) {
 				eq(members.role, "owner"),
 			),
 		);
+}
+
+/** Everyone who should hear about a billing change: owners and admins. */
+export async function getOrganizationBillingRecipients(organizationId: string) {
+	return db
+		.select({
+			id: authSchema.users.id,
+			name: authSchema.users.name,
+			email: authSchema.users.email,
+		})
+		.from(members)
+		.innerJoin(authSchema.users, eq(members.userId, authSchema.users.id))
+		.where(
+			and(
+				eq(members.organizationId, organizationId),
+				inArray(members.role, BILLING_ROLES),
+				isNull(authSchema.users.deletionRequestedAt),
+			),
+		);
+}
+
+/**
+ * Seats we charge for.
+ *
+ * Members whose user has requested deletion are excluded, because that is the
+ * same list the customer sees in the members UI. Counting every `members` row
+ * instead bills for people the organization can no longer see.
+ */
+export async function countBillableSeats(
+	organizationId: string,
+): Promise<number> {
+	const [row] = await db
+		.select({ count: count() })
+		.from(members)
+		.innerJoin(authSchema.users, eq(members.userId, authSchema.users.id))
+		.where(
+			and(
+				eq(members.organizationId, organizationId),
+				isNull(authSchema.users.deletionRequestedAt),
+			),
+		);
+
+	return row?.count ?? 0;
 }
 
 export function formatPrice(amountInCents: number, currency: string): string {

--- a/packages/auth/src/utils/billing.ts
+++ b/packages/auth/src/utils/billing.ts
@@ -27,13 +27,21 @@ export async function getOrganizationOwners(organizationId: string) {
 		);
 }
 
-/** Everyone who should hear about a billing change: owners and admins. */
+/**
+ * Everyone who should hear about a billing change: owners and admins.
+ *
+ * Returns the role too. Admins are told what happened, but anything that
+ * grants billing control — a Stripe portal session, which is a bearer link —
+ * stays with owners, because `requireOwnerWithCustomer` denies admins exactly
+ * that in the app.
+ */
 export async function getOrganizationBillingRecipients(organizationId: string) {
 	return db
 		.select({
 			id: authSchema.users.id,
 			name: authSchema.users.name,
 			email: authSchema.users.email,
+			role: members.role,
 		})
 		.from(members)
 		.innerJoin(authSchema.users, eq(members.userId, authSchema.users.id))

--- a/packages/auth/src/utils/index.ts
+++ b/packages/auth/src/utils/index.ts
@@ -1,1 +1,6 @@
-export { formatPrice, getOrganizationOwners } from "./billing";
+export {
+	countBillableSeats,
+	formatPrice,
+	getOrganizationBillingRecipients,
+	getOrganizationOwners,
+} from "./billing";

--- a/packages/auth/src/utils/invoice-preview.ts
+++ b/packages/auth/src/utils/invoice-preview.ts
@@ -1,0 +1,47 @@
+import type Stripe from "stripe";
+import { stripeClient } from "../stripe";
+import { formatPrice } from "./billing";
+
+export interface NextInvoicePreview {
+	prorationAmount: string;
+	nextInvoiceTotal: string;
+}
+
+function isProrationLine(line: Stripe.InvoiceLineItem): boolean {
+	return Boolean(
+		line.parent?.subscription_item_details?.proration ||
+			line.parent?.invoice_item_details?.proration,
+	);
+}
+
+/**
+ * What the next invoice actually comes to after a seat change: the new base
+ * plus the proration Stripe has already queued for the rest of the cycle.
+ *
+ * Returns null when Stripe cannot give a figure. Callers must then fall back
+ * to copy that quotes no number — a seat-change email that states a total the
+ * customer will not be charged is how a card limit gets set too low.
+ */
+export async function previewNextInvoice(
+	customerId: string,
+	subscriptionId: string,
+): Promise<NextInvoicePreview | null> {
+	try {
+		const preview = await stripeClient.invoices.createPreview({
+			customer: customerId,
+			subscription: subscriptionId,
+		});
+
+		const prorationCents = preview.lines.data
+			.filter(isProrationLine)
+			.reduce((total, line) => total + line.amount, 0);
+
+		return {
+			prorationAmount: formatPrice(prorationCents, preview.currency),
+			nextInvoiceTotal: formatPrice(preview.total, preview.currency),
+		};
+	} catch (error) {
+		console.error("[billing/invoice-preview] Preview failed:", error);
+		return null;
+	}
+}

--- a/packages/auth/src/utils/invoice-preview.ts
+++ b/packages/auth/src/utils/invoice-preview.ts
@@ -7,10 +7,13 @@ export interface NextInvoicePreview {
 	nextInvoiceTotal: string;
 }
 
-function isProrationLine(line: Stripe.InvoiceLineItem): boolean {
+function prorationForItem(
+	line: Stripe.InvoiceLineItem,
+	subscriptionItemId: string,
+): boolean {
+	const details = line.parent?.subscription_item_details;
 	return Boolean(
-		line.parent?.subscription_item_details?.proration ||
-			line.parent?.invoice_item_details?.proration,
+		details?.proration && details.subscription_item === subscriptionItemId,
 	);
 }
 
@@ -18,13 +21,16 @@ function isProrationLine(line: Stripe.InvoiceLineItem): boolean {
  * What the next invoice actually comes to after a seat change: the new base
  * plus the proration Stripe has already queued for the rest of the cycle.
  *
- * Returns null when Stripe cannot give a figure. Callers must then fall back
- * to copy that quotes no number — a seat-change email that states a total the
- * customer will not be charged is how a card limit gets set too low.
+ * Returns null when Stripe cannot give a figure, or when the numbers would not
+ * add up — callers must then fall back to copy that quotes no number. A
+ * seat-change email stating a total the customer will not be charged is how a
+ * card limit gets set too low, which is the whole reason this exists.
  */
 export async function previewNextInvoice(
 	customerId: string,
 	subscriptionId: string,
+	subscriptionItemId: string,
+	expectedSign: "charge" | "credit",
 ): Promise<NextInvoicePreview | null> {
 	try {
 		const preview = await stripeClient.invoices.createPreview({
@@ -32,12 +38,23 @@ export async function previewNextInvoice(
 			subscription: subscriptionId,
 		});
 
+		// `preview.lines` is paginated, so a long invoice would silently
+		// under-count and make the quoted figures disagree with the total.
+		if (preview.lines.has_more) return null;
+
+		// Only this seat change: an unrelated proration still on the upcoming
+		// invoice (a plan switch, an earlier seat move) is not what we changed.
 		const prorationCents = preview.lines.data
-			.filter(isProrationLine)
+			.filter((line) => prorationForItem(line, subscriptionItemId))
 			.reduce((total, line) => total + line.amount, 0);
 
+		if (prorationCents === 0) return null;
+		// A removal that nets to a charge is not "a credit for unused time".
+		if (expectedSign === "charge" && prorationCents < 0) return null;
+		if (expectedSign === "credit" && prorationCents > 0) return null;
+
 		return {
-			prorationAmount: formatPrice(prorationCents, preview.currency),
+			prorationAmount: formatPrice(Math.abs(prorationCents), preview.currency),
 			nextInvoiceTotal: formatPrice(preview.total, preview.currency),
 		};
 	} catch (error) {

--- a/packages/email/src/emails/billing/member-added.tsx
+++ b/packages/email/src/emails/billing/member-added.tsx
@@ -9,6 +9,7 @@ interface MemberAddedBillingEmailProps {
 	addedByName: string;
 	newSeatCount: number;
 	newMonthlyTotal: string;
+	billingInterval?: "monthly" | "yearly";
 	prorationAmount?: string | null;
 	nextInvoiceTotal?: string | null;
 }
@@ -21,10 +22,15 @@ export function MemberAddedBillingEmail({
 	addedByName = "John Smith",
 	newSeatCount = 5,
 	newMonthlyTotal = "$50.00",
+	billingInterval = "monthly",
 	prorationAmount = "$12.40",
 	nextInvoiceTotal = "$62.40",
 }: MemberAddedBillingEmailProps) {
 	const hasPreview = Boolean(prorationAmount && nextInvoiceTotal);
+	// unit_amount is per billing period, so on an annual price this total is
+	// yearly. Labelling it monthly understates the charge twelvefold.
+	const totalLabel =
+		billingInterval === "yearly" ? "New yearly total" : "New monthly total";
 
 	return (
 		<EmailLayout
@@ -46,7 +52,7 @@ export function MemberAddedBillingEmail({
 
 			<Hr className="border-border my-4" />
 			<DetailRow label="Seats" value={String(newSeatCount)} />
-			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			<DetailRow label={totalLabel} value={newMonthlyTotal} />
 			{hasPreview && (
 				<>
 					<DetailRow
@@ -60,8 +66,8 @@ export function MemberAddedBillingEmail({
 
 			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
 				{hasPreview
-					? `Your next invoice is ${nextInvoiceTotal} — the new monthly total plus ${prorationAmount} for the part of the current period the new seat covers.`
-					: "Your next invoice adds a prorated charge for the rest of the current period, so it will be higher than the monthly total above."}
+					? `Your next invoice is ${nextInvoiceTotal} — the new plan total plus ${prorationAmount} for the part of the current period the new seat covers.`
+					: "Your next invoice adds a prorated charge for the rest of the current period, so it will be higher than the plan total above."}
 			</Text>
 
 			<Text className="text-[13px] leading-5 text-muted m-0">

--- a/packages/email/src/emails/billing/member-added.tsx
+++ b/packages/email/src/emails/billing/member-added.tsx
@@ -2,24 +2,30 @@ import { Heading, Hr, Text } from "@react-email/components";
 import { DetailRow, EmailLayout } from "../../components";
 
 interface MemberAddedBillingEmailProps {
-	ownerName?: string | null;
+	recipientName?: string | null;
 	organizationName: string;
 	newMemberName: string;
 	newMemberEmail: string;
 	addedByName: string;
 	newSeatCount: number;
 	newMonthlyTotal: string;
+	prorationAmount?: string | null;
+	nextInvoiceTotal?: string | null;
 }
 
 export function MemberAddedBillingEmail({
-	ownerName = "there",
+	recipientName = "there",
 	organizationName = "Acme Inc",
 	newMemberName = "Jane Doe",
 	newMemberEmail = "jane@example.com",
 	addedByName = "John Smith",
 	newSeatCount = 5,
 	newMonthlyTotal = "$50.00",
+	prorationAmount = "$12.40",
+	nextInvoiceTotal = "$62.40",
 }: MemberAddedBillingEmailProps) {
+	const hasPreview = Boolean(prorationAmount && nextInvoiceTotal);
+
 	return (
 		<EmailLayout
 			preview={`Billing update: ${newMemberName} was added to ${organizationName}`}
@@ -29,7 +35,7 @@ export function MemberAddedBillingEmail({
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-				Hi {ownerName ?? "there"},
+				Hi {recipientName ?? "there"},
 			</Text>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
@@ -41,14 +47,25 @@ export function MemberAddedBillingEmail({
 			<Hr className="border-border my-4" />
 			<DetailRow label="Seats" value={String(newSeatCount)} />
 			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			{hasPreview && (
+				<>
+					<DetailRow
+						label="Prorated for the rest of this period"
+						value={prorationAmount as string}
+					/>
+					<DetailRow label="Next invoice" value={nextInvoiceTotal as string} />
+				</>
+			)}
 			<Hr className="border-border my-4" />
 
 			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
-				Your next invoice will include the prorated amount.
+				{hasPreview
+					? `Your next invoice is ${nextInvoiceTotal} — the new monthly total plus ${prorationAmount} for the part of the current period the new seat covers.`
+					: "Your next invoice adds a prorated charge for the rest of the current period, so it will be higher than the monthly total above."}
 			</Text>
 
 			<Text className="text-[13px] leading-5 text-muted m-0">
-				You're receiving this because you're an owner of {organizationName}.
+				You're receiving this because you manage billing for {organizationName}.
 			</Text>
 		</EmailLayout>
 	);

--- a/packages/email/src/emails/billing/member-removed.tsx
+++ b/packages/email/src/emails/billing/member-removed.tsx
@@ -2,24 +2,30 @@ import { Heading, Hr, Text } from "@react-email/components";
 import { DetailRow, EmailLayout } from "../../components";
 
 interface MemberRemovedBillingEmailProps {
-	ownerName?: string | null;
+	recipientName?: string | null;
 	organizationName: string;
 	removedMemberName: string;
 	removedMemberEmail: string;
 	removedByName: string;
 	newSeatCount: number;
 	newMonthlyTotal: string;
+	prorationAmount?: string | null;
+	nextInvoiceTotal?: string | null;
 }
 
 export function MemberRemovedBillingEmail({
-	ownerName = "there",
+	recipientName = "there",
 	organizationName = "Acme Inc",
 	removedMemberName = "Jane Doe",
 	removedMemberEmail = "jane@example.com",
 	removedByName = "John Smith",
 	newSeatCount = 4,
 	newMonthlyTotal = "$40.00",
+	prorationAmount = "-$8.20",
+	nextInvoiceTotal = "$31.80",
 }: MemberRemovedBillingEmailProps) {
+	const hasPreview = Boolean(prorationAmount && nextInvoiceTotal);
+
 	return (
 		<EmailLayout
 			preview={`Billing update: ${removedMemberName} was removed from ${organizationName}`}
@@ -29,7 +35,7 @@ export function MemberRemovedBillingEmail({
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-				Hi {ownerName ?? "there"},
+				Hi {recipientName ?? "there"},
 			</Text>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
@@ -41,14 +47,25 @@ export function MemberRemovedBillingEmail({
 			<Hr className="border-border my-4" />
 			<DetailRow label="Seats" value={String(newSeatCount)} />
 			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			{hasPreview && (
+				<>
+					<DetailRow
+						label="Credit for the rest of this period"
+						value={prorationAmount as string}
+					/>
+					<DetailRow label="Next invoice" value={nextInvoiceTotal as string} />
+				</>
+			)}
 			<Hr className="border-border my-4" />
 
 			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
-				Your next invoice will include a credit for the unused time.
+				{hasPreview
+					? `Your next invoice is ${nextInvoiceTotal} — the new monthly total with ${prorationAmount} credited for the unused time on the removed seat.`
+					: "Your next invoice includes a credit for the unused time on the removed seat, so it will differ from the monthly total above."}
 			</Text>
 
 			<Text className="text-[13px] leading-5 text-muted m-0">
-				You're receiving this because you're an owner of {organizationName}.
+				You're receiving this because you manage billing for {organizationName}.
 			</Text>
 		</EmailLayout>
 	);

--- a/packages/email/src/emails/billing/member-removed.tsx
+++ b/packages/email/src/emails/billing/member-removed.tsx
@@ -9,6 +9,7 @@ interface MemberRemovedBillingEmailProps {
 	removedByName: string;
 	newSeatCount: number;
 	newMonthlyTotal: string;
+	billingInterval?: "monthly" | "yearly";
 	prorationAmount?: string | null;
 	nextInvoiceTotal?: string | null;
 }
@@ -21,10 +22,15 @@ export function MemberRemovedBillingEmail({
 	removedByName = "John Smith",
 	newSeatCount = 4,
 	newMonthlyTotal = "$40.00",
+	billingInterval = "monthly",
 	prorationAmount = "-$8.20",
 	nextInvoiceTotal = "$31.80",
 }: MemberRemovedBillingEmailProps) {
 	const hasPreview = Boolean(prorationAmount && nextInvoiceTotal);
+	// unit_amount is per billing period, so on an annual price this total is
+	// yearly. Labelling it monthly understates the charge twelvefold.
+	const totalLabel =
+		billingInterval === "yearly" ? "New yearly total" : "New monthly total";
 
 	return (
 		<EmailLayout
@@ -46,7 +52,7 @@ export function MemberRemovedBillingEmail({
 
 			<Hr className="border-border my-4" />
 			<DetailRow label="Seats" value={String(newSeatCount)} />
-			<DetailRow label="New monthly total" value={newMonthlyTotal} />
+			<DetailRow label={totalLabel} value={newMonthlyTotal} />
 			{hasPreview && (
 				<>
 					<DetailRow
@@ -60,8 +66,8 @@ export function MemberRemovedBillingEmail({
 
 			<Text className="text-[13px] leading-5 text-muted m-0 mb-4">
 				{hasPreview
-					? `Your next invoice is ${nextInvoiceTotal} — the new monthly total with ${prorationAmount} credited for the unused time on the removed seat.`
-					: "Your next invoice includes a credit for the unused time on the removed seat, so it will differ from the monthly total above."}
+					? `Your next invoice is ${nextInvoiceTotal} — the new plan total with ${prorationAmount} credited for the unused time on the removed seat.`
+					: "Your next invoice includes a credit for the unused time on the removed seat, so it will differ from the plan total above."}
 			</Text>
 
 			<Text className="text-[13px] leading-5 text-muted m-0">

--- a/packages/email/src/emails/billing/payment-failed.tsx
+++ b/packages/email/src/emails/billing/payment-failed.tsx
@@ -2,7 +2,7 @@ import { Heading, Link, Section, Text } from "@react-email/components";
 import { Button, EmailLayout } from "../../components";
 
 interface PaymentFailedEmailProps {
-	ownerName?: string | null;
+	recipientName?: string | null;
 	organizationName: string;
 	planName: string;
 	amount: string;
@@ -11,7 +11,7 @@ interface PaymentFailedEmailProps {
 }
 
 export function PaymentFailedEmail({
-	ownerName = "there",
+	recipientName = "there",
 	organizationName = "Acme Inc",
 	planName = "Pro",
 	amount = "$50.00",
@@ -25,7 +25,7 @@ export function PaymentFailedEmail({
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-				Hi {ownerName ?? "there"},
+				Hi {recipientName ?? "there"},
 			</Text>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">

--- a/packages/email/src/emails/billing/subscription-cancelled.tsx
+++ b/packages/email/src/emails/billing/subscription-cancelled.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import { Button, DetailRow, EmailLayout } from "../../components";
 
 interface SubscriptionCancelledEmailProps {
-	ownerName?: string | null;
+	recipientName?: string | null;
 	organizationName: string;
 	planName: string;
 	accessEndsAt: Date;
@@ -11,7 +11,7 @@ interface SubscriptionCancelledEmailProps {
 }
 
 export function SubscriptionCancelledEmail({
-	ownerName = "there",
+	recipientName = "there",
 	organizationName = "Acme Inc",
 	planName = "Pro",
 	accessEndsAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
@@ -26,7 +26,7 @@ export function SubscriptionCancelledEmail({
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-				Hi {ownerName ?? "there"},
+				Hi {recipientName ?? "there"},
 			</Text>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -68,7 +68,34 @@ const EMPTY_ACTIVE_PLAN = {
 	cancelAt: null,
 	periodStart: null,
 	periodEnd: null,
+	billingInterval: null,
 };
+
+function isUnpaid(invoice: Stripe.Invoice): boolean {
+	return invoice.status === "open" || invoice.status === "uncollectible";
+}
+
+/**
+ * Drafts are not owed yet and voided invoices never will be; everything else
+ * — paid, open, uncollectible — is part of the customer's billing history.
+ */
+function isBillableInvoice(invoice: Stripe.Invoice): boolean {
+	return invoice.status === "paid" || isUnpaid(invoice);
+}
+
+function toInvoiceSummary(invoice: Stripe.Invoice) {
+	return {
+		id: invoice.id,
+		date: invoice.created,
+		status: invoice.status,
+		isUnpaid: isUnpaid(invoice),
+		amountPaid: invoice.amount_paid,
+		amountDue: invoice.amount_due,
+		currency: invoice.currency,
+		hostedInvoiceUrl: invoice.hosted_invoice_url,
+		dueDate: invoice.due_date,
+	};
+}
 
 export const billingRouter = {
 	activePlan: protectedProcedure.query(async ({ ctx }) => {
@@ -93,6 +120,7 @@ export const billingRouter = {
 			cancelAt: subscription.cancelAt,
 			periodStart: subscription.periodStart,
 			periodEnd: subscription.periodEnd,
+			billingInterval: subscription.billingInterval,
 		};
 	}),
 
@@ -119,19 +147,48 @@ export const billingRouter = {
 		const invoiceList = await stripeClient.invoices.list({
 			customer: organization.stripeCustomerId,
 			limit: 100,
-			status: "paid",
 			created: { gte: Math.floor(twelveMonthsAgo.getTime() / 1000) },
 		});
 
 		return invoiceList.data
+			.filter(isBillableInvoice)
 			.sort((a, b) => b.created - a.created)
-			.map((invoice) => ({
-				id: invoice.id,
-				date: invoice.created,
-				amount: invoice.amount_paid,
-				currency: invoice.currency,
-				hostedInvoiceUrl: invoice.hosted_invoice_url,
-			}));
+			.map(toInvoiceSummary);
+	}),
+
+	/**
+	 * The invoice a failed payment is about. Drives the amount and the direct
+	 * "Pay now" link on the payment-failure surfaces, which otherwise can only
+	 * say that something failed.
+	 */
+	outstandingInvoice: protectedProcedure.query(async ({ ctx }) => {
+		const activeOrgId = ctx.activeOrganizationId;
+		if (!activeOrgId) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "No active organization",
+			});
+		}
+
+		const organization = await db.query.organizations.findFirst({
+			where: eq(organizations.id, activeOrgId),
+			columns: { stripeCustomerId: true },
+		});
+
+		if (!organization?.stripeCustomerId) {
+			return null;
+		}
+
+		const invoiceList = await stripeClient.invoices.list({
+			customer: organization.stripeCustomerId,
+			limit: 20,
+		});
+
+		const unpaid = invoiceList.data
+			.filter(isUnpaid)
+			.sort((a, b) => b.created - a.created)[0];
+
+		return unpaid ? toInvoiceSummary(unpaid) : null;
 	}),
 
 	details: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -83,18 +83,34 @@ function isBillableInvoice(invoice: Stripe.Invoice): boolean {
 	return invoice.status === "paid" || isUnpaid(invoice);
 }
 
-function toInvoiceSummary(invoice: Stripe.Invoice) {
+function toInvoiceSummary(
+	invoice: Stripe.Invoice,
+	options: { includeHostedUrl?: boolean } = {},
+) {
 	return {
 		id: invoice.id,
 		date: invoice.created,
 		status: invoice.status,
 		isUnpaid: isUnpaid(invoice),
 		amountPaid: invoice.amount_paid,
-		amountDue: invoice.amount_due,
+		// amount_due is frozen at finalization; amount_remaining is what is
+		// still owed after any partial payment through the hosted invoice.
+		amountDue: invoice.amount_remaining ?? invoice.amount_due,
 		currency: invoice.currency,
-		hostedInvoiceUrl: invoice.hosted_invoice_url,
+		hostedInvoiceUrl:
+			options.includeHostedUrl === false ? null : invoice.hosted_invoice_url,
 		dueDate: invoice.due_date,
 	};
+}
+
+async function isBillingOwner(userId: string, organizationId: string) {
+	const member = await db.query.members.findFirst({
+		where: and(
+			eq(members.userId, userId),
+			eq(members.organizationId, organizationId),
+		),
+	});
+	return member?.role === "owner";
 }
 
 export const billingRouter = {
@@ -153,7 +169,7 @@ export const billingRouter = {
 		return invoiceList.data
 			.filter(isBillableInvoice)
 			.sort((a, b) => b.created - a.created)
-			.map(toInvoiceSummary);
+			.map((invoice) => toInvoiceSummary(invoice));
 	}),
 
 	/**
@@ -188,7 +204,10 @@ export const billingRouter = {
 			.filter(isUnpaid)
 			.sort((a, b) => b.created - a.created)[0];
 
-		return unpaid ? toInvoiceSummary(unpaid) : null;
+		if (!unpaid) return null;
+
+		const isOwner = await isBillingOwner(ctx.session.user.id, activeOrgId);
+		return toInvoiceSummary(unpaid, { includeHostedUrl: isOwner });
 	}),
 
 	details: protectedProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## What & why

A monthly Pro subscriber's renewal declined. The invoice was larger than the plan's monthly base because a mid-cycle seat increase put both the new base and the proration catch-up on the same invoice. Nothing in the app showed that amount, and while looking for it the customer hit a second bug that made it look like we were moving them to annual billing.

Six defects, all confirmed against `main`:

**1. The plans page billing toggle was hardcoded to Annual.** `useState(true)` was never seeded from the subscription. For a monthly subscriber that made `intervalMatches` false, which turned the Pro column's normally-disabled secondary "Current plan" into a live primary **"Change to Annual"**. One click called `subscription.upgrade({ annual: true, seats })` — a year billed up front instead of a month.

The toggle is now seeded from the resolved subscription interval, read from `subscriptions.billingInterval` (newly returned by `billing.activePlan`) and falling back to the period-length heuristic for rows written before that column existed. The seed is derived state, not an effect, so a late-arriving `activePlan` cannot stomp a toggle the user already flipped: `manualIsYearly ?? subscriptionIsYearly ?? true`.

*Default for free and enterprise:* **Annual**. They have no interval to read, it preserves the previous default so nothing changes for them, and the annual price is the one we lead with for someone who is not yet paying. The interval-change action is separately gated on `subscriptionIsYearly !== null`, so an unreadable interval now holds at "Current plan" instead of guessing.

**2. Failed and open invoices were invisible.** `billing.invoices` filtered `status: "paid"`, and `RecentInvoices` returns `null` on an empty list — so a customer whose only recent invoice had failed saw no invoice section at all. The query now returns paid, open and uncollectible invoices (drafts and voided ones stay out), each with `status`, `amountPaid`, `amountDue`, `dueDate` and `hostedInvoiceUrl`. `RecentInvoices` renders unpaid rows in amber with an `UNPAID` badge and a **Pay now** action onto the hosted invoice; paid rows keep the existing "View".

`RecentInvoices` also moves from the imperative `apiTrpcClient` to the `cloudTrpc` hook. `apiTrpcClient` does not send the organization header, so the list resolved against the *session's* organization rather than the one the window is showing — it returned another organization's invoices, or errored, in any multi-window or org-switched session. Every neighbouring billing component already uses `cloudTrpc`.

**3. The payment-failure surfaces never showed the amount.** New `billing.outstandingInvoice` query returns the newest unpaid invoice. The sidebar card now reads "Payment failed — $70.32 due" and its owner action goes straight to the hosted invoice rather than the billing portal, which costs several clicks to reach the same page. The plan row's badge and hint carry the amount too, with a "Pay now" button alongside "Cancel plan". Non-owner wording is unchanged apart from the amount — still no action that would dead-end at `requireBillingOwner`.

**4. Payment-failure email reached owners only.** The person holding the card is often an admin, not an owner, so nobody who could act was notified. New `getOrganizationBillingRecipients` includes owners *and* admins and excludes users pending deletion. Applied to payment-failed, subscription-cancelled and both seat-change emails; the affected templates now say "you manage billing for {organization}" instead of claiming the reader is an owner, and their `ownerName` prop is renamed `recipientName`.

**5. Seat-change email did not quote the proration.** It quoted a precise "New monthly total" and then said only that the next invoice "will include the prorated amount" — so anyone sizing a card limit off it set it to the base and declined on the prorated invoice. `previewNextInvoice` calls `stripeClient.invoices.createPreview` against the subscription after the quantity update and sums the lines where `parent.subscription_item_details.proration` is true. The email now quotes the proration and the resulting next-invoice total. **If Stripe does not return a figure the email quotes no number at all** and instead says the next invoice will be higher than the monthly total — no invented amounts.

**6. Seat quantity counted deactivated members.** `afterAddMember` and `afterRemoveMember` counted every `members` row. Checkout, however, passes `seats` from `listMembers`, which excludes users with `deletionRequestedAt` — so the initial subscription and every later seat change disagreed with each other. All three now use one helper, `countBillableSeats`, defined as *members whose user has not requested deletion*. The free-plan gate in `beforeAddMember` uses it too, so a deactivated member no longer blocks a free organization from adding someone.

One nuance worth stating: the members settings page passes `includeDeactivated: true` and still lists deactivated people behind a "Deactivated" badge, so this does not hide anyone — it just stops charging for accounts that are on their way out and aligns seat changes with what checkout already billed.

**Found in review, fixed here (7).** `price.unit_amount` is per billing period, so on an annual price the seat-change total is a yearly figure — and both templates hardcoded "New monthly total", understating an annual subscriber's charge twelvefold. Pre-existing, but the new next-invoice line sits right beside it, so it is fixed rather than left: the templates take `billingInterval` from `price.recurring.interval` and render "New yearly total" or "New monthly total". Rendered both variants to confirm.

Two other review findings were not acted on, with reasoning on the threads: hosted-invoice links have been readable by any organization member since before this PR (`billing.invoices` is a plain `protectedProcedure` and `RecentInvoices` was never owner-gated), so narrowing that is a separate product decision; and paginating `outstandingInvoice` past 20 would guard a case a `past_due` subscription cannot produce, since collection has stopped and no newer invoices accumulate ahead of the unpaid one.

## How I tested it

Driven against the real desktop app in this worktree over CDP, following `.agents/skills/cdp-verification/SKILL.md`. Renderer on this workspace's `DESKTOP_VITE_PORT` 9265, CDP 9280, API 9261; the owning Electron process was confirmed to live under this worktree path before testing.

**No production Stripe was touched.** `STRIPE_SECRET_KEY` was swapped to the repository's `sk_test_` key for the duration and restored afterwards. The `past_due` state was built entirely in Stripe **test mode** with a test clock, reproducing the incident shape: subscription at 2 seats × $20/mo, clock advanced 15 days, seats raised to 3 with `create_prorations`, default payment method swapped to `pm_card_chargeCustomerFail`, clock advanced past renewal. Result: a paid **$40.00** invoice and a failed **$70.32** one — $60.00 base plus **$10.32** proration — with the subscription landing in `past_due`. A fixture organization in this workspace's isolated Neon branch pointed at that test customer, with 4 member rows of which 1 is deactivated.

### End-to-end through visible UI (before → after)

Organization switched via the sidebar switcher; settings reached via the gear; pages reached by clicking "Billing" and "All plans". Screenshots captured at each step.

| Surface | Before | After |
|---|---|---|
| Plans toggle | `aria-checked="true"`, "Billed yearly", Pro **$15** | `aria-checked="false"`, "Billed monthly", Pro **$20** |
| Pro column button | **"Change to Annual"**, `disabled=false`, `bg-primary` | **"Current plan"**, `disabled=true`, secondary |
| Billing page invoices | no "Recent invoices" section at all | `Sep 24 2026 · $70.32 · UNPAID · Pay now` and `Aug 24 2026 · $40.00 · View` |
| Plan row | "Payment failed — update your payment method to keep this plan." | badge "PAYMENT FAILED — $70.32", "Payment failed — $70.32 is due. Pay it to keep this plan.", **Pay now** |
| Sidebar card | "Payment failed" / "We couldn't charge your payment method." / "Update payment method" | "Payment failed — $70.32 due" / "…for $70.32. Pay it to keep your plan." / "Pay now" |

Toggle seeding was exercised across a full renderer reload: fresh mount seeded Monthly/$20/"Current plan" disabled; a real click on the switch moved it to Annual/$15/"Change to Annual"; after passing the 30s `staleTime` and a real window-focus refetch of `activePlan`, the manual choice was still there. `console.error` was hooked for the whole journey and stayed empty.

`RecentInvoices`' own React state was read back from the fiber to confirm it holds the real Stripe objects — `in_…C6Hw6Mqq`, `status: "open"`, `isUnpaid: true`, `amountDue: 7032`, and the `test_` hosted invoice URL matching what the Stripe API returns.

### Verified below the UI, and what was not

- **Not end-to-end:** the `external.openUrl` → `shell.openExternal` hop. macOS on this machine routes `https` through a link handler owned by another application, so clicking "Pay now" could have handed the URL to a different app instance. The button, its amber styling and the exact hosted-invoice URL it carries were verified in the rendered page and in component state; the browser hand-off itself was not exercised. `openUrl` is the same mechanism the pre-existing "View" button already uses, unchanged.
- **Not end-to-end:** the better-auth `afterAddMember` / `afterRemoveMember` / `onEvent` hooks in full, because completing them sends live email through Resend. The changed logic inside them was executed directly against the real branch database and real test-mode Stripe:
  - `countBillableSeats` returns **3** for a fixture organization with **4** `members` rows — matching `listMembers` exactly. The pre-fix code would have set the Stripe quantity to 4.
  - `getOrganizationBillingRecipients` returns the owner **and the admin** where `getOrganizationOwners` returned only the owner, and excludes both the plain member and the deactivated user.
  - `previewNextInvoice` against a second test-clock subscription, at the exact moment a seat goes 2 → 3, returns `{ prorationAmount: "$10.32", nextInvoiceTotal: "$70.32" }`. Rendering `MemberAddedBillingEmail` with those values produces "Prorated for the rest of this period $10.32", "Next invoice $70.32", and "Your next invoice is $70.32 — the new monthly total plus $10.32…". Rendering it with nulls produces the fallback, which quotes no figure.
- **Not exercised deliberately:** the "Change to Annual" button was never clicked. Before the fix it would have opened a real checkout session; the defect is fully observable from the rendered button's label, variant and enabled state.
- No migrations were run. Test-mode Stripe fixtures and the fixture organization were deleted afterwards, and `.env` was restored.

### Checks

`bun run lint`, `bun run typecheck`, `bun run test` and `bunx sherif` all exit 0.

Note on the test step: a bare `bun test` across the monorepo reports ~178 failures, but they are an artifact of running every package in one process — `mock.module` is process-wide, so mocks leak across files. Those same files pass in isolation (`resolve-repo.test.ts`: 38/38) and none of them import anything this PR touches. CI runs `bun run test` (`turbo test`, one process per package), which passes: 18/18 tasks.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer payment-failure details, including outstanding invoice amounts and due dates.
  * Owners can pay outstanding invoices directly or update payment methods from billing settings.
  * Billing history now displays paid, unpaid, and uncollectible invoices with payment details and payment actions.
  * Billing plans now accurately reflect monthly or yearly intervals.
  * Billing notifications include proration and updated invoice totals.

* **Bug Fixes**
  * Improved billable seat counts by excluding deleted members.
  * Updated billing emails to reach eligible billing contacts.
  * Clarified payment-failure and subscription-cancellation email greetings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->