### PR TITLE
fix(host-service): record the descriptor table when git cannot be spawned

### DIFF
--- a/packages/host-service/src/trpc/error-diagnostics.ts
+++ b/packages/host-service/src/trpc/error-diagnostics.ts
@@ -1,0 +1,36 @@
+/**
+ * A side channel for state a throw site measured at the moment of failure and
+ * the Sentry middleware should report alongside the event.
+ *
+ * The middleware decides what to report from the status code alone and never
+ * reads error text; this is how a throw site hands it evidence without
+ * changing the error, its message, or its classification. Attaching is not a
+ * capture — an error carrying diagnostics is reported exactly when it would
+ * have been anyway.
+ *
+ * Keyed by a module-private symbol: the error travels on to tRPC's error
+ * formatter and out to the client, and only enumerable string keys go with it.
+ */
+const DIAGNOSTICS = Symbol("errorDiagnostics");
+
+/** Undefined values are kept: "we looked and could not read it" is a fact
+ * worth seeing in the event, and it is not the same as never having looked. */
+export type ErrorDiagnostics = Record<string, number | string | undefined>;
+
+export function attachErrorDiagnostics(
+	error: unknown,
+	diagnostics: ErrorDiagnostics,
+): void {
+	if (!(error instanceof Error)) return;
+	(error as unknown as Record<symbol, ErrorDiagnostics>)[DIAGNOSTICS] =
+		diagnostics;
+}
+
+export function readErrorDiagnostics(
+	error: unknown,
+): ErrorDiagnostics | undefined {
+	if (!(error instanceof Error)) return undefined;
+	return (error as unknown as Record<symbol, ErrorDiagnostics | undefined>)[
+		DIAGNOSTICS
+	];
+}

--- a/packages/host-service/src/trpc/index.ts
+++ b/packages/host-service/src/trpc/index.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import type { HostServiceContext } from "../types";
+import { readErrorDiagnostics } from "./error-diagnostics";
 import {
 	type DeleteInProgressCause,
 	isDeleteInProgressCause,
@@ -88,6 +89,9 @@ const sentryMiddleware = t.middleware(async ({ next, path, type }) => {
 			},
 			extra: {
 				trpc_message: error.message,
+				// State a throw site measured at the moment of failure. Reporting
+				// is unchanged: this only fills in an event that is already going.
+				...readErrorDiagnostics(originalError),
 			},
 		});
 	}

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -45,6 +45,7 @@ import {
 	REVIEW_THREADS_QUERY,
 } from "./utils/graphql";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
+import { attachSpawnFailureDiagnostics } from "./utils/spawn-failure-diagnostics";
 
 // Front-door cap for commit-file diffs. Statuses are admitted by
 // gitStatusRefreshLimiter; without a cap here, a burst of distinct-commit
@@ -243,6 +244,10 @@ export const gitRouter = router({
 				// worktree can vanish between resolveWorktreePath's existsSync
 				// check and the git spawn.
 				rethrowEnvironmentalGitError(error);
+				// A spawn that never produced a process reports with no
+				// first-party frame and no reason; record the descriptor table
+				// while we are still standing in the failure.
+				attachSpawnFailureDiagnostics(error);
 				throw error;
 			}
 		}),

