### PR TITLE
feat(desktop): equalize adjacent panes on border double click

### DIFF
--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -378,6 +378,66 @@ describe("split operations", () => {
 			}
 		}
 	});
+
+	it("equalizes only the tracks adjacent to a split boundary", () => {
+		const store = makeStore({
+			version: 1,
+			activeTabId: "t1",
+			tabs: [
+				{
+					id: "t1",
+					createdAt: 1,
+					activePaneId: "p3",
+					panes: {
+						p1: { id: "p1", kind: "test", data: { label: "p1" } },
+						p2: { id: "p2", kind: "test", data: { label: "p2" } },
+						p3: { id: "p3", kind: "test", data: { label: "p3" } },
+					},
+					layout: {
+						type: "split",
+						direction: "horizontal",
+						splitPercentage: 50,
+						first: { type: "pane", paneId: "p1" },
+						second: {
+							type: "split",
+							direction: "horizontal",
+							splitPercentage: 50,
+							first: { type: "pane", paneId: "p2" },
+							second: { type: "pane", paneId: "p3" },
+						},
+					},
+				},
+			],
+		});
+
+		store.getState().equalizeSplit({ tabId: "t1", path: [] });
+
+		const layout = store.getState().tabs[0]?.layout;
+		expect(layout?.type).toBe("split");
+		if (layout?.type === "split") {
+			expect(layout.splitPercentage).toBe(37.5);
+			if (layout.second.type === "split") {
+				expect(layout.second.splitPercentage).toBe(60);
+			}
+		}
+
+		store.getState().resizeSplit({
+			tabId: "t1",
+			path: ["second"],
+			splitPercentage: 85,
+		});
+		store.getState().equalizeSplit({ tabId: "t1", path: ["second"] });
+
+		const equalizedAgain = store.getState().tabs[0]?.layout;
+		expect(equalizedAgain?.type).toBe("split");
+		if (
+			equalizedAgain?.type === "split" &&
+			equalizedAgain.second.type === "split"
+		) {
+			expect(equalizedAgain.splitPercentage).toBe(37.5);
+			expect(equalizedAgain.second.splitPercentage).toBe(50);
+		}
+	});
 });
 
 describe("collapsing", () => {

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types";
 import {
 	equalizeAllSplits,
+	equalizeSplitBoundary,
 	findFirstPaneId,
 	findPaneInLayout,
 	generateId,
@@ -632,11 +633,7 @@ export function createWorkspaceStore<TData>(
 						t.id === args.tabId
 							? {
 									...t,
-									layout: updateAtPath(
-										tab.layout,
-										args.path,
-										equalizeAllSplits,
-									),
+									layout: equalizeSplitBoundary(tab.layout, args.path),
 								}
 							: t,
 					),

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -1,6 +1,7 @@
 export type { FocusDirection } from "./utils";
 export {
 	equalizeAllSplits,
+	equalizeSplitBoundary,
 	findFirstPaneId,
 	findPaneInLayout,
 	findPanePath,

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { LayoutNode } from "../../../types";
 import {
 	equalizeAllSplits,
+	equalizeSplitBoundary,
 	findFirstPaneId,
 	findPaneInLayout,
 	getActiveIdAfterRemoval,
@@ -375,6 +376,232 @@ describe("equalizeAllSplits", () => {
 				}
 			}
 		}
+	});
+});
+
+describe("equalizeSplitBoundary", () => {
+	function getTrackWeights(
+		node: LayoutNode,
+		direction: "horizontal" | "vertical",
+		weight = 1,
+	): number[] {
+		if (node.type !== "split" || node.direction !== direction) {
+			return [weight];
+		}
+
+		const firstWeight = (node.splitPercentage ?? 50) / 100;
+		return [
+			...getTrackWeights(node.first, direction, weight * firstWeight),
+			...getTrackWeights(node.second, direction, weight * (1 - firstWeight)),
+		];
+	}
+
+	it("equalizes only the tracks adjacent to a nested sash", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 60,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "horizontal",
+				splitPercentage: 70,
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "c" },
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, ["second"]);
+		expect(result.type).toBe("split");
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(60);
+			expect(result.second.type).toBe("split");
+			if (result.second.type === "split") {
+				expect(result.second.splitPercentage).toBe(50);
+			}
+		}
+	});
+
+	it("equalizes adjacent tracks across a nested group boundary", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 60,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "horizontal",
+				splitPercentage: 70,
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "c" },
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		expect(result.type).toBe("split");
+		if (result.type === "split") {
+			// a=60%, b=28%, c=12% → a=b=44%, c remains 12%.
+			expect(result.splitPercentage).toBe(44);
+			expect(result.second.type).toBe("split");
+			if (result.second.type === "split") {
+				expect(result.second.splitPercentage).toBeCloseTo(78.57, 1);
+			}
+		}
+	});
+
+	it("leaves perpendicular split sizes untouched", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 70,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "vertical",
+				splitPercentage: 25,
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "c" },
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		expect(result.type).toBe("split");
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(50);
+			expect(result.second).toEqual(layout.second);
+		}
+	});
+
+	it("restores a fully collapsed split", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 0,
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		expect(result.type).toBe("split");
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(50);
+		}
+	});
+
+	it("preserves both outer tracks when equalizing a four-track interior sash", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 20,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "horizontal",
+				splitPercentage: 25,
+				first: { type: "pane", paneId: "b" },
+				second: {
+					type: "split",
+					direction: "horizontal",
+					splitPercentage: 66.6666666667,
+					first: { type: "pane", paneId: "c" },
+					second: { type: "pane", paneId: "d" },
+				},
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, ["second"]);
+		const weights = getTrackWeights(result, "horizontal");
+
+		// a=20%, b=20%, c=40%, d=20% → b=c=30%; a/d stay fixed.
+		expect(weights[0]).toBeCloseTo(0.2, 6);
+		expect(weights[1]).toBeCloseTo(0.3, 6);
+		expect(weights[2]).toBeCloseTo(0.3, 6);
+		expect(weights[3]).toBeCloseTo(0.2, 6);
+	});
+
+	it("handles reverse nesting without changing the track before the clicked pair", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 70,
+			first: {
+				type: "split",
+				direction: "horizontal",
+				splitPercentage: 20,
+				first: { type: "pane", paneId: "a" },
+				second: { type: "pane", paneId: "b" },
+			},
+			second: { type: "pane", paneId: "c" },
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		const weights = getTrackWeights(result, "horizontal");
+
+		// a=14%, b=56%, c=30% → b=c=43%, while a remains 14%.
+		expect(weights[0]).toBeCloseTo(0.14, 6);
+		expect(weights[1]).toBeCloseTo(0.43, 6);
+		expect(weights[2]).toBeCloseTo(0.43, 6);
+	});
+
+	it("applies the same adjacent-only rule to vertical tracks", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			splitPercentage: 40,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "vertical",
+				splitPercentage: 25,
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "c" },
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		const weights = getTrackWeights(result, "vertical");
+
+		// a=40%, b=15%, c=45% → a=b=27.5%, while c remains 45%.
+		expect(weights[0]).toBeCloseTo(0.275, 6);
+		expect(weights[1]).toBeCloseTo(0.275, 6);
+		expect(weights[2]).toBeCloseTo(0.45, 6);
+	});
+
+	it("restores a collapsed adjacent track without changing the third track", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 0,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				direction: "horizontal",
+				splitPercentage: 50,
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "c" },
+			},
+		};
+
+		const result = equalizeSplitBoundary(layout, []);
+		const weights = getTrackWeights(result, "horizontal");
+
+		expect(weights[0]).toBeCloseTo(0.25, 6);
+		expect(weights[1]).toBeCloseTo(0.25, 6);
+		expect(weights[2]).toBeCloseTo(0.5, 6);
+	});
+
+	it("is idempotent and ignores invalid paths", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			splitPercentage: 60,
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+
+		const once = equalizeSplitBoundary(layout, []);
+		expect(equalizeSplitBoundary(once, [])).toEqual(once);
+		expect(equalizeSplitBoundary(layout, ["first"])).toBe(layout);
 	});
 });
 

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -165,6 +165,139 @@ function countLeaves(node: LayoutNode): number {
 	return countLeaves(node.first) + countLeaves(node.second);
 }
 
