### PR TITLE
fix(desktop): make the Changes pane header "Open file" clickable and restore file drag-and-drop

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -38,6 +38,7 @@ import {
 	toRelativeWorkspacePath,
 } from "shared/absolute-paths";
 import type { FoldSignal } from "../../ChangesFileList";
+import { setFileDragData } from "../../hooks/useFileDrag";
 import { FileRowContextMenuItems } from "./components/FileRowContextMenuItems";
 import { FolderContextMenuItems } from "./components/FolderContextMenuItems";
 import { ShadowRowHoverActions } from "./components/ShadowRowHoverActions";
@@ -273,6 +274,41 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		},
 	);
 
+	// Native file drag (drop a row on a terminal to paste its path). Pierre
+	// owns the row DOM and renders rows `draggable="false"`, so the drag
+	// source is this wrapper instead; Chromium still starts the drag from the
+	// nearest draggable ancestor. `dragstart` targets that source, not the
+	// row, so the row is captured on pointerdown and cancelled for non-files.
+	const dragRowRef = useRef<HTMLElement | null>(null);
+	const onPointerDownCapture = useCallback(
+		(e: React.PointerEvent) => {
+			dragRowRef.current = findFileRow(e);
+		},
+		[findFileRow],
+	);
+	const onDragStart = useCallback(
+		(e: React.DragEvent) => {
+			const row = dragRowRef.current;
+			const treePath = row?.getAttribute("data-item-path");
+			if (!row || !treePath || !worktreePath) {
+				e.preventDefault();
+				return;
+			}
+			const realPath = toRealPath.get(treePath) ?? treePath;
+			setFileDragData(
+				e.dataTransfer,
+				toAbsoluteWorkspacePath(worktreePath, realPath),
+			);
+			const rect = row.getBoundingClientRect();
+			e.dataTransfer.setDragImage(
+				row,
+				e.clientX - rect.left,
+				e.clientY - rect.top,
+			);
+		},
+		[worktreePath, toRealPath],
+	);
+
 	// Hoisted so the dialog outlives the menu/hover overlay that triggers it.
 	const [discardTarget, setDiscardTarget] = useState<ChangesetFile | null>(
 		null,
@@ -366,7 +402,13 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		: "";
 
 	return (
-		<div onClickCapture={onClickCapture}>
+		// biome-ignore lint/a11y/noStaticElementInteractions: drag source for rows Pierre renders inside a shadow root
+		<div
+			draggable
+			onClickCapture={onClickCapture}
+			onPointerDownCapture={onPointerDownCapture}
+			onDragStart={onDragStart}
+		>
 			<ShadowClickHint hint={filePolicy.hint} findRow={findFileRow}>
 				<ShadowRowHoverActions
 					findFileRow={findFileRow}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -39,6 +39,7 @@ import {
 	getChangesetFileKey,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
+import { useFileDrag } from "../../hooks/useFileDrag";
 
 function splitPath(path: string): { dir: string; basename: string } {
 	const lastSlash = path.lastIndexOf("/");
@@ -102,12 +103,14 @@ export const FileRow = memo(function FileRow({
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
 	const fileTier = policy.tierForIntent("file");
 	const externalTier = policy.tierForIntent("external");
+	const fileDrag = useFileDrag({ absolutePath });
 
 	const rowButton = (
 		<div className="group relative">
 			<button
 				type="button"
 				className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
+				{...fileDrag}
 				onClick={(e) => {
 					const intent = policy.getIntent(e);
 					if (intent === "external") onOpenInEditor?.(file.path);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useFileDrag/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useFileDrag/index.ts
@@ -1,0 +1,1 @@
+export { setFileDragData, useFileDrag } from "./useFileDrag";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useFileDrag/useFileDrag.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useFileDrag/useFileDrag.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+
+const FILE_PATH_MIME = "application/x-superset-file-path";
+
+/**
+ * Stamp a native drag with a file's absolute path. `text/plain` is what the
+ * terminal pane (and any plain text input) reads on drop; the custom MIME
+ * lets drop targets tell a file-path drag apart from arbitrary text.
+ */
+export function setFileDragData(
+	dataTransfer: DataTransfer,
+	absolutePath: string,
+): void {
+	dataTransfer.setData("text/plain", absolutePath);
+	dataTransfer.setData(FILE_PATH_MIME, absolutePath);
+	dataTransfer.effectAllowed = "copy";
+}
+
+/** Drag props for a regular-DOM changes row (folders view). */
+export function useFileDrag({ absolutePath }: { absolutePath?: string }) {
+	const onDragStart = useCallback(
+		(e: React.DragEvent) => {
+			if (!absolutePath) {
+				e.preventDefault();
+				return;
+			}
+			setFileDragData(e.dataTransfer, absolutePath);
+		},
+		[absolutePath],
+	);
+
+	return { draggable: Boolean(absolutePath), onDragStart };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/index.ts
@@ -1,0 +1,4 @@
+export {
+	type AssertedScroll,
+	shouldReassertScroll,
+} from "./shouldReassertScroll";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/shouldReassertScroll.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/shouldReassertScroll.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { shouldReassertScroll } from "./shouldReassertScroll";
+
+describe("shouldReassertScroll", () => {
+	test("scrolls for the first request", () => {
+		expect(shouldReassertScroll(null, "a:::1", 120)).toBe(true);
+	});
+
+	test("scrolls again for a new click or focus request", () => {
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: 120 },
+				"a:::2",
+				120,
+			),
+		).toBe(true);
+	});
+
+	test("stays put when the target has not moved", () => {
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: 120 },
+				"a:::1",
+				120,
+			),
+		).toBe(false);
+	});
+
+	test("re-scrolls when content above the target shifted it", () => {
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: 120 },
+				"a:::1",
+				980,
+			),
+		).toBe(true);
+	});
+
+	test("keeps asserting while the target has no layout yet", () => {
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: undefined },
+				"a:::1",
+				undefined,
+			),
+		).toBe(true);
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: 120 },
+				"a:::1",
+				undefined,
+			),
+		).toBe(true);
+		expect(
+			shouldReassertScroll(
+				{ scrollKey: "a:::1", targetTop: undefined },
+				"a:::1",
+				120,
+			),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/shouldReassertScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldReassertScroll/shouldReassertScroll.ts
@@ -1,0 +1,27 @@
+export interface AssertedScroll {
+	/** The click/focus request the last `scrollTo` served. */
+	scrollKey: string;
+	/** The target item's layout top (CodeView `getTopForItem`) at that time. */
+	targetTop: number | undefined;
+}
+
+/**
+ * Decide whether the sticky re-scroll should call `scrollTo` again.
+ *
+ * Every `scrollTo` makes CodeView suspend pointer events on its pinned
+ * header for a settle window and re-snap the viewport, so firing it on every
+ * unrelated re-render leaves the pinned header's buttons dropping clicks and
+ * yanks the user's scroll back. Only re-assert when this is a new request or
+ * the target actually moved (content above it resolved).
+ */
+export function shouldReassertScroll(
+	last: AssertedScroll | null,
+	scrollKey: string,
+	targetTop: number | undefined,
+): boolean {
+	if (last === null || last.scrollKey !== scrollKey) return true;
+	// Layout unknown for the target (not laid out yet): keep asserting so a
+	// late-resolving item still lands.
+	if (targetTop === undefined || last.targetTop === undefined) return true;
+	return last.targetTop !== targetTop;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -7,6 +7,10 @@ import {
 	getChangesetFileKey,
 } from "../../../../../useChangeset";
 import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
+import {
+	type AssertedScroll,
+	shouldReassertScroll,
+} from "./shouldReassertScroll";
 import { shouldRestoreCachedScrollState } from "./shouldRestoreCachedScrollState";
 
 interface UseDiffCodeViewScrollOptions {
@@ -53,6 +57,7 @@ export function useDiffCodeViewScroll({
 	const activeScrollKeyRef = useRef<string | null>(null);
 	const stickyRef = useRef(true);
 	const lastProgrammaticScrollAtRef = useRef(0);
+	const lastAssertedRef = useRef<AssertedScroll | null>(null);
 	const resolvedScrollStateKeyRef = useRef<string | null>(null);
 	const itemById = useMemo(() => {
 		const map = new Map<string, CodeViewItem<DiffAnnotationMetadata>>();
@@ -83,6 +88,7 @@ export function useDiffCodeViewScroll({
 		if (resolvedScrollStateKeyRef.current !== scrollStateKey) {
 			activeScrollKeyRef.current = null;
 			stickyRef.current = true;
+			lastAssertedRef.current = null;
 			if (shouldRestoreCachedScrollState(initialScrollState, data.focusTick)) {
 				const instance = codeViewRef.current?.getInstance();
 				if (!instance || items.length === 0) return;
@@ -134,7 +140,19 @@ export function useDiffCodeViewScroll({
 						behavior: "smooth-auto",
 					};
 
+		// Re-assert only when the target actually moved under us (or this is a
+		// new request). CodeView suspends pointer events on its pinned header
+		// for a settle window after every `scrollTo`, so re-firing on unrelated
+		// re-renders made the pinned header's buttons drop clicks and snapped
+		// the viewport back whenever the user scrolled away.
+		const targetTop = codeViewRef.current
+			?.getInstance()
+			?.getTopForItem(targetItemId);
+		if (!shouldReassertScroll(lastAssertedRef.current, scrollKey, targetTop))
+			return;
+
 		codeViewRef.current?.scrollTo(target);
+		lastAssertedRef.current = { scrollKey, targetTop };
 		lastProgrammaticScrollAtRef.current = Date.now();
 	}, [
 		codeViewRef,


### PR DESCRIPTION
## Summary
- Fix the Changes (diff) pane header's "Open in file viewer" arrow (and the binary "Open file" button) silently dropping clicks and the pane snapping back to the clicked file. Regression from #6679.
- Restore v1-parity file drag-and-drop from the Changes sidebar: drag a row (folders view or tree view) into a terminal to paste its absolute path.

## Why / Context
Since #6679 the diff pane's sticky follow-scroll re-fired `codeView.scrollTo` on every effect dep change, roughly once per second at idle (query refetches and callback identity churn). Each `scrollTo` makes `@pierre/diffs` put `pointer-events: none` on the pinned file header for a settle window and re-snap the viewport, so header buttons dropped human-speed clicks (mousedown hits the button, mouseup lands on the CodeView host, no click) and manual scrolls kept snapping back.

Separately, the v2 changes sidebar never ported v1's `useFileDrag` (drag a changed file into the terminal); Pierre tree rows render `draggable="false"`, so tree view needed a wrapper-based drag source.

## How It Works
- `useDiffCodeViewScroll`: new `shouldReassertScroll` gate. `scrollTo` fires only for a new click/focus request or when `getTopForItem(target)` reports the target actually moved (content above it resolved). This keeps #6679's fix for #6673 while removing the constant re-assert.
- `ChangesFileList/hooks/useFileDrag`: stamps `text/plain` + `application/x-superset-file-path` with the absolute path (same contract v1 used; the terminal pane's drop handler reads `text/plain` and shell-escapes it).
- `FileRow` (folders view) spreads the drag props on the row button.
- `ChangesTreeView` (Pierre tree) makes the wrapper the drag source: Chromium starts a drag from the nearest draggable ancestor even when rows are `user-drag: none`; the dragged row is captured on pointerdown (dragstart targets the source, not the row), used as the drag image, and folder rows cancel the drag.

## Manual QA (all verified live over CDP on this build, with screen recordings)
- [x] Click a changes row, then within ~1.2s click the pinned header's arrow: file opens in the file viewer (previously the click was dropped). Repeated with two files.
- [x] Idle `scrollTo` calls over 6s: 0 (was ~1/s before; instrumented via the CodeView instance).
- [x] Folders view: drag row into terminal, payload = absolute path, terminal pastes it.
- [x] Tree view: same, including collision-safe tree path mapping back to the real path.
- [x] Folder rows and empty space do not start drags; plain click still opens the diff; context menu and hover actions unaffected.

## Testing
- `bun test` for `useDiffCodeViewScroll` (8 pass, includes new `shouldReassertScroll` suite)
- `tsc --noEmit` (desktop typecheck) clean
- `bunx biome check` clean on touched files

## Risks / Rollout
- Risk: if `getTopForItem` were stale when items shift, the pane could under-scroll like pre-#6679; mitigated by re-asserting whenever the reported top changes or is unknown. Rollback is a two-commit revert with no data or schema impact.

https://claude.ai/code/session_01S3AzvWR1UfujLFmQHiZ8wF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sticky scroll in the Changes pane so the pinned header actions (“Open in file viewer” arrow and binary “Open file”) register clicks, and restores dragging files from the Changes sidebar into terminals. Previously the pane re-scrolled on idle, `@pierre/diffs` suppressed pointer events, clicks were dropped, and v2 lacked v1’s drag-to-terminal behavior.

- Gate sticky re-scrolls behind a new shouldReassertScroll check: only re-scroll on a new click/focus request or when the target’s layout top changes; extracted helper with unit tests.
- Reduce redundant scrollTo calls; header buttons are clickable again and manual scroll no longer snaps back.
- Add `useFileDrag` to stamp `text/plain` and `application/x-superset-file-path` with the absolute path; apply to folders view rows.
- Make `ChangesTreeView`’s wrapper the drag source for Pierre rows: capture the row on pointerdown, set the drag image, resolve tree-to-real path, and cancel drags for folders.

<sup>Written for commit 9ffe9fa8b6a1e19080a2b960698e12b84ea82c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native drag-and-drop support for files in the changes tree.
  - File paths are transferred when dragging available files, while invalid or unavailable items cannot be dragged.

- **Bug Fixes**
  - Improved diff-pane scrolling to avoid unnecessary repositioning during unrelated updates.
  - Preserved user interactions with pinned header controls and scrolling behavior.

- **Tests**
  - Added coverage for scroll-position reassertion across common navigation and layout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->