### PR TITLE
fix(desktop): normalise terminal theme colours before handing them to xterm

### DIFF
--- a/apps/desktop/src/renderer/stores/theme/utils/terminal-theme.test.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/terminal-theme.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import type { ITheme } from "@xterm/xterm";
+import type { TerminalColors } from "shared/themes/types";
+import { toXtermTheme } from "./terminal-theme";
+
+/**
+ * Mirrors how @xterm/addon-webgl reads the fill colour when rasterising a
+ * pattern glyph — the shade blocks ░ ▒ ▓ (customGlyphs/CustomGlyphRasterizer.ts,
+ * drawPatternChar). It inspects `ctx.fillStyle` as a string and understands only
+ * hex and `rgba()`; anything else throws, which aborts the frame before the
+ * WebGL renderer draws anything.
+ */
+function rasterizePatternGlyph(fillStyle: string): void {
+	if (fillStyle.startsWith("#") || fillStyle.startsWith("rgba")) {
+		return;
+	}
+	throw new Error(
+		`Unexpected fillStyle color format "${fillStyle}" when drawing pattern glyph`,
+	);
+}
+
+function colorValues(theme: ITheme): string[] {
+	return Object.values(theme).filter(
+		(value): value is string => typeof value === "string",
+	);
+}
+
+/** The terminal palette of the published "Obsidian" theme, verbatim. */
+const obsidianColors: TerminalColors = {
+	background: "oklch(0.1408 0.0044 265)",
+	foreground: "oklch(0.9824 0.0013 265)",
+	cursor: "oklch(0.9824 0.0013 265)",
+	cursorAccent: "oklch(0.1408 0.0044 265)",
+	selectionBackground: "oklch(0.58 0.12 265 / 35%)",
+	black: "oklch(0.1408 0.0044 265)",
+	red: "oklch(0.72 0.27 25)",
+	green: "oklch(0.78 0.25 155)",
+	yellow: "oklch(0.82 0.24 85)",
+	blue: "oklch(0.74 0.2 265)",
+	magenta: "oklch(0.72 0.2 315)",
+	cyan: "oklch(0.76 0.15 205)",
+	white: "oklch(0.9824 0.0013 265)",
+	brightBlack: "oklch(0.58 0.012 265)",
+	brightRed: "oklch(0.82 0.22 25)",
+	brightGreen: "oklch(0.84 0.2 155)",
+	brightYellow: "oklch(0.88 0.18 85)",
+	brightBlue: "oklch(0.82 0.16 265)",
+	brightMagenta: "oklch(0.82 0.17 315)",
+	brightCyan: "oklch(0.84 0.15 205)",
+	brightWhite: "oklch(1 0 0)",
+};
+
+const hexColors: TerminalColors = {
+	background: "#000000",
+	foreground: "#ffffff",
+	cursor: "#ffffff",
+	cursorAccent: "#000000",
+	selectionBackground: "#388bfd40",
+	black: "#2e3436",
+	red: "#cc0000",
+	green: "#4e9a06",
+	yellow: "#c4a000",
+	blue: "#3465a4",
+	magenta: "#75507b",
+	cyan: "#06989a",
+	white: "#d3d7cf",
+	brightBlack: "#555753",
+	brightRed: "#ef2929",
+	brightGreen: "#8ae234",
+	brightYellow: "#fce94f",
+	brightBlue: "#729fcf",
+	brightMagenta: "#ad7fa8",
+	brightCyan: "#34e2e2",
+	brightWhite: "#eeeeec",
+};
+
+describe("toXtermTheme", () => {
+	it("hands the pattern glyph rasteriser only colours it can parse", () => {
+		for (const value of colorValues(toXtermTheme(obsidianColors))) {
+			expect(() => rasterizePatternGlyph(value)).not.toThrow();
+		}
+	});
+
+	it("converts the palette entry from the reported crash", () => {
+		// "oklch(0.78 0.25 155)" is the fill colour in DESKTOP-11R.
+		expect(toXtermTheme(obsidianColors).green).toBe("#00e269");
+	});
+
+	it("keeps alpha when a colour is translucent", () => {
+		expect(toXtermTheme(obsidianColors).selectionBackground).toBe("#5777c159");
+	});
+
+	it("passes hex colours through unchanged", () => {
+		expect(toXtermTheme(hexColors)).toMatchObject(hexColors);
+	});
+
+	it("converts colours in any other notation rather than dropping them", () => {
+		const theme = toXtermTheme({
+			...hexColors,
+			red: "rgb(255, 0, 0)",
+			green: "hsl(120, 100%, 50%)",
+			blue: "rebeccapurple",
+		});
+		expect(theme.red).toBe("#ff0000");
+		expect(theme.green).toBe("#00ff00");
+		expect(theme.blue).toBe("#663399");
+	});
+
+	it("drops a colour it cannot parse instead of forwarding it", () => {
+		const theme = toXtermTheme({ ...hexColors, red: "not-a-color" });
+		expect(theme.red).toBeUndefined();
+		expect(theme.green).toBe("#4e9a06");
+	});
+});

