### PR TITLE
Enable editing in the diff pane

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -72,7 +72,7 @@
 		"@lezer/highlight": "1.2.3",
 		"@paper-design/shaders-react": "0.0.77",
 		"@parcel/watcher": "2.5.6",
-		"@pierre/diffs": "1.3.5",
+		"@pierre/diffs": "1.3.6",
 		"@pierre/trees": "1.0.0-beta.5",
 		"@radix-ui/react-dialog": "1.1.15",
 		"@radix-ui/react-label": "2.1.8",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -187,7 +187,13 @@ export function DiffPane({
 			const editedFile = editedFilesRef.current.get(itemId);
 			const file = fileByItemId.get(itemId);
 			const worktreePath = workspaceQuery.data?.worktreePath;
-			if (!editedFile || !file || !worktreePath) return true;
+			if (!editedFile) return true;
+			if (!file || !worktreePath) {
+				toast.error("Couldn't save edits", {
+					description: "The workspace is not ready yet. Try again.",
+				});
+				return false;
+			}
 			try {
 				const result = await writeFile.mutateAsync({
 					workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -2,11 +2,21 @@ import type {
 	CodeViewItem,
 	DiffLineAnnotation,
 	LineAnnotation,
+	FileContents as PierreFileContents,
 } from "@pierre/diffs";
-import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
+import { Editor, type EditorOptions } from "@pierre/diffs/edit";
+import {
+	CodeView,
+	type CodeViewHandle,
+	EditProvider,
+} from "@pierre/diffs/react";
+
 import type { RendererContext } from "@superset/panes";
+import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
-import { useCallback, useMemo, useRef } from "react";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuFileCode } from "react-icons/lu";
 import {
 	createPaneScrollStateKey,
@@ -14,6 +24,7 @@ import {
 	savePaneScrollState,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache";
 import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/MarkdownSearch";
+import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
 	type ChangesetFile,
@@ -38,6 +49,7 @@ import { useDiffCodeViewScroll } from "./hooks/useDiffCodeViewScroll";
 import { useDiffCodeViewTheme } from "./hooks/useDiffCodeViewTheme";
 import { useDiffCommentComposer } from "./hooks/useDiffCommentComposer";
 import { useDiffPaneSearch } from "./hooks/useDiffPaneSearch";
+import { getCharacterOffsetAtClientX } from "./utils/getCharacterOffsetAtClientX";
 
 interface CreateNewAgentSessionInput {
 	configId: string;
@@ -52,6 +64,17 @@ interface DiffPaneProps {
 	onCreateNewAgentSession?: (
 		input: CreateNewAgentSessionInput,
 	) => Promise<{ terminalId: string } | null>;
+}
+
+function canEditDiffFile(
+	file: ChangesetFile | undefined,
+): file is ChangesetFile {
+	return (
+		file != null &&
+		!file.isBinary &&
+		file.status !== "deleted" &&
+		(file.source.kind === "staged" || file.source.kind === "unstaged")
+	);
 }
 
 export function DiffPane({
@@ -83,6 +106,24 @@ export function DiffPane({
 	const { viewedSet, setViewed } = useViewedFiles(workspaceId);
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
 	const threadAnnotationsByPath = useDiffAnnotationsByPath({ workspaceId });
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
+	const utils = workspaceTrpc.useUtils();
+	const [editingSet, setEditingSet] = useState<ReadonlySet<string>>(new Set());
+	const [dirtyItemIds, setDirtyItemIds] = useState<ReadonlySet<string>>(
+		new Set(),
+	);
+	const [editorRevisionByItemId, setEditorRevisionByItemId] = useState<
+		ReadonlyMap<string, number>
+	>(new Map());
+	const editedFilesRef = useRef(new Map<string, PierreFileContents>());
+	const pendingEditorFocusRef = useRef<{
+		itemId: string;
+		lineNumber: number;
+		character: number;
+	} | null>(null);
 
 	const collapsedSet = useMemo(
 		() => new Set(data.collapsedFiles ?? []),
@@ -134,10 +175,115 @@ export function DiffPane({
 			workspaceId,
 			files,
 			collapsedSet,
+			editingSet,
+			editorRevisionByItemId,
 			annotationsByPath: threadAnnotationsByPath,
 			extraAnnotationsByItemId: composerAnnotationsByItemId,
 		});
 	fileByItemIdRef.current = fileByItemId;
+
+	const saveEditedItem = useCallback(
+		async (itemId: string): Promise<boolean> => {
+			const editedFile = editedFilesRef.current.get(itemId);
+			const file = fileByItemId.get(itemId);
+			const worktreePath = workspaceQuery.data?.worktreePath;
+			if (!editedFile || !file || !worktreePath) return true;
+			try {
+				const result = await writeFile.mutateAsync({
+					workspaceId,
+					absolutePath: toAbsoluteWorkspacePath(worktreePath, file.path),
+					content: editedFile.contents,
+					encoding: "utf-8",
+				});
+				if (!result.ok) {
+					toast.error("Couldn't save edits", {
+						description:
+							result.reason === "conflict"
+								? "The file changed on disk. Review it before saving again."
+								: "The file could not be written.",
+					});
+					return false;
+				}
+				setDirtyItemIds((current) => {
+					const next = new Set(current);
+					next.delete(itemId);
+					return next;
+				});
+				void utils.git.getStatus.invalidate({ workspaceId });
+				void utils.git.getDiff.invalidate({ workspaceId });
+				void utils.git.getDiffBulk.invalidate({ workspaceId });
+				return true;
+			} catch (error) {
+				toast.error("Couldn't save edits", {
+					description: error instanceof Error ? error.message : String(error),
+				});
+				return false;
+			}
+		},
+		[
+			fileByItemId,
+			workspaceQuery.data?.worktreePath,
+			writeFile,
+			workspaceId,
+			utils,
+		],
+	);
+
+	const exitEditing = useCallback((itemId: string) => {
+		editedFilesRef.current.delete(itemId);
+		setDirtyItemIds((current) => {
+			const next = new Set(current);
+			next.delete(itemId);
+			return next;
+		});
+		setEditingSet(new Set());
+	}, []);
+
+	const discardEditing = useCallback(
+		(itemId: string) => {
+			// Pierre retains editor documents by item id. Rotate the item's version
+			// so reopening starts from the diff contents instead of the discarded
+			// in-memory document.
+			setEditorRevisionByItemId((current) => {
+				const next = new Map(current);
+				next.set(itemId, (next.get(itemId) ?? 0) + 1);
+				return next;
+			});
+			exitEditing(itemId);
+		},
+		[exitEditing],
+	);
+
+	const requestExitEditing = useCallback(
+		(itemId: string) => {
+			if (!dirtyItemIds.has(itemId)) {
+				discardEditing(itemId);
+				return;
+			}
+			const file = fileByItemId.get(itemId);
+			alert({
+				title: `Do you want to save the changes you made to ${file?.path.split("/").pop() ?? "this file"}?`,
+				description: "Your changes will be lost if you don't save them.",
+				actions: [
+					{
+						label: "Save",
+						onClick: () => {
+							void saveEditedItem(itemId).then((saved) => {
+								if (saved) exitEditing(itemId);
+							});
+						},
+					},
+					{
+						label: "Don't Save",
+						variant: "secondary",
+						onClick: () => discardEditing(itemId),
+					},
+					{ label: "Cancel", variant: "ghost", onClick: () => {} },
+				],
+			});
+		},
+		[dirtyItemIds, discardEditing, exitEditing, fileByItemId, saveEditedItem],
+	);
 
 	const search = useDiffPaneSearch({
 		containerRef: searchContainerRef,
@@ -187,8 +333,64 @@ export function DiffPane({
 			enableGutterUtility: true,
 			onGutterUtilityClick,
 			onLineSelectionEnd,
+			onLineClick: (
+				line: {
+					annotationSide?: string;
+					event: PointerEvent;
+					lineElement: HTMLElement;
+					lineNumber: number;
+					numberColumn: boolean;
+				},
+				itemContext: { item: CodeViewItem<DiffAnnotationMetadata> },
+			) => {
+				if (
+					line.numberColumn ||
+					(line.annotationSide != null &&
+						line.annotationSide !== "additions") ||
+					editingSet.size > 0
+				)
+					return;
+				const file = fileByItemId.get(itemContext.item.id);
+				if (!canEditDiffFile(file)) return;
+				pendingEditorFocusRef.current = {
+					itemId: itemContext.item.id,
+					lineNumber: line.lineNumber,
+					character: getCharacterOffsetAtClientX(
+						line.lineElement,
+						line.event.clientX,
+					),
+				};
+				setEditingSet(new Set([getChangesetFileKey(file)]));
+			},
+			onLineEnter: (
+				line: {
+					annotationSide?: string;
+					lineElement: HTMLElement;
+					numberColumn: boolean;
+				},
+				itemContext: { item: CodeViewItem<DiffAnnotationMetadata> },
+			) => {
+				const file = fileByItemId.get(itemContext.item.id);
+				if (
+					!line.numberColumn &&
+					(line.annotationSide == null ||
+						line.annotationSide === "additions") &&
+					canEditDiffFile(file)
+				) {
+					line.lineElement.style.cursor = "text";
+				}
+			},
+			onLineLeave: (line: { lineElement: HTMLElement }) => {
+				line.lineElement.style.removeProperty("cursor");
+			},
 		}),
-		[options, onGutterUtilityClick, onLineSelectionEnd],
+		[
+			options,
+			onGutterUtilityClick,
+			onLineSelectionEnd,
+			editingSet,
+			fileByItemId,
+		],
 	);
 
 	const renderHeaderPrefix = useCallback(
@@ -212,6 +414,7 @@ export function DiffPane({
 			const file = fileByItemId.get(item.id);
 			if (!file) return null;
 			const changeKey = getChangesetFileKey(file);
+			const isEditing = editingSet.has(changeKey);
 			return (
 				<DiffHeaderMetadata
 					file={file}
@@ -221,6 +424,15 @@ export function DiffPane({
 					onSetViewed={setViewed}
 					onOpenFile={onOpenFile}
 					onOpenInExternalEditor={openInExternalEditor}
+					isEditing={isEditing}
+					isDirty={dirtyItemIds.has(item.id)}
+					isSaving={writeFile.isPending}
+					onSaveEditing={
+						isEditing ? () => void saveEditedItem(item.id) : undefined
+					}
+					onCancelEditing={
+						isEditing ? () => requestExitEditing(item.id) : undefined
+					}
 				/>
 			);
 		},
@@ -232,7 +444,64 @@ export function DiffPane({
 			setViewed,
 			onOpenFile,
 			openInExternalEditor,
+			editingSet,
+			dirtyItemIds,
+			writeFile.isPending,
+			saveEditedItem,
+			requestExitEditing,
 		],
+	);
+
+	const createEditor = useCallback(
+		(options: EditorOptions<DiffAnnotationMetadata>) =>
+			new Editor<DiffAnnotationMetadata>(options),
+		[],
+	);
+	const handleItemEditChange = useCallback(
+		(
+			item: CodeViewItem<DiffAnnotationMetadata>,
+			editedFile: PierreFileContents,
+		) => {
+			editedFilesRef.current.set(item.id, editedFile);
+			setDirtyItemIds((current) => new Set(current).add(item.id));
+		},
+		[],
+	);
+
+	// The activating click happens before Pierre mounts its editor. Restore that
+	// click's line intent as soon as the controlled item enters edit mode.
+	useEffect(() => {
+		const pending = pendingEditorFocusRef.current;
+		if (!pending || editingSet.size === 0) return;
+		const frame = requestAnimationFrame(() => {
+			const editor = codeViewRef.current?.getEditor(pending.itemId);
+			if (!(editor instanceof Editor)) return;
+			pendingEditorFocusRef.current = null;
+			editor.focus({
+				lineNumber: pending.lineNumber,
+				character: pending.character,
+			});
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [editingSet]);
+
+	const activeEditingItemId = items.find((item) => item.edit)?.id;
+	const handleEditorKeyDownCapture = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (!activeEditingItemId) return;
+			if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+				event.preventDefault();
+				event.stopPropagation();
+				void saveEditedItem(activeEditingItemId);
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				event.stopPropagation();
+				requestExitEditing(activeEditingItemId);
+			}
+		},
+		[activeEditingItemId, requestExitEditing, saveEditedItem],
 	);
 
 	const renderAnnotation = useCallback(
@@ -327,7 +596,11 @@ export function DiffPane({
 					count={currentSection.count}
 				/>
 			) : null}
-			<div ref={searchContainerRef} className="relative min-h-0 w-full flex-1">
+			<div
+				ref={searchContainerRef}
+				className="relative min-h-0 w-full flex-1"
+				onKeyDownCapture={handleEditorKeyDownCapture}
+			>
 				<MarkdownSearch
 					isOpen={search.isSearchOpen}
 					query={search.query}
@@ -340,17 +613,20 @@ export function DiffPane({
 					onFindPrevious={search.findPrevious}
 					onClose={search.closeSearch}
 				/>
-				<CodeView<DiffAnnotationMetadata>
-					ref={codeViewRef}
-					className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
-					style={style}
-					items={items}
-					options={codeViewOptions}
-					onScroll={handleScroll}
-					renderHeaderPrefix={renderHeaderPrefix}
-					renderHeaderMetadata={renderHeaderMetadata}
-					renderAnnotation={renderAnnotation}
-				/>
+				<EditProvider<DiffAnnotationMetadata> createEditor={createEditor}>
+					<CodeView<DiffAnnotationMetadata>
+						ref={codeViewRef}
+						className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
+						style={style}
+						items={items}
+						options={codeViewOptions}
+						onScroll={handleScroll}
+						renderHeaderPrefix={renderHeaderPrefix}
+						renderHeaderMetadata={renderHeaderMetadata}
+						renderAnnotation={renderAnnotation}
+						onItemEditChange={handleItemEditChange}
+					/>
+				</EditProvider>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -2,12 +2,13 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { LuCheck, LuCopy, LuExternalLink, LuUndo2, LuX } from "react-icons/lu";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useSidebarFilePolicy } from "renderer/lib/clickPolicy";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import type { ChangesetFile } from "../../../../../useChangeset";
+import { useDiffHeaderHover } from "../../hooks/useDiffHeaderHover";
 
 interface DiffHeaderMetadataProps {
 	file: ChangesetFile;
@@ -39,34 +40,9 @@ export function DiffHeaderMetadata({
 	onCancelEditing,
 }: DiffHeaderMetadataProps) {
 	const actionsRef = useRef<HTMLDivElement>(null);
-	const [headerHovered, setHeaderHovered] = useState(false);
+	const headerHovered = useDiffHeaderHover(actionsRef);
 	const { copyToClipboard, copied } = useCopyToClipboard();
 	const policy = useSidebarFilePolicy();
-
-	useEffect(() => {
-		const show = () => setHeaderHovered(true);
-		const hide = () => setHeaderHovered(false);
-		let header: Element | null = null;
-		let frame = 0;
-		const connect = () => {
-			header =
-				actionsRef.current
-					?.closest("diffs-container")
-					?.shadowRoot?.querySelector("[data-diffs-header='default']") ?? null;
-			if (!header) {
-				frame = requestAnimationFrame(connect);
-				return;
-			}
-			header.addEventListener("pointerenter", show);
-			header.addEventListener("pointerleave", hide);
-		};
-		connect();
-		return () => {
-			cancelAnimationFrame(frame);
-			header?.removeEventListener("pointerenter", show);
-			header?.removeEventListener("pointerleave", hide);
-		};
-	}, []);
 
 	const handleToggleViewed = useCallback(() => {
 		const next = !viewed;
@@ -135,12 +111,6 @@ export function DiffHeaderMetadata({
 				)}
 				data-diff-actions
 				data-editing={isEditing ? "" : undefined}
-				onFocusCapture={() => setHeaderHovered(true)}
-				onBlurCapture={(event) => {
-					if (!event.currentTarget.contains(event.relatedTarget)) {
-						setHeaderHovered(false);
-					}
-				}}
 			>
 				{isEditing && onSaveEditing && onCancelEditing ? (
 					<>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -1,13 +1,12 @@
-import { Checkbox } from "@superset/ui/checkbox";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useCallback, useId, useMemo, useState } from "react";
-import { LuArrowUpRight, LuCheck, LuCopy, LuUndo2 } from "react-icons/lu";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { LuCheck, LuCopy, LuExternalLink, LuUndo2, LuX } from "react-icons/lu";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useSidebarFilePolicy } from "renderer/lib/clickPolicy";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
-import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import type { ChangesetFile } from "../../../../../useChangeset";
 
 interface DiffHeaderMetadataProps {
@@ -18,6 +17,11 @@ interface DiffHeaderMetadataProps {
 	onSetViewed: (path: string, next: boolean) => void;
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 	onOpenInExternalEditor: (path: string) => void;
+	isEditing: boolean;
+	isDirty: boolean;
+	isSaving: boolean;
+	onSaveEditing?: () => void;
+	onCancelEditing?: () => void;
 }
 
 export function DiffHeaderMetadata({
@@ -28,10 +32,41 @@ export function DiffHeaderMetadata({
 	onSetViewed,
 	onOpenFile,
 	onOpenInExternalEditor,
+	isEditing,
+	isDirty,
+	isSaving,
+	onSaveEditing,
+	onCancelEditing,
 }: DiffHeaderMetadataProps) {
-	const viewedId = useId();
+	const actionsRef = useRef<HTMLDivElement>(null);
+	const [headerHovered, setHeaderHovered] = useState(false);
 	const { copyToClipboard, copied } = useCopyToClipboard();
 	const policy = useSidebarFilePolicy();
+
+	useEffect(() => {
+		const show = () => setHeaderHovered(true);
+		const hide = () => setHeaderHovered(false);
+		let header: Element | null = null;
+		let frame = 0;
+		const connect = () => {
+			header =
+				actionsRef.current
+					?.closest("diffs-container")
+					?.shadowRoot?.querySelector("[data-diffs-header='default']") ?? null;
+			if (!header) {
+				frame = requestAnimationFrame(connect);
+				return;
+			}
+			header.addEventListener("pointerenter", show);
+			header.addEventListener("pointerleave", hide);
+		};
+		connect();
+		return () => {
+			cancelAnimationFrame(frame);
+			header?.removeEventListener("pointerenter", show);
+			header?.removeEventListener("pointerleave", hide);
+		};
+	}, []);
 
 	const handleToggleViewed = useCallback(() => {
 		const next = !viewed;
@@ -92,70 +127,118 @@ export function DiffHeaderMetadata({
 
 	return (
 		<>
-			<div className="flex shrink-0 items-center gap-1.5">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={handleOpenClick}
-							aria-label="Open in file viewer"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
-						>
-							<LuArrowUpRight className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">{policy.hint}</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={() => void copyToClipboard(file.path)}
-							aria-label="Copy path"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
-						>
-							{copied ? (
-								<LuCheck className="size-3.5" />
-							) : (
-								<LuCopy className="size-3.5" />
+			<div
+				ref={actionsRef}
+				className={cn(
+					"-mr-1 flex shrink-0 items-center gap-1 transition-opacity duration-100",
+					!isEditing && !headerHovered && "pointer-events-none opacity-0",
+				)}
+				data-diff-actions
+				data-editing={isEditing ? "" : undefined}
+				onFocusCapture={() => setHeaderHovered(true)}
+				onBlurCapture={(event) => {
+					if (!event.currentTarget.contains(event.relatedTarget)) {
+						setHeaderHovered(false);
+					}
+				}}
+			>
+				{isEditing && onSaveEditing && onCancelEditing ? (
+					<>
+						<output
+							className={cn(
+								"size-1.5 rounded-full transition-colors",
+								isDirty ? "bg-amber-500" : "bg-muted-foreground/30",
 							)}
+							aria-label={isDirty ? "Unsaved changes" : "All changes saved"}
+						/>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={onSaveEditing}
+									aria-label="Save edits"
+									disabled={!isDirty || isSaving}
+									className="rounded bg-accent p-1 text-foreground transition-colors hover:bg-accent/80 disabled:opacity-40"
+								>
+									<LuCheck className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">Save edits (⌘S)</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={onCancelEditing}
+									aria-label="Cancel edits"
+									className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+								>
+									<LuX className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">Cancel edits</TooltipContent>
+						</Tooltip>
+					</>
+				) : (
+					<>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => void copyToClipboard(file.path)}
+									aria-label="Copy path"
+									className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+								>
+									{copied ? (
+										<LuCheck className="size-3.5" />
+									) : (
+										<LuCopy className="size-3.5" />
+									)}
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								{copied ? "Copied" : "Copy path"}
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={handleOpenClick}
+									aria-label="Open in file viewer"
+									className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+								>
+									<LuExternalLink className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">{policy.hint}</TooltipContent>
+						</Tooltip>
+						<button
+							type="button"
+							onClick={handleToggleViewed}
+							aria-pressed={viewed}
+							className="rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						>
+							{viewed ? "Viewed" : "Mark as viewed"}
 						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">
-						{copied ? "Copied" : "Copy path"}
-					</TooltipContent>
-				</Tooltip>
-				<StatusIndicator status={file.status} iconClassName="size-3.5" />
-				<div className="flex items-center gap-1">
-					<Checkbox
-						id={viewedId}
-						checked={viewed}
-						onCheckedChange={() => handleToggleViewed()}
-						className="size-3 border-muted-foreground/50"
-					/>
-					<label
-						htmlFor={viewedId}
-						className="hidden cursor-pointer select-none text-xs text-muted-foreground @min-[380px]/diff-header:inline"
-					>
-						Viewed
-					</label>
-				</div>
-				{requestDiscard ? (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								onClick={requestDiscard}
-								aria-label="Discard changes"
-								data-discard-button
-								className="rounded p-1 text-muted-foreground/60 opacity-0 transition-all hover:bg-accent hover:text-destructive"
-							>
-								<LuUndo2 className="size-3.5" />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom">Discard changes</TooltipContent>
-					</Tooltip>
-				) : null}
+						{requestDiscard ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										onClick={requestDiscard}
+										aria-label="Discard changes"
+										data-discard-button
+										className="rounded p-1 text-muted-foreground/60 transition-all hover:bg-accent hover:text-destructive"
+									>
+										<LuUndo2 className="size-3.5" />
+									</button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">Discard changes</TooltipContent>
+							</Tooltip>
+						) : null}
+					</>
+				)}
 			</div>
 			{canDiscard ? (
 				<DiscardConfirmDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -213,14 +213,6 @@ export function DiffHeaderMetadata({
 							</TooltipTrigger>
 							<TooltipContent side="bottom">{policy.hint}</TooltipContent>
 						</Tooltip>
-						<button
-							type="button"
-							onClick={handleToggleViewed}
-							aria-pressed={viewed}
-							className="rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-						>
-							{viewed ? "Viewed" : "Mark as viewed"}
-						</button>
 						{requestDiscard ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -237,6 +229,15 @@ export function DiffHeaderMetadata({
 								<TooltipContent side="bottom">Discard changes</TooltipContent>
 							</Tooltip>
 						) : null}
+						<button
+							type="button"
+							onClick={handleToggleViewed}
+							aria-pressed={viewed}
+							className="flex items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						>
+							{viewed ? <LuCheck className="size-3.5" /> : null}
+							{viewed ? "Marked as viewed" : "Mark as viewed"}
+						</button>
 					</>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
@@ -1,8 +1,9 @@
 import { cn } from "@superset/ui/utils";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import { FileIcon } from "renderer/lib/fileIcons";
 import type { ChangesetFile } from "../../../../../useChangeset";
+import { useDiffHeaderHover } from "../../hooks/useDiffHeaderHover";
 
 interface DiffHeaderPrefixProps {
 	file: ChangesetFile;
@@ -16,37 +17,11 @@ export function DiffHeaderPrefix({
 	onSetCollapsed,
 }: DiffHeaderPrefixProps) {
 	const prefixRef = useRef<HTMLDivElement>(null);
-	const [headerHovered, setHeaderHovered] = useState(false);
+	const headerHovered = useDiffHeaderHover(prefixRef);
 	const onToggle = useCallback(
 		() => onSetCollapsed(!collapsed),
 		[onSetCollapsed, collapsed],
 	);
-
-	useEffect(() => {
-		const show = () => setHeaderHovered(true);
-		const hide = () => setHeaderHovered(false);
-		let header: Element | null = null;
-		let frame = 0;
-		const connect = () => {
-			header =
-				prefixRef.current
-					?.closest("diffs-container")
-					?.shadowRoot?.querySelector("[data-diffs-header='default']") ?? null;
-			if (!header) {
-				frame = requestAnimationFrame(connect);
-				return;
-			}
-			header.addEventListener("pointerenter", show);
-			header.addEventListener("pointerleave", hide);
-			setHeaderHovered(header.matches(":hover"));
-		};
-		connect();
-		return () => {
-			cancelAnimationFrame(frame);
-			header?.removeEventListener("pointerenter", show);
-			header?.removeEventListener("pointerleave", hide);
-		};
-	}, []);
 
 	return (
 		<div ref={prefixRef} className="relative size-3.5 shrink-0">
@@ -64,8 +39,6 @@ export function DiffHeaderPrefix({
 					event.stopPropagation();
 					onToggle();
 				}}
-				onFocus={() => setHeaderHovered(true)}
-				onBlur={() => setHeaderHovered(false)}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
 				className={cn(
 					"absolute -inset-1 flex items-center justify-center rounded text-muted-foreground/60 transition-all duration-100 hover:bg-accent hover:text-muted-foreground",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
@@ -1,5 +1,6 @@
+import { cn } from "@superset/ui/utils";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FileIcon } from "renderer/lib/fileIcons";
 import type { ChangesetFile } from "../../../../../useChangeset";
 
@@ -14,20 +15,57 @@ export function DiffHeaderPrefix({
 	collapsed,
 	onSetCollapsed,
 }: DiffHeaderPrefixProps) {
+	const prefixRef = useRef<HTMLDivElement>(null);
+	const [headerHovered, setHeaderHovered] = useState(false);
 	const onToggle = useCallback(
 		() => onSetCollapsed(!collapsed),
 		[onSetCollapsed, collapsed],
 	);
 
+	useEffect(() => {
+		const show = () => setHeaderHovered(true);
+		const hide = () => setHeaderHovered(false);
+		let header: Element | null = null;
+		let frame = 0;
+		const connect = () => {
+			header =
+				prefixRef.current
+					?.closest("diffs-container")
+					?.shadowRoot?.querySelector("[data-diffs-header='default']") ?? null;
+			if (!header) {
+				frame = requestAnimationFrame(connect);
+				return;
+			}
+			header.addEventListener("pointerenter", show);
+			header.addEventListener("pointerleave", hide);
+			setHeaderHovered(header.matches(":hover"));
+		};
+		connect();
+		return () => {
+			cancelAnimationFrame(frame);
+			header?.removeEventListener("pointerenter", show);
+			header?.removeEventListener("pointerleave", hide);
+		};
+	}, []);
+
 	return (
 		// Flex wrapper: Tailwind preflight sets `img { display: block }`,
 		// so without this the FileIcon drops below the chevron button.
-		<div className="flex shrink-0 items-center gap-1">
+		<div ref={prefixRef} className="flex shrink-0 items-center gap-1">
 			<button
 				type="button"
-				onClick={onToggle}
+				onPointerDown={(event) => event.stopPropagation()}
+				onClick={(event) => {
+					event.stopPropagation();
+					onToggle();
+				}}
+				onFocus={() => setHeaderHovered(true)}
+				onBlur={() => setHeaderHovered(false)}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
-				className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				className={cn(
+					"rounded p-1 text-muted-foreground/60 transition-all duration-100 hover:bg-accent hover:text-muted-foreground",
+					!headerHovered && "pointer-events-none opacity-0",
+				)}
 			>
 				{collapsed ? (
 					<ChevronRight className="size-3.5" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
@@ -49,9 +49,14 @@ export function DiffHeaderPrefix({
 	}, []);
 
 	return (
-		// Flex wrapper: Tailwind preflight sets `img { display: block }`,
-		// so without this the FileIcon drops below the chevron button.
-		<div ref={prefixRef} className="flex shrink-0 items-center gap-1">
+		<div ref={prefixRef} className="relative size-3.5 shrink-0">
+			<FileIcon
+				fileName={file.path}
+				className={cn(
+					"size-3.5 transition-opacity duration-100",
+					headerHovered && "opacity-0",
+				)}
+			/>
 			<button
 				type="button"
 				onPointerDown={(event) => event.stopPropagation()}
@@ -63,7 +68,7 @@ export function DiffHeaderPrefix({
 				onBlur={() => setHeaderHovered(false)}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
 				className={cn(
-					"rounded p-1 text-muted-foreground/60 transition-all duration-100 hover:bg-accent hover:text-muted-foreground",
+					"absolute -inset-1 flex items-center justify-center rounded text-muted-foreground/60 transition-all duration-100 hover:bg-accent hover:text-muted-foreground",
 					!headerHovered && "pointer-events-none opacity-0",
 				)}
 			>
@@ -73,7 +78,6 @@ export function DiffHeaderPrefix({
 					<ChevronDown className="size-3.5" />
 				)}
 			</button>
-			<FileIcon fileName={file.path} className="size-3.5 shrink-0" />
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -26,6 +26,8 @@ interface UseDiffCodeViewItemsOptions {
 	workspaceId: string;
 	files: ChangesetFile[];
 	collapsedSet: ReadonlySet<string>;
+	editingSet: ReadonlySet<string>;
+	editorRevisionByItemId: ReadonlyMap<string, number>;
 	annotationsByPath: ReadonlyMap<
 		string,
 		DiffLineAnnotation<DiffAnnotationMetadata>[]
@@ -69,6 +71,8 @@ export function useDiffCodeViewItems({
 	workspaceId,
 	files,
 	collapsedSet,
+	editingSet,
+	editorRevisionByItemId,
 	annotationsByPath,
 	extraAnnotationsByItemId,
 }: UseDiffCodeViewItemsOptions): UseDiffCodeViewItemsResult {
@@ -203,6 +207,7 @@ export function useDiffCodeViewItems({
 			const itemId = getDiffItemId(file);
 			liveItemIds.add(itemId);
 			const collapsed = collapsedSet.has(getChangesetFileKey(file));
+			const editing = editingSet.has(getChangesetFileKey(file));
 
 			if (file.isBinary) {
 				// The placeholder item only has a single line, so re-anchor any
@@ -303,6 +308,8 @@ export function useDiffCodeViewItems({
 					file.additions,
 					file.deletions,
 					collapsed ? "1" : "0",
+					editing ? "editing" : "readonly",
+					editorRevisionByItemId.get(itemId) ?? 0,
 					getAnnotationsVersion(annotations),
 				].join("\0"),
 			);
@@ -313,6 +320,7 @@ export function useDiffCodeViewItems({
 				fileDiff,
 				annotations,
 				collapsed,
+				edit: editing,
 				version,
 			});
 		}
@@ -329,6 +337,8 @@ export function useDiffCodeViewItems({
 		diffContentByItemId,
 		annotationsByPath,
 		collapsedSet,
+		editingSet,
+		editorRevisionByItemId,
 		extraAnnotationsByItemId,
 	]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
@@ -142,13 +142,6 @@ export function useDiffCodeViewTheme() {
 				[data-diffs-header='default'] [data-deletions-count] {
 					color: ${deletionColor};
 				}
-				[data-diffs-header='default'] [data-discard-button] {
-					opacity: 0;
-				}
-				[data-diffs-header='default']:hover [data-discard-button],
-				[data-diffs-header='default']:focus-within [data-discard-button] {
-					opacity: 1;
-				}
 				/* Pierre sets --diffs-light-bg/--diffs-dark-bg
 				 * inline on <pre data-diff> from the Shiki theme;
 				 * inline beats :host so we override at the pre. */

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
@@ -116,6 +116,13 @@ export function useDiffCodeViewTheme() {
 				[data-diffs-header='default'] {
 					container-type: inline-size;
 					container-name: diff-header;
+					justify-content: flex-start;
+				}
+				[data-diffs-header='default'] [data-header-content] {
+					flex: 0 1 auto;
+				}
+				[data-diffs-header='default'] [data-metadata] {
+					flex-shrink: 0;
 				}
 				/* Drop Pierre's status badge — we render a language-specific
 				 * FileIcon in the prefix slot instead. */

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffHeaderHover/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffHeaderHover/index.ts
@@ -1,0 +1,1 @@
+export { useDiffHeaderHover } from "./useDiffHeaderHover";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffHeaderHover/useDiffHeaderHover.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffHeaderHover/useDiffHeaderHover.ts
@@ -1,0 +1,41 @@
+import { type RefObject, useEffect, useState } from "react";
+
+export function useDiffHeaderHover(
+	targetRef: RefObject<HTMLElement | null>,
+): boolean {
+	const [headerHovered, setHeaderHovered] = useState(false);
+
+	useEffect(() => {
+		const show = () => setHeaderHovered(true);
+		const hide = () => setHeaderHovered(false);
+		let header: Element | null = null;
+		let target: HTMLElement | null = null;
+		let frame = 0;
+		const connect = () => {
+			target = targetRef.current;
+			header =
+				target
+					?.closest("diffs-container")
+					?.shadowRoot?.querySelector("[data-diffs-header='default']") ?? null;
+			if (!header) {
+				frame = requestAnimationFrame(connect);
+				return;
+			}
+			header.addEventListener("pointerenter", show);
+			header.addEventListener("pointerleave", hide);
+			target?.addEventListener("focusin", show);
+			target?.addEventListener("focusout", hide);
+			setHeaderHovered(header.matches(":hover"));
+		};
+		connect();
+		return () => {
+			cancelAnimationFrame(frame);
+			header?.removeEventListener("pointerenter", show);
+			header?.removeEventListener("pointerleave", hide);
+			target?.removeEventListener("focusin", show);
+			target?.removeEventListener("focusout", hide);
+		};
+	}, [targetRef]);
+
+	return headerHovered;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/getCharacterOffsetAtClientX/getCharacterOffsetAtClientX.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/getCharacterOffsetAtClientX/getCharacterOffsetAtClientX.ts
@@ -1,0 +1,40 @@
+/** Resolve a horizontal pointer position to a zero-based offset in a rendered
+ * Pierre line. DOM ranges account for token spans, tabs, and proportional font
+ * fallbacks without assuming a fixed character width. */
+export function getCharacterOffsetAtClientX(
+	lineElement: HTMLElement,
+	clientX: number,
+): number {
+	const walker = document.createTreeWalker(lineElement, NodeFilter.SHOW_TEXT);
+	let totalOffset = 0;
+	let textNode = walker.nextNode();
+
+	while (textNode) {
+		const text = textNode.textContent ?? "";
+		if (text.length > 0) {
+			const nodeRange = document.createRange();
+			nodeRange.selectNodeContents(textNode);
+			const nodeRect = nodeRange.getBoundingClientRect();
+
+			if (clientX <= nodeRect.right) {
+				let low = 0;
+				let high = text.length;
+				while (low < high) {
+					const middle = Math.floor((low + high) / 2);
+					const characterRange = document.createRange();
+					characterRange.setStart(textNode, middle);
+					characterRange.setEnd(textNode, middle + 1);
+					const rect = characterRange.getBoundingClientRect();
+					const midpoint = rect.left + rect.width / 2;
+					if (clientX < midpoint) high = middle;
+					else low = middle + 1;
+				}
+				return totalOffset + low;
+			}
+			totalOffset += text.length;
+		}
+		textNode = walker.nextNode();
+	}
+
+	return totalOffset;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/getCharacterOffsetAtClientX/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/getCharacterOffsetAtClientX/index.ts
@@ -1,0 +1,1 @@
+export { getCharacterOffsetAtClientX } from "./getCharacterOffsetAtClientX";

--- a/bun.lock
+++ b/bun.lock
@@ -151,7 +151,7 @@
         "@lezer/highlight": "1.2.3",
         "@paper-design/shaders-react": "0.0.77",
         "@parcel/watcher": "2.5.6",
-        "@pierre/diffs": "1.3.5",
+        "@pierre/diffs": "1.3.6",
         "@pierre/trees": "1.0.0-beta.5",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-label": "2.1.8",
@@ -2447,7 +2447,7 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.3.5", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.6", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew=="],
 
     "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 


### PR DESCRIPTION
## Summary

- enable inline editing for writable staged and unstaged Pierre diff files
- place the caret at the clicked character or end of line and support save, cancel, keyboard shortcuts, and discard confirmation
- simplify file headers with contextual hover actions, a single viewed button, and reliable collapse controls
- upgrade `@pierre/diffs` to 1.3.6

## Verification

- `bun run typecheck` in `apps/desktop`
- Biome checks for changed DiffPane files
- `git diff --check`
- CDP verification in the running desktop app for edit focus/caret placement, dirty-state prompts, disk persistence, cancellation, and header hover visibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable inline editing in the diff pane for eligible files and refine headers for clearer review controls. The diff pane was read-only; now clicking the additions side opens an in-place editor, header actions appear on hover, the collapse control no longer intercepts line clicks, and diff counts align with file paths.

- Editing: Click a non-number column on the additions side of a non-binary, non-deleted staged/unstaged file to edit; only one file edits at a time; caret lands at the clicked character via a DOM range utility; cursor switches to text on editable lines.
- Save/cancel: Save via header or Cmd/Ctrl+S; cancel with Esc; on dirty exit, prompt Save/Don’t Save/Cancel. Saving writes through workspace TRPC (with workspace readiness checks); on success, invalidate git status/diff queries; show conflict/error toasts.
- Header actions: On hover, show copy path, open in viewer, mark as viewed, and discard; while editing, show a dirty dot, Save, and Cancel. The collapse chevron overlays the file icon and appears on header hover only.
- Internals: Integrate `Editor`/`EditProvider` and `onItemEditChange` from `@pierre/diffs/edit`; track per-item edit/dirty state; rotate an item revision to discard in-memory docs; add `useDiffHeaderHover` and `getCharacterOffsetAtClientX`; upgrade `@pierre/diffs` to `1.3.6`.

<sup>Written for commit ec2032a8326eebfc1e1bb303edbe1e278222e4c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for eligible diff files.
  * Added save, cancel, discard, and dirty-state controls.
  * Added keyboard shortcuts for saving and canceling edits.
  * Improved diff header actions and file navigation controls.

* **Bug Fixes**
  * Updated the diff viewer dependency to improve reliability and editing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->