--- a/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.test.ts
@@ -14,8 +14,17 @@ describe("attachSpawnFailureDiagnostics", () => {
 		// synchronously for EBADF, and simple-git keeps only String(err).
 		const { diagnostics } = diagnose("Error: spawn EBADF");
 		expect(diagnostics).toBeDefined();
+		// The count stays strict: both shipped platforms always let a process
+		// list its own descriptor table, so anything but a positive number here
+		// means the counter stopped working.
 		expect(diagnostics?.open_file_descriptors).toBeGreaterThan(0);
-		expect(diagnostics?.file_descriptor_soft_limit).toBeGreaterThan(0);
+		// The limit is the one that genuinely varies — a container with no cap
+		// reports it as "unlimited", which is a fact worth recording, not a
+		// failure. Anything else would be.
+		const limit = diagnostics?.file_descriptor_soft_limit;
+		expect(
+			limit === "unlimited" || (typeof limit === "number" && limit > 0),
+		).toBe(true);
 	});
 
 	test("spawn refused via the child's error event → recorded too", () => {

--- a/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { readErrorDiagnostics } from "../../../error-diagnostics";
+import { attachSpawnFailureDiagnostics } from "./spawn-failure-diagnostics";
+
+function diagnose(message: string) {
+	const error = new Error(message);
+	attachSpawnFailureDiagnostics(error);
+	return { error, diagnostics: readErrorDiagnostics(error) };
+}
+
+describe("attachSpawnFailureDiagnostics", () => {
+	test("spawn refused outright → descriptor table recorded", () => {
+		// Verbatim from HOST-SERVICE-4E / HOST-SERVICE-1R: child_process throws
+		// synchronously for EBADF, and simple-git keeps only String(err).
+		const { diagnostics } = diagnose("Error: spawn EBADF");
+		expect(diagnostics).toBeDefined();
+		expect(diagnostics?.open_file_descriptors).toBeGreaterThan(0);
+		expect(diagnostics?.file_descriptor_soft_limit).toBeGreaterThan(0);
+	});
+
+	test("spawn refused via the child's error event → recorded too", () => {
+		// EACCES/EAGAIN/EMFILE/ENFILE/ENOENT reach the child's error event
+		// instead of throwing, and simple-git puts err.stack on stderr. First
+		// line verbatim from the same trpc_path (releases 1.22.0 and 1.23.0);
+		// frames reproduced locally against a git binary that does not exist.
+		// EMFILE arrives this way, so the exhaustion case must not be excluded
+		// by the shape the message happens to take.
+		const { diagnostics } = diagnose(
+			"Error: spawn git EAGAIN\n" +
+				"    at ChildProcess._handle.onexit (node:internal/child_process:285:19)\n" +
+				"    at onErrorNT (node:internal/child_process:483:16)\n" +
+				"    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)",
+		);
+		expect(diagnostics).toBeDefined();
+		expect(diagnostics?.open_file_descriptors).toBeGreaterThan(0);
+	});
+
+	test("git ran and exited non-zero → nothing attached", () => {
+		// Real traffic from git.getStatus in the same week as the spawn groups.
+		// git started, did its work and refused: the descriptor table says
+		// nothing about a damaged object store, and attaching it here would
+		// turn the diagnostics into noise on the most common failures we see.
+		expect(diagnose("fatal: bad object HEAD\n").diagnostics).toBeUndefined();
+		expect(
+			diagnose(
+				"error: file .git/objects/pack/pack-816a419ea2792b300adb04c1f8bc739065981ebe.pack is far too short to be a packfile\n",
+			).diagnostics,
+		).toBeUndefined();
+		expect(
+			diagnose(
+				"fatal: not a git repository (or any of the parent directories): .git\n",
+			).diagnostics,
+		).toBeUndefined();
+	});
+
+	test("a spawn failure inside git's output is not our spawn failing", () => {
+		// The over-match this branch has to refuse: a clean filter that is
+		// itself a Node program crashes on its own spawn, and git relays the
+		// crash dump. Our spawn succeeded — git ran, and its stderr is
+		// quoting someone else's failure. Modelled on the filter failures in
+		// classify-git-error.test.ts, which are real traffic from this path.
+		expect(
+			diagnose(
+				"node:internal/child_process:421\n" +
+					"    throw errnoException(err, 'spawn');\n" +
+					"    ^\n\n" +
+					"Error: spawn image-optimiser ENOENT\n" +
+					"    at ChildProcess.spawn (node:internal/child_process:421:11)\n" +
+					"error: external filter 'media-filter' failed\n" +
+					"fatal: assets/img/hash.png: clean filter 'media' failed\n",
+			).diagnostics,
+		).toBeUndefined();
+	});
+
+	test("leaves the error itself alone", () => {
+		const { error } = diagnose("Error: spawn EBADF");
+		expect(error.message).toBe("Error: spawn EBADF");
+		expect(Object.keys(error)).toEqual([]);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
+++ b/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
@@ -1,0 +1,94 @@
+import { readdirSync } from "node:fs";
+import { attachErrorDiagnostics } from "../../../error-diagnostics";
+
+// Node's own text for a `spawn` that never produced a process. `errnoException`
+// builds it, so the syscall name and the errno are the whole line: `spawn
+// EBADF` when child_process throws synchronously, `spawn git EAGAIN` when it
+// defers to the child's error event (EACCES/EAGAIN/EMFILE/ENFILE/ENOENT take
+// that route). simple-git surfaces the first as `String(err)` and the second as
+// `err.stack` — one line, or that line followed by ` at ` frames.
+//
+// This is matched on text rather than on `err.code` because the errno is gone
+// as structure long before this seam: simple-git's onFatalException replaces
+// the SystemError with `new GitError(task, String(e))`, keeping only the
+// sentence, and the worker boundary then keeps only name/message/stack/code.
+// The syscall name and errno in that sentence are what survive.
+const SPAWN_SYSCALL_FAILURE_PATTERN = /^(?:Error: )?spawn (?:.+ )?E[A-Z0-9]+$/;
+
+/**
+ * Whether a git failure is the spawn syscall failing rather than git running
+ * and exiting non-zero.
+ *
+ * Anchored to the start of the message, which is what separates our own spawn
+ * from one mentioned inside git's output: when the spawn fails there is no
+ * process and so no git stderr, and the error text is the whole message. A
+ * hook or filter that is itself a Node program can print the same sentence,
+ * but it arrives mid-stream, behind the program's own output and ahead of the
+ * `fatal:` line git adds.
+ */
+export function isSpawnSyscallFailure(message: string): boolean {
+	const firstLine = message.split("\n", 1)[0] ?? "";
+	return SPAWN_SYSCALL_FAILURE_PATTERN.test(firstLine);
+}
+
+/**
+ * How many descriptors this process holds. `/proc/self/fd` on Linux, `/dev/fd`
+ * on macOS; both list the caller's own table, and worker threads share it with
+ * the main thread, so this is the table the failed spawn drew from. Counts the
+ * descriptor the listing itself holds.
+ */
+function countOpenFileDescriptors(): number | undefined {
+	const dir = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+	try {
+		return readdirSync(dir).length;
+	} catch {
+		return undefined;
+	}
+}
+
+// RLIMIT_NOFILE is inherited at exec and nothing in this process changes it,
+// so it is read once: process.report.getReport() is the only core API that
+// exposes it and it costs ~12ms, which this path would otherwise pay on every
+// poll — the failure repeats every couple of seconds for hours.
+let softLimit: number | string | undefined;
+let softLimitRead = false;
+
+function fileDescriptorSoftLimit(): number | string | undefined {
+	if (softLimitRead) return softLimit;
+	softLimitRead = true;
+	try {
+		const report = process.report?.getReport() as
+			| { userLimits?: { open_files?: { soft?: unknown } } }
+			| undefined;
+		const soft = report?.userLimits?.open_files?.soft;
+		// `soft` is a number, or "unlimited" where the platform reports no cap.
+		if (typeof soft === "number" || typeof soft === "string") softLimit = soft;
+	} catch {
+		// Diagnostics must never replace the failure they describe.
+	}
+	return softLimit;
+}
+
+/**
+ * Record the descriptor table on a git failure that never got as far as
+ * running git.
+ *
+ * These failures report with no first-party frame — the captured stack is
+ * entirely simple-git's executor — and nothing in the event says why the
+ * spawn was refused. The count against the soft limit separates the two
+ * candidates: at the limit is exhaustion, and the leak is ours to find;
+ * nowhere near it is a descriptor that went bad while we still held it. See
+ * HOST-SERVICE-4E and HOST-SERVICE-1R, where a machine enters this state and
+ * every subsequent poll fails the same way for hours.
+ *
+ * No-op for anything else, and no-op on the error itself: the message,
+ * classification and 500 are exactly what they were.
+ */
+export function attachSpawnFailureDiagnostics(error: unknown): void {
+	if (!(error instanceof Error)) return;
+	if (!isSpawnSyscallFailure(error.message)) return;
+	attachErrorDiagnostics(error, {
+		open_file_descriptors: countOpenFileDescriptors(),
+		file_descriptor_soft_limit: fileDescriptorSoftLimit(),
+	});
+}


### PR DESCRIPTION
## Problem

`git.getStatus` backs the source-control view on a ~2s poll. On two unrelated
machines, on two different releases, the *spawn* of the git subprocess began
failing before git ran, and never recovered: every subsequent poll failed the
same way for hours until the process restarted. ~14,700 events over seven days
from those two machines alone — the largest error source in this service.

Two things narrow it. On the machine I looked at, `git.getStatus` was the only
thing failing for two days; every other route kept answering, so this is not
machine-wide resource exhaustion. And it recurred on two machines and two
releases, so it is not a one-off.

Whether this change is worth making:

1. **User-visible harm.** A user's Changes view stops working entirely for
   hours, and the host burns a Sentry event every two seconds while it does.
   **This change does not remove that harm** — it makes the next occurrence
   diagnosable. Judged on that basis: the evidence needed is the descriptor
   table, and it does not exist today. The captured stack is 100% inside
   simple-git's executor with no first-party frame; simple-git's
   `onFatalException` replaces the Node `SystemError` with
   `new GitError(task, String(e))`, so `errno`/`syscall`/`code` are gone as
   structure before the error leaves the worker; and the event context carries
   memory but nothing about descriptors. The two live hypotheses — we leak
   descriptors, or one went bad while we still held it — imply completely
   different fixes and are indistinguishable in every event we have. Count
   against soft limit separates them in one occurrence.
2. **Reaches the failure.** `trpc_path` is `git.getStatus` on all 14.7k events.
   The `try/catch` at `git.ts:239-250` already runs for this error today —
   `rethrowEnvironmentalGitError` no-ops on `"Error: spawn EBADF"` and falls
   through to `throw error`. The snapshot runs in a `worker_thread`, which
   shares the process descriptor table, so counting from the main thread reads
   the same table the failed spawn drew from. Ships in the next
   desktop/host-service release; field releases today are 1.22.0–1.24.1 and the
   poll is continuous, so the next occurrence carries the numbers.
3. **Code is the right instrument.** An inbound filter or archive is forbidden
   by the PR #6164 contract and wrong anyway — it is a real bug. Local repro is
   not available: both machines ran for days before entering the state, and
   nothing identifies the trigger. Doing nothing leaves an escalating issue with
   no path to a fix. No in-flight work restructures this path (#6811, #6785,
   #6753 touch `workers/tasks/git.ts` and the cleanup routers, not the
   `getStatus` catch, the worker pool, or the reporter).

## Root cause

Unknown, deliberately — establishing it is what this instrumentation exists
for. What is established: the failure is `child_process.spawn` itself
returning `EBADF`, which Node throws synchronously (`EACCES`/`EAGAIN`/`EMFILE`/
`ENFILE`/`ENOENT` take the child's `error` event instead), and simple-git
surfaces it as `String(err)` — hence the exact message `Error: spawn EBADF`.
Nothing here tries to find or fix whatever makes the descriptor bad.

## Fix

Enrich the capture only.

- `spawn-failure-diagnostics.ts` recognises a spawn that never produced a
  process and attaches the open descriptor count (`/dev/fd`, `/proc/self/fd` on
  Linux) and the `RLIMIT_NOFILE` soft limit.
- `error-diagnostics.ts` is the side channel from a throw site to the existing
  Sentry middleware: a module-private symbol on the error, spread into the
  event's `extra` alongside `trpc_message`. Attaching is not a capture — an
  error carrying diagnostics reports exactly when it would have anyway.
- The `getStatus` catch calls it after `rethrowEnvironmentalGitError`.

Unchanged: the message, the classification, the 500, and the reporting rate. No
retry, backoff or rate-limiting. No typed `cause` — nothing reads one, so the
error is rethrown exactly as it was.

**The matcher, and what it must not match.** The errno is destroyed before this
seam, so the structural signal that survives is Node's own `errnoException`
text — the syscall name and errno, which is the whole line: `spawn EBADF`, or
`spawn git EAGAIN` for the deferred route. It is anchored to the **start of the
message**, which is what separates our spawn from one merely quoted inside
git's output. Named over-matches, all covered by negative tests over real
captured failures from this same `trpc_path`:

- ordinary non-zero git exits — `fatal: bad object HEAD`, the truncated-packfile
  error, `fatal: not a git repository`. Far more common, and a descriptor count
  means nothing for them.
- a clean/smudge filter that is itself a Node program crashing on *its* own
  spawn, relayed through git's stderr. Our spawn succeeded there; git ran. This
  is the case start-anchoring exists to refuse.

`spawn git EAGAIN` (112 events, same path, releases 1.22.0/1.23.0) is matched
deliberately: `EMFILE` — descriptor exhaustion, one of the two hypotheses —
arrives by that same route, and excluding it by message shape would drop the
exhaustion case.

Adjacent call sites that would want the same diagnostics and are deliberately
left alone: `getDiffStatsByWorkspaces` and `listBranches` both swallow git
failures entirely, so they report nothing to enrich; the remaining git
procedures never appear in these groups because the 2s poll is `getStatus`.

## Verification

`bunx biome check` on the five changed files (after one `--write` for import
order):

```
Checked 5 files in 12ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
 Tasks:    37 successful, 37 total
Cached:    12 cached, 37 total
  Time:    56.964s
```

`bun test packages/host-service/src/trpc/router/git`:

```
 123 pass
 0 fail
 271 expect() calls
Ran 123 tests across 11 files. [35.12s]
```

Both directions on the matcher. With the branch as written, all 5 pass. Loosening
the anchor to match the signature on *any* line (`/…/m` against the whole
message) — the obvious wrong version — makes the negative test fail, attaching a
descriptor count to a git failure that is not ours:

```
error: expect(received).toBeUndefined()

Received: {
  open_file_descriptors: 98,
  file_descriptor_soft_limit: 1048576,
}

(fail) attachSpawnFailureDiagnostics > a spawn failure inside git's output is not our spawn failing
 4 pass
 1 fail
```

Restored, `5 pass / 0 fail`.

Two things checked outside the test suite, since the change is worthless if
either is false:

- **The diagnostics actually reach the middleware.** A scratch tRPC router
  mirroring `sentryMiddleware` confirmed the thrown error's identity survives
  tRPC's wrapping — `result.error.cause` is the same instance — and the values
  land in `extra` next to `trpc_message`. Not kept as a test: it mirrors the
  middleware rather than importing it, and a mirror drifts.
- **The message shapes are real, not assumed.** `Error: spawn EBADF` is verbatim
  from the `trpc_message` extra on both issues. The deferred-route shape (first
  line, then ` at ` frames) was reproduced locally by pointing simple-git at a
  binary that does not exist, and the ordinary-failure shape (`fatal: …`, no
  spawn signature) alongside it.

One cost, measured: `process.report.getReport()` is the only core API exposing
`RLIMIT_NOFILE` and costs ~12ms. Since the failure repeats every ~2s for hours,
it is read once per process — the limit is inherited at exec and nothing here
changes it. The descriptor count is read every time (~0.014ms).

Refs HOST-SERVICE-4E
Refs HOST-SERVICE-1R

https://claude.ai/code/session_019K18zjoDbeUSqdmxtm9GgR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records open file descriptor count and RLIMIT_NOFILE soft limit when git.getStatus fails to spawn git, so EBADF/EAGAIN incidents are diagnosable. Behavior is unchanged: these still report as 500s; this only enriches Sentry event metadata.

- Flow: git.getStatus catch calls attachSpawnFailureDiagnostics; the Sentry middleware spreads readErrorDiagnostics into event.extra. No change to message, classification, or rate.
- Matching: start-anchored match on the first line (“spawn … E*”), including deferred child error path (e.g., “Error: spawn git EAGAIN”); excludes failures quoted in git stderr.
- Perf/safety: FD count read per failure; RLIMIT_NOFILE read once via process.report and cached; read failures become undefined; the error object is unmodified.
- Tests: matcher positives/negatives and error immutability; accept “unlimited” soft limits to cover container environments.
- Scope: limited to git.getStatus; other git routes unchanged. Refs HOST-SERVICE-4E, HOST-SERVICE-1R.

<sup>Written for commit ddf8955d294a767f7825821073bf3eecb2730634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for Git operations that fail because the system cannot start a process.
  - Sentry reports relevant file-descriptor usage and system limits for qualifying errors.
  - Diagnostic details remain internal and are not exposed in client-facing error responses.

- **Tests**
  - Added coverage for synchronous and asynchronous process-start failures, unrelated Git errors, and preservation of the original error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->