### PR TITLE
feat(desktop): add per-skill disable toggle to the Plugins page

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/plugins/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/plugins/index.ts
@@ -3,9 +3,11 @@ import { TRPCError } from "@trpc/server";
 import {
 	getBundledSkillContent,
 	getBundledSkillIcons,
+	getDisabledSkills,
 	getInstalledPlugins,
 	installPlugin,
 	setPluginEnabled,
+	setSkillEnabled,
 	uninstallPlugin,
 } from "main/lib/plugin-installs";
 import { z } from "zod";
@@ -41,6 +43,17 @@ export const createPluginsRouter = () => {
 			.input(z.object({ name: z.string().min(1) }))
 			.query(({ input }) => {
 				return { content: getBundledSkillContent(input.name) };
+			}),
+
+		/** Names of bundled managed skills the user disabled. */
+		getDisabledSkills: publicProcedure.query(() => {
+			return getDisabledSkills();
+		}),
+
+		setSkillEnabled: publicProcedure
+			.input(z.object({ name: z.string().min(1), enabled: z.boolean() }))
+			.mutation(({ input }) => {
+				return { disabled: setSkillEnabled(input.name, input.enabled) };
 			}),
 
 		install: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/plugins/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/plugins/index.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import {
 	getBundledSkillContent,
 	getBundledSkillIcons,
+	getBundledSkillPath,
 	getDisabledSkills,
 	getInstalledPlugins,
 	installPlugin,
@@ -38,11 +39,14 @@ export const createPluginsRouter = () => {
 			return getBundledSkillIcons();
 		}),
 
-		/** SKILL.md body of a bundled managed skill, for the preview modal. */
+		/** SKILL.md body and absolute path of a bundled managed skill, for the preview modal. */
 		getSkillContent: publicProcedure
 			.input(z.object({ name: z.string().min(1) }))
 			.query(({ input }) => {
-				return { content: getBundledSkillContent(input.name) };
+				return {
+					content: getBundledSkillContent(input.name),
+					path: getBundledSkillPath(input.name),
+				};
 			}),
 
 		/** Names of bundled managed skills the user disabled. */

--- a/apps/desktop/src/lib/trpc/routers/plugins/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/plugins/index.ts
@@ -57,7 +57,14 @@ export const createPluginsRouter = () => {
 		setSkillEnabled: publicProcedure
 			.input(z.object({ name: z.string().min(1), enabled: z.boolean() }))
 			.mutation(({ input }) => {
-				return { disabled: setSkillEnabled(input.name, input.enabled) };
+				const disabled = setSkillEnabled(input.name, input.enabled);
+				if (disabled === null) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `Unknown skill: ${input.name}`,
+					});
+				}
+				return { disabled };
 			}),
 
 		install: publicProcedure

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import {
 	setAgentSetupTemplatesDir,
 	setupAgentIntegrations,
 	writeSharedDisabledAgentIds,
+	writeSharedDisabledSkillIds,
 } from "@superset/agent-setup";
 import { settings } from "@superset/local-db";
 import { app, dialog, Notification, net, protocol, session } from "electron";
@@ -493,12 +494,17 @@ if (!gotTheLock) {
 			// The vite build copies @superset/agent-setup's templates (plus the
 			// bundled Claude plugin) next to this bundle; see vite/helpers.ts.
 			setAgentSetupTemplatesDir(path.join(__dirname, "templates"));
-			const disabledAgentHooks =
-				localDb.select().from(settings).get()?.disabledAgentHooks ?? [];
-			// Mirror the disable list so CLI-launched host-services on this
-			// machine honor it instead of re-provisioning disabled agents.
+			const settingsRow = localDb.select().from(settings).get();
+			const disabledAgentHooks = settingsRow?.disabledAgentHooks ?? [];
+			const disabledSkills = settingsRow?.disabledSkills ?? [];
+			// Mirror the disable lists so CLI-launched host-services on this
+			// machine honor them instead of re-provisioning disabled agents/skills.
 			writeSharedDisabledAgentIds(disabledAgentHooks);
-			setupAgentIntegrations({ disabledAgentIds: disabledAgentHooks });
+			writeSharedDisabledSkillIds(disabledSkills);
+			setupAgentIntegrations({
+				disabledAgentIds: disabledAgentHooks,
+				disabledSkillIds: disabledSkills,
+			});
 		} catch (error) {
 			console.error("[main] Failed to set up agent integrations:", error);
 		}

--- a/apps/desktop/src/main/lib/plugin-installs.ts
+++ b/apps/desktop/src/main/lib/plugin-installs.ts
@@ -89,26 +89,33 @@ export function uninstallPlugin(name: string): InstalledPlugin[] {
 }
 
 /**
- * SKILL.md body (frontmatter stripped) of a bundled managed skill, for the
- * preview modal. Allowlisted against the shipped skill set — the name never
- * touches the filesystem unless it's one of ours.
+ * Allowlisted against the shipped skill set — the name never touches the
+ * filesystem unless it's one of ours.
  */
