### PR TITLE
fix(mobile): give the file and pull request screens their back swipe back

### DIFF
--- a/apps/mobile/app/(authenticated)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/_layout.tsx
@@ -70,16 +70,18 @@ export default function AuthenticatedLayout() {
 					headerBackButtonDisplayMode: "minimal",
 					headerShadowVisible: false,
 					title: "Files changed",
+					// The one screen that has to keep this. Its code panes scroll
+					// sideways on a PanResponder, and the system gesture beats a JS
+					// responder every time — with the swipe on, a drag across a diff
+					// pops the screen instead of scrolling it. The cost is that iOS 26
+					// leaves this screen with no back swipe at all; a real horizontal
+					// ScrollView would earn it back, since UIKit defers to those.
 					fullScreenGestureEnabled: false,
 				}}
 			/>
 			<Stack.Screen
 				name="workspace/[id]/file"
-				options={{
-					...glassHeaderOptions,
-					title: "",
-					fullScreenGestureEnabled: false,
-				}}
+				options={{ ...glassHeaderOptions, title: "" }}
 			/>
 			<Stack.Screen
 				name="workspace/[id]/commits"
@@ -154,11 +156,7 @@ export default function AuthenticatedLayout() {
 			/>
 			<Stack.Screen
 				name="workspace/[id]/pull-request/[pullRequestId]/index"
-				options={{
-					...glassHeaderOptions,
-					title: "Pull request",
-					fullScreenGestureEnabled: false,
-				}}
+				options={{ ...glassHeaderOptions, title: "Pull request" }}
 			/>
 			<Stack.Screen
 				name="workspace/[id]/pull-request/[pullRequestId]/checks"


### PR DESCRIPTION
Follow-up to #6831, which found that `fullScreenGestureEnabled: false` disables the back swipe **entirely** on iOS 26 — the system's back gesture there is the full-screen one, and `react-native-screens` gates it on that flag, with no edge-only fallback. Three more screens still carried it. This decides them one at a time rather than dropping it everywhere.

## Dropped: file viewer, pull request

Neither has anything to protect. The file viewer wraps its code (no horizontal scroll anywhere in `code-block.tsx`) inside a vertical `ScrollView`; the pull request screen is a vertical `ScrollView`. The flag was only costing them the gesture. A probe carrying the same glass header options pops from both the edge and mid-screen.

## Kept: files changed

Its code panes scroll sideways on a `PanResponder` (`dx > 14 && |dy| < 12`), and a system gesture beats a JS responder. Verified with a probe carrying that exact gate:

| gesture setting | drag from mid-screen | edge swipe |
| --- | --- | --- |
| default | **pops the screen**, responder never fires | pops |
| `fullScreenGestureEnabled: false` | pans the content (`dx 179`) | dead |

So that screen trades its back swipe for horizontal diff scrolling. It now says so in a comment, including the way out: a real horizontal `ScrollView` would earn the gesture back, since UIKit defers to scroll views that scroll horizontally (`RNSScreenStack.mm` `shouldRequireFailureOfGestureRecognizer`). That is a diff-viewer rewrite, not a flag flip, so it is not in this PR.

It is also the only `PanResponder` in the app — the two horizontal `ScrollView`s (`ChecksFilter`, `TerminalTabs`) are the kind UIKit already coordinates with.

https://claude.ai/code/session_01JwmrtU7LZ5GrN5TrfG1J7n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the iOS back swipe on the file viewer and pull request screens by removing fullScreenGestureEnabled: false; keeps it on Files changed to preserve horizontal diff scrolling. On iOS 26, `react-native-screens` disables the only back gesture when this flag is false, so it was removing back swipe where unnecessary.

- File viewer and pull request are vertical ScrollViews with no horizontal pans; flag removed so edge and full-screen back swipes work again.
- Files changed uses a horizontal PanResponder; flag kept so drags scroll the diff instead of popping. Comment documents the tradeoff and that a real horizontal ScrollView would restore the gesture.
- Scope: layout options only in apps/mobile/app/(authenticated)/_layout.tsx; navigation/routes unchanged.

<sup>Written for commit b04514b729f19b1a96d4c1dc0497818bc716d944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enabled the standard full-screen back-swipe gesture on workspace file and pull request screens.
  * Preserved horizontal code-pane scrolling behavior on the changed-files screen while documenting its gesture configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->