+interface SplitGroupTrack {
+	path: SplitPath;
+	weight: number;
+}
+
+function flattenSplitGroupTracks(
+	node: LayoutNode,
+	direction: SplitDirection,
+	path: SplitPath = [],
+	weight = 1,
+): SplitGroupTrack[] {
+	if (node.type !== "split" || node.direction !== direction) {
+		return [{ path, weight }];
+	}
+
+	const firstWeight =
+		Math.min(100, Math.max(0, node.splitPercentage ?? 50)) / 100;
+	return [
+		...flattenSplitGroupTracks(
+			node.first,
+			direction,
+			[...path, "first"],
+			weight * firstWeight,
+		),
+		...flattenSplitGroupTracks(
+			node.second,
+			direction,
+			[...path, "second"],
+			weight * (1 - firstWeight),
+		),
+	];
+}
+
+function pathStartsWith(path: SplitPath, prefix: SplitPath): boolean {
+	return prefix.every((branch, index) => path[index] === branch);
+}
+
+function sumTrackWeights(tracks: SplitGroupTrack[], prefix: SplitPath): number {
+	return tracks.reduce(
+		(total, track) =>
+			pathStartsWith(track.path, prefix) ? total + track.weight : total,
+		0,
+	);
+}
+
+function applySplitGroupTrackWeights(
+	node: LayoutNode,
+	direction: SplitDirection,
+	tracks: SplitGroupTrack[],
+	path: SplitPath = [],
+): LayoutNode {
+	if (node.type !== "split" || node.direction !== direction) return node;
+
+	const firstPath: SplitPath = [...path, "first"];
+	const secondPath: SplitPath = [...path, "second"];
+	const firstWeight = sumTrackWeights(tracks, firstPath);
+	const secondWeight = sumTrackWeights(tracks, secondPath);
+	const totalWeight = firstWeight + secondWeight;
+
+	return {
+		...node,
+		splitPercentage: totalWeight === 0 ? 50 : (firstWeight / totalWeight) * 100,
+		first: applySplitGroupTrackWeights(
+			node.first,
+			direction,
+			tracks,
+			firstPath,
+		),
+		second: applySplitGroupTrackWeights(
+			node.second,
+			direction,
+			tracks,
+			secondPath,
+		),
+	};
+}
+
+/**
+ * Equalizes only the two tracks immediately adjacent to the sash at `path`.
+ *
+ * The persisted layout is binary, while editor grids such as VS Code flatten
+ * adjacent splits with the same direction into one sash group. Rebalance the
+ * two tracks on either side of the clicked boundary while preserving every
+ * other track and every perpendicular subtree.
+ */
+export function equalizeSplitBoundary(
+	node: LayoutNode,
+	path: SplitPath,
+): LayoutNode {
+	const target = getNodeAtPath(node, path);
+	if (target?.type !== "split") return node;
+
+	let groupPath = [...path];
+	while (groupPath.length > 0) {
+		const parentPath = groupPath.slice(0, -1);
+		const parent = getNodeAtPath(node, parentPath);
+		if (parent?.type !== "split" || parent.direction !== target.direction) {
+			break;
+		}
+		groupPath = parentPath;
+	}
+
+	return updateAtPath(node, groupPath, (group) => {
+		const tracks = flattenSplitGroupTracks(group, target.direction);
+		const targetPath = path.slice(groupPath.length);
+		const firstPrefix: SplitPath = [...targetPath, "first"];
+		const secondPrefix: SplitPath = [...targetPath, "second"];
+		let firstTrackIndex = -1;
+		for (const [index, track] of tracks.entries()) {
+			if (pathStartsWith(track.path, firstPrefix)) {
+				firstTrackIndex = index;
+			}
+		}
+		const secondTrackIndex = tracks.findIndex((track) =>
+			pathStartsWith(track.path, secondPrefix),
+		);
+
+		if (firstTrackIndex < 0 || secondTrackIndex !== firstTrackIndex + 1) {
+			return group;
+		}
+
+		const firstTrack = tracks[firstTrackIndex];
+		const secondTrack = tracks[secondTrackIndex];
+		if (!firstTrack || !secondTrack) return group;
+
+		const equalWeight = (firstTrack.weight + secondTrack.weight) / 2;
+		firstTrack.weight = equalWeight;
+		secondTrack.weight = equalWeight;
+
+		return applySplitGroupTrackWeights(group, target.direction, tracks);
+	});
+}
+
 export function equalizeAllSplits(node: LayoutNode): LayoutNode {
 	if (node.type === "pane") return node;
 

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -18,7 +18,12 @@ import type {
 	RendererContext,
 } from "../../../../types";
 import { Pane } from "./components/Pane";
-import { PANE_MIN_SIZE_CLASS_NAME } from "./constants";
+import {
+	PANE_MIN_SIZE_CLASS_NAME,
+	RESIZE_HANDLE_BASE_Z_INDEX,
+	RESIZE_HANDLE_CLICK_MAX_MOVEMENT_PX,
+	RESIZE_HANDLE_DOUBLE_CLICK_DELAY_MS,
+} from "./constants";
 
 interface TabProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -53,6 +58,14 @@ function SplitView<TData>({
 	onSplitResizeDragging?: TabProps<TData>["onSplitResizeDragging"];
 }) {
 	const groupRef = useRef<React.ComponentRef<typeof ResizablePanelGroup>>(null);
+	const activeHandlePointerRef = useRef<{
+		pointerId: number;
+		downAt: number;
+		x: number;
+		y: number;
+		moved: boolean;
+	} | null>(null);
+	const lastHandleClickPointerDownAtRef = useRef<number | null>(null);
 	const firstSize = node.splitPercentage ?? 50;
 	const secondSize = 100 - firstSize;
 	const resizeSourceId = `${tab.id}:${path.join(".") || "root"}`;
@@ -109,13 +122,78 @@ function SplitView<TData>({
 				/>
 			</ResizablePanel>
 			<ResizableHandle
+				// The active pane draws a 2px border on either side of the 1px
+				// divider. Cover that full visual border with the sash hit area.
+				hitAreaSize="large"
+				style={{ zIndex: RESIZE_HANDLE_BASE_Z_INDEX - path.length }}
+				onPointerDownCapture={(event) => {
+					if (event.button !== 0 || !event.isPrimary) return;
+
+					(event.currentTarget as unknown as HTMLElement).setPointerCapture(
+						event.pointerId,
+					);
+					activeHandlePointerRef.current = {
+						pointerId: event.pointerId,
+						downAt: Date.now(),
+						x: event.clientX,
+						y: event.clientY,
+						moved: false,
+					};
+				}}
+				onPointerMoveCapture={(event) => {
+					const activePointer = activeHandlePointerRef.current;
+					if (!activePointer || activePointer.pointerId !== event.pointerId)
+						return;
+
+					if (
+						Math.hypot(
+							event.clientX - activePointer.x,
+							event.clientY - activePointer.y,
+						) > RESIZE_HANDLE_CLICK_MAX_MOVEMENT_PX
+					) {
+						activePointer.moved = true;
+						lastHandleClickPointerDownAtRef.current = null;
+					}
+				}}
+				onPointerUpCapture={(event) => {
+					const activePointer = activeHandlePointerRef.current;
+					activeHandlePointerRef.current = null;
+					if (!activePointer || activePointer.pointerId !== event.pointerId)
+						return;
+
+					const moved =
+						activePointer.moved ||
+						Math.hypot(
+							event.clientX - activePointer.x,
+							event.clientY - activePointer.y,
+						) > RESIZE_HANDLE_CLICK_MAX_MOVEMENT_PX;
+					if (moved) {
+						lastHandleClickPointerDownAtRef.current = null;
+						return;
+					}
+
+					const lastClickAt = lastHandleClickPointerDownAtRef.current;
+					if (
+						lastClickAt === null ||
+						activePointer.downAt - lastClickAt >
+							RESIZE_HANDLE_DOUBLE_CLICK_DELAY_MS
+					) {
+						lastHandleClickPointerDownAtRef.current = activePointer.downAt;
+						return;
+					}
+
+					lastHandleClickPointerDownAtRef.current = null;
+					queueMicrotask(() => {
+						store.getState().equalizeSplit({ tabId: tab.id, path });
+					});
+				}}
+				onPointerCancel={() => {
+					activeHandlePointerRef.current = null;
+					lastHandleClickPointerDownAtRef.current = null;
+				}}
 				onDragging={(isDragging) =>
 					onSplitResizeDragging?.(resizeSourceId, isDragging)
 				}
-				onDoubleClick={(e) => {
-					e.stopPropagation();
-					groupRef.current?.setLayout([50, 50]);
-				}}
 			/>
 			<ResizablePanel
 				className={PANE_MIN_SIZE_CLASS_NAME}

--- a/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
@@ -1,1 +1,15 @@
 export const PANE_MIN_SIZE_CLASS_NAME = "min-h-[160px] min-w-[260px]";
+
+// react-resizable-panels owns the pointer lifecycle for resize handles. A
+// collapsed handle can move underneath the pointer before pointerup, so the
+// double-click gesture is recognized from pointer-down capture on the handle.
+export const RESIZE_HANDLE_DOUBLE_CLICK_DELAY_MS = 500;
+
+// Native double-click recognition tolerates a small amount of pointer jitter.
+// Movement beyond this threshold means the gesture was a resize, not a click.
+export const RESIZE_HANDLE_CLICK_MAX_MOVEMENT_PX = 4;
+
+// At a T-junction, a nested perpendicular handle can overlap its ancestor's
+// hit area. Shallower handles stay above deeper ones so the border under the
+// pointer does not change identity after that border is dragged.
+export const RESIZE_HANDLE_BASE_Z_INDEX = 100;

--- a/packages/ui/src/components/ui/resizable.tsx
+++ b/packages/ui/src/components/ui/resizable.tsx
@@ -30,16 +30,20 @@ function ResizablePanel({
 
 function ResizableHandle({
 	withHandle,
+	hitAreaSize = "default",
 	className,
 	...props
 }: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
 	withHandle?: boolean;
+	hitAreaSize?: "default" | "large";
 }) {
 	return (
 		<ResizablePrimitive.PanelResizeHandle
 			data-slot="resizable-handle"
 			className={cn(
 				"bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+				hitAreaSize === "large" &&
+					"after:w-2 data-[panel-group-direction=vertical]:after:h-2",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## What & why

Add VS Code-style double-click reset behavior to pane resize borders.

- Equalize only the two tracks immediately touching the clicked sash, preserving other same-direction panes and perpendicular subtrees.
- Keep the rendered panel layout synchronized after a programmatic reset.
- Give pane sashes an opt-in 8px DOM hit area while retaining the 1px visual divider, so an active pane's 2px selection border cannot intercept the gesture.
- Stabilize nested T-junction hit precedence and distinguish double-clicks from resize drags using captured pointer input.

This fixes resets falling through to the selected pane, targeting a different nested split, or becoming unreliable after a resize.

## How I tested it

- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (18/18 monorepo tasks passed)
- `bun test` in `packages/panes` after rebasing onto `main` (110 passed)
- CDP-driven desktop verification using real mouse input:
  - selected each pane and exercised the exact active-border pixels on all four sash sides
  - repeated double-click -> drag resize -> double-click 8 times per case without reselecting
  - 32/32 sequences passed with 0 gesture target misses
  - covered horizontal and vertical sashes, nested T-junctions, collapsed/near-collapsed tracks, and repeated resets
  - no renderer errors, unhandled rejections, or protocol exceptions

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not applicable; same-repository branch)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Equalizes only the two panes adjacent to a divider on double-click, matching VS Code behavior and fixing mis-targeting in nested splits. Previously, double-clicks equalized the whole split subtree or failed after a resize; now only the adjacent tracks change, perpendicular splits stay unchanged, and collapsed pairs restore to 50/50.

- Review notes:
  - Store: `equalizeSplit` now uses `equalizeSplitBoundary` to flatten a sash group and rebalance only the adjacent tracks. It is idempotent and ignores invalid paths.
  - React: `Tab.tsx` recognizes double-click via captured pointer input and a small movement threshold, preventing drags from counting as clicks. It queues `equalizeSplit` and keeps layout/renderer in sync.
  - UI: `ResizableHandle` adds `hitAreaSize="large"` (8px DOM target) while keeping a 1px visual divider, and layers handles with a stable z-index at T-junctions. Default behavior remains unchanged for other callers.

<sup>Written for commit 8d39606e6948a090b4f5497db5e493bd7fdf68d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-click a panel divider to equalize only the adjacent panes.
  * Improved divider interaction with a larger click target for easier resizing.
* **Bug Fixes**
  * Equalizing nested layouts now preserves unrelated pane sizes and perpendicular splits.
  * Collapsed and vertically arranged panes are handled correctly when equalizing.
* **Interaction Improvements**
  * Single-click resizing remains unaffected, while accidental movement is distinguished from double-click actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->