### PR TITLE
fix(mobile): let unpaid accounts reach the organizations sheet

### DIFF
--- a/apps/mobile/app/(authenticated)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/_layout.tsx
@@ -28,11 +28,18 @@ export default function AuthenticatedLayout() {
 	const { data: session } = useSession();
 	const pathname = usePathname();
 
-	// Unpaid sessions may only see home (which renders the paywall) and
-	// settings — App Review requires sign-out, org switching, and account
-	// deletion to stay reachable behind a gate.
+	// Unpaid sessions may only see home (which renders the paywall), the
+	// organizations sheet, and settings — App Review requires sign-out, org
+	// switching, and account deletion to stay reachable behind a gate, and that
+	// sheet is the only route to all three. Leaving it out sealed unpaid
+	// accounts in: it mounted and was redirected away in the same frame.
 	const unpaid = !!session && !session.session.plan;
-	if (unpaid && pathname !== "/" && !pathname.startsWith("/settings")) {
+	if (
+		unpaid &&
+		pathname !== "/" &&
+		pathname !== "/organizations" &&
+		!pathname.startsWith("/settings")
+	) {
 		return <Redirect href="/(authenticated)/(home)" />;
 	}
 


### PR DESCRIPTION
The authenticated layout gated unpaid sessions to `/` and `/settings*`. The org switcher resolves to `/organizations`, so it mounted and was redirected away in the same frame — the sheet opened and vanished before it could draw.

That sheet is the only route to org switching, Settings, sign-out, and account deletion, so an account on the Free plan was sealed in with nothing but the paywall's Refresh button. The comment directly above the guard already stated the opposite intent:

> App Review requires sign-out, org switching, and account deletion to stay reachable behind a gate.

Adds `/organizations` to the allowlist.

## Repro

Sign in on an account whose active organization is on the Free plan, then tap the org name in the header. Before: the sheet flashes and you stay on the paywall (PostHog screen events go `/` → `/organizations` → `/`). After: the sheet stays open.

## Verification

Driven on an iPhone 17 simulator (iOS 26.5) against production, on an account whose active org was on Free. Confirmed the screen-event sequence no longer bounces back to `/`, and the sheet renders its org list plus Settings and Log out.

## Notes

- Pre-existing since #6778 (2026-08-22); not a regression from anything in flight.
- Worth treating as an App Store submission blocker — it is exactly the reachability requirement the code comment describes.

https://claude.ai/code/session_01MmTRNzZsBgjggTXe1qc5TK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let unpaid sessions access the organizations sheet by allowlisting `/organizations` in the authenticated layout. Previously, unpaid users were redirected from `/organizations` to `/`, causing the sheet to flash and trapping Free-plan accounts on the paywall; now the sheet stays open and reaches org switching, Settings, sign-out, and account deletion.

- Guard now allows `/`, `/organizations`, and `/settings*` for unpaid sessions; no change for paid sessions.
- Review by testing an unpaid session: tap the org name to open the sheet and access Settings and Log out; ensure no redirect back to `/`.

<sup>Written for commit 262aacbcffc7047eb7c1984f4c0cbc45a6e1603c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unpaid authenticated sessions can now access the organizations page.
  - Existing access restrictions and redirects remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->