### PR TITLE
feat(marketing): add IDE and ADE guides

### DIFF
--- a/apps/marketing/content/compare/best-agent-development-environment.mdx
+++ b/apps/marketing/content/compare/best-agent-development-environment.mdx
@@ -1,0 +1,139 @@
+---
+title: "Best Agent Development Environment (ADE) in 2026"
+description: "Compare the best agent development environments for parallel coding agents, including Superset, Orca, Emdash, Conductor, Cursor, and Devin Desktop."
+date: 2026-08-24
+lastUpdated: 2026-08-24
+type: "roundup"
+competitors:
+  - orca
+  - emdash
+  - conductor
+  - cursor
+  - devin-desktop
+keywords:
+  - best agent development environment
+  - best ade for coding agents
+  - agent development environment
+  - agentic development environment
+  - ade coding
+  - multi agent coding environment
+---
+
+The best agent development environment (ADE) in 2026 depends on where your coding agents run. **Superset** is the strongest choice for running any CLI agent, solo or across a team's machines. **Orca** is the best open-source option for fan-out, and **Emdash** is the open-source pick for issue-tracker intake. **Conductor** is the focused Mac choice. Cursor and Devin Desktop combine an ADE with a full IDE.
+
+An ADE is the workspace around the agent. The coding agent writes and tests code; the ADE gives each task a safe environment, keeps sessions visible, and turns finished work into a diff, branch, or pull request you can review.
+
+---
+
+## The Short Version
+
+| ADE | Best for | Agent support | Isolation | Main tradeoff |
+|---|---|---|---|---|
+| **Superset** | Parallel work, automations, and programmable orchestration | Any CLI agent plus built-in chat | Git worktree per task, local and remote hosts | macOS desktop today; Linux support is experimental |
+| **Orca** | Open-source fan-out, automation, and mobile monitoring | Any CLI agent | Git worktree per task, local or SSH | Fast-moving product with fewer formal team controls |
+| **Emdash** | Open source, tracker intake, and recurring tasks | 30+ CLI agents | Worktrees on local or remote hosts | Less programmable outside the desktop app |
+| **Conductor** | Focused local and cloud workflow on Mac | Claude Code, Codex, Cursor, OpenCode | Local worktrees or cloud sandboxes | macOS only and a narrower agent list |
+| **Cursor Agents Window** | IDE and ADE in one product | Cursor Agent across supported models | Local worktrees, cloud, remote SSH | Tied to Cursor's editor and agent stack |
+| **Devin Desktop** | One command center for local and cloud agents | Devin plus ACP agents | Local and cloud workflows | Newer product direction and more opinionated stack |
+
+## How We Define an ADE
+
+A tool qualifies as an agent development environment when agents are the primary unit of work and it handles most of this loop:
+
+- Start or import a task
+- Create an isolated workspace, worktree, or sandbox
+- Launch and track one or more coding agents
+- Preserve the terminal, browser, environment, and task context
+- Review the resulting diff
+- Commit, push, merge, or open a pull request
+
+A terminal can run an agent, and an IDE can host one. An ADE manages the work around concurrent agent sessions. Read [What Is an ADE?](/compare/what-is-an-agent-development-environment) for the full definition.
+
+## The Best ADEs
+
+### Superset: Best for Teams and Programmable Workflows
+
+Superset gives every task its own Git worktree, branch, terminal sessions, ports, and agent context. It runs Claude Code, Codex, Amp, Gemini, OpenCode, Cursor Agent, and other CLI agents, plus a built-in chat. The review loop covers diffs, commits, pushes, and pull requests, while remote workspaces let the desktop reach agents running on another machine.
+
+Its biggest difference is the combination of programmable and team surfaces. A CLI, TypeScript SDK, and MCP server can create workspaces, launch agents, read terminals, and manage recurring automations. Slack and shared remote hosts take the workflow beyond one developer's desktop. Organization controls cover the team around it.
+
+Best for:
+
+- Many agents working on the same repository
+- Teams that want reviewable branches instead of shared-working-copy edits
+- Developers who want to script or schedule the workspace layer
+
+### Orca: Best Open-Source ADE for Fan-Out
+
+Orca is a free, MIT-licensed ADE for running any CLI agent in parallel worktrees. Its strongest workflow is fan-out: send the same prompt to many agents, compare their changes, and merge the best result. It also includes split terminals, a browser with Design Mode, diff annotation, and SSH worktrees. Scheduled automations, a broad CLI, experimental structured orchestration, and mobile companions extend it beyond your desk.
+
+Choose Orca if open source, desktop platform coverage, mobile reach, and deep local control matter most.
+
+For a direct comparison, see [Superset vs Orca](/compare/superset-vs-orca).
+
+### Emdash: Best Open-Source ADE for Task Intake
+
+Emdash runs 30+ CLI agents in local or remote worktrees and brings tasks in from GitHub, Linear, Jira, Notion, Asana, and other trackers. It includes diff review, an in-app browser, GitHub checks, reusable prompts and skills, shared MCP configuration, and recurring agent runs on a schedule.
+
+Choose Emdash when issue trackers are the front door to agent work or when you want a free cross-platform app with a broad provider list.
+
+For a direct comparison, see [Superset vs Emdash](/compare/superset-vs-emdash).
+
+### Conductor: Best Focused ADE for Mac
+
+Conductor is a polished macOS app that places Claude Code, Codex, Cursor, and OpenCode sessions inside isolated workspaces. Local tasks run in Git worktrees; paid plans add cloud workspaces, team collaboration, and an API. Its review flow covers the workspace branch, checks, diffs, and pull requests without asking you to manage worktree commands yourself.
+
+Choose Conductor if you use its supported agents, work on a Mac, and want a focused product with less configuration.
+
+For a direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Cursor Agents Window: Best IDE/ADE Combination
+
+Cursor's separate Agents Window runs many tasks across repositories and environments. Local agents can use worktrees, cloud agents keep running remotely, and remote SSH brings another machine into the same workflow. Finished work returns through Cursor's diff and editing surfaces.
+
+Choose Cursor when you want one vendor to own both the hands-on editor and the task-oriented agent workspace. Choose a separate ADE when you want to keep your agent subscriptions and editor choice independent.
+
+### Devin Desktop: Best Local-and-Cloud Hybrid
+
+Devin Desktop combines the editor formerly known as Windsurf with an Agent Command Center for local and cloud work. It includes a full IDE for tracing and debugging changes, then lets you move back to fleet-level monitoring. ACP support opens the command center to agents beyond Devin.
+
+Choose Devin Desktop when cloud handoff and a single integrated product matter more than bring-your-own-agent flexibility.
+
+## How To Choose
+
+Start with the constraint that would break your workflow:
+
+- Choose **Superset** for agent choice, worktree isolation, automations, and CLI/MCP/SDK control.
+- Choose **Orca** for a free open-source ADE with mobile companions, fan-out, and local automation.
+- Choose **Emdash** for a free open-source ADE fed by issue trackers and recurring tasks.
+- Choose **Conductor** for a focused Mac app with minimal configuration.
+- Choose **Cursor** when you want your IDE and ADE from the same product.
+- Choose **Devin Desktop** when local-to-cloud agent handoff is the priority.
+
+Then check the operational details: supported operating systems, where code runs, whether agents use your existing subscriptions, how secrets reach worktrees or sandboxes, and how finished changes return to your main branch.
+
+## Verdict
+
+Superset is the best ADE for developers who already have favorite coding agents and want a dependable layer around them. It makes parallel work safe by default, keeps review close to execution, and exposes the workflow through an app, CLI, SDK, and MCP.
+
+Orca and Emdash are strong open-source choices with different strengths. Conductor is the cleanest focused Mac experience. Cursor and Devin Desktop make sense when the ADE and editor should be one product.
+
+If you still spend most of your day editing one working copy with one agent, start with [Best IDE for AI Coding Agents](/compare/best-ide-for-ai-agents). If terminal quality is the bottleneck, see [Best Terminal for AI Coding Agents](/compare/best-terminal-for-ai-coding).
+
+## Frequently Asked Questions
+
+### What is the best agent development environment?
+
+Superset is the strongest choice for running different CLI agents in isolated worktrees across individual and team workflows. Orca is the best open-source fan-out and automation option, while Emdash is strongest for tracker intake and open-source scheduling.
+
+### Is an ADE the same as an IDE?
+
+No. An IDE centers on a human reading, writing, and debugging code. An ADE centers on agents doing tasks in separate environments while a human assigns, monitors, and reviews the work. Some products, including Cursor and Devin Desktop, provide both modes.
+
+### Does an ADE include the AI model?
+
+Sometimes. Cursor and Devin provide an integrated agent stack. Superset, Orca, Emdash, and Conductor sit around existing agent runtimes and subscriptions. The ADE is mainly responsible for execution environments, session state, isolation, and review.
+
+### Why do ADEs use Git worktrees?
+
+A worktree gives each task its own directory and branch. Agents can edit, install dependencies, and run tests at the same time without sharing one working copy. You can review or discard each result independently.