--- a/apps/desktop/src/renderer/stores/theme/utils/terminal-theme.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/terminal-theme.ts
@@ -1,36 +1,54 @@
 import type { ITheme } from "@xterm/xterm";
 import type { TerminalColors } from "shared/themes/types";
+import { toHexAuto } from "shared/themes/utils";
+
+const CANONICAL_HEX = /^#[0-9a-f]{6}([0-9a-f]{2})?$/i;
+
+/**
+ * xterm's WebGL renderer rasterises the shade blocks ░ ▒ ▓ by reading the fill
+ * colour back off the canvas as a string, and it parses only hex and `rgba()`.
+ * A theme colour in any other notation throws mid-frame, so normalise every
+ * colour here. Colours that cannot be parsed are dropped, leaving xterm to use
+ * its own default for that slot rather than forwarding a string that crashes.
+ */
+function toXtermColor(color: string | undefined): string | undefined {
+	if (color === undefined) {
+		return undefined;
+	}
+	const hex = toHexAuto(color);
+	return CANONICAL_HEX.test(hex) ? hex : undefined;
+}
 
 /**
  * Convert theme terminal colors to xterm.js ITheme format
  */
 export function toXtermTheme(colors: TerminalColors): ITheme {
 	return {
-		background: colors.background,
-		foreground: colors.foreground,
-		cursor: colors.cursor,
-		cursorAccent: colors.cursorAccent,
-		selectionBackground: colors.selectionBackground,
-		selectionForeground: colors.selectionForeground,
+		background: toXtermColor(colors.background),
+		foreground: toXtermColor(colors.foreground),
+		cursor: toXtermColor(colors.cursor),
+		cursorAccent: toXtermColor(colors.cursorAccent),
+		selectionBackground: toXtermColor(colors.selectionBackground),
+		selectionForeground: toXtermColor(colors.selectionForeground),
 
 		// Standard ANSI colors
-		black: colors.black,
-		red: colors.red,
-		green: colors.green,
-		yellow: colors.yellow,
-		blue: colors.blue,
-		magenta: colors.magenta,
-		cyan: colors.cyan,
-		white: colors.white,
+		black: toXtermColor(colors.black),
+		red: toXtermColor(colors.red),
+		green: toXtermColor(colors.green),
+		yellow: toXtermColor(colors.yellow),
+		blue: toXtermColor(colors.blue),
+		magenta: toXtermColor(colors.magenta),
+		cyan: toXtermColor(colors.cyan),
+		white: toXtermColor(colors.white),
 
 		// Bright ANSI colors
-		brightBlack: colors.brightBlack,
-		brightRed: colors.brightRed,
-		brightGreen: colors.brightGreen,
-		brightYellow: colors.brightYellow,
-		brightBlue: colors.brightBlue,
-		brightMagenta: colors.brightMagenta,
-		brightCyan: colors.brightCyan,
-		brightWhite: colors.brightWhite,
+		brightBlack: toXtermColor(colors.brightBlack),
+		brightRed: toXtermColor(colors.brightRed),
+		brightGreen: toXtermColor(colors.brightGreen),
+		brightYellow: toXtermColor(colors.brightYellow),
+		brightBlue: toXtermColor(colors.brightBlue),
+		brightMagenta: toXtermColor(colors.brightMagenta),
+		brightCyan: toXtermColor(colors.brightCyan),
+		brightWhite: toXtermColor(colors.brightWhite),
 	};
 }


