### PR TITLE
fix(ingest): let the retention loop run more than one batch

### DIFF
--- a/apps/api/src/app/api/ingest/jobs/enforce-retention/route.ts
+++ b/apps/api/src/app/api/ingest/jobs/enforce-retention/route.ts
@@ -6,6 +6,13 @@ import { verifyQstashRequest } from "@/lib/verifyQstash";
 export const dynamic = "force-dynamic";
 
 /**
+ * Matches the other long-running job routes. Without it this route took the
+ * platform default, which is shorter than a single batch now takes, so a run
+ * was killed mid-loop rather than ending on its own time budget.
+ */
+export const maxDuration = 300;
+
+/**
  * How long an event record itself is worth keeping, separate from its body.
  *
  * The constraint is idempotency, not storage: the unique indexes on these
@@ -21,13 +28,25 @@ const BATCH_SIZE = 5_000;
 
 /**
  * Ceiling per table per run. Deleting leaves dead tuples, so this is what stops
- * a backlog drain outrunning autovacuum. Against a 5-minute schedule it is
- * ~14M rows/day, comfortably ahead of the ~1.2M/day these tables take on.
+ * a backlog drain outrunning autovacuum.
+ *
+ * It has never been the binding constraint. TIME_BUDGET_MS is, because a batch
+ * costs far more than this file originally assumed — see there.
  */
 const MAX_ROWS_PER_TABLE = 50_000;
 
-/** Well inside the function timeout, so a run ends by choice rather than by kill. */
-const TIME_BUDGET_MS = 20_000;
+/**
+ * Has to exceed the cost of a batch, or the loop can only ever run one.
+ *
+ * A batch is `ORDER BY received_at LIMIT 5000` off the left edge of
+ * webhook_events_received_at_idx, and every prior delete leaves dead index
+ * entries in exactly that prefix for the next batch to walk. Measured against
+ * production over 1226 batches: 35s mean, 582s worst. At the previous 20s the
+ * deadline check after batch one always failed, so a run deleted 5k rows rather
+ * than the 50k intended — an order of magnitude under what the ceiling implies,
+ * and roughly break-even against intake once the backlog is drained.
+ */
+const TIME_BUDGET_MS = 240_000;
 
 interface RetentionTarget {
 	label: string;


### PR DESCRIPTION
Found by the 2026-08-24 schema audit (#6819). One file, no schema change, no migration.

## The bug

`TIME_BUDGET_MS` was **20s**. A batch measures **35s mean** against production — so the `while (Date.now() < deadline && ...)` check after batch one *always* failed, and a run deleted **5,000 rows instead of the 50,000** `MAX_ROWS_PER_TABLE` implies.

From `pg_stat_statements` over the job's first 43.5 hours:

| calls | rows_deleted | rows_per_call | mean_ms | max_s |
|---|---|---|---|---|
| 1,226 | 6,130,000 | **5,000** | **34,915** | **582** |

`rows_per_call` is exactly `BATCH_SIZE` on all 1,226 calls — the loop has never once run out of work, and `MAX_ROWS_PER_TABLE` has never once been the binding constraint.

Net effect: **~3.4M rows/day of drain against ~1.7M/day of intake**, not the "~14M rows/day, comfortably ahead of the ~1.2M/day" the comment claimed. That leaves a **65M-row over-retention backlog** on `ingest.webhook_events` (62% of the table) draining on a ~38-day horizon, and going break-even if intake grows — which it is: a like-for-like hour went 35,162 rows on 08-23 to 110,060 on 08-24.

## Also: no `maxDuration`

This was the **only** job route under `apps/api` without one, so it took the platform default — shorter than a single batch now costs, so runs were being killed mid-loop rather than ending on their own budget. `300` matches the other long-running job routes (`refresh-mrr`, `sweep-schedules`, `renew-watches`).

Set to 300 with a 240s budget, so the budget binds first and ~6 batches fit.

## What this does *not* fix

Batches are slow because each is `ORDER BY received_at LIMIT 5000` off the left edge of `webhook_events_received_at_idx`, and every prior delete leaves dead index entries in exactly that prefix for the next batch to walk. Autovacuum isn't clearing them at any useful rate — at 105M live rows the default `scale_factor = 0.2` puts the trigger near 21M dead tuples and the table sits at 3.4M. This PR only stops the time budget from capping the loop at one batch; it doesn't address the underlying scan cost.

Worth knowing: at ~6 batches/run the job will be deleting near-continuously. `FOR UPDATE SKIP LOCKED` already makes overlapping runs safe, but it does mean any `ACCESS EXCLUSIVE` DDL on `ingest.webhook_events` will now almost certainly queue behind a batch — which is why the unused-index drop the audit also recommended is being deliberately held until the backlog clears.

## Verification

`bunx turbo typecheck --filter=@superset/api` → exit 0. Biome check on the changed file → clean. Not exercised against production; the numbers above are read-only measurements taken during the audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the ingest retention job run more than one batch per run by raising the time budget and setting an explicit `maxDuration`. Previously, runs always stopped after the first 5k-row batch due to a 20s budget and platform timeouts; now the loop can reach the intended 50k rows per table per run.

- Increase `TIME_BUDGET_MS` from 20_000 to 240_000 so the loop can execute multiple batches and hit `MAX_ROWS_PER_TABLE` (50_000).
- Add `maxDuration = 300` to the route to avoid platform default kills and match other long-running jobs.
- No schema changes; no migrations.

**Operational impact**
- Expect ~6 batches per run; accelerates backlog drain noted in audit #6819.
- Overlapping runs remain safe via `FOR UPDATE SKIP LOCKED`; ongoing deletes may delay `ACCESS EXCLUSIVE` DDL on `ingest.webhook_events`.
- Does not change batch scan cost; dead index tuples will still accumulate until autovacuum clears them.

<sup>Written for commit e885e348bcffe9245e7db8f2b998d78eec9aea2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the retention job’s processing time budget to support larger batches.
  * Added a five-minute maximum execution window for the retention process.
  * Updated operational guidance to clarify batch cost and deadline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->