### PR TITLE
fix(desktop): redact home paths from updater errors sent to Sentry

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -8,6 +8,7 @@ import { env } from "main/env.main";
 import { setSkipQuitConfirmation } from "main/index";
 import { appState } from "main/lib/app-state";
 import { isEnvironmentUpdateError } from "main/lib/update-error-classification";
+import { redactUpdateError } from "main/lib/update-error-redaction";
 import { gte, prerelease } from "semver";
 import {
 	AUTO_UPDATE_STATUS,
@@ -369,7 +370,7 @@ export function setupAutoUpdater(): void {
 				freeStagingBytes(),
 			)
 		) {
-			Sentry.captureException(error);
+			Sentry.captureException(redactUpdateError(error));
 		}
 	});
 

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -257,3 +257,43 @@ describe("redactUpdateError stack coverage", () => {
 		expect(redacted.stack).toContain("main.js:1:1");
 	});
 });
+
+// An ASCII-only account-name class leaves non-ASCII accounts exposed: a name
+// with an accent is only partly rewritten, and a name with no ASCII in it does
+// not match at all. Account names are not ASCII in much of the world.
+describe("redactUpdateErrorMessage with non-ASCII account names", () => {
+	test("redacts accented and non-Latin account names completely", () => {
+		expect(redactUpdateErrorMessage("/Users/jos\u00e9/Library/Caches/x")).toBe(
+			"~/Library/Caches/x",
+		);
+		expect(redactUpdateErrorMessage("/Users/\u674e/Library/Caches/x")).toBe(
+			"~/Library/Caches/x",
+		);
+		expect(redactUpdateErrorMessage("/home/jos\u00e9/.cache/x")).toBe(
+			"~/.cache/x",
+		);
+		expect(
+			redactUpdateErrorMessage("C:\\Users\\\u674e\\AppData\\Local\\x"),
+		).toBe("~\\AppData\\Local\\x");
+	});
+
+	test("converges non-ASCII accounts with ASCII ones", () => {
+		expect(redactUpdateErrorMessage("/Users/\u674e/Library/x")).toBe(
+			redactUpdateErrorMessage("/Users/ada/Library/x"),
+		);
+	});
+
+	// Widening the account class must not let it run past the segment and eat
+	// the surrounding message.
+	test("stops at the segment, not at the end of the message", () => {
+		expect(redactUpdateErrorMessage("ditto: /Users/ada: No such file")).toBe(
+			"ditto: ~: No such file",
+		);
+		expect(redactUpdateErrorMessage("open '/Users/ada' failed")).toBe(
+			"open '~' failed",
+		);
+		expect(
+			redactUpdateErrorMessage("Cannot read /Users/ada/x and /Users/bob/y"),
+		).toBe("Cannot read ~/x and ~/y");
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+	redactUpdateError,
+	redactUpdateErrorMessage,
+} from "./update-error-redaction";
+
+// The failure this redaction exists for, with invented account names and
+// staging tokens. Two machines, two staging attempts, one condition.
+const DITTO_MISSING_ASAR_ADA =
+	"ditto: /Users/ada/Library/Caches/com.superset.desktop.ShipIt/update.qZ4mTb1/Superset.app/Contents/Resources/app.asar: No such file or directory";
+const DITTO_MISSING_ASAR_GRACE =
+	"ditto: /Users/grace.h/Library/Caches/com.superset.desktop.ShipIt/update.Kd9wRp7/Superset.app/Contents/Resources/app.asar: No such file or directory";
+
+// Messages that carry no home directory at all. Every one of these must come
+// back byte-for-byte, or the redaction is destroying evidence we rely on.
+const CHECKSUM_MISMATCH =
+	"sha512 checksum mismatch, expected 1PbOs3lC, got fT2wPk9d";
+const SIGNATURE_FAILURE =
+	'Could not get code signature for running application: Error: Command failed: codesign --verify -vvvv "/Applications/Superset.app"';
+const SYSTEM_LIBRARY_PATH =
+	"ENOENT: no such file or directory, open '/Library/Application Support/Superset/update.log'";
+const TEMP_PATH =
+	"ditto: /tmp/superset-updater/pending/Superset-1.24.0-mac.zip: Operation not permitted";
+const VERSION_TEXT =
+	"Cannot update from 1.22.0 to 1.24.0: update.yml is newer than update.zip";
+const SQUIRREL_NO_SPACE_ES =
+	"El archivo no puede guardarse porque no queda suficiente espacio.";
+
+describe("redactUpdateErrorMessage", () => {
+	test("removes the account name from a staged-update failure", () => {
+		const redacted = redactUpdateErrorMessage(DITTO_MISSING_ASAR_ADA);
+		expect(redacted).not.toContain("ada");
+		expect(redacted).not.toContain("/Users/");
+		// The parts we actually triage on survive.
+		expect(redacted).toContain("ditto:");
+		expect(redacted).toContain("app.asar");
+		expect(redacted).toContain("No such file or directory");
+		expect(redacted).toBe(
+			"ditto: ~/Library/Caches/com.superset.desktop.ShipIt/update.<id>/Superset.app/Contents/Resources/app.asar: No such file or directory",
+		);
+	});
+
+	test("converges the same failure from two different accounts", () => {
+		expect(redactUpdateErrorMessage(DITTO_MISSING_ASAR_ADA)).toBe(
+			redactUpdateErrorMessage(DITTO_MISSING_ASAR_GRACE),
+		);
+	});
+
+	test("passes messages without a home directory through unchanged", () => {
+		for (const message of [
+			CHECKSUM_MISMATCH,
+			SIGNATURE_FAILURE,
+			SYSTEM_LIBRARY_PATH,
+			TEMP_PATH,
+			VERSION_TEXT,
+			SQUIRREL_NO_SPACE_ES,
+		]) {
+			expect(redactUpdateErrorMessage(message)).toBe(message);
+		}
+	});
+
+	test("leaves paths that are not a user home alone", () => {
+		// /Users/Shared is a real macOS directory, not somebody's account.
+		expect(
+			redactUpdateErrorMessage(
+				"ditto: /Users/Shared/Superset/staged.zip: I/O error",
+			),
+		).toBe("ditto: /Users/Shared/Superset/staged.zip: I/O error");
+		// ...but an account that merely starts with "Shared" is still an account.
+		expect(redactUpdateErrorMessage("/Users/Sharedrive/Library")).toBe(
+			"~/Library",
+		);
+		expect(redactUpdateErrorMessage("/UsersGuide/readme.txt")).toBe(
+			"/UsersGuide/readme.txt",
+		);
+	});
+
+	test("rewrites only the staging directory segment, not similarly named files", () => {
+		expect(
+			redactUpdateErrorMessage(
+				"ditto: ./update.zip: Couldn't read pkzip signature.",
+			),
+		).toBe("ditto: ./update.zip: Couldn't read pkzip signature.");
+		expect(redactUpdateErrorMessage("Cannot parse update.yml")).toBe(
+			"Cannot parse update.yml",
+		);
+	});
+});
+
+describe("redactUpdateError", () => {
+	test("returns the very same error when there is nothing to redact", () => {
+		const error = new Error(CHECKSUM_MISMATCH);
+		expect(redactUpdateError(error)).toBe(error);
+	});
+
+	test("keeps the error name and redacts the stack too", () => {
+		const error = new Error(DITTO_MISSING_ASAR_ADA);
+		error.name = "UpdaterError";
+		error.stack = `UpdaterError: ${DITTO_MISSING_ASAR_ADA}\n    at /Users/ada/Applications/Superset.app/Contents/Resources/app.asar/main.js:1:1`;
+
+		const redacted = redactUpdateError(error);
+
+		expect(redacted.name).toBe("UpdaterError");
+		expect(redacted.message).not.toContain("ada");
+		expect(redacted.stack).not.toContain("/Users/");
+		expect(redacted.stack).toContain("main.js:1:1");
+	});
+
+	test("does not invent a stack for an error that never had one", () => {
+		const error = new Error(DITTO_MISSING_ASAR_ADA);
+		error.stack = undefined;
+		expect(redactUpdateError(error).stack).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -112,3 +112,50 @@ describe("redactUpdateError", () => {
 		expect(redactUpdateError(error).stack).toBeUndefined();
 	});
 });
+
+// The updater ships on Windows (nsis) and Linux (AppImage) as well as macOS,
+// and the same handler reports all three. Their staging directories live under
+// the user's home too — which is why the existing classifier already looks for
+// an "-updater" path marker alongside "shipit".
+describe("redactUpdateErrorMessage across platforms", () => {
+	test("removes the account name from a Linux staging path", () => {
+		const redacted = redactUpdateErrorMessage(
+			"ENOENT: no such file or directory, open '/home/ada/.cache/superset-updater/pending/Superset.AppImage'",
+		);
+		expect(redacted).not.toContain("ada");
+		expect(redacted).toBe(
+			"ENOENT: no such file or directory, open '~/.cache/superset-updater/pending/Superset.AppImage'",
+		);
+	});
+
+	test("removes the account name from a Windows staging path", () => {
+		const redacted = redactUpdateErrorMessage(
+			"EBUSY: resource busy or locked, open 'C:\\Users\\grace.h\\AppData\\Local\\superset-updater\\installer.exe'",
+		);
+		expect(redacted).not.toContain("grace.h");
+		expect(redacted).toBe(
+			"EBUSY: resource busy or locked, open '~\\AppData\\Local\\superset-updater\\installer.exe'",
+		);
+	});
+
+	test("converges the same Linux failure from two different accounts", () => {
+		expect(
+			redactUpdateErrorMessage("ditto: /home/ada/.cache/x: I/O error"),
+		).toBe(
+			redactUpdateErrorMessage("ditto: /home/grace.h/.cache/x: I/O error"),
+		);
+	});
+
+	// Negative cases: real system directories that are not somebody's account,
+	// and a "/home/" that is only a substring of a deeper path.
+	test("leaves non-account system directories alone", () => {
+		for (const message of [
+			"EPERM: operation not permitted, open 'C:\\Users\\Public\\Desktop\\Superset.lnk'",
+			"EPERM: operation not permitted, open 'C:\\Users\\Default\\NTUSER.DAT'",
+			"ditto: /home/linuxbrew/.linuxbrew/bin/superset: Permission denied",
+			"ENOENT: no such file or directory, open '/var/lib/home/superset/cache'",
+		]) {
+			expect(redactUpdateErrorMessage(message)).toBe(message);
+		}
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -297,3 +297,31 @@ describe("redactUpdateErrorMessage with non-ASCII account names", () => {
 		).toBe("Cannot read ~/x and ~/y");
 	});
 });
+
+// The carve-outs and the account segment have to agree on where a segment
+// ends. They did not: widening the account terminator to stop at whitespace,
+// quotes and colons without widening the carve-out boundary meant a reserved
+// system directory followed by one of those was treated as an account.
+describe("redactUpdateErrorMessage carve-outs at message delimiters", () => {
+	test("reserved directories survive at a delimiter, not just a separator", () => {
+		for (const message of [
+			"ditto: /Users/Shared: access denied",
+			"open '/Users/Shared' failed",
+			"ditto: /home/linuxbrew: permission denied",
+			"open '/home/linuxbrew' failed",
+			"EPERM: open 'C:\\Users\\Public' failed",
+			"EPERM: C:\\Users\\Public: access denied",
+		]) {
+			expect(redactUpdateErrorMessage(message)).toBe(message);
+		}
+	});
+
+	test("an account starting with a reserved name is still redacted at a delimiter", () => {
+		expect(redactUpdateErrorMessage("ditto: /Users/Sharedrive: denied")).toBe(
+			"ditto: ~: denied",
+		);
+		expect(redactUpdateErrorMessage("/Users/Sharedrive/Library")).toBe(
+			"~/Library",
+		);
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -159,3 +159,42 @@ describe("redactUpdateErrorMessage across platforms", () => {
 		}
 	});
 });
+
+// electron-updater builds its errors with `newError(message, code)`, which sets
+// an own `code` property, and Sentry serialises non-standard error properties.
+// Rebuilding the error must not drop them — the code is the most triageable
+// field on the whole report.
+describe("redactUpdateError property fidelity", () => {
+	test("keeps a code set by the updater", () => {
+		const error = new Error(DITTO_MISSING_ASAR_ADA) as Error & {
+			code?: string;
+		};
+		error.code = "ERR_UPDATER_ZIP_FILE_NOT_FOUND";
+
+		const redacted = redactUpdateError(error) as Error & { code?: string };
+
+		expect(redacted.message).not.toContain("ada");
+		expect(redacted.code).toBe("ERR_UPDATER_ZIP_FILE_NOT_FOUND");
+	});
+
+	test("redacts a home path carried on another property too", () => {
+		const error = new Error(DITTO_MISSING_ASAR_ADA) as Error & {
+			path?: string;
+		};
+		error.path = "/Users/ada/Library/Caches/com.superset.desktop.ShipIt";
+
+		const redacted = redactUpdateError(error) as Error & { path?: string };
+
+		expect(redacted.path).toBe("~/Library/Caches/com.superset.desktop.ShipIt");
+	});
+
+	test("carries non-string properties across untouched", () => {
+		const error = new Error(DITTO_MISSING_ASAR_ADA) as Error & {
+			statusCode?: number;
+		};
+		error.statusCode = 404;
+		expect(
+			(redactUpdateError(error) as Error & { statusCode?: number }).statusCode,
+		).toBe(404);
+	});
+});

--- a/apps/desktop/src/main/lib/update-error-redaction.test.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.test.ts
@@ -90,6 +90,9 @@ describe("redactUpdateErrorMessage", () => {
 describe("redactUpdateError", () => {
 	test("returns the very same error when there is nothing to redact", () => {
 		const error = new Error(CHECKSUM_MISMATCH);
+		// Pinned rather than left ambient: a real thrown error's stack carries
+		// whatever path the test file lives under, which would itself redact.
+		error.stack = `Error: ${CHECKSUM_MISMATCH}\n    at doUpdate (/Applications/Superset.app/Contents/Resources/app.asar/main.js:1:1)`;
 		expect(redactUpdateError(error)).toBe(error);
 	});
 
@@ -196,5 +199,61 @@ describe("redactUpdateError property fidelity", () => {
 		expect(
 			(redactUpdateError(error) as Error & { statusCode?: number }).statusCode,
 		).toBe(404);
+	});
+});
+
+// Every carve-out below was originally written with `\b`, which matches before
+// `.` and `-` — so an account whose name merely *starts* with a system
+// directory name was excluded from redaction and leaked. These pin that.
+describe("redactUpdateErrorMessage carve-out precision", () => {
+	test("an account whose name starts with a system directory is still an account", () => {
+		expect(redactUpdateErrorMessage("/Users/Shared.dev/Library/Caches/x")).toBe(
+			"~/Library/Caches/x",
+		);
+		expect(redactUpdateErrorMessage("/Users/Shared-user/Library/x")).toBe(
+			"~/Library/x",
+		);
+		expect(redactUpdateErrorMessage("/home/linuxbrew.dev/.cache/x")).toBe(
+			"~/.cache/x",
+		);
+		expect(redactUpdateErrorMessage("C:\\Users\\Public.dev\\AppData\\x")).toBe(
+			"~\\AppData\\x",
+		);
+	});
+
+	test("the exact system directories are still left alone", () => {
+		for (const message of [
+			"/Users/Shared/Superset/staged.zip",
+			"/home/linuxbrew/.linuxbrew/bin/superset",
+			"C:\\Users\\Public\\Desktop\\Superset.lnk",
+			"C:\\Users\\Default\\NTUSER.DAT",
+			"C:\\Users\\All Users\\Superset\\config",
+		]) {
+			expect(redactUpdateErrorMessage(message)).toBe(message);
+		}
+	});
+
+	test("Windows paths are case-insensitive", () => {
+		expect(redactUpdateErrorMessage("c:\\users\\ada\\AppData\\Local\\x")).toBe(
+			"~\\AppData\\Local\\x",
+		);
+		expect(redactUpdateErrorMessage("C:\\USERS\\PUBLIC\\Desktop\\x")).toBe(
+			"C:\\USERS\\PUBLIC\\Desktop\\x",
+		);
+	});
+});
+
+describe("redactUpdateError stack coverage", () => {
+	test("redacts a home path that appears only in the stack", () => {
+		// Real whenever the app is installed under ~/Applications: the message
+		// carries no path but every frame does.
+		const error = new Error(CHECKSUM_MISMATCH);
+		error.stack = `Error: ${CHECKSUM_MISMATCH}\n    at doUpdate (/Users/ada/Applications/Superset.app/Contents/Resources/app.asar/main.js:1:1)`;
+
+		const redacted = redactUpdateError(error);
+
+		expect(redacted.message).toBe(CHECKSUM_MISMATCH);
+		expect(redacted.stack).not.toContain("/Users/");
+		expect(redacted.stack).toContain("main.js:1:1");
 	});
 });

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -15,13 +15,19 @@
 // match before `.` and `-`, which would exempt real accounts like `Shared.dev`
 // from redaction and leak exactly what this exists to remove. Windows paths are
 // case-insensitive, so that pattern carries the `i` flag.
-const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:\/|$))[A-Za-z0-9._-]+/g;
+//
+// The account segment is "everything up to the separator" rather than an ASCII
+// class: account names are not ASCII in much of the world, and an ASCII class
+// only partly rewrites `jos\u00e9` and does not match `\u674e` at all, leaking exactly
+// what this removes. Whitespace, quotes and colons end the segment too, so a
+// path at the end of a sentence cannot run on and swallow the message after
+// it.
+const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:\/|$))[^/\s'":]+/g;
 // `/home/` only counts as the home root at the start of a path, so a deeper
 // directory that merely ends in `/home` (`/var/lib/home/...`) is left alone.
-const LINUX_HOME_PATH =
-	/(?<![A-Za-z0-9._-])\/home\/(?!linuxbrew(?:\/|$))[A-Za-z0-9._-]+/g;
+const LINUX_HOME_PATH = /(?<![^\s'"])\/home\/(?!linuxbrew(?:\/|$))[^/\s'":]+/g;
 const WINDOWS_HOME_PATH =
-	/[A-Za-z]:\\Users\\(?!(?:Public|Default|All Users)(?:\\|$))[A-Za-z0-9._-]+/gi;
+	/[A-Za-z]:\\Users\\(?!(?:Public|Default|All Users)(?:\\|$))[^\\\s'":]+/gi;
 
 // Every staging attempt unpacks into a freshly named `update.XXXXXXX`
 // directory, so one recurring condition otherwise groups as a brand-new issue

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -10,15 +10,18 @@
 // reports all three, so all three home layouts are covered — the existing
 // classifier already looks for an "-updater" path marker alongside "shipit"
 // for exactly that reason. Each pattern carves out the directories under that
-// root that are system locations rather than somebody's account; `\b` keeps
-// each carve-out from swallowing an account merely starting with the same word.
-const MACOS_HOME_PATH = /\/Users\/(?!Shared\b)[A-Za-z0-9._-]+/g;
+// root that are system locations rather than somebody's account. Each carve-out
+// requires a path separator or end of string after the name: `\b` would also
+// match before `.` and `-`, which would exempt real accounts like `Shared.dev`
+// from redaction and leak exactly what this exists to remove. Windows paths are
+// case-insensitive, so that pattern carries the `i` flag.
+const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:\/|$))[A-Za-z0-9._-]+/g;
 // `/home/` only counts as the home root at the start of a path, so a deeper
 // directory that merely ends in `/home` (`/var/lib/home/...`) is left alone.
 const LINUX_HOME_PATH =
-	/(?<![A-Za-z0-9._-])\/home\/(?!linuxbrew\b)[A-Za-z0-9._-]+/g;
+	/(?<![A-Za-z0-9._-])\/home\/(?!linuxbrew(?:\/|$))[A-Za-z0-9._-]+/g;
 const WINDOWS_HOME_PATH =
-	/[A-Za-z]:\\Users\\(?!Public\b|Default\b|All\b)[A-Za-z0-9._-]+/g;
+	/[A-Za-z]:\\Users\\(?!(?:Public|Default|All Users)(?:\\|$))[A-Za-z0-9._-]+/gi;
 
 // Every staging attempt unpacks into a freshly named `update.XXXXXXX`
 // directory, so one recurring condition otherwise groups as a brand-new issue
@@ -41,14 +44,19 @@ export function redactUpdateErrorMessage(message: string): string {
  */
 export function redactUpdateError(error: Error): Error {
 	const message = redactUpdateErrorMessage(error.message);
-	if (message === error.message) {
+	// The stack is checked too: a message can be clean while every frame carries
+	// a home path, which is the ordinary case when the app is installed under
+	// the user's own Applications folder.
+	const stack =
+		error.stack === undefined
+			? undefined
+			: redactUpdateErrorMessage(error.stack);
+	if (message === error.message && stack === error.stack) {
 		return error;
 	}
 	const redacted = new Error(message);
 	redacted.name = error.name;
-	redacted.stack = error.stack
-		? redactUpdateErrorMessage(error.stack)
-		: undefined;
+	redacted.stack = stack;
 	// electron-updater attaches an own `code` to the errors it builds, and Sentry
 	// serialises non-standard error properties, so rebuilding the error must
 	// carry them across or the report loses its most triageable field. String

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -49,5 +49,14 @@ export function redactUpdateError(error: Error): Error {
 	redacted.stack = error.stack
 		? redactUpdateErrorMessage(error.stack)
 		: undefined;
+	// electron-updater attaches an own `code` to the errors it builds, and Sentry
+	// serialises non-standard error properties, so rebuilding the error must
+	// carry them across or the report loses its most triageable field. String
+	// values go through the same redaction: a path can be carried out here too.
+	for (const key of Object.keys(error)) {
+		const value = (error as unknown as Record<string, unknown>)[key];
+		(redacted as unknown as Record<string, unknown>)[key] =
+			typeof value === "string" ? redactUpdateErrorMessage(value) : value;
+	}
 	return redacted;
 }

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -1,0 +1,41 @@
+// Squirrel.Mac and electron-updater report a staging failure by printing the
+// absolute path they were working on. That path starts in the user's home
+// directory, so reporting the message as-is carries the account name of
+// whoever hit the failure into the issue title, and from there into anywhere
+// issue titles are republished. Strip the account segment and nothing else:
+// the tool that failed, the file it wanted and the reason are what we triage
+// on, and they have to survive intact.
+//
+// `Shared` is a real macOS directory rather than an account, so it is left
+// alone; `\b` keeps that from swallowing an account merely starting with it.
+const USER_HOME_PATH = /\/Users\/(?!Shared\b)[A-Za-z0-9._-]+/g;
+
+// Every staging attempt unpacks into a freshly named `update.XXXXXXX`
+// directory, so one recurring condition otherwise groups as a brand-new issue
+// on every occurrence. Anchored on both slashes so it only ever rewrites a
+// path segment — `update.zip` and `update.yml` are real filenames that carry
+// meaning and must not be touched.
+const STAGING_ATTEMPT_DIR = /\/update\.[A-Za-z0-9]+\//g;
+
+export function redactUpdateErrorMessage(message: string): string {
+	return message
+		.replace(USER_HOME_PATH, "~")
+		.replace(STAGING_ATTEMPT_DIR, "/update.<id>/");
+}
+
+/**
+ * Returns an error safe to report, preserving the original when there is
+ * nothing to redact so that errors reaching Sentry keep their identity.
+ */
+export function redactUpdateError(error: Error): Error {
+	const message = redactUpdateErrorMessage(error.message);
+	if (message === error.message) {
+		return error;
+	}
+	const redacted = new Error(message);
+	redacted.name = error.name;
+	redacted.stack = error.stack
+		? redactUpdateErrorMessage(error.stack)
+		: undefined;
+	return redacted;
+}

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -18,13 +18,13 @@
 //
 // The account segment is "everything up to the separator" rather than an ASCII
 // class: account names are not ASCII in much of the world, and an ASCII class
-// only partly rewrites `jos\u00e9` and does not match `\u674e` at all, leaking exactly
-// what this removes. Whitespace, quotes and colons end the segment too, so a
-// path at the end of a sentence cannot run on and swallow the message after
-// it. The carve-outs end on that same delimiter set rather than on the
-// separator alone, so a reserved directory named at the end of a sentence
-// (`/Users/Shared: access denied`) is still recognised as reserved instead of
-// being rewritten as though it were somebody's account.
+// only partly rewrites an accented name and does not match a name written in a
+// non-Latin script at all, leaking exactly what this exists to remove.
+// Whitespace, quotes and colons end the segment too, so a path at the end of a
+// sentence cannot run on and swallow the message after it. The carve-outs end
+// on that same delimiter set rather than on the separator alone, so a reserved
+// directory named at the end of a sentence (`/Users/Shared: access denied`) is
+// still recognised as reserved instead of being rewritten as an account.
 const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:[/\s'":]|$))[^/\s'":]+/g;
 // `/home/` only counts as the home root at the start of a path, so a deeper
 // directory that merely ends in `/home` (`/var/lib/home/...`) is left alone.

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -6,9 +6,19 @@
 // the tool that failed, the file it wanted and the reason are what we triage
 // on, and they have to survive intact.
 //
-// `Shared` is a real macOS directory rather than an account, so it is left
-// alone; `\b` keeps that from swallowing an account merely starting with it.
-const USER_HOME_PATH = /\/Users\/(?!Shared\b)[A-Za-z0-9._-]+/g;
+// The updater ships on Windows and Linux as well as macOS and this handler
+// reports all three, so all three home layouts are covered — the existing
+// classifier already looks for an "-updater" path marker alongside "shipit"
+// for exactly that reason. Each pattern carves out the directories under that
+// root that are system locations rather than somebody's account; `\b` keeps
+// each carve-out from swallowing an account merely starting with the same word.
+const MACOS_HOME_PATH = /\/Users\/(?!Shared\b)[A-Za-z0-9._-]+/g;
+// `/home/` only counts as the home root at the start of a path, so a deeper
+// directory that merely ends in `/home` (`/var/lib/home/...`) is left alone.
+const LINUX_HOME_PATH =
+	/(?<![A-Za-z0-9._-])\/home\/(?!linuxbrew\b)[A-Za-z0-9._-]+/g;
+const WINDOWS_HOME_PATH =
+	/[A-Za-z]:\\Users\\(?!Public\b|Default\b|All\b)[A-Za-z0-9._-]+/g;
 
 // Every staging attempt unpacks into a freshly named `update.XXXXXXX`
 // directory, so one recurring condition otherwise groups as a brand-new issue
@@ -19,7 +29,9 @@ const STAGING_ATTEMPT_DIR = /\/update\.[A-Za-z0-9]+\//g;
 
 export function redactUpdateErrorMessage(message: string): string {
 	return message
-		.replace(USER_HOME_PATH, "~")
+		.replace(MACOS_HOME_PATH, "~")
+		.replace(LINUX_HOME_PATH, "~")
+		.replace(WINDOWS_HOME_PATH, "~")
 		.replace(STAGING_ATTEMPT_DIR, "/update.<id>/");
 }
 

--- a/apps/desktop/src/main/lib/update-error-redaction.ts
+++ b/apps/desktop/src/main/lib/update-error-redaction.ts
@@ -21,13 +21,17 @@
 // only partly rewrites `jos\u00e9` and does not match `\u674e` at all, leaking exactly
 // what this removes. Whitespace, quotes and colons end the segment too, so a
 // path at the end of a sentence cannot run on and swallow the message after
-// it.
-const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:\/|$))[^/\s'":]+/g;
+// it. The carve-outs end on that same delimiter set rather than on the
+// separator alone, so a reserved directory named at the end of a sentence
+// (`/Users/Shared: access denied`) is still recognised as reserved instead of
+// being rewritten as though it were somebody's account.
+const MACOS_HOME_PATH = /\/Users\/(?!Shared(?:[/\s'":]|$))[^/\s'":]+/g;
 // `/home/` only counts as the home root at the start of a path, so a deeper
 // directory that merely ends in `/home` (`/var/lib/home/...`) is left alone.
-const LINUX_HOME_PATH = /(?<![^\s'"])\/home\/(?!linuxbrew(?:\/|$))[^/\s'":]+/g;
+const LINUX_HOME_PATH =
+	/(?<![^\s'"])\/home\/(?!linuxbrew(?:[/\s'":]|$))[^/\s'":]+/g;
 const WINDOWS_HOME_PATH =
-	/[A-Za-z]:\\Users\\(?!(?:Public|Default|All Users)(?:\\|$))[^\\\s'":]+/gi;
+	/[A-Za-z]:\\Users\\(?!(?:Public|Default|All Users)(?:[\\\s'":]|$))[^\\\s'":]+/gi;
 
 // Every staging attempt unpacks into a freshly named `update.XXXXXXX`
 // directory, so one recurring condition otherwise groups as a brand-new issue


### PR DESCRIPTION
## Problem

When the macOS updater stages an update, it copies the new bundle out of a cache
directory under the user's home folder. When a file it expects is not there, it
reports the failure by printing the **full absolute path** of that file, and we
hand that message straight to Sentry.

That path begins with the user's home directory, so **every one of these reports
carried the account name of the person it came from** into the issue title — and
issue titles get republished, including into our own alerting channel. The same
path also contains a per-attempt random staging directory name, so each
occurrence formed a brand-new issue group and one recurring condition shredded
into an unbounded number of issues that could never be triaged as one thing.

The four referenced issues are one condition, not four; they are separate groups
only because that path differs per machine and per attempt. Roughly 108 events
across about a dozen releases in the last 14 days belong to the same family.

**Reachability.** The reported events come from the packaged desktop app's main
process, which is the only place `setupAutoUpdater` runs. The change sits on the
one `Sentry.captureException` in that handler, so it takes effect for every
future occurrence in the first desktop release cut after this merges, and reaches
everyone who auto-updates onto it. It does not retroactively change the events
already captured.

**Why code, and not something else.** Archiving the issues loses the condition
entirely and does nothing about the account names in the events already there or
the ones that keep arriving. An inbound Sentry filter would drop the reports
wholesale, which is worse: this failure is worth knowing about, it just must not
be worth knowing *who*. Fixing it further down — at the updater — is a different
question (why the staged bundle is incomplete) and does not stop the path from
being reported. A Sentry-side `beforeSend` scrubber is forbidden by repo law
(#6164), and correctly so: it would suppress at the wrong layer. The capture
site is the only place that can both keep the report and strip the identity, so
that is where this lands.

## Root cause

`Sentry.captureException(error)` in the `autoUpdater.on("error", ...)` handler
reported the updater's message verbatim. The message is generated by the staging
tool and is not ours, so nothing along the way had a chance to remove the
user-specific prefix before it became an issue title.

## Fix

A new `update-error-redaction.ts` beside the existing classifier, applied at the
capture call only:

- the account segment of an absolute home path becomes `~`
- the per-attempt staging directory becomes `update.<id>`

Everything else in the message — the tool that failed, the file it wanted, the
reason — is left exactly as it was, so the report stays as useful as it is today
and two machines now produce an identical message.

Illustrative shape, with invented account names (not a real captured path):

```
machine A in : ditto: /Users/ada/Library/Caches/com.superset.desktop.ShipIt/update.qZ4mTb1/Superset.app/Contents/Resources/app.asar: No such file or directory
machine B in : ditto: /Users/grace.h/Library/Caches/com.superset.desktop.ShipIt/update.Kd9wRp7/Superset.app/Contents/Resources/app.asar: No such file or directory
machine A out: ditto: ~/Library/Caches/com.superset.desktop.ShipIt/update.<id>/Superset.app/Contents/Resources/app.asar: No such file or directory
machine B out: ditto: ~/Library/Caches/com.superset.desktop.ShipIt/update.<id>/Superset.app/Contents/Resources/app.asar: No such file or directory
converged    : true
```

`redactUpdateError` returns the **original error object** when there is nothing
to redact, and otherwise preserves `name` and redacts the `stack` alongside the
message, so errors that do carry a stack (checksum and code-signature failures)
do not lose it.

Scope notes:

- **`isEnvironmentUpdateError` is untouched** — the file is byte-for-byte
  unchanged, and classification still runs on the *raw* message. This reports in
  exactly the cases it does today; only the reported text changes.
- **The log lines and the renderer status are untouched.** They stay on the user's
  own machine and were never the problem.
- **No typed `cause` added.** Nothing reads one here — no renderer branch, no
  retry decision, no test — so a `kind` would be code maintained for nothing.
- Not investigated here: *why* the staged bundle is incomplete. Separate question.
- Left alone, as a neighbouring capture that can also carry an absolute path:
  `host-service-coordinator.ts:974` puts the host-service `outputTail` into
  `extra`. It is secret-redacted but not path-redacted. It does not reach the
  issue title, so it neither leaks into republished titles nor shreds grouping.

### What the matcher deliberately does not match

Both patterns are narrow on purpose, because a matcher that rewrites more of the
message than the part it names is a defect. Named inputs it must leave alone, all
covered by tests:

- `/Users/Shared/...` — a real macOS directory, not somebody's account (while an
  account merely *starting* with "Shared" is still redacted)
- `/UsersGuide/...` — not a home path at all
- `/Applications/...`, `/Library/...`, `/tmp/...` — absolute, but not under a home
- `update.zip`, `update.yml`, `update.log` — real filenames, not the staging dir;
  the staging pattern is anchored on both slashes so it only rewrites a path segment
- version numbers (`1.22.0` → `1.24.0`) and error text (`sha512 checksum mismatch,
  expected …, got …`) pass through byte-for-byte

## Verification

The negative tests were written **before** the implementation and confirmed to
fail first (`Cannot find module './update-error-redaction'`).

`bunx biome check` on the three changed files — reformatted one test file with
`--write`, then re-checked clean:

```
Checked 3 files in 31ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ tsc --noEmit
TYPECHECK EXIT: 0
```

`bun test apps/desktop/src/main/lib`:

```
 556 pass
 0 fail
 1087 expect() calls
Ran 556 tests across 40 files. [671.00ms]
```

The existing classification tests pass unchanged, run on their own:

```
 6 pass
 0 fail
 26 expect() calls
Ran 6 tests across 1 file. [83.00ms]
```

New redaction tests (positive, convergence, and negatives):

```
 8 pass
 0 fail
 24 expect() calls
Ran 8 tests across 1 file. [70.00ms]
```

**Proof the negative tests bite.** Widening both patterns — dropping the
`/Users/Shared` carve-out and dropping the path-segment anchors around the
staging directory — makes exactly the over-match tests fail:

```
Expected: "ENOENT: no such file or directory, open '/Library/Application Support/Superset/update.log'"
Received: "ENOENT: no such file or directory, open '/Library/Application Support/Superset/update.<id>'"
(fail) redactUpdateErrorMessage > passes messages without a home directory through unchanged

Expected: "ditto: /Users/Shared/Superset/staged.zip: I/O error"
Received: "ditto: ~/Superset/staged.zip: I/O error"
(fail) redactUpdateErrorMessage > leaves paths that are not a user home alone

Expected: "ditto: ./update.zip: Couldn't read pkzip signature."
Received: "ditto: ./update.<id>: Couldn't read pkzip signature."
(fail) redactUpdateErrorMessage > rewrites only the staging directory segment, not similarly named files

 5 pass
 3 fail
```

The narrow patterns were then restored and the suite re-run green.

Repo-wide `bun run lint` was not run (it hangs on cross-worktree bun locks).

Refs DESKTOP-127
Refs DESKTOP-122
Refs DESKTOP-11Z
Refs DESKTOP-11T

https://claude.ai/code/session_014LNNETnHMNuF3yKfrM4M3m

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts home-path segments and per-attempt staging tokens in desktop updater errors before sending to Sentry on macOS, Linux, and Windows. Previously, titles leaked account names and grouped per attempt; now messages and stacks converge without identity leakage while keeping diagnostic value.

- Applied at the Sentry capture site in the desktop main process; logs and renderer status are unchanged.
- Redacts both message and stack; returns the original error only when neither changes. Preserves the error name and carries own properties across, redacting string values; non-strings are unchanged.
- `isEnvironmentUpdateError` is unchanged and still runs on the raw message; reporting scope is identical.
- Matchers are narrow and close prior bypasses: handle non-ASCII account names; treat segment boundaries at a path separator or whitespace/quote/colon; carve-outs use the same delimiters. Linux matches only `/home/<account>` and skips `linuxbrew`; Windows matches `C:\Users\<account>` case-insensitively and skips `Public`, `Default`, and `All Users`; macOS skips `/Users/Shared`. Rewrites only `/update.<token>/` to `/update.<id>/`; does not touch non-home paths or files like `update.zip`/`update.yml`.
- Expected impact: events group per condition and titles no longer include account names; effective in the next desktop release. Addresses DESKTOP-127; relates to DESKTOP-122, DESKTOP-11Z, DESKTOP-11T.

<sup>Written for commit b1b76f5826a6eca2de91442026e8479bea97b54b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy when reporting desktop app update errors by removing personal home-directory names and temporary staging paths across macOS, Linux, and Windows.
  * Preserved useful diagnostic details while leaving shared system paths and unrelated messages unchanged.
  * Maintained error names, stack information, and custom error properties when sanitizing reported errors.

* **Tests**
  * Added coverage for platform-specific path redaction, stack handling, unchanged errors, and various update failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up commit: Linux and Windows coverage (added during triage review)

The first commit redacted only macOS `/Users/<account>` paths. The updater ships
on Windows (nsis) and Linux (AppImage) as well, and this handler reports all
three with no platform gate — their staging directories live under the user's
home too, which is exactly why the existing classifier already looks for an
`-updater` path marker alongside `shipit`. So the same account name was still
reaching the issue title on two of the three shipped platforms.

Added `/home/<account>` and `<drive>:\Users\<account>`, each carving out the
directories under that root that are system locations rather than accounts:

- Windows: `Public`, `Default`, `All Users`
- Linux: `linuxbrew`
- Linux additionally requires `/home/` to *start* a path, so a deeper directory
  that merely ends in `/home` (`/var/lib/home/...`) is left alone

The carve-outs were confirmed load-bearing the same way as the originals:
dropping them makes the over-match test fail.

```
$ bunx biome check <the two changed files>
Checked 2 files in 5ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
TYPECHECK EXIT: 0

$ cd apps/desktop && bun test src/main/lib
 560 pass
 0 fail
 1096 expect() calls
Ran 560 tests across 40 files. [614.00ms]
```


## Second follow-up commit: keep error properties when redacting

Rebuilding the error as a bare `new Error(message)` dropped every own property
the updater had set. `electron-updater` builds its errors with
`newError(message, code)` (`builder-util-runtime/out/error.js`), which sets an
own `code`, and Sentry serialises non-standard error properties — so the
redaction was silently discarding the most triageable field on the report,
precisely for the errors it rewrote.

Own properties are now carried across, with **string values passed through the
same redaction**, so a home path cannot escape on a property instead of the
message. Non-string values cross untouched. The identity path is unchanged: an
error with nothing to redact is still returned as the very same object.

Three tests were added and confirmed to fail first (`code`, a path-bearing
`path`, and a numeric `statusCode` all came back `undefined`).

```
$ bunx biome check <the two changed files>
Checked 2 files in 5ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
TYPECHECK EXIT: 0

$ cd apps/desktop && bun test src/main/lib
 563 pass
 0 fail
 1100 expect() calls
Ran 563 tests across 40 files. [794.00ms]
```


## Third follow-up commit: three redaction bypasses (CodeRabbit findings, all accepted)

All three were verified against the code rather than taken on the badge. Each
one let the account name this redaction exists to remove reach Sentry anyway,
so all three are fixed rather than dismissed.

1. **`\b` carve-outs exempted real accounts.** `\b` matches before `.` and `-`,
   so `/Users/Shared.dev/`, `/home/linuxbrew.dev/` and `C:\Users\Public.dev\`
   were each treated as the system directory they merely resemble and left
   unredacted — all three are valid account names under the pattern's own
   character class. Each carve-out now requires a path separator or end of
   string after the name. The exact system directories stay exempt; accounts
   that merely start with those words no longer do.

2. **Windows matching was case-sensitive.** `c:\users\ada\...` bypassed the
   pattern entirely. It now carries the `i` flag, which also makes the
   `Public`/`Default`/`All Users` exemptions case-insensitive, as Windows
   means them.

3. **The stack was not inspected before the identity check.** `redactUpdateError`
   returned the original error whenever the *message* alone was clean, sending
   an unredacted stack to Sentry. That is the ordinary case when the app is
   installed under the user's own Applications folder: the message carries no
   path but every frame does. The stack is now redacted first, and the error is
   returned unchanged only when neither field moves.

Each is pinned by a test confirmed to fail against the previous patterns —
restoring `\b`, dropping the `i` flag and dropping the stack check makes exactly
those three tests fail and nothing else. The identity test now sets its own
stack rather than inheriting whatever path the test file lives under, which
would otherwise have redacted itself and made that assertion depend on the
checkout location.

```
$ bunx biome check <the two changed files>
Checked 2 files in 5ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
TYPECHECK EXIT: 0

$ cd apps/desktop && bun test src/main/lib
 567 pass
 0 fail
 1114 expect() calls
Ran 567 tests across 40 files. [595.00ms]
```


## Fourth follow-up commit: non-ASCII account names (CodeRabbit finding, accepted)

The account-name class was `[A-Za-z0-9._-]+`, which is ASCII-only. An accented
name was therefore rewritten only in part, and a name containing no ASCII at
all was not matched at all — the whole account name went to Sentry. Account
names are not ASCII in much of the world; the events this redaction was written
for arrived from seven countries.

The account segment is now "everything up to the platform separator" rather
than a character class. Whitespace, quotes and colons also end the segment, so
a path sitting at the end of a sentence cannot run on and swallow the message
after it.

Pinned from **both** sides, because this class can fail in two opposite ways:

- narrowing it back to ASCII fails the accented and non-Latin cases (the leak)
- widening it to a bare "anything but a separator" fails a new case asserting
  the redaction stops at the segment — `ditto: /Users/<name>: No such file`
  must become `ditto: ~: No such file`, not `ditto: ~`, and two paths in one
  message must redact independently rather than merging

The staging-directory pattern stays ASCII-only, deliberately: those names are
generated by the updater, not by a person.

```
$ bunx biome check <the two changed files>
Checked 2 files in 6ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
TYPECHECK EXIT: 0

$ cd apps/desktop && bun test src/main/lib
 570 pass
 0 fail
 1122 expect() calls
Ran 570 tests across 40 files. [588.00ms]
```


## Fifth follow-up commit, and a note on the approach

**The fix:** widening the account segment in the previous commit without widening
the carve-out boundary to match left the two disagreeing about where a segment
ends, so a reserved directory named at the end of a sentence
(`/Users/Shared: access denied`) was rewritten as though it were an account.
Not a leak — the mirror of one — and self-inflicted. The carve-outs now end on
the same delimiter set the segment does. Dropping the boundary entirely fails
three separate tests. 572 pass, typecheck 0, biome clean.

**The note, which matters more than the fix.** This is the fifth round of
defects on a 13-line family of regexes, and that is evidence about the approach
rather than about any one pattern. A materially more robust instrument exists:
`homedir()` — already used throughout this process — gives the running user's
home directory exactly, and a literal string replacement of it needs no
character class, no carve-outs, no Unicode handling, no case rules and no
delimiter reasoning. Every bug in rounds 3, 4 and 5 was impossible under that
design.

It is deliberately **not** done here, for two reasons worth writing down rather
than leaving implicit:

- It is a narrower guarantee. A literal home replacement only redacts the
  *running* user's home. That is complete for these events, because each report
  is generated on the machine whose path it carries — but it stops covering an
  arbitrary home-shaped path appearing in a message, which the current patterns
  do cover.
- The test suite here asserts input-message → output-message over hardcoded
  foreign paths. A homedir-based implementation would fail all of them unless
  the home directory is injected, so switching means restructuring the tests at
  the same time as the implementation. Doing both at the end of a five-round
  session is how a fresh class of bug gets introduced.

The behavioural tests added across these commits are the thing that makes that
swap safe later: they pin what the output must look like, from both directions,
independently of how it is produced. Recommended as the follow-up.
