### PR TITLE
fix(marketing): prevent hero demo clipping at mid-size viewports

### DIFF
--- a/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx
@@ -14,16 +14,19 @@ const SELECTOR_WIDTH = 240;
 // Undocked hero state: larger than the container and pushed down
 const HERO_SCALE = 1.08;
 const HERO_Y = 56;
+// The 8% hero oversize needs enough viewport gutter to remain fully visible.
+// Between the lg layout switch and this width, keep the mockup fitted instead.
+const HERO_EXPANSION_MEDIA_QUERY = "(min-width: 1440px)";
 
 export function ProductDemo() {
 	const [activeOption, setActiveOption] = useState<ActiveDemo>(
 		"Orchestrate Parallel Agents",
 	);
-	const [isDesktop, setIsDesktop] = useState(false);
+	const [hasHeroExpansionRoom, setHasHeroExpansionRoom] = useState(false);
 
 	useEffect(() => {
-		const mq = window.matchMedia("(min-width: 1024px)");
-		const update = () => setIsDesktop(mq.matches);
+		const mq = window.matchMedia(HERO_EXPANSION_MEDIA_QUERY);
+		const update = () => setHasHeroExpansionRoom(mq.matches);
 		update();
 		mq.addEventListener("change", update);
 		return () => mq.removeEventListener("change", update);
@@ -66,15 +69,13 @@ export function ProductDemo() {
 			<div className="relative flex-1 min-w-0">
 				<m.div
 					className="relative"
-					style={
-						isDesktop
-							? {
-									scale: mockupScale,
-									y: mockupY,
-									transformOrigin: "100% 100%",
-								}
-							: undefined
-					}
+					style={{
+						// Keep these style keys mounted so Framer Motion can attach the
+						// scroll-linked values when the media query changes after hydration.
+						scale: hasHeroExpansionRoom ? mockupScale : 1,
+						y: hasHeroExpansionRoom ? mockupY : 0,
+						transformOrigin: "100% 100%",
+					}}
 				>
 					{/* Stage lighting: soft ember-tinted glow behind the top of the
 					    window, falling off to the page black at the edges */}


### PR DESCRIPTION
## Summary
- keep the oversized hero demo animation disabled until the viewport has enough side gutter
- preserve Framer Motion transform bindings across hydration and responsive resizes
- prevent horizontal clipping in the 1024–1439px viewport range

## Verification
- `bun run --cwd apps/marketing typecheck`
- `bunx @biomejs/biome check apps/marketing/src/app/components/HeroSection/components/ProductDemo/ProductDemo.tsx`
- browser viewport sweep at 1024, 1307, 1439, 1440, and 1536px
- confirmed zero demo clipping and zero document overflow at each width

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent hero demo clipping by deferring the oversized mockup expansion to 1440px and up. Previously the hero expanded at ≥1024px, causing horizontal clipping and overflow; now it stays fitted from 1024–1439px and expands only when the viewport has enough gutter. Also keeps `framer-motion` transform bindings stable across hydration and resize.

- Uses a new HERO_EXPANSION_MEDIA_QUERY "(min-width: 1440px)" and `hasHeroExpansionRoom` state to gate expansion.
- Always mounts `scale`, `y`, and `transformOrigin` in inline styles (fallbacks: scale 1, y 0) so scroll-linked animations remain attached.

<sup>Written for commit d46eb36549ae31b0e0918c353d23abb48ffb3581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the product demo’s responsive behavior so hero expansion and scroll docking activate only on larger screens.
  * Improved layout stability on smaller desktop and tablet viewport widths by keeping the demo at its neutral scale and position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->