### PR TITLE
fix(agent-setup): bypass Codex hook trust in the wrapper so Stop events reach Superset

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -47,13 +47,16 @@ its hook entries into these files while preserving user-defined entries:
 
 For Codex specifically, Superset now relies on native `~/.codex/hooks.json`
 registration for durable prompt/tool lifecycle events. The wrapper in
-`~/.superset[-{workspace}]/bin/codex` enables those hooks and keeps the
-session-log watcher as a best-effort compatibility bridge for Start and
-permission events on older Codex releases. It does not override the legacy
-`notify` callback because that callback cannot distinguish main-agent and
-subagent completions. On startup, Superset rewrites only its own managed entries in
-`~/.codex/hooks.json` to point at the current environment's `notify.sh`, while
-preserving any user-defined Codex hooks.
+`~/.superset[-{workspace}]/bin/codex` enables those hooks — appending
+`--dangerously-bypass-hook-trust` when the launch command doesn't already pass
+it, because Codex silently skips untrusted `hooks.json` entries and Superset
+would otherwise lose the Stop signal — and keeps the session-log watcher as a
+best-effort compatibility bridge for Start and permission events on older
+Codex releases. It does not override the legacy `notify` callback because that
+callback cannot distinguish main-agent and subagent completions. On startup,
+Superset rewrites only its own managed entries in `~/.codex/hooks.json` to
+point at the current environment's `notify.sh`, while preserving any
+user-defined Codex hooks.
 
 ### `zsh/` and `bash/` - Shell Integration
 

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -155,7 +155,7 @@ describe("agent-wrappers copilot", () => {
 		const wrapper = readFileSync(wrapperPath, "utf-8");
 
 		expect(wrapper).toContain(
-			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks "$@"`,
+			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks \${_superset_bypass_hook_trust:+"$_superset_bypass_hook_trust"} "$@"`,
 		);
 		expect(wrapper).not.toContain("-c 'notify=");
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
@@ -244,6 +244,7 @@ exit 0
 				`projects={"${workspacePath}"={trust_level="trusted"}}`,
 				"--enable",
 				"hooks",
+				"--dangerously-bypass-hook-trust",
 			].join("\n")}\n`,
 		);
 	});
@@ -278,7 +279,61 @@ exit 0
 		});
 
 		expect(readFileSync(argsFile, "utf-8")).toBe(
-			`${["--enable", "hooks", "exec", "Reply with exactly OK."].join("\n")}\n`,
+			`${[
+				"--enable",
+				"hooks",
+				"--dangerously-bypass-hook-trust",
+				"exec",
+				"Reply with exactly OK.",
+			].join("\n")}\n`,
+		);
+	});
+
+	it("does not duplicate the hook-trust bypass when the launch command already passes it", () => {
+		const realBinDir = path.join(TEST_ROOT, "real-bin");
+		const realCodex = path.join(realBinDir, "codex");
+		const wrapperPath = path.join(TEST_BIN_DIR, "codex");
+		const argsFile = path.join(TEST_ROOT, "codex-bypass-args.txt");
+
+		mkdirSync(realBinDir, { recursive: true });
+		writeFileSync(
+			realCodex,
+			`#!/bin/bash
+printf '%s\n' "$@" > "${argsFile}"
+exit 0
+`,
+			{ mode: 0o755 },
+		);
+		chmodSync(realCodex, 0o755);
+
+		createCodexWrapper();
+
+		// The builtin preset command already carries the flag; codex errors on a
+		// repeated boolean flag, so the wrapper must not append a second one.
+		execFileSync(
+			wrapperPath,
+			[
+				"--dangerously-bypass-approvals-and-sandbox",
+				"--dangerously-bypass-hook-trust",
+			],
+			{
+				env: {
+					...process.env,
+					PATH: `${TEST_BIN_DIR}:${realBinDir}:${process.env.PATH || ""}`,
+					SUPERSET_WORKSPACE_PATH: "",
+					SUPERSET_TERMINAL_ID: "terminal-1",
+				},
+				encoding: "utf-8",
+			},
+		);
+
+		expect(readFileSync(argsFile, "utf-8")).toBe(
+			`${[
+				"--enable",
+				"hooks",
+				"--dangerously-bypass-approvals-and-sandbox",
+				"--dangerously-bypass-hook-trust",
+			].join("\n")}\n`,
 		);
 	});
 

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -335,6 +335,32 @@ exit 0
 				"--dangerously-bypass-hook-trust",
 			].join("\n")}\n`,
 		);
