### PR TITLE
fix(docs,marketing): stop blocking /_next/ in robots.txt so Google can fetch render assets

### DIFF
--- a/apps/docs/src/app/robots.ts
+++ b/apps/docs/src/app/robots.ts
@@ -6,8 +6,10 @@ export default function robots(): MetadataRoute.Robots {
 		rules: [
 			{
 				userAgent: "*",
+				// No /_next/ block: Google needs build assets (CSS, JS, fonts) to
+				// render pages, and blocking them triggers Search Console reports.
 				allow: "/",
-				disallow: ["/api/", "/_next/", "/llms.mdx/", "/llms-full.txt"],
+				disallow: ["/api/", "/llms.mdx/", "/llms-full.txt"],
 			},
 		],
 		sitemap: `${COMPANY.DOCS_URL}/sitemap.xml`,

--- a/apps/marketing/src/app/robots.txt/route.ts
+++ b/apps/marketing/src/app/robots.txt/route.ts
@@ -26,7 +26,6 @@ User-Agent: *
 Allow: /
 Allow: /api/llms.txt
 Disallow: /api/
-Disallow: /_next/
 
 # AI assistants and AI search crawlers: explicitly welcome
 ${WELCOME_AI_AGENTS.map((agent) => `User-Agent: ${agent}\nAllow: /`).join("\n\n")}


### PR DESCRIPTION
## What

Removes the `Disallow: /_next/` rule from both robots surfaces:

- `apps/docs/src/app/robots.ts` (docs.superset.sh / docs.boid.so)
- `apps/marketing/src/app/robots.txt/route.ts` (superset.sh / boid.so)

`/api/` stays blocked (with the `/api/llms.txt` allow exception), as do the docs llms paths.

## Why

Search Console flagged "Blocked by robots.txt" on the boid.so domain property: a woff2 font on docs.boid.so under `/_next/static/`, blocked by the `/_next/` disallow. Google's guidance is to not block the CSS/JS/font assets it needs to render pages.

Blocking `/_next/` at all turns out to be cargo cult, none of the reference Next.js production sites do it (checked live): vercel.com and linear.app block only `/api/`-style paths, nextjs.org blocks nothing. Assets aren't indexable as pages, so the disallow bought nothing and cost rendering fidelity plus recurring GSC warnings.

## Verification

- Blocked URL confirmed in the GSC indexing report for sc-domain:boid.so (1 affected page, a `docs.boid.so/_next/static/...woff2` font).
- vercel.com, nextjs.org, linear.app robots.txt fetched live 2026-08-24; none block `/_next/`.
- After deploy: robots.txt no longer lists `/_next/`, then "Validate fix" in GSC clears the report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search engines can now access required site assets under `/_next/`, improving page rendering and indexing.
  * Existing restrictions for API and LLM-related paths remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->