### PR TITLE
fix(desktop): restore active pane border

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -246,7 +246,11 @@ export function Pane<TData>({
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
-				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden`}
+				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden border-2 transition-colors duration-150 ${
+					isActive && parentDirection !== null
+						? "border-primary/15"
+						: "border-transparent"
+				}`}
 				onMouseDown={context.actions.focus}
 			>
 				<PaneHeader


### PR DESCRIPTION
## What & why

Restore the active-pane border removed in #6777. The highlight only appears when a tab has two or more panes, so a solo pane remains borderless.

## How I tested it

- `bun run --filter @superset/panes typecheck`
- `bun run --filter @superset/panes test` (100 passing)
- CDP on the real desktop renderer: opened a single terminal pane and confirmed its 2px border is transparent; used the visible Split pane control and confirmed the inactive pane remains transparent while the active pane uses `border-primary/15`.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (package-scoped typecheck passed; CI will run the full checks)
- [x] "Allow edits from maintainers" is checked on fork PRs (not a fork PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the active-pane border in the desktop renderer to make focus obvious in split views. Previously panes had no border; now only the active pane in a split shows a subtle 2px border, while single-pane tabs remain borderless.

- Review notes: Change is localized to `packages/panes` (`@superset/panes`). `Pane.tsx` always renders a 2px border and toggles color to `border-primary/15` when the pane is active and the tab is split; otherwise it stays `border-transparent` to avoid layout shift. Validate by splitting a tab: only the active pane should show the border; inactive and single-pane states should remain borderless.

<sup>Written for commit ab0a7bc16010730f86cb07244485837791b893d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the active pane’s appearance in split layouts with a border and partial highlight.
  * Added a smooth color transition when pane states change.
  * Preserved the transparent border for inactive panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->