+
+		// A prompt that merely mentions the flag after `--` is text, not a flag —
+		// the real bypass must still be appended.
+		execFileSync(
+			wrapperPath,
+			["--", "explain what --dangerously-bypass-hook-trust does"],
+			{
+				env: {
+					...process.env,
+					PATH: `${TEST_BIN_DIR}:${realBinDir}:${process.env.PATH || ""}`,
+					SUPERSET_WORKSPACE_PATH: "",
+					SUPERSET_TERMINAL_ID: "terminal-1",
+				},
+				encoding: "utf-8",
+			},
+		);
+
+		expect(readFileSync(argsFile, "utf-8")).toBe(
+			`${[
+				"--enable",
+				"hooks",
+				"--dangerously-bypass-hook-trust",
+				"--",
+				"explain what --dangerously-bypass-hook-trust does",
+			].join("\n")}\n`,
+		);
 	});
 
 	it("emits codex Start from the wrapper-owned TUI session log", () => {

--- a/packages/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/packages/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -122,7 +122,23 @@ fi
 # Native hooks separate the main Stop event from SubagentStop. Do not inject
 # Codex's legacy notify callback: it reports both as agent-turn-complete without
 # parent metadata, so Superset cannot filter subagent completions.
-"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks "$@"
+#
+# Codex gates each hooks.json entry behind per-hook trust, and an untrusted
+# hook is silently skipped — losing the Stop hook, Superset's only completion
+# signal for Codex, while the session watcher above still reports Start. The
+# builtin launch commands pass the bypass themselves; append it for every
+# other launch (manual `codex`, stale host agent configs, custom presets)
+# unless the caller already did — codex rejects the flag when repeated. Hooks
+# the user explicitly disabled stay disabled; the bypass only skips the trust
+# gate.
+_superset_bypass_hook_trust="--dangerously-bypass-hook-trust"
+for _superset_arg in "$@"; do
+  if [ "$_superset_arg" = "--dangerously-bypass-hook-trust" ]; then
+    _superset_bypass_hook_trust=""
+    break
+  fi
+done
+"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks ${_superset_bypass_hook_trust:+"$_superset_bypass_hook_trust"} "$@"
 SUPERSET_CODEX_STATUS=$?
 _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 

--- a/packages/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/packages/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -133,6 +133,9 @@ fi
 # gate.
 _superset_bypass_hook_trust="--dangerously-bypass-hook-trust"
 for _superset_arg in "$@"; do
+  # Tokens past `--` are prompt text, never flags — stop scanning there so a
+  # prompt that mentions the flag doesn't suppress the real one.
+  [ "$_superset_arg" = "--" ] && break
   if [ "$_superset_arg" = "--dangerously-bypass-hook-trust" ]; then
     _superset_bypass_hook_trust=""
     break


### PR DESCRIPTION
## Summary

Fixes SUPER-1985: Superset never noticed a Codex agent had stopped — agents sat on "working" forever and users had to cycle through workspaces by hand to find finished ones.

Since #6464 the native `Stop` hook in `~/.codex/hooks.json` is Superset's only completion signal for Codex (the legacy `notify=` callback was dropped because it can't distinguish subagent completions). But Codex gates every `hooks.json` entry behind per-hook trust, and an untrusted hook is silently skipped — on codex-cli 0.149.0 it can even stall `codex exec` for minutes. The `--dangerously-bypass-hook-trust` flag only lives in the builtin preset command strings (#5819), so it never reaches:

- host agent config rows snapshotted before #5819
- custom agents/presets
- plain `codex` typed into a Superset terminal
- account-profile `CODEX_HOME`s, whose `hooks.json` path never matches the trust ledger synced from the default home

On those launches the Stop hook never fires, while the wrapper's session-log watcher still emits `Start` on every user turn — so the binding wedges at working and no review/attention state ever surfaces. Production data corroborates: this host's DB has zero codex `detached` end-reasons vs 10 for Claude.

**Fix:** the codex wrapper — the one choke point every Superset-terminal Codex launch passes through, where `--enable hooks` is already appended — now also appends `--dangerously-bypass-hook-trust`, skipping it when the caller's argv already carries it (codex rejects the flag when repeated).

The bypass only skips the trust gate: hooks the user explicitly disabled (`enabled = false` trust state) stay disabled — verified on 0.149.

## Test Plan

- [x] E2E against real codex-cli 0.149.0: untrusted hooks + no bypass previously stalled `codex exec` with zero hook events; through the new wrapper logic `SessionStart` and `Stop` both fire
- [x] Launch command already carrying the flag isn't duplicated (codex errors on the repeated flag) — new wrapper test covers both branches
- [x] Bypass respects explicit `enabled = false` trust state (disabled entry stayed off while an untrusted entry fired in the same run)
- [x] `bun test` in packages/agent-setup: 250 pass; typecheck and biome clean

https://claude.ai/code/session_01FekweN7HKsS6jrV7nQwV7L

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Superset receives Codex Stop events by having the `codex` wrapper append `--dangerously-bypass-hook-trust` when missing. Previously, untrusted hooks skipped the Stop hook and agents stayed “working”; now the wrapper appends the bypass (without duplicating it) and ignores any mention of the flag after `--` prompt text, restoring completion detection (SUPER-1985). Explicitly disabled hooks remain disabled; only the trust gate is bypassed.

- Review notes:
  - Update in `packages/agent-setup/templates/codex-wrapper-exec.template.sh`: append `--dangerously-bypass-hook-trust` when absent; keep `--enable hooks`; do not duplicate the flag; stop the bypass-flag scan at `--`.
  - Tests in `packages/agent-setup/src/agent-wrappers.test.ts` cover presence/absence of the flag, the `--` terminator behavior, and argument ordering.
  - Docs in `apps/desktop/docs/EXTERNAL_FILES.md` reflect the bypass behavior.
  - No migration required; all Superset-terminal Codex launches pass through the wrapper.

<sup>Written for commit 18aa8172acc9ff472fad212941c9e7d0828680c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex hook handling so configured hooks remain trusted across supported launch scenarios.
  * Automatically applies the required trust setting when missing, while preventing duplicate settings.
  * Ensured prompt text mentioning the trust setting does not alter launch behavior.
  * Preserved explicitly disabled hooks and existing session-log compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->