### PR TITLE
fix(mobile): give the terminal screen its back swipe back

### DIFF
--- a/apps/mobile/app/(authenticated)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/_layout.tsx
@@ -61,7 +61,6 @@ export default function AuthenticatedLayout() {
 					headerBackButtonDisplayMode: "minimal",
 					headerShadowVisible: false,
 					title: "Workspace",
-					fullScreenGestureEnabled: false,
 				}}
 			/>
 			<Stack.Screen

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -60,11 +60,13 @@ import { WorkspacePlaceholder } from "./components/WorkspacePlaceholder";
 
 const NOTICE_MS = 1500;
 
+// No fullScreenGestureEnabled: false here. On iOS 26 the system's back swipe
+// IS the full-screen one, and react-native-screens reads that flag as "no back
+// gesture at all" rather than "edge only" — the old edge recognizer is gone.
 const headerOptions = {
 	headerShown: true,
 	headerBackButtonDisplayMode: "minimal",
 	headerShadowVisible: false,
-	fullScreenGestureEnabled: false,
 } as const;
 
 const PENDING_CREATE_POLL_MS = 2_000;
@@ -581,6 +583,17 @@ export function WorkspaceScreen() {
 								style={StyleSheet.absoluteFill}
 							/>
 						) : null}
+						{/* The WebView swallows every touch that lands on it, so the back
+						    swipe never starts over the terminal. This strip keeps a
+						    finger's width of the left edge native, which is all UIKit
+						    needs. collapsable={false} is load-bearing: with nothing to
+						    draw, the view is flattened away and the touch reaches WebKit
+						    again. Dragging further right stays the terminal's — WebKit
+						    still owns those touches, so no drag over output can pop. */}
+						<View
+							className="absolute bottom-0 left-0 top-0 w-5"
+							collapsable={false}
+						/>
 					</>
 				) : cloud && !workspace ? (
 					<CloudWorkspaceProvisioningState cloud={cloud} />

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -592,7 +592,9 @@ export function WorkspaceScreen() {
 						    blur; a Pressable also can't be flattened away, which an
 						    undrawn View would be — leaving the edge to WebKit again. */}
 						<Pressable
-							accessibilityLabel="Dismiss keyboard"
+							// Silent to VoiceOver: it is always mounted, and the backdrop
+							// above already offers Dismiss keyboard when there is one.
+							accessible={false}
 							className="absolute bottom-0 left-0 top-0 w-5"
 							onPress={() => composerRef.current?.blur()}
 						/>

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -586,13 +586,15 @@ export function WorkspaceScreen() {
 						{/* The WebView swallows every touch that lands on it, so the back
 						    swipe never starts over the terminal. This strip keeps a
 						    finger's width of the left edge native, which is all UIKit
-						    needs. collapsable={false} is load-bearing: with nothing to
-						    draw, the view is flattened away and the touch reaches WebKit
-						    again. Dragging further right stays the terminal's — WebKit
-						    still owns those touches, so no drag over output can pop. */}
-						<View
+						    needs. Dragging further right stays the terminal's — WebKit
+						    still owns those touches, so no drag over output can pop.
+						    It sits above the dismiss backdrop, so it carries the same
+						    blur; a Pressable also can't be flattened away, which an
+						    undrawn View would be — leaving the edge to WebKit again. */}
+						<Pressable
+							accessibilityLabel="Dismiss keyboard"
 							className="absolute bottom-0 left-0 top-0 w-5"
-							collapsable={false}
+							onPress={() => composerRef.current?.blur()}
 						/>
 					</>
 				) : cloud && !workspace ? (


### PR DESCRIPTION
Swiping in from the left edge did nothing on a workspace screen. Two separate causes, both verified on an iOS 26.5 simulator by A/B-ing a throwaway probe route with Maestro edge swipes.

## What was wrong

**`fullScreenGestureEnabled: false` disables the back swipe entirely on iOS 26** — not just the full-screen part of it. The system's back gesture there is the content pop, `react-native-screens` gates it on that flag (`isFullScreenSwipeEffectivelyEnabled` defaults to YES on 26), and the old edge recognizer is no longer a fallback. Verified: a pushed screen with **no WebView at all** and the flag set does not pop from an edge swipe; the identical screen without the flag pops.

**The WebView swallows every touch over its own area** — plain HTML or the xterm page, touch handlers or not, gesture enabled or not. So even with the flag gone, a swipe starting over the terminal never begins. An invisible 20pt strip keeps a finger's width of the left edge native, which is all UIKit needs.

`collapsable={false}` on that strip is load-bearing: with no background and no handlers, Fabric flattens the view away, no native view exists, and the touch reaches WebKit again. That is why a first attempt at the strip looked correct and did nothing.

## Verified

Probe route pushed on the same stack, driven with Maestro:

| screen content | full-screen flag | edge swipe pops |
| --- | --- | --- |
| plain RN view | default | yes |
| plain RN view | `false` | **no** |
| WebView (plain or xterm) | `false` | no |
| WebView | default | no |
| WebView + flattened strip | default | no |
| WebView + `collapsable={false}` strip | default | **yes** (from 4pt, 8pt, 16pt) |

Width was never the problem — 20pt is enough.

## Cost

The leftmost 20pt of the terminal stops taking taps, long-press-select and scroll drags. Roughly the first three character columns, and about the strip iOS already reserves in native apps.

Drags further right stay the terminal's, because WebKit still owns those touches — so enabling the gesture cannot pop the screen out from under a drag over output.

## Not in this PR

`files-changed`, `file` and `pull-request/[pullRequestId]/index` still set the same flag, so by the first finding they have **no back swipe on iOS 26** either. They are native-content screens, so dropping the flag should restore it fully, but I have not driven those screens — left for a follow-up.

https://claude.ai/code/session_01JwmrtU7LZ5GrN5TrfG1J7n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the iOS back swipe on the Workspace terminal screen by removing `fullScreenGestureEnabled: false` and reserving a 20pt native edge above the `WebView`. On iOS 26, edge swipes now pop as expected without interrupting terminal drags; the edge also dismisses the keyboard and is hidden from VoiceOver.

- Removes `fullScreenGestureEnabled: false` from the Workspace stack options and the screen’s `headerOptions`.
- Adds an absolute 20pt-wide `Pressable` over the left edge to keep it native and dismiss the keyboard on tap; sets `accessible={false}` so it’s not announced by VoiceOver.
- Side effect: the leftmost ~20pt no longer passes taps/selection/scroll to the terminal; drags further right remain terminal-only.
- Follow-up: `files-changed`, `file`, and `pull-request` screens still set the flag and have no back swipe on iOS 26.

<sup>Written for commit 75595a1e4a20a018e37de7b1d55aef525ccf743a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the native iOS edge-swipe gesture for navigating back from workspace screens.
  * Improved back-swipe responsiveness when starting the gesture over terminal content.
  * Preserved keyboard dismissal when tapping the terminal’s left edge.
  * Improved VoiceOver behavior by directing keyboard-dismissal actions through the accessible backdrop control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->