### PR DESCRIPTION
## Problem

With a theme whose terminal palette is authored in `oklch()`, the terminal stops painting whenever a shade block (`░` `▒` `▓` — U+2591–2593) is on screen. Those glyphs are common in TUI output: progress bars, meters, ASCII banners.

The failure is not cosmetic. In `@xterm/addon-webgl`, `WebglRenderer.renderRows` calls `_updateModel` **before** it issues any draw call. `_updateModel` → `updateCell` → `getRasterizedGlyph` → `_drawToCache` → `drawPatternChar` is where the throw happens, so `renderRows` unwinds without drawing and the frame produces nothing. `_innerRefresh` clears its debounce state before invoking the render callback, so the next refresh schedules another frame and throws again — five events landed in ~25 seconds on one machine on release 1.24.2.

**Who is worse off:** anyone using the published "Obsidian" theme (all 21 of its terminal colours are `oklch()`), or any theme they authored themselves in a modern colour notation. Every shade block in every ANSI colour trips it, because the fill colour passed to the rasteriser is the cell's foreground colour.

**Will this change reach the reported failure?** Yes. The event came from the renderer process of desktop 1.24.2 (`app:///dist/renderer/index.html`); `toXtermTheme` is renderer code in the same bundle, and it is the single boundary all three xterm theme hand-offs go through (`stores/theme/store.ts`, `lib/terminal/appearance/index.ts`, `.../TabsContent/Terminal/helpers.ts`). It ships in the next desktop release and reaches every user on update.

**Why code, and why here?** Archiving is wrong — this is a real render break, not just a telemetry entry. A Sentry-side filter is forbidden by repo law and would hide it. Editing `obsidian.json` to hex would fix exactly one theme and leave the next one to reintroduce it — and themes are user-installable JSON (`parseThemeConfigFile` accepts any string for every colour), so theme data cannot be the enforcement point. Fixing it upstream in xterm is the right long-term move but is not on our release cadence. `toXtermTheme` is the one chokepoint that covers the shipped theme, every other published theme, and any theme a user installs later.

## Root cause

`toXtermTheme` copied every field of our `TerminalColors` straight into xterm's `ITheme` with no conversion. The WebGL pattern-glyph rasteriser parses the fill colour by string inspection and understands only two notations:

```ts
// @xterm/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
if (fillStyle.startsWith('#')) { /* ... */ }
else if (fillStyle.startsWith('rgba')) { /* ... */ }
else { throw new Error(`Unexpected fillStyle color format "${fillStyle}" when drawing pattern glyph`); }
```

`oklch(0.78 0.25 155)` — Obsidian's `green` — matches neither, so it throws.

## Fix

Normalise every colour at the boundary with the existing `toHexAuto` helper (`packages/shared/src/themes/utils.ts`), which is already used elsewhere in the renderer. No new conversion helper, no change to any theme's colour data.

- Hex colours pass through byte-identical (`#ff0000` → `#ff0000`, `#388bfd40` → `#388bfd40`), so the 28 hex/`rgba()` themes are unaffected in value. `rgba()` becomes its canonical hex8 form — the same colour, and the notation xterm normalises to internally anyway.
- Alpha is preserved: `oklch(0.58 0.12 265 / 35%)` → `#5777c159`.
- **A colour the helper cannot parse is dropped rather than forwarded**, so xterm falls back to its own default for that slot — an unparseable string was never going to render as authored, and forwarding it is precisely what recreates the crash.