-export function getBundledSkillContent(name: string): string | null {
+function resolveBundledSkillPath(name: string): string | null {
 	if (!SUPERSET_MANAGED_SKILLS.some((skill) => skill.name === name)) {
 		return null;
 	}
-	const skillPath = path.join(
-		getBundledPluginDir(),
-		"skills",
-		name,
-		"SKILL.md",
-	);
+	return path.join(getBundledPluginDir(), "skills", name, "SKILL.md");
+}
+
+/** SKILL.md body (frontmatter stripped) of a bundled managed skill, for the preview modal. */
+export function getBundledSkillContent(name: string): string | null {
+	const skillPath = resolveBundledSkillPath(name);
+	if (!skillPath) return null;
 	try {
 		const raw = fs.readFileSync(skillPath, "utf-8");
 		return raw.replace(/^---\n[\s\S]*?\n---\n*/, "");
 	} catch {
 		return null;
 	}
+}
+
+/** Absolute path to a bundled skill's SKILL.md, for Open/Reveal in Finder. */
+export function getBundledSkillPath(name: string): string | null {
+	const skillPath = resolveBundledSkillPath(name);
+	if (!skillPath || !fs.existsSync(skillPath)) return null;
+	return skillPath;
 }
 
 const SKILL_ICON_FILES = [

--- a/apps/desktop/src/main/lib/plugin-installs.ts
+++ b/apps/desktop/src/main/lib/plugin-installs.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { syncManagedMcpServers } from "@superset/agent-setup";
+import {
+	createManagedSkills,
+	syncManagedMcpServers,
+	writeSharedDisabledSkillIds,
+} from "@superset/agent-setup";
 import { getBundledPluginDir } from "@superset/agent-setup/config";
 import { settings } from "@superset/local-db";
 import {
@@ -170,5 +174,36 @@ export function setPluginEnabled(
 			: installed;
 	saveInstalledPlugins(next);
 	syncInstalledPluginMcpServers();
+	return next;
+}
+
+export function getDisabledSkills(): string[] {
+	return localDb.select().from(settings).get()?.disabledSkills ?? [];
+}
+
+/**
+ * Toggling re-syncs immediately: disable reaps the skill from every agent
+ * (and the Claude plugin mirror), enable rewrites it. Mirrored to the shared
+ * disabled-skills file so CLI-launched host-services on this machine honor
+ * the choice instead of re-provisioning a skill the user just disabled.
+ */
+export function setSkillEnabled(name: string, enabled: boolean): string[] {
+	const current = new Set(getDisabledSkills());
+	if (enabled) {
+		current.delete(name);
+	} else {
+		current.add(name);
+	}
+	const next = [...current];
+	localDb
+		.insert(settings)
+		.values({ id: 1, disabledSkills: next })
+		.onConflictDoUpdate({
+			target: settings.id,
+			set: { disabledSkills: next },
+		})
+		.run();
+	writeSharedDisabledSkillIds(next);
+	void createManagedSkills({ disabledSkills: next });
 	return next;
 }

--- a/apps/desktop/src/main/lib/plugin-installs.ts
+++ b/apps/desktop/src/main/lib/plugin-installs.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
 	createManagedSkills,
+	resolveDisabledSkillIds,
 	syncManagedMcpServers,
 	writeSharedDisabledSkillIds,
 } from "@superset/agent-setup";
@@ -188,13 +189,32 @@ export function getDisabledSkills(): string[] {
 	return localDb.select().from(settings).get()?.disabledSkills ?? [];
 }
 
+// Serializes the createManagedSkills resyncs triggered by setSkillEnabled so
+// overlapping toggles can't interleave: createManagedSkills does multi-await
+// fs work, and without this a second toggle's resync could finish before the
+// first's, leaving disk state contradicting whichever DB write actually
+// happened last.
+let managedSkillsSyncQueue: Promise<void> = Promise.resolve();
+function queueManagedSkillsSync(disabledSkills: readonly string[]): void {
+	managedSkillsSyncQueue = managedSkillsSyncQueue
+		.catch(() => {}) // a prior failure must not stall later toggles
+		.then(() => createManagedSkills({ disabledSkills }));
+}
+
 /**
  * Toggling re-syncs immediately: disable reaps the skill from every agent
  * (and the Claude plugin mirror), enable rewrites it. Mirrored to the shared
  * disabled-skills file so CLI-launched host-services on this machine honor
  * the choice instead of re-provisioning a skill the user just disabled.
+ * Returns null for a name outside SUPERSET_MANAGED_SKILLS.
  */
-export function setSkillEnabled(name: string, enabled: boolean): string[] {
+export function setSkillEnabled(
+	name: string,
+	enabled: boolean,
+): string[] | null {
+	if (!SUPERSET_MANAGED_SKILLS.some((skill) => skill.name === name)) {
+		return null;
+	}
 	const current = new Set(getDisabledSkills());
 	if (enabled) {
 		current.delete(name);
@@ -211,6 +231,9 @@ export function setSkillEnabled(name: string, enabled: boolean): string[] {
 		})
 		.run();
 	writeSharedDisabledSkillIds(next);
-	void createManagedSkills({ disabledSkills: next });
+	// resolveDisabledSkillIds folds in SUPERSET_DISABLED_SKILLS — passing
+	// `next` straight through would silently re-enable an env-disabled skill
+	// on the next unrelated toggle.
+	queueManagedSkillsSync(resolveDisabledSkillIds(next));
 	return next;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/SkillsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/SkillsList.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@superset/ui/badge";
 import { useState } from "react";
 import { SkillIcon } from "renderer/routes/_authenticated/_dashboard/plugins/components/SkillIcon";
 import { SkillPreviewDialog } from "./components/SkillPreviewDialog";
+import { useSkillMutations } from "./hooks/useSkillMutations";
 
 interface ManagedSkill {
 	name: string;
@@ -10,12 +11,13 @@ interface ManagedSkill {
 }
 
 /**
- * Read-only for the MVP: these skills ship inside the managed Superset
- * plugin and are provisioned into every agent CLI automatically
- * (packages/agent-setup). Installable skill plugins come later.
+ * These skills ship inside the managed Superset plugin and are provisioned
+ * into every agent CLI automatically (packages/agent-setup) unless disabled
+ * from the preview dialog. Installable skill plugins come later.
  */
 export function SkillsList() {
 	const [previewSkill, setPreviewSkill] = useState<ManagedSkill | null>(null);
+	const { disabledSkills } = useSkillMutations();
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -24,27 +26,35 @@ export function SkillsList() {
 				automatically in every agent you use. Click one to preview it.
 			</p>
 			<div className="flex flex-col divide-y divide-border/60 rounded-lg border border-border/60">
-				{SUPERSET_MANAGED_SKILLS.map((skill) => (
-					<button
-						key={skill.name}
-						type="button"
-						onClick={() => setPreviewSkill(skill)}
-						className="flex items-center gap-3 p-3 text-left transition-colors hover:bg-fill-hover"
-					>
-						<SkillIcon skillName={skill.name} />
-						<div className="min-w-0 flex-1">
-							<div className="text-sm font-medium text-foreground">
-								{skill.name}
+				{SUPERSET_MANAGED_SKILLS.map((skill) => {
+					const isDisabled = disabledSkills.has(skill.name);
+					return (
+						<button
+							key={skill.name}
+							type="button"
+							onClick={() => setPreviewSkill(skill)}
+							className="flex items-center gap-3 p-3 text-left transition-colors hover:bg-fill-hover"
+						>
+							<SkillIcon skillName={skill.name} />
+							<div className="min-w-0 flex-1">
+								<div className="text-sm font-medium text-foreground">
+									{skill.name}
+								</div>
+								<p className="truncate text-xs text-muted-foreground">
+									{skill.description}
+								</p>
 							</div>
-							<p className="truncate text-xs text-muted-foreground">
-								{skill.description}
-							</p>
-						</div>
-						<Badge variant="secondary" className="shrink-0">
-							Managed
-						</Badge>
-					</button>
-				))}
+							{isDisabled && (
+								<span className="shrink-0 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+									Disabled
+								</span>
+							)}
+							<Badge variant="secondary" className="shrink-0">
+								Managed
+							</Badge>
+						</button>
+					);
+				})}
 			</div>
 			<SkillPreviewDialog
 				skill={previewSkill}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
@@ -1,15 +1,20 @@
 import { Badge } from "@superset/ui/badge";
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogDescription,
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { Spinner } from "@superset/ui/spinner";
+import { Switch } from "@superset/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { XIcon } from "lucide-react";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { SkillIcon } from "renderer/routes/_authenticated/_dashboard/plugins/components/SkillIcon";
+import { useSkillMutations } from "../../hooks/useSkillMutations";
 
 interface SkillPreviewDialogProps {
 	skill: { name: string; description: string } | null;
@@ -24,29 +29,69 @@ export function SkillPreviewDialog({
 		{ name: skill?.name ?? "" },
 		{ enabled: skill !== null },
 	);
+	const { disabledSkills, setEnabled, isBusy } = useSkillMutations();
+	const isEnabled = skill !== null && !disabledSkills.has(skill.name);
 
 	return (
 		<Dialog open={skill !== null} onOpenChange={(open) => !open && onClose()}>
 			{/* Fixed height so every skill opens the same-size modal; content
 			    scrolls. bg-card lifts it off the page background; the sm:
 			    variant is needed to beat the dialog's built-in sm:max-w-lg. */}
-			<DialogContent className="flex h-[80vh] max-w-4xl flex-col bg-card sm:max-w-4xl">
-				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2">
+			<DialogContent
+				showCloseButton={false}
+				// Without this, Radix auto-focuses the Switch on open (it's the
+				// first focusable element in the header row), which also opens
+				// its tooltip via :focus even though the user never hovered it.
+				onOpenAutoFocus={(event) => event.preventDefault()}
+				className="flex h-[80vh] max-w-4xl flex-col bg-card sm:max-w-4xl"
+			>
+				<div className="flex items-start justify-between gap-3">
+					<DialogHeader className="flex-1">
+						<DialogTitle className="flex items-center gap-2">
+							{skill !== null && (
+								<SkillIcon skillName={skill.name} className="size-7" />
+							)}
+							{skill?.name}
+							<Badge
+								variant="outline"
+								className="h-4 rounded px-1 text-[9px] font-medium tracking-wide text-muted-foreground uppercase"
+							>
+								Skill
+							</Badge>
+							<Badge variant="secondary">Managed</Badge>
+						</DialogTitle>
+						<DialogDescription>{skill?.description}</DialogDescription>
+					</DialogHeader>
+					<div className="flex shrink-0 items-center gap-3">
 						{skill !== null && (
-							<SkillIcon skillName={skill.name} className="size-7" />
+							<Tooltip delayDuration={700}>
+								{/* The Switch has its own data-state (checked/unchecked) that
+								    its styling depends on; asChild directly on it would let
+								    Radix's Slot overwrite that with the tooltip's own
+								    data-state, so the trigger target is this inert span instead. */}
+								<TooltipTrigger asChild>
+									<span className="inline-flex">
+										<Switch
+											checked={isEnabled}
+											disabled={isBusy}
+											aria-label={`${skill.name} enabled`}
+											onCheckedChange={(checked) =>
+												setEnabled(skill.name, checked)
+											}
+										/>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									{isEnabled ? "Disable skill" : "Enable skill"}
+								</TooltipContent>
+							</Tooltip>
 						)}
-						{skill?.name}
-						<Badge
-							variant="outline"
-							className="h-4 rounded px-1 text-[9px] font-medium tracking-wide text-muted-foreground uppercase"
-						>
-							Skill
-						</Badge>
-						<Badge variant="secondary">Managed</Badge>
-					</DialogTitle>
-					<DialogDescription>{skill?.description}</DialogDescription>
-				</DialogHeader>
+						<DialogClose className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+							<XIcon />
+							<span className="sr-only">Close</span>
+						</DialogClose>
+					</div>
+				</div>
 				{/* zoom scales the whole markdown type ramp down without fighting
 				    the renderer's own rem-based stylesheet. */}
 				<div className="min-h-0 flex-1 overflow-y-auto [zoom:0.85]">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
 import {
 	Dialog,
 	DialogClose,
@@ -7,12 +8,28 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { Spinner } from "@superset/ui/spinner";
 import { Switch } from "@superset/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { XIcon } from "lucide-react";
+import {
+	LuCheck,
+	LuCopy,
+	LuEllipsis,
+	LuExternalLink,
+	LuFolderOpen,
+} from "react-icons/lu";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { SkillIcon } from "renderer/routes/_authenticated/_dashboard/plugins/components/SkillIcon";
 import { useSkillMutations } from "../../hooks/useSkillMutations";
 
@@ -31,6 +48,40 @@ export function SkillPreviewDialog({
 	);
 	const { disabledSkills, setEnabled, isBusy } = useSkillMutations();
 	const isEnabled = skill !== null && !disabledSkills.has(skill.name);
+	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	const handleOpen = async () => {
+		if (!data?.path) return;
+		try {
+			await electronTrpcClient.external.openFileInEditor.mutate({
+				path: data.path,
+			});
+		} catch (error) {
+			toast.error(
+				`Failed to open file: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	const handleRevealInFinder = async () => {
+		if (!data?.path) return;
+		try {
+			await electronTrpcClient.external.openInFinder.mutate(data.path);
+		} catch (error) {
+			toast.error(
+				`Failed to reveal in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	const handleCopyMarkdown = () => {
+		if (!data?.content) return;
+		toast.promise(copyToClipboard(data.content), {
+			success: "Markdown copied",
+			error: (err: unknown) =>
+				`Failed to copy markdown: ${err instanceof Error ? err.message : "Unknown error"}`,
+		});
+	};
 
 	return (
 		<Dialog open={skill !== null} onOpenChange={(open) => !open && onClose()}>
@@ -86,26 +137,80 @@ export function SkillPreviewDialog({
 								</TooltipContent>
 							</Tooltip>
 						)}
+						{skill !== null && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon-xs"
+										className="text-muted-foreground"
+										aria-label={`${skill.name} actions`}
+									>
+										<LuEllipsis className="size-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									<DropdownMenuItem
+										onSelect={handleOpen}
+										disabled={!data?.path}
+									>
+										<LuExternalLink className="size-4" />
+										Open
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										onSelect={handleRevealInFinder}
+										disabled={!data?.path}
+									>
+										<LuFolderOpen className="size-4" />
+										Reveal in Finder
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										onSelect={handleCopyMarkdown}
+										disabled={!data?.content}
+									>
+										<LuCopy className="size-4" />
+										Copy Markdown
+									</DropdownMenuItem>
+								</DropdownMenuContent>
+							</DropdownMenu>
+						)}
 						<DialogClose className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
 							<XIcon />
 							<span className="sr-only">Close</span>
 						</DialogClose>
 					</div>
 				</div>
-				{/* zoom scales the whole markdown type ramp down without fighting
-				    the renderer's own rem-based stylesheet. */}
-				<div className="min-h-0 flex-1 overflow-y-auto [zoom:0.85]">
-					{isLoading ? (
-						<div className="flex justify-center py-8">
-							<Spinner className="size-5" />
-						</div>
-					) : data?.content ? (
-						<MarkdownRenderer content={data.content} />
-					) : (
-						<p className="text-sm text-muted-foreground">
-							Could not load this skill's content.
-						</p>
+				<div className="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-border/60 bg-background">
+					{data?.content && (
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							className="absolute top-2 right-2 z-10 text-muted-foreground"
+							aria-label="Copy markdown"
+							onClick={handleCopyMarkdown}
+						>
+							{copied ? (
+								<LuCheck className="size-4" />
+							) : (
+								<LuCopy className="size-4" />
+							)}
+						</Button>
 					)}
+					{/* zoom scales the whole markdown type ramp down without fighting
+					    the renderer's own rem-based stylesheet. */}
+					<div className="h-full overflow-y-auto p-4 [zoom:0.85]">
+						{isLoading ? (
+							<div className="flex justify-center py-8">
+								<Spinner className="size-5" />
+							</div>
+						) : data?.content ? (
+							<MarkdownRenderer content={data.content} />
+						) : (
+							<p className="text-sm text-muted-foreground">
+								Could not load this skill's content.
+							</p>
+						)}
+					</div>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/components/SkillPreviewDialog/SkillPreviewDialog.tsx
@@ -19,6 +19,7 @@ import { Spinner } from "@superset/ui/spinner";
 import { Switch } from "@superset/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { XIcon } from "lucide-react";
+import { useRef } from "react";
 import {
 	LuCheck,
 	LuCopy,
@@ -49,6 +50,7 @@ export function SkillPreviewDialog({
 	const { disabledSkills, setEnabled, isBusy } = useSkillMutations();
 	const isEnabled = skill !== null && !disabledSkills.has(skill.name);
 	const { copyToClipboard, copied } = useCopyToClipboard();
+	const initialFocusRef = useRef<HTMLDivElement>(null);
 
 	const handleOpen = async () => {
 		if (!data?.path) return;
@@ -90,13 +92,22 @@ export function SkillPreviewDialog({
 			    variant is needed to beat the dialog's built-in sm:max-w-lg. */}
 			<DialogContent
 				showCloseButton={false}
-				// Without this, Radix auto-focuses the Switch on open (it's the
-				// first focusable element in the header row), which also opens
-				// its tooltip via :focus even though the user never hovered it.
-				onOpenAutoFocus={(event) => event.preventDefault()}
+				// Left to Radix's default, autofocus lands on the Switch (the first
+				// focusable element in the header row), which also opens its
+				// tooltip via :focus even though the user never hovered it. Redirect
+				// focus to the header row itself instead of just suppressing it, so
+				// keyboard/screen-reader users still land inside the dialog.
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					initialFocusRef.current?.focus();
+				}}
 				className="flex h-[80vh] max-w-4xl flex-col bg-card sm:max-w-4xl"
 			>
-				<div className="flex items-start justify-between gap-3">
+				<div
+					ref={initialFocusRef}
+					tabIndex={-1}
+					className="flex items-start justify-between gap-3 outline-none"
+				>
 					<DialogHeader className="flex-1">
 						<DialogTitle className="flex items-center gap-2">
 							{skill !== null && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/index.ts
@@ -1,0 +1,1 @@
+export { useSkillMutations } from "./useSkillMutations";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/useSkillMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/useSkillMutations.ts
@@ -1,0 +1,37 @@
+import { toast } from "@superset/ui/sonner";
+import { useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { posthog } from "renderer/lib/posthog";
+
+/** Disabled-skill state and its toggle mutation, with shared toasts/analytics/invalidation. */
+export function useSkillMutations() {
+	const utils = electronTrpc.useUtils();
+	const disabledQuery = electronTrpc.plugins.getDisabledSkills.useQuery();
+	const disabledSkills = useMemo(
+		() => new Set(disabledQuery.data ?? []),
+		[disabledQuery.data],
+	);
+
+	const setEnabledMutation = electronTrpc.plugins.setSkillEnabled.useMutation({
+		onSuccess: (_data, variables) => {
+			void utils.plugins.getDisabledSkills.invalidate();
+			posthog.capture(variables.enabled ? "skill_enabled" : "skill_disabled", {
+				skill: variables.name,
+			});
+			toast.success(
+				`${variables.name} ${variables.enabled ? "enabled" : "disabled"}`,
+				{ description: "Takes effect in new agent sessions." },
+			);
+		},
+		onError: (error) => {
+			toast.error("Could not update skill", { description: error.message });
+		},
+	});
+
+	return {
+		disabledSkills,
+		setEnabled: (name: string, enabled: boolean) =>
+			setEnabledMutation.mutate({ name, enabled }),
+		isBusy: setEnabledMutation.isPending,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/useSkillMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/plugins/components/PluginsView/components/SkillsList/hooks/useSkillMutations/useSkillMutations.ts
@@ -32,6 +32,10 @@ export function useSkillMutations() {
 		disabledSkills,
 		setEnabled: (name: string, enabled: boolean) =>
 			setEnabledMutation.mutate({ name, enabled }),
-		isBusy: setEnabledMutation.isPending,
+		// Also true while the initial disabled-list fetch is in flight — until
+		// it resolves, disabledSkills is an empty Set, so every skill would
+		// otherwise render (and be toggleable) as enabled regardless of its
+		// real state.
+		isBusy: setEnabledMutation.isPending || disabledQuery.isLoading,
 	};
 }

--- a/packages/agent-setup/src/agent-setup.ts
+++ b/packages/agent-setup/src/agent-setup.ts
@@ -44,6 +44,7 @@ import {
 	removePiExtension,
 	removeVibeManagedHooks,
 } from "./agent-wrappers";
+import { resolveDisabledSkillIds } from "./disabled-skills";
 import { createManagedSkills } from "./managed-skills";
 import { createNotifyScript } from "./notify-hook";
 
@@ -221,6 +222,18 @@ export function setupSingleAgent(agentId: string): boolean {
 	const failed: string[] = [];
 	for (const [label, action] of BOOTSTRAP_SETUP) {
 		if (!runSetupAction(label, action)) failed.push(label);
+	}
+	// Re-adding/re-enabling one agent used to incidentally refresh managed
+	// skills too (it was part of BOOTSTRAP_SETUP); keep that behavior now
+	// that it's split out.
+	if (
+		!runSetupAction(
+			"managed-skills",
+			() =>
+				void createManagedSkills({ disabledSkills: resolveDisabledSkillIds() }),
+		)
+	) {
+		failed.push("managed-skills");
 	}
 	runAgentActions(agentId, definition.setup, failed);
 	warnOnFailures(failed);

--- a/packages/agent-setup/src/agent-setup.ts
+++ b/packages/agent-setup/src/agent-setup.ts
@@ -53,10 +53,6 @@ type LabeledAction = readonly [label: string, action: () => void];
 const BOOTSTRAP_SETUP: readonly LabeledAction[] = [
 	["cleanup-global-opencode-plugin", cleanupGlobalOpenCodePlugin],
 	["notify-script", createNotifyScript],
-	// Async fire-and-forget: every fs mutation inside is individually
-	// try/caught and logged, so nothing can reject unhandled, and boot
-	// never blocks on skill provisioning.
-	["managed-skills", () => void createManagedSkills()],
 ];
 
 interface AgentSetupDefinition {
@@ -176,15 +172,30 @@ interface SetupAgentCapabilitiesOptions {
 	 * versions or while the toggle changed offline.
 	 */
 	disabledAgentIds?: readonly string[];
+	/** Skills the user disabled; withheld from provisioning and reaped. */
+	disabledSkillIds?: readonly string[];
 }
 
 export function setupAgentCapabilities({
 	disabledAgentIds = [],
+	disabledSkillIds = [],
 }: SetupAgentCapabilitiesOptions = {}): void {
 	const disabled = new Set(disabledAgentIds);
 	const failed: string[] = [];
 	for (const [label, action] of BOOTSTRAP_SETUP) {
 		if (!runSetupAction(label, action)) failed.push(label);
+	}
+
+	// Async fire-and-forget: every fs mutation inside is individually
+	// try/caught and logged, so nothing can reject unhandled, and boot never
+	// blocks on skill provisioning.
+	if (
+		!runSetupAction(
+			"managed-skills",
+			() => void createManagedSkills({ disabledSkills: disabledSkillIds }),
+		)
+	) {
+		failed.push("managed-skills");
 	}
 
 	for (const target of AGENT_SETUP_TARGETS) {

--- a/packages/agent-setup/src/disabled-skills.test.ts
+++ b/packages/agent-setup/src/disabled-skills.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	getDisabledSkillsStateFilePath,
+	readSharedDisabledSkillIds,
+	resolveDisabledSkillIds,
+	writeSharedDisabledSkillIds,
+} from "./disabled-skills";
+
+const ORIGINAL_HOME_DIR = process.env.SUPERSET_HOME_DIR;
+const ORIGINAL_DISABLED = process.env.SUPERSET_DISABLED_SKILLS;
+
+let testHome: string;
+
+beforeEach(() => {
+	// A fresh directory per test (rather than wiping/reusing one shared dir)
+	// so this file has no directory-reuse race with anything else in the suite.
+	testHome = fs.mkdtempSync(path.join(os.tmpdir(), "superset-skills-"));
+	process.env.SUPERSET_HOME_DIR = testHome;
+	delete process.env.SUPERSET_DISABLED_SKILLS;
+});
+
+afterEach(() => {
+	if (ORIGINAL_HOME_DIR === undefined) delete process.env.SUPERSET_HOME_DIR;
+	else process.env.SUPERSET_HOME_DIR = ORIGINAL_HOME_DIR;
+	if (ORIGINAL_DISABLED === undefined)
+		delete process.env.SUPERSET_DISABLED_SKILLS;
+	else process.env.SUPERSET_DISABLED_SKILLS = ORIGINAL_DISABLED;
+	fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+describe("shared disabled-skills state", () => {
+	it("round-trips the disable list through the shared file", () => {
+		writeSharedDisabledSkillIds(["orchestrate", "doctor"]);
+
+		expect(readSharedDisabledSkillIds()).toEqual(["doctor", "orchestrate"]);
+		expect(
+			JSON.parse(fs.readFileSync(getDisabledSkillsStateFilePath(), "utf-8")),
+		).toEqual({ disabledSkillIds: ["doctor", "orchestrate"] });
+	});
+
+	it("treats a missing or corrupt file as nothing disabled", () => {
+		// Some sibling test file in this suite mock.module()s "./paths" for the
+		// whole process without restoring it, which can point this file's own
+		// resolveSupersetHomeDir() at a directory another test already wrote
+		// to — start this test by clearing whatever's there, wherever "there" is.
+		fs.rmSync(getDisabledSkillsStateFilePath(), { force: true });
+		expect(readSharedDisabledSkillIds()).toEqual([]);
+
+		fs.writeFileSync(getDisabledSkillsStateFilePath(), "{not json");
+		expect(readSharedDisabledSkillIds()).toEqual([]);
+
+		fs.writeFileSync(
+			getDisabledSkillsStateFilePath(),
+			JSON.stringify({ disabledSkillIds: "doctor" }),
+		);
+		expect(readSharedDisabledSkillIds()).toEqual([]);
+	});
+
+	it("uses the shared file when no explicit list is given", () => {
+		writeSharedDisabledSkillIds(["doctor"]);
+
+		expect(resolveDisabledSkillIds()).toEqual(["doctor"]);
+	});
+
+	it("lets an explicit list replace the file, with env on top", () => {
+		writeSharedDisabledSkillIds(["doctor"]);
+		process.env.SUPERSET_DISABLED_SKILLS = "orchestrate, feedback,,";
+
+		expect(resolveDisabledSkillIds(["10x"]).sort()).toEqual([
+			"10x",
+			"feedback",
+			"orchestrate",
+		]);
+		expect(resolveDisabledSkillIds().sort()).toEqual([
+			"doctor",
+			"feedback",
+			"orchestrate",
+		]);
+	});
+});

--- a/packages/agent-setup/src/disabled-skills.ts
+++ b/packages/agent-setup/src/disabled-skills.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveSupersetHomeDir } from "./paths";
+import { writeFileIfChanged } from "./write-file-if-changed";
+
+export const DISABLED_SKILLS_STATE_FILE = "disabled-skills.json";
+
+/**
+ * Machine-shared mirror of the user's per-skill disable choice. The desktop's
+ * SQLite settings row stays the source of truth for its UI, but multiple
+ * provisioners can run on one machine (the desktop plus one CLI host-service
+ * per org) and each re-applies setup at boot — without a shared view, a CLI
+ * host would resurrect a skill the user disabled in the desktop until the
+ * desktop's next boot tore it down again.
+ *
+ * The desktop rewrites this file at boot and on every toggle; headless
+ * provisioners read it (plus the SUPERSET_DISABLED_SKILLS env override, for
+ * hosts whose machine never runs the desktop).
+ */
+export function getDisabledSkillsStateFilePath(): string {
+	return path.join(resolveSupersetHomeDir(), DISABLED_SKILLS_STATE_FILE);
+}
+
+export function readSharedDisabledSkillIds(): string[] {
+	try {
+		const raw: unknown = JSON.parse(
+			fs.readFileSync(getDisabledSkillsStateFilePath(), "utf-8"),
+		);
+		const ids = (raw as { disabledSkillIds?: unknown })?.disabledSkillIds;
+		if (!Array.isArray(ids)) return [];
+		return ids.filter((id): id is string => typeof id === "string");
+	} catch {
+		// Missing or corrupt state means "nothing disabled" — the file is a
+		// mirror, never the source of truth.
+		return [];
+	}
+}
+
+export function writeSharedDisabledSkillIds(ids: readonly string[]): void {
+	try {
+		fs.mkdirSync(resolveSupersetHomeDir(), { recursive: true });
+		writeFileIfChanged(
+			getDisabledSkillsStateFilePath(),
+			`${JSON.stringify({ disabledSkillIds: [...ids].sort() }, null, "\t")}\n`,
+			0o644,
+		);
+	} catch (error) {
+		console.warn(
+			"[agent-setup] failed to write shared disabled-skills state:",
+			error,
+		);
+	}
+}
+
+function envDisabledSkillIds(): string[] {
+	return (process.env.SUPERSET_DISABLED_SKILLS ?? "")
+		.split(",")
+		.map((id) => id.trim())
+		.filter(Boolean);
+}
+
+/**
+ * The effective disable set for a provisioning run. An explicit list (the
+ * desktop's settings row — its caller mirrors it to the shared file first)
+ * takes the file's place; the env override always applies on top.
+ */
+export function resolveDisabledSkillIds(
+	explicit?: readonly string[],
+): string[] {
+	const base = explicit ?? readSharedDisabledSkillIds();
+	return [...new Set([...base, ...envDisabledSkillIds()])];
+}

--- a/packages/agent-setup/src/index.ts
+++ b/packages/agent-setup/src/index.ts
@@ -6,6 +6,7 @@ import {
 	teardownSingleAgent,
 } from "./agent-setup";
 import { resolveDisabledAgentIds } from "./disabled-agent-hooks";
+import { resolveDisabledSkillIds } from "./disabled-skills";
 import {
 	getBashDir,
 	getBinDir,
@@ -30,15 +31,20 @@ import {
  * process and the standalone (CLI-launched) host-service alike.
  *
  * Callers without their own settings store (headless hosts) omit
- * `disabledAgentIds`; the shared ~/.superset/agent-hooks.json mirror and the
- * SUPERSET_DISABLED_AGENT_HOOKS env override apply instead, so a machine
- * running both the desktop and CLI hosts converges on one disable set.
+ * `disabledAgentIds`/`disabledSkillIds`; the shared ~/.superset mirror files
+ * (agent-hooks.json, disabled-skills.json) and their SUPERSET_DISABLED_*
+ * env overrides apply instead, so a machine running both the desktop and CLI
+ * hosts converges on one disable set.
  */
 export function setupAgentIntegrations(
-	options: { disabledAgentIds?: readonly string[] } = {},
+	options: {
+		disabledAgentIds?: readonly string[];
+		disabledSkillIds?: readonly string[];
+	} = {},
 ): void {
 	console.log("[agent-setup] Provisioning agent integrations...");
 	const disabledAgentIds = resolveDisabledAgentIds(options.disabledAgentIds);
+	const disabledSkillIds = resolveDisabledSkillIds(options.disabledSkillIds);
 
 	fs.mkdirSync(getBinDir(), { recursive: true });
 	fs.mkdirSync(getHooksDir(), { recursive: true });
@@ -46,7 +52,7 @@ export function setupAgentIntegrations(
 	fs.mkdirSync(getBashDir(), { recursive: true });
 	fs.mkdirSync(getOpenCodePluginDir(), { recursive: true });
 
-	setupAgentCapabilities({ disabledAgentIds });
+	setupAgentCapabilities({ disabledAgentIds, disabledSkillIds });
 
 	runSetupAction("zsh-wrapper", createZshWrapper);
 	runSetupAction("bash-wrapper", createBashWrapper);
@@ -77,8 +83,13 @@ export {
 	writeSharedDisabledAgentIds,
 } from "./disabled-agent-hooks";
 export {
+	readSharedDisabledSkillIds,
+	writeSharedDisabledSkillIds,
+} from "./disabled-skills";
+export {
 	readExternallyConfiguredMcpServers,
 	type SyncManagedMcpServersOptions,
 	syncManagedMcpServers,
 } from "./managed-mcp-servers";
+export { createManagedSkills } from "./managed-skills";
 export { getBinDir, resolveSupersetHomeDir } from "./paths";

--- a/packages/agent-setup/src/index.ts
+++ b/packages/agent-setup/src/index.ts
@@ -84,6 +84,7 @@ export {
 } from "./disabled-agent-hooks";
 export {
 	readSharedDisabledSkillIds,
+	resolveDisabledSkillIds,
 	writeSharedDisabledSkillIds,
 } from "./disabled-skills";
 export {

--- a/packages/agent-setup/src/managed-skills.test.ts
+++ b/packages/agent-setup/src/managed-skills.test.ts
@@ -54,8 +54,12 @@ function seedBundledPlugin(): void {
 	writeFileSync(path.join(agentsExtra, "openai.yaml"), "model: test\n");
 }
 
-async function run(): Promise<void> {
-	await createManagedSkills({ homeDir: HOME_DIR, templatesDir: TEMPLATES_DIR });
+async function run(disabledSkills?: readonly string[]): Promise<void> {
+	await createManagedSkills({
+		homeDir: HOME_DIR,
+		templatesDir: TEMPLATES_DIR,
+		disabledSkills,
+	});
 }
 
 beforeEach(() => {
@@ -235,5 +239,26 @@ describe("createManagedSkills", () => {
 		expect(existsSync(path.join(claudePlugin, "skills", "feedback"))).toBe(
 			true,
 		);
+	});
+
+	it("withholds a disabled skill from every surface and reaps it if already provisioned", async () => {
+		await run();
+		expect(existsSync(path.join(agentsSkills, "superset-feedback"))).toBe(true);
+
+		await run(["feedback"]);
+
+		expect(existsSync(path.join(agentsSkills, "superset-feedback"))).toBe(
+			false,
+		);
+		expect(existsSync(path.join(commandsDir, "feedback.md"))).toBe(false);
+		expect(existsSync(path.join(claudePlugin, "skills", "feedback"))).toBe(
+			false,
+		);
+		// Untouched skills stay provisioned.
+		expect(existsSync(path.join(agentsSkills, "superset-10x"))).toBe(true);
+		expect(readFileSync(path.join(commandsDir, "10x.md"), "utf-8")).toContain(
+			MANAGED_SKILL_MARKER,
+		);
+		expect(existsSync(path.join(claudePlugin, "skills", "10x"))).toBe(true);
 	});
 });

--- a/packages/agent-setup/src/managed-skills.ts
+++ b/packages/agent-setup/src/managed-skills.ts
@@ -33,6 +33,8 @@ const COMMAND_SKILLS = ["feedback", "10x", "setup", "doctor"] as const;
 export interface ManagedSkillsOptions {
 	homeDir?: string;
 	templatesDir?: string;
+	/** Skill names to withhold provisioning for (and reap if already provisioned). */
+	disabledSkills?: readonly string[];
 }
 
 /**
@@ -88,10 +90,18 @@ function listFilesRecursive(root: string, relative = ""): string[] {
 
 /**
  * Mirrors src into dest file-by-file (writeFileIfChanged semantics), removing
- * previously-managed files that no longer exist in src.
+ * previously-managed files that no longer exist in src. Files for which
+ * `isExcluded` returns true are treated as absent from src — skipped on the
+ * way in, and reaped on the way out if a prior sync already wrote them.
  */
-async function syncDir(src: string, dest: string): Promise<void> {
-	const sourceFiles = listFilesRecursive(src);
+async function syncDir(
+	src: string,
+	dest: string,
+	isExcluded?: (relativePath: string) => boolean,
+): Promise<void> {
+	const sourceFiles = listFilesRecursive(src).filter(
+		(file) => !isExcluded?.(file),
+	);
 	for (const file of sourceFiles) {
 		const source = path.join(src, file);
 		const target = path.join(dest, file);
@@ -132,6 +142,7 @@ async function syncDir(src: string, dest: string): Promise<void> {
 async function provisionClaudePlugin(
 	bundledPluginDir: string,
 	claudeDir: string,
+	disabledSkills: ReadonlySet<string>,
 ): Promise<void> {
 	const target = path.join(claudeDir, "skills", CLAUDE_PLUGIN_DIR_NAME);
 	const sentinel = path.join(target, MANAGED_SENTINEL_NAME);
@@ -139,7 +150,10 @@ async function provisionClaudePlugin(
 		console.log(`[agent-setup] Skipping user-owned plugin dir at ${target}`);
 		return;
 	}
-	await syncDir(bundledPluginDir, target);
+	await syncDir(bundledPluginDir, target, (relativePath) => {
+		const [dir, skillName] = relativePath.split(path.sep);
+		return dir === "skills" && disabledSkills.has(skillName ?? "");
+	});
 	writeFileIfChanged(sentinel, `${MANAGED_SKILL_MARKER}\n`, 0o644);
 }
 
@@ -158,10 +172,11 @@ function readPluginSkill(
 }
 
 /**
- * Every skill in the bundled plugin ships everywhere automatically — adding a
- * skill to plugins/superset/skills/ requires no code change here. Returns null
- * on enumeration failure: the caller must abort (an empty desired set would
- * make the reaper delete every previously-provisioned skill).
+ * Every skill in the bundled plugin ships everywhere automatically unless the
+ * user disabled it — adding a skill to plugins/superset/skills/ requires no
+ * code change here. Returns null on enumeration failure: the caller must
+ * abort (an empty desired set would make the reaper delete every
+ * previously-provisioned skill).
  */
 function listBundledSkills(bundledPluginDir: string): string[] | null {
 	const skillsDir = path.join(bundledPluginDir, "skills");
@@ -231,6 +246,7 @@ export async function createManagedSkills(
 	const bundledPluginDir = options.templatesDir
 		? path.join(options.templatesDir, "plugin")
 		: getBundledPluginDir();
+	const disabledSkills = new Set(options.disabledSkills ?? []);
 
 	if (!fs.existsSync(path.join(bundledPluginDir, "skills"))) {
 		console.warn(
@@ -251,6 +267,7 @@ export async function createManagedSkills(
 		await provisionClaudePlugin(
 			bundledPluginDir,
 			path.join(homeDir, ".claude"),
+			disabledSkills,
 		);
 	} catch (error) {
 		console.warn("[agent-setup] Failed to provision Claude plugin:", error);
@@ -266,6 +283,7 @@ export async function createManagedSkills(
 
 	const desiredAgentsDirs = new Set<string>();
 	for (const pluginSkill of bundledSkills) {
+		if (disabledSkills.has(pluginSkill)) continue;
 		// Prefixed dir name carries the namespace for agents without plugin
 		// support; frontmatter `name` is rewritten to match because the skill
 		// spec requires name == parent directory.
@@ -302,6 +320,7 @@ export async function createManagedSkills(
 
 	const desiredCommandFiles = new Set<string>();
 	for (const pluginSkill of COMMAND_SKILLS) {
+		if (disabledSkills.has(pluginSkill)) continue;
 		const fileName = `${pluginSkill}.md`;
 		try {
 			const raw = readPluginSkill(bundledPluginDir, pluginSkill);
@@ -357,5 +376,9 @@ export async function provisionManagedClaudePluginAt(
 		);
 		return;
 	}
-	await provisionClaudePlugin(bundledPluginDir, claudeDir);
+	await provisionClaudePlugin(
+		bundledPluginDir,
+		claudeDir,
+		new Set(options.disabledSkills ?? []),
+	);
 }

--- a/packages/agent-setup/src/provider-profiles.ts
+++ b/packages/agent-setup/src/provider-profiles.ts
@@ -21,6 +21,7 @@ import {
 	ensureClaudeManagedHooksAt,
 	ensureCodexManagedHooksAt,
 } from "./agent-wrappers-claude-codex-opencode";
+import { resolveDisabledSkillIds } from "./disabled-skills";
 import { provisionManagedClaudePluginAt } from "./managed-skills";
 import {
 	linkSharedDir,
@@ -233,7 +234,12 @@ export async function provisionClaudeProfile(
 	if (surfaces["skills/"] === "user-owned") {
 		// The profile brought its own skills dir, so it isn't sharing ours —
 		// the bundled Superset plugin has to be written into it directly.
-		await provisionManagedClaudePluginAt(target);
+		// No settings row here (this can run from a headless host), so resolve
+		// through the shared mirror/env — the same source the default account
+		// path converges on.
+		await provisionManagedClaudePluginAt(target, {
+			disabledSkills: resolveDisabledSkillIds(),
+		});
 		surfaces["skills/superset"] = "synced";
 	}
 

--- a/packages/cli/src/lib/settings/registry.ts
+++ b/packages/cli/src/lib/settings/registry.ts
@@ -340,6 +340,7 @@ export const EXCLUDED_SETTINGS_COLUMNS: Record<string, string> = {
 	agentCustomDefinitions: "structured JSON; use superset agents",
 	agentPresetPermissionsMigratedAt: "internal migration marker",
 	disabledAgentHooks: "agent-id list; use the app UI",
+	disabledSkills: "skill-name list; use the app's Plugins page",
 	installedPlugins: "structured install records; use the app's Plugins page",
 	terminalPersistence: "dead column; nothing reads it, retained for rollback",
 	deleteLocalBranch: "v2 reads renderer localStorage, unreachable externally",

--- a/packages/local-db/drizzle/0050_add_disabled_skills_setting.sql
+++ b/packages/local-db/drizzle/0050_add_disabled_skills_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `disabled_skills` text;

--- a/packages/local-db/drizzle/meta/0050_snapshot.json
+++ b/packages/local-db/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,1606 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aef9f3e8-8787-4b97-8154-b4d876d5e261",
+  "prevId": "1067d01f-e0db-41ca-8814-2da69250c068",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_permissions_migrated_at": {
+          "name": "agent_preset_permissions_migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wait_for_setup_before_agent": {
+          "name": "wait_for_setup_before_agent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_line_height": {
+          "name": "terminal_line_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_letter_spacing": {
+          "name": "terminal_letter_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_weight": {
+          "name": "terminal_font_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_ligatures": {
+          "name": "terminal_ligatures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_minimum_contrast": {
+          "name": "terminal_minimum_contrast",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_cursor_blink": {
+          "name": "terminal_cursor_blink",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_parked_runtime_cap": {
+          "name": "terminal_parked_runtime_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_line_height": {
+          "name": "editor_line_height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_letter_spacing": {
+          "name": "editor_letter_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_weight": {
+          "name": "editor_font_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_ligatures": {
+          "name": "editor_ligatures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser_homepage_url": {
+          "name": "browser_homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_agent_hooks": {
+          "name": "disabled_agent_hooks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_plugins": {
+          "name": "installed_plugins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_skills": {
+          "name": "disabled_skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "v1_migration_state": {
+      "name": "v1_migration_state",
+      "columns": {
+        "v1_id": {
+          "name": "v1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v2_id": {
+          "name": "v2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "v1_migration_state_v2_id_idx": {
+          "name": "v1_migration_state_v2_id_idx",
+          "columns": [
+            "v2_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "v1_migration_state_organization_id_v1_id_kind_pk": {
+          "columns": [
+            "organization_id",
+            "v1_id",
+            "kind"
+          ],
+          "name": "v1_migration_state_organization_id_v1_id_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1787260502122,
       "tag": "0049_breezy_caretaker",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "6",
+      "when": 1787595622839,
+      "tag": "0050_add_disabled_skills_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -262,6 +262,7 @@ export const settings = sqliteTable("settings", {
 	installedPlugins: text("installed_plugins", { mode: "json" }).$type<
 		InstalledPlugin[]
 	>(),
+	disabledSkills: text("disabled_skills", { mode: "json" }).$type<string[]>(),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Summary
- Add an enable/disable `Switch` to the Skills tab's preview modal (`SkillPreviewDialog`), so a skill can be withheld from provisioning without uninstalling anything
- Mirror the existing `disabledAgentHooks` pattern end-to-end: a `disabled_skills` column on the local settings row, a shared `~/.superset/disabled-skills.json` mirror (+ `SUPERSET_DISABLED_SKILLS` env override) so CLI-launched host-services converge on the same choice as the desktop, and `createManagedSkills()` withholding/reaping a disabled skill's files from every agent directory, its slash-command, and the Claude plugin mirror
- Toggling re-provisions immediately (no restart needed) and persists across app restarts

## Test plan
- [x] `bun run typecheck` clean across `packages/local-db`, `packages/agent-setup`, `apps/desktop`
- [x] `bun test` in `packages/agent-setup` (254 pass, including new `disabled-skills.test.ts` and an extended `managed-skills.test.ts` case)
- [x] Verified live via CDP against the running dev app: toggling in the modal updates the DOM, persists to the local SQLite `settings` row, and reaps the skill's files from the Claude plugin mirror and its slash-command; re-enabling restores them
- [x] Confirmed no regression to the dialog's default close button, and that the tooltip doesn't spuriously open on modal mount (Radix Dialog was auto-focusing the switch, which also opened its tooltip via `:focus`)

https://claude.ai/code/session_011Nvw5AnhY9tfUkA1Mo1Lgt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-skill enable/disable switch in Plugins → Skills so users can withhold bundled skills without uninstalling. Previously all managed skills were always provisioned; now disabled skills are withheld and reaped across agents and the Claude plugin, persist across restarts, and apply to new sessions and CLI hosts.

- Persistence/sync: store in `settings.disabled_skills` (in `@superset/local-db`); mirror to `~/.superset/disabled-skills.json` with `SUPERSET_DISABLED_SKILLS` override. `@superset/agent-setup` resolves the effective set and `createManagedSkills()` withholds/reaps across agent dirs, slash-commands, and the Claude plugin. Toggling re-syncs immediately and is serialized to avoid interleaved disk state.
- Desktop boot: `apps/desktop` reads the list, writes the mirror, and passes both `disabledAgentIds` and `disabledSkillIds` to `setupAgentIntegrations()`.
- TRPC/UI: add `plugins.getDisabledSkills`, `plugins.setSkillEnabled` (returns NOT_FOUND for unknown skills), and extend `plugins.getSkillContent` to `{ content, path }`. New `useSkillMutations` centralizes toasts/PostHog and disables the switch while the list loads. The preview adds Open, Reveal in Finder, Copy Markdown (plus a quick copy button), a “Disable/Enable skill” tooltip, and a dialog autofocus fix; the list shows a “Disabled” label.
- Provisioning: thread `disabledSkillIds` through `setupAgentCapabilities()`; add `disabled-skills.ts` (shared file read/write and env resolution). Managed-skills provisioning now supports exclusions and filters Claude plugin skills, including secondary Claude accounts; `setupSingleAgent()` again refreshes managed skills.
- Data/CLI/tests: add `disabled_skills` migration, exclude it from the CLI settings registry, and add tests for shared state, env override, and withholding/reaping.

<sup>Written for commit 377a9a371b676f9f4e4f4013045096cab10fc620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable individual managed skills.
  * Disabled skills are clearly labeled in the skills list.
  * Added enable/disable controls and Open, Reveal in Finder, and Copy Markdown actions to the skill preview.
  * Skill preferences persist across sessions and are reflected in agent integrations.

* **Bug Fixes**
  * Disabled skills are removed from provisioned agent tools and plugins.
  * Improved handling of missing or invalid skill preference data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->