--- a/apps/marketing/content/compare/best-agentic-ide.mdx
+++ b/apps/marketing/content/compare/best-agentic-ide.mdx
@@ -29,6 +29,8 @@ Some tools are AI editors that grew an agent: you write code in a familiar edito
 
 Both are legitimately "agentic." But if your bottleneck is running several coding agents on the same repository without collisions, the deciding factor is isolation and orchestration, not autocomplete quality. That is where an agent-agnostic, worktree-per-task workspace like Superset stands apart.
 
+There are now clearer names for the two halves of this category. See [Best IDE for AI Coding Agents](/compare/best-ide-for-ai-agents) for editor-first tools, [Best Agent Development Environments](/compare/best-agent-development-environment) for agent-first workspaces, and [What Is an ADE?](/compare/what-is-an-agent-development-environment) for the distinction.
+
 ---
 
 ## The Short Version

--- a/apps/marketing/content/compare/best-ide-for-ai-agents.mdx
+++ b/apps/marketing/content/compare/best-ide-for-ai-agents.mdx
@@ -1,0 +1,141 @@
+---
+title: "Best IDE for AI Coding Agents in 2026"
+description: "Compare the best IDEs for AI coding agents, including Cursor, VS Code, Zed, JetBrains, and Devin Desktop, and learn when an ADE is the better tool."
+date: 2026-08-24
+lastUpdated: 2026-08-24
+type: "roundup"
+competitors:
+  - cursor
+  - github-copilot
+  - zed
+  - jetbrains-junie
+  - devin-desktop
+keywords:
+  - best ide for ai agents
+  - best ide for ai coding
+  - ai coding ide
+  - ide for coding agents
+  - best ai code editor
+  - ai agent ide
+---
+
+The best IDE for AI coding agents in 2026 is **Cursor** for an AI-first editing experience, **VS Code** for the broadest ecosystem, **Zed** for running external agents inside a fast editor, and **JetBrains** for deep language tooling. **Devin Desktop** is the strongest hybrid if you want a full editor and an agent command center in one product.
+
+One catch: an IDE centers on a person editing code. If your real job is dispatching Claude Code, Codex, or another CLI agent across isolated tasks, you may need an agent development environment (ADE) alongside it.
+
+---
+
+## The Short Version
+
+| IDE | Best for | Agent options | Parallel isolation | Main tradeoff |
+|---|---|---|---|---|
+| **Cursor** | Best AI-first editor | Cursor Agent, model choice, cloud agents | Local worktrees, cloud, remote SSH | Most opinionated and tied to Cursor's product |
+| **VS Code + Copilot** | Broadest extensions and platform support | Copilot plus configurable agent harnesses | Parallel sessions and isolated worktrees | Agent workflow spans the app and extensions |
+| **Zed** | Hosting external agents in a fast editor | Zed Agent, ACP agents, terminal agents | Optional worktree per thread | Smaller extension ecosystem than VS Code |
+| **JetBrains + AI Assistant** | Language-aware navigation and refactoring | Junie, Claude Agent, Codex, Copilot, ACP | Strong review, less worktree-centered | Heavier IDE and product-specific licensing |
+| **Devin Desktop** | Full IDE plus local and cloud agent management | Devin and ACP agents | Local and cloud agent workflows | New product direction after the Windsurf rename |
+
+## What Makes an IDE Good for Agents?
+
+Autocomplete is no longer enough. A useful IDE for agents should cover five parts of the loop:
+
+- **Code understanding:** symbols, references, diagnostics, and repository search
+- **Execution:** terminal commands, tests, builds, and browser tools
+- **Review:** clear multi-file diffs, checkpoints, and easy rollback
+- **Agent choice:** a good built-in agent or support for external agents
+- **Isolation:** worktrees, sandboxes, or branches when agents run at once
+
+The first three are classic IDE strengths. The last two are where IDEs are starting to overlap with ADEs.
+
+## The Best IDEs for AI Agents
+
+### Cursor: Best AI-First IDE
+
+Cursor is the strongest single-product answer for developers who want to edit code and delegate tasks in the same app. Its agent can search a repository, edit many files, run commands, use a browser, and fix errors. The separate Agents Window runs agents across local worktrees, cloud environments, and remote SSH hosts. Its `/best-of-n` workflow runs the same task across models in isolated worktrees.
+
+Choose Cursor if you want AI to shape the whole editing experience and you are comfortable adopting Cursor's models, account, and workflow.
+
+For a direct comparison, see [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### VS Code + GitHub Copilot: Best Ecosystem
+
+VS Code remains the safest default when language support, extensions, remote development, and team familiarity matter most. Copilot can edit files, run terminal commands, use tools, and review changes in the normal editor. The newer Agents Window adds a task-first surface across projects, parallel sessions, isolated worktrees, and diff review.
+
+Choose VS Code if you want one editor that fits almost every language and environment. The tradeoff is composition: extensions, Copilot plans, agent harnesses, and remote targets can take more setup than a single opinionated product.
+
+For a direct comparison, see [Superset vs GitHub Copilot](/compare/superset-vs-github-copilot).
+
+### Zed: Best IDE for External Agents
+
+Zed makes agent choice unusually explicit. You can use the native Zed Agent, install external agents such as Claude, Codex, OpenCode, Copilot, and Cursor through the Agent Client Protocol (ACP), or keep a CLI agent in a terminal-backed thread. Its Threads Sidebar manages concurrent sessions, and a worktree picker can isolate threads that might edit the same files.
+
+Choose Zed if you want a fast editor that treats third-party agents as first-class participants instead of forcing every task through one built-in agent.
+
+For a direct comparison, see [Superset vs Zed](/compare/superset-vs-zed).
+
+### JetBrains + AI Assistant: Best for Deep Language Tooling
+
+JetBrains IDEs remain strongest when project-aware refactoring, debugging, framework support, and language-specific inspections decide your day. AI Assistant now hosts Junie, Claude Agent, Codex, and GitHub Copilot, with custom agents available through ACP. Agents can edit files, run tests and commands, use MCP tools, and hand changes back for review.
+
+Choose JetBrains if you work in IntelliJ IDEA, PyCharm, WebStorm, GoLand, or another JetBrains IDE because of its code intelligence. The agent should strengthen that workflow, not make you give it up.
+
+### Devin Desktop: Best IDE and Agent-Manager Hybrid
+
+Devin Desktop is the new name and direction for Windsurf. It keeps a full IDE with syntax highlighting, autocomplete, extensions, and debugging, while putting an Agent Command Center for local and cloud agents at the front. ACP support gives it a path to agents beyond Devin.
+
+Choose it if you want one app to move between hands-on editing and higher-level delegation. This is the least settled choice because the product is still moving from an AI editor toward a multi-agent workspace.
+
+For a direct comparison, see [Superset vs Windsurf](/compare/superset-vs-windsurf).
+
+## IDE vs ADE: Which One Do You Need?
+
+Use an IDE when the main loop is:
+
+1. Open code.
+2. Ask an agent for help.
+3. Edit or debug beside it.
+4. Accept the changes.
+
+Use an ADE when the main loop is:
+
+1. Describe a set of tasks.
+2. Give each task an isolated workspace and agent.
+3. Watch for blockers instead of watching every edit.
+4. Review, compare, and merge finished work.
+
+Many developers use both. Keep Cursor, VS Code, Zed, or JetBrains for hands-on work, then use an ADE such as Superset to run a larger queue of agents. See [Best Agent Development Environments in 2026](/compare/best-agent-development-environment) for that comparison.
+
+## Best Picks by Use Case
+
+- **Best AI-first IDE:** Cursor
+- **Best general-purpose IDE:** VS Code + Copilot
+- **Best for external agents:** Zed
+- **Best for deep code intelligence:** JetBrains + AI Assistant
+- **Best IDE/ADE hybrid:** Devin Desktop
+- **Best companion for parallel CLI agents:** Superset
+
+## Verdict
+
+Cursor is the best all-around AI IDE if you want the editor and agent designed as one system. VS Code is the best default for ecosystem and portability. Zed is the best host for external agents, while JetBrains wins when language tooling and refactoring matter more than AI novelty.
+
+If you spend more time assigning tasks and reviewing diffs than typing in the editor, stop optimizing the IDE alone. Keep the editor you already like and add an ADE built for parallel agents.
+
+For the broader category map, see [Best Agentic IDE in 2026](/compare/best-agentic-ide) and [What Is an ADE?](/compare/what-is-an-agent-development-environment).
+
+## Frequently Asked Questions
+
+### What is the best IDE for AI coding agents?
+
+Cursor is the best AI-first editor. VS Code is best for ecosystem breadth, Zed for external agents, and JetBrains for deep language tooling. For many parallel CLI agents, pair one of them with an ADE such as Superset.
+
+### Is Cursor better than VS Code for AI coding?
+
+Cursor gives you a more opinionated AI-first experience with integrated agent workflows. VS Code gives you a broader extension ecosystem, more established remote-development options, and a familiar standard across teams. The better choice depends on whether AI integration or platform breadth matters more.
+
+### Can an IDE run many coding agents at once?
+
+Yes. Cursor, VS Code, Zed, and Devin Desktop all provide multi-session or multi-agent surfaces. Check how each isolates edits. Parallel sessions are safest when each task has its own Git worktree, branch, or cloud sandbox.
+
+### Do I need to replace my IDE to use Claude Code or Codex?
+
+No. Both agents run in terminals and can hand work back to your current editor. An ADE can also run them in separate worktrees and open each result in VS Code, Cursor, JetBrains, or another IDE for review.

--- a/apps/marketing/content/compare/best-terminal-for-ai-coding.mdx
+++ b/apps/marketing/content/compare/best-terminal-for-ai-coding.mdx
@@ -160,7 +160,7 @@ The more agent-heavy your workflow becomes, the more the winning criterion shift
 
 If that is your world, Superset is the terminal to optimize around.
 
-For a broader tool comparison, see [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026).
+For the adjacent categories, see [Best IDE for AI Coding Agents](/compare/best-ide-for-ai-agents) and [Best Agent Development Environments](/compare/best-agent-development-environment); for a broader tool comparison, [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026).
 
 ## Frequently Asked Questions
 

--- a/apps/marketing/content/compare/what-is-an-agent-development-environment.mdx
+++ b/apps/marketing/content/compare/what-is-an-agent-development-environment.mdx
@@ -1,0 +1,165 @@
+---
+title: "What Is an ADE? Agent Development Environments Explained"
+description: "An ADE is an agent development environment: the workspace for running, isolating, monitoring, and reviewing AI coding agents. Learn how ADEs differ from IDEs."
+date: 2026-08-24
+lastUpdated: 2026-08-24
+type: "tutorial"
+competitors:
+  - orca
+  - emdash
+  - conductor
+keywords:
+  - what is an ade
+  - ade meaning coding
+  - agent development environment
+  - agentic development environment
+  - ade vs ide
+  - ai agent workspace
+---
+
+An **ADE** is an **agent development environment**: a workspace for assigning software tasks to AI coding agents, giving each task a safe place to run, monitoring progress, and reviewing the resulting code.
+
+In older software literature, ADE can also mean "application development environment." Current AI coding tools use both "agent development environment" and "agentic development environment." The term is still settling.
+
+---
+
+## ADE in One Sentence
+
+An IDE helps you write code. An ADE helps you manage agents that write code.
+
+That does not mean an ADE removes the editor. Most keep a file viewer, diff editor, terminal, and browser, and can hand the work off to VS Code, Cursor, JetBrains, or Xcode. The difference is what sits at the center.
+
+In an IDE, the primary object is a project or file. In an ADE, the primary object is a task with an agent, an environment, a branch, and a result.
+
+## What an ADE Does
+
+A coding agent such as Claude Code or Codex already knows how to read files, edit code, run commands, and react to test failures. The ADE handles the system around that agent.
+
+### 1. Creates an environment for each task
+
+The ADE checks out a Git worktree, starts a sandbox, or connects to a remote machine. Dependencies, environment variables, ports, and setup scripts belong to that task.
+
+### 2. Launches and tracks agent sessions
+
+You choose an agent, write a prompt, and let it work. The ADE keeps the session visible and often preserves terminal state across app restarts or network disconnects.
+
+### 3. Isolates parallel work
+
+Two agents should not edit the same working directory. A strong ADE gives each task its own working directory and branch, or a full sandbox, so agents can share a repository without overwriting each other.
+
+### 4. Shows when an agent needs a human
+
+Agents pause for permissions, questions, errors, or review. An ADE collects those states so you do not have to scan a wall of terminal tabs to find the session waiting for input.
+
+### 5. Turns output into reviewable work
+
+When an agent finishes, the ADE shows the changed files and diff, then helps you revise, commit, push, merge, or open a pull request. The result is normal Git work, not a mysterious transcript.
+
+## ADE vs IDE
+
+| Question | IDE | ADE |
+|---|---|---|
+| What is the main unit? | File, project, editor tab | Task, agent session, workspace |
+| Who does most of the typing? | The developer | The coding agent |
+| What does the human watch? | Code, diagnostics, debugger | Status, questions, diffs, tests |
+| How is parallel work handled? | More windows or sessions | Separate worktrees, branches, or sandboxes |
+| What is the final handoff? | Saved files and a commit | A reviewed diff, branch, or pull request |
+
+The categories overlap. Cursor, VS Code, Zed, JetBrains, and Devin Desktop add task-oriented agent surfaces to full editors. Superset, Orca, Emdash, and Conductor start from the workspace and orchestration side, then add enough editing and review to complete the loop.
+
+"Agentic IDE" is a broad label for both shapes. "ADE" is more precise when agents and their environments are the primary objects.
+
+## ADE vs Coding Agent
+
+The agent and ADE are different layers:
+
+- **Model:** the language model that reasons about the task
+- **Agent or harness:** the loop that gives the model tools to read, edit, run, and iterate
+- **ADE:** the environment that launches agents, isolates tasks, preserves state, and presents work for review
+
+For example, Codex can be the agent running inside Superset. Codex decides which files to change and commands to run. Superset creates the worktree, keeps the terminal and workspace attached to the task, and presents the diff for review.
+
+Some products bundle all three layers. Others let you bring your own agent and subscription.
+
+## ADE vs Agent Orchestrator
+
+An orchestrator coordinates work across agents. An ADE gives that orchestration a usable development surface: repositories, worktrees, terminals, browsers, diffs, and Git actions.
+
+A headless script that assigns subtasks to five agents can orchestrate without becoming an ADE. A desktop app that launches those agents in isolated workspaces and lets you review each result is both.
+
+## Why ADEs Exist Now
+
+One coding agent fits comfortably in a terminal or editor sidebar. Five agents create a different problem:
+
+- Which session is still running?
+- Which one needs permission?
+- Are two agents changing the same files?
+- Which branch contains the useful result?
+- How do you compare attempts and discard the rest?
+- Can work continue on another machine or after the laptop closes?
+
+Terminal panes improve visibility, but they do not create isolation or a review queue. IDE chat improves editing, but agent sessions can still collide unless each has a separate environment. ADEs handle that coordination layer.
+
+## The Worktree-Per-Task Pattern
+
+Local ADEs commonly use Git worktrees. A worktree is another working directory connected to the same repository. Each task gets its own branch and files, while all tasks share repository history.
+
+That gives agent work three useful properties:
+
+- **Isolation:** agents do not overwrite one another's uncommitted edits
+- **Reviewability:** each task has a separate diff and branch
+- **Low overhead:** worktrees share Git objects instead of cloning the whole repository every time
+
+Worktrees do not solve every problem. Setup scripts must prepare dependencies and ignored files, services may need separate ports, and agents still need appropriate permissions. A good ADE manages those details instead of leaving them as manual Git chores.
+
+## What To Look For in an ADE
+
+Ignore the agent count in screenshots. Check the workflow:
+
+- Does every task get isolation by default?
+- Can it run the agents and subscriptions you already use?
+- Are setup, environment variables, ports, and secrets handled safely?
+- Can you see which sessions are running, blocked, or finished?
+- Is the full diff easy to review and revise?
+- Can you commit, push, and open a pull request without losing context?
+- Do sessions survive restarts and remote connections?
+- Can scripts, schedules, issue trackers, or other agents create work?
+
+The best choice depends on which of these becomes your bottleneck. See [Best Agent Development Environments in 2026](/compare/best-agent-development-environment) for a tool-by-tool comparison.
+
+## Do You Need an ADE?
+
+You probably do not need one if you run a single coding agent occasionally and review every edit as it happens. A good terminal or IDE is enough.
+
+An ADE becomes useful when you regularly:
+
+- Run two or more agents on one repository
+- Delegate tasks while continuing other work
+- Compare competing attempts at the same problem
+- Lose track of branches, terminals, or agent state
+- Want recurring agents to produce reviewable changes
+- Run agents on remote machines or managed sandboxes
+
+The practical setup is often an IDE plus an ADE. Use the IDE for direct coding and debugging. Use the ADE for parallel delegation and review.
+
+## Frequently Asked Questions
+
+### What does ADE stand for in AI coding?
+
+ADE stands for agent development environment or agentic development environment. Both describe a workspace built around running and reviewing coding agents. The acronym can also mean application development environment in older contexts, so check whether the surrounding text is about AI agents or classic app tooling.
+
+### Who coined the term ADE?
+
+No single person or standards body owns the term. AI coding products now use it to describe an agent-first development workspace. Treat it as an emerging category name, not a formal specification.
+
+### Is an ADE an AI code editor?
+
+Not necessarily. An AI code editor helps a developer write code with AI. An ADE manages tasks performed by agents. Some products combine the two, while dedicated ADEs often hand work off to your existing editor.
+
+### Is Superset an ADE?
+
+Yes. Superset treats each task as an isolated workspace with its own Git worktree, branch, terminals, ports, agent sessions, and review flow. It also exposes the workspace layer through a desktop app, CLI, SDK, and MCP server.
+
+### Can I use an ADE with my current IDE?
+
+Yes. A worktree managed by an ADE is still a normal directory and Git branch. You can open it in VS Code, Cursor, JetBrains, Xcode, Zed, or another editor whenever you want to inspect or edit the code directly.

--- a/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
+++ b/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
@@ -21,6 +21,8 @@ An agentic IDE is a development environment where AI agents can autonomously pla
 
 The term is new and a little overloaded, so this guide defines it clearly, separates the two things people mean by it, and explains how to choose.
 
+One of those meanings now has its own acronym. An **ADE**, or agent development environment, is a tool organized around agent tasks, isolated workspaces, and review rather than a human editing one working copy. See [What Is an ADE?](/compare/what-is-an-agent-development-environment) for the full definition.
+
 ---
 
 ## Autocomplete vs Agent


### PR DESCRIPTION
## What & why

Adds IDE and ADE comparison guides.

## How I tested it

`bun run lint`, `bun run typecheck`, `bun run test`, and prose lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three marketing guides that define ADE vs IDE and align existing comparison pages to the new category structure. This clarifies terminology, improves cross-links, and adds dedicated roundups for ADEs and IDEs.

- Verify new routes render: /compare/best-agent-development-environment, /compare/best-ide-for-ai-agents, /compare/what-is-an-agent-development-environment.
- Check updated internal links in best-agentic-ide.mdx, best-terminal-for-ai-coding.mdx, and what-is-an-agentic-ide.mdx resolve correctly.
- Confirm frontmatter (type, competitors, keywords, dates) matches SEO/indexing expectations and any nav/sitemap generation picks up the pages.
- Build and preview locally (bun run lint, bun run typecheck, bun run test, bun run dev) to validate MDX formatting and link integrity.

<sup>Written for commit eb098393bae0bde150ca985b137bd8d3b3088403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added guides comparing leading agent development environments and IDEs for AI coding agents.
  - Added a tutorial explaining agent development environments, their core capabilities, workflows, and differences from IDEs, coding agents, and orchestrators.

- **Documentation**
  - Added FAQs, evaluation criteria, use-case guidance, and recommendations across the new comparison content.
  - Improved cross-links between related IDE, terminal, AI coding, and agent development environment resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->