On the matcher: the only pattern here is `/^#[0-9a-f]{6}([0-9a-f]{2})?$/i`, applied to `toHexAuto`'s *own output*, not to user input. `toHexAuto` returns either canonical hex from culori or the input verbatim on parse failure, and culori parses every string of that shape — so there is no input this accepts that it should reject. `#12345` and `not-a-color` fall out as unparseable; `#1234` is valid CSS 4-digit hex and is converted, not dropped. Both directions are pinned by tests.

## Verification

`bunx biome check` on both changed files:

```
Checked 2 files in 10ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ tsc --noEmit
TYPECHECK_EXIT=0
```

**The new test fails before the change** — reproducing the exact error string from the issue:

```
$ bun test src/renderer/stores/theme/utils/terminal-theme.test.ts
80 |          expect(() => rasterizePatternGlyph(value)).not.toThrow();
error: expect(received).not.toThrow()
Error message: "Unexpected fillStyle color format \"oklch(0.1408 0.0044 265)\" when drawing pattern glyph"
(fail) toXtermTheme > hands the pattern glyph rasteriser only colours it can parse

86 |          expect(toXtermTheme(obsidianColors).green).toBe("#00e269");
error: expect(received).toBe(expected)
Expected: "#00e269"
Received: "oklch(0.78 0.25 155)"
(fail) toXtermTheme > converts the palette entry from the reported crash

111 |         expect(theme.red).toBeUndefined();
error: expect(received).toBeUndefined()
Received: "not-a-color"
(fail) toXtermTheme > drops a colour it cannot parse instead of forwarding it

 1 pass
 5 fail
Ran 6 tests across 1 file. [82.00ms]
```

**and passes after:**

```
$ bun test src/renderer/stores/theme/utils/terminal-theme.test.ts
 6 pass
 0 fail
 29 expect() calls
Ran 6 tests across 1 file. [70.00ms]
```

Suites over the touched and consuming directories:

```
$ cd apps/desktop && bun test src/renderer/stores/theme
 10 pass  0 fail  33 expect() calls   Ran 10 tests across 2 files. [83.00ms]

$ cd apps/desktop && bun test src/renderer/lib/terminal src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal
 384 pass  0 fail  1434 expect() calls   Ran 384 tests across 26 files. [572.00ms]

$ cd packages/shared && bun test src/themes
 26 pass  0 fail  76 expect() calls   Ran 26 tests across 3 files. [43.00ms]
```

The test asserts against xterm's accept-check transcribed from its source, not against a stub of our own behaviour, so it pins the real defect rather than the shape of the fix.

## Left alone deliberately

Other places terminal colours are read (`ThemeSwatch`, `editor-theme.ts` deriving CodeMirror colours) hand them to CSS, which parses `oklch()` natively — no conversion needed and none added. `obsidian.json` and `marketplace.ts` keep their `oklch()` values; the boundary is now the enforcement point.

Refs DESKTOP-11R

https://claude.ai/code/session_01QbnNzEyToNyUCQ6i7ug4dC


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes terminal theme colors to canonical hex before passing them to `@xterm/xterm`, preventing WebGL frame aborts when shade-block glyphs are rasterized. Previously `toXtermTheme` forwarded `oklch()` strings; `@xterm/addon-webgl` only accepts hex or rgba, threw during rasterization, and the terminal stopped painting.

- Converts all `TerminalColors` via `toHexAuto` at the renderer boundary (`toXtermTheme`): hex passes through, rgba becomes hex8, alpha is preserved, and unparseable values are omitted so `xterm` falls back to defaults. No theme JSON or CSS consumers changed. Tests mirror `@xterm/addon-webgl`’s accept rules and pin the fix. Refs DESKTOP-11R.

<sup>Written for commit d45b43a5644519c7d91c9e218b3b0c26fc9a850c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal theme color compatibility across supported formats, including RGB, HSL, named colors, transparency, and OKLCH.
  - Invalid or unsupported color values are now safely omitted, allowing terminal defaults to display instead of producing incorrect colors.
  - Preserved existing valid hexadecimal colors while normalizing all terminal theme colors consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->