### PR TITLE
feat(marketing): email download links to mobile visitors

### DIFF
--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { COMPANY } from "@superset/shared/constants";
 import { useRouter } from "next/navigation";
-import { HiMiniArrowDownTray, HiMiniClock } from "react-icons/hi2";
+import {
+	HiMiniArrowDownTray,
+	HiMiniClock,
+	HiMiniEnvelope,
+} from "react-icons/hi2";
 import { track } from "@/lib/analytics";
 import { isMacPlatform, Platform, usePlatform } from "../../hooks/useOS";
-import { type DropdownSection, PlatformDropdown } from "../PlatformDropdown";
 
 interface DownloadButtonProps {
 	size?: "sm" | "md";
@@ -44,78 +46,15 @@ export function DownloadButton({
 	};
 
 	if (platform === Platform.Mobile) {
-		const appleIcon = (
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="currentColor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-label="Apple logo"
-			>
-				<title>Apple logo</title>
-				<path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-			</svg>
-		);
-
-		const githubIcon = (
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 24 24"
-				fill="currentColor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-label="GitHub logo"
-			>
-				<title>GitHub logo</title>
-				<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-			</svg>
-		);
-
-		const sections: DropdownSection[] = [
-			{
-				items: [
-					{
-						id: "mac-download",
-						label: "Download for Mac",
-						description: "APPLE SILICON",
-						icon: appleIcon,
-						onClick: goToInterstitial,
-						variant: "primary",
-					},
-				],
-			},
-			{
-				title: "Other platforms",
-				items: [
-					{
-						id: "waitlist",
-						label: "Join waitlist for Windows & Linux",
-						icon: <HiMiniClock className="size-4" />,
-						onClick: () => {
-							track("waitlist_clicked");
-							onJoinWaitlist?.();
-						},
-					},
-					{
-						id: "build-from-source",
-						label: "Build from source on GitHub",
-						icon: githubIcon,
-						onClick: () => window.open(COMPANY.GITHUB_URL, "_blank"),
-					},
-				],
-			},
-		];
-
-		const trigger = (
-			<button type="button" className={buttonClasses}>
-				Download
-				{downloadIcon}
-			</button>
-		);
-
 		return (
-			<PlatformDropdown trigger={trigger} sections={sections} align="end" />
+			<button
+				type="button"
+				className={buttonClasses}
+				onClick={goToInterstitial}
+			>
+				Email me a link
+				<HiMiniEnvelope className="size-4" />
+			</button>
 		);
 	}
 

--- a/apps/marketing/src/app/download/components/DownloadInterstitial/DownloadInterstitial.tsx
+++ b/apps/marketing/src/app/download/components/DownloadInterstitial/DownloadInterstitial.tsx
@@ -11,6 +11,7 @@ import { AppMockup } from "@/app/components/HeroSection/components/AppMockup";
 import { WaitlistForm } from "@/app/components/WaitlistForm";
 import { isMacPlatform, Platform, usePlatform } from "@/app/hooks/useOS";
 import { track } from "@/lib/analytics";
+import { DownloadLinkForm } from "../DownloadLinkForm";
 
 const AUTO_DOWNLOAD_DELAY_MS = 600;
 
@@ -25,9 +26,11 @@ export function DownloadInterstitial() {
 	const firedRef = useRef(false);
 
 	const isMac = isMacPlatform(platform);
-	// Only auto-download on Mac (the only built binary). Windows/Linux/Mobile see
-	// the waitlist instead, never the .dmg. Unknown waits for detection.
-	const showWaitlist = !isMac && platform !== Platform.Unknown;
+	// Only auto-download on Mac (the only built binary). Mobile visitors can send
+	// the link to their desktop; Windows/Linux visitors see the platform waitlist.
+	const showEmailLink = platform === Platform.Mobile;
+	const showWaitlist =
+		!isMac && platform !== Platform.Unknown && !showEmailLink;
 
 	useEffect(() => {
 		if (firedRef.current) return;
@@ -54,7 +57,21 @@ export function DownloadInterstitial() {
 
 			<div className="mt-20 grid grid-cols-1 items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-16">
 				<div className="flex flex-col gap-6">
-					{showWaitlist ? (
+					{showEmailLink ? (
+						<>
+							<h1
+								className="text-3xl font-medium tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl"
+								style={{ fontFamily: "var(--font-ibm-plex-mono), monospace" }}
+							>
+								Get Superset on your Mac
+							</h1>
+							<p className="text-sm text-muted-foreground sm:text-base">
+								Superset is a desktop app. Enter your email and we&apos;ll send
+								you a download link to open on your Mac.
+							</p>
+							<DownloadLinkForm />
+						</>
+					) : showWaitlist ? (
 						<>
 							<h1
 								className="text-3xl font-medium tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl"

--- a/apps/marketing/src/app/download/components/DownloadLinkForm/DownloadLinkForm.tsx
+++ b/apps/marketing/src/app/download/components/DownloadLinkForm/DownloadLinkForm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { HiMiniArrowRight, HiMiniCheck } from "react-icons/hi2";
+import { track } from "@/lib/analytics";
+import { sendDownloadLink } from "./actions";
+
+export function DownloadLinkForm() {
+	const [email, setEmail] = useState("");
+	const [submittedEmail, setSubmittedEmail] = useState("");
+	const [error, setError] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		if (isSubmitting) return;
+		const formData = new FormData(event.currentTarget);
+		const honeypot = String(formData.get("company-website") ?? "");
+
+		setError("");
+		setIsSubmitting(true);
+		const result = await sendDownloadLink({ email, honeypot });
+		setIsSubmitting(false);
+
+		if (!result.success) {
+			setError(result.error);
+			return;
+		}
+
+		setSubmittedEmail(email);
+		track("download_link_emailed", { platform: "mobile" });
+	}
+
+	if (submittedEmail) {
+		return (
+			<div className="border-l-2 border-brand pl-4" aria-live="polite">
+				<div className="flex items-center gap-2 text-foreground">
+					<HiMiniCheck className="size-5 text-brand" />
+					<p className="font-medium">Check your inbox</p>
+				</div>
+				<p className="mt-1 text-sm text-muted-foreground">
+					We sent the download link to {submittedEmail}.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="w-full max-w-md">
+			<label
+				htmlFor="download-email"
+				className="mb-2 block font-mono text-xs uppercase tracking-wider text-muted-foreground"
+			>
+				Email address
+			</label>
+			<div className="flex flex-col gap-2 sm:flex-row sm:gap-0">
+				<input
+					id="download-email"
+					type="email"
+					name="email"
+					required
+					autoComplete="email"
+					inputMode="email"
+					placeholder="you@company.com"
+					value={email}
+					onChange={(event) => setEmail(event.target.value)}
+					className="min-w-0 flex-1 border border-border bg-background px-4 py-3 text-base text-foreground placeholder:text-muted-foreground/70 focus:border-foreground focus:outline-none sm:border-r-0"
+				/>
+				<button
+					type="submit"
+					disabled={isSubmitting}
+					className="group flex shrink-0 items-center justify-center gap-2 bg-foreground px-5 py-3 text-sm font-normal text-background transition-colors hover:bg-brand hover:text-white disabled:cursor-wait disabled:opacity-60"
+				>
+					{isSubmitting ? "Sending…" : "Email me the link"}
+					<HiMiniArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+				</button>
+			</div>
+
+			<input
+				type="text"
+				name="company-website"
+				tabIndex={-1}
+				autoComplete="off"
+				className="hidden"
+				aria-hidden="true"
+			/>
+
+			<p className="mt-3 text-xs text-muted-foreground">
+				We&apos;ll only use this to send your download link.
+			</p>
+			{error ? (
+				<p className="mt-2 text-sm text-red-500" role="alert">
+					{error}
+				</p>
+			) : null}
+		</form>
+	);
+}

--- a/apps/marketing/src/app/download/components/DownloadLinkForm/DownloadLinkForm.tsx
+++ b/apps/marketing/src/app/download/components/DownloadLinkForm/DownloadLinkForm.tsx
@@ -19,16 +19,20 @@ export function DownloadLinkForm() {
 
 		setError("");
 		setIsSubmitting(true);
-		const result = await sendDownloadLink({ email, honeypot });
-		setIsSubmitting(false);
+		try {
+			const result = await sendDownloadLink({ email, honeypot });
+			if (!result.success) {
+				setError(result.error);
+				return;
+			}
 
-		if (!result.success) {
-			setError(result.error);
-			return;
+			setSubmittedEmail(email);
+			track("download_link_emailed", { platform: "mobile" });
+		} catch {
+			setError("Something went wrong. Please try again.");
+		} finally {
+			setIsSubmitting(false);
 		}
-
-		setSubmittedEmail(email);
-		track("download_link_emailed", { platform: "mobile" });
 	}
 
 	if (submittedEmail) {

--- a/apps/marketing/src/app/download/components/DownloadLinkForm/actions.ts
+++ b/apps/marketing/src/app/download/components/DownloadLinkForm/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { DownloadLinkEmail } from "@superset/email/emails/marketing/download-link";
+import { Resend } from "resend";
+import { z } from "zod";
+import { env } from "@/env";
+import { checkEmailFormRateLimit } from "@/lib/email-rate-limit";
+import { sanitizeSingleLine, validateEmail } from "@/lib/form-utils";
+
+const resend = new Resend(env.RESEND_API_KEY);
+
+const downloadLinkSchema = z.object({
+	email: z.string(),
+	honeypot: z.string().optional(),
+});
+
+type SendDownloadLinkResult =
+	| { success: true }
+	| { success: false; error: string };
+
+export async function sendDownloadLink(
+	data: unknown,
+): Promise<SendDownloadLinkResult> {
+	const parsedData = downloadLinkSchema.safeParse(data);
+	if (!parsedData.success) {
+		return { success: false, error: "Enter a valid email address." };
+	}
+
+	const { email, honeypot } = parsedData.data;
+	if (honeypot) {
+		return { success: false, error: "Something went wrong. Please try again." };
+	}
+
+	const sanitizedEmail = sanitizeSingleLine(email).toLowerCase();
+	if (!validateEmail(sanitizedEmail)) {
+		return { success: false, error: "Enter a valid email address." };
+	}
+
+	try {
+		if (!(await checkEmailFormRateLimit(sanitizedEmail))) {
+			return {
+				success: false,
+				error: "Too many requests. Please try again later.",
+			};
+		}
+
+		const { error } = await resend.emails.send({
+			from: "Superset <noreply@superset.sh>",
+			to: sanitizedEmail,
+			subject: "Your Superset download link",
+			react: DownloadLinkEmail({ recipientEmail: sanitizedEmail }),
+		});
+
+		if (error) {
+			console.error("Failed to send download link:", error);
+			return {
+				success: false,
+				error: "Something went wrong. Please try again.",
+			};
+		}
+
+		return { success: true };
+	} catch (error) {
+		console.error("Failed to send download link:", error);
+		return {
+			success: false,
+			error: "Something went wrong. Please try again.",
+		};
+	}
+}

--- a/apps/marketing/src/app/download/components/DownloadLinkForm/actions.ts
+++ b/apps/marketing/src/app/download/components/DownloadLinkForm/actions.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { DownloadLinkEmail } from "@superset/email/emails/marketing/download-link";
+import { DownloadLinkEmail } from "@superset/email/emails/marketing/DownloadLinkEmail";
 import { Resend } from "resend";
 import { z } from "zod";
 import { env } from "@/env";
 import { checkEmailFormRateLimit } from "@/lib/email-rate-limit";
-import { sanitizeSingleLine, validateEmail } from "@/lib/form-utils";
+import { sanitizeSingleLine } from "@/lib/form-utils";
 
 const resend = new Resend(env.RESEND_API_KEY);
 
@@ -32,7 +32,7 @@ export async function sendDownloadLink(
 	}
 
 	const sanitizedEmail = sanitizeSingleLine(email).toLowerCase();
-	if (!validateEmail(sanitizedEmail)) {
+	if (!z.email().safeParse(sanitizedEmail).success) {
 		return { success: false, error: "Enter a valid email address." };
 	}
 

--- a/apps/marketing/src/app/download/components/DownloadLinkForm/index.ts
+++ b/apps/marketing/src/app/download/components/DownloadLinkForm/index.ts
@@ -1,0 +1,1 @@
+export { DownloadLinkForm } from "./DownloadLinkForm";

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,6 +11,7 @@
 		"typescript": "6.0.3"
 	},
 	"exports": {
+		"./emails/marketing/DownloadLinkEmail": "./src/emails/marketing/DownloadLinkEmail/index.ts",
 		"./emails/*": "./src/emails/*.tsx"
 	},
 	"private": true,

--- a/packages/email/src/emails/marketing/DownloadLinkEmail/DownloadLinkEmail.tsx
+++ b/packages/email/src/emails/marketing/DownloadLinkEmail/DownloadLinkEmail.tsx
@@ -1,5 +1,5 @@
 import { Heading, Section, Text } from "@react-email/components";
-import { Button, EmailLayout } from "../../components";
+import { Button, EmailLayout } from "../../../components";
 
 const DOWNLOAD_URL =
 	"https://superset.sh/download?utm_source=email&utm_medium=transactional&utm_campaign=mobile-download-link";

--- a/packages/email/src/emails/marketing/DownloadLinkEmail/index.ts
+++ b/packages/email/src/emails/marketing/DownloadLinkEmail/index.ts
@@ -1,0 +1,1 @@
+export { DownloadLinkEmail } from "./DownloadLinkEmail";

--- a/packages/email/src/emails/marketing/download-link.tsx
+++ b/packages/email/src/emails/marketing/download-link.tsx
@@ -1,0 +1,39 @@
+import { Heading, Section, Text } from "@react-email/components";
+import { Button, EmailLayout } from "../../components";
+
+const DOWNLOAD_URL =
+	"https://superset.sh/download?utm_source=email&utm_medium=transactional&utm_campaign=mobile-download-link";
+
+interface DownloadLinkEmailProps {
+	recipientEmail?: string;
+}
+
+export function DownloadLinkEmail({
+	recipientEmail,
+}: DownloadLinkEmailProps = {}) {
+	return (
+		<EmailLayout
+			preview="Your Superset desktop download link"
+			recipientEmail={recipientEmail}
+		>
+			<Heading className="m-0 mb-3 text-[22px] font-medium leading-8 text-foreground">
+				Get Superset on your Mac
+			</Heading>
+			<Text className="m-0 mb-6 text-[15px] leading-6 text-muted">
+				Open this email on your Mac, then use the button below to download
+				Superset. The right version will be selected automatically.
+			</Text>
+
+			<Section className="mb-8">
+				<Button href={DOWNLOAD_URL}>Download Superset</Button>
+			</Section>
+
+			<Text className="m-0 text-[13px] leading-5 text-muted">
+				Superset is available for macOS today. Windows and Linux support is on
+				the way.
+			</Text>
+		</EmailLayout>
+	);
+}
+
+export default DownloadLinkEmail;


### PR DESCRIPTION
## What & why

Mobile visitors currently get a desktop-download dropdown and are then classified with Windows/Linux visitors on `/download`, even though they cannot install the macOS app from their phone.

This replaces the mobile CTA with “Email me a link” and adds a dedicated mobile handoff flow:

- route mobile download CTAs to a focused email form
- send a transactional download email through the existing Resend setup
- validate and sanitize addresses, add honeypot protection, and reuse per-IP/per-email rate limiting
- show a clear confirmation state while leaving macOS auto-download and Windows/Linux waitlist behavior unchanged
- track successful download-link sends without including the submitted address

The interaction follows the established pattern used by desktop-first products such as Framer and Fing: explain that the app is desktop-only, collect one email address, and send a link to open on the desktop.

## How I tested it

- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck` — 37/37 tasks passed
- `bun run test` — 18/18 tasks passed
- Real browser verification at a 390×844 viewport with an iPhone user agent:
  - mobile hero rendered “Email me a link”
  - real click navigated to `/download`
  - form rendered without horizontal overflow
  - empty submission triggered native email validation and focused the field
  - no console errors
- Live end-to-end submission through the rendered mobile form:
  - server action returned HTTP 200
  - Resend accepted the transactional email
  - UI rendered “Check your inbox” with the submitted recipient

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] Full monorepo test suite passes
- [x] Branch is based on the latest `main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emails desktop download links to mobile visitors and removes the desktop download dropdown on phones. Previously, mobile saw the desktop dropdown and was grouped with Windows/Linux on `/download`; now mobile sees “Email me a link,” submits a short form, and receives a link to open on their Mac. macOS auto-download and Windows/Linux waitlist behavior remain unchanged.

- Replaces the mobile Download dropdown with a single “Email me a link” CTA that routes to `/download` and renders `DownloadLinkForm`; interstitial now shows the form for mobile, waitlist for Windows/Linux, and auto-download for macOS.
- Adds `DownloadLinkForm` and server action `sendDownloadLink`: sanitizes and validates emails, includes a honeypot, reuses existing email form rate limiting, and shows a confirmation state.
- Sends a transactional email via Resend using `@superset/email` template `emails/marketing/DownloadLinkEmail`; includes a UTM-tagged download button and tracks success as `download_link_emailed` without including the address in analytics.

<sup>Written for commit 534e38d5716ab313b806be4136c72abfb17950fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile visitors can request a download link by email.
  * Added email validation, confirmation messaging, and helpful error handling.
  * Download emails include platform availability and a direct download button.
* **Improvements**
  * Simplified the mobile download experience by replacing the platform dropdown with an “Email me a link” option.
  * Desktop platform-specific download behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->